### PR TITLE
ci: build IronClaw reborn release binaries with cargo-dist

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,16 +59,18 @@ Rules for a roll-up job that is (or may become) required:
    merge-queue/push run's clippy matrix is missing any of the three feature
    lanes, so a "green but slim" regression cannot come back silently.
 
-## Reborn release binary compile matrix
+## Reborn release binaries
 
-`reborn-release-compile.yml` is a compile-and-smoke preflight for the shipping
-Reborn `ironclaw` binary. The tag-only `release.yml` calls it for matching
-release tags. Under #6160's temporary compile-only policy below, the legacy
-`host` job stays disabled; if that job is restored, its dependency and success
-gate still prevent it from running unless every target succeeds. The preflight
-workflow can also run directly through `workflow_dispatch`; it is not triggered
-by pull requests, so ordinary CLI and WebUI changes do not start the
-seven-platform release matrix.
+`release.yml` uses cargo-dist to build and publish the standalone Reborn
+`ironclaw` binary on matching release tags. The workspace cargo-dist config
+allow-lists `ironclaw_reborn_cli`, so the legacy root package named `ironclaw`
+is not selected even though the public tag namespace remains
+`ironclaw-vX.Y.Z`. Release tags must match the Reborn CLI package version.
+
+`reborn-release-compile.yml` remains available as a direct
+`workflow_dispatch` compile-and-smoke preflight. It is not called from
+`release.yml` and is not triggered by pull requests, so ordinary CLI and WebUI
+changes do not start the seven-platform release matrix.
 
 | Rust target | GitHub runner |
 |---|---|
@@ -80,7 +82,7 @@ seven-platform release matrix.
 | `aarch64-apple-darwin` | `macos-15` |
 | `x86_64-pc-windows-msvc` | `windows-2022` |
 
-Each matrix entry performs a final `cargo build --locked --profile dist` link
+Each preflight matrix entry performs a final `cargo build --locked --profile dist` link
 for `ironclaw_reborn_cli` / `ironclaw` with an explicit compile feature
 contract owned by this workflow:
 `libsql,postgres,inmemory-turn-state`.
@@ -89,14 +91,14 @@ Before upload, the workflow executes that exact native binary with `--version`,
 reject a program interpreter or dynamic-library dependency, which prevents an
 installed musl loader on the build runner from hiding a non-portable artifact.
 This is shallow CLI startup coverage; it does not validate `serve`, external
-services, installers, or cargo-dist release packaging. The feature list is
+services, installers, or cargo-dist release packaging. The cargo-dist package
+metadata uses the same feature set for release builds. The feature list is
 intentionally not inferred from Docker or #6122.
 
-The uploaded `reborn-compile-*` artifacts are short-lived preflight evidence.
-Their prefix deliberately does not match the release host's `artifacts-*`
-download pattern, so they are not attached to the GitHub Release. Until #3483
-defines the canonical Reborn package/tag/installer contract,
-`ironclaw_reborn_cli` remains `dist = false`.
+The uploaded `reborn-compile-*` artifacts are short-lived preflight evidence
+only. Their prefix deliberately does not match the release host's `artifacts-*`
+download pattern, so direct preflight artifacts are not attached to a GitHub
+Release.
 
 ## Deep tier (nightly)
 
@@ -155,22 +157,19 @@ When adding a new workflow that runs on `push` to `main`, add its workflow
 
 ## Reborn-only release validation policy
 
-For #6160, `release.yml` temporarily keeps the legacy cargo-dist release chain
-visible but disables its `plan` root with the impossible
-`github.repository == ''` guard. Its dependent local/global artifact, WASM,
-GitHub Release host, registry-checksum, and announcement jobs therefore skip.
-The Reborn compile matrix merged in #6176 is the only intended active path.
-This compile-only mode produces short-lived Actions evidence artifacts; it does
-not create a GitHub Release or permanent downloadable release assets.
+For #6160/#3483, `release.yml` publishes the standalone Reborn CLI through
+cargo-dist. The active tag-release path is `plan` -> local/global cargo-dist
+artifact builds -> `host`, which creates the GitHub Release with cargo-dist's
+generated title, body, install links, checksums, and download table. Extension
+WASM publication and registry-checksum updates remain disabled for this
+Reborn-only binary release path.
 
 The release Docker caller retains its own impossible guard as an explicit
 defense against image publication. The reusable `docker.yml` workflow is
 unchanged, so its manual and hourly entry points remain available. Changes to
 the release, Docker, or reusable Reborn compile workflow enter the Reborn CLI
 smoke selector, and the required Code Style roll-up propagates that contract
