### PR TITLE
fix(bench): forward a 350-min job cap so heavy /benchmark suites complete

### DIFF
--- a/.github/workflows/nearai-bench-tests.yml
+++ b/.github/workflows/nearai-bench-tests.yml
@@ -36,6 +36,35 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Assert forwarded job timeout clears the run step's internal guard
+        run: |
+          set -euo pipefail
+          # The reusable workflow (nearai/benchmarks) bounds the actual
+          # benchmark with an in-step `timeout --kill-after=120s 290m` so an
+          # overrun exits gracefully — snapshotting a partial run, uploading it,
+          # and posting the PR comment. That only works if GitHub's job-level
+          # cap sits ABOVE 290m; if the job cap fires first, GitHub CANCELS the
+          # job and the compound-`if` upload/comment steps are skipped (this is
+          # exactly what cancelled run 29606955146 at the old 240 default). So
+          # the `timeout-minutes` the dispatcher forwards must satisfy
+          # 290 < N <= 360 (the ubuntu-16core hard cap). Lock that invariant in.
+          GUARD_MIN=290   # keep in sync with the reusable workflow's 'timeout 290m'
+          HARD_CAP=360    # GitHub-hosted runner max job minutes
+          # Anchor to the 6-space with:-entry indentation so a future job-level
+          # (4-space) timeout-minutes on the parse job can't be misread here.
+          forwarded=$(sed -nE 's@^      timeout-minutes:[[:space:]]*([0-9]+).*@\1@p' \
+            .github/workflows/nearai-bench.yml | head -1)
+          echo "forwarded timeout-minutes=${forwarded:-<none>} (guard=${GUARD_MIN}, cap=${HARD_CAP})"
+          if [ -z "$forwarded" ]; then
+            echo "::error::no timeout-minutes forwarded in nearai-bench.yml — it would fall to the reusable 240 default, below the ${GUARD_MIN}m internal guard, and overruns would be hard-cancelled"
+            exit 1
+          fi
+          if [ "$forwarded" -le "$GUARD_MIN" ] || [ "$forwarded" -gt "$HARD_CAP" ]; then
+            echo "::error::forwarded timeout-minutes=$forwarded must satisfy ${GUARD_MIN} < N <= ${HARD_CAP} so overruns exit via the graceful in-step guard, not a job cancellation"
+            exit 1
+          fi
+          echo "PASS  forwarded job timeout clears the internal run guard"
+
       - name: Run dispatcher parser fixtures
         run: |
           set -euo pipefail

--- a/.github/workflows/nearai-bench-tests.yml
+++ b/.github/workflows/nearai-bench-tests.yml
@@ -48,19 +48,25 @@ jobs:
           # exactly what cancelled run 29606955146 at the old 240 default). So
           # the `timeout-minutes` the dispatcher forwards must satisfy
           # 290 < N <= 360 (the ubuntu-16core hard cap). Lock that invariant in.
-          GUARD_MIN=290   # keep in sync with the reusable workflow's 'timeout 290m'
-          HARD_CAP=360    # GitHub-hosted runner max job minutes
+          GUARD_MIN=290        # keep in sync with the reusable workflow's 'timeout 290m'
+          SETUP_HEADROOM=30    # job cap also covers checkout/setup/container pull BEFORE
+                               # the benchmark step starts its in-step guard clock, so the
+                               # forwarded cap needs explicit pre-run headroom on top of it
+          HARD_CAP=360         # GitHub-hosted runner max job minutes
+          MIN_REQUIRED=$((GUARD_MIN + SETUP_HEADROOM))
           # Anchor to the 6-space with:-entry indentation so a future job-level
           # (4-space) timeout-minutes on the parse job can't be misread here.
-          forwarded=$(sed -nE 's@^      timeout-minutes:[[:space:]]*([0-9]+).*@\1@p' \
-            .github/workflows/nearai-bench.yml | head -1)
-          echo "forwarded timeout-minutes=${forwarded:-<none>} (guard=${GUARD_MIN}, cap=${HARD_CAP})"
+          # First match then quit — no `| head`, which under pipefail can turn a
+          # multi-match sed into a SIGPIPE (141) hard-fail.
+          forwarded=$(sed -nE '/^      timeout-minutes:[[:space:]]*[0-9]+/{s@^      timeout-minutes:[[:space:]]*([0-9]+).*@\1@p; q}' \
+            .github/workflows/nearai-bench.yml)
+          echo "forwarded timeout-minutes=${forwarded:-<none>} (guard=${GUARD_MIN}, setup headroom=${SETUP_HEADROOM}, cap=${HARD_CAP})"
           if [ -z "$forwarded" ]; then
             echo "::error::no timeout-minutes forwarded in nearai-bench.yml — it would fall to the reusable 240 default, below the ${GUARD_MIN}m internal guard, and overruns would be hard-cancelled"
             exit 1
           fi
