### PR TITLE
feat(run_state): persistent GateRecordStore for the capability-result collapse (§5.2.9)

### DIFF
--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -325,6 +325,7 @@ pub(crate) fn run_state_error_kind(error: &RunStateError) -> &'static str {
         RunStateError::InvocationAlreadyExists { .. } => "InvocationAlreadyExists",
         RunStateError::UnknownApprovalRequest { .. } => "UnknownApprovalRequest",
         RunStateError::ApprovalRequestAlreadyExists { .. } => "ApprovalRequestAlreadyExists",
+        RunStateError::GateRecordAlreadyExists { .. } => "GateRecordAlreadyExists",
         RunStateError::ApprovalNotPending { .. } => "ApprovalNotPending",
         RunStateError::InvalidPath(_) => "InvalidPath",
         RunStateError::Filesystem(_) => "Filesystem",

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -1942,6 +1942,7 @@ fn unavailable_from_run_state(error: RunStateError) -> HostRuntimeError {
         RunStateError::InvocationAlreadyExists { .. } => "run-state record already exists",
         RunStateError::UnknownApprovalRequest { .. } => "approval request not found",
         RunStateError::ApprovalRequestAlreadyExists { .. } => "approval request already exists",
+        RunStateError::GateRecordAlreadyExists { .. } => "gate record already exists",
         RunStateError::ApprovalNotPending { .. } => "approval request not pending",
         RunStateError::InvalidPath(_) => "run-state storage path invalid",
         RunStateError::Filesystem(_) => "run-state filesystem unavailable",

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -669,6 +669,7 @@ const PER_USER_ALIASES: &[&str] = &[
     "/outbound",
     "/run-state",
     "/approvals",
+    "/gate-records",
     "/threads",
     "/conversations",
     "/turns",
@@ -1407,5 +1408,57 @@ mod two_tenant_isolation_tests {
         let lease_b = store.lease_once(&scope_b, &handle).await.unwrap();
         let material_b = store.consume(&scope_b, lease_b.id).await.unwrap();
         assert_eq!(material_b.expose_secret(), "bob-secret");
+    }
+}
+
+#[cfg(test)]
+mod gate_record_production_mount_tests {
+    //! Production-shape mount coverage for the `/gate-records` alias: drives the
+    //! `GateRecordStore` seam over the real `wrap_scoped`/`invocation_mount_view`
+    //! wiring. Pins two things: the alias is actually registered in
+    //! [`PER_USER_ALIASES`] (an unregistered alias fails every save with
+    //! `MountNotFound`, making the store unusable in production), and the
+    //! per-tenant path rewriting keeps identically-shaped refs from colliding
+    //! across tenants.
+    use super::*;
+    use ironclaw_filesystem::InMemoryBackend;
+    use ironclaw_host_api::{
+        GateRecord, GateRef, InvocationId, ProjectId, SafeSummary, TenantId, UserId,
+    };
+    use ironclaw_run_state::{FilesystemGateRecordStore, GateRecordStore};
+
+    fn scope(tenant: &str, user: &str) -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new(tenant).unwrap(),
+            user_id: UserId::new(user).unwrap(),
+            agent_id: None,
+            project_id: Some(ProjectId::new("default").unwrap()),
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_records_save_and_load_through_the_production_mount_view() {
+        let scoped = wrap_scoped(Arc::new(InMemoryBackend::new()));
+        let store = FilesystemGateRecordStore::new(scoped);
+        let record = GateRecord::Approval {
+            summary: SafeSummary::new("awaiting decision").unwrap(),
+        };
+        let gate_ref = GateRef::new();
+        let scope_a = scope("tenant_a", "alice");
+
+        // The alias must resolve (a missing PER_USER_ALIASES entry fails here
+        // with MountNotFound), and the owner must read the record back.
+        store
+            .save(scope_a.clone(), gate_ref, record.clone())
+            .await
+            .unwrap();
+        assert_eq!(store.load(&scope_a, gate_ref).await.unwrap(), Some(record));
+
+        // Structural tenant isolation: same ref, different tenant → unknown.
+        let scope_b = scope("tenant_b", "bob");
+        assert_eq!(store.load(&scope_b, gate_ref).await.unwrap(), None);
     }
 }

--- a/crates/ironclaw_run_state/CLAUDE.md
+++ b/crates/ironclaw_run_state/CLAUDE.md
@@ -1,6 +1,6 @@
 # ironclaw_run_state guardrails
 
-- Own durable invocation state and approval request records.
+- Own durable invocation state, approval request records, and gate records (the model-visible `GateRecord` a pending gate renders from, keyed by `GateRef`; arch-simplification §5.2.9).
 - Do not own authorization policy, approval resolution, dispatch, runtime execution, process lifecycle, or product workflow.
 - All lookups and transitions are resource-owner scoped (tenant/user/agent/project/mission/thread); wrong-scope access must look unknown.
 - Durable persistence is the `Filesystem*Store` pair over a `ScopedFilesystem`; there are no separate per-backend run-state stores. The PostgreSQL/libSQL choice (gated by the `postgres`/`libsql` features) is made at the `RootFilesystem` layer underneath, not here. Writes use compare-and-swap (`CasExpectation::Version`) over versioned roots; only byte-only/`Unsupported` roots fall back to process-local serialization.

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -4,8 +4,8 @@
 //! invocations. It is separate from runtime events: events are append-only
 //! history, while run state answers "what is this invocation waiting on now?".
 //!
-//! Durable persistence is provided by [`FilesystemRunStateStore`] and
-//! [`FilesystemApprovalRequestStore`] over a
+//! Durable persistence is provided by [`FilesystemRunStateStore`],
+//! [`FilesystemApprovalRequestStore`], and [`FilesystemGateRecordStore`] over a
 //! [`ScopedFilesystem`](ironclaw_filesystem::ScopedFilesystem). The
 //! `RootFilesystem` choice (libSQL-backed, PostgreSQL-backed, in-memory, or
 //! local-disk) is made at the filesystem layer — the consumer-store level no
@@ -19,8 +19,8 @@ use ironclaw_filesystem::{
     ScopedFilesystem, cas_update,
 };
 use ironclaw_host_api::{
-    ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationId, ResourceScope,
-    ScopedPath, UserId,
+    ApprovalRequest, ApprovalRequestId, CapabilityId, GateRecord, GateRef, HostApiError,
+    InvocationId, ResourceScope, ScopedPath, UserId,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -29,8 +29,8 @@ use thiserror::Error;
 mod test_support;
 #[cfg(any(test, feature = "test-support"))]
 pub use test_support::{
-    in_memory_backed_approval_request_store, in_memory_backed_run_state_filesystem,
-    in_memory_backed_run_state_store,
+    in_memory_backed_approval_request_store, in_memory_backed_gate_record_store,
+    in_memory_backed_run_state_filesystem, in_memory_backed_run_state_store,
 };
 
 /// Current lifecycle state for one invocation.
@@ -96,6 +96,8 @@ pub enum RunStateError {
     UnknownApprovalRequest { request_id: ApprovalRequestId },
     #[error("approval request {request_id} already exists")]
     ApprovalRequestAlreadyExists { request_id: ApprovalRequestId },
+    #[error("gate record {gate_ref} already exists")]
+    GateRecordAlreadyExists { gate_ref: GateRef },
     #[error("approval request {request_id} is not pending (status: {status:?})")]
     ApprovalNotPending {
         request_id: ApprovalRequestId,
@@ -237,6 +239,48 @@ pub trait RunStateApprovalStore: RunStateStore + ApprovalRequestStore {
     ) -> Result<RunRecord, RunStateError>;
 }
 
+/// Durable store for the model-visible [`GateRecord`] a pending gate renders
+/// from (arch-simplification §5.2.9).
+///
+/// A [`Resolution`](ironclaw_host_api::Resolution) control-plane arm carries only
+/// an opaque [`GateRef`]; the content the loop renders the pending gate from —
+/// the auth gate's credential requirements (G3), the dependent-run staged result
+/// handle (G2), the redacted summary — lives in the referenced [`GateRecord`].
+/// Because a gate blocks on one turn and resumes on a **later** turn, that record
+/// must outlive the turn that produced it, so it needs persistence keyed by
+/// `GateRef`. (The sibling terminal `DenyRecord` is same-turn and needs no store.)
+///
+/// This port mirrors [`ApprovalRequestStore`]: resource-owner scoped, wrong-scope
+/// lookups look unknown. It intentionally exposes no removal method — a
+/// `GateRecord` is host-owned, write-once, model-visible content with no status
+/// field to tombstone, so (unlike `ApprovalRequestStore::discard_pending`, which
+/// tombstones a lifecycle *status*) there is no scope-safe soft-delete to mirror,
+/// and hard deletion of retained model-visible data would need an explicit
+/// product/retention contract (`database.md` "Data safety").
+#[async_trait]
+pub trait GateRecordStore: Send + Sync {
+    /// Persists the gate record for `gate_ref` in the exact resource-owner scope.
+    ///
+    /// Write-once: a `gate_ref` that already has a record is a
+    /// [`RunStateError::GateRecordAlreadyExists`], mirroring
+    /// [`ApprovalRequestStore::save_pending`]. `GateRef`s are freshly minted per
+    /// gate, so a collision is a caller invariant violation, not an update path.
+    async fn save(
+        &self,
+        scope: ResourceScope,
+        gate_ref: GateRef,
+        record: GateRecord,
+    ) -> Result<(), RunStateError>;
+
+    /// Loads the gate record for `gate_ref`; a wrong-scope lookup must look
+    /// unknown (`Ok(None)`), never leak another owner's record.
+    async fn load(
+        &self,
+        scope: &ResourceScope,
+        gate_ref: GateRef,
+    ) -> Result<Option<GateRecord>, RunStateError>;
+}
+
 /// `RecordKind` tag written on every run-state entry so byte-only backends
 /// (e.g. `DiskFilesystem`) are rejected with `Unsupported{WriteFile}` on
 /// first put, which `cas_update` maps to `CasUnsupported` (fail-closed).
@@ -245,6 +289,10 @@ const RUN_STATE_RECORD_KIND: &str = "run_state_record";
 /// `RecordKind` tag written on every approval-request entry for the same
 /// fail-closed CAS gate as [`RUN_STATE_RECORD_KIND`].
 const APPROVAL_RECORD_KIND: &str = "approval_record";
+
+/// `RecordKind` tag written on every gate-record entry for the same
+/// fail-closed CAS gate as [`RUN_STATE_RECORD_KIND`].
+const GATE_RECORD_KIND: &str = "gate_record";
 
 /// Filesystem-backed run-state store under the `/run-state` mount alias.
 ///
@@ -716,10 +764,111 @@ where
     }
 }
 
+/// Durable wrapper carrying the resource-owner scope alongside the host-owned
+/// [`GateRecord`]. `GateRecord` is a `host_api` vocabulary type with no scope
+/// field; persisting the scope beside it lets [`FilesystemGateRecordStore::load`]
+/// apply the same `same_scope_owner` defense-in-depth check the sibling
+/// [`ApprovalRecord`] does, so a wrong-scope read looks unknown. The scope is
+/// storage metadata only — `load` returns the bare [`GateRecord`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct StoredGateRecord {
+    scope: ResourceScope,
+    record: GateRecord,
+}
+
+/// Filesystem-backed gate-record store under the `/gate-records` mount alias.
+///
+/// See [`FilesystemRunStateStore`] for the structural-tenant-isolation
+/// rationale; this store applies the same shape to gate records under a sibling
+/// mount alias so a single composition can wire run state, approvals, and gate
+/// records to distinct alias targets while sharing one backend.
+pub struct FilesystemGateRecordStore<F>
+where
+    F: RootFilesystem,
+{
+    filesystem: Arc<ScopedFilesystem<F>>,
+}
+
+impl<F> FilesystemGateRecordStore<F>
+where
+    F: RootFilesystem,
+{
+    pub fn new(filesystem: Arc<ScopedFilesystem<F>>) -> Self {
+        Self { filesystem }
+    }
+
+    fn record_entry(record: &StoredGateRecord) -> Result<Entry, RunStateError> {
+        let body = serialize_pretty(record)?;
+        let kind =
+            RecordKind::new(GATE_RECORD_KIND).map_err(|e| RunStateError::Backend(e.to_string()))?;
+        let mut entry = Entry::bytes(body).with_content_type(ContentType::json());
+        entry.kind = Some(kind);
+        Ok(entry)
+    }
+}
+
+#[async_trait]
+impl<F> GateRecordStore for FilesystemGateRecordStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn save(
+        &self,
+        scope: ResourceScope,
+        gate_ref: GateRef,
+        record: GateRecord,
+    ) -> Result<(), RunStateError> {
+        let path = gate_record_path(&scope, gate_ref)?;
+        let stored = StoredGateRecord {
+            scope: scope.clone(),
+            record,
+        };
+        cas_update(
+            self.filesystem.as_ref(),
+            &scope,
+            &path,
+            |bytes: &[u8]| deserialize::<StoredGateRecord>(bytes),
+            |r: &StoredGateRecord| Self::record_entry(r),
+            |current: Option<StoredGateRecord>| {
+                let fresh = stored.clone();
+                // Write-once: reject a duplicate ref rather than clobbering the
+                // host-owned record a later resume turn still needs.
+                let outcome = if current.is_some() {
+                    Err(RunStateError::GateRecordAlreadyExists { gate_ref })
+                } else {
+                    Ok(CasApply::new(fresh, ()))
+                };
+                async move { outcome }
+            },
+        )
+        .await
+        .map_err(map_cas_error)
+    }
+
+    async fn load(
+        &self,
+        scope: &ResourceScope,
+        gate_ref: GateRef,
+    ) -> Result<Option<GateRecord>, RunStateError> {
+        let path = gate_record_path(scope, gate_ref)?;
+        let Some(versioned) = self.filesystem.get(scope, &path).await? else {
+            return Ok(None);
+        };
+        let stored = deserialize::<StoredGateRecord>(&versioned.entry.body)?;
+        // Defense-in-depth against a shared-path read; wrong scope looks unknown.
+        if same_scope_owner(&stored.scope, scope) {
+            Ok(Some(stored.record))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 // Path layout under the `/run-state` and `/approvals` mount aliases:
 //
 //     /run-state[/agents/<agent>][/projects/<project>][/missions/<mission>][/threads/<thread>]/runs/<invocation_id>.json
 //     /approvals[/agents/<agent>][/projects/<project>][/missions/<mission>][/threads/<thread>]/<request_id>.json
+//     /gate-records[/agents/<agent>][/projects/<project>][/missions/<mission>][/threads/<thread>]/<gate_ref>.json
 //
 // Tenant + user identity moves into the caller's `MountView` per the
 // per-tenant `MountAlias` rewriting, so neither prefix is encoded in the
@@ -729,6 +878,7 @@ where
 
 const RUN_STATE_PREFIX: &str = "/run-state";
 const APPROVALS_PREFIX: &str = "/approvals";
+const GATE_RECORDS_PREFIX: &str = "/gate-records";
 
 fn run_record_path(
     scope: &ResourceScope,
@@ -764,6 +914,13 @@ fn approval_records_root(scope: &ResourceScope) -> Result<ScopedPath, RunStateEr
 
 fn approval_records_root_string(scope: &ResourceScope) -> String {
     scope_owner_alias_string(APPROVALS_PREFIX, scope)
+}
+
+fn gate_record_path(scope: &ResourceScope, gate_ref: GateRef) -> Result<ScopedPath, RunStateError> {
+    scoped_path(&format!(
+        "{}/{gate_ref}.json",
+        scope_owner_alias_string(GATE_RECORDS_PREFIX, scope)
+    ))
 }
 
 /// Build the alias-relative owner prefix for a scope under the given mount

--- a/crates/ironclaw_run_state/src/test_support.rs
+++ b/crates/ironclaw_run_state/src/test_support.rs
@@ -31,11 +31,11 @@ use std::sync::Arc;
 use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
 use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
 
-use crate::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
+use crate::{FilesystemApprovalRequestStore, FilesystemGateRecordStore, FilesystemRunStateStore};
 
-/// A fresh, volatile `ScopedFilesystem<InMemoryBackend>` mounting both
-/// `/run-state` and `/approvals` — the in-memory backend seam the run-state and
-/// approval-request stores share in tests.
+/// A fresh, volatile `ScopedFilesystem<InMemoryBackend>` mounting `/run-state`,
+/// `/approvals`, and `/gate-records` — the in-memory backend seam the run-state,
+/// approval-request, and gate-record stores share in tests.
 pub fn in_memory_backed_run_state_filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
     let mounts = MountView::new(vec![
         MountGrant::new(
@@ -46,6 +46,11 @@ pub fn in_memory_backed_run_state_filesystem() -> Arc<ScopedFilesystem<InMemoryB
         MountGrant::new(
             MountAlias::new("/approvals").expect("static valid mount alias"), // safety: test-support scaffolding, static literal
             VirtualPath::new("/engine/approvals").expect("static valid virtual path"), // safety: test-support scaffolding, static literal
+            MountPermissions::read_write_list_delete(),
+        ),
+        MountGrant::new(
+            MountAlias::new("/gate-records").expect("static valid mount alias"), // safety: test-support scaffolding, static literal
+            VirtualPath::new("/engine/gate-records").expect("static valid virtual path"), // safety: test-support scaffolding, static literal
             MountPermissions::read_write_list_delete(),
         ),
     ])
@@ -67,4 +72,9 @@ pub fn in_memory_backed_run_state_store() -> FilesystemRunStateStore<InMemoryBac
 pub fn in_memory_backed_approval_request_store() -> FilesystemApprovalRequestStore<InMemoryBackend>
 {
     FilesystemApprovalRequestStore::new(in_memory_backed_run_state_filesystem())
+}
+
+/// The production gate-record store over a fresh in-memory backend.
+pub fn in_memory_backed_gate_record_store() -> FilesystemGateRecordStore<InMemoryBackend> {
+    FilesystemGateRecordStore::new(in_memory_backed_run_state_filesystem())
 }

--- a/crates/ironclaw_run_state/tests/gate_record_store_contract.rs
+++ b/crates/ironclaw_run_state/tests/gate_record_store_contract.rs
@@ -64,6 +64,36 @@ async fn gate_record_auth_variant_round_trips_credential_requirements() {
     }
 }
 
+/// The reason this store exists: a gate blocks on one turn and is rendered on a
+/// LATER resume turn, which carries a fresh `invocation_id`. The scope check
+/// must compare only the owner axes (tenant/user/agent/project/mission/thread)
+/// — if it ever included `invocation_id`, every legitimate resume load would
+/// look unknown and this test would fail.
+#[tokio::test]
+async fn gate_record_loads_on_a_later_resume_turn_with_a_new_invocation_id() {
+    let store = in_mem_gate_record_store();
+    let blocking_turn = sample_scope("tenant1", "user1");
+    let gate_ref = GateRef::new();
+    store
+        .save(
+            blocking_turn.clone(),
+            gate_ref,
+            GateRecord::Approval { summary: summary() },
+        )
+        .await
+        .unwrap();
+
+    let resume_turn = ResourceScope {
+        invocation_id: InvocationId::new(),
+        ..blocking_turn
+    };
+    assert_eq!(
+        store.load(&resume_turn, gate_ref).await.unwrap(),
+        Some(GateRecord::Approval { summary: summary() }),
+        "same owner on a later turn (new invocation_id) must still load the record"
+    );
+}
+
 #[tokio::test]
 async fn gate_record_load_of_missing_ref_returns_none() {
     let store = in_mem_gate_record_store();

--- a/crates/ironclaw_run_state/tests/gate_record_store_contract.rs
+++ b/crates/ironclaw_run_state/tests/gate_record_store_contract.rs
@@ -1,0 +1,234 @@
+//! Contract tests for [`GateRecordStore`] / [`FilesystemGateRecordStore`].
+//!
+//! The gate record is the model-visible content a pending gate renders from
+//! (arch-simplification §5.2.9); it must survive from the turn that blocks to a
+//! LATER resume turn, so it is persisted keyed by [`GateRef`]. These tests pin
+//! the seam that result-side wiring depends on: save/load round-trips for every
+//! [`GateRecord`] variant, a missing ref reads as `None`, a duplicate ref is
+//! rejected write-once, and a record saved under one scope is not loadable under
+//! another (the cross-tenant regression `database.md` / `safety-and-sandbox.md`
+//! require).
+
+use std::sync::Arc;
+
+use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
+use ironclaw_host_api::*;
+use ironclaw_run_state::*;
+
+#[tokio::test]
+async fn gate_record_store_round_trips_every_variant() {
+    let store = in_mem_gate_record_store();
+    let scope = sample_scope("tenant1", "user1");
+
+    for record in every_gate_record_variant() {
+        let gate_ref = GateRef::new();
+        store
+            .save(scope.clone(), gate_ref, record.clone())
+            .await
+            .unwrap();
+        let loaded = store.load(&scope, gate_ref).await.unwrap();
+        assert_eq!(
+            loaded,
+            Some(record.clone()),
+            "{}: save then load must reconstruct the record",
+            record.kind()
+        );
+    }
+}
+
+#[tokio::test]
+async fn gate_record_auth_variant_round_trips_credential_requirements() {
+    let store = in_mem_gate_record_store();
+    let scope = sample_scope("tenant1", "user1");
+    let gate_ref = GateRef::new();
+    let record = GateRecord::Auth {
+        summary: summary(),
+        credential_requirements: vec![credential_requirement()],
+    };
+
+    store
+        .save(scope.clone(), gate_ref, record.clone())
+        .await
+        .unwrap();
+
+    // The host-owned credential requirement is rendered FROM the record on a
+    // later resume turn, never reconstructed from model-visible data.
+    match store.load(&scope, gate_ref).await.unwrap() {
+        Some(GateRecord::Auth {
+            credential_requirements,
+            ..
+        }) => {
+            assert_eq!(credential_requirements, vec![credential_requirement()]);
+        }
+        other => panic!("expected Auth gate record, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn gate_record_load_of_missing_ref_returns_none() {
+    let store = in_mem_gate_record_store();
+    let scope = sample_scope("tenant1", "user1");
+
+    let loaded = store.load(&scope, GateRef::new()).await.unwrap();
+
+    assert_eq!(loaded, None);
+}
+
+#[tokio::test]
+async fn gate_record_save_is_write_once() {
+    let store = in_mem_gate_record_store();
+    let scope = sample_scope("tenant1", "user1");
+    let gate_ref = GateRef::new();
+    store
+        .save(
+            scope.clone(),
+            gate_ref,
+            GateRecord::Approval { summary: summary() },
+        )
+        .await
+        .unwrap();
+
+    let err = store
+        .save(
+            scope.clone(),
+            gate_ref,
+            GateRecord::Resource { summary: summary() },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::GateRecordAlreadyExists { gate_ref: g } if g == gate_ref
+    ));
+    // The original write-once record is intact — the rejected save did not clobber it.
+    assert_eq!(
+        store.load(&scope, gate_ref).await.unwrap(),
+        Some(GateRecord::Approval { summary: summary() })
+    );
+}
+
+#[tokio::test]
+async fn gate_record_load_is_scoped_to_tenant_and_user() {
+    let store = in_mem_gate_record_store();
+    let gate_ref = GateRef::new();
+    let tenant_a = sample_scope("tenant1", "user1");
+    let tenant_b = sample_scope("tenant2", "user1");
+
+    store
+        .save(
+            tenant_a.clone(),
+            gate_ref,
+            GateRecord::Approval { summary: summary() },
+        )
+        .await
+        .unwrap();
+
+    // A record saved under tenant A must not be loadable under tenant B.
+    assert_eq!(store.load(&tenant_b, gate_ref).await.unwrap(), None);
+    // The owner still sees it.
+    assert_eq!(
+        store.load(&tenant_a, gate_ref).await.unwrap(),
+        Some(GateRecord::Approval { summary: summary() })
+    );
+}
+
+#[tokio::test]
+async fn gate_record_load_is_scoped_to_within_tenant_axes() {
+    // Same tenant/user, different project — path-level within-tenant isolation.
+    let store = in_mem_gate_record_store();
+    let gate_ref = GateRef::new();
+    let project_a = scope_with_project("tenant1", "user1", "project-a");
+    let project_b = scope_with_project("tenant1", "user1", "project-b");
+
+    store
+        .save(
+            project_a.clone(),
+            gate_ref,
+            GateRecord::Approval { summary: summary() },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(store.load(&project_b, gate_ref).await.unwrap(), None);
+    assert_eq!(
+        store.load(&project_a, gate_ref).await.unwrap(),
+        Some(GateRecord::Approval { summary: summary() })
+    );
+}
+
+fn every_gate_record_variant() -> Vec<GateRecord> {
+    let result = ResultRef::parse("018f6a00-0000-7000-8000-000000000001").unwrap();
+    vec![
+        GateRecord::Approval { summary: summary() },
+        GateRecord::Auth {
+            summary: summary(),
+            credential_requirements: vec![credential_requirement()],
+        },
+        GateRecord::Resource { summary: summary() },
+        GateRecord::DependentRun {
+            summary: summary(),
+            result,
+            byte_len: 2048,
+        },
+        GateRecord::ExternalTool { summary: summary() },
+    ]
+}
+
+fn summary() -> SafeSummary {
+    SafeSummary::new("awaiting decision").unwrap()
+}
+
+fn credential_requirement() -> RuntimeCredentialAuthRequirement {
+    RuntimeCredentialAuthRequirement {
+        provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+        setup: RuntimeCredentialAccountSetup::ManualToken,
+        requester_extension: ExtensionId::new("github").unwrap(),
+        provider_scopes: vec!["repo".to_string()],
+    }
+}
+
+fn engine_filesystem() -> ironclaw_filesystem::InMemoryBackend {
+    ironclaw_filesystem::InMemoryBackend::new()
+}
+
+/// The production gate-record store over a fresh in-memory backend.
+fn in_mem_gate_record_store() -> FilesystemGateRecordStore<ironclaw_filesystem::InMemoryBackend> {
+    FilesystemGateRecordStore::new(scoped_gate_record_fs(Arc::new(engine_filesystem())))
+}
+
+/// Build a [`ScopedFilesystem`] exposing the `/gate-records` alias under a single
+/// tenant/user subtree of the underlying mount — mirrors the production shape
+/// where one `MountView` covers a consumer alias for a given tenant/user.
+fn scoped_gate_record_fs<F>(backend: Arc<F>) -> Arc<ScopedFilesystem<F>>
+where
+    F: RootFilesystem,
+{
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/gate-records").expect("alias"),
+        VirtualPath::new("/engine/tenants/test-tenant/users/test-user/gate-records")
+            .expect("target"),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("mount view");
+    Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts))
+}
+
+fn sample_scope(tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn scope_with_project(tenant: &str, user: &str, project: &str) -> ResourceScope {
+    ResourceScope {
+        project_id: Some(ProjectId::new(project).unwrap()),
+        ..sample_scope(tenant, user)
+    }
+}


### PR DESCRIPTION
## Why

The `CapabilityOutcome`→`Resolution` migration replaces inline gate payloads with opaque `GateRef`s. The model-visible content a pending gate renders from lives in a host_api [`GateRecord`](../blob/feat/host-api-result-record-vocab/crates/ironclaw_host_api/src/gate_record.rs) that must survive to a **later** resume turn — so it needs persistence keyed by `GateRef`. This store is the prerequisite the result-side wiring is blocked on. The sibling terminal `DenyRecord` is same-turn and needs no store (skipped).

## What (additive — new store, touches no existing behavior)

Mirrors the sibling `ApprovalRequestStore` / `FilesystemApprovalRequestStore` that already live in `ironclaw_run_state`:

- **`GateRecordStore` port** (`save` / `load`) — resource-owner scoped; wrong-scope lookups look unknown. Deliberately **no removal method**: a `GateRecord` is host-owned, write-once, model-visible content with no status field to tombstone, so unlike `ApprovalRequestStore::discard_pending` (which tombstones a lifecycle *status*) there is no scope-safe soft-delete to mirror, and hard deletion of retained model-visible data would need an explicit product/retention contract (`database.md` "Data safety").
- **`FilesystemGateRecordStore<F: RootFilesystem>`** over a `ScopedFilesystem` + shared `cas_update` (fail-closed on non-CAS backends), under a new `/gate-records` mount alias. A private `StoredGateRecord { scope, record }` wrapper carries the scope beside the scope-less host_api `GateRecord` so `load` can apply the same `same_scope_owner` defense-in-depth check `ApprovalRecord` does.
- **`GateRecordAlreadyExists`** error variant (write-once: a fresh-uuid `GateRef` collision is a caller invariant violation, not an update path).
- **`in_memory_backed_gate_record_store()`** test-support constructor; `/gate-records` added to the shared in-memory mount view.

### Type placement
Port + impl live in `ironclaw_run_state` — the domain crate that already owns `ApprovalRequestStore`/`FilesystemApprovalRequestStore` and the run-state/approval persistence contract (per `type-placement.md` §2: domain persistence type → the crate that owns the concept; `database.md`: domain crates own record schemas, not `host_api`). `GateRecord`/`GateRef` stay owned by `host_api`; this crate only persists them.

### Composition
**Not wired into production composition yet.** The store types + tests land first; result-side wiring is the follow-up slice (the store is `pub` and ready). No `TODO` marker needed in composition since nothing references it there yet.

## Tests (6, all pass)

`tests/gate_record_store_contract.rs`, driven through the public `GateRecordStore` seam over the production `FilesystemGateRecordStore<InMemoryBackend>`:

- save→load round-trips **every** `GateRecord` variant (Approval/Auth/Resource/DependentRun/ExternalTool)
- the `Auth` variant's `credential_requirements` round-trip
- load of a missing ref → `None`
- write-once: duplicate `GateRef` save → `GateRecordAlreadyExists`, original intact
- **scope isolation**: a record saved under tenant A is not loadable under tenant B (cross-tenant regression) — and the same for a within-tenant axis (project A vs project B)

## Verification

- `cargo test -p ironclaw_run_state --all-features` → 46 pass (6 new)
- `cargo clippy -p ironclaw_run_state --all-targets --all-features -- -D warnings` → clean (also default + libsql-only feature lanes)
- `cargo test -p ironclaw_architecture` → pass (no `InMemory*Store` added; `/gate-records` is a `Filesystem*Store`)
- No `.unwrap()`/`.expect()` in production; CAS errors cause-preserved via `map_cas_error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)