-result. To restore the non-Docker legacy release path, remove `plan`'s
-impossible guard; the workflow's tag-only trigger already scopes it to release
-tags. Restore the Docker caller's host-success condition separately only when
+result. Restore the Docker caller's host-success condition separately only when
 release image publication is intentionally re-enabled.
 
 ## Known accepted gaps (deliberate, revisit as needed)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -64,10 +64,10 @@ Rules for a roll-up job that is (or may become) required:
 `release.yml` uses cargo-dist to build and publish the standalone Reborn
 `ironclaw` binary on matching release tags. The workspace cargo-dist config
 allow-lists `ironclaw_reborn_cli`, so the legacy root package named `ironclaw`
-is not selected. The cargo-dist tag namespace is `ironclaw-`, including the
-delimiter, so `ironclaw-vX.Y.Z` is parsed as the version tag `vX.Y.Z` rather
-than a singular release for the legacy root package. Release tags must match the
-Reborn CLI package version.
+does not own release artifacts. Cargo-dist still parses public
+`ironclaw-vX.Y.Z` tags as a singular release for the root package named
+`ironclaw`, so the root package version and Reborn CLI package version must both
+match the release tag version.
 
 `reborn-release-compile.yml` remains available as a direct
 `workflow_dispatch` compile-and-smoke preflight. It is not called from

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -64,8 +64,10 @@ Rules for a roll-up job that is (or may become) required:
 `release.yml` uses cargo-dist to build and publish the standalone Reborn
 `ironclaw` binary on matching release tags. The workspace cargo-dist config
 allow-lists `ironclaw_reborn_cli`, so the legacy root package named `ironclaw`
-is not selected even though the public tag namespace remains
-`ironclaw-vX.Y.Z`. Release tags must match the Reborn CLI package version.
+is not selected. The cargo-dist tag namespace is `ironclaw-`, including the
+delimiter, so `ironclaw-vX.Y.Z` is parsed as the version tag `vX.Y.Z` rather
+than a singular release for the legacy root package. Release tags must match the
+Reborn CLI package version.
 
 `reborn-release-compile.yml` remains available as a direct
 `workflow_dispatch` compile-and-smoke preflight. It is not called from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
     needs:
       - plan
       - build-wasm-extensions
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by dist in create-release.
@@ -407,7 +407,7 @@ jobs:
       - build-local-artifacts
       - build-global-artifacts
       - build-wasm-extensions
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && needs.build-global-artifacts.result == 'success' && needs.build-local-artifacts.result == 'success' && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') }}
     permissions:
       contents: write
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@
 # Note that the GitHub Release will be created with a generated
 # title/body based on your changelogs.
 #
-# Temporary #6160 policy: only the Reborn compile preflight below runs;
-# the generated cargo-dist/WASM/GitHub Release and Docker jobs stay defined
-# for rollback but are skipped.
+# #6160/#3483 policy: publish the standalone Reborn `ironclaw` binary through
+# cargo-dist so release assets, installers, checksums, and release notes keep
+# the same shape as previous releases. Docker image publication stays disabled.
 
 name: Release
 permissions:
@@ -48,20 +48,8 @@ on:
       - 'ironclaw-v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Compile the shipping Reborn binary on every supported release target.
-  # This is intentionally separate from cargo-dist until #3483 resolves the
-  # Reborn package/tag/installer contract.
-  reborn-binary-compile:
-    name: Reborn binary compile
-    uses: ./.github/workflows/reborn-release-compile.yml
-    with:
-      ref: ${{ github.sha }}
-
-  # Keep the legacy cargo-dist/WASM/GitHub Release chain visible for rollback,
-  # but disable its root while #6160 makes this workflow Reborn-compile-only.
-  # The Reborn compile matrix above remains the only active release path.
+  # Plan the cargo-dist release for the standalone Reborn CLI.
   plan:
