### PR TITLE
feat(reborn): ResolutionBatch + parks() loop-suspension predicate + scripted-outcome fixture (§5.3 flip prep / Stage 1)

### DIFF
--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -10,7 +10,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_host_api::{CapabilityId, RuntimeKind, TenantId, ThreadId};
+use ironclaw_host_api::{
+    CapabilityId, Resolution, ResolutionBatch, RuntimeKind, TenantId, ThreadId,
+};
 use ironclaw_turns::{
     AgentLoopDriverDescriptor, LoopFailureKind, LoopGateRef, LoopMessageRef, LoopResultRef,
     RunProfileId, RunProfileVersion, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
@@ -33,7 +35,7 @@ use ironclaw_turns::{
         ResolvedRunProfile, ResourceBudgetPolicy, ResourceBudgetTier, RunClassId,
         RunProfileFingerprint, RuntimeProfileConstraints, SchedulingClass,
         StageCheckpointPayloadRequest, SteeringPolicy, VisibleCapabilityRequest,
-        VisibleCapabilitySurface,
+        VisibleCapabilitySurface, capability_outcome_to_resolution,
     },
 };
 
@@ -592,6 +594,37 @@ impl ScriptedCapabilityOutcome {
         Self::Failed {
             error_kind: scripted_failure_kind(error_kind.as_ref()),
         }
+    }
+}
+
+/// Convert a fixture [`CapabilityOutcome`] to its host_api [`Resolution`] channel
+/// via the production mapping ([`capability_outcome_to_resolution`]), discarding
+/// the side records the pure mapping also emits.
+///
+/// The §5.3 capability-result flip re-points the loop's ~150 existing
+/// `CapabilityOutcome` test fixtures at `Resolution`. This lets each of those
+/// convert through the real mapping instead of hand-rolling a `Resolution` by
+/// hand (which would drift from the acceptance table). Additive: nothing wires
+/// it yet.
+pub fn resolution_from_scripted_outcome(outcome: CapabilityOutcome) -> Resolution {
+    capability_outcome_to_resolution(outcome).resolution
+}
+
+/// Convert a batch of fixture [`CapabilityOutcome`]s to a [`ResolutionBatch`],
+/// mapping each through [`resolution_from_scripted_outcome`] and carrying the
+/// `stopped_on_suspension` flag through unchanged — the `Resolution`-over-
+/// `CapabilityOutcome` analogue of `CapabilityBatchOutcome`, for the flip's
+/// batch-loop test sites.
+pub fn resolution_batch_from_scripted(
+    outcomes: impl IntoIterator<Item = CapabilityOutcome>,
+    stopped_on_suspension: bool,
+) -> ResolutionBatch {
+    ResolutionBatch {
+        resolutions: outcomes
+            .into_iter()
+            .map(resolution_from_scripted_outcome)
+            .collect(),
+        stopped_on_suspension,
     }
 }
 
