### PR TITLE
Remove stale compile feature CI legs

### DIFF
--- a/.claude/rules/review-discipline.md
+++ b/.claude/rules/review-discipline.md
@@ -32,12 +32,11 @@ regression-check exemption rather than silently omitting coverage.
   feature-gated dead code — a `#[cfg(feature = "x")]`-only caller makes its
   helper *live* under `--all-features` and *dead* (a `-D warnings` error)
   everywhere the feature is off. **PR CI runs only the slim `all-features` lane;
-  the full `default` / `libsql-only` matrix runs post-merge**, so this class
-  breaks `main` after a green PR. If you add or move a `#[cfg(feature = ...)]`
-  gate, or touch a helper only reachable through one, run the full matrix
-  locally before merging (see "Required checks"). When you gate the only
-  caller(s) of a helper behind a feature, gate the helper's definition with the
-  same `#[cfg]`.
+  the broader `default` lane runs post-merge**, so this class can break `main`
+  after a green PR. If you add or move a `#[cfg(feature = ...)]` gate, or touch
+  a helper only reachable through one, run the relevant feature lanes locally
+  before merging (see "Required checks"). When you gate the only caller(s) of a
+  helper behind a feature, gate the helper's definition with the same `#[cfg]`.
 - **UTF-8:** never byte-slice user or external strings with `&value[..n]`.
   Use `char_indices()`, `chars()`, or an `is_char_boundary()`-checked boundary.
   Search changed Rust files for suspicious `[..` slicing.
@@ -72,13 +71,12 @@ Workspace-wide zero-warning clippy:
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-Full feature matrix — reproduces the post-merge `Code Style` gate that PR CI
-skips (it only runs the `all-features` lane). Run all three whenever a change
-adds, moves, or relies on a `#[cfg(feature = ...)]` gate:
+Feature matrix — reproduces the post-merge `Code Style` gate that PR CI skips
+(it only runs the `all-features` lane). Run both whenever a change adds, moves,
+or relies on a `#[cfg(feature = ...)]` gate:
 
 ```bash
 cargo clippy --all --tests --examples -- -D warnings                              # default
-cargo clippy --all --tests --examples --no-default-features --features libsql -- -D warnings  # libsql-only
 cargo clippy --all --tests --examples --all-features -- -D warnings               # all-features
 ```
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,7 +25,7 @@ they run the lane in the merge queue, before landing, without adding the full
 WASM build to ordinary PR feedback. Push and deep-CI runs remain exhaustive.
 
 History: the slim-vs-full clippy matrix violated this — the queue linted only
-`--all-features` while push linted `all-features`/`default`/`libsql-only`, so
+`--all-features` while push linted a broader matrix, so
 feature-gated dead code (e.g. a `#[cfg(feature = "postgres")]`-constructed enum
 variant) passed the queue and turned main red post-merge.
 

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -83,13 +83,13 @@ jobs:
     steps:
       - id: set
         run: |
-          FULL='[{"name":"all-features","flags":"--all-features"},{"name":"default","flags":""},{"name":"libsql-only","flags":"--no-default-features --features libsql"}]'
+          FULL='[{"name":"all-features","flags":"--all-features"},{"name":"default","flags":""}]'
           SLIM='[{"name":"all-features","flags":"--all-features"}]'
 
           # PRs get the fast single-lane matrix for quick feedback. The merge
           # queue is the production gate: it must run the same full feature
-          # matrix as pushes to main, otherwise feature-gated lints (e.g.
-          # libsql-only dead code) pass the queue and break main post-merge.
+          # matrix as pushes to main, otherwise feature-gated lints can pass
+          # the queue and break main post-merge.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "matrix=${SLIM}" >> "$GITHUB_OUTPUT"
           else
@@ -524,7 +524,7 @@ jobs:
           # This roll-up is a required check. A green result must mean the full
           # feature matrix was linted, so fail loudly if the matrix config ever
           # regresses to the slim PR lane on a merge-queue or push run.
-          for lane in all-features default libsql-only; do
+          for lane in all-features default; do
             if ! printf '%s' "$MATRIX_JSON" | jq -e --arg lane "$lane" 'any(.[]; .name == $lane)' > /dev/null; then
               echo "Required clippy lane missing from matrix on ${{ github.event_name }}: $lane"
               echo "Matrix was: $MATRIX_JSON"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,10 +11,9 @@
 # Viewing coverage reports:
 # - PRs automatically get coverage comments showing changes in coverage
 # - Visit https://codecov.io/gh/nearai/ironclaw for detailed coverage reports
-# - Coverage reports are generated for three configurations:
+# - Coverage reports are generated for two configurations:
 #   1. all-features: Full feature set
 #   2. default: Default features
-#   3. libsql-only: Minimal libSQL-only configuration
 # - E2E coverage tracks end-to-end test coverage separately
 #
 # Coverage files:
@@ -61,9 +60,6 @@ jobs:
           - name: default
             flags: ""
             has_postgres: true
-          - name: libsql-only
-            flags: "--no-default-features --features libsql"
-            has_postgres: false
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -223,8 +223,6 @@ jobs:
             flags: "--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"
           - name: default
             flags: ""
-          - name: libsql-only
-            flags: "--no-default-features --features libsql"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
     steps:
       - id: set
         run: |
-          FULL='[{"name":"all-features","flags":"--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"},{"name":"default","flags":""},{"name":"libsql-only","flags":"--no-default-features --features libsql"}]'
+          FULL='[{"name":"all-features","flags":"--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"},{"name":"default","flags":""}]'
           SLIM='[{"name":"all-features","flags":"--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"}]'
 
           if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "merge_group" ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,7 +334,7 @@ ironclaw_runner = { path = "crates/ironclaw_runner", version = "0.1.0" }
 # composing them in int-tier tests. All 17 of those modules are recompiled
 # into every int-tier test binary — a real, one-time build-time cost for the
 # lane, behaviorally inert for suites that never reference Slack types.
-ironclaw_reborn_composition = { path = "crates/ironclaw_reborn_composition", version = "0.1.0", features = ["test-support", "libsql"] }
+ironclaw_reborn_composition = { path = "crates/ironclaw_reborn_composition", version = "0.1.0", features = ["test-support"] }
 # Direct dev-dep: composition deliberately does NOT re-export the bare
 # `webui_v2_router`/`WebUiV2State` (facade-only rule), and the router smoke
 # drives the bare router, not the `webui_v2_app` wrapper. The v2 route surface

--- a/crates/README.md
+++ b/crates/README.md
@@ -116,7 +116,7 @@ A good rule of thumb: if a change adds new authority or persistence, put it in t
 - **Durable event history**: use `ironclaw_events` for contracts and `ironclaw_reborn_event_store` for backend adapters.
 - **Current invocation state**: use `ironclaw_run_state`, not event logs.
 - **User-visible read models and live projection streams**: prefer `ironclaw_event_projections`, `ironclaw_event_streams`, or `ironclaw_product_adapters` over parsing storage rows in UI code.
-- **Product workflow persistence**: keep orchestration and durable ledger adapters in `ironclaw_product_workflow`; concrete adapters stay behind the `storage`/`libsql`/`postgres` features and the `IdempotencyLedger` port.
+- **Product workflow persistence**: keep orchestration and durable ledger adapters in `ironclaw_product_workflow`; concrete adapters implement the `IdempotencyLedger` port without adding backend compile features.
 - **Agent loop/product orchestration**: use `ironclaw_agent_loop`, `ironclaw_loop_host`, `ironclaw_turns`, `ironclaw_engine`, or `ironclaw_runner` depending on layer.
 - **Web or terminal UI**: use `ironclaw_gateway`, `ironclaw_webui`, `ironclaw_webui`, or `ironclaw_tui`; keep authority and persistence in lower crates.
 
@@ -142,7 +142,7 @@ cargo test
 For targeted crate work, prefer the narrowest command first:
 
 ```bash
-cargo test -p ironclaw_secrets --features libsql
+cargo test -p ironclaw_secrets
 cargo clippy -p ironclaw_network --tests -- -D warnings
 ```
 

--- a/crates/ironclaw_agent_loop/Cargo.toml
+++ b/crates/ironclaw_agent_loop/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 layer = "loops"
 
 [features]
-default = []
 test-support = []
 
 [dependencies]

--- a/crates/ironclaw_authorization/Cargo.toml
+++ b/crates/ironclaw_authorization/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 layer = "kernel"
 
 [features]
-default = []
 # In-memory-backed capability-lease store constructor for this crate's own tests
 # and downstream integration tiers. The store itself is the production
 # `FilesystemCapabilityLeaseStore<InMemoryBackend>`; the helper just wires the

--- a/crates/ironclaw_channel_delivery/Cargo.toml
+++ b/crates/ironclaw_channel_delivery/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 layer = "products"
 
 [features]
-default = []
 test-support = []
 
 [dependencies]

--- a/crates/ironclaw_channel_host/Cargo.toml
+++ b/crates/ironclaw_channel_host/Cargo.toml
@@ -13,7 +13,6 @@ publish = false
 [package.metadata.ironclaw]
 layer = "products"
 
-[features]
 [dependencies]
 async-trait = "0.1"
 axum = { version = "0.8" }

--- a/crates/ironclaw_conversations/Cargo.toml
+++ b/crates/ironclaw_conversations/Cargo.toml
@@ -29,9 +29,6 @@ tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 
-[features]
-default = []
-
 [dev-dependencies]
 ironclaw_triggers = { path = "../ironclaw_triggers", version = "0.1.0", features = ["test-support"] }
 tempfile = "3"

--- a/crates/ironclaw_embeddings/Cargo.toml
+++ b/crates/ironclaw_embeddings/Cargo.toml
@@ -17,7 +17,6 @@ layer = "substrates"
 dist = false
 
 [features]
-default = []
 bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types"]
 # Exposes `MockEmbeddings` for downstream test harnesses. Off in release
 # builds so the deterministic-hash mock can't be reached from production

--- a/crates/ironclaw_filesystem/CLAUDE.md
+++ b/crates/ironclaw_filesystem/CLAUDE.md
@@ -154,10 +154,8 @@ consumers of the legacy methods — new code should call `put`/`get`/
 
 ## When you're editing this crate
 
-- Run the full crate tests, both feature combinations:
-  `cargo test -p ironclaw_filesystem --all-features`,
-  `cargo check -p ironclaw_filesystem --no-default-features --features libsql`,
-  `cargo check -p ironclaw_filesystem --no-default-features --features postgres`.
+- Run the full crate tests:
+  `cargo test -p ironclaw_filesystem`.
 - New `Entry` shapes (record kinds, indexed projections) belong in the
   consumer crate, not here. This crate only owns the trait surface and
   shared primitives.

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -13,25 +13,20 @@ publish = false
 [package.metadata.ironclaw]
 layer = "substrates"
 
-[features]
-default = []
-postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
-libsql = ["dep:libsql", "dep:deadpool"]
-
 [dependencies]
 async-trait = "0.1"
 blake3 = "1"
-deadpool = { version = "0.12", optional = true, default-features = false, features = ["managed", "rt_tokio_1"] }
-deadpool-postgres = { version = "0.14", optional = true }
+deadpool = { version = "0.12", default-features = false, features = ["managed", "rt_tokio_1"] }
+deadpool-postgres = "0.14"
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_observability = { path = "../ironclaw_observability" }
 ironclaw_safety = { path = "../ironclaw_safety", version = "0.2.2" }
