### PR TITLE
Fix WebUI skills toggle cache update

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useSkills.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useSkills.ts
@@ -47,7 +47,14 @@ export function useSkills() {
 
   const learnedAutoActivateMutation = useMutation({
     mutationFn: (enabled) => setAutoActivateLearnedRequest(enabled),
-    onSuccess: () => {
+    onSuccess: (_response, enabled) => {
+      queryClient.setQueryData(["skills"], (current) => {
+        if (!current) return current;
+        return {
+          ...current,
+          auto_activate_learned: enabled,
+        };
+      });
       queryClient.invalidateQueries({ queryKey: ["skills"] });
     },
   });


### PR DESCRIPTION
## Summary

- Update the WebUI skills hook to write successful global auto-activation toggles into the React Query `skills` cache immediately.
- Keep the existing query invalidation so the UI still performs backend read-back after the optimistic cache update.

## Root Cause

The Reborn WebUI v2 smoke test on `main` failed because the settings mutation succeeded and showed the success/status text, but the toggle button label still read from stale cached `list_skills` data long enough for Playwright to time out waiting for `Default: Off`.

## Validation

- `corepack pnpm -C crates/ironclaw_webui/frontend typecheck`
- `python3 -m pytest tests/e2e/scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_light_theme_semantic_colors_have_readable_contrast -v --timeout=120`

## Compatibility / Rollback

This is frontend cache-state only. Rolling back restores the previous read-after-invalidation behavior, but may reintroduce the CI race where the button label lags behind a successful mutation.
