### PR TITLE
refactor(reborn): complete host-side gate reconstitution — resume input_ref, local-dev gate persistence, GateRef reconcile (§5.3 flip prep / Stage 0)

### DIFF
--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -730,7 +730,7 @@ where
                 }
                 Ok(AuthorizeFold::Blocked {
                     result: AuthorizeResult::Blocked(Blocked::Approval(GateWaypoint::new(
-                        GateRef::from_uuid(approval_request_id.as_uuid()),
+                        GateRef::for_approval_request(approval_request_id),
                     ))),
                 })
             }
@@ -2036,7 +2036,7 @@ where
                 }
                 Ok(AuthorizeFold::Blocked {
                     result: AuthorizeResult::Blocked(Blocked::Approval(GateWaypoint::new(
-                        GateRef::from_uuid(approval_request_id.as_uuid()),
+                        GateRef::for_approval_request(approval_request_id),
                     ))),
                 })
             }

--- a/crates/ironclaw_host_api/src/ids.rs
+++ b/crates/ironclaw_host_api/src/ids.rs
@@ -248,6 +248,28 @@ uuid_id!(ErrRef);
 // unrepresentable — a kernel record id travels via `from_uuid`/`new`, never as
 // a caller-composed string.
 uuid_id!(GateRef);
+
+impl GateRef {
+    /// The canonical [`GateRef`] under which an approval gate's
+    /// [`GateRecord`](crate::GateRecord) is persisted and later resolved.
+    ///
+    /// Derived from the approval request's uuid so the host persist side
+    /// (`ironclaw_capabilities` authorize, the local-dev synthetic approval
+    /// producer, and any future host-side gate rendering per §5.2.9) and the
+    /// product read model derive the SAME record key from the one shared
+    /// [`ApprovalRequestId`]. The two must never diverge or a persisted gate is
+    /// unfindable (§5.3 Stage 0 flip prep).
+    ///
+    /// This is the typed GateRecord key — a uuid, per this ref family's
+    /// no-caller-composed-string contract above — and is deliberately distinct
+    /// from the loop-facing `gate:approval-{id}` routing ref
+    /// (`ironclaw_turns::GateRef`), which stays string-encoded so the
+    /// `is_approval_gate_ref` prefix predicate keeps routing approvals vs auth.
+    pub fn for_approval_request(approval_request_id: ApprovalRequestId) -> Self {
+        Self::from_uuid(approval_request_id.as_uuid())
+    }
+}
+
 uuid_id!(ProcessRef);
 uuid_id!(DenyRef);
 // Handle to the durably-stored full capability output. The full bytes stay
@@ -417,3 +439,24 @@ uuid_id!(RunId);
 // §1.1's "dead-future `idempotency_key`" becomes: unified into the invocation
 // identity rather than deleted.
 uuid_id!(ActivityId);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn approval_gate_record_ref_is_the_request_uuid_and_round_trips() {
+        // The canonical GateRecord key is the approval request's uuid, so the
+        // host persist side and the product read model derive an identical key
+        // from the one shared `ApprovalRequestId` (§5.3 Stage 0).
+        let request_id = ApprovalRequestId::new();
+        let gate_ref = GateRef::for_approval_request(request_id);
+        assert_eq!(gate_ref.as_uuid(), request_id.as_uuid());
+        // A second derivation from the same id yields the same key (stable, not
+        // freshly random like `GateRef::new()`).
+        assert_eq!(gate_ref, GateRef::for_approval_request(request_id));
+        // Distinct requests never collide.
+        let other = ApprovalRequestId::new();
+        assert_ne!(gate_ref, GateRef::for_approval_request(other));
+    }
+}

--- a/crates/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/ironclaw_loop_host/src/capability_port.rs
@@ -1737,19 +1737,16 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         // Slice C result-side collapse (§3/§5.3): produce the loop-facing outcome,
         // then persist the durable host_api gate record its `Resolution` channel
-        // renders from before returning it to the loop. The idempotency key is a
-        // pure function of the request (same derivation the dispatch cache uses),
-        // computed up front so replays that return a cached gate outcome do not
-        // persist a duplicate record — see `persist_gate_record_for_outcome`.
-        let effective_input_ref = request
-            .approval_resume
-            .as_ref()
-            .map(|resume| &resume.input_ref)
-            .unwrap_or(&request.input_ref);
-        let idempotency_key =
-            invocation_idempotency_key(&self.run_context, &request, effective_input_ref)?;
-        let outcome = self.invoke_capability_dispatch(request).await?;
-        self.persist_gate_record_for_outcome(&idempotency_key, &outcome)
+        // renders from before returning it to the loop. The idempotency key is
+        // derived INSIDE `persist_gate_record_for_outcome`, after dispatch and only
+        // for a gate-bearing outcome — its `resume.input_ref` binding is the
+        // STORE-derived one (same derivation the dispatch cache uses), so it stays
+        // byte-stable and identical to dispatch's (§5.3 Stage 0). Deriving it there
+        // (rather than up front) keeps dispatch's own resume identity/activity
+        // validation the FIRST error a malformed resume surfaces — a missing/stale
+        // resume payload must not pre-empt an `InvalidInvocation` activity mismatch.
+        let outcome = self.invoke_capability_dispatch(request.clone()).await?;
+        self.persist_gate_record_for_outcome(&request, &outcome)
             .await?;
         Ok(outcome)
     }
