### PR TITLE
feat(reborn): onboard launcher (REPL/Web UI), serve browser auto-open, clear corepack error

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/onboard/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/onboard/mod.rs
@@ -39,6 +39,11 @@ pub(crate) struct OnboardCommand {
     #[arg(long = "import-history")]
     import_history: bool,
 
+    /// Scaffold only — never offer to launch the REPL at the end, even on a
+    /// TTY. Use in scripts and CI.
+    #[arg(long = "no-launch")]
+    no_launch: bool,
+
     /// Skip installing/starting the OS service (launchd/systemd) at the end
     /// of onboarding. Always effectively on in a non-interactive session
     /// (headless CI, a piped/scripted invocation) regardless of this flag —
@@ -174,7 +179,67 @@ impl OnboardCommand {
         #[cfg(feature = "webui-v2-beta")]
         self.finish_with_service_and_login_link(&context, home, prompts.is_interactive())?;
 
+        // Offer to jump straight into a session. Web UI is offered only when
+        // this binary was built with `serve` (webui-v2-beta); otherwise just
+        // REPL.
+        self.maybe_offer_launch()?;
+
         Ok(())
+    }
+
+    /// After onboarding, offer to re-exec into a live session so the user lands
+    /// in chat instead of a bare shell prompt. Offers REPL and — when `serve`
+    /// is compiled in — Web UI. No-op for `--no-launch` or non-interactive.
+    fn maybe_offer_launch(&self) -> anyhow::Result<()> {
+        use std::io::{IsTerminal, Write};
+
+        if self.no_launch || !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+            return Ok(());
+        }
+        let webui = cfg!(feature = "webui-v2-beta");
+        if webui {
+            print!("\nStart now?  [1] Command line   [2] Web UI   [Enter] skip: ");
+        } else {
+            print!("\nStart a command-line chat now? [Y/n]: ");
+        }
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        if std::io::stdin().read_line(&mut answer)? == 0 {
+            return skip_launch_hint(webui); // EOF
+        }
+        let answer = answer.trim().to_ascii_lowercase();
+        let subcommand = if webui {
+            match answer.as_str() {
+                "1" | "cli" | "command line" | "commandline" | "terminal" | "repl" => "repl",
+                "2" | "web" | "web ui" | "webui" | "w" => "serve",
+                _ => return skip_launch_hint(true), // Enter / anything else = skip
+            }
+        } else {
+            match answer.as_str() {
+                "" | "y" | "yes" => "repl",
+                _ => return skip_launch_hint(false),
+            }
+        };
+        let exe = std::env::current_exe()?;
+        let label = match subcommand {
+            "serve" => "web UI",
+            _ => "command-line chat",
+        };
+        println!("starting {label}…");
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            // exec replaces this process; only returns on failure.
+            Err(std::process::Command::new(&exe)
+                .arg(subcommand)
+                .exec()
+                .into())
+        }
+        #[cfg(not(unix))]
+        {
+            let status = std::process::Command::new(&exe).arg(subcommand).status()?;
+            std::process::exit(status.code().unwrap_or(1));
+        }
     }
 
     /// Onboarding's last two steps, gated behind `webui-v2-beta` (both depend
@@ -250,7 +315,12 @@ impl OnboardCommand {
     /// is the sole `IsTerminal` check in this command) rather than re-deriving it here.
     #[cfg(feature = "webui-v2-beta")]
     fn should_install_service(&self, interactive: bool) -> bool {
-        !self.no_service && interactive
+        // Only when the interactive launcher is off (`--no-launch`). With the
+        // launcher active (default), the user picks REPL / Web UI and a
+        // foreground `serve` runs — installing a background service too would
+        // fight it for the port. So the background service is the `--no-launch`
+        // (headless/scripted) path's way to keep the Web UI running.
+        !self.no_service && interactive && self.no_launch
     }
 }
 
@@ -276,6 +346,18 @@ impl ServiceStartOutcome {
             Self::Failed(reason) => format!("failed: {reason}"),
         }
     }
+}
+
+/// Print how to start a session later when the user skips the launch prompt.
+fn skip_launch_hint(webui: bool) -> anyhow::Result<()> {
+    if webui {
+        println!(
+            "skipped. Start anytime with `ironclaw repl` (command line) or `ironclaw serve` (web UI)."
+        );
+    } else {
+        println!("skipped. Start anytime with `ironclaw repl`.");
+    }
+    Ok(())
 }
 
 pub(crate) fn onboarding_marker_path(home: &RebornHome) -> PathBuf {

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -106,6 +106,37 @@ impl ironclaw_reborn_composition::AdminApiTokenMinter for SignedSessionTokenMint
     }
 }
 
