### PR TITLE
fix(filesystem): index libSQL descendant listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(filesystem)* make libSQL descendant listings seek through the path index instead of scanning the full root-filesystem table, preventing extension-readiness fan-out from stalling unrelated WebUI requests.
 - *(webui-v2)* expose per-user secret provisioning in Admin user details with write-only values, handle-only listings, and confirmed deletion ([#6118](https://github.com/nearai/ironclaw/issues/6118)).
 - *(webui-v2)* render the Extensions Registry as soon as catalog data arrives instead of holding the skeleton screen for slower installed-extension enrichment ([#6052](https://github.com/nearai/ironclaw/issues/6052)).
 - *(webui-v2)* submit the latest composer value when Enter follows input before React rerenders, avoiding intermittently dropped follow-up messages ([#6044](https://github.com/nearai/ironclaw/issues/6044)).

--- a/crates/ironclaw_filesystem/src/db.rs
+++ b/crates/ironclaw_filesystem/src/db.rs
@@ -74,6 +74,15 @@ pub(crate) fn direct_children(
 }
 
 #[cfg(feature = "libsql")]
+pub(crate) fn descendant_path_range(path: &VirtualPath) -> (String, String) {
+    let prefix = path.as_str().trim_end_matches('/');
+    // Descendants share the literal "{prefix}/" component boundary. The
+    // exclusive upper bound "{prefix}0" works because '/' sorts before '0'
+    // in the normalized virtual path alphabet used by these storage paths.
+    (format!("{prefix}/"), format!("{prefix}0"))
+}
+
+#[cfg(feature = "libsql")]
 pub(crate) fn child_path_like_pattern(path: &VirtualPath) -> String {
     let mut pattern = String::new();
     for character in path.as_str().trim_end_matches('/').chars() {

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -6,10 +6,11 @@ use ironclaw_host_api::VirtualPath;
 
 use crate::backend::EventRecord;
 use crate::db::{
-    child_path_like_pattern, direct_children, directory_append_error, directory_write_error,
-    escape_like_literal, escape_like_with_trailing_wildcard, infrastructure_libsql_error,
-    is_not_found, libsql_db_error, not_found, page_offset_to_i64, record_version_from_i64,
-    record_version_to_i64, sql_index_name, system_time_from_unix_seconds, virtual_path_prefixes,
+    child_path_like_pattern, descendant_path_range, direct_children, directory_append_error,
+    directory_write_error, escape_like_literal, escape_like_with_trailing_wildcard,
+    infrastructure_libsql_error, is_not_found, libsql_db_error, not_found, page_offset_to_i64,
+    record_version_from_i64, record_version_to_i64, sql_index_name, system_time_from_unix_seconds,
+    virtual_path_prefixes,
 };
 #[cfg(feature = "libsql")]
 use crate::libsql_pool::{LibSqlPool, PooledLibSqlConnection, build_libsql_pool};
@@ -25,6 +26,18 @@ use crate::{
 pub struct LibSqlRootFilesystem {
     pool: LibSqlPool,
 }
+
+#[cfg(feature = "libsql")]
+const LIBSQL_CHILD_ENTRIES_SQL: &str = "SELECT path, length(contents), is_dir \
+    FROM root_filesystem_entries \
+    WHERE path >= ?1 AND path < ?2 \
+    ORDER BY path";
+
+#[cfg(feature = "libsql")]
+const LIBSQL_HAS_CHILD_ENTRY_SQL: &str = "SELECT 1 \
+    FROM root_filesystem_entries \
+    WHERE path >= ?1 AND path < ?2 \
+    LIMIT 1";
 
 #[cfg(feature = "libsql")]
 impl LibSqlRootFilesystem {
@@ -1321,11 +1334,11 @@ async fn has_child_entry_libsql(
     conn: &libsql::Connection,
     parent: &VirtualPath,
 ) -> Result<bool, FilesystemError> {
-    let pattern = child_path_like_pattern(parent);
+    let (prefix_lower, prefix_upper) = descendant_path_range(parent);
     let mut rows = conn
         .query(
-            "SELECT 1 FROM root_filesystem_entries WHERE path LIKE ?1 ESCAPE '!' LIMIT 1",
-            libsql::params![pattern],
+            LIBSQL_HAS_CHILD_ENTRY_SQL,
+            libsql::params![prefix_lower, prefix_upper],
         )
         .await
         .map_err(|error| libsql_db_error(parent.clone(), FilesystemOperation::Stat, error))?;
@@ -1488,11 +1501,11 @@ impl LibSqlRootFilesystem {
         operation: FilesystemOperation,
     ) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
         let conn = self.connect().await?;
-        let pattern = child_path_like_pattern(parent);
+        let (prefix_lower, prefix_upper) = descendant_path_range(parent);
         let mut rows = conn
             .query(
-                "SELECT path, length(contents), is_dir FROM root_filesystem_entries WHERE path LIKE ?1 ESCAPE '!' ORDER BY path",
-                libsql::params![pattern],
+                LIBSQL_CHILD_ENTRIES_SQL,
+                libsql::params![prefix_lower, prefix_upper],
             )
             .await
             .map_err(|error| libsql_db_error(parent.clone(), operation, error))?;
@@ -1528,19 +1541,7 @@ impl LibSqlRootFilesystem {
 
     async fn has_child_entry(&self, parent: &VirtualPath) -> Result<bool, FilesystemError> {
         let conn = self.connect().await?;
-        let pattern = child_path_like_pattern(parent);
-        let mut rows = conn
-            .query(
-                "SELECT 1 FROM root_filesystem_entries WHERE path LIKE ?1 ESCAPE '!' LIMIT 1",
-                libsql::params![pattern],
-            )
-            .await
-            .map_err(|error| libsql_db_error(parent.clone(), FilesystemOperation::Stat, error))?;
-        Ok(rows
-            .next()
-            .await
-            .map_err(|error| libsql_db_error(parent.clone(), FilesystemOperation::Stat, error))?
-            .is_some())
+        has_child_entry_libsql(&conn, parent).await
     }
 
     /// Resolve every FTS index name covering `path` whose first key is
@@ -2137,6 +2138,51 @@ mod tests {
         let fs = LibSqlRootFilesystem::new(db);
         fs.run_migrations().await.unwrap();
         (fs, dir)
+    }
+
+    #[tokio::test]
+    async fn child_entries_query_uses_the_path_index_for_descendant_ranges() {
+        let (fs, _dir) = fresh_backend().await;
+        let parent = VirtualPath::new("/tenants/tenant/users/user/secrets/product-auth").unwrap();
+        let (prefix_lower, prefix_upper) = descendant_path_range(&parent);
+        assert_eq!(
+            prefix_lower,
+            "/tenants/tenant/users/user/secrets/product-auth/"
+        );
+        assert_eq!(
+            prefix_upper,
+            "/tenants/tenant/users/user/secrets/product-auth0"
+        );
+        let conn = fs.connect().await.unwrap();
+        for query in [LIBSQL_CHILD_ENTRIES_SQL, LIBSQL_HAS_CHILD_ENTRY_SQL] {
+            let explain_sql = format!("EXPLAIN QUERY PLAN {query}");
+            let mut rows = conn
+                .query(
+                    &explain_sql,
+                    libsql::params![prefix_lower.clone(), prefix_upper.clone()],
+                )
+                .await
+                .unwrap();
+            let mut details = Vec::new();
+            while let Some(row) = rows.next().await.unwrap() {
+                details.push(row.get::<String>(3).unwrap());
+            }
+
+            assert!(
+                details.iter().any(|detail| {
+                    detail.contains("SEARCH root_filesystem_entries USING")
+                        && detail.contains("path>?")
+                        && detail.contains("path<?")
+                }),
+                "descendant lookup must seek through the path index, plan: {details:?}"
+            );
+            assert!(
+                details
+                    .iter()
+                    .all(|detail| !detail.contains("SCAN root_filesystem_entries")),
+                "descendant lookup must not scan the complete path index, plan: {details:?}"
+            );
+        }
     }
 
     /// Drive the phase-2 materialize step directly with a synthesised


### PR DESCRIPTION
## Summary

- replace libSQL descendant `LIKE 'prefix/%'` scans with the half-open `[prefix/, prefix0)` range already used by the PostgreSQL backend
- use the same indexed range for child-existence checks
- add an `EXPLAIN QUERY PLAN` regression covering both query forms

## Root cause

QA profiling on the current `main` deployment showed `/extensions` taking roughly 6.2–6.8 seconds. Per-extension credential-readiness checks fan out filesystem directory lookups; the previous libSQL `LIKE` predicate produced a full `root_filesystem_entries` index scan for each lookup. With 378k rows and eight concurrent readiness tasks matching the eight-connection pool, those scans saturated the pool and delayed unrelated requests.

The new predicates preserve the directory component boundary while allowing SQLite/libSQL to seek through the existing primary path index. No schema or migration is required.

## Validation

- `cargo test -p ironclaw_filesystem --all-features`
- `cargo clippy -p ironclaw_filesystem --all-targets --all-features -- -D warnings`
- `cargo clippy -p ironclaw_filesystem --no-default-features --features postgres --all-targets -- -D warnings`
- `cargo check -p ironclaw_filesystem --no-default-features --features libsql`
- `cargo check -p ironclaw_filesystem --no-default-features --features postgres`
- `cargo clippy --all --tests --examples -- -D warnings`
- `cargo clippy --all --tests --examples --no-default-features --features libsql -- -D warnings`
- `cargo clippy --all --tests --examples --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture`
- `scripts/pre-commit-safety.sh`

## Compatibility / rollback

- no storage-schema, data-format, configuration, or API changes
- query semantics still include descendants only, excluding the path itself and prefix-sharing siblings
- rollback is a straight commit revert

## Follow-ups

Credential snapshot batching and frontend refetch cleanup are intentionally kept out of this focused database-query fix.