### PR TITLE
fix(webui): preserve viewport while loading older chat messages

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.test.ts
@@ -29,6 +29,8 @@ function messageListSourceForTest() {
         .replace("export function isNearBottom", "function isNearBottom")
         .replace("export function shouldShowJumpToLatest", "function shouldShowJumpToLatest")
         .replace("export function scrollToBottom", "function scrollToBottom")
+        .replace("export function capturePrependScrollAnchor", "function capturePrependScrollAnchor")
+        .replace("export function restorePrependScrollAnchor", "function restorePrependScrollAnchor")
         .replace("export function messageKey", "function messageKey")
         .replace("export function isNewUserMessage", "function isNewUserMessage")
         .replace("export function MessageList", "function MessageList"),
@@ -44,6 +46,8 @@ globalThis.__testExports = {
   isNearBottom,
   shouldShowJumpToLatest,
   scrollToBottom,
+  capturePrependScrollAnchor,
+  restorePrependScrollAnchor,
   messageKey,
   isNewUserMessage,
 };`;
@@ -63,6 +67,8 @@ test("MessageList keeps scroll helpers exported", () => {
     "isNearBottom",
     "shouldShowJumpToLatest",
     "scrollToBottom",
+    "capturePrependScrollAnchor",
+    "restorePrependScrollAnchor",
     "messageKey",
     "isNewUserMessage",
   ]) {
@@ -136,6 +142,46 @@ test("MessageList scrollToBottom pins the viewport to the latest content", () =>
   assert.equal(distanceFromBottom(viewport), 0);
 });
 
+test("MessageList preserves the reading position when older messages are prepended", () => {
+  const { capturePrependScrollAnchor, restorePrependScrollAnchor } = loadHelpers();
+  let viewportTop = 100;
+  let anchorTop = 177;
+  const viewport = {
+    scrollHeight: 1000,
+    scrollTop: 24,
+    clientHeight: 600,
+    getBoundingClientRect: () => ({ top: viewportTop }),
+  };
+  const anchorElement = {
+    isConnected: true,
+    getBoundingClientRect: () => ({ top: anchorTop }),
+  };
+  const anchor = capturePrependScrollAnchor(viewport, anchorElement);
+
+  viewport.scrollHeight = 1480;
+  anchorTop = 657;
+  restorePrependScrollAnchor(viewport, anchor);
+
+  assert.equal(
+    viewport.scrollTop,
+    504,
+    "the previous viewport offset should move by exactly the prepended height",
+  );
+
+  // Chromium may apply native scroll anchoring before React's layout effect.
+  // Writing the absolute target keeps that browser correction idempotent.
+  viewport.scrollTop = 504;
+  anchorTop = 177;
+  restorePrependScrollAnchor(viewport, anchor);
+  assert.equal(viewport.scrollTop, 504);
+
+  // Fall back to the scroll-height delta if React replaced the anchor node.
+  anchorElement.isConnected = false;
+  viewport.scrollTop = 24;
+  restorePrependScrollAnchor(viewport, anchor);
+  assert.equal(viewport.scrollTop, 504);
+});
+
 test("MessageList force-follows when the latest message is newly sent by the user", () => {
   const { isNewUserMessage, messageKey } = loadHelpers();
   const previousAssistant = { id: "reply-1", role: "assistant" };
@@ -160,6 +206,21 @@ test("MessageList force-follows when the latest message is newly sent by the use
 });
 
 test("MessageList observes content growth from streamed markdown layout", () => {
+  assert.match(
+    messageListSource,
+    /const anchor = capturePrependScrollAnchor\([\s\S]*firstVisibleContentElement\(el, contentRef\.current\)[\s\S]*historyPrependAnchorRef\.current = \{[\s\S]*firstMessageKey:[\s\S]*restorePrependScrollAnchor\(el, anchor\);/,
+    "history pagination should restore the pre-prepend viewport before paint",
+  );
+  assert.match(
+    messageListSource,
+    /previousFirstStillPresent[\s\S]*firstKey !== anchor\.firstMessageKey[\s\S]*previousFirstStillPresent/,
+    "scroll restoration should only run when older messages were actually prepended",
+  );
+  assert.match(
+    messageListSource,
+    /loadOlder\(\);[\s\S]*onClick=\{loadOlder\}/,
+    "button and top-scroll pagination should share the anchored load path",
+  );
   assert.match(
     messageListSource,
     /const force = isNewUserMessage\(latestMessageKeyRef\.current, latestMessage\);[\s\S]*followLatest\(force\);/,

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
@@ -44,6 +44,48 @@ export function scrollToBottom(el) {
   el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
 }
 
+export function capturePrependScrollAnchor(el, anchorElement = null) {
+  if (!el) return null;
+  const anchorTop = anchorElement
+    ? anchorElement.getBoundingClientRect().top - el.getBoundingClientRect().top
+    : null;
+  return {
+    scrollHeight: el.scrollHeight,
+    scrollTop: el.scrollTop,
+    anchorElement,
+    anchorTop,
+  };
+}
+
+export function restorePrependScrollAnchor(el, anchor) {
+  if (!el || !anchor) return;
+  if (anchor.anchorElement?.isConnected && Number.isFinite(anchor.anchorTop)) {
+    const currentTop =
+      anchor.anchorElement.getBoundingClientRect().top -
+      el.getBoundingClientRect().top;
+    el.scrollTop = Math.max(0, el.scrollTop + currentTop - anchor.anchorTop);
+    return;
+  }
+  const prependedHeight = el.scrollHeight - anchor.scrollHeight;
+  el.scrollTop = Math.max(0, anchor.scrollTop + prependedHeight);
+}
+
+function firstVisibleContentElement(
+  viewport: HTMLElement | null,
+  content: HTMLElement | null,
+) {
+  if (!viewport || !content) return null;
+  const viewportTop = viewport.getBoundingClientRect().top;
+  return (
+    Array.from(content.children).find((child) => {
+      if (child.querySelector('[data-testid="message-list-load-older"]')) {
+        return false;
+      }
+      return child.getBoundingClientRect().bottom > viewportTop;
+    }) || null
+  );
+}
+
 export function messageKey(message) {
   if (!message?.id) return null;
   return `${message.role || ""}:${message.id}`;
@@ -79,6 +121,7 @@ export function MessageList({
   const scrollRafRef = React.useRef(null);
   const previousScrollTopRef = React.useRef(0);
   const userScrollIntentRef = React.useRef(false);
+  const historyPrependAnchorRef = React.useRef(null);
   const [showJumpToLatest, setShowJumpToLatest] = React.useState(false);
 
   const cancelFollow = React.useCallback(() => {
@@ -116,6 +159,62 @@ export function MessageList({
     window.cancelAnimationFrame(scrollRafRef.current);
     scrollRafRef.current = null;
   }, []);
+
+  const loadOlder = React.useCallback(() => {
+    const el = containerRef.current;
+    if (!el || !onLoadMore || isLoading || historyPrependAnchorRef.current) {
+      return;
+    }
+    const anchor = capturePrependScrollAnchor(
+      el,
+      firstVisibleContentElement(el, contentRef.current),
+    );
+    if (!anchor) return;
+    historyPrependAnchorRef.current = {
+      ...anchor,
+      firstMessageKey: messageKey(messages[0]),
+      threadId,
+    };
+    shouldScrollRef.current = false;
+    userScrollIntentRef.current = true;
+    cancelFollow();
+    try {
+      onLoadMore();
+    } catch (error) {
+      historyPrependAnchorRef.current = null;
+      throw error;
+    }
+  }, [cancelFollow, isLoading, messages, onLoadMore, threadId]);
+
+  React.useLayoutEffect(() => {
+    const anchor = historyPrependAnchorRef.current;
+    if (!anchor) return;
+    if (anchor.threadId !== threadId) {
+      historyPrependAnchorRef.current = null;
+      return;
+    }
+
+    const firstKey = messageKey(messages[0]);
+    const previousFirstStillPresent = messages.some(
+      (message) => messageKey(message) === anchor.firstMessageKey,
+    );
+    if (
+      firstKey &&
+      firstKey !== anchor.firstMessageKey &&
+      previousFirstStillPresent
+    ) {
+      const el = containerRef.current;
+      restorePrependScrollAnchor(el, anchor);
+      historyPrependAnchorRef.current = null;
+      if (el) {
+        previousScrollTopRef.current = el.scrollTop;
+        setShowJumpToLatest(shouldShowJumpToLatest(el));
+      }
+      return;
+    }
+
+    if (!isLoading) historyPrependAnchorRef.current = null;
+  }, [isLoading, messages, threadId]);
 
   // Keep the latest content in view. Re-runs on new messages and when the
   // run state flips — the typing indicator / streamed reply are rendered as
@@ -173,9 +272,9 @@ export function MessageList({
       onLoadMore &&
       !isLoading
     ) {
-      onLoadMore();
+      loadOlder();
     }
-  }, [hasMore, onLoadMore, isLoading, followLatest]);
+  }, [hasMore, onLoadMore, isLoading, followLatest, loadOlder]);
 
   const markUserScrollIntent = React.useCallback(() => {
     userScrollIntentRef.current = true;
@@ -257,7 +356,7 @@ export function MessageList({
         (
           <div className="text-center">
             <button
-              onClick={onLoadMore}
+              onClick={loadOlder}
               disabled={isLoading}
               data-testid="message-list-load-older"
               className="v2-button rounded-md border border-white/10 px-3 py-1.5 text-xs text-iron-300 hover:border-signal/35 hover:text-white disabled:opacity-50"

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
@@ -44,7 +44,22 @@ export function scrollToBottom(el) {
   el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
 }
 
-export function capturePrependScrollAnchor(el, anchorElement = null) {
+interface ScrollAnchor {
+  scrollHeight: number;
+  scrollTop: number;
+  anchorElement: Element | null;
+  anchorTop: number | null;
+}
+
+interface HistoryPrependAnchor extends ScrollAnchor {
+  firstMessageKey: string | null;
+  threadId: string | null | undefined;
+}
+
+export function capturePrependScrollAnchor(
+  el: HTMLElement | null,
+  anchorElement: Element | null = null,
+): ScrollAnchor | null {
   if (!el) return null;
   const anchorTop = anchorElement
     ? anchorElement.getBoundingClientRect().top - el.getBoundingClientRect().top
@@ -57,7 +72,10 @@ export function capturePrependScrollAnchor(el, anchorElement = null) {
   };
 }
 
-export function restorePrependScrollAnchor(el, anchor) {
+export function restorePrependScrollAnchor(
+  el: HTMLElement | null,
+  anchor: ScrollAnchor | null,
+): void {
   if (!el || !anchor) return;
   if (anchor.anchorElement?.isConnected && Number.isFinite(anchor.anchorTop)) {
     const currentTop =
@@ -73,7 +91,7 @@ export function restorePrependScrollAnchor(el, anchor) {
 function firstVisibleContentElement(
   viewport: HTMLElement | null,
   content: HTMLElement | null,
-) {
+): Element | null {
   if (!viewport || !content) return null;
   const viewportTop = viewport.getBoundingClientRect().top;
   return (
@@ -121,7 +139,7 @@ export function MessageList({
   const scrollRafRef = React.useRef(null);
   const previousScrollTopRef = React.useRef(0);
   const userScrollIntentRef = React.useRef(false);
-  const historyPrependAnchorRef = React.useRef(null);
+  const historyPrependAnchorRef = React.useRef<HistoryPrependAnchor | null>(null);
   const [showJumpToLatest, setShowJumpToLatest] = React.useState(false);
 
   const cancelFollow = React.useCallback(() => {
@@ -204,12 +222,11 @@ export function MessageList({
       previousFirstStillPresent
     ) {
       const el = containerRef.current;
-      restorePrependScrollAnchor(el, anchor);
       historyPrependAnchorRef.current = null;
-      if (el) {
-        previousScrollTopRef.current = el.scrollTop;
-        setShowJumpToLatest(shouldShowJumpToLatest(el));
-      }
+      if (!el) return;
+      restorePrependScrollAnchor(el, anchor);
+      previousScrollTopRef.current = el.scrollTop;
+      setShowJumpToLatest(shouldShowJumpToLatest(el));
       return;
     }
 

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -1551,6 +1551,158 @@ async def test_reborn_v2_timeline_pagination(reborn_v2_server):
         )
 
 
+async def test_reborn_v2_loading_older_messages_preserves_viewport(
+    reborn_v2_server, reborn_v2_browser
+):
+    """Prepending a timeline page keeps the previously visible message anchored."""
+    thread_id = "thread-history-scroll-anchor"
+    first_current_sequence = 21
+    context = await reborn_v2_browser.new_context(
+        viewport={"width": 1280, "height": 720}
+    )
+    page = await context.new_page()
+    await _install_fake_v2_event_source(page)
+
+    async def fulfill_json(route, body) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(body),
+        )
+
+    async def handle_session(route) -> None:
+        await fulfill_json(
+            route,
+            {
+                "tenant_id": "reborn-v2-e2e",
+                "user_id": USER_ID,
+                "capabilities": {},
+                "features": {"reborn_projects": False},
+                "attachments": {
+                    "accept": ["text/plain"],
+                    "max_files_per_message": 4,
+                    "max_bytes_per_file": 1048576,
+                    "max_bytes_per_message": 4194304,
+                },
+            },
+        )
+
+    async def handle_threads(route) -> None:
+        await fulfill_json(
+            route,
+            {
+                "threads": [
+                    {
+                        "thread_id": thread_id,
+                        "title": "History scroll anchor regression",
+                        "created_at": "2026-07-20T00:00:00Z",
+                        "updated_at": "2026-07-20T00:00:00Z",
+                    }
+                ],
+                "next_cursor": None,
+            },
+        )
+
+    def timeline_message(sequence: int) -> dict:
+        prefix = (
+            "Current anchor message"
+            if sequence == first_current_sequence
+            else "Timeline message"
+        )
+        return {
+            "message_id": f"history-{sequence}",
+            "kind": "user",
+            "content": f"{prefix} {sequence}",
+            "sequence": sequence,
+            "status": "accepted",
+            "created_at": f"2026-07-20T00:{sequence:02d}:00Z",
+        }
+
+    async def handle_timeline(route) -> None:
+        query = parse_qs(urlparse(route.request.url).query)
+        if query.get("cursor"):
+            await fulfill_json(
+                route,
+                {
+                    "messages": [timeline_message(i) for i in range(1, 21)],
+                    "next_cursor": None,
+                },
+            )
+            return
+        await fulfill_json(
+            route,
+            {
+                "messages": [timeline_message(i) for i in range(21, 41)],
+                "next_cursor": json.dumps(
+                    {"before_message_sequence": first_current_sequence}
+                ),
+            },
+        )
+
+    await page.route("**/api/webchat/v2/session", handle_session)
+    await page.route("**/api/webchat/v2/threads", handle_threads)
+    await page.route(
+        f"**/api/webchat/v2/threads/{thread_id}/timeline**", handle_timeline
+    )
+
+    try:
+        await page.goto(
+            f"{reborn_v2_server}/chat/{thread_id}?token={REBORN_V2_AUTH_TOKEN}"
+        )
+        viewport = page.locator(SEL_V2["message_list_scroll"])
+        anchor = page.locator(SEL_V2["msg_user"]).filter(
+            has_text=f"Current anchor message {first_current_sequence}"
+        )
+        await expect(anchor).to_be_visible(timeout=15000)
+        await expect(
+            page.locator(SEL_V2["message_list_load_older"])
+        ).to_be_attached()
+
+        before_top = await page.evaluate(
+            """({ viewportSelector, loadSelector, anchorText }) => {
+              const viewport = document.querySelector(viewportSelector);
+              const loadButton = document.querySelector(loadSelector);
+              const anchor = Array.from(
+                document.querySelectorAll('[data-testid="msg-user"]')
+              ).find((node) => node.textContent.includes(anchorText));
+              if (!viewport || !loadButton || !anchor) {
+                throw new Error('history scroll fixture did not render');
+              }
+              viewport.scrollTop = 0;
+              const top = anchor.getBoundingClientRect().top
+                - viewport.getBoundingClientRect().top;
+              loadButton.click();
+              return top;
+            }""",
+            {
+                "viewportSelector": SEL_V2["message_list_scroll"],
+                "loadSelector": SEL_V2["message_list_load_older"],
+                "anchorText": f"Current anchor message {first_current_sequence}",
+            },
+        )
+
+        await expect(page.get_by_text("Timeline message 1", exact=True)).to_be_visible(
+            timeout=10000
+        )
+        after_top = await anchor.evaluate(
+            """(node, viewportSelector) => {
+              const viewport = document.querySelector(viewportSelector);
+              if (!viewport) throw new Error('message viewport disappeared');
+              return node.getBoundingClientRect().top
+                - viewport.getBoundingClientRect().top;
+            }""",
+            SEL_V2["message_list_scroll"],
+        )
+
+        assert abs(after_top - before_top) <= 2, (
+            "the previously visible message moved after history prepend: "
+            f"before={before_top}, after={after_top}"
+        )
+        assert await viewport.evaluate("node => node.scrollTop") > 0
+    finally:
+        await context.close()
+
+
 async def test_reborn_v2_sse_streams_run_lifecycle(reborn_v2_server):
     """The SSE stream opens via the `?token=` shim and reports the run reaching completion.
 


### PR DESCRIPTION
## Summary

- Captures the first visible chat message as a DOM scroll anchor before requesting an older timeline page.
- Restores the anchored message to the same visual position before paint after older messages are prepended, with a scroll-height fallback when the DOM node is replaced.
- Routes both manual and top-scroll history loading through the anchored pagination path.
- Adds unit regression coverage and a real Reborn WebUI v2 Playwright scenario that verifies the same message remains at the same viewport offset.

<img width="650" height="830" alt="iShot_2026-07-20_19 21 07" src="https://github.com/user-attachments/assets/1ce37ca8-faa7-4d9f-a636-09a9f698889e" />


## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #6333

## Validation

- [x] `TZ=UTC corepack pnpm test` — 101 files, 816 tests passed
- [x] `corepack pnpm lint:conventions`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `cargo test -p ironclaw_webui --all-features`
- [x] `cargo clippy -p ironclaw_webui --all-targets --all-features -- -D warnings`
- [x] Playwright E2E: `test_reborn_v2_loading_older_messages_preserves_viewport`
- [x] `scripts/pre-commit-safety.sh`
- [x] Final implementation review completed

## Security Impact

None. This changes only client-side chat viewport behavior.

## Reborn Trust-Boundary Checklist

N/A. No trust boundaries, authority types, runtime behavior, or external inputs were changed.

## Database Impact

None. No schema, migration, or persistence changes.

## Blast Radius

Limited to WebChat v2 message-list history pagination and its frontend/browser tests.

## Rollback Plan

Revert the two commits to restore the previous unanchored history-loading behavior.

## Review Follow-Through

No blocking findings. WebKit-specific automation can be added later if the E2E harness gains a WebKit browser matrix.

---

**Review track**: B