### PR TITLE
docs: shorten onboarding quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 </p>
 
 <p align="center">
-  <a href="#ironclaw-reborn-quick-start">Reborn Quick Start</a> •
+  <a href="#quick-start">Quick Start</a> •
   <a href="#philosophy">Philosophy</a> •
   <a href="#features">Features</a> •
   <a href="#installation">Installation</a> •
@@ -37,342 +37,30 @@
 
 ---
 
-## IronClaw Reborn Quick Start
+## Quick Start
 
-IronClaw Reborn is the standalone runtime on the `reborn-integration` branch.
-It uses the separate `ironclaw-reborn` binary from the
-`ironclaw_reborn_cli` package and a separate Reborn state root. It does not use
-the legacy `ironclaw` state directory as its config root.
-
-For the older `ironclaw` binary, see [Installation](#installation) and
-[Legacy IronClaw Usage](#legacy-ironclaw-usage).
-
-### Build or run the binary
-
-From the repo root:
+Install the latest IronClaw release on macOS, Linux, or Windows/WSL:
 
 ```bash
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/nearai/ironclaw/releases/latest/download/ironclaw-installer.sh | sh
 ```
 
-Or build it first:
+Then run the guided setup:
 
 ```bash
-cargo build -p ironclaw_reborn_cli --bin ironclaw-reborn
-./target/debug/ironclaw-reborn --help
+ironclaw onboard
 ```
 
-The default Reborn home is `$HOME/.ironclaw/reborn`. Override it with an
-absolute path when you want isolated state:
-
-```bash
-export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path
-```
-
-`config path` and `doctor` are safe diagnostics; they report the resolved home,
-profile, `config.toml`, `providers.json`, and `v1_state: not-used`.
-They do not create Reborn state or seed config files.
-
-### Configure the model route
-
-The CLI-native way to configure Reborn's default model route is:
-
-```bash
-export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models set-provider openai --model gpt-5-mini
-```
-
-That writes `$IRONCLAW_REBORN_HOME/config.toml` with `[llm.default]` and the
-provider's credential env-var name. Check it with:
-
-```bash
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models list openai
-```
-
-For OpenAI, set the secret value in the environment before starting:
-
-```bash
-export OPENAI_API_KEY="sk-..."
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run --message "hello"
-```
-
-Omit `--message` or use `repl` for an interactive stdin session:
-
-```bash
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- repl
-```
-
-### `config.toml` shape
-
-`config init` creates editable starter files:
-
-```bash
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config init
-```
-
-It writes:
-
-- `$IRONCLAW_REBORN_HOME/config.toml`
-- `$IRONCLAW_REBORN_HOME/providers.json`
-
-A minimal configured model route looks like:
-
-```toml
-[llm.default]
-provider_id = "openai"
-model = "gpt-5-mini"
-api_key_env = "OPENAI_API_KEY"
-```
-
-`config.toml` may also include optional sections such as `[boot]`,
-`[identity]`, `[runner]`, and `[skills]`; `config init` writes commented
-guidance for the supported fields.
-
-If `config.toml` is missing, the first stateful runtime start through `run`,
-`repl`, or `serve` seeds a sparse file with `api_version` and the safe
-`local-dev` boot profile. Read-only commands and `run --dry-run` stay
-side-effect-free. One-off environment selections such as
-`IRONCLAW_REBORN_PROFILE=local-dev-yolo` are not persisted into the seeded
-file.
-
-Important: `api_key_env` is the name of an environment variable, not the secret
-itself. Reborn rejects inline secret-shaped values in `config.toml` and
-`providers.json`.
-
-Production storage uses the same env-only pattern. A production Reborn config
-may name the PostgreSQL URL variable, but must not contain the raw URL:
-
-```toml
-[storage]
-backend = "postgres"
-url_env = "IRONCLAW_REBORN_POSTGRES_URL"
-secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
-# Optional; defaults to 2. Keep below the PostgreSQL server or managed
-# session-pool cap after reserving capacity for restarts and operator sessions.
-pool_max_size = 2
-
-[policy]
-deployment_mode = "hosted_multi_tenant"
-default_profile = "secure_default"
-```
-
-Set `IRONCLAW_REBORN_POSTGRES_URL` in the process environment, and set
-`IRONCLAW_REBORN_SECRET_MASTER_KEY` to independent cryptographic key material.
-Managed remote PostgreSQL providers must use TLS, for example by appending
-`sslmode=require`.
-Production `run` also requires an explicit `[policy]` section. The first
-production launch slice supports runtime policies that do not require a
-tenant-sandbox process binding.
-
-Once `[llm.default]` exists, that config selects the provider. `LLM_BACKEND` is
-only an env fallback when no default LLM slot is configured. To switch providers
-after writing config, use `models set-provider <provider>` or edit
-`[llm.default].provider_id`.
-
-### Env-only model selection
-
-If `$IRONCLAW_REBORN_HOME/config.toml` is absent or has no `[llm.default]`,
-Reborn can resolve the LLM from environment variables. A sparse first-run
-seeded config does not include `[llm.default]`, so env-only model selection
-continues to work:
-
-```bash
-export IRONCLAW_REBORN_HOME="$PWD/.reborn-env-only"
-export LLM_BACKEND=openai
-export OPENAI_API_KEY="sk-..."
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run --message "hello"
-```
-
-Common provider env vars:
-
-| Provider | Selector | Required env |
-| --- | --- | --- |
-| OpenAI | `LLM_BACKEND=openai` | `OPENAI_API_KEY`; optional `OPENAI_MODEL`, `OPENAI_BASE_URL` |
-| Anthropic | `LLM_BACKEND=anthropic` | `ANTHROPIC_API_KEY`; optional `ANTHROPIC_MODEL`, `ANTHROPIC_BASE_URL` |
-| OpenAI-compatible | `LLM_BACKEND=openai_compatible` | `LLM_BASE_URL`; optional `LLM_API_KEY`, `LLM_MODEL` |
-| OpenRouter | `LLM_BACKEND=openrouter` | `OPENROUTER_API_KEY`; optional `OPENROUTER_MODEL` |
-| Ollama | `LLM_BACKEND=ollama` | no key; optional `OLLAMA_BASE_URL`, `OLLAMA_MODEL` |
-| Codex auth | `LLM_BACKEND=openai_codex` | `LLM_USE_CODEX_AUTH=true` or `CODEX_AUTH_PATH`; optional `OPENAI_CODEX_MODEL` |
-
-Use `models list <provider>` to see the exact provider metadata compiled into
-the current branch.
-
-### Startup variables
-
-| Variable | Purpose |
-| --- | --- |
-| `IRONCLAW_REBORN_HOME` | Absolute Reborn state root. Defaults to `$HOME/.ironclaw/reborn`. The resolver rejects unsafe paths and v1 state-root aliases such as `$HOME/.ironclaw`. |
-| `IRONCLAW_REBORN_PROFILE` | Boot profile selector. Supported values: `local-dev`, `local-dev-yolo`, `hosted-single-tenant`, `hosted-single-tenant-volume`, `production`, `migration-dry-run`. |
-| `IRONCLAW_REBORN_POSTGRES_URL` | Production PostgreSQL storage URL when `[storage].backend = "postgres"` and `[storage].url_env` names this variable. Keep it out of `config.toml`; remote providers must use TLS. |
-| `IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE` | Optional override for the Reborn PostgreSQL client pool size. Use this when a managed provider enforces a small session-pool cap. |
-| `IRONCLAW_FILESYSTEM_POSTGRES_MIGRATION_CONNECT_MAX_WAIT_SECS` | Optional startup wait window for Postgres filesystem migration connection retries. Defaults to 300 seconds. |
-| `IRONCLAW_REBORN_SECRET_MASTER_KEY` | Production Reborn secret master key when `[storage].secret_master_key_env` names this variable. Keep it independent from the database URL and out of `config.toml`. |
-| `IRONCLAW_REBORN_LOG` | Tracing filter for the Reborn binary, for example `debug,ironclaw_runner=trace`. |
-
-`run` and `repl` currently support local-runtime composition through
-`local-dev`, `local-dev-yolo`, and `hosted-single-tenant-volume`.
-`hosted-single-tenant-volume` uses the local-runtime libSQL substrate under
-`$IRONCLAW_REBORN_HOME/hosted-single-tenant-volume`, resolves the hosted
-secure-default runtime policy, and disables process-backed tools such as shell.
-It is intended for single-tenant preview deployments on a persistent volume,
-not as the full PostgreSQL production composition.
-
-`local-dev-yolo` grants trusted-laptop host access and must be confirmed
-explicitly:
-
-```bash
-export IRONCLAW_REBORN_PROFILE=local-dev-yolo
-cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- repl --confirm-host-access
-```
-
-### WebUI service
-
-The Reborn WebUI is compiled behind the `webui-v2-beta` Cargo feature. Builds
-with this feature require Node.js 22 with Corepack/pnpm so Cargo can generate
-and embed the SPA bundle. Build or run the binary with that feature to enable the `serve`
-command:
-
-```bash
-cargo run -q -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- serve --help
-cargo build -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn
-```
-
-The WebUI listener defaults to `127.0.0.1:3000`. The service requires an
-env-bearer token and a user id at startup. It also needs the model route from
-the earlier section, including that provider's credential env var:
-
-```bash
-export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
-export OPENAI_API_KEY="sk-..." # or the required env var for your configured provider
-export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"
-export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"
-
-cargo run -q -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- serve
-```
-
-Equivalent `config.toml` listener configuration:
-
-```toml
-[webui]
-listen_host = "127.0.0.1"
-listen_port = 3000
-env_token_var = "IRONCLAW_REBORN_WEBUI_TOKEN"
-env_user_id_var = "IRONCLAW_REBORN_WEBUI_USER_ID"
-allowed_origins = ["http://127.0.0.1:3000", "http://localhost:3000"]
-canonical_host = "127.0.0.1:3000"
-```
-
-`env_token_var` and `env_user_id_var` are env-var names. Keep the actual token
-and user id in the environment.
-
-Required WebUI env vars:
-
-| Variable | Purpose |
-| --- | --- |
-| `IRONCLAW_REBORN_WEBUI_TOKEN` | Bearer token for WebUI requests. If SSO is enabled, this also signs sessions and must be at least 32 bytes. |
-| `IRONCLAW_REBORN_WEBUI_USER_ID` | Reborn owner/user id for env-bearer requests. If `[identity].default_owner` is configured, it must match this value. |
-
-Optional WebUI OAuth env vars:
-
-| Variable | Purpose |
-| --- | --- |
-| `IRONCLAW_REBORN_WEBUI_BASE_URL` | Public base URL used for WebUI login and product-auth OAuth callbacks. Non-loopback deployments must use `https://`. |
-| `IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID` | Enables Google SSO when set. |
-| `IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET` | Required when Google SSO is enabled. |
-| `IRONCLAW_REBORN_WEBUI_GOOGLE_ALLOWED_HD` | Optional Google hosted-domain restriction. |
-| `IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_ID` | Enables GitHub SSO when set. |
-| `IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_SECRET` | Required when GitHub SSO is enabled. |
-| `IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS` | Required when any SSO provider is enabled. Comma-separated verified email domains. |
-| `IRONCLAW_REBORN_WEBUI_OAUTH_HTTP_TIMEOUT_SECS` | Optional OAuth HTTP timeout override. |
-
-For Google SSO, create a Google OAuth web client and register the Reborn WebUI
-redirect URI as:
-
-```text
-{IRONCLAW_REBORN_WEBUI_BASE_URL}/auth/callback/google
-```
-
-For example, with `IRONCLAW_REBORN_WEBUI_BASE_URL=https://ironclaw.example.com`,
-the authorized redirect URI in Google Cloud is:
-
-```text
-https://ironclaw.example.com/auth/callback/google
-```
-
-Notion MCP and other product-auth OAuth setup flows use the same public WebUI
-base URL when registering provider callback URLs. Do not include a trailing
-slash in `IRONCLAW_REBORN_WEBUI_BASE_URL`; Reborn trims it before building
-callback URLs. If the base URL is omitted, Reborn uses the actual listener
-address, such as `http://127.0.0.1:3000`, which is suitable only for
-loopback/local OAuth testing. Public or non-loopback OAuth deployments must set
-an `https://` base URL.
-
-Complete Google SSO startup env:
-
-```bash
-export IRONCLAW_REBORN_HOME="/var/lib/ironclaw-reborn"
-export IRONCLAW_REBORN_PROFILE=local-dev
-export OPENAI_API_KEY="sk-..." # or the required env var for your configured provider
-export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"
-export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"
-export IRONCLAW_REBORN_WEBUI_BASE_URL="https://ironclaw.example.com"
-export IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS="example.com,team.example.com"
-export IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID="..."
-export IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET="..."
-
-cargo run -q -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- serve --host 0.0.0.0 --port 3000
-```
-
-`IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS` is the actual admission
-allowlist. Google `hd` is only an optional provider-side hosted-domain hint; do
-not rely on it instead of the Reborn allowed-domain list. `IRONCLAW_REBORN_HOME`
-selects the state/config root for this service. `IRONCLAW_REBORN_PROFILE`
-defaults to `local-dev`; `local-dev-yolo` grants trusted-laptop host access and
-cannot be served on a non-loopback host.
-
-Use `serve --host <ip> --port <port>` to override the listener from the CLI.
-Binding to a non-loopback host is production-sensitive. `local-dev-yolo` serve
-mode also requires `--confirm-host-access` and refuses non-loopback hosts.
-
-### Slack service
-
-Slack support is compiled behind the `slack-v2-host-beta` Cargo feature. That
-feature includes `webui-v2-beta`, so Slack runs on the same `serve` command:
-
-```bash
-export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
-export OPENAI_API_KEY="sk-..." # or the required env var for your configured provider
-export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"
-export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"
-export IRONCLAW_REBORN_SLACK_ENABLED="true"
-
-cargo run -q -p ironclaw_reborn_cli --features slack-v2-host-beta --bin ironclaw-reborn -- serve
-```
-
-Enable Slack by setting `IRONCLAW_REBORN_SLACK_ENABLED=true`, or by adding a
-`[slack]` section to `config.toml`:
-
-```toml
-[slack]
-enabled = true
-```
-
-The env var overrides only the Slack route enablement gate: `true`/`1` mounts
-Slack, while `false`/`0` acts as a deployment kill switch. After the server
-starts, configure the Slack app ids, bot token, signing secret, and channel
-mappings from WebUI channel setup.
-
-Required Slack settings:
-
-| Name | Purpose |
-| --- | --- |
-| `[slack].enabled = true` or `IRONCLAW_REBORN_SLACK_ENABLED=true` | Mounts the Slack route during `serve`. |
-| WebUI Slack workspace setup | Stores Slack installation ids, channel mappings, and Slack bot/signing secrets. |
-
-More detailed Slack setup notes live in
-[`docs/reborn/setup-slack-for-reborn-binary.md`](docs/reborn/setup-slack-for-reborn-binary.md).
+Choose an LLM provider, enter its API key in the hidden prompt, and accept the
+default model or enter another one. IronClaw provisions its local configuration,
+encrypted credential store, and WebUI login token. On macOS and Linux it also
+installs and starts the background service, then prints a link that opens the
+WebUI.
+
+Use `ironclaw status` to check the service and print the login link again.
+Windows users can start the WebUI in the foreground with `ironclaw serve`.
+See [Installation](#installation) for Windows installers and source builds.
 
 ## Philosophy
 
@@ -420,17 +108,8 @@ IronClaw is the AI assistant you can actually trust with your personal and profe
 
 ## Installation
 
-### Prerequisites
-
-- Rust 1.96+
-- PostgreSQL 15+ with [pgvector](https://github.com/pgvector/pgvector) extension
-- Node.js 22+ with Corepack/pnpm for source builds that enable the `webui-v2-beta` feature
-- NEAR AI account (authentication handled via setup wizard)
-- `libclang` and a working C toolchain if you build the WeChat voice/SILK path from source
-
-## Download or Build
-
-Visit [Releases page](https://github.com/nearai/ironclaw/releases/) to see the latest updates.
+The [Releases page](https://github.com/nearai/ironclaw/releases/) provides
+pre-built binaries and installers.
 
 <details>
   <summary>Install via Windows Installer (Windows)</summary>
@@ -440,9 +119,9 @@ Download the [Windows Installer](https://github.com/nearai/ironclaw/releases/lat
 </details>
 
 <details>
-  <summary>Install via powershell script (Windows)</summary>
+  <summary>Install via PowerShell script (Windows)</summary>
 
-```sh
+```powershell
 irm https://github.com/nearai/ironclaw/releases/latest/download/ironclaw-installer.ps1 | iex
 ```
 
@@ -451,9 +130,11 @@ irm https://github.com/nearai/ironclaw/releases/latest/download/ironclaw-install
 <details>
   <summary>Install via shell script (macOS, Linux, Windows/WSL)</summary>
 
-```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/nearai/ironclaw/releases/latest/download/ironclaw-installer.sh | sh
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/nearai/ironclaw/releases/latest/download/ironclaw-installer.sh | sh
 ```
+
 </details>
 
 <details>
@@ -466,80 +147,63 @@ brew install ironclaw
 </details>
 
 <details>
-  <summary>Compile the source code (Cargo on Windows, Linux, macOS)</summary>
+  <summary>Build and install from source</summary>
 
-Install it with `cargo`, just make sure you have [Rust](https://rustup.rs) installed on your computer.
+Source builds require Rust 1.96+ and Node.js 22+ with Corepack/pnpm.
 
 ```bash
-# Clone the repository
 git clone https://github.com/nearai/ironclaw.git
 cd ironclaw
-
-# Build
-cargo build --release
-
-# Run tests
-cargo test
+corepack enable pnpm
+cargo install --locked --path crates/ironclaw_reborn_cli --features full
 ```
-
-For **full release** (after modifying channel sources), run `./scripts/build-all.sh` to rebuild channels first.
-
-> **Optional:** WeChat voice notes (`audio/silk`) require the standalone
-> `ironclaw-silk-decoder` helper to be transcribable. It's excluded from the
-> default workspace build because `silk-codec` pulls in `bindgen`/`libclang`.
-> Build it separately with `./crates/ironclaw_silk_decoder/build.sh` (needs
-> libclang + a C toolchain) and put the resulting binary on `$PATH`, beside
-> the `ironclaw` binary, or pointed at by `IRONCLAW_SILK_DECODER`. Without
-> it, voice messages are still delivered — just as raw `audio/silk` blobs.
 
 </details>
 
-### Database Setup
-
-```bash
-# Create database
-createdb ironclaw
-
-# Enable pgvector
-psql ironclaw -c "CREATE EXTENSION IF NOT EXISTS vector;"
-```
-
 ## Configuration
 
-Run the setup wizard to configure IronClaw:
+`ironclaw onboard` is the primary configuration path. It writes Reborn state
+under `$HOME/.ironclaw/reborn` by default, stores the selected LLM credential
+in the encrypted local secret store, and preserves existing configuration when
+it is run again.
+
+Inspect the current setup with:
 
 ```bash
-ironclaw onboard
+ironclaw status
+ironclaw models status
+ironclaw config list
 ```
 
-The wizard handles database connection, NEAR AI authentication (via browser OAuth),
-and secrets encryption (using your system keychain). Settings are persisted in the
-connected database; bootstrap variables (e.g. `DATABASE_URL`, `LLM_BACKEND`) are
-written to `~/.ironclaw/.env` so they are available before the database connects.
+To switch providers after onboarding, select the route and then store its API
+key using the hidden prompt:
 
-### Alternative LLM Providers
-
-IronClaw defaults to NEAR AI but supports many LLM providers out of the box.
-Built-in providers include **Anthropic**, **OpenAI**, **GitHub Copilot**, **Google Gemini**, **MiniMax**,
-**Mistral**, and **Ollama** (local). OpenAI-compatible services like **OpenRouter**
-(300+ models), **Together AI**, **Fireworks AI**, and self-hosted servers (**vLLM**,
-**LiteLLM**) are also supported.
-
-Select your provider in the wizard, or set environment variables directly:
-
-```env
-# Example: MiniMax (built-in, 204K context)
-LLM_BACKEND=minimax
-MINIMAX_API_KEY=...
-
-# Example: OpenAI-compatible endpoint
-LLM_BACKEND=openai_compatible
-LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_API_KEY=sk-or-...
-LLM_MODEL=anthropic/claude-sonnet-4
+```bash
+ironclaw models set-provider openai --model gpt-5-mini
+ironclaw config set openai.api_key
 ```
 
-See [docs/capabilities/llm-providers.md](docs/capabilities/llm-providers.md) for a full provider guide.
+Additional settings use the same command. For example:
+
+```bash
+ironclaw config set google.client_id YOUR_CLIENT_ID
+ironclaw config set google.client_secret
+ironclaw config set google.redirect_uri YOUR_REDIRECT_URI
+ironclaw config set webui.token --rotate
+```
+
+Secret values never accept a positional argument; IronClaw prompts for them
+without echoing the value. Configure Slack credentials and channel mappings
+from the WebUI Extensions page. To enable its route from the CLI, use:
+
+```bash
+ironclaw config set slack.enabled true
+ironclaw service restart
+```
+
+Configuration writes never restart the service automatically. Run
+`ironclaw service restart` after a change that affects the running service,
+and use `ironclaw config set --help` for the complete list of supported keys.
 
 ## Security
 
@@ -572,7 +236,7 @@ External content passes through multiple security layers:
 
 ### Data Protection
 
-- All data stored locally in your PostgreSQL database
+- All data stored locally in IronClaw's application state
 - Secrets encrypted with AES-256-GCM
 - No telemetry, analytics, or data sharing
 - Full audit log of all tool executions
@@ -632,17 +296,17 @@ External content passes through multiple security layers:
 | **Workspace** | Persistent memory with hybrid search |
 | **Safety Layer** | Prompt injection defense and content sanitization |
 
-## IronClaw Usage
+## Usage
 
 ```bash
-# First-time setup (configures database, auth, etc.)
-ironclaw onboard
+# Check the background service and print the WebUI login link
+ironclaw status
 
-# Start interactive REPL
-cargo run
+# Start an interactive terminal session
+ironclaw repl
 
-# REPL with debug logging
-RUST_LOG=ironclaw=debug cargo run
+# Run one turn
+ironclaw run --message "hello"
 ```
 
 ## Development


### PR DESCRIPTION
## Summary

- replace the branch-specific manual Reborn setup with the supported install → `ironclaw onboard` → WebUI flow
- retain Windows, Homebrew, and source-install alternatives in a shorter Installation section
- align post-onboarding configuration and usage examples with `config set`, `status`, and service management
- remove obsolete legacy PostgreSQL and environment-variable onboarding instructions

## Why

The root README currently presents several contradictory setup paths before a user can run IronClaw. This makes the first-time experience look substantially more complicated than the onboarding command now is.

The first screen now gives users the two commands they need, while advanced installation and configuration guidance remains available below.

## Release coordination

The curl URL targets the canonical Reborn installer asset. This docs change should merge with the release that publishes that asset so the quick start is live when users see it.

## Validation

- `git diff --check`
- `cargo metadata --no-deps --format-version 1` confirms the canonical `ironclaw` target and `full` feature
- `bash scripts/pre-commit-safety.sh`