### PR TITLE
refactor(host_runtime): delete the dead trust_decision field from the capability request family (#6168)

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -350,9 +350,10 @@ pub struct RuntimeCapabilityRequest {
 }
 
 impl RuntimeCapabilityRequest {
-    // Note: no `trust_decision` parameter. The legacy caller-supplied trust
-    // decision was a provably-dead field — `DefaultHostRuntime` discarded it and
-    // evaluated host-owned trust itself (§1.1 mechanism 3, arch-simplification).
+    // Deliberately NO `trust_decision` parameter — do not re-add one. Trust is
+    // host-owned: `DefaultHostRuntime` evaluates it itself, and a caller-supplied
+    // decision would be unvalidated authority input the runtime must ignore
+    // (arch-simplification §1.1).
     // Removed so it is no longer carried across the capability hops.
     pub fn new(
         context: ExecutionContext,

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -347,24 +347,18 @@ pub struct RuntimeCapabilityRequest {
     /// The host runtime still validates and forwards the key into
     /// observability spans for audit/tracing.
     pub idempotency_key: Option<IdempotencyKey>,
-    /// Legacy caller-supplied trust decision kept for transitional request-shape
-    /// compatibility.
-    ///
-    /// [`DefaultHostRuntime`](crate::DefaultHostRuntime) ignores this value: it
-    /// resolves the capability provider's package identity, evaluates the
-    /// host-owned policy, stamps the resulting effective trust onto the
-    /// execution context, and passes that host-owned decision to the capability
-    /// host. Callers must not rely on this field to widen or narrow authority.
-    pub trust_decision: TrustDecision,
 }
 
 impl RuntimeCapabilityRequest {
+    // Note: no `trust_decision` parameter. The legacy caller-supplied trust
+    // decision was a provably-dead field — `DefaultHostRuntime` discarded it and
+    // evaluated host-owned trust itself (§1.1 mechanism 3, arch-simplification).
+    // Removed so it is no longer carried across the capability hops.
     pub fn new(
         context: ExecutionContext,
         capability_id: CapabilityId,
         estimate: ResourceEstimate,
         input: Value,
-        trust_decision: TrustDecision,
     ) -> Self {
         Self {
             context,
@@ -372,7 +366,6 @@ impl RuntimeCapabilityRequest {
             estimate,
             input,
             idempotency_key: None,
-            trust_decision,
         }
     }
 
@@ -385,9 +378,8 @@ impl RuntimeCapabilityRequest {
 /// Request to resume one approval-blocked capability through the composed host runtime.
 ///
 /// The shape mirrors [`RuntimeCapabilityRequest`] but additionally carries the
-/// approval request selected by an upper approval workflow. Like invoke requests,
-/// `trust_decision` is transitional compatibility data: the default host runtime
-/// evaluates provider trust itself before delegating to `CapabilityHost`.
+/// approval request selected by an upper approval workflow. The default host
+/// runtime evaluates provider trust itself before delegating to `CapabilityHost`.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct RuntimeCapabilityResumeRequest {
@@ -397,7 +389,6 @@ pub struct RuntimeCapabilityResumeRequest {
     pub estimate: ResourceEstimate,
     pub input: Value,
     pub idempotency_key: Option<IdempotencyKey>,
-    pub trust_decision: TrustDecision,
 }
 
 impl RuntimeCapabilityResumeRequest {
@@ -407,7 +398,6 @@ impl RuntimeCapabilityResumeRequest {
         capability_id: CapabilityId,
         estimate: ResourceEstimate,
         input: Value,
-        trust_decision: TrustDecision,
     ) -> Self {
         Self {
             context,
@@ -416,7 +406,6 @@ impl RuntimeCapabilityResumeRequest {
             estimate,
             input,
             idempotency_key: None,
-            trust_decision,
         }
     }
 
@@ -440,7 +429,6 @@ pub struct RuntimeCapabilityAuthResumeRequest {
     pub estimate: ResourceEstimate,
     pub input: Value,
     pub idempotency_key: Option<IdempotencyKey>,
-    pub trust_decision: TrustDecision,
     /// Present when the invocation previously passed an approval gate.
     /// Used to locate and claim the matching fingerprinted approval lease
     /// so the re-dispatch does not require a second approval.
@@ -453,7 +441,6 @@ impl RuntimeCapabilityAuthResumeRequest {
         capability_id: CapabilityId,
         estimate: ResourceEstimate,
         input: Value,
-        trust_decision: TrustDecision,
         approval_request_id: Option<ApprovalRequestId>,
     ) -> Self {
         Self {
@@ -462,7 +449,6 @@ impl RuntimeCapabilityAuthResumeRequest {
             estimate,
             input,
             idempotency_key: None,
-            trust_decision,
             approval_request_id,
         }
     }

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -420,7 +420,6 @@ impl HostRuntime for DefaultHostRuntime {
             estimate,
             input,
             idempotency_key,
-            trust_decision: _caller_trust_decision,
         } = request;
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
@@ -612,7 +611,6 @@ impl HostRuntime for DefaultHostRuntime {
             estimate,
             input,
             idempotency_key,
-            trust_decision: _caller_trust_decision,
         } = request;
         let input = match host_runtime_spawn_input_for_capability(&capability_id, input)? {
             SpawnInputPreparation::Ready(input) => input,
@@ -724,7 +722,6 @@ impl HostRuntime for DefaultHostRuntime {
             estimate,
             input,
             idempotency_key,
-            trust_decision: _caller_trust_decision,
         } = request;
         if let Some(outcome) = self
             .resume_actor_preflight_guard(&context, &capability_id)
@@ -832,7 +829,6 @@ impl HostRuntime for DefaultHostRuntime {
             estimate,
             input,
             idempotency_key,
-            trust_decision: _caller_trust_decision,
             approval_request_id,
         } = request;
         if let Some(outcome) = self
@@ -957,7 +953,6 @@ impl HostRuntime for DefaultHostRuntime {
             estimate,
             input,
             idempotency_key,
-            trust_decision: _caller_trust_decision,
         } = request;
         if let Some(outcome) = self
             .resume_actor_preflight_guard(&context, &capability_id)

--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -26,7 +26,7 @@ use ironclaw_secrets::{
     InMemorySecretStore, SecretLease, SecretLeaseId, SecretMaterial, SecretMetadata, SecretStore,
     SecretStoreError,
 };
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use ironclaw_trust::TrustDecision;
 use serde_json::json;
 
 fn local_test_runtime_policy() -> ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy {
@@ -1002,7 +1002,6 @@ async fn default_host_runtime_fails_closed_when_resource_ceiling_lacks_required_
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "must not dispatch"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -1047,7 +1046,6 @@ async fn default_host_runtime_dispatches_when_resource_ceiling_is_satisfied() {
             capability_id(),
             ResourceEstimate::default().set_usd(1.into()),
             json!({"message": "obligated"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -1078,7 +1076,6 @@ async fn default_host_runtime_installs_configured_obligation_handler() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "obligated"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -1265,18 +1262,6 @@ fn execution_context(grants: CapabilitySet) -> ExecutionContext {
 
 fn capability_id() -> CapabilityId {
     CapabilityId::new("echo.say").unwrap()
-}
-
-fn trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::sandbox(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: chrono::Utc::now(),
-    }
 }
 
 #[derive(Debug)]

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -2423,7 +2423,6 @@ async fn builtin_rejects_oversized_inputs_before_dispatch() {
             capability_id(JSON_CAPABILITY_ID),
             ResourceEstimate::default(),
             json!({"operation": "validate", "data": "x".repeat(1_048_577)}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -2442,7 +2441,6 @@ async fn builtin_rejects_oversized_outputs_before_return() {
             capability_id(JSON_CAPABILITY_ID),
             ResourceEstimate::default(),
             json!({"operation": "stringify", "data": {"items": vec!["xxxxxxxx"; 80_000]}}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -3282,7 +3280,6 @@ async fn builtin_shell_invokes_copied_shell_core_through_host_runtime() {
             capability_id(SHELL_CAPABILITY_ID),
             ResourceEstimate::default(),
             json!({"command": "echo hello reborn"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -3871,7 +3868,6 @@ async fn builtin_json_rejects_v1_tool_output_stash_refs_without_leaking_input() 
                 "operation": "parse",
                 "source_tool_call_id": "call_RAW_SECRET_sk-provider-secret"
             }),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -6031,8 +6027,7 @@ async fn builtin_skill_install_url_path_accounts_wall_clock_time() {
             ),
             capability_id(SKILL_INSTALL_CAPABILITY_ID),
             ResourceEstimate::default(),
-            json!({"url": "https://raw.githubusercontent.com/Pika-Labs/Pika-Skills/main/slow-helper/SKILL.md"}),
-            trust_decision(),
+            json!({"url": "https://raw.githubusercontent.com/Pika-Labs/Pika-Skills/main/slow-helper/SKILL.md"})
         ))
         .await
         .unwrap();
@@ -6078,7 +6073,6 @@ async fn builtin_http_runtime_policy_denial_stops_before_egress() {
             capability_id(HTTP_CAPABILITY_ID),
             ResourceEstimate::default(),
             json!({"url": "https://api.example.test/v1/items"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -8042,7 +8036,6 @@ async fn builtin_missing_grant_denies_before_handler_dispatch() {
             capability_id(ECHO_CAPABILITY_ID),
             ResourceEstimate::default(),
             json!({"message":"must not run"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -8081,7 +8074,6 @@ async fn invoke_with_context<R: HostRuntime + ?Sized>(
             capability_id(capability),
             ResourceEstimate::default(),
             input,
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -8104,7 +8096,6 @@ async fn invoke_failure_with_context<R: HostRuntime + ?Sized>(
             capability_id(capability),
             ResourceEstimate::default(),
             input,
-            trust_decision(),
         ))
         .await
         .unwrap();

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -23,10 +23,7 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_triggers::InMemoryTriggerRepository;
-use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
-};
+use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 use ironclaw_turns::run_profile::LoopSafeSummary;
 use serde_json::{Value, json};
 
@@ -1518,7 +1515,6 @@ async fn invoke_with_context<R: HostRuntime + ?Sized>(
             CapabilityId::new(capability).unwrap(),
             ResourceEstimate::default(),
             input,
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -1541,7 +1537,6 @@ async fn invoke_completed_with_context<R: HostRuntime + ?Sized>(
             CapabilityId::new(capability).unwrap(),
             ResourceEstimate::default(),
             input,
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -1563,7 +1558,6 @@ async fn invoke_failure_with_context<R: HostRuntime + ?Sized>(
             CapabilityId::new(capability).unwrap(),
             ResourceEstimate::default(),
             input,
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -2113,16 +2107,4 @@ fn trust_policy() -> HostTrustPolicy {
         ),
     ]))])
     .unwrap()
-}
-
-fn trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: builtin_effects(),
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: chrono::Utc::now(),
-    }
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use chrono::Utc;
 use futures_util::FutureExt;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
@@ -27,10 +26,7 @@ use ironclaw_network::{
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount, ResourceTally};
 use ironclaw_run_state::{RunStateStore, RunStatus};
 use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
-use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
-};
+use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 use serde_json::{Value, json};
 
 const FIRST_PARTY_STAGED_SECRET: &str = "sk-first-party-staged-secret";
@@ -72,7 +68,6 @@ async fn host_runtime_invokes_first_party_handler_through_capability_host() {
             capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -152,7 +147,6 @@ async fn first_party_handler_uses_staged_secret_through_production_host_egress()
                 .set_network_egress_bytes(100)
                 .set_output_bytes(1024),
             json!({"url":"https://api.example.test/v1/native"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -435,7 +429,6 @@ async fn first_party_handler_error_reconciles_reported_usage_after_side_effect()
             capability_id(),
             ResourceEstimate::default().set_network_egress_bytes(100),
             json!({"message":"status"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -481,7 +474,6 @@ async fn first_party_handler_panic_fails_closed_and_releases_reservation() {
         capability_id(),
         ResourceEstimate::default().set_network_egress_bytes(100),
         json!({"message":"status"}),
-        trust_decision(),
     )))
     .catch_unwind()
     .await
@@ -531,7 +523,6 @@ async fn first_party_missing_handler_fails_closed_without_side_effect_handler() 
             capability_id(),
             ResourceEstimate::default(),
             json!({"message":"status"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -819,7 +810,6 @@ async fn invoke_http_fixture(
                 .set_network_egress_bytes(100)
                 .set_output_bytes(1024),
             input,
-            trust_decision(),
         ))
         .await
         .unwrap()
@@ -921,18 +911,6 @@ async fn stage_http_secret(
         )
         .await
         .unwrap();
-}
-
-fn trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn provider_id() -> ExtensionId {

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -2,7 +2,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use chrono::Utc;
 use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 use ironclaw_filesystem::DiskFilesystem;
@@ -29,8 +28,7 @@ use ironclaw_resources::{
 };
 use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
 use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
+    AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy, TrustDecision,
 };
 use ironclaw_wasm::{
     RecordingWasmHostHttp, WasmHostError, WasmHttpResponse, WitToolExecution, WitToolHost,
@@ -2299,13 +2297,7 @@ fn wasm_runtime_request_for_scope(
     input: serde_json::Value,
 ) -> RuntimeCapabilityRequest {
     let context = execution_context_with_dispatch_grant_for_scope(capability_id.clone(), scope);
-    RuntimeCapabilityRequest::new(
-        context,
-        capability_id,
-        wasm_http_estimate(),
-        input,
-        trust_decision_with_dispatch_authority(),
-    )
+    RuntimeCapabilityRequest::new(context, capability_id, wasm_http_estimate(), input)
 }
 
 fn execution_context_with_dispatch_grant_for_scope(
@@ -2359,23 +2351,6 @@ fn capability_grants(capability: CapabilityId) -> CapabilitySet {
         },
     });
     grants
-}
-
-fn trust_decision_with_dispatch_authority() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![
-                EffectKind::DispatchCapability,
-                EffectKind::Network,
-                EffectKind::UseSecret,
-                EffectKind::ExternalWrite,
-            ],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn execute_bundled_github_wasm(

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -94,7 +94,6 @@ async fn default_runtime_returns_completed_outcome_for_authorized_dispatch() {
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "hello"}),
-        trust_decision_with_dispatch_authority(),
     )
     .with_idempotency_key(IdempotencyKey::new("turn-1/tool-1").unwrap());
 
@@ -137,7 +136,6 @@ async fn default_runtime_surfaces_approval_required_with_persisted_request_id() 
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "hello"}),
-        trust_decision_with_dispatch_authority(),
     );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
@@ -181,7 +179,6 @@ async fn default_runtime_uses_combined_store_for_atomic_approval_block() {
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "hello"}),
-        trust_decision_with_dispatch_authority(),
     );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
@@ -251,7 +248,6 @@ async fn default_runtime_propagates_unavailable_when_run_state_lookup_fails_duri
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "hello"}),
-        trust_decision_with_dispatch_authority(),
     );
 
     let outcome = runtime.invoke_capability(request).await;
@@ -290,7 +286,6 @@ async fn default_runtime_returns_failed_for_unknown_capability() {
         capability_id(),
         ResourceEstimate::default(),
         json!({}),
-        trust_decision_with_dispatch_authority(),
     );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
@@ -341,7 +336,6 @@ async fn default_runtime_surfaces_authorization_failure_when_authorizer_denies()
         capability_id(),
         ResourceEstimate::default(),
         json!({}),
-        trust_decision_with_dispatch_authority(),
     );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
@@ -386,7 +380,6 @@ async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
         capability_id(),
         ResourceEstimate::default(),
         json!({"n": 1}),
-        trust_decision_with_dispatch_authority(),
     )
     .with_idempotency_key(key.clone());
     let _ = runtime.invoke_capability(request_a).await.unwrap();
@@ -397,7 +390,6 @@ async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
         capability_id(),
         ResourceEstimate::default(),
         json!({"n": 2}),
-        trust_decision_with_dispatch_authority(),
     )
     .with_idempotency_key(key);
     let _ = runtime.invoke_capability(request_b).await.unwrap();

--- a/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_credential_preflight_contract.rs
@@ -20,7 +20,6 @@ mod support;
 
 use std::sync::Arc;
 
-use chrono::Utc;
 use ironclaw_authorization::{GrantAuthorizer, in_memory_backed_capability_lease_store};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 use ironclaw_filesystem::DiskFilesystem;
@@ -32,10 +31,7 @@ use ironclaw_host_runtime::{
 use ironclaw_processes::ProcessServices;
 use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
-use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
-};
+use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 use serde_json::json;
 use support::legacy_capability_fixture_to_v2;
 
@@ -155,18 +151,6 @@ fn local_manifest_trust_policy(
     .unwrap()
 }
 
-fn trust_decision_with_dispatch_authority() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::UseSecret],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
-}
-
 // ─── Test A-regression: ProductAuthAccount must NOT trip pre-flight ──────────
 
 /// A required `ProductAuthAccount`-source credential must not trip the
@@ -223,7 +207,6 @@ async fn product_auth_account_credential_does_not_trip_preflight() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -281,7 +264,6 @@ async fn secret_handle_credential_absent_still_trips_preflight() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -357,7 +339,6 @@ async fn tenant_shared_secret_satisfies_credential_preflight() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -424,7 +405,6 @@ async fn invoke_capability_forged_scope_fails_before_preflight() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await;
 
@@ -485,7 +465,6 @@ async fn spawn_capability_forged_scope_fails_before_preflight() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await;
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -23,10 +23,7 @@ use ironclaw_processes::{
     ProcessError, ProcessManager, ProcessRecord, ProcessStart, ProcessStatus,
 };
 use ironclaw_run_state::{RunStart, RunStateStore, RunStatus};
-use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
-};
+use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 use serde_json::json;
 
 #[tokio::test]
@@ -78,7 +75,6 @@ async fn default_runtime_uses_persistent_policy_as_dispatch_authority() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -172,7 +168,6 @@ async fn default_runtime_uses_persistent_policy_as_auth_resume_authority() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
             None,
         ))
         .await
@@ -247,7 +242,6 @@ async fn default_runtime_uses_user_grantee_persistent_policy_as_dispatch_authori
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -323,7 +317,6 @@ async fn default_runtime_uses_threadless_filesystem_policy_after_thread_change()
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -387,7 +380,6 @@ async fn default_runtime_does_not_replay_tenant_grantee_persistent_policy() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -471,7 +463,6 @@ async fn default_runtime_skips_unusable_persistent_policy_for_later_match() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -515,7 +506,6 @@ async fn default_runtime_falls_back_when_persistent_policy_lookup_fails() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -579,7 +569,6 @@ async fn default_runtime_reuses_persistent_policy_for_manifest_ask() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -643,7 +632,6 @@ async fn default_runtime_skips_expired_persistent_policy() {
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -715,7 +703,6 @@ async fn default_runtime_uses_persistent_policy_for_no_project_no_thread_scope()
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -784,7 +771,6 @@ async fn default_runtime_uses_persistent_policy_as_spawn_capability_authority() 
             capability_id(),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_spawn_authority(),
         ))
         .await
         .unwrap();
@@ -1002,30 +988,6 @@ fn local_manifest_trust_policy_with_effects(allowed_effects: Vec<EffectKind>) ->
         ),
     ]))])
     .unwrap()