-    if: github.repository == ''
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
@@ -285,7 +273,8 @@ jobs:
   build-wasm-extensions:
     needs:
       - plan
-    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    # Keep extension WASM publication out of the Reborn binary release path.
+    if: github.repository == ''
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -418,10 +407,7 @@ jobs:
       - build-local-artifacts
       - build-global-artifacts
       - build-wasm-extensions
-      - reborn-binary-compile
-    # Only publish after the explicit Reborn target matrix succeeds. Existing
-    # cargo-dist jobs may still be skipped, but a failed Reborn compile is fatal.
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') && needs.reborn-binary-compile.result == 'success' }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.build-wasm-extensions.result == 'skipped' || needs.build-wasm-extensions.result == 'success') }}
     permissions:
       contents: write
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.99.1-rc.6"
+version = "0.99.1-rc.7"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.6"
+version = "0.99.1-rc.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.99.1-rc.7"
+version = "0.99.1-rc.8"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.7"
+version = "0.99.1-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.99.1-rc.3"
+version = "0.99.1-rc.4"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.3"
+version = "0.99.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.99.1-rc.8"
+version = "0.99.1-rc.9"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.8"
+version = "0.99.1-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.99.1-rc.4"
+version = "0.99.1-rc.5"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.4"
+version = "0.99.1-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.29.1"
+version = "0.99.1-rc.3"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.2"
+version = "0.99.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.99.1-rc.5"
+version = "0.99.1-rc.6"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.5"
+version = "0.99.1-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.1.0"
+version = "0.99.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "0.99.1-rc.9"
+version = "1.0.0-rc.1"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.9"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -629,7 +629,7 @@ packages = ["ironclaw_reborn_cli"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell", "npm", "msi"]
+installers = ["shell", "powershell", "msi"]
 # Publish jobs to run in CI
 publish-jobs = []
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.99.1-rc.6"
+version = "0.99.1-rc.7"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.99.1-rc.5"
+version = "0.99.1-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.99.1-rc.3"
+version = "0.99.1-rc.4"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.99.1-rc.7"
+version = "0.99.1-rc.8"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,6 +623,11 @@ lto = "thin"
 cargo-dist-version = "0.31.0"
 # Ignore out-of-date generated CI so custom release.yml jobs are allowed
 allow-dirty = ["ci"]
+# Release only the standalone Reborn CLI through cargo-dist. The workspace root
+# still contains the legacy package named `ironclaw`, so keep selection explicit.
+packages = ["ironclaw_reborn_cli"]
+# Preserve the existing public release tag namespace: ironclaw-vX.Y.Z.
+tag-namespace = "ironclaw"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.29.1"
+version = "0.99.1-rc.3"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"
@@ -626,11 +626,6 @@ allow-dirty = ["ci"]
 # Release only the standalone Reborn CLI through cargo-dist. The workspace root
 # still contains the legacy package named `ironclaw`, so keep selection explicit.
 packages = ["ironclaw_reborn_cli"]
-# Preserve the existing public release tag namespace: ironclaw-vX.Y.Z. Include
-# the delimiter so cargo-dist strips `ironclaw-` before tag selection instead of
-# treating the tag as a singular release for the legacy root package named
-# `ironclaw`.
-tag-namespace = "ironclaw-"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.99.1-rc.4"
+version = "0.99.1-rc.5"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.99.1-rc.9"
+version = "1.0.0-rc.1"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ unused_must_use = "deny"
 [package]
 name = "ironclaw"
 autobins = false
-version = "0.99.1-rc.8"
+version = "0.99.1-rc.9"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"
@@ -622,7 +622,7 @@ lto = "thin"
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.31.0"
 # Ignore out-of-date generated CI so custom release.yml jobs are allowed
