### PR TITLE
refactor(reborn): Suspension::DependentRun carries the staged child result (§5.3 flip prep / Stage 1b)

### DIFF
--- a/crates/ironclaw_host_api/src/resolution.rs
+++ b/crates/ironclaw_host_api/src/resolution.rs
@@ -114,6 +114,64 @@ impl ProcessWaypoint {
     }
 }
 
+/// The dependent child's staged result, carried **inline** on
+/// [`Suspension::DependentRun`] so the loop observes the child's output on
+/// resume without reading host storage — the loop cannot read the durable
+/// [`GateRecord::DependentRun`](crate::GateRecord) sidecar. This mirrors the way
+/// [`Resolution::Done`] carries a spawned child run's content on its [`Outcome`]:
+/// the record is the durable copy, this is the loop-visible one.
+///
+/// Every field is plain redacted vocabulary per the host_api charter — bounded
+/// metadata (`byte_len`), a redacted model-visible [`SafeSummary`], a redacted
+/// model-visible observation preview, and the preserved originating loop result
+/// ref. The full child bytes stay host-owned behind the record's [`ResultRef`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DependentRunResult {
+    /// Size of the staged child output in bytes — pure metadata, no PII. Feeds
+    /// the per-capability byte-cap strategy (was
+    /// `CapabilityResultMessage::byte_len`).
+    pub byte_len: u64,
+    /// Redacted, model-visible summary of the child result.
+    pub summary: SafeSummary,
+    /// Redacted, model-visible observation preview of the child result (was
+    /// `model_observation`, previously dropped on this channel). Redacted by
+    /// construction; the full bytes stay host-owned. `None` when no preview is
+    /// staged or the raw observation failed redaction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observation: Option<SafeSummary>,
+    /// The preserved originating loop result ref, so child output the loop
+    /// staged under its own ref stays reachable once the host [`ResultRef`]
+    /// handle is minted. `None` when there was no originating loop result ref.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<LoopRef>,
+}
+
+impl DependentRunResult {
+    /// A staged result carrying only the byte length and redacted summary. Use
+    /// the `with_*` setters to add the optional observation preview and
+    /// preserved origin (default-backed builder).
+    pub fn new(byte_len: u64, summary: SafeSummary) -> Self {
+        Self {
+            byte_len,
+            summary,
+            observation: None,
+            origin: None,
+        }
+    }
+
+    /// Carry the redacted, model-visible observation preview.
+    pub fn with_observation(mut self, observation: SafeSummary) -> Self {
+        self.observation = Some(observation);
+        self
+    }
+
+    /// Preserve the originating loop result ref.
+    pub fn with_origin(mut self, origin: LoopRef) -> Self {
+        self.origin = Some(origin);
+        self
+    }
+}
+
 /// A re-entrant gate: the invocation did not run and is waiting on a decision.
 /// Resolving the gate re-enters `authorize()` (§5.3.3: a resolved gate reserves
 /// against *then-current* budget — approval is consent, not an execution
