### PR TITLE
feat(reborn): Slice C W1a — activate Authorized seal + RuntimeLane::from_runtime_kind (#6168)

### DIFF
--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -3,7 +3,7 @@ use ironclaw_authorization::{
 };
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_host_api::{
-    CapabilityDescriptor, CapabilityDispatchRequest, CapabilityDispatchResult,
+    CapabilityAuthorizer, CapabilityDescriptor, CapabilityDispatchRequest, CapabilityDispatchResult,
     CapabilityDispatcher, CapabilityGrantId, CapabilityId, Decision, DenyReason, DispatchError,
     ExecutionContext, InvocationFingerprint, InvocationId, Obligation, ProcessId, ResourceEstimate,
     ResourceScope,
@@ -49,6 +49,15 @@ where
     process_manager: Option<&'a dyn ProcessManager>,
     obligation_handler: Option<&'a dyn CapabilityObligationHandler>,
 }
+
+// `CapabilityHost` IS the kernel authorizer (Slice-C wiring, arch-simplification
+// §3/§5.3.2). Implementing `CapabilityAuthorizer` here — and NOWHERE else, per
+// the `reborn_authorized_seal_ratchet` — is the "test-seal" half of the
+// `Authorized` witness: only this crate can mint an `AuthorizationGrant`, so only
+// the code that runs the authorize fold can seal an `Authorized`. The
+// `authorize()` method that consumes the grant lands in a following wiring slice;
+// this activates the seal so that ratchet becomes load-bearing.
+impl<'a, D> CapabilityAuthorizer for CapabilityHost<'a, D> where D: CapabilityDispatcher + ?Sized {}
 
 /// Specification for a lease that must be claimed AFTER authorization succeeds.
 ///

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -3,10 +3,10 @@ use ironclaw_authorization::{
 };
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_host_api::{
-    CapabilityAuthorizer, CapabilityDescriptor, CapabilityDispatchRequest, CapabilityDispatchResult,
-    CapabilityDispatcher, CapabilityGrantId, CapabilityId, Decision, DenyReason, DispatchError,
-    ExecutionContext, InvocationFingerprint, InvocationId, Obligation, ProcessId, ResourceEstimate,
-    ResourceScope,
+    CapabilityAuthorizer, CapabilityDescriptor, CapabilityDispatchRequest,
+    CapabilityDispatchResult, CapabilityDispatcher, CapabilityGrantId, CapabilityId, Decision,
+    DenyReason, DispatchError, ExecutionContext, InvocationFingerprint, InvocationId, Obligation,
+    ProcessId, ResourceEstimate, ResourceScope,
 };
 use ironclaw_processes::{ProcessManager, ProcessStart};
 use ironclaw_run_state::{

--- a/crates/ironclaw_host_api/src/lane.rs
+++ b/crates/ironclaw_host_api/src/lane.rs
@@ -80,6 +80,32 @@ runtime_lanes! {
     Process => "process",
 }
 
+impl RuntimeLane {
+    /// Resolve the execution lane for a descriptor's [`crate::RuntimeKind`]
+    /// (the loading taxonomy, §5.10). This is the one place the two axes meet:
+    /// `authorize()` reads the descriptor's kind and binds the resolved lane into
+    /// the `Authorized` witness so `dispatch()` routes without re-deriving it.
+    ///
+    /// - `Wasm`/`Mcp`/`FirstParty` map to their same-named lanes.
+    /// - `Script` runs **on** the [`RuntimeLane::Process`] lane (§4.2: "today's
+    ///   script/process adapter executes on the `Process` lane").
+    /// - `System` is host-internal (master-key ops, migrations, admin tooling)
+    ///   and is **not** an untrusted execution lane, so it maps to `None` — a
+    ///   `System` capability is not dispatched to a `RuntimeLane` at all. Callers
+    ///   must treat `None` as "host-internal, no untrusted lane", never as a
+    ///   default.
+    pub fn from_runtime_kind(kind: crate::RuntimeKind) -> Option<RuntimeLane> {
+        use crate::RuntimeKind;
+        match kind {
+            RuntimeKind::Wasm => Some(RuntimeLane::Wasm),
+            RuntimeKind::Mcp => Some(RuntimeLane::Mcp),
+            RuntimeKind::Script => Some(RuntimeLane::Process),
+            RuntimeKind::FirstParty => Some(RuntimeLane::FirstParty),
+            RuntimeKind::System => None,
+        }
+    }
+}
+
 impl std::fmt::Display for RuntimeLane {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
@@ -130,5 +156,29 @@ mod tests {
         assert_eq!(RuntimeLane::Wasm.as_str(), "wasm");
         assert_eq!(RuntimeLane::Mcp.as_str(), "mcp");
         assert_eq!(RuntimeLane::Process.as_str(), "process");
+    }
+
+    #[test]
+    fn from_runtime_kind_maps_the_loading_taxonomy_to_lanes() {
+        use crate::RuntimeKind;
+        assert_eq!(
+            RuntimeLane::from_runtime_kind(RuntimeKind::Wasm),
+            Some(RuntimeLane::Wasm)
+        );
+        assert_eq!(
+            RuntimeLane::from_runtime_kind(RuntimeKind::Mcp),
+            Some(RuntimeLane::Mcp)
+        );
+        assert_eq!(
+            RuntimeLane::from_runtime_kind(RuntimeKind::FirstParty),
+            Some(RuntimeLane::FirstParty)
+        );
+        // Script executes on the Process lane (§4.2).
+        assert_eq!(
+            RuntimeLane::from_runtime_kind(RuntimeKind::Script),
+            Some(RuntimeLane::Process)
+        );
+        // System is host-internal — no untrusted execution lane.
+        assert_eq!(RuntimeLane::from_runtime_kind(RuntimeKind::System), None);
     }
 }


### PR DESCRIPTION
## What
**First wiring step** (§9 step-2 prep) toward routing the capability path through `authorize()`/`dispatch()` over the C.1–C.7 vocabulary. Two safe, additive prerequisites for the `authorize()` fold. Stacked on the C.6/C.7 vocabulary branch (#6229).

- **`host_api` `RuntimeLane::from_runtime_kind`** — the one place the loading taxonomy (`RuntimeKind`, §5.10) resolves to the closed execution lane: `Wasm`/`Mcp`/`FirstParty` map 1:1; `Script → Process` (§4.2); `System → None` (host-internal, not an untrusted lane). `authorize()` will bind the resolved lane into `Authorized` so `dispatch()` routes without re-deriving it.
- **`impl CapabilityAuthorizer for CapabilityHost`** (in `ironclaw_capabilities`, and nowhere else per `reborn_authorized_seal_ratchet`) — this **activates C.7's seal**: only the kernel can now mint an `AuthorizationGrant`, so only the code that runs the authorize fold can seal an `Authorized`. Before this, the seal had zero production impls; the ratchet is now load-bearing.

## Safe by construction
Additive only — **no behavior change**; `invoke_json` is untouched. The next slices refactor `invoke_json` → `authorize()` (mints `Authorized` from the existing trust/approval/reservation checks) + `dispatch()` (consumes it), collapsing `CapabilityDispatchRequest`/`RuntimeCapabilityRequest`/`CapabilityInvocationRequest`/`RuntimeAdapterRequest`.

## Checks
`from_runtime_kind` mapping tests · seal ratchet passes (now with its one legitimate kernel impl) · `clippy -D warnings` clean · full `ironclaw_capabilities` suite (62) green · pre-commit clean.

## Next (W1b → W6)
`authorize(Invocation) -> AuthorizeResult` wrapping `invoke_json` steps 1–6 (integration-tested at the dispatch seam) → thread `&Authorized` through dispatch → collapse the four mirror DTOs → `RuntimeAdapter` `dyn`→`RuntimeLane` match → delete `HostRuntime`/`CapabilityDispatcher` traits → measure the type/`dyn`-count drop (§9 step 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)