### PR TITLE
docs(rules): 'removing a redundant layer un-masks behavior' review discipline

### DIFF
--- a/.claude/rules/review-discipline.md
+++ b/.claude/rules/review-discipline.md
@@ -93,6 +93,44 @@ problems discovered during the move. After moving or renaming code, search
 `.claude/`, `AGENTS.md`, `CLAUDE.md`, `crates/AGENTS.md`,
 `docs/reborn/contracts/`, and other Markdown references for stale paths.
 
+## Removing a "redundant" layer un-masks behavior
+
+A layer you delete as redundant is often silently *backstopping* behavior the
+downstream code does not reproduce. Deleting it does not remove the behavior —
+it exposes the gap, as a test failure if you are lucky and a silent regression
+if you are not. This is the dominant hazard of consolidation/dedup refactors.
+Motivating case: PRs #6386/#6392 (the `authorize()` policy consolidation) —
+removing `ironclaw_host_runtime`'s "redundant" pre-authorization surfaced five
+behaviors it had been masking (a stale import, model-message sanitization,
+run-record ordering for unknown capabilities, dropped runtime-policy enforcement
+on the resume paths, and a mismatch-vs-unknown precedence flip).
+
+Discipline when deleting a layer you believe is redundant:
+
+- **Run the full, unfiltered suite for every touched crate** — `cargo test -p
+  <crate> --no-fail-fast` — and do **not** pipe test output through `head`/`tail`.
+  A partial view under-counts failures (this hid three real failures twice
+  during #6392). Filtered green is not green.
+- **Every surfaced failure is a candidate real behavior, not a test to edit.**
+  For each, determine whether the deleted layer was providing it and whether the
+  surviving code reproduces it. **Preserve the behavior; do not weaken the
+  assertion to go green** unless you have proven the old behavior was itself
+  wrong (and say why in the PR). Silently updating a test to match the new output
+  is how a consolidation ships a regression.
+- **The load-bearing observable is the failure *kind* and durable state**
+  (`RuntimeFailureKind`, run-state transitions, audit `error_kind`) — not the
+  message text. Preserve the kind exactly; the sanitized model-visible message is
+  a separate, weaker contract (`error-handling.md`).
+- **"Redundant" is per-path.** A check redundant on one entry path (e.g.
+  invoke/spawn) can be the *only* copy on another (e.g. resume/auth-resume).
+  Confirm the survivor covers **every** path before deleting, not just the one
+  you inspected.
+
+When the work is sliced across subagents, give each the standing instruction to
+**stop and report a surfaced behavior rather than commit green or weaken a
+test** — the reviewer, not the slice author, decides whether a delta is
+acceptable.
+
 ## Guardrails are code
 
 Checks and hooks need regression tests, must handle multiline syntax, and must


### PR DESCRIPTION
Captures the reusable discipline from the `authorize()` policy consolidation (#6386/#6392): deleting a layer you believe is redundant exposes behaviors it was silently backstopping.

Adds a section to `.claude/rules/review-discipline.md`:
- run the full **unfiltered** suite (`--no-fail-fast`, no `head`/`tail`) — a partial view under-counted failures twice during #6392;
- treat every surfaced failure as a **real behavior to preserve**, never weaken the assertion to go green;
- the load-bearing observable is the failure **kind / durable state**, not the message text;
- **'redundant' is per-path** — a check redundant on invoke/spawn can be the only copy on resume/auth-resume;
- sliced subagents **stop-and-report** rather than commit green.

Documentation-only; grounded in the two real PRs (#6386/#6392) and makes no enforcement claim (it's a review discipline, not a mechanical check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)