@@ -191,8 +249,16 @@ impl Blocked {
 pub enum Suspension {
     /// A spawned OS process the turn now waits on.
     Process(ProcessWaypoint),
-    /// A dependent child run this invocation awaits.
-    DependentRun(GateWaypoint),
+    /// A dependent child run this invocation awaits. Carries the gate
+    /// `waypoint` it parks on **and** the child's staged [`DependentRunResult`]
+    /// inline, so the loop observes the child's output on resume without
+    /// reading host storage (mirrors how [`Resolution::Done`] carries a spawned
+    /// child run's content; the durable copy is the
+    /// [`GateRecord::DependentRun`](crate::GateRecord) sidecar).
+    DependentRun {
+        waypoint: GateWaypoint,
+        result: DependentRunResult,
+    },
     /// A client-supplied tool the host does not execute; control returns to the
     /// API client until it submits the output.
     ExternalTool(GateWaypoint),
@@ -203,7 +269,7 @@ impl Suspension {
     pub fn kind(&self) -> &'static str {
         match self {
             Suspension::Process(_) => "process",
-            Suspension::DependentRun(_) => "dependent_run",
+            Suspension::DependentRun { .. } => "dependent_run",
             Suspension::ExternalTool(_) => "external_tool",
         }
     }
@@ -213,7 +279,8 @@ impl Suspension {
     /// record instead — see [`Suspension::process_ref`].
     pub fn gate_ref(&self) -> Option<&GateRef> {
         match self {
-            Suspension::DependentRun(w) | Suspension::ExternalTool(w) => Some(&w.gate),
+            Suspension::DependentRun { waypoint, .. } => Some(&waypoint.gate),
+            Suspension::ExternalTool(w) => Some(&w.gate),
             Suspension::Process(_) => None,
         }
     }
@@ -222,7 +289,7 @@ impl Suspension {
     pub fn process_ref(&self) -> Option<&ProcessRef> {
         match self {
             Suspension::Process(w) => Some(&w.process),
-            Suspension::DependentRun(_) | Suspension::ExternalTool(_) => None,
+            Suspension::DependentRun { .. } | Suspension::ExternalTool(_) => None,
         }
     }
 
@@ -230,7 +297,19 @@ impl Suspension {
     pub fn origin(&self) -> Option<&LoopRef> {
         match self {
             Suspension::Process(w) => w.origin.as_ref(),
-            Suspension::DependentRun(w) | Suspension::ExternalTool(w) => w.origin.as_ref(),
+            Suspension::DependentRun { waypoint, .. } => waypoint.origin.as_ref(),
+            Suspension::ExternalTool(w) => w.origin.as_ref(),
+        }
+    }
+
+    /// The dependent child's staged result, present exactly on
+    /// [`Suspension::DependentRun`]. This is the loop-visible copy the executor
+    /// reads on resume; the durable copy lives in the
+    /// [`GateRecord::DependentRun`](crate::GateRecord) sidecar.
+    pub fn dependent_result(&self) -> Option<&DependentRunResult> {
+        match self {
+            Suspension::DependentRun { result, .. } => Some(result),
+            Suspension::Process(_) | Suspension::ExternalTool(_) => None,
         }
     }
 }
@@ -597,6 +676,17 @@ mod tests {
         ProcessWaypoint::new(proc_ref())
     }
 
+    fn dep_result() -> DependentRunResult {
+        DependentRunResult::new(256, SafeSummary::new("child staged 4 rows").unwrap())
+    }
+
+    fn dep_run() -> Suspension {
+        Suspension::DependentRun {
+            waypoint: gate_wp(),
+            result: dep_result(),
+        }
+    }
+
     #[test]
     fn blocked_serde_is_snake_case_tagged_and_roundtrips() {
         let blocked = Blocked::Approval(gate_wp());
@@ -662,7 +752,7 @@ mod tests {
         );
         for (suspension, tag) in [
             (Suspension::Process(proc_wp()), "process"),
-            (Suspension::DependentRun(gate_wp()), "dependent_run"),
+            (dep_run(), "dependent_run"),
             (Suspension::ExternalTool(gate_wp()), "external_tool"),
         ] {
             let wire = serde_json::to_value(&suspension).unwrap();
@@ -996,7 +1086,18 @@ mod tests {
             ),
             (
                 "AwaitDependentRun",
-                Resolution::Suspended(Suspension::DependentRun(GateWaypoint::new(gate()))),
+                Resolution::Suspended(Suspension::DependentRun {
+                    waypoint: GateWaypoint::new(gate()),
+                    // A fully-populated staged result so the generic round-trip
+                    // below proves byte_len, summary, observation, AND origin
+                    // all survive the wire.
+                    result: DependentRunResult::new(
+                        256,
+                        SafeSummary::new("child staged 4 rows").unwrap(),
+                    )
+                    .with_observation(SafeSummary::new("child preview: 4 rows").unwrap())
+                    .with_origin(LoopRef::new("result:child-1").unwrap()),
+                }),
                 true,
                 true,
             ),
@@ -1048,7 +1149,7 @@ mod tests {
             Resolution::Blocked(Blocked::Auth(gate_wp())),
             Resolution::Blocked(Blocked::Resource(gate_wp())),
             Resolution::Suspended(Suspension::Process(proc_wp())),
-            Resolution::Suspended(Suspension::DependentRun(gate_wp())),
+            Resolution::Suspended(dep_run()),
             Resolution::Suspended(Suspension::ExternalTool(gate_wp())),
         ];
         for resolution in &samples {
@@ -1158,6 +1259,26 @@ mod tests {
                     "suspended": { "process": { "process": "0f0e0d0c-0b0a-4908-8706-050403020100" } }
                 }),
             ),
+            // DependentRun is a struct variant: the parked-on `waypoint` plus the
+            // inline staged `result` (byte_len + redacted summary; observation and
+            // origin omitted here, exercising the skip_serializing_if defaults).
+            (
+                Resolution::Suspended(Suspension::DependentRun {
+                    waypoint: GateWaypoint::new(gate),
+                    result: DependentRunResult::new(
+                        256,
+                        SafeSummary::new("child staged 4 rows").unwrap(),
+                    ),
+                }),
+                serde_json::json!({
+                    "suspended": {
+                        "dependent_run": {
+                            "waypoint": { "gate": "01890a5d-ac96-774b-bcce-b302099a8057" },
+                            "result": { "byte_len": 256, "summary": "child staged 4 rows" }
+                        }
+                    }
+                }),
+            ),
         ];
         for (resolution, expected_wire) in cases {
             let wire = serde_json::to_value(&resolution).unwrap();
@@ -1168,5 +1289,70 @@ mod tests {
                 "round-trip must reconstruct the same channel"
             );
         }
+    }
+
+    /// The inline staged result carries the child's byte_len, redacted summary,
+    /// redacted observation preview, AND the preserved loop result origin across
+    /// the wire — the fields that were previously unreachable on this channel
+    /// (byte_len/summary folded into the host-only record, model_observation
+    /// dropped). Reached through the [`Suspension::dependent_result`] accessor.
+    #[test]
+    fn dependent_run_carries_the_staged_result_inline() {
+        let staged = DependentRunResult::new(2048, SafeSummary::new("child staged 7 rows").unwrap())
+            .with_observation(SafeSummary::new("child preview: 7 rows").unwrap())
+            .with_origin(LoopRef::new("result:child-9").unwrap());
+        let suspension = Suspension::DependentRun {
+            waypoint: gate_wp(),
+            result: staged.clone(),
+        };
+        // The accessor answers only for DependentRun.
+        assert_eq!(suspension.dependent_result(), Some(&staged));
+        assert_eq!(Suspension::ExternalTool(gate_wp()).dependent_result(), None);
+        assert_eq!(Suspension::Process(proc_wp()).dependent_result(), None);
+        // The gate the suspension parks on stays reachable alongside the result.
+        assert_eq!(suspension.gate_ref(), Some(&gate()));
+
+        // Every staged field survives a wire round-trip.
+        let back: Suspension =
+            serde_json::from_value(serde_json::to_value(&suspension).unwrap()).unwrap();
+        assert_eq!(back, suspension);
+        let result = back.dependent_result().expect("staged result");
+        assert_eq!(result.byte_len, 2048);
+        assert_eq!(result.summary.as_str(), "child staged 7 rows");
+        assert_eq!(
+            result.observation.as_ref().map(SafeSummary::as_str),
+            Some("child preview: 7 rows")
+        );
+        assert_eq!(result.origin.as_ref().map(LoopRef::as_str), Some("result:child-9"));
+    }
+
+    /// A hostile persisted staged result cannot rehydrate: the redacted
+    /// [`SafeSummary`] fields reject sensitive-marker / path-shaped content on the
+    /// wire, so the model-visible child text stays plain redacted vocabulary.
+    #[test]
+    fn dependent_run_result_rejects_an_unsafe_summary_on_the_wire() {
+        // A leaked secret in the summary is rejected at the SafeSummary boundary.
+        let json = serde_json::json!({
+            "byte_len": 1,
+            "summary": "api key: sk-ant-leak"
+        });
+        let err = serde_json::from_value::<DependentRunResult>(json)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("sensitive marker"),
+            "rejection must be for the summary redaction contract: {err}"
+        );
+
+        // A path-shaped observation is likewise rejected on the wire.
+        let json = serde_json::json!({
+            "byte_len": 1,
+            "summary": "ok",
+            "observation": "leaked path /etc/passwd"
+        });
+        assert!(
+            serde_json::from_value::<DependentRunResult>(json).is_err(),
+            "a path-shaped observation must not rehydrate into the staged result"
+        );
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/resolution_mapping.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolution_mapping.rs
@@ -41,8 +41,12 @@
 //!   host reconstitutes it from storage keyed by the token).
 //!
 //! `SpawnedProcess`'s `safe_summary` still has no host channel (a process
-//! suspension carries a [`ProcessRef`], not a summary). `AwaitDependentRun`'s and
-//! `SpawnedChildRun`'s `model_observation` ride the result preview where present.
+//! suspension carries a [`ProcessRef`], not a summary). `SpawnedChildRun`'s
+//! `model_observation` rides the [`Outcome`] result preview; `AwaitDependentRun`'s
+//! rides the inline [`DependentRunResult`] observation on the
+//! [`Suspension::DependentRun`] channel (was dropped entirely — §5.3 Stage 1b),
+//! so the loop observes the child's `byte_len`, redacted summary, and observation
+//! on resume without reading the host-persisted `GateRecord::DependentRun`.
 //!
 //! ## Loop refs: minted kernel handle + preserved origin
 //!
@@ -57,11 +61,12 @@
 //! crosses directly is [`TurnRunId`](crate::TurnRunId) → [`RunId`]: both wrap a
 //! `Uuid`, preserved via `RunId::from_uuid`.
 
+// arch-exempt: large_file, transitional CapabilityOutcome→Resolution mapping artifact deleted at the atomic flip; the Stage-1b growth is non-lossy tests, plan #6175
 use ironclaw_host_api::{
-    Blocked, Denial, DenyReason, DenyRecord, DenyRef, FailureKind, GateRecord, GateRef,
-    GateWaypoint, LoopRef, ModelFailureDiagnostic, ModelInputIssue, ModelInputIssues, Outcome,
-    OutcomeRefs, OutputDigest, ProcessRef, ProcessWaypoint, Resolution, ResultProgress, ResultRef,
-    ResumeToken, RunId, SafeSummary, Suspension, TerminateHint, ToolVerdict,
+    Blocked, Denial, DenyReason, DenyRecord, DenyRef, DependentRunResult, FailureKind, GateRecord,
+    GateRef, GateWaypoint, LoopRef, ModelFailureDiagnostic, ModelInputIssue, ModelInputIssues,
+    Outcome, OutcomeRefs, OutputDigest, ProcessRef, ProcessWaypoint, Resolution, ResultProgress,
+    ResultRef, ResumeToken, RunId, SafeSummary, Suspension, TerminateHint, ToolVerdict,
 };
 
 use super::content_digest::ContentDigest;
@@ -302,22 +307,37 @@ pub fn capability_outcome_to_resolution(outcome: CapabilityOutcome) -> MappedRes
             }))
             .bind_result(result_ref, minted)
         }