-}
-
-fn trust_decision_with_dispatch_authority() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
-}
-
-fn trust_decision_with_spawn_authority() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn capability_id() -> CapabilityId {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1505,7 +1505,6 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
         script_capability_id(),
         ResourceEstimate::default(),
         json!({"message": "from services"}),
-        trust_decision_with_dispatch_authority(),
     );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
@@ -1623,7 +1622,6 @@ async fn host_runtime_services_writes_runtime_events_to_durable_event_log_metada
             script_capability_id(),
             ResourceEstimate::default(),
             payload.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -1720,7 +1718,6 @@ async fn host_runtime_services_consumes_reborn_jsonl_event_store_without_v1_comp
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "from jsonl store"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -1787,7 +1784,6 @@ async fn host_runtime_services_durable_event_replay_cursor_and_gap_behavior() {
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "cursor replay"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -1881,7 +1877,6 @@ async fn host_runtime_services_runtime_events_project_through_replay_projection_
             script_capability_id(),
             ResourceEstimate::default(),
             payload.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -1972,7 +1967,6 @@ async fn host_runtime_services_projection_rejects_foreign_cursor_and_surfaces_re
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "scope a"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2078,7 +2072,6 @@ async fn host_runtime_services_jsonl_event_store_projects_same_runtime_sequence_
             script_capability_id(),
             ResourceEstimate::default(),
             payload.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2180,7 +2173,6 @@ async fn host_runtime_services_approval_resolution_projects_durable_audit_metada
             script_capability_id(),
             ResourceEstimate::default(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2568,7 +2560,6 @@ async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_on
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2611,7 +2602,6 @@ async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_on
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2668,7 +2658,6 @@ async fn host_runtime_services_resume_missing_runtime_secret_returns_auth_gate()
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2729,7 +2718,6 @@ async fn host_runtime_services_resume_changed_input_fails_before_lease_claim_or_
             script_capability_id(),
             estimate,
             json!({"message": "changed"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2777,7 +2765,6 @@ async fn host_runtime_services_resume_wrong_user_scope_is_hidden_before_dispatch
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2831,7 +2818,6 @@ async fn host_runtime_services_resume_expired_lease_fails_before_dispatch() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2876,7 +2862,6 @@ async fn host_runtime_services_resume_trust_preflight_failure_fails_only_matchin
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2898,7 +2883,6 @@ async fn host_runtime_services_resume_trust_preflight_failure_fails_only_matchin
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap_err();
@@ -2921,7 +2905,6 @@ async fn host_runtime_services_resume_trust_preflight_failure_fails_only_matchin
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2974,7 +2957,6 @@ async fn host_runtime_services_resume_runtime_policy_denial_fails_matching_block
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -3037,7 +3019,6 @@ async fn host_runtime_services_resume_rejects_changed_actor_before_preflight_mut
                 script_capability_id(),
                 estimate.clone(),
                 input.clone(),
-                trust_decision_with_dispatch_authority(),
             ))
             .await
             .unwrap();
@@ -3074,7 +3055,6 @@ async fn host_runtime_services_resume_rejects_changed_actor_before_preflight_mut
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -3123,7 +3103,6 @@ async fn host_runtime_services_auth_resume_rejects_changed_actor_before_prefligh
                 script_capability_id(),
                 estimate.clone(),
                 input.clone(),
-                trust_decision_with_dispatch_authority(),
                 None,
             ))
             .await
