### PR TITLE
fix(webui): expand workspace tree for deep-linked files

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/workspace/components/workspace-tree.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/components/workspace-tree.tsx
@@ -43,6 +43,8 @@ function TreeNode({ entry, depth, selectedPath, expandedPaths, filter, onToggleD
       <div>
         <button
           type="button"
+          data-testid="workspace-tree-entry"
+          data-entry-path={entry.path}
           onClick={() => {
             // Navigate so the main pane lists this folder, and toggle its
             // expansion in the tree — one click drives both the master (tree)
@@ -87,6 +89,8 @@ function TreeNode({ entry, depth, selectedPath, expandedPaths, filter, onToggleD
   return (
     <button
       type="button"
+      data-testid="workspace-tree-entry"
+      data-entry-path={entry.path}
       onClick={() => onSelectFile(entry.path)}
       className={[
         "flex min-h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm",

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/components/workspace-tree.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/components/workspace-tree.tsx
@@ -43,7 +43,7 @@ function TreeNode({ entry, depth, selectedPath, expandedPaths, filter, onToggleD
       <div>
         <button
           type="button"
-          data-testid="workspace-tree-entry"
+          data-testid={`workspace-tree-entry-${entry.path}`}
           data-entry-path={entry.path}
           onClick={() => {
             // Navigate so the main pane lists this folder, and toggle its
@@ -89,7 +89,7 @@ function TreeNode({ entry, depth, selectedPath, expandedPaths, filter, onToggleD
   return (
     <button
       type="button"
-      data-testid="workspace-tree-entry"
+      data-testid={`workspace-tree-entry-${entry.path}`}
       data-entry-path={entry.path}
       onClick={() => onSelectFile(entry.path)}
       className={[

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/components/workspace-tree.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/components/workspace-tree.tsx
@@ -43,7 +43,7 @@ function TreeNode({ entry, depth, selectedPath, expandedPaths, filter, onToggleD
       <div>
         <button
           type="button"
-          data-testid={`workspace-tree-entry-${entry.path}`}
+          data-testid="workspace-tree-entry"
           data-entry-path={entry.path}
           onClick={() => {
             // Navigate so the main pane lists this folder, and toggle its
@@ -89,7 +89,7 @@ function TreeNode({ entry, depth, selectedPath, expandedPaths, filter, onToggleD
   return (
     <button
       type="button"
-      data-testid={`workspace-tree-entry-${entry.path}`}
+      data-testid="workspace-tree-entry"
       data-entry-path={entry.path}
       onClick={() => onSelectFile(entry.path)}
       className={[

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/hooks/useWorkspaceBrowser.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/hooks/useWorkspaceBrowser.ts
@@ -11,7 +11,7 @@ import { expandWorkspaceSelection } from "../lib/workspace-presenters";
 export function useWorkspaceBrowser(selectedPath) {
   const t = useT();
   const queryClient = useQueryClient();
-  const [expandedPaths, setExpandedPaths] = React.useState(new Set());
+  const [expandedPaths, setExpandedPaths] = React.useState<Set<string>>(() => new Set());
   const [filter, setFilter] = React.useState("");
   const [result, setResult] = React.useState(null);
 

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/hooks/useWorkspaceBrowser.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/hooks/useWorkspaceBrowser.ts
@@ -11,7 +11,9 @@ import { expandWorkspaceSelection } from "../lib/workspace-presenters";
 export function useWorkspaceBrowser(selectedPath) {
   const t = useT();
   const queryClient = useQueryClient();
-  const [expandedPaths, setExpandedPaths] = React.useState<Set<string>>(() => new Set());
+  const [expandedPaths, setExpandedPaths] = React.useState<Set<string>>(() =>
+    expandWorkspaceSelection(new Set<string>(), selectedPath)
+  );
   const [filter, setFilter] = React.useState("");
   const [result, setResult] = React.useState(null);
 

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/hooks/useWorkspaceBrowser.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/hooks/useWorkspaceBrowser.ts
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import React from "react";
 import { useT } from "../../../lib/i18n";
 import { listWorkspace, readWorkspaceFile } from "../lib/workspace-api";
+import { expandWorkspaceSelection } from "../lib/workspace-presenters";
 
 // Read-only browser state for the agent filesystem viewer. The tree is rooted
 // at the mount list (empty path); selecting a file loads a preview, selecting a
@@ -13,6 +14,10 @@ export function useWorkspaceBrowser(selectedPath) {
   const [expandedPaths, setExpandedPaths] = React.useState(new Set());
   const [filter, setFilter] = React.useState("");
   const [result, setResult] = React.useState(null);
+
+  React.useEffect(() => {
+    setExpandedPaths((current) => expandWorkspaceSelection(current, selectedPath));
+  }, [selectedPath]);
 
   const rootQuery = useQuery({
     queryKey: ["workspace-list", ""],

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.test.ts
@@ -61,6 +61,12 @@ test("workspace selection expansion reuses state when all parents are already op
   );
 });
 
+test("workspace selection expansion tolerates an undefined selection", () => {
+  const expanded = new Set(["memory"]);
+
+  assert.equal(expandWorkspaceSelection(expanded, undefined), expanded);
+});
+
 test("workspace entry sorting tolerates missing display names", () => {
   const entries = [
     { name: "report.txt", path: "report.txt", is_dir: false },

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.test.ts
@@ -3,6 +3,7 @@ import { test, vi } from "vitest";
 
 import {
   areaDisplayName,
+  expandWorkspaceSelection,
   formatWorkspaceFileSize,
   sortEntries,
 } from "./workspace-presenters";
@@ -29,6 +30,34 @@ test("workspace root entries sort by their localized labels", () => {
   assert.deepEqual(
     sortEntries(entries, (entry) => areaDisplayName(entry.path, t)).map((entry) => entry.path),
     ["workspace", "memory"],
+  );
+});
+
+test("workspace deep links expand every parent without collapsing other branches", () => {
+  const expanded = new Set(["memory", "workspace/other"]);
+
+  const next = expandWorkspaceSelection(
+    expanded,
+    "workspace/projects/ironclaw/notes/plan.md",
+  );
+
+  assert.deepEqual([...next], [
+    "memory",
+    "workspace/other",
+    "workspace",
+    "workspace/projects",
+    "workspace/projects/ironclaw",
+    "workspace/projects/ironclaw/notes",
+  ]);
+  assert.deepEqual([...expanded], ["memory", "workspace/other"]);
+});
+
+test("workspace selection expansion reuses state when all parents are already open", () => {
+  const expanded = new Set(["workspace", "workspace/projects"]);
+
+  assert.equal(
+    expandWorkspaceSelection(expanded, "workspace/projects/plan.md"),
+    expanded,
   );
 });
 

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.ts
@@ -75,7 +75,10 @@ export function pathSegments(path) {
 // Expand every directory above the selected path while retaining branches the
 // user opened manually. Returning the existing Set when nothing changes keeps
 // route updates idempotent and avoids an unnecessary tree render.
-export function expandWorkspaceSelection(expandedPaths, selectedPath) {
+export function expandWorkspaceSelection(
+  expandedPaths: Set<string>,
+  selectedPath: string | undefined,
+): Set<string> {
   const parentSegments = pathSegments(selectedPath).slice(0, -1);
   const parentPaths = parentSegments.map((_, index) =>
     parentSegments.slice(0, index + 1).join("/"),

--- a/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/workspace/lib/workspace-presenters.ts
@@ -72,6 +72,22 @@ export function pathSegments(path) {
   return path.split("/").filter(Boolean);
 }
 
+// Expand every directory above the selected path while retaining branches the
+// user opened manually. Returning the existing Set when nothing changes keeps
+// route updates idempotent and avoids an unnecessary tree render.
+export function expandWorkspaceSelection(expandedPaths, selectedPath) {
+  const parentSegments = pathSegments(selectedPath).slice(0, -1);
+  const parentPaths = parentSegments.map((_, index) =>
+    parentSegments.slice(0, index + 1).join("/"),
+  );
+
+  if (parentPaths.every((path) => expandedPaths.has(path))) {
+    return expandedPaths;
+  }
+
+  return new Set([...expandedPaths, ...parentPaths]);
+}
+
 export function routeForWorkspacePath(path) {
   if (!path) return "/workspace";
   return `/workspace/${pathSegments(path).map(encodeURIComponent).join("/")}`;

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -265,7 +265,7 @@ SEL_V2 = {
     "workspace_directory_entry_for": (
         "[data-testid='workspace-directory-entry'][data-entry-path='{path}']"
     ),
-    "workspace_tree_entry_for": "workspace-tree-entry-{path}",
+    "workspace_tree_entry": "[data-testid='workspace-tree-entry']",
     "thread_delete_for": (
         '[data-testid="thread-delete"][data-thread-id="{id}"]'
     ),

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -265,9 +265,7 @@ SEL_V2 = {
     "workspace_directory_entry_for": (
         "[data-testid='workspace-directory-entry'][data-entry-path='{path}']"
     ),
-    "workspace_tree_entry_for": (
-        "[data-testid='workspace-tree-entry'][data-entry-path='{path}']"
-    ),
+    "workspace_tree_entry_for": "workspace-tree-entry-{path}",
     "thread_delete_for": (
         '[data-testid="thread-delete"][data-thread-id="{id}"]'
     ),

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -265,6 +265,9 @@ SEL_V2 = {
     "workspace_directory_entry_for": (
         "[data-testid='workspace-directory-entry'][data-entry-path='{path}']"
     ),
+    "workspace_tree_entry_for": (
+        "[data-testid='workspace-tree-entry'][data-entry-path='{path}']"
+    ),
     "thread_delete_for": (
         '[data-testid="thread-delete"][data-thread-id="{id}"]'
     ),

--- a/tests/e2e/scenarios/test_reborn_v2_file_download.py
+++ b/tests/e2e/scenarios/test_reborn_v2_file_download.py
@@ -228,11 +228,22 @@ async def test_workspace_deep_link_expands_selected_file_parents(reborn_v2_yolo_
     )
     await expect(page.locator(SEL_V2["workspace_heading"])).to_be_visible(timeout=15000)
 
-    for label in ("Home", "projects", "ironclaw", "notes"):
-        expanded_directory = page.locator('button[aria-expanded="true"]').filter(
-            has_text=label
+    for path in (
+        "workspace",
+        "workspace/projects",
+        "workspace/projects/ironclaw",
+        "workspace/projects/ironclaw/notes",
+    ):
+        expanded_directory = page.locator(
+            SEL_V2["workspace_tree_entry_for"].format(path=path)
         )
-        await expect(expanded_directory).to_be_visible(timeout=5000)
+        await expect(expanded_directory).to_have_attribute(
+            "aria-expanded", "true", timeout=5000
+        )
 
-    selected_file = page.locator("button.min-h-8").filter(has_text="plan")
+    selected_file = page.locator(
+        SEL_V2["workspace_tree_entry_for"].format(
+            path="workspace/projects/ironclaw/notes/plan"
+        )
+    )
     await expect(selected_file).to_be_visible(timeout=5000)

--- a/tests/e2e/scenarios/test_reborn_v2_file_download.py
+++ b/tests/e2e/scenarios/test_reborn_v2_file_download.py
@@ -234,14 +234,14 @@ async def test_workspace_deep_link_expands_selected_file_parents(reborn_v2_yolo_
         "workspace/projects/ironclaw",
         "workspace/projects/ironclaw/notes",
     ):
-        expanded_directory = page.locator(
+        expanded_directory = page.get_by_test_id(
             SEL_V2["workspace_tree_entry_for"].format(path=path)
         )
         await expect(expanded_directory).to_have_attribute(
             "aria-expanded", "true", timeout=5000
         )
 
-    selected_file = page.locator(
+    selected_file = page.get_by_test_id(
         SEL_V2["workspace_tree_entry_for"].format(
             path="workspace/projects/ironclaw/notes/plan"
         )

--- a/tests/e2e/scenarios/test_reborn_v2_file_download.py
+++ b/tests/e2e/scenarios/test_reborn_v2_file_download.py
@@ -191,6 +191,7 @@ async def test_workspace_deep_link_expands_selected_file_parents(reborn_v2_yolo_
     async def serve_listing(route):
         query = parse_qs(urlparse(route.request.url).query)
         path = query.get("path", [""])[0]
+        assert path in listings, f"unexpected Workspace listing path: {path}"
         await route.fulfill(
             content_type="application/json",
             body=json.dumps({"mount": "workspace", "entries": listings[path]}),

--- a/tests/e2e/scenarios/test_reborn_v2_file_download.py
+++ b/tests/e2e/scenarios/test_reborn_v2_file_download.py
@@ -228,22 +228,26 @@ async def test_workspace_deep_link_expands_selected_file_parents(reborn_v2_yolo_
     )
     await expect(page.locator(SEL_V2["workspace_heading"])).to_be_visible(timeout=15000)
 
-    for path in (
-        "workspace",
-        "workspace/projects",
-        "workspace/projects/ironclaw",
-        "workspace/projects/ironclaw/notes",
+    for path, label in (
+        ("workspace", "Home"),
+        ("workspace/projects", "projects"),
+        ("workspace/projects/ironclaw", "ironclaw"),
+        ("workspace/projects/ironclaw/notes", "notes"),
     ):
-        expanded_directory = page.get_by_test_id(
-            SEL_V2["workspace_tree_entry_for"].format(path=path)
+        expanded_directory = page.locator(SEL_V2["workspace_tree_entry"]).filter(
+            has_text=label
+        )
+        await expect(expanded_directory).to_have_attribute(
+            "data-entry-path", path, timeout=5000
         )
         await expect(expanded_directory).to_have_attribute(
             "aria-expanded", "true", timeout=5000
         )
 
-    selected_file = page.get_by_test_id(
-        SEL_V2["workspace_tree_entry_for"].format(
-            path="workspace/projects/ironclaw/notes/plan"
-        )
+    selected_file = page.locator(SEL_V2["workspace_tree_entry"]).filter(
+        has_text="plan"
+    )
+    await expect(selected_file).to_have_attribute(
+        "data-entry-path", "workspace/projects/ironclaw/notes/plan", timeout=5000
     )
     await expect(selected_file).to_be_visible(timeout=5000)

--- a/tests/e2e/scenarios/test_reborn_v2_file_download.py
+++ b/tests/e2e/scenarios/test_reborn_v2_file_download.py
@@ -18,6 +18,7 @@ LLM + Chromium); it is CI-run, not exercised by `cargo test`.
 import json
 import re
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 from playwright.async_api import expect
 
@@ -151,3 +152,86 @@ async def test_workspace_viewer_reports_download_failure(reborn_v2_yolo_page):
         has_text="Couldn't download this file. Please try again."
     )
     await expect(failure_toast).to_be_visible(timeout=5000)
+
+
+async def test_workspace_deep_link_expands_selected_file_parents(reborn_v2_yolo_page):
+    """A nested file deep link reveals its selected node in the Workspace tree."""
+    page = reborn_v2_yolo_page
+    listings = {
+        "": [{"name": "projects", "path": "projects", "kind": "directory"}],
+        "projects": [
+            {
+                "name": "ironclaw",
+                "path": "projects/ironclaw",
+                "kind": "directory",
+            }
+        ],
+        "projects/ironclaw": [
+            {
+                "name": "notes",
+                "path": "projects/ironclaw/notes",
+                "kind": "directory",
+            }
+        ],
+        "projects/ironclaw/notes": [
+            {
+                "name": "plan",
+                "path": "projects/ironclaw/notes/plan",
+                "kind": "file",
+            }
+        ],
+    }
+
+    async def serve_mounts(route):
+        await route.fulfill(
+            content_type="application/json",
+            body=json.dumps({"mounts": [{"mount": "workspace"}]}),
+        )
+
+    async def serve_listing(route):
+        query = parse_qs(urlparse(route.request.url).query)
+        path = query.get("path", [""])[0]
+        await route.fulfill(
+            content_type="application/json",
+            body=json.dumps({"mount": "workspace", "entries": listings[path]}),
+        )
+
+    async def serve_stat(route):
+        await route.fulfill(
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "stat": {
+                        "kind": "file",
+                        "mime_type": "text/markdown",
+                        "size_bytes": 6,
+                    }
+                }
+            ),
+        )
+
+    async def serve_content(route):
+        await route.fulfill(content_type="text/markdown", body="# Plan")
+
+    await page.route("**/api/webchat/v2/fs/mounts", serve_mounts)
+    await page.route(re.compile(r".*/api/webchat/v2/fs/list(?:\?.*)?$"), serve_listing)
+    await page.route(re.compile(r".*/api/webchat/v2/fs/stat(?:\?.*)?$"), serve_stat)
+    await page.route(
+        re.compile(r".*/api/webchat/v2/fs/content(?:\?.*)?$"),
+        serve_content,
+    )
+
+    origin = await page.evaluate("location.origin")
+    await page.goto(
+        f"{origin}/workspace/workspace/projects/ironclaw/notes/plan"
+    )
+    await expect(page.locator(SEL_V2["workspace_heading"])).to_be_visible(timeout=15000)
+
+    for label in ("Home", "projects", "ironclaw", "notes"):
+        expanded_directory = page.locator('button[aria-expanded="true"]').filter(
+            has_text=label
+        )
+        await expect(expanded_directory).to_be_visible(timeout=5000)
+
+    selected_file = page.locator("button.min-h-8").filter(has_text="plan")
+    await expect(selected_file).to_be_visible(timeout=5000)


### PR DESCRIPTION
## Summary

- Automatically expands every parent directory for a file selected through a Workspace deep link.
- Merges selected-path ancestors into the existing expanded tree state so manually opened branches remain visible.
- Adds unit regression coverage and a Reborn Playwright E2E test for canonical nested-file deep links.

## Change Type

- [x] Bug fix

## Linked Issue

Closes #6332

## Validation

- [x] `TZ=UTC corepack pnpm test` — 817 tests passed
- [x] `corepack pnpm lint:conventions`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `pytest -q tests/e2e/scenarios/test_reborn_v2_file_download.py` — 3 passed
- [x] `scripts/pre-commit-safety.sh`
- [x] `git diff --check`

## Security Impact

None. This only changes client-side Workspace tree state.

## Database Impact

None.

## Blast Radius

Limited to Workspace tree expansion when navigating to a selected nested path.

## Rollback Plan

Revert this PR to restore click-only Workspace tree expansion.

---

**Review track**: B