-          if [ "$forwarded" -le "$GUARD_MIN" ] || [ "$forwarded" -gt "$HARD_CAP" ]; then
-            echo "::error::forwarded timeout-minutes=$forwarded must satisfy ${GUARD_MIN} < N <= ${HARD_CAP} so overruns exit via the graceful in-step guard, not a job cancellation"
+          if [ "$forwarded" -lt "$MIN_REQUIRED" ] || [ "$forwarded" -gt "$HARD_CAP" ]; then
+            echo "::error::forwarded timeout-minutes=$forwarded must satisfy ${MIN_REQUIRED} <= N <= ${HARD_CAP}: the job cap covers setup BEFORE the ${GUARD_MIN}m in-step guard starts, so it needs ${SETUP_HEADROOM}m pre-run headroom for overruns to exit via the graceful guard, not a job cancellation"
             exit 1
           fi
           echo "PASS  forwarded job timeout clears the internal run guard"

--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -239,6 +239,19 @@ jobs:
       model: ${{ needs.parse.outputs.model }}
       # Empty when unspecified → the reusable workflow defaults to ironclaw.
       framework: ${{ needs.parse.outputs.framework }}
+      # Bump from the reusable workflow's 240 default. The /benchmark path is
+      # used for the heavy container suites — claw-swe-bench-lite (80 tasks,
+      # ~3-4h at its TOML parallelism=3) and clawbench — where 240 is too low:
+      # the last full-suite run (run 29606955146) was cancelled by the 240-min
+      # job cap after only 7/350 tasks. 350 also sits above the run step's own
+      # internal `timeout --kill-after=120s 290m` guard, so an overrun is killed
+      # gracefully by that guard (which snapshots a partial run, uploads it, and
+      # posts the PR comment) instead of GitHub cancelling the job at the cap —
+      # under cancellation the compound-`if` upload/comment steps are skipped,
+      # which is why the cancelled run left no result comment. 350 < the 360-min
+      # hard cap on the ubuntu-16core runner. Lightweight suites (ironclaw-smoke,
+      # pinchbench) finish well before this — it is a ceiling, not a duration.
+      timeout-minutes: 350
       trigger-comment-id: ${{ github.event.comment.id }}
     # Scope inherited secrets to only what the reusable workflow needs.
     # Replaces `secrets: inherit`, which gave the called workflow access


### PR DESCRIPTION
## Problem

The last full `claw-swe-bench` run ([run 29606955146](https://github.com/nearai/ironclaw/actions/runs/29606955146)) was **cancelled at the 240-min job cap after only 7/350 tasks**, leaving no result comment on the PR — it looked like someone cancelled it, but it was a timeout.

Root cause: the `/benchmark` dispatcher (`nearai-bench.yml`) forwards **no** `timeout-minutes` to the reusable `nearai/benchmarks` workflow, so the job cap falls to that workflow's **240** default. The reusable run bounds the actual benchmark with an in-step `timeout --kill-after=120s 290m` guard that is *designed* to exit gracefully on overrun — snapshot a partial run, upload it, post the PR comment. But that only works if GitHub's job cap sits **above** 290m. At 240 the job cap fires first → GitHub **cancels** the job → the compound-`if` upload/comment steps are skipped. (The guard's own comment even says *"290m sits under the 350m job cap"* — the 350 assumption was never wired into this dispatcher.)

## Fix

Forward `timeout-minutes: 350`:
- above the 290m internal guard (so overruns exit gracefully instead of being hard-cancelled),
- below the 360-min ubuntu-16core hard cap.

This fits **`claw-swe-bench-lite`** (80 tasks, ~3-4h at its TOML `parallelism = 3`) and restores the graceful-overrun path for every suite. It is a **ceiling, not a duration** — light suites (`ironclaw-smoke`, `pinchbench`) finish well before it and are unaffected.

`claw-swe-bench` full (350 tasks) still cannot fit this path at its `parallelism = 1` — that is a separate suite-config decision — but the lite suite now runs to completion.

## Regression test

`nearai-bench-tests.yml` gains an assertion that the forwarded `timeout-minutes` satisfies `290 < N <= 360`, so a future edit can't reintroduce a cap below the internal guard (the exact bug that hard-cancelled the run). Verified locally: `forwarded=350` passes; an absent or `<=290` value fails.

## Notes / follow-ups (not in this PR)
- The wedged-task amplifier from that run — one task (`apache__druid-14136`) burned 2h32m, apparently retrying through its `task_timeout=3600s` ~3× — lives in the `nearai/benchmarks` runner / agent loop, tracked separately.
- Per-run `--timeout-minutes` / `--parallelism` override flags on the dispatcher grammar are a possible future ergonomic add; not needed for lite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)