@@ -3149,7 +3128,6 @@ async fn host_runtime_services_auth_resume_rejects_changed_actor_before_prefligh
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
             None,
         ))
         .await
@@ -3205,7 +3183,6 @@ async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_a
             process_sandbox_capability_id(),
             estimate.clone(),
             input.clone(),
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -3241,7 +3218,6 @@ async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_a
                 process_sandbox_capability_id(),
                 estimate.clone(),
                 input.clone(),
-                process_sandbox_trust_decision(),
             ))
             .await
             .unwrap();
@@ -3281,7 +3257,6 @@ async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_a
             process_sandbox_capability_id(),
             estimate.clone(),
             invalid_process_sandbox_input(),
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -3301,7 +3276,6 @@ async fn host_runtime_services_resume_spawn_rejects_changed_actor_before_input_a
             process_sandbox_capability_id(),
             estimate,
             input,
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -3378,7 +3352,6 @@ async fn host_runtime_services_auth_resume_dispatches_blocked_auth_run() {
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -3410,7 +3383,6 @@ async fn host_runtime_services_auth_resume_dispatches_blocked_auth_run() {
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
             Some(gate.approval_request_id),
         ))
         .await
@@ -3504,7 +3476,6 @@ async fn host_runtime_services_auth_resume_trust_preflight_failure_fails_blocked
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
             None,
         ))
         .await
@@ -3533,7 +3504,6 @@ async fn host_runtime_services_auth_resume_trust_preflight_failure_fails_blocked
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
             None,
         ))
         .await
@@ -3625,7 +3595,6 @@ async fn host_runtime_services_auth_resume_with_approval_id_fails_blocked_auth_r
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
             Some(orphan_approval_id),
         ))
         .await