-allow-dirty = ["ci"]
+allow-dirty = ["ci", "msi"]
 # Release only the standalone Reborn CLI through cargo-dist. The workspace root
 # still contains the legacy package named `ironclaw`, so keep selection explicit.
 packages = ["ironclaw_reborn_cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -626,8 +626,11 @@ allow-dirty = ["ci"]
 # Release only the standalone Reborn CLI through cargo-dist. The workspace root
 # still contains the legacy package named `ironclaw`, so keep selection explicit.
 packages = ["ironclaw_reborn_cli"]
-# Preserve the existing public release tag namespace: ironclaw-vX.Y.Z.
-tag-namespace = "ironclaw"
+# Preserve the existing public release tag namespace: ironclaw-vX.Y.Z. Include
+# the delimiter so cargo-dist strips `ironclaw-` before tag selection instead of
+# treating the tag as a singular release for the legacy root package named
+# `ironclaw`.
+tag-namespace = "ironclaw-"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.2"
+version = "0.99.1-rc.3"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.3"
+version = "0.99.1-rc.4"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.9"
+version = "1.0.0-rc.1"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.4"
+version = "0.99.1-rc.5"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.6"
+version = "0.99.1-rc.7"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"
@@ -17,6 +17,12 @@ layer = "app"
 dist = true
 display-name = "ironclaw"
 features = ["libsql", "postgres", "inmemory-turn-state"]
+
+[package.metadata.wix]
+upgrade-guid = "D0156E61-BA37-451E-8AB9-1A2ECCCFA48F"
+path-guid = "F90B6EA6-87F7-499B-BB19-CF55DE1EB339"
+license = false
+eula = false
 
 [features]
 # libsql is the default storage backend: a file-backed local database needs

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.1.0"
+version = "0.99.1-rc.2"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.8"
+version = "0.99.1-rc.9"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.7"
+version = "0.99.1-rc.8"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_reborn_cli"
-version = "0.99.1-rc.5"
+version = "0.99.1-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "Standalone IronClaw Reborn binary"

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 [package.metadata.ironclaw]
 layer = "app"
 
-# Keep disabled until #3483 resolves cargo-dist tag/versioning + Windows WiX
-# packaging for the standalone Reborn binary.
 [package.metadata.dist]
-dist = false
+dist = true
+display-name = "ironclaw"
+features = ["libsql", "postgres", "inmemory-turn-state"]
 
 [features]
 # libsql is the default storage backend: a file-backed local database needs

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -353,12 +353,14 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         "release CI must use cargo-dist for planning, artifact builds, and hosting"
     );
     assert!(
-        workspace_manifest.contains("packages = [\"ironclaw_reborn_cli\"]")
-            && workspace_manifest.contains("tag-namespace = \"ironclaw-\""),
-        "cargo-dist must select only the Reborn CLI while preserving ironclaw-v* release tags"
+        workspace_manifest
+            .contains("name = \"ironclaw\"\nautobins = false\nversion = \"0.99.1-rc.3\"")
+            && workspace_manifest.contains("packages = [\"ironclaw_reborn_cli\"]")
+            && !workspace_manifest.contains("tag-namespace"),
+        "the public ironclaw-v* tag must be version-coherent with the root package while cargo-dist artifacts remain scoped to the Reborn CLI package"
     );
     assert!(
-        cli_manifest.contains("version = \"0.99.1-rc.2\"")
+        cli_manifest.contains("version = \"0.99.1-rc.3\"")
             && cli_manifest.contains("[package.metadata.dist]\ndist = true")
             && cli_manifest.contains("display-name = \"ironclaw\"")
             && cli_manifest

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -356,6 +356,8 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         workspace_manifest.contains("name = \"ironclaw\"\nautobins = false\nversion = \"")
             && workspace_manifest.contains("allow-dirty = [\"ci\", \"msi\"]")
             && workspace_manifest.contains("packages = [\"ironclaw_reborn_cli\"]")
+            && workspace_manifest.contains("installers = [\"shell\", \"powershell\", \"msi\"]")
+            && !workspace_manifest.contains("\"npm\"")
             && !workspace_manifest.contains("tag-namespace"),
         "the public ironclaw-v* tag must be version-coherent with the root package while cargo-dist artifacts remain scoped to the Reborn CLI package"
     );

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -183,6 +183,9 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     let release_workflow = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
         .expect("release workflow")
         .replace("\r\n", "\n");
