### PR TITLE
ci: publish Reborn release binaries

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,13 +61,13 @@ Rules for a roll-up job that is (or may become) required:
 
 ## Reborn release binary compile matrix
 
-`reborn-release-compile.yml` is a compile-and-smoke preflight for the shipping
+`reborn-release-compile.yml` is the compile-and-smoke matrix for the shipping
 Reborn `ironclaw` binary. The tag-only `release.yml` calls it for matching
-release tags. Under #6160's temporary compile-only policy below, the legacy
-`host` job stays disabled; if that job is restored, its dependency and success
-gate still prevent it from running unless every target succeeds. The preflight
-workflow can also run directly through `workflow_dispatch`; it is not triggered
-by pull requests, so ordinary CLI and WebUI changes do not start the
+release tags, then packages those matrix outputs into a GitHub Release through
+the Reborn-specific `publish-reborn-binaries` job. The reusable preflight
+workflow can also run directly through `workflow_dispatch`; direct dispatch only
+uploads temporary evidence artifacts and does not publish a release. It is not
+triggered by pull requests, so ordinary CLI and WebUI changes do not start the
 seven-platform release matrix.
 
 | Rust target | GitHub runner |
@@ -92,11 +92,13 @@ This is shallow CLI startup coverage; it does not validate `serve`, external
 services, installers, or cargo-dist release packaging. The feature list is
 intentionally not inferred from Docker or #6122.
 
-The uploaded `reborn-compile-*` artifacts are short-lived preflight evidence.
-Their prefix deliberately does not match the release host's `artifacts-*`
-download pattern, so they are not attached to the GitHub Release. Until #3483
-defines the canonical Reborn package/tag/installer contract,
-`ironclaw_reborn_cli` remains `dist = false`.
+The uploaded `reborn-compile-*` artifacts are the handoff from the compile
+matrix to `release.yml`'s Reborn publisher. On tag pushes, the publisher
+downloads them, emits per-target `ironclaw-<target>.tar.gz` assets plus
+per-asset `.sha256` files and `sha256.sum`, and creates or updates the GitHub
+Release for the tag. Until #3483 defines the canonical Reborn package/tag/
+installer contract, `ironclaw_reborn_cli` remains `dist = false` and these
+archives are intentionally produced outside cargo-dist.
 
 ## Deep tier (nightly)
 
@@ -155,23 +157,23 @@ When adding a new workflow that runs on `push` to `main`, add its workflow
 
 ## Reborn-only release validation policy
 
-For #6160, `release.yml` temporarily keeps the legacy cargo-dist release chain
-visible but disables its `plan` root with the impossible
+For #6160/#3483, `release.yml` temporarily keeps the legacy cargo-dist release
+chain visible but disables its `plan` root with the impossible
 `github.repository == ''` guard. Its dependent local/global artifact, WASM,
-GitHub Release host, registry-checksum, and announcement jobs therefore skip.
-The Reborn compile matrix merged in #6176 is the only intended active path.
-This compile-only mode produces short-lived Actions evidence artifacts; it does
-not create a GitHub Release or permanent downloadable release assets.
+legacy GitHub Release host, registry-checksum, and announcement jobs therefore
+skip. The Reborn compile matrix plus `publish-reborn-binaries` job is the only
+intended active tag-release path.
 
 The release Docker caller retains its own impossible guard as an explicit
 defense against image publication. The reusable `docker.yml` workflow is
 unchanged, so its manual and hourly entry points remain available. Changes to
 the release, Docker, or reusable Reborn compile workflow enter the Reborn CLI
 smoke selector, and the required Code Style roll-up propagates that contract
-result. To restore the non-Docker legacy release path, remove `plan`'s
-impossible guard; the workflow's tag-only trigger already scopes it to release
-tags. Restore the Docker caller's host-success condition separately only when
-release image publication is intentionally re-enabled.
+result. To restore the non-Docker legacy cargo-dist release path, remove
+`plan`'s impossible guard and retire or reconcile the Reborn-specific publisher;
+the workflow's tag-only trigger already scopes it to release tags. Restore the
+Docker caller's host-success condition separately only when release image
+publication is intentionally re-enabled.
 
 ## Known accepted gaps (deliberate, revisit as needed)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,8 @@ jobs:
           set -euo pipefail
 
           prerelease_flag=()