@@ -3675,7 +3644,6 @@ async fn host_runtime_services_resume_without_backing_stores_fails_closed() {
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "missing stores"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -3960,7 +3928,6 @@ async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor(
             process_sandbox_capability_id(),
             estimate.clone(),
             input.clone(),
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -3985,7 +3952,6 @@ async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor(
             process_sandbox_capability_id(),
             estimate,
             input,
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -4034,7 +4000,6 @@ async fn host_runtime_spawn_process_sandbox_resume_changed_input_fails_before_ex
             process_sandbox_capability_id(),
             estimate.clone(),
             input,
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -4052,7 +4017,6 @@ async fn host_runtime_spawn_process_sandbox_resume_changed_input_fails_before_ex
             process_sandbox_capability_id(),
             estimate,
             json!({"run": {"command": "echo", "args": ["changed"]}}),
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -4109,7 +4073,6 @@ async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_exe
             process_sandbox_capability_id(),
             estimate.clone(),
             input,
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -4130,7 +4093,6 @@ async fn host_runtime_spawn_process_sandbox_resume_invalid_plan_fails_before_exe
             process_sandbox_capability_id(),
             estimate,
             invalid_process_sandbox_input(),
-            process_sandbox_trust_decision(),
         ))
         .await
         .expect("invalid sandbox resume input must not be a terminal host runtime error");
@@ -4205,7 +4167,6 @@ async fn host_runtime_spawn_process_sandbox_resume_host_failure_fails_after_appr
             process_sandbox_capability_id(),
             estimate.clone(),
             input.clone(),
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -4223,7 +4184,6 @@ async fn host_runtime_spawn_process_sandbox_resume_host_failure_fails_after_appr
             process_sandbox_capability_id(),
             estimate,
             input,
-            process_sandbox_trust_decision(),
         ))
         .await
         .unwrap();
@@ -4265,7 +4225,6 @@ async fn host_runtime_services_installs_builtin_obligation_handler_with_audit_si
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "audited through services"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4308,7 +4267,6 @@ async fn host_runtime_services_maps_script_exit_failure_through_private_adapter(
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "fail through services"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4336,7 +4294,6 @@ async fn host_runtime_services_maps_mcp_client_failure_through_private_adapter()
             mcp_capability_id(),
             ResourceEstimate::default(),
             json!({"query": "fail through services"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4383,7 +4340,6 @@ async fn host_runtime_services_applies_scoped_mount_obligation_to_script_runtime
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "mount narrowed"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4436,7 +4392,6 @@ async fn host_runtime_services_rejects_broader_scoped_mount_before_dispatch() {
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "broader mount"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4487,7 +4442,6 @@ async fn host_runtime_services_writes_obligation_audit_records_to_durable_log_me
             script_capability_id(),
             ResourceEstimate::default(),
             payload.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4616,7 +4570,6 @@ async fn host_runtime_services_projects_resource_network_secret_obligation_audit
                 .set_network_egress_bytes(10)
                 .set_output_bytes(100),
             payload.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4729,7 +4682,6 @@ async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usa
                 .set_concurrency_slots(1)
                 .set_output_bytes(1024),
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4786,7 +4738,6 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
             script_capability_id(),
             ResourceEstimate::default().set_concurrency_slots(1),
             json!({"message": "missing runtime after reservation"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -4838,7 +4789,6 @@ async fn host_runtime_services_fails_closed_when_durable_obligation_audit_append
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "must not dispatch after audit append failure"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6126,7 +6076,6 @@ async fn invoke_capability_missing_credential_returns_auth_before_approval() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6213,7 +6162,6 @@ async fn invoke_capability_present_credential_proceeds_to_approval() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6296,7 +6244,6 @@ async fn spawn_capability_present_credential_proceeds_to_approval() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6336,7 +6283,6 @@ async fn invoke_capability_no_credential_requirement_proceeds_normally() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6394,7 +6340,6 @@ async fn spawn_capability_missing_credential_returns_auth_before_approval() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6468,7 +6413,6 @@ async fn invoke_capability_no_credential_requirement_with_wired_store_proceeds_n
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6558,7 +6502,6 @@ async fn invoke_capability_secret_store_error_skips_preflight() {
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -6636,7 +6579,6 @@ async fn invoke_capability_secret_store_error_skips_preflight() {
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -5,7 +5,6 @@ use support::legacy_capability_fixture_to_v2;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use chrono::Utc;
 use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
 use ironclaw_events::InMemoryAuditSink;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
@@ -19,7 +18,7 @@ use ironclaw_network::{
 };
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceGovernor};
 use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use ironclaw_trust::TrustDecision;
 use serde_json::json;
 
 fn local_test_runtime_policy() -> ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy {
@@ -92,7 +91,6 @@ async fn default_runtime_installs_configured_builtin_obligation_services() {
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "hello"}),
-        trust_decision_with_dispatch_authority(),
     );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
@@ -330,18 +328,6 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
         MountView::default(),
     )
     .unwrap()
-}
-
-fn trust_decision_with_dispatch_authority() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn capability_id() -> CapabilityId {

--- a/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
@@ -5,7 +5,6 @@ use support::legacy_capability_fixture_to_v2;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use chrono::Utc;
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 use ironclaw_host_api::*;
@@ -14,9 +13,8 @@ use ironclaw_host_runtime::{
     RuntimeCapabilityRequest, RuntimeFailureKind,
 };
 use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, InvalidationBus, TrustDecision, TrustPolicy, TrustPolicyInput,
-    TrustProvenance,
+    AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy, InvalidationBus,
+    TrustPolicyInput,
 };
 use serde_json::json;
 
@@ -28,39 +26,11 @@ fn local_test_runtime_policy() -> ironclaw_host_api::runtime_policy::EffectiveRu
     .unwrap()
 }
 
-#[tokio::test]
-async fn production_runtime_ignores_caller_supplied_privileged_trust_decision() {
-    let registry = Arc::new(registry_with_manifest(LOCAL_INSTALLED_MANIFEST));
-    let dispatcher = Arc::new(CountingDispatcher::default());
-    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
-    let runtime = DefaultHostRuntime::new(
-        Arc::clone(&registry),
-        dispatcher.clone(),
-        authorizer,
-        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
-        local_test_runtime_policy(),
-    );
-
-    let forged_decision = privileged_local_manifest_policy()
-        .evaluate(&trust_input_for_registry(&registry))
-        .unwrap();
-    let request = RuntimeCapabilityRequest::new(
-        execution_context_with_dispatch_grant(TrustClass::FirstParty),
-        capability_id(),
-        ResourceEstimate::default(),
-        json!({"message": "must not dispatch"}),
-        forged_decision,
-    );
-
-    let outcome = runtime.invoke_capability(request).await.unwrap();
-
-    assert_authorization_failed(outcome);
-    assert_eq!(
-        dispatcher.count(),
-        0,
-        "stale or caller-supplied privileged TrustDecision must not authorize dispatch"
-    );
-}
+// The former `production_runtime_ignores_caller_supplied_privileged_trust_decision`
+// test forged a caller-supplied `trust_decision` to prove the host ignored it.
+// That attack surface is now structurally eliminated: the request types no longer
+// carry a `trust_decision` field, so there is nothing for a caller to forge — the
+// host always evaluates trust itself.
 
 #[tokio::test]
 async fn production_runtime_uses_host_policy_decision_instead_of_request_claims() {
@@ -81,7 +51,6 @@ async fn production_runtime_uses_host_policy_decision_instead_of_request_claims(
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "host policy decides"}),
-        sandbox_caller_decision(),
     );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
@@ -116,13 +85,11 @@ async fn trust_downgrade_denies_future_invocation_before_dispatch_side_effects()
     .with_trust_policy(Arc::clone(&policy));
 
     let trusted_input = trust_input_for_registry(&registry);
-    let stale_privileged_decision = policy.evaluate(&trusted_input).unwrap();
     let first = RuntimeCapabilityRequest::new(
         execution_context_with_dispatch_grant(TrustClass::Sandbox),
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "before downgrade"}),
-        sandbox_caller_decision(),
     );
     let first_outcome = runtime.invoke_capability(first).await.unwrap();
     assert!(
@@ -152,7 +119,6 @@ async fn trust_downgrade_denies_future_invocation_before_dispatch_side_effects()
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "after downgrade"}),
-        stale_privileged_decision,
     );
     let second_outcome = runtime.invoke_capability(second).await.unwrap();
 
@@ -292,15 +258,6 @@ fn execution_context_with_dispatch_grant(trust: TrustClass) -> ExecutionContext 
         MountView::default(),
     )
     .unwrap()
