### PR TITLE
fix(reborn-cli): green the libsql-only coverage lane (models reads, onboard test gate, DTO dead-code)

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -92,11 +92,33 @@ impl ModelsListCommand {
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsListCommand {
     fn execute(self) -> anyhow::Result<()> {
-        let command = match self.provider.as_deref() {
-            Some(provider) => format!("list {provider}"),
-            None => "list".to_string(),
-        };
-        Err(feature_not_available(&command))
+        // Reads stay informational without the provider feature (the libsql-only
+        // lane's smoke tests pin this); only writes error — see ModelsSetCommand.
+        let slots = ironclaw_reborn_composition::reborn_model_slot_names();
+
+        if self.json {
+            let slots = slots
+                .iter()
+                .map(|slot| serde_json::json!({ "slot": slot }))
+                .collect::<Vec<_>>();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "slots": slots,
+                    "routes": "not-configured",
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn model slots");
+        for slot in slots {
+            println!("- {}", slot);
+        }
+        println!("routes: not-configured");
+        println!("v1_state: not-used");
+        Ok(())
     }
 }
 
@@ -166,7 +188,36 @@ fn feature_not_available(command: &str) -> anyhow::Error {
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsStatusCommand {
     fn execute(self) -> anyhow::Result<()> {
-        Err(feature_not_available("status"))
+        let slots = ironclaw_reborn_composition::reborn_model_slot_names();
+
+        if self.json {
+            let slot_status: serde_json::Map<String, serde_json::Value> = slots
+                .iter()
+                .map(|slot| {
+                    (
+                        (*slot).to_string(),
+                        serde_json::Value::from("not-configured"),
+                    )
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "routes": "not-configured",
+                    "slots": slot_status,
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn model status");
+        println!("routes: not-configured");
+        for slot in slots {
+            println!("{}: not-configured", slot);
+        }
+        println!("v1_state: not-used");
+        Ok(())
     }
 }
 

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -94,6 +94,16 @@ impl ModelsListCommand {
     fn execute(self) -> anyhow::Result<()> {
         // Reads stay informational without the provider feature (the libsql-only
         // lane's smoke tests pin this); only writes error — see ModelsSetCommand.
+        // A provider-detail request (`models list <provider>` / `--verbose`)
+        // needs real provider data, so answering it with the generic slot list
+        // would be silently wrong — those option-bearing invocations error like
+        // the write commands do.
+        if let Some(provider) = self.provider.as_deref() {
+            return Err(feature_not_available(&format!("list {provider}")));
+        }
+        if self.verbose {
+            return Err(feature_not_available("list --verbose"));
+        }
         let slots = ironclaw_reborn_composition::reborn_model_slot_names();
 
         if self.json {
@@ -103,11 +113,11 @@ impl ModelsListCommand {
                 .collect::<Vec<_>>();
             println!(
                 "{}",
-                serde_json::json!({
+                serde_json::to_string_pretty(&serde_json::json!({
                     "slots": slots,
                     "routes": "not-configured",
                     "v1_state": "not-used",
-                })
+                }))?
             );
             return Ok(());
         }
@@ -202,11 +212,11 @@ impl ModelsStatusCommand {
                 .collect();
             println!(
                 "{}",
-                serde_json::json!({
+                serde_json::to_string_pretty(&serde_json::json!({
                     "routes": "not-configured",
                     "slots": slot_status,
                     "v1_state": "not-used",
-                })
+                }))?
             );
             return Ok(());
         }

--- a/crates/ironclaw_reborn_cli/src/dto.rs
+++ b/crates/ironclaw_reborn_cli/src/dto.rs
@@ -40,6 +40,11 @@ pub(crate) struct StatusDto {
 /// an `Unknown` fallback) on every build.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+// The concrete states are constructed only by the `webui-v2-beta`-gated
+// resolver (`status::resolve_service_state`); the enum stays whole on every
+// build for wire stability, so the variants are legitimately unconstructed
+// (dead-code in the default/libsql clippy lanes) without that feature.
+#[cfg_attr(not(feature = "webui-v2-beta"), allow(dead_code))]
 pub(crate) enum ServiceStateDto {
     Running,
     Stopped,

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -5383,6 +5383,11 @@ fn onboard_import_history_records_pending_step() {
 /// bytes, the marker, providers.json) are still correct on disk, since
 /// `write_default_config_files` and the marker/master-key steps all run
 /// ahead of the LLM-credential step that fails.
+// The pinned failure (the LLM-credential step parsing the malformed
+// config.toml) exists only when the provider feature compiles that step in;
+// without it onboard legitimately succeeds, so the test would fail the
+// libsql-only lane for behavior that build cannot have.
+#[cfg(feature = "root-llm-provider")]
 #[test]
 fn onboard_preserves_existing_config_without_force() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1292,6 +1292,33 @@ fn models_list_no_default_features_does_not_resolve_reborn_home() {
 
 #[cfg(not(feature = "root-llm-provider"))]
 #[test]
+fn models_list_with_provider_reports_root_llm_provider_required_without_default_features() {
+    // A provider-detail request needs real provider data; without the feature
+    // it must error like the write commands rather than succeed with the
+    // unrelated generic slot list (2026-07-19 ironloopai review finding).
+    for args in [
+        &["models", "list", "openai"][..],
+        &["models", "list", "--verbose"][..],
+    ] {
+        let output = reborn_command()
+            .args(args)
+            .output()
+            .expect("ironclaw-reborn models list should run");
+        assert!(!output.status.success(), "command should fail: {args:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("requires the root-llm-provider feature"),
+            "stderr: {stderr}"
+        );
+        assert!(
+            !stderr.contains("HOME or USERPROFILE"),
+            "must not resolve Reborn home before feature error: {stderr}"
+        );
+    }
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+#[test]
 fn models_status_no_default_features_does_not_resolve_reborn_home() {
     let output = reborn_command()
         .arg("models")


### PR DESCRIPTION
## What

Main's **Coverage (libsql-only)** lane is red: three `ironclaw_reborn_cli --test smoke` failures after the #6211/#6174 merge wave — the recurring "PR CI runs only all-features" matrix trap (`.claude/rules/review-discipline.md`), where these tests/lanes only exist with `root-llm-provider` off.

- **`models list/status`**: #6211 error-stubbed *all* models commands without the provider feature, but main's split tests (#6174's write-only gating) pin list/status as informational reads (`IronClaw Reborn model slots`, `routes: not-configured`). Restored the pre-#6211 featureless read implementations; `set`/`set-provider` keep the error stub. *(My miss in #6211's conflict resolution — the tests were reconciled to main's semantics but the src side wasn't.)*
- **`onboard_preserves_existing_config_without_force`**: pins onboard *failing* on a malformed `config.toml` — but the parsing step (LLM-credential provisioning) is compiled in only under the provider feature, so the libsql-only build legitimately succeeds. Gated the test to the feature that makes its pinned behavior exist.
- **`ServiceStateDto` (pre-existing latent, same crate)**: concrete variants are constructed only by the `webui-v2-beta`-gated resolver — dead-code failing the default/libsql clippy lanes. Allowed with rationale (the DTO stays whole on every build for wire stability, per its own doc).

## Verification

All three lanes locally, clean env: clippy `-D warnings` **0 errors** in all-features / default / libsql-only; tests green — libsql-only 259, default 306, all-features smoke 134. The exact failing invocation (`cargo test -p ironclaw_reborn_cli --no-default-features --features libsql --test smoke`) goes 91/0.

A main-CI sentinel agent is now watching for further post-merge lane failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)