-libsql = { version = "0.9", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+libsql = { version = "0.9", default-features = false, features = ["core", "replication", "remote", "tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "sync", "time"] }
-tokio-postgres = { version = "0.7", optional = true, features = ["with-serde_json-1"] }
+tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/ironclaw_filesystem/src/db.rs
+++ b/crates/ironclaw_filesystem/src/db.rs
@@ -3,8 +3,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use ironclaw_host_api::{HostApiError, VirtualPath};
 
 use crate::{DirEntry, FileType, FilesystemError, FilesystemOperation};
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn directory_write_error(path: VirtualPath) -> FilesystemError {
     FilesystemError::Backend {
         path,
@@ -12,8 +10,6 @@ pub(crate) fn directory_write_error(path: VirtualPath) -> FilesystemError {
         reason: "cannot overwrite a directory".to_string(),
     }
 }
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn directory_append_error(path: VirtualPath) -> FilesystemError {
     FilesystemError::Backend {
         path,
@@ -21,8 +17,6 @@ pub(crate) fn directory_append_error(path: VirtualPath) -> FilesystemError {
         reason: "cannot append to a directory".to_string(),
     }
 }
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn virtual_path_prefixes(path: &VirtualPath) -> Result<Vec<VirtualPath>, HostApiError> {
     let mut prefixes = Vec::new();
     let mut current = String::new();
@@ -36,8 +30,6 @@ pub(crate) fn virtual_path_prefixes(path: &VirtualPath) -> Result<Vec<VirtualPat
     }
     Ok(prefixes)
 }
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn direct_children(
     parent: &VirtualPath,
     rows: Vec<(VirtualPath, u64, FileType)>,
@@ -72,8 +64,6 @@ pub(crate) fn direct_children(
     }
     Ok(entries.into_values().collect())
 }
-
-#[cfg(feature = "libsql")]
 pub(crate) fn descendant_path_range(path: &VirtualPath) -> (String, String) {
     let prefix = path.as_str().trim_end_matches('/');
     // Descendants share the literal "{prefix}/" component boundary. The
@@ -81,8 +71,6 @@ pub(crate) fn descendant_path_range(path: &VirtualPath) -> (String, String) {
     // in the normalized virtual path alphabet used by these storage paths.
     (format!("{prefix}/"), format!("{prefix}0"))
 }
-
-#[cfg(feature = "libsql")]
 pub(crate) fn child_path_like_pattern(path: &VirtualPath) -> String {
     let mut pattern = String::new();
     for character in path.as_str().trim_end_matches('/').chars() {
@@ -97,18 +85,12 @@ pub(crate) fn child_path_like_pattern(path: &VirtualPath) -> String {
     pattern.push_str("/%");
     pattern
 }
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn not_found(path: VirtualPath, operation: FilesystemOperation) -> FilesystemError {
     FilesystemError::NotFound { path, operation }
 }
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn is_not_found<T>(result: &Result<T, FilesystemError>) -> bool {
     matches!(result, Err(FilesystemError::NotFound { .. }))
 }
-
-#[cfg(feature = "postgres")]
 pub(crate) fn db_error(
     path: VirtualPath,
     operation: FilesystemOperation,
@@ -123,15 +105,11 @@ pub(crate) fn db_error(
         reason: error.to_string(),
     }
 }
-
-#[cfg(feature = "postgres")]
 fn is_postgres_contention(code: &tokio_postgres::error::SqlState) -> bool {
     code == &tokio_postgres::error::SqlState::T_R_SERIALIZATION_FAILURE
         || code == &tokio_postgres::error::SqlState::T_R_DEADLOCK_DETECTED
         || code == &tokio_postgres::error::SqlState::LOCK_NOT_AVAILABLE
 }
-
-#[cfg(feature = "libsql")]
 pub(crate) fn libsql_db_error(
     path: VirtualPath,
     operation: FilesystemOperation,
@@ -146,8 +124,6 @@ pub(crate) fn libsql_db_error(
         reason: error.to_string(),
     }
 }
-
-#[cfg(feature = "libsql")]
 fn is_libsql_contention(error: &libsql::Error) -> bool {
     const SQLITE_BUSY: i32 = 5;
     const SQLITE_LOCKED: i32 = 6;
@@ -161,8 +137,6 @@ fn is_libsql_contention(error: &libsql::Error) -> bool {
     };
     primary_code.is_some_and(|code| matches!(code & 0xff, SQLITE_BUSY | SQLITE_LOCKED))
 }
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn system_time_from_unix_seconds(seconds: i64) -> Option<SystemTime> {
     if seconds < 0 {
         return None;
@@ -178,7 +152,6 @@ pub(crate) fn system_time_from_unix_seconds(seconds: i64) -> Option<SystemTime> 
 /// placeholder masked which subsystem actually failed, so a real failure
 /// reported a fictional path. Backends now use this helper instead, and
 /// the variant explicitly omits `path`.
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn infrastructure_error(
     operation: FilesystemOperation,
     reason: impl Into<String>,
@@ -188,8 +161,6 @@ pub(crate) fn infrastructure_error(
         reason: reason.into(),
     }
 }
-
-#[cfg(feature = "postgres")]
 pub(crate) fn infrastructure_pg_error(
     operation: FilesystemOperation,
     error: tokio_postgres::Error,
@@ -202,8 +173,6 @@ pub(crate) fn infrastructure_pg_error(
     );
     infrastructure_error(operation, reason)
 }
-
-#[cfg(feature = "libsql")]
 pub(crate) fn infrastructure_libsql_error(
     operation: FilesystemOperation,
     error: libsql::Error,
@@ -216,7 +185,6 @@ pub(crate) fn infrastructure_libsql_error(
 /// so the only non-identifier characters we strip are the prefix's slashes.
 /// Length capped at 62 to fit Postgres' 63-char identifier cap so libsql
 /// and postgres share one naming convention.
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn sql_index_name(prefix: &str, name: &str) -> String {
     let prefix_clean: String = prefix
         .trim_matches('/')
@@ -252,7 +220,6 @@ pub(crate) fn sql_index_name(prefix: &str, name: &str) -> String {
 /// Reviewer note (PR #3661): this is **NOT** suitable for user-supplied
 /// LIKE input — use [`escape_like_literal`] instead, which escapes every
 /// special character including a trailing `%`.
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn escape_like_with_trailing_wildcard(pattern: &str) -> String {
     let mut out = String::with_capacity(pattern.len());
     let mut chars = pattern.chars().peekable();
@@ -270,7 +237,6 @@ pub(crate) fn escape_like_with_trailing_wildcard(pattern: &str) -> String {
 /// Fully-literal LIKE escape for user-supplied values. PR #3661 reviewer
 /// fix: a literal prefix like `tenant:%` must not become a wildcard at
 /// query time, so every `%`, `_`, and `!` is escaped.
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn escape_like_literal(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     for c in value.chars() {
@@ -290,7 +256,6 @@ pub(crate) fn escape_like_literal(value: &str) -> String {
 /// which silently masked a corrupt negative version to `0` — indistinguishable
 /// from a legitimately fresh row. This helper surfaces the corruption as
 /// [`FilesystemError::CorruptRecordVersion`] so the operator sees it.
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn record_version_from_i64(
     path: &VirtualPath,
     raw: i64,
@@ -310,7 +275,6 @@ pub(crate) fn record_version_from_i64(
 /// `WHERE version = ?` clause would never match. Surface
 /// `CorruptRecordVersion` instead of letting the write silently
 /// VersionMismatch.
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn record_version_to_i64(
     path: &VirtualPath,
     version: crate::RecordVersion,
@@ -327,7 +291,6 @@ pub(crate) fn record_version_to_i64(
 /// rejects with a cryptic backend error and Postgres rejects loudly but
 /// without naming what overflowed. Surface a typed `Backend` error
 /// naming the operation and value instead.
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 pub(crate) fn page_offset_to_i64(path: &VirtualPath, offset: u64) -> Result<i64, FilesystemError> {
     i64::try_from(offset).map_err(|_| FilesystemError::Backend {
         path: path.clone(),
@@ -336,7 +299,7 @@ pub(crate) fn page_offset_to_i64(path: &VirtualPath, offset: u64) -> Result<i64,
     })
 }
 
-#[cfg(all(test, feature = "libsql"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -383,7 +346,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "postgres"))]
+#[cfg(test)]
 mod postgres_tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -18,17 +18,13 @@
 mod backend;
 mod cas;
 mod catalog;
-#[cfg(any(feature = "postgres", feature = "libsql"))]
 mod db;
 mod hsm;
 mod in_memory;
 mod index;
-#[cfg(feature = "libsql")]
 mod libsql;
-#[cfg(feature = "libsql")]
 mod libsql_pool;
 mod local;
-#[cfg(feature = "postgres")]
 mod postgres;
 mod record;
 mod root;
@@ -45,10 +41,8 @@ pub use catalog::{CompositeRootFilesystem, MountDescriptor, PathPlacement};
 pub use hsm::HsmBackend;
 pub use in_memory::InMemoryBackend;
 pub use index::{Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page};
-#[cfg(feature = "libsql")]
 pub use libsql::LibSqlRootFilesystem;
 pub use local::DiskFilesystem;
-#[cfg(feature = "postgres")]
 pub use postgres::PostgresRootFilesystem;
 pub use record::{
     CasExpectation, ContentType, Entry, RecordKind, RecordVersion, SeqNo, VersionedEntry,

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -12,7 +12,6 @@ use crate::db::{
     record_version_from_i64, record_version_to_i64, sql_index_name, system_time_from_unix_seconds,
     virtual_path_prefixes,
 };
-#[cfg(feature = "libsql")]
 use crate::libsql_pool::{LibSqlPool, PooledLibSqlConnection, build_libsql_pool};
 use crate::vector::{cosine_similarity, decode_embedding_blob};
 use crate::{
@@ -20,26 +19,18 @@ use crate::{
     FileType, FilesystemError, FilesystemOperation, Filter, IndexKey, IndexKind, IndexSpec,
     IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, SeqNo, VersionedEntry,
 };
-
-#[cfg(feature = "libsql")]
 /// libSQL-backed [`RootFilesystem`] storing file contents by virtual path.
 pub struct LibSqlRootFilesystem {
     pool: LibSqlPool,
 }
-
-#[cfg(feature = "libsql")]
 const LIBSQL_CHILD_ENTRIES_SQL: &str = "SELECT path, length(contents), is_dir \
     FROM root_filesystem_entries \
     WHERE path >= ?1 AND path < ?2 \
     ORDER BY path";
-
-#[cfg(feature = "libsql")]
 const LIBSQL_HAS_CHILD_ENTRY_SQL: &str = "SELECT 1 \
     FROM root_filesystem_entries \
     WHERE path >= ?1 AND path < ?2 \
     LIMIT 1";
-
-#[cfg(feature = "libsql")]
 impl LibSqlRootFilesystem {
     pub fn new(db: Arc<libsql::Database>) -> Self {
         Self {
@@ -124,8 +115,6 @@ impl LibSqlRootFilesystem {
         })
     }
 }
-
-#[cfg(feature = "libsql")]
 #[async_trait]
 impl RootFilesystem for LibSqlRootFilesystem {
     fn capabilities(&self) -> BackendCapabilities {
@@ -1110,8 +1099,6 @@ impl RootFilesystem for LibSqlRootFilesystem {
         }
     }
 }
-
-#[cfg(feature = "libsql")]
 async fn put_libsql_inner(
     conn: &libsql::Connection,
     path: &VirtualPath,
@@ -1246,8 +1233,6 @@ async fn put_libsql_inner(
         }
     }
 }
-
-#[cfg(feature = "libsql")]
 async fn create_dir_all_libsql_inner(
     conn: &libsql::Connection,
     path: &VirtualPath,
@@ -1289,8 +1274,6 @@ async fn create_dir_all_libsql_inner(
     }
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 async fn exact_entry_libsql(
     conn: &libsql::Connection,
     path: &VirtualPath,
@@ -1328,8 +1311,6 @@ async fn exact_entry_libsql(
         system_time_from_unix_seconds(updated_at_epoch),
     )))
 }
-
-#[cfg(feature = "libsql")]
 async fn has_child_entry_libsql(
     conn: &libsql::Connection,
     parent: &VirtualPath,
@@ -1348,8 +1329,6 @@ async fn has_child_entry_libsql(
         .map_err(|error| libsql_db_error(parent.clone(), FilesystemOperation::Stat, error))?
         .is_some())
 }
-
-#[cfg(feature = "libsql")]
 async fn current_version_libsql(
     conn: &libsql::Connection,
     path: &VirtualPath,
@@ -1380,7 +1359,6 @@ async fn current_version_libsql(
 /// Running both statements on the same connection inside the same
 /// transaction is what makes the classification atomic: nothing else can
 /// delete-then-recreate the row between the DELETE and the diagnosis read.
-#[cfg(feature = "libsql")]
 async fn delete_if_version_libsql_inner(
     conn: &libsql::Connection,
     path: &VirtualPath,
@@ -1413,7 +1391,6 @@ async fn delete_if_version_libsql_inner(
 
 /// Body of `run_migrations` extracted so the outer caller can wrap the
 /// whole sequence in BEGIN IMMEDIATE / COMMIT with one rollback path.
-#[cfg(feature = "libsql")]
 async fn run_libsql_migrations_inner(conn: &libsql::Connection) -> Result<(), FilesystemError> {
     conn.execute_batch(LIBSQL_ROOT_FILESYSTEM_SCHEMA)
         .await
@@ -1425,8 +1402,6 @@ async fn run_libsql_migrations_inner(conn: &libsql::Connection) -> Result<(), Fi
     ensure_libsql_sequences_table(conn).await?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 async fn ensure_libsql_root_is_dir_column(
     conn: &libsql::Connection,
 ) -> Result<(), FilesystemError> {
@@ -1453,8 +1428,6 @@ async fn ensure_libsql_root_is_dir_column(
     .map_err(|error| infrastructure_libsql_error(FilesystemOperation::CreateDirAll, error))?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 impl LibSqlRootFilesystem {
     async fn exact_entry(
         &self,
@@ -1727,8 +1700,6 @@ impl LibSqlRootFilesystem {
         Ok(out)
     }
 }
-
-#[cfg(feature = "libsql")]
 fn build_entry(
     path: &VirtualPath,
     body: Vec<u8>,
@@ -1756,8 +1727,6 @@ fn build_entry(
         indexed,
     })
 }
-
-#[cfg(feature = "libsql")]
 async fn ensure_libsql_records_columns(conn: &libsql::Connection) -> Result<(), FilesystemError> {
     add_column_if_missing(
         conn,
@@ -1785,32 +1754,24 @@ async fn ensure_libsql_records_columns(conn: &libsql::Connection) -> Result<(), 
     .await?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 async fn ensure_libsql_index_specs_table(conn: &libsql::Connection) -> Result<(), FilesystemError> {
     conn.execute_batch(LIBSQL_INDEX_SPECS_SCHEMA)
         .await
         .map_err(|error| infrastructure_libsql_error(FilesystemOperation::EnsureIndex, error))?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 async fn ensure_libsql_events_table(conn: &libsql::Connection) -> Result<(), FilesystemError> {
     conn.execute_batch(LIBSQL_EVENTS_SCHEMA)
         .await
         .map_err(|error| infrastructure_libsql_error(FilesystemOperation::Append, error))?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 async fn ensure_libsql_sequences_table(conn: &libsql::Connection) -> Result<(), FilesystemError> {
     conn.execute_batch(LIBSQL_SEQUENCES_SCHEMA)
         .await
         .map_err(|error| infrastructure_libsql_error(FilesystemOperation::ReserveSeq, error))?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 fn seq_no_from_i64(
     path: &VirtualPath,
     raw: i64,
@@ -1834,7 +1795,6 @@ fn seq_no_from_i64(
 /// produces a non-empty fragment — `Filter::All` becomes the literal
 /// `TRUE`, empty `And` becomes `TRUE`, empty `Or` becomes `FALSE`. This
 /// matches the in-memory backend's `all`/`any` semantics.
-#[cfg(feature = "libsql")]
 fn translate_filter(
     path: &VirtualPath,
     filter: &Filter,
@@ -1934,8 +1894,6 @@ fn translate_filter(
         }
     }
 }
-
-#[cfg(feature = "libsql")]
 fn translate_compound(
     path: &VirtualPath,
     children: &[Filter],
@@ -1962,8 +1920,6 @@ fn translate_compound(
     out.push(')');
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 fn collect_fts_keys(filter: &Filter, out: &mut Vec<String>) {
     match filter {
         Filter::Fts { key, .. } => {
@@ -1984,7 +1940,6 @@ fn collect_fts_keys(filter: &Filter, out: &mut Vec<String>) {
 /// All ancestor paths of `path`, **most specific first**, ending at `/`.
 /// Used to find an FTS index declared on a higher prefix that should still
 /// cover descendant queries.
-#[cfg(feature = "libsql")]
 fn ancestor_prefixes(path: &str) -> Vec<String> {
     let mut out = vec![path.trim_end_matches('/').to_string()];
     let mut cur = path.trim_end_matches('/').to_string();
@@ -1998,8 +1953,6 @@ fn ancestor_prefixes(path: &str) -> Vec<String> {
     }
     out
 }
-
-#[cfg(feature = "libsql")]
 fn bind_index_value(
     path: &VirtualPath,
     value: &IndexValue,
@@ -2029,7 +1982,6 @@ fn bind_index_value(
 /// JSON booleans rather than `"boolean"`, so the bool guard checks for
 /// either. A prior version emitted `= 'integer'` for `IndexValue::Bool`,
 /// which never matched a stored boolean and silently dropped every row.
-#[cfg(feature = "libsql")]
 fn index_value_json_type_guard(key: &IndexKey, value: &IndexValue) -> String {
     let key = key.as_str();
     match value {
@@ -2043,8 +1995,6 @@ fn index_value_json_type_guard(key: &IndexKey, value: &IndexValue) -> String {
         IndexValue::Bytes(_) => format!("json_type(indexed, '$.{key}') = 'text'"),
     }
 }
-
-#[cfg(feature = "libsql")]
 async fn add_column_if_missing(
     conn: &libsql::Connection,
     column: &str,
@@ -2070,8 +2020,6 @@ async fn add_column_if_missing(
         .map_err(|error| infrastructure_libsql_error(FilesystemOperation::CreateDirAll, error))?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 const LIBSQL_ROOT_FILESYSTEM_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS root_filesystem_entries (
     path TEXT PRIMARY KEY,
@@ -2083,8 +2031,6 @@ CREATE TABLE IF NOT EXISTS root_filesystem_entries (
 -- The PRIMARY KEY on `path` already provides a unique index for equality
 -- lookups, so no separate index is created.
 "#;
-
-#[cfg(feature = "libsql")]
 const LIBSQL_INDEX_SPECS_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS root_filesystem_index_specs (
     prefix TEXT NOT NULL,
@@ -2094,8 +2040,6 @@ CREATE TABLE IF NOT EXISTS root_filesystem_index_specs (
     PRIMARY KEY (prefix, name)
 );
 "#;
-
-#[cfg(feature = "libsql")]
 const LIBSQL_EVENTS_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS root_filesystem_events (
     seq INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2106,8 +2050,6 @@ CREATE TABLE IF NOT EXISTS root_filesystem_events (
 CREATE INDEX IF NOT EXISTS idx_root_filesystem_events_path_seq
     ON root_filesystem_events(path, seq);
 "#;
-
-#[cfg(feature = "libsql")]
 const LIBSQL_SEQUENCES_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS root_filesystem_sequences (
     path TEXT PRIMARY KEY,

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1,5 +1,4 @@
 use std::{collections::BTreeMap, error::Error, time::Duration};
-#[cfg(feature = "postgres")]
 use std::{collections::HashSet, sync::OnceLock};
 
 use async_trait::async_trait;
@@ -19,29 +18,18 @@ use crate::{
     IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, SeqNo, TxnCapability,
     VersionedEntry,
 };
-
-#[cfg(feature = "postgres")]
 /// PostgreSQL-backed [`RootFilesystem`] storing file contents by virtual path.
 pub struct PostgresRootFilesystem {
     pool: deadpool_postgres::Pool,
 }
-
-#[cfg(feature = "postgres")]
 const POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV: &str =
     "IRONCLAW_FILESYSTEM_POSTGRES_MIGRATION_CONNECT_MAX_WAIT_SECS";
-#[cfg(feature = "postgres")]
 const POSTGRES_MIGRATION_CONNECT_DEFAULT_MAX_WAIT: Duration = Duration::from_secs(300);
-#[cfg(feature = "postgres")]
 const POSTGRES_MIGRATION_CONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
-#[cfg(feature = "postgres")]
 const POSTGRES_MIGRATION_CONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
-#[cfg(feature = "postgres")]
 const POSTGRES_ROOT_FILESYSTEM_MIGRATION_ADVISORY_LOCK: i64 = 824_917_203;
-#[cfg(feature = "postgres")]
 static POSTGRES_ROOT_FILESYSTEM_MIGRATED_SCHEMAS: OnceLock<tokio::sync::Mutex<HashSet<String>>> =
     OnceLock::new();
-
-#[cfg(feature = "postgres")]
 impl PostgresRootFilesystem {
     pub fn new(pool: deadpool_postgres::Pool) -> Self {
         Self { pool }
@@ -127,8 +115,6 @@ impl PostgresRootFilesystem {
         })
     }
 }
-
-#[cfg(feature = "postgres")]
 async fn drop_legacy_projection_indexes(
     transaction: &tokio_postgres::Transaction<'_>,
 ) -> Result<(), FilesystemError> {
@@ -155,13 +141,9 @@ async fn drop_legacy_projection_indexes(
     }
     Ok(())
 }
-
-#[cfg(feature = "postgres")]
 fn quote_postgres_identifier(identifier: &str) -> String {
     format!("\"{}\"", identifier.replace('"', "\"\""))
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_root_filesystem_migration_key(
     client: &deadpool_postgres::Object,
 ) -> Result<String, FilesystemError> {
@@ -190,15 +172,11 @@ async fn postgres_root_filesystem_migration_key(
         "{host}:{port}/{database}/{schema}@{postmaster_started_at}"
     ))
 }
-
-#[cfg(feature = "postgres")]
 fn postgres_migration_connect_backoff(attempt: u32) -> Duration {
     POSTGRES_MIGRATION_CONNECT_INITIAL_BACKOFF
         .saturating_mul(2u32.saturating_pow(attempt.min(16)))
         .min(POSTGRES_MIGRATION_CONNECT_MAX_BACKOFF)
 }
-
-#[cfg(feature = "postgres")]
 fn postgres_migration_connect_max_wait() -> Result<Duration, FilesystemError> {
     match std::env::var(POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV) {
         Ok(raw) => {
@@ -228,8 +206,6 @@ fn postgres_migration_connect_max_wait() -> Result<Duration, FilesystemError> {
         }),
     }
 }
-
-#[cfg(feature = "postgres")]
 fn format_error_chain(error: &(dyn Error + 'static)) -> String {
     let mut reason = error.to_string();
     let mut source = error.source();
@@ -240,8 +216,6 @@ fn format_error_chain(error: &(dyn Error + 'static)) -> String {
     }
     reason
 }
-
-#[cfg(feature = "postgres")]
 #[async_trait]
 impl RootFilesystem for PostgresRootFilesystem {
     fn capabilities(&self) -> BackendCapabilities {
@@ -909,8 +883,6 @@ impl RootFilesystem for PostgresRootFilesystem {
         Ok(())
     }
 }
-
-#[cfg(feature = "postgres")]
 impl PostgresRootFilesystem {
     async fn exact_entry_with_client(
         &self,
@@ -1082,15 +1054,11 @@ impl PostgresRootFilesystem {
         Ok(out)
     }
 }
-
-#[cfg(feature = "postgres")]
 struct PostgresStorageTxn {
     client: Option<deadpool_postgres::Object>,
     prefix: VirtualPath,
     active: bool,
 }
-
-#[cfg(feature = "postgres")]
 impl PostgresStorageTxn {
     fn client(&self) -> Result<&deadpool_postgres::Object, FilesystemError> {
         self.client
@@ -1110,8 +1078,6 @@ impl PostgresStorageTxn {
         }
     }
 }
-
-#[cfg(feature = "postgres")]
 #[async_trait]
 impl StorageTxn for PostgresStorageTxn {
     async fn put(
@@ -1168,8 +1134,6 @@ impl StorageTxn for PostgresStorageTxn {
         }
     }
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_reserve_sequence_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1191,8 +1155,6 @@ async fn postgres_reserve_sequence_with_client(
     let reserved: i64 = row.get("reserved");
     seq_no_from_i64(path, reserved, FilesystemOperation::ReserveSeq)
 }
-
-#[cfg(feature = "postgres")]
 impl Drop for PostgresStorageTxn {
     fn drop(&mut self) {
         if !self.active {
@@ -1221,7 +1183,6 @@ impl Drop for PostgresStorageTxn {
 /// at the call site. Index DDL remains uncached. The error type stays
 /// `tokio_postgres::Error` so existing `db_error` mapping at call sites is
 /// unchanged.
-#[cfg(feature = "postgres")]
 async fn cached_query_opt(
     client: &deadpool_postgres::Object,
     sql: &str,
@@ -1230,8 +1191,6 @@ async fn cached_query_opt(
     let statement = client.prepare_cached(sql).await?;
     client.query_opt(&statement, params).await
 }
-
-#[cfg(feature = "postgres")]
 async fn cached_query(
     client: &deadpool_postgres::Object,
     sql: &str,
@@ -1240,8 +1199,6 @@ async fn cached_query(
     let statement = client.prepare_cached(sql).await?;
     client.query(&statement, params).await
 }
-
-#[cfg(feature = "postgres")]
 async fn cached_query_one(
     client: &deadpool_postgres::Object,
     sql: &str,
@@ -1250,8 +1207,6 @@ async fn cached_query_one(
     let statement = client.prepare_cached(sql).await?;
     client.query_one(&statement, params).await
 }
-
-#[cfg(feature = "postgres")]
 async fn cached_execute(
     client: &deadpool_postgres::Object,
     sql: &str,
@@ -1264,7 +1219,6 @@ async fn cached_execute(
 /// `CasExpectation::Absent` put: insert iff `path` is not an implicit directory
 /// (no descendant in the half-open `[prefix/, prefix0)` range); the `ON CONFLICT
 /// DO NOTHING` also blocks an explicit directory or existing file at `path`.
-#[cfg(feature = "postgres")]
 const PUT_ABSENT_SQL: &str = r#"
     INSERT INTO root_filesystem_entries
         (path, contents, is_dir, content_type, kind, indexed, version)
@@ -1280,7 +1234,6 @@ const PUT_ABSENT_SQL: &str = r#"
 /// `CasExpectation::Version` put: update the file row at the expected version,
 /// rejecting an explicit directory (`is_dir = FALSE`) and — for parity with the
 /// insert arms — any implicit-directory descendant.
-#[cfg(feature = "postgres")]
 const PUT_VERSION_SQL: &str = r#"
     UPDATE root_filesystem_entries
     SET contents = $1,
@@ -1300,7 +1253,6 @@ const PUT_VERSION_SQL: &str = r#"
 /// `CasExpectation::Any` put: upsert unless a descendant makes `path` an
 /// implicit directory; the `ON CONFLICT` guard rejects an explicit directory.
 /// `RETURNING version` removes the separate version read-back.
-#[cfg(feature = "postgres")]
 const PUT_ANY_SQL: &str = r#"
     INSERT INTO root_filesystem_entries
         (path, contents, is_dir, content_type, kind, indexed, version)
@@ -1339,7 +1291,6 @@ const PUT_ANY_SQL: &str = r#"
 /// version) to reproduce the exact error the old pre-check and version read
 /// would have produced: `directory_write_error` for a directory conflict,
 /// `VersionMismatch` otherwise. The happy path never pays for it.
-#[cfg(feature = "postgres")]
 async fn postgres_put_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1471,7 +1422,6 @@ async fn postgres_put_with_client(
 /// pre-existing (the old 3-read pre-check had a wider window) and tracked
 /// separately — see `put_statements_are_single_round_trip` for the boundary of
 /// what the single-statement guard does and does not guarantee.
-#[cfg(feature = "postgres")]
 async fn diagnose_put_failure(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1489,8 +1439,6 @@ async fn diagnose_put_failure(
         found,
     })
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_get_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1525,8 +1473,6 @@ async fn postgres_get_with_client(
         version: record_version_from_i64(path, version_raw)?,
     }))
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_stat_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1593,8 +1539,6 @@ async fn postgres_stat_with_client(
         sensitive: false,
     })
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_delete_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1658,7 +1602,6 @@ async fn postgres_delete_with_client(
 /// relies on `created_at` being immutable after row creation; if a future
 /// writer mutates it on update, replacement detection would classify that
 /// update as a new incarnation.
-#[cfg(feature = "postgres")]
 const DELETE_IF_VERSION_ATOMIC_SQL: &str = r#"
     WITH candidate AS MATERIALIZED (
         SELECT version, created_at
@@ -1728,7 +1671,6 @@ const DELETE_IF_VERSION_ATOMIC_SQL: &str = r#"
 /// `diagnose_put_failure` / `postgres_current_version_with_client` are
 /// deliberately not reused here: reusing them would require a second
 /// statement, reopening the race this fix closes.
-#[cfg(feature = "postgres")]
 async fn postgres_delete_if_version_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1760,8 +1702,6 @@ async fn postgres_delete_if_version_with_client(
     }
     Err(not_found(path.clone(), FilesystemOperation::Delete))
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_current_version_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1785,7 +1725,6 @@ async fn postgres_current_version_with_client(
 /// Used only on the rare CAS-put failure path. Selects the `is_dir` flag alone
 /// and never reads `OCTET_LENGTH(contents)`, so it does not touch the
 /// (potentially TOAST'd) body to answer a question that only needs one boolean.
-#[cfg(feature = "postgres")]
 async fn postgres_is_dir_with_client(
     client: &deadpool_postgres::Object,
     path: &VirtualPath,
@@ -1799,8 +1738,6 @@ async fn postgres_is_dir_with_client(
     .map_err(|error| db_error(path.clone(), FilesystemOperation::Stat, error))?;
     Ok(row.is_some_and(|row| row.get::<_, bool>("is_dir")))
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_has_child_entry_with_client(
     client: &deadpool_postgres::Object,
     parent: &VirtualPath,
@@ -1815,8 +1752,6 @@ async fn postgres_has_child_entry_with_client(
     .map_err(|error| db_error(parent.clone(), FilesystemOperation::Stat, error))?;
     Ok(row.is_some())
 }
-
-#[cfg(feature = "postgres")]
 fn descendant_path_range(path: &VirtualPath) -> (String, String) {
     let prefix = path.as_str().trim_end_matches('/');
     // Descendants share the literal "{prefix}/" component boundary. The
@@ -1824,8 +1759,6 @@ fn descendant_path_range(path: &VirtualPath) -> (String, String) {
     // in the normalized virtual path alphabet used by these storage paths.
     (format!("{prefix}/"), format!("{prefix}0"))
 }
-
-#[cfg(feature = "postgres")]
 fn postgres_shared_projection_index_name(spec: &IndexSpec) -> String {
     let kind = match &spec.kind {
         IndexKind::Exact => "exact",
@@ -1839,8 +1772,6 @@ fn postgres_shared_projection_index_name(spec: &IndexSpec) -> String {
     }
     sql_index_name(&format!("/shared/{kind}/{keys}"), spec.name.as_str())
 }
-
-#[cfg(feature = "postgres")]
 fn postgres_projection_index_component(value: &str) -> String {
     format!("{}:{value}", value.len())
 }
@@ -1853,7 +1784,6 @@ fn postgres_projection_index_component(value: &str) -> String {
 ///   `FALSE` (matching in-memory `all`/`any` semantics).
 /// - `Filter::Range` on `IndexValue::I64` bounds casts both sides to
 ///   `BIGINT` so the comparison is numeric, not lexicographic on text.
-#[cfg(feature = "postgres")]
 fn translate_filter(
     path: &VirtualPath,
     filter: &Filter,
@@ -1958,8 +1888,6 @@ fn translate_filter(
         Filter::Or(children) => translate_compound(path, children, " OR ", "FALSE", out, params),
     }
 }
-
-#[cfg(feature = "postgres")]
 fn translate_compound(
     path: &VirtualPath,
     children: &[Filter],
@@ -1987,7 +1915,6 @@ fn translate_compound(
 /// Used to guard `Filter::Range` so cross-variant stored values are filtered
 /// out before any cast/comparison (PR #3659 review fix). Postgres returns:
 /// `"string"` / `"number"` / `"boolean"` / `"null"` / `"object"` / `"array"`.
-#[cfg(feature = "postgres")]
 fn index_value_jsonb_typeof(value: &IndexValue) -> &'static str {
     match value {
         IndexValue::Text(_) | IndexValue::Bytes(_) => "string",
@@ -1995,8 +1922,6 @@ fn index_value_jsonb_typeof(value: &IndexValue) -> &'static str {
         IndexValue::Bool(_) => "boolean",
     }
 }
-
-#[cfg(feature = "postgres")]
 fn bind_index_value(
     path: &VirtualPath,
     value: &IndexValue,
@@ -2024,8 +1949,6 @@ fn bind_index_value(
     params.push(bound);
     Ok(params.len())
 }
-
-#[cfg(feature = "postgres")]
 fn build_entry(
     path: &VirtualPath,
     body: Vec<u8>,
@@ -2053,8 +1976,6 @@ fn build_entry(
         indexed,
     })
 }
-
-#[cfg(feature = "postgres")]
 fn seq_no_from_i64(
     path: &VirtualPath,
     raw: i64,
@@ -2068,8 +1989,6 @@ fn seq_no_from_i64(
             reason: format!("event seq {raw} is not representable"),
         })
 }
-
-#[cfg(feature = "postgres")]
 fn backend_error(
     path: VirtualPath,
     operation: FilesystemOperation,
@@ -2081,8 +2000,6 @@ fn backend_error(
         reason: reason.into(),
     }
 }
-
-#[cfg(feature = "postgres")]
 const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = concat!(
     include_str!("../../../migrations/V26__root_filesystem_entries.sql"),
     "\n",
@@ -2099,7 +2016,7 @@ const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = concat!(
     include_str!("../../../migrations/V32__root_filesystem_sequences.sql"),
 );
 
-#[cfg(all(test, feature = "postgres"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/ironclaw_filesystem/tests/concurrent_cas_storm.rs
+++ b/crates/ironclaw_filesystem/tests/concurrent_cas_storm.rs
@@ -195,8 +195,6 @@ async fn in_memory_concurrent_delete_if_version_storm_has_exactly_one_winner_per
     let fs = Arc::new(scoped(Arc::new(InMemoryBackend::new()), "/engine/counters"));
     run_delete_storm(fs).await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn libsql_concurrent_cas_storm_has_no_errors_or_lost_updates() {
     let dir = tempfile::tempdir().unwrap();
@@ -207,8 +205,6 @@ async fn libsql_concurrent_cas_storm_has_no_errors_or_lost_updates() {
     let fs = Arc::new(scoped(root, "/engine/counters"));
     run_storm(fs).await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn libsql_concurrent_delete_if_version_storm_has_exactly_one_winner_per_round() {
     let dir = tempfile::tempdir().unwrap();
@@ -225,7 +221,6 @@ async fn libsql_concurrent_delete_if_version_storm_has_exactly_one_winner_per_ro
 /// `db_root_filesystem_contract.rs`'s skip-when-unreachable pattern so
 /// environments without Postgres pass vacuously rather than failing CI on
 /// infrastructure this test doesn't own.
-#[cfg(feature = "postgres")]
 async fn connect_postgres_for_storm() -> Option<Arc<ironclaw_filesystem::PostgresRootFilesystem>> {
     if std::env::var("IRONCLAW_SKIP_POSTGRES_TESTS").is_ok() {
         return None;
@@ -245,8 +240,6 @@ async fn connect_postgres_for_storm() -> Option<Arc<ironclaw_filesystem::Postgre
     }
     Some(root)
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn postgres_concurrent_cas_storm_has_no_errors_or_lost_updates() {
     let Some(root) = connect_postgres_for_storm().await else {
@@ -258,8 +251,6 @@ async fn postgres_concurrent_cas_storm_has_no_errors_or_lost_updates() {
     let fs = Arc::new(scoped(root, &target));
     run_storm(fs).await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn postgres_concurrent_delete_if_version_storm_has_exactly_one_winner_per_round() {
     let Some(root) = connect_postgres_for_storm().await else {

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1,19 +1,11 @@
-#![cfg(any(feature = "libsql", feature = "postgres"))]
-
 use ironclaw_filesystem::RootFilesystem;
-
-#[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
-#[cfg(feature = "libsql")]
 use ironclaw_filesystem::{
     Capability, CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, Filter,
     IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, LibSqlRootFilesystem, Page, RecordKind,
     SeqNo,
 };
-#[cfg(feature = "libsql")]
 use ironclaw_host_api::VirtualPath;
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_reads_writes_and_stats_files() {
     let filesystem = libsql_root().await;
@@ -29,8 +21,6 @@ async fn libsql_root_filesystem_reads_writes_and_stats_files() {
     assert!(stat.modified.is_some());
     assert!(!stat.sensitive);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_lists_direct_children_sorted_with_virtual_paths() {
     let filesystem = libsql_root().await;
@@ -75,8 +65,6 @@ async fn libsql_root_filesystem_lists_direct_children_sorted_with_virtual_paths(
     );
     assert_eq!(entries[1].file_type, FileType::Directory);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_appends_deletes_and_creates_directories() {
     let filesystem = libsql_root().await;
@@ -113,8 +101,6 @@ async fn libsql_root_filesystem_appends_deletes_and_creates_directories() {
         }
     ));
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_overwrites_existing_file() {
     let filesystem = libsql_root().await;
@@ -126,8 +112,6 @@ async fn libsql_root_filesystem_overwrites_existing_file() {
     assert_eq!(filesystem.read_file(&path).await.unwrap(), b"second");
     assert_eq!(filesystem.stat(&path).await.unwrap().len, 6);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_write_file_rejects_existing_directory() {
     let filesystem = libsql_root().await;
@@ -151,8 +135,6 @@ async fn libsql_root_filesystem_write_file_rejects_existing_directory() {
     );
     assert_eq!(filesystem.read_file(&child).await.unwrap(), b"one\n");
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_write_file_rejects_implicit_directory() {
     let filesystem = libsql_root().await;
@@ -175,8 +157,6 @@ async fn libsql_root_filesystem_write_file_rejects_implicit_directory() {
     );
     assert_eq!(filesystem.read_file(&child).await.unwrap(), b"child");
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_append_file_rejects_implicit_directory() {
     let filesystem = libsql_root().await;
@@ -202,8 +182,6 @@ async fn libsql_root_filesystem_append_file_rejects_implicit_directory() {
     );
     assert_eq!(filesystem.read_file(&child).await.unwrap(), b"child");
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_fails_closed_for_missing_paths_without_host_paths() {
     let filesystem = libsql_root().await;
@@ -222,15 +200,11 @@ async fn libsql_root_filesystem_fails_closed_for_missing_paths_without_host_path
     assert!(!display.contains("/tmp"));
     assert!(!display.contains(".db"));
 }
-
-#[cfg(feature = "postgres")]
 #[test]
 fn postgres_root_filesystem_implements_root_filesystem_contract() {
     fn assert_root<T: RootFilesystem>() {}
     assert_root::<PostgresRootFilesystem>();
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_root_filesystem_migration_failure_surfaces_infrastructure_variant() {
     // Audit finding F1: backend connect/migration paths used to wrap
@@ -294,8 +268,6 @@ async fn libsql_root_filesystem_migration_failure_surfaces_infrastructure_varian
         "infrastructure error must not fabricate a virtual path: {display}"
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_page_offset_overflow_surfaces_typed_error() {
     // Audit finding F6: `page.offset as i64` previously truncate-wrapped
@@ -330,14 +302,10 @@ async fn libsql_query_page_offset_overflow_surfaces_typed_error() {
         other => panic!("expected Backend error, got {other:?}"),
     }
 }
-
-#[cfg(feature = "libsql")]
 struct TestLibSqlRootFilesystem {
     filesystem: LibSqlRootFilesystem,
     _dir: tempfile::TempDir,
 }
-
-#[cfg(feature = "libsql")]
 impl std::ops::Deref for TestLibSqlRootFilesystem {
     type Target = LibSqlRootFilesystem;
 
@@ -345,8 +313,6 @@ impl std::ops::Deref for TestLibSqlRootFilesystem {
         &self.filesystem
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_native_put_get_round_trip_with_record_metadata() {
     let filesystem = libsql_root().await;
@@ -377,8 +343,6 @@ async fn libsql_native_put_get_round_trip_with_record_metadata() {
     assert!(got.entry.indexed.contains_key(&scope_key));
     assert!(got.entry.indexed.contains_key(&status_key));
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_native_put_cas_absent_rejects_existing_path() {
     let filesystem = libsql_root().await;
@@ -393,8 +357,6 @@ async fn libsql_native_put_cas_absent_rejects_existing_path() {
         .unwrap_err();
     assert!(matches!(err, FilesystemError::VersionMismatch { .. }));
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_native_put_cas_version_advances_and_rejects_stale() {
     let filesystem = libsql_root().await;
@@ -421,7 +383,6 @@ async fn libsql_native_put_cas_version_advances_and_rejects_stale() {
 /// closed with `found: None` rather than panicking or reporting a stale
 /// version, so callers can distinguish "never written" from "someone
 /// else won the race" on the version-mismatch error.
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_native_put_cas_version_on_missing_path_reports_no_found_version() {
     let filesystem = libsql_root().await;
@@ -444,8 +405,6 @@ async fn libsql_native_put_cas_version_on_missing_path_reports_no_found_version(
         other => panic!("expected VersionMismatch, got: {other:?}"),
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_delete_if_version_deletes_current_and_rejects_stale_or_missing() {
     let filesystem = libsql_root().await;
@@ -506,7 +465,6 @@ async fn libsql_delete_if_version_deletes_current_and_rejects_stale_or_missing()
 /// than being silently truncated into a bind parameter that could never
 /// match — and the guard must fire before any DELETE runs, so the entry
 /// survives untouched.
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_delete_if_version_rejects_out_of_range_expected_version() {
     let filesystem = libsql_root().await;
@@ -540,7 +498,6 @@ async fn libsql_delete_if_version_rejects_out_of_range_expected_version() {
 /// future change to libSQL's version-assignment (e.g. a sequence that
 /// doesn't reset) can't silently invalidate the trait doc's warning for
 /// this backend without a test noticing.
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_delete_if_version_is_vulnerable_to_aba_across_delete_recreate_cycles() {
     let filesystem = libsql_root().await;
@@ -578,7 +535,6 @@ async fn libsql_delete_if_version_is_vulnerable_to_aba_across_delete_recreate_cy
 /// `libsql_put_rejects_existing_directory`-style tests already pin for
 /// `put`. A directory-only path must diagnose as `NotFound` (no file-plane
 /// row at that path), never match/delete the directory row.
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_delete_if_version_excludes_explicit_directory_row() {
     let filesystem = libsql_root().await;
@@ -601,8 +557,6 @@ async fn libsql_delete_if_version_excludes_explicit_directory_row() {
          (is_dir = TRUE), got: {err:?}"
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_native_put_cas_any_increments_existing_version() {
     let filesystem = libsql_root().await;
@@ -620,16 +574,12 @@ async fn libsql_native_put_cas_any_increments_existing_version() {
     assert_eq!(got.version, v2);
     assert_eq!(got.entry.body, vec![2]);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_get_returns_none_for_missing_path() {
     let filesystem = libsql_root().await;
     let path = VirtualPath::new("/secrets/leases/missing").unwrap();
     assert!(filesystem.get(&path).await.unwrap().is_none());
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_write_file_after_put_resets_record_metadata_and_bumps_version() {
     // PR #3660 reviewer fix: legacy write_file/append_file used to update
@@ -661,8 +611,6 @@ async fn libsql_write_file_after_put_resets_record_metadata_and_bumps_version() 
     assert_eq!(got.entry.body, b"opaque");
     assert!(got.version > v1);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_ensure_index_is_idempotent_and_conflict_aware() {
     let filesystem = libsql_root().await;
@@ -685,8 +633,6 @@ async fn libsql_ensure_index_is_idempotent_and_conflict_aware() {
         .unwrap_err();
     assert!(matches!(err, FilesystemError::IndexConflict { .. }));
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_ensure_index_accepts_fts_kind_and_filter_matches_text() {
     // FTS5 vtable + sync triggers are created at declaration time, and
@@ -736,8 +682,6 @@ async fn libsql_ensure_index_accepts_fts_kind_and_filter_matches_text() {
         .unwrap();
     assert_eq!(results.len(), 2);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_fts_filter_picks_up_inserts_through_triggers() {
     // After ensure_index, inserting a new row through put() updates the
@@ -779,8 +723,6 @@ async fn libsql_fts_filter_picks_up_inserts_through_triggers() {
         .unwrap();
     assert_eq!(results.len(), 1);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_ensure_index_fts_rejects_path_with_sql_metacharacters() {
     // Regression: the FTS5 sync triggers splice the mount-prefix path
@@ -815,8 +757,6 @@ async fn libsql_ensure_index_fts_rejects_path_with_sql_metacharacters() {
         other => panic!("expected Backend error, got: {other:?}"),
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_vector_index_round_trips_and_ranks_by_cosine() {
     // IndexKind::Vector is accepted at declaration; storage shape is
@@ -884,8 +824,6 @@ async fn libsql_vector_index_round_trips_and_ranks_by_cosine() {
         Some(&IndexValue::Bytes(blob(&[1.0, 0.0, 0.0])))
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_filters_on_indexed_projection() {
     let filesystem = libsql_root().await;
@@ -956,8 +894,6 @@ async fn libsql_query_filters_on_indexed_projection() {
         .count();
     assert_eq!(acme_active_count, 2);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_prefix_filter_matches_text_prefix() {
     let filesystem = libsql_root().await;
@@ -996,8 +932,6 @@ async fn libsql_query_prefix_filter_matches_text_prefix() {
         .unwrap();
     assert_eq!(results.len(), 2);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_or_empty_matches_nothing_and_all_matches_every_row() {
     // PR #3661 reviewer fix: empty `Or` was returning every row instead
@@ -1053,8 +987,6 @@ async fn libsql_query_or_empty_matches_nothing_and_all_matches_every_row() {
         .unwrap();
     assert_eq!(and_all.len(), 2);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_prefix_filter_literal_percent_is_not_a_wildcard() {
     // PR #3661 reviewer fix: a literal prefix containing `%` was being
@@ -1097,8 +1029,6 @@ async fn libsql_query_prefix_filter_literal_percent_is_not_a_wildcard() {
         .unwrap();
     assert_eq!(results.len(), 1);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_range_on_bool_finds_matching_rows() {
     // Regression test for the libSQL Range/Bool bug: SQLite's `json_type`
@@ -1161,8 +1091,6 @@ async fn libsql_query_range_on_bool_finds_matching_rows() {
         .unwrap();
     assert_eq!(only_true.len(), 1);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_range_rejects_mixed_variant_bounds() {
     // Mixed-variant bounds (e.g. I64 lo + Text hi) used to silently fall
@@ -1195,8 +1123,6 @@ async fn libsql_query_range_rejects_mixed_variant_bounds() {
         "expected Unsupported for mixed-variant Range bounds, got {err:?}"
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_vector_nearest_stable_tie_break_on_equal_cosine() {
     // Regression test for the tie-breaker fix: equal-cosine candidates
@@ -1265,8 +1191,6 @@ async fn libsql_vector_nearest_stable_tie_break_on_equal_cosine() {
     assert_eq!(top_two[0].path.as_str(), "/memory/tie_break/aa");
     assert_eq!(top_two[1].path.as_str(), "/memory/tie_break/mm");
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_query_paginates_results() {
     let filesystem = libsql_root().await;
@@ -1315,8 +1239,6 @@ async fn libsql_query_paginates_results() {
         assert!(!first.iter().any(|f| f.entry.body == entry.entry.body));
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_append_and_tail_assigns_monotonic_seqno() {
     let filesystem = libsql_root().await;
@@ -1346,8 +1268,6 @@ async fn libsql_append_and_tail_assigns_monotonic_seqno() {
     let from_last = filesystem.tail(&log, s3).await.unwrap();
     assert!(from_last.is_empty());
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_append_batch_is_one_statement_with_contiguous_ordered_seqs() {
     let filesystem = libsql_root().await;
@@ -1386,8 +1306,6 @@ async fn libsql_append_batch_is_one_statement_with_contiguous_ordered_seqs() {
             .is_empty()
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_append_batch_spanning_multiple_statements_commits_atomically_in_order() {
     // 600 > the 256-row chunk size, so this exercises the multi-statement
@@ -1416,8 +1334,6 @@ async fn libsql_append_batch_spanning_multiple_statements_commits_atomically_in_
         assert_eq!(all[offset].seq, seqs[offset]);
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_tail_bounded_limits_records_before_materialization() {
     let filesystem = libsql_root().await;
@@ -1439,8 +1355,6 @@ async fn libsql_tail_bounded_limits_records_before_materialization() {
     assert_eq!(after_first[0].seq, s2);
     assert_eq!(filesystem.tail_bounded(&log, s3, 1).await.unwrap().len(), 0);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_head_seq_returns_none_for_empty_path() {
     let filesystem = libsql_root().await;
@@ -1448,8 +1362,6 @@ async fn libsql_head_seq_returns_none_for_empty_path() {
     let head = filesystem.head_seq(&log, SeqNo::ZERO).await.unwrap();
     assert_eq!(head, None);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_head_seq_returns_max_seq_after_appends() {
     let filesystem = libsql_root().await;
@@ -1462,8 +1374,6 @@ async fn libsql_head_seq_returns_max_seq_after_appends() {
     let head = filesystem.head_seq(&log, SeqNo::ZERO).await.unwrap();
     assert_eq!(head, Some(s3));
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_head_seq_returns_none_when_from_exceeds_all_seqs() {
     let filesystem = libsql_root().await;
@@ -1478,8 +1388,6 @@ async fn libsql_head_seq_returns_none_when_from_exceeds_all_seqs() {
     let head = filesystem.head_seq(&log, beyond).await.unwrap();
     assert_eq!(head, None);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_append_distinct_paths_share_global_seq_but_are_isolated_on_tail() {
     // Each path's tail returns only its own records, even though the
@@ -1510,15 +1418,11 @@ async fn libsql_append_distinct_paths_share_global_seq_but_are_isolated_on_tail(
     // Per-path seq is monotonic.
     assert!(a1 < a2);
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_capabilities_advertise_events() {
     let filesystem = libsql_root().await;
     assert!(filesystem.capabilities().has(Capability::Events));
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_create_dir_all_concurrent_shared_prefixes_waits_for_writer() {
     let db_dir = tempfile::tempdir().unwrap();
@@ -1550,8 +1454,6 @@ async fn libsql_create_dir_all_concurrent_shared_prefixes_waits_for_writer() {
         FileType::Directory
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_put_concurrent_distinct_children_waits_for_writer() {
     let db_dir = tempfile::tempdir().unwrap();
@@ -1587,8 +1489,6 @@ async fn libsql_put_concurrent_distinct_children_waits_for_writer() {
         vec![31]
     );
 }
-
-#[cfg(feature = "libsql")]
 async fn libsql_root() -> TestLibSqlRootFilesystem {
     let db_dir = tempfile::tempdir().unwrap();
     let db_path = db_dir.path().join("root-filesystem.db");
@@ -1610,8 +1510,6 @@ async fn libsql_root() -> TestLibSqlRootFilesystem {
 // race-idempotence, Range numeric vs text comparison) and gracefully skip
 // when no Postgres is reachable via `DATABASE_URL` /
 // `IRONCLAW_FILESYSTEM_POSTGRES_URL`.
-
-#[cfg(feature = "postgres")]
 mod postgres_tests {
     use super::*;
     use ironclaw_filesystem::{

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1,5 +1,5 @@
-use ironclaw_filesystem::RootFilesystem;
 use ironclaw_filesystem::PostgresRootFilesystem;
+use ironclaw_filesystem::RootFilesystem;
 use ironclaw_filesystem::{
     Capability, CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, Filter,
     IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, LibSqlRootFilesystem, Page, RecordKind,

--- a/crates/ironclaw_filesystem/tests/postgres_delete_if_version_race.rs
+++ b/crates/ironclaw_filesystem/tests/postgres_delete_if_version_race.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "postgres")]
-
 use std::sync::Arc;
 
 use ironclaw_filesystem::{

--- a/crates/ironclaw_hooks/Cargo.toml
+++ b/crates/ironclaw_hooks/Cargo.toml
@@ -9,7 +9,6 @@ layer = "substrates"
 description = "Reborn loop hook framework: trust-tiered points/kinds/decisions, sealed witness types, dispatcher contract."
 
 [features]
-default = []
 # The crate's dev-only seam. Two things live behind it:
 #
 #  * test-only constructors (e.g., `SanitizedArguments::for_tests`) that bypass

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -8,10 +8,9 @@ publish = false
 layer = "kernel"
 
 [features]
-default = []
 test-support = []
-postgres = ["dep:deadpool-postgres", "ironclaw_filesystem/postgres"]
-libsql = ["dep:libsql", "ironclaw_filesystem/libsql"]
+postgres = ["dep:deadpool-postgres"]
+libsql = ["dep:libsql"]
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_llm/Cargo.toml
+++ b/crates/ironclaw_llm/Cargo.toml
@@ -17,7 +17,6 @@ layer = "substrates"
 dist = false
 
 [features]
-default = []
 bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types"]
 # Opt-in registry-provider factory for composition roots that already own
 # provider resolution and do not want v1 SessionManager plumbing.

--- a/crates/ironclaw_memory_native/Cargo.toml
+++ b/crates/ironclaw_memory_native/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 layer = "substrates"
 
 [features]
-default = []
 # Exposes the trait-level contract test harness in
 # `src/contract_tests.rs` to downstream crates and integration tests.
 # Off by default so panic-style calls in the harness (`.expect`,

--- a/crates/ironclaw_outbound/Cargo.toml
+++ b/crates/ironclaw_outbound/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 layer = "substrates"
 
 [features]
-default = []
 # Exposes `test_support` in-memory-backed store constructors for downstream
 # crates' tests. Ships zero bytes in production binaries.
 test-support = []

--- a/crates/ironclaw_processes/Cargo.toml
+++ b/crates/ironclaw_processes/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 layer = "runtimes"
 
 [features]
-default = []
 # In-memory-backed process store constructors for this crate's own tests and
 # downstream tiers. The stores are the production `FilesystemProcess*Store<InMemoryBackend>`;
 # the helpers just wire the in-memory backend seam (arch-simplification §4.3).

--- a/crates/ironclaw_product_adapters/Cargo.toml
+++ b/crates/ironclaw_product_adapters/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 layer = "products"
 
 [features]
-default = []
 # Compile in-memory test fakes (FakeProductWorkflow, FakeProtocolHttpEgress,
 # FakeOutboundDeliverySink, FakeProjectionStream, etc.). Off by default so
 # production binaries don't carry the fake state machinery; downstream

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -14,13 +14,10 @@ publish = false
 layer = "products"
 
 [features]
-default = []
 # Compile in-memory fakes (FakeInboundTurnService, FakeConversationBindingService,
 # FakeIdempotencyLedger, etc.). Off by default so production binaries don't carry
 # the fake state machinery; downstream crates enable it from `[dev-dependencies]`.
 test-support = ["ironclaw_product_adapters/test-support"]
-libsql = ["ironclaw_filesystem/libsql"]
-postgres = ["ironclaw_filesystem/postgres"]
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_product_workflow/src/filesystem_ledger.rs
+++ b/crates/ironclaw_product_workflow/src/filesystem_ledger.rs
@@ -11,17 +11,13 @@ use crate::{
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use futures::StreamExt;
-#[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
-#[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{
     CasExpectation, Entry, FilesystemError, Filter, IndexKey, IndexValue, Page, RecordKind,
     RecordVersion, RootFilesystem, ScopedFilesystem,
 };
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{AgentId, InvocationId, ProjectId, TenantId, UserId};
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
 use ironclaw_host_api::{ResourceScope, ScopedPath};
 
@@ -54,12 +50,9 @@ impl<F> FilesystemIdempotencyLedger<F>
 where
     F: RootFilesystem + ?Sized + 'static,
 {
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     fn new_root(filesystem: Arc<F>) -> Self {
         Self::with_root_lease(filesystem, DEFAULT_IN_FLIGHT_LEASE)
     }
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     fn with_root_lease(filesystem: Arc<F>, in_flight_lease: Duration) -> Self {
         let root = default_scoped_ledger_root();
         Self {
@@ -72,8 +65,6 @@ where
             settled_since_prune: AtomicUsize::new(0),
         }
     }
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     fn with_root(filesystem: Arc<F>, root: VirtualPath, in_flight_lease: Duration) -> Self {
         let root = ScopedPath::new(root.as_str()).expect("virtual root is a valid scoped path"); // safety: both path types use the same absolute path grammar.
         Self {
@@ -527,12 +518,9 @@ where
 
 /// libSQL-backed product workflow idempotency ledger using the shared
 /// SQL filesystem backend for persistence.
-#[cfg(feature = "libsql")]
 pub struct RebornLibSqlIdempotencyLedger {
     inner: FilesystemIdempotencyLedger<LibSqlRootFilesystem>,
 }
-
-#[cfg(feature = "libsql")]
 impl RebornLibSqlIdempotencyLedger {
     pub fn new(filesystem: Arc<LibSqlRootFilesystem>) -> Self {
         Self {
@@ -569,8 +557,6 @@ impl RebornLibSqlIdempotencyLedger {
         self
     }
 }
-
-#[cfg(feature = "libsql")]
 #[async_trait]
 impl IdempotencyLedger for RebornLibSqlIdempotencyLedger {
     async fn begin_or_replay(
@@ -592,12 +578,9 @@ impl IdempotencyLedger for RebornLibSqlIdempotencyLedger {
 
 /// PostgreSQL-backed product workflow idempotency ledger using the shared
 /// SQL filesystem backend for persistence.
-#[cfg(feature = "postgres")]
 pub struct RebornPostgresIdempotencyLedger {
     inner: FilesystemIdempotencyLedger<PostgresRootFilesystem>,
 }
-
-#[cfg(feature = "postgres")]
 impl RebornPostgresIdempotencyLedger {
     pub fn new(filesystem: Arc<PostgresRootFilesystem>) -> Self {
         Self {
@@ -634,8 +617,6 @@ impl RebornPostgresIdempotencyLedger {
         self
     }
 }
-
-#[cfg(feature = "postgres")]
 #[async_trait]
 impl IdempotencyLedger for RebornPostgresIdempotencyLedger {
     async fn begin_or_replay(
@@ -658,8 +639,6 @@ impl IdempotencyLedger for RebornPostgresIdempotencyLedger {
 fn settled_prune_interval_for(limit: NonZeroUsize) -> NonZeroUsize {
     NonZeroUsize::new((limit.get() / 10).max(1)).expect("non-zero derived interval") // safety: max(1) guarantees a non-zero value.
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn root_scoped_filesystem<F>(filesystem: Arc<F>, root: &ScopedPath) -> Arc<ScopedFilesystem<F>>
 where
     F: RootFilesystem + ?Sized + 'static,
@@ -673,8 +652,6 @@ where
     .expect("root ledger mount view is valid"); // safety: the mount view contains one read-write grant with validated alias and target.
     Arc::new(ScopedFilesystem::with_fixed_view(filesystem, mounts))
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn root_mount_alias(root: &ScopedPath) -> String {
     let mut parts = root.as_str().split('/').filter(|part| !part.is_empty());
     let Some(first) = parts.next() else {
@@ -682,8 +659,6 @@ fn root_mount_alias(root: &ScopedPath) -> String {
     };
     format!("/{first}")
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn root_scope() -> ResourceScope {
     ResourceScope {
         tenant_id: TenantId::new("tenant:product-workflow-storage-root")

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -122,9 +122,7 @@ pub use fakes::{
     FakeInboundTurnService, rejecting_reborn_services_error,
 };
 pub use filesystem_ledger::RebornFilesystemIdempotencyLedger;
-#[cfg(feature = "libsql")]
 pub use filesystem_ledger::RebornLibSqlIdempotencyLedger;
-#[cfg(feature = "postgres")]
 pub use filesystem_ledger::RebornPostgresIdempotencyLedger;
 pub use in_memory_ledger::InMemoryIdempotencyLedger;
 pub use inbound_turn::{

--- a/crates/ironclaw_product_workflow/tests/durable_ledger_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/durable_ledger_contract.rs
@@ -1,18 +1,11 @@
-#![cfg(any(feature = "libsql", feature = "postgres"))]
-
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-#[cfg(feature = "postgres")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::Duration;
-#[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
-#[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
-#[cfg(feature = "libsql")]
 use ironclaw_product_workflow::RebornLibSqlIdempotencyLedger;
-#[cfg(feature = "postgres")]
 use ironclaw_product_workflow::RebornPostgresIdempotencyLedger;
 
 // Shared ledger test support was renamed on fold-in to avoid colliding with the
@@ -21,8 +14,6 @@ use ironclaw_product_workflow::RebornPostgresIdempotencyLedger;
 mod support;
 
 use support::*;
-
-#[cfg(feature = "postgres")]
 fn unique_suffix(name: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -30,8 +21,6 @@ fn unique_suffix(name: &str) -> String {
         .as_nanos();
     format!("{name}-{nanos}")
 }
-
-#[cfg(feature = "libsql")]
 async fn libsql_filesystem(path: &str) -> Arc<LibSqlRootFilesystem> {
     let db = Arc::new(
         libsql::Builder::new_local(path)
@@ -46,8 +35,6 @@ async fn libsql_filesystem(path: &str) -> Arc<LibSqlRootFilesystem> {
         .expect("run libsql filesystem migrations");
     filesystem
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_settled_action_survives_reopen_and_replays() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -59,8 +46,6 @@ async fn libsql_settled_action_survives_reopen_and_replays() {
     assert_settled_action_survives_reopen_and_replays(&ledger, &reopened, "libsql-settled-replay")
         .await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_in_flight_action_blocks_until_lease_expires() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -71,8 +56,6 @@ async fn libsql_in_flight_action_blocks_until_lease_expires() {
     );
     assert_in_flight_action_blocks_until_lease_expires(&ledger, "libsql-lease").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_release_allows_retry_without_waiting_for_lease() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -83,8 +66,6 @@ async fn libsql_release_allows_retry_without_waiting_for_lease() {
     );
     assert_release_allows_retry_without_waiting_for_lease(&ledger, "libsql-release").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_duplicate_reservation_contention_serializes() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -101,8 +82,6 @@ async fn libsql_duplicate_reservation_contention_serializes() {
 
     assert_duplicate_reservation_contention_serializes(&first, &second, "libsql-contention").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_settled_entry_limit_prunes_oldest() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -115,8 +94,6 @@ async fn libsql_settled_entry_limit_prunes_oldest() {
 
     assert_settled_entry_limit_prunes_oldest(&ledger, "libsql-retention").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_settled_prune_interval_defers_until_interval() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -130,8 +107,6 @@ async fn libsql_settled_prune_interval_defers_until_interval() {
 
     assert_settled_prune_interval_defers_until_interval(&ledger, "libsql-prune-interval").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_superseded_reservation_cannot_settle() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -143,8 +118,6 @@ async fn libsql_superseded_reservation_cannot_settle() {
 
     assert_superseded_reservation_cannot_settle(&ledger, "libsql-superseded").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_settle_missing_reservation_returns_transient() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -154,8 +127,6 @@ async fn libsql_settle_missing_reservation_returns_transient() {
 
     assert_settle_missing_reservation_returns_transient(&ledger, "libsql-missing-settle").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_custom_root_isolated_from_default_root() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -170,8 +141,6 @@ async fn libsql_custom_root_isolated_from_default_root() {
 
     assert_custom_root_isolated_from_default_root(&custom, &default, "libsql-custom-root").await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_actor_identity_is_part_of_fingerprint_path() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -181,8 +150,6 @@ async fn libsql_actor_identity_is_part_of_fingerprint_path() {
 
     assert_actor_identity_is_part_of_fingerprint_path(&ledger, "libsql-actor-isolation").await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_settled_action_survives_reopen_and_replays_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -198,8 +165,6 @@ async fn postgres_settled_action_survives_reopen_and_replays_when_configured() {
     )
     .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_in_flight_action_blocks_until_lease_expires_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -211,8 +176,6 @@ async fn postgres_in_flight_action_blocks_until_lease_expires_when_configured() 
     assert_in_flight_action_blocks_until_lease_expires(&ledger, &unique_suffix("postgres-lease"))
         .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_release_allows_retry_without_waiting_for_lease_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -227,8 +190,6 @@ async fn postgres_release_allows_retry_without_waiting_for_lease_when_configured
     )
     .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_duplicate_reservation_contention_serializes_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -248,8 +209,6 @@ async fn postgres_duplicate_reservation_contention_serializes_when_configured() 
     )
     .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_settled_entry_limit_prunes_oldest_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -261,8 +220,6 @@ async fn postgres_settled_entry_limit_prunes_oldest_when_configured() {
 
     assert_settled_entry_limit_prunes_oldest(&ledger, &unique_suffix("postgres-retention")).await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_settled_prune_interval_defers_until_interval_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -279,8 +236,6 @@ async fn postgres_settled_prune_interval_defers_until_interval_when_configured()
     )
     .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_superseded_reservation_cannot_settle_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -292,8 +247,6 @@ async fn postgres_superseded_reservation_cannot_settle_when_configured() {
     assert_superseded_reservation_cannot_settle(&ledger, &unique_suffix("postgres-superseded"))
         .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_settle_missing_reservation_returns_transient_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -307,8 +260,6 @@ async fn postgres_settle_missing_reservation_returns_transient_when_configured()
     )
     .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_custom_root_isolated_from_default_root_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -328,8 +279,6 @@ async fn postgres_custom_root_isolated_from_default_root_when_configured() {
     )
     .await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_actor_identity_is_part_of_fingerprint_path_when_configured() {
     let Some(filesystem) = postgres_filesystem().await else {
@@ -343,8 +292,6 @@ async fn postgres_actor_identity_is_part_of_fingerprint_path_when_configured() {
     )
     .await;
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_filesystem() -> Option<Arc<PostgresRootFilesystem>> {
     let url = match std::env::var("IRONCLAW_PRODUCT_WORKFLOW_POSTGRES_URL") {
         Ok(url) => url,

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -5627,8 +5627,8 @@ fn onboard_import_history_records_pending_step() {
 /// ahead of the LLM-credential step that fails.
 // The pinned failure (the LLM-credential step parsing the malformed
 // config.toml) exists only when the provider feature compiles that step in;
-// without it onboard legitimately succeeds, so the test would fail the
-// libsql-only lane for behavior that build cannot have.
+// without it onboard legitimately succeeds, so a provider-free build cannot
+// assert this behavior.
 #[test]
 fn onboard_preserves_existing_config_without_force() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -53,22 +53,14 @@ test-support = [
 migration-support = []
 libsql = [
     "dep:libsql",
-    "ironclaw_filesystem/libsql",
-    "ironclaw_reborn_openai_compat/libsql",
-    "ironclaw_product_workflow/libsql",
     "ironclaw_host_runtime/libsql",
     "ironclaw_runner/filesystem-goal-store",
-    "ironclaw_reborn_event_store/libsql",
-    "ironclaw_triggers/libsql",
 ]
 postgres = [
     "dep:deadpool-postgres",
-    "ironclaw_filesystem/postgres",
     "ironclaw_host_runtime/postgres",
     "ironclaw_runner/filesystem-goal-store",
     "ironclaw_runner/filesystem-local-trigger-access",
-    "ironclaw_reborn_event_store/postgres",
-    "ironclaw_triggers/postgres",
 ]
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_reborn_event_store/Cargo.toml
+++ b/crates/ironclaw_reborn_event_store/Cargo.toml
@@ -13,40 +13,27 @@ publish = false
 [package.metadata.ironclaw]
 layer = "substrates"
 
-[features]
-default = []
-postgres = [
-    "dep:deadpool-postgres",
-    "dep:tokio-postgres",
-    "dep:tokio-postgres-rustls",
-    "dep:rustls",
-    "dep:rustls-native-certs",
-    "dep:webpki-roots",
-    "ironclaw_filesystem/postgres",
-]
-libsql = ["dep:libsql", "ironclaw_filesystem/libsql"]
-
 [dependencies]
 async-trait = "0.1"
-deadpool-postgres = { version = "0.14", optional = true }
+deadpool-postgres = "0.14"
 hex = "0.4"
 ironclaw_events = { path = "../ironclaw_events", version = "0.1.0" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
-libsql = { version = "0.9", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
-rustls = { version = "0.23", optional = true, default-features = false, features = ["ring"] }
-rustls-native-certs = { version = "0.8", optional = true }
+libsql = { version = "0.9", default-features = false, features = ["core", "replication", "remote", "tls"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-native-certs = "0.8"
 secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "rt", "sync", "time"] }
-tokio-postgres = { version = "0.7", optional = true, features = ["with-serde_json-1"] }
-tokio-postgres-rustls = { version = "0.13", optional = true }
+tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
+tokio-postgres-rustls = "0.13"
 tracing = "0.1"
 urlencoding = "2"
-webpki-roots = { version = "1.0", optional = true }
+webpki-roots = "1.0"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -37,10 +37,8 @@ use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventReplay,
     EventStreamKey, InMemoryDurableAuditLog, InMemoryDurableEventLog, ReadScope, RuntimeEvent,
 };
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{AgentId, AuditEnvelope};
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -52,8 +50,6 @@ mod filesystem_store;
 
 pub use coalescing_sink::{CoalescingEventSink, EventBatchConfig};
 pub use filesystem_store::{FilesystemDurableAuditLog, FilesystemDurableEventLog};
-
-#[cfg(feature = "postgres")]
 pub const DEFAULT_POSTGRES_POOL_MAX_SIZE: usize = 2;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -86,7 +82,6 @@ impl std::str::FromStr for RebornPostgresSslMode {
 
 /// Open a PostgreSQL pool using the same TLS policy as the production event
 /// store backend.
-#[cfg(feature = "postgres")]
 pub fn open_postgres_pool(
     url: SecretString,
 ) -> Result<deadpool_postgres::Pool, RebornEventStoreError> {
@@ -94,7 +89,6 @@ pub fn open_postgres_pool(
 }
 
 /// Open a PostgreSQL pool with an explicit maximum connection count.
-#[cfg(feature = "postgres")]
 pub fn open_postgres_pool_with_max_size(
     url: SecretString,
     max_size: usize,
@@ -103,7 +97,6 @@ pub fn open_postgres_pool_with_max_size(
 }
 
 /// Open a PostgreSQL pool with explicit TLS options.
-#[cfg(feature = "postgres")]
 pub fn open_postgres_pool_with_tls_options(
     url: SecretString,
     max_size: usize,
@@ -144,7 +137,6 @@ pub enum RebornEventStoreConfig {
     ///
     /// Hosted production uses this to avoid opening a second independent
     /// Postgres pool for event logs when the substrate already owns a pool.
-    #[cfg(feature = "postgres")]
     PostgresPool { pool: deadpool_postgres::Pool },
     /// libSQL backend configuration. The store opens a
     /// [`LibSqlRootFilesystem`](ironclaw_filesystem::LibSqlRootFilesystem)
@@ -209,8 +201,6 @@ impl RebornEventStoreError {
     fn io(operation: &'static str, source: std::io::Error) -> Self {
         Self::Io { operation, source }
     }
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     fn backend<E>(backend: &'static str, operation: &'static str, _source: E) -> Self {
         Self::BackendOperation { backend, operation }
     }
@@ -248,20 +238,8 @@ pub async fn build_reborn_event_stores(
             })
         }
         RebornEventStoreConfig::Postgres { url, tls_options } => {
-            #[cfg(feature = "postgres")]
-            {
-                postgres_backed::build(url, tls_options).await
-            }
-            #[cfg(not(feature = "postgres"))]
-            {
-                let _ = tls_options;
-                let _ = url;
-                Err(RebornEventStoreError::BackendUnavailable {
-                    backend: "postgres",
-                })
-            }
+            postgres_backed::build(url, tls_options).await
         }
-        #[cfg(feature = "postgres")]
         RebornEventStoreConfig::PostgresPool { pool } => {
             postgres_backed::build_from_pool(pool).await
         }
@@ -272,15 +250,7 @@ pub async fn build_reborn_event_stores(
             if profile == RebornProfile::Production {
                 validate_production_libsql_target(&path_or_url)?;
             }
-            #[cfg(feature = "libsql")]
-            {
-                libsql_backed::build(path_or_url, auth_token).await
-            }
-            #[cfg(not(feature = "libsql"))]
-            {
-                let _ = (path_or_url, auth_token);
-                Err(RebornEventStoreError::BackendUnavailable { backend: "libsql" })
-            }
+            libsql_backed::build(path_or_url, auth_token).await
         }
     }
 }
@@ -294,7 +264,6 @@ pub async fn build_reborn_event_stores(
 ///
 /// The caller must run any backend schema migrations before calling this
 /// helper. Config-based builders perform their own migration step.
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub fn build_reborn_event_stores_from_root_filesystem<F>(
     root: Arc<F>,
 ) -> Result<RebornEventStores, RebornEventStoreError>
@@ -303,8 +272,6 @@ where
 {
     wrap_root_filesystem_as_event_stores(root)
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn wrap_root_filesystem_as_event_stores<F>(
     root: Arc<F>,
 ) -> Result<RebornEventStores, RebornEventStoreError>
@@ -321,7 +288,6 @@ where
 /// Wrap a [`RootFilesystem`] in a [`ScopedFilesystem`] whose [`MountView`]
 /// grants the `/events` plane the permissions the durable log needs
 /// (append → write, tail → read+list).
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn build_events_scoped_filesystem<F>(
     root: Arc<F>,
 ) -> Result<Arc<ScopedFilesystem<F>>, RebornEventStoreError>
@@ -419,8 +385,6 @@ fn validate_production_libsql_target(path_or_url: &str) -> Result<(), RebornEven
         | LibsqlTargetClass::LocalRelative => Ok(()),
     }
 }
-
-#[cfg(feature = "libsql")]
 mod libsql_backed {
     //! libSQL-backed [`RootFilesystem`] construction for the durable event
     //! store. The connection lives behind the standard
@@ -545,8 +509,6 @@ mod libsql_backed {
         }
     }
 }
-
-#[cfg(feature = "postgres")]
 mod postgres_backed {
     //! PostgreSQL-backed [`RootFilesystem`] construction for the durable
     //! event store. Mirrors `libsql_backed::build`: parse the URL, enforce
@@ -1981,8 +1943,6 @@ mod tests {
             Err(RebornEventStoreError::ProductionLibsqlAmbiguousTarget)
         ));
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn local_dev_still_allows_bare_relative_libsql_path() {
         // The bare-path rejection is a production-only policy. LocalDev /

--- a/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
@@ -11,7 +11,6 @@ use ironclaw_host_api::{
 use ironclaw_reborn_event_store::{
     RebornEventStoreConfig, RebornProfile, build_reborn_event_stores,
 };
-#[cfg(feature = "postgres")]
 use secrecy::SecretString;
 
 fn capability_id() -> CapabilityId {
@@ -67,8 +66,6 @@ fn audit_record(scope: &ResourceScope, status: &str) -> AuditEnvelope {
         }),
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_replay_advances_next_cursor_past_trailing_filtered_records() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -119,8 +116,6 @@ async fn libsql_replay_advances_next_cursor_past_trailing_filtered_records() {
         "filtered trailing records must advance SQL replay cursor"
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_append_batch_groups_by_stream_and_preserves_order() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -402,8 +397,6 @@ async fn jsonl_audit_log_survives_rebuild_and_filters_scope() {
         Some("project-a".to_string())
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_semantics() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -506,8 +499,6 @@ async fn libsql_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_sema
         Some("project-a".to_string())
     );
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_replay_advances_next_cursor_past_trailing_filtered_records() {
     let Ok(url) = std::env::var("IRONCLAW_REBORN_EVENT_STORE_POSTGRES_URL") else {
@@ -567,8 +558,6 @@ async fn postgres_replay_advances_next_cursor_past_trailing_filtered_records() {
         "filtered trailing records must advance Postgres replay cursor"
     );
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_semantics() {
     let Ok(url) = std::env::var("IRONCLAW_REBORN_EVENT_STORE_POSTGRES_URL") else {

--- a/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "postgres")]
 use ironclaw_reborn_event_store::PostgresPoolTlsOptions;
 use ironclaw_reborn_event_store::{
     RebornEventStoreConfig, RebornEventStoreError, RebornProfile, build_reborn_event_stores,
@@ -75,42 +74,6 @@ async fn production_jsonl_accepts_explicit_single_node_durable_config() {
     assert_eq!(std::sync::Arc::strong_count(&stores.audit), 1);
 }
 
-#[cfg(not(feature = "postgres"))]
-#[tokio::test]
-async fn unavailable_postgres_backend_error_does_not_leak_secret_config() {
-    let result = build_reborn_event_stores(
-        RebornProfile::Production,
-        RebornEventStoreConfig::Postgres {
-            url: SecretString::new(
-                "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@example.invalid/db"
-                    .to_string()
-                    .into_boxed_str(),
-            ),
-            tls_options: Default::default(),
-        },
-    )
-    .await;
-
-    let error = result
-        .err()
-        .expect("postgres adapter is unavailable when the feature is disabled");
-    assert!(matches!(
-        error,
-        RebornEventStoreError::BackendUnavailable {
-            backend: "postgres"
-        }
-    ));
-    let displayed = error.to_string();
-    assert!(!displayed.contains("RAW_PASSWORD_SENTINEL_3162"));
-    assert!(!displayed.contains("example.invalid"));
-    assert!(!displayed.contains("postgres://"));
-    let debug = format!("{error:?}");
-    assert!(!debug.contains("RAW_PASSWORD_SENTINEL_3162"));
-    assert!(!debug.contains("example.invalid"));
-    assert!(!debug.contains("postgres://"));
-}
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn production_postgres_rejects_remote_sslmode_disable_before_connecting() {
     let result = build_reborn_event_stores(
@@ -138,8 +101,6 @@ async fn production_postgres_rejects_remote_sslmode_disable_before_connecting() 
     assert!(!displayed.contains("db.example.com"));
     assert!(!displayed.contains("postgres://"));
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn production_postgres_event_store_honors_explicit_remote_cleartext_opt_in() {
     let result = build_reborn_event_stores(
@@ -173,8 +134,6 @@ async fn production_postgres_event_store_honors_explicit_remote_cleartext_opt_in
     assert!(!displayed.contains("example.invalid"));
     assert!(!displayed.contains("postgres://"));
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_connection_failure_does_not_fall_back_or_leak_secret_config() {
     let result = build_reborn_event_stores(
@@ -212,36 +171,6 @@ async fn postgres_connection_failure_does_not_fall_back_or_leak_secret_config() 
     assert!(!debug.contains("postgres://"));
 }
 
-#[cfg(not(feature = "libsql"))]
-#[tokio::test]
-async fn unavailable_libsql_backend_error_does_not_leak_secret_config() {
-    let result = build_reborn_event_stores(
-        RebornProfile::Production,
-        RebornEventStoreConfig::Libsql {
-            path_or_url: "libsql://RAW_HOST_SENTINEL_3162.example.invalid".to_string(),
-            auth_token: Some(SecretString::new(
-                "RAW_LIBSQL_TOKEN_SENTINEL_3162"
-                    .to_string()
-                    .into_boxed_str(),
-            )),
-        },
-    )
-    .await;
-
-    let error = result
-        .err()
-        .expect("libsql adapter is unavailable when the feature is disabled");
-    assert!(matches!(
-        error,
-        RebornEventStoreError::BackendUnavailable { backend: "libsql" }
-    ));
-    let displayed = error.to_string();
-    assert!(!displayed.contains("RAW_LIBSQL_TOKEN_SENTINEL_3162"));
-    assert!(!displayed.contains("RAW_HOST_SENTINEL_3162"));
-    assert!(!displayed.contains("libsql://"));
-}
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn production_libsql_builds_local_store_without_leaking_path_or_token() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/ironclaw_reborn_migration/Cargo.toml
+++ b/crates/ironclaw_reborn_migration/Cargo.toml
@@ -36,15 +36,11 @@ full-migration = ["dep:ironclaw"]
 libsql = [
     "dep:libsql",
     "ironclaw?/libsql",
-    "ironclaw_filesystem/libsql",
-    "ironclaw_triggers/libsql",
     "ironclaw_reborn_composition/libsql",
 ]
 postgres = [
     "dep:deadpool-postgres",
     "ironclaw?/postgres",
-    "ironclaw_filesystem/postgres",
-    "ironclaw_triggers/postgres",
     "ironclaw_reborn_composition/postgres",
 ]
 

--- a/crates/ironclaw_reborn_openai_compat/Cargo.toml
+++ b/crates/ironclaw_reborn_openai_compat/Cargo.toml
@@ -13,11 +13,6 @@ publish = false
 [package.metadata.ironclaw]
 layer = "products"
 
-[features]
-default = []
-libsql = ["ironclaw_filesystem/libsql"]
-postgres = ["ironclaw_filesystem/postgres"]
-
 [dependencies]
 async-trait = "0.1"
 base64 = "0.22"

--- a/crates/ironclaw_reborn_openai_compat/src/lib.rs
+++ b/crates/ironclaw_reborn_openai_compat/src/lib.rs
@@ -87,9 +87,7 @@ pub use refs::{
     OpenAiCompatTurnRunRef, OpenAiResponseId, unix_timestamp_now,
 };
 pub use refs_storage::FilesystemOpenAiCompatRefStore;
-#[cfg(feature = "libsql")]
 pub use refs_storage::RebornLibSqlOpenAiCompatRefStore;
-#[cfg(feature = "postgres")]
 pub use refs_storage::RebornPostgresOpenAiCompatRefStore;
 pub use responses::{
     OpenAiResponseErrorObject, OpenAiResponseInputTokensDetails, OpenAiResponseObject,

--- a/crates/ironclaw_reborn_openai_compat/src/refs_storage.rs
+++ b/crates/ironclaw_reborn_openai_compat/src/refs_storage.rs
@@ -16,14 +16,14 @@ use crate::{
     OpenAiCompatResourceBinding, OpenAiCompatResourceMapping, OpenAiCompatRouteSurface,
 };
 use async_trait::async_trait;
+use ironclaw_filesystem::LibSqlRootFilesystem;
+use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{
     CasExpectation, Entry, FilesystemError, RecordKind, RecordVersion, RootFilesystem,
 };
 use ironclaw_host_api::VirtualPath;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use ironclaw_filesystem::LibSqlRootFilesystem;
-use ironclaw_filesystem::PostgresRootFilesystem;
 
 const DEFAULT_REF_ROOT: &str = "/engine/openai_compat/refs";
 const MAPPING_RECORD_KIND: &str = "openai_compat_ref_mapping";

--- a/crates/ironclaw_reborn_openai_compat/src/refs_storage.rs
+++ b/crates/ironclaw_reborn_openai_compat/src/refs_storage.rs
@@ -22,10 +22,7 @@ use ironclaw_filesystem::{
 use ironclaw_host_api::VirtualPath;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-
-#[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
-#[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
 
 const DEFAULT_REF_ROOT: &str = "/engine/openai_compat/refs";
@@ -313,13 +310,9 @@ impl FilesystemOpenAiCompatRefStore {
         Err(OpenAiCompatRefError::StoreUnavailable)
     }
 }
-
-#[cfg(feature = "libsql")]
 pub struct RebornLibSqlOpenAiCompatRefStore {
     inner: FilesystemOpenAiCompatRefStore,
 }
-
-#[cfg(feature = "libsql")]
 impl RebornLibSqlOpenAiCompatRefStore {
     pub fn new(filesystem: Arc<LibSqlRootFilesystem>) -> Self {
         Self {
@@ -333,8 +326,6 @@ impl RebornLibSqlOpenAiCompatRefStore {
         }
     }
 }
-
-#[cfg(feature = "libsql")]
 #[async_trait]
 impl OpenAiCompatRefStore for RebornLibSqlOpenAiCompatRefStore {
     async fn reserve(
@@ -374,13 +365,9 @@ impl OpenAiCompatRefStore for RebornLibSqlOpenAiCompatRefStore {
         self.inner.lookup_authorized(request).await
     }
 }
-
-#[cfg(feature = "postgres")]
 pub struct RebornPostgresOpenAiCompatRefStore {
     inner: FilesystemOpenAiCompatRefStore,
 }
-
-#[cfg(feature = "postgres")]
 impl RebornPostgresOpenAiCompatRefStore {
     pub fn new(filesystem: Arc<PostgresRootFilesystem>) -> Self {
         Self {
@@ -394,8 +381,6 @@ impl RebornPostgresOpenAiCompatRefStore {
         }
     }
 }
-
-#[cfg(feature = "postgres")]
 #[async_trait]
 impl OpenAiCompatRefStore for RebornPostgresOpenAiCompatRefStore {
     async fn reserve(

--- a/crates/ironclaw_resources/Cargo.toml
+++ b/crates/ironclaw_resources/Cargo.toml
@@ -15,7 +15,6 @@ publish = false
 layer = "kernel"
 
 [features]
-default = []
 # Exposes `test_support` in-memory-backed store constructors for downstream
 # crates' tests. Disabled by default; enable only from [dev-dependencies].
 test-support = []

--- a/crates/ironclaw_run_state/Cargo.toml
+++ b/crates/ironclaw_run_state/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 layer = "kernel"
 
 [features]
-default = []
 # In-memory-backed run-state / approval-request store constructors for this
 # crate's own tests and downstream tiers. The stores are the production
 # `Filesystem*Store<InMemoryBackend>`; the helpers just wire the in-memory backend

--- a/crates/ironclaw_runner/Cargo.toml
+++ b/crates/ironclaw_runner/Cargo.toml
@@ -14,20 +14,11 @@ publish = false
 layer = "kernel"
 
 [features]
-default = []
-# Bare libSQL dependency toggle, mirroring the root `ironclaw` crate's `libsql`
-# feature. CI's `libsql-only` leg builds the whole workspace with
-# `--all --no-default-features --features libsql`; without this, feature
-# resolution fails because `ironclaw_runner` is the lone workspace member that
-# enables libSQL only through the more specific features below. Dies with the
-# `libsql-only` leg when the storage-backend split is removed.
-libsql = ["dep:libsql"]
 libsql-secrets = [
     "dep:ironclaw_secrets",
     "dep:libsql",
     "dep:secrecy",
     "dep:ironclaw_filesystem",
-    "ironclaw_filesystem/libsql",
     "filesystem-goal-store",
 ]
 filesystem-goal-store = ["dep:ironclaw_filesystem"]
@@ -43,7 +34,6 @@ filesystem-local-trigger-access = ["dep:ironclaw_filesystem"]
 libsql-restart-tests = [
     "dep:libsql",
     "dep:ironclaw_filesystem",
-    "ironclaw_filesystem/libsql",
     "filesystem-goal-store",
 ]
 

--- a/crates/ironclaw_secrets/Cargo.toml
+++ b/crates/ironclaw_secrets/Cargo.toml
@@ -7,9 +7,6 @@ publish = false
 [package.metadata.ironclaw]
 layer = "substrates"
 
-[features]
-default = []
-
 [dependencies]
 aes-gcm = "0.10"
 async-trait = "0.1"

--- a/crates/ironclaw_triggers/AGENTS.md
+++ b/crates/ironclaw_triggers/AGENTS.md
@@ -26,7 +26,6 @@
 ## Validation
 
 - Fast local check: `cargo test -p ironclaw_triggers`
-- Backend check: `cargo test -p ironclaw_triggers --features libsql`
 - Lint check: `cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings`
 - Boundary check after dependency changes: `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
 

--- a/crates/ironclaw_triggers/Cargo.toml
+++ b/crates/ironclaw_triggers/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 layer = "substrates"
 
 [features]
-default = []
-libsql = ["dep:libsql"]
-postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
 test-support = []
 
 [dependencies]
@@ -21,12 +18,12 @@ chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 cron = "0.17"
 hex = "0.4"
-deadpool-postgres = { version = "0.14", optional = true }
+deadpool-postgres = "0.14"
 ironclaw_common = { path = "../ironclaw_common" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_turns = { path = "../ironclaw_turns" }
-libsql = { version = "0.9", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
-tokio-postgres = { version = "0.7", optional = true }
+libsql = { version = "0.9", default-features = false, features = ["core", "replication", "remote", "tls"] }
+tokio-postgres = "0.7"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
 thiserror = "2"

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -23,10 +23,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 use ulid::Ulid;
-
-#[cfg(feature = "libsql")]
 mod libsql;
-#[cfg(feature = "postgres")]
 mod postgres;
 mod trusted_submit;
 mod worker;
@@ -493,8 +490,6 @@ impl TriggerSchedule {
         schedule.validate()?;
         Ok(schedule)
     }
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     pub(crate) fn timezone_text(&self) -> &str {
         match self {
             Self::Cron { timezone, .. } | Self::Once { timezone, .. } => timezone.as_str(),
@@ -502,7 +497,6 @@ impl TriggerSchedule {
     }
 
     // Returns (kind, expression, schedule_at)
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     pub(crate) fn to_storage(&self) -> (&'static str, &str, Option<String>) {
         match self {
             Self::Cron { expression, .. } => ("cron", expression.as_str(), None),
@@ -513,8 +507,6 @@ impl TriggerSchedule {
             ),
         }
     }
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     pub(crate) fn from_storage(
         kind: &str,
         expression: &str,
@@ -728,8 +720,6 @@ pub enum TriggerRunHistoryStatus {
     Ok,
     Error,
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn trigger_run_history_status_text(value: TriggerRunHistoryStatus) -> &'static str {
     match value {
         TriggerRunHistoryStatus::Running => "running",
@@ -737,8 +727,6 @@ pub(crate) fn trigger_run_history_status_text(value: TriggerRunHistoryStatus) ->
         TriggerRunHistoryStatus::Error => "error",
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn state_text_codec(value: TriggerState) -> &'static str {
     match value {
         TriggerState::Scheduled => "scheduled",
@@ -746,8 +734,6 @@ pub(crate) fn state_text_codec(value: TriggerState) -> &'static str {
         TriggerState::Completed => "completed",
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn parse_state_codec(value: &str) -> Result<TriggerState, TriggerError> {
     match value {
         "scheduled" => Ok(TriggerState::Scheduled),
@@ -759,15 +745,11 @@ pub(crate) fn parse_state_codec(value: &str) -> Result<TriggerState, TriggerErro
         }),
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn source_kind_text_codec(value: TriggerSourceKind) -> &'static str {
     match value {
         TriggerSourceKind::Schedule => "schedule",
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn parse_source_kind_codec(value: &str) -> Result<TriggerSourceKind, TriggerError> {
     match value {
         "schedule" => Ok(TriggerSourceKind::Schedule),
@@ -777,16 +759,12 @@ pub(crate) fn parse_source_kind_codec(value: &str) -> Result<TriggerSourceKind, 
         }),
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn status_text_codec(value: TriggerRunStatus) -> &'static str {
     match value {
         TriggerRunStatus::Ok => "ok",
         TriggerRunStatus::Error => "error",
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn parse_run_status_codec(value: &str) -> Result<TriggerRunStatus, TriggerError> {
     match value {
         "ok" => Ok(TriggerRunStatus::Ok),
@@ -797,8 +775,6 @@ pub(crate) fn parse_run_status_codec(value: &str) -> Result<TriggerRunStatus, Tr
         }),
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn parse_run_history_status_codec(
     value: &str,
 ) -> Result<TriggerRunHistoryStatus, TriggerError> {
@@ -1333,10 +1309,8 @@ pub trait TriggerRepository: Send + Sync {
 }
 
 /// Feature-gated durable libSQL repository type for composition/test wiring.
-#[cfg(feature = "libsql")]
 pub use libsql::LibSqlTriggerRepository;
 /// Feature-gated durable PostgreSQL repository type for composition/test wiring.
-#[cfg(feature = "postgres")]
 pub use postgres::PostgresTriggerRepository;
 pub use worker::{
     ACTIVE_HOLD_ELAPSED_OCCURRENCES_CAP, ACTIVE_HOLD_LOOKUP_TIMEOUT, ActiveHoldProjection,
@@ -3395,8 +3369,6 @@ mod tests {
             other => panic!("expected InvalidSchedule, got {other:?}"),
         }
     }
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[test]
     fn once_schedule_storage_round_trip_uses_schedule_at_column() {
         let at = Utc.with_ymd_and_hms(2026, 6, 15, 10, 0, 0).unwrap();

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -1,4 +1,3 @@
-use std::{collections::HashMap, sync::Arc};
 use crate::{
     ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire,
     ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
@@ -13,6 +12,7 @@ use ironclaw_common::AutomationName;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserId};
 use ironclaw_turns::TurnRunId;
 use libsql::params;
+use std::{collections::HashMap, sync::Arc};
 const TRIGGER_TABLE: &str = "trigger_records";
 const TRIGGER_RUN_TABLE: &str = "trigger_run_history";
 const TRIGGER_COLUMNS: &str = "\

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -1,7 +1,4 @@
-#[cfg(feature = "libsql")]
 use std::{collections::HashMap, sync::Arc};
-
-#[cfg(feature = "libsql")]
 use crate::{
     ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire,
     ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
@@ -10,31 +7,19 @@ use crate::{
     TriggerSchedule, TriggerState, reject_failed_result_after_active_run,
     reject_non_future_next_run_at, reject_run_ref_rewrite, trigger_run_history_status_text,
 };
-#[cfg(feature = "libsql")]
 use async_trait::async_trait;
-#[cfg(feature = "libsql")]
 use chrono::{DateTime, SecondsFormat, Utc};
-#[cfg(feature = "libsql")]
 use ironclaw_common::AutomationName;
-#[cfg(feature = "libsql")]
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserId};
-#[cfg(feature = "libsql")]
 use ironclaw_turns::TurnRunId;
-#[cfg(feature = "libsql")]
 use libsql::params;
-
-#[cfg(feature = "libsql")]
 const TRIGGER_TABLE: &str = "trigger_records";
-#[cfg(feature = "libsql")]
 const TRIGGER_RUN_TABLE: &str = "trigger_run_history";
-
-#[cfg(feature = "libsql")]
 const TRIGGER_COLUMNS: &str = "\
     trigger_id, tenant_id, creator_user_id, agent_id, project_id, \
     name, source, schedule_expression, schedule_timezone, schedule_kind, prompt, \
     state, next_run_at, last_run_at, last_fired_slot, last_status, \
     active_fire_slot, active_run_ref, created_at, schedule_at, delivery_target";
-#[cfg(feature = "libsql")]
 const RENAME_SCOPED_TRIGGER_SQL: &str = "\
     UPDATE trigger_records
        SET name = ?6
@@ -47,77 +32,42 @@ const RENAME_SCOPED_TRIGGER_SQL: &str = "\
        name, source, schedule_expression, schedule_timezone, schedule_kind, prompt,
        state, next_run_at, last_run_at, last_fired_slot, last_status,
        active_fire_slot, active_run_ref, created_at, schedule_at, delivery_target";
-
-#[cfg(feature = "libsql")]
 const TRIGGER_ID_COL: usize = 0;
-#[cfg(feature = "libsql")]
 const TENANT_ID_COL: usize = 1;
-#[cfg(feature = "libsql")]
 const CREATOR_USER_ID_COL: usize = 2;
-#[cfg(feature = "libsql")]
 const AGENT_ID_COL: usize = 3;
-#[cfg(feature = "libsql")]
 const PROJECT_ID_COL: usize = 4;
-#[cfg(feature = "libsql")]
 const NAME_COL: usize = 5;
-#[cfg(feature = "libsql")]
 const SOURCE_COL: usize = 6;
-#[cfg(feature = "libsql")]
 const SCHEDULE_EXPRESSION_COL: usize = 7;
-#[cfg(feature = "libsql")]
 const SCHEDULE_TIMEZONE_COL: usize = 8;
-#[cfg(feature = "libsql")]
 const SCHEDULE_KIND_COL: usize = 9;
-#[cfg(feature = "libsql")]
 const PROMPT_COL: usize = 10;
-#[cfg(feature = "libsql")]
 const STATE_COL: usize = 11;
-#[cfg(feature = "libsql")]
 const NEXT_RUN_AT_COL: usize = 12;
-#[cfg(feature = "libsql")]
 const LAST_RUN_AT_COL: usize = 13;
-#[cfg(feature = "libsql")]
 const LAST_FIRED_SLOT_COL: usize = 14;
-#[cfg(feature = "libsql")]
 const LAST_STATUS_COL: usize = 15;
-#[cfg(feature = "libsql")]
 const ACTIVE_FIRE_SLOT_COL: usize = 16;
-#[cfg(feature = "libsql")]
 const ACTIVE_RUN_REF_COL: usize = 17;
-#[cfg(feature = "libsql")]
 const CREATED_AT_COL: usize = 18;
-#[cfg(feature = "libsql")]
 const SCHEDULE_AT_COL: usize = 19;
-#[cfg(feature = "libsql")]
 const DELIVERY_TARGET_COL: usize = 20;
-
-#[cfg(feature = "libsql")]
 const TRIGGER_RUN_COLUMNS: &str = "\
     tenant_id, trigger_id, fire_slot, run_id, thread_id, status, submitted_at, completed_at";
-#[cfg(feature = "libsql")]
 const RUN_TENANT_ID_COL: usize = 0;
-#[cfg(feature = "libsql")]
 const RUN_TRIGGER_ID_COL: usize = 1;
-#[cfg(feature = "libsql")]
 const RUN_FIRE_SLOT_COL: usize = 2;
-#[cfg(feature = "libsql")]
 const RUN_ID_COL: usize = 3;
-#[cfg(feature = "libsql")]
 const RUN_THREAD_ID_COL: usize = 4;
-#[cfg(feature = "libsql")]
 const RUN_STATUS_COL: usize = 5;
-#[cfg(feature = "libsql")]
 const RUN_SUBMITTED_AT_COL: usize = 6;
-#[cfg(feature = "libsql")]
 const RUN_COMPLETED_AT_COL: usize = 7;
 
 /// Durable libSQL trigger repository.
-#[cfg(feature = "libsql")]
 pub struct LibSqlTriggerRepository {
     db: Arc<libsql::Database>,
 }
-
-#[cfg(feature = "libsql")]
 impl LibSqlTriggerRepository {
     pub fn new(db: Arc<libsql::Database>) -> Self {
         Self { db }
@@ -411,8 +361,6 @@ impl LibSqlTriggerRepository {
         Ok(conn)
     }
 }
-
-#[cfg(feature = "libsql")]
 #[async_trait]
 impl TriggerRepository for LibSqlTriggerRepository {
     async fn upsert_trigger(&self, record: TriggerRecord) -> Result<(), TriggerError> {
@@ -1361,8 +1309,6 @@ impl TriggerRepository for LibSqlTriggerRepository {
         Ok(runs_by_trigger)
     }
 }
-
-#[cfg(feature = "libsql")]
 fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
     let trigger_id = TriggerId::parse(&required_text(row, TRIGGER_ID_COL, "trigger_id")?)?;
     let tenant_id = TenantId::new(required_text(row, TENANT_ID_COL, "tenant_id")?)
@@ -1437,8 +1383,6 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
     record.validate()?;
     Ok(record)
 }
-
-#[cfg(feature = "libsql")]
 async fn fetch_record(
     conn: &libsql::Connection,
     tenant_id: &TenantId,
@@ -1462,8 +1406,6 @@ async fn fetch_record(
         Err(error) => Err(backend_error("read trigger record row", error)),
     }
 }
-
-#[cfg(feature = "libsql")]
 async fn returned_record(
     rows: &mut libsql::Rows,
     operation: &str,
@@ -1474,32 +1416,24 @@ async fn returned_record(
         Err(error) => Err(backend_error(operation, error)),
     }
 }
-
-#[cfg(feature = "libsql")]
 async fn begin_immediate(conn: &libsql::Connection, operation: &str) -> Result<(), TriggerError> {
     conn.execute("BEGIN IMMEDIATE", ())
         .await
         .map(|_| ())
         .map_err(|error| backend_error(operation, error))
 }
-
-#[cfg(feature = "libsql")]
 async fn commit(conn: &libsql::Connection, operation: &str) -> Result<(), TriggerError> {
     conn.execute("COMMIT", ())
         .await
         .map(|_| ())
         .map_err(|error| backend_error(operation, error))
 }
-
-#[cfg(feature = "libsql")]
 async fn rollback(conn: &libsql::Connection, operation: &str) -> Result<(), TriggerError> {
     conn.execute("ROLLBACK", ())
         .await
         .map(|_| ())
         .map_err(|error| backend_error(operation, error))
 }
-
-#[cfg(feature = "libsql")]
 async fn write_record(
     conn: &libsql::Connection,
     record: &TriggerRecord,
@@ -1561,8 +1495,6 @@ async fn write_record(
     .map_err(|error| backend_error("upsert trigger record", error))?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 async fn resolve_missed_fire_result_update(
     conn: &libsql::Connection,
     tenant_id: &TenantId,
@@ -1588,8 +1520,6 @@ async fn resolve_missed_fire_result_update(
         "update predicate failed while claimed fire remained active without a run ref",
     ))
 }
-
-#[cfg(feature = "libsql")]
 async fn mark_successful_fire_result(
     conn: &libsql::Connection,
     update: SuccessfulFireResultUpdate<'_>,
@@ -1708,8 +1638,6 @@ async fn mark_successful_fire_result(
     )
     .await
 }
-
-#[cfg(feature = "libsql")]
 struct SuccessfulFireResultUpdate<'a> {
     tenant_id: &'a TenantId,
     trigger_id: TriggerId,
@@ -1724,8 +1652,6 @@ struct SuccessfulFireResultUpdate<'a> {
     update_operation: &'static str,
     read_operation: &'static str,
 }
-
-#[cfg(feature = "libsql")]
 fn row_to_run_record(row: &libsql::Row) -> Result<TriggerRunRecord, TriggerError> {
     let tenant_id = TenantId::new(required_text(row, RUN_TENANT_ID_COL, "tenant_id")?)
         .map_err(|error| invalid_record("tenant_id", error.to_string()))?;
@@ -1762,8 +1688,6 @@ fn row_to_run_record(row: &libsql::Row) -> Result<TriggerRunRecord, TriggerError
         completed_at,
     })
 }
-
-#[cfg(feature = "libsql")]
 async fn upsert_run_history(
     conn: &libsql::Connection,
     run: &TriggerRunRecord,
@@ -1796,8 +1720,6 @@ async fn upsert_run_history(
     prune_run_history(conn, &run.tenant_id, run.trigger_id).await?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 fn trigger_ids_json_array(trigger_ids: &[TriggerId]) -> String {
     let mut value = String::from("[");
     for (index, trigger_id) in trigger_ids.iter().enumerate() {
@@ -1811,8 +1733,6 @@ fn trigger_ids_json_array(trigger_ids: &[TriggerId]) -> String {
     value.push(']');
     value
 }
-
-#[cfg(feature = "libsql")]
 async fn complete_run_history(
     conn: &libsql::Connection,
     tenant_id: &TenantId,
@@ -1848,8 +1768,6 @@ async fn complete_run_history(
     prune_run_history(conn, tenant_id, trigger_id).await?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 async fn prune_run_history(
     conn: &libsql::Connection,
     tenant_id: &TenantId,
@@ -1878,14 +1796,10 @@ async fn prune_run_history(
     .map_err(|error| backend_error("prune trigger run history", error))?;
     Ok(())
 }
-
-#[cfg(feature = "libsql")]
 fn required_text(row: &libsql::Row, index: usize, field: &str) -> Result<String, TriggerError> {
     row.get(index as i32)
         .map_err(|error| invalid_record(field, error.to_string()))
 }
-
-#[cfg(feature = "libsql")]
 fn optional_text(
     row: &libsql::Row,
     index: usize,
@@ -1894,54 +1808,38 @@ fn optional_text(
     row.get(index as i32)
         .map_err(|error| backend_error(&format!("read optional trigger field {field}"), error))
 }
-
-#[cfg(feature = "libsql")]
 fn parse_timestamp(value: &str, field: &str) -> Result<Timestamp, TriggerError> {
     DateTime::parse_from_rfc3339(value)
         .map(|value| value.with_timezone(&Utc))
         .map_err(|error| invalid_record(field, error.to_string()))
 }
-
-#[cfg(feature = "libsql")]
 fn parse_turn_run_id(value: &str) -> Result<TurnRunId, TriggerError> {
     parse_turn_run_id_with_field(value, "active_run_ref")
 }
-
-#[cfg(feature = "libsql")]
 fn parse_turn_run_id_with_field(value: &str, field: &str) -> Result<TurnRunId, TriggerError> {
     TurnRunId::parse(value).map_err(|error| invalid_record(field, error.to_string()))
 }
-
-#[cfg(feature = "libsql")]
 fn fmt_ts(value: &Timestamp) -> String {
     value.to_rfc3339_opts(SecondsFormat::Nanos, true)
 }
-
-#[cfg(feature = "libsql")]
 fn opt_ts(value: Option<&Timestamp>) -> libsql::Value {
     match value {
         Some(value) => libsql::Value::Text(fmt_ts(value)),
         None => libsql::Value::Null,
     }
 }
-
-#[cfg(feature = "libsql")]
 fn opt_turn_run_id(value: Option<&TurnRunId>) -> libsql::Value {
     match value {
         Some(value) => libsql::Value::Text(value.to_string()),
         None => libsql::Value::Null,
     }
 }
-
-#[cfg(feature = "libsql")]
 fn invalid_record(field: &str, reason: impl Into<String>) -> TriggerError {
     TriggerError::InvalidRecord {
         kind: crate::TriggerRecordValidationKind::Other,
         reason: format!("{field}: {}", reason.into()),
     }
 }
-
-#[cfg(feature = "libsql")]
 fn backend_error(operation: &str, error: impl std::fmt::Display) -> TriggerError {
     TriggerError::Backend {
         reason: format!("{operation}: {error}"),

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1,6 +1,7 @@
 use chrono::{SecondsFormat, TimeZone, Utc};
 use ironclaw_common::AutomationName;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserId};
+use ironclaw_triggers::PostgresTriggerRepository;
 use ironclaw_triggers::{
     ActiveTriggerScanCursor, ClearActiveFireRequest, InMemoryTriggerRepository,
     TriggerDeliveryTargetId, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
@@ -16,7 +17,6 @@ use {
     },
     tempfile::tempdir,
 };
-use ironclaw_triggers::PostgresTriggerRepository;
 
 fn ts(seconds: i64) -> Timestamp {
     Utc.timestamp_opt(seconds, 0).single().expect("valid ts")

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1,5 +1,3 @@
-#![cfg(any(feature = "libsql", feature = "postgres"))]
-
 use chrono::{SecondsFormat, TimeZone, Utc};
 use ironclaw_common::AutomationName;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserId};
@@ -9,8 +7,6 @@ use ironclaw_triggers::{
     TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use ironclaw_turns::TurnRunId;
-
-#[cfg(feature = "libsql")]
 use {
     ironclaw_triggers::LibSqlTriggerRepository,
     libsql::params,
@@ -20,8 +16,6 @@ use {
     },
     tempfile::tempdir,
 };
-
-#[cfg(feature = "postgres")]
 use ironclaw_triggers::PostgresTriggerRepository;
 
 fn ts(seconds: i64) -> Timestamp {
@@ -1124,8 +1118,6 @@ async fn assert_scoped_rename_updates_only_matching_scope(repo: &impl TriggerRep
         .expect("renamed record");
     assert_eq!(fetched.name, "morning inbox summary");
 }
-
-#[cfg(feature = "libsql")]
 async fn build_libsql_repo_with_db() -> (
     tempfile::TempDir,
     Arc<libsql::Database>,
@@ -1143,14 +1135,10 @@ async fn build_libsql_repo_with_db() -> (
     repo.run_migrations().await.expect("run migrations");
     (dir, db, repo)
 }
-
-#[cfg(feature = "libsql")]
 async fn build_libsql_repo() -> (tempfile::TempDir, LibSqlTriggerRepository) {
     let (dir, _db, repo) = build_libsql_repo_with_db().await;
     (dir, repo)
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_repository_contract_parity() {
     let (_dir, repo) = build_libsql_repo().await;
@@ -1186,8 +1174,6 @@ async fn libsql_repository_contract_parity() {
     let (_dir, repo) = build_libsql_repo().await;
     assert_scoped_rename_updates_only_matching_scope(&repo).await;
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_repository_run_migrations_is_idempotent() {
     let dir = tempdir().expect("tempdir");
@@ -1203,8 +1189,6 @@ async fn libsql_repository_run_migrations_is_idempotent() {
     repo.run_migrations().await.expect("first run migrations");
     repo.run_migrations().await.expect("second run migrations");
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn libsql_repository_busy_timeout_waits_for_write_lock() {
     let dir = tempdir().expect("tempdir");
@@ -1246,8 +1230,6 @@ async fn libsql_repository_busy_timeout_waits_for_write_lock() {
         "migration should have been blocked by the held write lock"
     );
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_repository_rejects_malformed_persisted_rows() {
     let (_dir, db, repo) = build_libsql_repo_with_db().await;
@@ -1289,8 +1271,6 @@ async fn libsql_repository_rejects_malformed_persisted_rows() {
         .expect("restore valid row");
     }
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_repository_contract_parity() {
     let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -1330,8 +1310,6 @@ async fn postgres_repository_contract_parity() {
     clear_postgres_triggers(&pool).await;
     assert_scoped_rename_updates_only_matching_scope(&repo).await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_repository_run_migrations_is_idempotent() {
     let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -1342,8 +1320,6 @@ async fn postgres_repository_run_migrations_is_idempotent() {
     repo.run_migrations().await.expect("first run migrations");
     repo.run_migrations().await.expect("second run migrations");
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_repository_rejects_malformed_persisted_rows() {
     let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -1391,8 +1367,6 @@ async fn postgres_repository_rejects_malformed_persisted_rows() {
         .expect("restore valid row");
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_repository_rejects_corrupted_once_rows() {
     let (_dir, db, repo) = build_libsql_repo_with_db().await;
@@ -1457,8 +1431,6 @@ async fn libsql_repository_rejects_corrupted_once_rows() {
         .await
         .expect("clear corrupted row");
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_repository_rejects_corrupted_once_rows() {
     let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -1617,8 +1589,6 @@ async fn assert_malformed_row_error(
         "expected malformed row to report {expected_field}, got {error:?}"
     );
 }
-
-#[cfg(feature = "postgres")]
 async fn postgres_pool_or_skip() -> Option<(
     testcontainers_modules::testcontainers::ContainerAsync<
         testcontainers_modules::postgres::Postgres,
@@ -1649,8 +1619,6 @@ async fn postgres_pool_or_skip() -> Option<(
     }
     Some((container, pool))
 }
-
-#[cfg(feature = "postgres")]
 async fn start_postgres_container() -> Option<(
     testcontainers_modules::testcontainers::ContainerAsync<
         testcontainers_modules::postgres::Postgres,
@@ -1697,8 +1665,6 @@ async fn start_postgres_container() -> Option<(
         format!("postgres://postgres:postgres@{host}:{port}/ironclaw_test"),
     ))
 }
-
-#[cfg(feature = "postgres")]
 async fn clear_postgres_triggers(pool: &deadpool_postgres::Pool) {
     pool.get()
         .await
@@ -1747,15 +1713,11 @@ async fn assert_round_trip_preserves_named_timezone(repo: &impl TriggerRepositor
         }
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_timezone_round_trip() {
     let (_dir, repo) = build_libsql_repo().await;
     assert_round_trip_preserves_named_timezone(&repo).await;
 }
-
-#[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_timezone_round_trip() {
     let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -1782,8 +1744,6 @@ async fn postgres_timezone_round_trip() {
 // run_migrations first, which the postgres harness does not support without
 // a separate DDL setup step; that coverage is deferred. See comment below.
 // ---------------------------------------------------------------------------
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_utc_backfill_on_legacy_row_without_schedule_timezone() {
     // Build the database without the schedule_timezone column — simulate the
@@ -3669,15 +3629,11 @@ mod fire_claim_contract {
         assert_fire_once_accept_with_none_next_run_at_succeeds(&repo).await;
         assert_scoped_state_transition_controls_fire_eligibility(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_fire_claim_contract() {
         let (_dir, repo) = build_libsql_repo().await;
         assert_durable_fire_claim_contract(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_option_next_run_at_contracts() {
         let (_dir, repo) = build_libsql_repo().await;
@@ -3685,8 +3641,6 @@ mod fire_claim_contract {
         let (_dir, repo) = build_libsql_repo().await;
         assert_fire_once_accept_with_none_next_run_at_succeeds(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_rejects_malformed_persisted_run_history_rows() {
         for (column, value, expected) in malformed_run_history_cases() {
@@ -3706,15 +3660,11 @@ mod fire_claim_contract {
                 .await;
         }
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_fire_claim_is_atomic() {
         let (_dir, repo) = build_libsql_repo().await;
         assert_durable_claim_is_atomic(std::sync::Arc::new(repo)).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_mark_fire_accepted_is_idempotent_under_concurrency() {
         let (_dir, repo) = build_libsql_repo().await;
@@ -3725,8 +3675,6 @@ mod fire_claim_contract {
         )
         .await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_mark_fire_replayed_is_idempotent_under_concurrency() {
         let (_dir, repo) = build_libsql_repo().await;
@@ -3737,8 +3685,6 @@ mod fire_claim_contract {
         )
         .await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_mark_fire_accepted_settles_equivalent_active_fire_timestamp_text() {
         let (_dir, db, repo) = build_libsql_repo_with_db().await;
@@ -3787,8 +3733,6 @@ mod fire_claim_contract {
         assert_eq!(runs[0].run_id, Some(run_id));
         assert_eq!(runs[0].thread_id, Some(thread_id));
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_mark_fire_replayed_settles_equivalent_active_fire_timestamp_text() {
         let (_dir, db, repo) = build_libsql_repo_with_db().await;
@@ -3837,8 +3781,6 @@ mod fire_claim_contract {
         assert_eq!(runs[0].run_id, Some(run_id));
         assert_eq!(runs[0].thread_id, Some(thread_id));
     }
-
-    #[cfg(feature = "libsql")]
     async fn rewrite_libsql_active_fire_slot_to_equivalent_text(
         db: &libsql::Database,
         tenant_id: &TenantId,
@@ -3864,8 +3806,6 @@ mod fire_claim_contract {
             .await
             .expect("rewrite active fire timestamp text");
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_fire_claim_contract() {
         let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -3876,8 +3816,6 @@ mod fire_claim_contract {
         assert_durable_fire_claim_contract(&repo).await;
         clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_rejects_malformed_persisted_run_history_rows() {
         let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -3918,8 +3856,6 @@ mod fire_claim_contract {
             .expect("clear trigger run history");
         clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_fire_claim_is_atomic() {
         let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -3930,8 +3866,6 @@ mod fire_claim_contract {
         assert_durable_claim_is_atomic(std::sync::Arc::new(repo)).await;
         clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_mark_fire_accepted_is_idempotent_under_concurrency() {
         let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -3947,8 +3881,6 @@ mod fire_claim_contract {
         .await;
         clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_mark_fire_accepted_settles_equivalent_active_fire_timestamp_text()
     {
@@ -4007,8 +3939,6 @@ mod fire_claim_contract {
         assert_eq!(runs[0].thread_id, Some(thread_id));
         clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_mark_fire_replayed_settles_equivalent_active_fire_timestamp_text()
     {
@@ -4066,8 +3996,6 @@ mod fire_claim_contract {
         assert_eq!(runs[0].thread_id, Some(thread_id));
         clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     async fn rewrite_postgres_active_fire_slot_to_equivalent_text(
         pool: &deadpool_postgres::Pool,
         tenant_id: &TenantId,
@@ -4096,8 +4024,6 @@ mod fire_claim_contract {
             .await
             .expect("rewrite active fire timestamp text");
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_mark_fire_replayed_is_idempotent_under_concurrency() {
         let Some((_container, pool)) = postgres_pool_or_skip().await else {
@@ -4206,22 +4132,16 @@ mod fire_claim_contract {
         let repo = InMemoryTriggerRepository::default();
         assert_fire_once_accept_with_none_next_run_at_succeeds(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_recurring_accept_rejects_non_future_next_run_at() {
         let (_dir, repo) = build_libsql_repo().await;
         assert_recurring_accept_rejects_non_future_next_run_at(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_fire_once_accept_with_none_next_run_at_succeeds() {
         let (_dir, repo) = build_libsql_repo().await;
         assert_fire_once_accept_with_none_next_run_at_succeeds(&repo).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_recurring_accept_rejects_non_future_next_run_at() {
         let Some((_container, pool)) = super::postgres_pool_or_skip().await else {
@@ -4232,8 +4152,6 @@ mod fire_claim_contract {
         assert_recurring_accept_rejects_non_future_next_run_at(&repo).await;
         super::clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_fire_once_accept_with_none_next_run_at_succeeds() {
         let Some((_container, pool)) = super::postgres_pool_or_skip().await else {
@@ -4346,22 +4264,16 @@ mod fire_claim_contract {
         let repo = InMemoryTriggerRepository::default();
         assert_recurring_replayed_rejects_none_next_run_at(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_recurring_accept_rejects_none_next_run_at() {
         let (_dir, repo) = build_libsql_repo().await;
         assert_recurring_accept_rejects_none_next_run_at(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_recurring_replayed_rejects_none_next_run_at() {
         let (_dir, repo) = build_libsql_repo().await;
         assert_recurring_replayed_rejects_none_next_run_at(&repo).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_recurring_accept_rejects_none_next_run_at() {
         let Some((_container, pool)) = super::postgres_pool_or_skip().await else {
@@ -4372,8 +4284,6 @@ mod fire_claim_contract {
         assert_recurring_accept_rejects_none_next_run_at(&repo).await;
         super::clear_postgres_triggers(&pool).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_recurring_replayed_rejects_none_next_run_at() {
         let Some((_container, pool)) = super::postgres_pool_or_skip().await else {
@@ -4507,15 +4417,11 @@ mod find_trigger_run_by_thread_id_contract {
         let repo = InMemoryTriggerRepository::default();
         assert_find_trigger_run_by_thread_id_contract(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_find_trigger_run_by_thread_id() {
         let (_dir, repo) = super::build_libsql_repo().await;
         assert_find_trigger_run_by_thread_id_contract(&repo).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_find_trigger_run_by_thread_id() {
         let Some((_container, pool)) = super::postgres_pool_or_skip().await else {
@@ -4598,15 +4504,11 @@ mod list_scoped_triggers_excluded_states_contract {
         let repo = InMemoryTriggerRepository::default();
         assert_list_scoped_triggers_excludes_states(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_list_scoped_triggers_excludes_completed_rows() {
         let (_dir, repo) = super::build_libsql_repo().await;
         assert_list_scoped_triggers_excludes_states(&repo).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_list_scoped_triggers_excludes_completed_rows() {
         let Some((_container, pool)) = super::postgres_pool_or_skip().await else {
@@ -4678,15 +4580,11 @@ mod list_scoped_triggers_excluded_states_contract {
         let repo = InMemoryTriggerRepository::default();
         assert_list_scoped_triggers_exclusion_precedes_limit(&repo).await;
     }
-
-    #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_list_scoped_triggers_exclusion_precedes_limit() {
         let (_dir, repo) = super::build_libsql_repo().await;
         assert_list_scoped_triggers_exclusion_precedes_limit(&repo).await;
     }
-
-    #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_list_scoped_triggers_exclusion_precedes_limit() {
         let Some((_container, pool)) = super::postgres_pool_or_skip().await else {
@@ -4698,8 +4596,6 @@ mod list_scoped_triggers_excluded_states_contract {
         super::clear_postgres_triggers(&pool).await;
     }
 }
-
-#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn libsql_once_trigger_completes_on_clear_active_fire() {
     let (_dir, repo) = build_libsql_repo().await;

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -14,9 +14,6 @@ publish = false
 [package.metadata.ironclaw]
 layer = "kernel"
 
-[features]
-default = []
-
 [dependencies]
 async-trait = "0.1"
 blake3 = "1"

--- a/crates/ironclaw_webui/Cargo.toml
+++ b/crates/ironclaw_webui/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 layer = "products"
 
 [features]
-default = []
 # Compile in `InMemorySessionStore` + `EmailUserDirectory` as public crate
 # items. Off by default so a production deployment cannot accidentally wire the
 # process-local store as a `SessionStore` impl — `SessionAuthenticator` would
@@ -86,7 +85,7 @@ ironclaw_product_adapters = { path = "../ironclaw_product_adapters" }
 # composed into `webui_v2_app`. It builds a local-dev
 # runtime through composition's public builders, so it needs composition's
 # `test-support` + `libsql` seams plus the model-gateway / capability-port traits.
-ironclaw_reborn_composition = { path = "../ironclaw_reborn_composition", features = ["test-support", "libsql"] }
+ironclaw_reborn_composition = { path = "../ironclaw_reborn_composition", features = ["test-support"] }
 ironclaw_loop_host = { path = "../ironclaw_loop_host" }
 tempfile = "3"
 ironclaw_threads = { path = "../ironclaw_threads" }

--- a/harness/latency/runner/Cargo.toml
+++ b/harness/latency/runner/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 async-trait = "0.1"
 axum = "0.8"
 deadpool-postgres = "0.14"
-ironclaw_filesystem = { path = "../../../crates/ironclaw_filesystem", features = ["libsql", "postgres"] }
+ironclaw_filesystem = { path = "../../../crates/ironclaw_filesystem" }
 ironclaw_host_runtime = { path = "../../../crates/ironclaw_host_runtime", features = ["libsql", "postgres"] }
 ironclaw_host_api = { path = "../../../crates/ironclaw_host_api" }
 ironclaw_reborn_composition = { path = "../../../crates/ironclaw_reborn_composition", features = ["libsql", "postgres"] }
-ironclaw_reborn_event_store = { path = "../../../crates/ironclaw_reborn_event_store", features = ["libsql", "postgres"] }
+ironclaw_reborn_event_store = { path = "../../../crates/ironclaw_reborn_event_store" }
 ironclaw_resources = { path = "../../../crates/ironclaw_resources" }
 ironclaw_run_state = { path = "../../../crates/ironclaw_run_state" }
 ironclaw_secrets = { path = "../../../crates/ironclaw_secrets" }
-ironclaw_triggers = { path = "../../../crates/ironclaw_triggers", features = ["libsql", "postgres"] }
+ironclaw_triggers = { path = "../../../crates/ironclaw_triggers" }
 ironclaw_trust = { path = "../../../crates/ironclaw_trust" }
 ironclaw_turns = { path = "../../../crates/ironclaw_turns" }
 chrono = "0.4"

--- a/scripts/ci/package-feature-flags.sh
+++ b/scripts/ci/package-feature-flags.sh
@@ -44,9 +44,7 @@ case "${package}" in
     printf '%s\n' "--features test-support,host-auth-mint"
     ;;
   ironclaw_product_workflow)
-    # `libsql` compiles + runs the durable idempotency-ledger contract folded in
-    # from the former ironclaw_product_workflow_storage crate.
-    printf '%s\n' "--features test-support,libsql"
+    printf '%s\n' "--features test-support"
     ;;
   ironclaw_reborn_composition)
     printf '%s\n' "--features test-support,libsql"
@@ -55,7 +53,6 @@ case "${package}" in
     printf '%s\n' "--features libsql-secrets,libsql-restart-tests,webui-user-store"
     ;;
   ironclaw_reborn_event_store)
-    printf '%s\n' "--features libsql"
     ;;
   ironclaw_hooks)
     # The durable libSQL/Postgres backends + parity matrix folded into this
@@ -77,10 +74,6 @@ case "${package}" in
     printf '%s\n' "--features test-support,libsql"
     ;;
   ironclaw_reborn_openai_compat)
-    # `libsql` exercises the durable ref-store contract folded in from the
-    # former ironclaw_reborn_openai_compat_storage crate. The route/workflow/
-    # streaming suites are unconditional.
-    printf '%s\n' "--features libsql"
     ;;
   ironclaw_architecture | \
   ironclaw_channel_delivery | \

--- a/scripts/ci/quality_gate_strict.sh
+++ b/scripts/ci/quality_gate_strict.sh
@@ -48,13 +48,6 @@ echo "==> WebUI frontend build"
 echo "==> clippy (all warnings)"
 cargo clippy --locked --all --benches --tests --examples --all-features -- -D warnings
 
-# Feature-matrix leg: the libsql-only build surfaces `cfg`/`dead_code` lints
-# that the all-features build hides (a variant constructed only under other
-# features reads as never-constructed here). This is the class that reds
-# `Clippy (libsql-only)` on main — e.g. the `Prebuilt` dead_code break (#5840).
-echo "==> clippy (libsql-only feature leg)"
-cargo clippy --locked --no-default-features --features libsql --all-targets -- -D warnings
-
 echo "==> static: include_str! paths + Docker COPY coverage"
 "$(git rev-parse --show-toplevel)/scripts/ci/check-include-str-paths.sh"
 

--- a/scripts/ci/reborn-coverage-lane-run.sh
+++ b/scripts/ci/reborn-coverage-lane-run.sh
@@ -121,9 +121,9 @@ for test_name in "${selected_names[@]}"; do
   test_args+=(--test "${test_name}")
 done
 
-echo "::group::cargo llvm-cov --workspace --features libsql test ${test_args[*]}"
+echo "::group::cargo llvm-cov --workspace --features ironclaw/libsql test ${test_args[*]}"
 timeout --signal=INT --kill-after=30s "${test_timeout}" \
-  cargo llvm-cov --workspace --features libsql test "${test_args[@]}" \
+  cargo llvm-cov --workspace --features ironclaw/libsql test "${test_args[@]}" \
     --lcov --output-path "${output_lcov}" \
     -- --nocapture
 echo "::endgroup::"

--- a/tools/ironclaw_stress/Cargo.toml
+++ b/tools/ironclaw_stress/Cargo.toml
@@ -13,18 +13,10 @@ publish = false
 [package.metadata.ironclaw]
 layer = "app"
 
-[features]
-default = ["libsql", "postgres"]
-libsql = ["dep:libsql"]
-postgres = [
-    "dep:deadpool-postgres",
-    "dep:tokio-postgres",
-]
-
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
-deadpool-postgres = { version = "0.14", optional = true }
+deadpool-postgres = "0.14"
 ironclaw_filesystem = { path = "../../crates/ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../../crates/ironclaw_host_api", version = "0.1.0" }
 ironclaw_llm = { path = "../../crates/ironclaw_llm", version = "0.1.0", features = ["registry-provider-factory"] }
@@ -32,7 +24,7 @@ ironclaw_resources = { path = "../../crates/ironclaw_resources", version = "0.1.
 ironclaw_secrets = { path = "../../crates/ironclaw_secrets", version = "0.1.0" }
 ironclaw_threads = { path = "../../crates/ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../../crates/ironclaw_turns", version = "0.1.0" }
-libsql = { version = "0.9", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+libsql = { version = "0.9", default-features = false, features = ["core", "replication", "remote", "tls"] }
 libc = "0.2"
 rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
 rust_decimal_macros = "1"
@@ -40,7 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
-tokio-postgres = { version = "0.7", optional = true, features = ["with-serde_json-1"] }
+tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/tools/ironclaw_stress/Cargo.toml
+++ b/tools/ironclaw_stress/Cargo.toml
@@ -15,11 +15,10 @@ layer = "app"
 
 [features]
 default = ["libsql", "postgres"]
-libsql = ["dep:libsql", "ironclaw_filesystem/libsql"]
+libsql = ["dep:libsql"]
 postgres = [
     "dep:deadpool-postgres",
     "dep:tokio-postgres",
-    "ironclaw_filesystem/postgres",
 ]
 
 [dependencies]

--- a/tools/ironclaw_stress/src/db_probe.rs
+++ b/tools/ironclaw_stress/src/db_probe.rs
@@ -2,7 +2,6 @@ use std::{io::ErrorKind, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "postgres")]
 use crate::redaction::redact_postgres_url;
 use crate::{Args, Backend};
 
@@ -109,7 +108,6 @@ async fn file_size(path: &std::path::Path) -> Result<u64, std::io::Error> {
     }
 }
 
-#[cfg(feature = "postgres")]
 async fn capture_postgres(args: &Args) -> DbProbeSnapshot {
     let url = match crate::resolve_postgres_url(args) {
         Ok(url) => url,
@@ -130,7 +128,6 @@ async fn capture_postgres(args: &Args) -> DbProbeSnapshot {
     }
 }
 
-#[cfg(feature = "postgres")]
 async fn try_capture_postgres(
     url: &str,
 ) -> Result<DbProbeSnapshot, Box<dyn std::error::Error + Send + Sync>> {
@@ -164,22 +161,12 @@ async fn try_capture_postgres(
     })
 }
 
-#[cfg(not(feature = "postgres"))]
-async fn capture_postgres(_args: &Args) -> DbProbeSnapshot {
-    DbProbeSnapshot {
-        error: Some("binary was built without the postgres feature".to_string()),
-        ..DbProbeSnapshot::default()
-    }
-}
-
-#[cfg(feature = "postgres")]
 pub(crate) fn sanitize_postgres_error(resolved_url: &str, error: impl std::fmt::Display) -> String {
     let mut message = format!("postgres probe failed: {error}");
     message = message.replace(resolved_url, &redact_postgres_url(resolved_url));
     message
 }
 
-#[cfg(feature = "postgres")]
 fn i64_to_u64(value: i64) -> Option<u64> {
     u64::try_from(value).ok()
 }

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -35,7 +35,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(feature = "postgres")]
 use crate::redaction::redact_postgres_url;
 use crate::{
     api_capacity::ApiCapacitySummary,
@@ -2291,7 +2290,6 @@ async fn build_backend(args: &Args, run_id: &str) -> Result<BackendHandle, Strin
     }
 }
 
-#[cfg(feature = "libsql")]
 async fn build_libsql_backend(args: &Args, run_id: &str) -> Result<BackendHandle, String> {
     let (filesystem, target) = build_libsql_root(args).await?;
     Ok(BackendHandle {
@@ -2300,7 +2298,6 @@ async fn build_libsql_backend(args: &Args, run_id: &str) -> Result<BackendHandle
     })
 }
 
-#[cfg(feature = "libsql")]
 pub(crate) async fn build_libsql_root(
     args: &Args,
 ) -> Result<(Arc<ironclaw_filesystem::LibSqlRootFilesystem>, String), String> {
@@ -2323,12 +2320,6 @@ pub(crate) async fn build_libsql_root(
     Ok((filesystem, redact_libsql_path(&path)))
 }
 
-#[cfg(not(feature = "libsql"))]
-async fn build_libsql_backend(_args: &Args, _run_id: &str) -> Result<BackendHandle, String> {
-    Err("binary was built without the libsql feature".to_string())
-}
-
-#[cfg(feature = "postgres")]
 async fn build_postgres_backend(args: &Args, run_id: &str) -> Result<BackendHandle, String> {
     let (filesystem, _pool, target) = build_postgres_root_and_pool(args).await?;
     Ok(BackendHandle {
@@ -2337,7 +2328,6 @@ async fn build_postgres_backend(args: &Args, run_id: &str) -> Result<BackendHand
     })
 }
 
-#[cfg(feature = "postgres")]
 pub(crate) async fn build_postgres_root_and_pool(
     args: &Args,
 ) -> Result<
@@ -2362,11 +2352,6 @@ pub(crate) async fn build_postgres_root_and_pool(
     let filesystem = Arc::new(PostgresRootFilesystem::new(pool.clone()));
     filesystem.run_migrations().await.map_err(display_err)?;
     Ok((filesystem, pool, redact_postgres_url(&url)))
-}
-
-#[cfg(not(feature = "postgres"))]
-async fn build_postgres_backend(_args: &Args, _run_id: &str) -> Result<BackendHandle, String> {
-    Err("binary was built without the postgres feature".to_string())
 }
 
 pub(crate) fn governor_from_root<F>(
@@ -2449,7 +2434,6 @@ fn panic_payload_to_string(payload: &Box<dyn Any + Send + 'static>) -> String {
     "non-string panic payload".to_string()
 }
 
-#[cfg(feature = "postgres")]
 pub(crate) fn resolve_postgres_url(args: &Args) -> Result<String, String> {
     if let Some(url) = args.postgres_url.clone() {
         return Ok(url);
@@ -2467,7 +2451,6 @@ pub(crate) fn resolve_postgres_url(args: &Args) -> Result<String, String> {
     )
 }
 
-#[cfg(feature = "postgres")]
 fn optional_env_var(name: &str) -> Result<Option<String>, String> {
     match std::env::var(name) {
         Ok(value) => Ok(Some(value)),

--- a/tools/ironclaw_stress/src/redaction.rs
+++ b/tools/ironclaw_stress/src/redaction.rs
@@ -4,7 +4,6 @@ pub(crate) fn redact_libsql_path(_path: &Path) -> String {
     "libsql://<redacted-local-path>".to_string()
 }
 
-#[cfg(any(feature = "postgres", test))]
 pub(crate) fn redact_postgres_url(url: &str) -> String {
     if let Some(redacted) = redact_postgres_uri(url, "postgres://") {
         return redacted;
@@ -18,7 +17,6 @@ pub(crate) fn redact_postgres_url(url: &str) -> String {
     "postgres://<redacted>".to_string()
 }
 
-#[cfg(any(feature = "postgres", test))]
 fn redact_postgres_uri(url: &str, scheme: &str) -> Option<String> {
     let rest = url.strip_prefix(scheme)?;
     let redacted_rest = match rest.find('@') {
@@ -28,7 +26,6 @@ fn redact_postgres_uri(url: &str, scheme: &str) -> Option<String> {
     Some(format!("{scheme}{redacted_rest}"))
 }
 
-#[cfg(any(feature = "postgres", test))]
 fn redact_uri_password_query(rest: &str) -> String {
     let Some((prefix, query)) = rest.split_once('?') else {
         return rest.to_string();
@@ -48,7 +45,6 @@ fn redact_uri_password_query(rest: &str) -> String {
     format!("{prefix}?{redacted_query}")
 }
 
-#[cfg(any(feature = "postgres", test))]
 fn redact_postgres_key_value_config(config: &str) -> Option<String> {
     let mut saw_assignment = false;
     let parts = config

--- a/tools/ironclaw_stress/src/secret_ops.rs
+++ b/tools/ironclaw_stress/src/secret_ops.rs
@@ -42,7 +42,6 @@ pub(crate) async fn build_secret_consume_workload(
     }
 }
 
-#[cfg(feature = "libsql")]
 async fn build_libsql_secret_consume_workload(
     args: &Args,
     run_id: &str,
@@ -51,29 +50,12 @@ async fn build_libsql_secret_consume_workload(
     secret_consume_workload_from_root(filesystem, run_id, target)
 }
 
-#[cfg(not(feature = "libsql"))]
-async fn build_libsql_secret_consume_workload(
-    _args: &Args,
-    _run_id: &str,
-) -> Result<SecretConsumeWorkload, String> {
-    Err("binary was built without the libsql feature".to_string())
-}
-
-#[cfg(feature = "postgres")]
 async fn build_postgres_secret_consume_workload(
     args: &Args,
     run_id: &str,
 ) -> Result<SecretConsumeWorkload, String> {
     let (filesystem, _pool, target) = crate::build_postgres_root_and_pool(args).await?;
     secret_consume_workload_from_root(filesystem, run_id, target)
-}
-
-#[cfg(not(feature = "postgres"))]
-async fn build_postgres_secret_consume_workload(
-    _args: &Args,
-    _run_id: &str,
-) -> Result<SecretConsumeWorkload, String> {
-    Err("binary was built without the postgres feature".to_string())
 }
 
 fn secret_consume_workload_from_root<F>(

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -871,7 +871,6 @@ fn human_summary_places_db_probe_errors_in_matching_columns() {
     );
 }
 
-#[cfg(feature = "postgres")]
 #[test]
 fn postgres_probe_error_redacts_resolved_url() {
     let url = "postgresql://postgres:secret@localhost:5432/app";

--- a/tools/ironclaw_stress/src/user_turn.rs
+++ b/tools/ironclaw_stress/src/user_turn.rs
@@ -90,9 +90,7 @@ where
 }
 
 pub(crate) enum UserTurnWorkload {
-    #[cfg(feature = "libsql")]
     Libsql(UserTurnServices<ironclaw_filesystem::LibSqlRootFilesystem>),
-    #[cfg(feature = "postgres")]
     Postgres(UserTurnServices<ironclaw_filesystem::PostgresRootFilesystem>),
 }
 
@@ -207,7 +205,6 @@ pub(crate) async fn build_user_turn_workload(
     }
 }
 
-#[cfg(feature = "libsql")]
 async fn build_libsql_user_turn_workload(
     args: &Args,
     run_id: &str,
@@ -226,15 +223,6 @@ async fn build_libsql_user_turn_workload(
     )?))
 }
 
-#[cfg(not(feature = "libsql"))]
-async fn build_libsql_user_turn_workload(
-    _args: &Args,
-    _run_id: &str,
-) -> Result<UserTurnWorkload, String> {
-    Err("binary was built without the libsql feature".to_string())
-}
-
-#[cfg(feature = "postgres")]
 async fn build_postgres_user_turn_workload(
     args: &Args,
     run_id: &str,
@@ -251,14 +239,6 @@ async fn build_postgres_user_turn_workload(
         args.turn_state_backend,
         args.turn_state_store_limits(),
     )?))
-}
-
-#[cfg(not(feature = "postgres"))]
-async fn build_postgres_user_turn_workload(
-    _args: &Args,
-    _run_id: &str,
-) -> Result<UserTurnWorkload, String> {
-    Err("binary was built without the postgres feature".to_string())
 }
 
 pub(crate) async fn run_user_turn_tasks(
@@ -596,9 +576,7 @@ fn format_prefill_errors(errors: &BTreeMap<String, u64>) -> String {
 impl UserTurnWorkload {
     pub(crate) fn target(&self) -> &str {
         match self {
-            #[cfg(feature = "libsql")]
             Self::Libsql(services) => &services.target,
-            #[cfg(feature = "postgres")]
             Self::Postgres(services) => &services.target,
         }
     }
@@ -612,13 +590,11 @@ impl UserTurnWorkload {
         span_budget: &AtomicUsize,
     ) -> Sample {
         match self {
-            #[cfg(feature = "libsql")]
             Self::Libsql(services) => {
                 services
                     .run_operation(args, identities, worker_index, operation_index, span_budget)
                     .await
             }
-            #[cfg(feature = "postgres")]
             Self::Postgres(services) => {
                 services
                     .run_operation(args, identities, worker_index, operation_index, span_budget)
@@ -635,13 +611,11 @@ impl UserTurnWorkload {
         turn_index: usize,
     ) -> Sample {
         match self {
-            #[cfg(feature = "libsql")]
             Self::Libsql(services) => {
                 services
                     .prefill_turn(args, identities, thread_index, turn_index)
                     .await
             }
-            #[cfg(feature = "postgres")]
             Self::Postgres(services) => {
                 services
                     .prefill_turn(args, identities, thread_index, turn_index)
@@ -657,13 +631,11 @@ impl UserTurnWorkload {
         thread_index: usize,
     ) -> Sample {
         match self {
-            #[cfg(feature = "libsql")]
             Self::Libsql(services) => {
                 services
                     .prefill_thread_list_thread(args, identities, thread_index)
                     .await
             }
-            #[cfg(feature = "postgres")]
             Self::Postgres(services) => {
                 services
                     .prefill_thread_list_thread(args, identities, thread_index)


### PR DESCRIPTION
## Summary

- remove no-op Cargo feature declarations and stale default feature tables
- collapse libSQL/Postgres compile gates in lower storage/product crates where both backends are now always available
- collapse `ironclaw_stress` backend features so the stress tool always compiles both DB adapters
- remove the obsolete `libsql-only` CI matrix lane and the `ironclaw_runner/libsql` compatibility shim
- update stale guidance that referenced removed backend feature combinations
- package-qualify the Reborn coverage lane `libsql` feature selection so workspace coverage no longer requires every crate to declare a `libsql` feature

## Impact

This reduces feature-matrix surface area and removes CI work that no longer exercises meaningful behavior. Backend contract tests now compile directly in the affected crates instead of being hidden behind backend feature gates.

## Validation

- `cargo metadata --format-version 1 --no-deps`
- `bash scripts/ci/test-package-feature-flags.sh`
- `cargo check -p ironclaw_filesystem --tests`
- `cargo check -p ironclaw_reborn_event_store --tests`
- `cargo check -p ironclaw_triggers --tests`
- `cargo check -p ironclaw_reborn_openai_compat --tests`
- `cargo check -p ironclaw_product_workflow --tests`
- `cargo check -p ironclaw_reborn_composition --features test-support,libsql --tests`
- `cargo check -p ironclaw_host_runtime --features test-support,libsql --tests`
- `cargo check -p ironclaw_webui --features test-support --tests`
- `cargo check -p ironclaw_runner --features libsql-secrets,libsql-restart-tests,webui-user-store --tests`
- `cargo check -p ironclaw_stress`
- `cargo test -p ironclaw_stress`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `cargo metadata --format-version 1 --no-deps --features ironclaw/libsql`
- `cargo test --workspace --features ironclaw/libsql --test reborn_integration_attach --no-run`
- `git diff --check`

## Notes

`inmemory-turn-state` is intentionally left untouched because it is covered by a parallel workstream. Higher-level root/composition/CLI storage feature switches remain for follow-up collapse.