### PR TITLE
refactor(turns): model LoopModelRouteSnapshot as an enum, not a three-field sentinel

### DIFF
--- a/crates/ironclaw_loop_host/tests/thread_loop_host_contract.rs
+++ b/crates/ironclaw_loop_host/tests/thread_loop_host_contract.rs
@@ -54,10 +54,9 @@ use ironclaw_turns::{
         LoopPromptBundleAuthority, LoopPromptBundleRef, LoopPromptBundleRequest, LoopPromptPort,
         LoopRunContext, LoopTranscriptPort, ModelVisibleToolObservation, ObservationTrust,
         ParentLoopOutput, PersonalContextPolicy, PromptMode, PromptSkillContextMetadata,
-        SkillTrustLevel,
-        ProviderToolCallReference, ProviderToolDefinition, SkillVisibility, ToolObservationDetail,
-        ToolObservationStatus, UpdateAssistantDraft, VisibleCapabilityRequest,
-        VisibleCapabilitySurface, resolution,
+        ProviderToolCallReference, ProviderToolDefinition, SkillTrustLevel, SkillVisibility,
+        ToolObservationDetail, ToolObservationStatus, UpdateAssistantDraft,
+        VisibleCapabilityRequest, VisibleCapabilitySurface, resolution,
     },
 };
 use tracing_test::traced_test;

--- a/crates/ironclaw_product_workflow/src/reborn_services/types.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/types.rs
@@ -547,7 +547,7 @@ impl RebornGetRunStateResponse {
         let priced_model = value
             .resolved_model_route
             .as_ref()
-            .map(|route| route.model_id.as_str())
+            .map(|route| route.model_id())
             .or(active_model_id)
             .map(str::trim)
             .filter(|model| !model.is_empty() && !model.eq_ignore_ascii_case("default"));

--- a/crates/ironclaw_runner/src/loop_driver_host.rs
+++ b/crates/ironclaw_runner/src/loop_driver_host.rs
@@ -1985,8 +1985,8 @@ where
             };
             let slot = slot_for_model_profile(&run_context)?;
             let route = crate::model_routes::ModelRoute::new(
-                snapshot.provider_id.clone(),
-                snapshot.model_id.clone(),
+                snapshot.provider_id().to_string(),
+                snapshot.model_id().to_string(),
             )
             .map_err(model_route_error_to_host_error)?;
             resolver

--- a/crates/ironclaw_runner/src/model_gateway.rs
+++ b/crates/ironclaw_runner/src/model_gateway.rs
@@ -407,7 +407,7 @@ where
             request
                 .resolved_model_route
                 .as_ref()
-                .map(|snapshot| snapshot.model_id.as_str()),
+                .map(|snapshot| snapshot.model_id()),
         )?;
         let model_profile_id = request.model_profile_id.clone();
         let run_id = request.run_id;
@@ -450,7 +450,7 @@ where
             request
                 .resolved_model_route
                 .as_ref()
-                .map(|snapshot| snapshot.model_id.as_str()),
+                .map(|snapshot| snapshot.model_id()),
         )?;
         let model_profile_id = request.model_profile_id.clone();
         let run_id = request.run_id;
@@ -493,7 +493,7 @@ where
             request
                 .resolved_model_route
                 .as_ref()
-                .map(|snapshot| snapshot.model_id.as_str()),
+                .map(|snapshot| snapshot.model_id()),
         )?;
         let model_profile_id = request.model_profile_id.clone();
         let run_id = request.run_id;
@@ -541,7 +541,7 @@ where
             request
                 .resolved_model_route
                 .as_ref()
-                .map(|snapshot| snapshot.model_id.as_str()),
+                .map(|snapshot| snapshot.model_id()),
         )?;
         let model_profile_id = request.model_profile_id.clone();
         let run_id = request.run_id;
