### PR TITLE
feat(composition): wire admin secret provisioner into production runtimes (#5013, bucket-2)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1170,6 +1170,10 @@ where
     /// user-management surface for production profiles where `local_runtime` is
     /// None; mirrors the local substrate's `admin_secret_provisioner`.
     pub(crate) admin_secret_provisioner: Arc<dyn crate::admin_secrets::AdminSecretProvisioner>,
+    /// First-class projects + membership (ACL) facade over the production scoped
+    /// filesystem. Backs the WebUI project surface for production profiles where
+    /// `local_runtime` is None; mirrors the local substrate's `project_service`.
+    pub(crate) project_service: Arc<dyn ProjectService>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -5248,7 +5252,7 @@ where
     let secret_store: Arc<dyn SecretStore> = stores.secret_credentials.secret_store.clone();
     let skill_management_filesystem: Arc<dyn RootFilesystem> = stores.filesystem.clone();
     let skill_management = Arc::new(RebornLocalSkillManagementPort::new_with_mount_resolver(
-        owner_user_id,
+        owner_user_id.clone(),
         skill_management_filesystem,
         Arc::new(production_skill_management_mount_view),
     ));
@@ -5298,6 +5302,24 @@ where
             Arc::clone(&stores.filesystem),
             Arc::clone(&stores.secret_credentials.crypto),
         ));
+    // Projects persist over the production scoped filesystem (tenant supplied
+    // per call; the scope carries only the control-plane owner/agent identity),
+    // exactly as the local substrate builds them — see the `local_runtime`
+    // project repository. Production is always durable, so there is no
+    // in-memory fallback arm here.
+    let project_agent_id = ironclaw_host_api::AgentId::new("reborn-projects").map_err(|error| {
+        RebornBuildError::InvalidConfig {
+            reason: format!("invalid project agent id: {error}"),
+        }
+    })?;
+    let project_repository: Arc<dyn ProjectRepository> =
+        Arc::new(ironclaw_projects::FilesystemProjectRepository::new(
+            Arc::clone(&stores.scoped_filesystem),
+            owner_user_id.clone(),
+            project_agent_id,
+        ));
+    let project_service: Arc<dyn ProjectService> =
+        Arc::new(RebornProjectService::new(project_repository));
     let production_runtime_graph = Arc::new(RebornProductionRuntimeStoreGraph {
         scoped_filesystem: Arc::clone(&stores.scoped_filesystem),
         extension_registry: Arc::clone(&extension_registry),
@@ -5311,6 +5333,7 @@ where
         event_log,
         audit_log,
         admin_secret_provisioner,
+        project_service,
     });
     let production_runtime = production_runtime_services(production_runtime_graph);
     // Same store-backed lookup the WebUI automations panel builds via

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1165,6 +1165,11 @@ where
     pub(crate) broadcast_budget_event_sink: Arc<BroadcastBudgetEventSink>,
     pub(crate) event_log: Arc<dyn DurableEventLog>,
     pub(crate) audit_log: Arc<dyn DurableAuditLog>,
+    /// Admin per-user secret provisioner over the production secret substrate
+    /// (raw root + the runtime's own crypto). Backs the WebUI admin
+    /// user-management surface for production profiles where `local_runtime` is
+    /// None; mirrors the local substrate's `admin_secret_provisioner`.
+    pub(crate) admin_secret_provisioner: Arc<dyn crate::admin_secrets::AdminSecretProvisioner>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -5042,6 +5047,11 @@ where
 {
     secret_store: Arc<FilesystemSecretStore<F>>,
     credential_broker: Arc<FilesystemCredentialBroker<F>>,
+    /// Retained so `build_backend_production` can build the admin secret
+    /// provisioner over the SAME crypto the runtime's own secret store uses —
+    /// material written by the provisioner must decrypt under the user's own
+    /// store and vice versa (mirrors the local `local_dev_secret_bundle.1`).
+    crypto: Arc<ironclaw_secrets::SecretsCrypto>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -5058,7 +5068,11 @@ where
                 Arc::clone(&scoped_filesystem),
                 Arc::clone(&crypto),
             )),
