### PR TITLE
perf(turns): serve durable turn-event reads via an indexed scope+cursor query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
  "ironclaw_host_api",
  "ironclaw_observability",
  "ironclaw_turns",
+ "libsql",
  "rand 0.10.1",
  "serde",
  "serde_jcs",

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -41,6 +41,14 @@ uuid = { version = "1", features = ["v4", "serde"] }
 [dev-dependencies]
 # Self-reference so the crate's own integration tests see `test_support`.
 ironclaw_turns = { path = ".", features = ["test-support"] }
+# Test-only: the durable-read perf harness (`events_query_stress`) builds a real
+# libSQL-backed store. Matches `ironclaw_filesystem`'s libsql feature set.
+libsql = { version = "0.9", default-features = false, features = [
+    "core",
+    "replication",
+    "remote",
+    "tls",
+] }
 rand = "0.10"
 static_assertions = "1"
 tempfile = "3"

--- a/crates/ironclaw_turns/src/filesystem_store/row_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store.rs
@@ -24,6 +24,7 @@ use super::{
 
 mod commit;
 mod delta;
+mod events_index;
 mod io;
 mod journal;
 mod load;
@@ -113,6 +114,13 @@ where
     /// [`TurnStateStoreLimits::max_pending_write_behind_deltas`]; at the cap
     /// the next non-critical op awaits the oldest before enqueuing.
     pending_write_behind: AsyncMutex<VecDeque<DeltaAck>>,
+    /// One-time-per-process readiness of the durable event-row index used by
+    /// the query-backed `read_turn_events_after` path: declares the event
+    /// indexes and runs the pre-index-projection backfill exactly once. Caches
+    /// `true` when the query path is usable and `false` when the mount does not
+    /// support `query`/`ensure_index` (byte-only fallback backends), so the
+    /// read path degrades to the legacy directory scan without re-probing.
+    events_index_ready: tokio::sync::OnceCell<bool>,
 }
 
 struct PendingRowCommit<T> {
@@ -157,6 +165,7 @@ where
             delta_journal: DeltaJournal::new(filesystem, materialize_gate),
             apply_timeout: FILESYSTEM_APPLY_TIMEOUT,
             pending_write_behind: AsyncMutex::new(VecDeque::new()),
+            events_index_ready: tokio::sync::OnceCell::new(),
         }
     }
 

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/events_index.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/events_index.rs
@@ -1,0 +1,221 @@
+//! Indexed-projection + query primitives for the durable turn-event rows.
+//!
+//! Event rows live under the `events` row collection keyed by a zero-padded
+//! [`EventCursor`] (`event_record_key`), so their on-disk path order already
+//! equals cursor order — both production backends (`libSQL`, `Postgres`) and
+//! the in-memory reference backend `ORDER BY path` in
+//! [`RootFilesystem::query`](ironclaw_filesystem::RootFilesystem::query). To
+//! serve `read_turn_events_after` with an indexed range scan (instead of
+//! listing the whole collection and reading every row body after the cursor
+//! across *all* of a store's threads), each event row projects two indexed
+//! values into [`Entry::indexed`](ironclaw_filesystem::Entry::indexed):
+//!
+//! - `scope_key` ([`IndexValue::Text`]) — the coarse
+//!   `(tenant, agent, project, thread)` scope key, deliberately *ignoring*
+//!   `thread_owner` (mirrors the active-run exclusivity key). A coarser key can
+//!   only ever over-fetch — `project_turn_events` re-filters on the full
+//!   [`TurnScope`] equality — so it never drops an in-scope event, while still
+//!   pruning the cross-thread rows that dominate a multi-thread store.
+//! - `cursor` ([`IndexValue::I64`]) — the event cursor, so a `cursor > after`
+//!   range predicate runs in the backend.
+//!
+//! The read path filters `And(Eq{scope_key}, Range{cursor})`; the resulting
+//! materialized bodies flow into the unchanged
+//! [`project_turn_events`](crate::events::project_turn_events), preserving every
+//! scope/owner/retention/rebase/pagination semantic the legacy directory scan
+//! produced.
+
+use std::collections::BTreeMap;
+
+use ironclaw_filesystem::{Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue};
+
+use crate::{EventCursor, TurnError, TurnLifecycleEvent, TurnScope};
+
+/// Indexed key carrying the coarse scope identity of an event row.
+const EVENTS_SCOPE_KEY: &str = "scope_key";
+/// Indexed key carrying the event cursor of an event row.
+const EVENTS_CURSOR_KEY: &str = "cursor";
+/// Declared index over `scope_key`.
+const EVENTS_SCOPE_INDEX_NAME: &str = "turn_events_scope";
+/// Declared index over `cursor`.
+const EVENTS_CURSOR_INDEX_NAME: &str = "turn_events_cursor";
+
+fn index_key(raw: &'static str) -> Result<IndexKey, TurnError> {
+    IndexKey::new(raw).map_err(|error| TurnError::Unavailable {
+        reason: format!("invalid turn-events index key {raw}: {error}"),
+    })
+}
+
+fn index_name(raw: &'static str) -> Result<IndexName, TurnError> {
+    IndexName::new(raw).map_err(|error| TurnError::Unavailable {
+        reason: format!("invalid turn-events index name {raw}: {error}"),
+    })
+}
+
+pub(super) fn scope_index_key() -> Result<IndexKey, TurnError> {
+    index_key(EVENTS_SCOPE_KEY)
+}
+
+pub(super) fn cursor_index_key() -> Result<IndexKey, TurnError> {
+    index_key(EVENTS_CURSOR_KEY)
+}
+
+/// Coarse `(tenant, agent, project, thread)` scope key, ignoring
+/// `thread_owner`. Equal-by-this-key scopes always produce byte-identical
+/// strings, so the projection never under-fetches an in-scope event; distinct
+/// threads produce distinct keys, which is the pruning the query relies on. A
+/// `\u{1f}` (unit separator) delimiter keeps unrelated ids from concatenating
+/// into a collision — but even a collision would only over-fetch (safe), never
+/// drop an event, because `project_turn_events` re-filters on full scope
+/// equality.
+pub(super) fn event_scope_index_value(scope: &TurnScope) -> String {
+    let agent = scope
+        .agent_id
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let project = scope
+        .project_id
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    format!(
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        scope.tenant_id, agent, project, scope.thread_id
+    )
+}
+
+/// Cursor values are assigned by a monotonic `u64`; a real deployment never
+/// approaches `i64::MAX`, but saturate rather than wrap so an out-of-range
+/// value degrades to "always the top of the range" instead of a negative
+/// integer the backend would compare incorrectly.
+fn cursor_to_i64(cursor: EventCursor) -> i64 {
+    i64::try_from(cursor.0).unwrap_or(i64::MAX)
+}
+
+/// The indexed projection written alongside an event row body so the durable
+/// read path can serve a scoped range scan.
+pub(super) fn event_indexed_projection(
+    event: &TurnLifecycleEvent,
+) -> Result<BTreeMap<IndexKey, IndexValue>, TurnError> {
+    let mut indexed = BTreeMap::new();
+    indexed.insert(
+        scope_index_key()?,
+        IndexValue::Text(event_scope_index_value(&event.scope)),
+    );
+    indexed.insert(
+        cursor_index_key()?,
+        IndexValue::I64(cursor_to_i64(event.cursor)),
+    );
+    Ok(indexed)
+}
+
+/// The index specs declared once on the events row prefix. Two single-key
+/// `Exact` indexes rather than one composite, so a backend that only supports
+/// single-key indexes still accepts them; the `And(Eq, Range)` filter works
+/// against either regardless of which the backend uses.
+pub(super) fn event_index_specs() -> Result<Vec<IndexSpec>, TurnError> {
+    Ok(vec![
+        IndexSpec::new(
+            index_name(EVENTS_SCOPE_INDEX_NAME)?,
+            vec![scope_index_key()?],
+            IndexKind::Exact,
+        ),
+        IndexSpec::new(
+            index_name(EVENTS_CURSOR_INDEX_NAME)?,
+            vec![cursor_index_key()?],
+            IndexKind::Exact,
+        ),
+    ])
+}
+
+/// Filter matching this scope's events with `cursor > after` — the exact set
+/// the legacy directory scan pre-filtered before `project_turn_events`.
+pub(super) fn events_query_filter(
+    scope: &TurnScope,
+    after: Option<EventCursor>,
+) -> Result<Filter, TurnError> {
+    let after_cursor = after.map(|cursor| cursor.0).unwrap_or(0);
+    // `cursor > after` == `cursor` in `[after + 1, i64::MAX]`.
+    let lo = cursor_to_i64(EventCursor(after_cursor)).saturating_add(1);
+    Ok(Filter::And(vec![
+        Filter::Eq {
+            key: scope_index_key()?,
+            value: IndexValue::Text(event_scope_index_value(scope)),
+        },
+        Filter::Range {
+            key: cursor_index_key()?,
+            lo: IndexValue::I64(lo),
+            hi: IndexValue::I64(i64::MAX),
+        },
+    ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+
+    use super::*;
+    use crate::TurnScope;
+
+    fn scope(thread: &str, owner: Option<&str>) -> TurnScope {
+        TurnScope::new_with_owner(
+            TenantId::new("tenant-a").expect("tenant"),
+            Some(AgentId::new("agent-a").expect("agent")),
+            Some(ProjectId::new("project-a").expect("project")),
+            ThreadId::new(thread).expect("thread"),
+            owner.map(|o| UserId::new(o).expect("owner")),
+        )
+    }
+
+    #[test]
+    fn scope_key_ignores_thread_owner_so_it_never_underfetches() {
+        // Two scopes equal on (tenant, agent, project, thread) but differing on
+        // owner MUST share a key — otherwise an owner change would hide events
+        // that `project_turn_events` (full-equality filter) still wants.
+        let a = event_scope_index_value(&scope("thread-a", Some("owner-1")));
+        let b = event_scope_index_value(&scope("thread-a", Some("owner-2")));
+        let c = event_scope_index_value(&scope("thread-a", None));
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn scope_key_distinguishes_threads() {
+        assert_ne!(
+            event_scope_index_value(&scope("thread-a", None)),
+            event_scope_index_value(&scope("thread-b", None)),
+        );
+    }
+
+    #[test]
+    fn query_filter_encodes_cursor_strictly_greater_than_after() {
+        let filter =
+            events_query_filter(&scope("thread-a", None), Some(EventCursor(5))).expect("filter");
+        let Filter::And(children) = filter else {
+            panic!("expected And filter, got {filter:?}");
+        };
+        assert!(matches!(
+            children.iter().find_map(|f| match f {
+                Filter::Range { lo, .. } => Some(lo),
+                _ => None,
+            }),
+            Some(IndexValue::I64(6))
+        ));
+    }
+
+    #[test]
+    fn query_filter_from_origin_starts_at_cursor_one() {
+        let filter = events_query_filter(&scope("thread-a", None), None).expect("filter");
+        let Filter::And(children) = filter else {
+            panic!("expected And filter");
+        };
+        assert!(matches!(
+            children.iter().find_map(|f| match f {
+                Filter::Range { lo, .. } => Some(lo),
+                _ => None,
+            }),
+            Some(IndexValue::I64(1))
+        ));
+    }
+}

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/io.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/io.rs
@@ -7,6 +7,7 @@ use crate::TurnError;
 const ROW_ROOT: &str = "/turns/rows/v1";
 const META_DIR: &str = "meta";
 const META_FILE: &str = "state.json";
+const EVENTS_INDEX_MARKER_FILE: &str = "events-index.json";
 const DELTA_LOG: &str = "deltas/log";
 
 pub(super) fn row_dir(collection: &str) -> Result<ScopedPath, TurnError> {
@@ -19,6 +20,25 @@ pub(super) fn row_path(collection: &str, key: &str) -> Result<ScopedPath, TurnEr
 
 pub(super) fn meta_path() -> Result<ScopedPath, TurnError> {
     scoped_row_path(format!("{ROW_ROOT}/{META_DIR}/{META_FILE}"))
+}
+
+/// Durable marker that the one-time backfill of `Entry::indexed` projections
+/// onto pre-existing event rows has completed. Kept as its own record rather
+/// than a field on [`RowStoreMeta`](super::delta::RowStoreMeta) so it stays
+/// independent of the journal-seq/retention-floor forward-merge CAS logic that
+/// governs the main meta record.
+pub(super) fn events_index_marker_path() -> Result<ScopedPath, TurnError> {
+    scoped_row_path(format!("{ROW_ROOT}/{META_DIR}/{EVENTS_INDEX_MARKER_FILE}"))
+}
+
+/// State of the durable event-index backfill migration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(super) struct EventsIndexMarker {
+    /// `true` once every event row persisted before the indexed-projection
+    /// change has been re-projected, so the query-backed read path will find
+    /// historical events.
+    #[serde(default)]
+    pub(super) backfilled: bool,
 }
 
 pub(super) fn delta_log_path() -> Result<ScopedPath, TurnError> {

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/journal.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/journal.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -7,7 +8,8 @@ use std::{
 };
 
 use ironclaw_filesystem::{
-    CasExpectation, ContentType, Entry, FilesystemError, RootFilesystem, ScopedFilesystem, SeqNo,
+    CasExpectation, ContentType, Entry, FilesystemError, IndexKey, IndexValue, RootFilesystem,
+    ScopedFilesystem, SeqNo,
 };
 use ironclaw_host_api::ResourceScope;
 use tokio::{
@@ -414,14 +416,7 @@ where
         delete_row(filesystem, RowCollection::Idempotency, key, journal_seq).await?;
     }
     for record in &delta.events_upsert {
-        put_row(
-            filesystem,
-            RowCollection::Events,
-            &event_record_key(record)?,
-            journal_seq,
-            record,
-        )
-        .await?;
+        put_event_row(filesystem, &event_record_key(record)?, journal_seq, record).await?;
     }
     for key in &delta.events_delete {
         delete_row(filesystem, RowCollection::Events, key, journal_seq).await?;
@@ -479,7 +474,41 @@ where
     T: serde::Serialize,
 {
     let body = serialize_materialized_row(journal_seq, Some(record), collection.as_str())?;
-    write_materialized_row(filesystem, collection, key, journal_seq, body).await
+    write_materialized_row(
+        filesystem,
+        collection,
+        key,
+        journal_seq,
+        body,
+        BTreeMap::new(),
+    )
+    .await
+}
+
+/// Materialize an event row *with* its indexed projection so the durable
+/// read path can serve a scoped `cursor > after` range scan. Same body layout
+/// and seq-skip CAS as [`put_row`]; only the `indexed` map differs.
+async fn put_event_row<F>(
+    filesystem: &ScopedFilesystem<F>,
+    key: &str,
+    journal_seq: SeqNo,
+    record: &crate::TurnLifecycleEvent,
+) -> Result<(), TurnError>
+where
+    F: RootFilesystem,
+{
+    let body =
+        serialize_materialized_row(journal_seq, Some(record), RowCollection::Events.as_str())?;
+    let indexed = super::events_index::event_indexed_projection(record)?;
+    write_materialized_row(
+        filesystem,
+        RowCollection::Events,
+        key,
+        journal_seq,
+        body,
+        indexed,
+    )
+    .await
 }
 
 async fn delete_row<F>(
@@ -493,7 +522,18 @@ where
 {
     let body =
         serialize_materialized_row::<serde_json::Value>(journal_seq, None, collection.as_str())?;
-    write_materialized_row(filesystem, collection, key, journal_seq, body).await
+    // Tombstones carry no indexed projection: they must never match a scoped
+    // event query (their `value` is `None`), and dropping the projection keeps
+    // the deleted cursor from lingering in the index.
+    write_materialized_row(
+        filesystem,
+        collection,
+        key,
+        journal_seq,
+        body,
+        BTreeMap::new(),
+    )
+    .await
 }
 
 async fn write_materialized_row<F>(
@@ -502,6 +542,7 @@ async fn write_materialized_row<F>(
     key: &str,
     journal_seq: SeqNo,
     body: Vec<u8>,
+    indexed: BTreeMap<IndexKey, IndexValue>,
 ) -> Result<(), TurnError>
 where
     F: RootFilesystem,
@@ -523,7 +564,8 @@ where
             }
             None => CasExpectation::Absent,
         };
-        let entry = Entry::bytes(body.clone()).with_content_type(ContentType::json());
+        let mut entry = Entry::bytes(body.clone()).with_content_type(ContentType::json());
+        entry.indexed = indexed.clone();
         match filesystem
             .put(&ResourceScope::system(), &path, entry, cas)
             .await

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/load.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/load.rs
@@ -512,54 +512,65 @@ where
             Err(error) => return Err(fs_error(error)),
         };
         let scope_key = events_index::scope_index_key()?;
-        let mut reprojected = 0usize;
-        for entry in entries {
-            if entry.file_type != FileType::File {
-                continue;
-            }
-            let Some(key) = entry.name.strip_suffix(".json") else {
-                continue;
-            };
-            let path = row_path(RowCollection::Events.as_str(), key)?;
-            let Some(versioned) = self
-                .filesystem
-                .get(&ResourceScope::system(), &path)
-                .await
-                .map_err(fs_error)?
-            else {
-                continue;
-            };
-            if versioned.entry.indexed.contains_key(&scope_key) {
-                continue; // already projected (written after the upgrade)
-            }
-            let Some(event) = deserialize_materialized_row::<TurnLifecycleEvent>(
-                &versioned.entry.body,
-                RowCollection::Events.as_str(),
-            )?
-            else {
-                continue; // tombstone — no projection needed
-            };
-            let mut new_entry =
-                Entry::bytes(versioned.entry.body.clone()).with_content_type(ContentType::json());
-            new_entry.indexed = events_index::event_indexed_projection(&event)?;
-            match self
-                .filesystem
-                .put(
-                    &ResourceScope::system(),
-                    &path,
-                    new_entry,
-                    CasExpectation::Version(versioned.version),
-                )
-                .await
-            {
-                Ok(_) => reprojected += 1,
-                // A concurrent materialize rewrote the row (with its own
-                // projection) or deleted it; either way our backfill is moot.
-                Err(FilesystemError::VersionMismatch { .. })
-                | Err(FilesystemError::NotFound { .. }) => {}
-                Err(error) => return Err(fs_error(error)),
-            }
-        }
+        let paths = entries
+            .into_iter()
+            .filter(|entry| entry.file_type == FileType::File)
+            .filter_map(|entry| entry.name.strip_suffix(".json").map(ToString::to_string))
+            .map(|key| row_path(RowCollection::Events.as_str(), &key))
+            .collect::<Result<Vec<_>, _>>()?;
+        // Re-project at the same bounded fan-out the row-collection read path
+        // uses (`ROW_COLLECTION_READ_CONCURRENCY`): each row is an independent
+        // CAS put, so ordering is irrelevant, and the one-time migration no
+        // longer stalls serially over a large (tombstone-inclusive) events
+        // collection where a per-row `get` latency would otherwise accumulate.
+        let scope_key = &scope_key;
+        let reprojected: usize = stream::iter(paths)
+            .map(|path| async move {
+                let Some(versioned) = self
+                    .filesystem
+                    .get(&ResourceScope::system(), &path)
+                    .await
+                    .map_err(fs_error)?
+                else {
+                    return Ok::<usize, TurnError>(0);
+                };
+                if versioned.entry.indexed.contains_key(scope_key) {
+                    return Ok(0); // already projected (written after the upgrade)
+                }
+                let Some(event) = deserialize_materialized_row::<TurnLifecycleEvent>(
+                    &versioned.entry.body,
+                    RowCollection::Events.as_str(),
+                )?
+                else {
+                    return Ok(0); // tombstone — no projection needed
+                };
+                let mut new_entry = Entry::bytes(versioned.entry.body.clone())
+                    .with_content_type(ContentType::json());
+                new_entry.indexed = events_index::event_indexed_projection(&event)?;
+                match self
+                    .filesystem
+                    .put(
+                        &ResourceScope::system(),
+                        &path,
+                        new_entry,
+                        CasExpectation::Version(versioned.version),
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(1),
+                    // A concurrent materialize rewrote the row (with its own
+                    // projection) or deleted it; either way our backfill is moot.
+                    Err(FilesystemError::VersionMismatch { .. })
+                    | Err(FilesystemError::NotFound { .. }) => Ok(0),
+                    Err(error) => Err(fs_error(error)),
+                }
+            })
+            .buffer_unordered(ROW_COLLECTION_READ_CONCURRENCY)
+            .try_fold(
+                0usize,
+                |acc, reprojected| async move { Ok(acc + reprojected) },
+            )
+            .await?;
         if reprojected > 0 {
             tracing::debug!(
                 reprojected,

--- a/crates/ironclaw_turns/src/filesystem_store/row_store/load.rs
+++ b/crates/ironclaw_turns/src/filesystem_store/row_store/load.rs
@@ -5,15 +5,17 @@
 use std::sync::Arc;
 
 use futures_util::stream::{self, StreamExt, TryStreamExt};
-use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem, SeqNo};
-use ironclaw_host_api::{ResourceScope, UserId};
+use ironclaw_filesystem::{
+    CasExpectation, ContentType, Entry, FileType, FilesystemError, Page, RootFilesystem, SeqNo,
+};
+use ironclaw_host_api::{ResourceScope, ScopedPath, UserId};
 use serde::de::DeserializeOwned;
 
 use crate::filesystem_store::{io as legacy_blob_io, projection};
 use crate::{
     EventCursor, GetLoopCheckpointRequest, GetRunStateRequest, LoopCheckpointRecord, TurnError,
-    TurnEventPage, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord, TurnRunState, TurnScope,
-    events::project_turn_events,
+    TurnEventPage, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord,
+    TurnRunState, TurnScope, events::project_turn_events,
 };
 
 use super::{
@@ -22,9 +24,10 @@ use super::{
         RowSnapshotState, RowStoreMeta, active_lock_record_key, event_record_key, keyed_records,
         row_store_hot_cache_snapshot, snapshot_delta,
     },
+    events_index,
     io::{
-        delta_log_path, deserialize_materialized_row, deserialize_row, fs_error, meta_path,
-        row_dir, row_path,
+        EventsIndexMarker, delta_log_path, deserialize_materialized_row, deserialize_row,
+        events_index_marker_path, fs_error, meta_path, row_dir, row_path,
     },
     journal::materialize_delta_log,
 };
@@ -351,6 +354,42 @@ where
         materialize_delta_log(self.filesystem.as_ref(), &self.materialize_gate, None).await?;
         self.ensure_legacy_blob_migrated_for_direct_row_read()
             .await?;
+        let retention_floor = self.read_meta().await?.event_retention_floor;
+
+        // Preferred path: an indexed `And(Eq{scope_key}, Range{cursor})` scan
+        // that reads only this scope's event bodies after `after`, instead of
+        // listing the whole events collection and reading every cross-thread
+        // row after the cursor. `project_turn_events` still owns every
+        // scope/owner/retention/rebase/pagination semantic, so feeding it the
+        // scope-pruned (superset-safe) set yields output identical to the scan.
+        if let Some(mut events) = self.read_scoped_events_via_query(scope, after).await? {
+            events.sort_by_key(|event| event.cursor);
+            return Ok(project_turn_events(
+                &events,
+                scope,
+                owner_user_id,
+                after,
+                limit,
+                retention_floor,
+            ));
+        }
+
+        // Fallback for a mount without `query`/`ensure_index` (byte-only
+        // backend): the legacy directory scan, unchanged.
+        self.read_turn_events_via_scan(scope, owner_user_id, after, limit, retention_floor)
+            .await
+    }
+
+    /// Legacy directory-scan read path, retained as a fallback for mounts that
+    /// do not serve `query`/`ensure_index`.
+    async fn read_turn_events_via_scan(
+        &self,
+        scope: &TurnScope,
+        owner_user_id: Option<&UserId>,
+        after: Option<EventCursor>,
+        limit: usize,
+        retention_floor: EventCursor,
+    ) -> Result<TurnEventPage, TurnError> {
         let after_key = after.map(|cursor| format!("{:020}", cursor.0));
         let events = keyed_records(
             &self
@@ -362,7 +401,6 @@ where
                 .await?,
             &event_record_key,
         )?;
-        let retention_floor = self.read_meta().await?.event_retention_floor;
         let mut events = events.into_values().collect::<Vec<_>>();
         events.sort_by_key(|event| event.cursor);
         Ok(project_turn_events(
@@ -373,6 +411,196 @@ where
             limit,
             retention_floor,
         ))
+    }
+
+    /// Read this scope's events with `cursor > after` via the indexed query.
+    /// Returns `Ok(None)` when the mount does not support `query`/`ensure_index`
+    /// so the caller can fall back to the directory scan.
+    async fn read_scoped_events_via_query(
+        &self,
+        scope: &TurnScope,
+        after: Option<EventCursor>,
+    ) -> Result<Option<Vec<TurnLifecycleEvent>>, TurnError> {
+        if !self.ensure_events_index_ready().await? {
+            return Ok(None);
+        }
+        let dir = row_dir(RowCollection::Events.as_str())?;
+        let filter = events_index::events_query_filter(scope, after)?;
+        let mut collected: Vec<TurnLifecycleEvent> = Vec::new();
+        let mut offset = 0u64;
+        loop {
+            let page = Page::new(offset, Page::MAX_LIMIT);
+            let entries = match self
+                .filesystem
+                .query(&ResourceScope::system(), &dir, &filter, page)
+                .await
+            {
+                Ok(entries) => entries,
+                Err(FilesystemError::Unsupported { .. }) => return Ok(None),
+                Err(error) => return Err(fs_error(error)),
+            };
+            let fetched = entries.len();
+            for versioned in entries {
+                if let Some(event) = deserialize_materialized_row::<TurnLifecycleEvent>(
+                    &versioned.entry.body,
+                    RowCollection::Events.as_str(),
+                )? {
+                    collected.push(event);
+                }
+            }
+            if fetched < Page::MAX_LIMIT as usize {
+                break;
+            }
+            offset = offset.saturating_add(fetched as u64);
+            // Total durable events are bounded by `max_events` (the engine
+            // prunes beyond it and advances the retention floor), so a single
+            // scope can never exceed it. This is a defensive stop that should
+            // not fire; log rather than truncate silently if it ever does.
+            if collected.len() >= self.limits.max_events {
+                tracing::debug!(
+                    scope_events = collected.len(),
+                    max_events = self.limits.max_events,
+                    "turn-state durable events query reached the max_events safety cap; stopping pagination",
+                );
+                break;
+            }
+        }
+        Ok(Some(collected))
+    }
+
+    /// Declare the event-row indexes and run the one-time pre-projection
+    /// backfill, exactly once per process. Caches `true` when the query path is
+    /// usable and `false` when the mount cannot serve `query`/`ensure_index`.
+    async fn ensure_events_index_ready(&self) -> Result<bool, TurnError> {
+        let ready = self
+            .events_index_ready
+            .get_or_try_init(|| async {
+                let dir = row_dir(RowCollection::Events.as_str())?;
+                for spec in events_index::event_index_specs()? {
+                    match self
+                        .filesystem
+                        .ensure_index(&ResourceScope::system(), &dir, &spec)
+                        .await
+                    {
+                        Ok(()) => {}
+                        Err(FilesystemError::Unsupported { .. }) => return Ok(false),
+                        Err(error) => return Err(fs_error(error)),
+                    }
+                }
+                self.backfill_event_indexes_if_needed(&dir).await?;
+                Ok::<bool, TurnError>(true)
+            })
+            .await?;
+        Ok(*ready)
+    }
+
+    /// Re-project `Entry::indexed` onto every event row written before the
+    /// indexed-projection change so the query path finds historical events.
+    /// Guarded by a durable marker (skipped on a fresh store or after a prior
+    /// completed backfill) and idempotent (rows already projected are skipped).
+    async fn backfill_event_indexes_if_needed(&self, dir: &ScopedPath) -> Result<(), TurnError> {
+        if self.read_events_index_marker().await?.backfilled {
+            return Ok(());
+        }
+        let entries = match self
+            .filesystem
+            .list_dir(&ResourceScope::system(), dir)
+            .await
+        {
+            Ok(entries) => entries,
+            Err(FilesystemError::NotFound { .. }) => Vec::new(),
+            Err(error) => return Err(fs_error(error)),
+        };
+        let scope_key = events_index::scope_index_key()?;
+        let mut reprojected = 0usize;
+        for entry in entries {
+            if entry.file_type != FileType::File {
+                continue;
+            }
+            let Some(key) = entry.name.strip_suffix(".json") else {
+                continue;
+            };
+            let path = row_path(RowCollection::Events.as_str(), key)?;
+            let Some(versioned) = self
+                .filesystem
+                .get(&ResourceScope::system(), &path)
+                .await
+                .map_err(fs_error)?
+            else {
+                continue;
+            };
+            if versioned.entry.indexed.contains_key(&scope_key) {
+                continue; // already projected (written after the upgrade)
+            }
+            let Some(event) = deserialize_materialized_row::<TurnLifecycleEvent>(
+                &versioned.entry.body,
+                RowCollection::Events.as_str(),
+            )?
+            else {
+                continue; // tombstone — no projection needed
+            };
+            let mut new_entry =
+                Entry::bytes(versioned.entry.body.clone()).with_content_type(ContentType::json());
+            new_entry.indexed = events_index::event_indexed_projection(&event)?;
+            match self
+                .filesystem
+                .put(
+                    &ResourceScope::system(),
+                    &path,
+                    new_entry,
+                    CasExpectation::Version(versioned.version),
+                )
+                .await
+            {
+                Ok(_) => reprojected += 1,
+                // A concurrent materialize rewrote the row (with its own
+                // projection) or deleted it; either way our backfill is moot.
+                Err(FilesystemError::VersionMismatch { .. })
+                | Err(FilesystemError::NotFound { .. }) => {}
+                Err(error) => return Err(fs_error(error)),
+            }
+        }
+        if reprojected > 0 {
+            tracing::debug!(
+                reprojected,
+                "backfilled turn-state event-row index projections"
+            );
+        }
+        self.write_events_index_marker().await
+    }
+
+    async fn read_events_index_marker(&self) -> Result<EventsIndexMarker, TurnError> {
+        match self
+            .filesystem
+            .get(&ResourceScope::system(), &events_index_marker_path()?)
+            .await
+        {
+            Ok(Some(versioned)) => {
+                deserialize_row(&versioned.entry.body, "turn-state events-index marker")
+            }
+            Ok(None) | Err(FilesystemError::NotFound { .. }) => Ok(EventsIndexMarker::default()),
+            Err(error) => Err(fs_error(error)),
+        }
+    }
+
+    async fn write_events_index_marker(&self) -> Result<(), TurnError> {
+        let marker = EventsIndexMarker { backfilled: true };
+        let body = serde_json::to_vec(&marker).map_err(|error| TurnError::Unavailable {
+            reason: format!("turn-state events-index marker serialization failed: {error}"),
+        })?;
+        let entry = Entry::bytes(body).with_content_type(ContentType::json());
+        // Idempotent single-value write (always `{backfilled:true}`), so a blind
+        // last-writer-wins overwrite is correct and keeps it off any CAS loop.
+        self.filesystem
+            .put(
+                &ResourceScope::system(),
+                &events_index_marker_path()?,
+                entry,
+                CasExpectation::Any,
+            )
+            .await
+            .map_err(fs_error)?;
+        Ok(())
     }
 
     pub(super) async fn read_loop_checkpoint_from_durable_rows(

--- a/crates/ironclaw_turns/tests/events_query_stress.rs
+++ b/crates/ironclaw_turns/tests/events_query_stress.rs
@@ -1,0 +1,280 @@
+//! Stress/perf harness for the durable turn-event read path (#6382 follow-up).
+//!
+//! Measures the indexed `query` read path against a faithful replica of the
+//! legacy directory scan on a real **libSQL** file database (the production
+//! durable backend for the default `ironclaw serve`), where a real B-tree index
+//! exists — unlike the in-memory backend, whose `query` is itself a linear scan
+//! and so hides the difference.
+//!
+//! Ignored by default (it seeds thousands of rows and is timing-sensitive). Run
+//! explicitly:
+//!
+//! ```bash
+//! cargo test -p ironclaw_turns --test events_query_stress -- --ignored --nocapture
+//! # tune the population:
+//! STRESS_THREADS=80 STRESS_EVENTS_PER_THREAD=200 \
+//!   cargo test -p ironclaw_turns --test events_query_stress -- --ignored --nocapture
+//! ```
+//!
+//! The scenario is the one the change targets: many threads' events interleaved
+//! across the global cursor space, then reading a single thread's timeline. The
+//! legacy scan must list + read every row after the cursor across *all* threads
+//! to return one thread's slice; the indexed query reads only that slice.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures_util::stream::{self, StreamExt, TryStreamExt};
+use ironclaw_filesystem::{
+    CasExpectation, ContentType, Entry, FileType, LibSqlRootFilesystem, ScopedFilesystem,
+};
+use ironclaw_host_api::{
+    AgentId, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, ResourceScope,
+    ScopedPath, TenantId, ThreadId, UserId, VirtualPath,
+};
+use ironclaw_turns::{
+    EventCursor, FilesystemTurnStateRowStore, TurnEventKind, TurnEventProjectionSource,
+    TurnLifecycleEvent, TurnRunId, TurnScope, TurnStatus,
+};
+
+const EVENTS_DIR: &str = "/turns/rows/v1/events";
+/// Matches `ROW_COLLECTION_READ_CONCURRENCY` in the production scan so the
+/// baseline is a fair replica, not an artificially sequential one.
+const SCAN_READ_CONCURRENCY: usize = 32;
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn thread_scope(index: usize) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("stress-tenant").unwrap(),
+        Some(AgentId::new("stress-agent").unwrap()),
+        Some(ProjectId::new("stress-project").unwrap()),
+        ThreadId::new(format!("thread-{index:04}")).unwrap(),
+    )
+}
+
+fn event(scope: &TurnScope, cursor: u64, run_id: TurnRunId) -> TurnLifecycleEvent {
+    TurnLifecycleEvent {
+        cursor: EventCursor(cursor),
+        scope: scope.clone(),
+        occurred_at: None,
+        owner_user_id: Some(UserId::new("stress-owner").unwrap()),
+        run_id,
+        status: TurnStatus::Queued,
+        kind: TurnEventKind::Submitted,
+        blocked_gate: None,
+        sanitized_reason: None,
+        retryable: None,
+        detail: None,
+    }
+}
+
+fn events_row_path(cursor: u64) -> ScopedPath {
+    ScopedPath::new(format!("{EVENTS_DIR}/{cursor:020}.json")).unwrap()
+}
+
+async fn build_libsql_scoped() -> (
+    tempfile::TempDir,
+    Arc<ScopedFilesystem<LibSqlRootFilesystem>>,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.path().join("turns-stress.db"))
+            .build()
+            .await
+            .unwrap(),
+    );
+    let root = Arc::new(LibSqlRootFilesystem::new(db));
+    root.run_migrations().await.unwrap();
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/turns").unwrap(),
+        VirtualPath::new("/turns").unwrap(),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .unwrap();
+    (
+        dir,
+        Arc::new(ScopedFilesystem::with_fixed_view(root, mounts)),
+    )
+}
+
+/// Seed `threads * events_per_thread` event rows as bare (unprojected) bodies —
+/// the pre-upgrade on-disk shape — interleaved across the global cursor space so
+/// each thread's events are scattered. Cursor `c` belongs to thread `c % threads`.
+/// The store's backfill re-projects them via production logic on first read.
+async fn seed(
+    scoped: &ScopedFilesystem<LibSqlRootFilesystem>,
+    threads: usize,
+    events_per_thread: usize,
+) -> usize {
+    let total = threads * events_per_thread;
+    for cursor in 1..=total as u64 {
+        let scope = thread_scope((cursor as usize - 1) % threads);
+        let entry =
+            Entry::bytes(serde_json::to_vec(&event(&scope, cursor, TurnRunId::new())).unwrap())
+                .with_content_type(ContentType::json());
+        scoped
+            .put(
+                &ResourceScope::system(),
+                &events_row_path(cursor),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+    total
+}
+
+/// Faithful replica of the legacy `read_row_collection_filtered(Events, key > after)`
+/// scan: list the whole events collection, filter names by cursor, read every
+/// matching body (buffered at the production concurrency), deserialize.
+async fn legacy_scan_read(
+    scoped: &ScopedFilesystem<LibSqlRootFilesystem>,
+    after: Option<EventCursor>,
+) -> usize {
+    let after_key = after.map(|cursor| format!("{:020}", cursor.0));
+    let dir = ScopedPath::new(EVENTS_DIR).unwrap();
+    let entries = scoped
+        .list_dir(&ResourceScope::system(), &dir)
+        .await
+        .unwrap();
+    let paths: Vec<ScopedPath> = entries
+        .into_iter()
+        .filter(|entry| entry.file_type == FileType::File)
+        .filter_map(|entry| entry.name.strip_suffix(".json").map(ToString::to_string))
+        .filter(|key| {
+            after_key
+                .as_ref()
+                .is_none_or(|after| key.as_str() > after.as_str())
+        })
+        .map(|key| ScopedPath::new(format!("{EVENTS_DIR}/{key}.json")).unwrap())
+        .collect();
+    let rows: Vec<TurnLifecycleEvent> = stream::iter(paths)
+        .map(|path| async move {
+            let versioned = scoped
+                .get(&ResourceScope::system(), &path)
+                .await?
+                .expect("row present");
+            Ok::<_, ironclaw_filesystem::FilesystemError>(
+                serde_json::from_slice::<TurnLifecycleEvent>(&versioned.entry.body).unwrap(),
+            )
+        })
+        .buffer_unordered(SCAN_READ_CONCURRENCY)
+        .try_collect()
+        .await
+        .unwrap();
+    rows.len()
+}
+
+async fn median_of<F, Fut>(iterations: usize, mut op: F) -> Duration
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        op().await;
+        samples.push(started.elapsed());
+    }
+    samples.sort();
+    samples[samples.len() / 2]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "perf stress harness; run explicitly with --ignored --nocapture"]
+async fn events_query_vs_scan_perf() {
+    let threads = env_usize("STRESS_THREADS", 40);
+    let events_per_thread = env_usize("STRESS_EVENTS_PER_THREAD", 100);
+    let iterations = env_usize("STRESS_ITERATIONS", 20);
+
+    let (_dir, scoped) = build_libsql_scoped().await;
+
+    let seed_started = Instant::now();
+    let total = seed(&scoped, threads, events_per_thread).await;
+    let seed_elapsed = seed_started.elapsed();
+
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let read_scope = thread_scope(0);
+
+    // First read triggers ensure_index + the one-time backfill of all seeded
+    // rows. Time it separately — it is the migration cost, paid once.
+    let backfill_started = Instant::now();
+    let first = store
+        .read_turn_events_after(&read_scope, None, None, 100)
+        .await
+        .unwrap();
+    let backfill_elapsed = backfill_started.elapsed();
+    assert!(
+        !first.entries.is_empty(),
+        "backfill must make the seeded rows queryable"
+    );
+
+    // Steady-state: read one thread's timeline from origin.
+    let query_from_origin = median_of(iterations, || async {
+        let page = store
+            .read_turn_events_after(&read_scope, None, None, 100)
+            .await
+            .unwrap();
+        std::hint::black_box(page.entries.len());
+    })
+    .await;
+
+    // Steady-state: a caught-up client (cursor near the newest of its thread).
+    let newest = first.entries.iter().map(|e| e.cursor).max().unwrap();
+    let query_caught_up = median_of(iterations, || async {
+        let page = store
+            .read_turn_events_after(&read_scope, None, Some(newest), 100)
+            .await
+            .unwrap();
+        std::hint::black_box(page.entries.len());
+    })
+    .await;
+
+    // Baseline: the legacy directory scan over the same data.
+    let scan_from_origin = median_of(iterations, || async {
+        std::hint::black_box(legacy_scan_read(&scoped, None).await);
+    })
+    .await;
+    let scan_caught_up = median_of(iterations, || async {
+        std::hint::black_box(legacy_scan_read(&scoped, Some(newest)).await);
+    })
+    .await;
+
+    let speedup = |scan: Duration, query: Duration| {
+        scan.as_secs_f64() / query.as_secs_f64().max(f64::MIN_POSITIVE)
+    };
+
+    println!("\n=== turn-event durable read: query vs legacy scan (libSQL) ===");
+    println!(
+        "population: {threads} threads x {events_per_thread} events = {total} rows; \
+         one thread = {} events; {iterations} iterations (median)",
+        first.entries.len()
+    );
+    println!("seed time:        {seed_elapsed:?}");
+    println!("backfill (1x):    {backfill_elapsed:?}  ({total} rows re-projected)");
+    println!("-- read one thread's timeline --");
+    println!(
+        "from origin:   scan {scan_from_origin:?}  |  query {query_from_origin:?}  |  {:.1}x faster",
+        speedup(scan_from_origin, query_from_origin)
+    );
+    println!(
+        "caught up:     scan {scan_caught_up:?}  |  query {query_caught_up:?}  |  {:.1}x faster",
+        speedup(scan_caught_up, query_caught_up)
+    );
+    println!("================================================================\n");
+
+    // Guard against a regression that would silently defeat the index: at this
+    // population the indexed query must not be slower than the full scan.
+    assert!(
+        query_from_origin <= scan_from_origin,
+        "indexed query ({query_from_origin:?}) must not be slower than the full scan \
+         ({scan_from_origin:?}) at {total} rows"
+    );
+}

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -3549,3 +3549,96 @@ async fn filesystem_turn_state_events_backfill_reprojects_preexisting_rows() {
         "the durable re-projection must persist across a row-store reopen"
     );
 }
+
+/// Write a pre-upgrade **tombstone** event row (materialized shape with a null
+/// `value` and no `indexed` projection) — the on-disk residue of a pruned event
+/// that the one-time backfill must read, recognize as a tombstone, and skip
+/// (never re-project, never surface) without failing or stalling the migration.
+async fn write_events_tombstone_row(
+    scoped: &ScopedFilesystem<CompositeRootFilesystem>,
+    cursor: u64,
+) {
+    let path = ScopedPath::new(format!("/turns/rows/v1/events/{cursor:020}.json")).unwrap();
+    let entry = Entry::bytes(br#"{"journal_seq":1,"value":null}"#.to_vec())
+        .with_content_type(ContentType::json());
+    scoped
+        .put(
+            &ResourceScope::system(),
+            &path,
+            entry,
+            CasExpectation::Absent,
+        )
+        .await
+        .expect("write tombstone event row");
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_events_backfill_skips_tombstones_and_reprojects_live_rows() {
+    // Regression for the durable-read backfill over a tombstone-inclusive events
+    // collection (#6390): the events collection retains a durable tombstone for
+    // every pruned event, so the one-time backfill scans a set NOT bounded by
+    // the live-event count. It must re-project every live pre-upgrade row (now
+    // at bounded concurrency, not serially), skip tombstones without surfacing
+    // or failing on them, and still write the completion marker so a reopen does
+    // not repeat the work.
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let scope = turn_scope("thread-events-backfill-tombstones");
+    let other = turn_scope("thread-events-backfill-other");
+
+    // Live pre-upgrade rows for the target scope, interleaved (by cursor) with
+    // tombstones and another scope's rows across the shared cursor space.
+    let mut live_run_ids = Vec::new();
+    for cursor in 1..=20u64 {
+        match cursor % 4 {
+            0 => write_events_tombstone_row(&scoped, cursor).await,
+            1 => {
+                let run_id = TurnRunId::new();
+                live_run_ids.push(run_id);
+                write_unprojected_event_row(&scoped, &raw_submitted_event(&scope, cursor, run_id))
+                    .await;
+            }
+            _ => {
+                write_unprojected_event_row(
+                    &scoped,
+                    &raw_submitted_event(&other, cursor, TurnRunId::new()),
+                )
+                .await;
+            }
+        }
+    }
+
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let page = store
+        .read_turn_events_after(&scope, None, None, 100)
+        .await
+        .unwrap();
+
+    for run_id in &live_run_ids {
+        assert!(
+            page.entries.iter().any(|event| event.run_id == *run_id),
+            "backfill must re-project every live pre-upgrade row for the target scope"
+        );
+    }
+    assert!(
+        page.entries.iter().all(|event| event.scope == scope),
+        "tombstones and other scopes' rows must never surface in the scoped query"
+    );
+
+    // The completion marker is written even over a tombstone-heavy collection,
+    // so a reopen serves from the index without re-running the backfill scan.
+    let marker = scoped
+        .get(
+            &ResourceScope::system(),
+            &ScopedPath::new("/turns/rows/v1/meta/events-index.json").unwrap(),
+        )
+        .await
+        .unwrap()
+        .expect("backfill completion marker present");
+    let marker: serde_json::Value = serde_json::from_slice(&marker.entry.body).unwrap();
+    assert_eq!(
+        marker.get("backfilled").and_then(|value| value.as_bool()),
+        Some(true),
+        "backfill must record completion even when the events collection is tombstone-heavy"
+    );
+}

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -16,24 +16,25 @@ use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
 use ironclaw_filesystem::{
     BackendCapabilities, BackendId, BackendKind, CasExpectation, CompositeRootFilesystem,
-    ContentKind, DirEntry, DiskFilesystem, Entry, FileStat, FilesystemError, FilesystemOperation,
-    InMemoryBackend, IndexPolicy, MountDescriptor, RecordVersion, RootFilesystem, ScopedFilesystem,
-    SeqNo, StorageClass, VersionedEntry,
+    ContentKind, ContentType, DirEntry, DiskFilesystem, Entry, FileStat, FilesystemError,
+    FilesystemOperation, InMemoryBackend, IndexPolicy, MountDescriptor, RecordVersion,
+    RootFilesystem, ScopedFilesystem, SeqNo, StorageClass, VersionedEntry,
 };
 use ironclaw_host_api::{
-    AgentId, HostPath, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, ScopedPath,
-    TenantId, ThreadId, UserId, VirtualPath,
+    AgentId, HostPath, MountAlias, MountGrant, MountPermissions, MountView, ProjectId,
+    ResourceScope, ScopedPath, TenantId, ThreadId, UserId, VirtualPath,
 };
 use ironclaw_turns::{
     AcceptedMessageRef, AdmissionRejection, AllowAllTurnAdmissionPolicy, BlockedReason,
-    CheckpointSchemaId, FilesystemTurnStateBlockPersistence, FilesystemTurnStateRowStore, GateRef,
-    GetLoopCheckpointRequest, GetRunStateRequest, IdempotencyKey, InMemoryRunProfileResolver,
-    LoopCheckpointStore, LoopExitMapping, ProductTurnContext, PutLoopCheckpointRequest,
-    ReplyTargetBindingRef, ResumeTurnPrecondition, ResumeTurnRequest, RunOriginAdapter,
-    RunProfileRequest, RunProfileVersion, SanitizedCancelReason, SanitizedFailure,
-    SourceBindingRef, SubmitChildRunRequest, SubmitTurnRequest, SubmitTurnResponse, TurnActor,
-    TurnAdmissionPolicy, TurnCheckpointId, TurnError, TurnEventKind, TurnEventProjectionSource,
-    TurnId, TurnLeaseToken, TurnOriginKind, TurnOwner, TurnRunId, TurnRunnerId, TurnScope,
+    CheckpointSchemaId, EventCursor, FilesystemTurnStateBlockPersistence,
+    FilesystemTurnStateRowStore, GateRef, GetLoopCheckpointRequest, GetRunStateRequest,
+    IdempotencyKey, InMemoryRunProfileResolver, LoopCheckpointStore, LoopExitMapping,
+    ProductTurnContext, PutLoopCheckpointRequest, ReplyTargetBindingRef, ResumeTurnPrecondition,
+    ResumeTurnRequest, RunOriginAdapter, RunProfileRequest, RunProfileVersion,
+    SanitizedCancelReason, SanitizedFailure, SourceBindingRef, SubmitChildRunRequest,
+    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
+    TurnError, TurnEventKind, TurnEventProjectionSource, TurnId, TurnLeaseToken,
+    TurnLifecycleEvent, TurnOriginKind, TurnOwner, TurnRunId, TurnRunnerId, TurnScope,
     TurnSpawnTreeStateStore, TurnStateBlockPersistence, TurnStateStore, TurnStateStoreLimits,
     TurnStatus,
     run_profile::{LoopCheckpointKind, LoopCheckpointStateRef},
@@ -3358,5 +3359,193 @@ async fn filesystem_turn_state_store_persists_product_context_through_snapshot_r
     assert!(
         state_none.product_context.is_none(),
         "None product_context must remain None after snapshot round-trip"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Durable turn-event indexed-query read path (#6382 follow-up).
+//
+// `read_turn_events_after` serves a scoped `cursor > after` range via the
+// backend `query` over an `Entry::indexed` projection, instead of listing the
+// whole events collection and reading every cross-thread row after the cursor.
+// These tests pin the three behaviors that path introduces: scope pruning,
+// query-only visibility (an unprojected row is invisible), and the one-time
+// backfill that re-projects pre-upgrade rows so historical events survive.
+// ---------------------------------------------------------------------------
+
+/// A bare (unwrapped) `TurnLifecycleEvent` row body — the `StoredRow::Raw`
+/// shape an event row persisted before the indexed-projection change would
+/// have on disk (no `journal_seq` wrapper, no `indexed` projection).
+fn raw_submitted_event(scope: &TurnScope, cursor: u64, run_id: TurnRunId) -> TurnLifecycleEvent {
+    TurnLifecycleEvent {
+        cursor: EventCursor(cursor),
+        scope: scope.clone(),
+        occurred_at: None,
+        owner_user_id: None,
+        run_id,
+        status: TurnStatus::Queued,
+        kind: TurnEventKind::Submitted,
+        blocked_gate: None,
+        sanitized_reason: None,
+        retryable: None,
+        detail: None,
+    }
+}
+
+/// Write a pre-upgrade event row (bare body, no `indexed` projection) at the
+/// exact scoped row path the store reads, through the same scoped filesystem.
+async fn write_unprojected_event_row(
+    scoped: &ScopedFilesystem<CompositeRootFilesystem>,
+    event: &TurnLifecycleEvent,
+) {
+    let path =
+        ScopedPath::new(format!("/turns/rows/v1/events/{:020}.json", event.cursor.0)).unwrap();
+    let entry =
+        Entry::bytes(serde_json::to_vec(event).unwrap()).with_content_type(ContentType::json());
+    scoped
+        .put(
+            &ResourceScope::system(),
+            &path,
+            entry,
+            CasExpectation::Absent,
+        )
+        .await
+        .expect("write unprojected event row");
+}
+
+/// Pre-mark the durable event-index backfill complete so the store does NOT
+/// re-project on read.
+async fn mark_events_index_backfilled(scoped: &ScopedFilesystem<CompositeRootFilesystem>) {
+    let path = ScopedPath::new("/turns/rows/v1/meta/events-index.json").unwrap();
+    let entry =
+        Entry::bytes(br#"{"backfilled":true}"#.to_vec()).with_content_type(ContentType::json());
+    scoped
+        .put(&ResourceScope::system(), &path, entry, CasExpectation::Any)
+        .await
+        .expect("write backfill marker");
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_events_query_isolates_scopes_across_threads() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateRowStore::new(scoped);
+    let resolver = InMemoryRunProfileResolver::default();
+
+    let scope_a = turn_scope("thread-events-a");
+    let scope_b = turn_scope("thread-events-b");
+    let run_a = accepted_run_id(
+        &store
+            .submit_turn(
+                submit_request_for(scope_a.clone(), "idem-events-a"),
+                &AllowAllTurnAdmissionPolicy,
+                &resolver,
+            )
+            .await
+            .unwrap(),
+    );
+    let run_b = accepted_run_id(
+        &store
+            .submit_turn(
+                submit_request_for(scope_b.clone(), "idem-events-b"),
+                &AllowAllTurnAdmissionPolicy,
+                &resolver,
+            )
+            .await
+            .unwrap(),
+    );
+
+    let page_a = retry_read_turn_events(&store, &scope_a).await;
+    assert!(
+        page_a.entries.iter().all(|event| event.scope == scope_a),
+        "the scoped indexed query must return only the requested scope's events"
+    );
+    assert!(
+        page_a
+            .entries
+            .iter()
+            .any(|event| event.run_id == run_a && event.kind == TurnEventKind::Submitted),
+        "thread-a's own Submitted event must be returned"
+    );
+    assert!(
+        !page_a.entries.iter().any(|event| event.run_id == run_b),
+        "thread-b's events must not leak into thread-a's timeline"
+    );
+
+    // The cursor range is exclusive-after: replaying past the newest cursor
+    // yields an empty page rather than re-serving the same events.
+    let newest = page_a
+        .entries
+        .iter()
+        .map(|event| event.cursor)
+        .max()
+        .expect("thread-a has at least one event");
+    let after_newest = store
+        .read_turn_events_after(&scope_a, None, Some(newest), 100)
+        .await
+        .unwrap();
+    assert!(
+        after_newest.entries.is_empty(),
+        "reading after the newest cursor must return no further events"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_events_query_hides_rows_missing_index_projection() {
+    // A pre-upgrade event row carries no `indexed` projection. With the backfill
+    // marker pre-set (so no re-projection runs), the indexed query must NOT
+    // surface it — this is what proves the read path is the indexed query and
+    // not the legacy directory scan (which ignores `indexed` and would find it).
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let scope = turn_scope("thread-events-unprojected");
+    write_unprojected_event_row(&scoped, &raw_submitted_event(&scope, 1, TurnRunId::new())).await;
+    mark_events_index_backfilled(&scoped).await;
+
+    let store = FilesystemTurnStateRowStore::new(scoped);
+    let page = store
+        .read_turn_events_after(&scope, None, None, 100)
+        .await
+        .unwrap();
+    assert!(
+        page.entries.is_empty(),
+        "the indexed query must not surface an event row that carries no scope_key projection"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_events_backfill_reprojects_preexisting_rows() {
+    // Same pre-upgrade row, but WITHOUT the backfill marker: first read must
+    // re-project it so the indexed query surfaces the historical event, and the
+    // projection must survive a reopen.
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let scope = turn_scope("thread-events-backfill");
+    let run_id = TurnRunId::new();
+    write_unprojected_event_row(&scoped, &raw_submitted_event(&scope, 1, run_id)).await;
+
+    let store = FilesystemTurnStateRowStore::new(Arc::clone(&scoped));
+    let page = store
+        .read_turn_events_after(&scope, None, None, 100)
+        .await
+        .unwrap();
+    assert!(
+        page.entries
+            .iter()
+            .any(|event| event.run_id == run_id && event.cursor == EventCursor(1)),
+        "backfill must re-project a pre-upgrade event row so the indexed query surfaces it"
+    );
+
+    let reopened = FilesystemTurnStateRowStore::new(scoped);
+    let reopened_page = reopened
+        .read_turn_events_after(&scope, None, None, 100)
+        .await
+        .unwrap();
+    assert!(
+        reopened_page
+            .entries
+            .iter()
+            .any(|event| event.run_id == run_id),
+        "the durable re-projection must persist across a row-store reopen"
     );
 }


### PR DESCRIPTION
## What & why

`read_turn_events_after` (the durable turn-event read behind the WebUI timeline / SSE reconnect) previously **listed the entire `events` row collection and read every row after the cursor across all of a store's threads**, then filtered down to one thread in memory — O(total events in the store). On a busy multi-thread user this is a full-collection scan per page.

This PR makes the read an **indexed, scope-pruned range query**:

- Event rows now project `scope_key` (coarse `tenant/agent/project/thread`) + `cursor` into `Entry::indexed` on the write path.
- The read serves `And(Eq{scope_key}, Range{cursor > after})` via the backend `query` API, reading **only the requested thread's slice**.
- `project_turn_events` still owns every scope/owner/retention/rebase/pagination semantic, so **projected output is byte-for-byte unchanged** — the query just feeds it a scope-pruned (superset-safe) input.

No composition change is needed: the `/tenants` mount already advertises `Query`+`IndexExact` through the backend capabilities (`IndexPolicy::NotIndexed` is FTS/vector content-embedding metadata, not a scalar-index gate).

## Migration safety

Event rows persisted before this change carry no `indexed` projection, so a naive switch would hide them from the query. A **one-time, marker-guarded backfill** re-projects existing event rows on first read (bounded by `max_events`), so durable libSQL/Postgres deployments keep their historical timeline. The read path also **falls back to the legacy directory scan** if a mount can't serve `query`/`ensure_index`. The volatile in-memory build starts fresh, so it's unaffected.

## Performance (release, libSQL file DB)

Reading one thread's timeline out of a multi-thread store; median of N iterations.

| Population | Read | Legacy scan | Indexed query | Speedup |
|---|---|---|---|---|
| 4,000 events (40 threads) | from origin | 35.3 ms | **446 µs** | **79×** |
| | caught-up client | 8.3 ms | **80 µs** | **104×** |
| 10,000 events (100 threads) | from origin | 91.8 ms | **446 µs** | **206×** |
| | caught-up client | 21.1 ms | **80 µs** | **265×** |

Query latency is **constant in thread size (446 µs / 80 µs), independent of total store size** — it stayed flat 4k→10k while the scan grew 35 ms → 92 ms (O(total)). One-time backfill: 280 ms (4k) / 740 ms (10k), marker-guarded thereafter.

Reproduce: `cargo test -p ironclaw_turns --test events_query_stress -- --ignored --nocapture`

## Tests

- `events_index.rs` unit tests: scope-key never under-fetches (ignores `thread_owner`), distinguishes threads, cursor-range filter shape.
- `filesystem_turn_state_contract.rs`:
  - `..._events_query_isolates_scopes_across_threads` — scope isolation + exclusive-after cursor through the query path.
  - `..._events_query_hides_rows_missing_index_projection` — proves the read is the indexed query, not the scan (an unprojected row is invisible when backfill is skipped).
  - `..._events_backfill_reprojects_preexisting_rows` — backfill makes a pre-upgrade row queryable and the projection survives reopen.
- `events_query_stress.rs` — ignored libSQL perf harness (adds a test-only `libsql` dev-dep to `ironclaw_turns`; `libsql` is already a hard dep of `ironclaw_filesystem`).

## Gate

`cargo fmt` clean · `cargo clippy --all --benches --tests --examples --all-features` zero warnings · `cargo test --lib` 1683 pass (one pre-existing env-only failure in an unrelated `ironclaw_reborn_composition` LLM-env-detection test, which passes with a clean environment) · `cargo test -p ironclaw_architecture` green (no new dependency edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
