### PR TITLE
refactor(composition): RebornBuildInput carries the DeploymentConfig

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_deployment_mode_branching_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_deployment_mode_branching_ratchet.rs
@@ -69,12 +69,6 @@ const ALLOWLIST: &[(&str, &str)] = &[
          label argument.",
     ),
     (
-        "input.rs",
-        "`RebornBuildInput` constructors take a profile and pass it through to \
-         `RebornServices::profile()`. Retires when the build input carries a \
-         `DeploymentConfig` instead of a profile.",
-    ),
-    (
         "local_runtime_profile.rs",
         "The composition edge itself: maps a profile to its config and rejects \
          deployments this local-runtime helper does not assemble. Retires into \

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1315,18 +1315,14 @@ pub async fn build_reborn_services(
     input: RebornBuildInput,
 ) -> Result<RebornServices, RebornBuildError> {
     tracing::debug!(
-        profile = %input.profile,
+        profile = %input.profile(),
         owner_id = %input.owner_id,
         "building Reborn composition facades"
     );
     // Substrate selection is deployment *data* (§4.4/§5.6), not a profile
     // match: the config says which substrate to assemble and this dispatches
     // on that value.
-    let substrate = crate::deployment::DeploymentConfig::for_profile(
-        input.profile,
-        input.grants_trusted_laptop_access(),
-    )
-    .substrate();
+    let substrate = input.deployment().substrate();
     match substrate {
         crate::deployment::RuntimeSubstrate::None => Ok(RebornServices::disabled()),
         crate::deployment::RuntimeSubstrate::Local => build_local_runtime(input).await,
@@ -1453,7 +1449,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
     #[cfg(any(test, feature = "test-support"))]
     let network_http_egress_for_test = input.network_http_egress_for_test.clone();
     let RebornBuildInput {
-        profile,
+        deployment,
         storage,
         runtime_policy,
         runtime_process_binding,
@@ -1468,6 +1464,8 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         turn_state_store_limits,
         ..
     } = input;
+    // Label for logging/errors; behaviour reads `deployment`'s axes.
+    let profile = deployment.profile();
     // Computed before `oauth_provider_configs` is consumed by
     // `compose_provider_client` below — see `google_oauth_configured`.
     let google_oauth_configured = google_oauth_configured(&oauth_provider_configs);
@@ -1481,7 +1479,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         postgres_resource_governor_singleton,
     ) = match storage {
         RebornStorageInput::LocalDev { .. }
-            if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+            if deployment.storage_shape()
                 == crate::deployment::StorageShape::HostedSingleTenantPool =>
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -1503,7 +1501,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         ),
         #[cfg(feature = "postgres")]
         RebornStorageInput::HostedSingleTenantPostgres { .. }
-            if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+            if deployment.storage_shape()
                 != crate::deployment::StorageShape::HostedSingleTenantPool =>
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -4515,7 +4513,7 @@ async fn build_production_shaped(
     input: RebornBuildInput,
 ) -> Result<RebornServices, RebornBuildError> {
     let RebornBuildInput {
-        profile,
+        deployment,
         owner_id,
         local_runtime_identity,
         storage,
@@ -4542,6 +4540,8 @@ async fn build_production_shaped(
         nearai_mcp_bootstrap_config: _,
         turn_state_store_limits,
     } = input;
+    // Label for logging/errors; behaviour reads `deployment`'s axes.
+    let profile = deployment.profile();
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     let wiring_config = production_config(
         required_runtime_backends,
@@ -6213,11 +6213,16 @@ mod tests {
     #[tokio::test]
     async fn hosted_single_tenant_rejects_local_dev_storage_input() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let mut input = RebornBuildInput::local_dev(
+        let input = RebornBuildInput::local_dev(
             "hosted-single-tenant-local-storage-owner",
             dir.path().join("local-dev"),
         );
-        input.profile = RebornCompositionProfile::HostedSingleTenant;
+        // Deliberate mismatch: a hosted single-tenant deployment paired with a
+        // local-dev storage input must be rejected by the storage-shape guard.
+        let input = input.with_deployment(crate::deployment::DeploymentConfig::for_profile(
+            RebornCompositionProfile::HostedSingleTenant,
+            false,
+        ));
 
         let error = match build_reborn_services(input).await {
             Ok(_) => {

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -28,6 +28,7 @@ use ironclaw_reborn_event_store::{PostgresPoolTlsOptions, RebornPostgresSslMode}
 
 #[cfg(feature = "postgres")]
 use crate::RebornBuildError;
+use crate::deployment::DeploymentConfig;
 use crate::product_auth::oauth::google_oauth::google_provider_spec;
 use crate::product_auth::oauth::notion_oauth::notion_provider_spec;
 use crate::product_auth::oauth::oauth_dcr::OAuthDcrProviderConfig;
@@ -176,7 +177,17 @@ impl RebornRuntimeProcessBinding {
 }
 
 pub struct RebornBuildInput {
-    pub(crate) profile: RebornCompositionProfile,
+    /// The deployment this build assembles, as data (§4.4/§5.6). Carries the
+    /// substrate, traffic, readiness, and storage-shape axes every consumer
+    /// reads instead of re-deriving them from a profile name.
+    ///
+    /// The **resolved** runtime policy rides `runtime_policy`, not this value:
+    /// `new` builds the config without a yolo host-access disclosure (it is not
+    /// known at construction), so callers that hold the operator's confirmation
+    /// install the accurate config through
+    /// [`RebornBuildInput::with_deployment`] — `local_runtime_build_input_with_options`
+    /// is the one that does.
+    pub(crate) deployment: DeploymentConfig,
     pub(crate) owner_id: String,
     pub(crate) local_runtime_identity: Option<RebornLocalRuntimeIdentity>,
     pub(crate) storage: RebornStorageInput,
@@ -244,9 +255,30 @@ pub(crate) enum RebornStorageInput {
 }
 
 impl RebornBuildInput {
-    /// Selected composition profile.
+    /// Selected composition profile — a display/telemetry label. Behaviour
+    /// comes from [`RebornBuildInput::deployment`].
     pub fn profile(&self) -> RebornCompositionProfile {
-        self.profile
+        self.deployment.profile()
+    }
+
+    /// The deployment axes this build assembles from.
+    pub fn deployment(&self) -> &DeploymentConfig {
+        &self.deployment
+    }
+
+    /// Replace the deployment this input was constructed with.
+    ///
+    /// Test-only: production builds the deployment at construction
+    /// (`RebornBuildInput::new` takes it, and `local_runtime_build_input_with_options`
+    /// supplies one built where the operator's yolo disclosure is known). This
+    /// exists so tests can construct a deliberately mismatched
+    /// deployment/storage pairing and drive the fail-closed guard in
+    /// `build_reborn_services` — production behaviour, reached through a
+    /// pairing production rejects.
+    #[cfg(test)]
+    pub(crate) fn with_deployment(mut self, deployment: DeploymentConfig) -> Self {
+        self.deployment = deployment;
+        self
     }
 
     /// Owner id (string form). Used by the assembled runtime to mint the
@@ -284,14 +316,14 @@ impl RebornBuildInput {
 
     pub fn disabled(owner_id: impl Into<String>) -> Self {
         Self::new(
-            RebornCompositionProfile::Disabled,
+            DeploymentConfig::disabled(),
             owner_id,
             RebornStorageInput::Disabled,
         )
     }
 
     pub fn local_dev(owner_id: impl Into<String>, root: PathBuf) -> Self {
-        Self::local_dev_with_profile(RebornCompositionProfile::LocalDev, owner_id, root)
+        Self::local_dev_from_deployment(DeploymentConfig::local_dev(), owner_id, root)
     }
 
     pub(crate) fn local_dev_with_profile(
@@ -299,9 +331,24 @@ impl RebornBuildInput {
         owner_id: impl Into<String>,
         root: PathBuf,
     ) -> Self {
-        debug_assert!(profile.uses_local_dev_storage_input());
+        Self::local_dev_from_deployment(
+            DeploymentConfig::for_profile(profile, false),
+            owner_id,
+            root,
+        )
+    }
+
+    /// Build a local-dev-storage-shaped input from an already-resolved
+    /// deployment. The `debug_assert` is on the storage-shape **axis**, not on
+    /// a list of profile names (§4.4).
+    pub(crate) fn local_dev_from_deployment(
+        deployment: DeploymentConfig,
+        owner_id: impl Into<String>,
+        root: PathBuf,
+    ) -> Self {
+        debug_assert!(deployment.uses_local_dev_storage_input());
         Self::new(
-            profile,
+            deployment,
             owner_id,
             RebornStorageInput::LocalDev {
                 root,
@@ -323,7 +370,7 @@ impl RebornBuildInput {
         // config's storage-shape axis rather than a profile-name comparison
         // (§4.4): a deployment that takes a hosted single-tenant pool is a
         // property of the deployment, not of its name.
-        if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+        if DeploymentConfig::for_profile(profile, false).storage_shape()
             != crate::deployment::StorageShape::HostedSingleTenantPool
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -333,7 +380,7 @@ impl RebornBuildInput {
             });
         }
         Ok(Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::HostedSingleTenantPostgres {
                 root,
@@ -357,7 +404,7 @@ impl RebornBuildInput {
         // config's storage-shape axis rather than a profile-name comparison
         // (§4.4): a deployment that takes a hosted single-tenant pool is a
         // property of the deployment, not of its name.
-        if crate::deployment::DeploymentConfig::for_profile(profile, false).storage_shape()
+        if DeploymentConfig::for_profile(profile, false).storage_shape()
             != crate::deployment::StorageShape::HostedSingleTenantPool
         {
             return Err(RebornBuildError::InvalidConfig {
@@ -373,7 +420,7 @@ impl RebornBuildInput {
             ..
         } = resolve_postgres_storage_from_config_and_env(profile, config_file)?;
         Ok(Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::HostedSingleTenantPostgres {
                 root,
@@ -487,7 +534,7 @@ impl RebornBuildInput {
         secret_master_key: ironclaw_secrets::SecretMaterial,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Libsql {
                 db,
@@ -508,7 +555,7 @@ impl RebornBuildInput {
         auth_token: Option<ironclaw_secrets::SecretMaterial>,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Libsql {
                 db,
@@ -529,7 +576,7 @@ impl RebornBuildInput {
         secret_master_key: ironclaw_secrets::SecretMaterial,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Postgres {
                 pool,
@@ -549,7 +596,7 @@ impl RebornBuildInput {
         url: ironclaw_secrets::SecretMaterial,
     ) -> Self {
         Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Postgres {
                 pool,
@@ -578,7 +625,7 @@ impl RebornBuildInput {
         let trust_policy = crate::builtin_first_party_trust_policy()?;
 
         Ok(Self::new(
-            profile,
+            DeploymentConfig::for_profile(profile, false),
             owner_id,
             RebornStorageInput::Postgres {
                 pool,
@@ -786,12 +833,12 @@ impl RebornBuildInput {
     }
 
     fn new(
-        profile: RebornCompositionProfile,
+        deployment: DeploymentConfig,
         owner_id: impl Into<String>,
         storage: RebornStorageInput,
     ) -> Self {
         Self {
-            profile,
+            deployment,
             owner_id: owner_id.into(),
             local_runtime_identity: None,
             storage,

--- a/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
+++ b/crates/ironclaw_reborn_composition/src/local_runtime_profile.rs
@@ -70,9 +70,15 @@ pub fn local_runtime_build_input_with_options(
         return hosted_single_tenant_volume_build_input(owner_id, root);
     }
 
-    let policy = local_runtime_policy(profile, options)?;
+    // Build the deployment once, here, where the operator's host-access
+    // confirmation is known, and carry it on the input rather than letting
+    // downstream re-derive it from the profile name (§4.4).
+    let deployment = deployment_config_for_profile(profile, options)?;
+    let policy = deployment
+        .resolve()?
+        .ok_or(RebornRuntimeProfileError::MissingPolicyRequest { profile })?;
     Ok(
-        RebornBuildInput::local_dev_with_profile(profile, owner_id, root)
+        RebornBuildInput::local_dev_from_deployment(deployment, owner_id, root)
             .with_runtime_policy(policy),
     )
 }
@@ -183,4 +189,92 @@ fn local_runtime_policy_for_local_dev_shape(
             unreachable!("{profile_name} carries a runtime-policy request")
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::runtime_policy::{ApprovalPolicy, RuntimeProfile};
+
+    use super::*;
+
+    #[test]
+    fn yolo_disclosure_reaches_both_the_carried_deployment_and_the_resolved_policy() {
+        // This module is the one place that holds the operator's host-access
+        // confirmation, so it must be the place that builds the deployment.
+        // The hazard being pinned: `RebornBuildInput::new` cannot know the
+        // disclosure, so a config built there would carry
+        // `yolo_disclosure_acknowledged: false` and resolve fail-closed. The
+        // input must carry the config built *here* instead.
+        let dir = std::env::temp_dir().join("reborn-yolo-disclosure-test");
+        let input = local_runtime_build_input_with_options(
+            RebornCompositionProfile::LocalDevYolo,
+            "yolo-owner",
+            dir,
+            RebornRuntimeProfileOptions {
+                confirm_host_access: true,
+            },
+        )
+        .expect("confirmed local-dev-yolo builds");
+
+        assert_eq!(
+            input.profile(),
+            RebornCompositionProfile::LocalDevYolo,
+            "the carried deployment must keep the requested profile label"
+        );
+        let carried = input
+            .deployment()
+            .resolve()
+            .expect("carried deployment resolves")
+            .expect("local-dev-yolo makes a policy request");
+        assert_eq!(
+            carried.resolved_profile,
+            RuntimeProfile::LocalYolo,
+            "the carried deployment must have the disclosure, or it would fail closed"
+        );
+        assert_eq!(carried.approval_policy, ApprovalPolicy::Minimal);
+    }
+
+    #[test]
+    fn unconfirmed_yolo_fails_closed_before_an_input_is_built() {
+        let dir = std::env::temp_dir().join("reborn-yolo-unconfirmed-test");
+        let error = local_runtime_build_input_with_options(
+            RebornCompositionProfile::LocalDevYolo,
+            "yolo-owner",
+            dir,
+            RebornRuntimeProfileOptions {
+                confirm_host_access: false,
+            },
+        );
+        let Err(error) = error else {
+            panic!("unconfirmed yolo must not produce a build input");
+        };
+        assert!(matches!(
+            error,
+            RebornRuntimeProfileError::Policy(ResolveError::YoloRequiresDisclosure { .. })
+        ));
+    }
+
+    #[test]
+    fn deployments_without_the_local_dev_storage_shape_are_rejected() {
+        // The helper builds the local-dev storage input shape; the rejection is
+        // expressed as the storage-shape axis, not a list of profile names.
+        for profile in [
+            RebornCompositionProfile::Disabled,
+            RebornCompositionProfile::HostedSingleTenant,
+            RebornCompositionProfile::Production,
+            RebornCompositionProfile::MigrationDryRun,
+        ] {
+            let error = deployment_config_for_profile(
+                profile,
+                RebornRuntimeProfileOptions {
+                    confirm_host_access: true,
+                },
+            )
+            .expect_err("non-local-dev-storage deployments are not this helper's business");
+            assert!(matches!(
+                error,
+                RebornRuntimeProfileError::UnsupportedProfile { .. }
+            ));
+        }
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3128,8 +3128,7 @@ pub async fn build_reborn_runtime(
     // The deployment this build assembles, as data (§4.4/§5.6). Every axis
     // below — live-traffic admission, the cutover gate, substrate selection —
     // reads a field on this value instead of re-matching the profile.
-    let deployment =
-        DeploymentConfig::for_profile(profile, services_input.grants_trusted_laptop_access());
+    let deployment = services_input.deployment().clone();
     if let Some(reason) = deployment.traffic().live_traffic_refusal(profile) {
         return Err(RebornRuntimeError::InvalidArgument { reason });
     }


### PR DESCRIPTION
Phase 4 of #6274. **Stacked on #6280** → #6279 → #6277.

Completes the pivot: the build input carries the deployment **as data**, instead of a profile name that every consumer re-derives one from.

## The change

`RebornBuildInput.profile: RebornCompositionProfile` → `deployment: DeploymentConfig`.

`profile()` stays as a delegating accessor, so **no external caller changes** (CLI, integration harness, QA suites are untouched). `deployment()` is the new read path.

This removes the re-derivation Phase 2 had to sprinkle at each point of use — `build_reborn_services`, `build_reborn_runtime`, and the storage-shape guards each called `DeploymentConfig::for_profile(profile, ..)` locally. The config is now built once and carried.

## The hazard that shaped the design

A config built inside `RebornBuildInput::new` **cannot know the operator's yolo host-access disclosure**. Its policy request would carry `yolo_disclosure_acknowledged: false`, and anything resolving it would fail closed — silently downgrading a confirmed trusted-laptop deployment.

Rather than paper over that with a default, `new` takes an **already-built** `DeploymentConfig`, and `local_runtime_build_input_with_options` — the one place holding the operator's confirmation — builds it and hands it in.

Pinned by `yolo_disclosure_reaches_both_the_carried_deployment_and_the_resolved_policy`, which resolves the *carried* config and asserts it reaches `RuntimeProfile::LocalYolo` / `ApprovalPolicy::Minimal`. Without the threading, that test fails.

## Ratchet progress

`input.rs` now names **zero** profile variants, so its `reborn_deployment_mode_branching_ratchet` entry retires. The allowlist is down to four:

| Entry | Status |
|---|---|
| `deployment.rs` | **terminal** — the one place a profile becomes data |
| `factory.rs` | test fixtures + one label argument |
| `local_runtime_profile.rs` | the composition edge itself |
| `readiness.rs` | operator-facing wire label on `RebornReadinessDiagnostic` |

## Smaller notes

- `local_dev_from_deployment` replaces the profile-name path; its `debug_assert` is on the **storage-shape axis** rather than a list of profile names.
- `with_deployment` is `#[cfg(test)]` with a doc comment explaining why: production builds the deployment at construction, and this exists only so a test can construct the deliberately mismatched deployment/storage pairing that drives the fail-closed guard in `build_reborn_services`. Gating it keeps a dead method off the production API rather than leaving it as unused surface.

## What is NOT in this PR

The single `build_runtime(cfg)` of §5.11 — merging the local and production store graphs into one backend-parameterized graph. That depends on Slice A store consolidation, which §9 explicitly gates behind **Slice 0**'s reference-model property suite:

> the model-based stateful property tests are not a follow-up: they are the safety net that makes Slice A's store consolidation checkable […] The repo has no stateful property-testing infrastructure today.

Landing the graph merge before that oracle exists is precisely what §9 forbids, so it stays tracked in #6274 rather than being rushed here. Nothing in this PR is blocked on it, and the architectural goal — no branching on a deployment mode past the composition edge — is fully met by Phases 1–4.

## Testing

New: `yolo_disclosure_reaches_both_the_carried_deployment_and_the_resolved_policy`, `unconfirmed_yolo_fails_closed_before_an_input_is_built`, `deployments_without_the_local_dev_storage_shape_are_rejected`.

```
cargo test -p ironclaw_reborn_composition --lib   # 1487 passed
cargo test -p ironclaw_architecture               # 11 suites, all green
cargo clippy -p ironclaw_reborn_composition -p ironclaw_architecture \
  --all-targets --all-features -- -D warnings     # clean
cargo check --workspace --all-targets --all-features  # clean
bash scripts/pre-commit-safety.sh                 # exit 0
```

Same three pre-existing `llm_admin::nearai_mcp::tests::bootstrap_config_from_env_*` failures as the rest of the stack — environmental (`NEARAI_API_KEY` set in my shell), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
