### PR TITLE
fix(e2e): stabilize offline extensions scenario

### DIFF
--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
@@ -713,6 +713,31 @@ async def test_reborn_legacy_extensions_offline_attempts_catalog_requests(
     page = await context.new_page()
     catalog_requests: list[str] = []
 
+    async def handle_llm_providers(route):
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "providers": [
+                        {
+                            "id": "openai",
+                            "description": "OpenAI API",
+                            "adapter": "open_ai_completions",
+                            "base_url": "https://api.openai.test/v1",
+                            "default_model": "mock-model",
+                            "builtin": True,
+                            "api_key_set": True,
+                            "api_key_required": True,
+                            "base_url_required": False,
+                            "accepts_api_key": True,
+                        }
+                    ],
+                    "active": {"provider_id": "openai", "model": "mock-model"},
+                }
+            ),
+        )
+
     def record_catalog_request(request):
         path = urlparse(request.url).path
         if path in {
@@ -722,9 +747,21 @@ async def test_reborn_legacy_extensions_offline_attempts_catalog_requests(
             catalog_requests.append(path)
 
     page.on("request", record_catalog_request)
+    await page.route(
+        "**/api/webchat/v2/llm/providers",
+        handle_llm_providers,
+    )
 
     try:
-        await page.goto(f"{reborn_v2_server}/settings?token={REBORN_V2_AUTH_TOKEN}")
+        async with page.expect_response("**/api/webchat/v2/llm/providers"):
+            await page.goto(
+                f"{reborn_v2_server}/settings?token={REBORN_V2_AUTH_TOKEN}"
+            )
+        await expect(
+            page.locator(
+                SEL_V2["llm_provider_card_for"].format(provider_id="openai")
+            )
+        ).to_be_visible(timeout=15000)
         await expect(page.get_by_role("link", name="Extensions").first).to_be_visible(
             timeout=15000
         )


### PR DESCRIPTION
## Summary

- make the offline extensions scenario return a deterministic active LLM-provider snapshot
- wait for the provider state to render before taking Chromium offline
- preserve the original assertions that both extension catalog requests are attempted and the retry flow recovers

## Root cause

Scheduled run https://github.com/nearai/ironclaw/actions/runs/29717067979 failed only in the legacy-settings-extensions shard. The offline scenario started on Settings without synchronizing the first-run provider query. When that query resolved with no active provider before the Extensions click, the onboarding gate redirected the SPA to Welcome instead of mounting Extensions. The test then waited for an alert that could never render. The aggregate Reborn Playwright job failed because that shard failed.

## Verification

- focused scenario: 1 passed in 3.09s
- full test_reborn_webui_v2_legacy_extensions.py: 43 passed in 19.39s
- git diff --check