### PR TITLE
test(live-canary): retry live QA cases once before recording a red

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -206,6 +206,16 @@ DEFAULT_USER_ID = "reborn-webui-v2-live-qa-user"
 ENDPOINT_STATUS_URL = "https://near.ai"
 PROVIDER = "reborn-webui-v2"
 MODE = "live"
+# Live QA is model- and network-nondeterministic: the same commit can pass then
+# flake red hours later. Retry a transient (assertion/behavioral) case failure up
+# to this many total attempts before recording a red. Default 2 = one retry;
+# override via REBORN_WEBUI_V2_LIVE_QA_CASE_ATTEMPTS.
+try:
+    LIVE_QA_CASE_ATTEMPTS = max(
+        1, int(os.environ.get("REBORN_WEBUI_V2_LIVE_QA_CASE_ATTEMPTS", "2"))
+    )
+except ValueError:
+    LIVE_QA_CASE_ATTEMPTS = 2
 HN_KEYWORD_SEARCH_URL = (
     "https://hn.algolia.com/api/v1/search_by_date"
     "?query=NEAR%20AI&tags=story&hitsPerPage=1"
@@ -1230,6 +1240,60 @@ def _is_provider_incident(result: ProbeResult) -> bool:
         "provider_unavailable",
         "provider_transient",
     }
