### PR TITLE
fix(reborn-cli): gate parse_channel_enabled_bool behind webui-v2-beta

### DIFF
--- a/.claude/rules/review-discipline.md
+++ b/.claude/rules/review-discipline.md
@@ -28,6 +28,16 @@ regression-check exemption rather than silently omitting coverage.
   `--all-targets --all-features -- -D warnings`. Before committing, run the
   Reborn workspace-wide command below and fix every warning it surfaces,
   including pre-existing warnings outside the immediate files.
+- **Feature matrix, not just `--all-features`:** `--all-features` cannot catch
+  feature-gated dead code — a `#[cfg(feature = "x")]`-only caller makes its
+  helper *live* under `--all-features` and *dead* (a `-D warnings` error)
+  everywhere the feature is off. **PR CI runs only the slim `all-features` lane;
+  the full `default` / `libsql-only` matrix runs post-merge**, so this class
+  breaks `main` after a green PR. If you add or move a `#[cfg(feature = ...)]`
+  gate, or touch a helper only reachable through one, run the full matrix
+  locally before merging (see "Required checks"). When you gate the only
+  caller(s) of a helper behind a feature, gate the helper's definition with the
+  same `#[cfg]`.
 - **UTF-8:** never byte-slice user or external strings with `&value[..n]`.
   Use `char_indices()`, `chars()`, or an `is_char_boundary()`-checked boundary.
   Search changed Rust files for suspicious `[..` slicing.
@@ -60,6 +70,16 @@ Workspace-wide zero-warning clippy:
 
 ```bash
 cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Full feature matrix — reproduces the post-merge `Code Style` gate that PR CI
+skips (it only runs the `all-features` lane). Run all three whenever a change
+adds, moves, or relies on a `#[cfg(feature = ...)]` gate:
+
+```bash
+cargo clippy --all --tests --examples -- -D warnings                              # default
+cargo clippy --all --tests --examples --no-default-features --features libsql -- -D warnings  # libsql-only
+cargo clippy --all --tests --examples --all-features -- -D warnings               # all-features
 ```
 
 Run the Reborn integration or E2E harness when the change crosses turns,

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -124,6 +124,11 @@ impl Command {
 
 /// Shared boolean parsing for channel-enablement env overrides
 /// (`IRONCLAW_REBORN_SLACK_ENABLED`, `IRONCLAW_REBORN_TELEGRAM_ENABLED`, …).
+///
+/// Only the `serve_slack` / `serve_telegram` commands consume this, and both are
+/// gated on `webui-v2-beta`; gate the definition identically so default and
+/// `libsql-only` builds don't see it as dead code.
+#[cfg(feature = "webui-v2-beta")]
 pub(crate) fn parse_channel_enabled_bool(field: &str, value: &str) -> anyhow::Result<bool> {
     match value.trim().to_ascii_lowercase().as_str() {
         "1" | "true" | "yes" | "on" => Ok(true),


### PR DESCRIPTION
## Problem

`main` is red on the **Code Style** gate. Clippy fails on the `default`, `libsql-only`, and both Windows lanes with:

```
error: function `parse_channel_enabled_bool` is never used
error: could not compile `ironclaw_reborn_cli` (bin "ironclaw-reborn" test) due to 1 previous error
```

`parse_channel_enabled_bool` (in `crates/ironclaw_reborn_cli/src/commands/mod.rs`) is defined ungated, but its only callers — `serve_slack.rs` and `serve_telegram.rs` — are gated behind `#[cfg(feature = "webui-v2-beta")]`. With that feature off (the `default` / `libsql-only` configs), the helper is dead code, which `-D warnings` rejects. The `all-features` lane passes because the feature is on there.

## Why it slipped past PR CI

The clippy matrix runs the **slim `all-features`-only lane on PRs** and the **full `default` / `libsql-only` matrix only on push / merge-queue** (see `code_style.yml` `clippy-matrix`). The originating PR was green under `all-features` and only broke `main` post-merge.

## Fix

- Gate the helper's definition with the same `#[cfg(feature = "webui-v2-beta")]` as its callers.
- Document the feature-matrix verification gap in `.claude/rules/review-discipline.md` (new "Feature matrix, not just `--all-features`" review flag + the three-lane local command block) so the next feature-gated change gets checked before merge.

## Verification

Reproduced the exact CI commands locally, both now green:

```
cargo clippy --all --tests --examples -- -D warnings                                          # default ✅
cargo clippy --all --tests --examples --no-default-features --features libsql -- -D warnings   # libsql-only ✅
```

`all-features` was already green (helper is live there); the `#[cfg]` gate is a subset of that config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)