@@ -1263,4 +1296,66 @@ fn lock_or_panic<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 
 fn clone_mutex_vec<T: Clone>(mutex: &Mutex<Vec<T>>) -> Vec<T> {
     lock_or_panic(mutex).clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fixture `CapabilityOutcome` from a scripted outcome via the same
+    /// private mapper the mock host uses, so these tests exercise the real
+    /// fixture-shaped inputs the flip will feed the helpers.
+    fn outcome(scripted: ScriptedCapabilityOutcome) -> CapabilityOutcome {
+        scripted_capability_outcome(scripted).expect("scripted fixture builds an outcome")
+    }
+
+    #[test]
+    fn scripted_outcome_maps_to_the_right_resolution_channel() {
+        // Completed → Done (ran, does not park).
+        let completed = resolution_from_scripted_outcome(outcome(
+            ScriptedCapabilityOutcome::completed("result:one"),
+        ));
+        assert_eq!(completed.kind(), "done");
+        assert!(!completed.parks());
+
+        // Failed → Done (a recoverable failure rides the Done channel; the model
+        // can retry) — it does not park.
+        let failed =
+            resolution_from_scripted_outcome(outcome(ScriptedCapabilityOutcome::failed("network")));
+        assert_eq!(failed.kind(), "done");
+        assert!(!failed.parks());
+
+        // ApprovalRequired → Blocked (a re-entrant gate): it parks but is NOT a
+        // suspension — the distinction parks() exists to preserve.
+        let approval = resolution_from_scripted_outcome(outcome(
+            ScriptedCapabilityOutcome::ApprovalRequired {
+                gate_ref: "gate:approve-1".to_string(),
+            },
+        ));
+        assert_eq!(approval.kind(), "blocked");
+        assert!(approval.parks());
+        assert!(!approval.is_suspension());
+    }
+
+    #[test]
+    fn resolution_batch_from_scripted_preserves_order_and_stop_flag() {
+        let batch = resolution_batch_from_scripted(
+            [
+                outcome(ScriptedCapabilityOutcome::completed("result:a")),
+                outcome(ScriptedCapabilityOutcome::AwaitDependentRun {
+                    gate_ref: "gate:dep-1".to_string(),
+                    result_ref: "result:dep-1".to_string(),
+                    byte_len: 0,
+                }),
+            ],
+            true,
+        );
+        assert!(batch.stopped_on_suspension);
+        assert_eq!(batch.resolutions.len(), 2);
+        assert_eq!(batch.resolutions[0].kind(), "done");
+        // AwaitDependentRun → Suspended: parks and is a suspension.
+        assert_eq!(batch.resolutions[1].kind(), "suspended");
+        assert!(batch.resolutions[1].parks());
+        assert!(batch.resolutions[1].is_suspension());
+    }
 }

