### PR TITLE
refactor(dispatcher): collapse RuntimeAdapter dyn registry into closed RuntimeLane executor

### DIFF
--- a/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
@@ -6,7 +6,7 @@ use ironclaw_approvals::{ApprovalResolver, LeaseApproval};
 use ironclaw_authorization::*;
 use ironclaw_capabilities::*;
 use ironclaw_dispatcher::{
-    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
+    RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher, RuntimeExecutor,
 };
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
 use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
@@ -382,9 +382,14 @@ impl RecordingRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
+impl RuntimeExecutor<DiskFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
+    fn supports_lane(&self, lane: RuntimeLane) -> bool {
+        lane == RuntimeLane::Wasm
+    }
+
     async fn dispatch_json(
         &self,
+        _lane: RuntimeLane,
         request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedRuntimeRequest {
@@ -426,11 +431,18 @@ impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingRunti
     }
 }
 
+type RecordingDispatcher = RuntimeDispatcher<
+    'static,
+    DiskFilesystem,
+    InMemoryResourceGovernor,
+    Arc<RecordingRuntimeAdapter>,
+>;
+
 fn runtime_dispatcher_stack(
     adapter: Arc<RecordingRuntimeAdapter>,
 ) -> (
     Arc<ironclaw_extensions::ExtensionRegistry>,
-    RuntimeDispatcher<'static, DiskFilesystem, InMemoryResourceGovernor>,
+    RecordingDispatcher,
     Arc<InMemoryResourceGovernor>,
     InMemoryEventSink,
 ) {
@@ -438,10 +450,13 @@ fn runtime_dispatcher_stack(
     let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let events = InMemoryEventSink::new();
-    let dispatcher =
-        RuntimeDispatcher::from_arcs(Arc::clone(&registry), filesystem, Arc::clone(&governor))
-            .with_runtime_adapter_arc(RuntimeKind::Wasm, adapter)
-            .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        Arc::clone(&registry),
+        filesystem,
+        Arc::clone(&governor),
+        adapter,
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
     (registry, dispatcher, governor, events)
 }
 

--- a/crates/ironclaw_dispatcher/AGENTS.md
+++ b/crates/ironclaw_dispatcher/AGENTS.md
@@ -12,7 +12,7 @@
 ## What This Crate Owns
 
 - The neutral runtime dispatch port that routes already-authorized capability requests to runtime lanes. Currently:
-- `RuntimeDispatcher` and the `RuntimeAdapter` trait (all runtime lanes register through it — no direct WASM/Script/MCP deps), with `RuntimeAdapterRequest` / `RuntimeAdapterResult`.
+- `RuntimeDispatcher<'a, F, G, E>` holds one monomorphized `RuntimeExecutor` (`E`) and routes each capability by matching the resolved `RuntimeLane` — a closed enum collapse of the former `HashMap<RuntimeKind, dyn RuntimeAdapter>` trait-object registry (arch-simplification §4.2). The concrete executor enum (`RuntimeLaneExecutor` over WASM/Script/MCP/first-party) lives host-runtime-side; this crate only owns the `RuntimeExecutor` port and the `RuntimeAdapter` per-lane execution shape, with `RuntimeAdapterRequest` / `RuntimeAdapterResult` (no direct WASM/Script/MCP deps).
 - The re-exported `ironclaw_host_api` dispatch contracts: `CapabilityDispatcher`, `CapabilityDispatchRequest`, `CapabilityDispatchResult`, `DispatchError`, `RuntimeDispatchErrorKind` (runtime errors redacted to stable kinds at the public surface).
 - Crate-local public API, tests, and fixtures needed to prove that ownership.
 

--- a/crates/ironclaw_dispatcher/CLAUDE.md
+++ b/crates/ironclaw_dispatcher/CLAUDE.md
@@ -4,4 +4,5 @@
 - Do not import authorization, approvals, run-state, capabilities, processes, host-runtime, concrete runtime crates, product workflow, or caller-facing state.
 - Event sink failures are best-effort and must not alter dispatch success/failure outcomes.
 - Runtime errors crossing public dispatch surfaces must be redacted to stable kinds.
-- Runtime lanes must be registered through `RuntimeAdapter`; do not add direct WASM/Script/MCP dependencies back to this crate.
+- Routing is a **closed** model (arch-simplification §4.2): the dispatcher holds one monomorphized `RuntimeExecutor` (`E`) resolved once at composition and routes each capability by matching the resolved `RuntimeLane` — not a `HashMap<RuntimeKind, dyn RuntimeAdapter>` trait-object registry. `RuntimeLane::from_runtime_kind` maps a descriptor's `RuntimeKind` to a lane; `None` (host-internal `System`) fails closed with `MissingRuntimeBackend`, never a default lane.
+- The concrete executor set (the `RuntimeLaneExecutor` enum over WASM/Script/MCP/first-party) lives host-runtime-side, behind the `RuntimeExecutor` port. `RuntimeAdapter` remains the per-lane execution shape but is no longer used as a trait object here. Do not add direct WASM/Script/MCP dependencies back to this crate.

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -5,7 +5,7 @@
 //! itself, or execute product workflows. Those responsibilities stay in the
 //! owning service crates.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_events::{EventSink, RuntimeEvent};
@@ -13,7 +13,7 @@ use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry, SharedExtensionRe
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityId, ExtensionId, MountView, ResourceEstimate, ResourceReceipt,
-    ResourceReservation, ResourceScope, ResourceUsage, RuntimeKind,
+    ResourceReservation, ResourceScope, ResourceUsage, RuntimeKind, RuntimeLane,
     runtime_policy::{
         ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
         NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
@@ -85,11 +85,17 @@ pub struct RuntimeAdapterResult {
     pub output_bytes: u64,
 }
 
-/// Runtime backend adapter used by [`RuntimeDispatcher`].
+/// Per-lane runtime backend execution shape.
 ///
-/// Implementations must not perform caller-facing authorization or approval
-/// resolution. They may reserve/reconcile resources through the provided
-/// governor and must surface only redacted [`DispatchError`] categories.
+/// This is the concrete-execution contract each runtime lane
+/// (`FirstParty`/`Wasm`/`Mcp`/`Process`) satisfies host-runtime-side. Unlike the
+/// former design it is **not** used as a trait object in a per-lane registry:
+/// routing now goes through the closed [`RuntimeExecutor`] (arch-simplification
+/// §4.2 — a `dyn`→enum collapse of the capability hot path). Implementations are
+/// called by static dispatch from the host-runtime lane executor; they must not
+/// perform caller-facing authorization or approval resolution, may
+/// reserve/reconcile resources through the provided governor, and must surface
+/// only redacted [`DispatchError`] categories.
 #[async_trait]
 pub trait RuntimeAdapter<F, G>: Send + Sync
 where
@@ -102,32 +108,99 @@ where
     ) -> Result<RuntimeAdapterResult, DispatchError>;
 }
 
-/// Narrow runtime dispatcher over already-discovered extensions and services.
-pub struct RuntimeDispatcher<'a, F, G>
+/// Closed runtime-lane router held by [`RuntimeDispatcher`].
+///
+/// This replaces the former `HashMap<RuntimeKind, dyn RuntimeAdapter>` per-lane
+/// vtable registry with a single monomorphized executor resolved once at
+/// composition (arch-simplification §4.2, "a single generic parameter resolved
+/// once at composition"). The dispatcher holds one `E: RuntimeExecutor` and
+/// never dynamic-dispatches per lane. The executor's own `dispatch_json` is the
+/// one place a [`RuntimeLane`] is matched exhaustively — adding a lane is a
+/// compile error until every arm handles it (§4.2 safety property).
+///
+/// The dependency boundary is preserved: the executor set (WASM/Script/MCP/
+/// first-party) lives host-runtime-side, so this crate gains no concrete-runtime
+/// dependency. This crate only owns the port.
+#[async_trait]
+pub trait RuntimeExecutor<F, G>: Send + Sync
 where
     F: RootFilesystem,
     G: ResourceGovernor,
+{
+    /// True when a backend is wired for `lane`. The dispatcher consults this
+    /// **before** emitting `RuntimeSelected`, so an unconfigured lane fails with
+    /// a redacted [`DispatchError::MissingRuntimeBackend`] and no reservation —
+    /// exactly as the former registry-miss path did.
+    fn supports_lane(&self, lane: RuntimeLane) -> bool;
+
+    /// Execute an already-validated request on the resolved `lane`. Called only
+    /// after [`Self::supports_lane`] returned true.
+    async fn dispatch_json(
+        &self,
+        lane: RuntimeLane,
+        request: RuntimeAdapterRequest<'_, F, G>,
+    ) -> Result<RuntimeAdapterResult, DispatchError>;
+}
+
+/// Smart-pointer delegation so an `Arc`-shared executor (e.g. one a caller keeps
+/// a handle to for inspection) satisfies the bound directly.
+#[async_trait]
+impl<F, G, T> RuntimeExecutor<F, G> for Arc<T>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+    T: RuntimeExecutor<F, G> + ?Sized,
+{
+    fn supports_lane(&self, lane: RuntimeLane) -> bool {
+        (**self).supports_lane(lane)
+    }
+
+    async fn dispatch_json(
+        &self,
+        lane: RuntimeLane,
+        request: RuntimeAdapterRequest<'_, F, G>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        (**self).dispatch_json(lane, request).await
+    }
+}
+
+/// Narrow runtime dispatcher over already-discovered extensions and services.
+///
+/// `E` is the closed [`RuntimeExecutor`] resolved once at composition — the
+/// dispatcher routes every capability through it by static dispatch, with no
+/// per-lane trait object or vtable map (arch-simplification §4.2).
+pub struct RuntimeDispatcher<'a, F, G, E>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+    E: RuntimeExecutor<F, G>,
 {
     registry: Arc<SharedExtensionRegistry>,
     filesystem: ServiceHandle<'a, F>,
     governor: ServiceHandle<'a, G>,
     runtime_policy: EffectiveRuntimePolicy,
-    runtime_adapters: HashMap<RuntimeKind, ServiceHandle<'a, dyn RuntimeAdapter<F, G> + 'a>>,
+    executor: E,
     event_sink: Option<ServiceHandle<'a, dyn EventSink + 'a>>,
 }
 