-            credential_broker: Arc::new(FilesystemCredentialBroker::new(scoped_filesystem, crypto)),
+            credential_broker: Arc::new(FilesystemCredentialBroker::new(
+                scoped_filesystem,
+                Arc::clone(&crypto),
+            )),
+            crypto,
         }
     }
 
@@ -5275,6 +5289,15 @@ where
     .await?;
     let event_log = Arc::clone(&event_stores.events);
     let audit_log = Arc::clone(&event_stores.audit);
+    // Admin per-user secret provisioner over the raw production root and the
+    // SAME crypto the runtime's own secret store uses, so material written for
+    // a target user decrypts under that user's own store (mirrors the local
+    // substrate's `admin_secret_provisioner`; see `admin_secrets.rs`).
+    let admin_secret_provisioner: Arc<dyn crate::admin_secrets::AdminSecretProvisioner> =
+        Arc::new(crate::admin_secrets::FilesystemAdminSecretProvisioner::new(
+            Arc::clone(&stores.filesystem),
+            Arc::clone(&stores.secret_credentials.crypto),
+        ));
     let production_runtime_graph = Arc::new(RebornProductionRuntimeStoreGraph {
         scoped_filesystem: Arc::clone(&stores.scoped_filesystem),
         extension_registry: Arc::clone(&extension_registry),
@@ -5287,6 +5310,7 @@ where
         broadcast_budget_event_sink,
         event_log,
         audit_log,
+        admin_secret_provisioner,
     });
     let production_runtime = production_runtime_services(production_runtime_graph);
     // Same store-backed lookup the WebUI automations panel builds via

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1714,6 +1714,34 @@ impl RebornRuntime {
         None
     }
 
+    /// First-class projects + membership (ACL) facade over the host-owned scoped
+    /// substrate, backing the WebUI project surface. `None` only when the runtime
+    /// has no durable substrate at all (neither a local-runtime nor a production
+    /// store graph). Production-shaped builds source it from the production graph.
+    pub(crate) fn reborn_project_service(
+        &self,
+    ) -> Option<Arc<dyn ironclaw_product_workflow::ProjectService>> {
+        if let Some(local) = self.services.local_runtime.as_ref() {
+            return Some(Arc::clone(&local.project_service));
+        }
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        {
+            if let Some(production) = self.services.production_runtime.as_ref() {
+                return Some(match production {
+                    #[cfg(feature = "libsql")]
+                    crate::factory::RebornProductionRuntimeServices::LibSql(graph) => {
+                        Arc::clone(&graph.project_service)
+                    }
+                    #[cfg(feature = "postgres")]
+                    crate::factory::RebornProductionRuntimeServices::Postgres(graph) => {
+                        Arc::clone(&graph.project_service)
+                    }
+                });
+            }
+        }
+        None
+    }
+
     /// The admin API-token minter supplied via
     /// [`RebornRuntimeInput::with_admin_api_token_minter`], if any.
     pub(crate) fn reborn_admin_token_minter(&self) -> Option<Arc<dyn crate::AdminApiTokenMinter>> {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1684,16 +1684,34 @@ impl RebornRuntime {
     }
 
     /// Admin per-user secret provisioner over the host-owned secret substrate,
-    /// scoped to an arbitrary target user (not the runtime owner). `None` when
-    /// no filesystem secret store was built. See `admin_secrets.rs`.
+    /// scoped to an arbitrary target user (not the runtime owner). `None` only
+    /// when no durable secret store was built (a no-storage local build).
+    /// Production-shaped builds source it from the production store graph.
+    /// See `admin_secrets.rs`.
     pub(crate) fn reborn_admin_secret_provisioner(
         &self,
     ) -> Option<Arc<dyn crate::admin_secrets::AdminSecretProvisioner>> {
-        self.services
-            .local_runtime
-            .as_ref()?
-            .admin_secret_provisioner
-            .clone()
+        if let Some(local) = self.services.local_runtime.as_ref() {
+            return local.admin_secret_provisioner.clone();
+        }
+        // Production-shaped substrate: the provisioner was built over the raw
+        // production root + the runtime's own crypto in `build_backend_production`.
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        {
+            if let Some(production) = self.services.production_runtime.as_ref() {
+                return Some(match production {
+                    #[cfg(feature = "libsql")]
+                    crate::factory::RebornProductionRuntimeServices::LibSql(graph) => {
+                        Arc::clone(&graph.admin_secret_provisioner)
+                    }
+                    #[cfg(feature = "postgres")]
+                    crate::factory::RebornProductionRuntimeServices::Postgres(graph) => {
+                        Arc::clone(&graph.admin_secret_provisioner)
+                    }
+                });
+            }
+        }
+        None
     }
 
     /// The admin API-token minter supplied via

--- a/crates/ironclaw_reborn_composition/src/webui/facade.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade.rs
@@ -399,10 +399,12 @@ pub(crate) fn build_webui_services_with_connectable_channels(
                 .with_scheduler_enabled(services.readiness.workers.trigger_poller),
         ));
     }
