### PR TITLE
feat(composition): wire the projects (ACL) facade into production runtimes (#5013, bucket-2)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1170,6 +1170,10 @@ where
     /// user-management surface for production profiles where `local_runtime` is
     /// None; mirrors the local substrate's `admin_secret_provisioner`.
     pub(crate) admin_secret_provisioner: Arc<dyn crate::admin_secrets::AdminSecretProvisioner>,
+    /// First-class projects + membership (ACL) facade over the production scoped
+    /// filesystem. Backs the WebUI project surface for production profiles where
+    /// `local_runtime` is None; mirrors the local substrate's `project_service`.
+    pub(crate) project_service: Arc<dyn ProjectService>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -5248,7 +5252,7 @@ where
     let secret_store: Arc<dyn SecretStore> = stores.secret_credentials.secret_store.clone();
     let skill_management_filesystem: Arc<dyn RootFilesystem> = stores.filesystem.clone();
     let skill_management = Arc::new(RebornLocalSkillManagementPort::new_with_mount_resolver(
-        owner_user_id,
+        owner_user_id.clone(),
         skill_management_filesystem,
         Arc::new(production_skill_management_mount_view),
     ));
@@ -5298,6 +5302,24 @@ where
             Arc::clone(&stores.filesystem),
             Arc::clone(&stores.secret_credentials.crypto),
         ));
+    // Projects persist over the production scoped filesystem (tenant supplied
+    // per call; the scope carries only the control-plane owner/agent identity),
+    // exactly as the local substrate builds them — see the `local_runtime`
+    // project repository. Production is always durable, so there is no
+    // in-memory fallback arm here.
+    let project_agent_id = ironclaw_host_api::AgentId::new("reborn-projects").map_err(|error| {
+        RebornBuildError::InvalidConfig {
+            reason: format!("invalid project agent id: {error}"),
+        }
+    })?;
+    let project_repository: Arc<dyn ProjectRepository> =
+        Arc::new(ironclaw_projects::FilesystemProjectRepository::new(
+            Arc::clone(&stores.scoped_filesystem),
+            owner_user_id.clone(),
+            project_agent_id,
+        ));
+    let project_service: Arc<dyn ProjectService> =
+        Arc::new(RebornProjectService::new(project_repository));
     let production_runtime_graph = Arc::new(RebornProductionRuntimeStoreGraph {
         scoped_filesystem: Arc::clone(&stores.scoped_filesystem),
         extension_registry: Arc::clone(&extension_registry),
@@ -5311,6 +5333,7 @@ where
         event_log,
         audit_log,
         admin_secret_provisioner,
+        project_service,
     });
     let production_runtime = production_runtime_services(production_runtime_graph);
     // Same store-backed lookup the WebUI automations panel builds via

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1714,6 +1714,34 @@ impl RebornRuntime {
         None
     }
 
+    /// First-class projects + membership (ACL) facade over the host-owned scoped
+    /// substrate, backing the WebUI project surface. `None` only when the runtime
+    /// has no durable substrate at all (neither a local-runtime nor a production
+    /// store graph). Production-shaped builds source it from the production graph.
+    pub(crate) fn reborn_project_service(
+        &self,
+    ) -> Option<Arc<dyn ironclaw_product_workflow::ProjectService>> {
+        if let Some(local) = self.services.local_runtime.as_ref() {
+            return Some(Arc::clone(&local.project_service));
+        }
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        {
+            if let Some(production) = self.services.production_runtime.as_ref() {
+                return Some(match production {
+                    #[cfg(feature = "libsql")]
+                    crate::factory::RebornProductionRuntimeServices::LibSql(graph) => {
+                        Arc::clone(&graph.project_service)
+                    }
+                    #[cfg(feature = "postgres")]
+                    crate::factory::RebornProductionRuntimeServices::Postgres(graph) => {
+                        Arc::clone(&graph.project_service)
+                    }
+                });
+            }
+        }
+        None
+    }
+
     /// The admin API-token minter supplied via
     /// [`RebornRuntimeInput::with_admin_api_token_minter`], if any.
     pub(crate) fn reborn_admin_token_minter(&self) -> Option<Arc<dyn crate::AdminApiTokenMinter>> {

--- a/crates/ironclaw_reborn_composition/src/webui/facade.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade.rs
@@ -399,10 +399,12 @@ pub(crate) fn build_webui_services_with_connectable_channels(
                 .with_scheduler_enabled(services.readiness.workers.trigger_poller),
         ));
     }