@@ -1792,14 +1789,24 @@ impl HostRuntimeLoopCapabilityPort {
     ///
     /// Fail-closed: a store write failure is a genuine host storage fault and
     /// propagates, consistent with `record_loop_completed`/`record_runtime_completed`.
+    ///
+    /// The idempotency key (the write-once replay guard) is derived HERE, after
+    /// dispatch and only once a gate record exists, from the SAME store-derived
+    /// input_ref dispatch used (hazard 3, §5.3 Stage 0): on a resume the payload
+    /// is reconstituted from the store, not the advisory loop-supplied
+    /// `resume.input_ref`, so the key is byte-stable. Deriving it lazily keeps a
+    /// missing/stale resume payload from pre-empting dispatch's own resume
+    /// identity/activity validation — a malformed resume surfaces
+    /// `InvalidInvocation` from dispatch, never a spurious payload-missing error.
     async fn persist_gate_record_for_outcome(
         &self,
-        idempotency_key: &IdempotencyKey,
+        request: &CapabilityInvocation,
         outcome: &CapabilityOutcome,
     ) -> Result<(), AgentLoopHostError> {
         let mapped = capability_outcome_to_resolution(outcome.clone());
         let Some(record) = mapped.gate_record else {
-            // Done / Denied / Suspended(Process): nothing durable to persist.
+            // Done / Denied / Suspended(Process): nothing durable to persist, and
+            // no idempotency key needed.
             return Ok(());
         };
         let Some(gate_ref) = gate_ref_for_resolution(&mapped.resolution) else {
@@ -1810,6 +1817,16 @@ impl HostRuntimeLoopCapabilityPort {
                 "mapped gate record has no gate ref on its resolution channel",
             ));
         };
+        // The dispatch that produced this gate outcome already reconstituted (and
+        // for a fresh raise, persisted) the resume payload, so this load hits a
+        // present record on a resume and returns `None` on a fresh dispatch.
+        let resume_payload = self.resume_replay_payload(request).await?;
+        let effective_input_ref = resume_payload
+            .as_ref()
+            .map(|payload| &payload.input_ref)
+            .unwrap_or(&request.input_ref);
+        let idempotency_key =
+            invocation_idempotency_key(&self.run_context, request, effective_input_ref)?;
         // Replay guard: the dispatch cache replays the same gate outcome for a
         // repeated invocation (same idempotency key); persisting again would
         // mint a fresh GateRef and orphan another write-once record per retry.
@@ -1823,7 +1840,7 @@ impl HostRuntimeLoopCapabilityPort {
             // Roll the guard entry back so a later replay retries the persist
             // instead of permanently skipping it after a transient store fault.
             lock_mut(&self.gate_records_persisted, "gate record replay guard")?
-                .remove(idempotency_key);
+                .remove(&idempotency_key);
             return Err(gate_record_store_error(error));
         }
         Ok(())
@@ -1891,6 +1908,35 @@ impl HostRuntimeLoopCapabilityPort {
     /// miss:** a resume whose payload is absent — including a wrong-scope read the
     /// store reports as unknown — is a sanitized terminal failure, never a silent
     /// empty-input dispatch (arch-simplification §5.3 Stage 2a-i).
+    /// Reconstitute the host-private replay payload a resume binds to, if this is
+    /// a resume. On a gate/auth resume the loop-supplied `input_ref` is ADVISORY:
+    /// the payload persisted at the FRESH gate raise is the host-side source of
+    /// truth for `input_ref` (and `{input, estimate}`), so the idempotency key
+    /// stays byte-stable regardless of what the loop echoes back, and a resume
+    /// whose payload is absent fails CLOSED (§5.3 Stage 2a-i / Stage 0).
+    ///
+    /// Returns `None` for a fresh dispatch and for the mutually-exclusive
+    /// both-resume-modes case — `invoke_capability_dispatch`'s `resume_mode`
+    /// resolution surfaces the latter as `InvalidInvocation`; this helper does not
+    /// pre-empt that with a payload load. Keeping the derivation in one place lets
+    /// the `invoke_capability` seam and dispatch compute the SAME key.
+    async fn resume_replay_payload(
+        &self,
+        request: &CapabilityInvocation,
+    ) -> Result<Option<ReplayPayload>, AgentLoopHostError> {
+        let invocation_id = match (
+            request.approval_resume.as_ref(),
+            request.auth_resume.as_ref(),
+        ) {
+            (Some(_), Some(_)) | (Option::None, Option::None) => return Ok(Option::None),
+            (Some(resume), Option::None) => invocation_id_from_resume_token(&resume.resume_token)?,
+            (Option::None, Some(auth_resume)) => {
+                invocation_id_from_resume_token(&auth_resume.resume_token)?
+            }
+        };
+        Ok(Some(self.replay_payload_for_resume(invocation_id).await?))
+    }
+
     async fn replay_payload_for_resume(
         &self,
         invocation_id: InvocationId,
@@ -1971,11 +2017,28 @@ impl HostRuntimeLoopCapabilityPort {
             }
             (Option::None, Option::None) => ResolvedResumeMode::None,
         };
-        let effective_input_ref = request
-            .approval_resume
+        // Host-side resume reconstitution (hazard 3, §5.3 Stage 0): on a resume the
+        // effective input_ref used for the idempotency key + validation is derived
+        // from the host-private payload persisted at the FRESH gate raise — loaded
+        // by the resume's invocation id — NOT from the advisory loop-supplied
+        // `resume.input_ref`. `resume_mode` above already validated token identity
+        // and the resume→activity match, so that precedence still runs before the
+        // registered-activity check below; the payload load fails CLOSED on a miss
+        // (§5.3 Stage 2a-i). The same payload is reused for `{input, estimate}`
+        // below, so a resume loads it exactly once here.
+        let resume_payload = match &resume_mode {
+            ResolvedResumeMode::Approval { invocation_id, .. }
+            | ResolvedResumeMode::Auth { invocation_id, .. } => {
+                Some(self.replay_payload_for_resume(*invocation_id).await?)
+            }
+            ResolvedResumeMode::None => Option::None,
+        };
+        // Owned clone so `effective_input_ref` borrows this local, not
+        // `resume_payload` — the payload is consumed for `{input, estimate}` below.
+        let resume_input_ref = resume_payload
             .as_ref()
-            .map(|resume| &resume.input_ref)
-            .unwrap_or(&request.input_ref);
+            .map(|payload| payload.input_ref.clone());
+        let effective_input_ref = resume_input_ref.as_ref().unwrap_or(&request.input_ref);
         self.validate_provider_tool_call_registration_activity(
             effective_input_ref,
             request.activity_id,
@@ -2087,18 +2150,14 @@ impl HostRuntimeLoopCapabilityPort {
                 safe_summary: "capability provider trust is unavailable".to_string(),
             }));
         };