-    // First-class projects + membership (ACL). The local-dev graph builds the
-    // access-controlled facade once; production wiring is a follow-up.
-    if let Some(local_runtime) = &services.local_runtime {
-        api = api.with_project_service(Arc::clone(&local_runtime.project_service));
+    // First-class projects + membership (ACL). Built once per runtime over the
+    // scoped substrate — local-dev from `local_runtime`, production-shaped from
+    // the production store graph — via the shared `reborn_project_service`
+    // accessor so both build paths wire the same access-controlled facade.
+    if let Some(project_service) = runtime.reborn_project_service() {
+        api = api.with_project_service(project_service);
     }
     if let Some(local_runtime) = &services.local_runtime {
         api = api.with_outbound_preferences_facade(Arc::new(RebornOutboundPreferencesFacade::new(

--- a/crates/ironclaw_reborn_composition/tests/admin_api_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/admin_api_e2e.rs
@@ -138,6 +138,21 @@ struct AdminHarness {
 async fn build_admin_harness() -> AdminHarness {
     let root = tempfile::tempdir().expect("tempdir");
     let storage_root: PathBuf = root.path().join("local-dev");
+    let build_input = RebornBuildInput::local_dev(OPERATOR_USER, storage_root)
+        .with_runtime_policy(local_dev_effective_policy());
+    build_admin_harness_from(root, build_input).await
+}
+
+/// Assemble the full admin HTTP harness over a caller-supplied
+/// `RebornBuildInput` (already carrying its profile, policy, trust, and process
+/// binding). Everything above the substrate — the shared signed session store /
+/// minter / authenticator, the WebUI bundle, and the composed router — is
+/// profile-agnostic, so the local-dev and production-shaped runs share it and
+/// only differ in the build input.
+async fn build_admin_harness_from(
+    root: tempfile::TempDir,
+    build_input: RebornBuildInput,
+) -> AdminHarness {
     let tenant = TenantId::new(TENANT).expect("tenant");
 
     // One signed session store, shared by the minter (issues bearers) and the
@@ -149,22 +164,19 @@ async fn build_admin_harness() -> AdminHarness {
         store: session_store.clone(),
     });
 
-    let input = RebornRuntimeInput::from_services(
-        RebornBuildInput::local_dev(OPERATOR_USER, storage_root)
-            .with_runtime_policy(local_dev_effective_policy()),
-    )
-    .with_identity(RebornRuntimeIdentity {
-        tenant_id: TENANT.to_string(),
-        agent_id: AGENT.to_string(),
-        source_binding_id: "admin-e2e-source".to_string(),
-        reply_target_binding_id: "admin-e2e-reply".to_string(),
-    })
-    .with_poll_settings(PollSettings {
-        interval: std::time::Duration::from_millis(10),
-        max_total: std::time::Duration::from_secs(10),
-    })
-    .with_model_gateway_override(Arc::new(NoOpGateway))
-    .with_admin_api_token_minter(minter);
+    let input = RebornRuntimeInput::from_services(build_input)
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: TENANT.to_string(),
+            agent_id: AGENT.to_string(),
+            source_binding_id: "admin-e2e-source".to_string(),
+            reply_target_binding_id: "admin-e2e-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: std::time::Duration::from_millis(10),
+            max_total: std::time::Duration::from_secs(10),
+        })
+        .with_model_gateway_override(Arc::new(NoOpGateway))
+        .with_admin_api_token_minter(minter);
 
     let runtime = build_reborn_runtime(input).await.expect("runtime builds");
     let bundle = build_webui_services(&runtime, None).expect("webui bundle");
@@ -867,5 +879,171 @@ async fn malformed_inputs_are_4xx_not_500() {
     assert!(
         status.is_client_error() && status != StatusCode::INTERNAL_SERVER_ERROR,
         "an invalid status enum is a 4xx (got {status}), never a 500"
+    );
+}
+
+// ─── production-profile admin surface (bucket-2 parity: secret provisioner) ──
+//
+// The harness above builds a local-dev runtime. These cover the production
+// store graph (`local_runtime: None`, `production_runtime: Some`), where the
+// admin user service is wired only when BOTH the identity directory (#6395) and
+// the admin secret provisioner are sourced from that graph. Gated on `libsql`
+// because the production-runtime path requires the libSQL substrate.
+
+#[cfg(feature = "libsql")]
+#[derive(Debug)]
+struct RecordingSandboxTransport;
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl ironclaw_host_runtime::SandboxCommandTransport for RecordingSandboxTransport {
+    async fn run_command(
+        &self,
+        _request: ironclaw_host_runtime::CommandExecutionRequest,
+    ) -> Result<
+        ironclaw_host_runtime::CommandExecutionOutput,
+        ironclaw_host_runtime::RuntimeProcessError,
+    > {
+        Ok(ironclaw_host_runtime::CommandExecutionOutput {
+            output: String::new(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: std::time::Duration::ZERO,
+        })
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn production_effective_policy() -> EffectiveRuntimePolicy {
+    EffectiveRuntimePolicy {
+        deployment: DeploymentMode::HostedMultiTenant,
+        requested_profile: RuntimeProfile::SecureDefault,
+        resolved_profile: RuntimeProfile::SecureDefault,
+        filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+        process_backend: ProcessBackendKind::TenantSandbox,
+        network_mode: NetworkMode::Deny,
+        secret_mode: SecretMode::BrokeredHandles,
+        approval_policy: ApprovalPolicy::AskAlways,
+        audit_mode: AuditMode::Standard,
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn build_admin_harness_production() -> AdminHarness {
+    use ironclaw_reborn_composition::{
+        RebornCompositionProfile, RebornRuntimeProcessBinding, builtin_first_party_trust_policy,
+    };
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let db = Arc::new(
+        libsql::Builder::new_local(root.path().join("reborn.db"))
+            .build()
+            .await
+            .expect("libsql db"),
+    );
+    let events = root.path().join("events.db").to_string_lossy().to_string();
+    let build_input = RebornBuildInput::libsql(
+        RebornCompositionProfile::Production,
+        OPERATOR_USER,
+        db,
+        events,
+        None,
+        ironclaw_secrets::SecretMaterial::from("01234567890123456789012345678901"),
+    )
+    .with_production_trust_policy(Arc::new(
+        builtin_first_party_trust_policy().expect("trust policy"),
+    ))
+    .with_runtime_policy(production_effective_policy())
+    .with_runtime_process_binding(RebornRuntimeProcessBinding::tenant_sandbox(Arc::new(
+        ironclaw_host_runtime::TenantSandboxProcessPort::new(Arc::new(RecordingSandboxTransport)),
+    )));
+    build_admin_harness_from(root, build_input).await
+}
+
+/// Regression for the bucket-2 admin-secret-provisioner parity gap. On a
+/// production-shaped runtime the admin user service is `RejectingAdminUserService`
+/// unless the identity directory (#6395) AND the admin secret provisioner are
+/// both sourced from the production store graph. Before the provisioner
+/// production fallback, `reborn_admin_secret_provisioner` returned `None`, so
+/// every admin op — including these — returned service-unavailable. Drives the
+/// full HTTP admin surface and asserts create-user + per-user secret
+/// provisioning work and are isolated across users.
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn production_admin_surface_provisions_and_isolates_per_user_secrets() {
+    let harness = build_admin_harness_production().await;
+    let operator = AdminApiDriver::new(harness.router.clone(), OPERATOR_TOKEN);
+
+    // The admin surface is reachable on production (not `RejectingAdminUserService`).
+    let (status, users) = operator.list_users().await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "admin user surface must be wired on production; got {users:?}"
+    );
+
+    // create_user needs the identity directory (#6395); its success confirms
+    // the directory half of the trio is sourced from the production graph.
+    let (status, user_a) = operator
+        .create_user(Some("a@prod.test"), "User A", "member")
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "operator creates a user on production"
+    );
+    let user_a = user_id_of(&user_a);
+    let (status, user_b) = operator
+        .create_user(Some("b@prod.test"), "User B", "member")
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    let user_b = user_id_of(&user_b);
+
+    // The admin secret provisioner (this change) accepts a per-user secret over
+    // the production secret substrate — the direct regression assertion.
+    let (status, put) = operator
+        .put_secret(&user_a, "openai_key", "sk-prod-secret-value")
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "admin secret provisioner must be wired on production; got {put:?}"
+    );
+    assert_eq!(put["secret"]["handle"].as_str(), Some("openai_key"));
+    assert!(
+        !put.to_string().contains("sk-prod-secret-value"),
+        "the secret material must never be echoed back"
+    );
+
+    // Per-user isolation: A's secret lists for A and NOT for B.
+    let (status, a_secrets) = operator.list_secrets(&user_a).await;
+    assert_eq!(status, StatusCode::OK);
+    let a_handles: Vec<&str> = a_secrets["secrets"]
+        .as_array()
+        .expect("secrets list")
+        .iter()
+        .filter_map(|entry| entry["handle"].as_str())
+        .collect();
+    assert!(
+        a_handles.contains(&"openai_key"),
+        "user A sees its provisioned secret"
+    );
+
+    let (status, b_secrets) = operator.list_secrets(&user_b).await;
+    assert_eq!(status, StatusCode::OK);
+    let b_handles: Vec<&str> = b_secrets["secrets"]
+        .as_array()
+        .expect("secrets list")
+        .iter()
+        .filter_map(|entry| entry["handle"].as_str())
+        .collect();
+    assert!(
+        !b_handles.contains(&"openai_key"),
+        "user B must NOT see user A's secret (per-user provisioner isolation)"
+    );
+    assert!(
+        !b_secrets.to_string().contains("sk-prod-secret-value"),
+        "no cross-user secret material leak"
     );
 }

--- a/crates/ironclaw_reborn_composition/tests/production_runtime_project_service.rs
+++ b/crates/ironclaw_reborn_composition/tests/production_runtime_project_service.rs
@@ -1,0 +1,184 @@
+//! Integration test: a production-shaped `RebornRuntime` wires the first-class
+//! projects (ACL) facade over its production store graph, and that facade is
+//! tenant/user scoped.
+//!
+//! Regression for the bucket-2 production-parity gap (#5013 / audit #6389).
+//! Production profiles have `local_runtime: None`; `build_webui_services` only
+//! called `with_project_service` for the local substrate, so on production the
+//! WebUI project surface fell through to the `RebornServicesApi` default, which
+//! returns `service_unavailable` for `create_project` / `list_projects`. The
+//! provisioner-style production fallback now sources the project service from
+//! the production store graph (`RebornProjectService` over
+//! `FilesystemProjectRepository` on the production scoped filesystem).
+//!
+//! Lives in its own integration-test binary (mirroring
+//! `production_runtime_automations.rs`) so the CPU-heavy production build does
+//! not starve the lib unit tests' hard `RunTimeout` budgets, and is gated on
+//! `libsql` because the production-runtime path requires the libSQL substrate.
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    AgentId, TenantId, UserId,
+    runtime_policy::{
+        ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
+        NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+    },
+};
+use ironclaw_host_runtime::{
+    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandTransport,
+    TenantSandboxProcessPort,
+};
+use ironclaw_product_workflow::{
+    RebornCreateProjectRequest, RebornListProjectsRequest, WebUiAuthenticatedCaller,
+};
+use ironclaw_reborn_composition::{
+    RebornBuildInput, RebornCompositionProfile, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProcessBinding, build_reborn_runtime, build_webui_services,
+    builtin_first_party_trust_policy,
+};
+
+const RUNTIME_TENANT: &str = "prod-projects-tenant";
+const RUNTIME_AGENT: &str = "prod-projects-agent";
+const OWNER: &str = "prod-projects-owner";
+
+// ─── minimal sandbox transport stub (production requires a process binding) ───
+
+#[derive(Debug)]
+struct RecordingSandboxTransport;
+
+#[async_trait]
+impl SandboxCommandTransport for RecordingSandboxTransport {
+    async fn run_command(
+        &self,
+        _request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        Ok(CommandExecutionOutput {
+            output: String::new(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: Duration::ZERO,
+        })
+    }
+}
+
+fn create_request(name: &str) -> RebornCreateProjectRequest {
+    RebornCreateProjectRequest {
+        name: name.to_string(),
+        description: "bucket-2 production parity".to_string(),
+        icon: None,
+        color: None,
+        metadata: None,
+    }
+}
+
+/// Regression guard: on a production runtime the project facade is reachable
+/// (not `service_unavailable`), persists round-trip over the production
+/// substrate, and is scoped so a different tenant cannot see the project.
+#[tokio::test]
+async fn production_runtime_wires_project_service_and_scopes_by_tenant() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.path().join("reborn.db"))
+            .build()
+            .await
+            .expect("libsql db"),
+    );
+
+    let input = RebornRuntimeInput::from_services(
+        RebornBuildInput::libsql(
+            RebornCompositionProfile::Production,
+            OWNER,
+            db,
+            dir.path().join("events.db").to_string_lossy(),
+            None,
+            ironclaw_secrets::SecretMaterial::from("01234567890123456789012345678901"),
+        )
+        .with_production_trust_policy(Arc::new(
+            builtin_first_party_trust_policy().expect("trust policy"),
+        ))
+        .with_runtime_policy(EffectiveRuntimePolicy {
+            deployment: DeploymentMode::HostedMultiTenant,
+            requested_profile: RuntimeProfile::SecureDefault,
+            resolved_profile: RuntimeProfile::SecureDefault,
+            filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+            process_backend: ProcessBackendKind::TenantSandbox,
+            network_mode: NetworkMode::Deny,
+            secret_mode: SecretMode::BrokeredHandles,
+            approval_policy: ApprovalPolicy::AskAlways,
+            audit_mode: AuditMode::Standard,
+        })
+        .with_runtime_process_binding(RebornRuntimeProcessBinding::tenant_sandbox(Arc::new(
+            TenantSandboxProcessPort::new(Arc::new(RecordingSandboxTransport)),
+        ))),
+    )
+    .with_identity(RebornRuntimeIdentity {
+        tenant_id: RUNTIME_TENANT.to_string(),
+        agent_id: RUNTIME_AGENT.to_string(),
+        source_binding_id: "prod-projects-source".to_string(),
+        reply_target_binding_id: "prod-projects-reply".to_string(),
+    });
+
+    let runtime = build_reborn_runtime(input)
+        .await
+        .expect("production runtime builds");
+    let bundle = build_webui_services(&runtime, None).expect("webui bundle builds");
+
+    let owner = WebUiAuthenticatedCaller::new(
+        TenantId::new(RUNTIME_TENANT).unwrap(),
+        UserId::new(OWNER).unwrap(),
+        Some(AgentId::new(RUNTIME_AGENT).unwrap()),
+        None,
+    );
+
+    // (1) THE WIRING. Before the production fallback, the facade fell through to
+    // the `RebornServicesApi` default and this returned
+    // `service_unavailable`. A successful create proves `with_project_service`
+    // was wired from the production store graph.
+    let created = bundle
+        .api
+        .create_project(owner.clone(), create_request("Prod Project"))
+        .await
+        .expect("production project facade must be reachable (not service_unavailable)");
+    assert_eq!(created.project.name, "Prod Project");
+    let project_id = created.project.project_id.clone();
+
+    // (2) ROUND-TRIP over the production scoped filesystem: the created project
+    // lists back for its owner.
+    let listed = bundle
+        .api
+        .list_projects(owner.clone(), RebornListProjectsRequest { limit: None })
+        .await
+        .expect("owner may list projects");
+    assert!(
+        listed.projects.iter().any(|p| p.project_id == project_id),
+        "the created project lists back from the production substrate"
+    );
+
+    // (3) TENANT SCOPING. A caller in a different tenant must not observe the
+    // owner's project — the repository partitions by the per-call tenant.
+    let other_tenant = WebUiAuthenticatedCaller::new(
+        TenantId::new("prod-projects-other-tenant").unwrap(),
+        UserId::new("prod-projects-other-user").unwrap(),
+        Some(AgentId::new(RUNTIME_AGENT).unwrap()),
+        None,
+    );
+    let other_listed = bundle
+        .api
+        .list_projects(other_tenant, RebornListProjectsRequest { limit: None })
+        .await
+        .expect("a foreign-tenant list is still reachable");
+    assert!(
+        !other_listed
+            .projects
+            .iter()
+            .any(|p| p.project_id == project_id),
+        "a different tenant must not see the owner's project (per-tenant scoping)"
+    );
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}


### PR DESCRIPTION
> Stacked on #6395 (identity resolver → production). Review/merge that first; this PR's base retargets to `main` once #6395 lands.

## What

Second bucket-2 production-parity item (audit #6389). `reborn_admin_secret_provisioner` `?`-returned on `local_runtime`, so on production-shaped builds it was `None`. Combined with the identity directory (fixed in #6395), `build_webui_services` fell back to `RejectingAdminUserService` and the **entire WebUI admin user-management surface returned `service_unavailable` on production profiles**.

## How

The provisioner needs the **raw production root** filesystem + the runtime's own **`SecretsCrypto`** (so admin-written material decrypts under the target user's own store). The crypto was built then discarded by `FilesystemSecretCredentialStores`; it's now retained there. The provisioner is built in `build_backend_production` over `stores.filesystem` + that crypto and stored as a `dyn` on `RebornProductionRuntimeStoreGraph` (mirroring the local substrate), and the accessor falls back to it.

Isolation is identical to local: `FilesystemAdminSecretProvisioner` mints a per-target-user `MountView` store **per call** (`/tenants/{tenant}/users/{user}/secrets`), so one provisioner instance serves every `(tenant, user)` by path.

## Test (test-first, red-verified)

`admin_api_e2e.rs` — which owns the admin-user-service seam — grows a **production-profile** run. `build_admin_harness` is refactored to take the `RebornBuildInput`, so the local-dev and production runs share the entire HTTP harness (auth, minter, router, drivers) and differ only in the build input. The new test drives the composed admin surface over HTTP and asserts:
- create-user works on production (identity directory wired, #6395);
- **per-user secret put/list works** (the provisioner — this change);
- **isolation** — user A's secret lists for A, never for B, and material is never echoed.

Verified **red** without the production arm: the surface returns `{"kind":"service_unavailable"}`.

With this + #6395, the production admin user service is fully wired: **directory + provisioner + a host-supplied token minter**.

## Verification

- `cargo test -p ironclaw_reborn_composition --features test-support,libsql --test admin_api_e2e` ✅ 10/10 (new production test + 9 local, harness refactor preserved)
- clippy `-D warnings`: libsql ✅, all-features ✅, `--no-default-features --features postgres,test-support` ✅
- `scripts/pre-commit-safety.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)