+
+
+def _is_case_retriable(result: ProbeResult) -> bool:
+    """Whether an unsuccessful case result is a transient failure worth re-running.
+
+    Only assertion/behavioral failures are retriable. Non-transient failures are
+    recorded as-is without wasting a retry: blocked preconditions, and
+    infrastructure/provider incidents (failure_class=="infrastructure",
+    inconclusive, or a model/provider incident per _is_provider_incident).
+    """
+    if result.success:
+        return False
+    details = result.details
+    if details.get("blocked"):
+        return False
+    if details.get("failure_class") == "infrastructure":
+        return False
+    if details.get("inconclusive"):
+        return False
+    if _is_provider_incident(result):
+        return False
+    return True
+
+
+async def _run_case_with_retries(
+    fn: CaseFn,
+    ctx: "LiveQaContext",
+    *,
+    attempts: int,
+    is_retriable: Callable[[ProbeResult], bool],
+) -> ProbeResult:
+    """Run a live-QA case, retrying a transient failure before recording a red.
+
+    Runs ``fn(ctx)``; on an unsuccessful *and* retriable result with attempts
+    remaining, runs it again; otherwise returns the (last) result. Re-running
+    ``fn(ctx)`` drives a fresh chat turn against the same already-running
+    server/ctx — no restart — which is the intended retry semantics for a
+    nondeterministic model/network flake. The number of attempts made is
+    recorded into ``result.details["attempts"]``.
+    """
+    total = max(1, attempts)
+    result: ProbeResult | None = None
+    for attempt in range(1, total + 1):
+        result = await fn(ctx)
+        result.details["attempts"] = attempt
+        if result.success or attempt >= total or not is_retriable(result):
+            return result
+        print(
+            "[reborn-webui-v2-live-qa] retrying case after retriable failure "
+            f"attempt={attempt}/{total}",
+            flush=True,
+        )
+    assert result is not None  # the loop body always runs at least once
+    return result
 
 
 def _record_assistant_reply_wait_result(
@@ -8253,7 +8317,12 @@ async def run_cases(args: argparse.Namespace) -> int:
                 write_preflight(args.output_dir, prepared_home)
                 shutil.copyfile(preflight_path, case_preflight_path)
             print(f"[reborn-webui-v2-live-qa] running case={name}", flush=True)
-            result = await CASES[name].fn(ctx)
+            result = await _run_case_with_retries(
+                CASES[name].fn,
+                ctx,
+                attempts=LIVE_QA_CASE_ATTEMPTS,
+                is_retriable=_is_case_retriable,
+            )
             result = _attach_browser_diagnostics(args.output_dir, result)
             results.append(result)
             print(

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -8651,5 +8651,136 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             )
 
 
+class RunCaseWithRetriesTests(unittest.TestCase):
+    @staticmethod
+    def _probe(success: bool, details: dict[str, object] | None = None):
+        return run_live_qa.ProbeResult(
+            provider="test",
+            mode="live:case",
+            success=success,
+            latency_ms=1,
+            details=dict(details or {}),
+        )
+
+    def test_retries_transient_failure_then_returns_success(self):
+        calls = {"count": 0}
+
+        async def flaky_fn(_ctx):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return self._probe(False, {"error": "assertion mismatch"})
+            return self._probe(True, {"text_excerpt": "ok"})
+
+        result = asyncio.run(
+            run_live_qa._run_case_with_retries(
+                flaky_fn,
+                object(),
+                attempts=2,
+                is_retriable=run_live_qa._is_case_retriable,
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.details["attempts"], 2)
+        self.assertEqual(calls["count"], 2)
+
+    def test_does_not_retry_blocked_failure(self):
+        calls = {"count": 0}
+
+        async def blocked_fn(_ctx):
+            calls["count"] += 1
+            return self._probe(False, {"blocked": True, "error": "precondition"})
+
+        result = asyncio.run(
+            run_live_qa._run_case_with_retries(
+                blocked_fn,
+                object(),
+                attempts=2,
+                is_retriable=run_live_qa._is_case_retriable,
+            )
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.details["attempts"], 1)
+        self.assertEqual(calls["count"], 1)
+        self.assertTrue(result.details["blocked"])
+
+    def test_does_not_retry_infrastructure_failure(self):
+        calls = {"count": 0}
+
+        async def infra_fn(_ctx):
+            calls["count"] += 1
+            return self._probe(
+                False,
+                {"failure_class": "infrastructure", "inconclusive": True},
+            )
+
+        result = asyncio.run(
+            run_live_qa._run_case_with_retries(
+                infra_fn,
+                object(),
+                attempts=2,
+                is_retriable=run_live_qa._is_case_retriable,
+            )
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.details["attempts"], 1)
+        self.assertEqual(calls["count"], 1)
+
+    def test_does_not_retry_provider_incident(self):
+        calls = {"count": 0}
+
+        async def incident_fn(_ctx):
+            calls["count"] += 1
+            return self._probe(
+                False,
+                {"failure_category": "model_unavailable", "error": "503"},
+            )
+
+        # _is_provider_incident must gate the retry.
+        self.assertTrue(
+            run_live_qa._is_provider_incident(
+                self._probe(False, {"failure_category": "model_unavailable"})
+            )
+        )
+        result = asyncio.run(
+            run_live_qa._run_case_with_retries(
+                incident_fn,
+                object(),
+                attempts=2,
+                is_retriable=run_live_qa._is_case_retriable,
+            )
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.details["attempts"], 1)
+        self.assertEqual(calls["count"], 1)
+
+    def test_returns_last_failure_after_exhausting_attempts(self):
+        calls = {"count": 0}
+
+        async def always_fails_fn(_ctx):
+            calls["count"] += 1
+            return self._probe(False, {"error": f"attempt {calls['count']}"})
+
+        result = asyncio.run(
+            run_live_qa._run_case_with_retries(
+                always_fails_fn,
+                object(),
+                attempts=3,
+                is_retriable=run_live_qa._is_case_retriable,
+            )
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.details["attempts"], 3)
+        self.assertEqual(calls["count"], 3)
+        self.assertEqual(result.details["error"], "attempt 3")
+
+    def test_default_attempts_constant_allows_one_retry(self):
+        self.assertGreaterEqual(run_live_qa.LIVE_QA_CASE_ATTEMPTS, 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Live QA cases (`scripts/reborn_webui_v2_live_qa/run_live_qa.py`) are model- and network-nondeterministic; single-run failures are common — the same commit passed then flaked red hours later. This adds a bounded per-case retry so a case is recorded red only after every attempt fails. This alone would have greened a recent canary run.

## The change (surgical: only `run_live_qa.py` + its test)

- New helper `async def _run_case_with_retries(fn, ctx, *, attempts, is_retriable) -> ProbeResult`: runs `fn(ctx)`; on an unsuccessful *and* retriable result with attempts remaining, runs it again; otherwise returns the last result. Records the number of attempts into `result.details["attempts"]`. Re-running `fn(ctx)` drives a fresh chat turn against the same already-running server/ctx (no restart) — the intended retry semantics, noted in a comment.
- `_is_case_retriable` returns `False` for non-transient failures — blocked preconditions (`details["blocked"]`), infrastructure/inconclusive (`failure_class == "infrastructure"`, `inconclusive`), and provider incidents (`_is_provider_incident`) — so only assertion/behavioral failures are retried.
- Wired at the `run_cases` call site (previously `result = await CASES[name].fn(ctx)`). The provider-incident short-circuit that follows is unchanged.
- Attempt count is the module constant `LIVE_QA_CASE_ATTEMPTS` (default `2` = one retry), overridable via `REBORN_WEBUI_V2_LIVE_QA_CASE_ATTEMPTS`.

## Tests

Unit-test the helper directly (unittest, mirroring existing style):
- transient failure on attempt 1 then success on attempt 2 → returns success with `attempts == 2`;
- blocked / infrastructure / provider-incident failures → not retried (`attempts == 1`), original failure returned;
- always-failing retriable case → returns last failure after exhausting `attempts`.

Test-first: the six new tests fail with `AttributeError: ... has no attribute '_run_case_with_retries'` before the helper exists, and pass after wiring. Full suite: `180 passed, 5 skipped, 28 subtests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)