### PR TITLE
fix(live-canary): give routine-creation turns headroom past 180s

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -2034,6 +2034,13 @@ def _trigger_record_count(reborn_home: Path, routine_name: str | None = None) ->
 ROUTINE_TRIGGER_RECORD_WAIT_TIMEOUT_SECONDS = 120.0
 ROUTINE_TRIGGER_RECORD_POLL_SECONDS = 2.0
 
+# Routine creation is a heavy, multi-step assistant turn (list sheets ->
+# read -> compose -> create trigger). The former 180s per-turn reply wait
+# timed out mid-work on slower model runs, blocking qa_2e / qa_6d / qa_9b at
+# a near-uniform ~182-184s with latest_final_reply_state='false'. 300s gives
+# it the same headroom as the comparably heavy calendar-prep live-chat turn.
+ROUTINE_CREATION_REPLY_TIMEOUT_SECONDS = 300.0
+
 
 async def _wait_for_trigger_record_after_count(
     reborn_home: Path,
@@ -4484,7 +4491,7 @@ async def _routine_creation_case(
             marker=marker,
             required_text=required_text,
             extensions=extensions,
-            timeout=180.0,
+            timeout=ROUTINE_CREATION_REPLY_TIMEOUT_SECONDS,
             extra_details=details,
         )
     else:
@@ -4494,7 +4501,7 @@ async def _routine_creation_case(
             prompt=prompt,
             marker=marker,
             required_text=required_text,
-            timeout=180.0,
+            timeout=ROUTINE_CREATION_REPLY_TIMEOUT_SECONDS,
             extra_details=details,
             routine_confirmation_follow_up=True,
             routine_follow_up_timezone_instruction=follow_up_timezone_instruction,

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -1113,12 +1113,14 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
     def test_routine_creation_case_fails_when_no_trigger_is_created(self):
         captured_prompts: list[str] = []
         captured_follow_up_flags: list[bool] = []
+        captured_timeouts: list[float] = []
 
         async def fake_live_chat_case(_ctx, **kwargs):
             captured_prompts.append(kwargs["prompt"])
             captured_follow_up_flags.append(
                 kwargs.get("routine_confirmation_follow_up", False)
             )
+            captured_timeouts.append(kwargs["timeout"])
             extra_details = kwargs.get("extra_details") or {}
             return run_live_qa.ProbeResult(
                 provider="test",
@@ -1158,6 +1160,13 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertFalse(result.success)
         self.assertEqual(captured_prompts, ["original sheet prompt"])
         self.assertEqual(captured_follow_up_flags, [True])
+        # Plain (non-extensions) routine-creation turn must also get the
+        # extended reply-wait headroom past the former 180.0 timeout.
+        self.assertEqual(
+            captured_timeouts,
+            [run_live_qa.ROUTINE_CREATION_REPLY_TIMEOUT_SECONDS],
+        )
+        self.assertGreater(captured_timeouts[0], 180.0)
         self.assertEqual(result.details["trigger_records_after"], 0)
         self.assertEqual(result.details["trigger_record_wait_ms"], 25)
         self.assertIn("did not add a trigger_record", result.details["error"])
@@ -1285,7 +1294,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIsNone(captured["marker"])
         self.assertEqual(captured["required_text"], ["routine"])
         self.assertEqual(captured["extensions"][0]["package_id"], "google-sheets")
-        self.assertEqual(captured["timeout"], 180.0)
+        # Heavy routine-creation turn must get the extended reply-wait headroom
+        # (regression: the former hardcoded 180.0 timed out mid-work).
+        self.assertEqual(
+            captured["timeout"], run_live_qa.ROUTINE_CREATION_REPLY_TIMEOUT_SECONDS
+        )
+        self.assertGreater(captured["timeout"], 180.0)
         self.assertTrue(result.details["fixture_ready"])
 
     def test_required_text_accepts_explicit_alternatives(self):


### PR DESCRIPTION
## Problem

A live canary run (commit `290bc0fc9`) had three BLOCKING cases fail at a near-uniform ~182–184s latency:

- `qa_2e_calendar_prep_email_routine`
- `qa_6d_gmail_to_sheet_routine`
- `qa_9b_routine_dm_delivery_exactly_once`

Each failed with `assistant reply did not contain required text before timeout ... latest_final_reply_state='false'` — the model was **still working** (final reply not yet emitted) when the per-turn assistant-reply wait gave up. Routine creation is a heavy multi-step turn (list sheets → read → compose → create trigger), and 180s is too tight for a slower model run.

## Root cause (one shared lever)

`_routine_creation_case` in `scripts/reborn_webui_v2_live_qa/run_live_qa.py` hardcoded `timeout=180.0` on **both** branches — the extensions path (`_live_chat_with_extensions_case`) and the plain path (`_live_chat_case`). `_slack_delivery_routine_case` (qa_9b) drives its creation turn through `_routine_creation_case`, so all three failing cases inherit the same 180s.

## Fix

- Add `ROUTINE_CREATION_REPLY_TIMEOUT_SECONDS = 300.0` near the other routine timeout constants, with a comment explaining why. 300s matches the comparably heavy calendar-prep live-chat turn (`qa_2d`) that already uses `timeout=300.0`.
- Replace both hardcoded `timeout=180.0` in `_routine_creation_case` with the constant.
- Unrelated 180s waiters (`_wait_for_slack_event_run_id`) are deliberately left untouched.

## Regression test (test through the caller)

Rather than add a redundant test, this extends the two existing caller-level tests that already drive `_routine_creation_case`:

- `test_routine_creation_case_can_preinstall_extensions` (extensions branch) — now asserts the captured `timeout` equals the new constant and is strictly `> 180.0` (previously asserted `== 180.0`).
- `test_routine_creation_case_fails_when_no_trigger_is_created` (plain branch) — now captures the `timeout` kwarg and asserts the same.

Both **fail before** the production edit (they see 180.0) and **pass after**:

```
# constant temporarily reverted to 180.0
>       self.assertGreater(captured_timeouts[0], 180.0)
E       AssertionError: 180.0 not greater than 180.0
2 failed, 177 deselected in 0.22s

# with the fix (300.0)
174 passed, 5 skipped, 28 subtests passed in 0.20s
```

## Out of scope (deliberate)

The sandbox-derailment observed in `qa_2e` — the agent has shell access under `ALLOW_LOCAL_TOOLS=true`/`AGENT_AUTO_APPROVE_TOOLS=true` and wandered into running Python that imported the QA harness's `case_matrix` — is **deliberately out of scope** here. That is a larger prompt/sandbox-scoping design question. Per-case retry (PR #6264) plus this timeout headroom mitigate the symptom; no sandbox changes are made in this PR.

## Scope

Surgical: only `scripts/reborn_webui_v2_live_qa/run_live_qa.py` and its test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