-}
-
-fn sandbox_caller_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::sandbox(),
-        authority_ceiling: AuthorityCeiling::empty(),
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn capability_id() -> CapabilityId {

--- a/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
@@ -5,7 +5,6 @@ use support::legacy_capability_fixture_to_v2;
 use std::{path::Path, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use chrono::Utc;
 use ironclaw_approvals::LeaseApproval;
 use ironclaw_authorization::{
     CapabilityLeaseStatus, CapabilityLeaseStore, FilesystemCapabilityLeaseStore, GrantAuthorizer,
@@ -40,8 +39,7 @@ use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptRuntime, ScriptRuntimeConfig,
 };
 use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
+    AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy, TrustDecision,
 };
 use serde_json::{Value, json};
 
@@ -105,7 +103,6 @@ async fn approval_resume_survives_filesystem_service_restart_and_consumes_lease_
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -180,7 +177,6 @@ async fn approval_resume_survives_filesystem_service_restart_and_consumes_lease_
             script_capability_id(),
             estimate,
             json!({"message": "restart approval"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -256,7 +252,6 @@ async fn approval_resume_survives_durable_libsql_reopen_and_consumes_lease_once(
             script_capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -331,7 +326,6 @@ async fn approval_resume_survives_durable_libsql_reopen_and_consumes_lease_once(
             script_capability_id(),
             estimate,
             json!({"message": "restart approval"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -432,7 +426,6 @@ async fn jsonl_event_and_audit_replay_survive_reopen_without_raw_sentinels() {
             script_capability_id(),
             ResourceEstimate::default(),
             payload.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -743,7 +736,6 @@ async fn block_for_approval(
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -1025,18 +1017,6 @@ fn local_manifest_trust_policy(
         ),
     ]))])
     .unwrap()
-}
-
-fn trust_decision_with_dispatch_authority() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn sample_scope(invocation_id: InvocationId) -> ResourceScope {

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -116,7 +116,6 @@ async fn reborn_e2e_gate_invokes_script_through_host_runtime_with_status_events_
             script_capability_id(),
             ResourceEstimate::default().set_output_bytes(4096),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -214,7 +213,6 @@ async fn reborn_e2e_gate_blocks_for_approval_resumes_once_and_rejects_replay() {
             script_capability_id(),
             ResourceEstimate::default(),
             input.clone(),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -250,7 +248,6 @@ async fn reborn_e2e_gate_blocks_for_approval_resumes_once_and_rejects_replay() {
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "approval resume through Reborn E2E gate"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -293,7 +290,6 @@ async fn reborn_e2e_gate_fails_unsupported_obligations_before_runtime_events_or_
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": "unsupported obligation"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -348,7 +344,6 @@ async fn reborn_e2e_gate_redacts_runtime_output_before_public_result() {
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"authorization": leaked, "message": "redact before public result"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -410,7 +405,6 @@ async fn reborn_e2e_gate_sanitizes_runtime_backend_failure_before_public_surface
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": input_sentinel}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -490,7 +484,6 @@ async fn reborn_e2e_gate_blocks_oversized_runtime_output_before_publication() {
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": forbidden}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -686,7 +679,6 @@ async fn block_for_approval(
             script_capability_id(),
             ResourceEstimate::default(),
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -8,7 +8,6 @@ use std::sync::{
 };
 
 use async_trait::async_trait;
-use chrono::Utc;
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
@@ -26,8 +25,7 @@ use ironclaw_resources::{
 };
 use ironclaw_run_state::{RunStateStore, RunStatus};
 use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
+    AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy, TrustDecision,
 };
 use serde_json::{Value, json};
 
@@ -69,7 +67,6 @@ async fn default_host_runtime_invokes_through_runtime_dispatcher_with_resources_
             capability_id(),
             estimate.clone(),
             input.clone(),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -135,7 +132,6 @@ async fn default_host_runtime_fails_unsupported_obligations_before_runtime_dispa
             capability_id(),
             ResourceEstimate::default(),
             json!({"message":"obligation"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -371,18 +367,6 @@ fn local_manifest_trust_policy() -> HostTrustPolicy {
         ),
     ]))])
     .unwrap()
-}
-
-fn trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn capability_id() -> CapabilityId {

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -156,7 +156,6 @@ pub(crate) async fn assert_services_use_combined_store_for_atomic_approval_block
             script_capability_id(),
             ResourceEstimate::default(),
             json!({"message": message}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -514,7 +513,6 @@ pub(crate) async fn block_for_approval(
             script_capability_id(),
             estimate,
             input,
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -2014,7 +2012,6 @@ pub(crate) fn process_sandbox_runtime_request_for_scope(
         process_sandbox_capability_id(),
         process_sandbox_estimate(),
         process_sandbox_input(),
-        process_sandbox_trust_decision(),
     )
 }
 
@@ -2199,13 +2196,7 @@ pub(crate) fn wasm_runtime_request_for_scope(
     input: serde_json::Value,
 ) -> RuntimeCapabilityRequest {
     let context = execution_context_with_dispatch_grant_for_scope(capability_id.clone(), scope);
-    RuntimeCapabilityRequest::new(
-        context,
-        capability_id,
-        wasm_http_estimate(),
-        input,
-        trust_decision_with_dispatch_authority(),
-    )
+    RuntimeCapabilityRequest::new(context, capability_id, wasm_http_estimate(), input)
 }
 
 pub(crate) fn wasm_http_estimate() -> ResourceEstimate {

--- a/crates/ironclaw_host_runtime/tests/support/trace_commons_dispatch.rs
+++ b/crates/ironclaw_host_runtime/tests/support/trace_commons_dispatch.rs
@@ -353,7 +353,6 @@ pub async fn invoke_with_context(
             capability_id(capability),
             ResourceEstimate::default(),
             input,
-            trust_decision(),
         ))
         .await
         .unwrap();

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -1026,7 +1026,6 @@ async fn visible_surface_marks_askable_capabilities_without_granting_authority()
             capability_id("echo.say"),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -1068,7 +1067,6 @@ async fn hidden_capability_direct_invoke_still_fails_closed_through_authorizatio
             capability_id("echo.say"),
             ResourceEstimate::default(),
             json!({"message": "hello"}),
-            trust_decision_with_dispatch_authority(),
         ))
         .await
         .unwrap();
@@ -1567,7 +1565,6 @@ async fn runtime_policy_denied_extension_invoke_does_not_dispatch() {
             capability_id("echo.say"),
             ResourceEstimate::default(),
             json!({"message": "blocked before dispatch"}),
-            trust_decision_for(vec![EffectKind::DispatchCapability, EffectKind::Network]),
         ))
         .await
         .unwrap();
@@ -1612,7 +1609,6 @@ async fn runtime_policy_denied_secret_invoke_does_not_dispatch() {
             capability_id("secret-tool.read"),
             ResourceEstimate::default(),
             json!({}),
-            trust_decision_for(vec![EffectKind::UseSecret]),
         ))
         .await
         .unwrap();
@@ -1660,7 +1656,6 @@ async fn runtime_policy_denied_mcp_http_invoke_does_not_dispatch_when_effect_und
             capability_id("mcp.search"),
             ResourceEstimate::default(),
             json!({"query": "blocked before mcp dispatch"}),
-            trust_decision_for(vec![EffectKind::DispatchCapability]),
         ))
         .await
         .unwrap();
@@ -2109,10 +2104,6 @@ fn context_with_secret_grant() -> ExecutionContext {
 
 fn capability_id(value: &str) -> CapabilityId {
     CapabilityId::new(value).unwrap()
-}
-
-fn trust_decision_with_dispatch_authority() -> TrustDecision {
-    trust_decision_for(vec![EffectKind::DispatchCapability])
 }
 
 struct PanicTrustPolicy;

--- a/crates/ironclaw_host_runtime/tests/user_profile_roundtrip.rs
+++ b/crates/ironclaw_host_runtime/tests/user_profile_roundtrip.rs
@@ -43,10 +43,7 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_triggers::InMemoryTriggerRepository;
-use ironclaw_trust::{
-    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
-    HostTrustPolicy, TrustDecision, TrustProvenance,
-};
+use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 use ironclaw_turns::{
     RunProfileResolver, TurnActor, TurnId, TurnRunId, TurnScope,
     run_profile::{InMemoryRunProfileResolver, LoopRuntimeContext, RunProfileResolutionRequest},
@@ -108,27 +105,6 @@ fn trust_policy() -> HostTrustPolicy {
         ),
     ]))])
     .unwrap()