+/// Auto-open the WebUI sign-in URL in the default browser — but only for an
+/// interactive foreground `serve` on a loopback address (never from a
+/// background service or a remote bind). Best-effort; the URL is also printed.
+fn maybe_open_browser(no_browser: bool, addr: SocketAddr, token: &str) {
+    use std::io::IsTerminal;
+    if no_browser || !std::io::stderr().is_terminal() || !addr.ip().is_loopback() {
+        return;
+    }
+    let url = format!("http://{addr}/v2/?token={token}");
+    eprintln!("ironclaw serve: opening {url}");
+    spawn_browser_open(url);
+}
+
+/// Best-effort open a URL in the default browser (macOS `open`, Linux
+/// `xdg-open`, Windows `start`), after a short delay so the listener is bound
+/// first. Failures are ignored — the URL was already printed.
+fn spawn_browser_open(url: String) {
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+        let opener: &[&str] = if cfg!(target_os = "macos") {
+            &["open"]
+        } else if cfg!(target_os = "windows") {
+            &["cmd", "/C", "start", ""]
+        } else {
+            &["xdg-open"]
+        };
+        let (cmd, pre) = opener.split_first().expect("opener is non-empty");
+        let _ = std::process::Command::new(cmd).args(pre).arg(&url).status();
+    });
+}
+
 #[derive(Debug, Args)]
 pub(crate) struct ServeCommand {
     /// Host interface for the Reborn WebChat v2 HTTP listener.
@@ -131,6 +162,11 @@ pub(crate) struct ServeCommand {
     /// Confirm trusted-laptop host filesystem access for local-dev-yolo.
     #[arg(long = "confirm-host-access")]
     confirm_host_access: bool,
+
+    /// Do not auto-open the browser when running `serve` interactively in the
+    /// foreground on a loopback address.
+    #[arg(long = "no-browser")]
+    no_browser: bool,
 }
 
 impl ServeCommand {
@@ -195,6 +231,9 @@ impl ServeCommand {
         )?;
         let webui_token_source = resolved_token.source;
         let token_value = resolved_token.value;
+        // Kept for the auto-open sign-in URL below; `token_value` is moved into
+        // the session-signing secret / authenticator before the listener binds.
+        let browser_token = token_value.clone();
         let user_id_raw = resolve_webui_user_id_raw(env_user_id_var, config_file.as_ref())?;
         let user_id = UserId::new(&user_id_raw)
             .map_err(|err| anyhow!("{env_user_id_var} value `{user_id_raw}` is invalid: {err}"))?;
@@ -777,6 +816,7 @@ impl ServeCommand {
                     .await
                     .context("hosted single-tenant startup WebChat v2 serve task failed to join")?
             } else {
+                maybe_open_browser(self.no_browser, listen_addr, &browser_token);
                 serve_webui_v2(RebornWebuiServeOptions {
                     addr: listen_addr,
                     router,

--- a/crates/ironclaw_webui/build.rs
+++ b/crates/ironclaw_webui/build.rs
@@ -132,7 +132,19 @@ fn required_frontend_dist_files(dist_dir: &Path) -> [PathBuf; 3] {
 }
 
 fn run_command(command: &str, args: &[&str], cwd: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let status = Command::new(command).args(args).current_dir(cwd).status()?;
+    let status = match Command::new(command).args(args).current_dir(cwd).status() {
+        Ok(status) => status,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(std::io::Error::other(format!(
+                "`{command}` was not found on PATH — the `webui-v2-beta` feature builds the \
+                 WebChat v2 frontend and needs Node 22 (which bundles corepack). Install Node 22+ \
+                 from https://nodejs.org (then `corepack enable`), or `npm i -g pnpm`. To build \
+                 without Node, ship a prebuilt SPA bundle. Underlying error: {err}"
+            ))
+            .into());
+        }
+        Err(err) => return Err(err.into()),
+    };
     if status.success() {
         return Ok(());
     }


### PR DESCRIPTION

<img width="1635" height="416" alt="Screenshot 2026-07-19 at 6 08 59 PM" src="https://github.com/user-attachments/assets/685cde64-a698-4a16-9704-0037135c8876" />

Test with 
cargo run --release -p ironclaw_reborn_cli --features full -- onboard

## Changes

- **onboard launcher** — after setup, offer to start a session: **`[1] REPL / [2] Web UI`** when `serve` is compiled in (`webui-v2-beta`/`full`), or REPL-only `[Y/n]` for a CLI-only build (so a build without `serve` never offers a Web UI it can't run). Re-execs into the chosen subcommand. `--no-launch` skips (scripts/CI).
- **no service/port conflict** — the background OS service is installed **only** under `--no-launch`. With the launcher active (default), the user starts a foreground `serve` themselves, so no competing background service is installed.
- **serve browser auto-open** — auto-open the WebUI sign-in URL (`/v2/?token=…`) in the default browser, but **only** for an interactive foreground `serve` on a **loopback** address (never a background service or remote bind). `--no-browser` opts out; the URL is printed regardless.
- **clear corepack error** — `ironclaw_webui/build.rs` emits an actionable "install Node 22 / `corepack enable` / `npm i -g pnpm`" message when corepack/pnpm is missing, instead of an opaque `Os NotFound`.

## Verification

fmt + clippy clean (default and `--features full`); default build compiles with no Node; webui build compiles; `onboard --help` shows `--no-launch`.

## Files
- `crates/ironclaw_reborn_cli/src/commands/onboard/mod.rs`
- `crates/ironclaw_reborn_cli/src/commands/serve.rs`
- `crates/ironclaw_webui/build.rs`

## Notes

Supersedes the onboarding parts of the earlier (now-closed #6285) branch — main independently landed the credential wizard, WebUI token provisioning + serve fallback, and login link, so those aren't duplicated. REPL spinner+markdown is #6289 (disjoint files).