### PR TITLE
feat(host_api): Slice C.4 — Outcome result value (SafeSummary/ToolVerdict) (#6168)

### DIFF
--- a/crates/ironclaw_host_api/src/error.rs
+++ b/crates/ironclaw_host_api/src/error.rs
@@ -30,6 +30,8 @@ pub enum HostApiError {
     InvalidNetworkTarget { value: String, reason: String },
     #[error("invalid runtime credential target '{value}': {reason}")]
     InvalidRuntimeCredentialTarget { value: String, reason: String },
+    #[error("invalid safe summary: {reason}")]
+    InvalidSafeSummary { reason: String },
     #[error("host API invariant violation: {reason}")]
     InvariantViolation { reason: String },
 }
@@ -83,6 +85,15 @@ impl HostApiError {
 
     pub(crate) fn invariant(reason: impl Into<String>) -> Self {
         Self::InvariantViolation {
+            reason: reason.into(),
+        }
+    }
+
+    /// Validation failure for a [`crate::SafeSummary`]. Deliberately carries only
+    /// the reason, never the rejected value — the value may hold exactly the raw
+    /// payload/credential material the redaction rule caught.
+    pub(crate) fn invalid_safe_summary(reason: impl Into<String>) -> Self {
+        Self::InvalidSafeSummary {
             reason: reason.into(),
         }
     }

--- a/crates/ironclaw_host_api/src/ids.rs
+++ b/crates/ironclaw_host_api/src/ids.rs
@@ -250,6 +250,10 @@ uuid_id!(ErrRef);
 uuid_id!(GateRef);
 uuid_id!(ProcessRef);
 uuid_id!(DenyRef);
+// Handle to the durably-stored full capability output. The full bytes stay
+// host-owned and are retrieved only through this ref (§3); model-visible metadata
+// rides `OutcomeRefs`/`SafeSummary` alongside it. UUID id like its siblings.
+uuid_id!(ResultRef);
 
 /// Provider-facing tool/function name.
 ///

--- a/crates/ironclaw_host_api/src/lib.rs
+++ b/crates/ironclaw_host_api/src/lib.rs
@@ -52,6 +52,7 @@ pub mod resolution;
 pub mod resource;
 pub mod runtime;
 pub mod runtime_policy;
+pub mod safe_summary;
 pub mod scope;
 pub mod trust;
 
@@ -78,6 +79,7 @@ pub use resolution::*;
 pub use resource::*;
 pub use runtime::*;
 pub use runtime_policy::*;
+pub use safe_summary::*;
 pub use scope::*;
 pub use trust::*;
 

--- a/crates/ironclaw_host_api/src/resolution.rs
+++ b/crates/ironclaw_host_api/src/resolution.rs
@@ -292,7 +292,7 @@ mod tests {
     fn outcome_roundtrips_and_carries_typed_verdict_not_a_sniffed_summary() {
         let outcome = Outcome {
             refs: OutcomeRefs {
-                result: ResultRef::new("result-01HZ0000000000000000000000").unwrap(),
+                result: ResultRef::parse("018f6a00-0000-7000-8000-000000000001").unwrap(),
                 byte_len: 4096,
             },
             verdict: ToolVerdict::RecoverableFailure,

--- a/crates/ironclaw_host_api/src/resolution.rs
+++ b/crates/ironclaw_host_api/src/resolution.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{GateRef, ProcessRef};
+use crate::{GateRef, ProcessRef, ResultRef, SafeSummary};
 
 /// A re-entrant gate: the invocation did not run and is waiting on a decision.
 /// Resolving the gate re-enters `authorize()` (§5.3.3: a resolved gate reserves
@@ -135,6 +135,69 @@ impl Suspension {
     }
 }
 
+/// The typed verdict of a dispatched capability — success or a recoverable
+/// failure — carried by [`Outcome`]. This is the fix for §1.2/§3's
+/// "summary-sniffed" outcome: the loop reads a typed verdict, never inspects a
+/// prose summary string to guess whether the call succeeded.
+///
+/// Maps the §5.3 acceptance table: `Completed` → [`ToolVerdict::Success`],
+/// `Failed` → [`ToolVerdict::RecoverableFailure`] (model-visible, correctable),
+/// `SpawnedChildRun` → [`ToolVerdict::ChildSpawned`] (non-suspending — the
+/// executor appends the child result and continues).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolVerdict {
+    /// The capability ran and succeeded.
+    Success,
+    /// The capability ran and failed in a model-visible, correctable way — NOT a
+    /// `HostFailure` (that is infrastructure, §1.2). The model may retry or adapt.
+    RecoverableFailure,
+    /// The capability spawned a child run; non-suspending (§5.3 table).
+    ChildSpawned,
+}
+
+impl ToolVerdict {
+    /// Whether the capability completed successfully.
+    pub fn is_success(&self) -> bool {
+        matches!(self, ToolVerdict::Success)
+    }
+
+    /// Stable discriminant (matches the serde tag).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            ToolVerdict::Success => "success",
+            ToolVerdict::RecoverableFailure => "recoverable_failure",
+            ToolVerdict::ChildSpawned => "child_spawned",
+        }
+    }
+}
+
+/// References to a completed capability's durably-stored output. The full bytes
+/// stay host-owned and are fetched only through [`ResultRef`]; only bounded
+/// metadata rides here (§3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutcomeRefs {
+    /// Handle to the full stored output.
+    pub result: ResultRef,
+    /// Size of the staged output in bytes — pure metadata, no PII. Used by the
+    /// per-capability byte-cap strategy.
+    pub byte_len: u64,
+}
+
+/// A dispatched capability's result — tool success OR recoverable failure (§3).
+///
+/// This is the `Resolution::Done` payload (a later slice adds the `Resolution`
+/// umbrella). It pairs with [`crate::Invocation`] as the two ends of a capability
+/// call: the request in, the outcome out. The typed [`ToolVerdict`] replaces
+/// variant-matching / summary-sniffing; the [`SafeSummary`] is model-visible and
+/// redacted; the full output is reached through [`OutcomeRefs`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Outcome {
+    pub refs: OutcomeRefs,
+    pub verdict: ToolVerdict,
+    pub summary: SafeSummary,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,5 +269,51 @@ mod tests {
             );
             assert_eq!(suspension.process_ref().is_some(), tag == "process");
         }
