### PR TITLE
refactor: deployment mode as config data — DeploymentConfig + LocalDev* family collapse (Slice B)

### DIFF
--- a/.claude/skills/ironclaw-reborn-architecture-review/references/worked-examples.md
+++ b/.claude/skills/ironclaw-reborn-architecture-review/references/worked-examples.md
@@ -29,7 +29,7 @@ Why it's wrong: one production impl means the trait encodes no variation — it'
 | Exemplar | Variation behind it | Re-verify |
 | --- | --- | --- |
 | `RootFilesystem` (`crates/ironclaw_filesystem/src/root.rs`) | local / postgres / libsql / in-memory / composite / HSM / memory-adapter | `rg -n "impl RootFilesystem for" crates/ironclaw_filesystem/src crates/ironclaw_memory_native/src` |
-| `PolicySource` (`crates/ironclaw_trust/src/sources.rs`) | AdminConfig / BundledRegistry / LocalDevOverride / SignedRegistry | `grep -n "impl PolicySource" crates/ironclaw_trust/src/sources.rs` |
+| `PolicySource` (`crates/ironclaw_trust/src/sources.rs`) | AdminConfig / BundledRegistry / DevTrustOverride / SignedRegistry | `grep -n "impl PolicySource" crates/ironclaw_trust/src/sources.rs` |
 | `EmbeddingProvider` (`crates/ironclaw_embeddings/src/provider.rs`) | OpenAI / NearAI / Ollama / Bedrock + caching decorator (v1-only shape example) | `rg -n "impl EmbeddingProvider for (OpenAi|NearAi|Ollama|Bedrock|Cached)" crates/ironclaw_embeddings/src` |
 
 **GOOD — one impl but a real boundary** (the acceptable exception): `SkillInferencePort` (`crates/ironclaw_skill_learning/src/lib.rs`) has one production adapter — supplied by composition — because the port exists to keep LLM/runtime deps *out* of a pure-domain crate. The justification is verifiable in Cargo.toml (its only workspace/domain dependency is `ironclaw_skills`; it has no LLM/runtime/filesystem deps), not in a comment.

