### PR TITLE
Remove orphan WebUI v2 static gitignore

### DIFF
--- a/crates/ironclaw_webui_v2_static/frontend/.gitignore
+++ b/crates/ironclaw_webui_v2_static/frontend/.gitignore
@@ -1,1 +1,0 @@
-node_modules/


### PR DESCRIPTION
## Summary

- Delete the stale `crates/ironclaw_webui_v2_static/frontend/.gitignore` left behind after the WebChat v2 SPA was folded into `crates/ironclaw_webui`.
- Leave the active ignore rules in `crates/ironclaw_webui/frontend/.gitignore`, which already covers `/node_modules/` and `/dist/`.

## Why

`ironclaw_webui_v2_static` no longer owns the SPA. The current owner is `ironclaw_webui`: the frontend lives in `crates/ironclaw_webui/frontend/`, and static serving lives under `crates/ironclaw_webui/src/webui_v2/static_assets/`.

## Validation

- `git diff --check`
- Verified `crates/ironclaw_webui/frontend/.gitignore` already contains `/node_modules/` and `/dist/`.

No Rust or frontend tests were run because this only removes an orphaned ignore file.