### PR TITLE
fix(webui-v2): green the nightly Reborn Playwright extensions suite

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/extensions/extensions-page.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/extensions/extensions-page.test.ts
@@ -235,13 +235,28 @@ test("ExtensionsPage replaces a failed registry with a retryable error banner", 
 });
 
 test("ExtensionsPage keeps installed channels visible when only the registry fails", () => {
+  const refetch = () => {};
   const { CatalogErrorBanner, ChannelsTab, rendered } = renderExtensionsPage("channels", {
     registryError: new Error("offline"),
+    refetch,
   });
   const values = templateValues(rendered);
 
   assert.ok(values.includes(CatalogErrorBanner));
   assert.ok(values.includes(ChannelsTab));
+
+  // A catalog (registry) failure must surface the full "Extension catalog
+  // unavailable" message even on a non-registry tab — the banner text follows
+  // the failure cause, not the tab. Regression: previously the inline banner on
+  // the channels tab hardcoded the partial "Some extension data" text.
+  const [bannerProps] = componentProps(rendered, CatalogErrorBanner);
+  assert.equal(bannerProps.isCatalogError, true);
+  const text = templateText(
+    CatalogErrorBanner({ isCatalogError: true, isRefetching: false, onRetry: refetch }),
+  );
+  assert.match(text, /Extension catalog unavailable/);
+  assert.match(text, /--v2-danger-text/);
+  assert.doesNotMatch(text, /Some extension data is unavailable/);
 });
 
 test("ExtensionsPage keeps the registry visible when installed-extension enrichment fails", () => {
@@ -252,7 +267,7 @@ test("ExtensionsPage keeps the registry visible when installed-extension enrichm
   });
   const values = templateValues(rendered);
   const banner = CatalogErrorBanner({
-    isPartial: true,
+    isCatalogError: false,
     isRefetching: false,
     onRetry: refetch,
   });
@@ -260,6 +275,9 @@ test("ExtensionsPage keeps the registry visible when installed-extension enrichm
 
   assert.ok(values.includes(CatalogErrorBanner));
   assert.ok(values.includes(RegistryTab));
+  // The inline banner on the registry tab reflects the enrichment failure cause.
+  const [bannerProps] = componentProps(rendered, CatalogErrorBanner);
+  assert.equal(bannerProps.isCatalogError, false);
   assert.match(text, /Some extension data is unavailable/);
   assert.match(text, /The available extension data is shown/);
   assert.match(text, /--v2-warning-text/);

--- a/crates/ironclaw_webui/frontend/src/pages/extensions/extensions-page.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/extensions/extensions-page.tsx
@@ -9,17 +9,22 @@ import { McpTab } from "./components/mcp-tab";
 import { RegistryTab } from "./components/registry-tab";
 import { useExtensions } from "./hooks/useExtensions";
 
-function CatalogErrorBanner({ isPartial = false, isRefetching, onRetry }) {
+// The banner text/tone follows the *cause* of the failure, not which tab it is
+// shown on: a failed catalog (registry) request is always "Extension catalog
+// unavailable" (danger), while a failed installed-extension enrichment request
+// is "Some extension data is unavailable" (warning). Whether the banner blocks
+// the whole tab or renders inline above still depends on the tab (see below).
+function CatalogErrorBanner({ isCatalogError = true, isRefetching, onRetry }) {
   const t = useT();
-  const toneClass = isPartial
-    ? "border-[color-mix(in_srgb,var(--v2-warning-text)_30%,transparent)] bg-[var(--v2-warning-soft)] text-[var(--v2-warning-text)]"
-    : "border-[color-mix(in_srgb,var(--v2-danger-text)_30%,transparent)] bg-[var(--v2-danger-soft)] text-[var(--v2-danger-text)]";
-  const titleKey = isPartial
-    ? "ext.catalog.partialErrorTitle"
-    : "ext.catalog.loadErrorTitle";
-  const descriptionKey = isPartial
-    ? "ext.catalog.partialErrorDesc"
-    : "ext.catalog.loadErrorDesc";
+  const toneClass = isCatalogError
+    ? "border-[color-mix(in_srgb,var(--v2-danger-text)_30%,transparent)] bg-[var(--v2-danger-soft)] text-[var(--v2-danger-text)]"
+    : "border-[color-mix(in_srgb,var(--v2-warning-text)_30%,transparent)] bg-[var(--v2-warning-soft)] text-[var(--v2-warning-text)]";
+  const titleKey = isCatalogError
+    ? "ext.catalog.loadErrorTitle"
+    : "ext.catalog.partialErrorTitle";
+  const descriptionKey = isCatalogError
+    ? "ext.catalog.loadErrorDesc"
+    : "ext.catalog.partialErrorDesc";
 
   return (
     <div
@@ -135,7 +140,11 @@ export function ExtensionsPage({ isAdmin = false } = {}) {
     return (
       <div className="flex h-full flex-col overflow-y-auto">
         <div className="v2-page-entrance flex-1 p-4 sm:p-6">
-          <CatalogErrorBanner isRefetching={isRefetching} onRetry={refetch} />
+          <CatalogErrorBanner
+            isCatalogError={tab === "registry"}
+            isRefetching={isRefetching}
+            onRetry={refetch}
+          />
         </div>
       </div>
     );
@@ -175,16 +184,19 @@ export function ExtensionsPage({ isAdmin = false } = {}) {
     />),
   };
 
-  const partialError = tab === "registry" ? extensionsError : registryError;
+  // The secondary (non-primary) query for this tab. On the registry tab that is
+  // the installed-extension enrichment; on the channels/mcp tabs it is the
+  // catalog. Render it inline above the tab content, with cause-driven text.
+  const secondaryError = tab === "registry" ? extensionsError : registryError;
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
       <div className="v2-page-entrance flex-1 p-4 sm:p-6">
         <div className="space-y-5">
           <ActionToast result={actionResult} onDismiss={clearResult} />
-          {partialError &&
+          {secondaryError &&
           (<CatalogErrorBanner
-            isPartial
+            isCatalogError={tab !== "registry"}
             isRefetching={isRefetching}
             onRetry={refetch}
           />)}

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
@@ -445,17 +445,19 @@ async def _open_card_menu(card):
     return card.get_by_role("menu")
 
 
-async def _capture_next_confirm(page, *, accept: bool):
-    loop = asyncio.get_running_loop()
-    dialog_future = loop.create_future()
+async def _resolve_remove_confirm(page, *, accept: bool, name: str):
+    """Drive the shared React confirmation modal that replaced the native
+    ``window.confirm`` for destructive extension actions (#6084).
 
-    def handle_dialog(dialog):
-        if not dialog_future.done():
-            dialog_future.set_result({"type": dialog.type, "message": dialog.message})
-        loop.create_task(dialog.accept() if accept else dialog.dismiss())
-
-    page.once("dialog", handle_dialog)
-    return dialog_future
+    Call this *after* clicking the "Remove" menu item — the modal opens on the
+    click. Asserts the modal names the extension, then confirms or cancels.
+    """
+    confirm_dialog = page.get_by_role("dialog")
+    await expect(confirm_dialog).to_be_visible(timeout=5000)
+    await expect(confirm_dialog).to_contain_text(name)
+    testid = "confirm-dialog-confirm" if accept else "confirm-dialog-cancel"
+    await confirm_dialog.get_by_test_id(testid).click()
+    await expect(confirm_dialog).to_have_count(0)
 
 
 async def _wait_for_request_count(
@@ -1035,11 +1037,8 @@ async def test_reborn_legacy_extensions_installed_actions(
         assert harness["activate_requests"] == ["inactive-mcp"]
 
         await active_card.get_by_label("More actions").click()
-        dialog_future = await _capture_next_confirm(page, accept=True)
         await page.get_by_role("menuitem", name="Remove").click()
-        dialog = await asyncio.wait_for(dialog_future, timeout=5)
-        assert dialog["type"] == "confirm"
-        assert "Active Tool" in dialog["message"]
+        await _resolve_remove_confirm(page, accept=True, name="Active Tool")
         await expect(page.get_by_text("Active Tool removed")).to_be_visible(timeout=5000)
         assert harness["remove_requests"] == ["active-tool"]
     finally:
@@ -1088,11 +1087,8 @@ async def test_reborn_legacy_extensions_remove_cancel_keeps_card(
         await expect(active_card).to_be_visible(timeout=5000)
 
         await active_card.get_by_label("More actions").click()
-        dialog_future = await _capture_next_confirm(page, accept=False)
         await page.get_by_role("menuitem", name="Remove").click()
-        dialog = await asyncio.wait_for(dialog_future, timeout=5)
-        assert dialog["type"] == "confirm"
-        assert "Active Tool" in dialog["message"]
+        await _resolve_remove_confirm(page, accept=False, name="Active Tool")
 
         await expect(active_card).to_be_visible(timeout=5000)
         assert harness["remove_requests"] == []
@@ -1123,11 +1119,8 @@ async def test_reborn_legacy_extensions_remove_failure_keeps_card(
         await expect(active_card.get_by_text("active", exact=True)).to_be_visible()
 
         await active_card.get_by_label("More actions").click()
-        dialog_future = await _capture_next_confirm(page, accept=True)
         await page.get_by_role("menuitem", name="Remove").click()
-        dialog = await asyncio.wait_for(dialog_future, timeout=5)
-        assert dialog["type"] == "confirm"
-        assert "Active Tool" in dialog["message"]
+        await _resolve_remove_confirm(page, accept=True, name="Active Tool")
 
         await expect(
             page.get_by_text("Active Tool is still handling an active run.")
@@ -1167,11 +1160,8 @@ async def test_reborn_legacy_extensions_remove_clears_installed_state(
         await expect(page.get_by_text("Installed", exact=True)).to_be_visible()
 
         await active_card.get_by_label("More actions").click()
-        dialog_future = await _capture_next_confirm(page, accept=True)
         await page.get_by_role("menuitem", name="Remove").click()
-        dialog = await asyncio.wait_for(dialog_future, timeout=5)
-        assert dialog["type"] == "confirm"
-        assert "Active Tool" in dialog["message"]
+        await _resolve_remove_confirm(page, accept=True, name="Active Tool")
         await expect(page.get_by_text("Active Tool removed")).to_be_visible(timeout=5000)
         assert harness["remove_requests"] == ["active-tool"]
 
@@ -1217,11 +1207,8 @@ async def test_reborn_legacy_extensions_reinstall_after_remove_requires_setup_ag
             page.get_by_role("menuitem", name="Reconfigure", exact=True)
         ).to_have_count(1)
 
-        dialog_future = await _capture_next_confirm(page, accept=True)
         await page.get_by_role("menuitem", name="Remove").click()
-        dialog = await asyncio.wait_for(dialog_future, timeout=5)
-        assert dialog["type"] == "confirm"
-        assert "Config Tool" in dialog["message"]
+        await _resolve_remove_confirm(page, accept=True, name="Config Tool")
         await expect(page.get_by_text("Config Tool removed")).to_be_visible(timeout=5000)
         assert harness["remove_requests"] == ["config-tool"]
 
@@ -2269,51 +2256,22 @@ async def test_reborn_legacy_configure_modal_enter_key_submits(
         await harness["context"].close()
 
 
-async def test_reborn_legacy_telegram_setup_preserves_token_characters(
+async def test_reborn_legacy_telegram_configure_hosts_pairing_panel(
     reborn_v2_server, reborn_v2_browser
 ):
-    token = "123456789:ABCdef_GHI-jkl_mnop-QRSTuvwxyz"
+    # #6159 retired the per-user Telegram bot-token secret form. The telegram
+    # channel now configures through the WebGeneratedCode pairing panel, which
+    # ConfigureModal hosts directly (design spec §4.2/§5) — never a manual-token
+    # form. Regression: the modal previously rendered a "Telegram Bot Token"
+    # secret entry and submitted it through /setup.
     harness = await _open_mocked_extensions_page(
         reborn_v2_server,
         reborn_v2_browser,
         installed=[TELEGRAM_CHANNEL_SETUP],
-        setup_payloads={
-            "telegram": {
-                "name": "telegram",
-                "kind": "wasm_channel",
-                "secrets": [
-                    {
-                        "name": "telegram_bot_token",
-                        "prompt": "Telegram Bot Token",
-                        "provided": False,
-                        "optional": False,
-                        "auto_generate": False,
-                    }
-                ],
-                "fields": [],
-                "onboarding": None,
-            }
-        },
         tab="channels",
     )
     try:
         page = harness["page"]
-        redeem_requests: list[dict] = []
-
-        async def handle_redeem(route):
-            redeem_requests.append(json.loads(route.request.post_data or "{}"))
-            await route.fulfill(
-                status=200,
-                content_type="application/json",
-                body=json.dumps(
-                    {
-                        "provider": "telegram",
-                        "provider_user_id": "123456789",
-                    }
-                ),
-            )
-
-        await page.route("**/api/webchat/v2/extensions/pairing/redeem", handle_redeem)
 
         card = _card_by_title(page, "Telegram")
         await expect(card).to_be_visible(timeout=5000)
@@ -2323,27 +2281,14 @@ async def test_reborn_legacy_telegram_setup_preserves_token_characters(
             page.get_by_role("heading", name="Configure Telegram")
         ).to_be_visible(timeout=5000)
         modal = page.get_by_label("Configure Telegram")
-        await expect(modal.get_by_text("Telegram Bot Token")).to_be_visible()
-        await modal.locator('input[type="password"]').fill(token)
-        await modal.get_by_role("button", name="Save").click()
 
-        await expect(
-            page.get_by_role("heading", name="Configure Telegram")
-        ).to_have_count(0)
-        assert redeem_requests == []
-        assert harness["activate_requests"] == []
-        assert harness["setup_submit_requests"] == [
-            {
-                "package_id": "telegram",
-                "body": {
-                    "action": "submit",
-                    "payload": {
-                        "secrets": {"telegram_bot_token": token},
-                        "fields": {},
-                    },
-                },
-            }
-        ]
+        # The modal hosts the pairing panel, not a bot-token secret form.
+        await expect(modal.get_by_test_id("telegram-pairing-panel")).to_be_visible(
+            timeout=5000
+        )
+        await expect(modal.get_by_text("Telegram Bot Token")).to_have_count(0)
+        await expect(modal.locator('input[type="password"]')).to_have_count(0)
+        assert harness["setup_submit_requests"] == []
     finally:
         await harness["context"].close()
 


### PR DESCRIPTION
## Problem

The scheduled **`Reborn Playwright`** suite (nightly cron, `workflow_dispatch` + `schedule` only — **not** a PR/push gate) has been red since 2026-07-16. Seven tests in the `legacy-settings-extensions` shard fail deterministically, across **three independent root causes**, all from extension-UI PRs that merged while e2e ran only nightly:

| # | Failing test(s) | Root cause | Kind |
|---|---|---|---|
| 1 | `catalog_failure_shows_retry` | #6088 keyed the catalog-error banner text/tone to the **tab**, not the **failure cause** — a catalog(registry) 503 on the channels tab rendered the partial "Some extension data is unavailable" instead of "Extension catalog unavailable" | **production bug** |
| 2 | `installed_actions`, `remove_cancel_keeps_card`, `remove_failure_keeps_card`, `remove_clears_installed_state`, `reinstall_after_remove_requires_setup_again` | #6084 replaced native `window.confirm` with the shared React `ConfirmDialog`; the tests still waited on a native dialog event that never fires | stale test |
| 3 | `telegram_setup_preserves_token_characters` | #6159 retired the per-user Telegram bot-token secret form for the WebGeneratedCode pairing panel (its own commit note calls out "stale per-user bot-token telegram tests") | stale test |

These slipped through because e2e/Playwright isn't run on PRs — the same gating gap behind the earlier clippy break on `main`.

## Fix

1. **Banner (production).** `CatalogErrorBanner` now selects its title/description/tone from *which query failed* (catalog → danger; enrichment → warning). Blocking-vs-inline placement still follows the tab. The page passes `isCatalogError` = "the shown error is the registry/catalog error" at both call sites. Satisfies all three banner scenarios (`catalog_failure`, `enrichment_failure`, `offline`).
2. **Remove confirmation.** `_capture_next_confirm` (native dialog) → `_resolve_remove_confirm`, which drives the React modal via the `confirm-dialog-confirm` / `confirm-dialog-cancel` testids.
3. **Telegram configure.** Replaced the obsolete token-entry test with one asserting the configure modal hosts the pairing panel (`telegram-pairing-panel`) and no longer offers a bot-token form.

Only #1 touches production code; #2/#3 align stale tests to shipped, intended behavior.

## Verification (local)

- The 7 previously-failing tests: **pass**
- Full `test_reborn_webui_v2_legacy_extensions.py` (43 tests): **pass**
- Frontend unit suite (`vitest run`, 812 tests) incl. extended `extensions-page.test.ts` regression assertion: **pass**
- `tsc --noEmit` and the source-conventions lint: **clean**

## Follow-up

The recurring theme (clippy feature-matrix, now nightly e2e) is that neither the full clippy matrix nor Playwright runs on PRs. I documented the clippy side in `.claude/rules/review-discipline.md` (PR #6224). Gating a fast subset of the extensions Playwright shard on PRs touching `crates/ironclaw_webui/frontend/**` would have caught all three of these at PR time — worth a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)