-impl<'a, F, G> RuntimeDispatcher<'a, F, G>
+impl<'a, F, G, E> RuntimeDispatcher<'a, F, G, E>
 where
     F: RootFilesystem,
     G: ResourceGovernor,
+    E: RuntimeExecutor<F, G>,
 {
-    pub fn new(registry: &'a ExtensionRegistry, filesystem: &'a F, governor: &'a G) -> Self {
+    pub fn new(
+        registry: &'a ExtensionRegistry,
+        filesystem: &'a F,
+        governor: &'a G,
+        executor: E,
+    ) -> Self {
         Self {
             registry: Arc::new(SharedExtensionRegistry::new(registry.clone())),
             filesystem: ServiceHandle::Borrowed(filesystem),
             governor: ServiceHandle::Borrowed(governor),
             runtime_policy: default_runtime_policy(),
-            runtime_adapters: HashMap::new(),
+            executor,
             event_sink: None,
         }
     }
@@ -136,7 +209,8 @@ where
         registry: Arc<ExtensionRegistry>,
         filesystem: Arc<F>,
         governor: Arc<G>,
-    ) -> RuntimeDispatcher<'static, F, G>
+        executor: E,
+    ) -> RuntimeDispatcher<'static, F, G, E>
     where
         F: 'static,
         G: 'static,
@@ -145,6 +219,7 @@ where
             Arc::new(SharedExtensionRegistry::new((*registry).clone())),
             filesystem,
             governor,
+            executor,
         )
     }
 
@@ -152,7 +227,8 @@ where
         registry: Arc<SharedExtensionRegistry>,
         filesystem: Arc<F>,
         governor: Arc<G>,
-    ) -> RuntimeDispatcher<'static, F, G>
+        executor: E,
+    ) -> RuntimeDispatcher<'static, F, G, E>
     where
         F: 'static,
         G: 'static,
@@ -162,7 +238,7 @@ where
             filesystem: ServiceHandle::Shared(filesystem),
             governor: ServiceHandle::Shared(governor),
             runtime_policy: default_runtime_policy(),
-            runtime_adapters: HashMap::new(),
+            executor,
             event_sink: None,
         }
     }
@@ -173,28 +249,6 @@ where
     /// concrete policy that should govern each dispatch request.
     pub fn with_runtime_policy(mut self, runtime_policy: EffectiveRuntimePolicy) -> Self {
         self.runtime_policy = runtime_policy;
-        self
-    }
-
-    pub fn with_runtime_adapter<T>(mut self, runtime: RuntimeKind, adapter: &'a T) -> Self
-    where
-        T: RuntimeAdapter<F, G> + 'a,
-    {
-        let adapter: &'a (dyn RuntimeAdapter<F, G> + 'a) = adapter;
-        self.runtime_adapters
-            .insert(runtime, ServiceHandle::Borrowed(adapter));
-        self
-    }
-
-    pub fn with_runtime_adapter_arc<T>(mut self, runtime: RuntimeKind, adapter: Arc<T>) -> Self
-    where
-        T: RuntimeAdapter<F, G> + 'static,
-        F: 'static,
-        G: 'static,
-    {
-        let adapter: Arc<dyn RuntimeAdapter<F, G>> = adapter;
-        self.runtime_adapters
-            .insert(runtime, ServiceHandle::Shared(adapter));
         self
     }
 
@@ -282,17 +336,25 @@ where
         }
 
         let runtime = descriptor.runtime;