-}
-
-fn trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![
-                EffectKind::DispatchCapability,
-                EffectKind::ReadFilesystem,
-                EffectKind::WriteFilesystem,
-                EffectKind::DeleteFilesystem,
-                EffectKind::Network,
-                EffectKind::SpawnProcess,
-                EffectKind::ExecuteCode,
-                EffectKind::ExternalWrite,
-            ],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: Utc::now(),
-    }
 }
 
 fn memory_mounts() -> MountView {
@@ -297,7 +273,6 @@ async fn profile_set_then_runtime_context_renders_local_time_and_profile_line() 
             ironclaw_host_api::CapabilityId::new(PROFILE_SET_CAPABILITY_ID).unwrap(),
             ResourceEstimate::default(),
             json!({"timezone": "Asia/Tokyo", "locale": "ja-JP", "location": "Tokyo, Japan"}),
-            trust_decision(),
         ))
         .await
         .unwrap();
@@ -413,7 +388,6 @@ async fn profile_set_for_one_user_is_not_visible_to_another() {
             ironclaw_host_api::CapabilityId::new(PROFILE_SET_CAPABILITY_ID).unwrap(),
             ResourceEstimate::default(),
             json!({"timezone": "America/New_York", "locale": "en-US"}),
-            trust_decision(),
         ))
         .await
         .unwrap();

--- a/crates/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/ironclaw_loop_host/src/capability_port.rs
@@ -2032,7 +2032,7 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                     invocation_context,
                     request.capability_id,
                     estimate.clone(),
-                    input.clone()
+                    input.clone(),
                 )
                 .with_idempotency_key(idempotency_key.clone());
                 dispatch_runtime_capability(self.runtime.as_ref(), runtime_request).await

--- a/crates/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/ironclaw_loop_host/src/capability_port.rs
@@ -1998,7 +1998,6 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                     request.capability_id,
                     estimate.clone(),
                     input.clone(),
-                    trust_decision,
                 )
                 .with_idempotency_key(idempotency_key.clone());
                 dispatch_runtime_capability_resume(self.runtime.as_ref(), runtime_request).await
@@ -2022,7 +2021,6 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                     request.capability_id,
                     estimate.clone(),
                     input.clone(),
-                    trust_decision,
                     prior_approval_id,
                 )
                 .with_idempotency_key(idempotency_key.clone());
@@ -2034,8 +2032,7 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                     invocation_context,
                     request.capability_id,
                     estimate.clone(),
-                    input.clone(),
-                    trust_decision,
+                    input.clone()
                 )
                 .with_idempotency_key(idempotency_key.clone());
                 dispatch_runtime_capability(self.runtime.as_ref(), runtime_request).await

--- a/crates/ironclaw_reborn_composition/src/approval_test_support.rs
+++ b/crates/ironclaw_reborn_composition/src/approval_test_support.rs
@@ -5,7 +5,6 @@ use ironclaw_host_runtime::{
     RuntimeFailureKind,
 };
 use ironclaw_run_state::ApprovalRequestStore;
-use ironclaw_trust::TrustDecision;
 
 use crate::local_dev_capability_policy::{
     LocalDevApprovalPolicyAction, LocalDevCapabilityPolicyError, local_dev_one_shot_lease_approval,
@@ -37,11 +36,8 @@ pub(crate) async fn invoke_json_with_local_dev_approval(
     capability_id: &str,
     context: ExecutionContext,
     input: serde_json::Value,
-    trust_decision: TrustDecision,
 ) -> Result<serde_json::Value, RuntimeFailureKind> {
-    match invoke_with_local_dev_approval(services, capability_id, context, input, trust_decision)
-        .await
-    {
+    match invoke_with_local_dev_approval(services, capability_id, context, input).await {
         RuntimeCapabilityOutcome::Completed(completed) => Ok(completed.output),
         RuntimeCapabilityOutcome::Failed(failure) => Err(failure.kind),
         other => panic!("unexpected runtime outcome: {other:?}"),
@@ -53,7 +49,6 @@ pub(crate) async fn invoke_with_local_dev_approval(
     capability_id: &str,
     context: ExecutionContext,
     input: serde_json::Value,
-    trust_decision: TrustDecision,
 ) -> RuntimeCapabilityOutcome {
     let runtime = services
         .host_runtime
@@ -71,7 +66,6 @@ pub(crate) async fn invoke_with_local_dev_approval(
             capability.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision.clone(),
         ))
         .await
         .expect("runtime invocation completes"); // safety: test-only helper in #[cfg(test)] module.
@@ -129,7 +123,6 @@ pub(crate) async fn invoke_with_local_dev_approval(
                     capability,
                     estimate,
                     input,
-                    trust_decision,
                 ))
                 .await
                 .expect("approved runtime invocation resumes") // safety: test-only helper in #[cfg(test)] module.

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
@@ -831,7 +831,6 @@ mod tests {
             EXTENSION_REMOVE_CAPABILITY_ID,
             remove_context,
             serde_json::json!({"extension_id": "slack"}),
-            trust_decision(),
         )
         .await
         .expect("remove succeeds");
@@ -845,7 +844,6 @@ mod tests {
             EXTENSION_REMOVE_CAPABILITY_ID,
             retry_remove_context,
             serde_json::json!({"extension_id": "slack"}),
-            trust_decision(),
         )
         .await
         .expect("retrying removal after the package is absent succeeds");
@@ -1015,7 +1013,6 @@ credential_handle = "channel_ext_token"
             EXTENSION_REMOVE_CAPABILITY_ID,
             remove_context,
             serde_json::json!({"extension_id": "channel-ext"}),
-            trust_decision(),
         )
         .await
         .expect("tool removal succeeds");
@@ -1098,7 +1095,6 @@ credential_handle = "channel_ext_token"
             EXTENSION_REMOVE_CAPABILITY_ID,
             remove_context,
             serde_json::json!({"extension_id": "slack"}),
-            trust_decision(),
         )
         .await
         .expect_err("personal cleanup without an authenticated actor must fail closed");
@@ -1312,7 +1308,6 @@ credential_handle = "channel_ext_token"
                 [EXTENSION_ACTIVATE_CAPABILITY_ID],
             ),
             serde_json::json!({"extension_id": "github"}),
-            trust_decision(),
         )
         .await;
         let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
@@ -1762,7 +1757,6 @@ credential_handle = "channel_ext_token"
             capability_id,
             execution_context([capability_id]),
             input,
-            trust_decision(),
         )
         .await
     }
@@ -1777,7 +1771,6 @@ credential_handle = "channel_ext_token"
             capability_id,
             execution_context([capability_id]),
             input,
-            trust_decision(),
         )
         .await
     }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities_auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities_auth_tests.rs
@@ -9,7 +9,6 @@ use ironclaw_host_api::{
     TrustClass, UserId,
 };
 use ironclaw_host_runtime::{RuntimeCapabilityOutcome, RuntimeFailureKind};
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 use crate::extension_host::extension_lifecycle::RebornLocalExtensionManagementPort;
 use crate::extension_host::extension_lifecycle_capabilities::{
@@ -269,7 +268,6 @@ async fn invoke_json_with_context(
         capability_id,
         context,
         input,
-        trust_decision(),
     )
     .await
 }
@@ -285,7 +283,6 @@ async fn invoke_outcome_with_context(
         capability_id,
         context,
         input,
-        trust_decision(),
     )
     .await
 }
@@ -381,16 +378,4 @@ fn allowed_effects() -> Vec<EffectKind> {
         EffectKind::WriteFilesystem,
         EffectKind::Network,
     ]
-}
-
-fn trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: allowed_effects(),
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::Default,
-        evaluated_at: chrono::Utc::now(),
-    }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -5510,7 +5510,7 @@ mod tests {
         RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver,
     };
     use ironclaw_product_workflow::{LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase};
-    use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     use rust_decimal_macros::dec;
     #[cfg(feature = "libsql")]
@@ -6738,7 +6738,6 @@ mod tests {
                 CapabilityId::new("notion.notion-search").unwrap(),
                 ResourceEstimate::default(),
                 serde_json::json!({ "query": "project notes" }),
-                notion_mcp_trust_decision(),
             ))
             .await
             .expect("runtime invocation completes");