-        let (input, estimate) = match &resume_mode {
-            ResolvedResumeMode::Approval { invocation_id, .. }
-            | ResolvedResumeMode::Auth { invocation_id, .. } => {
-                // Host-side resume replay: reconstitute {input, estimate} from the
-                // host-private payload the host persisted at the FRESH gate raise,
-                // keyed by this invocation id. Fail CLOSED on a miss — a resume
-                // whose payload is absent is a sanitized terminal failure, NEVER a
-                // silent empty-input dispatch (arch-simplification §5.3 Stage 2a-i).
-                let payload = self.replay_payload_for_resume(*invocation_id).await?;
-                (payload.input, payload.estimate)
-            }
-            ResolvedResumeMode::None => {
+        let (input, estimate) = match resume_payload {
+            // Host-side resume replay: reconstitute {input, estimate} from the
+            // host-private payload loaded up front (keyed by the resume's
+            // invocation id). `Some` iff this is a resume; a missing payload
+            // already failed CLOSED above — never a silent empty-input dispatch
+            // (arch-simplification §5.3 Stage 2a-i).
+            Some(payload) => (payload.input, payload.estimate),
+            Option::None => {
             let input = self
                 .input_resolver
                 .resolve_capability_input(&self.run_context, effective_input_ref)
@@ -8223,12 +8282,19 @@ mod tests {
             capability_id.clone(),
             provider_id.clone(),
         )]));
-        let port = runtime_capability_port(
+        // The resume now reconstitutes its effective input_ref from the host
+        // payload (hazard 3, §5.3 Stage 0), so seed the payload the mismatched
+        // resume loads — carrying the REGISTERED input_ref — and the port then
+        // runs the registered-activity check against it (the resume's own
+        // loop-supplied input_ref is advisory and ignored).
+        let replay_store = Arc::new(RecordingReplayPayloadStore::default());
+        let port = runtime_capability_port_with_replay_store(
             &capability_id,
             &provider_id,
             runtime.clone(),
             Arc::new(RecordingResultWriter::default()),
             dummy_milestone_sink(),
+            replay_store.clone(),
             "thread-approval-resume-effective-input-ref-mismatch",
         )
         .await;
@@ -8247,6 +8313,20 @@ mod tests {
                 break candidate_activity;
             }
         };
+        // Seed the payload the mismatched resume reconstitutes from, keyed by the
+        // resume token's invocation id, carrying the registered provider tool-call
+        // input_ref so the registered-activity check has the same input to reject.
+        replay_store.seed(
+            ResourceScope::system(),
+            InvocationId::from_uuid(mismatched_activity_id.as_uuid()),
+            ReplayPayload {
+                input: serde_json::json!({}),
+                estimate: ResourceEstimate::default(),
+                prior_approval: None,
+                input_ref: candidate.input_ref.clone(),
+                correlation_id: CorrelationId::new(),
+            },
+        );
         let err = port
             .invoke_capability(CapabilityInvocation {
                 activity_id: mismatched_activity_id,
@@ -8477,6 +8557,122 @@ mod tests {
             runtime.resume_request_count(),
             0,
             "the run must fail before re-dispatching with empty/absent input"
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_resume_derives_input_ref_and_key_from_store_not_loop_supplied() {
+        // Hazard 3 (§5.3 Stage 0): on resume the effective input_ref used for the
+        // idempotency key + validation is reconstituted from the host-persisted
+        // payload, NOT the advisory loop-supplied `resume.input_ref`. Proven two
+        // ways: (1) a resume whose loop-supplied input_ref is a WRONG/stale value
+        // still reconstitutes the ORIGINAL input from the store; (2) a second
+        // resume differing ONLY in that advisory input_ref collapses to the SAME
+        // idempotency key, so it REPLAYS the cached outcome instead of
+        // re-dispatching — the key is byte-stable regardless of the loop value.
+        use ironclaw_host_api::ApprovalRequestId;
+        use ironclaw_turns::run_profile::CapabilityApprovalResume;
+
+        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+        let provider_id = ExtensionId::new("demo").expect("valid provider id");
+        let runtime = Arc::new(RecordingResumeHostRuntime::new(vec![visible_capability(
+            capability_id.clone(),
+            provider_id.clone(),
+        )]));
+        let replay_store = Arc::new(RecordingReplayPayloadStore::default());
+        let port = runtime_capability_port_with_replay_store(
+            &capability_id,
+            &provider_id,
+            runtime.clone(),
+            Arc::new(RecordingResultWriter::default()),
+            dummy_milestone_sink(),
+            replay_store.clone(),
+            "thread-approval-resume-store-derived-input-ref",
+        )
+        .await;
+
+        let invocation = visible_runtime_invocation(&port).await;
+        let seeded_invocation_id = InvocationId::from_uuid(invocation.activity_id.as_uuid());
+        // The payload the FRESH gate raise persisted: the ORIGINAL input_ref +
+        // input the host reconstitutes on resume.
+        let original_input = serde_json::json!({"query": "original"});
+        replay_store.seed(
+            ResourceScope::system(),
+            seeded_invocation_id,
+            ReplayPayload {
+                input: original_input.clone(),
+                estimate: ResourceEstimate::default(),
+                prior_approval: None,
+                input_ref: invocation.input_ref.clone(),
+                correlation_id: CorrelationId::new(),
+            },
+        );
+
+        // Resume carrying a DELIBERATELY WRONG loop-supplied input_ref: the host
+        // must ignore it and reconstitute the original from the store.
+        let stale_ref =
+            CapabilityInputRef::new("input:stale-loop-supplied").expect("valid input ref");
+        let approval_request_id = ApprovalRequestId::new();
+        let resume_token = CapabilityResumeToken::new(invocation.activity_id.to_string())
+            .expect("valid resume token");
+        let correlation_id = CorrelationId::new();
+        let first = port
+            .invoke_capability(CapabilityInvocation {
+                activity_id: invocation.activity_id,
+                surface_version: invocation.surface_version.clone(),
+                capability_id: invocation.capability_id.clone(),
+                input_ref: stale_ref.clone(),
+                approval_resume: Some(CapabilityApprovalResume {
+                    approval_request_id,
+                    resume_token: resume_token.clone(),
+                    correlation_id,
+                    input_ref: stale_ref.clone(),
+                }),
+                auth_resume: None,
+            })
+            .await
+            .expect("resume reconstitutes from store despite a stale loop input_ref");
+        assert!(
+            matches!(first, CapabilityOutcome::Completed(_)),
+            "resume completes from the store payload, got {first:?}"
+        );
+        let requests = runtime.resume_requests();
+        assert_eq!(requests.len(), 1, "resume dispatched to the runtime once");
+        assert_eq!(
+            requests[0].input, original_input,
+            "resume must dispatch the STORE-reconstituted input, not re-resolve the stale loop ref"
+        );
+
+        // A second resume differing ONLY in the advisory loop-supplied input_ref
+        // derives the SAME store input_ref → SAME idempotency key → replays the
+        // cached outcome (no re-dispatch). Under the pre-fix behavior the key
+        // varied with the loop ref and this would re-dispatch (count 2).
+        let other_stale_ref =
+            CapabilityInputRef::new("input:other-stale-loop-supplied").expect("valid input ref");
+        let replayed = port
+            .invoke_capability(CapabilityInvocation {
+                activity_id: invocation.activity_id,
+                surface_version: invocation.surface_version,
+                capability_id: invocation.capability_id,
+                input_ref: other_stale_ref.clone(),
+                approval_resume: Some(CapabilityApprovalResume {
+                    approval_request_id,
+                    resume_token,
+                    correlation_id,
+                    input_ref: other_stale_ref,
+                }),
+                auth_resume: None,
+            })
+            .await
+            .expect("second resume replays the cached outcome");
+        assert!(
+            matches!(replayed, CapabilityOutcome::Completed(_)),
+            "second resume replays completion, got {replayed:?}"
+        );
+        assert_eq!(
+            runtime.resume_request_count(),
+            1,
+            "byte-stable key: a differing advisory loop input_ref must NOT re-dispatch"
         );
     }
 
@@ -9366,6 +9562,13 @@ mod tests {
                 .lock()
                 .expect("resume requests lock")
                 .len()
+        }
+
+        fn resume_requests(&self) -> Vec<RuntimeCapabilityResumeRequest> {
+            self.resume_requests
+                .lock()
+                .expect("resume requests lock")
+                .clone()
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/outbound_delivery.rs
@@ -5,7 +5,8 @@ use ironclaw_approvals::ToolPermissionOverride;
 use ironclaw_authorization::{CapabilityLeaseError, CapabilityLeaseStatus, CapabilityLeaseStore};
 use ironclaw_host_api::{
     Action, ApprovalRequest, ApprovalRequestId, CapabilityGrantId, CapabilityId, CorrelationId,
-    InvocationFingerprint, InvocationId, Principal, ResourceEstimate, ResourceScope, UserId,
+    GateRecord, GateRef, InvocationFingerprint, InvocationId, Principal, ResourceEstimate,
+    ResourceScope, SafeSummary, UserId,
 };
 use ironclaw_loop_host::{CapabilityResultWrite, DurablePersistence};
 use ironclaw_product_workflow::{
@@ -50,6 +51,7 @@ pub(super) fn outbound_delivery_capabilities(
     target_set_requires_approval: bool,
     approval_settings: Arc<dyn ApprovalSettingsProvider>,
     replay_payload_store: Arc<dyn ironclaw_capabilities::ReplayPayloadStore>,
+    gate_record_store: Arc<dyn ironclaw_run_state::GateRecordStore>,
 ) -> Result<Vec<SyntheticCapability>, AgentLoopHostError> {
     Ok(vec![
         SyntheticCapability::new(
@@ -81,6 +83,7 @@ pub(super) fn outbound_delivery_capabilities(
                 requires_approval: target_set_requires_approval,
                 approval_settings,
                 replay_payload_store,
+                gate_record_store,
             }),
         ),
     ])
@@ -140,6 +143,11 @@ impl SyntheticCapabilityHandler for OutboundDeliveryTargetsListHandler {
     }
 }
 
+/// Host-authored, model-independent summary for the outbound-delivery approval
+/// gate. Shared by the persisted [`GateRecord`] and the loop-facing outcome so
+/// the record the approver renders (§5.2.9) and the loop's summary never drift.
+const APPROVAL_GATE_SUMMARY: &str = "changing the outbound delivery target requires approval";
+
 struct OutboundDeliveryTargetSetHandler {
     facade: Arc<dyn OutboundPreferencesProductFacade>,
     fallback_user_id: UserId,
@@ -150,6 +158,13 @@ struct OutboundDeliveryTargetSetHandler {
     /// reconstitutes them on resume host-side (§5.3 Stage 2a-i) rather than
     /// round-tripping raw tool args through the loop checkpoint.
     replay_payload_store: Arc<dyn ironclaw_capabilities::ReplayPayloadStore>,
+    /// Durable model-visible gate-record store. Because this synthetic capability
+    /// raises its own approval gate OUTSIDE the loop-host persist seam
+    /// (`HostRuntimeLoopCapabilityPort::persist_gate_record_for_outcome`), it must
+    /// persist the [`GateRecord`] itself at the raise — keyed by the canonical
+    /// [`GateRef::for_approval_request`] the product read model re-derives — so the
+    /// approver-facing gate rendering (§5.2.9) has a record to read (§5.3 Stage 0).
+    gate_record_store: Arc<dyn ironclaw_run_state::GateRecordStore>,
     requires_approval: bool,
     approval_settings: Arc<dyn ApprovalSettingsProvider>,
 }
@@ -386,9 +401,39 @@ impl OutboundDeliveryTargetSetHandler {
             .await
             .map_err(|error| approval_store_error("save_pending_approval", error))?;
 
+        // Persist the model-visible gate record BEFORE returning the gate. This
+        // synthetic producer raises its own gate outside the loop-host persist
+        // seam, so without this the approver-facing gate rendering (§5.2.9) would
+        // have no record to read (§5.3 Stage 0). Keyed by the canonical
+        // `GateRef::for_approval_request` the product read model re-derives from
+        // the routing `gate:approval-{id}` ref, in the run's resource-owner scope
+        // (the same owner axes the replay payload uses, so raise and read agree).
+        let gate_summary = SafeSummary::new(APPROVAL_GATE_SUMMARY).map_err(|error| {
+            ironclaw_loop_host::raw_agent_loop_host_error(
+                "local_dev_outbound_delivery",
+                "gate_record_summary",
+                AgentLoopHostErrorKind::Internal,
+                "outbound delivery gate summary is not renderable",
+                error,
+            )
+        })?;
+        self.gate_record_store
+            .save(
+                super::local_dev_resource_scope_for_run(
+                    &invocation.run_context,
+                    &self.fallback_user_id,
+                ),
+                GateRef::for_approval_request(approval_request_id),
+                GateRecord::Approval {
+                    summary: gate_summary,
+                },
+            )
+            .await
+            .map_err(|error| approval_store_error("save_gate_record", error))?;
+
         Ok(CapabilityOutcome::ApprovalRequired {
             gate_ref: approval_gate_ref(approval_request_id)?,
-            safe_summary: "changing the outbound delivery target requires approval".to_string(),
+            safe_summary: APPROVAL_GATE_SUMMARY.to_string(),
             approval_resume: Some(CapabilityApprovalResume {
                 approval_request_id,
                 resume_token: resume_token_from_invocation_id(invocation_id)?,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/refreshing_capability_port.rs
@@ -323,6 +323,7 @@ impl RefreshingCapabilityPort {
                 self.outbound_delivery_target_set_requires_approval,
                 Arc::clone(&self.approval_settings),
                 Arc::clone(&self.replay_payload_store),
+                Arc::clone(&self.gate_record_store),
             )?);
         }
         let port = wrap_synthetic_capabilities(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -3628,6 +3628,15 @@ mod tests {
                 local_runtime.persistent_approval_policies.clone(),
             ),
         );
+        // A durable gate-record store shared with the assertion below: the
+        // local-dev approval producer persists a `GateRecord` at the gate raise
+        // (§5.3 Stage 0), keyed by the canonical `GateRef::for_approval_request`
+        // that the product read model re-derives, so a host-persisted gate is
+        // findable.
+        let gate_record_store: Arc<dyn ironclaw_run_state::GateRecordStore> =
+            Arc::new(ironclaw_run_state::FilesystemGateRecordStore::new(
+                crate::wrap_scoped(Arc::clone(&local_runtime.extension_filesystem)),
+            ));
         let factory = RefreshingLoopCapabilityPortFactory {
             runtime,
             fallback_user_id: fallback_user_id.clone(),
@@ -3650,9 +3659,7 @@ mod tests {
             thread_service: Arc::new(InMemorySessionThreadService::default()),
             approval_requests: local_runtime.approval_requests.clone(),
             capability_leases: local_runtime.capability_leases.clone(),
-            gate_record_store: Arc::new(ironclaw_run_state::FilesystemGateRecordStore::new(
-                crate::wrap_scoped(Arc::clone(&local_runtime.extension_filesystem)),
-            )),
+            gate_record_store: Arc::clone(&gate_record_store),
             replay_payload_store: Arc::new(
                 ironclaw_capabilities::FilesystemReplayPayloadStore::new(crate::wrap_scoped(
                     Arc::clone(&local_runtime.extension_filesystem),
@@ -3954,18 +3961,55 @@ mod tests {
             .invoke_capability(invocation_for_candidate(&set_candidate))
             .await
             .expect("set call reaches approval gate");
-        let approval_resume = match blocked_outcome {
+        let (approval_resume, set_gate_ref) = match blocked_outcome {
             CapabilityOutcome::ApprovalRequired {
                 gate_ref,
                 approval_resume: Some(resume),
                 ..
             } => {
                 assert!(gate_ref.as_str().starts_with("gate:approval-"));
-                resume
+                (resume, gate_ref)
             }
             outcome => panic!("set should require approval, got {outcome:?}"),
         };
         let approval_request_id = approval_resume.approval_request_id;
+        // Fix 2 (§5.3 Stage 0): the local-dev synthetic approval producer persists
+        // a durable `GateRecord` at the gate raise. Fix 3: it is keyed by the
+        // canonical `GateRef::for_approval_request`, which the product read model
+        // re-derives from the routing `gate:approval-{id}` ref — so a
+        // host-persisted approval gate resolves through the read model.
+        {
+            use ironclaw_product_workflow::approval_request_id_from_gate_ref;
+            // The routing ref the loop carries is `gate:approval-{id}`; the product
+            // read model recovers the approval id from it, agreeing with the id the
+            // gate was raised under.
+            let routing_ref = ironclaw_turns::GateRef::new(set_gate_ref.as_str())
+                .expect("routing gate ref is valid");
+            let recovered_id = approval_request_id_from_gate_ref(&routing_ref)
+                .expect("read model recovers the approval request id from the routing ref");
+            assert_eq!(
+                recovered_id, approval_request_id,
+                "routing ref must encode the same approval id the gate was raised under"
+            );
+            // The host persists the GateRecord under `GateRef::for_approval_request`
+            // (a host_api::GateRef), the canonical key the read model derives from
+            // the recovered id — proving both encodings agree.
+            let record_key =
+                ironclaw_host_api::GateRef::for_approval_request(recovered_id);
+            let record_scope = crate::runtime::local_dev::local_dev_resource_scope_for_run(
+                &run_context,
+                &fallback_user_id,
+            );
+            let persisted = gate_record_store
+                .load(&record_scope, record_key)
+                .await
+                .expect("gate record load succeeds")
+                .expect("local-dev approval gate persisted a durable gate record");
+            assert!(
+                matches!(persisted, ironclaw_host_api::GateRecord::Approval { .. }),
+                "persisted gate record is an approval record, got {persisted:?}"
+            );
+        }
         assert!(
             local_runtime
                 .outbound_preferences

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -3994,8 +3994,7 @@ mod tests {
             // The host persists the GateRecord under `GateRef::for_approval_request`
             // (a host_api::GateRef), the canonical key the read model derives from
             // the recovered id — proving both encodings agree.
-            let record_key =
-                ironclaw_host_api::GateRef::for_approval_request(recovered_id);
+            let record_key = ironclaw_host_api::GateRef::for_approval_request(recovered_id);
             let record_scope = crate::runtime::local_dev::local_dev_resource_scope_for_run(
                 &run_context,
                 &fallback_user_id,

--- a/crates/ironclaw_runner/src/planned_driver.rs
+++ b/crates/ironclaw_runner/src/planned_driver.rs
@@ -1208,7 +1208,6 @@ mod tests {
             resume_token: None,
             activity_id,
             prior_approval: None,
-            replay: None,
             disposition: None,
         });
         state
@@ -1361,7 +1360,7 @@ mod tests {
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
         use ironclaw_agent_loop::state::PendingApprovalResume;
-        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId};
         use ironclaw_turns::LoopGateRef;
         use ironclaw_turns::run_profile::{
             CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
@@ -1385,8 +1384,6 @@ mod tests {
                 .expect("valid input ref"),
             effective_capability_ids: Vec::new(),
             provider_replay: None,
-            input: serde_json::Value::Null,
-            estimate: ResourceEstimate::default(),
             disposition: None,
         });
         state
@@ -1551,7 +1548,7 @@ mod tests {
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
         use ironclaw_agent_loop::state::{PendingApprovalResume, PendingAuthResume};
-        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId};
         use ironclaw_turns::LoopGateRef;
         use ironclaw_turns::run_profile::{
             CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
@@ -1576,7 +1573,6 @@ mod tests {
             resume_token: None,
             activity_id: auth_activity_id,
             prior_approval: None,
-            replay: None,
             disposition: None,
         });
         state.pending_approval_resume = Some(PendingApprovalResume {
@@ -1593,8 +1589,6 @@ mod tests {
             input_ref: CapabilityInputRef::new("input:dual-approval").expect("valid input ref"),
             effective_capability_ids: Vec::new(),
             provider_replay: None,
-            input: serde_json::Value::Null,
-            estimate: ResourceEstimate::default(),
             disposition: None,
         });
         state
@@ -1741,7 +1735,7 @@ mod tests {
         context: &LoopRunContext,
     ) -> ironclaw_agent_loop::state::LoopExecutionState {
         use ironclaw_agent_loop::state::{PendingApprovalResume, PendingAuthResume};
-        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId, ResourceEstimate};
+        use ironclaw_host_api::{ApprovalRequestId, CapabilityId, CorrelationId};
         use ironclaw_turns::LoopGateRef;
         use ironclaw_turns::run_profile::{
             CapabilityInputRef, CapabilityResumeToken, CapabilitySurfaceVersion,
@@ -1763,7 +1757,6 @@ mod tests {
             resume_token: None,
             activity_id: auth_activity_id,
             prior_approval: None,
-            replay: None,
             disposition: None,
         });
         state.pending_approval_resume = Some(PendingApprovalResume {
@@ -1781,8 +1774,6 @@ mod tests {
                 .expect("valid input ref"),
             effective_capability_ids: Vec::new(),
             provider_replay: None,
-            input: serde_json::Value::Null,
-            estimate: ResourceEstimate::default(),
             disposition: None,
         });
         state


### PR DESCRIPTION
Stage 0 of the capability-result flip (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md`, §5.2.9/§5.3): a **no-flip** host-reconstitution slice closing two verified correctness hazards ahead of the atomic flip. The loop-facing trait is UNCHANGED and `CapabilityOutcome` is untouched; only host-side plumbing moves. Base tip verified at/after PR-B (`a0c497b2d` ancestor); 2a-i `ReplayPayloadStore` present.

## Fix 1 — resume-time `input_ref` reconstitution (hazard 3)
On a gate/auth resume, the effective `input_ref` used for the idempotency key **and** validation is now derived from the host-private `ReplayPayload` persisted at the fresh gate raise (loaded by the resume's invocation id) — **not** the advisory loop-supplied `approval_resume.input_ref`. A new `resume_replay_payload` helper centralizes the derivation so the `invoke_capability` seam and `invoke_capability_dispatch` compute the **same byte-stable key**.

The idempotency key is now derived **lazily inside `persist_gate_record_for_outcome`** (after dispatch, only once a gate record exists) so a missing/stale resume payload can never pre-empt dispatch's own resume identity/activity validation — a malformed resume still surfaces `InvalidInvocation`, a genuinely-missing payload still fails closed (the 2a-i missing-payload test stays green).

- **Wiring:** `invoke_capability` → `invoke_capability_dispatch(request.clone())` → `persist_gate_record_for_outcome(&request, &outcome)`; dispatch loads the payload once (after `resume_mode` validation) and reuses it for both the store-derived `input_ref` and `{input, estimate}`.
- **Test (failed first):** `approval_resume_derives_input_ref_and_key_from_store_not_loop_supplied` — a resume with a WRONG loop-supplied `input_ref` still reconstitutes the original input from the store, and a second resume differing ONLY in that advisory ref replays the cached outcome instead of re-dispatching. Verified red before the fix (`resume_request_count` == 2, re-dispatch), green after. Updated `invoke_capability_checks_registered_activity_on_approval_resume_input_ref` to seed the payload it now reconstitutes from.

## Fix 2 — gate-record persistence for the local-dev synthetic approval producer (hazard 2)
`OutboundDeliveryTargetSetHandler::request_approval` raises its approval gate **outside** the loop-host persist seam (the synthetic-capability wrapper bypasses `persist_gate_record_for_outcome`), so it now persists a `GateRecord::Approval` itself at the raise via the wired `GateRecordStore`, keyed by the canonical `GateRef::for_approval_request`, in the run's resource-owner scope. Without it the §5.2.9 host-side gate rendering would have no record to read after the flip.

- **Test (failed first):** the existing local-dev approval journey now asserts the `GateRecord` persisted at the raise loads and round-trips. Red before the fix (load returned `None`).

## Fix 3 — reconcile the two approval `GateRef` encodings
**Canonical encoding chosen:** `GateRef::for_approval_request(id) = GateRef::from_uuid(id.as_uuid())` — a new `ironclaw_host_api` helper — as the **GateRecordStore key**. This is the `ironclaw_host_api::GateRef` (a uuid newtype, the record key), a **different type** from the loop-facing `gate:approval-{id}` routing ref (`ironclaw_turns::GateRef`). `ironclaw_capabilities::host` now uses the helper at both authorize sites.

Because the canonical is the uuid record-key GateRef and **not** the routing string, this touches **no persisted wire format** and does not break the `is_approval_gate_ref` (`gate:approval-` prefix) predicate.

- **Test:** a host-persisted approval gate ref resolves through the read model — the routing `gate:approval-{id}` ref recovers the id via `approval_request_id_from_gate_ref`, the canonical key re-derives, and the persisted `GateRecord` is found (asserted in the local-dev approval test); plus a host_api round-trip unit test.

**Deviation note:** the brief suggested canonicalizing on `from_uuid` — that is exactly what this does for the record-key GateRef. The RISKY direction (rewriting the `gate:approval-{id}` routing string to a bare uuid) was **not** taken: it would break `is_approval_gate_ref` prefix routing used across production routing/projection/channel-delivery, plus persisted adapter command strings ("approve gate:approval-X") and delivered-gate route records — the STOP-and-report condition in the brief.

## Verification (all green)
- `cargo test -p ironclaw_loop_host` — 378 lib (incl. new + updated resume/seam/2a-i)
- `cargo test -p ironclaw_capabilities -p ironclaw_product_workflow -p ironclaw_run_state -p ironclaw_host_api --all-features`
- `cargo test -p ironclaw_reborn_composition --lib --all-features` — 1629 (env-clean; the only 6 failures are pre-existing `llm_admin` nearai env-var tests polluted by the machine's `NEARAI_API_KEY`/`LLM_BACKEND`, green with those unset, and touch none of this diff)
- Integration: `reborn_integration_outbound_target` (16), `reborn_integration_auth_gate` (18), `reborn_integration_reopen_resume_through_gate` (13), `reborn_group_approvals` (15)
- `cargo test -p ironclaw_architecture` green
- `cargo clippy --all-targets --all-features -- -D warnings` clean on all 6 touched crates
- `scripts/pre-commit-safety.sh` clean (exit 0)

**Trait unchanged; `CapabilityOutcome` untouched; `invoke_capability` not flipped; executor `Resolution` consumers not touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)