-        let Some(adapter) = self.runtime_adapters.get(&runtime) else {
-            let error = DispatchError::MissingRuntimeBackend { runtime };
-            self.emit_dispatch_failure(
-                scope,
-                capability_id,
-                Some(descriptor.provider.clone()),
-                Some(runtime),
-                &error,
-            )
-            .await?;
-            return Err(error);
+        // Resolve the runtime kind (loading taxonomy) to a closed execution
+        // lane, then confirm the executor has that lane wired. `System` maps to
+        // `None` (host-internal, never an untrusted lane) and an unconfigured
+        // lane both fail closed here — before any `RuntimeSelected` event or
+        // reservation, so the prepared reservation guard drops and releases.
+        let lane = match RuntimeLane::from_runtime_kind(runtime) {
+            Some(lane) if self.executor.supports_lane(lane) => lane,
+            _ => {
+                let error = DispatchError::MissingRuntimeBackend { runtime };
+                self.emit_dispatch_failure(
+                    scope,
+                    capability_id,
+                    Some(descriptor.provider.clone()),
+                    Some(runtime),
+                    &error,
+                )
+                .await?;
+                return Err(error);
+            }
         };
 
         self.emit_event(RuntimeEvent::runtime_selected(
@@ -303,23 +365,26 @@ where
         ))
         .await?;
 
-        let execution = match adapter
-            .as_ref()
-            .dispatch_json(RuntimeAdapterRequest {
-                package: &package,
-                descriptor: &descriptor,
-                filesystem: self.filesystem.as_ref(),
-                governor: self.governor.as_ref(),
-                runtime_policy: &self.runtime_policy,
-                capability_id: &request.capability_id,
-                scope: request.scope,
-                authenticated_actor_user_id: request.authenticated_actor_user_id,
-                run_id: request.run_id,
-                estimate: request.estimate,
-                mounts: request.mounts,
-                resource_reservation: reservation_guard.take(),
-                input: request.input,
-            })
+        let execution = match self
+            .executor
+            .dispatch_json(
+                lane,
+                RuntimeAdapterRequest {
+                    package: &package,
+                    descriptor: &descriptor,
+                    filesystem: self.filesystem.as_ref(),
+                    governor: self.governor.as_ref(),
+                    runtime_policy: &self.runtime_policy,
+                    capability_id: &request.capability_id,
+                    scope: request.scope,
+                    authenticated_actor_user_id: request.authenticated_actor_user_id,
+                    run_id: request.run_id,
+                    estimate: request.estimate,
+                    mounts: request.mounts,
+                    resource_reservation: reservation_guard.take(),
+                    input: request.input,
+                },
+            )
             .await
         {
             Ok(execution) => execution,
@@ -447,10 +512,11 @@ fn default_runtime_policy() -> EffectiveRuntimePolicy {
 }
 
 #[async_trait]
-impl<F, G> CapabilityDispatcher for RuntimeDispatcher<'_, F, G>
+impl<F, G, E> CapabilityDispatcher for RuntimeDispatcher<'_, F, G, E>
 where
     F: RootFilesystem,
     G: ResourceGovernor,
+    E: RuntimeExecutor<F, G>,
 {
     async fn dispatch_json(
         &self,

--- a/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
@@ -1,16 +1,13 @@
 mod support;
 
-use support::legacy_capability_fixture_to_v2;
+use support::{RecordingExecutor, legacy_capability_fixture_to_v2};
 
-use std::sync::{Arc, Mutex};
-
-use async_trait::async_trait;
 use ironclaw_dispatcher::*;
 use ironclaw_extensions::*;
 use ironclaw_filesystem::*;
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
-use serde_json::{Value, json};
+use serde_json::json;
 
 #[tokio::test]
 async fn dispatcher_routes_wasm_capability_through_registered_adapter() {
@@ -19,7 +16,8 @@ async fn dispatcher_routes_wasm_capability_through_registered_adapter() {
     registry
         .insert(package_from_manifest(WASM_MANIFEST))
         .unwrap();
-    let adapter = RecordingAdapter::new(RuntimeKind::Wasm, json!({"message": "hello adapter"}));
+    let executor = RecordingExecutor::new()
+        .static_output(RuntimeKind::Wasm, json!({"message": "hello adapter"}));
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -32,8 +30,7 @@ async fn dispatcher_routes_wasm_capability_through_registered_adapter() {
         )
         .unwrap();
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Wasm, &adapter);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, executor.clone());
     let result = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -58,7 +55,7 @@ async fn dispatcher_routes_wasm_capability_through_registered_adapter() {
     assert_eq!(governor.reserved_for(&account), ResourceTally::default());
     assert!(governor.usage_for(&account).output_bytes > 0);
 
-    let requests = adapter.requests();
+    let requests = executor.requests();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].provider, ExtensionId::new("echo").unwrap());
     assert_eq!(
@@ -66,6 +63,7 @@ async fn dispatcher_routes_wasm_capability_through_registered_adapter() {
         CapabilityId::new("echo.say").unwrap()
     );
     assert_eq!(requests[0].runtime, RuntimeKind::Wasm);
+    assert_eq!(requests[0].lane, RuntimeLane::Wasm);
     assert_eq!(requests[0].input, json!({"message": "hello dispatcher"}));
 }
 
@@ -76,7 +74,7 @@ async fn dispatcher_routes_script_capability_through_registered_adapter() {
     registry
         .insert(package_from_manifest(SCRIPT_MANIFEST))
         .unwrap();
-    let adapter = RecordingAdapter::new(
+    let executor = RecordingExecutor::new().static_output(
         RuntimeKind::Script,
         json!({
             "message": "hello script adapter"
@@ -95,8 +93,7 @@ async fn dispatcher_routes_script_capability_through_registered_adapter() {
         )
         .unwrap();
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Script, &adapter);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, executor);
     let result = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -133,8 +130,8 @@ async fn dispatcher_redacts_runtime_adapter_failure_details() {
     registry
         .insert(package_from_manifest(SCRIPT_MANIFEST))
         .unwrap();
-    let adapter =
-        RecordingAdapter::failing(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
+    let executor = RecordingExecutor::new()
+        .failing(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     governor
@@ -147,8 +144,7 @@ async fn dispatcher_redacts_runtime_adapter_failure_details() {
         )
         .unwrap();
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Script, &adapter);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, executor);
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -184,7 +180,7 @@ async fn dispatcher_routes_mcp_capability_through_registered_adapter() {
     registry
         .insert(package_from_manifest(MCP_MANIFEST))
         .unwrap();
-    let adapter = RecordingAdapter::new(
+    let executor = RecordingExecutor::new().static_output(
         RuntimeKind::Mcp,
         json!({
             "matches": ["ironclaw"]
@@ -203,8 +199,7 @@ async fn dispatcher_routes_mcp_capability_through_registered_adapter() {
         )
         .unwrap();
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Mcp, &adapter);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, executor);
     let result = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -241,10 +236,9 @@ async fn dispatcher_fails_unknown_capability_without_reserving_resources() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    let adapter = RecordingAdapter::new(RuntimeKind::Wasm, json!({}));
+    let executor = RecordingExecutor::new().static_output(RuntimeKind::Wasm, json!({}));
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Wasm, &adapter);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, executor.clone());
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -262,7 +256,7 @@ async fn dispatcher_fails_unknown_capability_without_reserving_resources() {
     assert!(matches!(err, DispatchError::UnknownCapability { .. }));
     assert_eq!(governor.reserved_for(&account), ResourceTally::default());
     assert_eq!(governor.usage_for(&account), ResourceTally::default());
-    assert!(adapter.requests().is_empty());
+    assert!(executor.requests().is_empty());
 }
 
 #[tokio::test]
@@ -276,7 +270,7 @@ async fn dispatcher_releases_prepared_reservation_when_validation_fails_before_a
     let reservation = governor.reserve(scope.clone(), estimate.clone()).unwrap();
     assert_eq!(governor.reserved_for(&account).concurrency_slots, 1);
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, RecordingExecutor::new());
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -307,7 +301,7 @@ async fn dispatcher_requires_mcp_backend_before_reserving_resources() {
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, RecordingExecutor::new());
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -345,7 +339,7 @@ async fn dispatcher_requires_script_backend_before_reserving_resources() {
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, RecordingExecutor::new());
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -383,7 +377,7 @@ async fn dispatcher_requires_wasm_backend_before_reserving_resources() {
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
 
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, RecordingExecutor::new());
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
             run_id: None,
@@ -408,106 +402,51 @@ async fn dispatcher_requires_wasm_backend_before_reserving_resources() {
     assert_eq!(governor.usage_for(&account), ResourceTally::default());
 }
 
-#[derive(Clone)]
-struct RecordingAdapter {
-    runtime: RuntimeKind,
-    output: Value,
-    failure: Option<RuntimeDispatchErrorKind>,
-    requests: Arc<Mutex<Vec<RecordedAdapterRequest>>>,
-}
+#[tokio::test]
+async fn dispatcher_fails_closed_for_system_runtime_without_routing_to_a_lane() {
+    // `RuntimeKind::System` is host-internal — `RuntimeLane::from_runtime_kind`
+    // returns `None`, so a System capability must never be dispatched to a lane.
+    // Even with every untrusted lane wired, the executor is not consulted and
+    // dispatch fails closed with the redacted `MissingRuntimeBackend`.
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_bundled_manifest(SYSTEM_MANIFEST))
+        .unwrap();
+    let executor = RecordingExecutor::new()
+        .echo(RuntimeKind::Wasm)
+        .echo(RuntimeKind::Mcp)
+        .echo(RuntimeKind::Script)
+        .echo(RuntimeKind::FirstParty);
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
 
-impl RecordingAdapter {
-    fn new(runtime: RuntimeKind, output: Value) -> Self {
-        Self {
-            runtime,
-            output,
-            failure: None,
-            requests: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    fn failing(runtime: RuntimeKind, failure: RuntimeDispatchErrorKind) -> Self {
-        Self {
-            runtime,
-            output: json!(null),
-            failure: Some(failure),
-            requests: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    fn requests(&self) -> Vec<RecordedAdapterRequest> {
-        self.requests.lock().unwrap().clone()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct RecordedAdapterRequest {
-    provider: ExtensionId,
-    capability_id: CapabilityId,
-    runtime: RuntimeKind,
-    input: Value,
-}
-
-#[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
-    async fn dispatch_json(
-        &self,
-        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
-    ) -> Result<RuntimeAdapterResult, DispatchError> {
-        self.requests.lock().unwrap().push(RecordedAdapterRequest {
-            provider: request.package.id.clone(),
-            capability_id: request.capability_id.clone(),
-            runtime: request.descriptor.runtime,
-            input: request.input.clone(),
-        });
-        if let Some(kind) = self.failure {
-            return Err(dispatch_error_for_runtime(self.runtime, kind));
-        }
-
-        let usage = ResourceUsage::default()
-            .set_output_bytes(serde_json::to_vec(&self.output).unwrap().len() as u64)
-            .set_process_count(u32::from(matches!(
-                self.runtime,
-                RuntimeKind::Script | RuntimeKind::Mcp
-            )));
-        let reservation = request
-            .governor
-            .reserve(request.scope.clone(), request.estimate.clone())
-            .map_err(|_| {
-                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
-            })?;
-        let receipt = request
-            .governor
-            .reconcile(reservation.id, usage.clone())
-            .map_err(|_| {
-                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
-            })?;
-        Ok(RuntimeAdapterResult {
-            output: self.output.clone(),
-            display_preview: None,
-            output_bytes: usage.output_bytes,
-            usage,
-            receipt,
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, executor.clone());
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            run_id: None,
+            capability_id: CapabilityId::new("system-ext.op").unwrap(),
+            scope,
+            authenticated_actor_user_id: None,
+            estimate: ResourceEstimate::default().set_concurrency_slots(1),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "host-internal"}),
         })
-    }
-}
+        .await
+        .unwrap_err();
 
-fn dispatch_error_for_runtime(
-    runtime: RuntimeKind,
-    kind: RuntimeDispatchErrorKind,
-) -> DispatchError {
-    match runtime {
-        RuntimeKind::Wasm => DispatchError::Wasm {
-            kind,
-            safe_summary: None,
-        },
-        RuntimeKind::Script => DispatchError::Script { kind },
-        RuntimeKind::Mcp => DispatchError::Mcp { kind },
-        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
-            capability: CapabilityId::new("system.unsupported").unwrap(),
-            runtime,
-        },
-    }
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::System
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+    // The closed executor was never consulted for a host-internal runtime.
+    assert!(executor.requests().is_empty());
 }
 
 fn mounted_empty_extension_root() -> DiskFilesystem {
@@ -535,6 +474,19 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
         &HostPortCatalog::empty(),
     )
     .unwrap()
+}
+
+// `System`/`FirstParty` runtimes are only assertible by a host-bundled source.
+fn package_from_bundled_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = legacy_capability_fixture_to_v2(manifest);
+    let manifest = ExtensionManifest::parse(
+        &manifest,
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
 }
 
 fn sample_scope() -> ResourceScope {
@@ -605,6 +557,25 @@ args = ["-c", "cat"]
 [[capabilities]]
 id = "script.echo"
 description = "Echo script"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;
+
+const SYSTEM_MANIFEST: &str = r#"
+id = "system-ext"
+name = "System Ext"
+version = "0.1.0"
+description = "Host-internal system runtime demo extension"
+trust = "untrusted"
+
+[runtime]
+kind = "system"
+service = "master-key"
+
+[[capabilities]]
+id = "system-ext.op"
+description = "Host-internal op"
 effects = ["dispatch_capability"]
 default_permission = "allow"
 parameters_schema = { type = "object" }

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use support::legacy_capability_fixture_to_v2;
+use support::{RecordingExecutor, legacy_capability_fixture_to_v2};
 
 use async_trait::async_trait;
 use ironclaw_dispatcher::*;
@@ -9,7 +9,7 @@ use ironclaw_extensions::*;
 use ironclaw_filesystem::*;
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
-use serde_json::{Value, json};
+use serde_json::json;
 use tracing::Instrument;
 use tracing_test::traced_test;
 
@@ -18,13 +18,12 @@ async fn dispatcher_emits_events_for_wasm_and_script_success() {
     let fs = filesystem_with_echo_extensions();
     let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
-    let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
-    let script_adapter = EchoAdapter::new(RuntimeKind::Script);
+    let executor = RecordingExecutor::new()
+        .echo(RuntimeKind::Wasm)
+        .echo(RuntimeKind::Script);
     let events = InMemoryEventSink::new();
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Wasm, &wasm_adapter)
-        .with_runtime_adapter(RuntimeKind::Script, &script_adapter)
-        .with_event_sink(&events);
+    let dispatcher =
+        RuntimeDispatcher::new(&registry, &fs, &governor, executor).with_event_sink(&events);
 
     dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -94,11 +93,10 @@ async fn dispatcher_ignores_event_sink_failures_on_success() {
     let fs = filesystem_with_echo_extensions();
     let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
-    let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
+    let executor = RecordingExecutor::new().echo(RuntimeKind::Wasm);
     let events = FailingEventSink;
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Wasm, &wasm_adapter)
-        .with_event_sink(&events);
+    let dispatcher =
+        RuntimeDispatcher::new(&registry, &fs, &governor, executor).with_event_sink(&events);
 
     let result = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -125,7 +123,8 @@ async fn dispatcher_preserves_original_error_when_failure_event_sink_fails() {
     let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
     let events = FailingEventSink;
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor).with_event_sink(&events);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, RecordingExecutor::new())
+        .with_event_sink(&events);
 
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -165,7 +164,7 @@ async fn dispatcher_logs_release_failure_without_masking_dispatch_error() {
             .set_concurrency_slots(1)
             .set_process_count(1),
     };
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, RecordingExecutor::new());
 
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -203,12 +202,11 @@ async fn dispatcher_emits_redacted_runtime_error_kind_for_adapter_failure() {
     let fs = filesystem_with_echo_extensions();
     let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
-    let script_adapter =
-        FailingRuntimeAdapter::new(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
+    let executor = RecordingExecutor::new()
+        .failing(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
     let events = InMemoryEventSink::new();
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Script, &script_adapter)
-        .with_event_sink(&events);
+    let dispatcher =
+        RuntimeDispatcher::new(&registry, &fs, &governor, executor).with_event_sink(&events);
 
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -247,11 +245,11 @@ async fn dispatcher_emits_events_for_mcp_success() {
         .insert(package_from_manifest(MCP_MANIFEST))
         .unwrap();
     let governor = InMemoryResourceGovernor::new();
-    let mcp_adapter = StaticAdapter::new(RuntimeKind::Mcp, json!({"matches": ["ironclaw"]}));
+    let executor =
+        RecordingExecutor::new().static_output(RuntimeKind::Mcp, json!({"matches": ["ironclaw"]}));
     let events = InMemoryEventSink::new();
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Mcp, &mcp_adapter)
-        .with_event_sink(&events);
+    let dispatcher =
+        RuntimeDispatcher::new(&registry, &fs, &governor, executor).with_event_sink(&events);
 
     dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -291,7 +289,8 @@ async fn dispatcher_emits_failed_event_for_missing_backend_without_reserving() {
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
     let events = InMemoryEventSink::new();
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor).with_event_sink(&events);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, RecordingExecutor::new())
+        .with_event_sink(&events);
 
     let err = dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -337,129 +336,6 @@ impl EventSink for FailingEventSink {
         Err(EventError::Sink {
             reason: "event sink unavailable".to_string(),
         })
-    }
-}
-
-#[derive(Clone)]
-struct EchoAdapter {
-    runtime: RuntimeKind,
-}
-
-impl EchoAdapter {
-    fn new(runtime: RuntimeKind) -> Self {
-        Self { runtime }
-    }
-}
-
-#[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for EchoAdapter {
-    async fn dispatch_json(
-        &self,
-        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
-    ) -> Result<RuntimeAdapterResult, DispatchError> {
-        adapter_result(
-            self.runtime,
-            request.governor,
-            request.scope,
-            request.estimate,
-            request.input,
-        )
-    }
-}
-
-#[derive(Clone)]
-struct StaticAdapter {
-    runtime: RuntimeKind,
-    output: Value,
-}
-
-impl StaticAdapter {
-    fn new(runtime: RuntimeKind, output: Value) -> Self {
-        Self { runtime, output }
-    }
-}
-
-#[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for StaticAdapter {
-    async fn dispatch_json(
-        &self,
-        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
-    ) -> Result<RuntimeAdapterResult, DispatchError> {
-        adapter_result(
-            self.runtime,
-            request.governor,
-            request.scope,
-            request.estimate,
-            self.output.clone(),
-        )
-    }
-}
-
-#[derive(Clone)]
-struct FailingRuntimeAdapter {
-    runtime: RuntimeKind,
-    kind: RuntimeDispatchErrorKind,
-}
-
-impl FailingRuntimeAdapter {
-    fn new(runtime: RuntimeKind, kind: RuntimeDispatchErrorKind) -> Self {
-        Self { runtime, kind }
-    }
-}
-
-#[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for FailingRuntimeAdapter {
-    async fn dispatch_json(
-        &self,
-        _request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
-    ) -> Result<RuntimeAdapterResult, DispatchError> {
-        Err(dispatch_error_for_runtime(self.runtime, self.kind))
-    }
-}
-
-fn adapter_result(
-    runtime: RuntimeKind,
-    governor: &InMemoryResourceGovernor,
-    scope: ResourceScope,
-    estimate: ResourceEstimate,
-    output: Value,
-) -> Result<RuntimeAdapterResult, DispatchError> {
-    let usage = ResourceUsage::default()
-        .set_output_bytes(serde_json::to_vec(&output).unwrap().len() as u64)
-        .set_process_count(u32::from(matches!(
-            runtime,
-            RuntimeKind::Script | RuntimeKind::Mcp
-        )));
-    let reservation = governor
-        .reserve(scope, estimate)
-        .map_err(|_| dispatch_error_for_runtime(runtime, RuntimeDispatchErrorKind::Resource))?;
-    let receipt = governor
-        .reconcile(reservation.id, usage.clone())
-        .map_err(|_| dispatch_error_for_runtime(runtime, RuntimeDispatchErrorKind::Resource))?;
-    Ok(RuntimeAdapterResult {
-        output,
-        display_preview: None,
-        output_bytes: usage.output_bytes,
-        usage,
-        receipt,
-    })
-}
-
-fn dispatch_error_for_runtime(
-    runtime: RuntimeKind,
-    kind: RuntimeDispatchErrorKind,
-) -> DispatchError {
-    match runtime {
-        RuntimeKind::Wasm => DispatchError::Wasm {
-            kind,
-            safe_summary: None,
-        },
-        RuntimeKind::Script => DispatchError::Script { kind },
-        RuntimeKind::Mcp => DispatchError::Mcp { kind },
-        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
-            capability: CapabilityId::new("system.unsupported").unwrap(),
-            runtime,
-        },
     }
 }
 

--- a/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
+++ b/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
@@ -1,10 +1,9 @@
 mod support;
 
-use support::legacy_capability_fixture_to_v2;
+use support::{RecordingExecutor, legacy_capability_fixture_to_v2};
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use async_trait::async_trait;
 use ironclaw_dispatcher::*;
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
 use ironclaw_extensions::*;
@@ -17,7 +16,7 @@ use ironclaw_host_api::{
     *,
 };
 use ironclaw_resources::*;
-use serde_json::{Value, json};
+use serde_json::json;
 
 #[tokio::test]
 async fn runtime_dispatcher_routes_already_authorized_request_through_public_trait_object() {
@@ -25,10 +24,8 @@ async fn runtime_dispatcher_routes_already_authorized_request_through_public_tra
     let filesystem = Arc::new(mounted_empty_extension_root());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let events = InMemoryEventSink::new();
-    let adapter = Arc::new(RecordingAdapter::new(
-        RuntimeKind::Wasm,
-        json!({"reply": "from adapter"}),
-    ));
+    let executor =
+        RecordingExecutor::new().static_output(RuntimeKind::Wasm, json!({"reply": "from adapter"}));
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
     let mounts = MountView::new(vec![MountGrant::new(
@@ -51,8 +48,8 @@ async fn runtime_dispatcher_routes_already_authorized_request_through_public_tra
         Arc::clone(&registry),
         Arc::clone(&filesystem),
         Arc::clone(&governor),
+        executor.clone(),
     )
-    .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter))
     .with_event_sink_arc(Arc::new(events.clone()));
     let dispatch_port: &dyn CapabilityDispatcher = &dispatcher;
     let authenticated_actor_user_id =
@@ -82,7 +79,7 @@ async fn runtime_dispatcher_routes_already_authorized_request_through_public_tra
     assert_eq!(governor.reserved_for(&account), ResourceTally::default());
     assert!(governor.usage_for(&account).output_bytes > 0);
 
-    let requests = adapter.requests();
+    let requests = executor.requests();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].provider, ExtensionId::new("echo").unwrap());
     assert_eq!(
@@ -90,6 +87,7 @@ async fn runtime_dispatcher_routes_already_authorized_request_through_public_tra
         CapabilityId::new("echo.say").unwrap()
     );
     assert_eq!(requests[0].runtime, RuntimeKind::Wasm);
+    assert_eq!(requests[0].lane, RuntimeLane::Wasm);
     assert_eq!(requests[0].network_mode, NetworkMode::Deny);
     assert_eq!(requests[0].scope, scope);
     assert_eq!(
@@ -120,13 +118,10 @@ async fn runtime_dispatcher_forwards_configured_runtime_policy_to_adapter() {
     let registry = Arc::new(registry_with_package(WASM_MANIFEST));
     let filesystem = Arc::new(mounted_empty_extension_root());
     let governor = Arc::new(InMemoryResourceGovernor::new());
-    let adapter = Arc::new(RecordingAdapter::new(
-        RuntimeKind::Wasm,
-        json!({"reply": "from adapter"}),
-    ));
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, filesystem, governor)
-        .with_runtime_policy(local_dev_policy())
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter));
+    let executor =
+        RecordingExecutor::new().static_output(RuntimeKind::Wasm, json!({"reply": "from adapter"}));
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, filesystem, governor, executor.clone())
+        .with_runtime_policy(local_dev_policy());
 
     dispatcher
         .dispatch_json(CapabilityDispatchRequest {
@@ -142,7 +137,7 @@ async fn runtime_dispatcher_forwards_configured_runtime_policy_to_adapter() {
         .await
         .unwrap();
 
-    let requests = adapter.requests();
+    let requests = executor.requests();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].network_mode, NetworkMode::DirectLogged);
 }
