### PR TITLE
refactor(reborn-migration): decouple from ironclaw_legacy before Tier B

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,11 +5067,14 @@ dependencies = [
 name = "ironclaw_reborn_migration"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "chrono",
+ "chrono-tz",
  "clap",
  "deadpool-postgres",
+ "hkdf 0.13.0",
  "ironclaw_common",
  "ironclaw_extensions",
  "ironclaw_filesystem",
@@ -5086,16 +5089,22 @@ dependencies = [
  "ironclaw_threads",
  "ironclaw_triggers",
  "libsql",
+ "rustls 0.23.41",
+ "rustls-native-certs 0.8.4",
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tracing",
  "tracing-subscriber",
  "ulid",
  "uuid",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5089,22 +5089,19 @@ dependencies = [
  "ironclaw_threads",
  "ironclaw_triggers",
  "libsql",
- "rustls 0.23.41",
- "rustls-native-certs 0.8.4",
  "secrecy",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
+ "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
- "tokio-postgres-rustls",
  "tracing",
  "tracing-subscriber",
  "ulid",
  "uuid",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -2773,12 +2773,15 @@ fn boundary_rules() -> Vec<BoundaryRule> {
     vec![
         BoundaryRule {
             // The v1→Reborn migration tool is an intentional one-way bridge:
-            // it reads through the root `ironclaw_legacy` crate and writes through the
-            // Reborn state substrate + composition's `migration-support` seam.
-            // That bridge must stay a *state* converter — it must not grow
-            // direct deps on the serving/runtime/engine layers (gateway, engine,
-            // runtime lanes, dispatcher, webui) or it would quietly become a
-            // second live entry point into Reborn.
+            // it reads through its own frozen v1 read path
+            // (`crates/ironclaw_reborn_migration/src/legacy_snapshot/`, ported
+            // off the live `ironclaw_legacy` crate so it survives Tier B) and
+            // writes through the Reborn state substrate + composition's
+            // `migration-support` seam. That bridge must stay a *state*
+            // converter — it must not grow direct deps on the serving/
+            // runtime/engine layers (gateway, engine, runtime lanes,
+            // dispatcher, webui) or it would quietly become a second live
+            // entry point into Reborn.
             crate_name: "ironclaw_reborn_migration",
             forbidden: vec![
                 "ironclaw_dispatcher",
@@ -3985,13 +3988,6 @@ const LAYER_MATRIX_EXCEPTIONS: &[LayerMatrixException] = &[
         introduced: "2026-07-09",
         removes_in: "W3.6",
         reason: "webui ingress still reaches composition until the composition webui module is folded into ingress and runtime handles are inverted",
-    },
-    LayerMatrixException {
-        crate_name: "ironclaw_reborn_migration",
-        dependency_name: "ironclaw_legacy",
-        introduced: "2026-07-09",
-        removes_in: "Tier B",
-        reason: "the migration app intentionally reads v1 state until the legacy root is retired",
     },
 ];
 

--- a/crates/ironclaw_reborn_migration/CLAUDE.md
+++ b/crates/ironclaw_reborn_migration/CLAUDE.md
@@ -5,12 +5,16 @@ state** into the **Reborn** state substrate. Ships as its own binary
 (`ironclaw-reborn-migration`); the conversion engine is a library
 (`run_migration`) so it can later be wired into `ironclaw` startup.
 
-- **Read side** = the root `ironclaw` crate (`ironclaw::db::connect_with_handles`)
-  — one v1 database (PostgreSQL **or** libSQL). Engine-v2 state is **not** a
-  separate DB: missions/projects/threads were persisted by the v2 bridge as JSON
-  blobs inside the v1 `memory_documents` table under `engine/…` /
+- **Read side** = `src/legacy_snapshot/` — a self-contained, frozen port of the
+  v1 read path (DB connect, the 7 queries this crate needs, secrets decrypt,
+  wasm tool/channel stores), independent of the live `ironclaw_legacy` crate.
+  Opens one v1 database (PostgreSQL **or** libSQL) directly. Engine-v2 state is
+  **not** a separate DB: missions/projects/threads were persisted by the v2
+  bridge as JSON blobs inside the v1 `memory_documents` table under `engine/…` /
   `.system/engine/…` paths. Parsed via the serde mirrors in `v2_model.rs` (the
   engine-v2 types were deleted; they survive only at git tag `old_engine_v2`).
+  `legacy_snapshot/` applies the same freeze-and-port pattern to the rest of
+  the v1 read surface — see "Decoupled from `ironclaw_legacy`" below.
 - **Write side** = Reborn domain stores built directly over a `RootFilesystem` /
   triggers DB in `target.rs`, without booting a `RebornRuntime`. Threads /
   secrets / identity force a concrete filesystem type, so they are built inside
@@ -74,6 +78,37 @@ a domain fails the build.
   The store is opened through the composition `migration-support` seam
   `extension_installation_store_for_migration` (mirrors composition's
   `*_for_test` accessors; ships zero bytes without the feature).
+
+## Decoupled from `ironclaw_legacy`
+
+This crate's `[dependencies]` no longer include `ironclaw_legacy` (`src/`, the
+v1 monolith). That dependency was tracked debt in
+`crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`'s
+`LAYER_MATRIX_EXCEPTIONS` (`removes_in: "Tier B"` — full `src/` retirement,
+see `docs/plans/2026-07-02-reborn-internal-module-refactor.md` §8), since
+`Database` is a 9-sub-trait, ~78-method supertrait that can't be partially
+implemented as a trait object. `src/legacy_snapshot/` freezes only the 7
+`Database` methods, the secrets decrypt scheme (AES-256-GCM + HKDF-SHA256,
+byte-for-byte — porting this wrong silently breaks decrypting real secrets),
+and the wasm tool/channel store queries this crate actually calls — the same
+pattern `v2_model.rs` already used for the deleted engine-v2 types.
+
+**One deliberate behavior change**: the original `ironclaw::db::connect_with_handles`
+applied v1 schema migrations as a side effect of connecting.
+`legacy_snapshot::connect` does not — reproducing the full migration-apply
+machinery (refinery + the consolidated libSQL schema) for a one-time cutover
+tool was out of proportion, so this reader instead requires the source
+database to already be at the schema version it was frozen against and fails
+loud with `LegacyError::SchemaMismatch` (naming the missing column) via
+`ensure_schema_current` rather than silently reading a partial row.
+
+**Known gap**: `tests/migration_roundtrip.rs` still seeds its v1 fixture
+through the *real* v1 write path (`ironclaw_legacy` as a `[dev-dependencies]`
+entry — this doesn't need a `LAYER_MATRIX_EXCEPTIONS` entry, that check only
+walks normal dependencies) for fidelity: the fixture must look exactly like
+what a live v1 install produces. When `src/` is actually deleted under Tier B,
+`seed_v1_fixture` and friends need rewriting to insert raw SQL directly
+against the frozen schema instead.
 
 ## Remaining follow-up — wire into `ironclaw` startup
 

--- a/crates/ironclaw_reborn_migration/Cargo.toml
+++ b/crates/ironclaw_reborn_migration/Cargo.toml
@@ -34,10 +34,6 @@ libsql = ["dep:libsql", "ironclaw_reborn_composition/libsql"]
 postgres = [
     "dep:deadpool-postgres",
     "dep:tokio-postgres",
-    "dep:tokio-postgres-rustls",
-    "dep:rustls",
-    "dep:rustls-native-certs",
-    "dep:webpki-roots",
     "ironclaw_reborn_composition/postgres",
 ]
 
@@ -85,13 +81,13 @@ sha2 = "0.11"
 deadpool-postgres = { version = "0.14", optional = true }
 libsql = { version = "0.9", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 tokio-postgres = { version = "0.7", optional = true, features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
-tokio-postgres-rustls = { version = "0.13", optional = true }
-rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "ring", "tls12"] }
-rustls-native-certs = { version = "0.8", optional = true }
-webpki-roots = { version = "1.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
+# Dev-only: `legacy_snapshot::postgres_tests` (Postgres coverage for the
+# frozen v1 reader) — skips gracefully when Docker is unavailable, same
+# pattern as `ironclaw_reborn_composition`/`ironclaw_triggers`.
+testcontainers-modules = { version = "0.12", features = ["postgres"] }
 # Dev-only: `tests/migration_roundtrip.rs` seeds its v1 fixture through the
 # real v1 write path (actual INSERT/migration code, not raw SQL) for fidelity —
 # the fixture must look exactly like what a real v1 install produces. This is

--- a/crates/ironclaw_reborn_migration/Cargo.toml
+++ b/crates/ironclaw_reborn_migration/Cargo.toml
@@ -21,33 +21,27 @@ dist = false
 [[bin]]
 name = "ironclaw-reborn-migration"
 path = "src/main.rs"
-required-features = ["full-migration"]
 
 [[bin]]
 name = "ironclaw-reborn-extension-ownership-migration"
 path = "src/extension_ownership_main.rs"
 
 [features]
-default = ["full-migration", "libsql", "postgres"]
-full-migration = ["dep:ironclaw"]
-# Backend features wire every Reborn write stack that dispatches on that
-# backend. When `full-migration` is also enabled, `ironclaw?/libsql` forwards
-# the same backend into the optional v1 read stack.
-libsql = [
-    "dep:libsql",
-    "ironclaw?/libsql",
-    "ironclaw_reborn_composition/libsql",
-]
+default = ["libsql", "postgres"]
+# Backend features wire both the Reborn write stack and the frozen v1 read
+# stack (`src/legacy_snapshot/`) that dispatches on that backend.
+libsql = ["dep:libsql", "ironclaw_reborn_composition/libsql"]
 postgres = [
     "dep:deadpool-postgres",
-    "ironclaw?/postgres",
+    "dep:tokio-postgres",
+    "dep:tokio-postgres-rustls",
+    "dep:rustls",
+    "dep:rustls-native-certs",
+    "dep:webpki-roots",
     "ironclaw_reborn_composition/postgres",
 ]
 
 [dependencies]
-# ── v1 / engine-v2 read side (the legacy monolith) ──────────────────────────
-ironclaw = { package = "ironclaw_legacy", path = "../..", default-features = false, optional = true }
-
 # ── Reborn write side (path deps; versions intentionally unpinned) ───────────
 ironclaw_common = { path = "../ironclaw_common" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
@@ -68,6 +62,7 @@ ironclaw_reborn_identity = { path = "../ironclaw_reborn_identity" }
 anyhow = "1"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 clap = { version = "4", features = ["derive", "env"] }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
@@ -79,17 +74,40 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = "1"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
+# ── frozen v1 read path (src/legacy_snapshot/) — AES-256-GCM + HKDF-SHA256,
+# byte-for-byte matching src/secrets/crypto.rs so previously-encrypted v1
+# secrets keep decrypting ────────────────────────────────────────────────────
+aes-gcm = "0.10"
+hkdf = "0.13"
+sha2 = "0.11"
+
 # backend-specific handles (optional, pulled in by feature)
 deadpool-postgres = { version = "0.14", optional = true }
 libsql = { version = "0.9", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+tokio-postgres = { version = "0.7", optional = true, features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres-rustls = { version = "0.13", optional = true }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "ring", "tls12"] }
+rustls-native-certs = { version = "0.8", optional = true }
+webpki-roots = { version = "1.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
+# Dev-only: `tests/migration_roundtrip.rs` seeds its v1 fixture through the
+# real v1 write path (actual INSERT/migration code, not raw SQL) for fidelity —
+# the fixture must look exactly like what a real v1 install produces. This is
+# a test-fixture concern, not a production dependency: `[dependencies]` above
+# has no `ironclaw_legacy` edge, so this does not need a
+# `LAYER_MATRIX_EXCEPTIONS` entry (that check filters to `kind == "normal"`
+# dependencies; see `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`
+# `is_normal_dependency`). When `src/` is actually deleted under Tier B, this
+# fixture setup needs rewriting to raw SQL against the frozen schema instead.
+ironclaw = { package = "ironclaw_legacy", path = "../..", default-features = false, features = [
+    "libsql",
+] }
 
 # Docker-free acceptance test: seeds a rich v1+engine-v2 libSQL fixture, runs the
-# migration, and asserts the round-trip + the exact gap set. Gated on the full
-# migration plus libsql so the ownership-only operator build stays legacy-free.
+# migration, and asserts the round-trip + the exact gap set.
 [[test]]
 name = "migration_roundtrip"
 path = "tests/migration_roundtrip.rs"
-required-features = ["full-migration", "libsql"]
+required-features = ["libsql"]

--- a/crates/ironclaw_reborn_migration/src/convert/automations.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/automations.rs
@@ -23,13 +23,13 @@
 
 use std::collections::HashMap;
 
-use ironclaw::agent::routine::{Routine, RoutineAction, Trigger};
 use ironclaw_host_api::ProjectId;
 use ironclaw_triggers::{TriggerRecord, TriggerSchedule, TriggerSourceKind, TriggerState};
 use uuid::Uuid;
 
 use crate::convert::threads::{ImportMessage, ImportRole, ThreadImport, write_thread};
 use crate::error::MigrationError;
+use crate::legacy_snapshot::{Routine, RoutineAction, Trigger};
 use crate::options::MigrationOptions;
 use crate::report::{Domain, LossReason, MigrationReport};
 use crate::source::V1Source;

--- a/crates/ironclaw_reborn_migration/src/convert/extensions.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/extensions.rs
@@ -25,8 +25,6 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use ironclaw::channels::wasm::{StoredWasmChannel, WasmChannelStore};
-use ironclaw::tools::wasm::{StoredWasmTool, ToolStatus, WasmToolStore};
 use ironclaw_extensions::{
     ExtensionActivationState, ExtensionCredentialBinding, ExtensionCredentialHandle,
     ExtensionInstallation, ExtensionInstallationError, ExtensionInstallationId,
@@ -37,6 +35,13 @@ use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle, UserId};
 use ironclaw_host_runtime::{default_host_api_contract_registry, default_host_port_catalog};
 
 use crate::error::MigrationError;
+#[cfg(feature = "libsql")]
+use crate::legacy_snapshot::wasm_stores::{LibSqlWasmChannelStore, LibSqlWasmToolStore};
+#[cfg(feature = "postgres")]
+use crate::legacy_snapshot::wasm_stores::{PostgresWasmChannelStore, PostgresWasmToolStore};
+use crate::legacy_snapshot::wasm_stores::{
+    StoredWasmChannel, StoredWasmTool, ToolStatus, WasmChannelStore, WasmToolStore,
+};
 use crate::options::MigrationOptions;
 use crate::report::{Domain, LossReason, MigrationReport};
 use crate::source::V1Source;
@@ -436,15 +441,11 @@ async fn tool_credential_bindings(
 fn build_tool_store(src: &V1Source) -> Option<Arc<dyn WasmToolStore>> {
     #[cfg(feature = "libsql")]
     if let Some(db) = src.handles.libsql_db.as_ref() {
-        return Some(Arc::new(ironclaw::tools::wasm::LibSqlWasmToolStore::new(
-            db.clone(),
-        )));
+        return Some(Arc::new(LibSqlWasmToolStore::new(db.clone())));
     }
     #[cfg(feature = "postgres")]
     if let Some(pool) = src.handles.pg_pool.as_ref() {
-        return Some(Arc::new(ironclaw::tools::wasm::PostgresWasmToolStore::new(
-            pool.clone(),
-        )));
+        return Some(Arc::new(PostgresWasmToolStore::new(pool.clone())));
     }
     None
 }
@@ -452,15 +453,11 @@ fn build_tool_store(src: &V1Source) -> Option<Arc<dyn WasmToolStore>> {
 fn build_channel_store(src: &V1Source) -> Option<Arc<dyn WasmChannelStore>> {
     #[cfg(feature = "libsql")]
     if let Some(db) = src.handles.libsql_db.as_ref() {
-        return Some(Arc::new(
-            ironclaw::channels::wasm::LibSqlWasmChannelStore::new(db.clone()),
-        ));
+        return Some(Arc::new(LibSqlWasmChannelStore::new(db.clone())));
     }
     #[cfg(feature = "postgres")]
     if let Some(pool) = src.handles.pg_pool.as_ref() {
-        return Some(Arc::new(
-            ironclaw::channels::wasm::PostgresWasmChannelStore::new(pool.clone()),
-        ));
+        return Some(Arc::new(PostgresWasmChannelStore::new(pool.clone())));
     }
     None
 }

--- a/crates/ironclaw_reborn_migration/src/convert/identities.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/identities.rs
@@ -14,6 +14,7 @@ use ironclaw_reborn_identity::{
 };
 
 use crate::error::MigrationError;
+use crate::legacy_snapshot::UserIdentityRecord;
 use crate::options::MigrationOptions;
 use crate::report::{Domain, LossReason, MigrationReport};
 use crate::source::V1Source;
@@ -89,7 +90,7 @@ async fn migrate_user_identities(
 
 fn build_oauth_identity(
     tgt: &RebornTarget,
-    rec: &ironclaw::db::UserIdentityRecord,
+    rec: &UserIdentityRecord,
     report: &mut MigrationReport,
 ) -> Option<ResolveExternalIdentity> {
     let source_id = format!("identity:{}:{}", rec.provider, rec.provider_user_id);

--- a/crates/ironclaw_reborn_migration/src/convert/secrets.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/secrets.rs
@@ -10,11 +10,11 @@
 
 use std::sync::Arc;
 
-use ironclaw::secrets::{SecretsCrypto, create_secrets_store};
 use ironclaw_host_api::{InvocationId, ResourceScope, SecretHandle};
 use ironclaw_secrets::SecretMaterial;
 
 use crate::error::MigrationError;
+use crate::legacy_snapshot::secrets::{LegacySecretsSource, SecretsCrypto, create_secrets_store};
 use crate::options::MigrationOptions;
 use crate::report::{Domain, LossReason, MigrationReport};
 use crate::source::V1Source;
@@ -76,7 +76,7 @@ pub(crate) async fn run(
             })?;
         for secret_ref in refs {
             migrate_one(
-                &*v1_store,
+                &v1_store,
                 secret_store.as_ref(),
                 tgt,
                 options,
@@ -95,7 +95,7 @@ pub(crate) async fn run(
 // per-secret context struct, plan v1-migration
 #[allow(clippy::too_many_arguments)]
 async fn migrate_one(
-    v1_store: &(dyn ironclaw::secrets::SecretsStore + Send + Sync),
+    v1_store: &LegacySecretsSource,
     secret_store: &dyn ironclaw_secrets::SecretStore,
     tgt: &RebornTarget,
     options: &MigrationOptions,

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/connect.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/connect.rs
@@ -13,8 +13,12 @@
 //! one-time cutover tool. Instead this reader requires the source database to
 //! already be at the schema version it was frozen against (realistic: the v1
 //! app was in normal use, applying its own migrations, right up until this
-//! tool runs) and [`ensure_schema_current`] fails loud with a specific
-//! missing-column error rather than silently reading a partial row.
+//! tool runs). [`ensure_schema_current`] checks this for `routines` — the
+//! table with the most migrations layered onto it, so the likeliest to go
+//! stale — and fails loud with a specific missing-column error there rather
+//! than silently reading a partial row; it is not a general guarantee across
+//! every table this reader touches (see [`super::queries`] and
+//! [`super::libsql_helpers`] for how the other tables degrade on drift).
 
 #[cfg(feature = "libsql")]
 use std::path::Path;
@@ -22,7 +26,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 #[cfg(feature = "postgres")]
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 
 use super::error::LegacyError;
 use crate::options::SourceDb;
@@ -117,65 +121,26 @@ async fn open_libsql(path: &Path) -> Result<libsql::Database, LegacyError> {
         .map_err(|e| LegacyError::Connect(format!("failed to open libSQL database: {e}")))
 }
 
-/// Build a rustls-based TLS connector, frozen from `src/db/tls.rs`. Tries the
-/// platform's native certificate store first, falling back to bundled
-/// Mozilla roots (`webpki-roots`) when the system store yields none (minimal
-/// container images without `ca-certificates`). No certificate-verification
-/// override — this must stay at least as strict as the original.
-#[cfg(feature = "postgres")]
-fn make_rustls_connector() -> Result<tokio_postgres_rustls::MakeRustlsConnect, rustls::Error> {
-    let mut root_store = rustls::RootCertStore::empty();
-
-    let native = rustls_native_certs::load_native_certs();
-    for e in &native.errors {
-        tracing::warn!("error loading system root certs: {e}");
-    }
-    for cert in native.certs {
-        if let Err(e) = root_store.add(cert) {
-            tracing::warn!("skipping invalid system root cert: {e}");
-        }
-    }
-
-    if root_store.is_empty() {
-        tracing::info!("no system root certificates found, using bundled Mozilla roots");
-        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    }
-
-    let config = rustls::ClientConfig::builder_with_provider(
-        rustls::crypto::ring::default_provider().into(),
-    )
-    .with_safe_default_protocol_versions()?
-    .with_root_certificates(root_store)
-    .with_no_client_auth();
-    Ok(tokio_postgres_rustls::MakeRustlsConnect::new(config))
-}
-
-/// Open a Postgres pool. Frozen from `Store::new` + `src/db/tls::create_pool`
-/// — always uses a TLS-capable connector (mirroring the original's `Prefer`/
-/// `Require` path); this migration tool is an operator-run, short-lived
-/// process against a database an operator supplies, so there is no
-/// `DATABASE_SSLMODE=disable` local-dev case to preserve here the way the
-/// long-running `ironclaw` service has.
+/// Open a Postgres pool via the canonical Reborn helper
+/// ([`ironclaw_reborn_composition::open_reborn_postgres_pool_with_max_size`]),
+/// the same one [`crate::target::open_postgres_pool`] uses for the write
+/// side — so the source connection inherits the same fail-closed remote-TLS
+/// policy (reject `sslmode=disable` on any non-local host, upgrade `Prefer`
+/// to `Require`) without this crate hand-rolling a second TLS connector.
 #[cfg(feature = "postgres")]
 fn open_postgres(url: &SecretString) -> Result<deadpool_postgres::Pool, LegacyError> {
-    let mut cfg = deadpool_postgres::Config::new();
-    cfg.url = Some(url.expose_secret().to_string());
-    cfg.pool = Some(deadpool_postgres::PoolConfig {
-        max_size: 4,
-        ..Default::default()
-    });
-
-    let tls = make_rustls_connector().map_err(|e| LegacyError::Connect(e.to_string()))?;
-    cfg.create_pool(Some(deadpool_postgres::Runtime::Tokio1), tls)
+    ironclaw_reborn_composition::open_reborn_postgres_pool_with_max_size(url.clone(), 4)
         .map_err(|e| LegacyError::Connect(e.to_string()))
 }
 
-/// Table/column pairs this reader depends on that were added by later v1
-/// migrations (rather than present in the original schema) — a good canary
-/// for "this source database predates the schema this reader was frozen
-/// against". Only `routines` columns are checked: it is the table with the
-/// most migrations layered onto it (notify_*, dedup_window_secs, state), so a
-/// missing column there is the most likely sign of an out-of-date database.
+/// Columns this reader depends on that were added by later v1 migrations
+/// (rather than present in the original schema) — checked only for
+/// `routines`, the table with the most migrations layered onto it (notify_*,
+/// dedup_window_secs, state), so a missing column there is the most likely
+/// sign of an out-of-date database. This is not exhaustive: it is the one
+/// canary this reader checks, not a guarantee that every table/column this
+/// crate reads is present (`postgres_row_to_routine` in [`super::queries`]
+/// reads exactly these 24 columns by name, so keep the two lists in sync).
 /// The check is skipped entirely if `routines` itself doesn't exist — a
 /// minimal v1 install legitimately has no routines table, and that is a
 /// normal empty-result case elsewhere in this crate, not a schema mismatch.

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/connect.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/connect.rs
@@ -1,0 +1,275 @@
+//! Opens the legacy v1 database directly (libSQL or PostgreSQL), independent
+//! of `ironclaw_legacy`.
+//!
+//! Frozen from `ironclaw::db::connect_with_handles` (`src/db/mod.rs`) minus
+//! the `Arc<dyn Database>` trait object it built — see [`super::queries`] for
+//! why: `Database` is a 9-sub-trait, ~78-method supertrait that cannot be
+//! partially implemented, so [`LegacyDb`] is a concrete enum instead.
+//!
+//! **Does not apply schema migrations.** `connect_with_handles` ran the v1
+//! migration suite (refinery for Postgres, the consolidated libSQL schema +
+//! incremental migrations) as a side effect of connecting — reproducing that
+//! here would mean porting the entire migration-application machinery for a
+//! one-time cutover tool. Instead this reader requires the source database to
+//! already be at the schema version it was frozen against (realistic: the v1
+//! app was in normal use, applying its own migrations, right up until this
+//! tool runs) and [`ensure_schema_current`] fails loud with a specific
+//! missing-column error rather than silently reading a partial row.
+
+#[cfg(feature = "libsql")]
+use std::path::Path;
+#[cfg(feature = "libsql")]
+use std::sync::Arc;
+
+#[cfg(feature = "postgres")]
+use secrecy::{ExposeSecret, SecretString};
+
+use super::error::LegacyError;
+use crate::options::SourceDb;
+
+/// The connected v1 database, dispatched on backend. Holds only what the 7
+/// queries in [`super::queries`] need — not the full v1 `Database` trait
+/// surface.
+pub(crate) enum LegacyDb {
+    #[cfg(feature = "libsql")]
+    LibSql(Arc<libsql::Database>),
+    #[cfg(feature = "postgres")]
+    Postgres(deadpool_postgres::Pool),
+}
+
+/// Backend-specific handles for satellite v1 readers (secrets, wasm tool/
+/// channel stores) that need their own connections rather than going through
+/// [`LegacyDb`]. Same shape as the original `ironclaw::db::DatabaseHandles`
+/// so call sites built around it (`convert::secrets`, `convert::extensions`,
+/// `convert::identities`) needed no changes beyond their imports.
+#[derive(Default, Clone)]
+pub(crate) struct LegacyHandles {
+    #[cfg(feature = "postgres")]
+    pub(crate) pg_pool: Option<deadpool_postgres::Pool>,
+    #[cfg(feature = "libsql")]
+    pub(crate) libsql_db: Option<Arc<libsql::Database>>,
+}
+
+impl LegacyHandles {
+    #[cfg(feature = "libsql")]
+    fn from_libsql(db: Arc<libsql::Database>) -> Self {
+        Self {
+            libsql_db: Some(db),
+            #[cfg(feature = "postgres")]
+            pg_pool: None,
+        }
+    }
+
+    #[cfg(feature = "postgres")]
+    fn from_postgres(pool: deadpool_postgres::Pool) -> Self {
+        Self {
+            pg_pool: Some(pool),
+            #[cfg(feature = "libsql")]
+            libsql_db: None,
+        }
+    }
+}
+
+pub(crate) async fn connect(source: &SourceDb) -> Result<(LegacyDb, LegacyHandles), LegacyError> {
+    match source {
+        #[cfg(feature = "libsql")]
+        SourceDb::LibSql { path } => {
+            let db = Arc::new(open_libsql(path).await?);
+            let legacy_db = LegacyDb::LibSql(Arc::clone(&db));
+            let handles = LegacyHandles::from_libsql(db);
+            ensure_schema_current(&legacy_db).await?;
+            Ok((legacy_db, handles))
+        }
+        #[cfg(not(feature = "libsql"))]
+        SourceDb::LibSql { .. } => Err(LegacyError::Connect(
+            "libsql feature not enabled in this build".to_string(),
+        )),
+        #[cfg(feature = "postgres")]
+        SourceDb::Postgres { url } => {
+            let pool = open_postgres(url)?;
+            // Cheap connectivity smoke test, mirroring `Store::new`.
+            let _ = pool
+                .get()
+                .await
+                .map_err(|e| LegacyError::Connect(e.to_string()))?;
+            let legacy_db = LegacyDb::Postgres(pool.clone());
+            let handles = LegacyHandles::from_postgres(pool);
+            ensure_schema_current(&legacy_db).await?;
+            Ok((legacy_db, handles))
+        }
+        #[cfg(not(feature = "postgres"))]
+        SourceDb::Postgres { .. } => Err(LegacyError::Connect(
+            "postgres feature not enabled in this build".to_string(),
+        )),
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn open_libsql(path: &Path) -> Result<libsql::Database, LegacyError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            LegacyError::Connect(format!("failed to create database directory: {e}"))
+        })?;
+    }
+    libsql::Builder::new_local(path)
+        .build()
+        .await
+        .map_err(|e| LegacyError::Connect(format!("failed to open libSQL database: {e}")))
+}
+
+/// Build a rustls-based TLS connector, frozen from `src/db/tls.rs`. Tries the
+/// platform's native certificate store first, falling back to bundled
+/// Mozilla roots (`webpki-roots`) when the system store yields none (minimal
+/// container images without `ca-certificates`). No certificate-verification
+/// override — this must stay at least as strict as the original.
+#[cfg(feature = "postgres")]
+fn make_rustls_connector() -> Result<tokio_postgres_rustls::MakeRustlsConnect, rustls::Error> {
+    let mut root_store = rustls::RootCertStore::empty();
+
+    let native = rustls_native_certs::load_native_certs();
+    for e in &native.errors {
+        tracing::warn!("error loading system root certs: {e}");
+    }
+    for cert in native.certs {
+        if let Err(e) = root_store.add(cert) {
+            tracing::warn!("skipping invalid system root cert: {e}");
+        }
+    }
+
+    if root_store.is_empty() {
+        tracing::info!("no system root certificates found, using bundled Mozilla roots");
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
+    let config = rustls::ClientConfig::builder_with_provider(
+        rustls::crypto::ring::default_provider().into(),
+    )
+    .with_safe_default_protocol_versions()?
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
+    Ok(tokio_postgres_rustls::MakeRustlsConnect::new(config))
+}
+
+/// Open a Postgres pool. Frozen from `Store::new` + `src/db/tls::create_pool`
+/// — always uses a TLS-capable connector (mirroring the original's `Prefer`/
+/// `Require` path); this migration tool is an operator-run, short-lived
+/// process against a database an operator supplies, so there is no
+/// `DATABASE_SSLMODE=disable` local-dev case to preserve here the way the
+/// long-running `ironclaw` service has.
+#[cfg(feature = "postgres")]
+fn open_postgres(url: &SecretString) -> Result<deadpool_postgres::Pool, LegacyError> {
+    let mut cfg = deadpool_postgres::Config::new();
+    cfg.url = Some(url.expose_secret().to_string());
+    cfg.pool = Some(deadpool_postgres::PoolConfig {
+        max_size: 4,
+        ..Default::default()
+    });
+
+    let tls = make_rustls_connector().map_err(|e| LegacyError::Connect(e.to_string()))?;
+    cfg.create_pool(Some(deadpool_postgres::Runtime::Tokio1), tls)
+        .map_err(|e| LegacyError::Connect(e.to_string()))
+}
+
+/// Table/column pairs this reader depends on that were added by later v1
+/// migrations (rather than present in the original schema) — a good canary
+/// for "this source database predates the schema this reader was frozen
+/// against". Only `routines` columns are checked: it is the table with the
+/// most migrations layered onto it (notify_*, dedup_window_secs, state), so a
+/// missing column there is the most likely sign of an out-of-date database.
+/// The check is skipped entirely if `routines` itself doesn't exist — a
+/// minimal v1 install legitimately has no routines table, and that is a
+/// normal empty-result case elsewhere in this crate, not a schema mismatch.
+async fn ensure_schema_current(db: &LegacyDb) -> Result<(), LegacyError> {
+    let expected_columns = [
+        "id",
+        "name",
+        "description",
+        "user_id",
+        "enabled",
+        "trigger_type",
+        "trigger_config",
+        "action_type",
+        "action_config",
+        "cooldown_secs",
+        "max_concurrent",
+        "dedup_window_secs",
+        "notify_channel",
+        "notify_user",
+        "notify_on_success",
+        "notify_on_failure",
+        "notify_on_attention",
+        "state",
+        "last_run_at",
+        "next_fire_at",
+        "run_count",
+        "consecutive_failures",
+        "created_at",
+        "updated_at",
+    ];
+
+    let existing = routines_columns(db).await?;
+    let Some(existing) = existing else {
+        // No `routines` table at all — nothing to check, nothing to migrate.
+        return Ok(());
+    };
+
+    for column in expected_columns {
+        if !existing.iter().any(|c| c == column) {
+            return Err(LegacyError::SchemaMismatch {
+                table: "routines".to_string(),
+                column: column.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Column names present on the `routines` table, or `None` if the table
+/// doesn't exist.
+async fn routines_columns(db: &LegacyDb) -> Result<Option<Vec<String>>, LegacyError> {
+    match db {
+        #[cfg(feature = "libsql")]
+        LegacyDb::LibSql(handle) => {
+            let conn = handle
+                .connect()
+                .map_err(|e| LegacyError::Connect(e.to_string()))?;
+            let mut rows = conn
+                .query("PRAGMA table_info(routines)", ())
+                .await
+                .map_err(|e| LegacyError::Query(e.to_string()))?;
+            let mut columns = Vec::new();
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| LegacyError::Query(e.to_string()))?
+            {
+                // PRAGMA table_info columns: cid(0), name(1), type(2), notnull(3), dflt_value(4), pk(5).
+                columns.push(row.get::<String>(1).unwrap_or_default());
+            }
+            if columns.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(columns))
+            }
+        }
+        #[cfg(feature = "postgres")]
+        LegacyDb::Postgres(pool) => {
+            let client = pool
+                .get()
+                .await
+                .map_err(|e| LegacyError::Connect(e.to_string()))?;
+            let rows = client
+                .query(
+                    "SELECT column_name FROM information_schema.columns WHERE table_name = 'routines'",
+                    &[],
+                )
+                .await
+                .map_err(|e| LegacyError::Query(e.to_string()))?;
+            if rows.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(rows.iter().map(|r| r.get::<_, String>(0)).collect()))
+            }
+        }
+    }
+}

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/error.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/error.rs
@@ -1,0 +1,30 @@
+//! Error type for the frozen v1 read path.
+
+/// Errors from the frozen v1 reader. Every variant maps to a
+/// [`crate::error::MigrationError`] at the call site via `.to_string()`, same
+/// as the original `ironclaw::db`/`ironclaw::secrets` error types did.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LegacyError {
+    #[error("failed to connect to legacy database: {0}")]
+    Connect(String),
+
+    /// The source database is missing a column/table this reader expects for
+    /// the schema version it was frozen against. Deliberately fails loud
+    /// instead of silently reading a partial row — this reader does not apply
+    /// migrations (see `connect::ensure_schema_current`), so an out-of-date
+    /// source database must be migrated by running the legacy `ironclaw`
+    /// binary once before this tool runs.
+    #[error(
+        "legacy database is not at the schema version this migration tool expects: \
+         table '{table}' is missing expected column '{column}'. Run the legacy `ironclaw` \
+         binary once against this database (it applies its own migrations on startup) \
+         before running the migration tool."
+    )]
+    SchemaMismatch { table: String, column: String },
+
+    #[error("legacy query failed: {0}")]
+    Query(String),
+
+    #[error("legacy row decode failed ({what}): {field}")]
+    Decode { what: String, field: String },
+}

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/libsql_helpers.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/libsql_helpers.rs
@@ -1,0 +1,70 @@
+//! libSQL row-reading helpers, frozen from `src/db/libsql/mod.rs`.
+//!
+//! Same behavior as the originals: NULL text columns default to empty string
+//! (`get_text`) or `None` (`get_opt_text`); unparseable timestamps log a
+//! warning and fall back to the Unix epoch / `None` rather than panicking.
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+
+pub(crate) fn get_text(row: &libsql::Row, idx: i32) -> String {
+    row.get::<String>(idx).unwrap_or_default()
+}
+
+pub(crate) fn get_opt_text(row: &libsql::Row, idx: i32) -> Option<String> {
+    row.get::<String>(idx).ok()
+}
+
+pub(crate) fn get_i64(row: &libsql::Row, idx: i32) -> i64 {
+    row.get::<i64>(idx).unwrap_or(0)
+}
+
+pub(crate) fn get_json(row: &libsql::Row, idx: i32) -> serde_json::Value {
+    row.get::<String>(idx)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+pub(crate) fn get_ts(row: &libsql::Row, idx: i32) -> DateTime<Utc> {
+    match row.get::<String>(idx) {
+        Ok(s) => match parse_timestamp(&s) {
+            Ok(dt) => dt,
+            Err(e) => {
+                tracing::warn!("Timestamp parse failure at column {}: {}", idx, e);
+                DateTime::UNIX_EPOCH
+            }
+        },
+        Err(_) => DateTime::UNIX_EPOCH,
+    }
+}
+
+pub(crate) fn get_opt_ts(row: &libsql::Row, idx: i32) -> Option<DateTime<Utc>> {
+    match row.get::<String>(idx) {
+        Ok(s) if s.is_empty() => None,
+        Ok(s) => match parse_timestamp(&s) {
+            Ok(dt) => Some(dt),
+            Err(e) => {
+                tracing::warn!("Timestamp parse failure at column {}: {}", idx, e);
+                None
+            }
+        },
+        Err(_) => None,
+    }
+}
+
+/// Parse an ISO-8601 timestamp string from SQLite into `DateTime<Utc>`.
+///
+/// Tries RFC 3339 first (the canonical write format), then two naive
+/// (assumed-UTC) fallback formats for legacy rows.
+pub(crate) fn parse_timestamp(s: &str) -> Result<DateTime<Utc>, String> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f") {
+        return Ok(ndt.and_utc());
+    }
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return Ok(ndt.and_utc());
+    }
+    Err(format!("unparseable timestamp: {s:?}"))
+}

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/mod.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod connect;
 pub(crate) mod error;
 #[cfg(feature = "libsql")]
 pub(crate) mod libsql_helpers;
+#[cfg(all(test, feature = "postgres"))]
+mod postgres_tests;
 pub(crate) mod queries;
 pub(crate) mod secrets;
 pub(crate) mod types;

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/mod.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/mod.rs
@@ -1,0 +1,23 @@
+//! Frozen, self-contained port of the v1 (`ironclaw_legacy`) read path this
+//! crate needs, so migration keeps working once `src/` is deleted under Tier
+//! B (`docs/plans/2026-07-02-reborn-internal-module-refactor.md` §8). Mirrors
+//! the pattern [`crate::v2_model`] already established for the deleted
+//! engine-v2 types: freeze the on-disk contract, stop depending on the live
+//! crate that used to own it.
+//!
+//! Scope: only what `convert::*` actually calls — 7 `Database` trait methods
+//! (`queries`), the v1 secrets store's list/get/decrypt (`secrets`), and the
+//! installed wasm tool/channel stores' list/get_capabilities (`wasm_stores`).
+//! Not a general-purpose v1 client.
+
+pub(crate) mod connect;
+pub(crate) mod error;
+#[cfg(feature = "libsql")]
+pub(crate) mod libsql_helpers;
+pub(crate) mod queries;
+pub(crate) mod secrets;
+pub(crate) mod types;
+pub(crate) mod wasm_stores;
+
+pub(crate) use connect::{LegacyDb, LegacyHandles, connect};
+pub(crate) use types::{Routine, RoutineAction, Trigger, UserIdentityRecord};

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/postgres_tests.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/postgres_tests.rs
@@ -1,0 +1,191 @@
+//! Postgres coverage for the frozen v1 reader — the one backend the crate's
+//! `tests/migration_roundtrip.rs` acceptance suite doesn't reach (it is
+//! `required-features = ["libsql"]`-only). Drives the same production entry
+//! points the libSQL suite does (`connect::connect`, `LegacyDb::list_all_routines`)
+//! against a real Postgres testcontainer, covering exactly the path review
+//! flagged as most fragile: `postgres_all_routines`'s `SELECT *` + by-name
+//! column reads, which panic (not a `Result`) on a schema drift that
+//! `ensure_schema_current` doesn't independently catch.
+//!
+//! Skips (does not fail) when Docker is unavailable, matching the pattern in
+//! `ironclaw_reborn_composition/tests/postgres_substrate.rs` and
+//! `ironclaw_triggers/tests/repository_contract.rs`.
+
+use secrecy::SecretString;
+use testcontainers_modules::testcontainers::{ImageExt, runners::AsyncRunner};
+
+use super::connect::connect;
+use super::types::{RoutineAction, Trigger};
+use crate::options::SourceDb;
+
+/// The production `routines` schema (`migrations/V6__routines.sql` +
+/// `migrations/V13__owner_scope_notify_targets.sql`'s `notify_user` nullable
+/// amendment) — exactly the 24 columns [`super::connect::ensure_schema_current`]
+/// checks and [`super::queries::postgres_row_to_routine`] reads by name.
+const ROUTINES_SCHEMA: &str = "
+    CREATE TABLE routines (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        user_id TEXT NOT NULL,
+        enabled BOOLEAN NOT NULL DEFAULT true,
+        trigger_type TEXT NOT NULL,
+        trigger_config JSONB NOT NULL,
+        action_type TEXT NOT NULL,
+        action_config JSONB NOT NULL,
+        cooldown_secs INTEGER NOT NULL DEFAULT 300,
+        max_concurrent INTEGER NOT NULL DEFAULT 1,
+        dedup_window_secs INTEGER,
+        notify_channel TEXT,
+        notify_user TEXT,
+        notify_on_success BOOLEAN NOT NULL DEFAULT false,
+        notify_on_failure BOOLEAN NOT NULL DEFAULT true,
+        notify_on_attention BOOLEAN NOT NULL DEFAULT true,
+        state JSONB NOT NULL DEFAULT '{}',
+        last_run_at TIMESTAMPTZ,
+        next_fire_at TIMESTAMPTZ,
+        run_count BIGINT NOT NULL DEFAULT 0,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )";
+
+/// Starts a Postgres testcontainer and returns its connection URL, or `None`
+/// if Docker isn't available — callers must skip (not fail) the test.
+async fn start_postgres_or_skip() -> Option<(
+    testcontainers_modules::testcontainers::ContainerAsync<
+        testcontainers_modules::postgres::Postgres,
+    >,
+    String,
+)> {
+    let image = testcontainers_modules::postgres::Postgres::default()
+        .with_db_name("ironclaw_migration_test")
+        .with_user("postgres")
+        .with_password("postgres")
+        .with_tag("16-alpine");
+
+    let container = match image.start().await {
+        Ok(container) => container,
+        Err(error) => {
+            eprintln!(
+                "skipping ironclaw_reborn_migration Postgres tests: docker/testcontainers unavailable ({error})"
+            );
+            return None;
+        }
+    };
+    let host_port = container.get_host_port_ipv4(5432).await.ok()?;
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{host_port}/ironclaw_migration_test");
+    Some((container, url))
+}
+
+#[tokio::test]
+async fn postgres_connect_and_list_all_routines_round_trips_a_real_row() {
+    let Some((_container, url)) = start_postgres_or_skip().await else {
+        return;
+    };
+
+    // Seed the production routines schema directly (frozen v1 SQL, not the
+    // reader under test), then one row exercising both a Cron trigger and a
+    // Lightweight action — the two variants `Trigger`/`RoutineAction::from_db`
+    // must parse back out correctly through the `SELECT *` path.
+    {
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .expect("must connect to seed the schema");
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client
+            .batch_execute(ROUTINES_SCHEMA)
+            .await
+            .expect("must create the routines table");
+        client
+            .execute(
+                "INSERT INTO routines \
+                    (name, user_id, trigger_type, trigger_config, action_type, action_config) \
+                 VALUES ($1, $2, 'cron', $3, 'lightweight', $4)",
+                &[
+                    &"nightly-digest",
+                    &"user-1",
+                    &serde_json::json!({"schedule": "0 0 * * *"}),
+                    &serde_json::json!({"prompt": "summarize the day"}),
+                ],
+            )
+            .await
+            .expect("must insert the fixture routine");
+    }
+
+    let source = SourceDb::Postgres {
+        url: SecretString::from(url),
+    };
+    let (db, _handles) = connect(&source)
+        .await
+        .expect("connect must succeed against a schema-current Postgres");
+
+    let routines = db
+        .list_all_routines()
+        .await
+        .expect("list_all_routines must read the seeded row back through SELECT *");
+
+    assert_eq!(routines.len(), 1, "exactly the one seeded routine");
+    let routine = &routines[0];
+    assert_eq!(routine.name, "nightly-digest");
+    assert_eq!(routine.user_id, "user-1");
+    assert!(
+        matches!(&routine.trigger, Trigger::Cron { schedule, .. } if schedule == "0 0 * * *"),
+        "cron trigger must round-trip: {:?}",
+        routine.trigger
+    );
+    assert!(
+        matches!(&routine.action, RoutineAction::Lightweight { prompt, .. } if prompt == "summarize the day"),
+        "lightweight action must round-trip: {:?}",
+        routine.action
+    );
+}
+
+#[tokio::test]
+async fn postgres_connect_fails_loud_on_stale_routines_schema() {
+    let Some((_container, url)) = start_postgres_or_skip().await else {
+        return;
+    };
+
+    // A `routines` table missing an expected column must be rejected by
+    // `connect()`'s `ensure_schema_current` check, not silently accepted and
+    // then panic later inside `postgres_all_routines`. `description` is the
+    // first column `ensure_schema_current` checks that this minimal table
+    // lacks.
+    {
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .expect("must connect to seed the schema");
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client
+            .batch_execute(
+                "CREATE TABLE routines (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    name TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    trigger_type TEXT NOT NULL,
+                    trigger_config JSONB NOT NULL,
+                    action_type TEXT NOT NULL,
+                    action_config JSONB NOT NULL
+                )",
+            )
+            .await
+            .expect("must create the stale routines table");
+    }
+
+    let source = SourceDb::Postgres {
+        url: SecretString::from(url),
+    };
+    let Err(error) = connect(&source).await else {
+        panic!("connect must reject a routines table missing an expected column");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("routines") && message.contains("description"),
+        "error must name the stale table and the first missing expected column: {message}"
+    );
+}

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/queries.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/queries.rs
@@ -1,0 +1,753 @@
+//! The 7 v1 read queries this crate needs, frozen from
+//! `src/history/store.rs` (Postgres) and `src/db/libsql/*.rs` (libSQL) —
+//! the entire `Database` trait method surface this crate ever called
+//! (`list_conversations_all_channels`, `list_conversation_messages`,
+//! `list_all_routines`, `list_documents`, `list_agent_jobs`,
+//! `list_identities_for_user`, `get_all_settings`). `Database` itself is a
+//! 9-sub-trait, ~78-method supertrait that cannot be partially implemented as
+//! a trait object — rather than port the whole thing, [`LegacyDb`] is a
+//! concrete enum with only these 7 inherent methods.
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use super::connect::LegacyDb;
+use super::error::LegacyError;
+#[cfg(feature = "libsql")]
+use super::types::normalize_notify_user;
+use super::types::{
+    AgentJobRecord, Conversation, ConversationMessage, MemoryDocument, NotifyConfig,
+    RoutineGuardrails, Trigger, UserIdentityRecord,
+};
+use super::types::{Routine, RoutineAction};
+
+/// Explicit column list for the `routines` table — libSQL positional reads
+/// match this order 1:1; Postgres reads `SELECT *` by name, so this is
+/// libSQL-only (see [`super::connect::ensure_schema_current`] for the
+/// independent, backend-agnostic expected-column list used to detect a stale
+/// source schema).
+#[cfg(feature = "libsql")]
+pub(crate) const ROUTINE_COLUMNS: &str = "\
+    id, name, description, user_id, enabled, \
+    trigger_type, trigger_config, action_type, action_config, \
+    cooldown_secs, max_concurrent, dedup_window_secs, \
+    notify_channel, notify_user, notify_on_success, notify_on_failure, notify_on_attention, \
+    state, last_run_at, next_fire_at, run_count, consecutive_failures, \
+    created_at, updated_at";
+
+impl LegacyDb {
+    pub(crate) async fn list_conversations_all_channels(
+        &self,
+        user_id: &str,
+        limit: i64,
+    ) -> Result<Vec<Conversation>, LegacyError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacyDb::LibSql(db) => libsql_conversations(db, user_id, limit).await,
+            #[cfg(feature = "postgres")]
+            LegacyDb::Postgres(pool) => postgres_conversations(pool, user_id, limit).await,
+        }
+    }
+
+    pub(crate) async fn list_conversation_messages(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Vec<ConversationMessage>, LegacyError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacyDb::LibSql(db) => libsql_conversation_messages(db, conversation_id).await,
+            #[cfg(feature = "postgres")]
+            LegacyDb::Postgres(pool) => postgres_conversation_messages(pool, conversation_id).await,
+        }
+    }
+
+    pub(crate) async fn list_all_routines(&self) -> Result<Vec<Routine>, LegacyError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacyDb::LibSql(db) => libsql_all_routines(db).await,
+            #[cfg(feature = "postgres")]
+            LegacyDb::Postgres(pool) => postgres_all_routines(pool).await,
+        }
+    }
+
+    pub(crate) async fn list_documents(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+    ) -> Result<Vec<MemoryDocument>, LegacyError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacyDb::LibSql(db) => libsql_documents(db, user_id, agent_id).await,
+            #[cfg(feature = "postgres")]
+            LegacyDb::Postgres(pool) => postgres_documents(pool, user_id, agent_id).await,
+        }
+    }
+
+    pub(crate) async fn list_agent_jobs(&self) -> Result<Vec<AgentJobRecord>, LegacyError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacyDb::LibSql(db) => libsql_agent_jobs(db).await,
+            #[cfg(feature = "postgres")]
+            LegacyDb::Postgres(pool) => postgres_agent_jobs(pool).await,
+        }
+    }
+
+    pub(crate) async fn list_identities_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<UserIdentityRecord>, LegacyError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacyDb::LibSql(db) => libsql_identities_for_user(db, user_id).await,
+            #[cfg(feature = "postgres")]
+            LegacyDb::Postgres(pool) => postgres_identities_for_user(pool, user_id).await,
+        }
+    }
+
+    pub(crate) async fn get_all_settings(
+        &self,
+        user_id: &str,
+    ) -> Result<HashMap<String, serde_json::Value>, LegacyError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacyDb::LibSql(db) => libsql_all_settings(db, user_id).await,
+            #[cfg(feature = "postgres")]
+            LegacyDb::Postgres(pool) => postgres_all_settings(pool, user_id).await,
+        }
+    }
+}
+
+// ============================== libSQL ======================================
+
+#[cfg(feature = "libsql")]
+use crate::legacy_snapshot::libsql_helpers::{
+    get_i64, get_json, get_opt_text, get_opt_ts, get_text, get_ts,
+};
+
+#[cfg(feature = "libsql")]
+async fn libsql_connect(
+    db: &std::sync::Arc<libsql::Database>,
+) -> Result<libsql::Connection, LegacyError> {
+    let conn = db
+        .connect()
+        .map_err(|e| LegacyError::Connect(e.to_string()))?;
+    conn.query("PRAGMA busy_timeout = 5000", ())
+        .await
+        .map_err(|e| LegacyError::Connect(e.to_string()))?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_conversations(
+    db: &std::sync::Arc<libsql::Database>,
+    user_id: &str,
+    limit: i64,
+) -> Result<Vec<Conversation>, LegacyError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            r#"
+            SELECT
+                c.id,
+                c.started_at,
+                c.last_activity,
+                c.metadata,
+                c.channel,
+                (SELECT COUNT(*) FROM conversation_messages m WHERE m.conversation_id = c.id AND m.role = 'user') AS message_count,
+                (SELECT substr(m2.content, 1, 100)
+                 FROM conversation_messages m2
+                 WHERE m2.conversation_id = c.id AND m2.role = 'user'
+                 ORDER BY m2.created_at ASC, m2.rowid ASC
+                 LIMIT 1
+                ) AS title
+            FROM conversations c
+            WHERE c.user_id = ?1
+            ORDER BY datetime(c.last_activity) DESC
+            LIMIT ?2
+            "#,
+            libsql::params![user_id, limit],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    let mut results = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?
+    {
+        let metadata = get_json(&row, 3);
+        let thread_type = metadata
+            .get("thread_type")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let sql_title = get_opt_text(&row, 6);
+        let title = sql_title.or_else(|| {
+            metadata
+                .get("routine_name")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        });
+        results.push(Conversation {
+            id: get_text(&row, 0).parse().unwrap_or_default(),
+            title,
+            channel: get_text(&row, 4),
+            thread_type,
+            started_at: get_ts(&row, 1),
+            last_activity: get_ts(&row, 2),
+        });
+    }
+    Ok(results)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_conversation_messages(
+    db: &std::sync::Arc<libsql::Database>,
+    conversation_id: Uuid,
+) -> Result<Vec<ConversationMessage>, LegacyError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            r#"
+            SELECT id, role, content, created_at
+            FROM conversation_messages
+            WHERE conversation_id = ?1
+            ORDER BY created_at ASC, rowid ASC
+            "#,
+            libsql::params![conversation_id.to_string()],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    let mut messages = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?
+    {
+        messages.push(ConversationMessage {
+            id: get_text(&row, 0).parse().unwrap_or_default(),
+            role: get_text(&row, 1),
+            content: get_text(&row, 2),
+            created_at: get_ts(&row, 3),
+        });
+    }
+    Ok(messages)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_all_routines(
+    db: &std::sync::Arc<libsql::Database>,
+) -> Result<Vec<Routine>, LegacyError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            &format!("SELECT {ROUTINE_COLUMNS} FROM routines ORDER BY name"),
+            (),
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    let mut routines = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?
+    {
+        routines.push(libsql_row_to_routine(&row)?);
+    }
+    Ok(routines)
+}
+
+#[cfg(feature = "libsql")]
+fn libsql_row_to_routine(row: &libsql::Row) -> Result<Routine, LegacyError> {
+    let trigger_type = get_text(row, 5);
+    let trigger_config = get_json(row, 6);
+    let action_type = get_text(row, 7);
+    let action_config = get_json(row, 8);
+    let cooldown_secs = get_i64(row, 9);
+    let max_concurrent = get_i64(row, 10);
+    let dedup_window_secs: Option<i64> = row.get::<i64>(11).ok();
+
+    let trigger = Trigger::from_db(&trigger_type, trigger_config)?;
+    let action = RoutineAction::from_db(&action_type, action_config)?;
+
+    Ok(Routine {
+        id: get_text(row, 0).parse().unwrap_or_default(),
+        name: get_text(row, 1),
+        description: get_text(row, 2),
+        user_id: get_text(row, 3),
+        enabled: get_i64(row, 4) != 0,
+        trigger,
+        action,
+        guardrails: RoutineGuardrails {
+            cooldown: std::time::Duration::from_secs(cooldown_secs as u64),
+            max_concurrent: max_concurrent as u32,
+            dedup_window: dedup_window_secs.map(|s| std::time::Duration::from_secs(s as u64)),
+        },
+        notify: NotifyConfig {
+            channel: get_opt_text(row, 12),
+            user: normalize_notify_user(get_opt_text(row, 13)),
+            on_success: get_i64(row, 14) != 0,
+            on_failure: get_i64(row, 15) != 0,
+            on_attention: get_i64(row, 16) != 0,
+        },
+        state: get_json(row, 17),
+        last_run_at: get_opt_ts(row, 18),
+        next_fire_at: get_opt_ts(row, 19),
+        run_count: get_i64(row, 20) as u64,
+        consecutive_failures: get_i64(row, 21) as u32,
+        created_at: get_ts(row, 22),
+        updated_at: get_ts(row, 23),
+    })
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_documents(
+    db: &std::sync::Arc<libsql::Database>,
+    user_id: &str,
+    agent_id: Option<Uuid>,
+) -> Result<Vec<MemoryDocument>, LegacyError> {
+    let conn = libsql_connect(db).await?;
+    let agent_id_str = agent_id.map(|id| id.to_string());
+    let mut rows = conn
+        .query(
+            r#"
+            SELECT id, user_id, agent_id, path, content,
+                   created_at, updated_at, metadata
+            FROM memory_documents
+            WHERE user_id = ?1 AND agent_id IS ?2
+            ORDER BY updated_at DESC
+            "#,
+            libsql::params![user_id, agent_id_str.as_deref()],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    let mut docs = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?
+    {
+        docs.push(MemoryDocument {
+            id: get_text(&row, 0).parse().unwrap_or_default(),
+            user_id: get_text(&row, 1),
+            agent_id: get_opt_text(&row, 2).and_then(|s| s.parse().ok()),
+            path: get_text(&row, 3),
+            content: get_text(&row, 4),
+            created_at: get_ts(&row, 5),
+            updated_at: get_ts(&row, 6),
+            metadata: get_json(&row, 7),
+        });
+    }
+    Ok(docs)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_agent_jobs(
+    db: &std::sync::Arc<libsql::Database>,
+) -> Result<Vec<AgentJobRecord>, LegacyError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            r#"
+            SELECT id, title, status, user_id, failure_reason,
+                   created_at, started_at, completed_at
+            FROM agent_jobs WHERE source = 'direct'
+            ORDER BY created_at DESC
+            "#,
+            (),
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    let mut jobs = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?
+    {
+        let id_str = get_text(&row, 0);
+        let Ok(id) = id_str.parse() else {
+            tracing::warn!("Skipping legacy agent job with invalid UUID: {}", id_str);
+            continue;
+        };
+        jobs.push(AgentJobRecord {
+            id,
+            title: get_text(&row, 1),
+            status: get_text(&row, 2),
+            user_id: get_text(&row, 3),
+            failure_reason: get_opt_text(&row, 4),
+            created_at: get_ts(&row, 5),
+            started_at: get_opt_ts(&row, 6),
+            completed_at: get_opt_ts(&row, 7),
+        });
+    }
+    Ok(jobs)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_identities_for_user(
+    db: &std::sync::Arc<libsql::Database>,
+    user_id: &str,
+) -> Result<Vec<UserIdentityRecord>, LegacyError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+             display_name, avatar_url, raw_profile, created_at, updated_at \
+             FROM user_identities WHERE user_id = ?1 ORDER BY created_at",
+            libsql::params![user_id],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    let mut result = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?
+    {
+        result.push(libsql_row_to_identity(&row)?);
+    }
+    Ok(result)
+}
+
+#[cfg(feature = "libsql")]
+fn libsql_row_to_identity(row: &libsql::Row) -> Result<UserIdentityRecord, LegacyError> {
+    let id_str = get_text(row, 0);
+    let id: Uuid = id_str
+        .parse()
+        .map_err(|e: uuid::Error| LegacyError::Decode {
+            what: "user_identities.id".into(),
+            field: e.to_string(),
+        })?;
+    let raw_str = get_text(row, 8);
+    let raw_profile: serde_json::Value =
+        serde_json::from_str(&raw_str).map_err(|e| LegacyError::Decode {
+            what: "user_identities.raw_profile".into(),
+            field: e.to_string(),
+        })?;
+    Ok(UserIdentityRecord {
+        id,
+        user_id: get_text(row, 1),
+        provider: get_text(row, 2),
+        provider_user_id: get_text(row, 3),
+        email: get_opt_text(row, 4),
+        email_verified: get_i64(row, 5) != 0,
+        display_name: get_opt_text(row, 6),
+        avatar_url: get_opt_text(row, 7),
+        raw_profile,
+        created_at: get_ts(row, 9),
+        updated_at: get_ts(row, 10),
+    })
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_all_settings(
+    db: &std::sync::Arc<libsql::Database>,
+    user_id: &str,
+) -> Result<HashMap<String, serde_json::Value>, LegacyError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            "SELECT key, value FROM settings WHERE user_id = ?1",
+            libsql::params![user_id],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    let mut map = HashMap::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?
+    {
+        map.insert(get_text(&row, 0), get_json(&row, 1));
+    }
+    Ok(map)
+}
+
+// ============================== PostgreSQL ==================================
+
+#[cfg(feature = "postgres")]
+async fn pg_client(
+    pool: &deadpool_postgres::Pool,
+) -> Result<deadpool_postgres::Client, LegacyError> {
+    pool.get()
+        .await
+        .map_err(|e| LegacyError::Connect(e.to_string()))
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_conversations(
+    pool: &deadpool_postgres::Pool,
+    user_id: &str,
+    limit: i64,
+) -> Result<Vec<Conversation>, LegacyError> {
+    let client = pg_client(pool).await?;
+    let rows = client
+        .query(
+            r#"
+            SELECT
+                c.id,
+                c.started_at,
+                c.last_activity,
+                c.metadata,
+                c.channel,
+                (SELECT COUNT(*) FROM conversation_messages m WHERE m.conversation_id = c.id AND m.role = 'user') AS message_count,
+                (SELECT LEFT(m2.content, 100)
+                 FROM conversation_messages m2
+                 WHERE m2.conversation_id = c.id AND m2.role = 'user'
+                 ORDER BY m2.created_at ASC
+                 LIMIT 1
+                ) AS title
+            FROM conversations c
+            WHERE c.user_id = $1
+            ORDER BY c.last_activity DESC
+            LIMIT $2
+            "#,
+            &[&user_id, &limit],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    Ok(rows
+        .iter()
+        .map(|r| {
+            let metadata: serde_json::Value = r.get("metadata");
+            let thread_type = metadata
+                .get("thread_type")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let sql_title: Option<String> = r.get("title");
+            let title = sql_title.or_else(|| {
+                metadata
+                    .get("routine_name")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            });
+            Conversation {
+                id: r.get("id"),
+                title,
+                channel: r.get("channel"),
+                thread_type,
+                started_at: r.get("started_at"),
+                last_activity: r.get("last_activity"),
+            }
+        })
+        .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_conversation_messages(
+    pool: &deadpool_postgres::Pool,
+    conversation_id: Uuid,
+) -> Result<Vec<ConversationMessage>, LegacyError> {
+    let client = pg_client(pool).await?;
+    let rows = client
+        .query(
+            r#"
+            SELECT id, role, content, created_at
+            FROM conversation_messages
+            WHERE conversation_id = $1
+            ORDER BY created_at ASC
+            "#,
+            &[&conversation_id],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    Ok(rows
+        .iter()
+        .map(|r| ConversationMessage {
+            id: r.get("id"),
+            role: r.get("role"),
+            content: r.get("content"),
+            created_at: r.get("created_at"),
+        })
+        .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_all_routines(
+    pool: &deadpool_postgres::Pool,
+) -> Result<Vec<Routine>, LegacyError> {
+    let client = pg_client(pool).await?;
+    let rows = client
+        .query("SELECT * FROM routines ORDER BY name", &[])
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+    rows.iter().map(postgres_row_to_routine).collect()
+}
+
+#[cfg(feature = "postgres")]
+fn postgres_row_to_routine(row: &tokio_postgres::Row) -> Result<Routine, LegacyError> {
+    let trigger_type: String = row.get("trigger_type");
+    let trigger_config: serde_json::Value = row.get("trigger_config");
+    let action_type: String = row.get("action_type");
+    let action_config: serde_json::Value = row.get("action_config");
+    let cooldown_secs: i32 = row.get("cooldown_secs");
+    let max_concurrent: i32 = row.get("max_concurrent");
+    let dedup_window_secs: Option<i32> = row.get("dedup_window_secs");
+
+    let trigger = Trigger::from_db(&trigger_type, trigger_config)?;
+    let action = RoutineAction::from_db(&action_type, action_config)?;
+
+    Ok(Routine {
+        id: row.get("id"),
+        name: row.get("name"),
+        description: row.get("description"),
+        user_id: row.get("user_id"),
+        enabled: row.get("enabled"),
+        trigger,
+        action,
+        guardrails: RoutineGuardrails {
+            cooldown: std::time::Duration::from_secs(cooldown_secs as u64),
+            max_concurrent: max_concurrent as u32,
+            dedup_window: dedup_window_secs.map(|s| std::time::Duration::from_secs(s as u64)),
+        },
+        notify: NotifyConfig {
+            channel: row.get("notify_channel"),
+            user: row.get("notify_user"),
+            on_attention: row.get("notify_on_attention"),
+            on_failure: row.get("notify_on_failure"),
+            on_success: row.get("notify_on_success"),
+        },
+        last_run_at: row.get("last_run_at"),
+        next_fire_at: row.get("next_fire_at"),
+        run_count: row.get::<_, i64>("run_count") as u64,
+        consecutive_failures: row.get::<_, i32>("consecutive_failures") as u32,
+        state: row.get("state"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_documents(
+    pool: &deadpool_postgres::Pool,
+    user_id: &str,
+    agent_id: Option<Uuid>,
+) -> Result<Vec<MemoryDocument>, LegacyError> {
+    let client = pg_client(pool).await?;
+    let rows = client
+        .query(
+            r#"
+            SELECT id, user_id, agent_id, path, content,
+                   created_at, updated_at, metadata
+            FROM memory_documents
+            WHERE user_id = $1 AND agent_id IS NOT DISTINCT FROM $2
+            ORDER BY updated_at DESC
+            "#,
+            &[&user_id, &agent_id],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    Ok(rows
+        .iter()
+        .map(|r| MemoryDocument {
+            id: r.get("id"),
+            user_id: r.get("user_id"),
+            agent_id: r.get("agent_id"),
+            path: r.get("path"),
+            content: r.get("content"),
+            created_at: r.get("created_at"),
+            updated_at: r.get("updated_at"),
+            metadata: r.get("metadata"),
+        })
+        .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_agent_jobs(
+    pool: &deadpool_postgres::Pool,
+) -> Result<Vec<AgentJobRecord>, LegacyError> {
+    let client = pg_client(pool).await?;
+    let rows = client
+        .query(
+            r#"
+            SELECT id, title, status, user_id, failure_reason,
+                   created_at, started_at, completed_at
+            FROM agent_jobs WHERE source = 'direct'
+            ORDER BY created_at DESC
+            "#,
+            &[],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    Ok(rows
+        .iter()
+        .map(|r| AgentJobRecord {
+            id: r.get("id"),
+            title: r.get("title"),
+            status: r.get("status"),
+            user_id: r.get::<_, Option<String>>("user_id").unwrap_or_default(),
+            failure_reason: r.get("failure_reason"),
+            created_at: r.get("created_at"),
+            started_at: r.get("started_at"),
+            completed_at: r.get("completed_at"),
+        })
+        .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_identities_for_user(
+    pool: &deadpool_postgres::Pool,
+    user_id: &str,
+) -> Result<Vec<UserIdentityRecord>, LegacyError> {
+    let client = pg_client(pool).await?;
+    let rows = client
+        .query(
+            "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+             display_name, avatar_url, raw_profile, created_at, updated_at \
+             FROM user_identities WHERE user_id = $1 ORDER BY created_at",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+
+    Ok(rows
+        .iter()
+        .map(|row| UserIdentityRecord {
+            id: row.get("id"),
+            user_id: row.get("user_id"),
+            provider: row.get("provider"),
+            provider_user_id: row.get("provider_user_id"),
+            email: row.get("email"),
+            email_verified: row.get("email_verified"),
+            display_name: row.get("display_name"),
+            avatar_url: row.get("avatar_url"),
+            raw_profile: row.get("raw_profile"),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        })
+        .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_all_settings(
+    pool: &deadpool_postgres::Pool,
+    user_id: &str,
+) -> Result<HashMap<String, serde_json::Value>, LegacyError> {
+    let client = pg_client(pool).await?;
+    let rows = client
+        .query(
+            "SELECT key, value FROM settings WHERE user_id = $1",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| LegacyError::Query(e.to_string()))?;
+    Ok(rows
+        .iter()
+        .map(|r| {
+            let key: String = r.get("key");
+            let value: serde_json::Value = r.get("value");
+            (key, value)
+        })
+        .collect())
+}

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/secrets.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/secrets.rs
@@ -1,0 +1,324 @@
+//! Frozen port of the v1 secrets store (`src/secrets/{crypto,store,types}.rs`)
+//! — read-only (list/get/decrypt), just enough for [`crate::convert::secrets`]
+//! to decrypt v1 secrets and re-encrypt them through Reborn's secret store.
+//!
+//! The AES-256-GCM + HKDF-SHA256 scheme below MUST stay byte-for-byte
+//! identical to v1's, or previously-encrypted secrets fail to decrypt. Ported
+//! verbatim from `src/secrets/crypto.rs` — do not "simplify" this file.
+
+use std::sync::Arc;
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use chrono::{DateTime, Utc};
+use hkdf::Hkdf;
+use secrecy::{ExposeSecret, SecretString};
+use sha2::Sha256;
+
+use super::connect::LegacyHandles;
+
+const KEY_SIZE: usize = 32;
+const NONCE_SIZE: usize = 12;
+const TAG_SIZE: usize = 16;
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub(crate) enum SecretError {
+    #[error("Secret not found: {0}")]
+    NotFound(String),
+    #[error("Secret has expired")]
+    Expired,
+    #[error("Decryption failed: {0}")]
+    DecryptionFailed(String),
+    #[error("Invalid master key")]
+    InvalidMasterKey,
+    #[error("Secret value is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("Database error: {0}")]
+    Database(String),
+}
+
+/// Frozen mirror of `ironclaw::secrets::SecretsCrypto`.
+pub(crate) struct SecretsCrypto {
+    master_key: SecretString,
+}
+
+impl SecretsCrypto {
+    pub(crate) fn new(master_key: SecretString) -> Result<Self, SecretError> {
+        if master_key.expose_secret().len() < KEY_SIZE {
+            return Err(SecretError::InvalidMasterKey);
+        }
+        Ok(Self { master_key })
+    }
+
+    pub(crate) fn decrypt(
+        &self,
+        encrypted_value: &[u8],
+        salt: &[u8],
+    ) -> Result<DecryptedSecret, SecretError> {
+        if encrypted_value.len() < NONCE_SIZE + TAG_SIZE {
+            return Err(SecretError::DecryptionFailed(
+                "Encrypted value too short".to_string(),
+            ));
+        }
+        let derived_key = self.derive_key(salt);
+        let cipher = Aes256Gcm::new_from_slice(&derived_key)
+            .map_err(|e| SecretError::DecryptionFailed(format!("Failed to create cipher: {e}")))?;
+        let (nonce_bytes, ciphertext) = encrypted_value.split_at(NONCE_SIZE);
+        let nonce = Nonce::from_slice(nonce_bytes);
+        let plaintext = cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|e| SecretError::DecryptionFailed(format!("Decryption failed: {e}")))?;
+        DecryptedSecret::from_bytes(plaintext)
+    }
+
+    fn derive_key(&self, salt: &[u8]) -> [u8; KEY_SIZE] {
+        let master_bytes = self.master_key.expose_secret().as_bytes();
+        let hk = Hkdf::<Sha256>::new(Some(salt), master_bytes);
+        let mut derived = [0u8; KEY_SIZE];
+        // Same 32-byte output requested from HKDF-SHA256 as the original —
+        // expand() only fails when the requested length exceeds 255 * hash
+        // output size, which 32 never does.
+        hk.expand(b"near-agent-secrets-v1", &mut derived)
+            .expect("HKDF-SHA256 expand to 32 bytes never fails");
+        derived
+    }
+}
+
+/// Frozen mirror of `ironclaw::secrets::types::Secret`.
+pub(crate) struct Secret {
+    pub(crate) encrypted_value: Vec<u8>,
+    pub(crate) key_salt: Vec<u8>,
+    pub(crate) expires_at: Option<DateTime<Utc>>,
+}
+
+/// Frozen mirror of `ironclaw::secrets::types::SecretRef`.
+pub(crate) struct SecretRef {
+    pub(crate) name: String,
+}
+
+/// Frozen mirror of `ironclaw::secrets::types::DecryptedSecret`.
+pub(crate) struct DecryptedSecret {
+    value: SecretString,
+}
+
+impl DecryptedSecret {
+    fn from_bytes(bytes: Vec<u8>) -> Result<Self, SecretError> {
+        let s = String::from_utf8(bytes).map_err(|_| SecretError::InvalidUtf8)?;
+        Ok(Self {
+            value: SecretString::from(s),
+        })
+    }
+
+    pub(crate) fn expose(&self) -> &str {
+        self.value.expose_secret()
+    }
+}
+
+/// Frozen mirror of `ironclaw::secrets::create_secrets_store` — returns `None`
+/// (not an error) when no backend handle is available, same as the original.
+pub(crate) fn create_secrets_store(
+    crypto: Arc<SecretsCrypto>,
+    handles: &LegacyHandles,
+) -> Option<LegacySecretsSource> {
+    #[cfg(feature = "libsql")]
+    if let Some(db) = handles.libsql_db.as_ref() {
+        return Some(LegacySecretsSource::LibSql(Arc::clone(db), crypto));
+    }
+    #[cfg(feature = "postgres")]
+    if let Some(pool) = handles.pg_pool.as_ref() {
+        return Some(LegacySecretsSource::Postgres(pool.clone(), crypto));
+    }
+    None
+}
+
+/// Frozen, read-only mirror of `ironclaw::secrets::SecretsStore` — only the
+/// `list`/`get`/`get_decrypted` methods `convert::secrets` calls.
+pub(crate) enum LegacySecretsSource {
+    #[cfg(feature = "libsql")]
+    LibSql(Arc<libsql::Database>, Arc<SecretsCrypto>),
+    #[cfg(feature = "postgres")]
+    Postgres(deadpool_postgres::Pool, Arc<SecretsCrypto>),
+}
+
+impl LegacySecretsSource {
+    fn crypto(&self) -> &SecretsCrypto {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacySecretsSource::LibSql(_, crypto) => crypto,
+            #[cfg(feature = "postgres")]
+            LegacySecretsSource::Postgres(_, crypto) => crypto,
+        }
+    }
+
+    pub(crate) async fn list(&self, user_id: &str) -> Result<Vec<SecretRef>, SecretError> {
+        match self {
+            #[cfg(feature = "libsql")]
+            LegacySecretsSource::LibSql(db, _) => libsql_list(db, user_id).await,
+            #[cfg(feature = "postgres")]
+            LegacySecretsSource::Postgres(pool, _) => postgres_list(pool, user_id).await,
+        }
+    }
+
+    pub(crate) async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        let name = name.to_lowercase();
+        let secret = match self {
+            #[cfg(feature = "libsql")]
+            LegacySecretsSource::LibSql(db, _) => libsql_get(db, user_id, &name).await?,
+            #[cfg(feature = "postgres")]
+            LegacySecretsSource::Postgres(pool, _) => postgres_get(pool, user_id, &name).await?,
+        };
+        if let Some(expires_at) = secret.expires_at
+            && expires_at < Utc::now()
+        {
+            return Err(SecretError::Expired);
+        }
+        Ok(secret)
+    }
+
+    pub(crate) async fn get_decrypted(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<DecryptedSecret, SecretError> {
+        let secret = self.get(user_id, name).await?;
+        self.crypto()
+            .decrypt(&secret.encrypted_value, &secret.key_salt)
+    }
+}
+
+const SECRET_COLUMNS: &str = "id, user_id, name, encrypted_value, key_salt, provider, expires_at, \
+     last_used_at, usage_count, created_at, updated_at";
+
+#[cfg(feature = "libsql")]
+async fn libsql_connect(db: &Arc<libsql::Database>) -> Result<libsql::Connection, SecretError> {
+    let conn = db
+        .connect()
+        .map_err(|e| SecretError::Database(format!("Connection failed: {e}")))?;
+    conn.query("PRAGMA busy_timeout = 5000", ())
+        .await
+        .map_err(|e| SecretError::Database(format!("Failed to set busy_timeout: {e}")))?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_list(
+    db: &Arc<libsql::Database>,
+    user_id: &str,
+) -> Result<Vec<SecretRef>, SecretError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            "SELECT name, provider FROM secrets WHERE user_id = ?1 ORDER BY name",
+            libsql::params![user_id],
+        )
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    let mut refs = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?
+    {
+        refs.push(SecretRef {
+            name: row.get::<String>(0).unwrap_or_default(),
+        });
+    }
+    Ok(refs)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_get(
+    db: &Arc<libsql::Database>,
+    user_id: &str,
+    name: &str,
+) -> Result<Secret, SecretError> {
+    let conn = libsql_connect(db).await?;
+    let mut rows = conn
+        .query(
+            &format!("SELECT {SECRET_COLUMNS} FROM secrets WHERE user_id = ?1 AND name = ?2"),
+            libsql::params![user_id, name],
+        )
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?
+    {
+        Some(row) => libsql_row_to_secret(&row),
+        None => Err(SecretError::NotFound(name.to_string())),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn libsql_row_to_secret(row: &libsql::Row) -> Result<Secret, SecretError> {
+    use super::libsql_helpers::parse_timestamp;
+
+    let encrypted_value: Vec<u8> = row
+        .get(3)
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    let key_salt: Vec<u8> = row
+        .get(4)
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    let expires_at = row
+        .get::<String>(6)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .and_then(|s| parse_timestamp(&s).ok());
+    Ok(Secret {
+        encrypted_value,
+        key_salt,
+        expires_at,
+    })
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_list(
+    pool: &deadpool_postgres::Pool,
+    user_id: &str,
+) -> Result<Vec<SecretRef>, SecretError> {
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    let rows = client
+        .query(
+            "SELECT name, provider FROM secrets WHERE user_id = $1 ORDER BY name",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    Ok(rows
+        .iter()
+        .map(|r| SecretRef {
+            name: r.get("name"),
+        })
+        .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get(
+    pool: &deadpool_postgres::Pool,
+    user_id: &str,
+    name: &str,
+) -> Result<Secret, SecretError> {
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    let row = client
+        .query_opt(
+            &format!("SELECT {SECRET_COLUMNS} FROM secrets WHERE user_id = $1 AND name = $2"),
+            &[&user_id, &name],
+        )
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+    match row {
+        Some(r) => Ok(Secret {
+            encrypted_value: r.get("encrypted_value"),
+            key_salt: r.get("key_salt"),
+            expires_at: r.get("expires_at"),
+        }),
+        None => Err(SecretError::NotFound(name.to_string())),
+    }
+}

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/secrets.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/secrets.rs
@@ -60,7 +60,7 @@ impl SecretsCrypto {
                 "Encrypted value too short".to_string(),
             ));
         }
-        let derived_key = self.derive_key(salt);
+        let derived_key = self.derive_key(salt)?;
         let cipher = Aes256Gcm::new_from_slice(&derived_key)
             .map_err(|e| SecretError::DecryptionFailed(format!("Failed to create cipher: {e}")))?;
         let (nonce_bytes, ciphertext) = encrypted_value.split_at(NONCE_SIZE);
@@ -71,16 +71,13 @@ impl SecretsCrypto {
         DecryptedSecret::from_bytes(plaintext)
     }
 
-    fn derive_key(&self, salt: &[u8]) -> [u8; KEY_SIZE] {
+    fn derive_key(&self, salt: &[u8]) -> Result<[u8; KEY_SIZE], SecretError> {
         let master_bytes = self.master_key.expose_secret().as_bytes();
         let hk = Hkdf::<Sha256>::new(Some(salt), master_bytes);
         let mut derived = [0u8; KEY_SIZE];
-        // Same 32-byte output requested from HKDF-SHA256 as the original —
-        // expand() only fails when the requested length exceeds 255 * hash
-        // output size, which 32 never does.
         hk.expand(b"near-agent-secrets-v1", &mut derived)
-            .expect("HKDF-SHA256 expand to 32 bytes never fails");
-        derived
+            .map_err(|_| SecretError::DecryptionFailed("HKDF expansion failed".to_string()))?;
+        Ok(derived)
     }
 }
 

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/types.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/types.rs
@@ -1,0 +1,369 @@
+//! Frozen mirror of v1 row types.
+//!
+//! `ironclaw_legacy` (`src/`) retires under Tier B (see
+//! `docs/plans/2026-07-02-reborn-internal-module-refactor.md` §8). These
+//! structs reproduce the exact v1 row shapes this crate's converters consume
+//! (`src/agent/routine.rs`, `src/history/mod.rs`, `src/workspace/document.rs`,
+//! `src/db/mod.rs`) so migration keeps working once the legacy crate is gone —
+//! the same freeze-and-port pattern `v2_model.rs` already applies to the
+//! deleted engine-v2 types. Read-only: nothing here writes v1 state.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use super::error::LegacyError;
+
+// ── routines (src/agent/routine.rs) ─────────────────────────────────────────
+
+/// Mirror of `ironclaw::agent::routine::Routine`.
+#[derive(Debug, Clone)]
+pub(crate) struct Routine {
+    pub(crate) id: Uuid,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) user_id: String,
+    pub(crate) enabled: bool,
+    pub(crate) trigger: Trigger,
+    pub(crate) action: RoutineAction,
+    pub(crate) guardrails: RoutineGuardrails,
+    pub(crate) notify: NotifyConfig,
+    pub(crate) last_run_at: Option<DateTime<Utc>>,
+    pub(crate) next_fire_at: Option<DateTime<Utc>>,
+    pub(crate) run_count: u64,
+    pub(crate) consecutive_failures: u32,
+    pub(crate) state: serde_json::Value,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+/// Mirror of `ironclaw::agent::routine::Trigger`.
+#[derive(Debug, Clone)]
+pub(crate) enum Trigger {
+    Cron {
+        schedule: String,
+        timezone: Option<String>,
+    },
+    Event {
+        channel: Option<String>,
+        pattern: String,
+    },
+    SystemEvent {
+        source: String,
+        event_type: String,
+        filters: HashMap<String, String>,
+    },
+    Webhook {
+        path: Option<String>,
+        secret: Option<String>,
+    },
+    Manual,
+}
+
+impl Trigger {
+    /// Mirror of `Trigger::from_db` — parses the `trigger_type`/`trigger_config`
+    /// columns. A stored timezone that no longer parses as a valid IANA name is
+    /// dropped to `None` (same tolerance as the original), not an error.
+    pub(crate) fn from_db(
+        trigger_type: &str,
+        config: serde_json::Value,
+    ) -> Result<Self, LegacyError> {
+        match trigger_type {
+            "cron" => {
+                let schedule = config
+                    .get("schedule")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| LegacyError::Decode {
+                        what: "cron trigger".into(),
+                        field: "schedule".into(),
+                    })?
+                    .to_string();
+                let timezone = config
+                    .get("timezone")
+                    .and_then(|v| v.as_str())
+                    .and_then(|tz| tz.parse::<chrono_tz::Tz>().ok().map(|_| tz.to_string()));
+                Ok(Trigger::Cron { schedule, timezone })
+            }
+            "event" => {
+                let pattern = config
+                    .get("pattern")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| LegacyError::Decode {
+                        what: "event trigger".into(),
+                        field: "pattern".into(),
+                    })?
+                    .to_string();
+                let channel = config
+                    .get("channel")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                Ok(Trigger::Event { channel, pattern })
+            }
+            "system_event" => {
+                let source = config
+                    .get("source")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| LegacyError::Decode {
+                        what: "system_event trigger".into(),
+                        field: "source".into(),
+                    })?
+                    .to_string();
+                let event_type = config
+                    .get("event_type")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| LegacyError::Decode {
+                        what: "system_event trigger".into(),
+                        field: "event_type".into(),
+                    })?
+                    .to_string();
+                let filters = config
+                    .get("filters")
+                    .and_then(|v| v.as_object())
+                    .map(|m| {
+                        m.iter()
+                            .filter_map(|(k, v)| {
+                                json_value_as_filter_string(v).map(|s| (k.clone(), s))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                Ok(Trigger::SystemEvent {
+                    source,
+                    event_type,
+                    filters,
+                })
+            }
+            "webhook" => {
+                let path = config
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let secret = config
+                    .get("secret")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                Ok(Trigger::Webhook { path, secret })
+            }
+            "manual" => Ok(Trigger::Manual),
+            other => Err(LegacyError::Decode {
+                what: "routine trigger".into(),
+                field: format!("unknown trigger_type '{other}'"),
+            }),
+        }
+    }
+}
+
+fn json_value_as_filter_string(v: &serde_json::Value) -> Option<String> {
+    match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// Mirror of `ironclaw::agent::routine::RoutineAction`.
+#[derive(Debug, Clone)]
+pub(crate) enum RoutineAction {
+    Lightweight {
+        prompt: String,
+        context_paths: Vec<String>,
+        max_tokens: u32,
+        use_tools: bool,
+        max_tool_rounds: u32,
+    },
+    FullJob {
+        title: String,
+        description: String,
+        max_iterations: u32,
+    },
+}
+
+const MAX_TOOL_ROUNDS_LIMIT: u32 = 20;
+
+impl RoutineAction {
+    /// Mirror of `RoutineAction::from_db` — parses `action_type`/`action_config`.
+    pub(crate) fn from_db(
+        action_type: &str,
+        config: serde_json::Value,
+    ) -> Result<Self, LegacyError> {
+        match action_type {
+            "lightweight" => {
+                let prompt = config
+                    .get("prompt")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| LegacyError::Decode {
+                        what: "lightweight action".into(),
+                        field: "prompt".into(),
+                    })?
+                    .to_string();
+                let context_paths = config
+                    .get("context_paths")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let max_tokens = config
+                    .get("max_tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(4096) as u32;
+                let use_tools = config
+                    .get("use_tools")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let max_tool_rounds = config
+                    .get("max_tool_rounds")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(3)
+                    .clamp(1, MAX_TOOL_ROUNDS_LIMIT as u64)
+                    as u32;
+                Ok(RoutineAction::Lightweight {
+                    prompt,
+                    context_paths,
+                    max_tokens,
+                    use_tools,
+                    max_tool_rounds,
+                })
+            }
+            "full_job" => {
+                let title = config
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| LegacyError::Decode {
+                        what: "full_job action".into(),
+                        field: "title".into(),
+                    })?
+                    .to_string();
+                let description = config
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| LegacyError::Decode {
+                        what: "full_job action".into(),
+                        field: "description".into(),
+                    })?
+                    .to_string();
+                let max_iterations = config
+                    .get("max_iterations")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(25) as u32;
+                Ok(RoutineAction::FullJob {
+                    title,
+                    description,
+                    max_iterations,
+                })
+            }
+            other => Err(LegacyError::Decode {
+                what: "routine action".into(),
+                field: format!("unknown action_type '{other}'"),
+            }),
+        }
+    }
+}
+
+/// Mirror of `ironclaw::agent::routine::RoutineGuardrails`.
+#[derive(Debug, Clone)]
+pub(crate) struct RoutineGuardrails {
+    pub(crate) cooldown: std::time::Duration,
+    pub(crate) max_concurrent: u32,
+    pub(crate) dedup_window: Option<std::time::Duration>,
+}
+
+/// Mirror of `ironclaw::agent::routine::NotifyConfig`.
+#[derive(Debug, Clone)]
+pub(crate) struct NotifyConfig {
+    pub(crate) channel: Option<String>,
+    pub(crate) user: Option<String>,
+    pub(crate) on_attention: bool,
+    pub(crate) on_failure: bool,
+    pub(crate) on_success: bool,
+}
+
+/// `NotifyConfig.user` column normalizer (`src/db/libsql/mod.rs::normalize_notify_user`):
+/// empty/whitespace-only/the literal `"default"` all mean "no explicit notify user".
+pub(crate) fn normalize_notify_user(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() || trimmed == "default" {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+// ── conversations (src/history/mod.rs) ──────────────────────────────────────
+
+/// Mirror of `ironclaw::history::ConversationSummary` (subset returned by
+/// `list_conversations_all_channels`).
+#[derive(Debug, Clone)]
+pub(crate) struct Conversation {
+    pub(crate) id: Uuid,
+    pub(crate) title: Option<String>,
+    pub(crate) channel: String,
+    pub(crate) thread_type: Option<String>,
+    pub(crate) started_at: DateTime<Utc>,
+    pub(crate) last_activity: DateTime<Utc>,
+}
+
+/// Mirror of `ironclaw::history::ConversationMessage`.
+#[derive(Debug, Clone)]
+pub(crate) struct ConversationMessage {
+    pub(crate) id: Uuid,
+    pub(crate) role: String,
+    pub(crate) content: String,
+    pub(crate) created_at: DateTime<Utc>,
+}
+
+// ── memory documents (src/workspace/document.rs) ────────────────────────────
+
+/// Mirror of `ironclaw::workspace::MemoryDocument`.
+#[derive(Debug, Clone)]
+pub(crate) struct MemoryDocument {
+    pub(crate) id: Uuid,
+    pub(crate) user_id: String,
+    pub(crate) agent_id: Option<Uuid>,
+    pub(crate) path: String,
+    pub(crate) content: String,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+    pub(crate) metadata: serde_json::Value,
+}
+
+// ── agent jobs (src/history/mod.rs) ─────────────────────────────────────────
+
+/// Mirror of `ironclaw::history::AgentJobRecord` (subset returned by
+/// `list_agent_jobs`).
+#[derive(Debug, Clone)]
+pub(crate) struct AgentJobRecord {
+    pub(crate) id: Uuid,
+    pub(crate) title: String,
+    pub(crate) status: String,
+    pub(crate) user_id: String,
+    pub(crate) failure_reason: Option<String>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) started_at: Option<DateTime<Utc>>,
+    pub(crate) completed_at: Option<DateTime<Utc>>,
+}
+
+// ── identities (src/db/mod.rs) ───────────────────────────────────────────────
+
+/// Mirror of `ironclaw::db::UserIdentityRecord`.
+#[derive(Debug, Clone)]
+pub(crate) struct UserIdentityRecord {
+    pub(crate) id: Uuid,
+    pub(crate) user_id: String,
+    pub(crate) provider: String,
+    pub(crate) provider_user_id: String,
+    pub(crate) email: Option<String>,
+    pub(crate) email_verified: bool,
+    pub(crate) display_name: Option<String>,
+    pub(crate) avatar_url: Option<String>,
+    pub(crate) raw_profile: serde_json::Value,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/wasm_stores.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/wasm_stores.rs
@@ -1,0 +1,370 @@
+//! Frozen, read-only port of the v1 installed-tool/channel stores
+//! (`src/tools/wasm/storage.rs`, `src/channels/wasm/storage.rs`) — only the
+//! `list`/`get_capabilities` surface [`crate::convert::extensions`] calls.
+
+#[cfg(feature = "libsql")]
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub(crate) enum WasmStorageError {
+    #[error("Database error: {0}")]
+    Database(String),
+}
+
+/// Frozen mirror of `ironclaw::tools::wasm::ToolStatus`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolStatus {
+    Active,
+    Disabled,
+    Quarantined,
+}
+
+impl std::str::FromStr for ToolStatus {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "active" => Ok(ToolStatus::Active),
+            "disabled" => Ok(ToolStatus::Disabled),
+            "quarantined" => Ok(ToolStatus::Quarantined),
+            _ => Err(format!("Unknown status: {s}")),
+        }
+    }
+}
+
+/// Frozen mirror of `ironclaw::tools::wasm::StoredWasmTool` (metadata fields
+/// this crate reads; trust_level/parameters_schema/source_url are parsed for
+/// contract fidelity even though `convert::extensions` doesn't consume them).
+#[derive(Debug, Clone)]
+pub(crate) struct StoredWasmTool {
+    pub(crate) id: Uuid,
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) description: String,
+    pub(crate) status: ToolStatus,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+/// Frozen mirror of `ironclaw::tools::wasm::StoredCapabilities` (only
+/// `allowed_secrets` is consumed downstream, the rest exists to document the
+/// on-disk contract).
+#[derive(Debug, Clone)]
+pub(crate) struct StoredCapabilities {
+    pub(crate) allowed_secrets: Vec<String>,
+}
+
+/// Frozen mirror of `ironclaw::channels::wasm::StoredWasmChannel`.
+#[derive(Debug, Clone)]
+pub(crate) struct StoredWasmChannel {
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) description: String,
+    pub(crate) status: String,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+/// Frozen mirror of `ironclaw::tools::wasm::WasmToolStore` — narrowed to the
+/// two methods this crate calls (not the full store contract: `store`/`get`/
+/// `get_with_binary`/`update_status`/`delete` have no migration use).
+#[async_trait]
+pub(crate) trait WasmToolStore: Send + Sync {
+    async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmTool>, WasmStorageError>;
+    async fn get_capabilities(
+        &self,
+        tool_id: Uuid,
+    ) -> Result<Option<StoredCapabilities>, WasmStorageError>;
+}
+
+/// Frozen mirror of `ironclaw::channels::wasm::WasmChannelStore` — narrowed to
+/// `list`.
+#[async_trait]
+pub(crate) trait WasmChannelStore: Send + Sync {
+    async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmChannel>, WasmStorageError>;
+}
+
+// ============================== libSQL ======================================
+
+#[cfg(feature = "libsql")]
+pub(crate) struct LibSqlWasmToolStore {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlWasmToolStore {
+    pub(crate) fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, WasmStorageError> {
+        let conn = self
+            .db
+            .connect()
+            .map_err(|e| WasmStorageError::Database(format!("Connection failed: {e}")))?;
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(|e| WasmStorageError::Database(format!("Failed to set busy_timeout: {e}")))?;
+        Ok(conn)
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl WasmToolStore for LibSqlWasmToolStore {
+    async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmTool>, WasmStorageError> {
+        use super::libsql_helpers::{get_text, get_ts};
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id, user_id, name, version, wit_version, description, parameters_schema,
+                       source_url, trust_level, status, created_at, updated_at
+                FROM wasm_tools
+                WHERE user_id = ?1
+                ORDER BY name
+                "#,
+                libsql::params![user_id],
+            )
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+
+        let mut tools = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?
+        {
+            let id_str = get_text(&row, 0);
+            let status_str = get_text(&row, 9);
+            tools.push(StoredWasmTool {
+                id: id_str
+                    .parse()
+                    .map_err(|e: uuid::Error| WasmStorageError::Database(e.to_string()))?,
+                name: get_text(&row, 2),
+                version: get_text(&row, 3),
+                description: get_text(&row, 5),
+                status: status_str.parse().map_err(WasmStorageError::Database)?,
+                updated_at: get_ts(&row, 11),
+            });
+        }
+        Ok(tools)
+    }
+
+    async fn get_capabilities(
+        &self,
+        tool_id: Uuid,
+    ) -> Result<Option<StoredCapabilities>, WasmStorageError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT allowed_secrets
+                FROM tool_capabilities
+                WHERE wasm_tool_id = ?1
+                "#,
+                libsql::params![tool_id.to_string()],
+            )
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+
+        match rows
+            .next()
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?
+        {
+            Some(row) => {
+                let allowed_secrets_str: String = row.get::<String>(0).unwrap_or_default();
+                let allowed_secrets: Vec<String> =
+                    serde_json::from_str(&allowed_secrets_str).unwrap_or_default();
+                Ok(Some(StoredCapabilities { allowed_secrets }))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(feature = "libsql")]
+pub(crate) struct LibSqlWasmChannelStore {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlWasmChannelStore {
+    pub(crate) fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, WasmStorageError> {
+        let conn = self
+            .db
+            .connect()
+            .map_err(|e| WasmStorageError::Database(format!("Connection failed: {e}")))?;
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(|e| WasmStorageError::Database(format!("Failed to set busy_timeout: {e}")))?;
+        Ok(conn)
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl WasmChannelStore for LibSqlWasmChannelStore {
+    async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmChannel>, WasmStorageError> {
+        use super::libsql_helpers::{get_text, parse_timestamp};
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id, user_id, name, version, wit_version, description,
+                       capabilities_json, status, created_at, updated_at
+                FROM wasm_channels
+                WHERE user_id = ?1
+                ORDER BY name
+                "#,
+                libsql::params![user_id],
+            )
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+
+        let mut channels = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?
+        {
+            let updated_at_str = get_text(&row, 9);
+            channels.push(StoredWasmChannel {
+                name: get_text(&row, 2),
+                version: get_text(&row, 3),
+                description: get_text(&row, 5),
+                status: get_text(&row, 7),
+                updated_at: parse_timestamp(&updated_at_str).map_err(WasmStorageError::Database)?,
+            });
+        }
+        Ok(channels)
+    }
+}
+
+// ============================== PostgreSQL ==================================
+
+#[cfg(feature = "postgres")]
+pub(crate) struct PostgresWasmToolStore {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresWasmToolStore {
+    pub(crate) fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait]
+impl WasmToolStore for PostgresWasmToolStore {
+    async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmTool>, WasmStorageError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        let rows = client
+            .query(
+                r#"
+                SELECT id, user_id, name, version, wit_version, description,
+                       parameters_schema, source_url, trust_level, status, created_at, updated_at
+                FROM wasm_tools
+                WHERE user_id = $1
+                ORDER BY name
+                "#,
+                &[&user_id],
+            )
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+
+        rows.iter()
+            .map(|r| {
+                let status_str: String = r.get("status");
+                Ok(StoredWasmTool {
+                    id: r.get("id"),
+                    name: r.get("name"),
+                    version: r.get("version"),
+                    description: r.get("description"),
+                    status: status_str.parse().map_err(WasmStorageError::Database)?,
+                    updated_at: r.get("updated_at"),
+                })
+            })
+            .collect()
+    }
+
+    async fn get_capabilities(
+        &self,
+        tool_id: Uuid,
+    ) -> Result<Option<StoredCapabilities>, WasmStorageError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        let row = client
+            .query_opt(
+                "SELECT allowed_secrets FROM tool_capabilities WHERE wasm_tool_id = $1",
+                &[&tool_id],
+            )
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        Ok(row.map(|r| StoredCapabilities {
+            allowed_secrets: r.get("allowed_secrets"),
+        }))
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) struct PostgresWasmChannelStore {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresWasmChannelStore {
+    pub(crate) fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait]
+impl WasmChannelStore for PostgresWasmChannelStore {
+    async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmChannel>, WasmStorageError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        let rows = client
+            .query(
+                r#"
+                SELECT id, user_id, name, version, wit_version, description,
+                       capabilities_json, status, created_at, updated_at
+                FROM wasm_channels
+                WHERE user_id = $1
+                ORDER BY name
+                "#,
+                &[&user_id],
+            )
+            .await
+            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| StoredWasmChannel {
+                name: r.get("name"),
+                version: r.get("version"),
+                description: r.get("description"),
+                status: r.get("status"),
+                updated_at: r.get("updated_at"),
+            })
+            .collect())
+    }
+}

--- a/crates/ironclaw_reborn_migration/src/lib.rs
+++ b/crates/ironclaw_reborn_migration/src/lib.rs
@@ -18,13 +18,10 @@ mod target;
 
 mod extension_ownership;
 
-#[cfg(feature = "full-migration")]
 mod convert;
-#[cfg(feature = "full-migration")]
+mod legacy_snapshot;
 mod mounts;
-#[cfg(feature = "full-migration")]
 mod source;
-#[cfg(feature = "full-migration")]
 mod v2_model;
 
 pub use extension_ownership::{
@@ -42,7 +39,6 @@ pub use report::{Domain, LossReason, LossyItem, MigrationReport, MigrationStats}
 /// Infrastructure failures (cannot open a store, cannot write a record) abort
 /// with a [`MigrationError`]. Per-item representation gaps do not abort — they
 /// are accumulated as [`LossyItem`]s on the returned report.
-#[cfg(feature = "full-migration")]
 pub async fn run_migration(options: MigrationOptions) -> Result<MigrationReport, MigrationError> {
     let mut report = MigrationReport::new(options.dry_run);
 

--- a/crates/ironclaw_reborn_migration/src/report.rs
+++ b/crates/ironclaw_reborn_migration/src/report.rs
@@ -9,7 +9,6 @@
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "full-migration")]
 use ironclaw_host_api::UserId;
 
 /// The domain a converted item or a loss belongs to. Keeps report entries
@@ -120,7 +119,6 @@ impl MigrationReport {
     /// (threads owner, secrets, memory docs, identities, routines, missions) so
     /// the "validate → skip + record" shape has a single definition and cannot
     /// drift between copies.
-    #[cfg(feature = "full-migration")]
     pub(crate) fn valid_user_id(
         &mut self,
         domain: Domain,

--- a/crates/ironclaw_reborn_migration/src/source.rs
+++ b/crates/ironclaw_reborn_migration/src/source.rs
@@ -1,31 +1,27 @@
 //! v1 / engine-v2 read side.
 //!
-//! Opens the legacy database through the root `ironclaw` crate and exposes it
-//! as an `Arc<dyn Database>` plus the backend-specific handles that satellite
-//! v1 stores (secrets, wasm tools, identities) need. Engine-v2 mission/project
-//! state is not a separate connection — it lives as JSON blobs inside the
-//! `memory_documents` table and is read through the same `Database` handle
-//! (see [`crate::convert::automations`] and [`crate::v2_model`]).
-
-use std::sync::Arc;
-
-use ironclaw::config::{DatabaseBackend, DatabaseConfig, SslMode};
-use ironclaw::db::{Database, DatabaseHandles, connect_with_handles};
-use secrecy::SecretString;
+//! Opens the legacy database through the frozen [`crate::legacy_snapshot`]
+//! read path (independent of `ironclaw_legacy`, see that module's docs) and
+//! exposes it as a [`legacy_snapshot::LegacyDb`] plus the backend-specific
+//! handles that satellite v1 stores (secrets, wasm tools, identities) need.
+//! Engine-v2 mission/project state is not a separate connection — it lives as
+//! JSON blobs inside the `memory_documents` table and is read through the
+//! same handle (see [`crate::convert::automations`] and [`crate::v2_model`]).
 
 use crate::error::MigrationError;
+use crate::legacy_snapshot::{self, LegacyDb, LegacyHandles};
 use crate::options::SourceDb;
 
-/// A live, migrations-applied handle to the v1 source database.
+/// A live handle to the v1 source database.
 ///
 /// Crate-internal: the only public entry point is [`crate::run_migration`], and
 /// this handle is consumed exclusively by the in-crate converters (mirrors the
 /// symmetric `RebornTarget` visibility).
 pub(crate) struct V1Source {
-    pub(crate) db: Arc<dyn Database>,
+    pub(crate) db: LegacyDb,
     /// Backend-specific handles for satellite v1 stores (secrets) and raw
     /// distinct-user / channel-identity discovery.
-    pub(crate) handles: DatabaseHandles,
+    pub(crate) handles: LegacyHandles,
 }
 
 /// Tables a v1 user_id can appear in. Queried independently so a DB missing one
@@ -35,8 +31,7 @@ const USER_ID_TABLES: [&str; 4] = ["conversations", "routines", "memory_document
 
 impl V1Source {
     pub(crate) async fn open(source: &SourceDb) -> Result<Self, MigrationError> {
-        let config = source_to_config(source);
-        let (db, handles) = connect_with_handles(&config)
+        let (db, handles) = legacy_snapshot::connect(source)
             .await
             .map_err(|e| MigrationError::OpenSource(e.to_string()))?;
         Ok(Self { db, handles })
@@ -123,28 +118,4 @@ pub(crate) fn is_missing_table_error(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
     lower.contains("no such table")
         || (lower.contains("relation") && lower.contains("does not exist"))
-}
-
-fn source_to_config(source: &SourceDb) -> DatabaseConfig {
-    match source {
-        SourceDb::LibSql { path } => DatabaseConfig {
-            backend: DatabaseBackend::LibSql,
-            // libSQL backend ignores `url`; the resolver uses this sentinel too.
-            url: SecretString::from("unused://libsql"),
-            pool_size: 4,
-            ssl_mode: SslMode::default(),
-            libsql_path: Some(path.clone()),
-            libsql_url: None,
-            libsql_auth_token: None,
-        },
-        SourceDb::Postgres { url } => DatabaseConfig {
-            backend: DatabaseBackend::Postgres,
-            url: url.clone(),
-            pool_size: 4,
-            ssl_mode: SslMode::default(),
-            libsql_path: None,
-            libsql_url: None,
-            libsql_auth_token: None,
-        },
-    }
 }

--- a/crates/ironclaw_reborn_migration/src/target.rs
+++ b/crates/ironclaw_reborn_migration/src/target.rs
@@ -15,29 +15,19 @@ use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{AgentId, TenantId, UserId};
 use ironclaw_reborn_identity::{FilesystemRebornIdentityStore, RebornUserDirectory};
 
-#[cfg(feature = "full-migration")]
 use ironclaw_host_api::ProjectId;
-#[cfg(feature = "full-migration")]
 use ironclaw_memory::MemoryService;
-#[cfg(feature = "full-migration")]
 use ironclaw_memory_native::NativeMemoryService;
-#[cfg(feature = "full-migration")]
 use ironclaw_reborn_identity::RebornIdentityResolver;
-#[cfg(feature = "full-migration")]
 use ironclaw_secrets::{FilesystemSecretStore, SecretStore, SecretsCrypto};
-#[cfg(feature = "full-migration")]
 use ironclaw_threads::{FilesystemSessionThreadService, SessionThreadService};
-#[cfg(feature = "full-migration")]
 use ironclaw_triggers::TriggerRepository;
-#[cfg(feature = "full-migration")]
 use secrecy::SecretString;
 
 use crate::error::MigrationError;
 use crate::options::TargetStore;
 
-#[cfg(feature = "full-migration")]
 use crate::mounts;
-#[cfg(feature = "full-migration")]
 use crate::options::MigrationOptions;
 
 /// The concrete Reborn backend the migration writes into. Both the KV substrate
@@ -48,20 +38,17 @@ pub(crate) enum Backend {
         root: Arc<ironclaw_filesystem::LibSqlRootFilesystem>,
         /// Shared handle for the triggers repo, which uses the raw DB (not the
         /// KV substrate). `LibSqlRootFilesystem` does not re-expose it.
-        #[cfg(feature = "full-migration")]
         db: Arc<libsql::Database>,
     },
     #[cfg(feature = "postgres")]
     Postgres {
         root: Arc<ironclaw_filesystem::PostgresRootFilesystem>,
-        #[cfg(feature = "full-migration")]
         pool: deadpool_postgres::Pool,
     },
 }
 
 /// Live Reborn write target: opened backend plus every constructed write
 /// service and the scope migrated records are written under.
-#[cfg(feature = "full-migration")]
 pub(crate) struct RebornTarget {
     /// Held for `identity_store` (the identity row-by-row follow-up); the other
     /// services already retain their own root/db Arcs.
@@ -124,7 +111,6 @@ impl ExtensionOwnershipTarget {
     }
 }
 
-#[cfg(feature = "full-migration")]
 impl RebornTarget {
     pub(crate) async fn open(options: &MigrationOptions) -> Result<Self, MigrationError> {
         let crypto = match &options.secret_master_key {
@@ -188,14 +174,12 @@ impl RebornTarget {
     }
 }
 
-#[cfg(feature = "full-migration")]
 fn build_crypto(key: &SecretString) -> Result<SecretsCrypto, MigrationError> {
     SecretsCrypto::new(key.clone())
         .map_err(|e| MigrationError::OpenTarget(format!("secrets master key: {e}")))
 }
 
 /// The KV-substrate write services built over one backend.
-#[cfg(feature = "full-migration")]
 type KvServices = (
     Arc<dyn SessionThreadService>,
     Arc<dyn MemoryService>,
@@ -204,7 +188,6 @@ type KvServices = (
 
 /// Build the filesystem-backed KV services over one concrete backend, returning
 /// them as trait objects.
-#[cfg(feature = "full-migration")]
 fn build_kv_services<F>(root: Arc<F>, crypto: Option<Arc<SecretsCrypto>>) -> KvServices
 where
     F: RootFilesystem + 'static,
@@ -233,7 +216,6 @@ where
     (thread_service, memory_service, secret_store)
 }
 
-#[cfg(feature = "full-migration")]
 #[allow(dead_code)] // wired for the identity row-by-row follow-up
 fn build_identity_store<F>(
     root: Arc<F>,
@@ -277,7 +259,6 @@ where
     Ok(store)
 }
 
-#[cfg(feature = "full-migration")]
 async fn build_trigger_repo(
     backend: &Backend,
 ) -> Result<Arc<dyn TriggerRepository>, MigrationError> {
@@ -320,11 +301,7 @@ async fn open_backend(target: &TargetStore) -> Result<Backend, MigrationError> {
             root.run_migrations()
                 .await
                 .map_err(|e| MigrationError::OpenTarget(e.to_string()))?;
-            Ok(Backend::LibSql {
-                root,
-                #[cfg(feature = "full-migration")]
-                db,
-            })
+            Ok(Backend::LibSql { root, db })
         }
         #[cfg(not(feature = "libsql"))]
         TargetStore::LibSql { .. } => Err(MigrationError::OpenTarget(
@@ -339,11 +316,7 @@ async fn open_backend(target: &TargetStore) -> Result<Backend, MigrationError> {
             root.run_migrations()
                 .await
                 .map_err(|e| MigrationError::OpenTarget(e.to_string()))?;
-            Ok(Backend::Postgres {
-                root,
-                #[cfg(feature = "full-migration")]
-                pool,
-            })
+            Ok(Backend::Postgres { root, pool })
         }
         #[cfg(not(feature = "postgres"))]
         TargetStore::Postgres { .. } => Err(MigrationError::OpenTarget(

--- a/crates/ironclaw_reborn_migration/tests/migration_roundtrip.rs
+++ b/crates/ironclaw_reborn_migration/tests/migration_roundtrip.rs
@@ -843,3 +843,63 @@ async fn dry_run_reports_without_writing() {
         "dry run wrote thread docs"
     );
 }
+
+/// `legacy_snapshot::connect` no longer runs v1 schema migrations on connect
+/// (the original `ironclaw::db::connect_with_handles` did, as a side effect).
+/// Against a `routines` table that predates a later v1 migration (missing
+/// `notify_on_attention`), the migration must fail loud naming the gap instead
+/// of silently reading a partial row — regression test for that deliberate
+/// behavior change (see `CLAUDE.md` "Decoupled from `ironclaw_legacy`").
+#[tokio::test]
+async fn migration_fails_loud_on_stale_routines_schema() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("v1_stale.db");
+    let dst = dir.path().join("reborn.db");
+
+    let db = libsql::Builder::new_local(&path)
+        .build()
+        .await
+        .expect("open stale fixture");
+    let conn = db.connect().expect("connect");
+    conn.execute(
+        "CREATE TABLE routines (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            enabled INTEGER NOT NULL,
+            trigger_type TEXT NOT NULL,
+            trigger_config TEXT NOT NULL,
+            action_type TEXT NOT NULL,
+            action_config TEXT NOT NULL,
+            cooldown_secs INTEGER NOT NULL,
+            max_concurrent INTEGER NOT NULL,
+            dedup_window_secs INTEGER,
+            notify_channel TEXT,
+            notify_user TEXT,
+            notify_on_success INTEGER NOT NULL,
+            notify_on_failure INTEGER NOT NULL,
+            state TEXT NOT NULL,
+            last_run_at TEXT,
+            next_fire_at TEXT,
+            run_count INTEGER NOT NULL,
+            consecutive_failures INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )",
+        (),
+    )
+    .await
+    .expect("create stale routines table (missing notify_on_attention)");
+    drop(conn);
+    drop(db);
+
+    let error = run_migration(options(path, dst, false))
+        .await
+        .expect_err("migration must fail loud against a stale v1 schema, not silently proceed");
+    let message = error.to_string();
+    assert!(
+        message.contains("routines") && message.contains("notify_on_attention"),
+        "error should name the missing table/column, got: {message}"
+    );
+}


### PR DESCRIPTION
## Summary

- Decouples `ironclaw_reborn_migration` (the v1→Reborn state migration tool) from `ironclaw_legacy` (`src/`), which was tracked as removal-blocking debt in `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`'s `LAYER_MATRIX_EXCEPTIONS` (`removes_in: "Tier B"`). Without this, deleting `src/` under the roadmap's "Clean up old architecture" epic would break the migration tool — the tool this change is meant to keep working.
- Adds a new self-contained `src/legacy_snapshot/` module that freezes exactly what the crate reads from v1: the 7 `Database` trait methods it calls (not the full ~78-method supertrait, which can't be partially implemented as a trait object), the v1 secrets decrypt scheme (AES-256-GCM + HKDF-SHA256, ported byte-for-byte so previously-encrypted secrets keep decrypting), and the wasm tool/channel store queries. Mirrors the freeze-and-port pattern the crate already used for deleted engine-v2 types (`v2_model.rs`).
- Drops the `ironclaw_legacy` dependency and the now-pointless `full-migration` Cargo feature entirely; removes the now-stale `LAYER_MATRIX_EXCEPTIONS` entry (confirmed failing on `main` prior to this cleanup, since the normal-dependency edge it exempted no longer exists).
- One deliberate, documented behavior change: the frozen reader no longer applies v1 schema migrations as a side effect of connecting (porting that machinery was out of proportion for a one-time cutover tool). It now fails loud with a specific missing-column error against a stale source schema instead of silently reading a partial row — covered by a new regression test.
- `tests/migration_roundtrip.rs` still seeds its v1 fixture through the real v1 write path (now a `[dev-dependencies]` entry, which the boundary test's normal-dependency scan doesn't see) for fidelity — flagged in the crate's `CLAUDE.md` as needing a raw-SQL rewrite once `src/` is actually deleted under Tier B.

## Test plan

- [x] `cargo test -p ironclaw_reborn_migration --features libsql --test migration_roundtrip` — all 6 tests pass (5 pre-existing + 1 new), identical counts/gap-set to the pre-change baseline
- [x] `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries` — all 34 tests pass
- [x] `cargo clippy -p ironclaw_reborn_migration --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy -p ironclaw_reborn_migration --no-default-features --features libsql --all-targets -- -D warnings` — clean (feature-matrix check)
- [x] `cargo clippy -p ironclaw_reborn_migration --no-default-features --features postgres --all-targets -- -D warnings` — clean (feature-matrix check)
- [x] `cargo tree -p ironclaw_reborn_migration --all-features -e normal` — confirms zero `ironclaw_legacy` in the production dependency graph
- [x] Reproduced the exact `Dockerfile.reborn` build command (`cargo build --package ironclaw_reborn_migration --no-default-features --features libsql --bin ironclaw-reborn-extension-ownership-migration`) — unaffected, still builds
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)