+    }
+
+    #[test]
+    fn tool_verdict_serde_tags_and_kinds_agree() {
+        for (verdict, tag) in [
+            (ToolVerdict::Success, "success"),
+            (ToolVerdict::RecoverableFailure, "recoverable_failure"),
+            (ToolVerdict::ChildSpawned, "child_spawned"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(verdict).unwrap(),
+                serde_json::Value::String(tag.to_string())
+            );
+            assert_eq!(verdict.kind(), tag);
+        }
+        assert!(ToolVerdict::Success.is_success());
+        assert!(!ToolVerdict::RecoverableFailure.is_success());
+    }
+
+    #[test]
+    fn outcome_roundtrips_and_carries_typed_verdict_not_a_sniffed_summary() {
+        let outcome = Outcome {
+            refs: OutcomeRefs {
+                result: ResultRef::new("result-01HZ0000000000000000000000").unwrap(),
+                byte_len: 4096,
+            },
+            verdict: ToolVerdict::RecoverableFailure,
+            summary: SafeSummary::new("tool input rejected").unwrap(),
+        };
+        let json = serde_json::to_value(&outcome).unwrap();
+        let back: Outcome = serde_json::from_value(json).unwrap();
+        assert_eq!(back, outcome);
+        // The verdict is read from the type, never inferred from the summary text.
+        assert!(!back.verdict.is_success());
+        assert_eq!(back.refs.byte_len, 4096);
+    }
+
+    #[test]
+    fn outcome_rejects_an_unsafe_summary_on_the_wire() {
+        // A hostile persisted summary cannot rehydrate into an Outcome.
+        let json = serde_json::json!({
+            "refs": { "result": "result-1", "byte_len": 1 },
+            "verdict": "success",
+            "summary": "api key: sk-ant-leak"
+        });
+        assert!(serde_json::from_value::<Outcome>(json).is_err());
     }
 }