@@ -156,8 +151,13 @@ async fn runtime_dispatcher_fails_closed_for_missing_backend_before_reservation_
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
 
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, filesystem, Arc::clone(&governor))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        filesystem,
+        Arc::clone(&governor),
+        RecordingExecutor::new(),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
     let dispatch_port: &dyn CapabilityDispatcher = &dispatcher;
 
     let err = dispatch_port
@@ -210,104 +210,6 @@ async fn registry_rejects_descriptor_package_runtime_mismatch_before_dispatcher_
         ExtensionError::InvalidManifest { reason }
             if reason.contains("package capability descriptors do not match")
     ));
-}
-
-#[derive(Clone)]
-struct RecordingAdapter {
-    runtime: RuntimeKind,
-    output: Value,
-    requests: Arc<Mutex<Vec<RecordedAdapterRequest>>>,
-}
-
-impl RecordingAdapter {
-    fn new(runtime: RuntimeKind, output: Value) -> Self {
-        Self {
-            runtime,
-            output,
-            requests: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    fn requests(&self) -> Vec<RecordedAdapterRequest> {
-        self.requests.lock().unwrap().clone()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct RecordedAdapterRequest {
-    provider: ExtensionId,
-    capability_id: CapabilityId,
-    runtime: RuntimeKind,
-    network_mode: NetworkMode,
-    scope: ResourceScope,
-    authenticated_actor_user_id: Option<UserId>,
-    mounts: Option<MountView>,
-    input: Value,
-}
-
-#[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
-    async fn dispatch_json(
-        &self,
-        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
-    ) -> Result<RuntimeAdapterResult, DispatchError> {
-        self.requests.lock().unwrap().push(RecordedAdapterRequest {
-            provider: request.package.id.clone(),
-            capability_id: request.capability_id.clone(),
-            runtime: request.descriptor.runtime,
-            network_mode: request.runtime_policy.network_mode,
-            scope: request.scope.clone(),
-            authenticated_actor_user_id: request.authenticated_actor_user_id.clone(),
-            mounts: request.mounts.clone(),
-            input: request.input.clone(),
-        });
-
-        let output_bytes = serde_json::to_vec(&self.output).unwrap().len() as u64;
-        let usage = ResourceUsage::default()
-            .set_output_bytes(output_bytes)
-            .set_process_count(u32::from(matches!(
-                self.runtime,
-                RuntimeKind::Script | RuntimeKind::Mcp
-            )));
-        let reservation = request
-            .governor
-            .reserve(request.scope, request.estimate)
-            .map_err(|_| {
-                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
-            })?;
-        let receipt = request
-            .governor
-            .reconcile(reservation.id, usage.clone())
-            .map_err(|_| {
-                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
-            })?;
-
-        Ok(RuntimeAdapterResult {
-            output: self.output.clone(),
-            display_preview: None,
-            usage,
-            receipt,
-            output_bytes,
-        })
-    }
-}
-
-fn dispatch_error_for_runtime(
-    runtime: RuntimeKind,
-    kind: RuntimeDispatchErrorKind,
-) -> DispatchError {
-    match runtime {
-        RuntimeKind::Wasm => DispatchError::Wasm {
-            kind,
-            safe_summary: None,
-        },
-        RuntimeKind::Script => DispatchError::Script { kind },
-        RuntimeKind::Mcp => DispatchError::Mcp { kind },
-        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
-            capability: CapabilityId::new("system.unsupported").unwrap(),
-            runtime,
-        },
-    }
 }
 
 fn registry_with_package(manifest: &str) -> ExtensionRegistry {

--- a/crates/ironclaw_dispatcher/tests/support/mod.rs
+++ b/crates/ironclaw_dispatcher/tests/support/mod.rs
@@ -1,5 +1,183 @@
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::{
+    DispatchError, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatchErrorKind,
+    RuntimeExecutor,
+};
+use ironclaw_filesystem::DiskFilesystem;
+use ironclaw_host_api::{
+    CapabilityId, ExtensionId, MountView, ResourceScope, ResourceUsage, RuntimeKind, RuntimeLane,
+    UserId, runtime_policy::NetworkMode,
+};
+use ironclaw_resources::{InMemoryResourceGovernor, ResourceGovernor};
+use serde_json::Value;
+
+/// Behavior a [`RecordingExecutor`] applies to a configured lane.
+#[derive(Clone)]
+pub enum LaneBehavior {
+    /// Echo the request input back as the output.
+    Echo,
+    /// Return a fixed output value.
+    Static(Value),
+    /// Fail with the given redacted runtime error kind.
+    Fail(RuntimeDispatchErrorKind),
+}
+
+/// One dispatch the executor was asked to route, captured for assertions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordedRequest {
+    pub lane: RuntimeLane,
+    pub provider: ExtensionId,
+    pub capability_id: CapabilityId,
+    pub runtime: RuntimeKind,
+    pub network_mode: NetworkMode,
+    pub scope: ResourceScope,
+    pub authenticated_actor_user_id: Option<UserId>,
+    pub mounts: Option<MountView>,
+    pub input: Value,
+}
+
+/// Shared test double implementing the closed [`RuntimeExecutor`] port.
+///
+/// Replaces the former per-file `RuntimeAdapter` doubles: lanes are configured
+/// per `RuntimeKind` (mapped to their execution [`RuntimeLane`]), every routed
+/// dispatch is recorded (including the resolved lane), and behavior is one of
+/// echo / static / fail. Reserve+reconcile mirrors the production adapters so
+/// resource-tally assertions hold.
+#[derive(Clone)]
+pub struct RecordingExecutor {
+    lanes: HashMap<RuntimeLane, LaneBehavior>,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+impl Default for RecordingExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RecordingExecutor {
+    pub fn new() -> Self {
+        Self {
+            lanes: HashMap::new(),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn lane_for(runtime: RuntimeKind) -> RuntimeLane {
+        RuntimeLane::from_runtime_kind(runtime)
+            .expect("test lane requires a runtime kind that maps to an execution lane")
+    }
+
+    /// Configure `runtime`'s lane to echo the request input.
+    pub fn echo(mut self, runtime: RuntimeKind) -> Self {
+        self.lanes
+            .insert(Self::lane_for(runtime), LaneBehavior::Echo);
+        self
+    }
+
+    /// Configure `runtime`'s lane to return a fixed output.
+    pub fn static_output(mut self, runtime: RuntimeKind, output: Value) -> Self {
+        self.lanes
+            .insert(Self::lane_for(runtime), LaneBehavior::Static(output));
+        self
+    }
+
+    /// Configure `runtime`'s lane to fail with `kind`.
+    pub fn failing(mut self, runtime: RuntimeKind, kind: RuntimeDispatchErrorKind) -> Self {
+        self.lanes
+            .insert(Self::lane_for(runtime), LaneBehavior::Fail(kind));
+        self
+    }
+
+    pub fn requests(&self) -> Vec<RecordedRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl RuntimeExecutor<DiskFilesystem, InMemoryResourceGovernor> for RecordingExecutor {
+    fn supports_lane(&self, lane: RuntimeLane) -> bool {
+        self.lanes.contains_key(&lane)
+    }
+
+    async fn dispatch_json(
+        &self,
+        lane: RuntimeLane,
+        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        let runtime = request.descriptor.runtime;
+        self.requests.lock().unwrap().push(RecordedRequest {
+            lane,
+            provider: request.package.id.clone(),
+            capability_id: request.capability_id.clone(),
+            runtime,
+            network_mode: request.runtime_policy.network_mode,
+            scope: request.scope.clone(),
+            authenticated_actor_user_id: request.authenticated_actor_user_id.clone(),
+            mounts: request.mounts.clone(),
+            input: request.input.clone(),
+        });
+
+        let Some(behavior) = self.lanes.get(&lane) else {
+            return Err(DispatchError::MissingRuntimeBackend { runtime });
+        };
+        let output = match behavior {
+            LaneBehavior::Echo => request.input.clone(),
+            LaneBehavior::Static(value) => value.clone(),
+            LaneBehavior::Fail(kind) => return Err(dispatch_error_for_runtime(runtime, *kind)),
+        };
+
+        let output_bytes = serde_json::to_vec(&output).unwrap().len() as u64;
+        let usage = ResourceUsage::default()
+            .set_output_bytes(output_bytes)
+            .set_process_count(u32::from(matches!(
+                runtime,
+                RuntimeKind::Script | RuntimeKind::Mcp
+            )));
+        let reservation = request
+            .governor
+            .reserve(request.scope.clone(), request.estimate.clone())
+            .map_err(|_| dispatch_error_for_runtime(runtime, RuntimeDispatchErrorKind::Resource))?;
+        let receipt = request
+            .governor
+            .reconcile(reservation.id, usage.clone())
+            .map_err(|_| dispatch_error_for_runtime(runtime, RuntimeDispatchErrorKind::Resource))?;
+
+        Ok(RuntimeAdapterResult {
+            output,
+            display_preview: None,
+            output_bytes,
+            usage,
+            receipt,
+        })
+    }
+}
+
+/// Map a redacted error kind to the runtime's `DispatchError` variant, matching
+/// the production `dispatch_error_for_runtime` shape.
+pub fn dispatch_error_for_runtime(
+    runtime: RuntimeKind,
+    kind: RuntimeDispatchErrorKind,
+) -> DispatchError {
+    match runtime {
+        RuntimeKind::Wasm => DispatchError::Wasm {
+            kind,
+            safe_summary: None,
+        },
+        RuntimeKind::Script => DispatchError::Script { kind },
+        RuntimeKind::Mcp => DispatchError::Mcp { kind },
+        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
+            capability: CapabilityId::new("system.unsupported").unwrap(),
+            runtime,
+        },
+    }
+}
+
 pub fn legacy_capability_fixture_to_v2(manifest: &str) -> String {
     if manifest.contains("schema_version") {
         return manifest.to_string();

--- a/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
@@ -1,8 +1,7 @@
 mod support;
 
-use support::legacy_capability_fixture_to_v2;
+use support::{RecordingExecutor, legacy_capability_fixture_to_v2};
 
-use async_trait::async_trait;
 use ironclaw_dispatcher::*;
 use ironclaw_extensions::*;
 use ironclaw_filesystem::*;
@@ -17,14 +16,12 @@ async fn vertical_slice_discovers_and_dispatches_registered_runtime_adapters() {
     assert_eq!(registry.extensions().count(), 3);
 
     let governor = InMemoryResourceGovernor::new();
-    let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
-    let script_adapter = EchoAdapter::new(RuntimeKind::Script);
-    let mcp_adapter = EchoAdapter::new(RuntimeKind::Mcp);
     let scope = sample_scope();
-    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
-        .with_runtime_adapter(RuntimeKind::Wasm, &wasm_adapter)
-        .with_runtime_adapter(RuntimeKind::Script, &script_adapter)
-        .with_runtime_adapter(RuntimeKind::Mcp, &mcp_adapter);
+    let executor = RecordingExecutor::new()
+        .echo(RuntimeKind::Wasm)
+        .echo(RuntimeKind::Script)
+        .echo(RuntimeKind::Mcp);
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor, executor);
 
     let wasm_scope = scope.clone();
     let wasm_account = ResourceAccount::tenant(wasm_scope.tenant_id.clone());
@@ -111,70 +108,6 @@ async fn vertical_slice_discovers_and_dispatches_registered_runtime_adapters() {
         ResourceTally::default()
     );
     assert_eq!(mcp.usage.process_count, 1);
-}
-
-#[derive(Clone)]
-struct EchoAdapter {
-    runtime: RuntimeKind,
-}
-
-impl EchoAdapter {
-    fn new(runtime: RuntimeKind) -> Self {
-        Self { runtime }
-    }
-}
-
-#[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for EchoAdapter {
-    async fn dispatch_json(
-        &self,
-        request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
-    ) -> Result<RuntimeAdapterResult, DispatchError> {
-        let output = request.input;
-        let usage = ResourceUsage::default()
-            .set_output_bytes(serde_json::to_vec(&output).unwrap().len() as u64)
-            .set_process_count(u32::from(matches!(
-                self.runtime,
-                RuntimeKind::Script | RuntimeKind::Mcp
-            )));
-        let reservation = request
-            .governor
-            .reserve(request.scope, request.estimate)
-            .map_err(|_| {
-                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
-            })?;
-        let receipt = request
-            .governor
-            .reconcile(reservation.id, usage.clone())
-            .map_err(|_| {
-                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
-            })?;
-        Ok(RuntimeAdapterResult {
-            output,
-            display_preview: None,
-            output_bytes: usage.output_bytes,
-            usage,
-            receipt,
-        })
-    }
-}
-
-fn dispatch_error_for_runtime(
-    runtime: RuntimeKind,
-    kind: RuntimeDispatchErrorKind,
-) -> DispatchError {
-    match runtime {
-        RuntimeKind::Wasm => DispatchError::Wasm {
-            kind,
-            safe_summary: None,
-        },
-        RuntimeKind::Script => DispatchError::Script { kind },
-        RuntimeKind::Mcp => DispatchError::Mcp { kind },
-        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
-            capability: CapabilityId::new("system.unsupported").unwrap(),
-            runtime,
-        },
-    }
 }
 
 fn filesystem_with_echo_extensions() -> DiskFilesystem {

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -15,7 +15,7 @@ use ironclaw_approvals::{ApprovalResolver, PersistentApprovalPolicyStore};
 use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_capabilities::CapabilityObligationHandler;
 use ironclaw_dispatcher::{
-    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
+    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher, RuntimeExecutor,
 };
 use ironclaw_events::{
     AuditSink, DurableAuditLog, DurableAuditSink, DurableEventLog, DurableEventSink, EventSink,
@@ -30,7 +30,8 @@ use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{DiskFilesystem, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     CapabilityDispatcher, CapabilityId, DispatchError, ResourceReservationId, ResourceScope,
-    ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeKind, SecretHandle,
+    ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeKind, RuntimeLane,
+    SecretHandle,
     runtime_policy::{
         DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind, NetworkMode,
         ProcessBackendKind, RuntimeProfile, SecretMode,
@@ -103,7 +104,7 @@ pub use production_wiring::{
     ProductionWiringIssue, ProductionWiringIssueKind, ProductionWiringReport,
 };
 use runtime_adapters::{
-    FirstPartyRuntimeAdapter, McpRuntimeAdapter, ScriptRuntimeAdapter,
+    FirstPartyRuntimeAdapter, McpRuntimeAdapter, RuntimeLaneExecutor, ScriptRuntimeAdapter,
     ServiceResolvedRuntimeAdapter, WasmRuntimeAdapter,
 };
 
@@ -381,18 +382,12 @@ where
             .wasm_runtime_credential_provider_captured
     }
 
-    /// Builds a runtime dispatcher with every configured runtime adapter.
-    fn runtime_dispatcher(&self) -> RuntimeDispatcher<'static, F, G> {
-        let mut dispatcher = RuntimeDispatcher::from_shared_registry(
-            Arc::clone(&self.registry),
-            Arc::clone(&self.filesystem),
-            Arc::clone(&self.governor),
-        )
-        .with_runtime_policy(
-            self.runtime_policy
-                .clone()
-                .unwrap_or_else(local_testing_runtime_policy),
-        );
+    /// Builds a runtime dispatcher over the closed [`RuntimeLaneExecutor`].
+    ///
+    /// Each configured lane becomes an enum variant; the dispatcher holds one
+    /// monomorphized executor and routes by `RuntimeLane` match rather than a
+    /// per-lane trait-object registry (arch-simplification §4.2).
+    fn runtime_dispatcher(&self) -> RuntimeDispatcher<'static, F, G, RuntimeLaneExecutor> {
         let mut invocation_services_resolver = LocalInvocationServicesResolver::new(
             Arc::clone(&self.filesystem) as Arc<dyn RootFilesystem>,
             runtime_http_egress(&self.runtime_http_egress),
@@ -416,42 +411,46 @@ where
         let invocation_services: Arc<dyn InvocationServicesResolver> =
             Arc::new(invocation_services_resolver);
 
-        if let Some(runtime) = &self.script_runtime {
-            dispatcher = dispatcher.with_runtime_adapter_arc(
-                RuntimeKind::Script,
-                Arc::new(ServiceResolvedRuntimeAdapter::new(
-                    Arc::new(ScriptRuntimeAdapter::from_executor(Arc::clone(runtime))),
-                    Arc::clone(&invocation_services),
-                )),
-            );
-        }
-        if let Some(runtime) = &self.mcp_runtime {
-            dispatcher = dispatcher.with_runtime_adapter_arc(
-                RuntimeKind::Mcp,
-                Arc::new(ServiceResolvedRuntimeAdapter::new(
-                    Arc::new(McpRuntimeAdapter::from_executor(Arc::clone(runtime))),
-                    Arc::clone(&invocation_services),
-                )),
-            );
-        }
-        if let Some(runtime) = &self.first_party_runtime {
-            dispatcher = dispatcher.with_runtime_adapter_arc(
-                RuntimeKind::FirstParty,
-                Arc::new(FirstPartyRuntimeAdapter::from_registry(
-                    Arc::clone(runtime),
-                    Arc::clone(&invocation_services),
-                )),
-            );
-        }
-        if let Some(runtime) = &self.wasm_runtime {
-            dispatcher = dispatcher.with_runtime_adapter_arc(
-                RuntimeKind::Wasm,
-                Arc::new(ServiceResolvedRuntimeAdapter::new(
-                    Arc::clone(runtime),
-                    Arc::clone(&invocation_services),
-                )),
-            );
-        }
+        // `Script` executes on the `Process` lane; `Mcp`/`Wasm` keep the
+        // service-resolution decorator; `FirstParty` resolves services itself
+        // (so it is not double-wrapped) — preserving the prior wiring exactly.
+        let process = self.script_runtime.as_ref().map(|runtime| {
+            ServiceResolvedRuntimeAdapter::new(
+                Arc::new(ScriptRuntimeAdapter::from_executor(Arc::clone(runtime))),
+                Arc::clone(&invocation_services),
+            )
+        });
+        let mcp = self.mcp_runtime.as_ref().map(|runtime| {
+            ServiceResolvedRuntimeAdapter::new(
+                Arc::new(McpRuntimeAdapter::from_executor(Arc::clone(runtime))),
+                Arc::clone(&invocation_services),
+            )
+        });
+        let first_party = self.first_party_runtime.as_ref().map(|runtime| {
+            FirstPartyRuntimeAdapter::from_registry(
+                Arc::clone(runtime),
+                Arc::clone(&invocation_services),
+            )
+        });
+        let wasm = self.wasm_runtime.as_ref().map(|runtime| {
+            ServiceResolvedRuntimeAdapter::new(
+                Arc::clone(runtime),
+                Arc::clone(&invocation_services),
+            )
+        });
+        let executor = RuntimeLaneExecutor::new(first_party, wasm, mcp, process);
+
+        let mut dispatcher = RuntimeDispatcher::from_shared_registry(
+            Arc::clone(&self.registry),
+            Arc::clone(&self.filesystem),
+            Arc::clone(&self.governor),
+            executor,
+        )
+        .with_runtime_policy(
+            self.runtime_policy
+                .clone()
+                .unwrap_or_else(local_testing_runtime_policy),
+        );
         if let Some(event_sink) = &self.event_sink {
             dispatcher = dispatcher.with_event_sink_arc(Arc::clone(event_sink));
         }

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -221,50 +221,73 @@ where
         }
     }
 
-    async fn dispatch_json(
-        &self,
+    // Hand-desugared (no `async fn`): the router RETURNS the lane adapter's
+    // already-boxed `#[async_trait]` future instead of wrapping it in a future
+    // of its own. The former `dyn RuntimeAdapter` registry contributed exactly
+    // one boxed future here; an `async fn` router would stack a second one on
+    // top of it, and the Reborn trace suite runs close enough to the 2 MiB
+    // test-thread stack limit that the extra layer overflowed it in CI
+    // (`reborn_trace_skill_management_first_party_tools_parity`). Zero-depth
+    // forwarding restores exact structural parity with the dyn registry while
+    // keeping the closed lane set.
+    #[allow(clippy::type_complexity)]
+    fn dispatch_json<'life0, 'life1, 'async_trait>(
+        &'life0 self,
         lane: RuntimeLane,
-        request: RuntimeAdapterRequest<'_, F, G>,
-    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        request: RuntimeAdapterRequest<'life1, F, G>,
+    ) -> core::pin::Pin<
+        Box<
+            dyn core::future::Future<Output = Result<RuntimeAdapterResult, DispatchError>>
+                + Send
+                + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
         match lane {
-            RuntimeLane::FirstParty => {
-                dispatch_configured_lane(self.first_party.as_ref(), request).await
-            }
-            RuntimeLane::Wasm => dispatch_configured_lane(self.wasm.as_ref(), request).await,
-            RuntimeLane::Mcp => dispatch_configured_lane(self.mcp.as_ref(), request).await,
-            RuntimeLane::Process => dispatch_configured_lane(self.process.as_ref(), request).await,
+            RuntimeLane::FirstParty => match self.first_party.as_ref() {
+                Some(adapter) => adapter.dispatch_json(request),
+                None => Box::pin(fail_unconfigured_lane(request)),
+            },
+            RuntimeLane::Wasm => match self.wasm.as_ref() {
+                Some(adapter) => adapter.dispatch_json(request),
+                None => Box::pin(fail_unconfigured_lane(request)),
+            },
+            RuntimeLane::Mcp => match self.mcp.as_ref() {
+                Some(adapter) => adapter.dispatch_json(request),
+                None => Box::pin(fail_unconfigured_lane(request)),
+            },
+            RuntimeLane::Process => match self.process.as_ref() {
+                Some(adapter) => adapter.dispatch_json(request),
+                None => Box::pin(fail_unconfigured_lane(request)),
+            },
         }
     }
 }
 
-/// Delegate to a lane's concrete adapter, or fail closed if the lane is
-/// unconfigured. The dispatcher gates this with `supports_lane`, so the `None`
-/// arm is defensive; it still releases any prepared reservation rather than
-/// leaking it.
-async fn dispatch_configured_lane<F, G, A>(
-    adapter: Option<&A>,
+/// Fail closed for an unconfigured lane. The dispatcher gates dispatch with
+/// `supports_lane`, so this arm is defensive; it still releases any prepared
+/// reservation rather than leaking it.
+async fn fail_unconfigured_lane<F, G>(
     request: RuntimeAdapterRequest<'_, F, G>,
 ) -> Result<RuntimeAdapterResult, DispatchError>
 where
     F: RootFilesystem,
     G: ResourceGovernor,
-    A: RuntimeAdapter<F, G> + ?Sized,
 {
-    match adapter {
-        Some(adapter) => adapter.dispatch_json(request).await,
-        None => {
-            release_adapter_reservation(
-                request.governor,
-                request
-                    .resource_reservation
-                    .as_ref()
-                    .map(|reservation| reservation.id),
-            );
-            Err(DispatchError::MissingRuntimeBackend {
-                runtime: request.descriptor.runtime,
-            })
-        }
-    }
+    release_adapter_reservation(
+        request.governor,
+        request
+            .resource_reservation
+            .as_ref()
+            .map(|reservation| reservation.id),
+    );
+    Err(DispatchError::MissingRuntimeBackend {
+        runtime: request.descriptor.runtime,
+    })
 }
 
 #[derive(Clone)]

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -14,10 +14,10 @@ use super::{
     McpError, McpExecutionRequest, McpExecutor, McpInvocation, NetworkObligationPolicyStore,
     PlannerError, PreparedWitTool, ResourceGovernor, ResourceReservationId, ResourceScope,
     RootFilesystem, RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult,
-    RuntimeDispatchErrorKind, RuntimeKind, ScriptError, ScriptExecutionRequest, ScriptExecutor,
-    ScriptInvocation, SharedRuntimeHttpEgress, WasmError, WasmRuntimeCredentialProvider,
-    WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WitToolHost, WitToolRuntime,
-    WitToolRuntimeConfig, plan_capability, runtime_http_egress,
+    RuntimeDispatchErrorKind, RuntimeExecutor, RuntimeKind, RuntimeLane, ScriptError,
+    ScriptExecutionRequest, ScriptExecutor, ScriptInvocation, SharedRuntimeHttpEgress, WasmError,
+    WasmRuntimeCredentialProvider, WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WitToolHost,
+    WitToolRuntime, WitToolRuntimeConfig, plan_capability, runtime_http_egress,
 };
 use crate::{
     FirstPartyCapabilityError,
@@ -168,6 +168,102 @@ where
             })?;
 
         self.inner.dispatch_json(request).await
+    }
+}
+
+/// Closed runtime-lane router: the host-runtime-side [`RuntimeExecutor`] the
+/// dispatcher monomorphizes over (arch-simplification §4.2, `dyn`→enum collapse
+/// of the capability hot path). Each configured lane is a field; adding a
+/// [`RuntimeLane`] variant is a compile error until the two exhaustive matches
+/// below handle it (the §4.2 safety property).
+///
+/// Lanes are `Option` because composition wires them conditionally on which
+/// runtimes are configured — exactly as the prior per-lane registry populated
+/// only the configured `RuntimeKind`s. The dispatcher checks
+/// [`RuntimeExecutor::supports_lane`] before selecting a runtime, so an
+/// unconfigured lane fails closed with `MissingRuntimeBackend` and no
+/// reservation.
+pub(super) struct RuntimeLaneExecutor {
+    first_party: Option<FirstPartyRuntimeAdapter>,
+    wasm: Option<ServiceResolvedRuntimeAdapter<WasmRuntimeAdapter>>,
+    mcp: Option<ServiceResolvedRuntimeAdapter<McpRuntimeAdapter>>,
+    process: Option<ServiceResolvedRuntimeAdapter<ScriptRuntimeAdapter>>,
+}
+
+impl RuntimeLaneExecutor {
+    pub(super) fn new(
+        first_party: Option<FirstPartyRuntimeAdapter>,
+        wasm: Option<ServiceResolvedRuntimeAdapter<WasmRuntimeAdapter>>,
+        mcp: Option<ServiceResolvedRuntimeAdapter<McpRuntimeAdapter>>,
+        process: Option<ServiceResolvedRuntimeAdapter<ScriptRuntimeAdapter>>,
+    ) -> Self {
+        Self {
+            first_party,
+            wasm,
+            mcp,
+            process,
+        }
+    }
+}
+
+#[async_trait]
+impl<F, G> RuntimeExecutor<F, G> for RuntimeLaneExecutor
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    fn supports_lane(&self, lane: RuntimeLane) -> bool {
+        match lane {
+            RuntimeLane::FirstParty => self.first_party.is_some(),
+            RuntimeLane::Wasm => self.wasm.is_some(),
+            RuntimeLane::Mcp => self.mcp.is_some(),
+            RuntimeLane::Process => self.process.is_some(),
+        }
+    }
+
+    async fn dispatch_json(
+        &self,
+        lane: RuntimeLane,
+        request: RuntimeAdapterRequest<'_, F, G>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        match lane {
+            RuntimeLane::FirstParty => {
+                dispatch_configured_lane(self.first_party.as_ref(), request).await
+            }
+            RuntimeLane::Wasm => dispatch_configured_lane(self.wasm.as_ref(), request).await,
+            RuntimeLane::Mcp => dispatch_configured_lane(self.mcp.as_ref(), request).await,
+            RuntimeLane::Process => dispatch_configured_lane(self.process.as_ref(), request).await,
+        }
+    }
+}
+
+/// Delegate to a lane's concrete adapter, or fail closed if the lane is
+/// unconfigured. The dispatcher gates this with `supports_lane`, so the `None`
+/// arm is defensive; it still releases any prepared reservation rather than
+/// leaking it.
+async fn dispatch_configured_lane<F, G, A>(
+    adapter: Option<&A>,
+    request: RuntimeAdapterRequest<'_, F, G>,
+) -> Result<RuntimeAdapterResult, DispatchError>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+    A: RuntimeAdapter<F, G> + ?Sized,
+{
+    match adapter {
+        Some(adapter) => adapter.dispatch_json(request).await,
+        None => {
+            release_adapter_reservation(
+                request.governor,
+                request
+                    .resource_reservation
+                    .as_ref()
+                    .map(|reservation| reservation.id),
+            );
+            Err(DispatchError::MissingRuntimeBackend {
+                runtime: request.descriptor.runtime,
+            })
+        }
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -5,8 +5,8 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_dispatcher::{
-    CapabilityDispatcher, DispatchError, RuntimeAdapter, RuntimeAdapterRequest,
-    RuntimeAdapterResult, RuntimeDispatchErrorKind, RuntimeDispatcher,
+    CapabilityDispatcher, DispatchError, RuntimeAdapterRequest, RuntimeAdapterResult,
+    RuntimeDispatchErrorKind, RuntimeDispatcher, RuntimeExecutor,
 };
 use ironclaw_extensions::{
     CapabilityVisibility, ExtensionError, ExtensionLifecycleService, ExtensionManifest,
@@ -17,8 +17,8 @@ use ironclaw_host_api::{
     CapabilityId, EffectKind, ExtensionId, HostPath, MountView, NetworkScheme,
     NetworkTargetPattern, PermissionMode, ReservationStatus, ResourceEstimate,
     ResourceReservationId, ResourceScope, ResourceUsage, RuntimeCredentialAccountProviderId,
-    RuntimeCredentialRequirementSource, RuntimeCredentialTarget, RuntimeKind, SecretHandle,
-    TenantId, UserId, VirtualPath,
+    RuntimeCredentialRequirementSource, RuntimeCredentialTarget, RuntimeKind, RuntimeLane,
+    SecretHandle, TenantId, UserId, VirtualPath,
 };
 use ironclaw_host_runtime::{
     default_host_api_contract_registry, default_host_port_catalog,
@@ -85,13 +85,13 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
                 .set_max_output_bytes(10_000),
         )
         .unwrap();
-    let adapter = Arc::new(RecordingAdapter::new(
-        RuntimeKind::Script,
-        json!({"message":"script ok"}),
-    ));
-    let dispatcher =
-        RuntimeDispatcher::from_arcs(Arc::new(discovered), Arc::new(fs), Arc::clone(&governor))
-            .with_runtime_adapter_arc(RuntimeKind::Script, Arc::clone(&adapter));
+    let adapter = RecordingAdapter::new(RuntimeKind::Script, json!({"message":"script ok"}));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        Arc::new(discovered),
+        Arc::new(fs),
+        Arc::clone(&governor),
+        adapter.clone(),
+    );
     let dispatch_port: &dyn CapabilityDispatcher = &dispatcher;
     let reservation = governor.reserve(scope.clone(), estimate.clone()).unwrap();
     let reservation_id = reservation.id;
@@ -471,9 +471,14 @@ struct RecordedAdapterRequest {
 }
 
 #[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+impl RuntimeExecutor<DiskFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+    fn supports_lane(&self, lane: RuntimeLane) -> bool {
+        RuntimeLane::from_runtime_kind(self.runtime) == Some(lane)
+    }
+
     async fn dispatch_json(
         &self,
+        _lane: RuntimeLane,
         request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedAdapterRequest {

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -10,7 +10,7 @@ use std::sync::{
 use async_trait::async_trait;
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_dispatcher::{
-    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
+    RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher, RuntimeExecutor,
 };
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
@@ -196,9 +196,14 @@ impl RecordingRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
+impl RuntimeExecutor<DiskFilesystem, InMemoryResourceGovernor> for RecordingRuntimeAdapter {
+    fn supports_lane(&self, lane: RuntimeLane) -> bool {
+        lane == RuntimeLane::Wasm
+    }
+
     async fn dispatch_json(
         &self,
+        _lane: RuntimeLane,
         request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         self.requests.lock().unwrap().push(RecordedRuntimeRequest {
@@ -284,11 +289,18 @@ impl TrustAwareCapabilityDispatchAuthorizer for ObligatingAuthorizer {
     }
 }
 
+type RecordingDispatcher = RuntimeDispatcher<
+    'static,
+    DiskFilesystem,
+    InMemoryResourceGovernor,
+    Arc<RecordingRuntimeAdapter>,
+>;
+
 fn runtime_dispatcher_stack(
     adapter: Arc<RecordingRuntimeAdapter>,
 ) -> (
     Arc<ExtensionRegistry>,
-    RuntimeDispatcher<'static, DiskFilesystem, InMemoryResourceGovernor>,
+    RecordingDispatcher,
     Arc<InMemoryResourceGovernor>,
     InMemoryEventSink,
 ) {
@@ -296,10 +308,13 @@ fn runtime_dispatcher_stack(
     let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let events = InMemoryEventSink::new();
-    let dispatcher =
-        RuntimeDispatcher::from_arcs(Arc::clone(&registry), filesystem, Arc::clone(&governor))
-            .with_runtime_adapter_arc(RuntimeKind::Wasm, adapter)
-            .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        Arc::clone(&registry),
+        filesystem,
+        Arc::clone(&governor),
+        adapter,
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
     (registry, dispatcher, governor, events)
 }
 

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -9,7 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_dispatcher::{
-    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
+    RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher, RuntimeExecutor,
 };
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
 use ironclaw_extensions::{
@@ -36,9 +36,13 @@ async fn wasm_lane_loads_component_from_root_filesystem_and_uses_fresh_instances
     let governor = Arc::new(governor_with_default_limit(sample_account()));
     let events = InMemoryEventSink::new();
     let adapter = Arc::new(WasmRuntimeAdapter::new());
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::clone(&adapter),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let first = dispatcher
         .dispatch_json(dispatch_request("wasm-smoke.count", json!({"call":1})))
@@ -89,9 +93,13 @@ async fn wasm_lane_guest_trap_releases_reservation_and_preserves_dispatch_failur
     let registry = Arc::new(registry_with_package(WASM_TRAP_MANIFEST));
     let governor = Arc::new(governor_with_default_limit(sample_account()));
     let events = InMemoryEventSink::new();
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::new(WasmRuntimeAdapter::new()),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request("wasm-smoke.trap", json!({"call":"trap"})))
@@ -153,9 +161,9 @@ async fn wasm_lane_execution_failure_reconciles_preserved_usage_from_runtime() {
     let adapter = Arc::new(WasmRuntimeAdapter::with_host(
         WitToolHost::deny_all().with_http(wasm_http),
     ));
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, adapter)
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher =
+        RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor), adapter)
+            .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request(
@@ -207,9 +215,13 @@ async fn wasm_lane_missing_module_file_returns_sanitized_filesystem_error() {
     let governor = Arc::new(governor_with_default_limit(sample_account()));
     let events = InMemoryEventSink::new();
     let adapter = Arc::new(WasmRuntimeAdapter::new());
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::clone(&adapter),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request(
@@ -253,9 +265,13 @@ async fn wasm_lane_malformed_module_returns_sanitized_manifest_error() {
     let registry = Arc::new(registry_with_package(WASM_MANIFEST));
     let governor = Arc::new(governor_with_default_limit(sample_account()));
     let events = InMemoryEventSink::new();
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::new(WasmRuntimeAdapter::new()),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request(
@@ -312,9 +328,13 @@ async fn wasm_lane_invalid_output_json_returns_sanitized_output_error() {
     let registry = Arc::new(registry_with_package(WASM_MANIFEST));
     let governor = Arc::new(governor_with_default_limit(sample_account()));
     let events = InMemoryEventSink::new();
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::new(WasmRuntimeAdapter::new()),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request(
@@ -361,9 +381,13 @@ async fn wasm_lane_rejects_unsupported_import_through_dispatcher_without_reserva
     let governor = Arc::new(governor_with_default_limit(sample_account()));
     let events = InMemoryEventSink::new();
     let adapter = Arc::new(WasmRuntimeAdapter::new());
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::clone(&adapter),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request(
@@ -421,9 +445,13 @@ async fn wasm_lane_enforces_memory_growth_budget_through_dispatcher() {
             .with_fuel(100_000)
             .with_timeout(Duration::from_secs(5)),
     });
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(adapter))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::new(adapter),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request(
@@ -497,9 +525,13 @@ async fn wasm_lane_caps_overdue_host_import_at_dispatch_execution_deadline() {
                 .with_timeout(Duration::from_millis(20)),
         },
     );
-    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(adapter))
-        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        registry,
+        Arc::new(fs),
+        Arc::clone(&governor),
+        Arc::new(adapter),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
 
     let err = dispatcher
         .dispatch_json(dispatch_request(
@@ -628,9 +660,14 @@ impl WasmRuntimeAdapter {
 }
 
 #[async_trait]
-impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for WasmRuntimeAdapter {
+impl RuntimeExecutor<DiskFilesystem, InMemoryResourceGovernor> for WasmRuntimeAdapter {
+    fn supports_lane(&self, lane: RuntimeLane) -> bool {
+        lane == RuntimeLane::Wasm
+    }
+
     async fn dispatch_json(
         &self,
+        _lane: RuntimeLane,
         request: RuntimeAdapterRequest<'_, DiskFilesystem, InMemoryResourceGovernor>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
         let module_path = match &request.package.manifest.runtime {


### PR DESCRIPTION
## What

Collapses the `RuntimeAdapter` open-trait `dyn` into a closed `RuntimeLane` match (arch-simplification §4.2). Removes trait-object dispatch + the per-lane vtable `HashMap` on the capability hot path.

`RuntimeDispatcher` no longer holds `HashMap<RuntimeKind, ServiceHandle<dyn RuntimeAdapter<F,G>>>`. It now holds **one** monomorphized `E: RuntimeExecutor<F,G>` resolved once at composition (§4.2 "a single generic parameter resolved once at composition"), and routes each capability by matching the resolved `RuntimeLane`.

**Full enum collapse achieved** — no minimal-fallback remainder.

## How

- **`ironclaw_dispatcher`** (port only — dep boundary respected):
  - New `RuntimeExecutor<F,G>` trait: `supports_lane(RuntimeLane) -> bool` + `dispatch_json(RuntimeLane, RuntimeAdapterRequest) -> Result<RuntimeAdapterResult, DispatchError>`, plus a blanket impl for `Arc<T>`.
  - `RuntimeDispatcher<'a,F,G,E>` gains the generic `E`, drops the adapters map and the `with_runtime_adapter*` builders.
  - Routing resolves `RuntimeLane::from_runtime_kind(descriptor.runtime)`. `None` (host-internal `System`) **and** an unconfigured lane both fail closed with the redacted `MissingRuntimeBackend` — emitted **before** `RuntimeSelected` and before `reservation_guard.take()`, so the prepared-reservation guard still drops and releases (event ordering + release-on-failure preserved exactly).
  - `RuntimeAdapter` is kept as the per-lane execution shape (called by static dispatch), no longer used as a trait object.
- **`ironclaw_host_runtime`** (closed executor set lives here — the executors depend on WASM/Script/MCP, which the dispatcher crate must not):
  - New closed `RuntimeLaneExecutor` enum-shaped struct `{ first_party, wasm, mcp, process }` implementing `RuntimeExecutor` with an **exhaustive `match RuntimeLane`** (the §4.2 safety property — a new lane is a compile error until every arm handles it). `Script` executes on the `Process` lane.
  - `runtime_dispatcher()` builds `RuntimeLaneExecutor` from the configured lanes instead of chained `with_runtime_adapter_arc` calls.

### `ServiceResolved` decorator + reservation-release path
Preserved as the **smaller behavior-preserving diff**: the enum keeps wrapping each concrete executor in its variant — `Mcp`/`Wasm` stay wrapped in `ServiceResolvedRuntimeAdapter` (runs `plan_capability` + `invocation_services.resolve`, releasing the reservation on failure), and `FirstParty` continues to resolve services itself (not double-wrapped). No reservation-release-on-failure path was dropped. The enum's `None` arm (unreachable in production because the dispatcher gates with `supports_lane`) also releases any prepared reservation defensively.

### `<F,G>` generics outcome
Kept intact and unchanged. `RuntimeExecutor<F,G>` carries the same `F: RootFilesystem, G: ResourceGovernor` bounds; `RuntimeLaneExecutor`'s impl is generic over `F,G` while the struct holds the concrete (non-`F,G`) adapters, so no `PhantomData` was needed. `RuntimeAdapterRequest`/`RuntimeAdapterResult`, `DispatchError`, and `CapabilityDispatchRequest` are **unchanged** (routing mechanism only; no DTO or `dispatch(Authorized)`/`Resolution` migration).

## Tests
- Consolidated the four per-file dispatcher `RuntimeAdapter` doubles into **one shared `RecordingExecutor`** in `tests/support/mod.rs` (echo/static/fail per lane, records the routed `RuntimeLane`). Migrated the host_runtime / wasm / capabilities integration doubles from `impl RuntimeAdapter` to `impl RuntimeExecutor` (single-lane), keeping `Arc`-shared request inspection via the blanket `Arc<T>` impl.
- **New negative test** (`dispatcher_fails_closed_for_system_runtime_without_routing_to_a_lane`): a `System` `RuntimeKind` (`from_runtime_kind == None`) fails closed with `MissingRuntimeBackend`, reserves nothing, and never consults the executor — even with all four lanes wired.
- The contract suites (`dispatch_contract`, `event_dispatch_contract`, `runtime_dispatcher_integration`, `vertical_slice_contract`) stay green and still assert the routed runtime/adapter + result.

### Verification (all green)
- `cargo test -p ironclaw_dispatcher` — 10 + 7 + 4 + 1 + 1 pass
- `cargo test -p ironclaw_host_runtime` — full suite pass (exit 0)
- `cargo test -p ironclaw_wasm -p ironclaw_capabilities` — pass
- `cargo test -p ironclaw_architecture` — pass (dep-boundary held; no WASM/Script/MCP dep added to the dispatcher crate)
- `cargo clippy -p ironclaw_dispatcher -p ironclaw_host_runtime -p ironclaw_wasm -p ironclaw_capabilities --all-targets --all-features` — zero warnings
- `cargo build --workspace` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)