-        // Parked work: awaits a dependent child run. Gate-shaped, so it carries a
-        // GateRecord holding the staged result handle + byte length (G2). Both the
-        // gate ref and the staged result ref are freshly minted and bound; the
-        // loop's model_observation has no home on DependentRun and is dropped.
+        // Parked work: awaits a dependent child run. Gate-shaped, so the durable
+        // GateRecord holds the staged result handle + byte length (G2). The
+        // channel ALSO carries the staged result inline (DependentRunResult) so
+        // the loop observes the child's output on resume without reading host
+        // storage — the same dual pattern as PR-B: the record is the durable
+        // copy, the inline payload the loop-visible one. model_observation now
+        // rides the inline observation preview (was dropped entirely). Both the
+        // gate ref and the staged result ref are freshly minted and bound.
         CapabilityOutcome::AwaitDependentRun {
             gate_ref,
             result_ref,
             safe_summary,
             byte_len,
-            ..
+            model_observation,
         } => {
             let minted_gate = GateRef::new();
             let minted_result = ResultRef::new();
             let waypoint = gate_waypoint(minted_gate, &gate_ref, None);
+            let mut staged =
+                DependentRunResult::new(byte_len, safe_summary_or_placeholder(safe_summary.clone()));
+            if let Some(observation) = observation_preview(model_observation) {
+                staged = staged.with_observation(observation);
+            }
+            if let Some(origin) = preserved_origin(result_ref.as_str()) {
+                staged = staged.with_origin(origin);
+            }
             MappedResolution::with_gate(
-                Resolution::Suspended(Suspension::DependentRun(waypoint)),
+                Resolution::Suspended(Suspension::DependentRun {
+                    waypoint,
+                    result: staged,
+                }),
                 GateRecord::DependentRun {
                     summary: safe_summary_or_placeholder(safe_summary),
                     result: minted_result,
@@ -592,6 +612,7 @@ fn deny_reason_from_kind(kind: &CapabilityDeniedReasonKind) -> DenyReason {
 #[cfg(test)]
 mod tests {
     use super::super::host::CapabilityInputRef;
+    use super::super::model_observation::ModelVisibleToolObservation;
     use super::super::{
         CapabilityFailureDetail, CapabilityFailureKind, CapabilityInputIssue, CapabilityProgress,
         LoopProcessRef, MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
@@ -630,6 +651,30 @@ mod tests {
             output_digest: None,
             model_observation: None,
         })
+    }
+
+    /// A model-visible tool observation whose `summary` is `summary` — the field
+    /// `observation_preview` reduces to the redacted preview `SafeSummary`.
+    fn observation(summary: &str) -> ModelVisibleToolObservation {
+        use super::super::model_observation::{
+            ObservationTrust, ToolObservationDetail, ToolObservationStatus,
+        };
+        ModelVisibleToolObservation {
+            schema_version: MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
+            status: ToolObservationStatus::Success,
+            summary: summary.to_string(),
+            detail: ToolObservationDetail::ResultReference {
+                result_ref: "result:staged".to_string(),
+                byte_len: 10,
+                preview: None,
+                total_bytes: None,
+                next_offset: None,
+                item_count: None,
+            },
+            artifacts: vec![],
+            recovery: None,
+            trust: ObservationTrust::UntrustedToolOutput,
+        }
     }
 
     /// The §5.3 acceptance table is the definition of done. Every one of the ten
@@ -1304,14 +1349,14 @@ mod tests {
             byte_len: 2048,
             model_observation: None,
         });
-        match mapped.gate_record {
+        match &mapped.gate_record {
             Some(GateRecord::DependentRun {
                 byte_len,
                 summary,
                 result_origin,
                 ..
             }) => {
-                assert_eq!(byte_len, 2048);
+                assert_eq!(*byte_len, 2048);
                 assert_eq!(summary.as_str(), "awaiting dependent");
                 // Stage-1 non-lossy: the staged result's originating loop ref
                 // is preserved ON THE DURABLE RECORD — the minted ResultRef is
@@ -1327,6 +1372,76 @@ mod tests {
             }
             other => panic!("expected GateRecord::DependentRun, got {other:?}"),
         }
+        // Stage-1b: the SAME staged content also rides the channel inline, so the
+        // loop observes it on resume without reading the durable record above.
+        match &mapped.resolution {
+            Resolution::Suspended(suspension @ Suspension::DependentRun { .. }) => {
+                let staged = suspension.dependent_result().expect("inline staged result");
+                assert_eq!(staged.byte_len, 2048);
+                assert_eq!(staged.summary.as_str(), "awaiting dependent");
+                assert_eq!(
+                    staged.origin.as_ref().map(LoopRef::as_str),
+                    Some(result_ref().as_str()),
+                    "the staged result's loop origin must also ride the inline channel"
+                );
+            }
+            other => panic!("expected Suspended(DependentRun), got {other:?}"),
+        }
+    }
+
+    /// Stage-1b non-lossy: `AwaitDependentRun`'s `model_observation` now rides the
+    /// inline [`DependentRunResult`] observation preview instead of being dropped
+    /// entirely — and it is redacted (a secret/path-shaped observation degrades to
+    /// absent, and a leaked summary degrades to the placeholder), so only plain
+    /// redacted host_api vocabulary crosses.
+    #[test]
+    fn dependent_run_carries_model_observation_inline_and_redacts() {
+        // The inline staged result reached through the channel accessor.
+        fn staged_of(mapped: &MappedResolution) -> DependentRunResult {
+            match &mapped.resolution {
+                Resolution::Suspended(suspension @ Suspension::DependentRun { .. }) => suspension
+                    .dependent_result()
+                    .expect("inline staged result")
+                    .clone(),
+                other => panic!("expected Suspended(DependentRun), got {other:?}"),
+            }
+        }
+
+        // Safe observation + summary → both cross verbatim onto the inline payload.
+        let mapped = capability_outcome_to_resolution(CapabilityOutcome::AwaitDependentRun {
+            gate_ref: gate_ref(),
+            result_ref: result_ref(),
+            safe_summary: "child produced 4 rows".to_string(),
+            byte_len: 512,
+            model_observation: Some(observation("child preview: 4 rows")),
+        });
+        let staged = staged_of(&mapped);
+        assert_eq!(
+            staged.observation.as_ref().map(SafeSummary::as_str),
+            Some("child preview: 4 rows"),
+            "model_observation must ride the inline observation (was dropped entirely)"
+        );
+        assert_eq!(staged.summary.as_str(), "child produced 4 rows");
+
+        // Hostile observation + summary → the observation drops to None and the
+        // summary degrades to the placeholder; no raw secret/path crosses.
+        let mapped = capability_outcome_to_resolution(CapabilityOutcome::AwaitDependentRun {
+            gate_ref: gate_ref(),
+            result_ref: result_ref(),
+            safe_summary: "leaked path /etc/passwd".to_string(),
+            byte_len: 512,
+            model_observation: Some(observation("api key: sk-ant-leak")),
+        });
+        let staged = staged_of(&mapped);
+        assert_eq!(
+            staged.observation, None,
+            "a secret-shaped observation must be dropped, never carried raw"
+        );
+        assert_eq!(
+            staged.summary,
+            SafeSummary::placeholder(),
+            "a path-shaped summary must degrade to the placeholder"
+        );
     }
 
     #[test]
@@ -1382,11 +1497,11 @@ mod tests {
         assert_eq!(loop_result, result_ref());
         match (&mapped.resolution, &mapped.gate_record) {
             (
-                Resolution::Suspended(Suspension::DependentRun(channel_gate)),
+                Resolution::Suspended(Suspension::DependentRun { waypoint, .. }),
                 Some(GateRecord::DependentRun { result, .. }),
             ) => {
                 assert_eq!(
-                    channel_gate.gate, minted_gate,
+                    waypoint.gate, minted_gate,
                     "gate binding matches channel"
                 );
                 assert_eq!(*result, minted_result, "result binding matches record");


### PR DESCRIPTION
## What & why

Stage 1b of the capability-result flip (`docs/reborn/2026-07-17-architecture-simplification-dto-dyn-local.md` §5.3). Small **additive** vocabulary slice that closes a verified hazard blocking the atomic flip.

**The hazard:** after the flip the executor gets only `Resolution::Suspended(Suspension::DependentRun(GateWaypoint))`. The mapping folds `result_ref`/`byte_len`/`safe_summary` into the host-persisted `GateRecord::DependentRun` (which the loop cannot read) and **drops `model_observation` entirely**. So `byte_len` (per-capability byte caps), `safe_summary` (model-visible child text), and `model_observation` become unreachable → the dependent-run parent observation would silently regress ("never drop model output"). `SpawnedChildRun` is unaffected — it rides `Done(Outcome)`.

## The inline payload shape

`Suspension::DependentRun` becomes a struct variant carrying its `GateWaypoint` **and** an inline staged result, mirroring how `Done(Outcome)`/`ToolVerdict::ChildSpawned` carries `SpawnedChildRun`'s content:

```rust
pub struct DependentRunResult {
    pub byte_len: u64,                    // feeds per-capability byte caps
    pub summary: SafeSummary,             // redacted, model-visible child summary
    pub observation: Option<SafeSummary>, // redacted model_observation preview (was dropped)
    pub origin: Option<LoopRef>,          // preserved loop result-ref origin
}

Suspension::DependentRun { waypoint: GateWaypoint, result: DependentRunResult }
```

- **Fields:** `byte_len`, `safe_summary` → `summary`, the loop result-ref origin → `origin` (a `LoopRef`, like the waypoint origin), and `model_observation` → `observation`.
- **`model_observation` carry:** reduced to a redacted `Option<SafeSummary>` via the *same* `observation_preview` helper that `Completed`/`SpawnedChildRun` already use for their `OutcomeRefs.preview` — the existing model-observation preview type. It is now carried instead of dropped.
- **Charter fit:** every field is plain redacted host_api vocabulary — bounded metadata, `SafeSummary` (redacted by construction), and a `LoopRef`. No raw paths/secrets; the full child bytes stay host-owned behind the record's `ResultRef`. New accessor `Suspension::dependent_result()`.

## The mapping change

`capability_outcome_to_resolution`'s `AwaitDependentRun` arm now populates the inline payload from the loop's `result_ref`/`byte_len`/`safe_summary`/`model_observation` (redaction applied), and the **"model_observation has no home … dropped" behavior is deleted**. The durable `GateRecord::DependentRun` sidecar is still persisted — inline payload = loop-visible copy, record = durable copy (same dual pattern as PR-B).

## Nothing consumes it yet

`LoopCapabilityPort` is not flipped, `CapabilityOutcome` is not deleted, executor consumers are untouched. Tree stays green (downstream build of `loop_host`/`agent_loop`/`runner`/`reborn_composition` passes).

## Tests (failed first, then green)

Test-first — the new struct variant + inline assertions cannot compile/pass against the pre-change tuple variant (fields absent / `model_observation` dropped):

- `resolution.rs`: acceptance-table row + serialization contract gain the staged result; `dependent_run_carries_the_staged_result_inline` (byte_len + summary + observation + origin round-trip via `dependent_result()`); `dependent_run_result_rejects_an_unsafe_summary_on_the_wire` (secret/path-shaped summary + observation rejected).
- `resolution_mapping.rs`: `dependent_run_record_carries_staged_result_and_byte_len` extended to assert the inline channel copy; `dependent_run_carries_model_observation_inline_and_redacts` (model_observation rides inline; hostile summary → placeholder, hostile observation → `None`). `GateRecord::DependentRun` persistence round-trip stays green.

## Verification (all green)

```
cargo test -p ironclaw_host_api -p ironclaw_turns -p ironclaw_run_state --all-features   # 147 + 34 pass
cargo clippy -p ironclaw_host_api -p ironclaw_turns --all-targets --all-features -- -D warnings
cargo test -p ironclaw_architecture                                                       # 10 pass
scripts/pre-commit-safety.sh                                                               # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
