### PR TITLE
refactor(composition): enforcement axes become resolved policy values, not profile matches

### DIFF
--- a/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
@@ -16,8 +16,9 @@ use ironclaw_approvals::{
 use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
 use ironclaw_host_api::{
     CapabilityId, EffectKind, InvocationId, Principal, ResourceScope,
-    runtime_policy::{ApprovalPolicy, EffectiveRuntimePolicy, RuntimeProfile},
+    runtime_policy::{ApprovalPolicy, EffectiveRuntimePolicy},
 };
+use ironclaw_runtime_policy::MinimalApprovalBypass;
 use tokio::sync::Notify;
 
 use crate::builtin_capability_policy::BuiltinCapabilityPolicy;
@@ -33,11 +34,11 @@ pub(crate) fn local_dev_authorizer(
     capability_policy: Arc<BuiltinCapabilityPolicy>,
     settings: Arc<dyn ApprovalSettingsProvider>,
 ) -> Arc<dyn TrustAwareCapabilityDispatchAuthorizer> {
-    let (approval_policy, resolved_profile) = local_dev_approval_policy(runtime_policy);
+    let (approval_policy, minimal_bypass) = local_dev_approval_policy(runtime_policy);
     let gate_effects = capability_policy.approval_gate_effects();
     let exempt_capabilities = capability_policy.approval_gate_exempt_capabilities();
     let gate_policy: Arc<dyn ProfileApprovalGatePolicy> = Arc::new(
-        RuntimeProfileApprovalGatePolicy::new(resolved_profile, gate_effects)
+        RuntimeProfileApprovalGatePolicy::new(minimal_bypass, gate_effects)
             .with_exempt_capabilities(exempt_capabilities),
     );
     profile_approval_authorizer(approval_policy, gate_policy, settings)
@@ -571,24 +572,31 @@ pub(crate) fn local_dev_effects_require_approval(
     capability_policy: &BuiltinCapabilityPolicy,
     effects: &[EffectKind],
 ) -> bool {
-    let (approval_policy, resolved_profile) = local_dev_approval_policy(runtime_policy);
-    RuntimeProfileApprovalGatePolicy::new(
-        resolved_profile,
-        capability_policy.approval_gate_effects(),
-    )
-    .effects_require_approval(approval_policy, effects)
+    let (approval_policy, minimal_bypass) = local_dev_approval_policy(runtime_policy);
+    RuntimeProfileApprovalGatePolicy::new(minimal_bypass, capability_policy.approval_gate_effects())
+        .effects_require_approval(approval_policy, effects)
 }
 
+/// Approval width plus the resolved `Minimal`-bypass value for a runtime
+/// policy.
+///
+/// The absent-policy case fails closed: `AskAlways` with the bypass denied.
+/// This deliberately replaces the previous `unwrap_or(RuntimeProfile::LocalDev)`
+/// fallback, which silently invented a *deployment profile* when none was
+/// resolved — the mode-as-type leak §4.4 removes, and a silent default on an
+/// authority decision that `.claude/rules/error-handling.md` forbids. Every
+/// production path resolves a policy (`build_reborn_runtime` rejects the input
+/// otherwise), so this arm is reachable only from callers that never had one.
 fn local_dev_approval_policy(
     runtime_policy: Option<&EffectiveRuntimePolicy>,
-) -> (ApprovalPolicy, RuntimeProfile) {
-    let approval_policy = runtime_policy
-        .map(|policy| policy.approval_policy)
-        .unwrap_or(ApprovalPolicy::AskDestructive);
-    let resolved_profile = runtime_policy
-        .map(|policy| policy.resolved_profile)
-        .unwrap_or(RuntimeProfile::LocalDev);
-    (approval_policy, resolved_profile)
+) -> (ApprovalPolicy, MinimalApprovalBypass) {
+    match runtime_policy {
+        Some(policy) => (
+            policy.approval_policy,
+            ironclaw_runtime_policy::minimal_approval_bypass(policy),
+        ),
+        None => (ApprovalPolicy::AskAlways, MinimalApprovalBypass::Denied),
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_composition/src/local_dev_authorization/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_authorization/tests.rs
@@ -1010,3 +1010,65 @@ async fn global_auto_approve_does_not_bypass_manifest_ineligible_tool_through_st
         "global auto-approve must not bypass a manifest-ineligible tool, got {decision:?}"
     );
 }
+
+#[test]
+fn absent_runtime_policy_fails_closed_to_ask_always_without_minimal_bypass() {
+    // Regression for the §4.4 mode-as-type leak: `local_dev_approval_policy`
+    // used to answer an absent runtime policy with
+    // `unwrap_or(RuntimeProfile::LocalDev)` — inventing a *deployment profile*
+    // to derive authority from, and defaulting the approval width to the
+    // narrower-than-safest `AskDestructive`. It now fails closed on both axes.
+    let policy = builtin_capability_policy().expect("capability policy");
+
+    // `ReadFilesystem` is not in either gate-effect set, so under the old
+    // `AskDestructive` default it did not require approval. Under the
+    // fail-closed `AskAlways` default any non-empty effect set does.
+    assert!(
+        local_dev_effects_require_approval(None, &policy, &[EffectKind::ReadFilesystem]),
+        "an absent runtime policy must fail closed to AskAlways"
+    );
+    // The empty effect set still needs no approval under AskAlways — the
+    // fallback tightens the width, it does not gate effect-free capabilities.
+    assert!(!local_dev_effects_require_approval(None, &policy, &[]));
+}
+
+#[test]
+fn resolved_yolo_policy_allows_minimal_bypass_but_org_ceiling_removes_it() {
+    // The paired positive case, driven through the production caller: a
+    // resolved trusted-laptop policy bypasses effect gates under `Minimal`,
+    // and the same request under an org ceiling does not.
+    let policy = builtin_capability_policy().expect("capability policy");
+    let effects = [EffectKind::SpawnProcess];
+
+    let yolo = ironclaw_runtime_policy::resolve(ironclaw_runtime_policy::ResolveRequest {
+        yolo_disclosure_acknowledged: true,
+        ..ironclaw_runtime_policy::ResolveRequest::new(
+            ironclaw_host_api::runtime_policy::DeploymentMode::LocalSingleUser,
+            ironclaw_host_api::runtime_policy::RuntimeProfile::LocalYolo,
+        )
+    })
+    .expect("local yolo resolves");
+    assert_eq!(
+        yolo.approval_policy,
+        ironclaw_host_api::runtime_policy::ApprovalPolicy::Minimal
+    );
+    assert!(
+        !local_dev_effects_require_approval(Some(&yolo), &policy, &effects),
+        "resolved local-yolo must bypass effect gates under Minimal"
+    );
+
+    let narrowed = ironclaw_runtime_policy::resolve(ironclaw_runtime_policy::ResolveRequest {
+        yolo_disclosure_acknowledged: true,
+        org_policy: ironclaw_runtime_policy::OrgPolicyConstraints::default()
+            .set_max_profile(ironclaw_host_api::runtime_policy::RuntimeProfile::LocalDev),
+        ..ironclaw_runtime_policy::ResolveRequest::new(
+            ironclaw_host_api::runtime_policy::DeploymentMode::LocalSingleUser,
+            ironclaw_host_api::runtime_policy::RuntimeProfile::LocalYolo,
+        )
+    })
+    .expect("narrowed local yolo resolves");
+    assert!(
+        local_dev_effects_require_approval(Some(&narrowed), &policy, &effects),
+        "an org ceiling that removes yolo must restore effect gates"
+    );
+}

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3159,12 +3159,18 @@ pub async fn build_reborn_runtime(
             reason: format!("profile={profile} must not start live Reborn runtime traffic"),
         });
     }
