### PR TITLE
perf(turns): long-lived authority + remove redundant global commit_gate from the turn-state row store (#6263 Step 1)

### DIFF
--- a/crates/ironclaw_turns/src/filesystem_store/row_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store.rs
@@ -62,6 +62,9 @@ const ROW_COLLECTION_READ_CONCURRENCY: usize = 32;
 /// Transitions still delegate to [`InMemoryTurnStateStore`]; only the durable
 /// representation changes from whole-snapshot CAS to a typed append log plus a
 /// process-local hot snapshot cache.
+// arch-exempt: large_file, long-lived embedded-authority refactor adds a shared
+// overlay-store acquisition helper (deduplicating the apply / targeted-delta
+// paths) rather than a second store-acquisition pipeline, plan #6263
 pub struct FilesystemTurnStateRowStore<F>
 where
     F: RootFilesystem,
@@ -70,7 +73,6 @@ where
     limits: InMemoryTurnStateStoreLimits,
     admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
     snapshot_state: AsyncMutex<Option<RowSnapshotState>>,
-    commit_gate: AsyncMutex<()>,
     legacy_migration_gate: Arc<AsyncMutex<()>>,
     materialize_gate: Arc<AsyncMutex<()>>,
     runner_leases: RunnerLeaseMemory,
@@ -146,7 +148,6 @@ where
             limits: InMemoryTurnStateStoreLimits::default(),
             admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
             snapshot_state: AsyncMutex::new(None),
-            commit_gate: AsyncMutex::new(()),
             legacy_migration_gate: Arc::new(AsyncMutex::new(())),
             materialize_gate: Arc::clone(&materialize_gate),
             runner_leases: Arc::new(RwLock::new(HashMap::new())),
@@ -746,6 +747,37 @@ where
         )
     }
 