--- a/crates/ironclaw_host_api/src/resolution.rs
+++ b/crates/ironclaw_host_api/src/resolution.rs
@@ -310,10 +310,16 @@ mod tests {
     fn outcome_rejects_an_unsafe_summary_on_the_wire() {
         // A hostile persisted summary cannot rehydrate into an Outcome.
         let json = serde_json::json!({
-            "refs": { "result": "result-1", "byte_len": 1 },
+            "refs": { "result": "018f6a00-0000-7000-8000-000000000001", "byte_len": 1 },
             "verdict": "success",
             "summary": "api key: sk-ant-leak"
         });
-        assert!(serde_json::from_value::<Outcome>(json).is_err());
+        let err = serde_json::from_value::<Outcome>(json)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("sensitive marker"),
+            "rejection must be for the summary, not an id-shape artifact: {err}"
+        );
     }
 }

--- a/crates/ironclaw_host_api/src/safe_summary.rs
+++ b/crates/ironclaw_host_api/src/safe_summary.rs
@@ -1,0 +1,222 @@
+//! Slice-C kernel vocabulary — the bounded, redacted result summary.
+//!
+//! Part of the capability-path result collapse
+//! (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md` §3):
+//! every result channel carries a `SafeSummary` — a short, model-visible string
+//! that is guaranteed to hold no raw payload, path, or credential material. Full
+//! output stays host-owned and is retrieved only through a result reference.
+//!
+//! ## Redaction contract
+//!
+//! This is the canonical home for the safe-summary rule. It is an **exact,
+//! non-weakening mirror** of `ironclaw_turns`' `validate_loop_safe_summary`
+//! (the loop-facing `safe_summary: String` fields on `CapabilityOutcome` and
+//! friends). Per `tools.md`, result vocabulary belongs in `host_api`; the doc's
+//! migration folds those ad-hoc `String` fields onto this type. Until that
+//! wiring slice lands, the turns validator is a temporary duplicate that must be
+//! reconciled to delegate here — it must never diverge from the rules below, and
+//! must never become *weaker* than them. The bound (512 bytes), the payload/path
+//! delimiter ban, the credential-marker denylist, and the secret-like-token
+//! detector are all defense-in-depth: the redactor at the construction site
+//! scrubs first, and this type refuses to hold anything that slipped through.
+
+use serde::{Deserialize, Serialize};
+
+use crate::HostApiError;
+
+/// Maximum length of a safe summary, in bytes. Matches the loop contract.
+const MAX_SAFE_SUMMARY_BYTES: usize = 512;
+
+/// A bounded, redacted, model-visible summary of a capability result.
+///
+/// Construction enforces the full redaction contract (see the module docs); a
+/// value that contains raw payload/path delimiters, a credential marker, or a
+/// secret-like token is rejected rather than stored.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SafeSummary(String);
+
+impl SafeSummary {
+    pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+        let value = value.into();
+        validate_safe_summary(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for SafeSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for SafeSummary {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for SafeSummary {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Revalidate on the wire: a persisted/relayed summary is re-checked
+        // against the current redaction rule, never trusted transparently.
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The canonical safe-summary redaction rule. Exact mirror of
+/// `ironclaw_turns::run_profile::host::validate_loop_safe_summary` (minus the
+/// turns-local `INPUT_ENCODE_HUMAN_SUMMARY` sentinel bypass, which is a
+/// loop-input-encoding concern, not a general redaction rule).
+fn validate_safe_summary(value: &str) -> Result<(), HostApiError> {
+    if value.is_empty() {
+        return Err(HostApiError::invalid_safe_summary("must not be empty"));
+    }
+    if value.len() > MAX_SAFE_SUMMARY_BYTES {
+        return Err(HostApiError::invalid_safe_summary(format!(
+            "must be at most {MAX_SAFE_SUMMARY_BYTES} bytes"
+        )));
+    }
+    // Mirror the loop contract exactly: ALL control characters are rejected
+    // (newlines/tabs included) — a summary is a single bounded line.
+    if value.chars().any(|c| c == '\0' || c.is_control()) {
+        return Err(HostApiError::invalid_safe_summary(
+            "must not contain NUL/control characters",
+        ));
+    }
+    if value.chars().any(|c| {
+        matches!(
+            c,
+            '{' | '}' | '[' | ']' | '`' | '<' | '>' | '/' | '\\'
+        )
+    }) {
+        return Err(HostApiError::invalid_safe_summary(
+            "must not contain raw payload or path delimiters",
+        ));
+    }
+
+    let lower = value.to_ascii_lowercase();
+    // Only credential markers are banned; descriptive error vocabulary
+    // ("provider error", "stack trace", "tool input", …) is allowed because the
+    // raw cause rides the dedicated model-visible detail channel.
+    for forbidden in [
+        "access token",
+        "api key",
+        "api_key",
+        "apikey",
+        "authorization:",
+        "bearer ",
+        "password",
+        "passwd",
+        "secret",
+    ] {
+        if lower.contains(forbidden) {
+            return Err(HostApiError::invalid_safe_summary(format!(
+                "must not contain sensitive marker `{forbidden}`"
+            )));
+        }
+    }
+    if contains_secret_like_token(&lower) {
+        return Err(HostApiError::invalid_safe_summary(
+            "must not contain API-key-like tokens",
+        ));
+    }
+    Ok(())
+}
+
+fn contains_secret_like_token(lower: &str) -> bool {
+    lower
+        .split(|character: char| {
+            !character.is_ascii_alphanumeric() && !matches!(character, '-' | '_' | '.')
+        })
+        .any(is_secret_like_token)
+}
+
+fn is_secret_like_token(token: &str) -> bool {
+    [
+        "sk-",
+        "sk-ant-",
+        "ghp_",
+        "github_pat_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        "glpat-",
+        "gcp-",
+        "ya29.",
+        "aiza",
+    ]
+    .iter()
+    .any(|prefix| token.starts_with(prefix))
+        || (token.len() >= 16 && (token.starts_with("akia") || token.starts_with("asia")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_plain_redacted_summary() {
+        let s = SafeSummary::new("read 3 files, no changes").unwrap();
+        assert_eq!(s.as_str(), "read 3 files, no changes");
+    }
+
+    #[test]
+    fn rejects_empty_and_overlong() {
+        assert!(SafeSummary::new("").is_err());
+        assert!(SafeSummary::new("x".repeat(MAX_SAFE_SUMMARY_BYTES + 1)).is_err());
+        assert!(SafeSummary::new("x".repeat(MAX_SAFE_SUMMARY_BYTES)).is_ok());
+    }
+
+    #[test]
+    fn rejects_payload_and_path_delimiters() {
+        for bad in ["{\"k\":1}", "a[0]", "path/to/x", "c:\\x", "<tag>", "`code`"] {
+            assert!(SafeSummary::new(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_credential_markers_and_secret_tokens() {
+        for bad in [
+            "api key leaked",
+            "Authorization: bearer x",
+            "the password is hunter2",
+            "token sk-ant-abc123",
+            "ghp_0123456789abcdef",
+            "AKIA0123456789ABCDEF",
+        ] {
+            assert!(SafeSummary::new(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn allows_descriptive_error_vocabulary() {
+        // The raw cause rides a separate channel; descriptive words are allowed.
+        for ok in ["provider error", "stack trace truncated", "tool input rejected"] {
+            assert!(SafeSummary::new(ok).is_ok(), "should allow {ok:?}");
+        }
+    }
+
+    #[test]
+    fn serde_revalidates_on_the_wire() {
+        let json = serde_json::to_string(&SafeSummary::new("ok summary").unwrap()).unwrap();
+        assert_eq!(json, "\"ok summary\"");
+        // A hostile wire value is rejected on deserialize, not trusted.
+        assert!(serde_json::from_str::<SafeSummary>("\"api key: sk-ant-x\"").is_err());
+    }
+}

--- a/crates/ironclaw_host_api/src/safe_summary.rs
+++ b/crates/ironclaw_host_api/src/safe_summary.rs
@@ -98,12 +98,10 @@ fn validate_safe_summary(value: &str) -> Result<(), HostApiError> {
             "must not contain NUL/control characters",
         ));
     }
-    if value.chars().any(|c| {
-        matches!(
-            c,
-            '{' | '}' | '[' | ']' | '`' | '<' | '>' | '/' | '\\'
-        )
-    }) {
+    if value
+        .chars()
+        .any(|c| matches!(c, '{' | '}' | '[' | ']' | '`' | '<' | '>' | '/' | '\\'))
+    {
         return Err(HostApiError::invalid_safe_summary(
             "must not contain raw payload or path delimiters",
         ));
@@ -176,17 +174,29 @@ mod tests {
         assert_eq!(s.as_str(), "read 3 files, no changes");
     }
 
+    fn rejection(value: impl Into<String>) -> String {
+        SafeSummary::new(value).unwrap_err().to_string()
+    }
+
     #[test]
     fn rejects_empty_and_overlong() {
-        assert!(SafeSummary::new("").is_err());
-        assert!(SafeSummary::new("x".repeat(MAX_SAFE_SUMMARY_BYTES + 1)).is_err());
+        // Assert the specific reason, not just is_err(), so an infrastructure
+        // failure can't masquerade as a validation pass.
+        assert!(rejection("").contains("must not be empty"));
+        assert!(
+            rejection("x".repeat(MAX_SAFE_SUMMARY_BYTES + 1)).contains("at most"),
+            "overlong must be rejected for length"
+        );
         assert!(SafeSummary::new("x".repeat(MAX_SAFE_SUMMARY_BYTES)).is_ok());
     }
 
     #[test]
     fn rejects_payload_and_path_delimiters() {
         for bad in ["{\"k\":1}", "a[0]", "path/to/x", "c:\\x", "<tag>", "`code`"] {
-            assert!(SafeSummary::new(bad).is_err(), "should reject {bad:?}");
+            assert!(
+                rejection(bad).contains("raw payload or path delimiters"),
+                "should reject {bad:?} for delimiters"
+            );
         }
     }
 
@@ -200,14 +210,22 @@ mod tests {
             "ghp_0123456789abcdef",
             "AKIA0123456789ABCDEF",
         ] {
-            assert!(SafeSummary::new(bad).is_err(), "should reject {bad:?}");
+            let why = rejection(bad);
+            assert!(
+                why.contains("sensitive marker") || why.contains("API-key-like tokens"),
+                "should reject {bad:?} for a credential-shaped reason, got: {why}"
+            );
         }
     }
 
     #[test]
     fn allows_descriptive_error_vocabulary() {
         // The raw cause rides a separate channel; descriptive words are allowed.
-        for ok in ["provider error", "stack trace truncated", "tool input rejected"] {
+        for ok in [
+            "provider error",
+            "stack trace truncated",
+            "tool input rejected",
+        ] {
             assert!(SafeSummary::new(ok).is_ok(), "should allow {ok:?}");
         }
     }
@@ -217,6 +235,12 @@ mod tests {
         let json = serde_json::to_string(&SafeSummary::new("ok summary").unwrap()).unwrap();
         assert_eq!(json, "\"ok summary\"");
         // A hostile wire value is rejected on deserialize, not trusted.
-        assert!(serde_json::from_str::<SafeSummary>("\"api key: sk-ant-x\"").is_err());
+        let err = serde_json::from_str::<SafeSummary>("\"api key: sk-ant-x\"")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("sensitive marker"),
+            "wire rejection must carry the validation reason: {err}"
+        );
     }
 }

--- a/crates/ironclaw_host_api/src/safe_summary.rs
+++ b/crates/ironclaw_host_api/src/safe_summary.rs
@@ -32,7 +32,8 @@ const MAX_SAFE_SUMMARY_BYTES: usize = 512;
 /// Construction enforces the full redaction contract (see the module docs); a
 /// value that contains raw payload/path delimiters, a credential marker, or a
 /// secret-like token is rejected rather than stored.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String")]
 pub struct SafeSummary(String);
 
 impl SafeSummary {
@@ -46,35 +47,31 @@ impl SafeSummary {
         &self.0
     }
 
-    pub fn into_string(self) -> String {
+    pub fn into_inner(self) -> String {
         self.0
+    }
+}
+
+impl TryFrom<String> for SafeSummary {
+    type Error = HostApiError;
+
+    /// Wire revalidation matches construction (types.md canonical template): a
+    /// persisted/relayed summary is re-checked against the current redaction
+    /// rule on deserialize, never trusted transparently.
+    fn try_from(value: String) -> Result<Self, HostApiError> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for SafeSummary {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 
 impl std::fmt::Display for SafeSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
-    }
-}
-
-impl Serialize for SafeSummary {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for SafeSummary {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        // Revalidate on the wire: a persisted/relayed summary is re-checked
-        // against the current redaction rule, never trusted transparently.
-        let value = String::deserialize(deserializer)?;
-        Self::new(value).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
## What
**Fourth sub-slice of Slice C** (§3/§5.3). Stacked on C.3 (#6226). Adds the success/recoverable-failure **result value** — the `Resolution::Done` payload, pairing with `Invocation` as the two ends of a capability call.

- **`safe_summary.rs`** (new): `SafeSummary` — a bounded (512 B), redacted, model-visible summary. Its validator is an **exact, non-weakening mirror** of `ironclaw_turns`' `validate_loop_safe_summary` (payload/path delimiter ban, credential-marker denylist, secret-like-token detector), placed in `host_api` as the canonical owner (`tools.md`: result vocabulary lives here). Revalidates on the wire.
- **`error.rs`**: `HostApiError::InvalidSafeSummary` — carries only the reason, **never** the rejected value (which may hold the very payload the rule caught).
- **`ids.rs`**: `ResultRef` — opaque handle to the durably-stored full output.
- **`resolution.rs`**: `ToolVerdict { Success | RecoverableFailure | ChildSpawned }` (the typed verdict that ends §1.2/§3's summary-sniffing), `OutcomeRefs` (result ref + byte_len), `Outcome { refs, verdict, summary }`.

### Redaction-validator duplication — deliberate and tracked
The turns validator is now a **temporary duplicate**. It's an exact copy at landing (no drift, no weakening), and the migration folds turns' ad-hoc `safe_summary: String` fields onto this type, reconciling the turns validator to *delegate here* at the wiring slice. Doing the turns edit now would be scope creep into a vocabulary PR. (The one intentional difference: this version omits turns' `INPUT_ENCODE_HUMAN_SUMMARY` sentinel bypass — a loop-input-encoding concern, not a general redaction rule.)

## Additive (§9)
Nothing produces `Outcome` yet; the `Resolution` umbrella is the next slice. No new `check-type-duplicates.py` collision.

## Testing
SafeSummary accept/reject matrix (delimiters, credential markers, secret tokens, allowed descriptive vocabulary), **wire revalidation** (a hostile persisted summary can't rehydrate), ToolVerdict tag agreement, and Outcome round-trip + hostile-summary rejection.

## Checks
`cargo test -p ironclaw_host_api` (56) · `clippy -D warnings` clean · `ironclaw_architecture` ratchets green · pre-commit clean.

## Next
- **C.5** — the `Resolution` umbrella (`Done(Outcome)` / `Denied(DenyRef)` / `Blocked` / `Suspended`) + an acceptance-table test mapping all 10 `CapabilityOutcome` rows (§5.3).
- **C.6** — sealed `Authorized` + `authorize()` (security milestone), then wire the four mediators and measure (§9 3–4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)