### PR TITLE
fix(tests): restore arg-visible tool-attempt assertions in the live canary

### DIFF
--- a/tests/e2e_live.rs
+++ b/tests/e2e_live.rs
@@ -69,7 +69,7 @@ mod live_tests {
         assert!(!responses.is_empty(), "Expected at least one response");
 
         let text: Vec<String> = responses.iter().map(|r| r.content.clone()).collect();
-        let tools = rig.tool_calls_started();
+        let tools = rig.tool_call_display_names();
 
         // Log diagnostics before asserting.
         eprintln!("[ZizmorScan] Tools used: {tools:?}");
@@ -79,8 +79,8 @@ mod live_tests {
         );
 
         // The agent should have used the shell tool to install/run zizmor.
-        // Tool events now carry args (e.g. `"shell(cmd)"`) via
-        // `format_action_display_name` in `src/bridge/router.rs`, so match both
+        // Tool events carry args (e.g. `"shell(cmd)"`) via `tool_call_detail`,
+        // surfaced by the harness's `tool_call_display_names`, so match both
         // the bare name and the argument-prefixed form.
         assert!(
             used_shell(&tools),
@@ -157,7 +157,7 @@ mod live_tests {
         assert!(!responses.is_empty(), "Expected at least one response");
 
         let text: Vec<String> = responses.iter().map(|r| r.content.clone()).collect();
-        let tools = rig.tool_calls_started();
+        let tools = rig.tool_call_display_names();
 
         eprintln!("[ZizmorScanV2] Tools used: {tools:?}");
         eprintln!(
@@ -170,8 +170,9 @@ mod live_tests {
         // V2 without auto-approve hits an approval gate for shell/tool_install.
         // The response may be the approval prompt itself rather than agent output.
         // Verify the agent at least attempted a relevant action. Tool events
-        // carry args (e.g. `"shell(cmd)"`) via `format_action_display_name`, so
-        // accept either the bare name or the argument-prefixed form.
+        // carry args (e.g. `"shell(cmd)"`) via `tool_call_detail`, surfaced by
+        // the harness's `tool_call_display_names`, so accept either the bare
+        // name or the argument-prefixed form.
         let attempted_relevant_tool = tools.iter().any(|t| {
             tool_name_matches(t, "shell")
                 || tool_name_matches(t, "tool_install")

--- a/tests/support/test_channel.rs
+++ b/tests/support/test_channel.rs
@@ -226,6 +226,30 @@ impl TestChannel {
             .collect()
     }
 
+    /// Return the display form of all `ToolStarted` events captured so far:
+    /// the argument-prefixed `name(detail)` when the event carries a contextual
+    /// detail (e.g. `shell(cargo run zizmor …)` — see `tool_call_detail`), or
+    /// the bare `name` otherwise.
+    ///
+    /// Assertions that check *what* a tool attempt targeted (e.g. the live
+    /// canary's "did any shell attempt mention zizmor") need the detail; engine
+    /// v2's `format_action_display_name` used to bake it into the started-event
+    /// name, and its removal (#5545) silently reduced those assertions to bare
+    /// names, stranding them. Use [`Self::tool_calls_started`] when only the
+    /// tool identity matters.
+    pub fn tool_call_display_names(&self) -> Vec<String> {
+        self.captured_status_events()
+            .iter()
+            .filter_map(|s| match s {
+                StatusUpdate::ToolStarted { name, detail, .. } => Some(match detail {
+                    Some(detail) => format!("{name}({detail})"),
+                    None => name.clone(),
+                }),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Return `(name, success)` for all `ToolCompleted` events captured so far.
     pub fn tool_calls_completed(&self) -> Vec<(String, bool)> {
         self.captured_status_events()

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -466,6 +466,13 @@ impl TestRig {
         self.channel.tool_calls_started()
     }
 
+    /// Return the display form (`name(detail)` when a contextual detail is
+    /// carried, bare `name` otherwise) of all `ToolStarted` events captured so
+    /// far — see `TestChannel::tool_call_display_names`.
+    pub fn tool_call_display_names(&self) -> Vec<String> {
+        self.channel.tool_call_display_names()
+    }
+
     /// Return the filtered list of captured responses so far.
     ///
     /// Mirrors the bootstrap-greeting filtering used by `wait_for_responses`.

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -256,9 +256,29 @@ mod test_channel_tests {
             )
             .await
             .unwrap();
+        channel
+            .send_status(
+                StatusUpdate::tool_started(
+                    "shell".to_string(),
+                    &serde_json::json!({"command": "cargo run zizmor --version"}),
+                ),
+                &metadata,
+            )
+            .await
+            .unwrap();
 
+        // The identity accessor stays bare-name (several suites compare with
+        // `==`); the display accessor carries the argument-prefixed form the
+        // live-canary assertions grep. Regression: after engine v2's removal no
+        // accessor surfaced the detail, so "did any shell attempt mention
+        // zizmor" could never see the command.
         let started = channel.tool_calls_started();
-        assert_eq!(started, vec!["memory_search", "echo"]);
+        assert_eq!(started, vec!["memory_search", "echo", "shell"]);
+        let display = channel.tool_call_display_names();
+        assert_eq!(
+            display,
+            vec!["memory_search", "echo", "shell(cargo run zizmor --version)"]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Running the `public-smoke` live-canary lane against latest main (post-merge sanity after the C-series/W1 wave) failed `zizmor_scan_v2` — but the failure is a **stranded harness assertion, not a product regression**: the agent ran zizmor successfully (full scan report in the response), yet the assertion "a tool attempt that mentions/runs zizmor" saw only `["shell", "shell", "shell"]`.

## Root cause

`TestChannel::tool_calls_started()` surfaces only `ToolStarted.name`. The command args live in the event's `detail` field (`tool_call_detail`), and the test comment still references `format_action_display_name` — an engine-v2 function that baked args into the name and was deleted with engine v2 (#5545). Since then, every "what did the attempt target" assertion has been structurally unable to see the command; the replay lane never noticed because the strict check is live-mode-only.

## Fix

- New `TestChannel::tool_call_display_names()` (+ `TestRig` delegation): the argument-prefixed `name(detail)` form (e.g. `shell(cargo run zizmor …)`); the zizmor scan tests switch to it. The existing `tool_name_matches` helper already accepts both forms.
- `tool_calls_started()` stays bare-name — several suites compare it with `==` (`write_file`, `tool_search`, …), so changing it in place would break them.
- Regression pinned in `support_unit_tests::tool_calls_started`: identity accessor yields `shell`, display accessor yields `shell(cargo run zizmor --version)`.
- Stale `format_action_display_name` comments corrected.

## Verification

- `cargo test --test support_unit_tests` — 112 passed.
- Replay-mode `cargo test --features libsql --test e2e_live -- --ignored` — 4 passed (fixture unchanged; the half-recorded fixture from the failed canary run was reverted, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)