### PR TITLE
refactor(reborn): inline the redundant LocalDevRootFilesystem alias -> CompositeRootFilesystem (§4.4.1)

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_inmemory_store_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_inmemory_store_ratchet.rs
@@ -23,9 +23,16 @@
 //! so keep test doubles under `tests/` (or justify an allowlist entry in
 //! review).
 //!
-//! Definition of done for this axis (§10): the allowlist reaches the empty set —
-//! every store is `Filesystem*Store<InMemoryBackend>` in tests. Until then this
-//! frozen set is the contract.
+//! Definition of done for this axis (§10): the **debt** shrinks to empty — every
+//! persistence-store duplicate becomes `Filesystem*Store<InMemoryBackend>` in
+//! tests. The mechanical consolidations (A1–A8: approvals, authorization,
+//! processes, run-state, budget-gate, and the whole outbound family) are done;
+//! see the annotated `FROZEN_INMEMORY_STORES` below for the per-entry status of
+//! the remainder. Note two entries (`InMemoryBoundedSubagentGoalStore`,
+//! `InMemoryOpenAiCompatRefStore`) are **justified bounded caches**, not
+//! persistence debt — a future PR may formally split them into a justified-keep
+//! list; for now they stay frozen with a do-not-consolidate note. Until then
+//! this frozen set is the contract.
 
 mod ratchet_support;
 
@@ -43,28 +50,58 @@ fn is_inmemory_store(ident: &str) -> bool {
 }
 
 /// The frozen inventory of pub-visible `struct InMemory*Store` definitions under