-          if [[ "$RELEASE_TAG" == *-* ]]; then
+          release_version="${RELEASE_TAG#ironclaw-v}"
+          if [[ "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             prerelease_flag=(--prerelease)
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@
 # Note that the GitHub Release will be created with a generated
 # title/body based on your changelogs.
 #
-# Temporary #6160 policy: only the Reborn compile preflight below runs;
-# the generated cargo-dist/WASM/GitHub Release and Docker jobs stay defined
-# for rollback but are skipped.
+# Temporary #6160/#3483 policy: publish the Reborn binaries built by the
+# explicit compile matrix below. The generated cargo-dist/WASM release chain and
+# Docker jobs stay defined for rollback but are skipped.
 
 name: Release
 permissions:
@@ -57,9 +57,106 @@ jobs:
     with:
       ref: ${{ github.sha }}
 
+  publish-reborn-binaries:
+    name: Publish Reborn release binaries
+    needs:
+      - reborn-binary-compile
+    runs-on: "ubuntu-22.04"
+    if: ${{ needs.reborn-binary-compile.result == 'success' }}
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_COMMIT: ${{ github.sha }}
+    steps:
+      - name: Download Reborn binary artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: reborn-compile-*
+          path: reborn-compile-artifacts
+
+      - name: Package Reborn release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p release-assets
+          shopt -s nullglob
+
+          artifact_dirs=(reborn-compile-artifacts/reborn-compile-*)
+          if [ "${#artifact_dirs[@]}" -eq 0 ]; then
+            echo "::error::No Reborn compile artifacts were downloaded"
+            exit 1
+          fi
+
+          for artifact_dir in "${artifact_dirs[@]}"; do
+            target="${artifact_dir##*/reborn-compile-}"
+            binary_path=""
+            for candidate in "$artifact_dir"/ironclaw "$artifact_dir"/ironclaw.exe; do
+              if [ -f "$candidate" ]; then
+                binary_path="$candidate"
+                break
+              fi
+            done
+
+            if [ -z "$binary_path" ]; then
+              echo "::error::No ironclaw binary found in $artifact_dir"
+              find "$artifact_dir" -maxdepth 2 -type f -print
+              exit 1
+            fi
+
+            binary_name="$(basename "$binary_path")"
+            staging="$RUNNER_TEMP/reborn-release/$target"
+            rm -rf "$staging"
+            mkdir -p "$staging"
+            cp "$binary_path" "$staging/$binary_name"
+
+            asset_name="ironclaw-${target}.tar.gz"
+            chmod 755 "$staging/$binary_name"
+            tar -C "$staging" -czf "release-assets/$asset_name" "$binary_name"
+            (cd release-assets && sha256sum "$asset_name" > "$asset_name.sha256")
+          done
+
+          (cd release-assets && sha256sum *.tar.gz > sha256.sum)
+          ls -la release-assets
+
+      - name: Create or update GitHub Release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          prerelease_flag=()
+          if [[ "$RELEASE_TAG" == *-* ]]; then
+            prerelease_flag=(--prerelease)
+          fi
+
+          notes="$RUNNER_TEMP/reborn-release-notes.md"
+          {
+            echo "IronClaw binary release for \`$RELEASE_TAG\`."
+            echo
+            echo "This release publishes the Reborn \`ironclaw\` binaries built by the release compile matrix."
+            echo "Docker image publication remains disabled for this release path."
+          } > "$notes"
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" release-assets/* --clobber
+            gh release edit "$RELEASE_TAG" \
+              "${prerelease_flag[@]}" \
+              --title "IronClaw $RELEASE_TAG" \
+              --notes-file "$notes"
+          else
+            gh release create "$RELEASE_TAG" \
+              --target "$RELEASE_COMMIT" \
+              "${prerelease_flag[@]}" \
+              --title "IronClaw $RELEASE_TAG" \
+              --notes-file "$notes" \
+              release-assets/*
+          fi
+
   # Keep the legacy cargo-dist/WASM/GitHub Release chain visible for rollback,
-  # but disable its root while #6160 makes this workflow Reborn-compile-only.
-  # The Reborn compile matrix above remains the only active release path.
+  # but disable its root while #6160/#3483 uses the Reborn-specific publisher
+  # above. Docker image publication remains disabled below.
   plan:
     if: github.repository == ''
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
       RELEASE_TAG: ${{ github.ref_name }}
       RELEASE_COMMIT: ${{ github.sha }}
     steps:

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -6781,7 +6781,7 @@ api_key_env = "REBORN_TEST_UNSET_BC8F4D_KEY"
 }
 
 #[test]
-fn release_ci_skips_legacy_publish_dag_without_disabling_independent_docker_runs() {
+fn release_ci_publishes_reborn_binaries_without_legacy_or_docker_publish() {
     let root = workspace_root();
     let release_workflow = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
         .expect("release workflow")
@@ -6827,6 +6827,20 @@ fn release_ci_skips_legacy_publish_dag_without_disabling_independent_docker_runs
                 .lines()
                 .any(|line| line.starts_with("    if:")),
         "the Reborn compile matrix must remain the active release path"
+    );
+
+    let publish_job = release_job("publish-reborn-binaries");
+    assert!(
+        publish_job.contains("\n      - reborn-binary-compile\n")
+            && publish_job.contains("contents: write")
+            && publish_job.contains("pattern: reborn-compile-*")
+            && publish_job.contains("ironclaw-${target}.tar.gz")
+            && publish_job.contains("$asset_name.sha256")
+            && publish_job.contains("sha256.sum")
+            && publish_job.contains("gh release create")
+            && publish_job.contains("gh release upload")
+            && !publish_job.contains("uses: ./.github/workflows/docker.yml"),
+        "release CI must publish Reborn binary archives from the compile matrix without invoking Docker"
     );
 
     let plan_job = release_job("plan");

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -6833,6 +6833,7 @@ fn release_ci_publishes_reborn_binaries_without_legacy_or_docker_publish() {
     assert!(
         publish_job.contains("\n      - reborn-binary-compile\n")
             && publish_job.contains("contents: write")
+            && publish_job.contains("GH_REPO: ${{ github.repository }}")
             && publish_job.contains("pattern: reborn-compile-*")
             && publish_job.contains("ironclaw-${target}.tar.gz")
             && publish_job.contains("$asset_name.sha256")

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -6838,6 +6838,11 @@ fn release_ci_publishes_reborn_binaries_without_legacy_or_docker_publish() {
             && publish_job.contains("ironclaw-${target}.tar.gz")
             && publish_job.contains("$asset_name.sha256")
             && publish_job.contains("sha256.sum")
+            && publish_job.contains("release_version=\"${RELEASE_TAG#ironclaw-v}\"")
+            && publish_job.contains(
+                "if [[ \"$release_version\" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+- ]]; then"
+            )
+            && !publish_job.contains("if [[ \"$RELEASE_TAG\" == *-* ]]; then")
             && publish_job.contains("gh release create")
             && publish_job.contains("gh release upload")
             && !publish_job.contains("uses: ./.github/workflows/docker.yml"),


### PR DESCRIPTION
## Summary

- Add a Reborn-specific release publisher that runs after the existing Reborn binary compile matrix succeeds.
- Package each compiled target as `ironclaw-<target>.tar.gz`, emit per-asset `.sha256` files plus `sha256.sum`, and create or update the GitHub Release for the pushed tag.
- Keep the legacy cargo-dist/WASM release chain and Docker image publication disabled.
- Update the workflow README and release workflow smoke contract to document/assert this behavior.

## Why

Tag pushes currently build the Reborn binaries but do not create a GitHub Release because the legacy release host path is intentionally guarded off. This lets a fork test publishing Reborn binary assets without re-enabling Docker image builds or cargo-dist packaging for `ironclaw_reborn_cli`.

## Validation

- `git diff --check -- .github/workflows/release.yml .github/workflows/README.md crates/ironclaw_reborn_cli/tests/smoke.rs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/reborn-release-compile.yml"); puts "workflow yaml parsed"'`
- Local shell simulation of the new packaging loop with fake Linux and Windows compile artifacts.
- `cargo fmt -p ironclaw_reborn_cli`

Could not complete `cargo test -p ironclaw_reborn_cli --test smoke release_workflows_enter_reborn_cli_smoke_selector -- --exact`: Cargo hung updating the configured `aliyun` registry index even with approved network access, and offline mode could not resolve the locked `unsafe-libyaml-norway` dependency from the local cache.