@@ -877,8 +877,11 @@ where
         slot: ModelSlot,
         snapshot: &HostManagedModelRouteSnapshot,
     ) -> Result<ModelSelectionMode, HostManagedModelError> {
-        let route = ModelRoute::new(snapshot.provider_id.clone(), snapshot.model_id.clone())
-            .map_err(map_model_route_error)?;
+        let route = ModelRoute::new(
+            snapshot.provider_id().to_string(),
+            snapshot.model_id().to_string(),
+        )
+        .map_err(map_model_route_error)?;
         self.route_resolver
             .validate_model_route(slot, &route)
             .map_err(map_model_route_error)
@@ -930,12 +933,15 @@ fn snapshot_from_host_request(
     snapshot: &HostManagedModelRouteSnapshot,
     policy_mode: ModelSelectionMode,
 ) -> Result<ResolvedModelRouteSnapshot, HostManagedModelError> {
-    let route = ModelRoute::new(snapshot.provider_id.clone(), snapshot.model_id.clone())
-        .map_err(map_model_route_error)?;
+    let route = ModelRoute::new(
+        snapshot.provider_id().to_string(),
+        snapshot.model_id().to_string(),
+    )
+    .map_err(map_model_route_error)?;
     let key = ModelRouteProviderKey::new(
         route,
-        snapshot.config_version.clone(),
-        snapshot.auth_version.clone(),
+        snapshot.config_version().to_string(),
+        snapshot.auth_version().to_string(),
     )
     .map_err(map_model_route_error)?;
     Ok(ResolvedModelRouteSnapshot::with_provider_key(

--- a/crates/ironclaw_turns/src/run_profile/host/run_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/host/run_context.rs
@@ -17,12 +17,28 @@ use super::validate::validate_model_route_component_value;
 /// caller-requested advisory hint rather than an operator-resolved route.
 const ADVISORY_MODEL_ROUTE_COMPONENT: &str = "requested";
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoopModelRouteSnapshot {
-    pub provider_id: String,
-    pub model_id: String,
-    pub config_version: String,
-    pub auth_version: String,
+/// A run's model route.
+///
+/// Persisted as a flat four-component object (`provider_id`, `model_id`,
+/// `config_version`, `auth_version`); this enum's custom serde preserves that
+/// exact wire shape, and an advisory route still writes the `"requested"`
+/// sentinel in the three non-model components, so historical stored routes
+/// round-trip byte-for-byte (no migration). In memory it is an enum so the two
+/// route kinds are distinct types rather than a sentinel smeared across three
+/// fields: `Advisory` carries only the caller-requested model id; `Resolved`
+/// carries the full operator route.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoopModelRouteSnapshot {
+    /// A caller-requested advisory hint (see [`LoopModelRouteSnapshot::advisory`]):
+    /// only `model_id` is meaningful.
+    Advisory { model_id: String },
+    /// An operator-resolved route with every component bound.
+    Resolved {
+        provider_id: String,
+        model_id: String,
+        config_version: String,
+        auth_version: String,
+    },
 }
 
 impl LoopModelRouteSnapshot {
@@ -32,12 +48,12 @@ impl LoopModelRouteSnapshot {
         config_version: impl Into<String>,
         auth_version: impl Into<String>,
     ) -> Self {
-        Self {
-            provider_id: provider_id.into(),
-            model_id: model_id.into(),
-            config_version: config_version.into(),
-            auth_version: auth_version.into(),
-        }
+        Self::from_components(
+            provider_id.into(),
+            model_id.into(),
+            config_version.into(),
+            auth_version.into(),
+        )
     }
 
     pub fn try_new(
@@ -51,8 +67,52 @@ impl LoopModelRouteSnapshot {
         Ok(snapshot)
     }
 
-    /// Build an *advisory* route from a caller-requested model string. The
-    /// provider/config/auth components are placeholders (`"requested"`) — only
+    /// Classify a flat four-component route into the typed enum: the advisory
+    /// sentinel in all three non-model components means [`Advisory`](Self::Advisory),
+    /// otherwise [`Resolved`](Self::Resolved). The single place the sentinel is
+    /// interpreted — shared by [`new`](Self::new) and `Deserialize`.
+    fn from_components(
+        provider_id: String,
+        model_id: String,
+        config_version: String,
+        auth_version: String,
+    ) -> Self {
+        if provider_id == ADVISORY_MODEL_ROUTE_COMPONENT
+            && config_version == ADVISORY_MODEL_ROUTE_COMPONENT
+            && auth_version == ADVISORY_MODEL_ROUTE_COMPONENT
+        {
+            Self::Advisory { model_id }
+        } else {
+            Self::Resolved {
+                provider_id,
+                model_id,
+                config_version,
+                auth_version,
+            }
+        }
+    }
+
+    /// The persisted flat components `(provider_id, model_id, config_version,
+    /// auth_version)`. An advisory route reports the `"requested"` sentinel for
+    /// the three non-model components, reproducing the historical wire shape.
+    fn components(&self) -> (&str, &str, &str, &str) {
+        match self {
+            Self::Advisory { model_id } => (
+                ADVISORY_MODEL_ROUTE_COMPONENT,
+                model_id,
+                ADVISORY_MODEL_ROUTE_COMPONENT,
+                ADVISORY_MODEL_ROUTE_COMPONENT,
+            ),
+            Self::Resolved {
+                provider_id,
+                model_id,
+                config_version,
+                auth_version,
+            } => (provider_id, model_id, config_version, auth_version),
+        }
+    }
+
+    /// Build an *advisory* route from a caller-requested model string — only
     /// `model_id` carries meaning. Advisory routes exist so a caller (e.g. an
     /// OpenAI-compatible client) can request a model without an operator-approved
     /// route binding: the non-routed gateway honors the model id when its
@@ -74,41 +134,89 @@ impl LoopModelRouteSnapshot {
         .ok()
     }
 
-    /// Whether this route is a caller-requested advisory hint (see
-    /// [`LoopModelRouteSnapshot::advisory`]) rather than an operator-resolved
-    /// route. A non-routed host passes an advisory snapshot through unvalidated
-    /// but fails closed on an operator route it cannot validate without a
-    /// resolver.
+    /// The requested (advisory) or resolved model id — meaningful for both kinds.
+    pub fn model_id(&self) -> &str {
+        match self {
+            Self::Advisory { model_id } | Self::Resolved { model_id, .. } => model_id,
+        }
+    }
+
+    /// The provider id component. An advisory route reports the `"requested"`
+    /// sentinel (only [`model_id`](Self::model_id) is meaningful for it); a
+    /// resolved route reports its bound provider. Prefer matching on the variant
+    /// when the distinction matters — use [`is_advisory`](Self::is_advisory).
+    pub fn provider_id(&self) -> &str {
+        self.components().0
+    }
+
+    /// The config-version component (advisory = the `"requested"` sentinel).
+    pub fn config_version(&self) -> &str {
+        self.components().2
+    }
+
+    /// The auth-version component (advisory = the `"requested"` sentinel).
+    pub fn auth_version(&self) -> &str {
+        self.components().3
+    }
+
+    /// Whether this route is a caller-requested advisory hint rather than an
+    /// operator-resolved route. A non-routed host passes an advisory snapshot
+    /// through unvalidated but fails closed on an operator route it cannot
+    /// validate without a resolver.
     pub fn is_advisory(&self) -> bool {
-        self.provider_id == ADVISORY_MODEL_ROUTE_COMPONENT
-            && self.config_version == ADVISORY_MODEL_ROUTE_COMPONENT
-            && self.auth_version == ADVISORY_MODEL_ROUTE_COMPONENT
+        matches!(self, Self::Advisory { .. })
     }
 
     pub fn validate(&self) -> Result<(), String> {
-        validate_model_route_component_value("provider_id", &self.provider_id, 128, |character| {
+        let (provider_id, model_id, config_version, auth_version) = self.components();
+        validate_model_route_component_value("provider_id", provider_id, 128, |character| {
             character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
         })?;
-        validate_model_route_component_value("model_id", &self.model_id, 256, |character| {
+        validate_model_route_component_value("model_id", model_id, 256, |character| {
             character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':' | '/')
         })?;
-        validate_model_route_component_value(
-            "config_version",
-            &self.config_version,
-            128,
-            |character| {
-                character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':')
-            },
-        )?;
-        validate_model_route_component_value(
-            "auth_version",
-            &self.auth_version,
-            128,
-            |character| {
-                character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':')
-            },
-        )?;
+        validate_model_route_component_value("config_version", config_version, 128, |character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':')
+        })?;
+        validate_model_route_component_value("auth_version", auth_version, 128, |character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':')
+        })?;
         Ok(())
+    }
+}
+
+/// Flat wire shape for [`LoopModelRouteSnapshot`], preserved across the
+/// enum refactor so historical persisted routes round-trip unchanged.
+#[derive(Serialize, Deserialize)]
+struct LoopModelRouteSnapshotWire {
+    provider_id: String,
+    model_id: String,
+    config_version: String,
+    auth_version: String,
+}
+
+impl Serialize for LoopModelRouteSnapshot {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let (provider_id, model_id, config_version, auth_version) = self.components();
+        LoopModelRouteSnapshotWire {
+            provider_id: provider_id.to_string(),
+            model_id: model_id.to_string(),
+            config_version: config_version.to_string(),
+            auth_version: auth_version.to_string(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LoopModelRouteSnapshot {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let wire = LoopModelRouteSnapshotWire::deserialize(deserializer)?;
+        Ok(Self::from_components(
+            wire.provider_id,
+            wire.model_id,
+            wire.config_version,
+            wire.auth_version,
+        ))
     }
 }
 
@@ -198,7 +306,7 @@ mod tests {
     #[test]
     fn advisory_model_route_carries_model_and_marks_itself_advisory() {
         let route = LoopModelRouteSnapshot::advisory("gpt-4o").expect("valid model");
-        assert_eq!(route.model_id, "gpt-4o");
+        assert_eq!(route.model_id(), "gpt-4o");
         assert!(route.is_advisory());
         assert!(route.validate().is_ok());
     }
@@ -210,6 +318,46 @@ mod tests {
     }
 
     #[test]
+    fn wire_shape_is_the_flat_four_component_object_and_round_trips() {
+        // The enum refactor must not change the persisted shape: historical
+        // stored routes (flat objects, advisory = the "requested" sentinel in
+        // three components) must deserialize to the right variant AND serialize
+        // back to the identical flat object, so pre-existing run records survive.
+        let advisory_json = r#"{"provider_id":"requested","model_id":"gpt-4o","config_version":"requested","auth_version":"requested"}"#;
+        let advisory: LoopModelRouteSnapshot =
+            serde_json::from_str(advisory_json).expect("advisory route deserializes");
+        assert_eq!(
+            advisory,
+            LoopModelRouteSnapshot::Advisory {
+                model_id: "gpt-4o".to_string()
+            }
+        );
+        assert!(advisory.is_advisory());
+        assert_eq!(
+            serde_json::to_string(&advisory).expect("serialize"),
+            advisory_json
+        );
+
+        let resolved_json = r#"{"provider_id":"anthropic","model_id":"claude","config_version":"cfg:v1","auth_version":"auth:v1"}"#;
+        let resolved: LoopModelRouteSnapshot =
+            serde_json::from_str(resolved_json).expect("resolved route deserializes");
+        assert_eq!(
+            resolved,
+            LoopModelRouteSnapshot::Resolved {
+                provider_id: "anthropic".to_string(),
+                model_id: "claude".to_string(),
+                config_version: "cfg:v1".to_string(),
+                auth_version: "auth:v1".to_string(),
+            }
+        );
+        assert!(!resolved.is_advisory());
+        assert_eq!(
+            serde_json::to_string(&resolved).expect("serialize"),
+            resolved_json
+        );
+    }
+
+    #[test]
     fn advisory_model_route_trims_and_rejects_empty_or_invalid_models() {
         assert_eq!(LoopModelRouteSnapshot::advisory("   "), None);
         assert_eq!(LoopModelRouteSnapshot::advisory(""), None);
@@ -217,7 +365,8 @@ mod tests {
         assert_eq!(LoopModelRouteSnapshot::advisory("gpt 4o"), None);
         // Surrounding whitespace is trimmed before validation.
         assert_eq!(
-            LoopModelRouteSnapshot::advisory("  claude-opus-4-6  ").map(|route| route.model_id),
+            LoopModelRouteSnapshot::advisory("  claude-opus-4-6  ")
+                .map(|route| route.model_id().to_string()),
             Some("claude-opus-4-6".to_string())
         );
     }

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -374,7 +374,7 @@ async fn submit_turn_records_advisory_model_route_from_requested_model() {
     let route = state
         .resolved_model_route
         .expect("advisory model route recorded from requested_model");
-    assert_eq!(route.model_id, "gpt-4o");
+    assert_eq!(route.model_id(), "gpt-4o");
     assert!(
         route.is_advisory(),
         "a caller-requested model is an advisory route, not an operator-resolved one"


### PR DESCRIPTION
## What & why

`LoopModelRouteSnapshot` told a **caller-requested advisory hint** apart from an **operator-resolved route** by smearing the string sentinel `"requested"` across its `provider_id` / `config_version` / `auth_version` fields — an advisory route was "a route whose three non-model components all equal a magic string." That is precisely the stringly-typed domain value `types.md` forbids: the distinction lived in a convention no type enforced.

Make the two kinds distinct in-memory types:

```rust
enum LoopModelRouteSnapshot {
    Advisory { model_id },
    Resolved { provider_id, model_id, config_version, auth_version },
}
```

- `from_components` is now the **single** place the sentinel is interpreted (shared by `new` and `Deserialize`); `is_advisory()` replaces sentinel comparison at call sites.
- Cross-crate readers (`ironclaw_runner::model_gateway` / `loop_driver_host`, the `ironclaw_product_workflow` route-model read) previously touched the struct fields directly; they now go through `model_id()` / `provider_id()` / `config_version()` / `auth_version()` accessors.

## Wire-preserving — no migration

The type is persisted in `RunRecord.resolved_model_route`, so this is a persisted-state change. A custom `Serialize`/`Deserialize` keeps the **exact historical flat four-component object** — an advisory route still writes `"requested"` in the three non-model components — and `from_components` classifies on the way back in. Old stored routes round-trip byte-for-byte.

A new round-trip test (`wire_shape_is_the_flat_four_component_object_and_round_trips`) pins both shapes: the advisory (sentinel) flat object deserializes to `Advisory` and re-serializes identically, and a resolved flat object deserializes to `Resolved` and re-serializes identically.

## Context

This is **deferred item #1 from #6398** — the only item of the typed-internals batch that was *not* behavior-preserving (it is a persisted-state + cross-crate wire migration), held out to be delivered on its own as planned.

**Stacked on #6398** (`refactor/turns-typed-internals`); review/merge that one first. That base branch also received a one-line `cargo fmt` reflow commit so it stays fmt-clean — it belongs to #6398's diff, not this one.

## Validation

- `cargo build` / `cargo clippy -p ironclaw_turns --all-targets --all-features` — zero warnings
- `cargo test` green across `ironclaw_turns`, `ironclaw_runner`, `ironclaw_loop_host`, `ironclaw_product_workflow`, `ironclaw_reborn_composition` (the one unrelated failure, `detect_env_llm_is_none_with_no_llm_env_vars_set`, is a pre-existing env-dependent test on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)