@@ -6800,7 +6799,6 @@ mod tests {
                     "provider": "brave",
                     "query": "ironclaw reborn"
                 }),
-                trust_decision(),
             ))
             .await
             .expect("runtime invocation completes");
@@ -7973,7 +7971,6 @@ mod tests {
             capability_id,
             context,
             input,
-            trust_decision(),
         )
         .await
     }
@@ -8217,18 +8214,6 @@ mod tests {
         ]
     }
 
-    fn trust_decision() -> TrustDecision {
-        TrustDecision {
-            effective_trust: EffectiveTrustClass::user_trusted(),
-            authority_ceiling: AuthorityCeiling {
-                allowed_effects: allowed_effects(),
-                max_resource_ceiling: None,
-            },
-            provenance: TrustProvenance::Default,
-            evaluated_at: chrono::Utc::now(),
-        }
-    }
-
     fn local_dev_minimal_approval_policy()
     -> ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy {
         let mut policy = crate::local_dev_runtime_policy().expect("local-dev policy resolves");
@@ -8236,18 +8221,6 @@ mod tests {
         policy.resolved_profile = ironclaw_host_api::runtime_policy::RuntimeProfile::LocalYolo;
         policy.approval_policy = ironclaw_host_api::runtime_policy::ApprovalPolicy::Minimal;
         policy
-    }
-
-    fn notion_mcp_trust_decision() -> TrustDecision {
-        TrustDecision {
-            effective_trust: EffectiveTrustClass::user_trusted(),
-            authority_ceiling: AuthorityCeiling {
-                allowed_effects: notion_mcp_allowed_effects(),
-                max_resource_ceiling: None,
-            },
-            provenance: TrustProvenance::Default,
-            evaluated_at: chrono::Utc::now(),
-        }
     }
 
     fn skill_md(name: &str, description: &str, prompt: &str) -> String {

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -3,7 +3,6 @@ use std::{
     time::Duration,
 };
 
-use chrono::Utc;
 use ironclaw_approvals::{
     ApprovalResolver, AutoApproveSettingInput, AutoApproveSettingStore,
     CapabilityPermissionOverrideStore, DenyApproval, LeaseApproval, PersistentApprovalAction,
@@ -22,7 +21,6 @@ use ironclaw_host_runtime::{
     RuntimeCapabilityResumeRequest, RuntimeFailureKind, SHELL_CAPABILITY_ID,
 };
 use ironclaw_run_state::{ApprovalRequestStore, ApprovalStatus};
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 use super::*;
 use crate::local_dev_capability_policy::local_dev_one_shot_lease_approval;
@@ -58,7 +56,6 @@ async fn local_dev_ask_destructive_shell_invocation_blocks_then_resumes_with_one
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("shell invocation returns approval gate");
@@ -84,7 +81,6 @@ async fn local_dev_ask_destructive_shell_invocation_blocks_then_resumes_with_one
             capability_id,
             estimate,
             input,
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("approved shell invocation resumes");
@@ -133,7 +129,6 @@ async fn local_dev_approved_shell_uses_injected_tenant_sandbox_process_port() {
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("shell invocation returns approval gate");
@@ -148,7 +143,6 @@ async fn local_dev_approved_shell_uses_injected_tenant_sandbox_process_port() {
             capability_id,
             estimate,
             input,
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("approved shell invocation resumes");
@@ -204,7 +198,6 @@ async fn local_dev_yolo_shell_invocation_asks_when_global_auto_approve_is_off() 
             capability_id.clone(),
             ResourceEstimate::default(),
             serde_json::json!({"command": "echo yolo"}),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("local-dev-yolo shell invocation resolves");
@@ -261,7 +254,6 @@ async fn local_dev_auto_approve_setting_update_skips_next_shell_gate() {
             capability_id,
             ResourceEstimate::default(),
             serde_json::json!({"command": "echo auto approve"}),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("auto-approved shell invocation succeeds");
@@ -307,7 +299,6 @@ async fn local_dev_default_allow_echo_auto_approves_when_global_unset() {
             capability_id,
             ResourceEstimate::default(),
             serde_json::json!({"message": "auto approve echo"}),
-            trust_decision(echo_spawn_allowed_effects()),
         ))
         .await
         .expect("echo invocation resolves"); // safety: test-only capability invocation assertion.
@@ -350,7 +341,6 @@ async fn local_dev_default_allow_echo_asks_when_global_auto_approve_is_off() {
             capability_id.clone(),
             ResourceEstimate::default(),
             serde_json::json!({"message": "ask for echo"}),
-            trust_decision(echo_spawn_allowed_effects()),
         ))
         .await
         .expect("echo invocation resolves");
@@ -407,7 +397,6 @@ async fn local_dev_ask_each_time_echo_approval_resume_uses_one_shot_lease() {
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(echo_dispatch_allowed_effects()),
         ))
         .await
         .expect("echo invocation resolves");
@@ -429,7 +418,6 @@ async fn local_dev_ask_each_time_echo_approval_resume_uses_one_shot_lease() {
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(echo_dispatch_allowed_effects()),
         ))
         .await
         .expect("pending echo approval resume resolves to non-completion");
@@ -481,7 +469,6 @@ async fn local_dev_ask_each_time_echo_approval_resume_uses_one_shot_lease() {
             capability_id,
             estimate,
             input,
-            trust_decision(echo_dispatch_allowed_effects()),
         ))
         .await
         .expect("approved echo invocation resumes");
@@ -547,7 +534,6 @@ async fn local_dev_legacy_persistent_echo_grant_does_not_override_global_off() {
             capability_id.clone(),
             ResourceEstimate::default(),
             serde_json::json!({"message": "ask despite legacy grant"}),
-            trust_decision(echo_spawn_allowed_effects()),
         ))
         .await
         .expect("echo invocation resolves");
@@ -619,7 +605,6 @@ async fn local_dev_settings_page_always_allow_echo_overrides_global_off() {
             capability_id,
             ResourceEstimate::default(),
             serde_json::json!({"message": "skip approval for echo"}),
-            trust_decision(echo_spawn_allowed_effects()),
         ))
         .await
         .expect("settings persistent echo invocation succeeds");