-    if services_input.runtime_policy().is_none() {
-        return Err(RebornRuntimeError::InvalidArgument {
-            reason: "RebornRuntimeInput.services must include a resolved runtime policy"
-                .to_string(),
-        });
-    }
+    // Capture the resolved policy before `build_reborn_services` consumes the
+    // input. Downstream wiring selects enforcement behaviour from resolved
+    // policy *values* (§4.4) rather than re-branching on the deployment
+    // profile, so the policy has to outlive the services input.
+    let runtime_policy =
+        services_input
+            .runtime_policy()
+            .cloned()
+            .ok_or(RebornRuntimeError::InvalidArgument {
+                reason: "RebornRuntimeInput.services must include a resolved runtime policy"
+                    .to_string(),
+            })?;
 
     let validated_identity = validate_runtime_identity(identity)?;
     services_input = services_input.with_local_runtime_identity(
@@ -3418,8 +3424,11 @@ pub async fn build_reborn_runtime(
     let resolved_cost_table = llm_cost_table_arc;
 
     // Build the model budget accountant from the resolved cost table plus
-    // the local-dev governor. `local-dev-yolo` is the explicit local
-    // exception: it inherits host trust and must not pause on budget gates.
+    // the local-dev governor. `BudgetEnforcement::Unenforced` — the resolved
+    // trusted-laptop boundary — is the explicit exception: it inherits host
+    // trust and must not pause on budget gates. Reading the resolved value
+    // rather than the deployment profile means a tenant/org ceiling that
+    // narrows yolo away also restores enforcement (§4.4).
     // When neither an LLM policy nor a test override supplies a cost table
     // we deliberately skip the accountant — there's no spend to track and
     // the cascade would never fire.
@@ -3437,8 +3446,11 @@ pub async fn build_reborn_runtime(
     // re-read by the wiring helper).
     let model_budget_accountant: Option<
         Arc<dyn ironclaw_turns::run_profile::LoopModelBudgetAccountant>,
-    > = match (profile, resolved_cost_table) {
-        (RebornCompositionProfile::LocalDevYolo, _) => None,
+    > = match (
+        ironclaw_runtime_policy::budget_enforcement(&runtime_policy),
+        resolved_cost_table,
+    ) {
+        (ironclaw_runtime_policy::BudgetEnforcement::Unenforced, _) => None,
         (_, Some(cost_table)) => {
             let resolved_budget_defaults = match budget_defaults {
                 Some(defaults) => {

--- a/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
@@ -1,7 +1,5 @@
-use ironclaw_host_api::{
-    CapabilityId, EffectKind,
-    runtime_policy::{ApprovalPolicy, RuntimeProfile},
-};
+use ironclaw_host_api::{CapabilityId, EffectKind, runtime_policy::ApprovalPolicy};
+use ironclaw_runtime_policy::MinimalApprovalBypass;
 
 use crate::profile_approval_authorization::ProfileApprovalGatePolicy;
 
@@ -22,18 +20,22 @@ impl RuntimeProfileApprovalGateEffectSets {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeProfileApprovalGatePolicy {
-    resolved_profile: RuntimeProfile,
+    /// Whether `ApprovalPolicy::Minimal` may bypass effect gates, as a
+    /// resolved policy *value* — not a deployment profile this type then asks
+    /// about itself (§4.4). `ironclaw_runtime_policy::minimal_approval_bypass`
+    /// is the one place that classification lives.
+    minimal_bypass: MinimalApprovalBypass,
     effects: RuntimeProfileApprovalGateEffectSets,
     exempt_capabilities: Vec<CapabilityId>,
 }
 
 impl RuntimeProfileApprovalGatePolicy {
     pub(crate) fn new(
-        resolved_profile: RuntimeProfile,
+        minimal_bypass: MinimalApprovalBypass,
         effects: RuntimeProfileApprovalGateEffectSets,
     ) -> Self {
         Self {
-            resolved_profile,
+            minimal_bypass,
             effects,
             exempt_capabilities: Vec::new(),
         }
@@ -48,7 +50,7 @@ impl RuntimeProfileApprovalGatePolicy {
     }
 
     fn profile_allows_minimal_bypass(&self) -> bool {
-        self.resolved_profile.allows_minimal_approval_bypass()
+        self.minimal_bypass == MinimalApprovalBypass::Allowed
     }
 }
 
@@ -97,19 +99,44 @@ impl ProfileApprovalGatePolicy for RuntimeProfileApprovalGatePolicy {
 mod tests {
     use ironclaw_host_api::{
         EffectKind,
-        runtime_policy::{ApprovalPolicy, RuntimeProfile},
+        runtime_policy::{ApprovalPolicy, DeploymentMode, RuntimeProfile},
     };
+    use ironclaw_runtime_policy::{OrgPolicyConstraints, ResolveRequest};
 
     use super::*;
 
+    /// Build the gate policy the way production does: resolve the profile
+    /// through the sanctioned resolver, then classify the resolved policy.
+    /// Driving the real resolver here (rather than hand-picking a bypass
+    /// value) keeps this suite honest about which profiles actually reach
+    /// `MinimalApprovalBypass::Allowed`.
     fn policy(profile: RuntimeProfile) -> RuntimeProfileApprovalGatePolicy {
         RuntimeProfileApprovalGatePolicy::new(
-            profile,
+            bypass_for(profile),
             RuntimeProfileApprovalGateEffectSets::new(
                 vec![EffectKind::WriteFilesystem, EffectKind::SpawnProcess],
                 vec![EffectKind::SpawnProcess],
             ),
         )
+    }
+
+    fn bypass_for(profile: RuntimeProfile) -> MinimalApprovalBypass {
+        let deployment = match profile {
+            RuntimeProfile::HostedSafe
+            | RuntimeProfile::HostedDev
+            | RuntimeProfile::HostedYoloTenantScoped => DeploymentMode::HostedMultiTenant,
+            RuntimeProfile::EnterpriseSafe
+            | RuntimeProfile::EnterpriseDev
+            | RuntimeProfile::EnterpriseYoloDedicated => DeploymentMode::EnterpriseDedicated,
+            _ => DeploymentMode::LocalSingleUser,
+        };
+        let resolved = ironclaw_runtime_policy::resolve(ResolveRequest {
+            yolo_disclosure_acknowledged: true,
+            org_policy: OrgPolicyConstraints::default().set_admin_approves_dedicated_yolo(true),
+            ..ResolveRequest::new(deployment, profile)
+        })
+        .expect("test profile resolves");
+        ironclaw_runtime_policy::minimal_approval_bypass(&resolved)
     }
 
     #[test]
@@ -167,6 +194,35 @@ mod tests {
                 "{profile:?} should fail closed if Minimal reaches a non-minimal profile"
             );
         }
+    }
+
+    #[test]
+    fn org_ceiling_narrowing_yolo_away_restores_minimal_approval_gates() {
+        // Regression for the mode-as-type leak (§4.4): the gate policy used to
+        // hold a `RuntimeProfile` and ask it about itself. It now consumes a
+        // resolved value, so a tenant/org ceiling that narrows `LocalYolo`
+        // down to `LocalDev` also re-gates `Minimal` — authority reductions
+        // reach this axis instead of stopping at the requested profile.
+        let narrowed = ironclaw_runtime_policy::resolve(ResolveRequest {
+            yolo_disclosure_acknowledged: true,
+            org_policy: OrgPolicyConstraints::default().set_max_profile(RuntimeProfile::LocalDev),
+            ..ResolveRequest::new(DeploymentMode::LocalSingleUser, RuntimeProfile::LocalYolo)
+        })
+        .expect("narrowed local yolo resolves");
+        assert!(narrowed.was_reduced());
+
+        let gate_policy = RuntimeProfileApprovalGatePolicy::new(
+            ironclaw_runtime_policy::minimal_approval_bypass(&narrowed),
+            RuntimeProfileApprovalGateEffectSets::new(
+                vec![EffectKind::WriteFilesystem, EffectKind::SpawnProcess],
+                vec![EffectKind::SpawnProcess],
+            ),
+        );
+        assert!(
+            gate_policy
+                .effects_require_approval(ApprovalPolicy::Minimal, &[EffectKind::SpawnProcess]),
+            "an org ceiling that removes yolo must restore Minimal approval gates"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_runtime_policy/src/lib.rs
+++ b/crates/ironclaw_runtime_policy/src/lib.rs
@@ -30,6 +30,16 @@
 //!   compatibility matrix prevents this at the `(deployment, profile)` step
 //!   before the backend mapping runs.
 //!
+//! ## Resolved policy values
+//!
+//! Beyond the backend/mode fields on [`EffectiveRuntimePolicy`], this crate
+//! classifies the resolved policy into the enforcement axes composition needs:
+//! [`budget_enforcement`] and [`minimal_approval_bypass`]. Both are keyed on
+//! the *resolved* profile, so a tenant/org ceiling narrowing authority reaches
+//! them for free. They exist so no consumer past the composition edge branches
+//! on a deployment mode — §4.4 of
+//! `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`.
+//!
 //! ## Determinism and audit
 //!
 //! [`resolve`] is deterministic — equal inputs always produce equal outputs,
@@ -41,7 +51,10 @@
 
 mod resolver;
 
-pub use resolver::{OrgPolicyConstraints, ResolveError, ResolveRequest, resolve};
+pub use resolver::{
+    BudgetEnforcement, MinimalApprovalBypass, OrgPolicyConstraints, ResolveError, ResolveRequest,
+    budget_enforcement, minimal_approval_bypass, resolve,
+};
 
 // `EffectiveRuntimePolicy` appears in `resolve`'s return type, so it must be
 // reachable from the crate root. Other host-api runtime_policy types are not

--- a/crates/ironclaw_runtime_policy/src/resolver.rs
+++ b/crates/ironclaw_runtime_policy/src/resolver.rs
@@ -447,6 +447,88 @@ fn audit_for(deployment: DeploymentMode) -> AuditMode {
     }
 }
 
+/// Whether the resolved runtime boundary enforces model-spend budgets.
+///
+/// A resolved policy *value*, not a deployment mode. Composition selects the
+/// budget accountant from this instead of branching on a profile name — §4.4
+/// of `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`
+/// ("resolve mode to policy data at the composition edge; the kernel never
+/// names a mode").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetEnforcement {
+    /// Reserve model spend against budget accounts and pause the run on a
+    /// budget gate. The default for every deployment.
+    Enforced,
+    /// Skip the budget accountant entirely: no reservation, no gate, no
+    /// cascade. Reserved for the single-user trusted-laptop boundary, which
+    /// already inherits full host trust and must not pause on spend.
+    Unenforced,
+}
+
+/// Whether [`ApprovalPolicy::Minimal`] may bypass approval gates under the
+/// resolved runtime boundary.
+///
+/// Same shape and rationale as [`BudgetEnforcement`]: the approval gate policy
+/// consumes this value rather than storing a [`RuntimeProfile`] and asking it
+/// about itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MinimalApprovalBypass {
+    /// `Minimal` suppresses effect-driven approval gates.
+    Allowed,
+    /// `Minimal` still gates effects — the fail-closed default.
+    Denied,
+}
+
+/// Classify budget enforcement for a resolved policy.
+///
+/// Keyed on `resolved_profile`, so a tenant/org ceiling that narrows
+/// `LocalYolo` down to `LocalDev` restores budget enforcement: authority
+/// reductions reach this axis for free, which a caller branching on its own
+/// requested deployment mode does not get.
+///
+/// [`RuntimeProfile`] is `#[non_exhaustive]`, so every variant is listed
+/// explicitly and the required wildcard fails closed to
+/// [`BudgetEnforcement::Enforced`]: an unclassified future profile keeps
+/// budgets on rather than silently inheriting the laptop exception.
+pub fn budget_enforcement(policy: &EffectiveRuntimePolicy) -> BudgetEnforcement {
+    match policy.resolved_profile {
+        // The trusted-laptop boundary: single-user, host-trust-inheriting, and
+        // explicitly disclosed. Every other profile — including the hosted and
+        // enterprise yolo tiers, which are multi-tenant or org-owned — keeps
+        // budgets enforced.
+        RuntimeProfile::LocalYolo => BudgetEnforcement::Unenforced,
+        RuntimeProfile::SecureDefault
+        | RuntimeProfile::LocalSafe
+        | RuntimeProfile::LocalDev
+        | RuntimeProfile::HostedSafe
+        | RuntimeProfile::HostedDev
+        | RuntimeProfile::HostedYoloTenantScoped
+        | RuntimeProfile::EnterpriseSafe
+        | RuntimeProfile::EnterpriseDev
+        | RuntimeProfile::EnterpriseYoloDedicated
+        | RuntimeProfile::Sandboxed
+        | RuntimeProfile::Experiment => BudgetEnforcement::Enforced,
+        // Fail closed: a profile variant added upstream and not yet classified
+        // here keeps budgets enforced.
+        _ => BudgetEnforcement::Enforced,
+    }
+}
+
+/// Classify `Minimal`-approval bypass for a resolved policy.
+///
+/// Mirrors [`RuntimeProfile::allows_minimal_approval_bypass`], which this
+/// function is the sanctioned entry point for: consumers read the resolved
+/// value instead of holding a profile.
+pub fn minimal_approval_bypass(policy: &EffectiveRuntimePolicy) -> MinimalApprovalBypass {
+    if policy.resolved_profile.allows_minimal_approval_bypass() {
+        MinimalApprovalBypass::Allowed
+    } else {
+        MinimalApprovalBypass::Denied
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -933,5 +1015,119 @@ mod tests {
             assert_eq!(policy.requested_profile, profile);
             assert_eq!(policy.resolved_profile, profile);
         }
+    }
+
+    // --- resolved policy values (§4.4: mode becomes data) ------------------
+
+    #[test]
+    fn budget_enforcement_is_unenforced_only_for_the_trusted_laptop_boundary() {
+        let laptop = resolve(req_yolo(
+            DeploymentMode::LocalSingleUser,
+            RuntimeProfile::LocalYolo,
+        ))
+        .expect("local yolo resolves");
+        assert_eq!(
+            budget_enforcement(&laptop),
+            BudgetEnforcement::Unenforced,
+            "local-yolo is the single trusted-laptop exception"
+        );
+
+        // Every other resolvable (deployment, profile) pair keeps budgets
+        // enforced — including the hosted and enterprise yolo tiers, which
+        // are multi-tenant or org-owned and must never inherit the laptop
+        // exception.
+        let enforced_pairs = [
+            (
+                DeploymentMode::LocalSingleUser,
+                RuntimeProfile::SecureDefault,
+            ),
+            (DeploymentMode::LocalSingleUser, RuntimeProfile::LocalSafe),
+            (DeploymentMode::LocalSingleUser, RuntimeProfile::LocalDev),
+            (DeploymentMode::LocalSingleUser, RuntimeProfile::Sandboxed),
+            (DeploymentMode::LocalSingleUser, RuntimeProfile::Experiment),
+            (
+                DeploymentMode::HostedMultiTenant,
+                RuntimeProfile::HostedSafe,
+            ),
+            (DeploymentMode::HostedMultiTenant, RuntimeProfile::HostedDev),
+            (
+                DeploymentMode::HostedMultiTenant,
+                RuntimeProfile::HostedYoloTenantScoped,
+            ),
+            (
+                DeploymentMode::EnterpriseDedicated,
+                RuntimeProfile::EnterpriseSafe,
+            ),
+            (
+                DeploymentMode::EnterpriseDedicated,
+                RuntimeProfile::EnterpriseDev,
+            ),
+        ];
+        for (deployment, profile) in enforced_pairs {
+            let policy = resolve(req_yolo(deployment, profile))
+                .unwrap_or_else(|e| panic!("({deployment:?}, {profile:?}) failed: {e}"));
+            assert_eq!(
+                budget_enforcement(&policy),
+                BudgetEnforcement::Enforced,
+                "{profile:?} under {deployment:?} must keep budgets enforced"
+            );
+        }
+    }
+
+    #[test]
+    fn org_ceiling_narrowing_restores_budget_enforcement() {
+        // The regression this axis exists to prevent: today's composition
+        // branches on the *requested* deployment profile, so an org ceiling
+        // that narrows local-yolo down to local-dev would still skip the
+        // budget accountant. Keying on `resolved_profile` fixes that.
+        let narrowed = resolve(ResolveRequest {
+            org_policy: OrgPolicyConstraints::default().set_max_profile(RuntimeProfile::LocalDev),
+            ..req_yolo(DeploymentMode::LocalSingleUser, RuntimeProfile::LocalYolo)
+        })
+        .expect("narrowed local yolo resolves");
+
+        assert!(narrowed.was_reduced(), "ceiling must narrow the profile");
+        assert_eq!(narrowed.requested_profile, RuntimeProfile::LocalYolo);
+        assert_eq!(narrowed.resolved_profile, RuntimeProfile::LocalDev);
+        assert_eq!(
+            budget_enforcement(&narrowed),
+            BudgetEnforcement::Enforced,
+            "an org ceiling that removes yolo must also restore budget enforcement"
+        );
+    }
+
+    #[test]
+    fn minimal_approval_bypass_tracks_the_resolved_profile() {
+        let bypass = resolve(req_yolo(
+            DeploymentMode::LocalSingleUser,
+            RuntimeProfile::LocalYolo,
+        ))
+        .expect("local yolo resolves");
+        assert_eq!(
+            minimal_approval_bypass(&bypass),
+            MinimalApprovalBypass::Allowed
+        );
+
+        let gated = resolve(req(
+            DeploymentMode::LocalSingleUser,
+            RuntimeProfile::LocalDev,
+        ))
+        .expect("local dev resolves");
+        assert_eq!(
+            minimal_approval_bypass(&gated),
+            MinimalApprovalBypass::Denied
+        );
+
+        // Same ceiling property as budgets: narrowing away yolo removes the
+        // bypass.
+        let narrowed = resolve(ResolveRequest {
+            org_policy: OrgPolicyConstraints::default().set_max_profile(RuntimeProfile::LocalDev),
+            ..req_yolo(DeploymentMode::LocalSingleUser, RuntimeProfile::LocalYolo)
+        })
+        .expect("narrowed local yolo resolves");
+        assert_eq!(
+            minimal_approval_bypass(&narrowed),
+            MinimalApprovalBypass::Denied
+        );
     }
 }


### PR DESCRIPTION
Phase 1 of #6274 — finishing `DeploymentConfig` as the main composition config (§4.4 / §5.6 of `docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`).

## The problem

Two composition sites derived **enforcement authority** by branching on a deployment mode instead of consuming resolved policy data — the "policy encoded as kernel types" violation §2.1 is about:

| Site | Branched on |
|---|---|
| `runtime.rs` model-budget accountant | `match (profile, cost_table)` with `RebornCompositionProfile::LocalDevYolo => None` |
| `RuntimeProfileApprovalGatePolicy` | stored a `RuntimeProfile`, asked it `allows_minimal_approval_bypass()` |

## The change

Both now read values classified once by the sanctioned resolver:

```rust
ironclaw_runtime_policy::budget_enforcement(&policy)      -> BudgetEnforcement { Enforced, Unenforced }
ironclaw_runtime_policy::minimal_approval_bypass(&policy) -> MinimalApprovalBypass { Allowed, Denied }
```

The classification lives in the one crate the guardrails already name as the only producer of `EffectiveRuntimePolicy`, so **no consumer past the composition edge names a deployment mode** for either axis.

## A real bug this fixes

Both classifications key on `resolved_profile` — the *post-narrowing* profile. The old code branched on the **requested** composition profile, so a tenant/org ceiling that narrowed `LocalYolo` down to `LocalDev` left budgets unenforced and `Minimal` still bypassing approval gates. Authority reductions now reach both axes. Two of the regression tests pin exactly this.

## Fail-closed fallback

`local_dev_approval_policy` used `unwrap_or(RuntimeProfile::LocalDev)` — inventing a *deployment profile* to derive authority from when no policy was resolved — plus an `AskDestructive` approval-width default that is weaker than the safest option. The absent-policy path now fails closed to `AskAlways` with the bypass denied, per `.claude/rules/error-handling.md`. Every production path resolves a policy (`build_reborn_runtime` rejects the input otherwise), so this arm is reachable only from callers that never had one.

## Design note: why not fields on `EffectiveRuntimePolicy`?

The issue plan proposed stored fields. Building it surfaced the cost: the resolver is the **only** production constructor — the other 99 construction sites are all test fixtures — so each stored axis means a 39-file mechanical diff to express a value that is a pure function of `resolved_profile`, itself already serialized into the audit payload and the capability-surface digest. Resolver-owned classification functions give the same ownership, the same org-ceiling property, and the same fail-closed guarantee at a fraction of the churn. If an axis ever needs to be set *independently* of the profile (an org that wants budgets enforced under yolo), converting to a stored field is mechanical at that point.

`RuntimeProfile` is `#[non_exhaustive]`, so both matches list every variant explicitly and the required wildcard fails closed (`Enforced` / `Denied`).

## Scope note

The issue listed 1c (readiness as data) and 1d (traffic/cutover axis) under Phase 1. Both need `DeploymentConfig` to cover all seven composition profiles — it covers three today — so they move into the Phase 2 pivot where that constructor set lands. Issue updated.

## Testing

Regression tests, each failing before the change:

- `budget_enforcement_is_unenforced_only_for_the_trusted_laptop_boundary`, `org_ceiling_narrowing_restores_budget_enforcement`, `minimal_approval_bypass_tracks_the_resolved_profile` — resolver tier
- `org_ceiling_narrowing_yolo_away_restores_minimal_approval_gates` — gate-policy tier, driven through the real resolver rather than a hand-picked value
- `absent_runtime_policy_fails_closed_to_ask_always_without_minimal_bypass`, `resolved_yolo_policy_allows_minimal_bypass_but_org_ceiling_removes_it` — driven through `local_dev_effects_require_approval`, the production caller

```
cargo test -p ironclaw_runtime_policy                  # 24 passed
cargo test -p ironclaw_reborn_composition --lib        # 1478 passed
cargo test -p ironclaw_architecture                    # 10 passed
cargo clippy -p ironclaw_runtime_policy -p ironclaw_reborn_composition \
  --all-targets --all-features -- -D warnings          # clean
bash scripts/pre-commit-safety.sh                      # OK
```

Three `llm_admin::nearai_mcp::tests::bootstrap_config_from_env_*` failures are pre-existing and environmental — they self-assert `NEARAI_API_KEY must be unset for deterministic env tests`, which is set in my shell. Unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