--- a/crates/ironclaw_host_api/src/resolution.rs
+++ b/crates/ironclaw_host_api/src/resolution.rs
@@ -523,7 +523,13 @@ impl Resolution {
     /// closes ahead of the atomic flip. `Done` (ran, including the non-suspending
     /// `ChildSpawned`) and terminal `Denied` do not park.
     pub fn parks(&self) -> bool {
-        matches!(self, Resolution::Blocked(_) | Resolution::Suspended(_))
+        // Exhaustive match, not `matches!`: a new `Resolution` variant must be
+        // a compile error here (§11.9 no-wildcard) so its parking behavior is
+        // decided deliberately, never silently defaulted to `false`.
+        match self {
+            Resolution::Blocked(_) | Resolution::Suspended(_) => true,
+            Resolution::Done(_) | Resolution::Denied(_) => false,
+        }
     }
 
     /// Whether this is a re-entrant gate (resolving it re-enters `authorize()`).

--- a/crates/ironclaw_host_api/src/resolution.rs
+++ b/crates/ironclaw_host_api/src/resolution.rs
@@ -494,8 +494,36 @@ impl Resolution {
     /// suspends — a `Done` with a `ChildSpawned` verdict is explicitly
     /// non-suspending (§5.3 table: the executor appends the child result and
     /// continues). Getting this wrong is the #6137 bug class.
+    ///
+    /// This is the *narrow* suspension question ("is this the parked-work
+    /// channel?"). A batch loop that stops early on the first invocation that
+    /// cannot be followed by more work must use [`Resolution::parks`] instead —
+    /// it also stops on a re-entrant gate, which `is_suspension` deliberately
+    /// excludes.
     pub fn is_suspension(&self) -> bool {
         matches!(self, Resolution::Suspended(_))
+    }
+
+    /// Whether the batch loop *parks* on this resolution — the loop-semantics
+    /// suspension predicate the §5.3 flip's batch loops must gate on, a strict
+    /// SUPERSET of [`Resolution::is_suspension`].
+    ///
+    /// A batch that stops "on first suspension" must also stop on a re-entrant
+    /// gate ([`Resolution::Blocked`] — approval/auth/resource): the gated
+    /// invocation did not run, so nothing after it in the batch can proceed
+    /// until it is resolved, exactly as parked work ([`Resolution::Suspended`] —
+    /// process/dependent-run/external-tool) blocks the batch. `parks()` answers
+    /// the *loop* question "does the batch stop here?"; `is_suspension()` answers
+    /// the narrower "is this the parked-work channel?".
+    ///
+    /// `parks()` ⊋ `is_suspension()`: every `Suspended` parks, but a
+    /// `Blocked::Approval` parks while it is NOT a suspension. Using
+    /// `is_suspension()` where `parks()` is meant silently lets a gate fall
+    /// through as if the call had completed — the verified hazard §5.3 Stage 1
+    /// closes ahead of the atomic flip. `Done` (ran, including the non-suspending
+    /// `ChildSpawned`) and terminal `Denied` do not park.
+    pub fn parks(&self) -> bool {
+        matches!(self, Resolution::Blocked(_) | Resolution::Suspended(_))
     }
 
     /// Whether this is a re-entrant gate (resolving it re-enters `authorize()`).
@@ -511,6 +539,33 @@ impl Resolution {
             _ => None,
         }
     }
+}
+
+/// The loop-facing result of a *batch* of capability invocations — the §5.3
+/// flip's [`Resolution`]-over-`CapabilityOutcome` replacement for the loop's
+/// current `CapabilityBatchOutcome` (`ironclaw_turns`). It mirrors that type's
+/// shape and semantics exactly: the per-invocation [`Resolution`]s in call
+/// order, plus whether the executor stopped early because one of them *parked*.
+///
+/// The stop flag keeps its established name, `stopped_on_suspension`, to match
+/// `CapabilityBatchOutcome`; note the flip's loop must set it whenever an
+/// invocation [`Resolution::parks`] — a re-entrant gate as well as a suspension —
+/// not only on the narrower [`Resolution::is_suspension`]. That is precisely the
+/// predicate this slice provides so the flip has one canonical, tested site to
+/// call.
+///
+/// Additive (§9): nothing produces or consumes a `ResolutionBatch` yet — the
+/// flip's batch loops adopt it. Wire-stable serde (a bounded `Vec` + `bool`, per
+/// the `host_api` charter) so a persisted or transported batch keeps its
+/// contract if it is ever serialized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolutionBatch {
+    /// The resolution for each invocation, in call order.
+    pub resolutions: Vec<Resolution>,
+    /// True when the batch stopped early because an invocation parked
+    /// ([`Resolution::parks`]) and the batch was configured to stop on the first
+    /// such park.
+    pub stopped_on_suspension: bool,
 }
 
 #[cfg(test)]