+    let workspace_manifest = std::fs::read_to_string(root.join("Cargo.toml"))
+        .expect("workspace manifest")
+        .replace("\r\n", "\n");
     let cli_manifest = std::fs::read_to_string(root.join("crates/ironclaw_reborn_cli/Cargo.toml"))
         .expect("Reborn CLI manifest")
         .replace("\r\n", "\n");
@@ -330,23 +333,36 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     );
     assert!(
         release_workflow.contains(release_tag_trigger)
-            && release_workflow.contains("uses: ./.github/workflows/reborn-release-compile.yml")
-            && release_workflow.contains("needs.reborn-binary-compile.result == 'success'")
+            && !release_workflow.contains("uses: ./.github/workflows/reborn-release-compile.yml")
+            && !release_workflow.contains("needs.reborn-binary-compile")
             && compile_workflow.contains("  workflow_call:\n")
             && compile_workflow.contains("  workflow_dispatch:\n")
             && !release_workflow.contains("\n  pull_request:\n")
             && !compile_workflow.contains("  pull_request:\n"),
-        "the tag-only release workflow must wait for the Reborn matrix while keeping an independent manual preflight"
+        "the tag-only release workflow must publish through cargo-dist while keeping the Reborn matrix as an independent manual preflight"
     );
     assert!(
-        release_workflow.contains("needs.plan.outputs.publishing == 'true'")
+        release_workflow.contains("dist host --steps=create")
+            && release_workflow.contains("dist build $TAG_FLAG --print=linkage")
+            && release_workflow
+                .contains("dist build $TAG_FLAG --output-format=json \"--artifacts=global\"")
+            && release_workflow.contains("dist host $TAG_FLAG --steps=upload --steps=release")
+            && release_workflow.contains("needs.plan.outputs.publishing == 'true'")
             && !release_workflow.contains("if: ${{ github.event_name != 'pull_request' }}")
             && compile_workflow.contains("permissions:\n  contents: read"),
-        "release compilation must remain read-only without adding PR-only cargo-dist gates"
+        "release CI must use cargo-dist for planning, artifact builds, and hosting"
     );
     assert!(
-        cli_manifest.contains("[package.metadata.dist]\ndist = false"),
-        "#6160 must not opt Reborn into cargo-dist before #3483 is resolved"
+        workspace_manifest.contains("packages = [\"ironclaw_reborn_cli\"]")
+            && workspace_manifest.contains("tag-namespace = \"ironclaw\""),
+        "cargo-dist must select only the Reborn CLI while preserving ironclaw-v* release tags"
+    );
+    assert!(
+        cli_manifest.contains("[package.metadata.dist]\ndist = true")
+            && cli_manifest.contains("display-name = \"ironclaw\"")
+            && cli_manifest
+                .contains("features = [\"libsql\", \"postgres\", \"inmemory-turn-state\"]"),
+        "the standalone Reborn CLI must be the dist-able package with the production release feature set"
     );
 }
 
@@ -6781,7 +6797,7 @@ api_key_env = "REBORN_TEST_UNSET_BC8F4D_KEY"
 }
 
 #[test]
