### PR TITLE
Add streaming retry resilience coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The itemized changes since 0.29.1 follow.
 
 ### Fixed
 
+- *(reborn)* route Rig-backed model calls through provider streaming for WebUI v2 runs, cover delayed/broken/cancelled/transient mock LLM behavior in served E2E tests, and verify failed runs can retry after a transient checkpoint-state outage, including failures before the first checkpoint.
 - *(reborn)* activating an extension whose OAuth provider was never configured on the instance now fails immediately with the exact `ironclaw config set` commands and restart step, instead of parking an unresolvable auth gate ([#6335](https://github.com/nearai/ironclaw/issues/6335)).
 - *(reborn)* host-authored remediation text reaches the model intact again instead of degrading to "capability summary unavailable" ([#6335](https://github.com/nearai/ironclaw/issues/6335)).
 - *(webui-v2)* report settings imports with no supported entries as failures instead of showing a false success message ([#6179](https://github.com/nearai/ironclaw/issues/6179)).

--- a/crates/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/ironclaw_llm/src/rig_adapter.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, Rig provider bridge keeps streaming and non-streaming conversions co-located until provider adapter decomposition, plan #6175
 //! Generic adapter that bridges rig-core's `CompletionModel` trait to IronClaw's `LlmProvider`.
 //!
 //! This lets us use any rig-core provider (OpenAI, Anthropic, Ollama, etc.) as an
@@ -5,9 +6,10 @@
 
 use crate::config::CacheRetention;
 use async_trait::async_trait;
+use futures::StreamExt;
 use rig::OneOrMany;
 use rig::completion::{
-    AssistantContent, CompletionModel, CompletionRequest as RigRequest,
+    AssistantContent, CompletionModel, CompletionRequest as RigRequest, GetTokenUsage,
     ToolDefinition as RigToolDefinition, Usage as RigUsage,
 };
 use rig::message::{
@@ -15,6 +17,7 @@ use rig::message::{
     ToolChoice as RigToolChoice, ToolFunction, ToolResult as RigToolResult, ToolResultContent,
     UserContent,
 };
+use rig::streaming::{StreamedAssistantContent, StreamingCompletionResponse};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::Serialize;
@@ -26,8 +29,8 @@ use std::str::FromStr;
 
 use crate::error::LlmError;
 use crate::provider::{
-    ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider,
-    ReasoningDetail as IronReasoningDetail, ReasoningDetails as IronReasoningDetails,
+    ChatMessage, CompletionRequest, CompletionResponse, CompletionStreamSink, FinishReason,
+    LlmProvider, ReasoningDetail as IronReasoningDetail, ReasoningDetails as IronReasoningDetails,
     ToolCall as IronToolCall, ToolCompletionRequest, ToolCompletionResponse,
     ToolDefinition as IronToolDefinition, strip_unsupported_completion_params,
     strip_unsupported_tool_params,
@@ -319,6 +322,52 @@ impl<M: CompletionModel> RigAdapter<M> {
     /// Strip unsupported fields from a `ToolCompletionRequest` in place.
     fn strip_unsupported_tool_params(&self, req: &mut ToolCompletionRequest) {
         strip_unsupported_tool_params(&self.unsupported_params, req);
+    }
+
+    async fn drain_streaming_response(
+        &self,
+        mut stream: StreamingCompletionResponse<M::StreamingResponse>,
+        sink: std::sync::Arc<dyn CompletionStreamSink>,
+    ) -> Result<DrainedStreamingResponse, LlmError> {
+        let mut streamed_reasoning = StreamedReasoningAccumulator::default();
+        while let Some(chunk) = stream.next().await {
+            match chunk.map_err(|e| map_rig_error(&self.model_name, e))? {
+                StreamedAssistantContent::Text(text) if !text.text.is_empty() => {
+                    sink.text_delta(text.text).await;
+                }
+                StreamedAssistantContent::Reasoning(reasoning) => {
+                    streamed_reasoning.push_reasoning(&reasoning);
+                }
+                StreamedAssistantContent::ReasoningDelta { id, reasoning } => {
+                    streamed_reasoning.push_delta(id, reasoning);
+                }
+                _ => {}
+            }
+        }
+
+        let usage = stream
+            .response
+            .as_ref()
+            .and_then(GetTokenUsage::token_usage)
+            .unwrap_or_default();
+        let cache_creation_input_tokens = stream
+            .response
+            .as_ref()
+            .map(extract_cache_creation)
+            .unwrap_or(0);
+        let (text, tool_calls, finish, reasoning, reasoning_details) =
+            extract_response(&stream.choice, &usage);
+        let (streamed_reasoning, streamed_reasoning_details) = streamed_reasoning.finish();
+
+        Ok(DrainedStreamingResponse {
+            text,
+            tool_calls,
+            finish,
+            reasoning: reasoning.or(streamed_reasoning),
+            reasoning_details: reasoning_details.or(streamed_reasoning_details),
+            usage,
+            cache_creation_input_tokens,
+        })
     }
 }
 
@@ -759,6 +808,63 @@ fn extract_response(
     (text, tool_calls, finish, reasoning, typed_reasoning)
 }
 
+#[derive(Default)]
+struct StreamedReasoningAccumulator {
+    parts: Vec<String>,
+    details: Vec<IronReasoningDetail>,
+    id: Option<String>,
+}
+
+impl StreamedReasoningAccumulator {
+    fn push_reasoning(&mut self, reasoning: &rig::message::Reasoning) {
+        if self.id.is_none() {
+            self.id = reasoning.id.clone();
+        }
+        if let Some(details) = rig_reasoning_to_iron(reasoning) {
+            if let Some(display_text) = details.display_text() {
+                self.parts.push(display_text);
+            }
+            self.details.extend(details.content);
+        }
+    }
+
+    fn push_delta(&mut self, id: Option<String>, reasoning: String) {
+        if self.id.is_none() {
+            self.id = id;
+        }
+        if !reasoning.trim().is_empty() {
+            self.parts.push(reasoning);
+        }
+    }
+
+    fn finish(self) -> (Option<String>, Option<IronReasoningDetails>) {
+        let reasoning = if self.parts.is_empty() {
+            None
+        } else {
+            Some(self.parts.join("\n"))
+        };
+        let details = if self.details.is_empty() {
+            None
+        } else {
+            Some(IronReasoningDetails {
+                id: self.id,
+                content: self.details,
+            })
+        };
+        (reasoning, details)
+    }
+}
+
+struct DrainedStreamingResponse {
+    text: Option<String>,
+    tool_calls: Vec<IronToolCall>,
+    finish: FinishReason,
+    reasoning: Option<String>,
+    reasoning_details: Option<IronReasoningDetails>,
+    usage: RigUsage,
+    cache_creation_input_tokens: u32,
+}
+
 /// Saturate u64 to u32 for token counts.
 fn saturate_u32(val: u64) -> u32 {
     val.min(u32::MAX as u64) as u32
@@ -993,6 +1099,62 @@ where
         Ok(resp)
     }
 
+    async fn complete_streaming(
+        &self,
+        mut request: CompletionRequest,
+        sink: std::sync::Arc<dyn CompletionStreamSink>,
+    ) -> Result<CompletionResponse, LlmError> {
+        let model_override = request.take_model_override();
+
+        self.strip_unsupported_completion_params(&mut request);
+
+        let mut messages = request.messages;
+        crate::provider::sanitize_tool_messages(&mut messages);
+        let (preamble, history) = convert_messages(&messages);
+
+        let mut rig_req = build_rig_request(
+            preamble,
+            history,
+            Vec::new(),
+            None,
+            request.temperature,
+            request.max_tokens,
+            self.cache_retention,
+        )?;
+
+        merge_additional_params(&mut rig_req, self.default_additional_params.as_ref());
+        inject_model_override(&mut rig_req, model_override.as_deref());
+
+        let stream = self
+            .model
+            .stream(rig_req)
+            .await
+            .map_err(|e| map_rig_error(&self.model_name, e))?;
+        let drained = self.drain_streaming_response(stream, sink).await?;
+
+        let resp = CompletionResponse {
+            content: drained.text.unwrap_or_default(),
+            input_tokens: saturate_u32(drained.usage.input_tokens),
+            output_tokens: saturate_u32(drained.usage.output_tokens),
+            finish_reason: drained.finish,
+            reasoning: drained.reasoning,
+            cache_read_input_tokens: saturate_u32(drained.usage.cached_input_tokens),
+            cache_creation_input_tokens: drained.cache_creation_input_tokens,
+        };
+
+        if resp.cache_read_input_tokens > 0 {
+            tracing::debug!(
+                model = %self.model_name,
+                input = resp.input_tokens,
+                output = resp.output_tokens,
+                cache_read = resp.cache_read_input_tokens,
+                "prompt cache hit",
+            );
+        }
+
+        Ok(resp)
+    }
+
     async fn complete_with_tools(
         &self,
         mut request: ToolCompletionRequest,
@@ -1065,6 +1227,88 @@ where
             cache_creation_input_tokens: extract_cache_creation(&response.raw_response),
             reasoning,
             reasoning_details,
+        };
+
+        if resp.cache_read_input_tokens > 0 {
+            tracing::debug!(
+                model = %self.model_name,
+                input = resp.input_tokens,
+                output = resp.output_tokens,
+                cache_read = resp.cache_read_input_tokens,
+                "prompt cache hit",
+            );
+        }
+
+        Ok(resp)
+    }
+
+    async fn complete_with_tools_streaming(
+        &self,
+        mut request: ToolCompletionRequest,
+        sink: std::sync::Arc<dyn CompletionStreamSink>,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        let model_override = request.take_model_override();
+
+        self.strip_unsupported_tool_params(&mut request);
+
+        let known_tool_names: HashSet<String> =
+            request.tools.iter().map(|t| t.name.clone()).collect();
+
+        let mut messages = request.messages;
+        crate::provider::sanitize_tool_messages(&mut messages);
+        let (preamble, history) = convert_messages(&messages);
+        let tools = convert_tools(&request.tools);
+        let tool_choice = convert_tool_choice(request.tool_choice.as_deref());
+
+        let mut rig_req = build_rig_request(
+            preamble,
+            history,
+            tools,
+            tool_choice,
+            request.temperature,
+            request.max_tokens,
+            self.cache_retention,
+        )?;
+
+        merge_additional_params(&mut rig_req, self.default_additional_params.as_ref());
+        inject_model_override(&mut rig_req, model_override.as_deref());
+
+        let stream = self
+            .model
+            .stream(rig_req)
+            .await
+            .map_err(|e| map_rig_error(&self.model_name, e))?;
+        let mut drained = self.drain_streaming_response(stream, sink).await?;
+
+        // Normalize tool call names: some proxies prepend "proxy_" prefixes.
+        for tc in &mut drained.tool_calls {
+            let normalized = normalize_tool_name(&tc.name, &known_tool_names);
+            if normalized != tc.name {
+                tracing::debug!(
+                    original = %tc.name,
+                    normalized = %normalized,
+                    "Normalized tool call name from provider",
+                );
+                tc.name = normalized;
+            }
+        }
+
+        crate::tool_schema::strip_unset_optional_fields(
+            &mut drained.tool_calls,
+            &request.tools,
+            crate::tool_schema::PlaceholderStrippingMode::NullOnly,
+        );
+
+        let resp = ToolCompletionResponse {
+            content: drained.text,
+            tool_calls: drained.tool_calls,
+            input_tokens: saturate_u32(drained.usage.input_tokens),
+            output_tokens: saturate_u32(drained.usage.output_tokens),
+            finish_reason: drained.finish,
+            cache_read_input_tokens: saturate_u32(drained.usage.cached_input_tokens),
+            cache_creation_input_tokens: drained.cache_creation_input_tokens,
+            reasoning: drained.reasoning,
+            reasoning_details: drained.reasoning_details,
         };
 
         if resp.cache_read_input_tokens > 0 {
@@ -1178,7 +1422,9 @@ fn normalize_tool_name(name: &str, known_tools: &HashSet<String>) -> String {
 mod tests {
     use super::*;
     use rig::completion::CompletionError;
-    use rig::streaming::StreamingCompletionResponse;
+    use rig::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse};
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
 
     #[test]
     fn map_rig_error_auth_401_unauthorized() {
@@ -1368,6 +1614,133 @@ mod tests {
                 "stream unsupported".to_string(),
             ))
         }
+    }
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    struct StubStreamingResponse {
+        input_tokens: u64,
+        output_tokens: u64,
+    }
+
+    impl GetTokenUsage for StubStreamingResponse {
+        fn token_usage(&self) -> Option<RigUsage> {
+            Some(RigUsage {
+                input_tokens: self.input_tokens,
+                output_tokens: self.output_tokens,
+                total_tokens: self.input_tokens + self.output_tokens,
+                cached_input_tokens: 0,
+            })
+        }
+    }
+
+    #[derive(Clone)]
+    struct StreamingOnlyCompletionModel;
+
+    impl CompletionModel for StreamingOnlyCompletionModel {
+        type Response = serde_json::Value;
+        type StreamingResponse = StubStreamingResponse;
+        type Client = ();
+
+        fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+            Self
+        }
+
+        async fn completion(
+            &self,
+            _request: RigRequest,
+        ) -> Result<rig::completion::CompletionResponse<Self::Response>, CompletionError> {
+            Err(CompletionError::ProviderError(
+                "non-streaming path must not be used".to_string(),
+            ))
+        }
+
+        async fn stream(
+            &self,
+            _request: RigRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            let stream = futures::stream::iter(vec![
+                Ok(RawStreamingChoice::Message("Hel".to_string())),
+                Ok(RawStreamingChoice::ReasoningDelta {
+                    id: Some("rsn-stream".to_string()),
+                    reasoning: "thinking".to_string(),
+                }),
+                Ok(RawStreamingChoice::Message("lo".to_string())),
+                Ok(RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
+                    "call-1".to_string(),
+                    "search".to_string(),
+                    serde_json::json!({"query": "ironclaw"}),
+                ))),
+                Ok(RawStreamingChoice::FinalResponse(StubStreamingResponse {
+                    input_tokens: 3,
+                    output_tokens: 4,
+                })),
+            ]);
+            Ok(StreamingCompletionResponse::stream(Box::pin(stream)))
+        }
+    }
+
+    struct RecordingCompletionStreamSink {
+        sender: mpsc::UnboundedSender<String>,
+    }
+
+    #[async_trait]
+    impl CompletionStreamSink for RecordingCompletionStreamSink {
+        async fn text_delta(&self, delta: String) {
+            let _ = self.sender.send(delta);
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_streaming_preserves_reasoning_deltas() {
+        let adapter = RigAdapter::new(StreamingOnlyCompletionModel, "streaming-only");
+        let request = CompletionRequest::new(vec![ChatMessage::user("hello")]);
+        let (delta_tx, mut delta_rx) = mpsc::unbounded_channel();
+        let sink = Arc::new(RecordingCompletionStreamSink { sender: delta_tx });
+
+        let response = adapter
+            .complete_streaming(request, sink)
+            .await
+            .expect("streaming completion succeeds");
+
+        assert_eq!(delta_rx.try_recv().expect("first delta"), "Hel");
+        assert_eq!(delta_rx.try_recv().expect("second delta"), "lo");
+        assert_eq!(response.content, "Hello");
+        assert_eq!(response.reasoning.as_deref(), Some("thinking"));
+        assert_eq!(response.input_tokens, 3);
+        assert_eq!(response.output_tokens, 4);
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_streaming_uses_rig_stream_and_emits_deltas() {
+        let adapter = RigAdapter::new(StreamingOnlyCompletionModel, "streaming-only");
+        let request = ToolCompletionRequest::new(
+            vec![ChatMessage::user("search")],
+            vec![IronToolDefinition {
+                name: "search".to_string(),
+                description: "Search the index".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                }),
+            }],
+        );
+        let (delta_tx, mut delta_rx) = mpsc::unbounded_channel();
+        let sink = Arc::new(RecordingCompletionStreamSink { sender: delta_tx });
+
+        let response = adapter
+            .complete_with_tools_streaming(request, sink)
+            .await
+            .expect("streaming completion succeeds");
+
+        assert_eq!(delta_rx.try_recv().expect("first delta"), "Hel");
+        assert_eq!(delta_rx.try_recv().expect("second delta"), "lo");
+        assert_eq!(response.content.as_deref(), Some("Hello"));
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].name, "search");
+        assert_eq!(response.reasoning.as_deref(), Some("thinking"));
+        assert_eq!(response.input_tokens, 3);
+        assert_eq!(response.output_tokens, 4);
     }
 
     #[test]

--- a/crates/ironclaw_runner/tests/loop_driver_host.rs
+++ b/crates/ironclaw_runner/tests/loop_driver_host.rs
@@ -2368,6 +2368,128 @@ async fn turn_runner_worker_full_reborn_fails_when_checkpoint_state_disk_is_full
 }
 
 #[tokio::test]
+async fn turn_runner_worker_full_reborn_retry_recovers_after_transient_checkpoint_state_outage() {
+    let fixture = HostFixture::new_unsubmitted(
+        "thread-full-reborn-checkpoint-transient",
+        "hello transient checkpoint outage",
+    )
+    .await;
+    let turn_store = Arc::new(in_memory_turn_state_store());
+    let resolver = default_planned_run_profile_resolver().expect("planned profile resolver");
+    let failed_run_id = queue_fixture_turn(
+        &fixture,
+        turn_store.as_ref(),
+        &resolver,
+        "idem-full-reborn-checkpoint-transient",
+    )
+    .await;
+    let driver = planned_driver_for_full_reborn_test();
+    let descriptor = driver.descriptor();
+    let mut registry = DriverRegistry::new();
+    registry
+        .register_driver(
+            driver,
+            planned_requirements_without_capabilities(),
+            DriverKind::Reference,
+        )
+        .unwrap();
+    let checkpoint_state_store = Arc::new(NthPutUnavailableCheckpointStateStore::new(
+        in_memory_checkpoint_state_store(),
+        1,
+    ));
+    let loop_checkpoint_store: Arc<dyn LoopCheckpointStore> = turn_store.clone();
+    let factory = RebornLoopDriverHostFactory::new(
+        fixture.thread_service.clone(),
+        fixture.thread_scope.clone(),
+        fixture.gateway.clone(),
+        checkpoint_state_store.clone(),
+        turn_store.clone(),
+        loop_checkpoint_store,
+        fixture.milestone_sink.clone(),
+        TextOnlyLoopHostConfig {
+            max_messages: 8,
+            require_model_route_snapshot: false,
+        },
+        InstructionSafetyContext::local_development_noop(),
+    )
+    .with_driver_requirements(driver_requirements_for(
+        &descriptor,
+        planned_requirements_without_capabilities(),
+    ));
+    let executor = Arc::new(RebornTurnRunExecutor::new(
+        loop_exit_applier_for_fixture(&fixture, turn_store.clone()),
+        Arc::new(registry),
+        Arc::new(factory) as Arc<dyn HostFactory>,
+        None,
+    ));
+    let scheduler_handle = TurnRunScheduler::new(
+        turn_store.clone() as Arc<dyn ironclaw_turns::runner::TurnRunTransitionPort>,
+        executor,
+        full_reborn_chaos_scheduler_config(),
+    )
+    .start();
+
+    let failed = wait_for_run_status(
+        turn_store.as_ref(),
+        &fixture.context.scope,
+        failed_run_id,
+        TurnStatus::Failed,
+        "full reborn run should record transient checkpoint outage as failed",
+    )
+    .await;
+    assert_eq!(
+        failed.failure.expect("failure").category(),
+        "host_stage_unavailable_checkpoint"
+    );
+    assert_eq!(checkpoint_state_store.put_attempts(), 1);
+    assert!(
+        fixture.gateway.requests().is_empty(),
+        "first checkpoint failure should happen before the model provider is called"
+    );
+
+    let retry = turn_store
+        .retry_turn(ironclaw_turns::RetryTurnRequest {
+            scope: fixture.context.scope.clone(),
+            actor: TurnActor::new(UserId::new("user-text-host").unwrap()),
+            run_id: failed_run_id,
+            source_binding_ref: SourceBindingRef::new("source-web-retry").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-retry").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-full-reborn-checkpoint-transient-retry")
+                .unwrap(),
+        })
+        .await
+        .expect("retry failed run");
+    assert_eq!(retry.status, TurnStatus::Queued);
+
+    let completed = wait_for_run_status(
+        turn_store.as_ref(),
+        &fixture.context.scope,
+        retry.run_id,
+        TurnStatus::Completed,
+        "retry should complete after transient checkpoint outage clears",
+    )
+    .await;
+    scheduler_handle.shutdown().await;
+
+    assert!(completed.failure.is_none());
+    assert_eq!(checkpoint_state_store.put_attempts(), 3);
+    assert_eq!(fixture.gateway.requests().len(), 1);
+    let history = fixture
+        .thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: fixture.thread_scope.clone(),
+            thread_id: fixture.thread_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(history.messages.iter().any(|message| {
+        message.kind == MessageKind::Assistant
+            && message.status == MessageStatus::Finalized
+            && message.content.as_deref() == Some("model says hi")
+    }));
+}
+
+#[tokio::test]
 async fn turn_runner_worker_full_reborn_fails_cleanly_when_model_provider_is_offline() {
     let fixture =
         HostFixture::new_unsubmitted("thread-full-reborn-model-offline", "hello model outage")
@@ -9216,6 +9338,49 @@ impl CheckpointStateStore for DiskFullCheckpointStateStore {
         Err(TurnError::Unavailable {
             reason: "checkpoint state disk full".to_string(),
         })
+    }
+}
+
+struct NthPutUnavailableCheckpointStateStore {
+    inner: Arc<dyn CheckpointStateStore>,
+    fail_on_put_attempt: usize,
+    put_attempts: AtomicUsize,
+}
+
+impl NthPutUnavailableCheckpointStateStore {
+    fn new(inner: Arc<dyn CheckpointStateStore>, fail_on_put_attempt: usize) -> Self {
+        Self {
+            inner,
+            fail_on_put_attempt,
+            put_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn put_attempts(&self) -> usize {
+        self.put_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl CheckpointStateStore for NthPutUnavailableCheckpointStateStore {
+    async fn put_checkpoint_state(
+        &self,
+        request: PutCheckpointStateRequest,
+    ) -> Result<ironclaw_turns::CheckpointStateRecord, TurnError> {
+        let attempt = self.put_attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt == self.fail_on_put_attempt {
+            return Err(TurnError::Unavailable {
+                reason: "transient checkpoint state outage".to_string(),
+            });
+        }
+        self.inner.put_checkpoint_state(request).await
+    }
+
+    async fn get_checkpoint_state(
+        &self,
+        request: GetCheckpointStateRequest,
+    ) -> Result<Option<ironclaw_turns::CheckpointStateRecord>, TurnError> {
+        self.inner.get_checkpoint_state(request).await
     }
 }
 

--- a/crates/ironclaw_turns/src/filesystem_store/turn_state_engine/mod.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/turn_state_engine/mod.rs
@@ -324,53 +324,6 @@ impl TurnStateEngine {
         }
     }
 
-    /// Attach a durable sink for gate-blocked turns (persist-on-block). Off the
-    /// hot path — the sink is called only when the blocked-run set changes.
-    // Preserved engine API now reachable only in-crate after the public store
-    // was eliminated (#6263); no behavior change.
-    #[allow(dead_code)]
-    pub(crate) fn with_block_persistence(
-        mut self,
-        block_persistence: Arc<dyn crate::TurnStateBlockPersistence>,
-    ) -> Self {
-        self.block_persistence = Some(block_persistence);
-        // Seed the gate-persisted set from any *gate-touched, not-yet-terminal*
-        // run rehydrated from a recovery snapshot via `from_persistence_snapshot`.
-        // `mark_gate_persisted` only fires for runs that block *live* after the
-        // sink is attached, so the restore path must be seeded here or a recovered
-        // run would reach a terminal state with `is_gate_persisted == false`, skip
-        // its durable terminal-convergence write, and be resurrected as live on
-        // the next restart.
-        //
-        // A currently-blocked run is the obvious case, but a run that blocked then
-        // resumed is persisted as `Queued`/`Running`, so status alone misses it.
-        // `checkpoint_id` is set only on the gate-block paths (`block_run` and the
-        // loop-exit block) and is not cleared on resume, so it is the durable
-        // marker that a not-yet-terminal run was gate-touched — seed from that.
-        let gate_touched: Vec<TurnRunId> = {
-            let inner = match self.inner.lock() {
-                Ok(inner) => inner,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            inner
-                .records
-                .iter()
-                .filter(|(_, record)| {
-                    !record.status.get().is_terminal() && record.checkpoint_id.is_some()
-                })
-                .map(|(run_id, _)| *run_id)
-                .collect()
-        };
-        if !gate_touched.is_empty() {
-            let mut set = match self.gate_persisted_runs.lock() {
-                Ok(set) => set,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            set.extend(gate_touched);
-        }
-        self
-    }
-
     #[allow(dead_code)] // preserved engine API, in-crate-only post-#6263
     pub(crate) fn with_admission_limit_provider(
         admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
@@ -1153,7 +1106,7 @@ impl Inner {
         } else {
             None
         };
-        let retryable = (kind == TurnEventKind::Failed).then(|| record.checkpoint_id.is_some());
+        let retryable = (kind == TurnEventKind::Failed).then(|| self.failed_run_retryable(record));
         self.events.push(TurnLifecycleEvent {
             cursor: record.event_cursor,
             scope: record.scope.clone(),

--- a/crates/ironclaw_turns/src/filesystem_store/turn_state_engine/transitions.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/turn_state_engine/transitions.rs
@@ -388,17 +388,25 @@ impl Inner {
                     run_id: request.run_id,
                 });
             }
-            let Some(source_checkpoint_id) = failed.checkpoint_id else {
-                return Err(TurnError::RunNotRetryable {
-                    run_id: request.run_id,
-                });
-            };
-            let Some(source_checkpoint) =
-                self.retryable_loop_checkpoint(failed, source_checkpoint_id)
-            else {
-                return Err(TurnError::RunNotRetryable {
-                    run_id: request.run_id,
-                });
+            let source_checkpoint = match failed.checkpoint_id {
+                Some(source_checkpoint_id) => {
+                    let Some(source_checkpoint) =
+                        self.retryable_loop_checkpoint(failed, source_checkpoint_id)
+                    else {
+                        return Err(TurnError::RunNotRetryable {
+                            run_id: request.run_id,
+                        });
+                    };
+                    Some(source_checkpoint)
+                }
+                None => {
+                    if self.run_has_loop_checkpoint(&failed.scope, failed.turn_id, failed.run_id) {
+                        return Err(TurnError::RunNotRetryable {
+                            run_id: request.run_id,
+                        });
+                    }
+                    None
+                }
             };
             (
                 TurnActiveLockKey::from(&failed.scope),
@@ -433,8 +441,9 @@ impl Inner {
         ) {
             return Err(TurnError::AdmissionRejected(rejection));
         }
-        let retry_checkpoint_id =
-            self.link_loop_checkpoint_for_retry(&source_checkpoint, new_run_id, now);
+        let retry_checkpoint_id = source_checkpoint.as_ref().map(|source_checkpoint| {
+            self.link_loop_checkpoint_for_retry(source_checkpoint, new_run_id, now)
+        });
         let event_cursor = self.next_cursor();
         let mut record = RunRecord::queued(QueuedRunFields {
             scope,
@@ -448,7 +457,7 @@ impl Inner {
             event_cursor,
             received_at: now,
         });
-        record.checkpoint_id = Some(retry_checkpoint_id);
+        record.checkpoint_id = retry_checkpoint_id;
         record.parent_run_id = parent_run_id;
         record.subagent_depth = subagent_depth;
         record.spawn_tree_root_run_id = spawn_tree_root_run_id;
@@ -1064,7 +1073,7 @@ impl Inner {
     /// "safe to re-drive from scratch" condition. A run that recorded a
     /// checkpoint (even a non-resumable `Final` one) already did work and must
     /// NOT be re-driven from scratch.
-    fn run_has_loop_checkpoint(
+    pub(super) fn run_has_loop_checkpoint(
         &self,
         scope: &TurnScope,
         turn_id: crate::TurnId,
@@ -1075,6 +1084,11 @@ impl Inner {
                 && checkpoint.turn_id == turn_id
                 && checkpoint.run_id == run_id
         })
+    }
+
+    pub(super) fn failed_run_retryable(&self, record: &RunRecord) -> bool {
+        record.checkpoint_id.is_some()
+            || !self.run_has_loop_checkpoint(&record.scope, record.turn_id, record.run_id)
     }
 
     fn latest_resumable_loop_checkpoint(

--- a/crates/ironclaw_turns/tests/retry_failed_turn_store_contract.rs
+++ b/crates/ironclaw_turns/tests/retry_failed_turn_store_contract.rs
@@ -449,20 +449,45 @@ where
     )
     .await;
     fail_claimed_run(store, &no_checkpoint_claimed).await;
-    let no_checkpoint_error = store
+    let no_checkpoint_retry = store
         .retry_turn(retry_request(
             &no_checkpoint_thread,
             no_checkpoint_claimed.state.run_id,
             &format!("idem-{prefix}-no-checkpoint-retry"),
         ))
         .await
-        .unwrap_err();
-    assert_eq!(
-        no_checkpoint_error,
-        TurnError::RunNotRetryable {
-            run_id: no_checkpoint_claimed.state.run_id
-        }
+        .unwrap();
+    assert_ne!(
+        no_checkpoint_retry.run_id,
+        no_checkpoint_claimed.state.run_id
     );
+    assert_eq!(no_checkpoint_retry.status, TurnStatus::Queued);
+    let no_checkpoint_retry_state = store
+        .get_run_state(GetRunStateRequest {
+            scope: scope(&no_checkpoint_thread),
+            run_id: no_checkpoint_retry.run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(no_checkpoint_retry_state.checkpoint_id, None);
+    let no_checkpoint_claimed_retry = store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: TurnRunnerId::new(),
+            lease_token: TurnLeaseToken::new(),
+            scope_filter: Some(scope(&no_checkpoint_thread)),
+        })
+        .await
+        .unwrap()
+        .expect("checkpointless retry should replay from the accepted message");
+    assert_eq!(
+        no_checkpoint_claimed_retry.state.run_id,
+        no_checkpoint_retry.run_id
+    );
+    assert_eq!(
+        no_checkpoint_claimed_retry.state.accepted_message_ref,
+        no_checkpoint_claimed.state.accepted_message_ref
+    );
+    assert_eq!(no_checkpoint_claimed_retry.state.checkpoint_id, None);
 
     let side_effect_thread = format!("{prefix}-side-effect");
     let (side_effect_run_id, _) = seed_failed_run_with_checkpoint(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -675,6 +675,11 @@ async def reset_mock_llm_state(mock_llm_server):
         )
         response.raise_for_status()
         response = await client.post(
+            f"{mock_llm_server}/__mock/llm_faults/reset",
+            timeout=10,
+        )
+        response.raise_for_status()
+        response = await client.post(
             f"{mock_llm_server}/__mock/capability_policy/reset",
             timeout=10,
         )

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -954,6 +954,32 @@ TOOL_CALL_PATTERNS = [
 _github_api_url: str = "https://api.github.com"
 _last_chat_request: dict | None = None
 _chat_requests: list[dict] = []
+_llm_fault_scripts: list[dict] = []
+
+
+def _reset_llm_fault_scripts() -> None:
+    _llm_fault_scripts.clear()
+
+
+def _latest_user_matches_fault(messages: list[dict], match_text: str) -> bool:
+    latest_user = _last_user_content(messages).lower()
+    return match_text.lower() in latest_user
+
+
+def _next_llm_fault_action(messages: list[dict]) -> dict | None:
+    for script in list(_llm_fault_scripts):
+        match_text = str(script.get("match", ""))
+        actions = script.get("actions")
+        if not match_text or not isinstance(actions, list):
+            continue
+        if not _latest_user_matches_fault(messages, match_text):
+            continue
+        if not actions:
+            continue
+        action = actions.pop(0)
+        script["applied"] = int(script.get("applied", 0)) + 1
+        return action if isinstance(action, dict) else None
+    return None
 
 
 def _new_oauth_state() -> dict:
@@ -2434,6 +2460,52 @@ async def _dispatch_special_response(
     return await _stream_text(request, cid, text)
 
 
+async def _broken_stream_before_text(request: web.Request, cid: str) -> web.StreamResponse:
+    resp = web.StreamResponse(
+        status=200,
+        headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+    )
+    await resp.prepare(request)
+    await resp.write(f"data: {{\"id\":\"{cid}\",\"choices\":[{{\"delta\":".encode())
+    return resp
+
+
+async def _apply_llm_fault_action(
+    request: web.Request,
+    cid: str,
+    stream: bool,
+    action: dict,
+) -> web.StreamResponse | web.Response | None:
+    action_type = action.get("type")
+    if action_type == "delay":
+        await asyncio.sleep(float(action.get("seconds", 1.0)))
+        return None
+    if action_type == "http_error":
+        status = int(action.get("status", 502))
+        return web.json_response(
+            {
+                "error": {
+                    "message": action.get("message", "scripted mock LLM failure"),
+                    "type": "server_error",
+                }
+            },
+            status=status,
+        )
+    if action_type == "broken_stream_before_text":
+        if stream:
+            return await _broken_stream_before_text(request, cid)
+        return web.json_response(
+            {
+                "error": {
+                    "message": "scripted stream fault requested for non-streaming call",
+                    "type": "server_error",
+                }
+            },
+            status=502,
+        )
+    return None
+
+
 async def chat_completions(request: web.Request) -> web.StreamResponse:
     """Handle POST /v1/chat/completions and /chat/completions."""
     global _last_chat_request
@@ -2446,6 +2518,17 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
     has_tools = bool(tools)
     available_tool_names = _advertised_tool_names(tools)
     cid = f"mock-{uuid.uuid4().hex[:8]}"
+
+    fault_action = _next_llm_fault_action(messages)
+    if fault_action:
+        fault_response = await _apply_llm_fault_action(
+            request,
+            cid,
+            stream,
+            fault_action,
+        )
+        if fault_response is not None:
+            return fault_response
 
     slow_response_delay = _conversation_slow_response_delay(messages)
     if slow_response_delay > 0:
@@ -3272,11 +3355,64 @@ def main():
         _chat_requests.clear()
         return web.json_response({"ok": True})
 
+    async def set_llm_faults(request: web.Request) -> web.Response:
+        body = await request.json()
+        faults = body.get("faults", [])
+        if not isinstance(faults, list):
+            return web.json_response(
+                {"ok": False, "error": "faults must be a list"},
+                status=400,
+            )
+        parsed_scripts = []
+        for fault in faults:
+            if not isinstance(fault, dict):
+                return web.json_response(
+                    {"ok": False, "error": "each fault must be an object"},
+                    status=400,
+                )
+            match_text = fault.get("match")
+            actions = fault.get("actions")
+            if not isinstance(match_text, str) or not match_text:
+                return web.json_response(
+                    {"ok": False, "error": "fault.match must be a non-empty string"},
+                    status=400,
+                )
+            if not isinstance(actions, list):
+                return web.json_response(
+                    {"ok": False, "error": "fault.actions must be a list"},
+                    status=400,
+                )
+            if not all(isinstance(action, dict) for action in actions):
+                return web.json_response(
+                    {"ok": False, "error": "fault.actions entries must be objects"},
+                    status=400,
+                )
+            parsed_scripts.append(
+                {
+                    "match": match_text,
+                    "actions": [dict(action) for action in actions],
+                    "applied": 0,
+                }
+            )
+        _reset_llm_fault_scripts()
+        _llm_fault_scripts.extend(parsed_scripts)
+        return web.json_response({"ok": True, "faults": _llm_fault_scripts})
+
+    async def get_llm_faults(request: web.Request) -> web.Response:
+        return web.json_response({"faults": _llm_fault_scripts})
+
+    async def reset_llm_faults(request: web.Request) -> web.Response:
+        _reset_llm_fault_scripts()
+        return web.json_response({"ok": True})
+
     app.router.add_post("/__mock/set_github_api_url", set_github_api_url)
     app.router.add_get("/__mock/github_api_url", get_github_api_url)
     app.router.add_get("/__mock/last_chat_request", get_last_chat_request)
     app.router.add_get("/__mock/chat_requests", get_chat_requests)
     app.router.add_post("/__mock/chat_requests/reset", reset_chat_requests)
+    app.router.add_post("/__mock/llm_faults", set_llm_faults)
+    app.router.add_get("/__mock/llm_faults", get_llm_faults)
+    app.router.add_post("/__mock/llm_faults/reset", reset_llm_faults)
     # Mock MCP server endpoints
     app.router.add_post("/mcp", mcp_endpoint)
     app.router.add_post("/mcp-400", mcp_endpoint_400)

--- a/tests/e2e/scenarios/test_reborn_webui_v2_streaming_run_control_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_streaming_run_control_api.py
@@ -6,25 +6,198 @@ contract proxies to caller-facing coverage through a real
 the browser suites; this file focuses on served SSE and control routes.
 """
 
+import asyncio
 import json
 
 import aiohttp
 import httpx
 
 from helpers import REBORN_V2_AUTH_TOKEN, sse_stream, wait_for_sse_line
-from reborn_webui_harness import client_action_id, create_thread, reborn_bearer_headers
+from reborn_webui_harness import (
+    client_action_id,
+    create_thread,
+    fetch_timeline,
+    reborn_bearer_headers,
+)
 
 pytest_plugins = ["reborn_webui_harness"]
 
 
-async def _submit_message(client: httpx.AsyncClient, base_url: str, thread_id: str) -> dict:
+async def _submit_message(
+    client: httpx.AsyncClient,
+    base_url: str,
+    thread_id: str,
+    content: str = "hello streaming",
+) -> dict:
     response = await client.post(
         f"{base_url}/api/webchat/v2/threads/{thread_id}/messages",
-        json={"client_action_id": client_action_id(), "content": "hello streaming"},
+        json={"client_action_id": client_action_id(), "content": content},
         timeout=30,
     )
     assert response.status_code in (200, 202), response.text
     return response.json()
+
+
+async def _set_llm_faults(mock_llm_server: str, faults: list[dict]) -> None:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{mock_llm_server}/__mock/llm_faults",
+            json={"faults": faults},
+            timeout=10,
+        )
+        response.raise_for_status()
+
+
+def _message_text(message: dict) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                parts.append(part["text"])
+        return " ".join(parts)
+    return ""
+
+
+def _request_has_user_marker(request: dict, marker: str) -> bool:
+    for message in request.get("messages", []):
+        if message.get("role") == "user" and marker.lower() in _message_text(message).lower():
+            return True
+    return False
+
+
+async def _mock_llm_requests_matching(mock_llm_server: str, marker: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{mock_llm_server}/__mock/chat_requests",
+            timeout=10,
+        )
+        response.raise_for_status()
+    return [
+        request
+        for request in response.json().get("requests", [])
+        if _request_has_user_marker(request, marker)
+    ]
+
+
+async def _wait_for_mock_llm_request_count(
+    mock_llm_server: str,
+    marker: str,
+    count: int,
+    *,
+    timeout: float = 30.0,
+) -> list[dict]:
+    deadline = asyncio.get_running_loop().time() + timeout
+    last_requests: list[dict] = []
+    while asyncio.get_running_loop().time() < deadline:
+        last_requests = await _mock_llm_requests_matching(mock_llm_server, marker)
+        if len(last_requests) >= count:
+            return last_requests
+        await asyncio.sleep(0.25)
+    raise AssertionError(
+        f"Timed out waiting for {count} mock LLM request(s) matching {marker!r}; "
+        f"observed {len(last_requests)}"
+    )
+
+
+async def _wait_for_assistant_content(
+    client: httpx.AsyncClient,
+    base_url: str,
+    thread_id: str,
+    needle: str,
+    *,
+    timeout: float = 45.0,
+) -> dict:
+    deadline = asyncio.get_running_loop().time() + timeout
+    last_timeline: dict = {}
+    while asyncio.get_running_loop().time() < deadline:
+        last_timeline = await fetch_timeline(client, base_url, thread_id)
+        for message in last_timeline.get("messages", []):
+            if (
+                message.get("kind") == "assistant"
+                and message.get("status") == "finalized"
+                and needle.lower() in (message.get("content") or "").lower()
+            ):
+                return message
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"Timed out waiting for assistant content containing {needle!r}. "
+        f"Last timeline: {last_timeline}"
+    )
+
+
+async def _wait_for_run_completed_sse_event(
+    response,
+    run_id: str,
+    *,
+    timeout: float = 60.0,
+) -> dict:
+    line = await wait_for_sse_line(
+        response,
+        predicate=lambda value: value.startswith("data:")
+        and run_id in value
+        and '"status":"completed"' in value,
+        timeout=timeout,
+    )
+    event = json.loads(line.removeprefix("data:").strip())
+    assert event.get("cursor"), event
+    return event
+
+
+async def _run_fault_scenario(
+    reborn_v2_server: str,
+    mock_llm_server: str,
+    *,
+    marker: str,
+    actions: list[dict],
+    expected_request_count: int,
+) -> None:
+    await _set_llm_faults(
+        mock_llm_server,
+        [{"match": marker, "actions": actions}],
+    )
+
+    headers = reborn_bearer_headers()
+    async with httpx.AsyncClient(headers=headers) as client:
+        thread_id = await create_thread(client, reborn_v2_server)
+        async with sse_stream(
+            reborn_v2_server,
+            path=f"/api/webchat/v2/threads/{thread_id}/events",
+            token=REBORN_V2_AUTH_TOKEN,
+            timeout=65,
+        ) as events:
+            assert events.status == 200
+            submitted = await _submit_message(
+                client,
+                reborn_v2_server,
+                thread_id,
+                f"{marker}: what is 2+2?",
+            )
+            sse_event = await _wait_for_run_completed_sse_event(
+                events,
+                submitted["run_id"],
+                timeout=60,
+            )
+            assistant = await _wait_for_assistant_content(
+                client,
+                reborn_v2_server,
+                thread_id,
+                "4",
+                timeout=60,
+            )
+
+    requests = await _wait_for_mock_llm_request_count(
+        mock_llm_server,
+        marker,
+        expected_request_count,
+    )
+    assert submitted["run_id"] in json.dumps(sse_event)
+    assert assistant["content"] == "The answer is 4."
+    assert all(
+        request.get("stream") is True for request in requests[:expected_request_count]
+    )
 
 
 async def test_reborn_v2_sse_stream_accepts_bearer_served(
@@ -164,3 +337,117 @@ async def test_reborn_v2_cancel_and_gate_control_routes_served(reborn_v2_server)
             timeout=15,
         )
         assert unauthenticated_gate.status_code == 401
+
+
+async def test_reborn_v2_retries_mock_llm_http_error_then_finalizes(
+    reborn_v2_server,
+    mock_llm_server,
+):
+    marker = "mock llm http retry e2e"
+    await _run_fault_scenario(
+        reborn_v2_server,
+        mock_llm_server,
+        marker=marker,
+        actions=[
+            {
+                "type": "http_error",
+                "status": 502,
+                "message": "scripted transient provider failure",
+            }
+        ],
+        expected_request_count=2,
+    )
+
+
+async def test_reborn_v2_retries_mock_llm_broken_sse_stream_then_finalizes(
+    reborn_v2_server,
+    mock_llm_server,
+):
+    marker = "mock llm broken sse retry e2e"
+    await _run_fault_scenario(
+        reborn_v2_server,
+        mock_llm_server,
+        marker=marker,
+        actions=[{"type": "broken_stream_before_text"}],
+        expected_request_count=2,
+    )
+
+
+async def test_reborn_v2_delayed_mock_llm_response_finalizes(
+    reborn_v2_server,
+    mock_llm_server,
+):
+    marker = "mock llm delayed response e2e"
+    await _run_fault_scenario(
+        reborn_v2_server,
+        mock_llm_server,
+        marker=marker,
+        actions=[{"type": "delay", "seconds": 1.25}],
+        expected_request_count=1,
+    )
+
+
+async def test_reborn_v2_cancel_delayed_mock_llm_inference_releases_thread(
+    reborn_v2_server,
+    mock_llm_server,
+):
+    marker = "mock llm cancel delayed inference e2e"
+    await _set_llm_faults(
+        mock_llm_server,
+        [
+            {
+                "match": marker,
+                "actions": [{"type": "delay", "seconds": 10.0}],
+            }
+        ],
+    )
+
+    headers = reborn_bearer_headers()
+    async with httpx.AsyncClient(headers=headers) as client:
+        thread_id = await create_thread(client, reborn_v2_server)
+        submitted = await _submit_message(
+            client,
+            reborn_v2_server,
+            thread_id,
+            f"{marker}: hold this inference open",
+        )
+        run_id = submitted["run_id"]
+
+        await _wait_for_mock_llm_request_count(mock_llm_server, marker, 1, timeout=15)
+
+        cancel = await client.post(
+            f"{reborn_v2_server}/api/webchat/v2/threads/{thread_id}/runs/{run_id}/cancel",
+            json={
+                "client_action_id": client_action_id(),
+                "reason": "user_requested",
+            },
+            timeout=15,
+        )
+        assert cancel.status_code == 200, cancel.text
+        cancel_body = cancel.json()
+        assert cancel_body["run_id"] == run_id
+        assert cancel_body["status"] in {"CancelRequested", "Cancelled"}
+
+        for _ in range(60):
+            follow_up = await _submit_message(
+                client,
+                reborn_v2_server,
+                thread_id,
+                "post cancel follow-up: what is 2+2?",
+            )
+            if follow_up.get("outcome") in {"submitted", "already_submitted"}:
+                break
+            assert follow_up.get("outcome") == "rejected_busy", follow_up
+            await asyncio.sleep(0.5)
+        else:
+            raise AssertionError("Thread stayed busy after cancelling a delayed inference")
+
+        assistant = await _wait_for_assistant_content(
+            client,
+            reborn_v2_server,
+            thread_id,
+            "4",
+            timeout=60,
+        )
+
+    assert assistant["content"] == "The answer is 4."


### PR DESCRIPTION
## Summary

- Wire Rig-backed LLM calls through provider streaming and preserve streamed reasoning while emitting text deltas through the existing sink.
- Add programmable Python mock LLM faults for delayed responses, transient HTTP errors, and broken SSE streams, committed atomically after validation.
- Cover WebUI v2 served streaming/retry/cancel behavior, including `stream: true` request assertions and lifecycle SSE completion.
- Allow failed runs with no checkpoint records to retry from the accepted user message, while preserving checkpoint resume for resumable checkpoints and rejecting non-resumable checkpoint states.
- Add runner coverage for retrying after a transient checkpoint-state outage before the first checkpoint write.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check` equivalent: `cargo fmt -p ironclaw_llm -p ironclaw_turns -p ironclaw_runner`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` equivalent: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass:
  - `python3 -m py_compile tests/e2e/mock_llm.py tests/e2e/conftest.py tests/e2e/scenarios/test_reborn_webui_v2_streaming_run_control_api.py`
  - `cargo test -p ironclaw_llm rig_adapter`
  - `cargo test -p ironclaw_turns --test retry_failed_turn_store_contract`
  - `cargo test -p ironclaw_runner --all-features --test loop_driver_host`
  - `python3 -m pytest -q tests/e2e/scenarios/test_reborn_webui_v2_streaming_run_control_api.py`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: served WebUI v2 E2E exercises mock LLM delay, broken stream, transient error, streaming request shape, and cancellation thread release.
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review: addressed unresolved review threads and reran local validation.

## Security Impact

No new credentials, permissions, sandbox policy, or file access. This changes provider request shape to use streaming for Rig-backed model calls and adds hermetic mock-server fault controls under E2E tests only.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new public trust-bearing types; retry stays inside the turn-state store and existing coordinator/runner path.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: unchanged; original accepted user message ref is replayed through the existing turn execution path.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: no hash changes.
- [x] New/changed status, exit, policy, runtime, or error variants: no new variants; existing `host_stage_unavailable_checkpoint` and retryable lifecycle flag are reused. Audited through `rg -n "host_stage_unavailable_checkpoint|RunNotRetryable|retry_turn_once|run_has_loop_checkpoint" crates/ironclaw_turns crates/ironclaw_runner`.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: no new persisted fields or schema changes.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: retry remains under existing admission/thread-lock/idempotency paths; mock fault scripts are reset between tests and committed atomically.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent): existing checkpoint unavailable category remains stable and retryable when safe.
- [x] Sandbox/native/host names accurately describe trust boundary: no sandbox/native host naming changes.

## Database Impact

None. No migrations or schema changes. Turn-state retry semantics are covered against the filesystem-backed row store contract.

## Blast Radius

Touches Rig-backed LLM streaming, Reborn turn retry classification, runner checkpoint-outage behavior, and WebUI v2 served E2E mock LLM scenarios. Regressions would most likely appear as provider streaming request-shape issues, missing reasoning metadata in streamed completions, or incorrect retry affordances for failed runs.

## Rollback Plan

Revert this PR commit. That returns Rig-backed WebUI runs to the previous non-streaming provider path and restores the old checkpoint-only retry behavior. No data migration rollback is required.

## Review Follow-Through

Addressed review feedback for reasoning propagation, duplicated stream-drain logic, dead test seam shape after turn-state decomposition, duplicate checkpoint helper use, atomic mock LLM fault validation, and duplicated E2E fault scenario structure. Existing IronLoop reviewer could not run validation in its environment; local validation above was run after the latest rebase.

---

**Review track**: C (runtime/turn retry and provider streaming behavior)