@@ -691,7 +676,6 @@ async fn local_dev_settings_page_always_allow_policy_skips_next_shell_gate() {
             capability_id,
             ResourceEstimate::default(),
             serde_json::json!({"command": "echo settings allow"}),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("settings persistent approval shell invocation succeeds");
@@ -751,7 +735,6 @@ async fn local_dev_yolo_explicit_ask_each_time_still_requires_approval_gate() {
             capability_id.clone(),
             ResourceEstimate::default(),
             serde_json::json!({"command": "echo yolo ask"}),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("local-dev-yolo shell invocation resolves");
@@ -821,7 +804,6 @@ async fn local_dev_denied_shell_approval_does_not_issue_resume_lease() {
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("shell invocation returns approval gate");
@@ -851,7 +833,6 @@ async fn local_dev_denied_shell_approval_does_not_issue_resume_lease() {
             capability_id,
             estimate,
             input,
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("denied shell invocation returns failed outcome");
@@ -997,18 +978,6 @@ fn echo_dispatch_lease_approval() -> LeaseApproval {
     })
 }
 
-fn trust_decision(allowed_effects: Vec<EffectKind>) -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects,
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::AdminConfig,
-        evaluated_at: Utc::now(),
-    }
-}
-
 fn tenant_sandbox_process_policy() -> ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy {
     let mut policy = local_dev_policy();
     policy.process_backend = ironclaw_host_api::runtime_policy::ProcessBackendKind::TenantSandbox;
@@ -1064,7 +1033,6 @@ async fn local_dev_minimal_policy_shell_invocation_asks_when_global_auto_approve
             capability_id.clone(),
             ResourceEstimate::default(),
             serde_json::json!({"command": "echo minimal"}),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("minimal shell invocation resolves"); // safety: test-only helper in #[cfg(test)] module.
@@ -1107,7 +1075,6 @@ async fn local_dev_minimal_with_enterprise_profile_still_gates_shell() {
             capability_id,
             ResourceEstimate::default(),
             serde_json::json!({"command": "echo ent"}),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("enterprise minimal shell invocation resolves"); // safety: test-only helper in #[cfg(test)] module.
@@ -1159,7 +1126,6 @@ async fn local_dev_ask_destructive_spawn_capability_blocks_then_resumes() {
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("spawn invocation returns approval gate"); // safety: test-only helper in #[cfg(test)] module.
@@ -1188,7 +1154,6 @@ async fn local_dev_ask_destructive_spawn_capability_blocks_then_resumes() {
             capability_id,
             estimate,
             input,
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("approved spawn invocation resumes"); // safety: test-only helper in #[cfg(test)] module.
@@ -1233,7 +1198,6 @@ async fn local_dev_ask_destructive_spawn_dispatch_only_capability_requires_appro
             capability_id,
             ResourceEstimate::default(),
             serde_json::json!({"message": "spawn echo"}),
-            trust_decision(echo_spawn_allowed_effects()),
         ))
         .await
         .expect("spawn invocation resolves"); // safety: test-only helper in #[cfg(test)] module.
@@ -1320,7 +1284,6 @@ async fn local_dev_ungranted_capability_returns_denied_not_approval_gate() {
             capability_id,
             ResourceEstimate::default(),
             serde_json::json!({}),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("invocation completes (with failure)"); // safety: test-only helper in #[cfg(test)] module.
@@ -1362,7 +1325,6 @@ async fn local_dev_one_shot_lease_regates_on_second_invocation() {
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("first invocation"); // safety: test-only helper in #[cfg(test)] module.
@@ -1379,7 +1341,6 @@ async fn local_dev_one_shot_lease_regates_on_second_invocation() {
             capability_id.clone(),
             estimate.clone(),
             input.clone(),
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("first resume"); // safety: test-only helper in #[cfg(test)] module.
@@ -1398,7 +1359,6 @@ async fn local_dev_one_shot_lease_regates_on_second_invocation() {
             capability_id,
             estimate,
             input,
-            trust_decision(shell_allowed_effects()),
         ))
         .await
         .expect("second invocation"); // safety: test-only helper in #[cfg(test)] module.

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -440,7 +440,6 @@ async fn assert_process_capabilities_unavailable_for_processless_runtime(
             CapabilityId::new(SHELL_CAPABILITY_ID).unwrap(),
             ResourceEstimate::default(),
             json!({"command": "echo should-not-run"}),
-            production_builtin_trust_decision(),
         ))
         .await
         .expect("shell invocation returns an outcome");
@@ -457,7 +456,6 @@ async fn assert_process_capabilities_unavailable_for_processless_runtime(
             CapabilityId::new(SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
             ResourceEstimate::default(),
             json!({}),
-            production_builtin_trust_decision(),
         ))
         .await
         .expect("spawn_subagent invocation returns an outcome");
@@ -500,7 +498,6 @@ async fn invoke_trigger_management(
             CapabilityId::new(capability).unwrap(),
             ResourceEstimate::default(),
             input,
-            trigger_management_trust_decision(),
         ))
         .await
         .expect("trigger management capability invoke");
@@ -537,19 +534,6 @@ fn trigger_management_execution_context() -> ExecutionContext {
         MountView::default(),
     )
     .unwrap()
-}
-
-#[cfg(feature = "libsql")]
-fn trigger_management_trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::ExternalWrite],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::AdminConfig,
-        evaluated_at: Utc::now(),
-    }
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -38,7 +38,6 @@ use ironclaw_triggers::{
     TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerId, TriggerPollerWorkerConfig, TriggerRecord,
     TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use ironclaw_turns::run_profile::{
     LoopCapabilityPort, ProviderToolCall, RegisterProviderToolCallRequest,
 };
@@ -487,7 +486,6 @@ async fn invoke_trigger_create(runtime: &RebornRuntime, input: Value) -> Value {
             CapabilityId::new(TRIGGER_CREATE_CAPABILITY_ID).expect("capability id"),
             ResourceEstimate::default(),
             input,
-            trigger_management_trust_decision(),
         ))
         .await
         .expect("trigger create invocation completes");
@@ -537,18 +535,6 @@ fn trigger_management_execution_context() -> ExecutionContext {
     context.resource_scope.agent_id = Some(agent_id);
     context.resource_scope.project_id = None;
     context
-}
-
-fn trigger_management_trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::ExternalWrite],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::AdminConfig,
-        evaluated_at: Utc::now(),
-    }
 }
 
 #[tokio::test]

--- a/tests/integration/support/doubles/parking_host_runtime.rs
+++ b/tests/integration/support/doubles/parking_host_runtime.rs
@@ -184,12 +184,10 @@ impl HostRuntime for ParkingHostRuntime {
 mod tests {
     use std::time::Duration;
 
-    use chrono::Utc;
     use ironclaw_host_api::{
-        CapabilityId, CapabilitySet, EffectKind, ExecutionContext, ExtensionId, MountView,
-        ResourceEstimate, RuntimeKind, TrustClass, UserId,
+        CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, MountView, ResourceEstimate,
+        RuntimeKind, TrustClass, UserId,
     };
-    use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
     use serde_json::Value;
 
     use super::*;
@@ -277,15 +275,6 @@ mod tests {
             CapabilityId::new("echo.say").unwrap(),
             ResourceEstimate::default(),
             Value::Null,
-            TrustDecision {
-                effective_trust: EffectiveTrustClass::user_trusted(),
-                authority_ceiling: AuthorityCeiling {
-                    allowed_effects: vec![EffectKind::DispatchCapability],
-                    max_resource_ceiling: None,
-                },
-                provenance: TrustProvenance::Default,
-                evaluated_at: Utc::now(),
-            },
         )
     }
 

--- a/tests/reborn_qa_routines.rs
+++ b/tests/reborn_qa_routines.rs
@@ -50,7 +50,6 @@ use ironclaw_reborn_composition::{
     local_runtime_build_input_with_options,
 };
 use ironclaw_triggers::{TriggerId, TriggerPollerWorkerConfig, TriggerRunStatus, TriggerState};
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use ironclaw_turns::TurnStatus;
 use parity_qa_support::binary_e2e::RebornBinaryE2EHarness;
 use parity_qa_support::model_replay::{
@@ -616,7 +615,6 @@ async fn invoke_trigger_create(runtime: &RebornRuntime, input: Value) -> Value {
             CapabilityId::new(TRIGGER_CREATE_CAPABILITY_ID).expect("capability id"),
             ResourceEstimate::default(),
             input,
-            trigger_management_trust_decision(),
         ))
         .await
         .expect("trigger create invocation completes");
@@ -666,16 +664,4 @@ fn trigger_management_execution_context() -> ExecutionContext {
     context.resource_scope.agent_id = Some(agent_id);
     context.resource_scope.project_id = None;
     context
-}
-
-fn trigger_management_trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::user_trusted(),
-        authority_ceiling: AuthorityCeiling {
-            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::ExternalWrite],
-            max_resource_ceiling: None,
-        },
-        provenance: TrustProvenance::AdminConfig,
-        evaluated_at: Utc::now(),
-    }
 }


### PR DESCRIPTION
## What
Deletes the provably-**dead** `trust_decision` field from the `RuntimeCapability*Request` family (arch-simplification §1.1 mechanism 3 — "dead fields copied at every hop"). `DefaultHostRuntime` discarded the caller-supplied value (`_caller_trust_decision`) and evaluated host-owned trust itself; **zero code read it**.

Removed from all three request types + constructors: `RuntimeCapabilityRequest`, `RuntimeCapabilityResumeRequest`, `RuntimeCapabilityAuthResumeRequest`. Fixed ~174 `::new(...)` callers across `host_runtime` tests, `ironclaw_loop_host`, and `ironclaw_reborn_composition`, plus the `production.rs` destructures, and removed the now-dead trust test helpers + cascaded unused imports.

## Security: a structural upgrade
The deleted test `production_runtime_ignores_caller_supplied_privileged_trust_decision` verified *at runtime* that a **forged** caller trust decision was ignored. With the field gone there is no caller trust to forge — the anti-privilege-escalation property is now enforced **structurally** (no field) instead of by a runtime check. Net **−537 lines**.

## Scope
Standalone off `main`, **no vocabulary dependency** — independent of the C.1–C.7 stack. First concrete DTO-shrink of the §9 collapse.

## Checks
`cargo test -p ironclaw_host_runtime` ~990 pass · `clippy --tests -D warnings` clean on `host_runtime` + `reborn_composition` · `loop_host` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)