-fn release_ci_skips_legacy_publish_dag_without_disabling_independent_docker_runs() {
+fn release_ci_publishes_reborn_with_cargo_dist_without_docker() {
     let root = workspace_root();
     let release_workflow = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
         .expect("release workflow")
@@ -6819,37 +6835,41 @@ fn release_ci_skips_legacy_publish_dag_without_disabling_independent_docker_runs
         job_body
     };
 
-    let reborn_compile_job = release_job("reborn-binary-compile");
     assert!(
-        reborn_compile_job.contains("uses: ./.github/workflows/reborn-release-compile.yml")
-            && reborn_compile_job.contains("ref: ${{ github.sha }}")
-            && !reborn_compile_job
-                .lines()
-                .any(|line| line.starts_with("    if:")),
-        "the Reborn compile matrix must remain the active release path"
+        !release_workflow.contains("\n  reborn-binary-compile:\n"),
+        "release.yml must not run the old compile-only preflight as its active release path"
     );
 
     let plan_job = release_job("plan");
     assert!(
-        plan_job.contains("if: github.repository == ''")
+        !plan_job.contains("if: github.repository == ''")
             && plan_job.contains("dist host --steps=create")
             && plan_job.contains("dist plan --output-format=json"),
-        "release CI must retain but skip the legacy cargo-dist plan root"
+        "release CI must enable the cargo-dist plan root"
     );
-    for legacy_job_name in [
+    for cargo_dist_job_name in [
         "build-local-artifacts",
         "build-global-artifacts",
-        "build-wasm-extensions",
         "host",
-        "update-registry-checksums",
         "announce",
     ] {
-        let legacy_job = release_job(legacy_job_name);
+        let cargo_dist_job = release_job(cargo_dist_job_name);
         assert!(
-            legacy_job.contains("\n      - plan\n"),
-            "legacy release job {legacy_job_name} must remain downstream of the disabled plan root"
+            cargo_dist_job.contains("\n      - plan\n"),
+            "cargo-dist release job {cargo_dist_job_name} must remain downstream of the plan root"
         );
     }
+    let wasm_job = release_job("build-wasm-extensions");
+    assert!(
+        wasm_job.contains("if: github.repository == ''"),
+        "Reborn binary releases must not also publish extension WASM artifacts"
+    );
+    let registry_job = release_job("update-registry-checksums");
+    assert!(
+        registry_job.contains("needs.host.result == 'success'")
+            && registry_job.contains("needs.build-wasm-extensions.result == 'success'"),
+        "registry checksum updates must stay gated behind disabled WASM publication"
+    );
 
     let docker_job = release_job("docker-image");
     assert!(

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -353,15 +353,14 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         "release CI must use cargo-dist for planning, artifact builds, and hosting"
     );
     assert!(
-        workspace_manifest
-            .contains("name = \"ironclaw\"\nautobins = false\nversion = \"0.99.1-rc.3\"")
+        workspace_manifest.contains("name = \"ironclaw\"\nautobins = false\nversion = \"")
+            && workspace_manifest.contains("allow-dirty = [\"ci\", \"msi\"]")
             && workspace_manifest.contains("packages = [\"ironclaw_reborn_cli\"]")
             && !workspace_manifest.contains("tag-namespace"),
         "the public ironclaw-v* tag must be version-coherent with the root package while cargo-dist artifacts remain scoped to the Reborn CLI package"
     );
     assert!(
-        cli_manifest.contains("version = \"0.99.1-rc.3\"")
-            && cli_manifest.contains("[package.metadata.dist]\ndist = true")
+        cli_manifest.contains("[package.metadata.dist]\ndist = true")
             && cli_manifest.contains("display-name = \"ironclaw\"")
             && cli_manifest
                 .contains("features = [\"libsql\", \"postgres\", \"inmemory-turn-state\"]"),

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -354,11 +354,12 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     );
     assert!(
         workspace_manifest.contains("packages = [\"ironclaw_reborn_cli\"]")
-            && workspace_manifest.contains("tag-namespace = \"ironclaw\""),
+            && workspace_manifest.contains("tag-namespace = \"ironclaw-\""),
         "cargo-dist must select only the Reborn CLI while preserving ironclaw-v* release tags"
     );
     assert!(
-        cli_manifest.contains("[package.metadata.dist]\ndist = true")
+        cli_manifest.contains("version = \"0.99.1-rc.2\"")
+            && cli_manifest.contains("[package.metadata.dist]\ndist = true")
             && cli_manifest.contains("display-name = \"ironclaw\"")
             && cli_manifest
                 .contains("features = [\"libsql\", \"postgres\", \"inmemory-turn-state\"]"),

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -128,14 +128,6 @@
                                 Source='$(var.CargoTargetBinDir)\ironclaw-legacy.exe'
                                 KeyPath='yes'/>
                         </Component>
-                        <Component Id='binary1' Guid='*'>
-                            <File
-                                Id='exe1'
-                                Name='sandbox_daemon.exe'
-                                DiskId='1'
-                                Source='$(var.CargoTargetBinDir)\sandbox_daemon.exe'
-                                KeyPath='yes'/>
-                        </Component>
                     </Directory>
                 </Directory>
             </Directory>
@@ -158,8 +150,6 @@
             <!--<ComponentRef Id='License'/>-->
 
             <ComponentRef Id='binary0'/>
-            <ComponentRef Id='binary1'/>
-
             <Feature
                 Id='Environment'
                 Title='PATH Environment Variable'

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -150,6 +150,7 @@
             <!--<ComponentRef Id='License'/>-->
 
             <ComponentRef Id='binary0'/>
+
             <Feature
                 Id='Environment'
                 Title='PATH Environment Variable'

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -69,7 +69,7 @@
 
         <Package Id='*'
             Keywords='Installer'
-            Description='Standalone IronClaw Reborn binary'
+            Description='Secure personal AI assistant that protects your data and expands its capabilities on the fly'
             Manufacturer='NEAR AI'
             InstallerVersion='450'
             Languages='1033'

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -60,7 +60,7 @@
 
     <Product
         Id='*'
-        Name='ironclaw'
+        Name='ironclaw_reborn_cli'
         UpgradeCode='D0156E61-BA37-451E-8AB9-1A2ECCCFA48F'
         Manufacturer='NEAR AI'
         Language='1033'
@@ -69,7 +69,7 @@
 
         <Package Id='*'
             Keywords='Installer'
-            Description='Secure personal AI assistant that protects your data and expands its capabilities on the fly'
+            Description='Standalone IronClaw Reborn binary'
             Manufacturer='NEAR AI'
             InstallerVersion='450'
             Languages='1033'
@@ -83,11 +83,11 @@
             DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'/>
 
         <Media Id='1' Cabinet='media1.cab' EmbedCab='yes' DiskPrompt='CD-ROM #1'/>
-        <Property Id='DiskPrompt' Value='ironclaw Installation'/>
+        <Property Id='DiskPrompt' Value='ironclaw_reborn_cli Installation'/>
 
         <Directory Id='TARGETDIR' Name='SourceDir'>
             <Directory Id='$(var.PlatformProgramFilesFolder)' Name='PFiles'>
-                <Directory Id='APPLICATIONFOLDER' Name='ironclaw'>
+                <Directory Id='APPLICATIONFOLDER' Name='ironclaw_reborn_cli'>
                     
                     <!--
                       Enabling the license sidecar file in the installer is a four step process:
@@ -123,9 +123,9 @@
                         <Component Id='binary0' Guid='*'>
                             <File
                                 Id='exe0'
-                                Name='ironclaw-legacy.exe'
+                                Name='ironclaw.exe'
                                 DiskId='1'
-                                Source='$(var.CargoTargetBinDir)\ironclaw-legacy.exe'
+                                Source='$(var.CargoTargetBinDir)\ironclaw.exe'
                                 KeyPath='yes'/>
                         </Component>
                     </Directory>


### PR DESCRIPTION
## Summary

Prepare the release pipeline to publish `ironclaw-v1.0.0-rc.1` binaries with cargo-dist.

This PR scopes cargo-dist releases to the standalone Reborn CLI package while preserving the public `ironclaw-v*` tag shape used by previous releases. It also keeps Docker image publication disabled for this release path so the workflow only builds and publishes binary release assets.

## Changes

- Configure cargo-dist for the Reborn CLI binary package and seven release targets:
  - `aarch64-apple-darwin`
  - `aarch64-unknown-linux-gnu`
  - `aarch64-unknown-linux-musl`
  - `x86_64-apple-darwin`
  - `x86_64-unknown-linux-gnu`
  - `x86_64-unknown-linux-musl`
  - `x86_64-pc-windows-msvc`
- Require cargo-dist artifact jobs before the host job uploads or creates the GitHub release.
- Keep generated release artifacts separate from Reborn compile evidence artifacts.
- Add Reborn CLI cargo-dist and WiX metadata so MSI/archive installers build for the shipping `ironclaw` binary.
- Prepare root and Reborn CLI package versions for `1.0.0-rc.1`.
- Update smoke-test contracts for the release workflow without hard-coding individual rc patch attempts.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check -- Cargo.toml crates/ironclaw_reborn_cli/Cargo.toml Cargo.lock .github/workflows/release.yml crates/ironclaw_reborn_cli/tests/smoke.rs wix/main.wxs`

## Notes

After this lands, pushing tag `ironclaw-v1.0.0-rc.1` should run the release workflow and publish cargo-dist release assets. Because this is an rc tag, cargo-dist/GitHub will treat it as a prerelease.
