### PR TITLE
fix(reborn): make NEARAI_* env-reading composition tests hermetic under a real NEARAI_API_KEY

### DIFF
--- a/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
@@ -1639,9 +1639,14 @@ mod tests {
         for key in ["NEARAI_API_KEY", "NEARAI_BASE_URL"] {
             ironclaw_common::env_helpers::remove_runtime_env(key);
         }
+        // An EMPTY value is semantically unset to `env_or_override`, so only a
+        // non-empty real value can change the asserted base URL — treat empty
+        // as absent to keep the precondition environment-independent.
         assert!(
-            std::env::var_os("NEARAI_BASE_URL").is_none(),
-            "NEARAI_BASE_URL must be unset in the real environment for this snapshot test"
+            std::env::var_os("NEARAI_BASE_URL")
+                .map(|value| value.is_empty())
+                .unwrap_or(true),
+            "NEARAI_BASE_URL must be unset (or empty) in the real environment for this snapshot test"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
@@ -1628,14 +1628,21 @@ mod tests {
             .expect("nearai provider in snapshot")
     }
 
+    /// Clear the runtime-overlay NEARAI_* entries so overlay state from other
+    /// tests cannot leak into snapshot assertions. A real `NEARAI_API_KEY`
+    /// exported by the developer shell is deliberately tolerated: the
+    /// snapshot assertions below only depend on the base URL, and this
+    /// `#![forbid(unsafe_code)]` crate cannot remove real process env vars.
+    /// `NEARAI_BASE_URL` would change the asserted base URL, so its absence
+    /// from the real env is still checked loudly.
     fn clear_nearai_snapshot_env() {
         for key in ["NEARAI_API_KEY", "NEARAI_BASE_URL"] {
             ironclaw_common::env_helpers::remove_runtime_env(key);
-            assert!(
-                ironclaw_common::env_helpers::env_or_override(key).is_none(),
-                "{key} must be unset for this branch-specific snapshot test"
-            );
         }
+        assert!(
+            std::env::var_os("NEARAI_BASE_URL").is_none(),
+            "NEARAI_BASE_URL must be unset in the real environment for this snapshot test"
+        );
     }
 
     /// nearai has exactly one default now — cloud — regardless of whether an

--- a/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
@@ -91,10 +91,23 @@ pub(crate) fn nearai_mcp_endpoint_from_env() -> Result<NearAiMcpEndpoint, String
 
 pub fn nearai_mcp_bootstrap_config_from_env()
 -> Result<Option<NearAiMcpBootstrapConfig>, NearAiMcpBootstrapConfigError> {
-    let configured_base = ironclaw_common::env_helpers::env_or_override("NEARAI_BASE_URL")
+    nearai_mcp_bootstrap_config_from_lookup(ironclaw_common::env_helpers::env_or_override)
+}
+
+/// Env-shape parsing behind [`nearai_mcp_bootstrap_config_from_env`], with the
+/// variable lookup injected so tests stay hermetic. `env_or_override` consults
+/// the real process environment before the runtime overlay, so a developer
+/// shell exporting a real `NEARAI_API_KEY` cannot be masked by overlay
+/// mutation, and this `#![forbid(unsafe_code)]` crate cannot call
+/// `std::env::remove_var`. Tests therefore drive this function with an
+/// in-memory lookup instead of mutating process state.
+fn nearai_mcp_bootstrap_config_from_lookup(
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<Option<NearAiMcpBootstrapConfig>, NearAiMcpBootstrapConfigError> {
+    let configured_base = lookup("NEARAI_BASE_URL")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let api_key = ironclaw_common::env_helpers::env_or_override("NEARAI_API_KEY")
+    let api_key = lookup("NEARAI_API_KEY")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .map(SecretString::from);
@@ -453,39 +466,16 @@ mod tests {
     use super::*;
     use ironclaw_host_api::{InvocationId, UserId};
 
-    struct NearAiEnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl NearAiEnvGuard {
-        fn new() -> Self {
-            let lock = ironclaw_common::env_helpers::lock_env();
-            assert!(
-                std::env::var_os("NEARAI_BASE_URL").is_none(),
-                "NEARAI_BASE_URL must be unset for deterministic env tests"
-            );
-            assert!(
-                std::env::var_os("NEARAI_API_KEY").is_none(),
-                "NEARAI_API_KEY must be unset for deterministic env tests"
-            );
-            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_BASE_URL");
-            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_API_KEY");
-            Self { _lock: lock }
-        }
-
-        fn set_base_url(&self, value: &str) {
-            ironclaw_common::env_helpers::set_runtime_env("NEARAI_BASE_URL", value);
-        }
-
-        fn set_api_key(&self, value: &str) {
-            ironclaw_common::env_helpers::set_runtime_env("NEARAI_API_KEY", value);
-        }
-    }
-
-    impl Drop for NearAiEnvGuard {
-        fn drop(&mut self) {
-            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_BASE_URL");
-            ironclaw_common::env_helpers::remove_runtime_env("NEARAI_API_KEY");
+    /// Hermetic stand-in for the env lookup injected into
+    /// [`nearai_mcp_bootstrap_config_from_lookup`]: tests must not depend on
+    /// (or mutate) the process environment, where a developer shell may
+    /// legitimately export a real `NEARAI_API_KEY`.
+    fn lookup_from<'a>(entries: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |key| {
+            entries
+                .iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| (*value).to_string())
         }
     }
 
@@ -677,12 +667,12 @@ mod tests {
 
     #[test]
     fn bootstrap_config_from_env_defaults_base_url_when_only_api_key_set() {
-        let env = NearAiEnvGuard::new();
-        env.set_api_key("nearai-test-key");
-
-        let config = nearai_mcp_bootstrap_config_from_env()
-            .expect("env config")
-            .expect("present config");
+        let config = nearai_mcp_bootstrap_config_from_lookup(lookup_from(&[(
+            "NEARAI_API_KEY",
+            "nearai-test-key",
+        )]))
+        .expect("env config")
+        .expect("present config");
 
         assert_eq!(config.base_url, DEFAULT_NEARAI_MCP_BASE_URL);
         assert_eq!(config.api_key.expose_secret(), "nearai-test-key");
@@ -690,13 +680,12 @@ mod tests {
 
     #[test]
     fn bootstrap_config_from_env_uses_both_env_vars_when_set() {
-        let env = NearAiEnvGuard::new();
-        env.set_base_url(" https://search.example.test/v1/ ");
-        env.set_api_key(" nearai-test-key ");
-
-        let config = nearai_mcp_bootstrap_config_from_env()
-            .expect("env config")
-            .expect("present config");
+        let config = nearai_mcp_bootstrap_config_from_lookup(lookup_from(&[
+            ("NEARAI_BASE_URL", " https://search.example.test/v1/ "),
+            ("NEARAI_API_KEY", " nearai-test-key "),
+        ]))
+        .expect("env config")
+        .expect("present config");
 
         assert_eq!(config.base_url, "https://search.example.test/v1/");
         assert_eq!(config.api_key.expose_secret(), "nearai-test-key");
@@ -708,10 +697,8 @@ mod tests {
 
     #[test]
     fn bootstrap_config_from_env_returns_none_when_no_env_vars() {
-        let _env = NearAiEnvGuard::new();
-
         assert!(
-            nearai_mcp_bootstrap_config_from_env()
+            nearai_mcp_bootstrap_config_from_lookup(lookup_from(&[]))
                 .expect("env config")
                 .is_none()
         );


### PR DESCRIPTION
## Failure mode

`crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs` tests `bootstrap_config_from_env_{defaults_base_url_when_only_api_key_set,uses_both_env_vars_when_set,returns_none_when_no_env_vars}` failed on any developer machine whose shell legitimately exports a real `NEARAI_API_KEY`:

```
thread '...' panicked: NEARAI_API_KEY must be unset for deterministic env tests
```

The old `NearAiEnvGuard` had no choice but to *assert* the real env was clean: `ironclaw_common::env_helpers::env_or_override` consults the real process environment **before** the runtime overlay (so overlay mutation cannot shadow a real export), and the crate is `#![forbid(unsafe_code)]` (so `std::env::remove_var` is unavailable). The sibling `llm_config_service.rs` snapshot tests had the same fragile assert in `clear_nearai_snapshot_env`.

## Fix — inject the env lookup

- `nearai_mcp_bootstrap_config_from_env()` is now a thin production wrapper over a new `nearai_mcp_bootstrap_config_from_lookup(lookup: impl Fn(&str) -> Option<String>)` that owns all the trim/empty-filter/`from_optional_parts` logic. Production passes `env_or_override`; the tests pass an in-memory map — no process-env dependency, no env mutex, parallel-safe. This mirrors the existing parameterized seams in the same file (`nearai_mcp_endpoint_from_base`, `from_optional_parts`); the repo's env-mutation guard pattern (`ironclaw_reborn_cli::runtime::test_env::EnvGuard`) is unavailable here because of `forbid(unsafe_code)`.
- `llm_config_service.rs`: `clear_nearai_snapshot_env` no longer asserts `NEARAI_API_KEY` absence — the snapshot assertions there depend only on the base URL, so a real exported key is deliberately tolerated. The `NEARAI_BASE_URL` precondition stays a loud assert because that variable would change the asserted URL and cannot be masked in this crate.
- `NEARAI_API_KEY` / `NEARAI_BASE_URL` remain untouched as the production configuration contract.

## Regression coverage

Per repo convention the changed tests are themselves the regression tests — they failed before the fix and pass after, under an exported key:

```
NEARAI_API_KEY=test-shell-key cargo test -p ironclaw_reborn_composition nearai_mcp   # 18 passed; 0 failed (was 3 failed)
env -u NEARAI_API_KEY cargo test -p ironclaw_reborn_composition nearai_mcp           # 18 passed; 0 failed
NEARAI_API_KEY=test-shell-key cargo test -p ironclaw_reborn_composition --all-features llm_config_service  # 35 passed (snapshot tests previously panicked)
```

`cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings` clean; `scripts/pre-commit-safety.sh` exits 0.

Note (out of scope): `runtime/tests/core.rs::RuntimeEnvGuard` clears `NEARAI_API_KEY` only in the runtime overlay, so a real export can still leak into those feature-gated tests; masking it there needs the same lookup-injection treatment in the runtime seams and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)