### PR TITLE
docs(release): 1.0.0-rc.1 release notes + destale reborn-binary.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.1] - 2026-07-20
+
+First release candidate of the rearchitected IronClaw, internally called
+**Reborn**. This is not an increment on the 0.29.x line — it is a ground-up
+rebuild of the agent runtime, storage, extension host, and web UI.
+
+**The `ironclaw` binary is now the Reborn CLI.** The v1 monolith now builds as
+the `ironclaw-legacy` binary and is no longer published; 1.0.0-rc.1 publishes
+the Reborn `ironclaw` binary only.
+
+### This is not an in-place upgrade from 0.29.x
+
+There is no migration for v1 config, databases, settings, or secrets, and
+installing 1.0.0-rc.1 does not touch your existing v1 data. Treat it as a
+fresh install: point `IRONCLAW_REBORN_HOME` at a new directory, run
+`ironclaw onboard`, and reconnect your providers and channels. Do not point
+it at a v1 data directory.
+
+### What ships
+
+- **Platforms.** Seven targets — macOS (Apple Silicon, Intel), Linux
+  (`x86_64`/`aarch64`, gnu and static musl), and Windows (`x86_64`), with shell,
+  PowerShell, and MSI installers.
+- **Guided setup.** `ironclaw onboard` provisions the config, the encrypted
+  credential store, an LLM provider (interactive key entry with a live probe),
+  a WebUI login token, and — on macOS and Linux — the background service. The
+  credential store's master key is provisioned in the OS keychain when one is
+  available, falling back to a locally cached key file otherwise.
+- **Model providers.** 26 providers in the built-in catalog, including NEAR AI,
+  OpenAI, Anthropic, Gemini, Bedrock, Ollama, OpenRouter, Groq, DeepSeek, and
+  any OpenAI-compatible endpoint. Manage routes with `ironclaw models`.
+- **Web UI.** `ironclaw serve` starts the WebChat v2 interface with the frontend
+  embedded in the binary — no separate asset deploy. Chat, extensions,
+  automations, settings, and admin surfaces are served from root-level routes.
+- **Extensions.** Twelve first-party extensions ship embedded and install
+  without a network fetch: GitHub, Gmail, Google Calendar, Docs, Drive, Sheets,
+  Slides, Notion, NEAR AI MCP, Slack, Telegram, and web access. Manage them with
+  `ironclaw extension` or the WebUI registry.
+- **Channels.** Slack and Telegram, both configured from the WebUI; Slack
+  connects per user through OAuth, Telegram through a per-user pairing code.
+- **Runtime.** Skills, scheduled and triggered automations, subagents, workspace
+  memory, and trace capture.
+- **Storage.** File-backed libSQL by default, so a stock install needs no
+  external database; PostgreSQL is opt-in via `[storage]`.
+- **Service management.** `ironclaw service install|start|stop|restart|status|uninstall`
+  runs the binary as a launchd user agent (macOS) or systemd user unit (Linux).
+
+### Known limitations
+
+- `ironclaw channels list`, `hooks list`, and `logs` appear in `--help` but
+  return an explicit "not implemented yet" error.
+- `mcp`, `memory`, `pairing`, `import`, and `login` subcommands from v1 have no
+  Reborn equivalent; MCP servers and memory are reached through extensions and
+  the WebUI instead.
+- `onboard --import-history` parses but does nothing.
+- `skills` is list-only from the CLI.
+- `extension` and `skills` work out of the box: `ironclaw onboard` defaults to
+  the `local-dev` profile, where both are fully supported (as under
+  `local-dev-yolo`, `hosted-single-tenant`, and `hosted-single-tenant-volume`).
+  Only operators who explicitly choose `production` or `migration-dry-run`
+  hit a clear error instead.
+
+Please report problems at https://github.com/nearai/ironclaw/issues — include
+`ironclaw status --json` output.
+
+The itemized changes since 0.29.1 follow.
+
 ### Added
 
 - *(reborn)* automations and `trigger_list` now surface why a scheduled trigger is currently held (approval/auth/in-progress) and how many scheduled occurrences elapsed while held ([#5886](https://github.com/nearai/ironclaw/issues/5886)).
@@ -22,16 +89,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(webui-v2)* render the Extensions Registry as soon as catalog data arrives instead of holding the skeleton screen for slower installed-extension enrichment ([#6052](https://github.com/nearai/ironclaw/issues/6052)).
 - *(webui-v2)* submit the latest composer value when Enter follows input before React rerenders, avoiding intermittently dropped follow-up messages ([#6044](https://github.com/nearai/ironclaw/issues/6044)).
 - *(reborn)* recover the filesystem resource governor after transient libSQL writer contention without bypassing durable accounting, reject stale authority writes during recovery, and distinguish accounting outages from provider budget failures.
-- *(reborn)* `builtin.result_read` input errors now carry a structured, model-visible `CapabilityInputIssue` (field path, issue code, expected/received) with model-controlled echoes secret-redacted, and truncated previews of top-level JSON-array results report the array's `item_count` — persisted end-to-end through the observation validator ([#6059](https://github.com/nearai/ironclaw/pull/6059)).
+- *(reborn)* `builtin.result_read` input errors now carry structured, model-visible input-error detail (field path, issue code, expected/received) with model-controlled echoes secret-redacted, and truncated previews of top-level JSON-array results report the array's `item_count` — persisted end-to-end through the observation validator ([#6059](https://github.com/nearai/ironclaw/pull/6059)).
 - *(reborn)* ride out transient model-provider outages with cancellation-aware availability retries, fail fast when no provider is configured, and preserve actionable shell/coding failure reasons for the model ([#5959](https://github.com/nearai/ironclaw/pull/5959)).
 - *(slack)* resolve known DM conversation IDs through an exact Slack lookup before encoding mentions, avoiding wrong-target posts when conversation lists are long or display names are ambiguous.
 - *(reborn)* add an explicit tenant extension-ownership migration that assigns every installed extension to every existing user, and clean up the departing user's external connection and personal credentials without tearing down the package for remaining users.
-- *(reborn)* make extension-scoped OAuth and explicit extension removal restart-safe and fenced: malformed callbacks now terminalize durable flows, status reads are observational with an explicit reconciliation command, multi-credential activation waits without revoking completed credentials, Slack cleanup fences ingress before fallible identity deletion, and uninstall cleanup obligations survive catalog/package loss.
+- *(reborn)* make extension-scoped OAuth and explicit extension removal restart-safe and fenced: malformed callbacks now terminate durable flows, status reads are observational with an explicit reconciliation command, multi-credential activation waits without revoking completed credentials, Slack cleanup fences ingress before fallible identity deletion, and uninstall cleanup obligations survive catalog/package loss.
 - *(reborn)* allow `builtin.time` parse, convert, format, and diff operations to consume JSON numbers or numeric strings containing Unix seconds, integral Unix milliseconds, and fractional Slack timestamps in addition to ISO 8601 strings.
 
 ### Changed
 
-- *(reborn)* move product-neutral channel delivery into `ironclaw_channel_delivery` and make the Telegram host own its concrete state, setup-revision workflow, and trigger-delivery behavior while composition remains mount/registration-only ([#6159](https://github.com/nearai/ironclaw/pull/6159)).
+- *(reborn)* move product-neutral channel delivery into its own crate and make the Telegram host own its concrete state, setup-revision workflow, and trigger-delivery behavior while composition remains mount/registration-only ([#6159](https://github.com/nearai/ironclaw/pull/6159)).
 - *(webui-v2)* serve the Reborn WebUI from root-level browser routes, with temporary `/v2` compatibility redirects that preserve deep links and login query parameters; `/api/webchat/v2/*` remains unchanged ([#6142](https://github.com/nearai/ironclaw/issues/6142)).
 - *(reborn)* raise the default agent-loop runaway backstop from 256 to 1,024 iterations and the subagent ceiling from 16 to 256 ([#5959](https://github.com/nearai/ironclaw/pull/5959)).
 - *(reborn-cli)* document the standalone `config init` atomic-write dependency on `tempfile` and call out the default runner cadence change to 5s heartbeats / 200ms polling (down from 10s / 2s).

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -50,9 +50,17 @@ ironclaw run
 ironclaw run --confirm-host-access
 ironclaw serve
 ironclaw serve --confirm-host-access
+ironclaw service install
+ironclaw service start
+ironclaw service stop
+ironclaw service restart
+ironclaw service status
+ironclaw service uninstall
 ironclaw skills list
 ironclaw skills list --json
 ironclaw skills list --verbose
+ironclaw status
+ironclaw status --json
 ```
 
 The `traces` command tree is a contributor-only trace client; see
@@ -69,14 +77,19 @@ surface that looks similar (it also used to read a not-yet-real registry) but
 is a genuine working implementation reading real `SKILL.md` files; it is not
 part of this disable.
 
-It intentionally does not yet support:
+Known limitations of this 1.0 release:
 
 - real `channels`/`hooks`/`logs` backends (see above);
-- replacing `ironclaw` behavior;
-- daemon/service installation;
 - v1 config, DB, settings, or secrets migration;
-- production extension/tool execution;
-- long-lived Reborn runtime services.
+- production extension/tool execution: `extension` and `skills` need a
+  local-runtime substrate profile (`local-dev`, `local-dev-yolo`,
+  `hosted-single-tenant`, `hosted-single-tenant-volume`); `production` and
+  `migration-dry-run` fail with `extension lifecycle is available only for
+  local-dev Reborn services`. In a default source build (no `postgres`
+  feature), `hosted-single-tenant`, `production`, and `migration-dry-run`
+  bail even earlier with `` requires a binary built with the `postgres`
+  feature ``, so only `local-dev`, `local-dev-yolo`, and
+  `hosted-single-tenant-volume` work out of the box from source.
 
 The WebChat v2 web UI **is** supported through `serve`. It is an early beta
 operator surface, not a production gateway. See [Running with the WebUI (`serve`)](#running-with-the-webui-serve).
@@ -116,11 +129,13 @@ cargo run -q -p ironclaw --bin ironclaw -- \
   models set-provider nearai
 export NEARAI_API_KEY="your-key-here"
 
-# 3. WebUI auth. serve REQUIRES both values or it refuses to start. The variable
-#    NAMES below are the defaults; override them via [webui].env_token_var and
-#    [webui].env_user_id_var in config.toml if you prefer different names.
+# 3. WebUI auth. serve REQUIRES the token or it refuses to start. USER_ID is
+#    optional: if unset, it falls back to [identity].default_owner, then to
+#    the literal "reborn-cli". The variable NAMES below are the defaults;
+#    override them via [webui].env_token_var and [webui].env_user_id_var in
+#    config.toml if you prefer different names.
 export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"   # bearer token you log in with
-export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"             # must match [identity].default_owner
+export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"             # optional; must match [identity].default_owner if set
 
 # 4. Launch.
 cargo run -q -p ironclaw --bin ironclaw -- serve
@@ -182,7 +197,6 @@ single-line `Error:` and exits.
 | Error message contains | Cause | Fix |
 | --- | --- | --- |
 | `must be set to the WebChat v2 bearer token` | `IRONCLAW_REBORN_WEBUI_TOKEN` unset | Export the token env var (step 3). |
-| `must be set to the UserId an env-bearer-authenticated caller maps to` | `IRONCLAW_REBORN_WEBUI_USER_ID` unset | Export the user-id env var (step 3). |
 | `default_owner ... must match the WebChat v2 authenticated user` | `[identity].default_owner` ≠ `IRONCLAW_REBORN_WEBUI_USER_ID` | Set the env user to the config owner (default `reborn-cli`), or remove/align `[identity].default_owner`. |
 | `workspace root must not overlap default skill root /skills` | Reborn home is **inside** the current working directory | Point `IRONCLAW_REBORN_HOME` at a path outside your repo/cwd. |
 
@@ -445,6 +459,8 @@ Supported profiles:
 
 - `local-dev` (default)
 - `local-dev-yolo`
+- `hosted-single-tenant`
+- `hosted-single-tenant-volume`
 - `production`
 - `migration-dry-run`
 
@@ -528,8 +544,9 @@ cargo run -q -p ironclaw --bin ironclaw -- repl
 
 ### `serve`
 
-Starts the WebChat v2 HTTP listener (browser UI). Requires the two
-`IRONCLAW_REBORN_WEBUI_*` auth env vars.
+Starts the WebChat v2 HTTP listener (browser UI). Requires
+`IRONCLAW_REBORN_WEBUI_TOKEN`; `IRONCLAW_REBORN_WEBUI_USER_ID` is optional and
+falls back to `[identity].default_owner`, then `"reborn-cli"`.
 See [Running with the WebUI (`serve`)](#running-with-the-webui-serve) for the
 full walkthrough, auth setup, common startup errors, and an API smoke test.
 
@@ -540,11 +557,13 @@ cargo run -q -p ironclaw --bin ironclaw -- serve --host 127.0.0.1 --port 3000
 
 ### `skills list`
 
-Reports configured Reborn local-dev skills from `<reborn-home>/local-dev/skills`
-and `<reborn-home>/local-dev/system/skills` through the Reborn composition
-skill listing function. It does not read v1 skill discovery paths, and a missing
-local-dev storage root is reported as an empty skill list without creating
-directories.
+Reports configured Reborn skills from `<reborn-home>/<profile-subdir>/skills`
+and `<reborn-home>/<profile-subdir>/system/skills` through the Reborn
+composition skill listing function, where `<profile-subdir>` is
+`hosted-single-tenant` or `hosted-single-tenant-volume` for those profiles and
+`local-dev` for `local-dev`, `local-dev-yolo`, `production`, and
+`migration-dry-run`. It does not read v1 skill discovery paths, and a missing
+storage root is reported as an empty skill list without creating directories.
 
 ```bash
 cargo run -q -p ironclaw --bin ironclaw -- skills list
@@ -563,7 +582,8 @@ Expected fields include:
 `--verbose` adds the resolved `profile`, `reborn_home`, `local_dev_root`, and
 `owner_id`; text output also includes per-skill `version`, `keywords`, `tags`,
 and `requires_skills` when present. `skills list` currently supports
-`local-dev` and `local-dev-yolo` profiles and rejects `production` /
+`local-dev`, `local-dev-yolo`, `hosted-single-tenant`, and
+`hosted-single-tenant-volume` profiles and rejects `production` /
 `migration-dry-run` until those catalog backends are wired.
 
 ## State and config root
@@ -585,6 +605,8 @@ Supported values:
 
 - `local-dev` (default)
 - `local-dev-yolo`
+- `hosted-single-tenant`
+- `hosted-single-tenant-volume`
 - `production`
 - `migration-dry-run`
 


### PR DESCRIPTION
Prepares the changelog for the `ironclaw-v1.0.0-rc.1` tag.

**This must merge before the tag is pushed.** cargo-dist builds the GitHub Release body by matching the version heading in `CHANGELOG.md`. Tag first and the release publishes with installer instructions and no notes, which can't be retrofitted without deleting the tag and re-running the pipeline.

## CHANGELOG.md

Promotes `[Unreleased]` to `## [1.0.0-rc.1] - 2026-07-20` and adds a narrative preamble: what the release is (first RC of the rearchitected Reborn stack), that there is no in-place upgrade from 0.29.x, what ships, and known gaps. Itemized entries follow underneath unchanged except for three internal-detail leaks (`CapabilityInputIssue`, a crate name, "terminalize").

Heading format is deliberately plain rather than the inline-compare-link style of prior versions — a v1↔Reborn compare diff isn't useful, and the plain form is what cargo-dist's parser matches.

## docs/reborn-binary.md

The doc predated this release and contradicted it. Corrected:

- listed daemon/service installation and long-lived runtime services as unsupported — both shipped in #6157
- framed Reborn as not yet replacing `ironclaw`, which this release makes false
- omitted `service` and `status` from the command inventory
- claimed `serve` hard-requires `IRONCLAW_REBORN_WEBUI_USER_ID`; it now falls back to `[identity].default_owner`, then `reborn-cli`
- listed 4 of 6 profiles in two places
- said `skills list` accepts 2 profiles; it accepts 4
- asserted a `local-dev`-only skills path that is wrong for the hosted profiles

## Verification

Docs only, no production code. Claims were checked against live code; the capability list was verified against a binary built with the actual release features (`libsql,postgres,inmemory-turn-state`), which behaves differently from a default `cargo run` build.

One claim worth noting because it was in doubt: a default `ironclaw onboard` writes `profile = "local-dev"`, and `extension search`/`extension install`/`skills list` all succeed there. The profile restriction in the limitations section only affects operators who explicitly choose `production` or `migration-dry-run`.

Not covered: whether the macOS binaries are signed/notarized. No signing config was found in the dist metadata or workflows, but absence of config isn't proof — the notes make no claim either way, and it should be settled before wide announcement.

Related: compile preflight for this release is green on all 7 targets (run 29769880457).

🤖 Generated with [Claude Code](https://claude.com/claude-code)