-    // First-class projects + membership (ACL). The local-dev graph builds the
-    // access-controlled facade once; production wiring is a follow-up.
-    if let Some(local_runtime) = &services.local_runtime {
-        api = api.with_project_service(Arc::clone(&local_runtime.project_service));
+    // First-class projects + membership (ACL). Built once per runtime over the
+    // scoped substrate — local-dev from `local_runtime`, production-shaped from
+    // the production store graph — via the shared `reborn_project_service`
+    // accessor so both build paths wire the same access-controlled facade.
+    if let Some(project_service) = runtime.reborn_project_service() {
+        api = api.with_project_service(project_service);
     }
     if let Some(local_runtime) = &services.local_runtime {
         api = api.with_outbound_preferences_facade(Arc::new(RebornOutboundPreferencesFacade::new(

--- a/crates/ironclaw_reborn_composition/tests/production_runtime_project_service.rs
+++ b/crates/ironclaw_reborn_composition/tests/production_runtime_project_service.rs
@@ -1,0 +1,184 @@
+//! Integration test: a production-shaped `RebornRuntime` wires the first-class
+//! projects (ACL) facade over its production store graph, and that facade is
+//! tenant/user scoped.
+//!
+//! Regression for the bucket-2 production-parity gap (#5013 / audit #6389).
+//! Production profiles have `local_runtime: None`; `build_webui_services` only
+//! called `with_project_service` for the local substrate, so on production the
+//! WebUI project surface fell through to the `RebornServicesApi` default, which
+//! returns `service_unavailable` for `create_project` / `list_projects`. The
+//! provisioner-style production fallback now sources the project service from
+//! the production store graph (`RebornProjectService` over
+//! `FilesystemProjectRepository` on the production scoped filesystem).
+//!
+//! Lives in its own integration-test binary (mirroring
+//! `production_runtime_automations.rs`) so the CPU-heavy production build does
+//! not starve the lib unit tests' hard `RunTimeout` budgets, and is gated on
+//! `libsql` because the production-runtime path requires the libSQL substrate.
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    AgentId, TenantId, UserId,
+    runtime_policy::{
+        ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
+        NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+    },
+};
+use ironclaw_host_runtime::{
+    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandTransport,
+    TenantSandboxProcessPort,
+};
+use ironclaw_product_workflow::{
+    RebornCreateProjectRequest, RebornListProjectsRequest, WebUiAuthenticatedCaller,
+};
+use ironclaw_reborn_composition::{
+    RebornBuildInput, RebornCompositionProfile, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProcessBinding, build_reborn_runtime, build_webui_services,
+    builtin_first_party_trust_policy,
+};
+
+const RUNTIME_TENANT: &str = "prod-projects-tenant";
+const RUNTIME_AGENT: &str = "prod-projects-agent";
+const OWNER: &str = "prod-projects-owner";
+
+// ─── minimal sandbox transport stub (production requires a process binding) ───
+
+#[derive(Debug)]
+struct RecordingSandboxTransport;
+
+#[async_trait]
+impl SandboxCommandTransport for RecordingSandboxTransport {
+    async fn run_command(
+        &self,
+        _request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        Ok(CommandExecutionOutput {
+            output: String::new(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: Duration::ZERO,
+        })
+    }
+}
+
+fn create_request(name: &str) -> RebornCreateProjectRequest {
+    RebornCreateProjectRequest {
+        name: name.to_string(),
+        description: "bucket-2 production parity".to_string(),
+        icon: None,
+        color: None,
+        metadata: None,
+    }
+}
+
+/// Regression guard: on a production runtime the project facade is reachable
+/// (not `service_unavailable`), persists round-trip over the production
+/// substrate, and is scoped so a different tenant cannot see the project.
+#[tokio::test]
+async fn production_runtime_wires_project_service_and_scopes_by_tenant() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.path().join("reborn.db"))
+            .build()
+            .await
+            .expect("libsql db"),
+    );
+
+    let input = RebornRuntimeInput::from_services(
+        RebornBuildInput::libsql(
+            RebornCompositionProfile::Production,
+            OWNER,
+            db,
+            dir.path().join("events.db").to_string_lossy(),
+            None,
+            ironclaw_secrets::SecretMaterial::from("01234567890123456789012345678901"),
+        )
+        .with_production_trust_policy(Arc::new(
+            builtin_first_party_trust_policy().expect("trust policy"),
+        ))
+        .with_runtime_policy(EffectiveRuntimePolicy {
+            deployment: DeploymentMode::HostedMultiTenant,
+            requested_profile: RuntimeProfile::SecureDefault,
+            resolved_profile: RuntimeProfile::SecureDefault,
+            filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+            process_backend: ProcessBackendKind::TenantSandbox,
+            network_mode: NetworkMode::Deny,
+            secret_mode: SecretMode::BrokeredHandles,
+            approval_policy: ApprovalPolicy::AskAlways,
+            audit_mode: AuditMode::Standard,
+        })
+        .with_runtime_process_binding(RebornRuntimeProcessBinding::tenant_sandbox(Arc::new(
+            TenantSandboxProcessPort::new(Arc::new(RecordingSandboxTransport)),
+        ))),
+    )
+    .with_identity(RebornRuntimeIdentity {
+        tenant_id: RUNTIME_TENANT.to_string(),
+        agent_id: RUNTIME_AGENT.to_string(),
+        source_binding_id: "prod-projects-source".to_string(),
+        reply_target_binding_id: "prod-projects-reply".to_string(),
+    });
+
+    let runtime = build_reborn_runtime(input)
+        .await
+        .expect("production runtime builds");
+    let bundle = build_webui_services(&runtime, None).expect("webui bundle builds");
+
+    let owner = WebUiAuthenticatedCaller::new(
+        TenantId::new(RUNTIME_TENANT).unwrap(),
+        UserId::new(OWNER).unwrap(),
+        Some(AgentId::new(RUNTIME_AGENT).unwrap()),
+        None,
+    );
+
+    // (1) THE WIRING. Before the production fallback, the facade fell through to
+    // the `RebornServicesApi` default and this returned
+    // `service_unavailable`. A successful create proves `with_project_service`
+    // was wired from the production store graph.
+    let created = bundle
+        .api
+        .create_project(owner.clone(), create_request("Prod Project"))
+        .await
+        .expect("production project facade must be reachable (not service_unavailable)");
+    assert_eq!(created.project.name, "Prod Project");
+    let project_id = created.project.project_id.clone();
+
+    // (2) ROUND-TRIP over the production scoped filesystem: the created project
+    // lists back for its owner.
+    let listed = bundle
+        .api
+        .list_projects(owner.clone(), RebornListProjectsRequest { limit: None })
+        .await
+        .expect("owner may list projects");
+    assert!(
+        listed.projects.iter().any(|p| p.project_id == project_id),
+        "the created project lists back from the production substrate"
+    );
+
+    // (3) TENANT SCOPING. A caller in a different tenant must not observe the
+    // owner's project — the repository partitions by the per-call tenant.
+    let other_tenant = WebUiAuthenticatedCaller::new(
+        TenantId::new("prod-projects-other-tenant").unwrap(),
+        UserId::new("prod-projects-other-user").unwrap(),
+        Some(AgentId::new(RUNTIME_AGENT).unwrap()),
+        None,
+    );
+    let other_listed = bundle
+        .api
+        .list_projects(other_tenant, RebornListProjectsRequest { limit: None })
+        .await
+        .expect("a foreign-tenant list is still reachable");
+    assert!(
+        !other_listed
+            .projects
+            .iter()
+            .any(|p| p.project_id == project_id),
+        "a different tenant must not see the owner's project (per-tenant scoping)"
+    );
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}


### PR DESCRIPTION
> Stack: `main ← #6395 (identity) ← #6397 (admin secret provisioner) ← this`. Merge the parents first; base retargets to `main` as they land.

## What

Third bucket-2 production-parity item (audit #6389). `build_webui_services` called `with_project_service` only for the local substrate — the code literally said *"production wiring is a follow-up"* — so on production-shaped builds (`local_runtime: None`) the WebUI project surface fell through to the `RebornServicesApi` default, which returns `service_unavailable` for `create_project` / `list_projects` / `get_project` / etc.

## How

Same identity-style fallback: `RebornProjectService` over a `FilesystemProjectRepository` on the production `scoped_filesystem` is built in `build_backend_production` (tenant supplied per call; the scope carries only the control-plane owner/agent, exactly as the local substrate builds it), stored on `RebornProductionRuntimeStoreGraph`, and exposed through a new `reborn_project_service()` accessor. `build_webui_services` wires `with_project_service` from that accessor for **both** build paths, so local-dev and production share the one access-controlled facade.

## Test (test-first, red-verified)

`tests/production_runtime_project_service.rs` builds a production `RebornRuntime` and, through the WebUI facade, asserts:
1. **reachable** — `create_project` succeeds instead of 503 (proves `with_project_service` wired);
2. **round-trip** — the project lists back over the production substrate;
3. **tenant scoping** — a different-tenant caller cannot see it.

Verified **red** without the production arm: `create_project` → `503 ServiceUnavailable`.

## Verification

- `cargo test -p ironclaw_reborn_composition --features libsql --test production_runtime_project_service` ✅ (red-verified)
- clippy `-D warnings`: libsql ✅, all-features ✅, `--no-default-features --features postgres,test-support` ✅
- `scripts/pre-commit-safety.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)