### PR TITLE
refactor(composition): de-prefix local_dev builder names to the shared mechanism they are

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_deployment_mode_branching_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_deployment_mode_branching_ratchet.rs
@@ -69,12 +69,6 @@ const ALLOWLIST: &[(&str, &str)] = &[
          label argument.",
     ),
     (
-        "input.rs",
-        "`RebornBuildInput` constructors take a profile and pass it through to \
-         `RebornServices::profile()`. Retires when the build input carries a \
-         `DeploymentConfig` instead of a profile.",
-    ),
-    (
         "local_runtime_profile.rs",
         "The composition edge itself: maps a profile to its config and rejects \
          deployments this local-runtime helper does not assemble. Retires into \

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1315,18 +1315,14 @@ pub async fn build_reborn_services(
     input: RebornBuildInput,
 ) -> Result<RebornServices, RebornBuildError> {
     tracing::debug!(
-        profile = %input.profile,
+        profile = %input.profile(),
         owner_id = %input.owner_id,
         "building Reborn composition facades"
     );
     // Substrate selection is deployment *data* (§4.4/§5.6), not a profile
     // match: the config says which substrate to assemble and this dispatches
     // on that value.
-    let substrate = crate::deployment::DeploymentConfig::for_profile(
-        input.profile,
-        input.grants_trusted_laptop_access(),
-    )
-    .substrate();
+    let substrate = input.deployment().substrate();
     match substrate {
         crate::deployment::RuntimeSubstrate::None => Ok(RebornServices::disabled()),
         crate::deployment::RuntimeSubstrate::Local => build_local_runtime(input).await,
@@ -1453,7 +1449,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
     #[cfg(any(test, feature = "test-support"))]
     let network_http_egress_for_test = input.network_http_egress_for_test.clone();
     let RebornBuildInput {
-        profile,
+        deployment,
         storage,
         runtime_policy,
         runtime_process_binding,
@@ -1468,6 +1464,8 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         turn_state_store_limits,
         ..
     } = input;
+    // Label for logging/errors; behaviour reads `deployment`'s axes.
+    let profile = deployment.profile();
     // Computed before `oauth_provider_configs` is consumed by
     // `compose_provider_client` below — see `google_oauth_configured`.
     let google_oauth_configured = google_oauth_configured(&oauth_provider_configs);
@@ -1481,7 +1479,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         postgres_resource_governor_singleton,
     ) = match storage {
         RebornStorageInput::LocalDev { .. }
-            if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+            if deployment.storage_shape()
                 == crate::deployment::StorageShape::HostedSingleTenantPool =>
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -1503,7 +1501,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         ),
         #[cfg(feature = "postgres")]
         RebornStorageInput::HostedSingleTenantPostgres { .. }
-            if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+            if deployment.storage_shape()
                 != crate::deployment::StorageShape::HostedSingleTenantPool =>
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -4515,7 +4513,7 @@ async fn build_production_shaped(
     input: RebornBuildInput,
 ) -> Result<RebornServices, RebornBuildError> {
     let RebornBuildInput {
-        profile,
+        deployment,
         owner_id,
         local_runtime_identity,
         storage,
@@ -4542,6 +4540,8 @@ async fn build_production_shaped(
         nearai_mcp_bootstrap_config: _,
         turn_state_store_limits,
     } = input;
+    // Label for logging/errors; behaviour reads `deployment`'s axes.
+    let profile = deployment.profile();
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     let wiring_config = production_config(
         required_runtime_backends,
@@ -6213,11 +6213,16 @@ mod tests {
     #[tokio::test]
     async fn hosted_single_tenant_rejects_local_dev_storage_input() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let mut input = RebornBuildInput::local_dev(
+        let input = RebornBuildInput::local_dev(
             "hosted-single-tenant-local-storage-owner",
             dir.path().join("local-dev"),
         );
-        input.profile = RebornCompositionProfile::HostedSingleTenant;
+        // Deliberate mismatch: a hosted single-tenant deployment paired with a
+        // local-dev storage input must be rejected by the storage-shape guard.
+        let input = input.with_deployment(crate::deployment::DeploymentConfig::for_profile(
+            RebornCompositionProfile::HostedSingleTenant,
+            false,
+        ));
 
         let error = match build_reborn_services(input).await {
             Ok(_) => {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -206,7 +206,7 @@ use crate::{
     RebornFacadeReadiness, RebornProductAuthServices, RebornReadiness, RebornWorkerReadiness,
 };
 
-/// Output of [`build_local_dev_root_filesystem`]: the composed local-dev
+/// Output of [`build_local_runtime_root_filesystem`]: the composed local-dev
 /// root filesystem and, when libSQL is the substrate, a clone of the raw
 /// libSQL handle. The handle backs both the local-dev trigger repository
 /// and the canonical Reborn identity store, so each rides the same
@@ -235,7 +235,7 @@ enum StorageBackendInput {
     Postgres(deadpool_postgres::Pool),
 }
 
-type LocalDevWorkspaceFilesystems = (
+type WorkspaceFilesystems = (
     Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     MountView,
@@ -695,7 +695,7 @@ impl RebornServices {
     }
 
     /// Test-support access to the local-dev communication-preference repository
-    /// (W6-COLD-SPOTS seam). This is the SAME `Arc` that `build_local_dev_store_graph`
+    /// (W6-COLD-SPOTS seam). This is the SAME `Arc` that `build_local_runtime_store_graph`
     /// wires into `RebornRuntimeSubstrate::outbound_preferences` via
     /// `local_dev_outbound_store`, for tests only. Returns `None` for
     /// production-profile compositions without a local-dev runtime.
@@ -709,7 +709,7 @@ impl RebornServices {
 
     /// Test-support access to the on-disk local-dev storage root (W6-COLD-SPOTS
     /// seam), for tests only — mirrors the same `local_runtime.local_dev_storage_root`
-    /// that `build_local_dev_store_graph` establishes in production. Used to reopen
+    /// that `build_local_runtime_store_graph` establishes in production. Used to reopen
     /// a fresh outbound-preferences store at the same root (see
     /// `open_local_dev_outbound_preferences_store_for_test`). Returns `None` for
     /// production-profile compositions without a local-dev runtime.
@@ -1593,7 +1593,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         }
     })?;
     crate::extension_host::bundled_skills::ensure_bundled_reborn_skills_installed(&root).await?;
-    let filesystem_bundle = build_local_dev_root_filesystem(
+    let filesystem_bundle = build_local_runtime_root_filesystem(
         &root,
         &workspace_root,
         host_home_root.as_ref(),
@@ -1677,7 +1677,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         owner_user_id.clone(),
         local_runtime_identity_for_nearai_mcp.as_ref(),
     )?;
-    let mut store_graph = build_local_dev_store_graph(RebornStoreGraphInput {
+    let mut store_graph = build_local_runtime_store_graph(RebornStoreGraphInput {
         filesystem: Arc::clone(&filesystem),
         owner_user_id,
         local_runtime_identity,
@@ -1703,7 +1703,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     let local_dev_product_auth_filesystem = local_dev_scoped_filesystem(Arc::clone(&filesystem));
     #[cfg(any(feature = "libsql", feature = "postgres"))]
-    let local_dev_secret_bundle = build_local_dev_secret_store(
+    let local_dev_secret_bundle = build_secret_store(
         &root,
         Arc::clone(&local_dev_product_auth_filesystem),
         secret_master_key,
@@ -2448,7 +2448,7 @@ fn local_dev_extension_installation_state_path(
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-async fn build_local_dev_store_graph(
+async fn build_local_runtime_store_graph(
     input: RebornStoreGraphInput,
 ) -> Result<RebornStoreGraph, RebornBuildError> {
     let RebornStoreGraphInput {
@@ -2678,7 +2678,7 @@ async fn build_local_dev_store_graph(
 }
 
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-async fn build_local_dev_store_graph(
+async fn build_local_runtime_store_graph(
     input: RebornStoreGraphInput,
 ) -> Result<RebornStoreGraph, RebornBuildError> {
     let RebornStoreGraphInput {
@@ -3157,7 +3157,7 @@ fn build_budget_sinks() -> BudgetSinks {
     }
 }
 
-async fn build_local_dev_root_filesystem(
+async fn build_local_runtime_root_filesystem(
     root: &Path,
     workspace_root: &Path,
     host_home_root: Option<&HostHomeRoot>,
@@ -3227,7 +3227,7 @@ async fn open_local_dev_libsql_database(
 // (`build_default_local_dev_database_roots_for_test`) can call this
 // without duplicating the 4-step libSQL setup sequence (Builder →
 // LibSqlRootFilesystem → run_migrations → mount). Production callers
-// stay inside this module (`build_local_dev_root_filesystem`).
+// stay inside this module (`build_local_runtime_root_filesystem`).
 pub(crate) async fn build_default_local_dev_database_roots(
     root: &Path,
     composite: &mut CompositeRootFilesystem,
@@ -3319,7 +3319,7 @@ pub(crate) async fn open_local_dev_slack_host_state_filesystem_for_test(
     storage_root: &Path,
 ) -> Result<Arc<ScopedFilesystem<CompositeRootFilesystem>>, RebornBuildError> {
     let workspace_root = storage_root.join("workspace");
-    let bundle = build_local_dev_root_filesystem(
+    let bundle = build_local_runtime_root_filesystem(
         storage_root,
         &workspace_root,
         None,
@@ -3426,7 +3426,7 @@ pub(crate) async fn open_local_dev_approval_request_store_for_test(
 /// W6-COLD-SPOTS: fresh `CommunicationPreferenceRepository` reopen, mirrors
 /// [`open_local_dev_approval_request_store_for_test`]. Reuses
 /// [`local_dev_outbound_store`] — the same composition-owned construction the
-/// production `build_local_dev_store_graph` path uses — so the reopen path
+/// production `build_local_runtime_store_graph` path uses — so the reopen path
 /// never drifts from production and needs no `disallowed_methods` exception.
 /// Tests only.
 #[cfg(all(feature = "test-support", feature = "libsql"))]
@@ -3446,7 +3446,7 @@ pub(crate) async fn open_local_dev_outbound_preferences_store_for_test(
 /// [`open_local_dev_approval_request_store_for_test`] (same on-disk root;
 /// sibling capability stores). Reuses [`mount_default_local_dev_database_roots`]
 /// plus the production [`crate::wrap_scoped`] so the reopen mounts and scopes
-/// the SAME way `build_local_dev_store_graph` does when it first builds
+/// the SAME way `build_local_runtime_store_graph` does when it first builds
 /// `tool_permission_overrides` / `auto_approve_settings` /
 /// `persistent_approval_policies` (above) — the reopen path never drifts from
 /// production. Tests only; zero bytes in production builds.
@@ -3522,7 +3522,7 @@ where
 // (`mount_local_dev_database_roots_for_test`) can forward to it across the
 // crate boundary for downstream integration tests without a second copy of the
 // mount truth. Production callers stay inside this module
-// (`build_local_dev_root_filesystem` / `build_default_local_dev_database_roots`).
+// (`build_local_runtime_root_filesystem` / `build_default_local_dev_database_roots`).
 pub(crate) fn mount_local_dev_database_roots<F>(
     root: &mut CompositeRootFilesystem,
     database: Arc<F>,
@@ -3590,7 +3590,7 @@ fn mount_local_dev_project_roots(
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub(crate) async fn build_local_dev_secret_store<F>(
+pub(crate) async fn build_secret_store<F>(
     root: &Path,
     scoped_filesystem: Arc<ScopedFilesystem<F>>,
     explicit_master_key: Option<ironclaw_secrets::SecretMaterial>,
@@ -3629,11 +3629,11 @@ where
 ///   and reconstructing the whole composite just to reach one mount is
 ///   heavy and risks silently diverging from `serve`'s copy.
 /// - `/secrets`'s physical backing is the same local-dev libSQL file
-///   `build_local_dev_root_filesystem` opens for `/tenants` in production —
+///   `build_local_runtime_root_filesystem` opens for `/tenants` in production —
 ///   a key written here is immediately visible to `serve`, no extra
 ///   coordination needed.
 /// - Uses the same resolver chain as production (env -> cached dotfile ->
-///   OS keychain -> generate-and-cache, via [`build_local_dev_secret_store`]).
+///   OS keychain -> generate-and-cache, via [`build_secret_store`]).
 /// - `run_migrations()` here and again on `serve`'s later open is safe —
 ///   already relied on as idempotent elsewhere in this module's tests.
 #[cfg(feature = "libsql")]
@@ -3644,7 +3644,7 @@ pub async fn open_local_dev_secret_store(
     let filesystem = Arc::new(LibSqlRootFilesystem::new(db));
     filesystem.run_migrations().await?;
     let scoped = crate::wrap_scoped(filesystem);
-    let (store, _crypto) = build_local_dev_secret_store(root, scoped, None).await?;
+    let (store, _crypto) = build_secret_store(root, scoped, None).await?;
     Ok(store as Arc<dyn SecretStore>)
 }
 
@@ -4139,7 +4139,7 @@ fn build_workspace_filesystems(
     filesystem: Arc<CompositeRootFilesystem>,
     workspace_root: &Path,
     host_home_root: Option<&HostHomeRoot>,
-) -> Result<LocalDevWorkspaceFilesystems, RebornBuildError> {
+) -> Result<WorkspaceFilesystems, RebornBuildError> {
     let read_only_workspace_mounts = workspace_mount_view(MountPermissions::read_only(), &[])
         .map_err(|error| RebornBuildError::InvalidConfig {
             reason: error.to_string(),
@@ -6410,7 +6410,7 @@ mod tests {
             .expect("manual-token account should survive local-dev rebuild");
         assert_eq!(rebuilt_account.access_secret.as_ref(), Some(&access_secret));
 
-        let rebuilt_filesystem = build_local_dev_root_filesystem(
+        let rebuilt_filesystem = build_local_runtime_root_filesystem(
             &local_dev_root,
             &local_dev_root.join("workspace"),
             None,
@@ -6419,7 +6419,7 @@ mod tests {
         .await
         .expect("local-dev filesystem rebuild")
         .filesystem;
-        let (rebuilt_secret_store, _rebuilt_secret_crypto) = build_local_dev_secret_store(
+        let (rebuilt_secret_store, _rebuilt_secret_crypto) = build_secret_store(
             &local_dev_root,
             local_dev_scoped_filesystem(rebuilt_filesystem),
             None,
@@ -6484,7 +6484,7 @@ mod tests {
         std::fs::create_dir_all(local_dev_root.join("system/extensions"))
             .expect("system extensions dir");
 
-        let root_filesystem = build_local_dev_root_filesystem(
+        let root_filesystem = build_local_runtime_root_filesystem(
             &local_dev_root,
             &local_dev_root.join("workspace"),
             None,

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -28,6 +28,7 @@ use ironclaw_reborn_event_store::{PostgresPoolTlsOptions, RebornPostgresSslMode}
 
 #[cfg(feature = "postgres")]
 use crate::RebornBuildError;
+use crate::deployment::DeploymentConfig;
 use crate::product_auth::oauth::google_oauth::google_provider_spec;
 use crate::product_auth::oauth::notion_oauth::notion_provider_spec;
 use crate::product_auth::oauth::oauth_dcr::OAuthDcrProviderConfig;
@@ -176,7 +177,17 @@ impl RebornRuntimeProcessBinding {
 }
 
 pub struct RebornBuildInput {
-    pub(crate) profile: RebornCompositionProfile,
+    /// The deployment this build assembles, as data (§4.4/§5.6). Carries the
+    /// substrate, traffic, readiness, and storage-shape axes every consumer
+    /// reads instead of re-deriving them from a profile name.
+    ///
+    /// The **resolved** runtime policy rides `runtime_policy`, not this value:
+    /// `new` builds the config without a yolo host-access disclosure (it is not
+    /// known at construction), so callers that hold the operator's confirmation
+    /// install the accurate config through
+    /// [`RebornBuildInput::with_deployment`] — `local_runtime_build_input_with_options`
+    /// is the one that does.
+    pub(crate) deployment: DeploymentConfig,
     pub(crate) owner_id: String,
     pub(crate) local_runtime_identity: Option<RebornLocalRuntimeIdentity>,
     pub(crate) storage: RebornStorageInput,
@@ -244,9 +255,30 @@ pub(crate) enum RebornStorageInput {
 }
 
 impl RebornBuildInput {
-    /// Selected composition profile.
+    /// Selected composition profile — a display/telemetry label. Behaviour
+    /// comes from [`RebornBuildInput::deployment`].
     pub fn profile(&self) -> RebornCompositionProfile {
-        self.profile
+        self.deployment.profile()
+    }
+
+    /// The deployment axes this build assembles from.
+    pub fn deployment(&self) -> &DeploymentConfig {
+        &self.deployment
+    }
+
+    /// Replace the deployment this input was constructed with.
+    ///
+    /// Test-only: production builds the deployment at construction
+    /// (`RebornBuildInput::new` takes it, and `local_runtime_build_input_with_options`
+    /// supplies one built where the operator's yolo disclosure is known). This
+    /// exists so tests can construct a deliberately mismatched
+    /// deployment/storage pairing and drive the fail-closed guard in
+    /// `build_reborn_services` — production behaviour, reached through a
+    /// pairing production rejects.
+    #[cfg(test)]
+    pub(crate) fn with_deployment(mut self, deployment: DeploymentConfig) -> Self {
+        self.deployment = deployment;
+        self
     }
 
     /// Owner id (string form). Used by the assembled runtime to mint the
@@ -284,14 +316,14 @@ impl RebornBuildInput {
 
     pub fn disabled(owner_id: impl Into<String>) -> Self {
         Self::new(
-            RebornCompositionProfile::Disabled,
+            DeploymentConfig::disabled(),
             owner_id,
             RebornStorageInput::Disabled,
         )
     }
 
     pub fn local_dev(owner_id: impl Into<String>, root: PathBuf) -> Self {
-        Self::local_dev_with_profile(RebornCompositionProfile::LocalDev, owner_id, root)
+        Self::local_dev_from_deployment(DeploymentConfig::local_dev(), owner_id, root)
     }
 
     pub(crate) fn local_dev_with_profile(
@@ -299,9 +331,24 @@ impl RebornBuildInput {
         owner_id: impl Into<String>,
         root: PathBuf,
     ) -> Self {
-        debug_assert!(profile.uses_local_dev_storage_input());
+        Self::local_dev_from_deployment(
+            DeploymentConfig::for_profile(profile, false),
+            owner_id,
+            root,
+        )
+    }
+
+    /// Build a local-dev-storage-shaped input from an already-resolved
+    /// deployment. The `debug_assert` is on the storage-shape **axis**, not on
+    /// a list of profile names (§4.4).
+    pub(crate) fn local_dev_from_deployment(
+        deployment: DeploymentConfig,
+        owner_id: impl Into<String>,
+        root: PathBuf,
+    ) -> Self {
+        debug_assert!(deployment.uses_local_dev_storage_input());
         Self::new(
-            profile,
+            deployment,
             owner_id,
             RebornStorageInput::LocalDev {
                 root,
@@ -323,7 +370,7 @@ impl RebornBuildInput {
         // config's storage-shape axis rather than a profile-name comparison
         // (§4.4): a deployment that takes a hosted single-tenant pool is a
         // property of the deployment, not of its name.
-        if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+        if DeploymentConfig::for_profile(profile, false).storage_shape()
             != crate::deployment::StorageShape::HostedSingleTenantPool
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -333,7 +380,7 @@ impl RebornBuildInput {
             });
         }
         Ok(Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::HostedSingleTenantPostgres {
                 root,
@@ -357,7 +404,7 @@ impl RebornBuildInput {
         // config's storage-shape axis rather than a profile-name comparison
         // (§4.4): a deployment that takes a hosted single-tenant pool is a
         // property of the deployment, not of its name.
-        if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+        if DeploymentConfig::for_profile(profile, false).storage_shape()
             != crate::deployment::StorageShape::HostedSingleTenantPool
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -373,7 +420,7 @@ impl RebornBuildInput {
             ..
         } = resolve_postgres_storage_from_config_and_env(profile, config_file)?;
         Ok(Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::HostedSingleTenantPostgres {
                 root,
@@ -487,7 +534,7 @@ impl RebornBuildInput {
         secret_master_key: ironclaw_secrets::SecretMaterial,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Libsql {
                 db,
@@ -508,7 +555,7 @@ impl RebornBuildInput {
         auth_token: Option<ironclaw_secrets::SecretMaterial>,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Libsql {
                 db,
@@ -529,7 +576,7 @@ impl RebornBuildInput {
         secret_master_key: ironclaw_secrets::SecretMaterial,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Postgres {
                 pool,
@@ -549,7 +596,7 @@ impl RebornBuildInput {
         url: ironclaw_secrets::SecretMaterial,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Postgres {
                 pool,
@@ -578,7 +625,7 @@ impl RebornBuildInput {
         let trust_policy = crate::builtin_first_party_trust_policy()?;
 
         Ok(Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Postgres {
                 pool,
@@ -786,12 +833,12 @@ impl RebornBuildInput {
     }
 
     fn new(
-        profile: RebornCompositionProfile,
+        deployment: DeploymentConfig,
         owner_id: impl Into<String>,
         storage: RebornStorageInput,
     ) -> Self {
         Self {
-            profile,
+            deployment,
             owner_id: owner_id.into(),
             local_runtime_identity: None,
             storage,

--- a/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
+++ b/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
@@ -70,9 +70,15 @@ pub fn local_runtime_build_input_with_options(
         return hosted_single_tenant_volume_build_input(owner_id, root);
     }
 
-    let policy = local_runtime_policy(profile, options)?;
+    // Build the deployment once, here, where the operator's host-access
+    // confirmation is known, and carry it on the input rather than letting
+    // downstream re-derive it from the profile name (§4.4).
+    let deployment = deployment_config_for_profile(profile, options)?;
+    let policy = deployment
+        .resolve()?
+        .ok_or(RebornRuntimeProfileError::MissingPolicyRequest { profile })?;
     Ok(
-        RebornBuildInput::local_dev_with_profile(profile, owner_id, root)
+        RebornBuildInput::local_dev_from_deployment(deployment, owner_id, root)
             .with_runtime_policy(policy),
     )
 }
@@ -183,4 +189,92 @@ fn local_runtime_policy_for_local_dev_shape(
             unreachable!("{profile_name} carries a runtime-policy request")
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::runtime_policy::{ApprovalPolicy, RuntimeProfile};
+
+    use super::*;
+
+    #[test]
+    fn yolo_disclosure_reaches_both_the_carried_deployment_and_the_resolved_policy() {
+        // This module is the one place that holds the operator's host-access
+        // confirmation, so it must be the place that builds the deployment.
+        // The hazard being pinned: `RebornBuildInput::new` cannot know the
+        // disclosure, so a config built there would carry
+        // `yolo_disclosure_acknowledged: false` and resolve fail-closed. The
+        // input must carry the config built *here* instead.
+        let dir = std::env::temp_dir().join("reborn-yolo-disclosure-test");
+        let input = local_runtime_build_input_with_options(
+            RebornCompositionProfile::LocalDevYolo,
+            "yolo-owner",
+            dir,
+            RebornRuntimeProfileOptions {
+                confirm_host_access: true,
+            },
+        )
+        .expect("confirmed local-dev-yolo builds");
+
+        assert_eq!(
+            input.profile(),
+            RebornCompositionProfile::LocalDevYolo,
+            "the carried deployment must keep the requested profile label"
+        );
+        let carried = input
+            .deployment()
+            .resolve()
+            .expect("carried deployment resolves")
+            .expect("local-dev-yolo makes a policy request");
+        assert_eq!(
+            carried.resolved_profile,
+            RuntimeProfile::LocalYolo,
+            "the carried deployment must have the disclosure, or it would fail closed"
+        );
+        assert_eq!(carried.approval_policy, ApprovalPolicy::Minimal);
+    }
+
+    #[test]
+    fn unconfirmed_yolo_fails_closed_before_an_input_is_built() {
+        let dir = std::env::temp_dir().join("reborn-yolo-unconfirmed-test");
+        let error = local_runtime_build_input_with_options(
+            RebornCompositionProfile::LocalDevYolo,
+            "yolo-owner",
+            dir,
+            RebornRuntimeProfileOptions {
+                confirm_host_access: false,
+            },
+        );
+        let Err(error) = error else {
+            panic!("unconfirmed yolo must not produce a build input");
+        };
+        assert!(matches!(
+            error,
+            RebornRuntimeProfileError::Policy(ResolveError::YoloRequiresDisclosure { .. })
+        ));
+    }
+
+    #[test]
+    fn deployments_without_the_local_dev_storage_shape_are_rejected() {
+        // The helper builds the local-dev storage input shape; the rejection is
+        // expressed as the storage-shape axis, not a list of profile names.
+        for profile in [
+            RebornCompositionProfile::Disabled,
+            RebornCompositionProfile::HostedSingleTenant,
+            RebornCompositionProfile::Production,
+            RebornCompositionProfile::MigrationDryRun,
+        ] {
+            let error = deployment_config_for_profile(
+                profile,
+                RebornRuntimeProfileOptions {
+                    confirm_host_access: true,
+                },
+            )
+            .expect_err("non-local-dev-storage deployments are not this helper's business");
+            assert!(matches!(
+                error,
+                RebornRuntimeProfileError::UnsupportedProfile { .. }
+            ));
+        }
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3128,8 +3128,7 @@ pub async fn build_reborn_runtime(
     // The deployment this build assembles, as data (§4.4/§5.6). Every axis
     // below — live-traffic admission, the cutover gate, substrate selection —
     // reads a field on this value instead of re-matching the profile.
-    let deployment =
-        DeploymentConfig::for_profile(profile, services_input.grants_trusted_laptop_access());
+    let deployment = services_input.deployment().clone();
     if let Some(reason) = deployment.traffic().live_traffic_refusal(profile) {
         return Err(RebornRuntimeError::InvalidArgument { reason });
     }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -741,16 +741,16 @@ impl RegistryPersistentApprovalGranteeResolver {
 /// test accessor: production wires one for audit-log observability only, not
 /// correctness the test needs. Propagates policy/resolver construction failures
 /// instead of collapsing them to `None`. Thin wrapper over
-/// `build_local_dev_approval_interaction_service_with_turn_run_source` using
+/// `build_approval_interaction_service_with_turn_run_source` using
 /// `local_runtime.turn_state` as the turn-run snapshot source — production
 /// behavior is unchanged by the seam below.
-pub(crate) fn build_local_dev_approval_interaction_service(
+pub(crate) fn build_approval_interaction_service(
     local_runtime: &crate::factory::RebornRuntimeSubstrate,
     builtin_capability_policy: Arc<BuiltinCapabilityPolicy>,
     turn_coordinator: Arc<dyn TurnCoordinator>,
     audit_sink: Option<Arc<dyn ironclaw_events::AuditSink>>,
 ) -> Result<Arc<dyn ApprovalInteractionService>, RebornRuntimeError> {
-    build_local_dev_approval_interaction_service_with_turn_run_source(
+    build_approval_interaction_service_with_turn_run_source(
         local_runtime,
         builtin_capability_policy,
         turn_coordinator,
@@ -759,17 +759,17 @@ pub(crate) fn build_local_dev_approval_interaction_service(
     )
 }
 
-/// Identical to [`build_local_dev_approval_interaction_service`]
+/// Identical to [`build_approval_interaction_service`]
 /// except the approval turn-run locator reads `turn_run_source` instead of
 /// always deriving it from `local_runtime.turn_state`. Lets a caller whose
 /// real runs live in a DIFFERENT `TurnStateStore` composition (e.g.
 /// `RebornIntegrationGroup`'s own `build_default_planned_runtime`, whose runs
 /// are invisible to this crate's `local_runtime.turn_state`) substitute its
-/// own store. `build_local_dev_approval_interaction_service` is the
+/// own store. `build_approval_interaction_service` is the
 /// production entry point and is a thin wrapper over this function with
 /// `local_runtime.turn_state` as the source, so production behavior is
 /// unchanged.
-pub(crate) fn build_local_dev_approval_interaction_service_with_turn_run_source(
+pub(crate) fn build_approval_interaction_service_with_turn_run_source(
     local_runtime: &crate::factory::RebornRuntimeSubstrate,
     builtin_capability_policy: Arc<BuiltinCapabilityPolicy>,
     turn_coordinator: Arc<dyn TurnCoordinator>,
@@ -1017,7 +1017,7 @@ struct SnapshotApprovalTurnRunLocator {
     /// A trait object (not the concrete `ComposedTurnStateStore`) so a
     /// caller can substitute a different turn-state store's snapshot view —
     /// see `turn_run_snapshot::TurnRunSnapshotSource` and
-    /// `build_local_dev_approval_interaction_service_with_turn_run_source`.
+    /// `build_approval_interaction_service_with_turn_run_source`.
     turn_state: Arc<dyn TurnRunSnapshotSource>,
 }
 
@@ -3947,7 +3947,7 @@ pub async fn build_reborn_runtime(
         if let (Some(local_runtime), Some(builtin_capability_policy)) =
             (local_runtime, builtin_capability_policy)
         {
-            build_local_dev_approval_interaction_service(
+            build_approval_interaction_service(
                 local_runtime,
                 builtin_capability_policy,
                 Arc::clone(&planned_turn_coordinator),
@@ -4215,7 +4215,7 @@ fn build_webui_auth_interaction_service(
 /// Identical to [`build_webui_auth_interaction_service`] except
 /// the auth read model reads `turn_run_source` instead of a hardcoded
 /// `ComposedTurnStateStore`. See
-/// `build_local_dev_approval_interaction_service_with_turn_run_source`'s doc
+/// `build_approval_interaction_service_with_turn_run_source`'s doc
 /// for why this seam exists.
 fn build_webui_auth_interaction_service_with_turn_run_source(
     product_auth: Option<&RebornProductAuthServices>,

--- a/crates/ironclaw_reborn_composition/src/runtime/test_support.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/test_support.rs
@@ -13,7 +13,7 @@ use super::*;
 
 impl RebornServices {
     /// Real `DefaultApprovalInteractionService` wired like `build_reborn_runtime`, via the
-    /// shared `build_local_dev_approval_interaction_service` recipe so the two never drift.
+    /// shared `build_approval_interaction_service` recipe so the two never drift.
     /// `Ok(None)` without a local-dev runtime; `Err` surfaces a local-dev capability-policy
     /// or grantee-resolver construction failure instead of collapsing it into `None`. No
     /// audit sink threaded — production wires one for audit-log observability only, not
@@ -33,7 +33,7 @@ impl RebornServices {
                 reason: format!("local-dev capability policy is invalid: {error}"),
             }
         })?);
-        Ok(Some(build_local_dev_approval_interaction_service(
+        Ok(Some(build_approval_interaction_service(
             local_runtime,
             builtin_capability_policy,
             turn_coordinator,
@@ -92,7 +92,7 @@ impl RebornServices {
             }
         })?);
         Ok(Some(
-            build_local_dev_approval_interaction_service_with_turn_run_source(
+            build_approval_interaction_service_with_turn_run_source(
                 local_runtime,
                 builtin_capability_policy,
                 turn_coordinator,

--- a/crates/ironclaw_reborn_composition/src/test_support/local_dev_boot.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/local_dev_boot.rs
@@ -3,7 +3,7 @@
 //! `build_approval_gate_evidence_for_test`,
 //! `build_default_local_dev_database_roots_for_test`,
 //! `mount_local_dev_database_roots_for_test`,
-//! `build_local_dev_secret_store_for_test` — mirror the production local-dev
+//! `build_secret_store_for_test` — mirror the production local-dev
 //! boot sequence so the integration-test harness (`tests/support/reborn/`)
 //! drives the real local-dev composition paths without duplicating the wiring
 //! logic.
@@ -15,7 +15,7 @@
 pub const LOCAL_DEV_DB_FILENAME: &str = crate::factory::LOCAL_DEV_DB_FILENAME;
 
 /// Test-only accessor mirroring the full local-dev database-roots boot path
-/// (`build_local_dev_root_filesystem` → `build_default_local_dev_database_roots`).
+/// (`build_local_runtime_root_filesystem` → `build_default_local_dev_database_roots`).
 ///
 /// Constructs the durable database backend and mounts it across the
 /// control-plane roots (`/tenants`, `/memory`, `/events`) of `composite`,
@@ -26,7 +26,7 @@ pub const LOCAL_DEV_DB_FILENAME: &str = crate::factory::LOCAL_DEV_DB_FILENAME;
 /// Called by the Reborn integration-test framework's `StorageMode::LibSql`
 /// builder arm (`tests/support/reborn/builder.rs:build_storage_composite`) so
 /// the 4-step libSQL setup sequence lives once (production call site:
-/// `build_local_dev_root_filesystem` → `build_default_local_dev_database_roots`).
+/// `build_local_runtime_root_filesystem` → `build_default_local_dev_database_roots`).
 /// For tests only — gated behind `test-support`, ships zero bytes in production.
 #[cfg(feature = "test-support")]
 pub async fn build_default_local_dev_database_roots_for_test(
@@ -37,7 +37,7 @@ pub async fn build_default_local_dev_database_roots_for_test(
 }
 
 /// Test-only accessor mirroring the production local-dev boot path
-/// (`build_local_dev_root_filesystem` → `mount_local_dev_database_roots`).
+/// (`build_local_runtime_root_filesystem` → `mount_local_dev_database_roots`).
 ///
 /// Mounts `database` across the control-plane roots (`/tenants`, `/memory`,
 /// `/events`) of `root` exactly as the libSQL local-dev boot path does, so
@@ -62,7 +62,7 @@ where
 /// Reborn runtime assembly.
 ///
 /// Mirrors the production wiring in `build_local_runtime` where
-/// `build_local_dev_secret_store` is called with the scoped filesystem and a
+/// `build_secret_store` is called with the scoped filesystem and a
 /// master key resolved from the environment or the root directory's cached key
 /// file. Tests that need a real `FilesystemSecretStore` — for example, to
 /// verify `put` + `lease_once` + `consume` round-trips against an in-process
@@ -76,16 +76,16 @@ where
 /// secret written by the first. For tests only — zero bytes shipped in
 /// production builds.
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub async fn build_local_dev_secret_store_for_test<F>(
+pub async fn build_secret_store_for_test<F>(
     root: &std::path::Path,
     scoped: std::sync::Arc<ironclaw_filesystem::ScopedFilesystem<F>>,
 ) -> Result<std::sync::Arc<ironclaw_secrets::FilesystemSecretStore<F>>, crate::RebornBuildError>
 where
     F: ironclaw_filesystem::RootFilesystem + 'static,
 {
-    // `build_local_dev_secret_store` also returns the crypto (for the admin
+    // `build_secret_store` also returns the crypto (for the admin
     // secret provisioner); this test helper only needs the store.
-    let (store, _crypto) = crate::factory::build_local_dev_secret_store(root, scoped, None).await?;
+    let (store, _crypto) = crate::factory::build_secret_store(root, scoped, None).await?;
     Ok(store)
 }
 

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -16,7 +16,7 @@
 //! 3. [`local_dev_boot`] — `build_approval_gate_evidence_for_test`,
 //!    `build_default_local_dev_database_roots_for_test`,
 //!    `mount_local_dev_database_roots_for_test`,
-//!    `build_local_dev_secret_store_for_test` — mirror the production
+//!    `build_secret_store_for_test` — mirror the production
 //!    local-dev boot sequence so the integration-test harness
 //!    (`tests/support/reborn/`) drives the real local-dev composition paths
 //!    without duplicating the wiring logic.
@@ -96,7 +96,7 @@ pub use durable::{
 };
 pub use local_dev_boot::LOCAL_DEV_DB_FILENAME;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-pub use local_dev_boot::build_local_dev_secret_store_for_test;
+pub use local_dev_boot::build_secret_store_for_test;
 #[cfg(feature = "test-support")]
 pub use local_dev_boot::{
     build_approval_gate_evidence_for_test, build_default_local_dev_database_roots_for_test,
@@ -120,14 +120,13 @@ pub use projection::build_webui_event_stream_for_test;
 #[cfg(feature = "test-support")]
 pub use refreshing_capability_port::{
     ExtensionManagementTestHandle, RefreshingCapabilityPortTestParts,
-    build_local_dev_extension_management_for_test, create_refreshing_capability_port_for_test,
+    build_extension_management_for_test, create_refreshing_capability_port_for_test,
 };
 #[cfg(feature = "test-support")]
 pub use result_read::{RESULT_READ_CAPABILITY_ID, wrap_result_read_capability_for_test};
 #[cfg(feature = "test-support")]
 pub use skill_activation::{
-    SKILL_ACTIVATE_CAPABILITY_ID, SkillActivationTestSource,
-    build_local_dev_skill_context_source_for_test,
+    SKILL_ACTIVATE_CAPABILITY_ID, SkillActivationTestSource, build_skill_context_source_for_test,
 };
 #[cfg(all(feature = "test-support", feature = "slack-v2-host-beta"))]
 pub use slack_channel_connection::{

--- a/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/refreshing_capability_port.rs
@@ -39,7 +39,7 @@ pub struct RefreshingCapabilityPortTestParts {
     pub result_writer: std::sync::Arc<dyn ironclaw_loop_host::LoopCapabilityResultWriter>,
     pub milestone_sink: std::sync::Arc<dyn ironclaw_turns::run_profile::LoopHostMilestoneSink>,
     /// Opaque handle built by
-    /// `test_support::build_local_dev_skill_context_source_for_test`. Wraps
+    /// `test_support::build_skill_context_source_for_test`. Wraps
     /// the crate-private `ComposedSelectableSkillContextSource` so it never
     /// appears in this (public, `test-support`-gated) struct's field types;
     /// the private type is recovered internally via
@@ -53,7 +53,7 @@ pub struct RefreshingCapabilityPortTestParts {
     /// (`local_dev.rs` `create_capability_port`).
     pub thread_service: std::sync::Arc<dyn ironclaw_threads::SessionThreadService>,
     /// Opaque handle built by
-    /// [`build_local_dev_extension_management_for_test`]. Wraps the
+    /// [`build_extension_management_for_test`]. Wraps the
     /// crate-private (`pub(crate)`) `RebornLocalExtensionManagementPort` so it
     /// never appears in this (public, `test-support`-gated) struct's field
     /// types; mirrors `skill_activation_source` above. Active-extension
@@ -142,7 +142,7 @@ impl ExtensionManagementTestHandle {
 /// install/activate an extension can also just omit this call and leave the
 /// field `None` for the same no-op surface.
 #[cfg(feature = "test-support")]
-pub fn build_local_dev_extension_management_for_test(
+pub fn build_extension_management_for_test(
     services: &crate::RebornServices,
 ) -> Option<ExtensionManagementTestHandle> {
     let extension_management = services

--- a/crates/ironclaw_reborn_composition/src/test_support/skill_activation.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/skill_activation.rs
@@ -46,7 +46,7 @@ impl SkillActivationTestSource {
 /// composed. Mirrors `build_user_profile_source_for_test` (E-SKILL seam).
 /// Tests only.
 #[cfg(feature = "test-support")]
-pub fn build_local_dev_skill_context_source_for_test(
+pub fn build_skill_context_source_for_test(
     services: &crate::RebornServices,
     tenant_id: &ironclaw_host_api::TenantId,
     regex_skill_activation_enabled: bool,

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -1,3 +1,7 @@
+// arch-exempt: large_file, pre-existing ~1.9K-line facade test suite; this change is a net-zero rename of build_local_dev_secret_store_for_test call sites with no cases added, plan #6168
+//
+// Decomposition of this suite travels with the composition god-crate shrink
+// (#6168); do not add unrelated cases here.
 #[cfg(feature = "postgres")]
 #[path = "support/postgres.rs"]
 mod postgres_support;
@@ -1311,7 +1315,7 @@ async fn local_dev_secret_store_falls_through_suppressed_keychain_to_dotfile() {
     let composite = std::sync::Arc::new(composite);
     let scoped = ironclaw_reborn_composition::wrap_scoped(std::sync::Arc::clone(&composite));
 
-    ironclaw_reborn_composition::test_support::build_local_dev_secret_store_for_test(
+    ironclaw_reborn_composition::test_support::build_secret_store_for_test(
         root,
         std::sync::Arc::clone(&scoped),
     )
@@ -1323,7 +1327,7 @@ async fn local_dev_secret_store_falls_through_suppressed_keychain_to_dotfile() {
     );
     let cached = std::fs::read_to_string(&key_path).expect("read generated dotfile");
 
-    ironclaw_reborn_composition::test_support::build_local_dev_secret_store_for_test(root, scoped)
+    ironclaw_reborn_composition::test_support::build_secret_store_for_test(root, scoped)
         .await
         .expect("second store build must read the now-cached dotfile idempotently");
     assert_eq!(

--- a/tests/integration/CLAUDE.md
+++ b/tests/integration/CLAUDE.md
@@ -376,7 +376,7 @@ On a harness built from a `live_approvals` group:
 
 `ironclaw_reborn_composition::test_support` exposes:
 
-- `build_local_dev_secret_store_for_test(root, scoped)` — constructs the `LocalDevSecretStore` used by production local-dev composition; for store read-back in secrets tests.
+- `build_secret_store_for_test(root, scoped)` — constructs the `LocalDevSecretStore` used by production local-dev composition; for store read-back in secrets tests.
 
 `RebornServices` (returned by `build_reborn_services`/exposed via `RebornRuntime::services()`, methods defined in `crates/ironclaw_reborn_composition/src/runtime/test_support.rs`) exposes:
 

--- a/tests/integration/secrets.rs
+++ b/tests/integration/secrets.rs
@@ -23,7 +23,7 @@ use ironclaw_filesystem::{CompositeRootFilesystem, LibSqlRootFilesystem};
 use ironclaw_host_api::SecretHandle;
 use ironclaw_reborn_composition::test_support::{
     LOCAL_DEV_DB_FILENAME, build_default_local_dev_database_roots_for_test,
-    build_local_dev_secret_store_for_test, mount_local_dev_database_roots_for_test,
+    build_secret_store_for_test, mount_local_dev_database_roots_for_test,
 };
 use ironclaw_reborn_composition::wrap_scoped;
 use ironclaw_secrets::{SecretMaterial, SecretStore, SecretStoreError};
@@ -48,7 +48,7 @@ async fn secret_persists_across_libsql_reopen() {
         .expect("build default local-dev db roots");
     let composite = Arc::new(composite);
     let scoped = wrap_scoped(Arc::clone(&composite));
-    let store = build_local_dev_secret_store_for_test(dir.path(), Arc::clone(&scoped))
+    let store = build_secret_store_for_test(dir.path(), Arc::clone(&scoped))
         .await
         .expect("build first secret store");
 
@@ -93,7 +93,7 @@ async fn secret_persists_across_libsql_reopen() {
         .expect("mount fresh composite");
     let fresh_composite = Arc::new(fresh_composite);
     let fresh_scoped = wrap_scoped(Arc::clone(&fresh_composite));
-    let fresh_store = build_local_dev_secret_store_for_test(dir.path(), fresh_scoped)
+    let fresh_store = build_secret_store_for_test(dir.path(), fresh_scoped)
         .await
         .expect("build fresh secret store (same root → same crypto key)");
 
@@ -127,7 +127,7 @@ async fn secret_read_back_fails_for_unknown_handle() {
         .expect("build default local-dev db roots");
     let composite = Arc::new(composite);
     let scoped = wrap_scoped(Arc::clone(&composite));
-    let store = build_local_dev_secret_store_for_test(dir.path(), scoped)
+    let store = build_secret_store_for_test(dir.path(), scoped)
         .await
         .expect("build secret store");
 
@@ -174,7 +174,7 @@ async fn secret_read_back_fails_for_wrong_tenant_scope() {
         .expect("build default local-dev db roots");
     let composite = Arc::new(composite);
     let scoped = wrap_scoped(Arc::clone(&composite));
-    let store = build_local_dev_secret_store_for_test(dir.path(), scoped)
+    let store = build_secret_store_for_test(dir.path(), scoped)
         .await
         .expect("build secret store");
 

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -668,7 +668,7 @@ impl HostRuntimeCapabilityHarness {
         }) {
             let tenant = skill_activation_tenant
                 .ok_or("skill_activation_tools harness requires with_skill_activation_tenant")?;
-            ironclaw_reborn_composition::test_support::build_local_dev_skill_context_source_for_test(
+            ironclaw_reborn_composition::test_support::build_skill_context_source_for_test(
                 &services, &tenant, true,
             )
             .map(Arc::new)
@@ -1536,7 +1536,7 @@ impl HostRuntimeCapabilityHarness {
         // through the real activation handshake (`extension_surface_source`'s
         // `ExtensionCapabilitySurface::provider_trust()`, same
         // `extension_management` + grantee production's factory reads) --
-        // queried the SAME way `build_local_dev_extension_management_for_test`
+        // queried the SAME way `build_extension_management_for_test`
         // -> `extension_surface_source` will read it downstream in
         // `create_refreshing_capability_port_for_test`. NOT the same
         // as "this harness has `reborn_services` wired": a harness can have
@@ -1617,90 +1617,89 @@ impl HostRuntimeCapabilityHarness {
                 }
             })
             .collect();
-        let parts =
-            ironclaw_reborn_composition::test_support::RefreshingCapabilityPortTestParts {
-                runtime: self.runtime.lock().unwrap().clone(),
-                run_context: run_context.clone(),
-                fallback_user_id: dispatch_user,
-                // All four mount views = this harness's single `mounts` view.
-                // Production splits skill/memory/system-extensions mounts off
-                // the local-dev workspace root, but this harness has ONE
-                // profile-built view and the pre-seam behavior was "every
-                // capability executes (and is granted) under `self.mounts`
-                // unless `capability_mount_overrides` says otherwise" — a
-                // `MountView::default()` here would instead OVERRIDE the
-                // memory/skill capability families down to an empty view via
-                // `build_inner`'s per-domain `with_capability_execution_mount`
-                // special-cases, silently blinding `builtin.memory_*`.
-                workspace_mounts: self.mounts.clone(),
-                skill_mounts: self.mounts.clone(),
-                memory_mounts: self.mounts.clone(),
-                system_extensions_lifecycle_mounts: self.mounts.clone(),
-                input_resolver,
-                result_writer,
-                milestone_sink: milestone_sink.clone() as Arc<dyn LoopHostMilestoneSink>,
-                skill_activation_source: self.skill_activation_source.clone(),
-                project_service,
-                // result_read (durable tool-result projection seam, issue
-                // #5838): production always wires the run's session thread
-                // service into the synthetic `result_read` capability, so
-                // this is a required (non-`Option`) field. Harnesses that
-                // opted into `.with_durable_capability_io()` populate
-                // `durable_capability_io_thread_service` with the REAL group
-                // thread service; every other harness gets a fresh in-memory
-                // no-op service, mirroring the `project_service`/
-                // `tool_permission_overrides` "no opinion -> default" pattern
-                // above -- `result_read` is simply never granted for those
-                // harnesses (not in `capability_ids`), so the default is
-                // never actually read.
-                thread_service: self
-                    .durable_capability_io_thread_service
-                    .lock()
-                    .unwrap()
-                    .clone()
-                    .unwrap_or_else(|| {
-                        Arc::new(ironclaw_threads::InMemorySessionThreadService::default())
-                    }),
-                trajectory_observer: None,
-                // Feeds the same active-extension authority (installed +
-                // activated extensions like `github`, `gmail`, MCP servers)
-                // production's `capability_wiring` folds into every refresh
-                // (`runtime/local_dev.rs:132-133`); `None` when this harness
-                // was built without `RebornServices` (mirrors the old
-                // `local_dev_active_extension_authority_for_test` early-return).
-                extension_management: self.reborn_services.as_ref().and_then(|services| {
-                    ironclaw_reborn_composition::test_support::build_local_dev_extension_management_for_test(
-                        services,
-                    )
+        let parts = ironclaw_reborn_composition::test_support::RefreshingCapabilityPortTestParts {
+            runtime: self.runtime.lock().unwrap().clone(),
+            run_context: run_context.clone(),
+            fallback_user_id: dispatch_user,
+            // All four mount views = this harness's single `mounts` view.
+            // Production splits skill/memory/system-extensions mounts off
+            // the local-dev workspace root, but this harness has ONE
+            // profile-built view and the pre-seam behavior was "every
+            // capability executes (and is granted) under `self.mounts`
+            // unless `capability_mount_overrides` says otherwise" — a
+            // `MountView::default()` here would instead OVERRIDE the
+            // memory/skill capability families down to an empty view via
+            // `build_inner`'s per-domain `with_capability_execution_mount`
+            // special-cases, silently blinding `builtin.memory_*`.
+            workspace_mounts: self.mounts.clone(),
+            skill_mounts: self.mounts.clone(),
+            memory_mounts: self.mounts.clone(),
+            system_extensions_lifecycle_mounts: self.mounts.clone(),
+            input_resolver,
+            result_writer,
+            milestone_sink: milestone_sink.clone() as Arc<dyn LoopHostMilestoneSink>,
+            skill_activation_source: self.skill_activation_source.clone(),
+            project_service,
+            // result_read (durable tool-result projection seam, issue
+            // #5838): production always wires the run's session thread
+            // service into the synthetic `result_read` capability, so
+            // this is a required (non-`Option`) field. Harnesses that
+            // opted into `.with_durable_capability_io()` populate
+            // `durable_capability_io_thread_service` with the REAL group
+            // thread service; every other harness gets a fresh in-memory
+            // no-op service, mirroring the `project_service`/
+            // `tool_permission_overrides` "no opinion -> default" pattern
+            // above -- `result_read` is simply never granted for those
+            // harnesses (not in `capability_ids`), so the default is
+            // never actually read.
+            thread_service: self
+                .durable_capability_io_thread_service
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or_else(|| {
+                    Arc::new(ironclaw_threads::InMemorySessionThreadService::default())
                 }),
-                outbound_preferences_facade,
-                outbound_delivery_target_set_requires_approval,
-                tool_permission_overrides,
-                auto_approve_settings,
-                persistent_approval_policies,
-                approval_requests,
-                capability_leases,
-                // `self.capability_mount_overrides` is the SAME per-capability
-                // mount-override list production's `skill_mounts`/`memory_mounts`/
-                // `system_extensions_lifecycle_mounts` special-cases apply
-                // automatically for their own fixed capability-id lists; passing
-                // it here too (rather than splitting it across those three
-                // fields, which this harness has no per-domain tracking for)
-                // reaches the SAME final per-capability mount via the override
-                // map, applied after those defaults in `build_inner`.
-                capability_execution_mount_overrides: self
-                    .capability_mount_overrides
-                    .iter()
-                    .cloned()
-                    .collect(),
-                additional_provider_trust,
-                // Whole-set narrowing over the FULL granted-capability set to
-                // this harness's exhaustive `capability_ids` allowlist,
-                // including the empty case (zero grants). See
-                // `additional_capability_grants` doc for the invariant.
-                capability_id_filter: Some(self.capability_ids.iter().cloned().collect()),
-                additional_capability_grants,
-            };
+            trajectory_observer: None,
+            // Feeds the same active-extension authority (installed +
+            // activated extensions like `github`, `gmail`, MCP servers)
+            // production's `capability_wiring` folds into every refresh
+            // (`runtime/local_dev.rs:132-133`); `None` when this harness
+            // was built without `RebornServices` (mirrors the old
+            // `local_dev_active_extension_authority_for_test` early-return).
+            extension_management: self.reborn_services.as_ref().and_then(|services| {
+                ironclaw_reborn_composition::test_support::build_extension_management_for_test(
+                    services,
+                )
+            }),
+            outbound_preferences_facade,
+            outbound_delivery_target_set_requires_approval,
+            tool_permission_overrides,
+            auto_approve_settings,
+            persistent_approval_policies,
+            approval_requests,
+            capability_leases,
+            // `self.capability_mount_overrides` is the SAME per-capability
+            // mount-override list production's `skill_mounts`/`memory_mounts`/
+            // `system_extensions_lifecycle_mounts` special-cases apply
+            // automatically for their own fixed capability-id lists; passing
+            // it here too (rather than splitting it across those three
+            // fields, which this harness has no per-domain tracking for)
+            // reaches the SAME final per-capability mount via the override
+            // map, applied after those defaults in `build_inner`.
+            capability_execution_mount_overrides: self
+                .capability_mount_overrides
+                .iter()
+                .cloned()
+                .collect(),
+            additional_provider_trust,
+            // Whole-set narrowing over the FULL granted-capability set to
+            // this harness's exhaustive `capability_ids` allowlist,
+            // including the empty case (zero grants). See
+            // `additional_capability_grants` doc for the invariant.
+            capability_id_filter: Some(self.capability_ids.iter().cloned().collect()),
+            additional_capability_grants,
+        };
         let port =
             ironclaw_reborn_composition::test_support::create_refreshing_capability_port_for_test(
                 parts,


### PR DESCRIPTION
Phase 3 of #6274 — §4.4.1 category 2: *"mis-prefixed shared substrate — not local at all. De-prefix, don't configify."*

**Stacked on #6279** (Phase 2), which is stacked on #6277 (Phase 1).

## Why these are misnamed

None of these builders is local-dev-specific. Both `build_local_dev_store_graph` variants are **already called by the hosted single-tenant volume deployment** as well as local-dev, and the rest are the ordinary shared substrate every deployment assembles. The `local_dev` prefix claimed a deployment mode the code does not have — the §4.4.1 finding that these are shared mechanism wearing a mode's name.

## Renames

Mechanical, no logic change:

| Before | After |
|---|---|
| `build_local_dev_store_graph` | `build_local_runtime_store_graph` |
| `build_local_dev_root_filesystem` | `build_local_runtime_root_filesystem` |
| `build_local_dev_secret_store` | `build_secret_store` |
| `build_local_dev_secret_store_for_test` | `build_secret_store_for_test` |
| `build_local_dev_approval_interaction_service{,_with_turn_run_source}` | `build_approval_interaction_service{,_with_turn_run_source}` |
| `build_local_dev_extension_management_for_test` | `build_extension_management_for_test` |
| `build_local_dev_skill_context_source_for_test` | `build_skill_context_source_for_test` |
| `type LocalDevWorkspaceFilesystems` | `type WorkspaceFilesystems` |

The two `build_local_runtime_*` names keep a qualifier deliberately: they genuinely select the **local runtime substrate** (`RuntimeSubstrate::Local`, Phase 2) rather than the production-shaped one. That is a substrate distinction, not a deployment mode, so the name should keep it.

## Ratchet

`reborn_localdev_typename_ratchet`'s allowlist is **already empty** — that axis reached its definition of done before this PR — so no entry retires here. The private `LocalDevWorkspaceFilesystems` alias sat below the ratchet's pub-visibility scan and is cleaned up for consistency rather than because a check demanded it.

## Scope

Call sites updated across the composition crate, its tests, the integration harness, `tests/integration/secrets.rs`, and `tests/integration/CLAUDE.md`. Verified against HEAD that none of the new names collides with an existing symbol.

## Testing

```
cargo test -p ironclaw_reborn_composition --lib   # 1484 passed
cargo test -p ironclaw_architecture               # 11 suites, all green
cargo clippy -p ironclaw_reborn_composition -p ironclaw_architecture \
  --all-targets --all-features -- -D warnings     # clean
bash scripts/pre-commit-safety.sh                 # exit 0
```

Same three pre-existing `llm_admin::nearai_mcp::tests::bootstrap_config_from_env_*` failures as the other two PRs — environmental (`NEARAI_API_KEY` set in my shell), unrelated.

No new tests: this is a pure rename with no behaviour change, and the existing suites exercise every renamed function through its production callers.

One `arch-exempt: large_file` added to the pre-existing ~1.9K-line `tests/facade_factory.rs`. The change there is a net-zero two-line rename with no cases added; the annotation is what the mechanical check requires, citing #6168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