+    /// Acquire the long-lived embedded authority with the runner-lease overlay
+    /// applied, without rebuilding it from a full-snapshot clone.
+    ///
+    /// For [`RunnerLeaseOverlay::None`] and [`RunnerLeaseOverlay::Run`] this
+    /// reuses the cached authority in place (the `Run` case overlays a single
+    /// run record's live lease heartbeat onto it) — an O(1) reuse rather than a
+    /// per-op O(store-size) `from_persistence_snapshot` rebuild. Only
+    /// [`RunnerLeaseOverlay::All`] (expired-lease recovery) still rebuilds from
+    /// an overlaid snapshot clone, because it must overlay every run's lease.
+    async fn acquire_overlaid_store(
+        &self,
+        cached_store: Arc<InMemoryTurnStateStore>,
+        overlay_baseline: Option<TurnPersistenceSnapshot>,
+        overlay_run: Option<TurnRunRecord>,
+        overlay: RunnerLeaseOverlay,
+    ) -> Result<Arc<InMemoryTurnStateStore>, TurnError> {
+        if let Some(baseline) = overlay_baseline {
+            let (overlaid_snapshot, _) = self
+                .runner_lease_store()
+                .overlay((baseline, None), overlay)
+                .await?;
+            Ok(Arc::new(self.build_in_memory_store(overlaid_snapshot)?))
+        } else {
+            if let Some(run) = overlay_run {
+                let overlaid = self.runner_lease_store().overlay_run_record(run).await?;
+                cached_store.overlay_runner_lease_record(overlaid)?;
+            }
+            Ok(cached_store)
+        }
+    }
+
     async fn apply<T, A, Fut>(
         &self,
         overlay: RunnerLeaseOverlay,
@@ -757,20 +789,31 @@ where
         T: Send,
     {
         let critical = async {
-            let _commit_guard = self.commit_gate.lock().await;
             let mut guard = self.snapshot_state.lock().await;
             let mut refreshed_after_stale_error = false;
             loop {
                 self.ensure_snapshot_cache_for_mutation(&mut guard).await?;
-                let (baseline, current_journal_seq) = guard
-                    .as_ref()
-                    .map(|state| (state.snapshot.clone(), state.journal_seq))
-                    .unwrap_or_else(|| (TurnPersistenceSnapshot::default(), SeqNo::ZERO));
-                let (overlaid_snapshot, _) = self
-                    .runner_lease_store()
-                    .overlay((baseline.clone(), None), overlay)
+                let (baseline, current_journal_seq, cached_store, overlay_baseline, overlay_run) = {
+                    let state = guard.as_ref().ok_or_else(|| TurnError::Unavailable {
+                        reason: "row snapshot cache was not initialized".to_string(),
+                    })?;
+                    let overlay_baseline =
+                        matches!(overlay, RunnerLeaseOverlay::All).then(|| state.snapshot.clone());
+                    let overlay_run = match overlay {
+                        RunnerLeaseOverlay::Run(run_id) => state.run_record_by_id(run_id),
+                        RunnerLeaseOverlay::None | RunnerLeaseOverlay::All => None,
+                    };
+                    (
+                        state.snapshot.clone(),
+                        state.journal_seq,
+                        Arc::clone(&state.store),
+                        overlay_baseline,
+                        overlay_run,
+                    )
+                };
+                let store = self
+                    .acquire_overlaid_store(cached_store, overlay_baseline, overlay_run, overlay)
                     .await?;
-                let store = Arc::new(self.build_in_memory_store(overlaid_snapshot)?);
                 let outcome = apply(Arc::clone(&store)).await;
                 let mut new_snapshot = store.persistence_snapshot();
                 preserve_loop_checkpoints(&baseline, &mut new_snapshot);
@@ -1567,17 +1610,6 @@ where
         }
     }
 
-    async fn apply_cached_delta(&self, delta: SnapshotDelta) -> Result<(), TurnError> {
-        if delta.is_empty() {
-            return Ok(());
-        }
-        let mut guard = self.snapshot_state.lock().await;
-        if let Some(state) = guard.as_mut() {
-            state.apply_delta(delta, state.journal_seq)?;
-        }
-        Ok(())
-    }
-
     async fn apply_with_targeted_delta<T, A, Fut, D>(
         &self,
         overlay: RunnerLeaseOverlay,
@@ -1597,7 +1629,6 @@ where
         T: Send,
     {
         let critical = async {
-            let _commit_guard = self.commit_gate.lock().await;
             let mut guard = self.snapshot_state.lock().await;
             let mut build_delta = Some(build_delta);
             let mut refreshed_after_stale_error = false;
@@ -1620,19 +1651,9 @@ where
                         overlay_run,
                     )
                 };
-                let store = if let Some(baseline) = overlay_baseline {
-                    let (overlaid_snapshot, _) = self
-                        .runner_lease_store()
-                        .overlay((baseline, None), overlay)
-                        .await?;
-                    Arc::new(self.build_in_memory_store(overlaid_snapshot)?)
-                } else {
-                    if let Some(run) = overlay_run {
-                        let overlaid = self.runner_lease_store().overlay_run_record(run).await?;
-                        cached_store.overlay_runner_lease_record(overlaid)?;
-                    }
-                    cached_store
-                };
+                let store = self
+                    .acquire_overlaid_store(cached_store, overlay_baseline, overlay_run, overlay)
+                    .await?;
                 let outcome = apply(Arc::clone(&store)).await;
                 let value = match outcome {
                     Ok(value) => value,

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
@@ -365,13 +365,19 @@ where
             let record = loop_checkpoint_record_from_request(request);
             let delta = SnapshotDelta::default().set_loop_checkpoints_upsert(vec![record.clone()]);
             let ack = {
-                let _commit_guard = self.commit_gate.lock().await;
+                // Serialize the durable enqueue on the shared snapshot-state lock
+                // — the same lock every apply path holds across its
+                // read-seq -> enqueue window — so the delta journal observes a
+                // consistent append order without a separate commit gate.
+                let mut guard = self.snapshot_state.lock().await;
                 let ack = self
                     .enqueue_delta(row_store_durable_delta(delta.clone()))
                     .map_err(|error| match error {
                         RowPersistError::Turn(error) => error,
                     })?;
-                self.apply_cached_delta(delta).await?;
+                if let Some(state) = guard.as_mut() {
+                    state.apply_delta(delta, state.journal_seq)?;
+                }
                 ack
             };
             self.await_pending_commit(

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/traits.rs
@@ -375,8 +375,16 @@ where
                     .map_err(|error| match error {
                         RowPersistError::Turn(error) => error,
                     })?;
-                if let Some(state) = guard.as_mut() {
-                    state.apply_delta(delta, state.journal_seq)?;
+                if let Some(state) = guard.as_mut()
+                    && let Err(error) = state.apply_delta(delta, state.journal_seq)
+                {
+                    // A failed in-memory apply may leave the cached snapshot
+                    // partially mutated; drop it so the next read rebuilds from
+                    // durable state, matching `apply` / `apply_with_targeted_delta`.
+                    // (The durable enqueue already succeeded, so recovery replays
+                    // it — the cache is the only thing to invalidate.)
+                    *guard = None;
+                    return Err(error);
                 }
                 ack
             };


### PR DESCRIPTION
Step 1 of the turn-state consolidation in #6263. A pure latency/CPU + contention refactor of `FilesystemTurnStateRowStore`; **durability and crash-recovery semantics are unchanged (write-through preserved).**

## What
- **Removed the process-wide `commit_gate` async mutex.** It was held *in addition to* the `snapshot_state` mutex the mutation path already held across its read-seq → apply → enqueue window. Production wires a single shared row-store instance, so that redundant global lock serialized every user's turn-state transition. `snapshot_state` is now the single serialization point (held microseconds — CPU apply + delta build + mpsc send, never across the durable ack); journal-sequence ordering is preserved because enqueue order already equals reservation-seq order under it.
- **Stopped the per-op full engine rebuild on the non-hot `apply()` path** (retry / submit_child / tree / recover / fail / relinquish / record_model_route): the long-lived cached `InMemoryTurnStateStore` authority is reused in place for the None/Run lease overlays instead of reconstructed from a full-snapshot clone per call. Only the All-overlay (expired-lease recovery, off the hot path) still rebuilds. The hot chat-turn ops (submit/claim/complete/block/cancel/resume) already used the targeted-delta path and are untouched.

## Durability preserved
Every mutation still `enqueue_delta` → awaits the durable journal ack before returning. `load_snapshot_from_rows`, `migrate_legacy_blob_if_needed`, `materialize_delta_log`, `remove_orphan_active_locks`, backend seq assignment, and the entire runner-lease overlay/heartbeat surface are unmodified. This is **not** the async-write-behind change — that's #6263 Step 3, gated on the crash-consistency property suite.

## Measured (chat-turn contention sweep, `filesystem-row`, 32-core box; before = byte-identical main)
| conc | p50 before→after | goodput c100 | turn_conflict c100 |
|---|---|---|---|
| 32 | 24.0 → 17.4 ms | — | — |
| 64 | 136.6 → 107.8 ms | — | — |
| 100 | 229.8 → 175.9 ms | **277 → 625 ops** | **99 → 43** |

Store-isolated per-transition p50 down ~20-27% at c32-c100; goodput at c100 more than doubled; conflict errors roughly halved. The c8 p50 (~7 ms) is unchanged — it's the synchronous durable-ack floor, which only Step 3 (async write-behind) addresses.

## Tests
`cargo test -p ironclaw_turns`: 599 passed / 0 failed (full 47-test row-store contract suite incl. concurrency/crash/reservation cases), independently re-verified. `ironclaw_runner` (filesystem-goal-store) and `ironclaw_reborn_composition` turn-state tests green. clippy `-D warnings` clean; pre-commit-safety exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)