### PR TITLE
refactor(reborn): rename LocalDevOutboundStores -> OutboundStores (§4.4)

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
@@ -75,7 +75,6 @@ const FROZEN_LOCALDEV_TYPES: &[&str] = &[
     "LocalDevExtensionSurfaceSource",
     "LocalDevMountProfile",
     "LocalDevNetworkProfile",
-    "LocalDevOutboundStores",
     "LocalDevOverride",
     "LocalDevPersistentApprovalPolicyStore",
     "LocalDevProviderPolicy",

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -3839,7 +3839,7 @@ fn local_dev_scoped_filesystem(
 /// (where `DeliveredGateRouteStore`/`TriggeredRunDeliveryStore` used separate
 /// in-memory instances not visible to the shared preference tree).
 /// See docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md.
-pub(crate) struct LocalDevOutboundStores {
+pub(crate) struct OutboundStores {
     pub(crate) outbound_preferences: Arc<dyn CommunicationPreferenceRepository>,
     #[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
     pub(crate) outbound_state: Arc<dyn OutboundStateStore>,
@@ -3849,7 +3849,7 @@ pub(crate) struct LocalDevOutboundStores {
     pub(crate) triggered_run_delivery: Arc<dyn TriggeredRunDeliveryStore>,
 }
 
-fn local_dev_outbound_store(filesystem: Arc<CompositeRootFilesystem>) -> LocalDevOutboundStores {
+fn local_dev_outbound_store(filesystem: Arc<CompositeRootFilesystem>) -> OutboundStores {
     // One store instance over the composition-owned per-user scoped filesystem
     // (`/outbound` → `/tenants/<t>/users/<u>/outbound`). All four outbound
     // roles — preferences, state, delivered-gate routes, triggered-run delivery
@@ -3862,7 +3862,7 @@ fn local_dev_outbound_store(filesystem: Arc<CompositeRootFilesystem>) -> LocalDe
     let store: Arc<FilesystemOutboundStateStore<CompositeRootFilesystem>> = Arc::new(
         FilesystemOutboundStateStore::new(local_dev_scoped_filesystem(filesystem)),
     );
-    LocalDevOutboundStores {
+    OutboundStores {
         outbound_preferences: Arc::clone(&store) as Arc<dyn CommunicationPreferenceRepository>,
         #[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
         outbound_state: Arc::clone(&store) as Arc<dyn OutboundStateStore>,


### PR DESCRIPTION
## What

Second §4.4 de-prefix (after C1's `LocalDevRootFilesystem` inline). Advances the doc's §4.4 enforcement endgame — *"no public type name contains `Local`/`LocalDev`/`Hosted`/`Enterprise`"* — one more type.

`LocalDevOutboundStores` is a plain bundle struct (four outbound-store handle fields), **not** a cfg-switched policy/mode type. Its own constructor comment states it "works in both durable (libsql/postgres) and no-durable (in-memory backend) builds" — so the `LocalDev` prefix is **factually wrong** (used in libsql/postgres *production* builds, not just local-dev). This is a bucket-2-style mis-prefix (a genuine composition type that only *looks* like a mode leak), so the fix is a de-prefix rename — not the bucket-1 `DeploymentConfig` resolution the cfg-switched `LocalDev*Store` aliases require.

## Changes

- Rename the struct + its 3 use sites (all in `factory.rs`) → `OutboundStores` (name was free).
- Trim it from the R2 `reborn_localdev_typename` ratchet allowlist.
- `local_dev_outbound_store` builder fn keeps its name (fn names aren't type-name leaks; the ratchet inventories types only).

Pure type rename, semantically identical.

## Verification

- localdev ratchet 4 tests; `cargo build -p ironclaw_reborn_composition` (default + libsql+slack+telegram) clean; clippy `-D warnings` clean; fmt + pre-commit clean

## Stack

Stacked on #6218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)