--- a/crates/ironclaw_architecture/tests/reborn_composition_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_composition_boundaries.rs
@@ -148,12 +148,12 @@ fn extension_host_cluster_stays_internal() {
         "extension_host must not become public"
     );
     assert!(
-        has_module_decl(&lib, "mod local_dev_capability_policy;"),
-        "local_dev_capability_policy is runtime-profile policy and must stay at the crate root"
+        has_module_decl(&lib, "mod builtin_capability_policy;"),
+        "builtin_capability_policy is runtime-profile policy and must stay at the crate root"
     );
     assert!(
-        !extension_host.contains("local_dev_capability_policy"),
-        "local_dev_capability_policy must not be dragged into extension_host"
+        !extension_host.contains("builtin_capability_policy"),
+        "builtin_capability_policy must not be dragged into extension_host"
     );
 
     for module in EXTENSION_HOST_INTERNAL_MODULES {

--- a/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
@@ -127,15 +127,12 @@ const FROZEN_OTHER_MODE_TYPES: &[&str] = &[
     "RebornLocalExtensionManagementPort",
     "RebornLocalLifecycleFacade",
     "RebornLocalRuntimeIdentity",
-    "RebornLocalRuntimeServices",
     "RebornLocalServiceLifecycle",
     "RebornLocalSkillManagementError",
     "RebornLocalSkillManagementPort",
-    //   mid-name LocalDev (the sibling ratchet owns only the LocalDev prefix):
-    //     Slice-B family, shrinks with the LocalDev* collapse:
-    "RebornLocalDevApprovalTestParts",
-    "RefreshingLocalDevCapabilityPortConfig",
-    "RefreshingLocalDevCapabilityPortTestParts",
+    //   mid-name LocalDev entries: none — cleared by the DeploymentConfig
+    //     refactor (Slice B); the sibling ratchet's empty allowlist plus
+    //     `contains_mode_term` here keep new ones out.
 ];
 
 #[test]

--- a/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
@@ -127,8 +127,6 @@ const FROZEN_OTHER_MODE_TYPES: &[&str] = &[
     "RebornLocalExtensionManagementPort",
     "RebornLocalLifecycleFacade",
     "RebornLocalRuntimeIdentity",
-    "RebornLocalRuntimeProfileError",
-    "RebornLocalRuntimeProfileOptions",
     "RebornLocalRuntimeServices",
     "RebornLocalServiceLifecycle",
     "RebornLocalSkillManagementError",

--- a/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_localdev_typename_ratchet.rs
@@ -56,35 +56,13 @@ fn is_localdev_type(ident: &str) -> bool {
 /// leak that Slice B removes by resolving mode to a `DeploymentConfig` value.
 /// Remove an entry in the same PR that deletes its type; never add one.
 const FROZEN_LOCALDEV_TYPES: &[&str] = &[
-    "LocalDevActiveExtensionAuthorityForTest",
-    "LocalDevApprovalDefaultsPolicy",
-    "LocalDevApprovalGatePolicy",
-    "LocalDevApprovalLeaseTermsProvider",
-    "LocalDevApprovalPolicyAction",
-    "LocalDevApprovalRequestStore",
-    "LocalDevAuthInteractionReadModel",
-    "LocalDevAutoApproveSettingStore",
-    "LocalDevCapabilityGrantPolicy",
-    "LocalDevCapabilityLeaseStore",
-    "LocalDevCapabilityPolicy",
-    "LocalDevCapabilityPolicyError",
-    "LocalDevCapabilityWiring",
-    "LocalDevConstraintPolicy",
-    "LocalDevDurableBackend",
-    "LocalDevExtensionSurface",
-    "LocalDevExtensionSurfaceSource",
-    "LocalDevMountProfile",
-    "LocalDevNetworkProfile",
-    "LocalDevOverride",
-    "LocalDevPersistentApprovalPolicyStore",
-    "LocalDevProviderPolicy",
-    "LocalDevSelectableSkillContextSource",
-    "LocalDevSyntheticCapability",
-    "LocalDevSyntheticCapabilityDescriptor",
-    "LocalDevSyntheticCapabilityHandler",
-    "LocalDevSyntheticCapabilityInvocation",
-    "LocalDevToolPermissionOverrideStore",
-    "LocalDevTurnStateStore",
+    // EMPTY — the §4.4 definition of done for this axis, reached by the
+    // DeploymentConfig refactor: deployment mode is one config value
+    // (`ironclaw_reborn_composition::deployment::DeploymentConfig`) and the
+    // former `LocalDev*` shadow-runtime types are renamed to the shared
+    // mechanism they always were (Builtin*/Composed*/Staged*/Synthetic*/
+    // Snapshot* families). Any new `LocalDev*` type definition fails this
+    // ratchet outright.
 ];
 
 #[test]

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -78,7 +78,7 @@ async fn production_wiring_reports_missing_persistent_approval_policies() {
 // production wiring. `in_memory_backed_persistent_approval_policy_store()` returns
 // `FilesystemPersistentApprovalPolicyStore<InMemoryBackend>` — the exact concrete
 // type the no-durable-features composition wires (factory.rs
-// `LocalDevPersistentApprovalPolicyStore`), so this guards the real shape, not a
+// `ComposedPersistentApprovalPolicyStore`), so this guards the real shape, not a
 // synthetic one. The durable libSQL/Postgres monomorphizations are distinct types
 // and fall through to `ProductionCandidate`.
 #[tokio::test]

--- a/crates/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/ironclaw_loop_host/src/capability_port.rs
@@ -65,7 +65,7 @@ const PROVIDER_TOOL_CALL_INPUT_REF_PREFIX: &str = "input:provider-tool-";
 /// **Input-only.** This layer stages completed outcomes through
 /// [`LoopCapabilityResultWriter`], not through the port, so it does not observe
 /// results: result events belong to whichever result-writer the composition
-/// installs (e.g. reborn's `LocalDevCapabilityIo`), keyed back to `call_id`.
+/// installs (e.g. reborn's `StagedCapabilityIo`), keyed back to `call_id`.
 /// Keeping the substrate observer input-only avoids advertising a result
 /// callback this layer would never fire.
 ///

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -19,8 +19,8 @@ use ironclaw_reborn_composition::host_api::{AgentId, TenantId};
 use ironclaw_reborn_composition::hosted_single_tenant_runtime_policy;
 use ironclaw_reborn_composition::{
     CredentialRefreshSettings, OAuthClientConfig, OperatorLogLayer, PollSettings, RebornBuildInput,
-    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntimeIdentity,
-    RebornRuntimeInput, TurnRunnerSettings, build_reborn_runtime,
+    RebornCompositionProfile, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProfileOptions, TurnRunnerSettings, build_reborn_runtime,
     local_runtime_build_input_with_options, nearai_mcp_bootstrap_config_from_env,
 };
 #[cfg(feature = "webui-v2-beta")]

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -19,7 +19,7 @@ use ironclaw_reborn_composition::host_api::{AgentId, TenantId};
 use ironclaw_reborn_composition::hosted_single_tenant_runtime_policy;
 use ironclaw_reborn_composition::{
     CredentialRefreshSettings, OAuthClientConfig, OperatorLogLayer, PollSettings, RebornBuildInput,
-    RebornCompositionProfile, RebornLocalRuntimeProfileOptions, RebornRuntimeIdentity,
+    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntimeIdentity,
     RebornRuntimeInput, TurnRunnerSettings, build_reborn_runtime,
     local_runtime_build_input_with_options, nearai_mcp_bootstrap_config_from_env,
 };
@@ -696,7 +696,7 @@ fn build_standalone_local_runtime_services_input(
         composition_profile(profile),
         owner_id,
         local_runtime_root,
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access: options.confirm_host_access,
         },
     )

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -4,7 +4,7 @@
 - Expose facade-shaped handles only: `HostRuntime`, `TurnCoordinator`, product-auth `RebornProductAuthServices`, WebUI `RebornServicesApi`, readiness.
 - Keep lower substrate handles private to factories and owning crates.
 - Substrate handles MAY be exposed via `#[cfg(any(test, feature = "test-support"))]` pub accessors on `RebornRuntime` when downstream integration tests need to drive production-shape state the facade doesn't yet surface (e.g. seeding `TriggerRecord` rows, `pair_external_actor` calls). These seams ship zero bytes in production binaries. New test-support accessors must carry a doc-comment naming the production call site they mirror and an explicit note that the handle is for tests only.
-- Outbound state stores are composition-owned via `RebornLocalRuntimeServices`; do not construct `FilesystemOutboundStateStore` in consumer modules (lint-enforced via `clippy::disallowed-methods`).
+- Outbound state stores are composition-owned via `RebornRuntimeSubstrate`; do not construct `FilesystemOutboundStateStore` in consumer modules (lint-enforced via `clippy::disallowed-methods`).
 - Do not depend on the root `ironclaw` crate or `src/` modules.
 - Do not add legacy bridge modes here until an accepted migration contract exists.
 - Do not route live v1/product traffic here; callers must opt in through explicit Reborn adapters.

--- a/crates/ironclaw_reborn_composition/src/approval_test_support.rs
+++ b/crates/ironclaw_reborn_composition/src/approval_test_support.rs
@@ -7,10 +7,10 @@ use ironclaw_host_runtime::{
 use ironclaw_run_state::ApprovalRequestStore;
 use ironclaw_trust::TrustDecision;
 
-use crate::local_dev_capability_policy::{
-    LocalDevApprovalPolicyAction, LocalDevCapabilityPolicyError, local_dev_one_shot_lease_approval,
+use crate::builtin_capability_policy::{
+    BuiltinApprovalPolicyAction, BuiltinCapabilityPolicyError, builtin_one_shot_lease_approval,
 };
-use crate::{RebornServices, factory::RebornLocalRuntimeServices};
+use crate::{RebornServices, factory::RebornRuntimeSubstrate};
 
 /// Turn the global auto-approve switch off for `context`'s actor scope.
 /// Global auto-approve defaults ON, so any test exercising the per-tool approval
@@ -18,7 +18,7 @@ use crate::{RebornServices, factory::RebornLocalRuntimeServices};
 /// integration-test and root-crate binaries keep their own copies (they cannot
 /// see this crate-internal helper).
 pub(crate) async fn disable_global_auto_approve(
-    local_runtime: &RebornLocalRuntimeServices,
+    local_runtime: &RebornRuntimeSubstrate,
     context: &ExecutionContext,
 ) {
     local_runtime
@@ -83,7 +83,7 @@ pub(crate) async fn invoke_with_local_dev_approval(
                 .await
                 .expect("local-dev approval record read") // safety: test-only helper in #[cfg(test)] module.
                 .expect("local-dev approval request persisted"); // safety: test-only helper in #[cfg(test)] module.
-            let policy_action = LocalDevApprovalPolicyAction::from_host_action(
+            let policy_action = BuiltinApprovalPolicyAction::from_host_action(
                 approval_record.request.action.as_ref(),
             )
             .expect("dispatch or spawn action in local-dev approval"); // safety: test-only approval helper compiled only under #[cfg(test)].
@@ -99,7 +99,7 @@ pub(crate) async fn invoke_with_local_dev_approval(
                 &local_runtime.system_extensions_lifecycle_mounts,
             ) {
                 Ok(approval) => approval,
-                Err(LocalDevCapabilityPolicyError::MissingGrant { .. }) => {
+                Err(BuiltinCapabilityPolicyError::MissingGrant { .. }) => {
                     lease_approval_from_context(&context, &capability)
                 }
                 Err(error) => {
@@ -153,5 +153,5 @@ fn lease_approval_from_context(
         .expect("matching test capability grant") // safety: test-only helper in #[cfg(test)] module.
         .constraints
         .clone();
-    local_dev_one_shot_lease_approval(constraints)
+    builtin_one_shot_lease_approval(constraints)
 }

--- a/crates/ironclaw_reborn_composition/src/builtin_capability_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/builtin_capability_policy.rs
@@ -14,10 +14,10 @@ use thiserror::Error;
 
 use crate::runtime_profile_approval_policy::RuntimeProfileApprovalGateEffectSets;
 
-const LOCAL_DEV_CAPABILITY_POLICY_TOML: &str = include_str!("local_dev_capability_policy.toml");
+const BUILTIN_CAPABILITY_POLICY_TOML: &str = include_str!("builtin_capability_policy.toml");
 
 #[derive(Debug, Error)]
-pub(crate) enum LocalDevCapabilityPolicyError {
+pub(crate) enum BuiltinCapabilityPolicyError {
     #[error("local-dev capability policy TOML is invalid: {0}")]
     InvalidToml(#[from] toml::de::Error),
     #[error("local-dev capability policy has no grants")]
@@ -42,22 +42,22 @@ pub(crate) enum LocalDevCapabilityPolicyError {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LocalDevCapabilityPolicy {
-    pub(crate) provider: LocalDevProviderPolicy,
-    pub(crate) approval_gates: LocalDevApprovalGatePolicy,
-    pub(crate) approval_defaults: LocalDevApprovalDefaultsPolicy,
-    pub(crate) grants: Vec<LocalDevCapabilityGrantPolicy>,
+pub(crate) struct BuiltinCapabilityPolicy {
+    pub(crate) provider: BuiltinProviderPolicy,
+    pub(crate) approval_gates: BuiltinApprovalGatePolicy,
+    pub(crate) approval_defaults: BuiltinApprovalDefaultsPolicy,
+    pub(crate) grants: Vec<BuiltinCapabilityGrantPolicy>,
 }
 
-impl LocalDevCapabilityPolicy {
+impl BuiltinCapabilityPolicy {
     fn grant(
         &self,
         capability: &CapabilityId,
-    ) -> Result<&LocalDevCapabilityGrantPolicy, LocalDevCapabilityPolicyError> {
+    ) -> Result<&BuiltinCapabilityGrantPolicy, BuiltinCapabilityPolicyError> {
         self.grants
             .iter()
             .find(|grant| grant.capability == *capability)
-            .ok_or_else(|| LocalDevCapabilityPolicyError::MissingGrant {
+            .ok_or_else(|| BuiltinCapabilityPolicyError::MissingGrant {
                 capability: capability.clone(),
             })
     }
@@ -70,14 +70,14 @@ impl LocalDevCapabilityPolicy {
     pub(crate) fn skill_management_capability_ids(&self) -> impl Iterator<Item = &CapabilityId> {
         self.grants
             .iter()
-            .filter(|grant| grant.mounts == LocalDevMountProfile::SkillManagement)
+            .filter(|grant| grant.mounts == CapabilityMountProfile::SkillManagement)
             .map(|grant| &grant.capability)
     }
 
     pub(crate) fn memory_capability_ids(&self) -> impl Iterator<Item = &CapabilityId> {
         self.grants
             .iter()
-            .filter(|grant| grant.mounts == LocalDevMountProfile::Memory)
+            .filter(|grant| grant.mounts == CapabilityMountProfile::Memory)
             .map(|grant| &grant.capability)
     }
 
@@ -86,7 +86,7 @@ impl LocalDevCapabilityPolicy {
     ) -> impl Iterator<Item = &CapabilityId> {
         self.grants
             .iter()
-            .filter(|grant| grant.mounts == LocalDevMountProfile::SystemExtensionsLifecycle)
+            .filter(|grant| grant.mounts == CapabilityMountProfile::SystemExtensionsLifecycle)
             .map(|grant| &grant.capability)
     }
 
@@ -126,7 +126,7 @@ impl LocalDevCapabilityPolicy {
         skill_mounts: &MountView,
         memory_mounts: &MountView,
         system_extensions_mounts: &MountView,
-    ) -> Result<GrantConstraints, LocalDevCapabilityPolicyError> {
+    ) -> Result<GrantConstraints, BuiltinCapabilityPolicyError> {
         let grant = self.grant(capability)?;
         Ok(constraint_terms(
             grant,
@@ -140,21 +140,21 @@ impl LocalDevCapabilityPolicy {
 
     pub(crate) fn lease_approval_for(
         &self,
-        action: LocalDevApprovalPolicyAction<'_>,
+        action: BuiltinApprovalPolicyAction<'_>,
         workspace_mounts: &MountView,
         skill_mounts: &MountView,
         memory_mounts: &MountView,
         system_extensions_mounts: &MountView,
-    ) -> Result<LeaseApproval, LocalDevCapabilityPolicyError> {
+    ) -> Result<LeaseApproval, BuiltinCapabilityPolicyError> {
         let constraints = match action {
-            LocalDevApprovalPolicyAction::Dispatch { capability } => self.grant_constraints_for(
+            BuiltinApprovalPolicyAction::Dispatch { capability } => self.grant_constraints_for(
                 capability,
                 workspace_mounts,
                 skill_mounts,
                 memory_mounts,
                 system_extensions_mounts,
             )?,
-            LocalDevApprovalPolicyAction::SpawnCapability { capability } => {
+            BuiltinApprovalPolicyAction::SpawnCapability { capability } => {
                 match self.grant(capability) {
                     Ok(grant) => constraint_terms(
                         grant,
@@ -164,7 +164,7 @@ impl LocalDevCapabilityPolicy {
                         system_extensions_mounts,
                         Some(EffectKind::SpawnProcess),
                     ),
-                    Err(LocalDevCapabilityPolicyError::MissingGrant { .. }) => {
+                    Err(BuiltinCapabilityPolicyError::MissingGrant { .. }) => {
                         tracing::debug!(
                             %capability,
                             "local-dev spawn capability approval is using default lease terms"
@@ -182,7 +182,7 @@ impl LocalDevCapabilityPolicy {
                 }
             }
         };
-        Ok(local_dev_one_shot_lease_approval(constraints))
+        Ok(builtin_one_shot_lease_approval(constraints))
     }
 
     pub(crate) fn approval_gate_effects(&self) -> RuntimeProfileApprovalGateEffectSets {
@@ -197,7 +197,7 @@ impl LocalDevCapabilityPolicy {
     }
 }
 
-pub(crate) fn local_dev_one_shot_lease_approval(constraints: GrantConstraints) -> LeaseApproval {
+pub(crate) fn builtin_one_shot_lease_approval(constraints: GrantConstraints) -> LeaseApproval {
     LeaseApproval {
         issued_by: Principal::HostRuntime,
         constraints: GrantConstraints {
@@ -216,7 +216,7 @@ pub(crate) fn local_dev_one_shot_lease_approval(constraints: GrantConstraints) -
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LocalDevProviderPolicy {
+pub(crate) struct BuiltinProviderPolicy {
     pub(crate) id: PackageId,
     pub(crate) manifest_path: String,
     pub(crate) authority_effects: Vec<EffectKind>,
@@ -224,7 +224,7 @@ pub(crate) struct LocalDevProviderPolicy {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LocalDevApprovalGatePolicy {
+pub(crate) struct BuiltinApprovalGatePolicy {
     pub(crate) ask_writes: Vec<EffectKind>,
     pub(crate) ask_destructive: Vec<EffectKind>,
     #[serde(default)]
@@ -233,30 +233,30 @@ pub(crate) struct LocalDevApprovalGatePolicy {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LocalDevApprovalDefaultsPolicy {
-    pub(crate) spawn_capability: LocalDevConstraintPolicy,
+pub(crate) struct BuiltinApprovalDefaultsPolicy {
+    pub(crate) spawn_capability: BuiltinConstraintPolicy,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LocalDevCapabilityGrantPolicy {
+pub(crate) struct BuiltinCapabilityGrantPolicy {
     pub(crate) capability: CapabilityId,
     pub(crate) effects: Vec<EffectKind>,
-    pub(crate) mounts: LocalDevMountProfile,
-    pub(crate) network: LocalDevNetworkProfile,
+    pub(crate) mounts: CapabilityMountProfile,
+    pub(crate) network: CapabilityNetworkProfile,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LocalDevConstraintPolicy {
+pub(crate) struct BuiltinConstraintPolicy {
     pub(crate) effects: Vec<EffectKind>,
-    pub(crate) mounts: LocalDevMountProfile,
-    pub(crate) network: LocalDevNetworkProfile,
+    pub(crate) mounts: CapabilityMountProfile,
+    pub(crate) network: CapabilityNetworkProfile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum LocalDevMountProfile {
+pub(crate) enum CapabilityMountProfile {
     Workspace,
     Ambient,
     SkillManagement,
@@ -266,18 +266,18 @@ pub(crate) enum LocalDevMountProfile {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum LocalDevNetworkProfile {
+pub(crate) enum CapabilityNetworkProfile {
     Default,
-    LocalDevWildcard,
+    DevWildcard,
 }
 
 #[derive(Clone, Copy)]
-pub(crate) enum LocalDevApprovalPolicyAction<'a> {
+pub(crate) enum BuiltinApprovalPolicyAction<'a> {
     Dispatch { capability: &'a CapabilityId },
     SpawnCapability { capability: &'a CapabilityId },
 }
 
-impl<'a> LocalDevApprovalPolicyAction<'a> {
+impl<'a> BuiltinApprovalPolicyAction<'a> {
     pub(crate) fn from_host_action(action: &'a Action) -> Option<Self> {
         match action {
             Action::Dispatch { capability, .. } => Some(Self::Dispatch { capability }),
@@ -303,68 +303,68 @@ impl<'a> LocalDevApprovalPolicyAction<'a> {
     }
 }
 
-trait LocalDevConstraintSource {
+trait BuiltinConstraintSource {
     fn effects(&self) -> &[EffectKind];
-    fn mounts(&self) -> LocalDevMountProfile;
-    fn network(&self) -> LocalDevNetworkProfile;
+    fn mounts(&self) -> CapabilityMountProfile;
+    fn network(&self) -> CapabilityNetworkProfile;
 }
 
-impl LocalDevConstraintSource for LocalDevCapabilityGrantPolicy {
+impl BuiltinConstraintSource for BuiltinCapabilityGrantPolicy {
     fn effects(&self) -> &[EffectKind] {
         &self.effects
     }
 
-    fn mounts(&self) -> LocalDevMountProfile {
+    fn mounts(&self) -> CapabilityMountProfile {
         self.mounts
     }
 
-    fn network(&self) -> LocalDevNetworkProfile {
+    fn network(&self) -> CapabilityNetworkProfile {
         self.network
     }
 }
 
-impl LocalDevConstraintSource for LocalDevConstraintPolicy {
+impl BuiltinConstraintSource for BuiltinConstraintPolicy {
     fn effects(&self) -> &[EffectKind] {
         &self.effects
     }
 
-    fn mounts(&self) -> LocalDevMountProfile {
+    fn mounts(&self) -> CapabilityMountProfile {
         self.mounts
     }
 
-    fn network(&self) -> LocalDevNetworkProfile {
+    fn network(&self) -> CapabilityNetworkProfile {
         self.network
     }
 }
 
-pub(crate) fn local_dev_capability_policy()
--> Result<LocalDevCapabilityPolicy, LocalDevCapabilityPolicyError> {
-    static POLICY: OnceLock<Result<LocalDevCapabilityPolicy, String>> = OnceLock::new();
+pub(crate) fn builtin_capability_policy()
+-> Result<BuiltinCapabilityPolicy, BuiltinCapabilityPolicyError> {
+    static POLICY: OnceLock<Result<BuiltinCapabilityPolicy, String>> = OnceLock::new();
     POLICY
         .get_or_init(|| {
-            parse_local_dev_capability_policy(LOCAL_DEV_CAPABILITY_POLICY_TOML)
+            parse_builtin_capability_policy(BUILTIN_CAPABILITY_POLICY_TOML)
                 .map_err(|error| error.to_string())
         })
         .clone()
-        .map_err(|reason| LocalDevCapabilityPolicyError::CachedInvalid { reason })
+        .map_err(|reason| BuiltinCapabilityPolicyError::CachedInvalid { reason })
 }
 
-fn parse_local_dev_capability_policy(
+fn parse_builtin_capability_policy(
     input: &str,
-) -> Result<LocalDevCapabilityPolicy, LocalDevCapabilityPolicyError> {
-    let policy: LocalDevCapabilityPolicy = toml::from_str(input)?;
+) -> Result<BuiltinCapabilityPolicy, BuiltinCapabilityPolicyError> {
+    let policy: BuiltinCapabilityPolicy = toml::from_str(input)?;
     validate_policy(&policy)?;
     Ok(policy)
 }
 
-fn validate_policy(policy: &LocalDevCapabilityPolicy) -> Result<(), LocalDevCapabilityPolicyError> {
+fn validate_policy(policy: &BuiltinCapabilityPolicy) -> Result<(), BuiltinCapabilityPolicyError> {
     ExtensionId::new(policy.provider.id.as_str())
-        .map_err(LocalDevCapabilityPolicyError::InvalidProviderExtensionId)?;
+        .map_err(BuiltinCapabilityPolicyError::InvalidProviderExtensionId)?;
     if policy.provider.manifest_path.trim().is_empty() {
-        return Err(LocalDevCapabilityPolicyError::EmptyProviderManifestPath);
+        return Err(BuiltinCapabilityPolicyError::EmptyProviderManifestPath);
     }
     if !policy.provider.manifest_path.starts_with('/') {
-        return Err(LocalDevCapabilityPolicyError::NonAbsoluteProviderManifestPath);
+        return Err(BuiltinCapabilityPolicyError::NonAbsoluteProviderManifestPath);
     }
     validate_effects(
         "provider authority_effects",
@@ -383,12 +383,12 @@ fn validate_policy(policy: &LocalDevCapabilityPolicy) -> Result<(), LocalDevCapa
         &policy.approval_defaults.spawn_capability.effects,
     )?;
     if policy.grants.is_empty() {
-        return Err(LocalDevCapabilityPolicyError::EmptyGrants);
+        return Err(BuiltinCapabilityPolicyError::EmptyGrants);
     }
     let mut seen = BTreeSet::new();
     for grant in &policy.grants {
         if !seen.insert(grant.capability.clone()) {
-            return Err(LocalDevCapabilityPolicyError::DuplicateGrant {
+            return Err(BuiltinCapabilityPolicyError::DuplicateGrant {
                 capability: grant.capability.clone(),
             });
         }
@@ -403,16 +403,16 @@ fn validate_policy(policy: &LocalDevCapabilityPolicy) -> Result<(), LocalDevCapa
 fn validate_effects(
     target: &str,
     effects: &[EffectKind],
-) -> Result<(), LocalDevCapabilityPolicyError> {
+) -> Result<(), BuiltinCapabilityPolicyError> {
     if effects.is_empty() {
-        return Err(LocalDevCapabilityPolicyError::EmptyEffects {
+        return Err(BuiltinCapabilityPolicyError::EmptyEffects {
             target: target.to_string(),
         });
     }
     let mut seen = HashSet::new();
     for effect in effects {
         if !seen.insert(*effect) {
-            return Err(LocalDevCapabilityPolicyError::DuplicateEffect {
+            return Err(BuiltinCapabilityPolicyError::DuplicateEffect {
                 target: target.to_string(),
                 effect: *effect,
             });
@@ -422,7 +422,7 @@ fn validate_effects(
 }
 
 fn constraint_terms(
-    source: &impl LocalDevConstraintSource,
+    source: &impl BuiltinConstraintSource,
     workspace_mounts: &MountView,
     skill_mounts: &MountView,
     memory_mounts: &MountView,
@@ -430,15 +430,15 @@ fn constraint_terms(
     required_effect: Option<EffectKind>,
 ) -> GrantConstraints {
     let mounts = match source.mounts() {
-        LocalDevMountProfile::Workspace => workspace_mounts.clone(),
-        LocalDevMountProfile::Ambient => MountView::default(),
-        LocalDevMountProfile::SkillManagement => skill_mounts.clone(),
-        LocalDevMountProfile::Memory => memory_mounts.clone(),
-        LocalDevMountProfile::SystemExtensionsLifecycle => system_extensions_mounts.clone(),
+        CapabilityMountProfile::Workspace => workspace_mounts.clone(),
+        CapabilityMountProfile::Ambient => MountView::default(),
+        CapabilityMountProfile::SkillManagement => skill_mounts.clone(),
+        CapabilityMountProfile::Memory => memory_mounts.clone(),
+        CapabilityMountProfile::SystemExtensionsLifecycle => system_extensions_mounts.clone(),
     };
     let network = match source.network() {
-        LocalDevNetworkProfile::Default => NetworkPolicy::default(),
-        LocalDevNetworkProfile::LocalDevWildcard => local_dev_wildcard_network_policy(),
+        CapabilityNetworkProfile::Default => NetworkPolicy::default(),
+        CapabilityNetworkProfile::DevWildcard => dev_wildcard_network_policy(),
     };
     let mut allowed_effects = source.effects().to_vec();
     if let Some(effect) = required_effect
@@ -457,7 +457,7 @@ fn constraint_terms(
     }
 }
 
-pub(crate) fn local_dev_wildcard_network_policy() -> NetworkPolicy {
+pub(crate) fn dev_wildcard_network_policy() -> NetworkPolicy {
     NetworkPolicy {
         allowed_targets: vec![NetworkTargetPattern {
             scheme: None,
@@ -478,8 +478,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bundled_local_dev_capability_policy_parses() {
-        let policy = local_dev_capability_policy().expect("policy parses");
+    fn bundled_builtin_capability_policy_parses() {
+        let policy = builtin_capability_policy().expect("policy parses");
 
         assert_eq!(policy.provider.id.as_str(), "builtin");
         assert_eq!(
@@ -537,11 +537,11 @@ mod tests {
         );
         assert_eq!(
             policy.approval_defaults.spawn_capability.mounts,
-            LocalDevMountProfile::Workspace
+            CapabilityMountProfile::Workspace
         );
         assert_eq!(
             policy.approval_defaults.spawn_capability.network,
-            LocalDevNetworkProfile::Default
+            CapabilityNetworkProfile::Default
         );
         assert!(
             policy
@@ -601,10 +601,10 @@ mod tests {
                 EffectKind::ExternalWrite,
             ]
         );
-        assert_eq!(onboard.mounts, LocalDevMountProfile::Ambient);
+        assert_eq!(onboard.mounts, CapabilityMountProfile::Ambient);
         // Onboarding posts to an operator-chosen invite origin, so it needs the
         // wildcard egress profile (private/metadata IP ranges stay blocked).
-        assert_eq!(onboard.network, LocalDevNetworkProfile::LocalDevWildcard);
+        assert_eq!(onboard.network, CapabilityNetworkProfile::DevWildcard);
         for capability in [
             "builtin.trace_commons.status",
             "builtin.trace_commons.credits",
@@ -616,8 +616,8 @@ mod tests {
                 grant.effects,
                 vec![EffectKind::DispatchCapability, EffectKind::ReadFilesystem]
             );
-            assert_eq!(grant.mounts, LocalDevMountProfile::Ambient);
-            assert_eq!(grant.network, LocalDevNetworkProfile::Default);
+            assert_eq!(grant.mounts, CapabilityMountProfile::Ambient);
+            assert_eq!(grant.network, CapabilityNetworkProfile::Default);
         }
         // builtin.profile_set writes context/profile.json under the memory mount.
         // It mirrors memory_write's effect set (read+write filesystem, memory mount,
@@ -633,8 +633,11 @@ mod tests {
                 EffectKind::WriteFilesystem,
             ]
         );
-        assert_eq!(builtin_profile_set.mounts, LocalDevMountProfile::Memory);
-        assert_eq!(builtin_profile_set.network, LocalDevNetworkProfile::Default);
+        assert_eq!(builtin_profile_set.mounts, CapabilityMountProfile::Memory);
+        assert_eq!(
+            builtin_profile_set.network,
+            CapabilityNetworkProfile::Default
+        );
 
         // profile_token writes profile_token.jwt (0600), so its grant carries
         // WriteFilesystem; trace_commons.profile_set only reads policy + posts, so it does not.
@@ -653,11 +656,8 @@ mod tests {
                 EffectKind::ExternalWrite,
             ]
         );
-        assert_eq!(profile_token.mounts, LocalDevMountProfile::Ambient);
-        assert_eq!(
-            profile_token.network,
-            LocalDevNetworkProfile::LocalDevWildcard
-        );
+        assert_eq!(profile_token.mounts, CapabilityMountProfile::Ambient);
+        assert_eq!(profile_token.network, CapabilityNetworkProfile::DevWildcard);
         let profile_set = policy
             .grant(&CapabilityId::new("builtin.trace_commons.profile_set").expect("capability id"))
             .expect("trace_commons.profile_set grant");
@@ -670,22 +670,19 @@ mod tests {
                 EffectKind::ExternalWrite,
             ]
         );
-        assert_eq!(profile_set.mounts, LocalDevMountProfile::Ambient);
-        assert_eq!(
-            profile_set.network,
-            LocalDevNetworkProfile::LocalDevWildcard
-        );
+        assert_eq!(profile_set.mounts, CapabilityMountProfile::Ambient);
+        assert_eq!(profile_set.network, CapabilityNetworkProfile::DevWildcard);
     }
 
     #[test]
     fn network_effect_grants_use_non_empty_network_policy() {
-        let policy = local_dev_capability_policy().expect("policy parses");
+        let policy = builtin_capability_policy().expect("policy parses");
 
         for grant in &policy.grants {
             if grant.effects.contains(&EffectKind::Network) {
                 assert_ne!(
                     grant.network,
-                    LocalDevNetworkProfile::Default,
+                    CapabilityNetworkProfile::Default,
                     "{} declares network authority but would stage an empty network policy",
                     grant.capability
                 );
@@ -694,7 +691,7 @@ mod tests {
     }
 
     fn assert_trigger_grant(
-        policy: &LocalDevCapabilityPolicy,
+        policy: &BuiltinCapabilityPolicy,
         capability: &str,
         effects: &[EffectKind],
     ) {
@@ -702,17 +699,17 @@ mod tests {
             .grant(&CapabilityId::new(capability).expect("capability id"))
             .expect("trigger grant");
         assert_eq!(grant.effects, effects);
-        assert_eq!(grant.mounts, LocalDevMountProfile::Ambient);
-        assert_eq!(grant.network, LocalDevNetworkProfile::Default);
+        assert_eq!(grant.mounts, CapabilityMountProfile::Ambient);
+        assert_eq!(grant.network, CapabilityNetworkProfile::Default);
     }
 
     #[test]
     fn spawn_capability_approval_adds_required_spawn_effect_for_grants_without_it() {
-        let policy = local_dev_capability_policy().expect("policy parses");
+        let policy = builtin_capability_policy().expect("policy parses");
         let capability = CapabilityId::new("builtin.echo").expect("capability id");
         let approval = policy
             .lease_approval_for(
-                LocalDevApprovalPolicyAction::SpawnCapability {
+                BuiltinApprovalPolicyAction::SpawnCapability {
                     capability: &capability,
                 },
                 &MountView::default(),
@@ -741,11 +738,11 @@ mod tests {
 
     #[test]
     fn spawn_capability_approval_does_not_duplicate_declared_spawn_effect() {
-        let policy = local_dev_capability_policy().expect("policy parses");
+        let policy = builtin_capability_policy().expect("policy parses");
         let capability = CapabilityId::new("builtin.shell").expect("capability id");
         let approval = policy
             .lease_approval_for(
-                LocalDevApprovalPolicyAction::SpawnCapability {
+                BuiltinApprovalPolicyAction::SpawnCapability {
                     capability: &capability,
                 },
                 &MountView::default(),
@@ -767,26 +764,26 @@ mod tests {
     }
 
     #[test]
-    fn bundled_local_dev_capability_policy_rejects_unknown_fields() {
-        let invalid = LOCAL_DEV_CAPABILITY_POLICY_TOML.replace(
+    fn bundled_builtin_capability_policy_rejects_unknown_fields() {
+        let invalid = BUILTIN_CAPABILITY_POLICY_TOML.replace(
             "manifest_path = \"/system/extensions/builtin/manifest.toml\"",
             "manifest_path = \"/system/extensions/builtin/manifest.toml\"\nunknown = true",
         );
 
         assert!(matches!(
-            parse_local_dev_capability_policy(&invalid),
-            Err(LocalDevCapabilityPolicyError::InvalidToml(_))
+            parse_builtin_capability_policy(&invalid),
+            Err(BuiltinCapabilityPolicyError::InvalidToml(_))
         ));
     }
 
     #[test]
-    fn bundled_local_dev_capability_policy_rejects_invalid_capability_ids() {
-        let invalid = LOCAL_DEV_CAPABILITY_POLICY_TOML
+    fn bundled_builtin_capability_policy_rejects_invalid_capability_ids() {
+        let invalid = BUILTIN_CAPABILITY_POLICY_TOML
             .replace("capability = \"builtin.echo\"", "capability = \"echo\"");
 
         assert!(matches!(
-            parse_local_dev_capability_policy(&invalid),
-            Err(LocalDevCapabilityPolicyError::InvalidToml(_))
+            parse_builtin_capability_policy(&invalid),
+            Err(BuiltinCapabilityPolicyError::InvalidToml(_))
         ));
     }
 }

--- a/crates/ironclaw_reborn_composition/src/builtin_capability_policy.toml
+++ b/crates/ironclaw_reborn_composition/src/builtin_capability_policy.toml
@@ -105,13 +105,13 @@ network = "default"
 capability = "builtin.http"
 effects = ["dispatch_capability", "network"]
 mounts = "ambient"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.http.save"
 effects = ["dispatch_capability", "network", "write_filesystem"]
 mounts = "workspace"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.memory_search"
@@ -157,7 +157,7 @@ effects = [
     "network",
 ]
 mounts = "ambient"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.read_file"
@@ -211,7 +211,7 @@ network = "default"
 capability = "builtin.extension_activate"
 effects = ["dispatch_capability", "read_filesystem", "write_filesystem", "network"]
 mounts = "system_extensions_lifecycle"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.extension_remove"
@@ -229,7 +229,7 @@ network = "default"
 capability = "builtin.skill_install"
 effects = ["dispatch_capability", "read_filesystem", "write_filesystem", "delete_filesystem", "network"]
 mounts = "skill_management"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.skill_remove"
@@ -271,7 +271,7 @@ network = "default"
 capability = "builtin.trace_commons.onboard"
 effects = ["dispatch_capability", "read_filesystem", "write_filesystem", "network", "external_write"]
 mounts = "ambient"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.trace_commons.status"
@@ -289,13 +289,13 @@ network = "default"
 capability = "builtin.trace_commons.profile_token"
 effects = ["dispatch_capability", "read_filesystem", "write_filesystem", "network", "external_write"]
 mounts = "ambient"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.trace_commons.profile_set"
 effects = ["dispatch_capability", "read_filesystem", "network", "external_write"]
 mounts = "ambient"
-network = "local_dev_wildcard"
+network = "dev_wildcard"
 
 [[grants]]
 capability = "builtin.outbound_delivery_target_set"

--- a/crates/ironclaw_reborn_composition/src/deployment.rs
+++ b/crates/ironclaw_reborn_composition/src/deployment.rs
@@ -1,0 +1,143 @@
+//! Deployment configuration: a deployment mode is policy *data* resolved at
+//! the composition edge, never a type the kernel or a substrate names.
+//!
+//! This is the Slice B artifact of
+//! `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`
+//! (§4.4 "Eliminate `Local*`", §5.6 "The deployment interface — modes are
+//! data"). Each deployment target is one [`DeploymentConfig`] value built by a
+//! named constructor; the difference between local-dev, local-dev-yolo, and
+//! the hosted volume preview is readable on this one page as data.
+//!
+//! Two deliberate boundaries:
+//!
+//! - The sanctioned resolver in `ironclaw_runtime_policy` stays the **only**
+//!   producer of [`EffectiveRuntimePolicy`]; [`DeploymentConfig::resolve`] is
+//!   a thin adapter over [`ResolveRequest`], not a second policy engine.
+//! - Storage roots, workspace paths, and connection pools are runtime
+//!   *handles*, not deployment policy — they continue to ride
+//!   `RebornStorageInput`. This value carries only the policy request.
+
+use ironclaw_host_api::runtime_policy::{DeploymentMode, RuntimeProfile};
+use ironclaw_runtime_policy::{
+    EffectiveRuntimePolicy, OrgPolicyConstraints, ResolveError, ResolveRequest,
+};
+
+/// The runtime-policy request one deployment target makes, expressed as data.
+///
+/// Consumed at the composition edge (`local_runtime_profile`): a
+/// `RebornCompositionProfile` maps to one of the named constructors below and
+/// everything downstream consumes the resolved policy values — no code past
+/// this edge branches on a deployment mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeploymentConfig {
+    /// Where IronClaw is running and who owns the machine boundary.
+    pub(crate) deployment: DeploymentMode,
+    /// The operator-requested runtime preset for this deployment.
+    pub(crate) requested_profile: RuntimeProfile,
+    /// Operator acknowledgement required before a `*Yolo*` profile resolves.
+    pub(crate) yolo_disclosure_acknowledged: bool,
+    /// Tenant/org ceiling constraints applied by the resolver.
+    pub(crate) org_policy: OrgPolicyConstraints,
+}
+
+impl DeploymentConfig {
+    /// Standalone local development on a single-user machine.
+    pub(crate) fn local_dev() -> Self {
+        Self {
+            deployment: DeploymentMode::LocalSingleUser,
+            requested_profile: RuntimeProfile::LocalDev,
+            yolo_disclosure_acknowledged: false,
+            org_policy: OrgPolicyConstraints::default(),
+        }
+    }
+
+    /// Trusted-laptop local development with minimal approvals. Requires the
+    /// operator's explicit host-access confirmation; without it the resolver
+    /// fails closed with [`ResolveError::YoloRequiresDisclosure`].
+    pub(crate) fn local_dev_yolo(confirm_host_access: bool) -> Self {
+        Self {
+            deployment: DeploymentMode::LocalSingleUser,
+            requested_profile: RuntimeProfile::LocalYolo,
+            yolo_disclosure_acknowledged: confirm_host_access,
+            org_policy: OrgPolicyConstraints::default(),
+        }
+    }
+
+    /// Hosted single-tenant preview backed by the local runtime substrate:
+    /// process execution disabled, scoped virtual filesystem, brokered
+    /// network/secrets, ask-always approvals (the resolver-owned secure
+    /// default under a hosted deployment boundary).
+    pub(crate) fn hosted_single_tenant_volume() -> Self {
+        Self {
+            deployment: DeploymentMode::HostedMultiTenant,
+            requested_profile: RuntimeProfile::SecureDefault,
+            yolo_disclosure_acknowledged: false,
+            org_policy: OrgPolicyConstraints::default(),
+        }
+    }
+
+    /// Resolve this deployment request through the sanctioned resolver.
+    pub(crate) fn resolve(&self) -> Result<EffectiveRuntimePolicy, ResolveError> {
+        ironclaw_runtime_policy::resolve(ResolveRequest {
+            deployment: self.deployment,
+            requested_profile: self.requested_profile,
+            org_policy: self.org_policy.clone(),
+            yolo_disclosure_acknowledged: self.yolo_disclosure_acknowledged,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::runtime_policy::{ApprovalPolicy, ProcessBackendKind};
+
+    use super::*;
+
+    #[test]
+    fn local_dev_resolves_to_local_host_policy() {
+        let policy = DeploymentConfig::local_dev().resolve().expect("resolves");
+        assert_eq!(policy.deployment, DeploymentMode::LocalSingleUser);
+        assert_eq!(policy.resolved_profile, RuntimeProfile::LocalDev);
+        assert_eq!(policy.process_backend, ProcessBackendKind::LocalHost);
+        assert_eq!(policy.approval_policy, ApprovalPolicy::AskDestructive);
+    }
+
+    #[test]
+    fn local_dev_yolo_without_disclosure_fails_closed() {
+        let error = DeploymentConfig::local_dev_yolo(false)
+            .resolve()
+            .expect_err("yolo without disclosure must fail");
+        assert!(matches!(error, ResolveError::YoloRequiresDisclosure { .. }));
+    }
+
+    #[test]
+    fn local_dev_yolo_with_disclosure_resolves_minimal_approvals() {
+        let policy = DeploymentConfig::local_dev_yolo(true)
+            .resolve()
+            .expect("resolves");
+        assert_eq!(policy.resolved_profile, RuntimeProfile::LocalYolo);
+        assert_eq!(policy.approval_policy, ApprovalPolicy::Minimal);
+    }
+
+    #[test]
+    fn hosted_single_tenant_volume_resolves_secure_default_without_processes() {
+        let policy = DeploymentConfig::hosted_single_tenant_volume()
+            .resolve()
+            .expect("resolves");
+        assert_eq!(policy.deployment, DeploymentMode::HostedMultiTenant);
+        assert_eq!(policy.resolved_profile, RuntimeProfile::SecureDefault);
+        assert_eq!(policy.process_backend, ProcessBackendKind::None);
+        assert_eq!(policy.approval_policy, ApprovalPolicy::AskAlways);
+    }
+
+    #[test]
+    fn deployment_targets_differ_only_as_data() {
+        // The whole local/hosted diff is field values on one struct — the
+        // §4.4 claim this module exists to make true.
+        assert_ne!(
+            DeploymentConfig::local_dev(),
+            DeploymentConfig::hosted_single_tenant_volume()
+        );
+        assert_eq!(DeploymentConfig::local_dev(), DeploymentConfig::local_dev());
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/deployment.rs
+++ b/crates/ironclaw_reborn_composition/src/deployment.rs
@@ -85,6 +85,25 @@ impl DeploymentConfig {
             yolo_disclosure_acknowledged: self.yolo_disclosure_acknowledged,
         })
     }
+
+    /// The deployment's capability-policy *data* (§4.4.1 category 1): the
+    /// embedded `builtin_capability_policy.toml` — provider policy, approval
+    /// gates/defaults, and capability grants — parsed once through the
+    /// `OnceLock`-cached loader. Like [`DeploymentConfig::resolve`], this is a
+    /// thin adapter over the owning module's loader, not a second policy
+    /// source.
+    // dead_code allow: config-scoped accessor added by the §4.4 relocation;
+    // existing composition call sites still reach the module loader directly
+    // and migrate here separately.
+    #[allow(dead_code)]
+    pub(crate) fn builtin_capability_policy(
+        &self,
+    ) -> Result<
+        crate::builtin_capability_policy::BuiltinCapabilityPolicy,
+        crate::builtin_capability_policy::BuiltinCapabilityPolicyError,
+    > {
+        crate::builtin_capability_policy::builtin_capability_policy()
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -156,7 +156,7 @@ pub(crate) struct ActiveExtensionCapability {
     pub(crate) network_targets: Vec<NetworkTargetPattern>,
     /// Who the providing extension's installation belongs to (#5459 P1).
     /// Tenant-owned capabilities are grant-minted for every user; user-owned
-    /// ones only for their owner (filtered in `LocalDevExtensionSurface`).
+    /// ones only for their owner (filtered in `ExtensionCapabilitySurface`).
     pub(crate) owner: InstallationOwner,
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -153,6 +153,7 @@ use ironclaw_turns::{
 use ironclaw_turns::{InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore};
 
 use crate::RebornProductAuthServicePorts;
+use crate::builtin_capability_policy::{BuiltinCapabilityPolicy, builtin_capability_policy};
 #[cfg(feature = "telegram-v2-host-beta")]
 use crate::extension_host::available_extensions::telegram_manifest_digest;
 #[cfg(feature = "slack-v2-host-beta")]
@@ -189,7 +190,6 @@ use crate::lifecycle_auth_continuation::{
     LifecycleAuthContinuationDispatcher, LifecycleProductFacadeSlot,
 };
 use crate::local_dev_authorization::{StoreApprovalSettingsProvider, local_dev_authorizer};
-use crate::local_dev_capability_policy::{LocalDevCapabilityPolicy, local_dev_capability_policy};
 use crate::local_dev_mounts::{
     ambient_workspace_mount_view, memory_mount_view, scoped_skill_context_mount_view,
     skill_management_mount_view, system_extensions_lifecycle_mount_view, workspace_mount_view,
@@ -212,15 +212,15 @@ use crate::{
 /// and the canonical Reborn identity store, so each rides the same
 /// `reborn-local-dev.db` rather than opening a second handle to the file
 /// (see `RebornRuntime::open_reborn_identity_resolver`).
-struct LocalDevRootFilesystemBundle {
+struct RootFilesystemBundle {
     filesystem: Arc<CompositeRootFilesystem>,
-    durable_backend: LocalDevDurableBackend,
+    durable_backend: DurableBackend,
 }
 
 // `pub(crate)` to match `build_default_local_dev_database_roots` (also
 // `pub(crate)` for the `test_support` accessor): a `pub(crate)` fn returning a
 // private enum trips `private_interfaces`. The enum stays crate-internal.
-pub(crate) enum LocalDevDurableBackend {
+pub(crate) enum DurableBackend {
     #[cfg(feature = "libsql")]
     LibSql(Arc<libsql::Database>),
     #[cfg(feature = "postgres")]
@@ -229,7 +229,7 @@ pub(crate) enum LocalDevDurableBackend {
     Ephemeral,
 }
 
-enum LocalDevStorageBackendInput {
+enum StorageBackendInput {
     LocalDefault,
     #[cfg(feature = "postgres")]
     Postgres(deadpool_postgres::Pool),
@@ -269,17 +269,17 @@ impl ironclaw_network::NetworkHttpEgress for TestNetworkHttpEgress {
     not(feature = "inmemory-turn-state"),
     any(feature = "libsql", feature = "postgres")
 ))]
-pub(crate) type LocalDevTurnStateStore = FilesystemTurnStateStoreKind<CompositeRootFilesystem>;
+pub(crate) type ComposedTurnStateStore = FilesystemTurnStateStoreKind<CompositeRootFilesystem>;
 #[cfg(any(
     feature = "inmemory-turn-state",
     not(any(feature = "libsql", feature = "postgres"))
 ))]
-pub(crate) type LocalDevTurnStateStore = InMemoryTurnStateStore;
+pub(crate) type ComposedTurnStateStore = InMemoryTurnStateStore;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-type LocalDevResourceGovernor = FilesystemResourceGovernor<CompositeRootFilesystem>;
+type ComposedResourceGovernor = FilesystemResourceGovernor<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-type LocalDevResourceGovernor = InMemoryResourceGovernor;
+type ComposedResourceGovernor = InMemoryResourceGovernor;
 
 // One run-state / approval-request store, backend-injected — the production
 // `Filesystem*Store<F>` every deployment uses, never a bespoke `InMemory*Store`
@@ -287,18 +287,18 @@ type LocalDevResourceGovernor = InMemoryResourceGovernor;
 // `InMemoryBackend` directly, so the concrete type is `<InMemoryBackend>`, which
 // the host-runtime production-wiring guard classifies `LocalOnly`.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-type LocalDevRunStateStore = FilesystemRunStateStore<CompositeRootFilesystem>;
+type ComposedRunStateStore = FilesystemRunStateStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-type LocalDevRunStateStore = FilesystemRunStateStore<InMemoryBackend>;
+type ComposedRunStateStore = FilesystemRunStateStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub(crate) type LocalDevApprovalRequestStore =
+pub(crate) type ComposedApprovalRequestStore =
     FilesystemApprovalRequestStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevApprovalRequestStore = FilesystemApprovalRequestStore<InMemoryBackend>;
+pub(crate) type ComposedApprovalRequestStore = FilesystemApprovalRequestStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub(crate) type LocalDevCapabilityLeaseStore =
+pub(crate) type ComposedCapabilityLeaseStore =
     FilesystemCapabilityLeaseStore<CompositeRootFilesystem>;
 // One capability-lease store, backend-injected — the production
 // `FilesystemCapabilityLeaseStore<F>` every deployment uses, never a bespoke
@@ -307,7 +307,7 @@ pub(crate) type LocalDevCapabilityLeaseStore =
 // `<InMemoryBackend>`, which the host-runtime production-wiring guard classifies
 // `LocalOnly`.
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevCapabilityLeaseStore = FilesystemCapabilityLeaseStore<InMemoryBackend>;
+pub(crate) type ComposedCapabilityLeaseStore = FilesystemCapabilityLeaseStore<InMemoryBackend>;
 
 // One store per approval domain, backend-injected — the production
 // `Filesystem*Store<F>` every deployment uses, never a bespoke `InMemory*Store`
@@ -319,28 +319,28 @@ pub(crate) type LocalDevCapabilityLeaseStore = FilesystemCapabilityLeaseStore<In
 // Durable builds use the libSQL/Postgres-backed composite root filesystem, whose
 // type is distinct and correctly classifies as a production candidate.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub(crate) type LocalDevPersistentApprovalPolicyStore =
+pub(crate) type ComposedPersistentApprovalPolicyStore =
     FilesystemPersistentApprovalPolicyStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevPersistentApprovalPolicyStore =
+pub(crate) type ComposedPersistentApprovalPolicyStore =
     FilesystemPersistentApprovalPolicyStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub(crate) type LocalDevToolPermissionOverrideStore =
+pub(crate) type ComposedToolPermissionOverrideStore =
     FilesystemToolPermissionOverrideStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevToolPermissionOverrideStore =
+pub(crate) type ComposedToolPermissionOverrideStore =
     FilesystemToolPermissionOverrideStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub(crate) type LocalDevAutoApproveSettingStore =
+pub(crate) type ComposedAutoApproveSettingStore =
     FilesystemAutoApproveSettingStore<CompositeRootFilesystem>;
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-pub(crate) type LocalDevAutoApproveSettingStore =
+pub(crate) type ComposedAutoApproveSettingStore =
     FilesystemAutoApproveSettingStore<InMemoryBackend>;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-type LocalDevProcessServices = ProcessServices<
+type ComposedProcessServices = ProcessServices<
     ironclaw_processes::FilesystemProcessStore<CompositeRootFilesystem>,
     ironclaw_processes::FilesystemProcessResultStore<CompositeRootFilesystem>,
 >;
@@ -351,7 +351,7 @@ type LocalDevProcessServices = ProcessServices<
 // `<InMemoryBackend>`, which the host-runtime production-wiring guard
 // classifies `LocalOnly`.
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-type LocalDevProcessServices = ProcessServices<
+type ComposedProcessServices = ProcessServices<
     ironclaw_processes::FilesystemProcessStore<InMemoryBackend>,
     ironclaw_processes::FilesystemProcessResultStore<InMemoryBackend>,
 >;
@@ -400,7 +400,7 @@ where
 fn local_dev_process_port_for_policy(
     runtime_policy: &Option<ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy>,
     workspace_root: &Path,
-    host_home_root: Option<&LocalDevHostHomeRoot>,
+    host_home_root: Option<&HostHomeRoot>,
 ) -> Option<HostProcessPort> {
     let runtime_policy = runtime_policy.as_ref()?;
     if runtime_policy.process_backend != ProcessBackendKind::LocalHost {
@@ -514,7 +514,7 @@ pub struct RebornServices {
     pub product_auth: Option<Arc<RebornProductAuthServices>>,
     pub readiness: RebornReadiness,
     pub(crate) skill_management: Option<Arc<RebornLocalSkillManagementPort>>,
-    pub(crate) local_runtime: Option<Arc<RebornLocalRuntimeServices>>,
+    pub(crate) local_runtime: Option<Arc<RebornRuntimeSubstrate>>,
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     // arch-exempt: optional_arc, local-dev vs production split pending RebornServices split, plan #4471
     pub(crate) production_runtime: Option<RebornProductionRuntimeServices>,
@@ -611,13 +611,13 @@ impl RebornServices {
     }
 
     #[cfg(feature = "test-support")]
-    pub fn local_dev_approval_test_parts(&self) -> Option<RebornLocalDevApprovalTestParts> {
+    pub fn local_dev_approval_test_parts(&self) -> Option<RebornApprovalTestParts> {
         let local_runtime = self.local_runtime.as_ref()?;
         let approval_requests: Arc<dyn ironclaw_run_state::ApprovalRequestStore> =
             local_runtime.approval_requests.clone();
         let capability_leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
             local_runtime.capability_leases.clone();
-        Some(RebornLocalDevApprovalTestParts {
+        Some(RebornApprovalTestParts {
             approval_requests,
             capability_leases,
         })
@@ -677,10 +677,10 @@ impl RebornServices {
     /// Test-support access to the local-dev session thread service (durable
     /// tool-result projection seam, issue #5838). This is the SAME `Arc`
     /// production's `capability_wiring` passes to
-    /// `LocalDevCapabilityIo::new_with_durable_previews` and to the
+    /// `StagedCapabilityIo::new_with_durable_previews` and to the
     /// `result_read` synthetic capability, so a harness built over this
-    /// `RebornServices` can drive its own real `LocalDevCapabilityIo` through
-    /// `local_dev_capability_io_for_test`. Returns `None` for production-profile
+    /// `RebornServices` can drive its own real `StagedCapabilityIo` through
+    /// `staged_capability_io_for_test`. Returns `None` for production-profile
     /// compositions without a local-dev runtime.
     #[cfg(feature = "test-support")]
     pub fn local_dev_thread_service_for_test(
@@ -692,7 +692,7 @@ impl RebornServices {
 
     /// Test-support access to the local-dev communication-preference repository
     /// (W6-COLD-SPOTS seam). This is the SAME `Arc` that `build_local_dev_store_graph`
-    /// wires into `RebornLocalRuntimeServices::outbound_preferences` via
+    /// wires into `RebornRuntimeSubstrate::outbound_preferences` via
     /// `local_dev_outbound_store`, for tests only. Returns `None` for
     /// production-profile compositions without a local-dev runtime.
     #[cfg(feature = "test-support")]
@@ -847,7 +847,7 @@ impl RebornServices {
     /// Test-support authority snapshot for active local-dev extensions.
     ///
     /// Binary-E2E harnesses build capability ports at the host-runtime boundary
-    /// instead of going through `LocalDevLoopCapabilityPortFactory`, so they need
+    /// instead of going through `RefreshingLoopCapabilityPortFactory`, so they need
     /// the same active-extension grants and provider trust that production
     /// local-dev recomputes whenever the model-visible surface is refreshed.
     #[cfg(feature = "test-support")]
@@ -855,10 +855,7 @@ impl RebornServices {
         &self,
         grantee: &ExtensionId,
     ) -> Option<
-        Result<
-            LocalDevActiveExtensionAuthorityForTest,
-            ironclaw_product_workflow::ProductWorkflowError,
-        >,
+        Result<ActiveExtensionAuthorityForTest, ironclaw_product_workflow::ProductWorkflowError>,
     > {
         let extension_management = self.local_runtime.as_ref()?.extension_management.as_ref()?;
         Some(active_extension_authority_for_test(extension_management, grantee).await)
@@ -866,7 +863,7 @@ impl RebornServices {
 }
 
 #[cfg(feature = "test-support")]
-pub struct LocalDevActiveExtensionAuthorityForTest {
+pub struct ActiveExtensionAuthorityForTest {
     pub grants: Vec<CapabilityGrant>,
     pub provider_trust: Vec<(ExtensionId, TrustDecision)>,
 }
@@ -875,8 +872,7 @@ pub struct LocalDevActiveExtensionAuthorityForTest {
 async fn active_extension_authority_for_test(
     extension_management: &RebornLocalExtensionManagementPort,
     grantee: &ExtensionId,
-) -> Result<LocalDevActiveExtensionAuthorityForTest, ironclaw_product_workflow::ProductWorkflowError>
-{
+) -> Result<ActiveExtensionAuthorityForTest, ironclaw_product_workflow::ProductWorkflowError> {
     let active_capabilities = extension_management
         .active_model_visible_capabilities()
         .await?;
@@ -919,7 +915,7 @@ async fn active_extension_authority_for_test(
             )
         })
         .collect();
-    Ok(LocalDevActiveExtensionAuthorityForTest {
+    Ok(ActiveExtensionAuthorityForTest {
         grants,
         provider_trust,
     })
@@ -996,16 +992,16 @@ pub struct AttachmentTestSupport {
 
 #[cfg(feature = "test-support")]
 #[derive(Clone)]
-pub struct RebornLocalDevApprovalTestParts {
+pub struct RebornApprovalTestParts {
     pub approval_requests: Arc<dyn ironclaw_run_state::ApprovalRequestStore>,
     pub capability_leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore>,
 }
 
-pub(crate) struct RebornLocalRuntimeServices {
+pub(crate) struct RebornRuntimeSubstrate {
     pub(crate) extension_lifecycle_surface_context: LifecycleProductSurfaceContext,
     pub(crate) owner_user_id: UserId,
-    pub(crate) approval_requests: Arc<LocalDevApprovalRequestStore>,
-    pub(crate) capability_leases: Arc<LocalDevCapabilityLeaseStore>,
+    pub(crate) approval_requests: Arc<ComposedApprovalRequestStore>,
+    pub(crate) capability_leases: Arc<ComposedCapabilityLeaseStore>,
     /// Per-runtime catalog of client-supplied ("external") tools. Shared between
     /// the loop capability host (which offers them to the model and parks calls)
     /// and the OpenAI-compatible Responses surface (which registers tool specs
@@ -1015,11 +1011,11 @@ pub(crate) struct RebornLocalRuntimeServices {
     // Used in approval_test_support (cfg(test) only); suppress the dead-code
     // lint on non-test builds where that module is not compiled in.
     #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) capability_policy: Arc<LocalDevCapabilityPolicy>,
-    pub(crate) persistent_approval_policies: Arc<LocalDevPersistentApprovalPolicyStore>,
-    pub(crate) tool_permission_overrides: Arc<LocalDevToolPermissionOverrideStore>,
-    pub(crate) auto_approve_settings: Arc<LocalDevAutoApproveSettingStore>,
-    pub(crate) turn_state: Arc<LocalDevTurnStateStore>,
+    pub(crate) capability_policy: Arc<BuiltinCapabilityPolicy>,
+    pub(crate) persistent_approval_policies: Arc<ComposedPersistentApprovalPolicyStore>,
+    pub(crate) tool_permission_overrides: Arc<ComposedToolPermissionOverrideStore>,
+    pub(crate) auto_approve_settings: Arc<ComposedAutoApproveSettingStore>,
+    pub(crate) turn_state: Arc<ComposedTurnStateStore>,
     pub(crate) trigger_repository: Arc<dyn TriggerRepository>,
     /// Facade-shaped handle (not the raw `ProjectRepository`): composition
     /// modules wire the access-controlled service, never the substrate repo.
@@ -1223,7 +1219,7 @@ impl RebornProductionRuntimeServices {
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-impl RebornLocalRuntimeServices {
+impl RebornRuntimeSubstrate {
     pub(crate) async fn durable_trigger_conversation_services(
         &self,
     ) -> Result<RebornFilesystemConversationServices, InboundTurnError> {
@@ -1237,19 +1233,19 @@ impl RebornLocalRuntimeServices {
     }
 }
 
-struct RebornLocalDevStoreGraph {
-    run_state: Arc<LocalDevRunStateStore>,
-    approval_requests: Arc<LocalDevApprovalRequestStore>,
-    capability_leases: Arc<LocalDevCapabilityLeaseStore>,
-    persistent_approval_policies: Arc<LocalDevPersistentApprovalPolicyStore>,
-    turn_state: Arc<LocalDevTurnStateStore>,
-    local_runtime: Arc<RebornLocalRuntimeServices>,
-    resource_governor: Arc<LocalDevResourceGovernor>,
-    process_services: LocalDevProcessServices,
+struct RebornStoreGraph {
+    run_state: Arc<ComposedRunStateStore>,
+    approval_requests: Arc<ComposedApprovalRequestStore>,
+    capability_leases: Arc<ComposedCapabilityLeaseStore>,
+    persistent_approval_policies: Arc<ComposedPersistentApprovalPolicyStore>,
+    turn_state: Arc<ComposedTurnStateStore>,
+    local_runtime: Arc<RebornRuntimeSubstrate>,
+    resource_governor: Arc<ComposedResourceGovernor>,
+    process_services: ComposedProcessServices,
     trigger_repository: Arc<dyn TriggerRepository>,
 }
 
-struct RebornLocalDevStoreGraphInput {
+struct RebornStoreGraphInput {
     filesystem: Arc<CompositeRootFilesystem>,
     owner_user_id: UserId,
     local_runtime_identity: Option<RebornLocalRuntimeIdentity>,
@@ -1475,7 +1471,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             root,
             workspace_root,
             host_home_root,
-            LocalDevStorageBackendInput::LocalDefault,
+            StorageBackendInput::LocalDefault,
             None::<ironclaw_secrets::SecretMaterial>,
             None::<bool>,
         ),
@@ -1499,7 +1495,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             root,
             workspace_root,
             host_home_root,
-            LocalDevStorageBackendInput::Postgres(pool),
+            StorageBackendInput::Postgres(pool),
             Some(secret_master_key),
             Some(process_local_resource_governor_singleton),
         ),
@@ -1531,7 +1527,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         policy.filesystem_backend == FilesystemBackendKind::HostWorkspaceAndHome
     });
     let host_home_root = match (include_host_home, host_home_root) {
-        (true, Some(path)) => Some(LocalDevHostHomeRoot {
+        (true, Some(path)) => Some(HostHomeRoot {
             canonical_root: canonicalize_local_dev_host_home_root(&path)?,
             raw_alias: path,
         }),
@@ -1584,12 +1580,12 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
     // substrate DB the runtime owns rather than a second handle.
     #[cfg(all(feature = "libsql", feature = "postgres"))]
     let identity_substrate_db = match &filesystem_bundle.durable_backend {
-        LocalDevDurableBackend::LibSql(database) => Some(Arc::clone(database)),
-        LocalDevDurableBackend::Postgres(_) => None,
+        DurableBackend::LibSql(database) => Some(Arc::clone(database)),
+        DurableBackend::Postgres(_) => None,
     };
     #[cfg(all(feature = "libsql", not(feature = "postgres")))]
     let identity_substrate_db = {
-        let LocalDevDurableBackend::LibSql(database) = &filesystem_bundle.durable_backend;
+        let DurableBackend::LibSql(database) = &filesystem_bundle.durable_backend;
         Some(Arc::clone(database))
     };
     let trigger_repository =
@@ -1654,7 +1650,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         owner_user_id.clone(),
         local_runtime_identity_for_nearai_mcp.as_ref(),
     )?;
-    let mut store_graph = build_local_dev_store_graph(RebornLocalDevStoreGraphInput {
+    let mut store_graph = build_local_dev_store_graph(RebornStoreGraphInput {
         filesystem: Arc::clone(&filesystem),
         owner_user_id,
         local_runtime_identity,
@@ -2424,9 +2420,9 @@ fn local_dev_extension_installation_state_path(
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 async fn build_local_dev_store_graph(
-    input: RebornLocalDevStoreGraphInput,
-) -> Result<RebornLocalDevStoreGraph, RebornBuildError> {
-    let RebornLocalDevStoreGraphInput {
+    input: RebornStoreGraphInput,
+) -> Result<RebornStoreGraph, RebornBuildError> {
+    let RebornStoreGraphInput {
         filesystem,
         owner_user_id,
         local_runtime_identity,
@@ -2469,7 +2465,7 @@ async fn build_local_dev_store_graph(
     // Runtime-wedge fix: with `inmemory-turn-state`, the whole local-dev/hosted
     // runtime family (incl. hosted-single-tenant-volume) coordinates turn state
     // in one in-process authority — no per-user `state.json` CAS livelock.
-    // Otherwise the durable filesystem row store is used. `LocalDevTurnStateStore`
+    // Otherwise the durable filesystem row store is used. `ComposedTurnStateStore`
     // resolves to the matching concrete type via the same feature cfg, so both
     // arms satisfy every downstream consumer (coordinator, `LoopCheckpointStore`,
     // `RuntimeTurnStateStore`) with no trait-object plumbing.
@@ -2522,20 +2518,21 @@ async fn build_local_dev_store_graph(
     let resource_governor = FilesystemResourceGovernor::new(Arc::clone(&scoped_filesystem))
         .with_event_sink(Arc::clone(&budget_event_sink));
     resource_governor.warm_authority()?;
-    let resource_governor: Arc<LocalDevResourceGovernor> = Arc::new(resource_governor);
+    let resource_governor: Arc<ComposedResourceGovernor> = Arc::new(resource_governor);
     let skill_mounts =
         skill_management_mount_view().map_err(|error| RebornBuildError::InvalidConfig {
             reason: error.to_string(),
         })?;
-    let capability_policy = Arc::new(local_dev_capability_policy().map_err(|error| {
-        RebornBuildError::InvalidConfig {
-            reason: format!("local-dev capability policy is invalid: {error}"),
-        }
-    })?);
-    let tool_permission_overrides = Arc::new(LocalDevToolPermissionOverrideStore::new(Arc::clone(
+    let capability_policy =
+        Arc::new(
+            builtin_capability_policy().map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("local-dev capability policy is invalid: {error}"),
+            })?,
+        );
+    let tool_permission_overrides = Arc::new(ComposedToolPermissionOverrideStore::new(Arc::clone(
         &scoped_filesystem,
     )));
-    let auto_approve_settings = Arc::new(LocalDevAutoApproveSettingStore::new(Arc::clone(
+    let auto_approve_settings = Arc::new(ComposedAutoApproveSettingStore::new(Arc::clone(
         &scoped_filesystem,
     )));
     let memory_mounts =
@@ -2562,7 +2559,7 @@ async fn build_local_dev_store_graph(
     let skill_management =
         build_local_skill_management_port(owner_user_id.clone(), Arc::clone(&filesystem))?;
     let outbound_stores = local_dev_outbound_store(Arc::clone(&filesystem));
-    let local_runtime = Arc::new(RebornLocalRuntimeServices {
+    let local_runtime = Arc::new(RebornRuntimeSubstrate {
         extension_lifecycle_surface_context,
         owner_user_id: owner_user_id.clone(),
         approval_requests: Arc::clone(&approval_requests),
@@ -2638,7 +2635,7 @@ async fn build_local_dev_store_graph(
     });
     let process_services = ProcessServices::filesystem(Arc::clone(&scoped_filesystem));
 
-    Ok(RebornLocalDevStoreGraph {
+    Ok(RebornStoreGraph {
         run_state,
         approval_requests,
         capability_leases,
@@ -2653,9 +2650,9 @@ async fn build_local_dev_store_graph(
 
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 async fn build_local_dev_store_graph(
-    input: RebornLocalDevStoreGraphInput,
-) -> Result<RebornLocalDevStoreGraph, RebornBuildError> {
-    let RebornLocalDevStoreGraphInput {
+    input: RebornStoreGraphInput,
+) -> Result<RebornStoreGraph, RebornBuildError> {
+    let RebornStoreGraphInput {
         filesystem,
         owner_user_id,
         local_runtime_identity,
@@ -2714,21 +2711,22 @@ async fn build_local_dev_store_graph(
     let budget_gate_store: Arc<dyn ironclaw_resources::BudgetGateStore> = Arc::new(
         FilesystemBudgetGateStore::new(crate::wrap_scoped(Arc::new(InMemoryBackend::new()))),
     );
-    let resource_governor: Arc<LocalDevResourceGovernor> =
+    let resource_governor: Arc<ComposedResourceGovernor> =
         Arc::new(InMemoryResourceGovernor::new().with_event_sink(Arc::clone(&budget_event_sink)));
     let skill_mounts =
         skill_management_mount_view().map_err(|error| RebornBuildError::InvalidConfig {
             reason: error.to_string(),
         })?;
-    let capability_policy = Arc::new(local_dev_capability_policy().map_err(|error| {
-        RebornBuildError::InvalidConfig {
-            reason: format!("local-dev capability policy is invalid: {error}"),
-        }
-    })?);
-    let tool_permission_overrides = Arc::new(LocalDevToolPermissionOverrideStore::new(Arc::clone(
+    let capability_policy =
+        Arc::new(
+            builtin_capability_policy().map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("local-dev capability policy is invalid: {error}"),
+            })?,
+        );
+    let tool_permission_overrides = Arc::new(ComposedToolPermissionOverrideStore::new(Arc::clone(
         &approvals_filesystem,
     )));
-    let auto_approve_settings = Arc::new(LocalDevAutoApproveSettingStore::new(Arc::clone(
+    let auto_approve_settings = Arc::new(ComposedAutoApproveSettingStore::new(Arc::clone(
         &approvals_filesystem,
     )));
     let memory_mounts =
@@ -2757,7 +2755,7 @@ async fn build_local_dev_store_graph(
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     let trigger_conversation_services = local_dev_trigger_conversation_services();
     let outbound_stores = local_dev_outbound_store(Arc::clone(&filesystem));
-    let local_runtime = Arc::new(RebornLocalRuntimeServices {
+    let local_runtime = Arc::new(RebornRuntimeSubstrate {
         extension_lifecycle_surface_context,
         owner_user_id: owner_user_id.clone(),
         approval_requests: Arc::clone(&approval_requests),
@@ -2822,7 +2820,7 @@ async fn build_local_dev_store_graph(
     let process_services =
         ProcessServices::filesystem(crate::wrap_scoped(Arc::new(InMemoryBackend::new())));
 
-    Ok(RebornLocalDevStoreGraph {
+    Ok(RebornStoreGraph {
         run_state,
         approval_requests,
         capability_leases,
@@ -2836,11 +2834,11 @@ async fn build_local_dev_store_graph(
 }
 
 async fn local_dev_trigger_repository(
-    backend: &LocalDevDurableBackend,
+    backend: &DurableBackend,
 ) -> Result<Arc<dyn TriggerRepository>, RebornBuildError> {
     match backend {
         #[cfg(feature = "libsql")]
-        LocalDevDurableBackend::LibSql(database) => {
+        DurableBackend::LibSql(database) => {
             let repository = ironclaw_triggers::LibSqlTriggerRepository::new(Arc::clone(database));
             repository
                 .run_migrations()
@@ -2851,7 +2849,7 @@ async fn local_dev_trigger_repository(
             Ok(Arc::new(repository))
         }
         #[cfg(feature = "postgres")]
-        LocalDevDurableBackend::Postgres(pool) => {
+        DurableBackend::Postgres(pool) => {
             let repository = ironclaw_triggers::PostgresTriggerRepository::new(pool.clone());
             repository
                 .run_migrations()
@@ -2862,7 +2860,7 @@ async fn local_dev_trigger_repository(
             Ok(Arc::new(repository))
         }
         #[cfg(not(feature = "libsql"))]
-        LocalDevDurableBackend::Ephemeral => Ok(Arc::new(
+        DurableBackend::Ephemeral => Ok(Arc::new(
             ironclaw_triggers::InMemoryTriggerRepository::default(),
         )),
     }
@@ -2874,7 +2872,7 @@ fn local_dev_trigger_conversation_services() -> InMemoryConversationServices {
 }
 
 fn local_dev_trigger_create_hook(
-    local_runtime: &Arc<RebornLocalRuntimeServices>,
+    local_runtime: &Arc<RebornRuntimeSubstrate>,
 ) -> Arc<dyn TriggerCreateHook> {
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     {
@@ -2970,7 +2968,7 @@ impl TriggerCreateHook for InMemoryTriggerCreatorPairingHook {
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 struct LocalRuntimeTriggerCreatorPairingHook {
-    runtime: Arc<RebornLocalRuntimeServices>,
+    runtime: Arc<RebornRuntimeSubstrate>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -3133,9 +3131,9 @@ fn build_budget_sinks() -> BudgetSinks {
 async fn build_local_dev_root_filesystem(
     root: &Path,
     workspace_root: &Path,
-    host_home_root: Option<&LocalDevHostHomeRoot>,
-    storage_backend_input: LocalDevStorageBackendInput,
-) -> Result<LocalDevRootFilesystemBundle, RebornBuildError> {
+    host_home_root: Option<&HostHomeRoot>,
+    storage_backend_input: StorageBackendInput,
+) -> Result<RootFilesystemBundle, RebornBuildError> {
     let local = Arc::new(local_dev_project_filesystem(
         root,
         workspace_root,
@@ -3144,18 +3142,18 @@ async fn build_local_dev_root_filesystem(
     let mut composite = CompositeRootFilesystem::new();
     let durable_backend = match storage_backend_input {
         #[cfg(feature = "postgres")]
-        LocalDevStorageBackendInput::Postgres(pool) => {
+        StorageBackendInput::Postgres(pool) => {
             let database = Arc::new(PostgresRootFilesystem::new(pool.clone()));
             database.run_migrations().await?;
             mount_local_dev_database_roots(&mut composite, database)?;
-            LocalDevDurableBackend::Postgres(pool)
+            DurableBackend::Postgres(pool)
         }
-        LocalDevStorageBackendInput::LocalDefault => {
+        StorageBackendInput::LocalDefault => {
             build_default_local_dev_database_roots(root, &mut composite).await?
         }
     };
     mount_local_dev_project_roots(&mut composite, local)?;
-    Ok(LocalDevRootFilesystemBundle {
+    Ok(RootFilesystemBundle {
         filesystem: Arc::new(composite),
         durable_backend,
     })
@@ -3196,14 +3194,14 @@ async fn open_local_dev_libsql_database(
 pub(crate) async fn build_default_local_dev_database_roots(
     root: &Path,
     composite: &mut CompositeRootFilesystem,
-) -> Result<LocalDevDurableBackend, RebornBuildError> {
+) -> Result<DurableBackend, RebornBuildError> {
     #[cfg(feature = "libsql")]
     {
         let db = open_local_dev_libsql_database(root).await?;
         let database = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&db)));
         database.run_migrations().await?;
         mount_local_dev_database_roots(composite, database)?;
-        Ok(LocalDevDurableBackend::LibSql(db))
+        Ok(DurableBackend::LibSql(db))
     }
     #[cfg(not(feature = "libsql"))]
     {
@@ -3212,13 +3210,13 @@ pub(crate) async fn build_default_local_dev_database_roots(
             "local-dev: control-plane filesystem roots are backed by InMemoryBackend; runtime state is ephemeral and will be lost on restart"
         );
         mount_local_dev_database_roots(composite, Arc::new(InMemoryBackend::new()))?;
-        Ok(LocalDevDurableBackend::Ephemeral)
+        Ok(DurableBackend::Ephemeral)
     }
 }
 
 /// Thin void wrapper over [`build_default_local_dev_database_roots`] for
 /// `#[cfg(feature = "test-support")]` callers that need to mount the local-dev
-/// database roots but don't need the opaque `LocalDevDurableBackend` handle
+/// database roots but don't need the opaque `DurableBackend` handle
 /// (which is private to this module).
 ///
 /// Used by `test_support::build_default_local_dev_database_roots_for_test`.
@@ -3235,7 +3233,7 @@ pub(crate) async fn mount_default_local_dev_database_roots(
 fn local_dev_project_filesystem(
     root: &Path,
     workspace_root: &Path,
-    host_home_root: Option<&LocalDevHostHomeRoot>,
+    host_home_root: Option<&HostHomeRoot>,
 ) -> Result<DiskFilesystem, RebornBuildError> {
     let mut filesystem = DiskFilesystem::new();
     filesystem.mount_local(
@@ -3271,7 +3269,7 @@ fn local_dev_project_filesystem(
 /// reconstructs it. Tests only; zero bytes in production builds.
 ///
 /// `libsql`-only (not `any(libsql, postgres)`): the body reopens via
-/// `LocalDevStorageBackendInput::LocalDefault`, whose non-libsql arm mounts a
+/// `StorageBackendInput::LocalDefault`, whose non-libsql arm mounts a
 /// fresh `InMemoryBackend` — under a postgres-composed runtime that would be
 /// a brand-new empty store, not the live Postgres-backed host state, so a
 /// postgres gate here would compile a probe that can only report absence.
@@ -3288,7 +3286,7 @@ pub(crate) async fn open_local_dev_slack_host_state_filesystem_for_test(
         storage_root,
         &workspace_root,
         None,
-        LocalDevStorageBackendInput::LocalDefault,
+        StorageBackendInput::LocalDefault,
     )
     .await?;
     Ok(local_dev_slack_host_state_filesystem(bundle.filesystem))
@@ -3430,11 +3428,11 @@ pub(crate) async fn open_local_dev_approval_settings_stores_for_test(
     mount_default_local_dev_database_roots(storage_root, &mut composite).await?;
     let scoped = crate::wrap_scoped(Arc::new(composite));
     let tool_permission_overrides: Arc<dyn ironclaw_approvals::ToolPermissionOverrideStore> =
-        Arc::new(LocalDevToolPermissionOverrideStore::new(Arc::clone(
+        Arc::new(ComposedToolPermissionOverrideStore::new(Arc::clone(
             &scoped,
         )));
     let auto_approve_settings: Arc<dyn ironclaw_approvals::AutoApproveSettingStore> =
-        Arc::new(LocalDevAutoApproveSettingStore::new(Arc::clone(&scoped)));
+        Arc::new(ComposedAutoApproveSettingStore::new(Arc::clone(&scoped)));
     let persistent_approval_policies: Arc<dyn ironclaw_approvals::PersistentApprovalPolicyStore> =
         Arc::new(FilesystemPersistentApprovalPolicyStore::new(scoped));
     Ok((
@@ -3458,7 +3456,7 @@ pub(crate) async fn open_local_dev_trigger_repository_for_test(
     storage_root: &Path,
 ) -> Result<Arc<dyn TriggerRepository>, RebornBuildError> {
     let db = open_local_dev_libsql_database(storage_root).await?;
-    local_dev_trigger_repository(&LocalDevDurableBackend::LibSql(db)).await
+    local_dev_trigger_repository(&DurableBackend::LibSql(db)).await
 }
 
 fn mount_local_dev_memory_root<F>(
@@ -3954,12 +3952,12 @@ fn canonicalize_local_dev_path(path: &Path, label: &str) -> Result<PathBuf, Rebo
     })
 }
 
-struct LocalDevHostHomeRoot {
+struct HostHomeRoot {
     canonical_root: PathBuf,
     raw_alias: PathBuf,
 }
 
-impl LocalDevHostHomeRoot {
+impl HostHomeRoot {
     fn aliases(&self) -> Vec<&Path> {
         vec![self.raw_alias.as_path(), self.canonical_root.as_path()]
     }
@@ -3975,7 +3973,7 @@ impl LocalDevHostHomeRoot {
 fn build_workspace_filesystems(
     filesystem: Arc<CompositeRootFilesystem>,
     workspace_root: &Path,
-    host_home_root: Option<&LocalDevHostHomeRoot>,
+    host_home_root: Option<&HostHomeRoot>,
 ) -> Result<LocalDevWorkspaceFilesystems, RebornBuildError> {
     let read_only_workspace_mounts = workspace_mount_view(MountPermissions::read_only(), &[])
         .map_err(|error| RebornBuildError::InvalidConfig {
@@ -4164,10 +4162,9 @@ fn local_dev_builtin_extension_registry() -> Result<ExtensionRegistry, RebornBui
 }
 
 pub fn builtin_first_party_trust_policy() -> Result<HostTrustPolicy, RebornBuildError> {
-    let policy =
-        local_dev_capability_policy().map_err(|error| RebornBuildError::InvalidConfig {
-            reason: format!("local-dev capability policy is invalid: {error}"),
-        })?;
+    let policy = builtin_capability_policy().map_err(|error| RebornBuildError::InvalidConfig {
+        reason: format!("local-dev capability policy is invalid: {error}"),
+    })?;
     #[cfg_attr(
         not(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta")),
         allow(unused_mut)
@@ -4178,7 +4175,7 @@ pub fn builtin_first_party_trust_policy() -> Result<HostTrustPolicy, RebornBuild
             policy.provider.manifest_path,
             None,
             HostTrustAssignment::first_party(),
-            // Sourced from local_dev_capability_policy.toml `[provider]
+            // Sourced from builtin_capability_policy.toml `[provider]
             // authority_effects`, which includes `external_write` — required by
             // builtin.trace_commons.onboard (operator-invite enrollment posts to
             // an external onboarding server).
@@ -5516,10 +5513,10 @@ mod tests {
     #[cfg(feature = "libsql")]
     use secrecy::ExposeSecret;
 
-    use crate::extension_host::extension_lifecycle::ExtensionActivationMode;
-    use crate::local_dev_capability_policy::{
-        LocalDevApprovalPolicyAction, LocalDevCapabilityPolicyError,
+    use crate::builtin_capability_policy::{
+        BuiltinApprovalPolicyAction, BuiltinCapabilityPolicyError,
     };
+    use crate::extension_host::extension_lifecycle::ExtensionActivationMode;
     use crate::{
         RebornReadinessDiagnostic, RebornReadinessState, runtime::SKILL_ACTIVATE_CAPABILITY_ID,
     };
@@ -5869,7 +5866,7 @@ mod tests {
     }
 
     #[cfg(any(feature = "libsql", feature = "postgres"))]
-    async fn local_runtime_with_failing_trigger_conversations() -> Arc<RebornLocalRuntimeServices> {
+    async fn local_runtime_with_failing_trigger_conversations() -> Arc<RebornRuntimeSubstrate> {
         let local_dev_root = tempfile::tempdir().expect("tempdir");
         let owner_user_id = "pairing-owner";
         let services = build_reborn_services(RebornBuildInput::local_dev(
@@ -5896,7 +5893,7 @@ mod tests {
                 Arc::new(FailingConversationStateFilesystem),
             )
             .expect("mount failing backend");
-        Arc::new(RebornLocalRuntimeServices {
+        Arc::new(RebornRuntimeSubstrate {
             extension_lifecycle_surface_context: base_runtime
                 .extension_lifecycle_surface_context
                 .clone(),
@@ -6248,7 +6245,7 @@ mod tests {
             &local_dev_root,
             &local_dev_root.join("workspace"),
             None,
-            LocalDevStorageBackendInput::LocalDefault,
+            StorageBackendInput::LocalDefault,
         )
         .await
         .expect("local-dev filesystem rebuild")
@@ -6321,7 +6318,7 @@ mod tests {
             &local_dev_root,
             &local_dev_root.join("workspace"),
             None,
-            LocalDevStorageBackendInput::LocalDefault,
+            StorageBackendInput::LocalDefault,
         )
         .await
         .expect("local-dev root filesystem")
@@ -6603,7 +6600,7 @@ mod tests {
             CapabilityId::new("gmail.send_message").expect("valid Gmail capability id");
         assert!(matches!(
             local_runtime.capability_policy.lease_approval_for(
-                LocalDevApprovalPolicyAction::Dispatch {
+                BuiltinApprovalPolicyAction::Dispatch {
                     capability: &gmail_capability,
                 },
                 &local_runtime.workspace_mounts,
@@ -6611,7 +6608,7 @@ mod tests {
                 &local_runtime.memory_mounts,
                 &local_runtime.system_extensions_lifecycle_mounts,
             ),
-            Err(LocalDevCapabilityPolicyError::MissingGrant { .. })
+            Err(BuiltinCapabilityPolicyError::MissingGrant { .. })
         ));
         let auth_scope =
             AuthProductScope::new(gmail_context.resource_scope.clone(), AuthSurface::Api);
@@ -8029,7 +8026,7 @@ mod tests {
     /// first-party tool dispatch; enabling it here mirrors the operator
     /// having flipped it on before letting the agent run tools.
     async fn enable_global_auto_approve_for_context(
-        local_runtime: &RebornLocalRuntimeServices,
+        local_runtime: &RebornRuntimeSubstrate,
         context: &ExecutionContext,
     ) {
         local_runtime
@@ -8259,7 +8256,7 @@ mod tests {
     /// trait-object roles.
     ///
     /// The assertion reads the four trait-object pointers from the built
-    /// `RebornLocalRuntimeServices` and compares their data halves via
+    /// `RebornRuntimeSubstrate` and compares their data halves via
     /// `std::ptr::addr_eq` (trait objects of different traits cannot be compared
     /// with `Arc::ptr_eq` directly).
     #[cfg(all(

--- a/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
@@ -1070,7 +1070,7 @@ fn provider_scope(value: &str) -> ProviderScope {
 #[cfg(test)]
 async fn submit_and_block_auth_run(
     turn_coordinator: &dyn ironclaw_turns::TurnCoordinator,
-    local_runtime: &RebornLocalRuntimeServices,
+    local_runtime: &RebornRuntimeSubstrate,
     scope: TurnScope,
     actor: TurnActor,
     gate_ref: &str,

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -25,7 +25,7 @@ use ironclaw_run_state::{ApprovalRequestStore, ApprovalStatus};
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 use super::*;
-use crate::local_dev_capability_policy::local_dev_one_shot_lease_approval;
+use crate::builtin_capability_policy::builtin_one_shot_lease_approval;
 
 use crate::approval_test_support::disable_global_auto_approve;
 
@@ -930,7 +930,7 @@ fn shell_network_policy() -> NetworkPolicy {
 }
 
 async fn approve_shell_dispatch(
-    local_runtime: &RebornLocalRuntimeServices,
+    local_runtime: &RebornRuntimeSubstrate,
     context: &ExecutionContext,
     gate: &RuntimeApprovalGate,
 ) {
@@ -948,7 +948,7 @@ async fn approve_shell_dispatch(
 }
 
 async fn pending_approval_count(
-    local_runtime: &RebornLocalRuntimeServices,
+    local_runtime: &RebornRuntimeSubstrate,
     context: &ExecutionContext,
 ) -> usize {
     local_runtime
@@ -974,7 +974,7 @@ fn operator_tool_permission_scope_for_test(scope: &ResourceScope) -> ResourceSco
 }
 
 fn shell_lease_approval() -> LeaseApproval {
-    local_dev_one_shot_lease_approval(GrantConstraints {
+    builtin_one_shot_lease_approval(GrantConstraints {
         allowed_effects: shell_allowed_effects(),
         mounts: MountView::default(),
         network: shell_network_policy(),
@@ -986,7 +986,7 @@ fn shell_lease_approval() -> LeaseApproval {
 }
 
 fn echo_dispatch_lease_approval() -> LeaseApproval {
-    local_dev_one_shot_lease_approval(GrantConstraints {
+    builtin_one_shot_lease_approval(GrantConstraints {
         allowed_effects: echo_dispatch_allowed_effects(),
         mounts: MountView::default(),
         network: NetworkPolicy::default(),

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -29,6 +29,8 @@ mod admin_user_directory;
 mod approval_test_support;
 mod automation;
 mod blocked_auth_resume;
+mod builtin_capability_policy;
+mod deployment;
 mod error;
 mod extension_host;
 mod factory;
@@ -36,8 +38,6 @@ mod input;
 mod lifecycle_auth_continuation;
 mod llm_admin;
 mod local_dev_authorization;
-mod local_dev_capability_policy;
-mod deployment;
 mod local_dev_mounts;
 mod local_runtime_profile;
 mod observability;
@@ -80,7 +80,7 @@ pub use extension_host::skill_listing::{RebornSkillListError, list_reborn_local_
 #[cfg(feature = "test-support")]
 pub use factory::AttachmentTestSupport;
 #[cfg(feature = "test-support")]
-pub use factory::RebornLocalDevApprovalTestParts;
+pub use factory::RebornApprovalTestParts;
 #[cfg(feature = "migration-support")]
 pub use factory::extension_installation_store_for_migration;
 pub use factory::{RebornServices, build_reborn_services, builtin_first_party_trust_policy};
@@ -151,9 +151,9 @@ pub use llm_admin::provider_admin_product_command::RebornProviderAdminProductCom
 #[cfg(feature = "root-llm-provider")]
 pub use llm_admin::provider_repo::{ProviderRepo, ProviderRepoError};
 pub use local_runtime_profile::{
-    RebornRuntimeProfileError, RebornRuntimeProfileOptions,
-    hosted_single_tenant_runtime_policy, hosted_single_tenant_volume_runtime_policy,
-    local_dev_runtime_policy, local_dev_yolo_runtime_policy, local_runtime_build_input,
+    RebornRuntimeProfileError, RebornRuntimeProfileOptions, hosted_single_tenant_runtime_policy,
+    hosted_single_tenant_volume_runtime_policy, local_dev_runtime_policy,
+    local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,
 };
 pub use observability::budget::build_default_budget_accountant;

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -37,6 +37,7 @@ mod lifecycle_auth_continuation;
 mod llm_admin;
 mod local_dev_authorization;
 mod local_dev_capability_policy;
+mod deployment;
 mod local_dev_mounts;
 mod local_runtime_profile;
 mod observability;
@@ -150,7 +151,7 @@ pub use llm_admin::provider_admin_product_command::RebornProviderAdminProductCom
 #[cfg(feature = "root-llm-provider")]
 pub use llm_admin::provider_repo::{ProviderRepo, ProviderRepoError};
 pub use local_runtime_profile::{
-    RebornLocalRuntimeProfileError, RebornLocalRuntimeProfileOptions,
+    RebornRuntimeProfileError, RebornRuntimeProfileOptions,
     hosted_single_tenant_runtime_policy, hosted_single_tenant_volume_runtime_policy,
     local_dev_runtime_policy, local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,

--- a/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
@@ -20,7 +20,7 @@ use ironclaw_host_api::{
 };
 use tokio::sync::Notify;
 
-use crate::local_dev_capability_policy::LocalDevCapabilityPolicy;
+use crate::builtin_capability_policy::BuiltinCapabilityPolicy;
 use crate::{
     profile_approval_authorization::{
         ApprovalSettingsProvider, ProfileApprovalGatePolicy, profile_approval_authorizer,
@@ -30,7 +30,7 @@ use crate::{
 
 pub(crate) fn local_dev_authorizer(
     runtime_policy: Option<&EffectiveRuntimePolicy>,
-    capability_policy: Arc<LocalDevCapabilityPolicy>,
+    capability_policy: Arc<BuiltinCapabilityPolicy>,
     settings: Arc<dyn ApprovalSettingsProvider>,
 ) -> Arc<dyn TrustAwareCapabilityDispatchAuthorizer> {
     let (approval_policy, resolved_profile) = local_dev_approval_policy(runtime_policy);
@@ -568,7 +568,7 @@ fn operator_tool_permission_scope(scope: &ResourceScope) -> ResourceScope {
 
 pub(crate) fn local_dev_effects_require_approval(
     runtime_policy: Option<&EffectiveRuntimePolicy>,
-    capability_policy: &LocalDevCapabilityPolicy,
+    capability_policy: &BuiltinCapabilityPolicy,
     effects: &[EffectKind],
 ) -> bool {
     let (approval_policy, resolved_profile) = local_dev_approval_policy(runtime_policy);

--- a/crates/ironclaw_reborn_composition/src/local_dev_authorization/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_authorization/tests.rs
@@ -30,7 +30,7 @@ use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, Trust
 use serde_json::json;
 
 use super::*;
-use crate::local_dev_capability_policy::local_dev_capability_policy;
+use crate::builtin_capability_policy::builtin_capability_policy;
 
 struct ErroringToolPermissionOverrideStore;
 
@@ -361,7 +361,7 @@ fn local_dev_shell_authorization_inputs(
         network_targets: Vec::new(),
         resource_profile: None,
     };
-    let policy = local_dev_capability_policy().expect("capability policy");
+    let policy = builtin_capability_policy().expect("capability policy");
     let grants = policy.builtin_grants(
         &provider_id,
         &MountView::default(),
@@ -412,7 +412,7 @@ async fn trace_commons_authorize_decision(
         network_targets: Vec::new(),
         resource_profile: None,
     };
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let provider_id = ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER).expect("provider id");
     let grants = policy.builtin_grants(
         &provider_id,
@@ -541,7 +541,7 @@ async fn local_dev_authorizer_refreshes_approval_settings_on_next_invocation() {
         auto_approve.clone(),
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
 
     // Global auto-approve now defaults ON, so explicitly disable it first to
@@ -599,7 +599,7 @@ async fn local_dev_authorizer_observes_global_auto_approve_revocation_on_next_in
         auto_approve.clone(),
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
 
     let before = local_dev_shell_decision_with_authorizer(authorizer.as_ref(), &user_id).await;
@@ -638,7 +638,7 @@ async fn local_dev_authorizer_caches_global_auto_approve_within_one_invocation()
         auto_approve.clone(),
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
     let (descriptor, context, trust_decision) = local_dev_shell_authorization_inputs(&user_id);
 
@@ -715,7 +715,7 @@ async fn local_dev_authorizer_coalesces_concurrent_global_auto_approve_misses() 
         auto_approve.clone(),
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
     let (descriptor, context, trust_decision) = local_dev_shell_authorization_inputs(&user_id);
 
@@ -912,7 +912,7 @@ async fn local_dev_authorizer_fails_closed_when_override_lookup_errors() {
         auto_approve,
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
 
     let decision = local_dev_shell_decision_with_authorizer(authorizer.as_ref(), &user_id).await;
@@ -938,7 +938,7 @@ async fn per_tool_disabled_overrides_global_auto_approve_through_store() {
         auto_approve,
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
 
     let decision = local_dev_shell_decision_with_authorizer(authorizer.as_ref(), &user_id).await;
@@ -961,7 +961,7 @@ async fn per_tool_ask_each_time_overrides_global_auto_approve_through_store() {
         auto_approve,
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
 
     let decision = local_dev_shell_decision_with_authorizer(authorizer.as_ref(), &user_id).await;
@@ -985,7 +985,7 @@ async fn global_auto_approve_does_not_bypass_manifest_ineligible_tool_through_st
         auto_approve,
         Arc::new(in_memory_backed_persistent_approval_policy_store()),
     ));
-    let policy = Arc::new(local_dev_capability_policy().expect("capability policy"));
+    let policy = Arc::new(builtin_capability_policy().expect("capability policy"));
     let authorizer = local_dev_authorizer(None, policy, settings);
 
     // `Deny` manifest permission is not durable-approval eligible, so the

--- a/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
+++ b/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
@@ -32,9 +32,9 @@ pub(crate) fn deployment_config_for_profile(
 ) -> Result<DeploymentConfig, RebornRuntimeProfileError> {
     match profile {
         RebornCompositionProfile::LocalDev => Ok(DeploymentConfig::local_dev()),
-        RebornCompositionProfile::LocalDevYolo => {
-            Ok(DeploymentConfig::local_dev_yolo(options.confirm_host_access))
-        }
+        RebornCompositionProfile::LocalDevYolo => Ok(DeploymentConfig::local_dev_yolo(
+            options.confirm_host_access,
+        )),
         RebornCompositionProfile::HostedSingleTenantVolume => {
             Ok(DeploymentConfig::hosted_single_tenant_volume())
         }
@@ -95,8 +95,8 @@ pub(crate) fn hosted_single_tenant_volume_build_input(
     }
 
     #[cfg(feature = "libsql")]
-    let policy = hosted_single_tenant_volume_runtime_policy()
-        .map_err(RebornRuntimeProfileError::Policy)?;
+    let policy =
+        hosted_single_tenant_volume_runtime_policy().map_err(RebornRuntimeProfileError::Policy)?;
     #[cfg(feature = "libsql")]
     Ok(RebornBuildInput::local_dev_with_profile(
         RebornCompositionProfile::HostedSingleTenantVolume,

--- a/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
+++ b/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
-use ironclaw_host_api::runtime_policy::{DeploymentMode, RuntimeProfile};
 use ironclaw_runtime_policy::{EffectiveRuntimePolicy as ResolvedRuntimePolicy, ResolveError};
 use thiserror::Error;
 
+use crate::deployment::DeploymentConfig;
 use crate::{RebornBuildInput, RebornCompositionProfile};
 
 #[derive(Debug, Error)]
-pub enum RebornLocalRuntimeProfileError {
+pub enum RebornRuntimeProfileError {
     #[error("profile={profile} is not a local Reborn runtime profile")]
     UnsupportedProfile { profile: RebornCompositionProfile },
     #[error(
@@ -19,8 +19,32 @@ pub enum RebornLocalRuntimeProfileError {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct RebornLocalRuntimeProfileOptions {
+pub struct RebornRuntimeProfileOptions {
     pub confirm_host_access: bool,
+}
+
+/// Map a composition profile to its [`DeploymentConfig`] value — the one
+/// place a profile name becomes deployment policy data (§4.4). Everything
+/// past this edge consumes resolved policy values, never a mode.
+pub(crate) fn deployment_config_for_profile(
+    profile: RebornCompositionProfile,
+    options: RebornRuntimeProfileOptions,
+) -> Result<DeploymentConfig, RebornRuntimeProfileError> {
+    match profile {
+        RebornCompositionProfile::LocalDev => Ok(DeploymentConfig::local_dev()),
+        RebornCompositionProfile::LocalDevYolo => {
+            Ok(DeploymentConfig::local_dev_yolo(options.confirm_host_access))
+        }
+        RebornCompositionProfile::HostedSingleTenantVolume => {
+            Ok(DeploymentConfig::hosted_single_tenant_volume())
+        }
+        RebornCompositionProfile::Disabled
+        | RebornCompositionProfile::HostedSingleTenant
+        | RebornCompositionProfile::Production
+        | RebornCompositionProfile::MigrationDryRun => {
+            Err(RebornRuntimeProfileError::UnsupportedProfile { profile })
+        }
+    }
 }
 
 /// Build the local runtime substrate input and its matching runtime policy from
@@ -29,12 +53,12 @@ pub fn local_runtime_build_input(
     profile: RebornCompositionProfile,
     owner_id: impl Into<String>,
     root: PathBuf,
-) -> Result<RebornBuildInput, RebornLocalRuntimeProfileError> {
+) -> Result<RebornBuildInput, RebornRuntimeProfileError> {
     local_runtime_build_input_with_options(
         profile,
         owner_id,
         root,
-        RebornLocalRuntimeProfileOptions::default(),
+        RebornRuntimeProfileOptions::default(),
     )
 }
 
@@ -44,8 +68,8 @@ pub fn local_runtime_build_input_with_options(
     profile: RebornCompositionProfile,
     owner_id: impl Into<String>,
     root: PathBuf,
-    options: RebornLocalRuntimeProfileOptions,
-) -> Result<RebornBuildInput, RebornLocalRuntimeProfileError> {
+    options: RebornRuntimeProfileOptions,
+) -> Result<RebornBuildInput, RebornRuntimeProfileError> {
     if profile == RebornCompositionProfile::HostedSingleTenantVolume {
         return hosted_single_tenant_volume_build_input(owner_id, root);
     }
@@ -62,17 +86,17 @@ pub fn local_runtime_build_input_with_options(
 pub(crate) fn hosted_single_tenant_volume_build_input(
     owner_id: impl Into<String>,
     root: PathBuf,
-) -> Result<RebornBuildInput, RebornLocalRuntimeProfileError> {
+) -> Result<RebornBuildInput, RebornRuntimeProfileError> {
     #[cfg(not(feature = "libsql"))]
     {
         let _ = owner_id;
         let _ = root;
-        Err(RebornLocalRuntimeProfileError::MissingLibsqlFeature)
+        Err(RebornRuntimeProfileError::MissingLibsqlFeature)
     }
 
     #[cfg(feature = "libsql")]
     let policy = hosted_single_tenant_volume_runtime_policy()
-        .map_err(RebornLocalRuntimeProfileError::Policy)?;
+        .map_err(RebornRuntimeProfileError::Policy)?;
     #[cfg(feature = "libsql")]
     Ok(RebornBuildInput::local_dev_with_profile(
         RebornCompositionProfile::HostedSingleTenantVolume,
@@ -97,11 +121,7 @@ pub fn hosted_single_tenant_runtime_policy() -> Result<ResolvedRuntimePolicy, Re
 /// scoped virtual filesystem, brokered network, brokered secret handles, and
 /// ask-always approval posture from the resolver-owned secure default.
 pub fn hosted_single_tenant_volume_runtime_policy() -> Result<ResolvedRuntimePolicy, ResolveError> {
-    let request = ironclaw_runtime_policy::ResolveRequest::new(
-        DeploymentMode::HostedMultiTenant,
-        RuntimeProfile::SecureDefault,
-    );
-    ironclaw_runtime_policy::resolve(request)
+    DeploymentConfig::hosted_single_tenant_volume().resolve()
 }
 
 /// Resolved policy for trusted single-user local development with inherited
@@ -111,16 +131,16 @@ pub fn local_dev_yolo_runtime_policy(
 ) -> Result<ResolvedRuntimePolicy, ResolveError> {
     local_runtime_policy(
         RebornCompositionProfile::LocalDevYolo,
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access,
         },
     )
     .map_err(|error| match error {
-        RebornLocalRuntimeProfileError::Policy(error) => error,
-        RebornLocalRuntimeProfileError::MissingLibsqlFeature => {
+        RebornRuntimeProfileError::Policy(error) => error,
+        RebornRuntimeProfileError::MissingLibsqlFeature => {
             unreachable!("local-dev-yolo is not the hosted volume profile")
         }
-        RebornLocalRuntimeProfileError::UnsupportedProfile { .. } => {
+        RebornRuntimeProfileError::UnsupportedProfile { .. } => {
             unreachable!("local-dev-yolo is a local runtime profile")
         }
     })
@@ -128,30 +148,9 @@ pub fn local_dev_yolo_runtime_policy(
 
 fn local_runtime_policy(
     profile: RebornCompositionProfile,
-    options: RebornLocalRuntimeProfileOptions,
-) -> Result<ResolvedRuntimePolicy, RebornLocalRuntimeProfileError> {
-    let runtime_profile = match profile {
-        RebornCompositionProfile::LocalDev => RuntimeProfile::LocalDev,
-        RebornCompositionProfile::LocalDevYolo => RuntimeProfile::LocalYolo,
-        RebornCompositionProfile::HostedSingleTenantVolume => {
-            return hosted_single_tenant_volume_runtime_policy()
-                .map_err(RebornLocalRuntimeProfileError::Policy);
-        }
-        RebornCompositionProfile::Disabled
-        | RebornCompositionProfile::HostedSingleTenant
-        | RebornCompositionProfile::Production
-        | RebornCompositionProfile::MigrationDryRun => {
-            return Err(RebornLocalRuntimeProfileError::UnsupportedProfile { profile });
-        }
-    };
-    let request = ironclaw_runtime_policy::ResolveRequest {
-        yolo_disclosure_acknowledged: options.confirm_host_access,
-        ..ironclaw_runtime_policy::ResolveRequest::new(
-            DeploymentMode::LocalSingleUser,
-            runtime_profile,
-        )
-    };
-    Ok(ironclaw_runtime_policy::resolve(request)?)
+    options: RebornRuntimeProfileOptions,
+) -> Result<ResolvedRuntimePolicy, RebornRuntimeProfileError> {
+    Ok(deployment_config_for_profile(profile, options)?.resolve()?)
 }
 
 fn local_runtime_policy_for_local_dev_shape(
@@ -159,14 +158,14 @@ fn local_runtime_policy_for_local_dev_shape(
 ) -> Result<ResolvedRuntimePolicy, ResolveError> {
     local_runtime_policy(
         RebornCompositionProfile::LocalDev,
-        RebornLocalRuntimeProfileOptions::default(),
+        RebornRuntimeProfileOptions::default(),
     )
     .map_err(|error| match error {
-        RebornLocalRuntimeProfileError::Policy(error) => error,
-        RebornLocalRuntimeProfileError::MissingLibsqlFeature => {
+        RebornRuntimeProfileError::Policy(error) => error,
+        RebornRuntimeProfileError::MissingLibsqlFeature => {
             unreachable!("{profile_name} is not the hosted volume profile")
         }
-        RebornLocalRuntimeProfileError::UnsupportedProfile { .. } => {
+        RebornRuntimeProfileError::UnsupportedProfile { .. } => {
             unreachable!("{profile_name} uses the local-dev runtime policy shape")
         }
     })

--- a/crates/ironclaw_reborn_composition/src/observability/budget_evidence.rs
+++ b/crates/ironclaw_reborn_composition/src/observability/budget_evidence.rs
@@ -4,18 +4,18 @@ use async_trait::async_trait;
 use ironclaw_runner::loop_exit_applier::ResourceGateEvidenceStore;
 use ironclaw_turns::{LoopGateRef, TurnError, TurnScope};
 
-pub(crate) fn local_dev_resource_gate_evidence(
+pub(crate) fn budget_gate_evidence(
     budget_gate_store: Arc<dyn ironclaw_resources::BudgetGateStore>,
 ) -> Arc<dyn ResourceGateEvidenceStore> {
-    Arc::new(LocalDevResourceGateEvidence { budget_gate_store })
+    Arc::new(BudgetGateEvidence { budget_gate_store })
 }
 
-struct LocalDevResourceGateEvidence {
+struct BudgetGateEvidence {
     budget_gate_store: Arc<dyn ironclaw_resources::BudgetGateStore>,
 }
 
 #[async_trait]
-impl ResourceGateEvidenceStore for LocalDevResourceGateEvidence {
+impl ResourceGateEvidenceStore for BudgetGateEvidence {
     async fn pending_resource_gate(
         &self,
         scope: &TurnScope,

--- a/crates/ironclaw_reborn_composition/src/observability/trajectory_observer.rs
+++ b/crates/ironclaw_reborn_composition/src/observability/trajectory_observer.rs
@@ -38,7 +38,7 @@
 //! Callbacks fire inline on the per-capability hot path and are best-effort:
 //! implementations must never block and must not rely on being called (a
 //! panicking observer is caught and dropped at the call site — see
-//! `HostRuntimeLoopCapabilityPort` / `LocalDevCapabilityIo`). An observer that
+//! `HostRuntimeLoopCapabilityPort` / `StagedCapabilityIo`). An observer that
 //! needs to do I/O or contend on a lock must hand the event to its own
 //! non-blocking queue and return immediately.
 
@@ -204,7 +204,7 @@ impl RebornTrajectoryObserver for SafePreviewTrajectoryObserver {
 /// [`CapabilityTrajectoryObserver`] the loop-host capability port consumes,
 /// so the facade trait never appears in this crate's loop-host boundary. The
 /// substrate trait is input-only; the composition observer's result half is
-/// driven separately by `LocalDevCapabilityIo`.
+/// driven separately by `StagedCapabilityIo`.
 #[derive(Debug)]
 struct CapabilityTrajectoryObserverAdapter {
     inner: Arc<dyn RebornTrajectoryObserver>,
@@ -224,7 +224,7 @@ impl CapabilityTrajectoryObserver for CapabilityTrajectoryObserverAdapter {
 
 /// Adapt a composition observer to the substrate observer the loop-host
 /// capability port (the input hook) drives. The result hook lives on
-/// `LocalDevCapabilityIo`, which calls the composition trait directly.
+/// `StagedCapabilityIo`, which calls the composition trait directly.
 pub(crate) fn as_capability_observer(
     observer: Arc<dyn RebornTrajectoryObserver>,
 ) -> Arc<dyn CapabilityTrajectoryObserver> {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -106,8 +106,8 @@ use ironclaw_turns::run_profile::UserProfileContext;
 
 use self::latency::{trace_runtime_latency_error, trace_runtime_latency_ok};
 use self::runtime_turn_scheduler::RuntimeTurnScheduler;
-use crate::factory::{LocalDevTurnStateStore, builtin_extension_registry};
-use crate::local_dev_capability_policy::{LocalDevCapabilityPolicy, local_dev_capability_policy};
+use crate::builtin_capability_policy::{BuiltinCapabilityPolicy, builtin_capability_policy};
+use crate::factory::{ComposedTurnStateStore, builtin_extension_registry};
 #[cfg(any(test, feature = "test-support"))]
 use crate::outbound::outbound_preferences::OutboundDeliveryTargetEntry;
 use crate::outbound::{
@@ -185,7 +185,7 @@ impl HostUserProfileSource for MemoryBackedUserProfileSourceAdapter {
 }
 
 struct RuntimeStoreParts<'a> {
-    local_runtime: Option<&'a crate::factory::RebornLocalRuntimeServices>,
+    local_runtime: Option<&'a crate::factory::RebornRuntimeSubstrate>,
     turn_state_store: Arc<dyn RuntimeTurnStateStore>,
     checkpoint_state_store: Arc<dyn ironclaw_turns::CheckpointStateStore>,
     loop_checkpoint_store: Arc<dyn ironclaw_turns::LoopCheckpointStore>,
@@ -300,7 +300,7 @@ impl AwaitDependentRunEvidenceStore for NonDurableAwaitDependentRunEvidence {
 }
 
 fn local_runtime_parts(
-    local_runtime: &crate::factory::RebornLocalRuntimeServices,
+    local_runtime: &crate::factory::RebornRuntimeSubstrate,
 ) -> RuntimeStoreParts<'_> {
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     let subagent_goal_store = Arc::new(FilesystemSubagentGoalStore::new(Arc::clone(
@@ -660,7 +660,7 @@ pub struct RebornRuntime {
     /// wired (e.g. production-parts launches); the durable filesystem store
     /// already persists every transition, so it needs no shutdown flush.
     #[cfg(feature = "inmemory-turn-state")]
-    turn_state_flush: Option<Arc<LocalDevTurnStateStore>>,
+    turn_state_flush: Option<Arc<ComposedTurnStateStore>>,
     turn_tree_store: Arc<dyn TurnSpawnTreeStateStore>,
     thread_service: Arc<dyn SessionThreadService>,
     thread_scope: ThreadScope,
@@ -709,8 +709,8 @@ pub struct RebornRuntime {
     webui_event_log: Arc<dyn DurableEventLog>,
     default_run_profile_id: String,
     send_locks: Mutex<HashMap<ConversationId, Arc<Mutex<()>>>>,
-    skill_activation_source: Option<Arc<LocalDevSelectableSkillContextSource>>,
-    skill_execution_adapter: Option<Arc<LocalDevSkillExecutionAdapter>>,
+    skill_activation_source: Option<Arc<ComposedSelectableSkillContextSource>>,
+    skill_execution_adapter: Option<Arc<ComposedSkillExecutionAdapter>>,
     /// Operator boot config, carried so the WebUI facade can compose the
     /// LLM-config settings service over `providers.json` / `config.toml`.
     #[cfg(feature = "root-llm-provider")]
@@ -762,14 +762,14 @@ impl RegistryPersistentApprovalGranteeResolver {
 /// `local_runtime.turn_state` as the turn-run snapshot source — production
 /// behavior is unchanged by the seam below.
 pub(crate) fn build_local_dev_approval_interaction_service(
-    local_runtime: &crate::factory::RebornLocalRuntimeServices,
-    local_dev_capability_policy: Arc<LocalDevCapabilityPolicy>,
+    local_runtime: &crate::factory::RebornRuntimeSubstrate,
+    builtin_capability_policy: Arc<BuiltinCapabilityPolicy>,
     turn_coordinator: Arc<dyn TurnCoordinator>,
     audit_sink: Option<Arc<dyn ironclaw_events::AuditSink>>,
 ) -> Result<Arc<dyn ApprovalInteractionService>, RebornRuntimeError> {
     build_local_dev_approval_interaction_service_with_turn_run_source(
         local_runtime,
-        local_dev_capability_policy,
+        builtin_capability_policy,
         turn_coordinator,
         audit_sink,
         Arc::clone(&local_runtime.turn_state) as Arc<dyn TurnRunSnapshotSource>,
@@ -787,13 +787,13 @@ pub(crate) fn build_local_dev_approval_interaction_service(
 /// `local_runtime.turn_state` as the source, so production behavior is
 /// unchanged.
 pub(crate) fn build_local_dev_approval_interaction_service_with_turn_run_source(
-    local_runtime: &crate::factory::RebornLocalRuntimeServices,
-    local_dev_capability_policy: Arc<LocalDevCapabilityPolicy>,
+    local_runtime: &crate::factory::RebornRuntimeSubstrate,
+    builtin_capability_policy: Arc<BuiltinCapabilityPolicy>,
     turn_coordinator: Arc<dyn TurnCoordinator>,
     audit_sink: Option<Arc<dyn ironclaw_events::AuditSink>>,
     turn_run_source: Arc<dyn TurnRunSnapshotSource>,
 ) -> Result<Arc<dyn ApprovalInteractionService>, RebornRuntimeError> {
-    let approval_turn_runs = Arc::new(LocalDevApprovalTurnRunLocator::new(turn_run_source));
+    let approval_turn_runs = Arc::new(SnapshotApprovalTurnRunLocator::new(turn_run_source));
     let approval_read_model = Arc::new(RunStateApprovalInteractionReadModel::new(
         local_runtime.approval_requests.clone(),
         approval_turn_runs,
@@ -810,14 +810,14 @@ pub(crate) fn build_local_dev_approval_interaction_service_with_turn_run_source(
     Ok(Arc::new(
         DefaultApprovalInteractionService::new(
             approval_read_model,
-            Arc::new(approval::LocalDevApprovalLeaseTermsProvider::new(
-                local_dev_capability_policy,
+            Arc::new(approval::PolicyApprovalLeaseTermsProvider::new(
+                builtin_capability_policy,
                 Arc::clone(&local_runtime.extension_registry),
                 local_runtime.workspace_mounts.clone(),
                 local_runtime.skill_mounts.clone(),
                 local_runtime.memory_mounts.clone(),
                 local_runtime.system_extensions_lifecycle_mounts.clone(),
-                local_dev::extension_surface::LocalDevExtensionSurfaceSource::new(
+                local_dev::extension_surface::ExtensionCapabilitySurfaceSource::new(
                     local_runtime.extension_management.clone(),
                 ),
             )),
@@ -832,9 +832,9 @@ pub(crate) fn build_local_dev_approval_interaction_service_with_turn_run_source(
     ))
 }
 
-pub(crate) type LocalDevSelectableSkillContextSource =
+pub(crate) type ComposedSelectableSkillContextSource =
     SelectableSkillContextSource<FilesystemSkillBundleSource<CompositeRootFilesystem>>;
-type LocalDevSkillExecutionAdapter =
+type ComposedSkillExecutionAdapter =
     SkillExecutionAdapter<FilesystemSkillBundleSource<CompositeRootFilesystem>>;
 
 // TODO(#4416): when a second test-only handle is
@@ -870,7 +870,7 @@ struct TriggerPollerServices {
 }
 
 async fn build_trigger_poller_services(
-    local_runtime: &crate::factory::RebornLocalRuntimeServices,
+    local_runtime: &crate::factory::RebornRuntimeSubstrate,
     turn_coordinator: Arc<dyn TurnCoordinator>,
     thread_service: Arc<dyn SessionThreadService>,
     authorizer_config: TriggerPollerAuthorizerConfig,
@@ -1024,21 +1024,21 @@ where
 }
 
 fn build_trigger_active_run_lookup(
-    turn_state_store: Arc<LocalDevTurnStateStore>,
+    turn_state_store: Arc<ComposedTurnStateStore>,
 ) -> Arc<dyn ironclaw_triggers::TriggerActiveRunLookup> {
     let snapshot_source = turn_state_store as Arc<dyn TurnRunSnapshotSource>;
     Arc::new(SnapshotActiveRunLookup::new(snapshot_source))
 }
 
-struct LocalDevApprovalTurnRunLocator {
-    /// A trait object (not the concrete `LocalDevTurnStateStore`) so a
+struct SnapshotApprovalTurnRunLocator {
+    /// A trait object (not the concrete `ComposedTurnStateStore`) so a
     /// caller can substitute a different turn-state store's snapshot view —
     /// see `turn_run_snapshot::TurnRunSnapshotSource` and
     /// `build_local_dev_approval_interaction_service_with_turn_run_source`.
     turn_state: Arc<dyn TurnRunSnapshotSource>,
 }
 
-impl LocalDevApprovalTurnRunLocator {
+impl SnapshotApprovalTurnRunLocator {
     fn new(turn_state: Arc<dyn TurnRunSnapshotSource>) -> Self {
         Self { turn_state }
     }
@@ -1056,23 +1056,23 @@ impl LocalDevApprovalTurnRunLocator {
     }
 }
 
-struct LocalDevApprovalGateEvidence {
+struct ApprovalRequestGateEvidence {
     approval_requests: Arc<dyn ironclaw_run_state::ApprovalRequestStore>,
 }
 
-/// Test-only constructor for [`LocalDevApprovalGateEvidence`].
+/// Test-only constructor for [`ApprovalRequestGateEvidence`].
 ///
 /// Mirrors the production wiring in `build_local_runtime` (runtime.rs ~line 2799)
-/// where `LocalDevApprovalGateEvidence` is constructed inline and passed to
+/// where `ApprovalRequestGateEvidence` is constructed inline and passed to
 /// `loop_exit_evidence.with_approval_gate_evidence`. Exists so `test_support.rs`
 /// can build the real evidence type without needing the struct or its field to be
 /// `pub(crate)`. For tests only — gated behind `test-support`, ships zero bytes
 /// in production binaries.
 #[cfg(feature = "test-support")]
-pub(crate) fn build_local_dev_approval_gate_evidence_for_test(
+pub(crate) fn build_approval_gate_evidence_for_test(
     approval_requests: std::sync::Arc<dyn ironclaw_run_state::ApprovalRequestStore>,
 ) -> std::sync::Arc<dyn ironclaw_runner::loop_exit_applier::ApprovalGateEvidenceStore> {
-    std::sync::Arc::new(LocalDevApprovalGateEvidence { approval_requests })
+    std::sync::Arc::new(ApprovalRequestGateEvidence { approval_requests })
 }
 
 /// Test-support forwarder for the `result_read` synthetic-capability wrap
@@ -1107,18 +1107,18 @@ pub(crate) fn wrap_result_read_capability_for_test(
 /// `activation_source` (backing `skill_activate`) that `test_support.rs` needs.
 /// Reuses the private [`local_dev_filesystem_skill_context_source`] so the
 /// wiring never drifts, but deliberately does NOT return the internal
-/// [`LocalDevSkillContextSource`] struct — that type (and its
+/// [`ComposedSkillContextSource`] struct — that type (and its
 /// `execution_adapter` field) stays private to this module; only the two
 /// fields an external caller actually consumes cross the boundary. Tests only.
 #[cfg(feature = "test-support")]
 pub(crate) fn local_dev_filesystem_skill_context_source_for_test(
-    local_runtime: &crate::factory::RebornLocalRuntimeServices,
+    local_runtime: &crate::factory::RebornRuntimeSubstrate,
     tenant_id: &TenantId,
     regex_skill_activation_enabled: bool,
 ) -> Result<
     (
         Arc<dyn HostSkillContextSource>,
-        Arc<LocalDevSelectableSkillContextSource>,
+        Arc<ComposedSelectableSkillContextSource>,
     ),
     RebornRuntimeError,
 > {
@@ -1131,41 +1131,41 @@ pub(crate) fn local_dev_filesystem_skill_context_source_for_test(
 }
 
 /// Test-support forwarder (harness-port-seam P1 seam) for
-/// `create_refreshing_local_dev_capability_port`
+/// `create_refreshing_capability_port`
 /// (`refreshing_capability_port.rs:75`), production's sole capability-port
 /// factory. Bridges the private `local_dev` module to `test_support`; mirrors
 /// the `outbound_delivery` forwarder above. For tests only -- gated behind
 /// `test-support`, ships zero bytes in production builds.
 #[cfg(feature = "test-support")]
-pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
-    parts: crate::test_support::RefreshingLocalDevCapabilityPortTestParts,
+pub(crate) async fn create_refreshing_capability_port_for_test(
+    parts: crate::test_support::RefreshingCapabilityPortTestParts,
 ) -> Result<
     std::sync::Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>,
     ironclaw_turns::run_profile::AgentLoopHostError,
 > {
-    local_dev::create_refreshing_local_dev_capability_port_for_test(parts).await
+    local_dev::create_refreshing_capability_port_for_test(parts).await
 }
 
-/// Test-support forwarder exposing production's real `LocalDevCapabilityIo`
-/// wiring (`local_dev.rs`'s `local_dev_capability_io_for_test`, which mirrors
+/// Test-support forwarder exposing production's real `StagedCapabilityIo`
+/// wiring (`local_dev.rs`'s `staged_capability_io_for_test`, which mirrors
 /// `capability_wiring`'s `new_with_durable_previews` call). Bridges the
 /// private `local_dev` module to `test_support`; mirrors the
-/// `create_refreshing_local_dev_capability_port_for_test` forwarder above.
+/// `create_refreshing_capability_port_for_test` forwarder above.
 /// For tests only -- gated behind `test-support`, ships zero bytes in
 /// production builds.
 #[cfg(feature = "test-support")]
-pub(crate) fn local_dev_capability_io_for_test(
+pub(crate) fn staged_capability_io_for_test(
     thread_service: std::sync::Arc<dyn ironclaw_threads::SessionThreadService>,
     fallback_user_id: ironclaw_host_api::UserId,
 ) -> (
     std::sync::Arc<dyn ironclaw_loop_host::LoopCapabilityInputResolver>,
     std::sync::Arc<dyn ironclaw_loop_host::LoopCapabilityResultWriter>,
 ) {
-    local_dev::local_dev_capability_io_for_test(thread_service, fallback_user_id)
+    local_dev::staged_capability_io_for_test(thread_service, fallback_user_id)
 }
 
 #[async_trait::async_trait]
-impl ApprovalGateEvidenceStore for LocalDevApprovalGateEvidence {
+impl ApprovalGateEvidenceStore for ApprovalRequestGateEvidence {
     async fn pending_approval_gate(
         &self,
         scope: &TurnScope,
@@ -1195,7 +1195,7 @@ fn approval_request_id_from_gate_ref(gate_ref: &LoopGateRef) -> Option<ApprovalR
 }
 
 #[async_trait::async_trait]
-impl ApprovalTurnRunLocator for LocalDevApprovalTurnRunLocator {
+impl ApprovalTurnRunLocator for SnapshotApprovalTurnRunLocator {
     async fn blocked_approval_runs(
         &self,
         scope: &ApprovalInteractionScope,
@@ -1900,7 +1900,7 @@ impl RebornRuntime {
     /// call is silently ignored. Returns `false` when the local-runtime slot is
     /// unavailable or already occupied, `true` on first successful set. Shares
     /// the same `OnceLock` the handler reads
-    /// (`RebornLocalRuntimeServices::channel_connection_facade_slot`).
+    /// (`RebornRuntimeSubstrate::channel_connection_facade_slot`).
     #[cfg(any(feature = "slack-v2-host-beta", feature = "telegram-v2-host-beta"))]
     pub(crate) fn set_channel_connection_facade(
         &self,
@@ -1922,7 +1922,7 @@ impl RebornRuntime {
 
     pub(crate) fn webui_skill_activation_source(
         &self,
-    ) -> Option<Arc<LocalDevSelectableSkillContextSource>> {
+    ) -> Option<Arc<ComposedSelectableSkillContextSource>> {
         self.skill_activation_source.clone()
     }
 
@@ -3489,14 +3489,13 @@ pub async fn build_reborn_runtime(
         Arc::clone(&checkpoint_state_store) as Arc<dyn ironclaw_turns::CheckpointStateStore>
     );
     if let Some(local_runtime) = local_runtime {
-        loop_exit_evidence = loop_exit_evidence.with_approval_gate_evidence(Arc::new(
-            LocalDevApprovalGateEvidence {
+        loop_exit_evidence =
+            loop_exit_evidence.with_approval_gate_evidence(Arc::new(ApprovalRequestGateEvidence {
                 approval_requests: Arc::clone(&local_runtime.approval_requests)
                     as Arc<dyn ironclaw_run_state::ApprovalRequestStore>,
-            },
-        ));
+            }));
         loop_exit_evidence = loop_exit_evidence.with_resource_gate_evidence(
-            crate::observability::budget_evidence::local_dev_resource_gate_evidence(Arc::clone(
+            crate::observability::budget_evidence::budget_gate_evidence(Arc::clone(
                 &local_runtime.budget_gate_store,
             )),
         );
@@ -3567,21 +3566,20 @@ pub async fn build_reborn_runtime(
         capability_result_writer,
         capability_surface_resolver,
         model_gateway,
-        local_dev_capability_policy,
+        builtin_capability_policy,
         display_previews,
     ) = if local_runtime.is_some() {
-        let local_dev_capability_policy =
-            Arc::new(local_dev_capability_policy().map_err(|error| {
-                tracing::error!(%error, "local-dev capability policy is invalid");
-                RebornRuntimeError::InvalidArgument {
-                    reason: format!("local-dev capability policy is invalid: {error}"),
-                }
-            })?);
+        let builtin_capability_policy = Arc::new(builtin_capability_policy().map_err(|error| {
+            tracing::error!(%error, "local-dev capability policy is invalid");
+            RebornRuntimeError::InvalidArgument {
+                reason: format!("local-dev capability policy is invalid: {error}"),
+            }
+        })?);
         let local_dev_capabilities = local_dev::capability_wiring(
             &services,
             Arc::clone(&thread_service) as Arc<dyn SessionThreadService>,
             actor_user_id.clone(),
-            Arc::clone(&local_dev_capability_policy),
+            Arc::clone(&builtin_capability_policy),
             model_gateway,
             milestone_sink.clone(),
             skill_activation_source.clone(),
@@ -3596,7 +3594,7 @@ pub async fn build_reborn_runtime(
             Arc::new(AllowAllCapabilitySurfaceResolver)
                 as Arc<dyn CapabilitySurfaceProfileResolver>,
             local_dev_capabilities.model_gateway,
-            Some(local_dev_capability_policy),
+            Some(builtin_capability_policy),
             Some(local_dev_capabilities.display_previews),
         )
     } else {
@@ -3945,12 +3943,12 @@ pub async fn build_reborn_runtime(
     let planned_turn_coordinator: Arc<dyn TurnCoordinator> = composition.coordinator.clone();
     let approval_audit_sink = Arc::new(InMemoryAuditSink::new());
     let approval_interaction_service: Arc<dyn ApprovalInteractionService> =
-        if let (Some(local_runtime), Some(local_dev_capability_policy)) =
-            (local_runtime, local_dev_capability_policy)
+        if let (Some(local_runtime), Some(builtin_capability_policy)) =
+            (local_runtime, builtin_capability_policy)
         {
             build_local_dev_approval_interaction_service(
                 local_runtime,
-                local_dev_capability_policy,
+                builtin_capability_policy,
                 Arc::clone(&planned_turn_coordinator),
                 Some(approval_audit_sink.clone()),
             )?
@@ -4180,7 +4178,7 @@ pub async fn build_reborn_runtime(
 /// seam below.
 fn build_webui_auth_interaction_service(
     product_auth: Option<&RebornProductAuthServices>,
-    turn_state_store: Arc<LocalDevTurnStateStore>,
+    turn_state_store: Arc<ComposedTurnStateStore>,
     turn_coordinator: Arc<dyn TurnCoordinator>,
 ) -> Arc<dyn AuthInteractionService> {
     build_webui_auth_interaction_service_with_turn_run_source(
@@ -4192,7 +4190,7 @@ fn build_webui_auth_interaction_service(
 
 /// Identical to [`build_webui_auth_interaction_service`] except
 /// the auth read model reads `turn_run_source` instead of a hardcoded
-/// `LocalDevTurnStateStore`. See
+/// `ComposedTurnStateStore`. See
 /// `build_local_dev_approval_interaction_service_with_turn_run_source`'s doc
 /// for why this seam exists.
 fn build_webui_auth_interaction_service_with_turn_run_source(
@@ -4212,7 +4210,7 @@ fn build_webui_auth_interaction_service_with_turn_run_source(
         return Arc::new(auth_interaction::UnavailableAuthInteractionService);
     };
     Arc::new(DefaultAuthInteractionService::new(
-        Arc::new(auth_interaction::LocalDevAuthInteractionReadModel::new(
+        Arc::new(auth_interaction::SnapshotAuthInteractionReadModel::new(
             turn_run_source,
             flow_records,
         )),
@@ -4277,11 +4275,11 @@ async fn append_trusted_laptop_access_audit(
         })
 }
 
-struct LocalDevSkillContextSource {
+struct ComposedSkillContextSource {
     bundle_source: Arc<FilesystemSkillBundleSource<CompositeRootFilesystem>>,
     source: Arc<dyn HostSkillContextSource>,
-    activation_source: Arc<LocalDevSelectableSkillContextSource>,
-    execution_adapter: Arc<LocalDevSkillExecutionAdapter>,
+    activation_source: Arc<ComposedSelectableSkillContextSource>,
+    execution_adapter: Arc<ComposedSkillExecutionAdapter>,
 }
 
 const LOCAL_DEV_MAX_SKILL_CONTEXT_TOKENS: usize = 6000;
@@ -4376,10 +4374,10 @@ fn skill_injection_mode_from(value: &str) -> Result<SkillInjectionMode, RebornRu
 }
 
 fn local_dev_filesystem_skill_context_source(
-    local_runtime: &crate::factory::RebornLocalRuntimeServices,
+    local_runtime: &crate::factory::RebornRuntimeSubstrate,
     tenant_id: &TenantId,
     regex_skill_activation_enabled: bool,
-) -> Result<LocalDevSkillContextSource, RebornRuntimeError> {
+) -> Result<ComposedSkillContextSource, RebornRuntimeError> {
     let extension = FirstPartySkillsExtension::new(
         Arc::clone(&local_runtime.skill_filesystem),
         FirstPartySkillsExtensionHandles::without_tenant_shared().map_err(|reason| {
@@ -4400,7 +4398,7 @@ fn local_dev_filesystem_skill_context_source(
         Arc::clone(&local_runtime.skill_auto_activate_learned),
     );
     let bundle_source = extension.bundle_source();
-    Ok(LocalDevSkillContextSource {
+    Ok(ComposedSkillContextSource {
         source: selectable_skills.host_skill_context_source(),
         activation_source: selectable_skills.activation_source(),
         execution_adapter: selectable_skills.execution_adapter(),

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -9,33 +9,33 @@ use ironclaw_product_workflow::{
     ProductWorkflowError,
 };
 
-use crate::local_dev_capability_policy::{
-    LocalDevApprovalPolicyAction, LocalDevCapabilityPolicy, LocalDevCapabilityPolicyError,
-    local_dev_one_shot_lease_approval,
+use crate::builtin_capability_policy::{
+    BuiltinApprovalPolicyAction, BuiltinCapabilityPolicy, BuiltinCapabilityPolicyError,
+    builtin_one_shot_lease_approval,
 };
 use crate::outbound::OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID;
 
-use super::local_dev::extension_surface::LocalDevExtensionSurfaceSource;
+use super::local_dev::extension_surface::ExtensionCapabilitySurfaceSource;
 
-pub(super) struct LocalDevApprovalLeaseTermsProvider {
-    policy: Arc<LocalDevCapabilityPolicy>,
+pub(super) struct PolicyApprovalLeaseTermsProvider {
+    policy: Arc<BuiltinCapabilityPolicy>,
     registry: Arc<ExtensionRegistry>,
     workspace_mounts: MountView,
     skill_mounts: MountView,
     memory_mounts: MountView,
     system_extensions_lifecycle_mounts: MountView,
-    extension_surface_source: LocalDevExtensionSurfaceSource,
+    extension_surface_source: ExtensionCapabilitySurfaceSource,
 }
 
-impl LocalDevApprovalLeaseTermsProvider {
+impl PolicyApprovalLeaseTermsProvider {
     pub(super) fn new(
-        policy: Arc<LocalDevCapabilityPolicy>,
+        policy: Arc<BuiltinCapabilityPolicy>,
         registry: Arc<ExtensionRegistry>,
         workspace_mounts: MountView,
         skill_mounts: MountView,
         memory_mounts: MountView,
         system_extensions_lifecycle_mounts: MountView,
-        extension_surface_source: LocalDevExtensionSurfaceSource,
+        extension_surface_source: ExtensionCapabilitySurfaceSource,
     ) -> Self {
         Self {
             policy,
@@ -51,7 +51,7 @@ impl LocalDevApprovalLeaseTermsProvider {
     async fn extension_lease_terms_for(
         &self,
         gate: &ApprovalGateRecord,
-        action: LocalDevApprovalPolicyAction<'_>,
+        action: BuiltinApprovalPolicyAction<'_>,
     ) -> Result<LeaseApproval, ProductWorkflowError> {
         self.extension_lease_terms_for_active_capability(gate, action)
             .await?
@@ -61,7 +61,7 @@ impl LocalDevApprovalLeaseTermsProvider {
     async fn extension_lease_terms_for_active_capability(
         &self,
         gate: &ApprovalGateRecord,
-        action: LocalDevApprovalPolicyAction<'_>,
+        action: BuiltinApprovalPolicyAction<'_>,
     ) -> Result<Option<LeaseApproval>, ProductWorkflowError> {
         let capability = action.capability();
         let Principal::Extension(extension_id) = &gate.request().requested_by else {
@@ -98,12 +98,12 @@ impl LocalDevApprovalLeaseTermsProvider {
             );
             return Err(lease_terms_unavailable());
         }
-        Ok(Some(local_dev_one_shot_lease_approval(grant.constraints)))
+        Ok(Some(builtin_one_shot_lease_approval(grant.constraints)))
     }
 
     async fn active_extension_persistent_approval_allowed(
         &self,
-        action: LocalDevApprovalPolicyAction<'_>,
+        action: BuiltinApprovalPolicyAction<'_>,
     ) -> Result<bool, ProductWorkflowError> {
         let surface = self
             .extension_surface_source
@@ -130,12 +130,12 @@ impl LocalDevApprovalLeaseTermsProvider {
 }
 
 #[async_trait]
-impl ApprovalLeaseTermsProvider for LocalDevApprovalLeaseTermsProvider {
+impl ApprovalLeaseTermsProvider for PolicyApprovalLeaseTermsProvider {
     async fn lease_terms_for(
         &self,
         gate: &ApprovalGateRecord,
     ) -> Result<ironclaw_approvals::LeaseApproval, ProductWorkflowError> {
-        let action = LocalDevApprovalPolicyAction::from_host_action(gate.request().action.as_ref())
+        let action = BuiltinApprovalPolicyAction::from_host_action(gate.request().action.as_ref())
             .ok_or(ProductWorkflowError::ApprovalInteractionRejected {
                 kind: ApprovalInteractionRejectionKind::UnsupportedAction,
             })?;
@@ -154,7 +154,7 @@ impl ApprovalLeaseTermsProvider for LocalDevApprovalLeaseTermsProvider {
             &self.system_extensions_lifecycle_mounts,
         ) {
             Ok(approval) => Ok(approval),
-            Err(LocalDevCapabilityPolicyError::MissingGrant { .. }) => {
+            Err(BuiltinCapabilityPolicyError::MissingGrant { .. }) => {
                 self.extension_lease_terms_for(gate, action).await
             }
             Err(error) => {
@@ -168,7 +168,7 @@ impl ApprovalLeaseTermsProvider for LocalDevApprovalLeaseTermsProvider {
         &self,
         gate: &ApprovalGateRecord,
     ) -> Result<(), ProductWorkflowError> {
-        let action = LocalDevApprovalPolicyAction::from_host_action(gate.request().action.as_ref())
+        let action = BuiltinApprovalPolicyAction::from_host_action(gate.request().action.as_ref())
             .ok_or(ProductWorkflowError::ApprovalInteractionRejected {
                 kind: ApprovalInteractionRejectionKind::UnsupportedAction,
             })?;
@@ -189,7 +189,7 @@ impl ApprovalLeaseTermsProvider for LocalDevApprovalLeaseTermsProvider {
                 &self.system_extensions_lifecycle_mounts,
             ) {
                 Ok(_) => return Ok(()),
-                Err(LocalDevCapabilityPolicyError::MissingGrant { .. }) => {}
+                Err(BuiltinCapabilityPolicyError::MissingGrant { .. }) => {}
                 Err(error) => {
                     tracing::error!(
                         %error,
@@ -230,10 +230,10 @@ mod tests {
     use ironclaw_product_workflow::approval_gate_ref;
     use ironclaw_turns::{GateRef, TurnRunId};
 
+    use crate::builtin_capability_policy::builtin_capability_policy;
     use crate::extension_host::extension_lifecycle::ActiveExtensionCapability;
-    use crate::local_dev_capability_policy::local_dev_capability_policy;
     use crate::runtime::local_dev::extension_surface::{
-        LocalDevExtensionSurface, LocalDevExtensionSurfaceSource,
+        ExtensionCapabilitySurface, ExtensionCapabilitySurfaceSource,
     };
 
     use super::*;
@@ -243,8 +243,8 @@ mod tests {
         let capability = CapabilityId::new("gmail.send_message").expect("capability id");
         let provider = ExtensionId::new("gmail").expect("provider id");
         let caller = ExtensionId::new("caller").expect("caller id");
-        let source = LocalDevExtensionSurfaceSource::from_surface(
-            LocalDevExtensionSurface::from_active_capabilities(vec![ActiveExtensionCapability {
+        let source = ExtensionCapabilitySurfaceSource::from_surface(
+            ExtensionCapabilitySurface::from_active_capabilities(vec![ActiveExtensionCapability {
                 id: capability.clone(),
                 provider,
                 effects: vec![EffectKind::Network, EffectKind::UseSecret],
@@ -254,8 +254,8 @@ mod tests {
                 owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
+        let terms_provider = PolicyApprovalLeaseTermsProvider::new(
+            Arc::new(builtin_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
             MountView::default(),
             MountView::default(),
@@ -297,8 +297,8 @@ mod tests {
         let provider = ExtensionId::new("gmail").expect("provider id");
         let caller = ExtensionId::new("caller").expect("caller id");
         let secret = SecretHandle::new("gmail_token").expect("secret handle");
-        let source = LocalDevExtensionSurfaceSource::from_surface(
-            LocalDevExtensionSurface::from_active_capabilities(vec![ActiveExtensionCapability {
+        let source = ExtensionCapabilitySurfaceSource::from_surface(
+            ExtensionCapabilitySurface::from_active_capabilities(vec![ActiveExtensionCapability {
                 id: capability.clone(),
                 provider,
                 effects: vec![
@@ -326,8 +326,8 @@ mod tests {
                 owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
+        let terms_provider = PolicyApprovalLeaseTermsProvider::new(
+            Arc::new(builtin_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
             MountView::default(),
             MountView::default(),
@@ -368,8 +368,8 @@ mod tests {
         let capability = CapabilityId::new("gmail.send_message").expect("capability id");
         let provider = ExtensionId::new("gmail").expect("provider id");
         let caller = ExtensionId::new("caller").expect("caller id");
-        let source = LocalDevExtensionSurfaceSource::from_surface(
-            LocalDevExtensionSurface::from_active_capabilities(vec![ActiveExtensionCapability {
+        let source = ExtensionCapabilitySurfaceSource::from_surface(
+            ExtensionCapabilitySurface::from_active_capabilities(vec![ActiveExtensionCapability {
                 id: capability.clone(),
                 provider,
                 effects: vec![EffectKind::Network],
@@ -379,8 +379,8 @@ mod tests {
                 owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
+        let terms_provider = PolicyApprovalLeaseTermsProvider::new(
+            Arc::new(builtin_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
             MountView::default(),
             MountView::default(),
@@ -408,8 +408,8 @@ mod tests {
         let capability = CapabilityId::new("gmail.send_message").expect("capability id");
         let provider = ExtensionId::new("gmail").expect("provider id");
         let caller = ExtensionId::new("caller").expect("caller id");
-        let source = LocalDevExtensionSurfaceSource::from_surface(
-            LocalDevExtensionSurface::from_active_capabilities(vec![ActiveExtensionCapability {
+        let source = ExtensionCapabilitySurfaceSource::from_surface(
+            ExtensionCapabilitySurface::from_active_capabilities(vec![ActiveExtensionCapability {
                 id: capability.clone(),
                 provider,
                 effects: vec![EffectKind::Network],
@@ -419,8 +419,8 @@ mod tests {
                 owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
+        let terms_provider = PolicyApprovalLeaseTermsProvider::new(
+            Arc::new(builtin_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
             MountView::default(),
             MountView::default(),
@@ -448,14 +448,14 @@ mod tests {
         let capability =
             CapabilityId::new(OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID).expect("capability id");
         let caller = ExtensionId::new("loop-driver").expect("caller id");
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
+        let terms_provider = PolicyApprovalLeaseTermsProvider::new(
+            Arc::new(builtin_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
             MountView::default(),
             MountView::default(),
             MountView::default(),
             MountView::default(),
-            LocalDevExtensionSurfaceSource::default(),
+            ExtensionCapabilitySurfaceSource::default(),
         );
         let gate = approval_gate_record(
             ApprovalRequestId::new(),
@@ -477,8 +477,8 @@ mod tests {
         let capability = CapabilityId::new("gmail.send_message").expect("capability id");
         let provider = ExtensionId::new("gmail").expect("provider id");
         let caller = ExtensionId::new("caller").expect("caller id");
-        let source = LocalDevExtensionSurfaceSource::from_surface(
-            LocalDevExtensionSurface::from_active_capabilities(vec![ActiveExtensionCapability {
+        let source = ExtensionCapabilitySurfaceSource::from_surface(
+            ExtensionCapabilitySurface::from_active_capabilities(vec![ActiveExtensionCapability {
                 id: capability.clone(),
                 provider,
                 effects: vec![EffectKind::Network],
@@ -488,8 +488,8 @@ mod tests {
                 owner: ironclaw_extensions::InstallationOwner::Tenant,
             }]),
         );
-        let terms_provider = LocalDevApprovalLeaseTermsProvider::new(
-            Arc::new(local_dev_capability_policy().expect("policy parses")),
+        let terms_provider = PolicyApprovalLeaseTermsProvider::new(
+            Arc::new(builtin_capability_policy().expect("policy parses")),
             Arc::new(ExtensionRegistry::new()),
             MountView::default(),
             MountView::default(),

--- a/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
@@ -21,8 +21,8 @@ struct BlockedAuthRun {
     gate_ref: GateRef,
 }
 
-pub(super) struct LocalDevAuthInteractionReadModel {
-    /// A trait object (not the concrete `LocalDevTurnStateStore`) so a
+pub(super) struct SnapshotAuthInteractionReadModel {
+    /// A trait object (not the concrete `ComposedTurnStateStore`) so a
     /// caller can substitute a different turn-state store's snapshot view —
     /// see `turn_run_snapshot::TurnRunSnapshotSource` and
     /// `build_webui_auth_interaction_service_with_turn_run_source`.
@@ -49,7 +49,7 @@ impl AuthInteractionService for UnavailableAuthInteractionService {
     }
 }
 
-impl LocalDevAuthInteractionReadModel {
+impl SnapshotAuthInteractionReadModel {
     pub(super) fn new(
         turn_state: Arc<dyn TurnRunSnapshotSource>,
         flow_records: Arc<dyn AuthFlowRecordSource>,
@@ -216,7 +216,7 @@ fn matching_flow_for_run(
         .cloned())
 }
 
-impl LocalDevAuthInteractionReadModel {
+impl SnapshotAuthInteractionReadModel {
     async fn owner_flows(
         &self,
         scope: &AuthInteractionScope,
@@ -226,7 +226,7 @@ impl LocalDevAuthInteractionReadModel {
 }
 
 #[async_trait]
-impl AuthInteractionReadModel for LocalDevAuthInteractionReadModel {
+impl AuthInteractionReadModel for SnapshotAuthInteractionReadModel {
     async fn auth_gates(
         &self,
         scope: &AuthInteractionScope,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -40,16 +40,16 @@ use ironclaw_turns::{
     },
 };
 
+use crate::builtin_capability_policy::BuiltinCapabilityPolicy;
 use crate::local_dev_authorization::{
     StoreApprovalSettingsProvider, local_dev_effects_require_approval,
 };
-use crate::local_dev_capability_policy::LocalDevCapabilityPolicy;
 use crate::local_dev_mounts::scoped_skill_management_mount_view;
 use crate::profile_approval_authorization::ApprovalSettingsProvider;
 use crate::{
     RebornServices,
     projection::{CapabilityDisplayPreviewResult, CapabilityDisplayPreviewStore},
-    runtime::LocalDevSelectableSkillContextSource,
+    runtime::ComposedSelectableSkillContextSource,
 };
 
 pub(super) mod extension_surface;
@@ -68,11 +68,11 @@ mod synthetic_capability;
 pub(crate) use crate::outbound::{
     OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID, OUTBOUND_DELIVERY_TARGETS_LIST_CAPABILITY_ID,
 };
-use extension_surface::{LocalDevExtensionSurface, LocalDevExtensionSurfaceSource};
+use extension_surface::{ExtensionCapabilitySurface, ExtensionCapabilitySurfaceSource};
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) use project_create::PROJECT_CREATE_CAPABILITY_ID;
 use refreshing_capability_port::{
-    RefreshingLocalDevCapabilityPortConfig, create_refreshing_local_dev_capability_port,
+    RefreshingCapabilityPortConfig, create_refreshing_capability_port,
 };
 #[cfg(feature = "test-support")]
 pub(crate) use result_read::RESULT_READ_CAPABILITY_ID_FOR_TEST;
@@ -82,11 +82,11 @@ pub(crate) use skill_activation::SKILL_ACTIVATE_CAPABILITY_ID;
 /// Test-only bridge (result_read seam, issue #5838), co-located with the
 /// capability it wraps and re-exported here for the `runtime` caller.
 #[cfg(feature = "test-support")]
-pub(super) use refreshing_capability_port::create_refreshing_local_dev_capability_port_for_test;
+pub(super) use refreshing_capability_port::create_refreshing_capability_port_for_test;
 #[cfg(feature = "test-support")]
 pub(super) use result_read::wrap_result_read_capability_for_test;
 
-pub(super) struct LocalDevCapabilityWiring {
+pub(super) struct CapabilityPortWiring {
     pub(super) capability_factory: Arc<dyn LoopCapabilityPortFactory>,
     pub(super) capability_input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     pub(super) capability_result_writer: Arc<dyn LoopCapabilityResultWriter>,
@@ -99,13 +99,13 @@ pub(super) fn capability_wiring(
     services: &RebornServices,
     thread_service: Arc<dyn SessionThreadService>,
     fallback_user_id: UserId,
-    policy: Arc<LocalDevCapabilityPolicy>,
+    policy: Arc<BuiltinCapabilityPolicy>,
     model_gateway: Arc<dyn HostManagedModelGateway>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
-    skill_activation_source: Option<Arc<LocalDevSelectableSkillContextSource>>,
+    skill_activation_source: Option<Arc<ComposedSelectableSkillContextSource>>,
     outbound_preferences_facade: Option<Arc<dyn OutboundPreferencesProductFacade>>,
     trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
-) -> Option<LocalDevCapabilityWiring> {
+) -> Option<CapabilityPortWiring> {
     let runtime = services.host_runtime.clone()?;
     let local_runtime = services.local_runtime.as_ref()?;
     let workspace_mounts = local_runtime.workspace_mounts.clone();
@@ -130,7 +130,7 @@ pub(super) fn capability_wiring(
         &[EffectKind::ExternalWrite],
     );
     let extension_surface_source =
-        LocalDevExtensionSurfaceSource::new(local_runtime.extension_management.clone());
+        ExtensionCapabilitySurfaceSource::new(local_runtime.extension_management.clone());
     // First-class project creation reuses the same access-controlled
     // `ProjectService` facade the WebUI v2 surface wires (composition owns the
     // service, never the raw repository), so an agent-created project is a real
@@ -138,7 +138,7 @@ pub(super) fn capability_wiring(
     let project_service: Arc<dyn ProjectService> = Arc::clone(&local_runtime.project_service);
     let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
     let capability_io = Arc::new(
-        LocalDevCapabilityIo::new_with_durable_previews(
+        StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             Arc::clone(&thread_service),
             fallback_user_id.clone(),
@@ -153,7 +153,7 @@ pub(super) fn capability_wiring(
     let external_tool_catalog: Arc<dyn ExternalToolCatalog> =
         Arc::clone(&local_runtime.external_tool_catalog);
     let capability_factory: Arc<dyn LoopCapabilityPortFactory> =
-        Arc::new(LocalDevLoopCapabilityPortFactory {
+        Arc::new(RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id,
             policy,
@@ -175,7 +175,7 @@ pub(super) fn capability_wiring(
             capability_leases,
             external_tool_catalog,
         });
-    Some(LocalDevCapabilityWiring {
+    Some(CapabilityPortWiring {
         capability_factory,
         capability_input_resolver,
         capability_result_writer,
@@ -185,18 +185,18 @@ pub(super) fn capability_wiring(
 }
 
 #[derive(Clone)]
-struct LocalDevLoopCapabilityPortFactory {
+struct RefreshingLoopCapabilityPortFactory {
     runtime: Arc<dyn HostRuntime>,
     fallback_user_id: UserId,
-    policy: Arc<LocalDevCapabilityPolicy>,
+    policy: Arc<BuiltinCapabilityPolicy>,
     workspace_mounts: MountView,
     memory_mounts: MountView,
     system_extensions_lifecycle_mounts: MountView,
-    extension_surface_source: LocalDevExtensionSurfaceSource,
+    extension_surface_source: ExtensionCapabilitySurfaceSource,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
-    skill_activation_source: Option<Arc<LocalDevSelectableSkillContextSource>>,
+    skill_activation_source: Option<Arc<ComposedSelectableSkillContextSource>>,
     project_service: Arc<dyn ProjectService>,
     thread_service: Arc<dyn SessionThreadService>,
     trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
@@ -212,7 +212,7 @@ struct LocalDevLoopCapabilityPortFactory {
 }
 
 #[async_trait::async_trait]
-impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
+impl LoopCapabilityPortFactory for RefreshingLoopCapabilityPortFactory {
     async fn create_capability_port(
         &self,
         run_context: &LoopRunContext,
@@ -222,7 +222,7 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             &self.fallback_user_id,
         ))
         .map_err(host_api_agent_loop_error)?;
-        create_refreshing_local_dev_capability_port(RefreshingLocalDevCapabilityPortConfig {
+        create_refreshing_capability_port(RefreshingCapabilityPortConfig {
             runtime: Arc::clone(&self.runtime),
             run_context: run_context.clone(),
             fallback_user_id: self.fallback_user_id.clone(),
@@ -239,7 +239,7 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             project_service: Arc::clone(&self.project_service),
             thread_service: Arc::clone(&self.thread_service),
             // Same observer drives both the input hook (on the capability port the
-            // refreshing helper builds) and the result hook (on `LocalDevCapabilityIo`),
+            // refreshing helper builds) and the result hook (on `StagedCapabilityIo`),
             // so the two callbacks correlate by `call_id` for one tool call.
             trajectory_observer: self.trajectory_observer.clone(),
             outbound_preferences_facade: self.outbound_preferences_facade.clone(),
@@ -250,7 +250,7 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             capability_leases: Arc::clone(&self.capability_leases),
             external_tool_catalog: Arc::clone(&self.external_tool_catalog),
             // Test-support-only knobs (see each field's doc-comment on
-            // `RefreshingLocalDevCapabilityPortConfig`): always empty here.
+            // `RefreshingCapabilityPortConfig`): always empty here.
             capability_execution_mount_overrides: HashMap::new(),
             additional_provider_trust: BTreeMap::new(),
             capability_id_filter: None,
@@ -269,7 +269,7 @@ const LOCAL_DEV_DURABLE_TOOL_RESULT_MAX_BYTES: usize = 4 * 1024 * 1024;
 /// that pages past `next_offset` sees no gap or overlap.
 const LOCAL_DEV_RESULT_PREVIEW_MAX_BYTES: usize = TOOL_RESULT_RECORD_READ_MAX_BYTES;
 
-struct LocalDevCapabilityIo {
+struct StagedCapabilityIo {
     inputs: StdMutex<StagedValueStore>,
     results: StdMutex<StagedValueStore>,
     display_previews: Arc<CapabilityDisplayPreviewStore>,
@@ -291,13 +291,13 @@ struct DurableCapabilityDisplayPreviewSink {
     fallback_user_id: UserId,
 }
 
-impl Default for LocalDevCapabilityIo {
+impl Default for StagedCapabilityIo {
     fn default() -> Self {
         Self::new(Arc::new(CapabilityDisplayPreviewStore::default()))
     }
 }
 
-impl LocalDevCapabilityIo {
+impl StagedCapabilityIo {
     fn new(display_previews: Arc<CapabilityDisplayPreviewStore>) -> Self {
         Self {
             inputs: StdMutex::new(StagedValueStore::default()),
@@ -533,14 +533,14 @@ impl LocalDevCapabilityIo {
 /// never persists a durable record. For tests only -- gated behind
 /// `test-support`, ships zero bytes in production builds.
 #[cfg(feature = "test-support")]
-pub(super) fn local_dev_capability_io_for_test(
+pub(super) fn staged_capability_io_for_test(
     thread_service: Arc<dyn SessionThreadService>,
     fallback_user_id: UserId,
 ) -> (
     Arc<dyn LoopCapabilityInputResolver>,
     Arc<dyn LoopCapabilityResultWriter>,
 ) {
-    let io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
+    let io = Arc::new(StagedCapabilityIo::new_with_durable_previews(
         Arc::new(CapabilityDisplayPreviewStore::default()),
         thread_service,
         fallback_user_id,
@@ -650,7 +650,7 @@ fn staged_value_bytes(value: &serde_json::Value) -> Result<usize, AgentLoopHostE
 }
 
 #[async_trait::async_trait]
-impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
+impl LoopCapabilityInputResolver for StagedCapabilityIo {
     async fn resolve_capability_input(
         &self,
         run_context: &LoopRunContext,
@@ -722,7 +722,7 @@ impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
 }
 
 #[async_trait::async_trait]
-impl LoopCapabilityResultWriter for LocalDevCapabilityIo {
+impl LoopCapabilityResultWriter for StagedCapabilityIo {
     async fn write_capability_result(
         &self,
         write: CapabilityResultWrite<'_>,
@@ -1060,19 +1060,19 @@ fn local_dev_thread_scope_for_run(
     ))
 }
 
-struct LocalDevVisibleCapabilityInputs<'a> {
+struct VisibleCapabilityInputs<'a> {
     workspace_mounts: &'a MountView,
     skill_mounts: &'a MountView,
     memory_mounts: &'a MountView,
     system_extensions_lifecycle_mounts: &'a MountView,
-    policy: &'a LocalDevCapabilityPolicy,
-    extension_surface: &'a LocalDevExtensionSurface,
+    policy: &'a BuiltinCapabilityPolicy,
+    extension_surface: &'a ExtensionCapabilitySurface,
 }
 
-fn local_dev_visible_capability_request(
+fn visible_capability_request(
     run_context: &LoopRunContext,
     fallback_user_id: &UserId,
-    inputs: LocalDevVisibleCapabilityInputs<'_>,
+    inputs: VisibleCapabilityInputs<'_>,
 ) -> Result<HostVisibleCapabilityRequest, AgentLoopHostError> {
     let extension_id = loop_driver_execution_extension_id(run_context)?;
     // Resolved BEFORE grant minting: extension grants are filtered per caller

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -17,13 +17,13 @@ use ironclaw_first_party_extensions::{
 use ironclaw_product_workflow::ProductWorkflowError;
 
 #[derive(Clone, Default)]
-pub(in crate::runtime) struct LocalDevExtensionSurfaceSource {
+pub(in crate::runtime) struct ExtensionCapabilitySurfaceSource {
     extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
     #[cfg(test)]
-    static_surface: Option<LocalDevExtensionSurface>,
+    static_surface: Option<ExtensionCapabilitySurface>,
 }
 
-impl LocalDevExtensionSurfaceSource {
+impl ExtensionCapabilitySurfaceSource {
     pub(in crate::runtime) fn new(
         extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
     ) -> Self {
@@ -35,7 +35,7 @@ impl LocalDevExtensionSurfaceSource {
     }
 
     #[cfg(test)]
-    pub(in crate::runtime) fn from_surface(surface: LocalDevExtensionSurface) -> Self {
+    pub(in crate::runtime) fn from_surface(surface: ExtensionCapabilitySurface) -> Self {
         Self {
             extension_management: None,
             static_surface: Some(surface),
@@ -44,24 +44,24 @@ impl LocalDevExtensionSurfaceSource {
 
     pub(in crate::runtime) async fn snapshot(
         &self,
-    ) -> Result<LocalDevExtensionSurface, ProductWorkflowError> {
+    ) -> Result<ExtensionCapabilitySurface, ProductWorkflowError> {
         #[cfg(test)]
         if let Some(surface) = &self.static_surface {
             return Ok(surface.clone());
         }
         let Some(extension_management) = self.extension_management.as_deref() else {
-            return Ok(LocalDevExtensionSurface::default());
+            return Ok(ExtensionCapabilitySurface::default());
         };
-        LocalDevExtensionSurface::from_extension_management(extension_management).await
+        ExtensionCapabilitySurface::from_extension_management(extension_management).await
     }
 }
 
 #[derive(Debug, Clone, Default)]
-pub(in crate::runtime) struct LocalDevExtensionSurface {
+pub(in crate::runtime) struct ExtensionCapabilitySurface {
     active_capabilities: Vec<ActiveExtensionCapability>,
 }
 
-impl LocalDevExtensionSurface {
+impl ExtensionCapabilitySurface {
     #[cfg(test)]
     pub(in crate::runtime) fn from_active_capabilities(
         active_capabilities: Vec<ActiveExtensionCapability>,
@@ -258,7 +258,7 @@ mod tests {
             network_targets: Vec::new(),
             owner,
         };
-        let surface = LocalDevExtensionSurface::from_active_capabilities(vec![
+        let surface = ExtensionCapabilitySurface::from_active_capabilities(vec![
             capability(
                 "market-data.snp500",
                 "market-data",

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/external_tool_capability.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/external_tool_capability.rs
@@ -1,6 +1,6 @@
 //! Loop capability decorator for client-supplied ("external") tools.
 //!
-//! Mirrors [`super::synthetic_capability::LocalDevSyntheticCapabilityPort`] but,
+//! Mirrors [`super::synthetic_capability::SyntheticCapabilityPort`] but,
 //! instead of executing a synthetic capability, it *parks* the run and returns
 //! control to the API client. The caller tool definitions come from the
 //! per-run [`ExternalToolCatalog`] (registered by the OpenAI-compatible
@@ -44,7 +44,7 @@ use ironclaw_turns::{LoopGateRef, TurnRunId};
 /// no external-tool capability could ever apply — the decorator itself is cheap
 /// and fetches specs lazily at surface-resolution time, so it is always safe to
 /// install.
-pub(super) fn wrap_local_dev_external_tools(
+pub(super) fn wrap_external_tools(
     inner: Arc<dyn LoopCapabilityPort>,
     run_context: LoopRunContext,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
@@ -838,7 +838,7 @@ mod tests {
             .expect("register external tools");
         let catalog: Arc<dyn ExternalToolCatalog> = catalog;
         (
-            wrap_local_dev_external_tools(
+            wrap_external_tools(
                 Arc::new(EmptyInnerPort),
                 run_context.clone(),
                 Arc::new(TestInputResolver),
@@ -854,7 +854,7 @@ mod tests {
     ) -> (Arc<dyn LoopCapabilityPort>, LoopRunContext) {
         let run_context = run_context().await;
         (
-            wrap_local_dev_external_tools(
+            wrap_external_tools(
                 Arc::new(EmptyInnerPort),
                 run_context.clone(),
                 Arc::new(TestInputResolver),
@@ -985,7 +985,7 @@ mod tests {
             .register(run_context.run_id, vec![external_tool_spec("get_weather")])
             .await
             .expect("register external tool");
-        let port = wrap_local_dev_external_tools(
+        let port = wrap_external_tools(
             Arc::new(EmptyInnerPort),
             run_context.clone(),
             Arc::new(TestInputResolver),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
@@ -34,8 +34,8 @@ use crate::outbound::{
 };
 use crate::profile_approval_authorization::ApprovalSettingsProvider;
 use crate::runtime::local_dev::synthetic_capability::{
-    LocalDevSyntheticCapability, LocalDevSyntheticCapabilityDescriptor,
-    LocalDevSyntheticCapabilityHandler, LocalDevSyntheticCapabilityInvocation,
+    SyntheticCapability, SyntheticCapabilityDescriptor, SyntheticCapabilityHandler,
+    SyntheticCapabilityInvocation,
 };
 
 pub(super) fn outbound_delivery_capabilities(
@@ -45,10 +45,10 @@ pub(super) fn outbound_delivery_capabilities(
     capability_leases: Arc<dyn CapabilityLeaseStore>,
     target_set_requires_approval: bool,
     approval_settings: Arc<dyn ApprovalSettingsProvider>,
-) -> Result<Vec<LocalDevSyntheticCapability>, AgentLoopHostError> {
+) -> Result<Vec<SyntheticCapability>, AgentLoopHostError> {
     Ok(vec![
-        LocalDevSyntheticCapability::new(
-            LocalDevSyntheticCapabilityDescriptor::new(
+        SyntheticCapability::new(
+            SyntheticCapabilityDescriptor::new(
                 OUTBOUND_DELIVERY_TARGETS_LIST_CAPABILITY_ID,
                 OUTBOUND_DELIVERY_TARGETS_LIST_PROVIDER_TOOL_NAME,
                 OUTBOUND_DELIVERY_TARGETS_LIST_DESCRIPTION,
@@ -60,8 +60,8 @@ pub(super) fn outbound_delivery_capabilities(
                 fallback_user_id: fallback_user_id.clone(),
             }),
         ),
-        LocalDevSyntheticCapability::new(
-            LocalDevSyntheticCapabilityDescriptor::new(
+        SyntheticCapability::new(
+            SyntheticCapabilityDescriptor::new(
                 OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID,
                 OUTBOUND_DELIVERY_TARGET_SET_PROVIDER_TOOL_NAME,
                 OUTBOUND_DELIVERY_TARGET_SET_DESCRIPTION,
@@ -86,7 +86,7 @@ struct OutboundDeliveryTargetsListHandler {
 }
 
 #[async_trait]
-impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetsListHandler {
+impl SyntheticCapabilityHandler for OutboundDeliveryTargetsListHandler {
     fn validate_provider_arguments(
         &self,
         arguments: &serde_json::Value,
@@ -98,7 +98,7 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetsListHandler {
 
     async fn invoke(
         &self,
-        invocation: LocalDevSyntheticCapabilityInvocation,
+        invocation: SyntheticCapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         let input =
             parse_outbound_delivery_targets_list_input(&invocation.input).map_err(input_error)?;
@@ -166,7 +166,7 @@ enum OutboundDeliveryApprovalSettingsDecision {
 }
 
 #[async_trait]
-impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
+impl SyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
     fn validate_provider_arguments(
         &self,
         arguments: &serde_json::Value,
@@ -178,7 +178,7 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
 
     async fn invoke(
         &self,
-        invocation: LocalDevSyntheticCapabilityInvocation,
+        invocation: SyntheticCapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         if invocation.request.auth_resume.is_some() {
             return Err(AgentLoopHostError::new(
@@ -284,7 +284,7 @@ impl LocalDevSyntheticCapabilityHandler for OutboundDeliveryTargetSetHandler {
 impl OutboundDeliveryTargetSetHandler {
     async fn settings_decision(
         &self,
-        invocation: &LocalDevSyntheticCapabilityInvocation,
+        invocation: &SyntheticCapabilityInvocation,
         capability_id: &CapabilityId,
     ) -> Result<OutboundDeliveryApprovalSettingsDecision, AgentLoopHostError> {
         let scope = settings_scope_for_run(&invocation.run_context, &self.fallback_user_id);
@@ -315,7 +315,7 @@ impl OutboundDeliveryTargetSetHandler {
 
     async fn request_approval(
         &self,
-        invocation: &LocalDevSyntheticCapabilityInvocation,
+        invocation: &SyntheticCapabilityInvocation,
         input: &serde_json::Value,
         target_id: &RebornOutboundDeliveryTargetId,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
@@ -368,7 +368,7 @@ impl OutboundDeliveryTargetSetHandler {
 
     async fn verify_approved_resume(
         &self,
-        invocation: &LocalDevSyntheticCapabilityInvocation,
+        invocation: &SyntheticCapabilityInvocation,
         resume: &CapabilityApprovalResume,
         input: &serde_json::Value,
     ) -> Result<ApprovedResumeDecision, AgentLoopHostError> {
@@ -473,7 +473,7 @@ impl OutboundDeliveryTargetSetHandler {
 }
 
 async fn write_completed_result(
-    invocation: LocalDevSyntheticCapabilityInvocation,
+    invocation: SyntheticCapabilityInvocation,
     output: serde_json::Value,
     safe_summary: String,
 ) -> Result<CapabilityOutcome, AgentLoopHostError> {
@@ -500,9 +500,7 @@ async fn write_completed_result(
     }))
 }
 
-fn invocation_replay_input(
-    invocation: &LocalDevSyntheticCapabilityInvocation,
-) -> &serde_json::Value {
+fn invocation_replay_input(invocation: &SyntheticCapabilityInvocation) -> &serde_json::Value {
     invocation
         .request
         .approval_resume
@@ -512,7 +510,7 @@ fn invocation_replay_input(
 }
 
 fn invocation_effective_input_ref(
-    invocation: &LocalDevSyntheticCapabilityInvocation,
+    invocation: &SyntheticCapabilityInvocation,
 ) -> &CapabilityInputRef {
     invocation
         .request
@@ -523,7 +521,7 @@ fn invocation_effective_input_ref(
 }
 
 fn caller_for_run(
-    invocation: &LocalDevSyntheticCapabilityInvocation,
+    invocation: &SyntheticCapabilityInvocation,
     fallback_user_id: &UserId,
 ) -> WebUiAuthenticatedCaller {
     WebUiAuthenticatedCaller::new(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/project_create.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/project_create.rs
@@ -13,8 +13,8 @@ use ironclaw_turns::run_profile::{
 };
 
 use crate::runtime::local_dev::synthetic_capability::{
-    LocalDevSyntheticCapability, LocalDevSyntheticCapabilityDescriptor,
-    LocalDevSyntheticCapabilityHandler, LocalDevSyntheticCapabilityInvocation,
+    SyntheticCapability, SyntheticCapabilityDescriptor, SyntheticCapabilityHandler,
+    SyntheticCapabilityInvocation,
 };
 
 pub(crate) const PROJECT_CREATE_CAPABILITY_ID: &str = "builtin.project_create";
@@ -29,9 +29,9 @@ const MAX_PROJECT_NAME_BYTES: usize = 200;
 pub(super) fn project_create_capability(
     project_service: Arc<dyn ProjectService>,
     fallback_user_id: UserId,
-) -> Result<LocalDevSyntheticCapability, AgentLoopHostError> {
-    Ok(LocalDevSyntheticCapability::new(
-        LocalDevSyntheticCapabilityDescriptor::new(
+) -> Result<SyntheticCapability, AgentLoopHostError> {
+    Ok(SyntheticCapability::new(
+        SyntheticCapabilityDescriptor::new(
             PROJECT_CREATE_CAPABILITY_ID,
             PROJECT_CREATE_PROVIDER_TOOL_NAME,
             PROJECT_CREATE_DESCRIPTION,
@@ -51,7 +51,7 @@ struct ProjectCreateHandler {
 }
 
 #[async_trait]
-impl LocalDevSyntheticCapabilityHandler for ProjectCreateHandler {
+impl SyntheticCapabilityHandler for ProjectCreateHandler {
     fn validate_provider_arguments(
         &self,
         arguments: &serde_json::Value,
@@ -61,7 +61,7 @@ impl LocalDevSyntheticCapabilityHandler for ProjectCreateHandler {
 
     async fn invoke(
         &self,
-        invocation: LocalDevSyntheticCapabilityInvocation,
+        invocation: SyntheticCapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         let input = parse_project_create_input(&invocation.input)?;
         // Identity is authority-bearing: the caller is derived from the trusted

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
@@ -21,37 +21,37 @@ use ironclaw_turns::run_profile::{
 };
 use tokio::sync::Mutex as AsyncMutex;
 
-use crate::local_dev_capability_policy::LocalDevCapabilityPolicy;
+use crate::builtin_capability_policy::BuiltinCapabilityPolicy;
 use crate::profile_approval_authorization::ApprovalSettingsProvider;
-use crate::runtime::LocalDevSelectableSkillContextSource;
-use crate::runtime::local_dev::extension_surface::LocalDevExtensionSurfaceSource;
-use crate::runtime::local_dev::external_tool_capability::wrap_local_dev_external_tools;
+use crate::runtime::ComposedSelectableSkillContextSource;
+use crate::runtime::local_dev::extension_surface::ExtensionCapabilitySurfaceSource;
+use crate::runtime::local_dev::external_tool_capability::wrap_external_tools;
 use crate::runtime::local_dev::outbound_delivery::outbound_delivery_capabilities;
 use crate::runtime::local_dev::project_create::project_create_capability;
 use crate::runtime::local_dev::result_read::result_read_capability;
 use crate::runtime::local_dev::skill_activation::skill_activation_capability;
-use crate::runtime::local_dev::surface_disclosure::wrap_local_dev_surface_disclosure;
-use crate::runtime::local_dev::synthetic_capability::wrap_local_dev_synthetic_capabilities;
+use crate::runtime::local_dev::surface_disclosure::wrap_surface_disclosure;
+use crate::runtime::local_dev::synthetic_capability::wrap_synthetic_capabilities;
 
 use super::{
-    LocalDevVisibleCapabilityInputs, capability_io_error, host_api_agent_loop_error,
-    local_dev_visible_capability_request,
+    VisibleCapabilityInputs, capability_io_error, host_api_agent_loop_error,
+    visible_capability_request,
 };
 
-pub(crate) struct RefreshingLocalDevCapabilityPortConfig {
+pub(crate) struct RefreshingCapabilityPortConfig {
     pub(super) runtime: Arc<dyn HostRuntime>,
     pub(super) run_context: LoopRunContext,
     pub(super) fallback_user_id: UserId,
-    pub(super) policy: Arc<LocalDevCapabilityPolicy>,
+    pub(super) policy: Arc<BuiltinCapabilityPolicy>,
     pub(super) workspace_mounts: MountView,
     pub(super) skill_mounts: MountView,
     pub(super) memory_mounts: MountView,
     pub(super) system_extensions_lifecycle_mounts: MountView,
-    pub(super) extension_surface_source: LocalDevExtensionSurfaceSource,
+    pub(super) extension_surface_source: ExtensionCapabilitySurfaceSource,
     pub(super) input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     pub(super) result_writer: Arc<dyn LoopCapabilityResultWriter>,
     pub(super) milestone_sink: Arc<dyn LoopHostMilestoneSink>,
-    pub(super) skill_activation_source: Option<Arc<LocalDevSelectableSkillContextSource>>,
+    pub(super) skill_activation_source: Option<Arc<ComposedSelectableSkillContextSource>>,
     pub(super) project_service: Arc<dyn ProjectService>,
     pub(super) thread_service: Arc<dyn SessionThreadService>,
     pub(super) trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
@@ -85,10 +85,10 @@ pub(crate) struct RefreshingLocalDevCapabilityPortConfig {
     pub(super) additional_capability_grants: Vec<ironclaw_host_api::CapabilityGrant>,
 }
 
-pub(crate) async fn create_refreshing_local_dev_capability_port(
-    config: RefreshingLocalDevCapabilityPortConfig,
+pub(crate) async fn create_refreshing_capability_port(
+    config: RefreshingCapabilityPortConfig,
 ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
-    let port = Arc::new(RefreshingLocalDevCapabilityPort {
+    let port = Arc::new(RefreshingCapabilityPort {
         runtime: config.runtime,
         run_context: config.run_context,
         fallback_user_id: config.fallback_user_id,
@@ -126,20 +126,20 @@ pub(crate) async fn create_refreshing_local_dev_capability_port(
     Ok(port)
 }
 
-struct RefreshingLocalDevCapabilityPort {
+struct RefreshingCapabilityPort {
     runtime: Arc<dyn HostRuntime>,
     run_context: LoopRunContext,
     fallback_user_id: UserId,
-    policy: Arc<LocalDevCapabilityPolicy>,
+    policy: Arc<BuiltinCapabilityPolicy>,
     workspace_mounts: MountView,
     skill_mounts: MountView,
     memory_mounts: MountView,
     system_extensions_lifecycle_mounts: MountView,
-    extension_surface_source: LocalDevExtensionSurfaceSource,
+    extension_surface_source: ExtensionCapabilitySurfaceSource,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
-    skill_activation_source: Option<Arc<LocalDevSelectableSkillContextSource>>,
+    skill_activation_source: Option<Arc<ComposedSelectableSkillContextSource>>,
     project_service: Arc<dyn ProjectService>,
     thread_service: Arc<dyn SessionThreadService>,
     trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
@@ -157,17 +157,17 @@ struct RefreshingLocalDevCapabilityPort {
     refresh_lock: AsyncMutex<()>,
 }
 
-impl RefreshingLocalDevCapabilityPort {
+impl RefreshingCapabilityPort {
     async fn build_inner(&self) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
         let extension_surface = self
             .extension_surface_source
             .snapshot()
             .await
             .map_err(host_api_agent_loop_error)?;
-        let mut visible_request = local_dev_visible_capability_request(
+        let mut visible_request = visible_capability_request(
             &self.run_context,
             &self.fallback_user_id,
-            LocalDevVisibleCapabilityInputs {
+            VisibleCapabilityInputs {
                 workspace_mounts: &self.workspace_mounts,
                 skill_mounts: &self.skill_mounts,
                 memory_mounts: &self.memory_mounts,
@@ -253,7 +253,7 @@ impl RefreshingLocalDevCapabilityPort {
         .with_execution_mounts(self.workspace_mounts.clone())
         // Adapt the composition-owned observer to the loop-host substrate
         // trait the capability port consumes (the input hook). The result hook
-        // calls the composition trait directly from `LocalDevCapabilityIo`.
+        // calls the composition trait directly from `StagedCapabilityIo`.
         .with_trajectory_observer(
             self.trajectory_observer
                 .clone()
@@ -307,7 +307,7 @@ impl RefreshingLocalDevCapabilityPort {
                 Arc::clone(&self.approval_settings),
             )?);
         }
-        let port = wrap_local_dev_synthetic_capabilities(
+        let port = wrap_synthetic_capabilities(
             port,
             synthetic_capabilities,
             self.run_context.clone(),
@@ -317,10 +317,10 @@ impl RefreshingLocalDevCapabilityPort {
             // wrapper needs the observer to emit `on_capability_input` itself.
             self.trajectory_observer.clone(),
         )?;
-        let port = wrap_local_dev_surface_disclosure(port, &self.workspace_mounts);
+        let port = wrap_surface_disclosure(port, &self.workspace_mounts);
         // Outermost: external (client-supplied) tools see the full resolved
         // surface (for shadow-rejection) and park instead of executing.
-        Ok(wrap_local_dev_external_tools(
+        Ok(wrap_external_tools(
             port,
             self.run_context.clone(),
             Arc::clone(&self.input_resolver),
@@ -379,7 +379,7 @@ impl RefreshingLocalDevCapabilityPort {
 }
 
 #[async_trait::async_trait]
-impl LoopCapabilityPort for RefreshingLocalDevCapabilityPort {
+impl LoopCapabilityPort for RefreshingCapabilityPort {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
         self.current_port()?.tool_definitions()
     }
@@ -439,18 +439,18 @@ impl LoopCapabilityPort for RefreshingLocalDevCapabilityPort {
 }
 
 /// Test-support constructor (harness-port-seam P1 seam): assembles a
-/// [`RefreshingLocalDevCapabilityPortConfig`] from the harness's injectable
-/// parts and drives the REAL [`create_refreshing_local_dev_capability_port`]
+/// [`RefreshingCapabilityPortConfig`] from the harness's injectable
+/// parts and drives the REAL [`create_refreshing_capability_port`]
 /// above, so the harness exercises every wrap layer `build_inner` applies.
 /// Parts the harness has no opinion on get the same no-op production types
 /// the sole call site (`local_dev.rs`'s `create_capability_port`) passes -- never `capability_wiring`'s
 /// `RebornServices`-entangled defaults. For tests only -- gated behind
 /// `test-support`, ships zero bytes in production builds.
 #[cfg(feature = "test-support")]
-pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
-    parts: crate::test_support::RefreshingLocalDevCapabilityPortTestParts,
+pub(crate) async fn create_refreshing_capability_port_for_test(
+    parts: crate::test_support::RefreshingCapabilityPortTestParts,
 ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
-    let crate::test_support::RefreshingLocalDevCapabilityPortTestParts {
+    let crate::test_support::RefreshingCapabilityPortTestParts {
         runtime,
         run_context,
         fallback_user_id,
@@ -480,7 +480,7 @@ pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
     } = parts;
 
     let policy = Arc::new(
-        crate::local_dev_capability_policy::local_dev_capability_policy()
+        crate::builtin_capability_policy::builtin_capability_policy()
             .map_err(host_api_agent_loop_error)?,
     );
     let approval_settings: Arc<dyn ApprovalSettingsProvider> = Arc::new(
@@ -490,12 +490,12 @@ pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
             persistent_approval_policies,
         ),
     );
-    // Recover the crate-private `LocalDevSelectableSkillContextSource` from
+    // Recover the crate-private `ComposedSelectableSkillContextSource` from
     // the opaque `SkillActivationTestSource` handle the harness passed in
-    // (see the field's doc-comment on `RefreshingLocalDevCapabilityPortTestParts`).
+    // (see the field's doc-comment on `RefreshingCapabilityPortTestParts`).
     let skill_activation_source = skill_activation_source.map(|handle| handle.activation_source());
 
-    create_refreshing_local_dev_capability_port(RefreshingLocalDevCapabilityPortConfig {
+    create_refreshing_capability_port(RefreshingCapabilityPortConfig {
         runtime,
         run_context,
         fallback_user_id,
@@ -510,7 +510,7 @@ pub(crate) async fn create_refreshing_local_dev_capability_port_for_test(
         // `ExtensionManagementTestHandle` (see its doc-comment); `None` when
         // the harness never wired one, reproducing the prior always-no-op
         // surface.
-        extension_surface_source: LocalDevExtensionSurfaceSource::new(
+        extension_surface_source: ExtensionCapabilitySurfaceSource::new(
             extension_management.map(|handle| handle.extension_management()),
         ),
         input_resolver,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/result_read.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/result_read.rs
@@ -19,17 +19,17 @@ use ironclaw_turns::run_profile::{
 use super::{
     local_dev_thread_scope_for_run,
     synthetic_capability::{
-        LocalDevSyntheticCapability, LocalDevSyntheticCapabilityDescriptor,
-        LocalDevSyntheticCapabilityHandler, LocalDevSyntheticCapabilityInvocation,
+        SyntheticCapability, SyntheticCapabilityDescriptor, SyntheticCapabilityHandler,
+        SyntheticCapabilityInvocation,
     },
 };
 
 /// Test-support wrap: layers the synthetic `result_read` capability onto
 /// `inner`, mirroring how `refreshing_capability_port.rs`'s `build_inner`
-/// wires it in production (unconditionally, via `wrap_local_dev_synthetic_capabilities`).
+/// wires it in production (unconditionally, via `wrap_synthetic_capabilities`).
 /// `input_resolver`/`result_writer` MUST be the SAME shared io object the
 /// harness's capability port already uses -- see
-/// `RefreshingLocalDevCapabilityPortTestParts::input_resolver` in
+/// `RefreshingCapabilityPortTestParts::input_resolver` in
 /// `test_support/refreshing_capability_port.rs` for the identical
 /// same-object requirement. Tests only -- gated behind `test-support`,
 /// ships zero bytes in production builds.
@@ -42,7 +42,7 @@ pub(crate) fn wrap_result_read_capability_for_test(
     input_resolver: Arc<dyn ironclaw_loop_host::LoopCapabilityInputResolver>,
     result_writer: Arc<dyn ironclaw_loop_host::LoopCapabilityResultWriter>,
 ) -> Result<Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>, AgentLoopHostError> {
-    super::synthetic_capability::wrap_local_dev_synthetic_capabilities(
+    super::synthetic_capability::wrap_synthetic_capabilities(
         inner,
         vec![result_read_capability(thread_service, fallback_user_id)?],
         run_context,
@@ -66,9 +66,9 @@ const RESULT_READ_MAX_BYTES: u64 = TOOL_RESULT_RECORD_READ_MAX_BYTES as u64;
 pub(super) fn result_read_capability(
     thread_service: Arc<dyn SessionThreadService>,
     fallback_user_id: UserId,
-) -> Result<LocalDevSyntheticCapability, AgentLoopHostError> {
-    Ok(LocalDevSyntheticCapability::new(
-        LocalDevSyntheticCapabilityDescriptor::new(
+) -> Result<SyntheticCapability, AgentLoopHostError> {
+    Ok(SyntheticCapability::new(
+        SyntheticCapabilityDescriptor::new(
             RESULT_READ_CAPABILITY_ID,
             RESULT_READ_PROVIDER_TOOL_NAME,
             "Read a bounded continuation of a previously completed tool result by result reference.",
@@ -88,7 +88,7 @@ struct ResultReadHandler {
 }
 
 #[async_trait]
-impl LocalDevSyntheticCapabilityHandler for ResultReadHandler {
+impl SyntheticCapabilityHandler for ResultReadHandler {
     fn validate_provider_arguments(
         &self,
         _arguments: &serde_json::Value,
@@ -101,7 +101,7 @@ impl LocalDevSyntheticCapabilityHandler for ResultReadHandler {
 
     async fn invoke(
         &self,
-        invocation: LocalDevSyntheticCapabilityInvocation,
+        invocation: SyntheticCapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         let input = match parse_result_read_input(&invocation.input) {
             Ok(input) => input,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -16,7 +16,7 @@ use ironclaw_turns::{
 };
 
 use super::{
-    LocalDevCapabilityIo, LocalDevExtensionSurfaceSource, LocalDevLoopCapabilityPortFactory,
+    ExtensionCapabilitySurfaceSource, RefreshingLoopCapabilityPortFactory, StagedCapabilityIo,
 };
 
 async fn run_context(label: &str) -> LoopRunContext {
@@ -83,12 +83,12 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
     let workspace_mounts = local_runtime.workspace_mounts.clone();
     let memory_mounts = local_runtime.memory_mounts.clone();
     let policy = Arc::new(
-        crate::local_dev_capability_policy::local_dev_capability_policy().expect("policy parses"),
+        crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
     );
-    let capability_io = Arc::new(LocalDevCapabilityIo::default());
+    let capability_io = Arc::new(StagedCapabilityIo::default());
     let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
     let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-    let factory = LocalDevLoopCapabilityPortFactory {
+    let factory = RefreshingLoopCapabilityPortFactory {
         runtime,
         fallback_user_id: UserId::new("local-dev-shell-user").expect("user id"),
         policy,
@@ -97,7 +97,7 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
         system_extensions_lifecycle_mounts: local_runtime
             .system_extensions_lifecycle_mounts
             .clone(),
-        extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+        extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
         input_resolver,
         result_writer,
         milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -65,7 +65,7 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
             crate::RebornCompositionProfile::LocalDevYolo,
             "local-dev-shell-owner",
             storage_root,
-            crate::RebornLocalRuntimeProfileOptions {
+            crate::RebornRuntimeProfileOptions {
                 confirm_host_access: true,
             },
         )

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/skill_activation.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/skill_activation.rs
@@ -9,10 +9,10 @@ use ironclaw_turns::run_profile::{
 };
 
 use crate::runtime::{
-    LocalDevSelectableSkillContextSource,
+    ComposedSelectableSkillContextSource,
     local_dev::synthetic_capability::{
-        LocalDevSyntheticCapability, LocalDevSyntheticCapabilityDescriptor,
-        LocalDevSyntheticCapabilityHandler, LocalDevSyntheticCapabilityInvocation,
+        SyntheticCapability, SyntheticCapabilityDescriptor, SyntheticCapabilityHandler,
+        SyntheticCapabilityInvocation,
     },
 };
 
@@ -23,10 +23,10 @@ const SKILL_ACTIVATE_DESCRIPTION: &str =
 const MAX_SKILL_ACTIVATE_NAMES: usize = 16;
 
 pub(super) fn skill_activation_capability(
-    skill_activation_source: Arc<LocalDevSelectableSkillContextSource>,
-) -> Result<LocalDevSyntheticCapability, AgentLoopHostError> {
-    Ok(LocalDevSyntheticCapability::new(
-        LocalDevSyntheticCapabilityDescriptor::new(
+    skill_activation_source: Arc<ComposedSelectableSkillContextSource>,
+) -> Result<SyntheticCapability, AgentLoopHostError> {
+    Ok(SyntheticCapability::new(
+        SyntheticCapabilityDescriptor::new(
             SKILL_ACTIVATE_CAPABILITY_ID,
             SKILL_ACTIVATE_PROVIDER_TOOL_NAME,
             SKILL_ACTIVATE_DESCRIPTION,
@@ -40,11 +40,11 @@ pub(super) fn skill_activation_capability(
 }
 
 struct SkillActivationHandler {
-    skill_activation_source: Arc<LocalDevSelectableSkillContextSource>,
+    skill_activation_source: Arc<ComposedSelectableSkillContextSource>,
 }
 
 #[async_trait]
-impl LocalDevSyntheticCapabilityHandler for SkillActivationHandler {
+impl SyntheticCapabilityHandler for SkillActivationHandler {
     fn validate_provider_arguments(
         &self,
         arguments: &serde_json::Value,
@@ -54,7 +54,7 @@ impl LocalDevSyntheticCapabilityHandler for SkillActivationHandler {
 
     async fn invoke(
         &self,
-        invocation: LocalDevSyntheticCapabilityInvocation,
+        invocation: SyntheticCapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         // Normalise to lowercase at the parse boundary so that `names` (passed
         // to `activate_skills_for_run`) and the response-filter set both use the

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/surface_disclosure.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/surface_disclosure.rs
@@ -12,24 +12,24 @@ use ironclaw_turns::run_profile::{
     RegisterProviderToolCallRequest, VisibleCapabilityRequest, VisibleCapabilitySurface,
 };
 
-pub(super) fn wrap_local_dev_surface_disclosure(
+pub(super) fn wrap_surface_disclosure(
     inner: Arc<dyn LoopCapabilityPort>,
     workspace_mounts: &MountView,
 ) -> Arc<dyn LoopCapabilityPort> {
-    let disclosure = LocalDevSurfaceDisclosure::from_workspace_mounts(workspace_mounts);
+    let disclosure = HostSurfaceDisclosure::from_workspace_mounts(workspace_mounts);
     if !disclosure.enabled() {
         return inner;
     }
-    Arc::new(LocalDevSurfaceDisclosurePort { inner, disclosure })
+    Arc::new(HostSurfaceDisclosurePort { inner, disclosure })
 }
 
-struct LocalDevSurfaceDisclosurePort {
+struct HostSurfaceDisclosurePort {
     inner: Arc<dyn LoopCapabilityPort>,
-    disclosure: LocalDevSurfaceDisclosure,
+    disclosure: HostSurfaceDisclosure,
 }
 
 #[async_trait::async_trait]
-impl LoopCapabilityPort for LocalDevSurfaceDisclosurePort {
+impl LoopCapabilityPort for HostSurfaceDisclosurePort {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
         let mut definitions = self.inner.tool_definitions()?;
         for definition in &mut definitions {
@@ -85,11 +85,11 @@ impl LoopCapabilityPort for LocalDevSurfaceDisclosurePort {
     }
 }
 
-struct LocalDevSurfaceDisclosure {
+struct HostSurfaceDisclosure {
     scoped_roots_note: Option<String>,
 }
 
-impl LocalDevSurfaceDisclosure {
+impl HostSurfaceDisclosure {
     fn from_workspace_mounts(workspace_mounts: &MountView) -> Self {
         let aliases = model_visible_workspace_aliases(workspace_mounts);
         Self {
@@ -224,7 +224,7 @@ mod tests {
             crate::local_dev_mounts::workspace_mount_view(MountPermissions::read_write(), &[])
                 .expect("workspace mounts build");
 
-        let disclosure = LocalDevSurfaceDisclosure::from_workspace_mounts(&workspace_mounts);
+        let disclosure = HostSurfaceDisclosure::from_workspace_mounts(&workspace_mounts);
 
         assert!(disclosure.scoped_roots_note.is_none());
     }
@@ -237,7 +237,7 @@ mod tests {
         )
         .expect("workspace mounts build");
 
-        let disclosure = LocalDevSurfaceDisclosure::from_workspace_mounts(&workspace_mounts);
+        let disclosure = HostSurfaceDisclosure::from_workspace_mounts(&workspace_mounts);
         let note = disclosure
             .scoped_roots_note
             .expect("confirmed host mount is disclosed");

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/synthetic_capability.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/synthetic_capability.rs
@@ -18,9 +18,9 @@ use ironclaw_turns::{
     },
 };
 
-pub(super) fn wrap_local_dev_synthetic_capabilities(
+pub(super) fn wrap_synthetic_capabilities(
     inner: Arc<dyn LoopCapabilityPort>,
-    capabilities: Vec<LocalDevSyntheticCapability>,
+    capabilities: Vec<SyntheticCapability>,
     run_context: LoopRunContext,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
@@ -29,7 +29,7 @@ pub(super) fn wrap_local_dev_synthetic_capabilities(
     if capabilities.is_empty() {
         return Ok(inner);
     }
-    Ok(Arc::new(LocalDevSyntheticCapabilityPort::new(
+    Ok(Arc::new(SyntheticCapabilityPort::new(
         inner,
         capabilities,
         run_context,
@@ -39,15 +39,15 @@ pub(super) fn wrap_local_dev_synthetic_capabilities(
     )?))
 }
 
-pub(super) struct LocalDevSyntheticCapability {
-    descriptor: LocalDevSyntheticCapabilityDescriptor,
-    handler: Arc<dyn LocalDevSyntheticCapabilityHandler>,
+pub(super) struct SyntheticCapability {
+    descriptor: SyntheticCapabilityDescriptor,
+    handler: Arc<dyn SyntheticCapabilityHandler>,
 }
 
-impl LocalDevSyntheticCapability {
+impl SyntheticCapability {
     pub(super) fn new(
-        descriptor: LocalDevSyntheticCapabilityDescriptor,
-        handler: Arc<dyn LocalDevSyntheticCapabilityHandler>,
+        descriptor: SyntheticCapabilityDescriptor,
+        handler: Arc<dyn SyntheticCapabilityHandler>,
     ) -> Self {
         Self {
             descriptor,
@@ -56,7 +56,7 @@ impl LocalDevSyntheticCapability {
     }
 }
 
-pub(super) struct LocalDevSyntheticCapabilityDescriptor {
+pub(super) struct SyntheticCapabilityDescriptor {
     capability_id: CapabilityId,
     provider_tool_name: ProviderToolName,
     description: String,
@@ -64,7 +64,7 @@ pub(super) struct LocalDevSyntheticCapabilityDescriptor {
     parameters_schema: serde_json::Value,
 }
 
-impl LocalDevSyntheticCapabilityDescriptor {
+impl SyntheticCapabilityDescriptor {
     pub(super) fn new(
         capability_id: &str,
         provider_tool_name: &str,
@@ -113,7 +113,7 @@ impl LocalDevSyntheticCapabilityDescriptor {
     }
 }
 
-pub(super) struct LocalDevSyntheticCapabilityInvocation {
+pub(super) struct SyntheticCapabilityInvocation {
     pub(super) run_context: LoopRunContext,
     pub(super) request: CapabilityInvocation,
     pub(super) input: serde_json::Value,
@@ -121,7 +121,7 @@ pub(super) struct LocalDevSyntheticCapabilityInvocation {
 }
 
 #[async_trait]
-pub(super) trait LocalDevSyntheticCapabilityHandler: Send + Sync {
+pub(super) trait SyntheticCapabilityHandler: Send + Sync {
     fn validate_provider_arguments(
         &self,
         arguments: &serde_json::Value,
@@ -129,16 +129,16 @@ pub(super) trait LocalDevSyntheticCapabilityHandler: Send + Sync {
 
     async fn invoke(
         &self,
-        invocation: LocalDevSyntheticCapabilityInvocation,
+        invocation: SyntheticCapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError>;
 }
 
-struct LocalDevSyntheticCapabilityPort {
+struct SyntheticCapabilityPort {
     inner: Arc<dyn LoopCapabilityPort>,
     run_context: LoopRunContext,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
-    capabilities_by_id: HashMap<CapabilityId, LocalDevSyntheticCapability>,
+    capabilities_by_id: HashMap<CapabilityId, SyntheticCapability>,
     capability_ids_by_provider_tool_name: HashMap<ProviderToolName, CapabilityId>,
     current_surface_version: StdMutex<Option<CapabilitySurfaceVersion>>,
     provider_tool_call_registrations:
@@ -146,7 +146,7 @@ struct LocalDevSyntheticCapabilityPort {
     /// Synthetic calls resolve input + write the result here, bypassing the
     /// inner `HostRuntimeLoopCapabilityPort` input hook. Hold the observer so we
     /// can emit `on_capability_input` ourselves — otherwise consumers see the
-    /// result event (from `LocalDevCapabilityIo`) with no matching input.
+    /// result event (from `StagedCapabilityIo`) with no matching input.
     trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
 }
 
@@ -155,10 +155,10 @@ struct SyntheticProviderToolCallRegistration {
     capability_id: CapabilityId,
 }
 
-impl LocalDevSyntheticCapabilityPort {
+impl SyntheticCapabilityPort {
     fn new(
         inner: Arc<dyn LoopCapabilityPort>,
-        capabilities: Vec<LocalDevSyntheticCapability>,
+        capabilities: Vec<SyntheticCapability>,
         run_context: LoopRunContext,
         input_resolver: Arc<dyn LoopCapabilityInputResolver>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
@@ -216,7 +216,7 @@ impl LocalDevSyntheticCapabilityPort {
     fn synthetic_provider_call(
         &self,
         tool_call: &ProviderToolCall,
-    ) -> Option<(&CapabilityId, &LocalDevSyntheticCapability)> {
+    ) -> Option<(&CapabilityId, &SyntheticCapability)> {
         self.capability_ids_by_provider_tool_name
             .get(&tool_call.name)
             .and_then(|capability_id| self.capabilities_by_id.get_key_value(capability_id))
@@ -329,7 +329,7 @@ impl LocalDevSyntheticCapabilityPort {
 }
 
 #[async_trait]
-impl LoopCapabilityPort for LocalDevSyntheticCapabilityPort {
+impl LoopCapabilityPort for SyntheticCapabilityPort {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
         let mut definitions = self.inner.tool_definitions()?;
         if self
@@ -479,7 +479,7 @@ impl LoopCapabilityPort for LocalDevSyntheticCapabilityPort {
             }
         };
         // The inner port's input hook is bypassed for synthetic capabilities, so
-        // emit the input event here — otherwise `LocalDevCapabilityIo` would stage
+        // emit the input event here — otherwise `StagedCapabilityIo` would stage
         // a result with no matching input and consumers would see an unpaired
         // event missing the tool arguments. Best-effort + panic-isolated, matching
         // the other observer call sites.
@@ -499,7 +499,7 @@ impl LoopCapabilityPort for LocalDevSyntheticCapabilityPort {
             }
         }
         handler
-            .invoke(LocalDevSyntheticCapabilityInvocation {
+            .invoke(SyntheticCapabilityInvocation {
                 run_context: self.run_context.clone(),
                 request,
                 input,
@@ -608,7 +608,7 @@ mod tests {
     struct TestSyntheticHandler;
 
     #[async_trait]
-    impl LocalDevSyntheticCapabilityHandler for TestSyntheticHandler {
+    impl SyntheticCapabilityHandler for TestSyntheticHandler {
         fn validate_provider_arguments(
             &self,
             _arguments: &serde_json::Value,
@@ -618,7 +618,7 @@ mod tests {
 
         async fn invoke(
             &self,
-            _invocation: LocalDevSyntheticCapabilityInvocation,
+            _invocation: SyntheticCapabilityInvocation,
         ) -> Result<CapabilityOutcome, AgentLoopHostError> {
             Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Internal,
@@ -632,7 +632,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl LocalDevSyntheticCapabilityHandler for CountingSyntheticHandler {
+    impl SyntheticCapabilityHandler for CountingSyntheticHandler {
         fn validate_provider_arguments(
             &self,
             _arguments: &serde_json::Value,
@@ -642,7 +642,7 @@ mod tests {
 
         async fn invoke(
             &self,
-            _invocation: LocalDevSyntheticCapabilityInvocation,
+            _invocation: SyntheticCapabilityInvocation,
         ) -> Result<CapabilityOutcome, AgentLoopHostError> {
             self.invocations.fetch_add(1, Ordering::SeqCst);
             Ok(CapabilityOutcome::Completed(
@@ -678,16 +678,16 @@ mod tests {
         )
     }
 
-    async fn synthetic_port() -> LocalDevSyntheticCapabilityPort {
+    async fn synthetic_port() -> SyntheticCapabilityPort {
         synthetic_port_with_io(Arc::new(TestSyntheticHandler), Arc::new(NoopResultWriter)).await
     }
 
     async fn synthetic_port_with_io(
-        handler: Arc<dyn LocalDevSyntheticCapabilityHandler>,
+        handler: Arc<dyn SyntheticCapabilityHandler>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
-    ) -> LocalDevSyntheticCapabilityPort {
-        let capability = LocalDevSyntheticCapability::new(
-            LocalDevSyntheticCapabilityDescriptor::new(
+    ) -> SyntheticCapabilityPort {
+        let capability = SyntheticCapability::new(
+            SyntheticCapabilityDescriptor::new(
                 TEST_CAPABILITY_ID,
                 TEST_PROVIDER_TOOL_NAME,
                 "Synthetic test capability",
@@ -697,7 +697,7 @@ mod tests {
             .expect("descriptor"),
             handler,
         );
-        let port = LocalDevSyntheticCapabilityPort::new(
+        let port = SyntheticCapabilityPort::new(
             Arc::new(EmptyLoopCapabilityPort),
             vec![capability],
             run_context().await,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_dev_visible_capability_request_uses_run_actor_for_runtime_scope() {
+    async fn visible_capability_request_uses_run_actor_for_runtime_scope() {
         let run_context = run_context("actor-runtime-scope")
             .await
             .with_actor(TurnActor::new(
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_dev_visible_capability_request_uses_explicit_subject_for_runtime_scope() {
+    async fn visible_capability_request_uses_explicit_subject_for_runtime_scope() {
         let subject_user_id = UserId::new("team-agent-user").expect("subject user id");
         let run_context = run_context_with_scope(TurnScope::new_with_owner(
             TenantId::new("tenant-subject").expect("tenant id"),
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_dev_visible_capability_request_keeps_fallback_user_without_actor() {
+    async fn visible_capability_request_keeps_fallback_user_without_actor() {
         let run_context = run_context("fallback-runtime-scope").await;
         let fallback_user_id = UserId::new("env-operator").expect("fallback user id");
         let request = visible_request_for_runtime_scope(&run_context, &fallback_user_id);
@@ -244,20 +244,20 @@ mod tests {
         run_context: &LoopRunContext,
         fallback_user_id: &UserId,
     ) -> HostVisibleCapabilityRequest {
-        let policy = crate::local_dev_capability_policy::local_dev_capability_policy()
-            .expect("policy parses");
+        let policy =
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses");
         let empty_mounts = MountView::default();
 
-        local_dev_visible_capability_request(
+        visible_capability_request(
             run_context,
             fallback_user_id,
-            LocalDevVisibleCapabilityInputs {
+            VisibleCapabilityInputs {
                 workspace_mounts: &empty_mounts,
                 skill_mounts: &empty_mounts,
                 memory_mounts: &empty_mounts,
                 system_extensions_lifecycle_mounts: &empty_mounts,
                 policy: &policy,
-                extension_surface: &LocalDevExtensionSurface::default(),
+                extension_surface: &ExtensionCapabilitySurface::default(),
             },
         )
         .expect("visible request")
@@ -390,7 +390,7 @@ mod tests {
     }
 
     async fn assert_github_capabilities_visible(
-        wiring: &LocalDevCapabilityWiring,
+        wiring: &CapabilityPortWiring,
         run_context: &LoopRunContext,
     ) {
         let port = wiring
@@ -427,7 +427,7 @@ mod tests {
     }
 
     async fn assert_gsuite_capabilities_visibility(
-        wiring: &LocalDevCapabilityWiring,
+        wiring: &CapabilityPortWiring,
         run_context: &LoopRunContext,
         expected: GsuiteCapabilityVisibility,
     ) {
@@ -463,7 +463,7 @@ mod tests {
     }
 
     async fn visible_capability_ids(
-        wiring: &LocalDevCapabilityWiring,
+        wiring: &CapabilityPortWiring,
         run_context: &LoopRunContext,
     ) -> (Vec<String>, Vec<String>) {
         let port = wiring
@@ -509,7 +509,7 @@ mod tests {
             Arc::new(InMemorySessionThreadService::default()),
             user_id,
             Arc::new(
-                crate::local_dev_capability_policy::local_dev_capability_policy()
+                crate::builtin_capability_policy::builtin_capability_policy()
                     .expect("policy parses"),
             ),
             Arc::new(UnavailableModelGateway),
@@ -581,7 +581,7 @@ mod tests {
 
     struct GsuiteSurfaceHarness {
         _dir: tempfile::TempDir,
-        wiring: LocalDevCapabilityWiring,
+        wiring: CapabilityPortWiring,
         run_context: LoopRunContext,
     }
 
@@ -621,7 +621,7 @@ mod tests {
             Arc::new(InMemorySessionThreadService::default()),
             UserId::new(user).expect("user id"),
             Arc::new(
-                crate::local_dev_capability_policy::local_dev_capability_policy()
+                crate::builtin_capability_policy::builtin_capability_policy()
                     .expect("policy parses"),
             ),
             Arc::new(UnavailableModelGateway),
@@ -773,7 +773,7 @@ mod tests {
             .await
             .expect("thread exists");
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service.clone(),
             fallback_user_id.clone(),
@@ -869,7 +869,7 @@ mod tests {
         // would have appended under a mismatched scope and failed; the run-scope
         // derivation must ignore this fallback because the run carries an owner.
         let unrelated_fallback = UserId::new("env-operator-unrelated").expect("fallback user id");
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service.clone(),
             unrelated_fallback,
@@ -949,7 +949,7 @@ mod tests {
             .await
             .expect("actor-owned thread exists");
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service.clone(),
             runtime_owner_id,
@@ -1009,7 +1009,7 @@ mod tests {
         // No thread is registered, so the result cannot be made retrievable.
         let thread_service = Arc::new(InMemorySessionThreadService::default());
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service,
             fallback_user_id,
@@ -1062,7 +1062,7 @@ mod tests {
             .await
             .expect("thread exists");
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service.clone(),
             fallback_user_id,
@@ -1124,7 +1124,7 @@ mod tests {
     /// raw record (readable through `SessionThreadService`), and
     /// `delete_capability_result` must leave that durable record intact and
     /// only clear the transient staging copy — pinning the retention
-    /// invariant `37fe3ac04` fixed at the `LocalDevCapabilityIo` level
+    /// invariant `37fe3ac04` fixed at the `StagedCapabilityIo` level
     /// directly, rather than only through a rollback-path mock.
     #[tokio::test]
     async fn update_and_delete_capability_result_preserve_durable_record() {
@@ -1144,7 +1144,7 @@ mod tests {
             .await
             .expect("thread exists");
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service.clone(),
             fallback_user_id,
@@ -1246,7 +1246,7 @@ mod tests {
             .await
             .expect("thread exists");
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service,
             fallback_user_id,
@@ -1340,7 +1340,7 @@ mod tests {
             .expect("thread exists");
 
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = Arc::new(StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service.clone(),
             fallback_user_id.clone(),
@@ -1436,7 +1436,7 @@ mod tests {
         // Continue reading from `next_offset` through the production
         // `result_read` capability and confirm the two chunks concatenate
         // with no gap or overlap.
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: fallback_user_id.clone(),
             policy: Arc::clone(&local_runtime.capability_policy),
@@ -1445,7 +1445,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -1531,7 +1531,7 @@ mod tests {
             .await
             .expect("thread exists");
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service,
             fallback_user_id,
@@ -1677,7 +1677,7 @@ mod tests {
             .expect("thread exists");
 
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = Arc::new(StagedCapabilityIo::new_with_durable_previews(
             Arc::clone(&display_previews),
             thread_service.clone(),
             fallback_user_id.clone(),
@@ -1740,7 +1740,7 @@ mod tests {
             .await
             .expect("finalized reference exists");
 
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: fallback_user_id.clone(),
             policy: Arc::clone(&local_runtime.capability_policy),
@@ -1749,7 +1749,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -1829,7 +1829,7 @@ mod tests {
 
     #[tokio::test]
     async fn capability_io_resolves_input_refs_repeatedly() {
-        let capability_io = LocalDevCapabilityIo::default();
+        let capability_io = StagedCapabilityIo::default();
         let run_context = run_context("repeat-input").await;
         let input_ref = capability_io
             .register_provider_tool_call_input(
@@ -1854,7 +1854,7 @@ mod tests {
 
     #[tokio::test]
     async fn capability_io_rejects_cross_run_and_unstaged_input_refs() {
-        let capability_io = LocalDevCapabilityIo::default();
+        let capability_io = StagedCapabilityIo::default();
         let current_context = run_context("input-scope-a").await;
         let other_context = run_context("input-scope-b").await;
         let input_ref = capability_io
@@ -1906,8 +1906,8 @@ mod tests {
 
     #[test]
     fn local_dev_builtin_surface_grants_capability_classes() {
-        let policy = crate::local_dev_capability_policy::local_dev_capability_policy()
-            .expect("policy parses");
+        let policy =
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses");
         let capability_ids = policy
             .capability_ids()
             .map(|capability| capability.as_str())
@@ -1917,7 +1917,7 @@ mod tests {
         assert!(capability_ids.contains(&APPLY_PATCH_CAPABILITY_ID));
         assert!(capability_ids.contains(&SKILL_LIST_CAPABILITY_ID));
         // SKILL_ACTIVATE_CAPABILITY_ID is a synthetic capability added by
-        // wrap_local_dev_synthetic_capabilities, not a policy capability.
+        // wrap_synthetic_capabilities, not a policy capability.
         assert!(!capability_ids.contains(&SKILL_ACTIVATE_CAPABILITY_ID));
         assert!(capability_ids.contains(&SKILL_INSTALL_CAPABILITY_ID));
         assert!(capability_ids.contains(&SKILL_REMOVE_CAPABILITY_ID));
@@ -1930,7 +1930,7 @@ mod tests {
             EffectKind::WriteFilesystem,
         ];
         let local_dev_shell_network_policy =
-            crate::local_dev_capability_policy::local_dev_wildcard_network_policy();
+            crate::builtin_capability_policy::dev_wildcard_network_policy();
         assert_eq!(
             local_dev_allowed_effects,
             vec![
@@ -2205,14 +2205,13 @@ mod tests {
         )
         .expect("skill context source");
         let activation_source = skill_context.activation_source;
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let policy = Arc::new(
-            crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: UserId::new("skill-activate-user").expect("user id"),
             policy,
@@ -2221,7 +2220,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -2345,8 +2344,7 @@ mod tests {
         )
         .expect("skill context source");
         let policy = Arc::new(
-            crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
         let wiring = capability_wiring(
             &services,
@@ -2414,14 +2412,13 @@ mod tests {
             )
             .await
             .expect("external tool catalog registers");
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let policy = Arc::new(
-            crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: UserId::new("external-tool-provider-name-user").expect("user id"),
             policy,
@@ -2430,7 +2427,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -2496,10 +2493,10 @@ mod tests {
             .local_runtime
             .as_ref()
             .expect("local runtime substrate");
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: UserId::new("project-create-fallback-user").expect("user id"),
             policy: Arc::clone(&local_runtime.capability_policy),
@@ -2508,7 +2505,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -2688,14 +2685,14 @@ mod tests {
         );
 
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = Arc::new(StagedCapabilityIo::new_with_durable_previews(
             display_previews,
             thread_service.clone(),
             fallback_user_id.clone(),
         ));
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id,
             policy: Arc::clone(&local_runtime.capability_policy),
@@ -2704,7 +2701,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -3018,10 +3015,10 @@ mod tests {
             .expect("local runtime substrate");
         let fallback_user_id = UserId::new("result-read-validation-owner").expect("user id");
         let run_context = run_context("result-read-validation").await;
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id,
             policy: Arc::clone(&local_runtime.capability_policy),
@@ -3030,7 +3027,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -3434,14 +3431,14 @@ mod tests {
             FilesystemSessionThreadService::new(scoped_thread_filesystem(backend)),
         );
         let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-        let capability_io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
+        let capability_io = Arc::new(StagedCapabilityIo::new_with_durable_previews(
             display_previews,
             thread_service.clone(),
             fallback_user_id.clone(),
         ));
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id,
             policy: Arc::clone(&local_runtime.capability_policy),
@@ -3450,7 +3447,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -3552,7 +3549,7 @@ mod tests {
                 target_provider,
             ));
         let policy = Arc::clone(&local_runtime.capability_policy);
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let fallback_user_id = UserId::new("outbound-delivery-fallback-user").expect("user id");
@@ -3567,7 +3564,7 @@ mod tests {
                 local_runtime.persistent_approval_policies.clone(),
             ),
         );
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: fallback_user_id.clone(),
             policy,
@@ -3576,7 +3573,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -3796,7 +3793,7 @@ mod tests {
         let missing_approval = local_runtime
             .capability_policy
             .lease_approval_for(
-                crate::local_dev_capability_policy::LocalDevApprovalPolicyAction::Dispatch {
+                crate::builtin_capability_policy::BuiltinApprovalPolicyAction::Dispatch {
                     capability: &set_capability_id,
                 },
                 &local_runtime.workspace_mounts,
@@ -3922,7 +3919,7 @@ mod tests {
         let approval = local_runtime
             .capability_policy
             .lease_approval_for(
-                crate::local_dev_capability_policy::LocalDevApprovalPolicyAction::Dispatch {
+                crate::builtin_capability_policy::BuiltinApprovalPolicyAction::Dispatch {
                     capability: &set_capability_id,
                 },
                 &local_runtime.workspace_mounts,
@@ -4280,13 +4277,12 @@ mod tests {
             .as_ref()
             .expect("local runtime substrate");
         let policy = Arc::new(
-            crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io;
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: UserId::new("outbound-delivery-fallback-user").expect("user id"),
             policy,
@@ -4295,7 +4291,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -4392,13 +4388,12 @@ mod tests {
             .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
         let workspace_mounts = local_runtime.workspace_mounts.clone();
         let policy = Arc::new(
-            crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: UserId::new("local-yolo-host-user").expect("user id"), // safety: literal test id is valid.
             policy,
@@ -4407,7 +4402,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -4638,13 +4633,12 @@ mod tests {
             .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
         let workspace_mounts = local_runtime.workspace_mounts.clone();
         let policy = Arc::new(
-            crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: UserId::new("local-dev-skill-port-user").expect("user id"), // safety: literal test id is valid.
             policy,
@@ -4653,7 +4647,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -4753,13 +4747,12 @@ mod tests {
             .expect("local runtime substrate"); // safety: test-only assertion in #[cfg(test)] module.
         let workspace_mounts = local_runtime.workspace_mounts.clone();
         let policy = Arc::new(
-            crate::local_dev_capability_policy::local_dev_capability_policy()
-                .expect("policy parses"),
+            crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let capability_io = Arc::new(StagedCapabilityIo::default());
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory {
+        let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: UserId::new("local-dev-no-host-user").expect("user id"), // safety: literal test id is valid.
             policy,
@@ -4768,7 +4761,7 @@ mod tests {
             system_extensions_lifecycle_mounts: local_runtime
                 .system_extensions_lifecycle_mounts
                 .clone(),
-            extension_surface_source: LocalDevExtensionSurfaceSource::default(),
+            extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -4942,7 +4935,7 @@ mod tests {
             Arc::new(InMemorySessionThreadService::default()),
             UserId::new("local-dev-github-user").expect("user id"),
             Arc::new(
-                crate::local_dev_capability_policy::local_dev_capability_policy()
+                crate::builtin_capability_policy::builtin_capability_policy()
                     .expect("policy parses"),
             ),
             Arc::new(UnavailableModelGateway),
@@ -4971,7 +4964,7 @@ mod tests {
             Arc::new(InMemorySessionThreadService::default()),
             UserId::new("local-dev-live-github-user").expect("user id"),
             Arc::new(
-                crate::local_dev_capability_policy::local_dev_capability_policy()
+                crate::builtin_capability_policy::builtin_capability_policy()
                     .expect("policy parses"),
             ),
             Arc::new(UnavailableModelGateway),
@@ -5098,7 +5091,7 @@ mod tests {
             thread_service,
             fallback_user_id,
             Arc::new(
-                crate::local_dev_capability_policy::local_dev_capability_policy()
+                crate::builtin_capability_policy::builtin_capability_policy()
                     .expect("policy parses"),
             ),
             Arc::new(UnavailableModelGateway),
@@ -5168,7 +5161,7 @@ mod tests {
             Arc::new(InMemorySessionThreadService::default()),
             UserId::new("local-dev-mid-response-user").expect("user id"),
             Arc::new(
-                crate::local_dev_capability_policy::local_dev_capability_policy()
+                crate::builtin_capability_policy::builtin_capability_policy()
                     .expect("policy parses"),
             ),
             Arc::new(UnavailableModelGateway),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests/tests/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests/tests/display_preview.rs
@@ -11,7 +11,7 @@ use ironclaw_threads::{
 };
 
 use super::{
-    CapabilityDisplayPreviewStore, LocalDevCapabilityIo, UserId, local_dev_thread_scope_for_run,
+    CapabilityDisplayPreviewStore, StagedCapabilityIo, UserId, local_dev_thread_scope_for_run,
     provider_tool_call, run_context,
 };
 
@@ -34,7 +34,7 @@ async fn capability_io_writes_display_preview_to_durable_history() {
         })
         .await
         .expect("thread exists");
-    let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+    let capability_io = StagedCapabilityIo::new_with_durable_previews(
         Arc::new(CapabilityDisplayPreviewStore::default()),
         thread_service.clone(),
         fallback_user_id.clone(),
@@ -121,7 +121,7 @@ async fn capability_io_writes_failure_display_preview_to_durable_history() {
         })
         .await
         .expect("thread exists");
-    let capability_io = LocalDevCapabilityIo::new_with_durable_previews(
+    let capability_io = StagedCapabilityIo::new_with_durable_previews(
         Arc::new(CapabilityDisplayPreviewStore::default()),
         thread_service.clone(),
         fallback_user_id.clone(),

--- a/crates/ironclaw_reborn_composition/src/runtime/test_support.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/test_support.rs
@@ -28,15 +28,14 @@ impl RebornServices {
         let Some(local_runtime) = self.local_runtime.as_ref() else {
             return Ok(None);
         };
-        let local_dev_capability_policy =
-            Arc::new(local_dev_capability_policy().map_err(|error| {
-                RebornRuntimeError::InvalidArgument {
-                    reason: format!("local-dev capability policy is invalid: {error}"),
-                }
-            })?);
+        let builtin_capability_policy = Arc::new(builtin_capability_policy().map_err(|error| {
+            RebornRuntimeError::InvalidArgument {
+                reason: format!("local-dev capability policy is invalid: {error}"),
+            }
+        })?);
         Ok(Some(build_local_dev_approval_interaction_service(
             local_runtime,
-            local_dev_capability_policy,
+            builtin_capability_policy,
             turn_coordinator,
             None,
         )?))
@@ -87,16 +86,15 @@ impl RebornServices {
         let Some(local_runtime) = self.local_runtime.as_ref() else {
             return Ok(None);
         };
-        let local_dev_capability_policy =
-            Arc::new(local_dev_capability_policy().map_err(|error| {
-                RebornRuntimeError::InvalidArgument {
-                    reason: format!("local-dev capability policy is invalid: {error}"),
-                }
-            })?);
+        let builtin_capability_policy = Arc::new(builtin_capability_policy().map_err(|error| {
+            RebornRuntimeError::InvalidArgument {
+                reason: format!("local-dev capability policy is invalid: {error}"),
+            }
+        })?);
         Ok(Some(
             build_local_dev_approval_interaction_service_with_turn_run_source(
                 local_runtime,
-                local_dev_capability_policy,
+                builtin_capability_policy,
                 turn_coordinator,
                 None,
                 turn_state as Arc<dyn TurnRunSnapshotSource>,

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -3795,7 +3795,7 @@ async fn local_dev_runtime_exposes_host_runtime_capabilities_to_model_calls() {
 /// Records both trajectory callbacks so the e2e test can assert the
 /// observer fires through a real `build_reborn_runtime` turn — driving the
 /// input hook (`HostRuntimeLoopCapabilityPort`) and the result hook
-/// (`LocalDevCapabilityIo::write_capability_result`) on the actual dispatch
+/// (`StagedCapabilityIo::write_capability_result`) on the actual dispatch
 /// path, not a direct helper call.
 #[derive(Debug, Default)]
 struct RecordingTrajectoryObserver {

--- a/crates/ironclaw_reborn_composition/src/slack/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_host_beta.rs
@@ -646,7 +646,7 @@ impl SlackPersonalUserBinder for ProvisioningSlackPersonalUserBinder {
 
 #[derive(Clone)]
 struct SlackHostBetaRuntimeParts {
-    local_runtime: Arc<crate::factory::RebornLocalRuntimeServices>,
+    local_runtime: Arc<crate::factory::RebornRuntimeSubstrate>,
     thread_service: Arc<dyn SessionThreadService>,
     turn_coordinator: Arc<dyn TurnCoordinator>,
     approval_interaction_service: Arc<dyn ApprovalInteractionService>,

--- a/crates/ironclaw_reborn_composition/src/telegram/telegram_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/telegram/telegram_host_beta.rs
@@ -247,7 +247,7 @@ pub async fn build_telegram_host_runtime_mounts(
 }
 
 fn connect_account_status(
-    local_runtime: &crate::factory::RebornLocalRuntimeServices,
+    local_runtime: &crate::factory::RebornRuntimeSubstrate,
     account_status: Arc<dyn ironclaw_product_workflow::AccountConnectionStatusSource>,
 ) -> Result<(), TelegramHostBuildError> {
     let Some(extension_management) = &local_runtime.extension_management else {

--- a/crates/ironclaw_reborn_composition/src/test_support/local_dev_boot.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/local_dev_boot.rs
@@ -1,6 +1,6 @@
 //! Reborn integration-test framework local-dev boot accessors.
 //!
-//! `build_local_dev_approval_gate_evidence_for_test`,
+//! `build_approval_gate_evidence_for_test`,
 //! `build_default_local_dev_database_roots_for_test`,
 //! `mount_local_dev_database_roots_for_test`,
 //! `build_local_dev_secret_store_for_test` — mirror the production local-dev
@@ -91,7 +91,7 @@ where
 
 /// Mirrors the production approval-gate evidence wiring done by
 /// `build_local_runtime` (runtime.rs ~line 2799) — returns the REAL
-/// `LocalDevApprovalGateEvidence` so the gate-evidence lookup logic
+/// `ApprovalRequestGateEvidence` so the gate-evidence lookup logic
 /// (the `gate:approval-` prefix parse + `ApprovalStatus::Pending` check)
 /// never drifts from production. Tests only.
 ///
@@ -102,8 +102,8 @@ where
 /// request at loop exit and genuinely pauses — mirrors the production
 /// `runtime.rs` path with the real type, never a hand-mirrored copy.
 #[cfg(feature = "test-support")]
-pub fn build_local_dev_approval_gate_evidence_for_test(
+pub fn build_approval_gate_evidence_for_test(
     approval_requests: std::sync::Arc<dyn ironclaw_run_state::ApprovalRequestStore>,
 ) -> std::sync::Arc<dyn ironclaw_runner::loop_exit_applier::ApprovalGateEvidenceStore> {
-    crate::runtime::build_local_dev_approval_gate_evidence_for_test(approval_requests)
+    crate::runtime::build_approval_gate_evidence_for_test(approval_requests)
 }

--- a/crates/ironclaw_reborn_composition/src/test_support/local_dev_capability_io.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/local_dev_capability_io.rs
@@ -1,4 +1,4 @@
-//! Production `LocalDevCapabilityIo` test support (durable tool-result
+//! Production `StagedCapabilityIo` test support (durable tool-result
 //! projection seam, issue #5838).
 //!
 //! Drives the REAL constructor production's `capability_wiring`
@@ -8,21 +8,21 @@
 //! `result_read` continuation instead of the ephemeral `ProductLiveCapabilityIo`
 //! test double.
 
-/// Real `LocalDevCapabilityIo`, wired like production's `capability_wiring`
+/// Real `StagedCapabilityIo`, wired like production's `capability_wiring`
 /// (`new_with_durable_previews`). Returns two `Arc` clones of ONE underlying
 /// io object -- input resolver and result writer MUST share the same object
-/// (see `RefreshingLocalDevCapabilityPortTestParts::input_resolver`'s doc for
+/// (see `RefreshingCapabilityPortTestParts::input_resolver`'s doc for
 /// why: input-ref/result-ref correlation by `call_id` depends on it).
 ///
 /// For tests only -- gated behind `test-support`, ships zero bytes in
 /// production builds.
 #[cfg(feature = "test-support")]
-pub fn local_dev_capability_io_for_test(
+pub fn staged_capability_io_for_test(
     thread_service: std::sync::Arc<dyn ironclaw_threads::SessionThreadService>,
     fallback_user_id: ironclaw_host_api::UserId,
 ) -> (
     std::sync::Arc<dyn ironclaw_loop_host::LoopCapabilityInputResolver>,
     std::sync::Arc<dyn ironclaw_loop_host::LoopCapabilityResultWriter>,
 ) {
-    crate::runtime::local_dev_capability_io_for_test(thread_service, fallback_user_id)
+    crate::runtime::staged_capability_io_for_test(thread_service, fallback_user_id)
 }

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -13,7 +13,7 @@
 //!    [`OAuthProductAuthTestBundle`], `build_oauth_product_auth_for_test`,
 //!    `build_google_oauth_product_auth_for_test` — real store / real client /
 //!    scripted HTTP egress for OAuth connect, refresh, and error-path tests.
-//! 3. [`local_dev_boot`] — `build_local_dev_approval_gate_evidence_for_test`,
+//! 3. [`local_dev_boot`] — `build_approval_gate_evidence_for_test`,
 //!    `build_default_local_dev_database_roots_for_test`,
 //!    `mount_local_dev_database_roots_for_test`,
 //!    `build_local_dev_secret_store_for_test` — mirror the production
@@ -44,12 +44,12 @@
 //! 11. [`projection`] — `build_webui_event_stream_for_test`, a deliberately
 //!     narrowed `ProjectionStream` (turn-lifecycle events only) for the SSE
 //!     activity-stream scenario (W5-WEBUI-API-1 Enabler A).
-//! 12. [`refreshing_capability_port`] — `create_refreshing_local_dev_capability_port_for_test`,
-//!     the production `create_refreshing_local_dev_capability_port` factory
+//! 12. [`refreshing_capability_port`] — `create_refreshing_capability_port_for_test`,
+//!     the production `create_refreshing_capability_port` factory
 //!     (all wrap layers) driven with harness-injectable parts (harness-port-seam
 //!     P1 seam).
-//! 13. [`local_dev_capability_io`] — `local_dev_capability_io_for_test`, the
-//!     production `LocalDevCapabilityIo` constructor (`capability_wiring`'s
+//! 13. [`local_dev_capability_io`] — `staged_capability_io_for_test`, the
+//!     production `StagedCapabilityIo` constructor (`capability_wiring`'s
 //!     `new_with_durable_previews` call), for durable tool-result projection
 //!     coverage (issue #5838).
 //! 14. [`result_read`] — `wrap_result_read_capability_for_test`, the
@@ -99,11 +99,11 @@ pub use local_dev_boot::LOCAL_DEV_DB_FILENAME;
 pub use local_dev_boot::build_local_dev_secret_store_for_test;
 #[cfg(feature = "test-support")]
 pub use local_dev_boot::{
-    build_default_local_dev_database_roots_for_test,
-    build_local_dev_approval_gate_evidence_for_test, mount_local_dev_database_roots_for_test,
+    build_approval_gate_evidence_for_test, build_default_local_dev_database_roots_for_test,
+    mount_local_dev_database_roots_for_test,
 };
 #[cfg(feature = "test-support")]
-pub use local_dev_capability_io::local_dev_capability_io_for_test;
+pub use local_dev_capability_io::staged_capability_io_for_test;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub use oauth_product_auth::build_google_oauth_product_auth_for_test;
 pub use oauth_product_auth::{
@@ -119,9 +119,8 @@ pub use project_create::PROJECT_CREATE_CAPABILITY_ID;
 pub use projection::build_webui_event_stream_for_test;
 #[cfg(feature = "test-support")]
 pub use refreshing_capability_port::{
-    ExtensionManagementTestHandle, RefreshingLocalDevCapabilityPortTestParts,
-    build_local_dev_extension_management_for_test,
-    create_refreshing_local_dev_capability_port_for_test,
+    ExtensionManagementTestHandle, RefreshingCapabilityPortTestParts,
+    build_local_dev_extension_management_for_test, create_refreshing_capability_port_for_test,
 };
 #[cfg(feature = "test-support")]
 pub use result_read::{RESULT_READ_CAPABILITY_ID, wrap_result_read_capability_for_test};

--- a/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
@@ -2,26 +2,26 @@
 //!
 //! Lets the Reborn integration-test harness assemble its capability port
 //! through the REAL production factory
-//! (`create_refreshing_local_dev_capability_port`,
+//! (`create_refreshing_capability_port`,
 //! `runtime::local_dev::refreshing_capability_port.rs:75`) instead of hand-
 //! rebuilding the wrap order, so every current and future production layer
 //! (surface disclosure, external tools, StaleSurface refresh, the shared
-//! `LocalDevCapabilityIo`) is automatically exercised by the harness too.
+//! `StagedCapabilityIo`) is automatically exercised by the harness too.
 
 /// Typed bundle of the parts the harness controls, passed by value through
 /// the `test_support` -> `runtime` -> `runtime::local_dev` forwarding chain
 /// so no layer needs `#[allow(clippy::too_many_arguments)]`. Mirrors
-/// `RefreshingLocalDevCapabilityPortConfig` minus the no-op-by-default parts
+/// `RefreshingCapabilityPortConfig` minus the no-op-by-default parts
 /// (`external_tool_catalog`, `policy`). `extension_surface_source` itself
 /// stays no-op-by-default too — the harness supplies the raw
 /// `extension_management` port below (Change 3, harness-port-seam P1
-/// follow-up) and `create_refreshing_local_dev_capability_port_for_test`
-/// wraps it in `LocalDevExtensionSurfaceSource::new(..)` internally, the SAME
+/// follow-up) and `create_refreshing_capability_port_for_test`
+/// wraps it in `ExtensionCapabilitySurfaceSource::new(..)` internally, the SAME
 /// constructor production's `capability_wiring` calls
 /// (`runtime/local_dev.rs:132-133`) — this crate is the only place that can
 /// name the `pub(in crate::runtime)` wrapper type.
 #[cfg(feature = "test-support")]
-pub struct RefreshingLocalDevCapabilityPortTestParts {
+pub struct RefreshingCapabilityPortTestParts {
     /// Host runtime the assembled port dispatches builtin capabilities
     /// through (harness passes a recording double).
     pub runtime: std::sync::Arc<dyn ironclaw_host_runtime::HostRuntime>,
@@ -33,14 +33,14 @@ pub struct RefreshingLocalDevCapabilityPortTestParts {
     pub system_extensions_lifecycle_mounts: ironclaw_host_api::MountView,
     /// Input resolver AND [`result_writer`](Self::result_writer) must be two
     /// `Arc::clone`s of the SAME shared io object — production assigns one
-    /// `LocalDevCapabilityIo` to both roles so input-ref/result-ref
+    /// `StagedCapabilityIo` to both roles so input-ref/result-ref
     /// correlation by `call_id` works; never source them independently.
     pub input_resolver: std::sync::Arc<dyn ironclaw_loop_host::LoopCapabilityInputResolver>,
     pub result_writer: std::sync::Arc<dyn ironclaw_loop_host::LoopCapabilityResultWriter>,
     pub milestone_sink: std::sync::Arc<dyn ironclaw_turns::run_profile::LoopHostMilestoneSink>,
     /// Opaque handle built by
     /// `test_support::build_local_dev_skill_context_source_for_test`. Wraps
-    /// the crate-private `LocalDevSelectableSkillContextSource` so it never
+    /// the crate-private `ComposedSelectableSkillContextSource` so it never
     /// appears in this (public, `test-support`-gated) struct's field types;
     /// the private type is recovered internally via
     /// `SkillActivationTestSource::activation_source` when forwarding to the
@@ -61,7 +61,7 @@ pub struct RefreshingLocalDevCapabilityPortTestParts {
     /// servers) whose capabilities and provider trust get folded into the
     /// visible-capability grants on every refresh — mirrors production
     /// `capability_wiring`'s
-    /// `LocalDevExtensionSurfaceSource::new(local_runtime.extension_management.clone())`
+    /// `ExtensionCapabilitySurfaceSource::new(local_runtime.extension_management.clone())`
     /// (`runtime/local_dev.rs:132-133`). `None` (the default a harness gets by
     /// simply omitting extension setup) reproduces the no-op surface this
     /// struct always had before this field existed — extension-lane
@@ -82,18 +82,18 @@ pub struct RefreshingLocalDevCapabilityPortTestParts {
     pub approval_requests: std::sync::Arc<dyn ironclaw_run_state::ApprovalRequestStore>,
     pub capability_leases: std::sync::Arc<dyn ironclaw_authorization::CapabilityLeaseStore>,
     /// Test-only config extension (empty = production behavior). See
-    /// `RefreshingLocalDevCapabilityPortConfig::capability_execution_mount_overrides`.
+    /// `RefreshingCapabilityPortConfig::capability_execution_mount_overrides`.
     pub capability_execution_mount_overrides:
         std::collections::HashMap<ironclaw_host_api::CapabilityId, ironclaw_host_api::MountView>,
     /// Test-only config extension (empty = production behavior). See
-    /// `RefreshingLocalDevCapabilityPortConfig::additional_provider_trust`.
+    /// `RefreshingCapabilityPortConfig::additional_provider_trust`.
     pub additional_provider_trust:
         std::collections::BTreeMap<ironclaw_host_api::ExtensionId, ironclaw_trust::TrustDecision>,
     /// Test-only config extension (`None` = production behavior, i.e. no
-    /// filtering). See `RefreshingLocalDevCapabilityPortConfig::capability_id_filter`.
+    /// filtering). See `RefreshingCapabilityPortConfig::capability_id_filter`.
     pub capability_id_filter: Option<std::collections::HashSet<ironclaw_host_api::CapabilityId>>,
     /// Test-only config extension (empty = production behavior). See
-    /// `RefreshingLocalDevCapabilityPortConfig::additional_capability_grants`
+    /// `RefreshingCapabilityPortConfig::additional_capability_grants`
     /// — hand-minted grants for capability ids an ad-hoc test-only
     /// `HostRuntime` backend (mock MCP, GitHub/web-access WASM) dispatches
     /// without a real extension activation.
@@ -133,11 +133,11 @@ impl ExtensionManagementTestHandle {
 /// Reads the same `local_runtime.extension_management` handle production's
 /// `capability_wiring` reads (`runtime/local_dev.rs:132-133`) off a built
 /// `RebornServices`, for wiring
-/// [`RefreshingLocalDevCapabilityPortTestParts::extension_management`].
+/// [`RefreshingCapabilityPortTestParts::extension_management`].
 /// `None` when the services were built without a local-dev runtime (mirrors
 /// `local_dev_active_extension_authority_for_test`'s `None`-propagation
 /// shape), OR when no extension is currently active (matches production:
-/// `LocalDevExtensionSurfaceSource::new` accepts the port either way and
+/// `ExtensionCapabilitySurfaceSource::new` accepts the port either way and
 /// `snapshot()` just returns an empty surface); tests that never
 /// install/activate an extension can also just omit this call and leave the
 /// field `None` for the same no-op surface.
@@ -156,15 +156,15 @@ pub fn build_local_dev_extension_management_for_test(
 }
 
 /// Test-support entry point that drives the real
-/// `create_refreshing_local_dev_capability_port` (production's sole port
+/// `create_refreshing_capability_port` (production's sole port
 /// factory) with the harness's injectable parts, supplying the same no-op
 /// defaults production uses for the rest. Never hand-rebuilds the wrap order.
 #[cfg(feature = "test-support")]
-pub async fn create_refreshing_local_dev_capability_port_for_test(
-    parts: RefreshingLocalDevCapabilityPortTestParts,
+pub async fn create_refreshing_capability_port_for_test(
+    parts: RefreshingCapabilityPortTestParts,
 ) -> Result<
     std::sync::Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>,
     ironclaw_turns::run_profile::AgentLoopHostError,
 > {
-    crate::runtime::create_refreshing_local_dev_capability_port_for_test(parts).await
+    crate::runtime::create_refreshing_capability_port_for_test(parts).await
 }

--- a/crates/ironclaw_reborn_composition/src/test_support/result_read.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/result_read.rs
@@ -11,7 +11,7 @@ pub const RESULT_READ_CAPABILITY_ID: &str = crate::runtime::RESULT_READ_CAPABILI
 /// Test-support entry point for the `result_read` synthetic-capability wrap.
 /// Lets the integration-test harness inject the synthetic `result_read`
 /// capability onto its host-runtime capability port via the real production
-/// wrap (`wrap_local_dev_synthetic_capabilities` + `result_read_capability`),
+/// wrap (`wrap_synthetic_capabilities` + `result_read_capability`),
 /// so the dispatch path never drifts from production's unconditional wire-in
 /// (`refreshing_capability_port.rs`'s `build_inner`).
 #[cfg(feature = "test-support")]

--- a/crates/ironclaw_reborn_composition/src/test_support/skill_activation.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/skill_activation.rs
@@ -7,15 +7,15 @@
 pub const SKILL_ACTIVATE_CAPABILITY_ID: &str = crate::runtime::SKILL_ACTIVATE_CAPABILITY_ID;
 
 /// Opaque handle (E-SKILL seam) carrying the built local-dev skill context
-/// source. Hides the crate-private `LocalDevSelectableSkillContextSource` from
+/// source. Hides the crate-private `ComposedSelectableSkillContextSource` from
 /// the integration-test crate, which cannot name it. Exposes the
 /// `HostSkillContextSource` for runtime wiring; the activation source travels
-/// inside for the harness's `RefreshingLocalDevCapabilityPortTestParts`. Tests
+/// inside for the harness's `RefreshingCapabilityPortTestParts`. Tests
 /// only.
 #[cfg(feature = "test-support")]
 pub struct SkillActivationTestSource {
     source: std::sync::Arc<dyn ironclaw_loop_host::HostSkillContextSource>,
-    activation_source: std::sync::Arc<crate::runtime::LocalDevSelectableSkillContextSource>,
+    activation_source: std::sync::Arc<crate::runtime::ComposedSelectableSkillContextSource>,
 }
 
 #[cfg(feature = "test-support")]
@@ -29,12 +29,12 @@ impl SkillActivationTestSource {
 
     /// Crate-internal accessor for the wrapped activation source. Kept
     /// `pub(crate)` (never `pub`) so the crate-private
-    /// `LocalDevSelectableSkillContextSource` type never appears in this
+    /// `ComposedSelectableSkillContextSource` type never appears in this
     /// crate's public API; only `runtime::local_dev`'s test-support
     /// constructor (which already names the type) may call this.
     pub(crate) fn activation_source(
         &self,
-    ) -> std::sync::Arc<crate::runtime::LocalDevSelectableSkillContextSource> {
+    ) -> std::sync::Arc<crate::runtime::ComposedSelectableSkillContextSource> {
         self.activation_source.clone()
     }
 }

--- a/crates/ironclaw_reborn_composition/src/test_support/slack_channel_connection.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/slack_channel_connection.rs
@@ -2,7 +2,7 @@
 //!
 //! Builds the REAL [`SlackChannelConnectionFacade`] over the composed
 //! local-dev runtime's durable Slack host state and late-binds it into
-//! `RebornLocalRuntimeServices::channel_connection_facade_slot`, mirroring the
+//! `RebornRuntimeSubstrate::channel_connection_facade_slot`, mirroring the
 //! production wiring in
 //! `slack_connectable_channel::build_webui_services_with_slack_host_beta_mounts`
 //! (facade construction + `set_channel_connection_facade`). With the slot

--- a/crates/ironclaw_reborn_composition/src/turn_run_snapshot.rs
+++ b/crates/ironclaw_reborn_composition/src/turn_run_snapshot.rs
@@ -1,13 +1,13 @@
 //! Turn-run persistence-snapshot abstraction shared by every reader of live
 //! turn-run state in this crate: the local-dev approval/auth interaction
-//! locators (`LocalDevApprovalTurnRunLocator` in `runtime.rs`,
-//! `LocalDevAuthInteractionReadModel` in `runtime/auth_interaction.rs`) and
+//! locators (`SnapshotApprovalTurnRunLocator` in `runtime.rs`,
+//! `SnapshotAuthInteractionReadModel` in `runtime/auth_interaction.rs`) and
 //! the trigger poller's active-run lookup (`SnapshotActiveRunLookup` in
 //! `trigger_poller/active_run_lookup.rs`).
 //!
 //! Exists so a `test-support` caller can substitute the turn-state store a
 //! locator reads from without those locators depending on the specific
-//! concrete `LocalDevTurnStateStore` type: `RebornIntegrationGroup`'s
+//! concrete `ComposedTurnStateStore` type: `RebornIntegrationGroup`'s
 //! real runs execute against its own `shared.turn_store`
 //! (`FilesystemTurnStateStore<HarnessTurnBackend>`, built by
 //! `build_default_planned_runtime`) — a DIFFERENT store than
@@ -32,11 +32,11 @@ pub(crate) trait TurnRunSnapshotSource: Send + Sync {
 }
 
 // Durable filesystem store: async fallible snapshot. Generic over any
-// `RootFilesystem` backend so both `LocalDevTurnStateStore` (production/
+// `RootFilesystem` backend so both `ComposedTurnStateStore` (production/
 // local-dev, when it resolves to `FilesystemTurnStateStore<CompositeRootFilesystem>`)
 // and a caller's own store (e.g. `RebornIntegrationGroup`'s
 // `FilesystemTurnStateStore<HarnessTurnBackend>`) implement this identically.
-// Unconditional (not cfg-gated on which backend `LocalDevTurnStateStore`
+// Unconditional (not cfg-gated on which backend `ComposedTurnStateStore`
 // happens to alias to in this build, nor on this crate's `libsql`/`postgres`
 // features): `FilesystemTurnStateStore` is defined unconditionally in
 // `ironclaw_turns`, and this impl targets a different concrete type per `F`

--- a/crates/ironclaw_reborn_composition/src/webui/facade.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade.rs
@@ -513,7 +513,7 @@ impl OperatorStatusService for ReadinessOperatorStatusService {
 struct LocalSkillsProductFacade {
     skill_management: Arc<RebornLocalSkillManagementPort>,
     // The skill activation selector's live master switch (see
-    // `RebornLocalRuntimeServices::skill_auto_activate_learned`); writing it here
+    // `RebornRuntimeSubstrate::skill_auto_activate_learned`); writing it here
     // changes the next turn's selection without a runtime rebuild. `None` when no
     // flag-reading selector is wired (the production assembly) — the toggle then
     // reports unavailable instead of writing to a flag nothing reads.

--- a/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
+++ b/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
@@ -3,11 +3,10 @@
 #[cfg(not(feature = "libsql"))]
 use ironclaw_reborn_composition::RebornRuntimeProfileError;
 use ironclaw_reborn_composition::{
-    RebornBuildInput, RebornCompositionProfile, RebornFacadeReadiness,
-    RebornRuntimeProfileOptions, RebornReadiness, RebornReadinessDiagnostic,
-    RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
-    RebornReadinessDiagnosticStatus, RebornReadinessState, RebornWorkerReadiness,
-    build_reborn_services, hosted_single_tenant_volume_runtime_policy,
+    RebornBuildInput, RebornCompositionProfile, RebornFacadeReadiness, RebornReadiness,
+    RebornReadinessDiagnostic, RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
+    RebornReadinessDiagnosticStatus, RebornReadinessState, RebornRuntimeProfileOptions,
+    RebornWorkerReadiness, build_reborn_services, hosted_single_tenant_volume_runtime_policy,
     local_dev_yolo_runtime_policy, local_runtime_build_input_with_options,
 };
 

--- a/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
+++ b/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
@@ -1,10 +1,10 @@
 // Only the `#[cfg(not(feature = "libsql"))]` no-libsql regression test below
 // consumes this error type; `webui-v2-beta` (hence CI) pulls in `libsql`.
 #[cfg(not(feature = "libsql"))]
-use ironclaw_reborn_composition::RebornLocalRuntimeProfileError;
+use ironclaw_reborn_composition::RebornRuntimeProfileError;
 use ironclaw_reborn_composition::{
     RebornBuildInput, RebornCompositionProfile, RebornFacadeReadiness,
-    RebornLocalRuntimeProfileOptions, RebornReadiness, RebornReadinessDiagnostic,
+    RebornRuntimeProfileOptions, RebornReadiness, RebornReadinessDiagnostic,
     RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
     RebornReadinessDiagnosticStatus, RebornReadinessState, RebornWorkerReadiness,
     build_reborn_services, hosted_single_tenant_volume_runtime_policy,
@@ -483,7 +483,7 @@ fn hosted_single_tenant_volume_input_errors_without_libsql_feature() {
 
     assert!(matches!(
         result,
-        Err(RebornLocalRuntimeProfileError::MissingLibsqlFeature)
+        Err(RebornRuntimeProfileError::MissingLibsqlFeature)
     ));
 }
 
@@ -515,7 +515,7 @@ async fn local_dev_yolo_factory_readiness_includes_non_production_diagnostic() {
         RebornCompositionProfile::LocalDevYolo,
         "readiness-yolo-owner",
         dir.path().to_path_buf(),
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access: true,
         },
     )

--- a/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/ironclaw_reborn_composition/tests/refreshing_capability_port_test_support.rs
@@ -1,13 +1,13 @@
 //! Crate-tier RED-then-GREEN coverage for the harness-port-seam P1 Change 1
-//! test-support constructor: `test_support::create_refreshing_local_dev_capability_port_for_test`
+//! test-support constructor: `test_support::create_refreshing_capability_port_for_test`
 //! must drive the REAL production capability-port factory
-//! (`create_refreshing_local_dev_capability_port`) with in-crate stub
+//! (`create_refreshing_capability_port`) with in-crate stub
 //! doubles, not a hand-rebuilt wrap order.
 //!
 //! Stubs here are intentionally minimal: a `HostRuntime` that echoes back a
 //! `VisibleCapability` per granted capability id (so `capability_id_filter`
 //! narrowing is observable), and a shared input/result io double standing in
-//! for production's `LocalDevCapabilityIo` (one object, both roles).
+//! for production's `StagedCapabilityIo` (one object, both roles).
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
@@ -46,9 +46,8 @@ use ironclaw_product_workflow::{
     RebornUpdateMemberRoleRequest, RebornUpdateProjectRequest,
 };
 use ironclaw_reborn_composition::test_support::{
-    PROJECT_CREATE_CAPABILITY_ID, RESULT_READ_CAPABILITY_ID,
-    RefreshingLocalDevCapabilityPortTestParts,
-    create_refreshing_local_dev_capability_port_for_test,
+    PROJECT_CREATE_CAPABILITY_ID, RESULT_READ_CAPABILITY_ID, RefreshingCapabilityPortTestParts,
+    create_refreshing_capability_port_for_test,
 };
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityInputRef, CapabilityInvocation,
@@ -184,7 +183,7 @@ impl HostRuntime for StubHostRuntime {
     }
 }
 
-/// Stands in for production's `LocalDevCapabilityIo`: ONE object implementing
+/// Stands in for production's `StagedCapabilityIo`: ONE object implementing
 /// both `LoopCapabilityInputResolver` and `LoopCapabilityResultWriter`, so
 /// `Arc::clone`s into both config fields let input-ref/result-ref correlate
 /// through a single shared store (the invariant the config's shared-io
@@ -383,8 +382,8 @@ fn test_parts(
     capability_id_filter: Option<HashSet<CapabilityId>>,
     capability_execution_mount_overrides: HashMap<CapabilityId, ironclaw_host_api::MountView>,
     additional_provider_trust: BTreeMap<ExtensionId, ironclaw_trust::TrustDecision>,
-) -> RefreshingLocalDevCapabilityPortTestParts {
-    RefreshingLocalDevCapabilityPortTestParts {
+) -> RefreshingCapabilityPortTestParts {
+    RefreshingCapabilityPortTestParts {
         runtime,
         run_context,
         fallback_user_id: UserId::new("user-stub").expect("user id"),
@@ -430,7 +429,7 @@ async fn port_builds_and_includes_synthetic_capabilities() {
         HashMap::new(),
         BTreeMap::new(),
     );
-    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+    let port = create_refreshing_capability_port_for_test(parts)
         .await
         .expect("port assembles through the real production factory");
 
@@ -456,13 +455,13 @@ async fn port_builds_and_includes_synthetic_capabilities() {
 ///
 /// This test only exercises builtin grants because there is no cheap way to
 /// inject an extension-grant fixture from this external integration-test
-/// crate: `LocalDevExtensionSurfaceSource`'s test constructors
+/// crate: `ExtensionCapabilitySurfaceSource`'s test constructors
 /// (`from_surface`/`from_active_capabilities`) are `#[cfg(test)]`-gated to
-/// the crate's own unit tests, and `RefreshingLocalDevCapabilityPortTestParts`
+/// the crate's own unit tests, and `RefreshingCapabilityPortTestParts`
 /// does not expose `extension_surface_source` at all -- the test-support
-/// constructor always wires `LocalDevExtensionSurfaceSource::new(None)`
+/// constructor always wires `ExtensionCapabilitySurfaceSource::new(None)`
 /// (empty extension surface). The whole-set semantic is pinned by the
-/// doc-comment on `RefreshingLocalDevCapabilityPortConfig::capability_id_filter`
+/// doc-comment on `RefreshingCapabilityPortConfig::capability_id_filter`
 /// and the inline comment at its `retain` call site in `build_inner`.
 #[tokio::test]
 async fn capability_id_filter_narrows_visible_surface() {
@@ -477,7 +476,7 @@ async fn capability_id_filter_narrows_visible_surface() {
         HashMap::new(),
         BTreeMap::new(),
     );
-    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+    let port = create_refreshing_capability_port_for_test(parts)
         .await
         .expect("port assembles");
 
@@ -513,7 +512,7 @@ async fn capability_id_filter_some_empty_grants_zero_capabilities() {
         HashMap::new(),
         BTreeMap::new(),
     );
-    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+    let port = create_refreshing_capability_port_for_test(parts)
         .await
         .expect("port assembles");
 
@@ -561,7 +560,7 @@ async fn input_and_result_refs_correlate_through_one_shared_io() {
         HashMap::new(),
         BTreeMap::new(),
     );
-    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+    let port = create_refreshing_capability_port_for_test(parts)
         .await
         .expect("port assembles");
 
@@ -649,7 +648,7 @@ async fn capability_execution_mount_overrides_reach_invocation_context() {
         overrides,
         BTreeMap::new(),
     );
-    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+    let port = create_refreshing_capability_port_for_test(parts)
         .await
         .expect("port assembles");
 
@@ -698,7 +697,7 @@ fn distinguishing_trust_decision() -> ironclaw_trust::TrustDecision {
             allowed_effects: vec![EffectKind::ReadFilesystem],
             max_resource_ceiling: None,
         },
-        // `Bundled` is never produced by `local_dev_visible_capability_request`
+        // `Bundled` is never produced by `visible_capability_request`
         // itself (which only ever inserts `AdminConfig`), so seeing it back
         // out proves the test's entry -- not the canonical helper's -- won.
         provenance: ironclaw_trust::TrustProvenance::Bundled,
@@ -728,7 +727,7 @@ async fn additional_provider_trust_is_forwarded_to_visible_request() {
         HashMap::new(),
         additional_provider_trust,
     );
-    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+    let port = create_refreshing_capability_port_for_test(parts)
         .await
         .expect("port assembles");
     // Construction already triggers one `visible_capabilities` refresh; drive
@@ -782,7 +781,7 @@ async fn multi_entry_collection_knobs_round_trip() {
     // `builtin_trust` overrides the "builtin" provider used to invoke both
     // capabilities below, so its ceiling must cover both grants' effects
     // (`dispatch_capability`/`read_filesystem`/`write_filesystem` per
-    // local_dev_capability_policy.toml) or invocation is denied as untrusted.
+    // builtin_capability_policy.toml) or invocation is denied as untrusted.
     let mut builtin_trust = distinguishing_trust_decision();
     builtin_trust.authority_ceiling.allowed_effects = vec![
         EffectKind::DispatchCapability,
@@ -802,7 +801,7 @@ async fn multi_entry_collection_knobs_round_trip() {
         overrides,
         additional_provider_trust,
     );
-    let port = create_refreshing_local_dev_capability_port_for_test(parts)
+    let port = create_refreshing_capability_port_for_test(parts)
         .await
         .expect("port assembles");
 

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -28,7 +28,7 @@ use ironclaw_loop_host::{
     HostManagedModelResponse,
 };
 use ironclaw_reborn_composition::{
-    RebornCompositionProfile, RebornLocalRuntimeProfileOptions, RebornRuntime,
+    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntime,
     RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerSettings, build_reborn_runtime,
     local_runtime_build_input_with_options,
 };
@@ -397,7 +397,7 @@ async fn build_runtime_with<G: HostManagedModelGateway + 'static>(
         RebornCompositionProfile::LocalDevYolo,
         USER,
         root.path().join("local-dev"),
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access: true,
         },
     )
@@ -435,7 +435,7 @@ async fn build_runtime_with_tool_disclosure<G: HostManagedModelGateway + 'static
         RebornCompositionProfile::LocalDevYolo,
         USER,
         root.path().join("local-dev"),
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access: true,
         },
     )

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -28,8 +28,8 @@ use ironclaw_loop_host::{
     HostManagedModelResponse,
 };
 use ironclaw_reborn_composition::{
-    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntime,
-    RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerSettings, build_reborn_runtime,
+    RebornCompositionProfile, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProfileOptions, TriggerPollerSettings, build_reborn_runtime,
     local_runtime_build_input_with_options,
 };
 use ironclaw_runner::runtime::ToolDisclosureMode;
@@ -154,7 +154,7 @@ impl HostManagedModelGateway for RecordingGateway {
 /// Whichever registrations succeed (capability visible + permitted) are
 /// forwarded together as one `capability_calls` response, which the loop
 /// will actually dispatch — including staging the real JSON input through
-/// the run's real `LocalDevCapabilityIo`, so a genuinely unpatched surface
+/// the run's real `StagedCapabilityIo`, so a genuinely unpatched surface
 /// would really create a second trigger and/or remove/pause/resume the
 /// target trigger. If every registration is denied (the fixed, expected
 /// behavior), there is nothing to dispatch and a plain reply is returned
@@ -1491,7 +1491,7 @@ async fn scheduled_trigger_denies_mutators_with_tool_disclosure(
     // would return `Ok(candidate)` for it — with a REAL, run-scoped staged
     // input, because `register_provider_tool_call` is the exact path a
     // native provider tool call uses to stage its arguments through the
-    // run's real `LocalDevCapabilityIo`. The loop would then actually
+    // run's real `StagedCapabilityIo`. The loop would then actually
     // dispatch that mutator against the staged input, and either the marker
     // trigger asserted absent below WOULD exist, or the original trigger's
     // state WOULD have changed. Reverting any one entry of the

--- a/crates/ironclaw_reborn_composition/tests/trigger_webui_timeline_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_webui_timeline_e2e.rs
@@ -60,9 +60,9 @@ use ironclaw_loop_host::{
     HostManagedModelResponse,
 };
 use ironclaw_reborn_composition::{
-    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntime,
-    RebornRuntimeIdentity, RebornRuntimeInput, RebornWebuiBundle, TriggerPollerSettings,
-    build_reborn_runtime, build_webui_services, local_runtime_build_input_with_options,
+    RebornCompositionProfile, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProfileOptions, RebornWebuiBundle, TriggerPollerSettings, build_reborn_runtime,
+    build_webui_services, local_runtime_build_input_with_options,
 };
 use ironclaw_triggers::{
     TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,

--- a/crates/ironclaw_reborn_composition/tests/trigger_webui_timeline_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_webui_timeline_e2e.rs
@@ -60,7 +60,7 @@ use ironclaw_loop_host::{
     HostManagedModelResponse,
 };
 use ironclaw_reborn_composition::{
-    RebornCompositionProfile, RebornLocalRuntimeProfileOptions, RebornRuntime,
+    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntime,
     RebornRuntimeIdentity, RebornRuntimeInput, RebornWebuiBundle, TriggerPollerSettings,
     build_reborn_runtime, build_webui_services, local_runtime_build_input_with_options,
 };
@@ -130,7 +130,7 @@ async fn build_timeline_runtime(root: &tempfile::TempDir) -> RebornRuntime {
         RebornCompositionProfile::LocalDevYolo,
         USER,
         root.path().join("local-dev"),
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access: true,
         },
     )

--- a/crates/ironclaw_trust/CONTRACT.md
+++ b/crates/ironclaw_trust/CONTRACT.md
@@ -144,7 +144,7 @@ matches, the policy falls through to a fail-closed default.
 | `BundledRegistry` | `package_id` AND `source == Bundled` AND (`digest` if pinned) | `(effective_trust, allowed_effects, max_resource_ceiling)` provenance `Bundled` | `Ok(None)` — fall through |
 | `AdminConfig` | `package_id` AND **exact** `PackageSource` match (incl. `LocalManifest { path }` / `Registry { url }`) AND (`digest` if pinned) | provenance `AdminConfig` | `Ok(None)` |
 | `SignedRegistry` | (currently inert; see §10) | — | `Ok(None)` always in V1 |
-| `LocalDevOverride` | (currently inert; see §10) | — | `Ok(None)` always in V1 |
+| `DevTrustOverride` | (currently inert; see §10) | — | `Ok(None)` always in V1 |
 
 Match-key rules:
 
@@ -208,7 +208,7 @@ Recommended chain order for production wiring:
     BundledRegistry,    // host-controlled, signed-bundle baseline
     SignedRegistry,     // remote signature verification (when live)
     AdminConfig,        // operator overrides
-    LocalDevOverride,   // dev-only opt-in (when live)
+    DevTrustOverride,   // dev-only opt-in (when live)
 ]
 ```
 
@@ -429,7 +429,7 @@ This slice intentionally keeps the substrate narrow:
   `Ok(None)`. Real signature verification (binding `(signer,
   package_id, digest)` so a verified signature on package X does not
   vouch for an unrelated package Y) belongs to a follow-up.
-- `LocalDevOverride` is inert — `enabled_for_test` is compiled only for
+- `DevTrustOverride` is inert — `enabled_for_test` is compiled only for
   this crate's `#[cfg(test)]` targets, so future dev-mode opt-in has a
   stable seam without exposing a production feature. The inert contract is
   pinned by test T17.

--- a/crates/ironclaw_trust/src/sources.rs
+++ b/crates/ironclaw_trust/src/sources.rs
@@ -2,7 +2,7 @@
 //!
 //! [`PolicySource`] is the extension point for host-controlled trust
 //! assignment. PR1b ships in-memory [`BundledRegistry`] and [`AdminConfig`]
-//! sources; [`SignedRegistry`] and [`LocalDevOverride`] are interface seams
+//! sources; [`SignedRegistry`] and [`DevTrustOverride`] are interface seams
 //! that real signature verification / dev-tool overrides will fill in
 //! later, but they expose enough shape that downstream wiring can target a
 //! stable surface today.
@@ -570,15 +570,15 @@ impl PolicySource for SignedRegistry {
     }
 }
 
-/// Local development override — interface seam for an opt-in,
+/// Development trust override — interface seam for an opt-in,
 /// administratively-blessed dev mode that lets a developer mark specific
-/// local packages as privileged for testing.
+/// packages as privileged for testing.
 ///
 /// PR1b ships only the shape. The future implementation will require
 /// explicit configuration (e.g., a CLI flag or a config file outside any
 /// user-writable location) and audit logging on every match. Without that
 /// configuration the source is inert.
-pub(crate) struct LocalDevOverride {
+pub(crate) struct DevTrustOverride {
     /// Packages the operator has explicitly opted in for elevated trust in
     /// development. Empty means the source has nothing to evaluate even
     /// once the implementation lands.
@@ -590,8 +590,8 @@ pub(crate) struct LocalDevOverride {
     enabled: bool,
 }
 
-impl LocalDevOverride {
-    /// Construct an inert `LocalDevOverride`. PR1b has no production opt-in
+impl DevTrustOverride {
+    /// Construct an inert `DevTrustOverride`. PR1b has no production opt-in
     /// path — the source is documented as future-compatible and never
     /// matches.
     pub(crate) fn inert() -> Self {
@@ -617,7 +617,7 @@ impl LocalDevOverride {
             .len()
     }
 
-    /// Test-only: construct a `LocalDevOverride` that has been "enabled"
+    /// Test-only: construct a `DevTrustOverride` that has been "enabled"
     /// and pre-staged with override entries.
     ///
     /// Even with this, [`PolicySource::evaluate`] returns `Ok(None)` —
@@ -637,15 +637,15 @@ impl LocalDevOverride {
     }
 }
 
-impl Default for LocalDevOverride {
+impl Default for DevTrustOverride {
     fn default() -> Self {
         Self::inert()
     }
 }
 
-impl PolicySource for LocalDevOverride {
+impl PolicySource for DevTrustOverride {
     fn name(&self) -> &'static str {
-        "local_dev_override"
+        "dev_trust_override"
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/ironclaw_trust/src/tests/policy_contract.rs
+++ b/crates/ironclaw_trust/src/tests/policy_contract.rs
@@ -8,7 +8,7 @@
 //!   - T15: default_decision fail-closed across every PackageSource
 //!   - T16, T16b–c: TrustChange no-op / downgrade / upgrade / kind-change
 //!     semantics + InvalidationBus publish-time guard
-//!   - T17: LocalDevOverride inert-contract pinning (forward-compat seam)
+//!   - T17: DevTrustOverride inert-contract pinning (forward-compat seam)
 //!   - T18: EffectiveTrustClass audit wire-shape for all four variants
 //!
 //! Test fixtures live in `mod support` below: `FakeAuthorizer` (gates
@@ -28,7 +28,7 @@ use crate::fixtures::{
 use crate::invalidation::{
     TrustChange, TrustChangeListener, authority_changed, grant_retention_eligible, identity_changed,
 };
-use crate::sources::{LocalDevOverride, PolicySource};
+use crate::sources::{DevTrustOverride, PolicySource};
 use crate::{
     AdminConfig, AdminEntry, BundledRegistry, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, InvalidationBus, TrustDecision, TrustError, TrustPolicy, TrustPolicyInput,
@@ -1586,9 +1586,9 @@ fn t16c_invalidation_bus_publish_drops_no_op_struct_literal_in_release() {
 }
 
 // ---------------------------------------------------------------------------
-// T17 — `LocalDevOverride` stays inert even when enabled and pre-staged.
+// T17 — `DevTrustOverride` stays inert even when enabled and pre-staged.
 //
-// PR1b ships `LocalDevOverride` as a forward-compat seam: the type and
+// PR1b ships `DevTrustOverride` as a forward-compat seam: the type and
 // `PolicySource` impl exist, but the implementation is intentionally
 // non-functional until a future PR wires up explicit operator opt-in +
 // audit logging. The `enabled_for_test` fixture lets the test suite
@@ -1597,8 +1597,8 @@ fn t16c_invalidation_bus_publish_drops_no_op_struct_literal_in_release() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn t17_local_dev_override_remains_inert_even_when_enabled_and_staged() {
-    let staged = LocalDevOverride::enabled_for_test(vec![(
+fn t17_dev_trust_override_remains_inert_even_when_enabled_and_staged() {
+    let staged = DevTrustOverride::enabled_for_test(vec![(
         pkg("dev_pkg"),
         admin_entry_for_test(
             pkg("dev_pkg"),
@@ -1637,7 +1637,7 @@ fn t17_local_dev_override_remains_inert_even_when_enabled_and_staged() {
     };
     assert!(
         staged.evaluate(&probe).unwrap().is_none(),
-        "LocalDevOverride must remain inert until the dev-override \
+        "DevTrustOverride must remain inert until the dev-override \
          implementation lands — a future PR is what flips this assertion"
     );
 }

--- a/docs/plans/composition-pubuse.snapshot
+++ b/docs/plans/composition-pubuse.snapshot
@@ -15,7 +15,7 @@ pub use extension_host::skill_listing::{RebornSkillListError, list_reborn_local_
 #[cfg(feature = "test-support")]
 pub use factory::AttachmentTestSupport;
 #[cfg(feature = "test-support")]
-pub use factory::RebornLocalDevApprovalTestParts;
+pub use factory::RebornApprovalTestParts;
 #[cfg(feature = "migration-support")]
 pub use factory::extension_installation_store_for_migration;
 pub use factory::{RebornServices, build_reborn_services, builtin_first_party_trust_policy};
@@ -67,9 +67,9 @@ pub use llm_admin::provider_admin_product_command::RebornProviderAdminProductCom
 #[cfg(feature = "root-llm-provider")]
 pub use llm_admin::provider_repo::{ProviderRepo, ProviderRepoError};
 pub use local_runtime_profile::{
-    RebornLocalRuntimeProfileError, RebornLocalRuntimeProfileOptions,
-    hosted_single_tenant_runtime_policy, hosted_single_tenant_volume_runtime_policy,
-    local_dev_runtime_policy, local_dev_yolo_runtime_policy, local_runtime_build_input,
+    RebornRuntimeProfileError, RebornRuntimeProfileOptions, hosted_single_tenant_runtime_policy,
+    hosted_single_tenant_volume_runtime_policy, local_dev_runtime_policy,
+    local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,
 };
 pub use observability::budget::build_default_budget_accountant;

--- a/tests/integration/project_create.rs
+++ b/tests/integration/project_create.rs
@@ -1,7 +1,7 @@
 //! E-PROJ seam smoke test: the `project_lifecycle` group surfaces the local-dev
 //! synthetic `project_create` capability; a scripted `builtin.project_create`
 //! call dispatches through the REAL synthetic-capability wrap
-//! (`wrap_local_dev_synthetic_capabilities` + `project_create_capability`) and
+//! (`wrap_synthetic_capabilities` + `project_create_capability`) and
 //! persists a project via the real `ProjectService`.
 //!
 //! A result-contains assertion alone would pass a silent-no-op regression that

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -332,8 +332,8 @@ impl RebornIntegrationHarness {
 
     /// Harness-port-seam Change 4: assert the LATEST captured `tools` argument
     /// carries a definition named `name` whose `description` contains
-    /// `needle` — pins `wrap_local_dev_surface_disclosure`'s scoped-roots note
-    /// mutation (`LocalDevSurfaceDisclosure::apply_to_surface_fields`), which
+    /// `needle` — pins `wrap_surface_disclosure`'s scoped-roots note
+    /// mutation (`HostSurfaceDisclosure::apply_to_surface_fields`), which
     /// mutates `ProviderToolDefinition::description`/`parameters`, not tool
     /// presence/absence.
     pub async fn assert_model_tool_description_contains(

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -308,7 +308,7 @@ impl RebornIntegrationHarnessBuilder {
     }
 
     /// `write_file`/`read_file` tools (same set as `file_tools()`), backed by
-    /// the REAL `LocalDevCapabilityIo` (durable tool-result projection seam,
+    /// the REAL `StagedCapabilityIo` (durable tool-result projection seam,
     /// issue #5838) instead of the ephemeral `ProductLiveCapabilityIo` test
     /// double, so a large `read_file` output is persisted durably and
     /// `result_read` can page through it.
@@ -318,7 +318,7 @@ impl RebornIntegrationHarnessBuilder {
     }
 
     /// Harness-port-seam Change 4: same as `.with_builtin_http_tools()` plus a
-    /// confirmed `/host` mount grant, so `wrap_local_dev_surface_disclosure`'s
+    /// confirmed `/host` mount grant, so `wrap_surface_disclosure`'s
     /// scoped-roots note is observable on `read_file`'s captured tool
     /// definition (the layer is disabled without a confirmed host-home mount).
     pub fn with_confirmed_host_mount(mut self) -> Self {

--- a/tests/integration/support/capability_backend.rs
+++ b/tests/integration/support/capability_backend.rs
@@ -50,14 +50,14 @@ pub(super) enum RebornCapabilityBackend {
     /// `RecordingRuntimeHttpEgress` bypasses that whole pipeline.
     BuiltinHttpToolsRealEgress,
     /// `write_file`/`read_file` (same as `file_tools()`), but backed by the
-    /// REAL `LocalDevCapabilityIo` (durable tool-result projection seam,
+    /// REAL `StagedCapabilityIo` (durable tool-result projection seam,
     /// issue #5838) instead of the ephemeral `ProductLiveCapabilityIo` test
     /// double -- so a large `read_file` result is persisted durably and
     /// `result_read` can page through it.
     FileToolsDurableIo,
     /// Harness-port-seam Change 4: the same `BuiltinHttpTools` backend with an
     /// additional confirmed `/host` mount grant, so
-    /// `wrap_local_dev_surface_disclosure`'s scoped-roots note (a no-op
+    /// `wrap_surface_disclosure`'s scoped-roots note (a no-op
     /// without a confirmed host-home mount) is observable at the
     /// integration tier.
     BuiltinHttpToolsConfirmedHostMount,

--- a/tests/integration/support/doubles/harness_capability_port_factory.rs
+++ b/tests/integration/support/doubles/harness_capability_port_factory.rs
@@ -1,5 +1,5 @@
 /// Test double substituting the production `LoopCapabilityPortFactory` wiring
-/// (`LocalDevLoopCapabilityPortFactory` / `HostRuntimeLoopCapabilityPortFactory`)
+/// (`RefreshingLoopCapabilityPortFactory` / `HostRuntimeLoopCapabilityPortFactory`)
 /// for the Echo (`RecordingTestCapabilityPort`) backend.
 use std::sync::Arc;
 

--- a/tests/integration/support/doubles/host_runtime_harness_capability_port_factory.rs
+++ b/tests/integration/support/doubles/host_runtime_harness_capability_port_factory.rs
@@ -1,5 +1,5 @@
 /// Test double substituting the production `LoopCapabilityPortFactory` wiring:
-/// `LocalDevLoopCapabilityPortFactory` (`crates/ironclaw_reborn_composition/src/runtime/local_dev.rs`)
+/// `RefreshingLoopCapabilityPortFactory` (`crates/ironclaw_reborn_composition/src/runtime/local_dev.rs`)
 /// and `HostRuntimeLoopCapabilityPortFactory` (`crates/ironclaw_loop_host/src/capability_port.rs`).
 use std::sync::Arc;
 

--- a/tests/integration/support/doubles/recording_capability_result_writer.rs
+++ b/tests/integration/support/doubles/recording_capability_result_writer.rs
@@ -1,9 +1,9 @@
 /// Test double substituting the production `LoopCapabilityResultWriter` impl
-/// (`LocalDevCapabilityIo`, `crates/ironclaw_reborn_composition/src/runtime/local_dev.rs`).
+/// (`StagedCapabilityIo`, `crates/ironclaw_reborn_composition/src/runtime/local_dev.rs`).
 ///
 /// Also implements `LoopCapabilityInputResolver`, delegating straight to
 /// `input_resolver` (no recording — only result writes are recorded).
-/// Harness-port-seam P1 Change 2: production assigns ONE `LocalDevCapabilityIo`
+/// Harness-port-seam P1 Change 2: production assigns ONE `StagedCapabilityIo`
 /// to both the `input_resolver` and `result_writer` config roles so
 /// input-ref/result-ref correlation by `call_id` works; this double must be
 /// usable the same way — `input_resolver` and `result_writer` below must be
@@ -34,7 +34,7 @@ use super::super::harness::RecordedCapabilityResult;
 
 /// Wraps whatever real io the harness is currently backed by -- production's
 /// ephemeral `ProductLiveCapabilityIo` test double by default, or the real
-/// `LocalDevCapabilityIo` (durable tool-result projection seam, issue #5838)
+/// `StagedCapabilityIo` (durable tool-result projection seam, issue #5838)
 /// when the harness opts into `.with_durable_capability_io()`. Trait-object
 /// fields so this recorder is agnostic to which one is underneath.
 pub(crate) struct RecordingCapabilityResultWriter {

--- a/tests/integration/support/doubles/recording_test_capability_port.rs
+++ b/tests/integration/support/doubles/recording_test_capability_port.rs
@@ -2,7 +2,7 @@
 
 /// Test double substituting the whole production capability-port dispatch
 /// pipeline (`HostRuntimeLoopCapabilityPortFactory` +
-/// `LocalDevLoopCapabilityPortFactory`) with a lightweight in-memory Echo backend.
+/// `RefreshingLoopCapabilityPortFactory`) with a lightweight in-memory Echo backend.
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicUsize, Ordering},

--- a/tests/integration/support/doubles/unavailable_project_service.rs
+++ b/tests/integration/support/doubles/unavailable_project_service.rs
@@ -1,5 +1,5 @@
 //! No-op `ProjectService` for harness-port-seam P1 Change 2: production's
-//! `RefreshingLocalDevCapabilityPortConfig::project_service` is a plain
+//! `RefreshingCapabilityPortConfig::project_service` is a plain
 //! required `Arc<dyn ProjectService>` (the synthetic `project_create`
 //! capability is always assembled by `build_inner`, independent of whether
 //! `PROJECT_CREATE_CAPABILITY_ID` is in a harness's `capability_ids`), so

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -819,7 +819,7 @@ impl RebornIntegrationGroupBuilder {
         .with_checkpoint_state_store(checkpoint_state_store.clone());
         if let Some(approval_requests) = capability_recorder.approval_requests_store() {
             evidence = evidence.with_approval_gate_evidence(
-                ironclaw_reborn_composition::test_support::build_local_dev_approval_gate_evidence_for_test(
+                ironclaw_reborn_composition::test_support::build_approval_gate_evidence_for_test(
                     approval_requests,
                 ),
             );

--- a/tests/integration/support/harness/assembly.rs
+++ b/tests/integration/support/harness/assembly.rs
@@ -42,7 +42,7 @@ use super::HarnessResult;
 /// resolver + result writer). Every `HostRuntimeCapabilityHarness`
 /// constructor that does not opt into `.with_durable_capability_io()`
 /// (issue #5838) uses this so both roles keep sharing one underlying object,
-/// matching production's `LocalDevCapabilityIo` invariant.
+/// matching production's `StagedCapabilityIo` invariant.
 pub(crate) fn default_capability_io_pair() -> (
     Arc<dyn ironclaw_loop_host::LoopCapabilityInputResolver>,
     Arc<dyn ironclaw_loop_host::LoopCapabilityResultWriter>,

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -604,7 +604,7 @@ impl HostRuntimeCapabilityHarness {
                 ironclaw_reborn_composition::RebornCompositionProfile::LocalDevYolo,
                 service_label,
                 storage_root,
-                ironclaw_reborn_composition::RebornLocalRuntimeProfileOptions {
+                ironclaw_reborn_composition::RebornRuntimeProfileOptions {
                     confirm_host_access: true,
                 },
             )?

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -46,8 +46,8 @@ use ironclaw_network::{NetworkHttpRequest, NetworkTransportRequest};
 use ironclaw_product_workflow::{ProjectService, ResolvedBinding};
 use ironclaw_reborn_composition::test_support::SkillActivationTestSource;
 use ironclaw_reborn_composition::{
-    ProductLiveCapabilityIo, RebornBuildInput, RebornLocalDevApprovalTestParts,
-    RebornProductAuthServices, build_reborn_services,
+    ProductLiveCapabilityIo, RebornApprovalTestParts, RebornBuildInput, RebornProductAuthServices,
+    build_reborn_services,
 };
 use ironclaw_trust::EffectiveTrustClass;
 use ironclaw_turns::{
@@ -177,7 +177,7 @@ pub(crate) struct HostRuntimeCapabilityHarness {
     /// this harness is already `Arc`'d — the same chicken-and-egg constraint
     /// `io`/`result_writer_io` document above `install_durable_capability_io`.
     runtime: Mutex<Arc<dyn HostRuntime>>,
-    approval_parts: Option<RebornLocalDevApprovalTestParts>,
+    approval_parts: Option<RebornApprovalTestParts>,
     auto_approve_settings: Option<Arc<dyn ironclaw_approvals::AutoApproveSettingStore>>,
     pending_approval_scopes: Arc<Mutex<HashMap<ApprovalRequestId, ResourceScope>>>,
     /// Input-resolver half of this harness's capability io. Default (every
@@ -271,7 +271,7 @@ pub(crate) struct HostRuntimeCapabilityHarness {
     outbound_target_tools: Option<OutboundTargetToolsParts>,
     /// C-MULTIUSER seam: when `true`, [`create_capability_port`] resolves the
     /// capability-execution user from the RUN's owner/actor (mirroring
-    /// production `local_dev_visible_capability_request`,
+    /// production `visible_capability_request`,
     /// `crates/ironclaw_reborn_composition/src/runtime/local_dev.rs`) instead of
     /// this harness's single fixed `user_id`. That is what lets two distinct
     /// actors dispatching over the group's ONE shared capability backend run
@@ -836,15 +836,15 @@ impl HostRuntimeCapabilityHarness {
     }
 
     /// Durable tool-result projection seam (issue #5838): swap this
-    /// harness's capability io for the REAL `LocalDevCapabilityIo`
-    /// (`ironclaw_reborn_composition::test_support::local_dev_capability_io_for_test`,
+    /// harness's capability io for the REAL `StagedCapabilityIo`
+    /// (`ironclaw_reborn_composition::test_support::staged_capability_io_for_test`,
     /// which mirrors production's `capability_wiring`), wired over
     /// `thread_service`.
     ///
     /// `thread_service` MUST be the SAME `SessionThreadService` the calling
     /// group's turns actually dispatch against (`group.rs`'s `into_group`
     /// builds it as `group_thread_harness.service`, BEFORE this harness's
-    /// capability parts are assembled) -- `LocalDevCapabilityIo::write_capability_result`
+    /// capability parts are assembled) -- `StagedCapabilityIo::write_capability_result`
     /// resolves the run's thread scope and appends the durable record keyed
     /// by `run_context.thread_id`; a different (e.g. this harness's own
     /// local-dev-only) thread service would never have that thread and every
@@ -864,7 +864,7 @@ impl HostRuntimeCapabilityHarness {
         thread_service: Arc<dyn ironclaw_threads::SessionThreadService>,
     ) {
         let (io, result_writer_io) =
-            ironclaw_reborn_composition::test_support::local_dev_capability_io_for_test(
+            ironclaw_reborn_composition::test_support::staged_capability_io_for_test(
                 thread_service.clone(),
                 self.user_id.clone(),
             );
@@ -1413,11 +1413,11 @@ impl HostRuntimeCapabilityHarness {
 
     /// Assembles the recording `LoopCapabilityPort` for one run by driving the
     /// REAL production capability-port factory
-    /// (`create_refreshing_local_dev_capability_port`, harness-port-seam P1
+    /// (`create_refreshing_capability_port`, harness-port-seam P1
     /// Change 2) with this harness's fields, then wrapping the returned port
     /// in the invocation-recording port (outermost, unchanged). Every
     /// production wrap layer (synthetic capabilities, surface disclosure,
-    /// external tools, StaleSurface refresh, the shared `LocalDevCapabilityIo`)
+    /// external tools, StaleSurface refresh, the shared `StagedCapabilityIo`)
     /// is now exercised automatically — this method no longer hand-rebuilds
     /// any of them. Owned here (rather than in the
     /// `HostRuntimeHarnessCapabilityPortFactory` test double) because the
@@ -1427,7 +1427,7 @@ impl HostRuntimeCapabilityHarness {
     /// this method.
     ///
     /// The returned port refreshes itself internally
-    /// (`RefreshingLocalDevCapabilityPort`'s own `StaleSurface` recovery), so
+    /// (`RefreshingCapabilityPort`'s own `StaleSurface` recovery), so
     /// there is no harness-level refresh wrapper layered on top anymore — one
     /// refresh mechanism (production's), not two.
     pub(crate) async fn create_recording_capability_port(
@@ -1442,7 +1442,7 @@ impl HostRuntimeCapabilityHarness {
         // port, matching the per-run construction this method already had.
         let dispatch_user = self.dispatch_user_for_run(run_context);
         // ONE shared io, both roles: production assigns a single
-        // `LocalDevCapabilityIo` to both `input_resolver` and `result_writer`
+        // `StagedCapabilityIo` to both `input_resolver` and `result_writer`
         // so input-ref/result-ref correlation by `call_id` works.
         // `RecordingCapabilityResultWriter` implements both traits over
         // `self.io` (recording only result writes) — `Arc::clone` the SAME
@@ -1522,8 +1522,8 @@ impl HostRuntimeCapabilityHarness {
             .map(|parts| parts.requires_approval)
             .unwrap_or(false);
         // Grantee = the loop-driver execution extension — the SAME principal
-        // production's `local_dev_visible_capability_request` executes under
-        // and mints extension grants for (`LocalDevExtensionSurface::grants`);
+        // production's `visible_capability_request` executes under
+        // and mints extension grants for (`ExtensionCapabilitySurface::grants`);
         // a `Principal::User` grantee (the pre-seam harness's choice, matched
         // to its removed hand-built User-principal authority) is skipped by
         // authorization under the production request. Computed early (moved
@@ -1534,11 +1534,11 @@ impl HostRuntimeCapabilityHarness {
             ironclaw_loop_host::loop_driver_execution_extension_id(run_context)?;
         // Which providers ALREADY have a production trust decision arriving
         // through the real activation handshake (`extension_surface_source`'s
-        // `LocalDevExtensionSurface::provider_trust()`, same
+        // `ExtensionCapabilitySurface::provider_trust()`, same
         // `extension_management` + grantee production's factory reads) --
         // queried the SAME way `build_local_dev_extension_management_for_test`
         // -> `extension_surface_source` will read it downstream in
-        // `create_refreshing_local_dev_capability_port_for_test`. NOT the same
+        // `create_refreshing_capability_port_for_test`. NOT the same
         // as "this harness has `reborn_services` wired": a harness can have
         // `reborn_services` (so `new_with_options`) while only ever calling
         // the `publish_bundled_extension_for_test` SHORTCUT (registers the
@@ -1618,7 +1618,7 @@ impl HostRuntimeCapabilityHarness {
             })
             .collect();
         let parts =
-            ironclaw_reborn_composition::test_support::RefreshingLocalDevCapabilityPortTestParts {
+            ironclaw_reborn_composition::test_support::RefreshingCapabilityPortTestParts {
                 runtime: self.runtime.lock().unwrap().clone(),
                 run_context: run_context.clone(),
                 fallback_user_id: dispatch_user,
@@ -1701,7 +1701,10 @@ impl HostRuntimeCapabilityHarness {
                 capability_id_filter: Some(self.capability_ids.iter().cloned().collect()),
                 additional_capability_grants,
             };
-        let port = ironclaw_reborn_composition::test_support::create_refreshing_local_dev_capability_port_for_test(parts)
+        let port =
+            ironclaw_reborn_composition::test_support::create_refreshing_capability_port_for_test(
+                parts,
+            )
             .await?;
         Ok(Arc::new(RecordingDelegatingCapabilityPort {
             inner: port,
@@ -1734,7 +1737,7 @@ impl HostRuntimeCapabilityHarness {
     }
 
     /// The capability-execution `UserId` for one run. Mirrors production
-    /// `local_dev_visible_capability_request`'s owner→actor→fallback resolution
+    /// `visible_capability_request`'s owner→actor→fallback resolution
     /// (`runtime/local_dev.rs`): when [`scope_capability_by_run_owner`] is set,
     /// prefer the run scope's explicit owner, then the run actor, then fall back
     /// to the fixed harness `user_id`. Without the flag, always the fixed
@@ -1774,7 +1777,7 @@ impl HostRuntimeCapabilityHarness {
     }
 
     /// Builds the composition-facing `additional_provider_trust` map this
-    /// harness forwards to `RefreshingLocalDevCapabilityPortTestParts` on
+    /// harness forwards to `RefreshingCapabilityPortTestParts` on
     /// every capability-port refresh (`create_recording_capability_port`
     /// calls this and passes the result straight through).
     ///

--- a/tests/integration/support/harness/options.rs
+++ b/tests/integration/support/harness/options.rs
@@ -62,8 +62,8 @@ pub(crate) struct HostRuntimeHarnessOptions {
     /// leaves the real service unwrapped.
     pub(crate) project_service_fault_injection: bool,
     /// Durable tool-result projection seam (issue #5838): when `true`, the
-    /// harness backs its capability io with the REAL `LocalDevCapabilityIo`
-    /// (via `ironclaw_reborn_composition::test_support::local_dev_capability_io_for_test`,
+    /// harness backs its capability io with the REAL `StagedCapabilityIo`
+    /// (via `ironclaw_reborn_composition::test_support::staged_capability_io_for_test`,
     /// wired over this harness's own local-dev `thread_service`) instead of
     /// the ephemeral `ProductLiveCapabilityIo` test double. Opt-in and
     /// explicit rather than a profile default, so the ~100 other
@@ -136,7 +136,7 @@ impl HostRuntimeHarnessOptions {
         self
     }
 
-    /// Opt into the real `LocalDevCapabilityIo` (durable tool-result
+    /// Opt into the real `StagedCapabilityIo` (durable tool-result
     /// projection seam, issue #5838) instead of the ephemeral
     /// `ProductLiveCapabilityIo` test double.
     pub(crate) fn with_durable_capability_io(mut self) -> Self {

--- a/tests/integration/support/harness/profiles/core_builtin.rs
+++ b/tests/integration/support/harness/profiles/core_builtin.rs
@@ -193,9 +193,9 @@ pub(crate) async fn core_builtin_tools_default() -> HarnessResult<HostRuntimeCap
 /// workspace mount view — mirrors `local_dev_mounts::ambient_workspace_mount_view`
 /// appending a `/host` alias when `host_home_aliases` is non-empty. This is
 /// the ONLY integration-tier construction with a confirmed host-home mount,
-/// so it is the sole way to observe `wrap_local_dev_surface_disclosure`'s
+/// so it is the sole way to observe `wrap_surface_disclosure`'s
 /// scoped-roots note (the layer is a no-op — disabled — without a `/host`
-/// alias present, see `LocalDevSurfaceDisclosure::enabled`).
+/// alias present, see `HostSurfaceDisclosure::enabled`).
 pub(crate) async fn core_builtin_tools_with_confirmed_host_mount()
 -> HarnessResult<HostRuntimeCapabilityHarness> {
     let mut harness = core_builtin_tools(CoreBuiltinOptions::default()).await?;

--- a/tests/integration/support/harness/profiles/file.rs
+++ b/tests/integration/support/harness/profiles/file.rs
@@ -68,7 +68,7 @@ pub(crate) async fn file_tools_requiring_approval() -> HarnessResult<HostRuntime
 }
 
 /// Same capability set as [`file_tools`], but opts the harness into the real
-/// `LocalDevCapabilityIo` (durable tool-result projection seam, issue #5838)
+/// `StagedCapabilityIo` (durable tool-result projection seam, issue #5838)
 /// instead of the ephemeral `ProductLiveCapabilityIo` test double, so
 /// `read_file`'s large output is persisted durably and `result_read` can page
 /// through it. Auto-approve on, like `file_tools`.

--- a/tests/integration/support/project_service_fault.rs
+++ b/tests/integration/support/project_service_fault.rs
@@ -5,7 +5,7 @@
 //!
 //! Deliberately forces `ProjectServiceError::Denied`, not
 //! `Unavailable`/`Internal`: those retry via `DefaultRecoveryStrategy` and hit
-//! a real `LocalDevCapabilityIo` input-ref restaging bug (issue #5608),
+//! a real `StagedCapabilityIo` input-ref restaging bug (issue #5608),
 //! collapsing the retry contract into an immediate `driver_unavailable`.
 //! `Denied` surfaces to the model on the first attempt, avoiding the bug.
 

--- a/tests/integration/surface_disclosure.rs
+++ b/tests/integration/surface_disclosure.rs
@@ -1,5 +1,5 @@
 //! Harness-port-seam P1 Change 4: RED-first integration-tier pin for
-//! `wrap_local_dev_surface_disclosure` — one of the production port layers
+//! `wrap_surface_disclosure` — one of the production port layers
 //! the OLD harness (`apply_synthetic_capability_wrappers` hand-rebuilding
 //! three of the seven production wrap layers) never applied at all, so it was
 //! invisible to every integration test before this seam PR.
@@ -7,10 +7,10 @@
 //! Ground truth (verified against
 //! `crates/ironclaw_reborn_composition/src/runtime/local_dev/surface_disclosure.rs`,
 //! NOT the plan doc's "must deny rather than execute" framing, which does not
-//! match the code): `wrap_local_dev_surface_disclosure` never hides or denies
+//! match the code): `wrap_surface_disclosure` never hides or denies
 //! a capability. It is a description/schema ANNOTATION layer, disabled unless
 //! the workspace mount view carries a confirmed `/host` alias
-//! (`LocalDevSurfaceDisclosure::enabled`). When enabled, it appends a
+//! (`HostSurfaceDisclosure::enabled`). When enabled, it appends a
 //! "confirmed scoped roots" note to the `description`/`parameters` of the
 //! local-dev scoped-path capabilities (`read_file`, `write_file`, `list_dir`,
 //! `glob`, `grep`, `apply_patch`) and a local-host-shell note to
@@ -42,7 +42,7 @@ const FLAT_READ_FILE_TOOL_NAME: &str = "builtin__read_file";
 /// Flat wire name for `builtin.shell` (same `.` -> `__` encoding).
 const FLAT_SHELL_TOOL_NAME: &str = "builtin__shell";
 
-/// Substring of `LocalDevSurfaceDisclosure`'s `confirmed_host_roots_note`
+/// Substring of `HostSurfaceDisclosure`'s `confirmed_host_roots_note`
 /// output stable across `local_dev_mounts.rs` mount-alias wording changes.
 const SCOPED_ROOTS_NOTE_NEEDLE: &str = "Available scoped roots";
 
@@ -57,7 +57,7 @@ const SHELL_LOCAL_HOST_NOTE_NEEDLE: &str = "Runs on the local host with local-de
 /// `.with_confirmed_host_mount()` backend) must surface the scoped-roots note
 /// on `read_file`'s captured tool definition. Before the harness-port-seam
 /// switch, `create_recording_capability_port` never called
-/// `wrap_local_dev_surface_disclosure` at all, so this assertion fails for
+/// `wrap_surface_disclosure` at all, so this assertion fails for
 /// the right reason on the OLD harness (RED) regardless of the mount grant —
 /// the switch (not just the new mount backend) is what turns it GREEN.
 #[tokio::test]
@@ -78,7 +78,7 @@ async fn confirmed_host_mount_adds_scoped_roots_note_to_read_file() {
 
 /// Negative control: the plain `BuiltinHttpTools` backend's workspace mounts
 /// carry only `/workspace` (no confirmed `/host` alias), so
-/// `LocalDevSurfaceDisclosure::enabled()` is false and the note never
+/// `HostSurfaceDisclosure::enabled()` is false and the note never
 /// appears — proves the positive assertion above discriminates on the mount
 /// grant, not on `read_file` always carrying the note.
 #[tokio::test]
@@ -101,9 +101,9 @@ async fn workspace_only_mount_excludes_scoped_roots_note() {
 /// (`capability_id.as_str() == SHELL_CAPABILITY_ID`, checked before the
 /// scoped-path capability match): it appends `LOCAL_DEV_LOCAL_HOST_SHELL_NOTE`
 /// unconditionally rather than gating on `scoped_roots_note`. But the whole
-/// port is still gated on `LocalDevSurfaceDisclosure::enabled()`
+/// port is still gated on `HostSurfaceDisclosure::enabled()`
 /// (`scoped_roots_note.is_some()`, i.e. a confirmed `/host` mount) in
-/// `wrap_local_dev_surface_disclosure` — without a confirmed host mount the
+/// `wrap_surface_disclosure` — without a confirmed host mount the
 /// wrapper is skipped entirely and `builtin.shell` never gets annotated. This
 /// pins the enabled case; the negative control below pins the disabled case.
 #[tokio::test]
@@ -123,7 +123,7 @@ async fn confirmed_host_mount_adds_local_host_shell_note_to_shell() {
 }
 
 /// Negative control: without a confirmed `/host` mount `enabled()` is false,
-/// so `wrap_local_dev_surface_disclosure` returns the inner port unwrapped
+/// so `wrap_surface_disclosure` returns the inner port unwrapped
 /// and `builtin.shell`'s description is never touched.
 #[tokio::test]
 async fn workspace_only_mount_excludes_local_host_shell_note() {
@@ -143,9 +143,9 @@ async fn workspace_only_mount_excludes_local_host_shell_note() {
 
 /// Change 4's second pin: the input-ref/result-ref round trip crosses ONE
 /// staged store. A full `builtin.time` dispatch (register -> invoke ->
-/// completed) only succeeds if the SAME shared `LocalDevCapabilityIo`
+/// completed) only succeeds if the SAME shared `StagedCapabilityIo`
 /// resolves the input ref it staged and accepts the result write under a
-/// correlated ref — the invariant `RefreshingLocalDevCapabilityPortTestParts`
+/// correlated ref — the invariant `RefreshingCapabilityPortTestParts`
 /// documents ("input_resolver AND result_writer must be two `Arc::clone`s of
 /// the SAME shared io object"). A harness wiring two independently-sourced io
 /// objects would fail this dispatch outright (unresolvable input ref), not

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -474,7 +474,7 @@ fn large_durable_file_content() -> String {
 }
 
 /// Durable tool-result projection (issue #5838 / PR #5902): a `read_file`
-/// result routed through the REAL `LocalDevCapabilityIo`
+/// result routed through the REAL `StagedCapabilityIo`
 /// (`.with_durable_capability_io_file_tools()`, which wires
 /// `new_with_durable_previews` over this harness's own local-dev session
 /// thread service — mirrors production's `capability_wiring`) must reach the
@@ -528,7 +528,7 @@ async fn durable_large_read_file_result_reaches_model_as_truncated_preview() {
     // messages (not ANY role): the model's OWN `write_file` tool-call
     // arguments legitimately echo the full content elsewhere in history —
     // this asserts the absence specifically from the persisted TOOL RESULT
-    // side, which is what `LocalDevCapabilityIo` controls.
+    // side, which is what `StagedCapabilityIo` controls.
     assert!(
         h.assert_conversation_history_role_contains(MessageKind::ToolResultReference, TAIL_MARKER)
             .await

--- a/tests/reborn_qa_routines.rs
+++ b/tests/reborn_qa_routines.rs
@@ -45,8 +45,8 @@ use ironclaw_loop_host::{
     HostManagedModelRequest, HostManagedModelResponse, HostManagedToolResultContent,
 };
 use ironclaw_reborn_composition::{
-    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntime,
-    RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerSettings, build_reborn_runtime,
+    RebornCompositionProfile, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProfileOptions, TriggerPollerSettings, build_reborn_runtime,
     local_runtime_build_input_with_options,
 };
 use ironclaw_triggers::{TriggerId, TriggerPollerWorkerConfig, TriggerRunStatus, TriggerState};

--- a/tests/reborn_qa_routines.rs
+++ b/tests/reborn_qa_routines.rs
@@ -45,7 +45,7 @@ use ironclaw_loop_host::{
     HostManagedModelRequest, HostManagedModelResponse, HostManagedToolResultContent,
 };
 use ironclaw_reborn_composition::{
-    RebornCompositionProfile, RebornLocalRuntimeProfileOptions, RebornRuntime,
+    RebornCompositionProfile, RebornRuntimeProfileOptions, RebornRuntime,
     RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerSettings, build_reborn_runtime,
     local_runtime_build_input_with_options,
 };
@@ -273,7 +273,7 @@ async fn build_qa_fire_runtime(
         RebornCompositionProfile::LocalDevYolo,
         QA_USER,
         root.path().join("local-dev"),
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access: true,
         },
     )

--- a/tests/support/reborn_parity_qa/qa_trace.rs
+++ b/tests/support/reborn_parity_qa/qa_trace.rs
@@ -45,7 +45,7 @@ use ironclaw_network::{
 };
 use ironclaw_product_workflow::RebornOutboundDeliveryTargetId;
 use ironclaw_reborn_composition::{
-    AssistantReply, PollSettings, RebornCompositionProfile, RebornLocalRuntimeProfileOptions,
+    AssistantReply, PollSettings, RebornCompositionProfile, RebornRuntimeProfileOptions,
     RebornProductAuthServices, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
     RebornTurnDriveOutcome, TriggerPollerSettings, build_reborn_runtime, build_reborn_services,
     local_runtime_build_input_with_options,
@@ -356,7 +356,7 @@ async fn build_qa_trace_runtime_with_http_interceptor_and_trigger_poller(
         RebornCompositionProfile::LocalDevYolo,
         QA_USER,
         root.path().join("local-dev"),
-        RebornLocalRuntimeProfileOptions {
+        RebornRuntimeProfileOptions {
             confirm_host_access: true,
         },
     )
@@ -823,7 +823,7 @@ impl RebornQaCredentialSource {
             RebornCompositionProfile::LocalDev,
             &self.user,
             self.local_dev_root.clone(),
-            RebornLocalRuntimeProfileOptions::default(),
+            RebornRuntimeProfileOptions::default(),
         )
         .expect("Reborn QA credential source input")
         .with_local_runtime_identity(

--- a/tests/support/reborn_parity_qa/qa_trace.rs
+++ b/tests/support/reborn_parity_qa/qa_trace.rs
@@ -45,8 +45,8 @@ use ironclaw_network::{
 };
 use ironclaw_product_workflow::RebornOutboundDeliveryTargetId;
 use ironclaw_reborn_composition::{
-    AssistantReply, PollSettings, RebornCompositionProfile, RebornRuntimeProfileOptions,
-    RebornProductAuthServices, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
+    AssistantReply, PollSettings, RebornCompositionProfile, RebornProductAuthServices,
+    RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput, RebornRuntimeProfileOptions,
     RebornTurnDriveOutcome, TriggerPollerSettings, build_reborn_runtime, build_reborn_services,
     local_runtime_build_input_with_options,
 };


### PR DESCRIPTION
## Summary

Implements **Slice B** of `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md` (§4.4 "Eliminate `Local*`: deployment mode is policy, not a kernel type", §5.6 "The deployment interface — modes are data"): deployment targets become **one config value**, and the `LocalDev*` shadow-runtime type family is gone — the `reborn_localdev_typename_ratchet` allowlist is now **empty** (the §10 definition of done for this axis).

### What changed

**1. `DeploymentConfig` (new, `ironclaw_reborn_composition/src/deployment.rs`)**
- The runtime-policy *request* a deployment makes, as data: `{deployment, requested_profile, yolo_disclosure_acknowledged, org_policy}` with named constructors `local_dev()` / `local_dev_yolo(confirm)` / `hosted_single_tenant_volume()`.
- `RebornCompositionProfile` maps to a `DeploymentConfig` at one edge (`deployment_config_for_profile` in `local_runtime_profile.rs`); the hardcoded `(DeploymentMode, RuntimeProfile)` pairs previously inlined there collapse into these constructors.
- The sanctioned `ironclaw_runtime_policy` resolver remains the **only** producer of `EffectiveRuntimePolicy`; `DeploymentConfig::resolve()` is a thin adapter, not a second policy engine. Storage roots/pools stay runtime handles on `RebornStorageInput`.
- The embedded capability-policy TOML is reachable as config data via `DeploymentConfig::builtin_capability_policy()` (§4.4.1 category 1).

**2. `LocalDev*` family renamed to what it always was (behavior-preserving, zero logic changes)**

| Cluster | Old → New |
|---|---|
| Capability policy data (`local_dev_capability_policy.{rs,toml}` → `builtin_capability_policy.{rs,toml}`) | `LocalDevCapabilityPolicy`→`BuiltinCapabilityPolicy` + Provider/ApprovalGate/ApprovalDefaults/Grant/Constraint policies →`Builtin*`; `LocalDevMountProfile`→`CapabilityMountProfile`; `LocalDevNetworkProfile`→`CapabilityNetworkProfile` (variant `LocalDevWildcard`→`DevWildcard`) |
| Store aliases + backend selection (`factory.rs`) | `LocalDev{TurnState,RunState,ApprovalRequest,CapabilityLease,PersistentApprovalPolicy,ToolPermissionOverride,AutoApproveSetting}Store`/`LocalDevResourceGovernor`/`LocalDevProcessServices` → `Composed*`; `LocalDevDurableBackend`→`DurableBackend`; `LocalDevStorageBackendInput`→`StorageBackendInput`; `LocalDevRootFilesystemBundle`→`RootFilesystemBundle`; `LocalDevHostHomeRoot`→`HostHomeRoot`; `RebornLocalDevStoreGraph{,Input}`→`RebornStoreGraph{,Input}`; `RebornLocalRuntimeServices`→`RebornRuntimeSubstrate`; `RebornLocalDevApprovalTestParts`→`RebornApprovalTestParts` |
| Capability-port wiring (`runtime/local_dev/`) | `LocalDevCapabilityIo`→`StagedCapabilityIo`; `LocalDevLoopCapabilityPortFactory`→`RefreshingLoopCapabilityPortFactory`; `RefreshingLocalDevCapabilityPort{,Config,TestParts}`→`RefreshingCapabilityPort{,Config,TestParts}`; `LocalDevSyntheticCapability*`→`SyntheticCapability*`; `LocalDevExtensionSurface{,Source}`→`ExtensionCapabilitySurface{,Source}`; `LocalDevSurfaceDisclosure{,Port}`→`HostSurfaceDisclosure{,Port}`; skill aliases →`Composed*` |
| Mis-prefixed shared substrate (§4.4.1 cat. 2) | `LocalDevApprovalGateEvidence`→`ApprovalRequestGateEvidence`; `LocalDevResourceGateEvidence`→`BudgetGateEvidence`; `LocalDevApprovalTurnRunLocator`→`SnapshotApprovalTurnRunLocator`; `LocalDevAuthInteractionReadModel`→`SnapshotAuthInteractionReadModel`; `LocalDevApprovalLeaseTermsProvider`→`PolicyApprovalLeaseTermsProvider`; inert trust stub `LocalDevOverride`→`DevTrustOverride` (still inert) |
| Profile adapter | `RebornLocalRuntimeProfile{Options,Error}`→`RebornRuntimeProfile{Options,Error}` |

**3. Ratchets flipped/trimmed in lock-step (§10)**
- `reborn_localdev_typename_ratchet`: `FROZEN_LOCALDEV_TYPES` **28 → 0** — any new `LocalDev*` type now fails outright.
- `reborn_deployment_mode_typename_ratchet`: mid-name `LocalDev` section cleared; `RebornLocalRuntimeServices` + profile-adapter entries removed.
- `reborn_composition_boundaries`: module-path assertion updated for `builtin_capability_policy`; `docs/plans/composition-pubuse.snapshot` regenerated for the renamed facade exports (intentional surface change: renames only).

### Deliberately out of scope (follow-ups)
- Module/dir names (`runtime/local_dev/`, `local_runtime_profile.rs`) and `build_local_dev_*`/`local_runtime` fn/field names — identifier-level churn without ratchet value.
- `RebornCompositionProfile::LocalDev`/`LocalDevYolo` enum variants and `LocalTriggerAccessSource::LocalDev*Bootstrap` variants (edge vocabulary / persisted provenance tags; the ratchets scan type definitions).
- `LocalInvocationServicesResolver`, `LocalTriggerAccess*` family, `RebornLocal{Extension,Skill,Service,RuntimeIdentity}*` (remaining entries on the deployment-mode ratchet's shrink list).
- Wiring port-decorator booleans through `DeploymentConfig` (§4.4.1 cat. 3) — triggers today are already data/handle-presence driven.

### Behavior notes
- Everything is rename/relocation except: the embedded TOML wire value `local_dev_wildcard`→`dev_wildcard` (compile-time `include_str!` config, no external consumers — verified by grep) and the inert `DevTrustOverride`'s diagnostic `name()` label `local_dev_override`→`dev_trust_override` (no consumers match on it; `evaluate()` still returns `Ok(None)`).
- No test-only wiring added; test doubles follow the renamed production types.

### Verification
- `cargo test -p ironclaw_architecture` — all suites green, including both typename ratchets (LocalDev list at empty) and the pub-use snapshot.
- `cargo test -p ironclaw_reborn_composition -p ironclaw_trust -p ironclaw_runtime_policy --all-features` — green (5 `llm_admin` nearai env-var tests fail only when `NEARAI_API_KEY` leaks from the shell; reproduced identically on unmodified main, pass under `env -u`).
- `cargo clippy` three-lane matrix (all-features / default / libsql-only) with `-D warnings` — the cfg-switched store-alias arms compile in every lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