-/// `crates/`, as of the run-state slice (§4.3, A4). Remove an entry in the same
-/// PR that deletes its store; never add one. Grouped by whether it is a
-/// remaining Slice-A consolidation target or a peripheral store outside the
-/// domain-store scope of §4.3 (the axis is still complete only when the whole
-/// list is empty).
+/// `crates/`. Remove an entry in the same PR that deletes its store; never add
+/// one. Comments are stripped by the scanner, so the per-entry status notes
+/// below are documentation only — the enforced contract is the string set.
+///
+/// **Status of the remainder (assessed 2026-07-18, after the mechanical §4.3
+/// slices A1–A8 landed the approvals/authorization/processes/run-state/budget-gate
+/// and the whole outbound family).** The clean mechanical consolidations are
+/// DONE; every entry still here is blocked on non-mechanical work OR is a
+/// justified keep — so the §10 "shrink to empty" goal is not reachable by a
+/// swap. Each entry is annotated with WHAT it needs, so the next contributor
+/// picks up a scoped task instead of re-deriving the blocker. See
+/// `../.worklog/reborn-refactor.md` (store triage) for the full analysis.
 const FROZEN_INMEMORY_STORES: &[&str] = &[
-    // --- remaining Slice-A domain store: turns (do last, reconcile-then-delete;
-    //     `InMemoryTurnStateStore` is also the `inmemory-turn-state` production
-    //     runtime authority, so it is not a mechanical delete) ---
+    // --- turns cluster: DEFERRED, not mechanical. `InMemoryTurnStateStore` is the
+    //     `inmemory-turn-state` production runtime authority (pessimistic Mutex,
+    //     no-CAS-livelock); a `FilesystemTurnStateStore<InMemoryBackend>` swap needs
+    //     a concurrency stress test PROVING it keeps the no-livelock property first.
+    //     Checkpoint/LoopCheckpoint/InstructionMaterialization also need a filesystem
+    //     variant BUILT (some cross-crate in `ironclaw_loop_host`). ---
     "InMemoryTurnStateStore",
     "InMemoryCheckpointStateStore",
     "InMemoryLoopCheckpointStore",
     "InMemoryInstructionMaterializationStore",
-    // --- peripheral stores (outside §4.3's five core domains; listed so the
-    //     ratchet stays exhaustive and no new InMemory store slips in) ---
+    // --- JUSTIFIED KEEPS — bounded in-memory CACHES, not persistence-store debt.
+    //     A durable `Filesystem*` variant would be semantically wrong (you do not
+    //     persist evicted transient entries). Do NOT "consolidate" these; they are
+    //     the §4.3 duplication only in name. ---
+    //   BoundedSubagentGoal: capacity-bounded, evict-oldest (VecDeque insertion
+    //     order) cache of in-flight subagent-spawn goals — goal_store.rs.
     "InMemoryBoundedSubagentGoalStore",
-    "InMemoryExtensionInstallationStore",
+    //   OpenAiCompatRef: bounded-LRU (`max_mappings`/`with_capacity`) AND the
+    //     crate's documented filesystem-free default so contract-only consumers pull
+    //     no `ironclaw_filesystem` dep (openai_compat CLAUDE.md). Test-only.
     "InMemoryOpenAiCompatRefStore",
+    // --- BLOCKED — cross-crate placement. `FilesystemExtensionInstallationStore`
+    //     exists but in high `ironclaw_reborn_composition` and depends on a
+    //     composition-internal contract registry, so it can't move DOWN to
+    //     `ironclaw_extensions` (whose own tests need an in-memory store). Needs the
+    //     filesystem store (or its contract dep) relocated first. Prod already wires
+    //     Filesystem. ---
+    "InMemoryExtensionInstallationStore",
+    // --- SECURITY-SENSITIVE — secrets subsystem; deliberate careful work, not a
+    //     mechanical swap. ---
     "InMemorySecretStore",
+    // --- BUILD-FIRST — no filesystem variant exists. `InMemorySessionStore`
+    //     (webui login sessions, TTL-expiring bearer tokens) would gain restart
+    //     durability from a `FilesystemSessionStore`, but that store must be BUILT
+    //     (auth-adjacent — handle with care). ~63 usages. ---
     "InMemorySessionStore",
     // --- pub(crate) stores the visibility-aware scanner also inventories
-    //     (same debt class, just crate-private) ---
+    //     (crate-private; not yet individually triaged — assess build-vs-justified
+    //     when picked up, same as the peripheral set above). ---
     "InMemorySecretsStore",
     "InMemorySlackChannelRouteStore",
     "InMemorySlackPersonalDmTargetStore",

--- a/crates/ironclaw_architecture/tests/reborn_inmemory_store_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_inmemory_store_ratchet.rs
@@ -58,31 +58,38 @@ fn is_inmemory_store(ident: &str) -> bool {
 /// slices A1–A8 landed the approvals/authorization/processes/run-state/budget-gate
 /// and the whole outbound family).** The clean mechanical consolidations are
 /// DONE; every entry still here is blocked on non-mechanical work OR is a
-/// justified keep — so the §10 "shrink to empty" goal is not reachable by a
-/// swap. Each entry is annotated with WHAT it needs, so the next contributor
-/// picks up a scoped task instead of re-deriving the blocker. See
-/// `../.worklog/reborn-refactor.md` (store triage) for the full analysis.
+/// justified keep — except the trailing pub(crate) trio, which is not yet
+/// individually triaged. Triaged entries are annotated with WHAT they need, so
+/// the next contributor picks up a scoped task instead of re-deriving the
+/// blocker; untriaged entries say so explicitly.
 const FROZEN_INMEMORY_STORES: &[&str] = &[
     // --- turns cluster: DEFERRED, not mechanical. `InMemoryTurnStateStore` is the
     //     `inmemory-turn-state` production runtime authority (pessimistic Mutex,
     //     no-CAS-livelock); a `FilesystemTurnStateStore<InMemoryBackend>` swap needs
     //     a concurrency stress test PROVING it keeps the no-livelock property first.
-    //     Checkpoint/LoopCheckpoint/InstructionMaterialization also need a filesystem
-    //     variant BUILT (some cross-crate in `ironclaw_loop_host`). ---
+    //     `FilesystemCheckpointStateStore` already EXISTS in `ironclaw_loop_host`
+    //     (contract-tested, composition-wired) — that entry only needs the test-seam
+    //     swap + allowlist trim; LoopCheckpoint/InstructionMaterialization still need
+    //     a filesystem variant BUILT (cross-crate in `ironclaw_loop_host`). ---
     "InMemoryTurnStateStore",
     "InMemoryCheckpointStateStore",
     "InMemoryLoopCheckpointStore",
     "InMemoryInstructionMaterializationStore",
-    // --- JUSTIFIED KEEPS — bounded in-memory CACHES, not persistence-store debt.
-    //     A durable `Filesystem*` variant would be semantically wrong (you do not
-    //     persist evicted transient entries). Do NOT "consolidate" these; they are
-    //     the §4.3 duplication only in name. ---
+    // --- JUSTIFIED KEEPS — bounded in-memory caches serving the test/no-durable
+    //     fallback role. Durable production variants ALREADY EXIST and are wired
+    //     (`FilesystemSubagentGoalStore` in the libSQL/Postgres runner adapters;
+    //     `FilesystemOpenAiCompatRefStore` in OpenAI-compatible serving) — these
+    //     in-memory types are not missing consolidations, they are the bounded
+    //     volatile role next to those stores. Do NOT swap them for a durable
+    //     store in tests that specifically exercise the bounded/evicting cache
+    //     semantics. ---
     //   BoundedSubagentGoal: capacity-bounded, evict-oldest (VecDeque insertion
     //     order) cache of in-flight subagent-spawn goals — goal_store.rs.
     "InMemoryBoundedSubagentGoalStore",
-    //   OpenAiCompatRef: bounded-LRU (`max_mappings`/`with_capacity`) AND the
+    //   OpenAiCompatRef: capacity-bounded with oldest-created eviction (evicts the
+    //     minimum `created_at`; reads do not refresh recency — NOT an LRU) AND the
     //     crate's documented filesystem-free default so contract-only consumers pull
-    //     no `ironclaw_filesystem` dep (openai_compat CLAUDE.md). Test-only.
+    //     no `ironclaw_filesystem` dep (openai_compat CLAUDE.md).
     "InMemoryOpenAiCompatRefStore",
     // --- BLOCKED — cross-crate placement. `FilesystemExtensionInstallationStore`
     //     exists but in high `ironclaw_reborn_composition` and depends on a

--- a/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
@@ -79,7 +79,6 @@ const FROZEN_LOCALDEV_TYPES: &[&str] = &[
     "LocalDevOverride",
     "LocalDevPersistentApprovalPolicyStore",
     "LocalDevProviderPolicy",
-    "LocalDevRootFilesystem",
     "LocalDevSelectableSkillContextSource",
     "LocalDevSyntheticCapability",
     "LocalDevSyntheticCapabilityDescriptor",

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -16,7 +16,7 @@ use ironclaw_approvals::{
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_auth::AuthProviderClient;
 use ironclaw_auth::{AuthProductScope, AuthSurface};
-// Used by both the durable (`<LocalDevRootFilesystem>`) and no-durable
+// Used by both the durable (`<CompositeRootFilesystem>`) and no-durable
 // (`<InMemoryBackend>`) capability-lease aliases/builders, so the import is
 // unconditional (arch-simplification §4.3).
 use ironclaw_authorization::FilesystemCapabilityLeaseStore;
@@ -109,7 +109,7 @@ use ironclaw_resources::FilesystemBudgetGateStore;
 use ironclaw_resources::{
     BroadcastBudgetEventSink, BudgetGateStore, FilesystemResourceGovernor, ResourceGovernor,
 };
-// Used by both the durable (`<LocalDevRootFilesystem>`) and no-durable
+// Used by both the durable (`<CompositeRootFilesystem>`) and no-durable
 // (`<InMemoryBackend>`) run-state/approval aliases + builders, so the import is
 // unconditional (arch-simplification §4.3).
 use ironclaw_run_state::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
@@ -206,8 +206,6 @@ use crate::{
     RebornFacadeReadiness, RebornProductAuthServices, RebornReadiness, RebornWorkerReadiness,
 };
 
-pub(crate) type LocalDevRootFilesystem = CompositeRootFilesystem;
-
 /// Output of [`build_local_dev_root_filesystem`]: the composed local-dev
 /// root filesystem and, when libSQL is the substrate, a clone of the raw
 /// libSQL handle. The handle backs both the local-dev trigger repository
@@ -215,7 +213,7 @@ pub(crate) type LocalDevRootFilesystem = CompositeRootFilesystem;
 /// `reborn-local-dev.db` rather than opening a second handle to the file
 /// (see `RebornRuntime::open_reborn_identity_resolver`).
 struct LocalDevRootFilesystemBundle {
-    filesystem: Arc<LocalDevRootFilesystem>,
+    filesystem: Arc<CompositeRootFilesystem>,
     durable_backend: LocalDevDurableBackend,
 }
 
@@ -238,8 +236,8 @@ enum LocalDevStorageBackendInput {
 }
 
 type LocalDevWorkspaceFilesystems = (
-    Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
-    Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    Arc<ScopedFilesystem<CompositeRootFilesystem>>,
+    Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     MountView,
 );
 
@@ -271,7 +269,7 @@ impl ironclaw_network::NetworkHttpEgress for TestNetworkHttpEgress {
     not(feature = "inmemory-turn-state"),
     any(feature = "libsql", feature = "postgres")
 ))]
-pub(crate) type LocalDevTurnStateStore = FilesystemTurnStateStoreKind<LocalDevRootFilesystem>;
+pub(crate) type LocalDevTurnStateStore = FilesystemTurnStateStoreKind<CompositeRootFilesystem>;
 #[cfg(any(
     feature = "inmemory-turn-state",
     not(any(feature = "libsql", feature = "postgres"))
@@ -279,7 +277,7 @@ pub(crate) type LocalDevTurnStateStore = FilesystemTurnStateStoreKind<LocalDevRo
 pub(crate) type LocalDevTurnStateStore = InMemoryTurnStateStore;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-type LocalDevResourceGovernor = FilesystemResourceGovernor<LocalDevRootFilesystem>;
+type LocalDevResourceGovernor = FilesystemResourceGovernor<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 type LocalDevResourceGovernor = InMemoryResourceGovernor;
 
@@ -289,19 +287,19 @@ type LocalDevResourceGovernor = InMemoryResourceGovernor;
 // `InMemoryBackend` directly, so the concrete type is `<InMemoryBackend>`, which
 // the host-runtime production-wiring guard classifies `LocalOnly`.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-type LocalDevRunStateStore = FilesystemRunStateStore<LocalDevRootFilesystem>;
+type LocalDevRunStateStore = FilesystemRunStateStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 type LocalDevRunStateStore = FilesystemRunStateStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevApprovalRequestStore =
-    FilesystemApprovalRequestStore<LocalDevRootFilesystem>;
+    FilesystemApprovalRequestStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 pub(crate) type LocalDevApprovalRequestStore = FilesystemApprovalRequestStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevCapabilityLeaseStore =
-    FilesystemCapabilityLeaseStore<LocalDevRootFilesystem>;
+    FilesystemCapabilityLeaseStore<CompositeRootFilesystem>;
 // One capability-lease store, backend-injected — the production
 // `FilesystemCapabilityLeaseStore<F>` every deployment uses, never a bespoke
 // `InMemory*Store` (arch-simplification §4.3). The no-durable-features build
@@ -322,29 +320,29 @@ pub(crate) type LocalDevCapabilityLeaseStore = FilesystemCapabilityLeaseStore<In
 // type is distinct and correctly classifies as a production candidate.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevPersistentApprovalPolicyStore =
-    FilesystemPersistentApprovalPolicyStore<LocalDevRootFilesystem>;
+    FilesystemPersistentApprovalPolicyStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 pub(crate) type LocalDevPersistentApprovalPolicyStore =
     FilesystemPersistentApprovalPolicyStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevToolPermissionOverrideStore =
-    FilesystemToolPermissionOverrideStore<LocalDevRootFilesystem>;
+    FilesystemToolPermissionOverrideStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 pub(crate) type LocalDevToolPermissionOverrideStore =
     FilesystemToolPermissionOverrideStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) type LocalDevAutoApproveSettingStore =
-    FilesystemAutoApproveSettingStore<LocalDevRootFilesystem>;
+    FilesystemAutoApproveSettingStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 pub(crate) type LocalDevAutoApproveSettingStore =
     FilesystemAutoApproveSettingStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 type LocalDevProcessServices = ProcessServices<
-    ironclaw_processes::FilesystemProcessStore<LocalDevRootFilesystem>,
-    ironclaw_processes::FilesystemProcessResultStore<LocalDevRootFilesystem>,
+    ironclaw_processes::FilesystemProcessStore<CompositeRootFilesystem>,
+    ironclaw_processes::FilesystemProcessResultStore<CompositeRootFilesystem>,
 >;
 // One process store pair, backend-injected — the production
 // `FilesystemProcess*Store<F>` every deployment uses, never a bespoke
@@ -604,7 +602,7 @@ impl RebornServices {
     /// two can never drift apart.
     pub(crate) fn read_write_workspace_filesystem(
         &self,
-    ) -> Option<Arc<ScopedFilesystem<LocalDevRootFilesystem>>> {
+    ) -> Option<Arc<ScopedFilesystem<CompositeRootFilesystem>>> {
         let local_runtime = self.local_runtime.as_ref()?;
         Some(Arc::new(ScopedFilesystem::with_fixed_view(
             Arc::clone(&local_runtime.extension_filesystem),
@@ -727,7 +725,7 @@ impl RebornServices {
     #[cfg(feature = "test-support")]
     fn local_dev_workspace_attachment_reader_for_test(
         &self,
-    ) -> Option<Arc<crate::support::fs::ProjectScopedAttachmentReader<LocalDevRootFilesystem>>>
+    ) -> Option<Arc<crate::support::fs::ProjectScopedAttachmentReader<CompositeRootFilesystem>>>
     {
         let local_runtime = self.local_runtime.as_ref()?;
         Some(Arc::new(
@@ -1061,7 +1059,7 @@ pub(crate) struct RebornLocalRuntimeServices {
     /// reads it today, hence `dead_code` when that feature is off.
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[allow(dead_code)]
-    pub(crate) identity_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    pub(crate) identity_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     /// Admin per-user secret provisioner (target-user-scoped secret store over
     /// the shared root + crypto). `None` when no filesystem secret store was
     /// built. Read only by the WebUI v2 admin surface.
@@ -1133,13 +1131,13 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) skill_mounts: MountView,
     pub(crate) memory_mounts: MountView,
     pub(crate) system_extensions_lifecycle_mounts: MountView,
-    pub(crate) skill_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
-    pub(crate) workspace_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    pub(crate) skill_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
+    pub(crate) workspace_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     #[cfg(all(
         any(feature = "libsql", feature = "postgres"),
         feature = "slack-v2-host-beta"
     ))]
-    pub(crate) host_state_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    pub(crate) host_state_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     /// Telegram analog of `host_state_filesystem`: a `ScopedFilesystem` whose
     /// fixed resolver is [`crate::telegram_host_state_mount_view`], backing the
     /// durable Telegram setup/pairing/binding/DM-target stores plus the
@@ -1150,12 +1148,12 @@ pub(crate) struct RebornLocalRuntimeServices {
     ))]
     pub(crate) telegram_host_state_filesystem: Arc<ScopedFilesystem<dyn RootFilesystem>>,
     #[cfg(any(feature = "libsql", feature = "postgres"))]
-    pub(crate) subagent_goal_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    pub(crate) subagent_goal_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     /// Tenant-scoped root filesystem used for third-party extension hook
     /// discovery (`/system/extensions/<tenant>`). The runtime derives the
     /// discovery root from the authenticated tenant id; this is the same
     /// backend the rest of local-dev composition uses.
-    pub(crate) extension_filesystem: Arc<LocalDevRootFilesystem>,
+    pub(crate) extension_filesystem: Arc<CompositeRootFilesystem>,
     pub(crate) workspace_mounts: MountView,
     pub(crate) local_dev_storage_root: PathBuf,
     pub(crate) default_system_prompt_path: PathBuf,
@@ -1252,12 +1250,12 @@ struct RebornLocalDevStoreGraph {
 }
 
 struct RebornLocalDevStoreGraphInput {
-    filesystem: Arc<LocalDevRootFilesystem>,
+    filesystem: Arc<CompositeRootFilesystem>,
     owner_user_id: UserId,
     local_runtime_identity: Option<RebornLocalRuntimeIdentity>,
     runtime_policy: Option<EffectiveRuntimePolicy>,
-    skill_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
-    workspace_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    skill_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
+    workspace_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     workspace_mounts: MountView,
     local_dev_storage_root: PathBuf,
     default_system_prompt_path: PathBuf,
@@ -3284,7 +3282,7 @@ fn local_dev_project_filesystem(
 ))]
 pub(crate) async fn open_local_dev_slack_host_state_filesystem_for_test(
     storage_root: &Path,
-) -> Result<Arc<ScopedFilesystem<LocalDevRootFilesystem>>, RebornBuildError> {
+) -> Result<Arc<ScopedFilesystem<CompositeRootFilesystem>>, RebornBuildError> {
     let workspace_root = storage_root.join("workspace");
     let bundle = build_local_dev_root_filesystem(
         storage_root,
@@ -3823,8 +3821,8 @@ fn local_dev_mount_descriptor(
 }
 
 fn local_dev_scoped_filesystem(
-    filesystem: Arc<LocalDevRootFilesystem>,
-) -> Arc<ScopedFilesystem<LocalDevRootFilesystem>> {
+    filesystem: Arc<CompositeRootFilesystem>,
+) -> Arc<ScopedFilesystem<CompositeRootFilesystem>> {
     crate::wrap_scoped(filesystem)
 }
 
@@ -3851,17 +3849,17 @@ pub(crate) struct LocalDevOutboundStores {
     pub(crate) triggered_run_delivery: Arc<dyn TriggeredRunDeliveryStore>,
 }
 
-fn local_dev_outbound_store(filesystem: Arc<LocalDevRootFilesystem>) -> LocalDevOutboundStores {
+fn local_dev_outbound_store(filesystem: Arc<CompositeRootFilesystem>) -> LocalDevOutboundStores {
     // One store instance over the composition-owned per-user scoped filesystem
     // (`/outbound` → `/tenants/<t>/users/<u>/outbound`). All four outbound
     // roles — preferences, state, delivered-gate routes, triggered-run delivery
     // — are Arc-cloned from this single instance so the WebUI delivery-defaults
     // facade and the Slack delivery path share the same backing tree. Works in
     // both durable (libsql/postgres) and no-durable (in-memory backend) builds
-    // because `LocalDevRootFilesystem` is `CompositeRootFilesystem` in both.
+    // because `CompositeRootFilesystem` is `CompositeRootFilesystem` in both.
     // composition-owned construction site, the only one allowed.
     #[allow(clippy::disallowed_methods)]
-    let store: Arc<FilesystemOutboundStateStore<LocalDevRootFilesystem>> = Arc::new(
+    let store: Arc<FilesystemOutboundStateStore<CompositeRootFilesystem>> = Arc::new(
         FilesystemOutboundStateStore::new(local_dev_scoped_filesystem(filesystem)),
     );
     LocalDevOutboundStores {
@@ -3880,8 +3878,8 @@ fn local_dev_outbound_store(filesystem: Arc<LocalDevRootFilesystem>) -> LocalDev
     feature = "slack-v2-host-beta"
 ))]
 fn local_dev_slack_host_state_filesystem(
-    filesystem: Arc<LocalDevRootFilesystem>,
-) -> Arc<ScopedFilesystem<LocalDevRootFilesystem>> {
+    filesystem: Arc<CompositeRootFilesystem>,
+) -> Arc<ScopedFilesystem<CompositeRootFilesystem>> {
     Arc::new(ScopedFilesystem::new(
         filesystem,
         crate::slack_host_state_mount_view,
@@ -3893,7 +3891,7 @@ fn local_dev_slack_host_state_filesystem(
     feature = "telegram-v2-host-beta"
 ))]
 fn local_dev_telegram_host_state_filesystem(
-    filesystem: Arc<LocalDevRootFilesystem>,
+    filesystem: Arc<CompositeRootFilesystem>,
 ) -> Arc<ScopedFilesystem<dyn RootFilesystem>> {
     let filesystem: Arc<dyn RootFilesystem> = filesystem;
     Arc::new(ScopedFilesystem::new(
@@ -3904,7 +3902,7 @@ fn local_dev_telegram_host_state_filesystem(
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 fn local_dev_event_log(
-    filesystem: Arc<LocalDevRootFilesystem>,
+    filesystem: Arc<CompositeRootFilesystem>,
 ) -> Result<Arc<dyn DurableEventLog>, RebornBuildError> {
     let scoped = Arc::new(ScopedFilesystem::with_fixed_view(
         filesystem,
@@ -3921,7 +3919,7 @@ fn local_dev_event_log(
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 fn local_dev_audit_log(
-    filesystem: Arc<LocalDevRootFilesystem>,
+    filesystem: Arc<CompositeRootFilesystem>,
 ) -> Result<Arc<dyn DurableAuditLog>, RebornBuildError> {
     let scoped = Arc::new(ScopedFilesystem::with_fixed_view(
         filesystem,
@@ -3938,14 +3936,14 @@ fn local_dev_audit_log(
 
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 fn local_dev_event_log(
-    _filesystem: Arc<LocalDevRootFilesystem>,
+    _filesystem: Arc<CompositeRootFilesystem>,
 ) -> Result<Arc<dyn DurableEventLog>, RebornBuildError> {
     Ok(Arc::new(InMemoryDurableEventLog::new()))
 }
 
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 fn local_dev_audit_log(
-    _filesystem: Arc<LocalDevRootFilesystem>,
+    _filesystem: Arc<CompositeRootFilesystem>,
 ) -> Result<Arc<dyn DurableAuditLog>, RebornBuildError> {
     Ok(Arc::new(InMemoryDurableAuditLog::new()))
 }
@@ -3975,7 +3973,7 @@ impl LocalDevHostHomeRoot {
 /// real local paths resolve through the same virtual roots as `/workspace` and
 /// `/host`.
 fn build_workspace_filesystems(
-    filesystem: Arc<LocalDevRootFilesystem>,
+    filesystem: Arc<CompositeRootFilesystem>,
     workspace_root: &Path,
     host_home_root: Option<&LocalDevHostHomeRoot>,
 ) -> Result<LocalDevWorkspaceFilesystems, RebornBuildError> {

--- a/crates/ironclaw_reborn_composition/src/llm_admin/openai_compat_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/openai_compat_serve.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, §4.4.1 mechanical inline of the redundant LocalDevRootFilesystem alias -> CompositeRootFilesystem (de-prefix, no logic change), plan #6168
 //! Reborn host composition for OpenAI-compatible API routes.
 //!
 //! The route crate owns DTOs and HTTP handlers, but the Reborn host owns the
@@ -1581,9 +1582,9 @@ fn thread_scope_from_projection_read(
 }
 
 fn openai_compat_ledger_filesystem(
-    root: Arc<crate::factory::LocalDevRootFilesystem>,
+    root: Arc<ironclaw_filesystem::CompositeRootFilesystem>,
     tenant_id: &TenantId,
-) -> Result<Arc<ScopedFilesystem<crate::factory::LocalDevRootFilesystem>>, RebornBuildError> {
+) -> Result<Arc<ScopedFilesystem<ironclaw_filesystem::CompositeRootFilesystem>>, RebornBuildError> {
     Ok(Arc::new(ScopedFilesystem::with_fixed_view(
         root,
         MountView::new(vec![MountGrant::new(

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -106,7 +106,7 @@ use ironclaw_turns::run_profile::UserProfileContext;
 
 use self::latency::{trace_runtime_latency_error, trace_runtime_latency_ok};
 use self::runtime_turn_scheduler::RuntimeTurnScheduler;
-use crate::factory::{LocalDevRootFilesystem, LocalDevTurnStateStore, builtin_extension_registry};
+use crate::factory::{LocalDevTurnStateStore, builtin_extension_registry};
 use crate::local_dev_capability_policy::{LocalDevCapabilityPolicy, local_dev_capability_policy};
 #[cfg(any(test, feature = "test-support"))]
 use crate::outbound::outbound_preferences::OutboundDeliveryTargetEntry;
@@ -118,6 +118,7 @@ use crate::outbound::{
 use crate::projection::{RebornProjectionServices, build_reborn_projection_services};
 use crate::root::default_system_prompt::DefaultSystemPromptIdentitySource;
 use crate::turn_run_snapshot::TurnRunSnapshotSource;
+use ironclaw_filesystem::CompositeRootFilesystem;
 
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Clone)]
@@ -832,9 +833,9 @@ pub(crate) fn build_local_dev_approval_interaction_service_with_turn_run_source(
 }
 
 pub(crate) type LocalDevSelectableSkillContextSource =
-    SelectableSkillContextSource<FilesystemSkillBundleSource<LocalDevRootFilesystem>>;
+    SelectableSkillContextSource<FilesystemSkillBundleSource<CompositeRootFilesystem>>;
 type LocalDevSkillExecutionAdapter =
-    SkillExecutionAdapter<FilesystemSkillBundleSource<LocalDevRootFilesystem>>;
+    SkillExecutionAdapter<FilesystemSkillBundleSource<CompositeRootFilesystem>>;
 
 // TODO(#4416): when a second test-only handle is
 // needed off the trigger poller seam (e.g. trusted_submitter,
@@ -1938,8 +1939,9 @@ impl RebornRuntime {
     /// C-ATTACH test seam so the two views can never drift apart.
     pub(crate) fn webui_workspace_filesystem(
         &self,
-    ) -> Option<Arc<ironclaw_filesystem::ScopedFilesystem<crate::factory::LocalDevRootFilesystem>>>
-    {
+    ) -> Option<
+        Arc<ironclaw_filesystem::ScopedFilesystem<ironclaw_filesystem::CompositeRootFilesystem>>,
+    > {
         self.services.read_write_workspace_filesystem()
     }
 
@@ -1954,8 +1956,9 @@ impl RebornRuntime {
     /// a strictly read-only, multi-mount navigation view.
     pub(crate) fn webui_browse_filesystem(
         &self,
-    ) -> Option<Arc<ironclaw_filesystem::ScopedFilesystem<crate::factory::LocalDevRootFilesystem>>>
-    {
+    ) -> Option<
+        Arc<ironclaw_filesystem::ScopedFilesystem<ironclaw_filesystem::CompositeRootFilesystem>>,
+    > {
         let rt = self.services.local_runtime.as_ref()?;
         Some(Arc::new(ironclaw_filesystem::ScopedFilesystem::new(
             Arc::clone(&rt.extension_filesystem),
@@ -2619,7 +2622,7 @@ impl RebornRuntime {
 
     fn skill_execution_plan_for_run(
         &self,
-        adapter: &SkillExecutionAdapter<FilesystemSkillBundleSource<LocalDevRootFilesystem>>,
+        adapter: &SkillExecutionAdapter<FilesystemSkillBundleSource<CompositeRootFilesystem>>,
         scope: &TurnScope,
         run_id: TurnRunId,
     ) -> Result<RebornSkillExecutionPlan, RebornRuntimeError> {
@@ -3871,7 +3874,7 @@ pub async fn build_reborn_runtime(
         // `context/profile.json` via the workspace filesystem. When a local-dev workspace
         // filesystem is available, the `MemoryBackedUserProfileSource` adapter reads it;
         // otherwise `EmptyUserProfileSource` degrades gracefully to `None` (profile unknown).
-        // `extension_filesystem` is the raw `Arc<LocalDevRootFilesystem>` (=
+        // `extension_filesystem` is the raw `Arc<CompositeRootFilesystem>` (=
         // `CompositeRootFilesystem`) — the underlying RootFilesystem the workspace
         // mounts are built from. `MemoryBackedUserProfileSource` constructs its own
         // full virtual paths via `profile_scope_and_path` and does not use the
@@ -4275,7 +4278,7 @@ async fn append_trusted_laptop_access_audit(
 }
 
 struct LocalDevSkillContextSource {
-    bundle_source: Arc<FilesystemSkillBundleSource<LocalDevRootFilesystem>>,
+    bundle_source: Arc<FilesystemSkillBundleSource<CompositeRootFilesystem>>,
     source: Arc<dyn HostSkillContextSource>,
     activation_source: Arc<LocalDevSelectableSkillContextSource>,
     execution_adapter: Arc<LocalDevSkillExecutionAdapter>,

--- a/crates/ironclaw_reborn_composition/src/turn_run_snapshot.rs
+++ b/crates/ironclaw_reborn_composition/src/turn_run_snapshot.rs
@@ -33,7 +33,7 @@ pub(crate) trait TurnRunSnapshotSource: Send + Sync {
 
 // Durable filesystem store: async fallible snapshot. Generic over any
 // `RootFilesystem` backend so both `LocalDevTurnStateStore` (production/
-// local-dev, when it resolves to `FilesystemTurnStateStore<LocalDevRootFilesystem>`)
+// local-dev, when it resolves to `FilesystemTurnStateStore<CompositeRootFilesystem>`)
 // and a caller's own store (e.g. `RebornIntegrationGroup`'s
 // `FilesystemTurnStateStore<HarnessTurnBackend>`) implement this identically.
 // Unconditional (not cfg-gated on which backend `LocalDevTurnStateStore`


### PR DESCRIPTION
## What

First **§4.4.1** slice (deployment-mode-as-type cleanup) — a fresh axis now that the mechanical §4.3 store family is complete.

`LocalDevRootFilesystem` was a `pub(crate) type LocalDevRootFilesystem = CompositeRootFilesystem;` alias — a pure redundant indirection whose `LocalDev` prefix falsely read as a **deployment tier** when it is just the composition's `CompositeRootFilesystem` (the same type factory.rs already used directly, interchangeably, in dozens of places). This is the doc's §4.4.1 **bucket-(b)**: mis-prefixed shared substrate → de-prefix to the honest type.

## Changes

- Inlined the alias → `ironclaw_filesystem::CompositeRootFilesystem` across the 4 composition files that used it (factory / runtime / openai_compat_serve / turn_run_snapshot, ~54 sites), deleted the alias, and repointed imports (consumers now import the real type from `ironclaw_filesystem` instead of the re-exported `crate::factory` alias).
- The private, genuinely-local-dev `LocalDevRootFilesystemBundle` struct keeps its name (word-boundary rename left it untouched; it's not on the ratchet — the visibility-aware scanner skips private types).
- **R2 ratchet** (`reborn_localdev_typename`): drop `LocalDevRootFilesystem` from the frozen allowlist — one fewer deployment-mode-as-type leak.

Pure type-alias inline, **semantically identical**. Net-zero line count (a rename).

## Verification

- `cargo build -p ironclaw_reborn_composition` (default + libsql+slack) — clean
- localdev ratchet 4 tests; clippy `-D warnings` clean; **local_dev composition tests 233 pass**; fmt + pre-commit clean

## Stack

Stacked on #6216. Opens the §4.4.1 axis (`LocalDev*` → `DeploymentConfig` / de-prefix) after the §4.3 store family completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)