@@ -877,16 +932,21 @@ mod tests {
     #[test]
     fn resolution_covers_the_full_acceptance_table() {
         let proc = || ProcessRef::parse("0f0e0d0c-0b0a-4908-8706-050403020100").unwrap();
-        // (today's CapabilityOutcome variant, the Resolution channel, is_suspension)
-        let rows: [(&str, Resolution, bool); 10] = [
+        // (today's CapabilityOutcome variant, the Resolution channel,
+        //  is_suspension, parks). `parks` ⊇ `is_suspension`: it adds the three
+        // re-entrant gate variants (Approval/Auth/Resource) the batch loop must
+        // also stop on — see `parks_is_a_strict_superset_of_is_suspension`.
+        let rows: [(&str, Resolution, bool, bool); 10] = [
             (
                 "Completed",
                 Resolution::Done(outcome(ToolVerdict::Success)),
+                false,
                 false,
             ),
             (
                 "Failed",
                 Resolution::Done(outcome(recoverable_failure())),
+                false,
                 false,
             ),
             (
@@ -895,25 +955,30 @@ mod tests {
                     DenyRef::parse("018f6a00-0000-7000-8000-000000000002").unwrap(),
                 )),
                 false,
+                false,
             ),
             (
                 "ApprovalRequired",
                 Resolution::Blocked(Blocked::Approval(GateWaypoint::new(gate()))),
                 false,
+                true,
             ),
             (
                 "AuthRequired",
                 Resolution::Blocked(Blocked::Auth(GateWaypoint::new(gate()))),
                 false,
+                true,
             ),
             (
                 "ResourceBlocked",
                 Resolution::Blocked(Blocked::Resource(GateWaypoint::new(gate()))),
                 false,
+                true,
             ),
             (
                 "SpawnedProcess",
                 Resolution::Suspended(Suspension::Process(ProcessWaypoint::new(proc()))),
+                true,
                 true,
             ),
             // Non-suspending — the one that has bitten before (#6137, §5.3 table).
@@ -921,30 +986,113 @@ mod tests {
                 "SpawnedChildRun",
                 Resolution::Done(outcome(child_spawned())),
                 false,
+                false,
             ),
             (
                 "AwaitDependentRun",
                 Resolution::Suspended(Suspension::DependentRun(GateWaypoint::new(gate()))),
+                true,
                 true,
             ),
             (
                 "ExternalToolPending",
                 Resolution::Suspended(Suspension::ExternalTool(GateWaypoint::new(gate()))),
                 true,
+                true,
             ),
         ];
         assert_eq!(rows.len(), 10, "all ten CapabilityOutcome variants covered");
-        for (variant, resolution, suspends) in rows {
+        for (variant, resolution, suspends, parks) in rows {
             assert_eq!(
                 resolution.is_suspension(),
                 suspends,
                 "{variant}: suspension semantics"
             );
+            assert_eq!(resolution.parks(), parks, "{variant}: park semantics");
             // Round-trips through the wire like every channel.
             let json = serde_json::to_value(&resolution).unwrap();
             let back: Resolution = serde_json::from_value(json).unwrap();
             assert_eq!(back, resolution, "{variant}: round-trip");
         }
+    }
+
+    /// `parks()` is the loop-suspension predicate the §5.3 batch loops must gate
+    /// on — a STRICT superset of `is_suspension()`. The inner match is
+    /// exhaustive by construction: a new `Resolution` variant added later will
+    /// fail to compile here until its park semantics are declared (§11.9).
+    #[test]
+    fn parks_is_a_strict_superset_of_is_suspension() {
+        fn expected_parks(resolution: &Resolution) -> bool {
+            match resolution {
+                // Ran (incl. the non-suspending ChildSpawned) or terminally
+                // denied: the batch continues past it.
+                Resolution::Done(_) | Resolution::Denied(_) => false,
+                // Re-entrant gates AND parked work: the batch stops here.
+                Resolution::Blocked(_) | Resolution::Suspended(_) => true,
+            }
+        }
+
+        let samples = [
+            Resolution::Done(outcome(ToolVerdict::Success)),
+            Resolution::Done(outcome(child_spawned())),
+            Resolution::Denied(Denial::new(
+                DenyRef::parse("018f6a00-0000-7000-8000-000000000002").unwrap(),
+            )),
+            Resolution::Blocked(Blocked::Approval(gate_wp())),
+            Resolution::Blocked(Blocked::Auth(gate_wp())),
+            Resolution::Blocked(Blocked::Resource(gate_wp())),
+            Resolution::Suspended(Suspension::Process(proc_wp())),
+            Resolution::Suspended(Suspension::DependentRun(gate_wp())),
+            Resolution::Suspended(Suspension::ExternalTool(gate_wp())),
+        ];
+        for resolution in &samples {
+            assert_eq!(
+                resolution.parks(),
+                expected_parks(resolution),
+                "parks() disagrees for {}",
+                resolution.kind()
+            );
+            // Superset direction: every suspension parks.
+            if resolution.is_suspension() {
+                assert!(
+                    resolution.parks(),
+                    "{}: is_suspension ⊆ parks",
+                    resolution.kind()
+                );
+            }
+        }
+
+        // STRICT: a re-entrant approval gate parks but is NOT a suspension — the
+        // exact variant a naive `is_suspension()` batch guard would mis-handle
+        // as if the call had completed (the hazard §5.3 Stage 1 closes).
+        let gate = Resolution::Blocked(Blocked::Approval(gate_wp()));
+        assert!(gate.parks(), "an approval gate parks");
+        assert!(
+            !gate.is_suspension(),
+            "an approval gate is not a suspension"
+        );
+    }
+
+    #[test]
+    fn resolution_batch_mirrors_capability_batch_outcome_and_roundtrips() {
+        let batch = ResolutionBatch {
+            resolutions: vec![
+                Resolution::Done(outcome(ToolVerdict::Success)),
+                Resolution::Blocked(Blocked::Approval(GateWaypoint::new(gate()))),
+            ],
+            stopped_on_suspension: true,
+        };
+        // Order and the stop flag survive a wire round-trip.
+        let back: ResolutionBatch =
+            serde_json::from_value(serde_json::to_value(&batch).unwrap()).unwrap();
+        assert_eq!(back, batch);
+        assert!(back.stopped_on_suspension);
+        assert_eq!(back.resolutions.len(), 2);
+        assert_eq!(back.resolutions[0].kind(), "done");
+        // The batch stopped on a variant that parks (a gate) — exactly why the
+        // flip's loop must gate on parks(), not the narrower is_suspension().
+        assert!(back.resolutions[1].parks());
+        assert!(!back.resolutions[1].is_suspension());
     }
 
     #[test]

--- a/crates/ironclaw_runner/src/planned_driver.rs
+++ b/crates/ironclaw_runner/src/planned_driver.rs
@@ -1208,7 +1208,6 @@ mod tests {
             resume_token: None,
             activity_id,
             prior_approval: None,
-            replay: None,
             disposition: None,
         });
         state
@@ -1361,7 +1360,7 @@ mod tests {
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
         use ironclaw_agent_loop::state::PendingApprovalResume;
-        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId};
         use ironclaw_turns::LoopGateRef;
         use ironclaw_turns::run_profile::{
             CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
@@ -1385,8 +1384,6 @@ mod tests {
                 .expect("valid input ref"),
             effective_capability_ids: Vec::new(),
             provider_replay: None,
-            input: serde_json::Value::Null,
-            estimate: ResourceEstimate::default(),
             disposition: None,
         });
         state
@@ -1551,7 +1548,7 @@ mod tests {
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
         use ironclaw_agent_loop::state::{PendingApprovalResume, PendingAuthResume};
-        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId};
         use ironclaw_turns::LoopGateRef;
         use ironclaw_turns::run_profile::{
             CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
@@ -1576,7 +1573,6 @@ mod tests {
             resume_token: None,
             activity_id: auth_activity_id,
             prior_approval: None,
-            replay: None,
             disposition: None,
         });
         state.pending_approval_resume = Some(PendingApprovalResume {
@@ -1593,8 +1589,6 @@ mod tests {
             input_ref: CapabilityInputRef::new("input:dual-approval").expect("valid input ref"),
             effective_capability_ids: Vec::new(),
             provider_replay: None,
-            input: serde_json::Value::Null,
-            estimate: ResourceEstimate::default(),
             disposition: None,
         });
         state
@@ -1741,7 +1735,7 @@ mod tests {
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
         use ironclaw_agent_loop::state::{PendingApprovalResume, PendingAuthResume};
-        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId};
         use ironclaw_turns::LoopGateRef;
         use ironclaw_turns::run_profile::{
             CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
@@ -1763,7 +1757,6 @@ mod tests {
             resume_token: None,
             activity_id: auth_activity_id,
             prior_approval: None,
-            replay: None,
             disposition: None,
         });
         state.pending_approval_resume = Some(PendingApprovalResume {
@@ -1781,8 +1774,6 @@ mod tests {
                 .expect("valid input ref"),
             effective_capability_ids: Vec::new(),
             provider_replay: None,
-            input: serde_json::Value::Null,
-            estimate: ResourceEstimate::default(),
             disposition: None,
         });
         state


### PR DESCRIPTION
## Stage 1 of the capability-result flip — additive vocabulary + fixtures

Small ADDITIVE slice ahead of the §5.3 capability-result flip
(`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`).
Nothing consumes the new items yet, so the tree stays green — no trait
flip, no consumer change, `CapabilityOutcome` untouched.

### The hazard this closes (verified)

`Resolution::is_suspension()` is `Suspended(_)` **only**. But the batch
loops the flip rewrites (gating on `stop_on_first_suspension`) must also
stop on the **re-entrant gate** variants — `Resolution::Blocked`
(Approval/Auth/Resource) — which map to `Blocked`, **not** `Suspended`.
A naive `is_suspension()` batch guard would silently let a gate fall
through as if the call had completed (the #6137 bug class). This slice
provides the correct predicate now so the flip has one canonical, tested
site to call.

Verified red: temporarily defining `parks()` as the naive
`matches!(self, Suspended(_))` makes the exhaustive test fail
(`parks() disagrees for blocked`); the correct impl is green.

### What's added

**`ironclaw_host_api` (next to `Resolution`)**

- `Resolution::parks(&self) -> bool` — the loop-semantics suspension
  predicate. `true` for **every** `Blocked` variant (Approval/Auth/
  Resource — re-entrant gates) **and** every `Suspended` variant
  (Process/DependentRun/ExternalTool — parked work); `false` for `Done`
  (incl. the non-suspending `ChildSpawned`) and terminal `Denied`.
  `parks()` ⊋ `is_suspension()`: a `Blocked::Approval` parks but is not a
  suspension. `is_suspension()` keeps its narrow meaning, unchanged. (In
  the host_api model, `AwaitDependentRun` is not a distinct channel — it
  is `Suspended(Suspension::DependentRun)` — so it is covered by the
  `Suspended(_)` arm.)
- `ResolutionBatch { resolutions: Vec<Resolution>, stopped_on_suspension: bool }`
  — the loop-facing batch result the flip adopts, mirroring
  `CapabilityBatchOutcome`'s shape/semantics over `Resolution`. Wire-
  stable serde (bounded `Vec` + `bool`, per the host_api charter). The
  stop flag keeps the established name `stopped_on_suspension`; the flip's
  loop must set it whenever an invocation `parks()`, not only on
  `is_suspension()`.

**`ironclaw_agent_loop::test_support` (behind the existing `test-support` feature)**

- `resolution_from_scripted_outcome(outcome: CapabilityOutcome) -> Resolution`
  — wraps `capability_outcome_to_resolution(outcome).resolution`.
- `resolution_batch_from_scripted(outcomes, stopped_on_suspension) -> ResolutionBatch`
  — maps each outcome through the above, carrying the flag.

These let the flip's ~150 `CapabilityOutcome` fixture sites convert
through the real production mapping instead of hand-rolling `Resolution`.

### Tests (written first, watched fail, then green)

- **host_api** — extended `resolution_covers_the_full_acceptance_table`
  with a `parks` column across all 10 CapabilityOutcome→Resolution rows;
  new `parks_is_a_strict_superset_of_is_suspension` with an **exhaustive
  `match`** that compile-fails if a new `Resolution` variant is added
  (§11.9), proving `parks()` ⊋ `is_suspension()` (a `Blocked::Approval`
  parks but is not a suspension); new `ResolutionBatch` round-trip.
- **agent_loop test-support** — `scripted_outcome_maps_to_the_right_resolution_channel`
  round-trips Completed/Failed/ApprovalRequired to the right channel;
  `resolution_batch_from_scripted_preserves_order_and_stop_flag`.

### Verification (all green)

- `cargo test -p ironclaw_host_api --all-features` — 88 pass
- `cargo test -p ironclaw_agent_loop --features test-support` — 401 pass (incl. the 2 new fixture tests)
- `cargo clippy -p ironclaw_host_api --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p ironclaw_agent_loop --all-targets --all-features -- -D warnings` — clean
- `cargo test -p ironclaw_architecture` — 10 pass
- `scripts/pre-commit-safety.sh` — exit 0

Nothing outside the definitions and their tests references the new items
(confirmed by grep) — purely additive, no flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
