### PR TITLE
fix(onboard): let Esc at the API-key prompt return to the provider menu (#6360)

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/config/set.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/set.rs
@@ -387,13 +387,25 @@ impl SecretValueSource for StdinSecretValueSource {
             .context("flush stdout before secret prompt")?;
         let read = crate::commands::onboard::prompts::read_masked_line()?;
         println!();
-        match read {
-            crate::commands::onboard::prompts::MaskedLine::Entered(value) => Ok(value),
-            // Esc used to be ignored here (the read loop kept waiting); it now
-            // backs out of the prompt without writing anything.
-            crate::commands::onboard::prompts::MaskedLine::Cancelled => {
-                anyhow::bail!("`config set {label}` cancelled at the value prompt; nothing written")
-            }
+        masked_line_to_secret(read, label)
+    }
+}
+
+/// Turns a [`MaskedLine`](crate::commands::onboard::prompts::MaskedLine)
+/// read from the terminal into the prompt's result. Pulled out as a free
+/// function (rather than left inline in `StdinSecretValueSource::prompt`)
+/// so the cancel decision can be unit-tested without a real terminal —
+/// `StdinSecretValueSource` itself can only be exercised interactively.
+fn masked_line_to_secret(
+    line: crate::commands::onboard::prompts::MaskedLine,
+    label: &str,
+) -> anyhow::Result<String> {
+    match line {
+        crate::commands::onboard::prompts::MaskedLine::Entered(value) => Ok(value),
+        // Esc used to be ignored here (the read loop kept waiting); it now
+        // backs out of the prompt without writing anything.
+        crate::commands::onboard::prompts::MaskedLine::Cancelled => {
+            anyhow::bail!("`config set {label}` cancelled at the value prompt; nothing written")
         }
     }
 }
@@ -553,6 +565,28 @@ mod tests {
         let message = unknown_key_message("nonsense.key");
         assert!(message.contains("unknown config key `nonsense.key`"));
         assert!(message.contains("config list"));
+    }
+
+    #[test]
+    fn masked_line_cancelled_errors_without_writing_anything() {
+        let err = masked_line_to_secret(
+            crate::commands::onboard::prompts::MaskedLine::Cancelled,
+            "llm.api_key",
+        )
+        .expect_err("Cancelled must not resolve to a value");
+        let message = err.to_string();
+        assert!(message.contains("llm.api_key"), "error: {message}");
+        assert!(message.contains("nothing written"), "error: {message}");
+    }
+
+    #[test]
+    fn masked_line_entered_returns_the_typed_value() {
+        let value = masked_line_to_secret(
+            crate::commands::onboard::prompts::MaskedLine::Entered("some-value".to_string()),
+            "llm.api_key",
+        )
+        .expect("Entered must resolve to the typed value");
+        assert_eq!(value, "some-value");
     }
 
     struct FailingStoreOpener;

--- a/crates/ironclaw_reborn_cli/src/commands/config/set.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/set.rs
@@ -381,13 +381,20 @@ impl SecretValueSource for StdinSecretValueSource {
                  entered with input hidden"
             );
         }
-        print!("{label} (input hidden): ");
+        print!("{label} (input hidden, Esc to cancel): ");
         std::io::stdout()
             .flush()
             .context("flush stdout before secret prompt")?;
-        let value = crate::commands::onboard::prompts::read_masked_line()?;
+        let read = crate::commands::onboard::prompts::read_masked_line()?;
         println!();
-        Ok(value)
+        match read {
+            crate::commands::onboard::prompts::MaskedLine::Entered(value) => Ok(value),
+            // Esc used to be ignored here (the read loop kept waiting); it now
+            // backs out of the prompt without writing anything.
+            crate::commands::onboard::prompts::MaskedLine::Cancelled => {
+                anyhow::bail!("`config set {label}` cancelled at the value prompt; nothing written")
+            }
+        }
     }
 }
 

--- a/crates/ironclaw_reborn_cli/src/commands/onboard/llm_credentials.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/onboard/llm_credentials.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 
 use ironclaw_reborn_config::RebornHome;
 
+#[cfg(feature = "libsql")]
+use super::prompts::ApiKeyAnswer;
 use super::prompts::{LlmCredentialPromptError, PromptSource};
 
 /// Outcome of onboard's LLM provider/API-key prompt step. Every variant is a
