### PR TITLE
fix(reborn): compile Telegram host in production image

### DIFF
--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -58,7 +58,7 @@ WORKDIR /app
 RUN cargo chef cook \
     --profile dist \
     --package ironclaw_reborn_cli \
-    --features webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state \
+    --features webui-v2-beta,slack-v2-host-beta,telegram-v2-host-beta,libsql,postgres,inmemory-turn-state \
     --recipe-path recipe.json
 RUN cargo chef cook \
     --profile dist \
@@ -88,7 +88,7 @@ WORKDIR /app
 RUN cargo build \
     --profile dist \
     --package ironclaw_reborn_cli \
-    --features webui-v2-beta,slack-v2-host-beta,libsql,postgres,inmemory-turn-state \
+    --features webui-v2-beta,slack-v2-host-beta,telegram-v2-host-beta,libsql,postgres,inmemory-turn-state \
     --bin ironclaw-reborn
 
 RUN cargo build \

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -110,16 +110,16 @@ fn write_sparse_reborn_config(reborn_home: &Path) {
 }
 
 #[test]
-fn dockerfile_reborn_builds_with_postgres_feature() {
+fn dockerfile_reborn_builds_with_production_features() {
     let dockerfile = std::fs::read_to_string(workspace_root().join("Dockerfile.reborn"))
         .expect("Dockerfile.reborn");
 
     assert!(
         dockerfile
-            .matches("webui-v2-beta,slack-v2-host-beta,libsql,postgres")
+            .matches("webui-v2-beta,slack-v2-host-beta,telegram-v2-host-beta,libsql,postgres",)
             .count()
             >= 2,
-        "Dockerfile.reborn must compile both cargo-chef deps and final binary with libsql and postgres: {dockerfile}"
+        "Dockerfile.reborn must compile both cargo-chef deps and final binary with Slack, Telegram, libsql, and postgres: {dockerfile}"
     );
     assert!(
         dockerfile.contains("corepack enable pnpm")


### PR DESCRIPTION
## What changed

- add `telegram-v2-host-beta` to the `Dockerfile.reborn` cargo-chef dependency build
- add the same feature to the final `ironclaw-reborn` production binary build
- strengthen the existing Dockerfile smoke test so both build stages must retain Slack, Telegram, libSQL, and Postgres support

## Why

PR #6159 added the Telegram host behind a compile-time feature, but the Railway Docker image still built without that feature. The merged deployment could succeed while omitting Telegram entirely; setting `IRONCLAW_REBORN_TELEGRAM_ENABLED=true` on that image would fail startup.

## Deployment and compatibility

The Telegram host remains runtime-disabled by default, so the larger binary does not change existing Slack, storage, or ingress behavior until an operator enables it. After this lands and deploys, QA and prod can set `IRONCLAW_REBORN_TELEGRAM_ENABLED=true`, then configure their separate bot tokens through the operator Channels → Telegram setup surface.

Rollback is to unset `IRONCLAW_REBORN_TELEGRAM_ENABLED` before reverting this PR; reverting while the flag remains true would intentionally fail startup because the binary no longer contains the requested host. No schema migration is involved.

## Verification

- red/green: `cargo test -p ironclaw_reborn_cli --test smoke dockerfile_reborn_builds_with_production_features`
- `cargo check -p ironclaw_reborn_cli --features webui-v2-beta,slack-v2-host-beta,telegram-v2-host-beta,libsql,postgres,inmemory-turn-state --bin ironclaw-reborn`
- `cargo fmt --check`
- `git diff --check`
- `scripts/pre-commit-safety.sh`