### PR TITLE
fix(telegram): finish LocalFilesystem->DiskFilesystem rename in test code

### DIFF
--- a/crates/ironclaw_telegram_extension/src/egress.rs
+++ b/crates/ironclaw_telegram_extension/src/egress.rs
@@ -332,7 +332,7 @@ mod tests {
     use async_trait::async_trait;
     use ironclaw_authorization::GrantAuthorizer;
     use ironclaw_extensions::ExtensionRegistry;
-    use ironclaw_filesystem::{InMemoryBackend, LocalFilesystem};
+    use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
     use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
     use ironclaw_network::{
         NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
@@ -419,14 +419,14 @@ mod tests {
     }
 
     fn test_host_runtime_services() -> HostRuntimeServices<
-        LocalFilesystem,
+        DiskFilesystem,
         InMemoryResourceGovernor,
         FilesystemProcessStore<InMemoryBackend>,
         FilesystemProcessResultStore<InMemoryBackend>,
     > {
         HostRuntimeServices::new(
             Arc::new(ExtensionRegistry::new()),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(DiskFilesystem::new()),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ironclaw_processes::in_memory_backed_process_services(),

--- a/crates/ironclaw_telegram_extension/src/test_support.rs
+++ b/crates/ironclaw_telegram_extension/src/test_support.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_filesystem::{
     BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError,
     FilesystemOperation, InMemoryBackend, RecordVersion, RootFilesystem, ScopedFilesystem,
@@ -319,7 +319,7 @@ fn network_response(status: u16, body: Vec<u8>) -> NetworkHttpResponse {
 fn host_egress_port(network: impl NetworkHttpEgress + 'static) -> HostRuntimeHttpEgressPort {
     let services = HostRuntimeServices::new(
         Arc::new(ExtensionRegistry::new()),
-        Arc::new(LocalFilesystem::new()),
+        Arc::new(DiskFilesystem::new()),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::in_memory_backed_process_services(),


### PR DESCRIPTION
## What

The §4.4 Bucket-2 rename `LocalFilesystem` → `DiskFilesystem` (#6168) missed **five references in `ironclaw_telegram_extension` test code**:

- `crates/ironclaw_telegram_extension/src/egress.rs` — `#[cfg(test)]` module (import + `HostRuntimeServices` type param + `::new()`)
- `crates/ironclaw_telegram_extension/src/test_support.rs` — import + `::new()`

`ironclaw_filesystem` no longer exports `LocalFilesystem` (only `pub use local::DiskFilesystem`), so `cargo test --tests --workspace` fails to compile with `E0432: unresolved import`, breaking the **Code Coverage** workflow on `main`.

## Why CI missed it on the rename PR

The stale refs live only in **test targets**. Regular `cargo build` / `clippy` for the crate stayed green; only the coverage job (which compiles `--tests` across the whole workspace) surfaced it.

- Failing run: https://github.com/nearai/ironclaw/actions/runs/29623554735
- Error: `error[E0432]: unresolved import ironclaw_filesystem::LocalFilesystem` → `could not compile ironclaw_telegram_extension (lib test)`

## Change

Mechanical rename only, no logic change. `cargo fmt` re-sorted the affected import. Verified `cargo test -p ironclaw_telegram_extension --no-run` now compiles cleanly. The crate's existing tests are the regression coverage — they now build and run.

Swept the whole tree: `ironclaw_telegram_extension` was the only crate with remaining real (non-comment) `LocalFilesystem` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)