@@ -364,6 +366,13 @@ fn open_llm_key_store(
 /// Drives the full numbered provider menu, factored out so the "declined
 /// confirm" and "nothing detected" branches share one implementation. See
 /// [`provision_llm_credentials`]'s doc for the store-then-config write ordering.
+///
+/// Loops on [`ApiKeyAnswer::Back`] (issue #6360): an operator who realizes at
+/// the key prompt that they picked the wrong provider gets the menu again
+/// instead of having to cancel onboarding. Everything above the two durable
+/// writes is a pure read, so a re-selection discards nothing persisted — and
+/// each pass blocks on at least one operator answer, so the loop cannot spin
+/// on its own.
 #[cfg(feature = "libsql")]
 fn provision_via_menu(
     store_root: &Path,
@@ -375,65 +384,17 @@ fn provision_via_menu(
     let entries = admin
         .menu_entries()
         .map_err(|error| LlmCredentialPromptError::Other(error.into()))?;
-    let selection = prompts.provider_menu(&entries)?;
-    // Re-resolve to keep this call site's id agreeing with `set_provider`'s
-    // own resolution (menu offers canonical ids already, but stay consistent).
-    let canonical_provider_id = admin
-        .resolve_provider_id(&selection)
-        .map_err(|error| LlmCredentialPromptError::Other(error.into()))?;
-    let entry = entries
-        .iter()
-        .find(|entry| entry.id == canonical_provider_id)
-        .ok_or_else(|| {
-            LlmCredentialPromptError::Other(anyhow::anyhow!(
-                "selected provider `{canonical_provider_id}` is not on the onboarding menu"
-            ))
-        })?;
 
-    // Both prompts run BEFORE any write (pure reads), so only the two durable
-    // writes below remain fallible — no prompt can fail with a secret already
-    // committed. See `provision_llm_credentials`'s doc for write ordering.
-    let initial_key = if entry.api_key_required {
-        let key = prompts.api_key(&canonical_provider_id)?;
-        // Defense in depth: guards every `PromptSource` impl against a blank
-        // key reaching the secret store (`StdinPromptSource` already re-prompts).
-        if key.trim().is_empty() {
-            return Err(LlmCredentialPromptError::Other(anyhow::anyhow!(
-                "LLM API key must not be blank"
-            )));
+    let selected = loop {
+        if let Some(selected) = select_provider_and_key(&entries, admin, prompts, probe)? {
+            break selected;
         }
-        Some(key)
-    } else {
-        None
     };
-
-    let default_model = admin
-        .list(Some(&canonical_provider_id), false)
-        .map_err(|error| LlmCredentialPromptError::Other(error.into()))?
-        .providers
-        .into_iter()
-        .next()
-        .map(|info| info.default_model)
-        .unwrap_or_default();
-    let model = prompts.model(&canonical_provider_id, &default_model)?;
-    let effective_model = model.as_deref().unwrap_or(default_model.as_str());
-
-    // Live key/model verification — key-required providers only. Paths that
-    // never reach this function (headless seeding, env-detect confirm-yes)
-    // are never probed — env-sourced/keyless credentials are already trusted.
-    // `nearai` is `api_key_required: true` here (menu-level override), so it
-    // takes this same branch like any other key-required provider.
-    let key = match initial_key {
-        Some(key) => Some(probe_and_confirm_key(
-            prompts,
-            probe,
-            admin,
-            &canonical_provider_id,
-            effective_model,
-            key,
-        )?),
-        None => None,
-    };
+    let SelectedProvider {
+        canonical_provider_id,
+        key,
+        model,
+    } = selected;
 
     if let Some(key) = key {
         let store = open_llm_key_store(store_root, store_opener)
@@ -458,6 +419,101 @@ fn provision_via_menu(
     })
 }
 
+/// What one pass of the provider menu resolved to: the provider, the key to
+/// store for it (`None` for a keyless menu entry), and the model override the
+/// operator typed (`None` = use the catalog default).
+#[cfg(feature = "libsql")]
+struct SelectedProvider {
+    canonical_provider_id: String,
+    key: Option<String>,
+    model: Option<String>,
+}
+
+/// One pass of provider menu → API key → model → probe. All pure reads, no
+/// durable write — [`provision_via_menu`] performs those once this returns.
+///
+/// `Ok(None)` means the operator backed out at a key prompt
+/// ([`ApiKeyAnswer::Back`]) and wants the menu again; nothing entered on this
+/// pass survives it.
+#[cfg(feature = "libsql")]
+fn select_provider_and_key(
+    entries: &[ironclaw_reborn_composition::ProviderMenuEntry],
+    admin: &ironclaw_reborn_composition::RebornProviderAdmin,
+    prompts: &mut dyn PromptSource,
+    probe: &dyn LlmProbe,
+) -> Result<Option<SelectedProvider>, LlmCredentialPromptError> {
+    let selection = prompts.provider_menu(entries)?;
+    // Re-resolve to keep this call site's id agreeing with `set_provider`'s
+    // own resolution (menu offers canonical ids already, but stay consistent).
+    let canonical_provider_id = admin
+        .resolve_provider_id(&selection)
+        .map_err(|error| LlmCredentialPromptError::Other(error.into()))?;
+    let entry = entries
+        .iter()
+        .find(|entry| entry.id == canonical_provider_id)
+        .ok_or_else(|| {
+            LlmCredentialPromptError::Other(anyhow::anyhow!(
+                "selected provider `{canonical_provider_id}` is not on the onboarding menu"
+            ))
+        })?;
+
+    let initial_key = if entry.api_key_required {
+        match prompts.api_key(&canonical_provider_id)? {
+            ApiKeyAnswer::Back => return Ok(None),
+            ApiKeyAnswer::Key(key) => {
+                // Defense in depth: guards every `PromptSource` impl against a
+                // blank key reaching the secret store (`StdinPromptSource`
+                // already re-prompts).
+                if key.trim().is_empty() {
+                    return Err(LlmCredentialPromptError::Other(anyhow::anyhow!(
+                        "LLM API key must not be blank"
+                    )));
+                }
+                Some(key)
+            }
+        }
+    } else {
+        None
+    };
+
+    let default_model = admin
+        .list(Some(&canonical_provider_id), false)
+        .map_err(|error| LlmCredentialPromptError::Other(error.into()))?
+        .providers
+        .into_iter()
+        .next()
+        .map(|info| info.default_model)
+        .unwrap_or_default();
+    let model = prompts.model(&canonical_provider_id, &default_model)?;
+    let effective_model = model.as_deref().unwrap_or(default_model.as_str());
+
+    // Live key/model verification — key-required providers only. Paths that
+    // never reach this function (headless seeding, env-detect confirm-yes)
+    // are never probed — env-sourced/keyless credentials are already trusted.
+    // `nearai` is `api_key_required: true` here (menu-level override), so it
+    // takes this same branch like any other key-required provider.
+    let key = match initial_key {
+        Some(key) => match probe_and_confirm_key(
+            prompts,
+            probe,
+            admin,
+            &canonical_provider_id,
+            effective_model,
+            key,
+        )? {
+            ApiKeyAnswer::Back => return Ok(None),
+            ApiKeyAnswer::Key(key) => Some(key),
+        },
+        None => None,
+    };
+
+    Ok(Some(SelectedProvider {
+        canonical_provider_id,
+        key,
+        model,
+    }))
+}
+
 /// Probe `candidate_key` against `provider_id`/`effective_model` and, on
 /// failure, either reprompt for a new key or accept the operator's "store
 /// anyway" answer — the loop [`provision_via_menu`] runs after the key and
@@ -471,6 +527,9 @@ fn provision_via_menu(
 /// - Successful probe with a non-empty model list missing `effective_model`
 ///   prints a warning but still returns the key (provider lists are often
 ///   incomplete); an empty model list warns about nothing.
+/// - A reprompt the operator backs out of returns [`ApiKeyAnswer::Back`], the
+///   same "re-show the provider menu" signal the first key prompt uses — the
+///   reprompt IS that prompt, so it must offer the same escape.
 #[cfg(feature = "libsql")]
 fn probe_and_confirm_key(
     prompts: &mut dyn PromptSource,
@@ -479,7 +538,7 @@ fn probe_and_confirm_key(
     provider_id: &str,
     effective_model: &str,
     mut candidate_key: String,
-) -> Result<String, LlmCredentialPromptError> {
+) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
     const MAX_PROBE_ATTEMPTS: u8 = 3;
     let mut attempt = 1u8;
     loop {
@@ -501,13 +560,13 @@ fn probe_and_confirm_key(
                     outcome.models.len()
                 );
             }
-            return Ok(candidate_key);
+            return Ok(ApiKeyAnswer::Key(candidate_key));
         }
 
         println!("{}", outcome.message);
         let question = format!("Could not reach {provider_id} to verify — store anyway?");
         if prompts.confirm(&question)? {
-            return Ok(candidate_key);
+            return Ok(ApiKeyAnswer::Key(candidate_key));
         }
 
         if attempt >= MAX_PROBE_ATTEMPTS {
@@ -517,7 +576,10 @@ fn probe_and_confirm_key(
             )));
         }
         attempt += 1;
-        candidate_key = prompts.api_key(provider_id)?;
+        candidate_key = match prompts.api_key(provider_id)? {
+            ApiKeyAnswer::Key(key) => key,
+            ApiKeyAnswer::Back => return Ok(ApiKeyAnswer::Back),
+        };
         if candidate_key.trim().is_empty() {
             return Err(LlmCredentialPromptError::Other(anyhow::anyhow!(
                 "LLM API key must not be blank"
@@ -681,8 +743,8 @@ mod tests {
                 })
         }
 
-        fn api_key(&mut self, _provider: &str) -> Result<String, LlmCredentialPromptError> {
-            Ok(self.key.to_string())
+        fn api_key(&mut self, _provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
+            Ok(ApiKeyAnswer::Key(self.key.to_string()))
         }
 
         fn model(
@@ -716,7 +778,7 @@ mod tests {
             unreachable!("provider_menu() must not be called once is_interactive() is false")
         }
 
-        fn api_key(&mut self, _provider: &str) -> Result<String, LlmCredentialPromptError> {
+        fn api_key(&mut self, _provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
             unreachable!("api_key must not be prompted once provider_menu() has already failed")
         }
 
@@ -753,7 +815,7 @@ mod tests {
             panic!("provider_menu() must not be called on an idempotent, already-configured rerun")
         }
 
-        fn api_key(&mut self, _provider: &str) -> Result<String, LlmCredentialPromptError> {
+        fn api_key(&mut self, _provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
             panic!("api_key() must not be called on an idempotent, already-configured rerun")
         }
 
@@ -902,12 +964,13 @@ mod tests {
                 })
         }
 
-        fn api_key(&mut self, _provider: &str) -> Result<String, LlmCredentialPromptError> {
-            Ok(self
-                .keys
-                .pop_front()
-                .expect("ScriptedKeyPromptSource: api_key() called more times than scripted")
-                .to_string())
+        fn api_key(&mut self, _provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
+            Ok(ApiKeyAnswer::Key(
+                self.keys
+                    .pop_front()
+                    .expect("ScriptedKeyPromptSource: api_key() called more times than scripted")
+                    .to_string(),
+            ))
         }
 
         fn model(
@@ -1113,6 +1176,230 @@ mod tests {
                 provider_id: "openai".to_string(),
                 model: "gpt-5-mini".to_string(),
             }
+        );
+    }
+
+    /// A [`PromptSource`] that walks the provider menu more than once: each
+    /// `provider_menu()` call answers the next id in `providers`, each
+    /// `api_key()` call the next scripted [`ApiKeyAnswer`]. Records the
+    /// providers it was asked a key for so a test can prove the second menu
+    /// pass really happened (and which provider it landed on).
+    struct BackThenSwitchPromptSource {
+        providers: std::collections::VecDeque<&'static str>,
+        answers: std::collections::VecDeque<ApiKeyAnswer>,
+        /// Answers to the probe-failure "store anyway?" question, in order.
+        confirms: std::collections::VecDeque<bool>,
+        key_prompts: Vec<String>,
+        menu_calls: usize,
+    }
+
+    impl PromptSource for BackThenSwitchPromptSource {
+        fn is_interactive(&self) -> bool {
+            true
+        }
+
+        fn provider_menu(
+            &mut self,
+            entries: &[ironclaw_reborn_composition::ProviderMenuEntry],
+        ) -> Result<String, LlmCredentialPromptError> {
+            self.menu_calls += 1;
+            let wanted = self.providers.pop_front().expect(
+                "BackThenSwitchPromptSource: provider_menu() called more times than scripted",
+            );
+            entries
+                .iter()
+                .find(|entry| entry.id == wanted)
+                .map(|entry| entry.id.clone())
+                .ok_or_else(|| {
+                    LlmCredentialPromptError::Other(anyhow::anyhow!(
+                        "fake-selected provider `{wanted}` is not on the menu"
+                    ))
+                })
+        }
+
+        fn api_key(&mut self, provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
+            self.key_prompts.push(provider.to_string());
+            Ok(self
+                .answers
+                .pop_front()
+                .expect("BackThenSwitchPromptSource: api_key() called more times than scripted"))
+        }
+
+        fn model(
+            &mut self,
+            _provider_id: &str,
+            _default_model: &str,
+        ) -> Result<Option<String>, LlmCredentialPromptError> {
+            Ok(None)
+        }
+
+        fn confirm(&mut self, _question: &str) -> Result<bool, LlmCredentialPromptError> {
+            Ok(self
+                .confirms
+                .pop_front()
+                .expect("BackThenSwitchPromptSource: confirm() called more times than scripted"))
+        }
+    }
+
+    /// Regression, issue #6360: the API-key prompt used to be a terminal state
+    /// — an operator who picked the wrong provider could only supply a key or
+    /// abort onboarding entirely. [`ApiKeyAnswer::Back`] must instead re-show
+    /// the provider menu, and the provider chosen on the SECOND pass is the
+    /// one that gets persisted: `nearai` (backed out of) must leave neither a
+    /// stored key nor a `config.toml` selection behind, `openai` must land
+    /// both.
+    #[test]
+    fn provision_llm_credentials_back_at_the_key_prompt_returns_to_the_provider_menu() {
+        let _env_guard = crate::runtime::test_env::lock_runtime_env();
+        let (_tmp, context) = RebornCliContext::test_context();
+        let home = context.boot_config().home();
+        std::fs::create_dir_all(home.path()).expect("create reborn home");
+        seed_cached_master_key(home);
+
+        let mut prompts = BackThenSwitchPromptSource {
+            providers: ["nearai", "openai"].into_iter().collect(),
+            answers: [
+                ApiKeyAnswer::Back,
+                ApiKeyAnswer::Key("sk-second-choice".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            confirms: std::collections::VecDeque::new(),
+            key_prompts: Vec::new(),
+            menu_calls: 0,
+        };
+        let outcome = provision_llm_credentials(
+            home,
+            context.boot_config(),
+            &mut prompts,
+            &EncryptedLlmKeyStoreOpener,
+            &StubOkProbe,
+            false,
+        )
+        .expect("backing out of the key prompt must re-show the menu, not fail onboarding");
+
+        assert_eq!(
+            outcome,
+            LlmCredentialProvisionOutcome::Configured {
+                provider_id: "openai".to_string(),
+                model: "gpt-5-mini".to_string(),
+            }
+        );
+        assert_eq!(
+            prompts.menu_calls, 2,
+            "the provider menu must be shown again after Back"
+        );
+        assert_eq!(prompts.key_prompts, vec!["nearai", "openai"]);
+
+        let home_path = home.path().join("local-dev");
+        let (nearai_key, openai_key) = crate::runtime::block_on_cli(async move {
+            let store = ironclaw_reborn_composition::open_local_dev_secret_store(&home_path)
+                .await
+                .map_err(anyhow::Error::from)?;
+            let store = ironclaw_reborn_composition::LlmKeyStore::new(store);
+            let nearai = store.read("nearai").await.map_err(anyhow::Error::from)?;
+            let openai = store.read("openai").await.map_err(anyhow::Error::from)?;
+            Ok::<_, anyhow::Error>((nearai, openai))
+        })
+        .expect("read back through a fresh open of the same root");
+        assert!(
+            nearai_key.is_none(),
+            "the backed-out-of provider must not have a stored key"
+        );
+        assert_eq!(
+            secrecy::ExposeSecret::expose_secret(
+                &openai_key.expect("the re-selected provider's key must be stored")
+            ),
+            "sk-second-choice"
+        );
+
+        let config_text =
+            std::fs::read_to_string(home.config_file_path()).expect("read config.toml");
+        assert!(
+            config_text.contains("provider_id = \"openai\""),
+            "config.toml must name the re-selected provider: {config_text}"
+        );
+    }
+
+    /// Regression, issue #6360, second `Back` exit: the key prompt that
+    /// `probe_and_confirm_key` re-runs after a failed probe IS the same
+    /// prompt, so backing out there must also return to the provider menu
+    /// rather than aborting. Walks the full failure path — key entered, probe
+    /// rejects it, operator declines "store anyway?", then backs out at the
+    /// reprompt — and lands on a second provider that probes clean.
+    #[test]
+    fn provision_llm_credentials_back_at_the_probe_reprompt_returns_to_the_provider_menu() {
+        let _env_guard = crate::runtime::test_env::lock_runtime_env();
+        let (_tmp, context) = RebornCliContext::test_context();
+        let home = context.boot_config().home();
+        std::fs::create_dir_all(home.path()).expect("create reborn home");
+        seed_cached_master_key(home);
+
+        let mut prompts = BackThenSwitchPromptSource {
+            providers: ["nearai", "openai"].into_iter().collect(),
+            answers: [
+                ApiKeyAnswer::Key("sk-rejected".to_string()),
+                ApiKeyAnswer::Back,
+                ApiKeyAnswer::Key("sk-accepted".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            confirms: [false].into_iter().collect(),
+            key_prompts: Vec::new(),
+            menu_calls: 0,
+        };
+        let probe = ScriptedProbe::new(vec![
+            probe_outcome(false, vec![], "invalid api key"),
+            probe_outcome(true, vec![], ""),
+        ]);
+        let outcome = provision_llm_credentials(
+            home,
+            context.boot_config(),
+            &mut prompts,
+            &EncryptedLlmKeyStoreOpener,
+            &probe,
+            false,
+        )
+        .expect("backing out at the probe reprompt must re-show the menu, not fail onboarding");
+
+        assert_eq!(
+            outcome,
+            LlmCredentialProvisionOutcome::Configured {
+                provider_id: "openai".to_string(),
+                model: "gpt-5-mini".to_string(),
+            }
+        );
+        assert_eq!(
+            prompts.menu_calls, 2,
+            "the provider menu must be shown again after Back at the reprompt"
+        );
+        // nearai twice: the first key, then the post-probe reprompt backed out of.
+        assert_eq!(prompts.key_prompts, vec!["nearai", "nearai", "openai"]);
+        let probe_calls = probe.calls();
+        assert_eq!(probe_calls.len(), 2, "{probe_calls:?}");
+        assert_eq!(probe_calls[0].provider_id, "nearai");
+        assert_eq!(probe_calls[1].provider_id, "openai");
+
+        let home_path = home.path().join("local-dev");
+        let (nearai_key, openai_key) = crate::runtime::block_on_cli(async move {
+            let store = ironclaw_reborn_composition::open_local_dev_secret_store(&home_path)
+                .await
+                .map_err(anyhow::Error::from)?;
+            let store = ironclaw_reborn_composition::LlmKeyStore::new(store);
+            let nearai = store.read("nearai").await.map_err(anyhow::Error::from)?;
+            let openai = store.read("openai").await.map_err(anyhow::Error::from)?;
+            Ok::<_, anyhow::Error>((nearai, openai))
+        })
+        .expect("read back through a fresh open of the same root");
+        assert!(
+            nearai_key.is_none(),
+            "the probe-rejected key must never reach the secret store"
+        );
+        assert_eq!(
+            secrecy::ExposeSecret::expose_secret(
+                &openai_key.expect("the re-selected provider's key must be stored")
+            ),
+            "sk-accepted"
         );
     }
 
@@ -1481,8 +1768,8 @@ mod tests {
                 })
         }
 
-        fn api_key(&mut self, _provider: &str) -> Result<String, LlmCredentialPromptError> {
-            Ok(self.key.to_string())
+        fn api_key(&mut self, _provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
+            Ok(ApiKeyAnswer::Key(self.key.to_string()))
         }
 
         fn model(
@@ -1518,7 +1805,7 @@ mod tests {
             unreachable!("provider_menu() must not be called once is_interactive() is false")
         }
 
-        fn api_key(&mut self, _provider: &str) -> Result<String, LlmCredentialPromptError> {
+        fn api_key(&mut self, _provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
             unreachable!("api_key() must not be called once is_interactive() is false")
         }
 

--- a/crates/ironclaw_reborn_cli/src/commands/onboard/llm_credentials.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/onboard/llm_credentials.rs
@@ -212,8 +212,8 @@ impl LlmProbe for LiveLlmProbe {}
 ///
 /// Menu step (via [`super::prompts::PromptSource::provider_menu`]): prompts for
 /// provider, API key (if required), model override, then persists.
-/// - Both prompts run BEFORE any write (pure reads, nothing durable), so the
-///   only fallible steps left are the two durable writes.
+/// - No DURABLE WRITE occurs before the two below, though key/model
+///   verification (`probe_and_confirm_key`) performs external network I/O.
 /// - Write order: secret store (`LlmKeyStore`, key `llm_provider_<id>_api_key`
 ///   — same handle webui2 settings writes and `apply_startup_stored_llm_key`
 ///   reads at boot) FIRST, then `[llm.default]` in `config.toml` SECOND
@@ -369,10 +369,11 @@ fn open_llm_key_store(
 ///
 /// Loops on [`ApiKeyAnswer::Back`] (issue #6360): an operator who realizes at
 /// the key prompt that they picked the wrong provider gets the menu again
-/// instead of having to cancel onboarding. Everything above the two durable
-/// writes is a pure read, so a re-selection discards nothing persisted — and
-/// each pass blocks on at least one operator answer, so the loop cannot spin
-/// on its own.
+/// instead of having to cancel onboarding. Nothing above the two durable
+/// writes persists anything (key/model verification may perform external
+/// network I/O, but writes nothing durable), so a re-selection discards
+/// nothing persisted — and each pass blocks on at least one operator answer,
+/// so the loop cannot spin on its own.
 #[cfg(feature = "libsql")]
 fn provision_via_menu(
     store_root: &Path,
@@ -429,8 +430,9 @@ struct SelectedProvider {
     model: Option<String>,
 }
 
-/// One pass of provider menu → API key → model → probe. All pure reads, no
-/// durable write — [`provision_via_menu`] performs those once this returns.
+/// One pass of provider menu → API key → model → probe. No durable write here
+/// — [`provision_via_menu`] performs those once this returns — though the
+/// probe step performs external network I/O.
 ///
 /// `Ok(None)` means the operator backed out at a key prompt
 /// ([`ApiKeyAnswer::Back`]) and wants the menu again; nothing entered on this

--- a/crates/ironclaw_reborn_cli/src/commands/onboard/prompts.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/onboard/prompts.rs
@@ -82,11 +82,24 @@ pub(crate) trait PromptSource {
 /// `Key` is the key *as typed* — it carries no probe/verification status; that
 /// is `probe_and_confirm_key`'s job downstream.
 #[cfg(feature = "libsql")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) enum ApiKeyAnswer {
     Key(String),
     /// Return to the provider menu without entering a key (Esc at the prompt).
     Back,
+}
+
+/// Manual `Debug`, not derived: `Key` wraps a plaintext LLM API key, and a
+/// derived impl would print it verbatim on any `{:?}` formatting (e.g. a
+/// panic message or a debug log). Redact it instead.
+#[cfg(feature = "libsql")]
+impl std::fmt::Debug for ApiKeyAnswer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Key(_) => write!(f, "Key(<redacted>)"),
+            Self::Back => write!(f, "Back"),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/ironclaw_reborn_cli/src/commands/onboard/prompts.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/onboard/prompts.rs
@@ -42,9 +42,11 @@ pub(crate) trait PromptSource {
         entries: &[ironclaw_reborn_composition::ProviderMenuEntry],
     ) -> Result<String, LlmCredentialPromptError>;
 
-    /// Prompt for `provider`'s API key with input masked (not echoed).
+    /// Prompt for `provider`'s API key with input masked (not echoed), or
+    /// report that the operator wants to pick a different provider
+    /// ([`ApiKeyAnswer::Back`]).
     #[cfg(feature = "libsql")]
-    fn api_key(&mut self, provider: &str) -> Result<String, LlmCredentialPromptError>;
+    fn api_key(&mut self, provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError>;
 
     /// Ask a yes/no `question`, defaulting to yes on a blank answer (`[Y/n]`
     /// framing). Used by onboard's env-detect-and-confirm step: "Found
@@ -65,6 +67,26 @@ pub(crate) trait PromptSource {
         provider_id: &str,
         default_model: &str,
     ) -> Result<Option<String>, LlmCredentialPromptError>;
+}
+
+/// What the operator answered at the API-key prompt.
+///
+/// `Back` is a normal outcome, not an error: the API-key prompt used to be a
+/// terminal state (a key, or an error that aborted onboarding), so an operator
+/// who realized mid-flow that they had picked the wrong provider had to cancel
+/// the whole run and start over. `Back` is the control-flow signal
+/// [`super::llm_credentials::provision_llm_credentials`] loops on to re-show
+/// the provider menu — same "success variant, not an error" shape
+/// [`ArrowMenuOutcome::Cancelled`] already uses.
+///
+/// `Key` is the key *as typed* — it carries no probe/verification status; that
+/// is `probe_and_confirm_key`'s job downstream.
+#[cfg(feature = "libsql")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ApiKeyAnswer {
+    Key(String),
+    /// Return to the provider menu without entering a key (Esc at the prompt).
+    Back,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -140,7 +162,7 @@ impl PromptSource for StdinPromptSource {
     }
 
     #[cfg(feature = "libsql")]
-    fn api_key(&mut self, provider: &str) -> Result<String, LlmCredentialPromptError> {
+    fn api_key(&mut self, provider: &str) -> Result<ApiKeyAnswer, LlmCredentialPromptError> {
         if !std::io::stdin().is_terminal() {
             return Err(LlmCredentialPromptError::NonInteractive);
         }
@@ -151,15 +173,22 @@ impl PromptSource for StdinPromptSource {
         // request.
         const MAX_ATTEMPTS: u8 = 3;
         for attempt in 1..=MAX_ATTEMPTS {
-            print!("{provider} API key (input hidden): ");
+            print!("{provider} API key (input hidden, Esc to pick a different provider): ");
             std::io::stdout()
                 .flush()
                 .map_err(|error| LlmCredentialPromptError::Other(error.into()))?;
-            let key = read_masked_line()
-                .map_err(|error| LlmCredentialPromptError::Other(error.into()))?;
+            let key = match read_masked_line()
+                .map_err(|error| LlmCredentialPromptError::Other(error.into()))?
+            {
+                MaskedLine::Entered(key) => key,
+                MaskedLine::Cancelled => {
+                    println!();
+                    return Ok(ApiKeyAnswer::Back);
+                }
+            };
             println!();
             if !key.trim().is_empty() {
-                return Ok(key);
+                return Ok(ApiKeyAnswer::Key(key));
             }
             if attempt < MAX_ATTEMPTS {
                 println!("API key must not be blank; please try again.");
@@ -554,13 +583,18 @@ fn render_menu(
 ///
 /// `pub(crate)` — reused by `commands::config::set` for secret-valued
 /// `config set` keys so a plaintext secret never echoes to the terminal.
-pub(crate) fn read_masked_line() -> std::io::Result<String> {
+///
+/// Esc returns [`MaskedLine::Cancelled`] (discarding anything typed so far)
+/// rather than being ignored, so callers can offer an escape hatch out of a
+/// secret prompt — onboarding's API-key prompt turns it into
+/// [`ApiKeyAnswer::Back`], `config set` into an explicit "cancelled" error.
+pub(crate) fn read_masked_line() -> std::io::Result<MaskedLine> {
     use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use crossterm::{execute, style::Print, terminal};
 
     let mut input = String::new();
     terminal::enable_raw_mode()?;
-    let result = (|| -> std::io::Result<()> {
+    let result = (|| -> std::io::Result<bool> {
         drain_pending_events();
         loop {
             if let Event::Key(KeyEvent {
@@ -572,6 +606,7 @@ pub(crate) fn read_masked_line() -> std::io::Result<String> {
             {
                 match code {
                     KeyCode::Enter => break,
+                    KeyCode::Esc => return Ok(true),
                     KeyCode::Backspace if !input.is_empty() => {
                         input.pop();
                         execute!(std::io::stdout(), Print("\x08 \x08"))?;
@@ -593,11 +628,24 @@ pub(crate) fn read_masked_line() -> std::io::Result<String> {
                 }
             }
         }
-        Ok(())
+        Ok(false)
     })();
     terminal::disable_raw_mode()?;
-    result?;
-    Ok(input)
+    Ok(if result? {
+        // Drop anything typed before Esc — a cancelled prompt must not leak a
+        // partial secret back to the caller.
+        MaskedLine::Cancelled
+    } else {
+        MaskedLine::Entered(input)
+    })
+}
+
+/// Outcome of [`read_masked_line`]: a submitted line (Enter), or a prompt the
+/// operator backed out of (Esc). Ctrl-C stays an `Interrupted` `io::Error`, as
+/// before — that aborts, it does not hand control back to the caller.
+pub(crate) enum MaskedLine {
+    Entered(String),
+    Cancelled,
 }
 
 /// Discard any terminal input events buffered before raw mode was entered,

--- a/docs/reborn/onboarding.md
+++ b/docs/reborn/onboarding.md
@@ -53,13 +53,27 @@ bootstrap and startup will not re-enable it.
 Legacy IronClaw startup also uses the same env pair to bootstrap the persisted
 `nearai` MCP server config described in `.env.example`.
 
+## Interactive LLM Credential Prompts
+
+On an interactive terminal, `onboard` prompts for the LLM provider (arrow-key
+menu, falling back to a numbered list), then that provider's API key (input
+masked), then an optional model override, and probes the key before storing it.
+Writes go to the encrypted secret store first and `[llm.default]` in
+`config.toml` second, so the config can never name a provider whose key failed
+to persist.
+
+**Esc at the API-key prompt returns to the provider menu** rather than
+cancelling onboarding — including at the reprompt that follows a failed probe.
+Nothing entered on the abandoned pass is stored: every prompt is a pure read
+and both durable writes happen only after a provider is finally settled on.
+
+A rerun where `[llm.default]` already names a provider *and* the secret store
+already holds its key skips these prompts entirely (`--force` re-runs them).
+
 ## Non-Goals In This Slice
 
 - No v1 `src/setup/wizard.rs` reuse.
 - No automatic first-run invocation before `ironclaw run`.
-- No interactive provider credential prompts.
-- No keychain or encrypted secret setup for LLM keys.
-- No model picker.
 - No channel, extension, or WebUI setup flow.
 - No conversation-history import.
 


### PR DESCRIPTION
Closes #6360

## Verified bug

`ironclaw onboard`'s provider flow made the API-key prompt a terminal state. Reproduced structurally on `origin/main` @ `ba730475c`:

- `provision_via_menu` called `prompts.provider_menu(...)` exactly once, then fell straight through to `api_key` → `model` → probe → writes.
- `PromptSource::api_key` returned `String` — no vocabulary for "go back". The only exits were a key or a `LlmCredentialPromptError` that aborted the whole run.
- `read_masked_line` classified `KeyCode::Esc` into its `_ => {}` arm, i.e. silently ignored.

RED proof: a staged stub (`Back` → error) made the new regression test fail with `Other(STAGE-A: back-to-provider-menu not implemented yet)`; it passes once the loop lands. Both new tests were additionally mutation-checked — breaking each `Back` propagation fails that test and only that test.

## Root cause

The API-key prompt had no way to express "operator wants a different provider", so neither the terminal implementation nor the caller could act on it.

## Fix

- `ApiKeyAnswer::{Key, Back}` — `Back` is a success variant, not an error, matching the existing `ArrowMenuOutcome::Cancelled` precedent in the same module.
- `MaskedLine::{Entered, Cancelled}` — Esc now returns `Cancelled`, discarding anything typed before it so a cancelled prompt cannot surface a partial secret. Ctrl-C still aborts as an `Interrupted` io error.
- `provision_via_menu` loops over an extracted `select_provider_and_key`, which returns `Ok(None)` on `Back`. `probe_and_confirm_key` propagates `Back` too — its reprompt *is* the key prompt, so it must offer the same escape.
- Prompt text names the affordance: `<provider> API key (input hidden, Esc to pick a different provider):`.

Invariants preserved: every prompt is a pure read, so an abandoned pass persists nothing; the secret-store-before-`config.toml` write ordering is untouched (the loop wraps only the reads above it).

No re-selection cap — each pass blocks on at least one operator answer, so the loop cannot spin on its own.

## Issue part 2 — already shipped, no change

"The first provider selection step should be hidden once a provider has already been selected and the user re-enters onboarding" is already implemented by `already_configured_outcome` and pinned by the existing `provision_llm_credentials_writes_config_and_secret_store_through_fake_prompts`, whose second call uses `PanickingPromptSource` and must never reach `provider_menu`.

## Behavior change outside the issue

`commands/config/set.rs` shares `read_masked_line`. Esc there used to be silently ignored (the read loop kept waiting); it now cancels with `` `config set <key>` cancelled at the value prompt; nothing written ``. Forced by sharing the loop, and consistent with the Esc-means-cancel convention the arrow menu already uses.

## Regression tests

Crate-tier caller-level, driving the production caller `provision_llm_credentials`:

- `provision_llm_credentials_back_at_the_key_prompt_returns_to_the_provider_menu` — Back at the first key prompt; asserts the menu is shown twice, the backed-out-of provider has **no** stored key, and `config.toml` names the re-selected one.
- `provision_llm_credentials_back_at_the_probe_reprompt_returns_to_the_provider_menu` — key entered → probe rejects → "store anyway?" declined → Back at the reprompt; asserts the probe-rejected key never reaches the secret store.

Tier rationale: `tests/integration/` drives Reborn turns, not a terminal wizard. `provision_llm_credentials` is the production caller of the `PromptSource` seam, so this is the highest tier that can reach the path.

## Verification

```
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo test -p ironclaw --bins        # 444 passed, 0 failed
cargo test -p ironclaw_architecture                                 # 74 passed, 0 failed
cargo clippy -p ironclaw --all-targets --all-features -- -D warnings # clean
cargo clippy -p ironclaw --all-targets --no-default-features --features libsql -- -D warnings # clean
bash scripts/pre-commit-safety.sh                                   # OK
cargo fmt
```

## Coverage limits (deliberate)

- `read_masked_line`'s Esc arm and `StdinSecretValueSource`'s cancel bail are raw-mode terminal paths with no test seam — the same tier as the pre-existing Ctrl-C and Backspace arms in that identical loop, none of which are unit-tested. Extracting an `apply_menu_key`-style reducer to test one arm was reviewed and rejected as over-engineering: that existing split is justified by wrap-around index arithmetic, which has no analogue here.
- `docs/reborn/onboarding.md` had three Non-Goals that shipped long ago (interactive provider prompts, encrypted LLM key storage, model picker). Corrected those and documented the new Esc affordance. Broader staleness in that doc is pre-existing and left alone.

## Review

`code-review` (8 reviewers) and `thermo-nuclear-code-quality-review` both ran on the final diff. No security, correctness, performance, or architectural findings. The one actionable finding — the probe-reprompt `Back` path shipping untested — is fixed by the second regression test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

### Correction (verification claim)

An earlier revision of this description listed a bare `--no-default-features` clippy lane as clean. That was wrong — I read the exit code of a piped `tail`, not of clippy. Corrected above to the lane the repo actually documents (`--no-default-features --features libsql`), which does pass (exit 0, verified unpiped).

For the record, bare `--no-default-features` on this crate fails with 3 errors (unused `std::path::Path` and `Arc` imports in `config/set.rs`, dead `MasterKeyProvisionOutcome` variants in `onboard/master_key.rs`). I reproduced those on a clean `origin/main` @ `ba730475c` worktree — **pre-existing, not introduced here**. That configuration isn't one of the three documented matrix lanes (this crate's `default = ["libsql"]`), so it appears to be unsupported rather than broken.

### Review round 2

- **Fixed** — `ApiKeyAnswer` derived `Debug` over a plaintext key; now a redacting manual impl (thanks @coderabbitai).
- **Fixed** — "pure reads" doc overclaimed; `probe_and_confirm_key` does network I/O. Reworded at all three sites to the real invariant (no durable writes).
- **Fixed** — `config set`'s Esc-cancel arm lifted into a pure `masked_line_to_secret` and covered by two tests.
- **Deferred to a follow-up** — `stdout().is_terminal()` on the secret prompt (@gemini-code-assist). The premise is right, but the gap is wider than one line: `prompts.rs`'s own per-prompt gates (`api_key` and three others) have the identical stdin-only check. It's a pre-existing codebase-wide pattern, and patching one site here would half-fix it while worsening the scope objection already raised on this file.
- **Declined** — a terminal-path test for `read_masked_line`'s Esc arm. It's a single `return Ok(true)` beside the equally untested `Ctrl-C` and `Backspace` arms in the same raw-mode loop, with no state or arithmetic to isolate. Testing it means injecting an event-stream seam into production code for a one-line branch. The `config set` cancel arm got the opposite treatment precisely because it's pure and needed no terminal — that's the line drawn.
