### PR TITLE
test(stores): Tier 1 — approvals/threads/turns/events/authz + RootFilesystem folds through the real store

### DIFF
--- a/crates/ironclaw_approvals/Cargo.toml
+++ b/crates/ironclaw_approvals/Cargo.toml
@@ -31,6 +31,8 @@ tracing = "0.1"
 [dev-dependencies]
 # Enables the in-memory-backed capability-lease store constructor for tests only.
 ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
+# FaultInjecting decorator: test store fault paths through the real store
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 # Enables the in-memory-backed run-state/approval store constructors for tests only.
 ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 tempfile = "3"

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -1,9 +1,71 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use ironclaw_approvals::*;
 use ironclaw_authorization::*;
 use ironclaw_events::{AuditSink, EventError, InMemoryAuditSink};
+use ironclaw_filesystem::{
+    Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, ScopedFilesystem,
+};
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
+
+/// The production `FilesystemApprovalRequestStore` over a [`FaultInjecting`]
+/// backend armed to fail the approval-status write. On the `/approvals` mount,
+/// `save_pending` is the 1st `WriteFile` and `approve` is the 2nd, so failing the
+/// 2nd lets the pending record persist and then faults the status transition.
+/// Replaces the former whole-trait `FailingApproveApprovalStore` fake: the real
+/// store now runs its genuine CAS read-modify-write and
+/// `FilesystemError -> RunStateError::Filesystem` mapping under the injected
+/// backend fault, so the test exercises the production store path instead of a
+/// hand-rolled stand-in that reimplemented the trait.
+fn approval_store_failing_status_write()
+-> FilesystemApprovalRequestStore<FaultInjecting<InMemoryBackend>> {
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("approvals")
+                .nth(2)
+                .backend("injected approval write failure"),
+        ),
+    );
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/approvals").unwrap(),
+        VirtualPath::new("/engine/approvals").unwrap(),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .unwrap();
+    FilesystemApprovalRequestStore::new(Arc::new(ScopedFilesystem::with_fixed_view(
+        backend, mounts,
+    )))
+}
+
+/// The production `FilesystemCapabilityLeaseStore` over a [`FaultInjecting`]
+/// backend armed to fail every write on the `/authorization` mount, so
+/// `issue(...)` fails at its first backend write. Replaces the former
+/// whole-trait `FailingIssueLeaseStore` fake: the real store now runs its
+/// genuine lease serialization and `FilesystemError -> CapabilityLeaseError`
+/// mapping (`Backend -> Persistence`) under the injected fault, proving the
+/// mapping the fake short-circuited.
+fn lease_store_failing_issue_write()
+-> FilesystemCapabilityLeaseStore<FaultInjecting<InMemoryBackend>> {
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("authorization")
+                .backend("injected lease write failure"),
+        ),
+    );
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/authorization").unwrap(),
+        VirtualPath::new("/engine/authorization").unwrap(),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .unwrap();
+    FilesystemCapabilityLeaseStore::new(Arc::new(ScopedFilesystem::with_fixed_view(
+        backend, mounts,
+    )))
+}
 
 #[tokio::test]
 async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
@@ -146,7 +208,7 @@ async fn approving_pending_request_marks_request_approved_even_when_lease_issue_
     // the system can surface the error to the caller and re-attempt
     // lease issuance later.
     let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
-    let leases = FailingIssueLeaseStore;
+    let leases = lease_store_failing_issue_write();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -201,13 +263,13 @@ async fn approving_pending_request_issues_no_lease_when_approval_update_fails() 
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
     let request_id = approval.id;
-    let approvals = FailingApproveApprovalStore {
-        record: ApprovalRecord {
-            scope: scope.clone(),
-            request: approval,
-            status: ApprovalStatus::Pending,
-        },
-    };
+    let approvals = approval_store_failing_status_write();
+    // 1st `/approvals` write persists the pending record; the armed fault fires
+    // on the 2nd write (the `approve` status transition below).
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
 
@@ -231,8 +293,22 @@ async fn approving_pending_request_issues_no_lease_when_approval_update_fails() 
         .await
         .unwrap_err();
 
+    // The real store mapped the injected `FilesystemError::Backend` through its
+    // CAS write path to `RunStateError::Filesystem` (which the old whole-trait
+    // fake short-circuited), surfaced as `ApprovalResolutionError::RunState`.
     assert!(matches!(err, ApprovalResolutionError::RunState(_)));
     assert_eq!(leases.leases_for_scope(&scope).await, Vec::new());
+    // The faulted status write left the record `Pending` — the real store's CAS
+    // behavior the old whole-trait fake could not prove.
+    assert_eq!(
+        approvals
+            .get(&scope, request_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ApprovalStatus::Pending
+    );
 }
 
 #[tokio::test]
@@ -753,62 +829,6 @@ impl AuditSink for FailingAuditSink {
     }
 }
 
-struct FailingApproveApprovalStore {
-    record: ApprovalRecord,
-}
-
-#[async_trait]
-impl ApprovalRequestStore for FailingApproveApprovalStore {
-    async fn save_pending(
-        &self,
-        _scope: ResourceScope,
-        _request: ApprovalRequest,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        Ok(self.record.clone())
-    }
-
-    async fn get(
-        &self,
-        scope: &ResourceScope,
-        request_id: ApprovalRequestId,
-    ) -> Result<Option<ApprovalRecord>, RunStateError> {
-        if self.record.scope == *scope && self.record.request.id == request_id {
-            Ok(Some(self.record.clone()))
-        } else {
-            Ok(None)
-        }
-    }
-
-    async fn approve(
-        &self,
-        _scope: &ResourceScope,
-        _request_id: ApprovalRequestId,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        Err(RunStateError::Filesystem(
-            "injected approval write failure".to_string(),
-        ))
-    }
-
-    async fn deny(
-        &self,
-        _scope: &ResourceScope,
-        _request_id: ApprovalRequestId,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        Ok(self.record.clone())
-    }
-
-    async fn records_for_scope(
-        &self,
-        scope: &ResourceScope,
-    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
-        if same_tenant_user_for_test(&self.record.scope, scope) {
-            Ok(vec![self.record.clone()])
-        } else {
-            Ok(Vec::new())
-        }
-    }
-}
-
 struct AlreadyResolvedOnApproveStore {
     record: ApprovalRecord,
     resolved_status: ApprovalStatus,
@@ -867,78 +887,6 @@ impl ApprovalRequestStore for AlreadyResolvedOnApproveStore {
         } else {
             Ok(Vec::new())
         }
-    }
-}
-
-struct FailingIssueLeaseStore;
-
-#[async_trait]
-impl CapabilityLeaseStore for FailingIssueLeaseStore {
-    async fn issue(
-        &self,
-        _lease: CapabilityLease,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::Persistence {
-            reason: "injected lease write failure".to_string(),
-        })
-    }
-
-    async fn revoke(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn get(
-        &self,
-        _scope: &ResourceScope,
-        _lease_id: CapabilityGrantId,
-    ) -> Option<CapabilityLease> {
-        None
-    }
-
-    async fn claim(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-        _invocation_fingerprint: &InvocationFingerprint,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn consume(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn begin_dispatch_claimed(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-        _invocation_fingerprint: &InvocationFingerprint,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn abort_dispatch_claimed(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn leases_for_scope(&self, _scope: &ResourceScope) -> Vec<CapabilityLease> {
-        Vec::new()
-    }
-
-    async fn active_leases_for_context(&self, _context: &ExecutionContext) -> Vec<CapabilityLease> {
-        Vec::new()
     }
 }
 

--- a/crates/ironclaw_authorization/Cargo.toml
+++ b/crates/ironclaw_authorization/Cargo.toml
@@ -26,5 +26,8 @@ thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
+# FaultInjecting decorator: fold the hand-rolled `CountingFilesystem` op-recorder
+# onto the real backend seam so tests assert on genuine `list_dir` traffic.
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -1,13 +1,9 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
-};
+use std::sync::Arc;
 
-use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::*;
 use ironclaw_filesystem::{
-    DirEntry, DiskFilesystem, FileStat, FilesystemError, InMemoryBackend, RootFilesystem,
+    DiskFilesystem, FaultInjecting, FilesystemOperation, InMemoryBackend, RootFilesystem,
     ScopedFilesystem,
 };
 use ironclaw_host_api::*;
@@ -740,14 +736,17 @@ async fn filesystem_lease_store_persists_and_reloads_issued_leases() {
 
 #[tokio::test]
 async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocation_roots() {
-    // Wrap the underlying [`DiskFilesystem`] in a [`CountingFilesystem`]
-    // so we can assert that `leases_for_scope` reads the owner index
-    // rather than fanning out to `list_dir` per invocation. The
-    // [`ScopedFilesystem`] layer on top binds the `/authorization` alias
-    // to a tenant/user-scoped target — same as `engine_filesystem()`.
-    let counting = Arc::new(CountingFilesystem::new(local_filesystem_with_engine_mount()));
+    // Wrap the underlying [`DiskFilesystem`] in
+    // [`ironclaw_filesystem::FaultInjecting`] (op-recorder mode, no faults armed)
+    // so we can assert that `leases_for_scope` reads the owner index rather than
+    // fanning out to `list_dir` per invocation. Folds the former hand-rolled
+    // `CountingFilesystem` observer onto the shared decorator, exercising the
+    // real backend traffic instead of a bespoke counting wrapper. The
+    // [`ScopedFilesystem`] layer on top binds the `/authorization` alias to a
+    // tenant/user-scoped target — same as `engine_filesystem()`.
+    let backend = Arc::new(FaultInjecting::new(local_filesystem_with_engine_mount()));
     let fs = build_scoped_fs(
-        Arc::clone(&counting),
+        Arc::clone(&backend),
         "/engine/tenants/test/users/test/authorization",
     );
     let context = execution_context(CapabilitySet::default());
@@ -769,7 +768,7 @@ async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocati
         store.issue(lease).await.unwrap();
     }
 
-    counting.reset_list_dir_calls();
+    let list_dir_before = backend.count(FilesystemOperation::ListDir);
     let leases = store.leases_for_scope(&context.resource_scope).await;
 
     let mut actual = leases
@@ -780,7 +779,7 @@ async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocati
     expected.sort_by_key(|lease_id| lease_id.as_uuid());
     assert_eq!(actual, expected);
     assert_eq!(
-        counting.list_dir_calls(),
+        backend.count(FilesystemOperation::ListDir) - list_dir_before,
         0,
         "indexed lease listing should not scan every invocation directory"
     );
@@ -1161,81 +1160,6 @@ async fn revoked_lease_no_longer_authorizes_dispatch() {
             reason: DenyReason::MissingGrant
         }
     ));
-}
-
-struct CountingFilesystem {
-    inner: DiskFilesystem,
-    list_dir_calls: Arc<AtomicUsize>,
-}
-
-impl CountingFilesystem {
-    fn new(inner: DiskFilesystem) -> Self {
-        Self {
-            inner,
-            list_dir_calls: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-
-    fn reset_list_dir_calls(&self) {
-        self.list_dir_calls.store(0, Ordering::SeqCst);
-    }
-
-    fn list_dir_calls(&self) -> usize {
-        self.list_dir_calls.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for CountingFilesystem {
-    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        self.inner.read_file(path).await
-    }
-
-    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.write_file(path, bytes).await
-    }
-
-    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.append_file(path, bytes).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.list_dir_calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-
-    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.create_dir_all(path).await
-    }
-
-    // After PR #3659 the trait default `get`/`put` are `Unsupported`.
-    // Forward to the inner DiskFilesystem (which implements them
-    // natively) so this counting wrapper keeps participating in the
-    // unified surface used by FilesystemCapabilityLeaseStore's read_lease
-    // / write_lease / read_lease_index / write_lease_index ops.
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: ironclaw_filesystem::Entry,
-        cas: ironclaw_filesystem::CasExpectation,
-    ) -> Result<ironclaw_filesystem::RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(
-        &self,
-        path: &VirtualPath,
-    ) -> Result<Option<ironclaw_filesystem::VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
 }
 
 fn trust_decision(

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -1346,6 +1346,10 @@ async fn concurrent_auth_resume_claim_loser_returns_lease_error_without_failing_
     // A lease store that delegates everything to an inner FilesystemCapabilityLeaseStore<InMemoryBackend>
     // except `claim()`, which returns InactiveLease { status: Claimed } once the
     // `fail_next_claim` flag is set — simulating the loser of a concurrent claim race.
+    // domain-state fake, not an I/O fault — cannot move to
+    // ironclaw_filesystem::FaultInjecting: it returns a domain
+    // `CapabilityLeaseError::InactiveLease{Claimed}` (the concurrent winner already
+    // claimed) that no backend fault (which only yields `Persistence`) can produce.
     struct ClaimFailingLeaseStore {
         inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         fail_next_claim: AtomicBool,
@@ -1792,6 +1796,10 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
     // `begin_dispatch_claimed`, creating the real data race on the state
     // machine transition: one wins (Claimed→Dispatching), the other loses
     // (sees Dispatching → InactiveLease{Dispatching}).
+    // Synchronization primitive, not an I/O fault — cannot move to
+    // ironclaw_filesystem::FaultInjecting: FaultInjecting injects errors + records
+    // ops but is explicitly NOT a read/write-interleaving barrier (see
+    // ironclaw_filesystem/CLAUDE.md). The Barrier(2) interleave is the whole test.
     struct BarrierLeaseStore {
         inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         /// Both concurrent auth_resume_json callers rendezvous here after
@@ -2948,6 +2956,10 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
     // store, suspends the caller until `claim_release` is notified.  Any other
     // caller that runs `matching_approval_lease` during this window finds None
     // (lease is Claimed, not Active) and falls into the REUSE branch.
+    // Synchronization primitive, not an I/O fault — cannot move to
+    // ironclaw_filesystem::FaultInjecting: the Notify gate suspends a caller
+    // mid-`claim` to force an interleaving; FaultInjecting only injects errors +
+    // records ops and is explicitly not a synchronization barrier.
     struct GatedLeaseStore {
         inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         claim_entered: StdArc<Notify>,

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -2106,6 +2106,11 @@ impl RunStateStore for FailOnFailRunStateStore {
     }
 }
 
+// Synchronization primitive + domain-state fake, not an I/O fault — cannot move
+// to ironclaw_filesystem::FaultInjecting: it uses `tokio::sync::Notify` to
+// interleave two concurrent `claim` calls and returns a domain
+// `CapabilityLeaseError::InactiveLease{Consumed}` for the loser. FaultInjecting
+// is neither a synchronization barrier nor able to produce that domain error.
 struct CoordinatedClaimConflictLeaseStore {
     inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
     claim_calls: AtomicUsize,
@@ -2204,6 +2209,13 @@ impl CapabilityLeaseStore for CoordinatedClaimConflictLeaseStore {
     }
 }
 
+// I/O-shaped (returns `CapabilityLeaseError::Persistence` on `consume`), but kept:
+// FaultInjecting gates by FilesystemOperation + path only, and `consume`'s CAS
+// write is indistinguishable — same op (WriteFile) and same lease-file path — from
+// the `claim`/`begin_dispatch_claimed` CAS writes in the same `resume_json` call,
+// so a backend fault cannot isolate the consume failure this test needs. This is
+// the documented FaultInjecting limitation ("can't fault only versioned writes";
+// ironclaw_filesystem/CLAUDE.md), not a domain-double.
 struct ConsumeFailingLeaseStore {
     inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
 }

--- a/crates/ironclaw_event_projections/Cargo.toml
+++ b/crates/ironclaw_event_projections/Cargo.toml
@@ -19,7 +19,8 @@ thiserror = "2"
 
 [dev-dependencies]
 ironclaw_extensions = { path = "../ironclaw_extensions" }
-ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+# FaultInjecting decorator: test the projection source-error path through the real store
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 ironclaw_memory = { path = "../ironclaw_memory" }
 ironclaw_memory_native = { path = "../ironclaw_memory_native" }
 ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -14,12 +14,16 @@ use ironclaw_events::{
     EventStreamKey, InMemoryDurableAuditLog, InMemoryDurableEventLog, ReadScope, RuntimeEvent,
     RuntimeEventId, RuntimeEventKind, UNCLASSIFIED_ERROR_KIND,
 };
+use ironclaw_filesystem::{
+    Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, ScopedFilesystem,
+};
 use ironclaw_host_api::{
     Action, ActionResultSummary, ActionSummary, AgentId, AuditEnvelope, AuditEventId, AuditStage,
-    CapabilityId, CapabilitySet, CorrelationId, DenyReason, ExtensionId, InvocationId, MountView,
-    ProcessId, ProjectId, ResourceScope, RuntimeKind, ScopedPath, TenantId, ThreadId, TrustClass,
-    UserId,
+    CapabilityId, CapabilitySet, CorrelationId, DenyReason, ExtensionId, InvocationId, MountAlias,
+    MountGrant, MountPermissions, MountView, ProcessId, ProjectId, ResourceScope, RuntimeKind,
+    ScopedPath, TenantId, ThreadId, TrustClass, UserId, VirtualPath,
 };
+use ironclaw_reborn_event_store::FilesystemDurableEventLog;
 
 #[test]
 fn audit_projection_stage_wire_strings_stay_compatible_with_audit_stage() {
@@ -1901,7 +1905,7 @@ async fn replay_projection_output_does_not_expose_raw_runtime_details() {
 
 #[tokio::test]
 async fn replay_projection_errors_do_not_expose_backend_details() {
-    let service = ReplayEventProjectionService::new(Arc::new(FailingDurableEventLog));
+    let service = ReplayEventProjectionService::new(projection_source_failing_with_sentinels());
     let scope = scope_for_thread(ThreadId::new("thread-a").unwrap());
 
     let error = service
@@ -1927,42 +1931,49 @@ async fn replay_projection_errors_do_not_expose_backend_details() {
     assert!(message.contains("projection source failed"));
 }
 
-struct FailingDurableEventLog;
-
-#[async_trait]
-impl DurableEventLog for FailingDurableEventLog {
-    async fn append(
-        &self,
-        _event: RuntimeEvent,
-    ) -> Result<EventLogEntry<RuntimeEvent>, EventError> {
-        Err(EventError::DurableLog {
-            reason: "DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live".to_string(),
-        })
-    }
-
-    async fn read_after_cursor(
-        &self,
-        _stream: &EventStreamKey,
-        _filter: &ReadScope,
-        _after: Option<EventCursor>,
-        _limit: usize,
-    ) -> Result<EventReplay<RuntimeEvent>, EventError> {
-        Err(EventError::DurableLog {
-            reason: "DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live".to_string(),
-        })
-    }
-
-    async fn head_cursor(
-        &self,
-        _stream: &EventStreamKey,
-        _after: EventCursor,
-    ) -> Result<EventCursor, EventError> {
-        Err(EventError::DurableLog {
-            reason: "DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live".to_string(),
-        })
-    }
+/// The real [`FilesystemDurableEventLog`] over a [`FaultInjecting`] backend
+/// armed to fail the replay `Tail` op with a backend reason that embeds
+/// sentinel tokens (a fake DB marker, a private host path, a secret-shaped
+/// string). Replaces the former whole-trait `FailingDurableEventLog` fake:
+/// the projection service now sanitizes an error produced by the *real*
+/// store's `FilesystemError -> EventError` mapping, whose `Backend` Display
+/// (`"filesystem backend error during {operation} at {path}: {reason}"`)
+/// threads the injected reason through `map_filesystem_tail_error` verbatim.
+/// This proves the projection boundary strips genuine backend detail the store
+/// actually surfaces, not just a fake's hand-returned string.
+fn projection_source_failing_with_sentinels()
+-> Arc<FilesystemDurableEventLog<FaultInjecting<InMemoryBackend>>> {
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::Tail)
+                .backend("DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live"),
+        ),
+    );
+    // The filesystem log routes every stream through scoped paths under
+    // `/events`; grant the read/tail permissions the replay path needs.
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/events").expect("alias"),
+        VirtualPath::new("/events").expect("target"),
+        MountPermissions {
+            read: true,
+            write: true,
+            delete: false,
+            list: true,
+            execute: false,
+        },
+    )])
+    .expect("mount view");
+    Arc::new(FilesystemDurableEventLog::new(Arc::new(
+        ScopedFilesystem::with_fixed_view(backend, mounts),
+    )))
 }
 
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. Serves canned `entries` at fixed cursors
+// and records the `after` cursor of each `read_after_cursor` call to assert the
+// projection service's pagination/cursor-advance behavior. Those are
+// above-the-store observations (cursor arguments, not filesystem ops) that
+// FaultInjecting — which records only op+path — cannot reproduce.
 struct CountingDurableEventLog {
     entries: Vec<EventLogEntry<RuntimeEvent>>,
     reads: Mutex<Vec<Option<EventCursor>>>,
@@ -2435,6 +2446,12 @@ async fn replay_projection_updates_with_small_limit_handles_long_prefix() {
 /// the first `read_after_cursor(after=None, ..)` call and an empty page
 /// otherwise. Used for regressions that need to inject hand-built
 /// `RuntimeEvent`s that bypass the typed sanitizing constructors.
+//
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. Its whole purpose is to feed the
+// projection service hand-built events that bypass the typed sanitizing
+// constructors; the real store serializes/deserializes through that sanitizer,
+// so it structurally cannot carry these unsanitized records.
 struct StaticDurableEventLog {
     entries: Vec<EventLogEntry<RuntimeEvent>>,
 }

--- a/crates/ironclaw_events/tests/durable_log_contract.rs
+++ b/crates/ironclaw_events/tests/durable_log_contract.rs
@@ -1013,6 +1013,13 @@ async fn read_scope_filter_isolates_project_within_same_stream() {
 /// `succeed_count` calls and fails for every subsequent call.  `append_batch`
 /// is deliberately NOT overridden so the test exercises the default
 /// implementation in [`DurableEventLog`].
+//
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. It exists to exercise the trait's
+// *default* `append_batch` loop, which the filesystem-backed store overrides
+// (so the real store never runs this path); and the filesystem store lives in
+// the downstream `ironclaw_reborn_event_store` crate, unreachable from
+// `ironclaw_events` without a circular dependency.
 struct PartialFailLog {
     call_count: std::sync::atomic::AtomicUsize,
     succeed_count: usize,

--- a/crates/ironclaw_filesystem/src/cas/tests.rs
+++ b/crates/ironclaw_filesystem/src/cas/tests.rs
@@ -22,6 +22,14 @@ use crate::{
     FilesystemOperation, InMemoryBackend, RecordKind, RecordVersion, RootFilesystem,
     ScopedFilesystem, VersionedEntry,
 };
+// The generic get/put backend-error regressions inject a `Backend` fault below
+// the real CAS-capable `InMemoryBackend` via the shared `FaultInjecting`
+// decorator instead of hand-rolling a whole-trait fake. `FaultInjecting` lives
+// behind the `test-support` feature, so the import and the two tests that use
+// it are gated to keep the default `cargo test` lane compiling with the feature
+// off.
+#[cfg(feature = "test-support")]
+use crate::{Fault, FaultInjecting};
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────
 
@@ -611,54 +619,6 @@ async fn unsupported_write_file_maps_to_cas_unsupported() {
     );
 }
 
-// ─── A CAS-capable backend whose `get` returns a generic error ────────────────
-
-/// CAS-capable backend whose `get` always returns a [`FilesystemError::Backend`]
-/// error — not a not-found / `Ok(None)`, not a `VersionMismatch`. Used to
-/// exercise the `get`-error arm of `cas_update_loop` — the
-/// `Err(error) => return Err(CasUpdateError::Backend(error))` branch of the
-/// `match filesystem.get(...)` — when the read itself fails. The pre-flight
-/// gate passes because full capabilities are declared; `get` then fails before any
-/// decode or apply runs.
-struct GetErrorBackend;
-
-#[async_trait]
-impl RootFilesystem for GetErrorBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        // Full CAS-capable shape — pre-flight gate passes and the loop enters.
-        BackendCapabilities::in_memory_full()
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        // A plain infrastructure error on the read path. Not a not-found
-        // (`Ok(None)`) and not a `VersionMismatch` — a backend that is simply
-        // broken or temporarily unavailable. The loop's get-error arm must
-        // forward it unchanged as `CasUpdateError::Backend`.
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::ReadFile,
-            reason: "simulated backend read failure".to_string(),
-        })
-    }
-
-    async fn put(
-        &self,
-        _path: &VirtualPath,
-        _entry: Entry,
-        _cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        unimplemented!("GetErrorBackend::put is unreachable in this test")
-    }
-
-    async fn list_dir(&self, _path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        unimplemented!("GetErrorBackend::list_dir is unreachable in this test")
-    }
-
-    async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        unimplemented!("GetErrorBackend::stat is unreachable in this test")
-    }
-}
-
 // ─── A backend whose `get` returns a record with an unparseable body ──────────
 
 /// CAS-capable backend whose `get` always returns a [`VersionedEntry`] whose
@@ -758,57 +718,17 @@ impl RootFilesystem for PutTrackingBackend {
     }
 }
 
-// ─── A CAS-capable backend whose `put` returns a generic non-CAS error ────────
+// ─── Generic backend get/put errors, injected via `FaultInjecting` ────────────
+//
+// `GetErrorBackend` and `GenericPutErrorBackend` (hand-rolled whole-trait
+// `RootFilesystem` fakes) folded into `ironclaw_filesystem::FaultInjecting`:
+// each test now wraps the real CAS-capable `InMemoryBackend` and injects a
+// `Backend` fault on the read / write op, so the regression exercises the
+// genuine backend under the injected fault rather than a bespoke stand-in.
+// Gated on `test-support` because `FaultInjecting` is (the default `cargo test`
+// lane keeps compiling this module with the feature off).
 
-/// CAS-capable backend whose `get` returns `Ok(None)` and whose `put` returns
-/// a plain [`FilesystemError::Backend`] — neither `VersionMismatch` nor
-/// `Unsupported { operation: WriteFile }`. Used to exercise the catch-all
-/// `Err(error) => Err(CasUpdateError::Backend(error))` arm in `cas_update_loop`
-/// — the fallback after the `VersionMismatch` and `Unsupported { operation:
-/// WriteFile, .. }` arms on the `match filesystem.put(...)`. The pre-flight gate
-/// passes because full capabilities are declared; `get` returns absent so the
-/// loop attempts a first write; `put` then returns the generic error the loop
-/// must forward as-is.
-struct GenericPutErrorBackend;
-
-#[async_trait]
-impl RootFilesystem for GenericPutErrorBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        // Full CAS-capable shape — pre-flight gate passes and the loop enters.
-        BackendCapabilities::in_memory_full()
-    }
-
-    async fn get(&self, _path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        // No existing record — loop takes the first-write path and reaches `put`.
-        Ok(None)
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        _entry: Entry,
-        _cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        // A plain backend failure that is neither `VersionMismatch` (which
-        // would trigger a retry) nor `Unsupported { WriteFile }` (which maps
-        // to `CasUnsupported`). The loop's catch-all arm must forward it as
-        // `CasUpdateError::Backend`.
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::WriteFile,
-            reason: "simulated generic backend failure".to_string(),
-        })
-    }
-
-    async fn list_dir(&self, _path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        unimplemented!("GenericPutErrorBackend::list_dir is unreachable in this test")
-    }
-
-    async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        unimplemented!("GenericPutErrorBackend::stat is unreachable in this test")
-    }
-}
-
+#[cfg(feature = "test-support")]
 #[tokio::test]
 async fn backend_put_error_maps_to_backend() {
     // Regression for the catch-all `Err(error) => Err(CasUpdateError::Backend(error))`
@@ -816,14 +736,17 @@ async fn backend_put_error_maps_to_backend() {
     // after the `VersionMismatch` (retry) and `Unsupported { operation: WriteFile,
     // .. }` (CasUnsupported) arms.
     //
-    // The backend advertises full CAS capability so the pre-flight gate passes
-    // and the helper enters the loop. `get` returns `Ok(None)` so the loop
+    // `InMemoryBackend` advertises full CAS capability so the pre-flight gate
+    // passes and the helper enters the loop. The record is absent so the loop
     // takes the first-write (`CasExpectation::Absent`) path and calls `put`.
-    // `put` returns `FilesystemError::Backend` — a generic infrastructure
-    // failure that is neither `VersionMismatch` (retry) nor
-    // `Unsupported { WriteFile }` (maps to CasUnsupported). The helper must
+    // `FaultInjecting` faults that write with `FilesystemError::Backend` — a
+    // generic infrastructure failure that is neither `VersionMismatch` (retry)
+    // nor `Unsupported { WriteFile }` (maps to CasUnsupported). The helper must
     // forward it unchanged as `CasUpdateError::Backend(_)`.
-    let fs = Arc::new(scoped(Arc::new(GenericPutErrorBackend)));
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::WriteFile).backend("simulated generic backend failure"),
+    ));
+    let fs = Arc::new(scoped(backend));
     let scope = ResourceScope::system();
 
     let result: Result<u64, CasUpdateError<TestError>> = cas_update(
@@ -843,17 +766,22 @@ async fn backend_put_error_maps_to_backend() {
     );
 }
 
+#[cfg(feature = "test-support")]
 #[tokio::test]
 async fn backend_get_error_maps_to_backend() {
     // Regression for the `get`-error arm in `cas_update_loop`:
     // `Err(error) => return Err(CasUpdateError::Backend(error))` on the
     // `match filesystem.get(...)`.
     //
-    // The backend advertises full CAS capability so the pre-flight gate passes
-    // and the helper enters the loop. `get` then returns a plain infrastructure
-    // error (not `Ok(None)` and not a `VersionMismatch`). The helper must
-    // forward it unchanged as `CasUpdateError::Backend(_)`.
-    let fs = Arc::new(scoped(Arc::new(GetErrorBackend)));
+    // `InMemoryBackend` advertises full CAS capability so the pre-flight gate
+    // passes and the helper enters the loop. `FaultInjecting` faults the read
+    // with a plain infrastructure `Backend` error (not `Ok(None)` and not a
+    // `VersionMismatch`). The helper must forward it unchanged as
+    // `CasUpdateError::Backend(_)`.
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::ReadFile).backend("simulated backend read failure"),
+    ));
+    let fs = Arc::new(scoped(backend));
     let scope = ResourceScope::system();
 
     let result: Result<u64, CasUpdateError<TestError>> = cas_update(

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::{
-    DirEntry, DiskFilesystem, FileStat, FileType, FilesystemError, FilesystemOperation,
-    RootFilesystem,
+    DirEntry, DiskFilesystem, Fault, FaultInjecting, FileStat, FileType, FilesystemError,
+    FilesystemOperation, RootFilesystem,
 };
 use ironclaw_host_api::runtime_policy::{
     ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
@@ -142,10 +142,13 @@ async fn builtin_coding_list_and_grep_skip_entries_when_stat_fails() {
     std::fs::write(temp.path().join("skip.rs"), "needle\n").unwrap();
 
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
-    let runtime = runtime_with_filesystem(StatFailureFilesystem {
-        inner: filesystem,
-        fail_suffix: "/skip.rs",
-    });
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::Stat)
+                .path("/skip.rs")
+                .backend("injected stat failure"),
+        ),
+    );
     let context = execution_context_with_mounts(coding_capability_ids(), mounts);
 
     let listed = invoke_with_context(
@@ -176,10 +179,13 @@ async fn builtin_coding_grep_skips_entries_when_read_fails_during_directory_sear
     std::fs::write(temp.path().join("skip.rs"), "needle\n").unwrap();
 
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
-    let runtime = runtime_with_filesystem(ReadFailureFilesystem {
-        inner: filesystem,
-        fail_suffix: "/skip.rs",
-    });
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/skip.rs")
+                .backend("injected read failure"),
+        ),
+    );
     let context = execution_context_with_mounts(coding_capability_ids(), mounts);
 
     let grepped = invoke_with_context(
@@ -200,10 +206,13 @@ async fn builtin_coding_grep_fails_on_explicit_file_read_error() {
     std::fs::write(temp.path().join("fail.rs"), "needle\n").unwrap();
 
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
-    let runtime = runtime_with_filesystem(ReadFailureFilesystem {
-        inner: filesystem,
-        fail_suffix: "/fail.rs",
-    });
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/fail.rs")
+                .backend("injected read failure"),
+        ),
+    );
     let context = execution_context_with_mounts(coding_capability_ids(), mounts);
 
     let error = invoke_with_context(
@@ -1820,41 +1829,6 @@ fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (DiskFilesy
     (filesystem, mounts)
 }
 
-struct StatFailureFilesystem {
-    inner: DiskFilesystem,
-    fail_suffix: &'static str,
-}
-
-#[async_trait]
-impl RootFilesystem for StatFailureFilesystem {
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        if path.as_str().ends_with(self.fail_suffix) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::Stat,
-                reason: "injected stat failure".to_string(),
-            });
-        }
-        self.inner.stat(path).await
-    }
-
-    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        self.inner.read_file(path).await
-    }
-
-    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.write_file(path, bytes).await
-    }
-
-    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.create_dir_all(path).await
-    }
-}
-
 struct StatLenOverrideFilesystem {
     inner: DiskFilesystem,
     suffix: &'static str,
@@ -1888,41 +1862,15 @@ impl RootFilesystem for StatLenOverrideFilesystem {
     }
 }
 
-struct ReadFailureFilesystem {
-    inner: DiskFilesystem,
-    fail_suffix: &'static str,
-}
-
-#[async_trait]
-impl RootFilesystem for ReadFailureFilesystem {
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        if path.as_str().ends_with(self.fail_suffix) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "injected read failure".to_string(),
-            });
-        }
-        self.inner.read_file(path).await
-    }
-
-    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.write_file(path, bytes).await
-    }
-
-    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.create_dir_all(path).await
-    }
-}
-
+/// KEPT (not folded to `ironclaw_filesystem::FaultInjecting`): the coding
+/// `write_file`/`apply_patch` tools call `create_dir_all` on the target's parent
+/// before writing (see `coding::paths::create_parent_dir_unless_sensitive`).
+/// `FaultInjecting` gates only the unified entry/event ops and leaves the legacy
+/// `create_dir_all` at its trait default, which returns `Unsupported` instead of
+/// delegating to the inner `DiskFilesystem` — the tool maps that to
+/// `FilesystemDenied`/`Authorization`, masking the injected write fault. This
+/// delegator forwards `create_dir_all` to the real backend and faults only
+/// `write_file`, preserving the `Backend` assertion.
 struct WriteFailureFilesystem {
     inner: DiskFilesystem,
     fail_suffix: &'static str,
@@ -1942,7 +1890,7 @@ impl RootFilesystem for WriteFailureFilesystem {
         self.inner.read_file(path).await
     }
 
-    async fn write_file(&self, path: &VirtualPath, _bytes: &[u8]) -> Result<(), FilesystemError> {
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         if path.as_str().ends_with(self.fail_suffix) {
             return Err(FilesystemError::Backend {
                 path: path.clone(),
@@ -1950,7 +1898,7 @@ impl RootFilesystem for WriteFailureFilesystem {
                 reason: "disk full".to_string(),
             });
         }
-        self.inner.write_file(path, _bytes).await
+        self.inner.write_file(path, bytes).await
     }
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
@@ -1958,6 +1906,11 @@ impl RootFilesystem for WriteFailureFilesystem {
     }
 }
 
+/// KEPT (not folded to `ironclaw_filesystem::FaultInjecting`): this fake returns
+/// [`FilesystemError::BackendInfrastructure`], a variant `FaultKind` cannot
+/// express (it covers only `Backend`/`BackendBusy`/`NotFound`/`Unsupported`).
+/// Folding it would change the injected error and lose the
+/// `BackendInfrastructure -> Backend` mapping this test pins.
 struct ReadInfrastructureFailureFilesystem {
     inner: DiskFilesystem,
     fail_suffix: &'static str,

--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
@@ -1808,8 +1808,8 @@ mod tests {
     use async_trait::async_trait;
     use ironclaw_extensions::{ExtensionManifest, ManifestSource};
     use ironclaw_filesystem::{
-        BackendCapabilities, DirEntry, FileStat, FilesystemError, FilesystemOperation,
-        InMemoryBackend,
+        BackendCapabilities, DirEntry, Fault, FaultInjecting, FileStat, FilesystemError,
+        FilesystemOperation, InMemoryBackend,
     };
     use ironclaw_host_api::{
         EffectKind, HostPortCatalog, PermissionMode, RuntimeCredentialAccountSetup,
@@ -2867,7 +2867,15 @@ handle = "web_token"
 
     #[tokio::test]
     async fn materialize_fails_on_filesystem_error_and_rolls_back_written_assets() {
-        let fs = FailingWriteFilesystem::default();
+        // The wasm write is faulted at the backend; the real materialize path
+        // then rolls back the manifest write it already committed. `recorded_*`
+        // proves the true op stream (writes include the faulted wasm write; the
+        // rollback deletes the one prior committed asset).
+        let fs = FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("fixture.wasm")
+                .backend("write rejected"),
+        );
         let extension = test_extension_package();
 
         let error = materialize_available_extension(&fs, &extension)
@@ -2875,16 +2883,25 @@ handle = "web_token"
             .expect_err("second write fails");
 
         assert!(matches!(error, ProductWorkflowError::Transient { .. }));
-        let state = fs.state.lock().unwrap();
+        let writes = fs
+            .recorded_paths(FilesystemOperation::WriteFile)
+            .iter()
+            .map(|path| path.as_str().to_string())
+            .collect::<Vec<_>>();
         assert_eq!(
-            state.writes,
+            writes,
             vec![
                 "/system/extensions/fixture/manifest.toml".to_string(),
                 "/system/extensions/fixture/wasm/fixture.wasm".to_string()
             ]
         );
+        let deletes = fs
+            .recorded_paths(FilesystemOperation::Delete)
+            .iter()
+            .map(|path| path.as_str().to_string())
+            .collect::<Vec<_>>();
         assert_eq!(
-            state.deletes,
+            deletes,
             vec!["/system/extensions/fixture/manifest.toml".to_string()]
         );
     }
@@ -2985,17 +3002,6 @@ credential_handle = "channel_ext_token"
     }
 
     #[derive(Default)]
-    struct FailingWriteFilesystem {
-        state: Arc<Mutex<FailingWriteState>>,
-    }
-
-    #[derive(Default)]
-    struct FailingWriteState {
-        writes: Vec<String>,
-        deletes: Vec<String>,
-    }
-
-    #[derive(Default)]
     struct RecordingMaterializeFilesystem {
         files: Arc<Mutex<HashMap<String, Vec<u8>>>>,
         writes: Arc<Mutex<Vec<String>>>,
@@ -3053,56 +3059,6 @@ credential_handle = "channel_ext_token"
                 .lock()
                 .unwrap()
                 .insert(path.as_str().to_string(), bytes.to_vec());
-            Ok(())
-        }
-    }
-
-    #[async_trait]
-    impl RootFilesystem for FailingWriteFilesystem {
-        fn capabilities(&self) -> BackendCapabilities {
-            BackendCapabilities::default()
-        }
-
-        async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-            Err(FilesystemError::Unsupported {
-                path: path.clone(),
-                operation: FilesystemOperation::ListDir,
-            })
-        }
-
-        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-            Err(FilesystemError::NotFound {
-                path: path.clone(),
-                operation: FilesystemOperation::Stat,
-            })
-        }
-
-        async fn write_file(
-            &self,
-            path: &VirtualPath,
-            _bytes: &[u8],
-        ) -> Result<(), FilesystemError> {
-            self.state
-                .lock()
-                .unwrap()
-                .writes
-                .push(path.as_str().to_string());
-            if path.as_str().ends_with("fixture.wasm") {
-                return Err(FilesystemError::Backend {
-                    path: path.clone(),
-                    operation: FilesystemOperation::WriteFile,
-                    reason: "write rejected".to_string(),
-                });
-            }
-            Ok(())
-        }
-
-        async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-            self.state
-                .lock()
-                .unwrap()
-                .deletes
-                .push(path.as_str().to_string());
             Ok(())
         }
     }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
@@ -8,8 +8,7 @@ use ironclaw_extensions::{
     ExtensionManifestRef, InstallationOwner, MANIFEST_SCHEMA_VERSION,
 };
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemOperation,
-    InMemoryBackend, RecordVersion, RootFilesystem, VersionedEntry,
+    Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, RootFilesystem,
 };
 use ironclaw_host_api::{HostPortCatalog, SecretHandle};
 
@@ -58,7 +57,10 @@ async fn load_at_treats_not_found_as_empty_state() {
 
 #[tokio::test]
 async fn load_at_sanitizes_filesystem_read_errors() {
-    let filesystem: Arc<dyn RootFilesystem> = Arc::new(ReadFailureFilesystem::new());
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new())
+            .with_fault(Fault::on(FilesystemOperation::ReadFile).backend("raw backend detail")),
+    );
     let state_path = VirtualPath::new("/tenants/acme/system/extensions/.installations/state.json")
         .expect("valid state path");
 
@@ -446,7 +448,7 @@ async fn load_at_rejects_credential_conflicts_without_rewriting_state() {
 
 #[tokio::test]
 async fn load_at_returns_rewrite_failure_without_exposing_normalized_store() {
-    let backend = Arc::new(InMemoryBackend::new());
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
     let seed_filesystem: Arc<dyn RootFilesystem> = backend.clone();
     let state_path = test_state_path();
     let original = seed_state(
@@ -468,9 +470,14 @@ async fn load_at_returns_rewrite_failure_without_exposing_normalized_store() {
         ],
     )
     .await;
-    let failing_filesystem: Arc<dyn RootFilesystem> = Arc::new(WriteFailureFilesystem {
-        inner: backend.clone(),
-    });
+    // Arm the write fault only after seeding, so the store's canonical rewrite
+    // during load fails at the backend and flows through the real store's
+    // `FilesystemError -> ExtensionInstallationError` mapping.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .backend("injected extension installation write failure"),
+    );
+    let failing_filesystem: Arc<dyn RootFilesystem> = backend.clone();
 
     let error =
         match FilesystemExtensionInstallationStore::load_at(failing_filesystem, state_path.clone())
@@ -684,70 +691,9 @@ fn stored_installation_with_bindings(
     .unwrap()
 }
 
-struct FailNextWriteFilesystem {
-    inner: Arc<InMemoryBackend>,
-    fail_next: std::sync::atomic::AtomicBool,
-}
-
-impl FailNextWriteFilesystem {
-    fn new() -> Self {
-        Self {
-            inner: Arc::new(InMemoryBackend::new()),
-            fail_next: std::sync::atomic::AtomicBool::new(false),
-        }
-    }
-
-    fn fail_next_write(&self) {
-        self.fail_next
-            .store(true, std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for FailNextWriteFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        if self
-            .fail_next
-            .swap(false, std::sync::atomic::Ordering::SeqCst)
-        {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::WriteFile,
-                reason: "injected one-shot write failure".to_string(),
-            });
-        }
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
 #[tokio::test]
 async fn failed_snapshot_write_rolls_back_the_in_memory_mutation_so_retry_converges() {
-    let filesystem = Arc::new(FailNextWriteFilesystem::new());
+    let filesystem = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
     let state_path = test_state_path();
     let store = FilesystemExtensionInstallationStore::load_at(
         Arc::clone(&filesystem) as Arc<dyn RootFilesystem>,
@@ -762,7 +708,14 @@ async fn failed_snapshot_write_rolls_back_the_in_memory_mutation_so_retry_conver
         .await
         .expect("seed installation");
 
-    filesystem.fail_next_write();
+    // One-shot: fault the next write (the delete's snapshot rewrite) only; the
+    // retry's write passes through so the delete converges. `nth(1)` on a freshly
+    // added fault fires on the first matching write after arming, then is spent.
+    filesystem.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .nth(1)
+            .backend("injected one-shot write failure"),
+    );
     let error = store
         .delete_installation(&installation_id)
         .await
@@ -802,90 +755,3 @@ async fn failed_snapshot_write_rolls_back_the_in_memory_mutation_so_retry_conver
     );
 }
 
-struct WriteFailureFilesystem {
-    inner: Arc<InMemoryBackend>,
-}
-
-#[async_trait]
-impl RootFilesystem for WriteFailureFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        _entry: Entry,
-        _cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::WriteFile,
-            reason: "injected extension installation write failure".to_string(),
-        })
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
-struct ReadFailureFilesystem {
-    inner: InMemoryBackend,
-}
-
-impl ReadFailureFilesystem {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for ReadFailureFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::ReadFile,
-            reason: "raw backend detail".to_string(),
-        })
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -2657,9 +2657,7 @@ mod tests {
         ExtensionManifest, ExtensionRegistry, InMemoryExtensionInstallationStore,
         SharedExtensionRegistry,
     };
-    use ironclaw_filesystem::{
-        DirEntry, DiskFilesystem, FileStat, FilesystemError, FilesystemOperation,
-    };
+    use ironclaw_filesystem::{DiskFilesystem, Fault, FaultInjecting, FilesystemOperation};
     use ironclaw_host_api::{
         AgentId, CapabilityId, ExtensionLifecycleOperation, HostPath, HostPortCatalog,
         InvocationId, MountAlias, MountGrant, MountPermissions, MountView, NetworkMethod,
@@ -8045,9 +8043,10 @@ output_schema_ref = "schemas/run.output.json"
                 HostPath::from_path_buf(storage_root.join("system/extensions")),
             )
             .expect("mount system extensions");
-        let filesystem: Arc<dyn RootFilesystem> = Arc::new(filesystem);
-        let root_filesystem: Arc<dyn RootFilesystem> =
-            Arc::new(DeleteFailingRootFilesystem { inner: filesystem });
+        let root_filesystem: Arc<dyn RootFilesystem> = Arc::new(
+            FaultInjecting::new(filesystem)
+                .with_fault(Fault::on(FilesystemOperation::Delete).backend("delete failed")),
+        );
         let active_registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
         let trust_policy = test_extension_trust_policy();
         let installation_store = Arc::new(InMemoryExtensionInstallationStore::default());
@@ -8320,45 +8319,6 @@ output_schema_ref = "schemas/run.output.json"
             .expect("read fixture installation")
             .expect("fixture installation remains")
             .activation_state()
-    }
-
-    struct DeleteFailingRootFilesystem {
-        inner: Arc<dyn RootFilesystem>,
-    }
-
-    #[async_trait]
-    impl RootFilesystem for DeleteFailingRootFilesystem {
-        fn capabilities(&self) -> ironclaw_filesystem::BackendCapabilities {
-            self.inner.capabilities()
-        }
-
-        async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-            self.inner.list_dir(path).await
-        }
-
-        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-            self.inner.stat(path).await
-        }
-
-        async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-            self.inner.read_file(path).await
-        }
-
-        async fn write_file(
-            &self,
-            path: &VirtualPath,
-            bytes: &[u8],
-        ) -> Result<(), FilesystemError> {
-            self.inner.write_file(path, bytes).await
-        }
-
-        async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-            Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::Delete,
-                reason: "delete failed".to_string(),
-            })
-        }
     }
 
     async fn assert_enabled_active_extension_state<S>(

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -5602,10 +5602,8 @@ mod tests {
     };
     use ironclaw_authorization::{CapabilityLeaseStatus, CapabilityLeaseStore, GrantAuthorizer};
     use ironclaw_filesystem::FilesystemError;
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
-    use ironclaw_filesystem::{
-        DirEntry, FileStat, FilesystemOperation, RootFilesystem, VersionedEntry,
-    };
+    #[cfg(feature = "libsql")]
+    use ironclaw_filesystem::RootFilesystem;
     use ironclaw_host_api::{
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
         ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias, MountGrant,
@@ -5835,32 +5833,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
-    struct FailingConversationStateFilesystem;
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
-    #[async_trait::async_trait]
-    impl RootFilesystem for FailingConversationStateFilesystem {
-        async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-            Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "conversation state load failed".to_string(),
-            })
-        }
-
-        async fn list_dir(&self, _path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-            Ok(Vec::new())
-        }
-
-        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-            Err(FilesystemError::NotFound {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-            })
-        }
-    }
-
     /// Per-trigger delivery targets validate against the SAME registry the
     /// outbound target surface publishes from: an id a provider resolves for
     /// the caller is accepted; an unknown id (or an empty registry) fails
@@ -6017,7 +5989,17 @@ mod tests {
                     BackendCapabilities::default(),
                 )
                 .expect("mount descriptor"),
-                Arc::new(FailingConversationStateFilesystem),
+                Arc::new(
+                    ironclaw_filesystem::FaultInjecting::new(
+                        ironclaw_filesystem::InMemoryBackend::new(),
+                    )
+                    .with_fault(
+                        ironclaw_filesystem::Fault::on(
+                            ironclaw_filesystem::FilesystemOperation::ReadFile,
+                        )
+                        .backend("conversation state load failed"),
+                    ),
+                ),
             )
             .expect("mount failing backend");
         Arc::new(RebornRuntimeSubstrate {

--- a/crates/ironclaw_reborn_event_store/tests/coalescing_sink_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/coalescing_sink_contract.rs
@@ -43,6 +43,16 @@ fn scope_for(user: &str, project: &str) -> ResourceScope {
 /// partial-failure result vector: the first event succeeds (committed to the
 /// inner log) and the remaining events fail with an injected error. This lets
 /// tests verify that `flush()` propagates a per-event rejection as `Err`.
+//
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. This is a double for the log dependency
+// while the *sink* (`CoalescingEventSink`) is under test, and its assertions
+// observe the sink->log call shape *above* the store: it distinguishes single
+// `append` from `append_batch`, records each batch's size (`batch_sizes`), and
+// returns a partial-failure results vector (`[Ok, Err, ..]`). FaultInjecting
+// records only one `Append` op per call (no single-vs-batch distinction, no
+// size) and faults whole ops, so the real `FilesystemDurableEventLog` over it
+// could reproduce none of those observations without dropping coverage.
 struct CountingEventLog {
     inner: InMemoryDurableEventLog,
     append_calls: AtomicUsize,

--- a/crates/ironclaw_skills/Cargo.toml
+++ b/crates/ironclaw_skills/Cargo.toml
@@ -46,5 +46,7 @@ urlencoding = { version = "2", optional = true }
 tempfile = { version = "3", optional = true }
 
 [dev-dependencies]
+# FaultInjecting decorator: test store fault paths through the real store.
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{
-    BackendCapabilities, DirEntry, FileStat, FilesystemError, FilesystemOperation, InMemoryBackend,
-    RootFilesystem,
+    BackendCapabilities, DirEntry, Fault, FaultInjecting, FileStat, FilesystemError,
+    FilesystemOperation, InMemoryBackend, RootFilesystem,
 };
 use ironclaw_host_api::{
     MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, ScopedPath, VirtualPath,
@@ -394,13 +394,18 @@ async fn install_rejects_invalid_bundle_files() {
 
 #[tokio::test]
 async fn install_bundle_failure_cleans_up_partial_directory() {
-    let inner = Arc::new(InMemoryBackend::default());
-    let filesystem = Arc::new(FailingBundleWriteFilesystem {
-        inner: inner.clone(),
-        fail_suffix: "/scripts/run.py",
-        fail_delete: false,
-    });
-    let context = skill_management_context_with_root(filesystem, skill_mounts());
+    // The real byte-write path faulted at the backend seam via the shared
+    // `FaultInjecting` decorator: the `scripts/run.py` bundle write (routed
+    // through the entry-plane `put`) surfaces `FilesystemError::Backend`
+    // (→ `InvalidSkill`), triggering the partial-directory cleanup.
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::default()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("scripts/run.py")
+                .backend("injected bundle write failure"),
+        ),
+    );
+    let context = skill_management_context_with_root(backend.clone(), skill_mounts());
 
     let error = install_skill(
         &context,
@@ -425,9 +430,9 @@ async fn install_bundle_failure_cleans_up_partial_directory() {
     .unwrap_err();
     assert_eq!(error.kind(), SkillManagementErrorKind::InvalidSkill);
 
-    assert_missing(&inner, "/projects/skills/partial-helper/SKILL.md").await;
+    assert_missing(backend.as_ref(), "/projects/skills/partial-helper/SKILL.md").await;
     assert_missing(
-        &inner,
+        backend.as_ref(),
         "/projects/skills/partial-helper/references/guide.md",
     )
     .await;
@@ -463,14 +468,18 @@ async fn install_rejects_preexisting_skill_directory_without_deleting_contents()
 
     assert_eq!(error.kind(), SkillManagementErrorKind::Conflict);
     assert_file_contents(
-        &filesystem,
+        filesystem.as_ref(),
         "/projects/skills/existing-helper/references/guide.md",
         b"# Keep\n",
     )
     .await;
-    assert_missing(&filesystem, "/projects/skills/existing-helper/SKILL.md").await;
     assert_missing(
-        &filesystem,
+        filesystem.as_ref(),
+        "/projects/skills/existing-helper/SKILL.md",
+    )
+    .await;
+    assert_missing(
+        filesystem.as_ref(),
         "/projects/skills/existing-helper/scripts/run.py",
     )
     .await;
@@ -507,7 +516,7 @@ async fn install_serializes_concurrent_same_name_requests() {
     let results = [first, second];
     assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 2);
     assert_file_contents(
-        &filesystem,
+        filesystem.as_ref(),
         "/projects/skills/shared-helper/SKILL.md",
         content.as_bytes(),
     )
@@ -516,13 +525,18 @@ async fn install_serializes_concurrent_same_name_requests() {
 
 #[tokio::test]
 async fn install_metadata_write_failure_cleans_up_partial_directory() {
-    let inner = Arc::new(InMemoryBackend::default());
-    let filesystem = Arc::new(FailingBundleWriteFilesystem {
-        inner: inner.clone(),
-        fail_suffix: "/.ironclaw-install.json",
-        fail_delete: false,
-    });
-    let context = skill_management_context_with_root(filesystem, skill_mounts());
+    // The install-metadata write (`.ironclaw-install.json`) faulted at the
+    // backend seam via `FaultInjecting`: the entry-plane `put` for that path
+    // surfaces `FilesystemError::Backend` (→ `InvalidSkill`), triggering the
+    // partial-directory cleanup after the earlier bundle file already landed.
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::default()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path(".ironclaw-install.json")
+                .backend("injected bundle write failure"),
+        ),
+    );
+    let context = skill_management_context_with_root(backend.clone(), skill_mounts());
 
     let error = install_skill(
         &context,
@@ -541,9 +555,9 @@ async fn install_metadata_write_failure_cleans_up_partial_directory() {
     .unwrap_err();
     assert_eq!(error.kind(), SkillManagementErrorKind::InvalidSkill);
 
-    assert_missing(&inner, "/projects/skills/metadata-helper/SKILL.md").await;
+    assert_missing(backend.as_ref(), "/projects/skills/metadata-helper/SKILL.md").await;
     assert_missing(
-        &inner,
+        backend.as_ref(),
         "/projects/skills/metadata-helper/references/guide.md",
     )
     .await;
@@ -552,10 +566,8 @@ async fn install_metadata_write_failure_cleans_up_partial_directory() {
 #[tokio::test]
 async fn install_cleanup_failure_is_reported() {
     let inner = Arc::new(InMemoryBackend::default());
-    let filesystem = Arc::new(FailingBundleWriteFilesystem {
+    let filesystem = Arc::new(CleanupDeleteDenyingFilesystem {
         inner: inner.clone(),
-        fail_suffix: "/scripts/run.py",
-        fail_delete: true,
     });
     let context = skill_management_context_with_root(filesystem, skill_mounts());
 
@@ -583,7 +595,7 @@ async fn install_cleanup_failure_is_reported() {
 
     assert_eq!(error.kind(), SkillManagementErrorKind::FilesystemDenied);
     assert_file_contents(
-        &inner,
+        inner.as_ref(),
         "/projects/skills/cleanup-helper/references/guide.md",
         b"# Guide\n",
     )
@@ -734,8 +746,14 @@ async fn search_skills_returns_bounded_matches_with_truncation() {
 
 #[tokio::test]
 async fn search_skills_propagates_filesystem_error() {
-    let context =
-        skill_management_context_with_root(Arc::new(FailingListFilesystem), skill_mounts());
+    // The directory listing faulted at the backend seam via `FaultInjecting`:
+    // `list_dir_bounded` routes through the entry-plane `list_dir`, which
+    // surfaces `FilesystemError::Backend` (→ `InvalidSkill`).
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::default())
+            .with_fault(Fault::on(FilesystemOperation::ListDir).backend("injected list failure")),
+    );
+    let context = skill_management_context_with_root(backend, skill_mounts());
 
     let error = search_skills(
         &context,
@@ -933,13 +951,13 @@ async fn skill_management_root_filesystem_delete_if_version_delegates_to_inner_b
     assert!(inner.get(&path).await.unwrap().is_none());
 }
 
-async fn write_file(root: &InMemoryBackend, path: &str, body: String) {
+async fn write_file<R: RootFilesystem + ?Sized>(root: &R, path: &str, body: String) {
     root.write_file(&VirtualPath::new(path).unwrap(), body.as_bytes())
         .await
         .unwrap();
 }
 
-async fn read_file(root: &InMemoryBackend, path: &str) -> String {
+async fn read_file<R: RootFilesystem + ?Sized>(root: &R, path: &str) -> String {
     let bytes = root
         .read_file_bounded(
             &VirtualPath::new(path).unwrap(),
@@ -951,7 +969,7 @@ async fn read_file(root: &InMemoryBackend, path: &str) -> String {
     String::from_utf8(bytes).unwrap()
 }
 
-async fn assert_missing(root: &InMemoryBackend, path: &str) {
+async fn assert_missing<R: RootFilesystem + ?Sized>(root: &R, path: &str) {
     match root
         .read_file_bounded(&VirtualPath::new(path).unwrap(), 1024)
         .await
@@ -962,7 +980,7 @@ async fn assert_missing(root: &InMemoryBackend, path: &str) {
     }
 }
 
-async fn assert_file_contents(root: &InMemoryBackend, path: &str, expected: &[u8]) {
+async fn assert_file_contents<R: RootFilesystem + ?Sized>(root: &R, path: &str, expected: &[u8]) {
     let bytes = root
         .read_file_bounded(&VirtualPath::new(path).unwrap(), 1024)
         .await
@@ -971,15 +989,22 @@ async fn assert_file_contents(root: &InMemoryBackend, path: &str, expected: &[u8
     assert_eq!(bytes, expected);
 }
 
+/// KEPT (not folded into `ironclaw_filesystem::FaultInjecting`):
+/// `install_cleanup_failure_is_reported` needs the cleanup `delete` to fail
+/// with `FilesystemError::PermissionDenied` (→ `FilesystemDenied`).
+/// `FaultInjecting` can only inject `Backend`/`BackendBusy`/`NotFound`/
+/// `Unsupported` errors, so it cannot reproduce the specific
+/// `PermissionDenied → FilesystemDenied` mapping this test pins. Faults the
+/// `/scripts/run.py` bundle write (to trigger the cleanup path) and denies the
+/// subsequent cleanup `delete` with `PermissionDenied`; every other op
+/// delegates to the real `InMemoryBackend`.
 #[derive(Clone)]
-struct FailingBundleWriteFilesystem {
+struct CleanupDeleteDenyingFilesystem {
     inner: Arc<InMemoryBackend>,
-    fail_suffix: &'static str,
-    fail_delete: bool,
 }
 
 #[async_trait]
-impl RootFilesystem for FailingBundleWriteFilesystem {
+impl RootFilesystem for CleanupDeleteDenyingFilesystem {
     fn capabilities(&self) -> BackendCapabilities {
         self.inner.capabilities()
     }
@@ -1001,7 +1026,7 @@ impl RootFilesystem for FailingBundleWriteFilesystem {
     }
 
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        if path.as_str().ends_with(self.fail_suffix) {
+        if path.as_str().ends_with("/scripts/run.py") {
             return Err(FilesystemError::Backend {
                 operation: FilesystemOperation::WriteFile,
                 path: path.clone(),
@@ -1016,46 +1041,9 @@ impl RootFilesystem for FailingBundleWriteFilesystem {
     }
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        if self.fail_delete {
-            return Err(FilesystemError::PermissionDenied {
-                path: ScopedPath::new(path.as_str().to_string()).unwrap(),
-                operation: FilesystemOperation::Delete,
-            });
-        }
-        self.inner.delete(path).await
-    }
-}
-
-#[derive(Clone)]
-struct FailingListFilesystem;
-
-#[async_trait]
-impl RootFilesystem for FailingListFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        BackendCapabilities::default()
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        Err(FilesystemError::Backend {
-            operation: FilesystemOperation::ListDir,
-            path: path.clone(),
-            reason: "injected list failure".to_string(),
-        })
-    }
-
-    async fn list_dir_bounded(
-        &self,
-        path: &VirtualPath,
-        _max_entries: usize,
-    ) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        Err(FilesystemError::Backend {
-            operation: FilesystemOperation::Stat,
-            path: path.clone(),
-            reason: "injected stat failure".to_string(),
+        Err(FilesystemError::PermissionDenied {
+            path: ScopedPath::new(path.as_str().to_string()).unwrap(),
+            operation: FilesystemOperation::Delete,
         })
     }
 }

--- a/crates/ironclaw_threads/Cargo.toml
+++ b/crates/ironclaw_threads/Cargo.toml
@@ -37,5 +37,7 @@ test-support = []
 
 [dev-dependencies]
 ironclaw_threads = { path = ".", features = ["test-support"] }
+# FaultInjecting decorator: test store fault paths through the real store
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -12,15 +12,15 @@ use std::{
     collections::HashMap,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, FileStat,
-    FilesystemError, FilesystemOperation, Filter, InMemoryBackend, Page, RecordVersion,
+    BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, Fault, FaultInjecting,
+    FileStat, FilesystemError, FilesystemOperation, Filter, InMemoryBackend, Page, RecordVersion,
     RootFilesystem, ScopedFilesystem, SeqNo, StorageTxn, TxnCapability, VersionedEntry,
 };
 use ironclaw_host_api::{
@@ -1055,7 +1055,7 @@ async fn filesystem_redacts_append_only_finalized_assistant_message() {
 
 #[tokio::test]
 async fn filesystem_lookup_index_write_failure_does_not_fail_message_contract() {
-    let backend = Arc::new(LookupIndexWriteFailureBackend::new());
+    let backend = Arc::new(lookup_index_write_failure_backend());
     let scoped = scoped_threads_fs_at(backend, "tenant-lookup-index-failure", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("lookup-index-failure");
@@ -1105,7 +1105,7 @@ async fn filesystem_lookup_index_write_failure_does_not_fail_message_contract() 
 
 #[tokio::test]
 async fn filesystem_lookup_index_read_failure_falls_back_to_transcript_scan() {
-    let backend = Arc::new(LookupIndexReadFailureBackend::new());
+    let backend = Arc::new(lookup_index_read_failure_backend());
     let scoped = scoped_threads_fs_at(backend, "tenant-lookup-index-read-failure", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("lookup-index-read-failure");
@@ -2270,7 +2270,7 @@ async fn filesystem_list_threads_does_not_treat_partial_source_cache_as_complete
 async fn filesystem_list_threads_retries_bootstrap_after_source_read_error() {
     use ironclaw_threads::ListThreadsForScopeRequest;
 
-    let backend = Arc::new(FailOnceThreadRecordReadBackend::new("legacy-flaky-read"));
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
     let scoped = scoped_threads_fs_at(
         Arc::clone(&backend),
         "tenant-index-bootstrap-retry",
@@ -2299,7 +2299,16 @@ async fn filesystem_list_threads_retries_bootstrap_after_source_read_error() {
         )
         .await
         .expect("test setup removes one derived index row");
-    backend.fail_next_thread_record_read();
+    // Arm the fault mid-test through the shared `Arc`: `.nth(1)` counts only
+    // matching reads that occur AFTER `add_fault`, so the first `thread.json`
+    // read for `legacy-flaky-read` during the following list fails exactly
+    // once — the same one-shot semantics the old `fail_next_read` flag had.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::ReadFile)
+            .path("/threads/legacy-flaky-read/thread.json")
+            .nth(1)
+            .backend("thread record reads disabled once by contract test"),
+    );
     service.clear_thread_index_cache_for_scope(&scope);
 
     let first = service
@@ -3128,33 +3137,41 @@ where
     Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts))
 }
 
-struct LookupIndexWriteFailureBackend {
-    inner: InMemoryBackend,
+/// Real thread store backend that fails every write to a message lookup-index
+/// row (`/indexes/assistant-runs/…`, `/indexes/tool-results/…`) so the store
+/// runs its genuine "lookup-index backfill is best-effort, fall back to a
+/// transcript scan" path. Folds the former hand-rolled
+/// `LookupIndexWriteFailureBackend` onto `FaultInjecting` — two path-scoped
+/// `WriteFile` faults, one per lookup-index family.
+fn lookup_index_write_failure_backend() -> FaultInjecting<InMemoryBackend> {
+    FaultInjecting::new(InMemoryBackend::new())
+        .with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("/indexes/assistant-runs/")
+                .backend("lookup index writes disabled by contract test"),
+        )
+        .with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("/indexes/tool-results/")
+                .backend("lookup index writes disabled by contract test"),
+        )
 }
 
-impl LookupIndexWriteFailureBackend {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
-
-    fn is_lookup_index_path(path: &VirtualPath) -> bool {
-        path.as_str().contains("/indexes/assistant-runs/")
-            || path.as_str().contains("/indexes/tool-results/")
-    }
-}
-
-struct LookupIndexReadFailureBackend {
-    inner: InMemoryBackend,
-}
-
-impl LookupIndexReadFailureBackend {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
+/// As [`lookup_index_write_failure_backend`], but fails every lookup-index
+/// *read* so the store must fall back to a transcript scan. Folds the former
+/// hand-rolled `LookupIndexReadFailureBackend`.
+fn lookup_index_read_failure_backend() -> FaultInjecting<InMemoryBackend> {
+    FaultInjecting::new(InMemoryBackend::new())
+        .with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/indexes/assistant-runs/")
+                .backend("lookup index reads disabled by contract test"),
+        )
+        .with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/indexes/tool-results/")
+                .backend("lookup index reads disabled by contract test"),
+        )
 }
 
 struct QueryCountingBackend {
@@ -3178,31 +3195,6 @@ impl QueryCountingBackend {
 
     fn get_count(&self) -> usize {
         self.get_count.load(Ordering::SeqCst)
-    }
-}
-
-struct FailOnceThreadRecordReadBackend {
-    inner: InMemoryBackend,
-    thread_id: String,
-    fail_next_read: AtomicBool,
-}
-
-impl FailOnceThreadRecordReadBackend {
-    fn new(thread_id: &str) -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-            thread_id: thread_id.to_string(),
-            fail_next_read: AtomicBool::new(false),
-        }
-    }
-
-    fn fail_next_thread_record_read(&self) {
-        self.fail_next_read.store(true, Ordering::SeqCst);
-    }
-
-    fn is_target_thread_record_path(&self, path: &VirtualPath) -> bool {
-        path.as_str()
-            .contains(&format!("/threads/{}/thread.json", self.thread_id))
     }
 }
 
@@ -3308,102 +3300,6 @@ impl TransactionalRaceTxn {
 }
 
 #[async_trait]
-impl RootFilesystem for LookupIndexWriteFailureBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        if Self::is_lookup_index_path(path) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::WriteFile,
-                reason: "lookup index writes disabled by contract test".to_string(),
-            });
-        }
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for LookupIndexReadFailureBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        if LookupIndexWriteFailureBackend::is_lookup_index_path(path) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "lookup index reads disabled by contract test".to_string(),
-            });
-        }
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
-#[async_trait]
 impl RootFilesystem for QueryCountingBackend {
     fn capabilities(&self) -> BackendCapabilities {
         self.inner.capabilities()
@@ -3451,56 +3347,6 @@ impl RootFilesystem for QueryCountingBackend {
 
     async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
         self.inner.reserve_sequence(path).await
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for FailOnceThreadRecordReadBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        if self.is_target_thread_record_path(path)
-            && self.fail_next_read.swap(false, Ordering::SeqCst)
-        {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "thread record reads disabled once by contract test".to_string(),
-            });
-        }
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
     }
 }
 
@@ -4078,79 +3924,25 @@ async fn filesystem_summary_spanning_interior_draft_is_not_applied() {
     assert_eq!(context.messages[1].content, "third");
 }
 
-// Backend that fails only the summary-artifact write, so all prior reads in
-// `create_summary_artifact` succeed and only the final CAS `put` errors —
-// the shape `persist_summary` (ironclaw_loop_host::compaction_task) hits
-// in production (#5838).
-struct SummaryWriteFailureBackend {
-    inner: InMemoryBackend,
-}
-
-impl SummaryWriteFailureBackend {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
-
-    fn is_summary_path(path: &VirtualPath) -> bool {
-        path.as_str().contains("/summaries/")
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for SummaryWriteFailureBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        if Self::is_summary_path(path) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::WriteFile,
-                reason: "synthetic summary artifact write failure (contract test)".to_string(),
-            });
-        }
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
+// Real thread store backend that fails only the summary-artifact write, so all
+// prior reads in `create_summary_artifact` succeed and only the final CAS `put`
+// errors — the shape `persist_summary` (ironclaw_loop_host::compaction_task)
+// hits in production (#5838). Folds the former hand-rolled
+// `SummaryWriteFailureBackend` onto `FaultInjecting`: an always-firing
+// path-scoped `WriteFile` fault on `/summaries/`.
+fn summary_write_failure_backend() -> FaultInjecting<InMemoryBackend> {
+    FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path("/summaries/")
+            .backend("synthetic summary artifact write failure (contract test)"),
+    )
 }
 
 #[tokio::test]
 async fn create_summary_artifact_surfaces_backend_error_on_storage_write_failure() {
     // Regression for #5838: the backend cause must survive to the caller
     // instead of being collapsed away before it reaches `persist_summary`.
-    let backend = Arc::new(SummaryWriteFailureBackend::new());
+    let backend = Arc::new(summary_write_failure_backend());
     let scoped = scoped_threads_fs_at(backend, "tenant-summary-write-fail", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("fs-summary-write-fail");

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -41,6 +41,11 @@ uuid = { version = "1", features = ["v4", "serde"] }
 [dev-dependencies]
 # Self-reference so the crate's own integration tests see `test_support`.
 ironclaw_turns = { path = ".", features = ["test-support"] }
+# FaultInjecting decorator: drive store fault paths through the real
+# `FilesystemTurnStateRowStore` instead of a hand-rolled whole-trait fake.
+ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0", features = [
+    "test-support",
+] }
 rand = "0.10"
 static_assertions = "1"
 tempfile = "3"

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -622,23 +622,6 @@ mod tests {
         }
     }
 
-    struct FailingProjectionSource;
-
-    #[async_trait]
-    impl TurnEventProjectionSource for FailingProjectionSource {
-        async fn read_turn_events_after(
-            &self,
-            _scope: &TurnScope,
-            _owner_user_id: Option<&UserId>,
-            _after: Option<EventCursor>,
-            _limit: usize,
-        ) -> Result<TurnEventPage, TurnError> {
-            Err(TurnError::Unavailable {
-                reason: "event store offline".to_string(),
-            })
-        }
-    }
-
     #[test]
     fn blocked_gate_kind_from_status_ignores_non_blocked_statuses() {
         for status in [
@@ -834,7 +817,23 @@ mod tests {
 
     #[tokio::test]
     async fn projection_service_preserves_source_read_error_cause() {
-        let service = TurnEventProjectionService::new(std::sync::Arc::new(FailingProjectionSource));
+        use ironclaw_filesystem::{Fault, FaultInjecting, FilesystemOperation, InMemoryBackend};
+
+        // The projection source is the real `FilesystemTurnStateRowStore` (which
+        // implements `TurnEventProjectionSource`) over a `FaultInjecting` backend
+        // armed to fail its first durable read. `read_turn_events_after` now runs
+        // the store's genuine durable-row read and its
+        // `FilesystemError::Backend -> TurnError::Unavailable` mapping, replacing
+        // the former hand-rolled `FailingProjectionSource` fake. The service must
+        // still wrap and preserve that read-error cause under the same
+        // `read_turn_events_after` operation label.
+        let backend = std::sync::Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::ReadFile).backend("injected turn-state read failure"),
+        ));
+        let source = std::sync::Arc::new(crate::FilesystemTurnStateRowStore::new(
+            crate::test_support::scoped_turns_filesystem(backend),
+        ));
+        let service = TurnEventProjectionService::new(source);
         let error = service
             .snapshot(crate::events::TurnEventProjectionRequest {
                 scope: scope("thread-source-error"),
@@ -845,12 +844,14 @@ mod tests {
             .await
             .expect_err("source error should propagate");
 
+        // The cause is the real store's mapped error (`fs_error`), not the fake's
+        // former "event store offline" string.
         assert!(matches!(
             error,
             TurnEventProjectionError::Source {
                 operation: "read_turn_events_after",
                 reason: TurnError::Unavailable { reason }
-            } if reason == "event store offline"
+            } if reason == "turn state row-store persistence temporarily unavailable"
         ));
     }
 

--- a/crates/ironclaw_turns/src/test_support.rs
+++ b/crates/ironclaw_turns/src/test_support.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_filesystem::{InMemoryBackend, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
 
 use crate::FilesystemTurnStateRowStore;
@@ -41,11 +41,14 @@ pub fn in_memory_turns_filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
     scoped_turns_filesystem(Arc::new(InMemoryBackend::new()))
 }
 
-/// Wrap a specific [`InMemoryBackend`] in the scoped `/turns` mount the row
-/// store expects. Handy when a test needs to hold the backend itself.
-pub fn scoped_turns_filesystem(
-    backend: Arc<InMemoryBackend>,
-) -> Arc<ScopedFilesystem<InMemoryBackend>> {
+/// Wrap a specific backend in the scoped `/turns` mount the row store expects.
+/// Handy when a test needs to hold the backend itself — e.g. a bare
+/// [`InMemoryBackend`], or an
+/// [`ironclaw_filesystem::FaultInjecting`]`<InMemoryBackend>` so a store fault
+/// path runs through the real store's `FilesystemError -> TurnError` mapping.
+pub fn scoped_turns_filesystem<F: RootFilesystem>(
+    backend: Arc<F>,
+) -> Arc<ScopedFilesystem<F>> {
     let mounts = MountView::new(vec![MountGrant::new(
         MountAlias::new("/turns").expect("turns alias"),
         VirtualPath::new("/turns").expect("turns target"),

--- a/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
+++ b/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
@@ -1,57 +1,14 @@
+use std::sync::Arc;
+
 use chrono::{TimeZone, Utc};
+use ironclaw_filesystem::{Fault, FaultInjecting, FilesystemOperation, InMemoryBackend};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_turns::test_support::scoped_turns_filesystem;
 use ironclaw_turns::{
-    AcceptedMessageRef, AllowAllTurnAdmissionPolicy, IdempotencyKey, InMemoryRunProfileResolver,
-    ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef, TurnActiveRunRefState, TurnActor,
-    TurnError, TurnRunId, TurnScope, TurnStateStore, TurnStatus,
+    AcceptedMessageRef, AllowAllTurnAdmissionPolicy, FilesystemTurnStateRowStore, IdempotencyKey,
+    InMemoryRunProfileResolver, ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef,
+    TurnActiveRunRefState, TurnActor, TurnError, TurnRunId, TurnScope, TurnStateStore, TurnStatus,
 };
-
-struct FailingTurnStateStore;
-
-#[async_trait::async_trait]
-impl TurnStateStore for FailingTurnStateStore {
-    async fn submit_turn(
-        &self,
-        _request: ironclaw_turns::SubmitTurnRequest,
-        _admission_policy: &dyn ironclaw_turns::TurnAdmissionPolicy,
-        _run_profile_resolver: &dyn ironclaw_turns::RunProfileResolver,
-    ) -> Result<ironclaw_turns::SubmitTurnResponse, TurnError> {
-        unreachable!("active_run_ref_state only calls get_run_state")
-    }
-
-    async fn resume_turn(
-        &self,
-        _request: ironclaw_turns::ResumeTurnRequest,
-    ) -> Result<ironclaw_turns::ResumeTurnResponse, TurnError> {
-        unreachable!("active_run_ref_state only calls get_run_state")
-    }
-
-    async fn retry_turn(
-        &self,
-        request: ironclaw_turns::RetryTurnRequest,
-    ) -> Result<ironclaw_turns::RetryTurnResponse, TurnError> {
-        // WS-3 implements this.
-        Err(TurnError::RunNotRetryable {
-            run_id: request.run_id,
-        })
-    }
-
-    async fn request_cancel(
-        &self,
-        _request: ironclaw_turns::CancelRunRequest,
-    ) -> Result<ironclaw_turns::CancelRunResponse, TurnError> {
-        unreachable!("active_run_ref_state only calls get_run_state")
-    }
-
-    async fn get_run_state(
-        &self,
-        _request: ironclaw_turns::GetRunStateRequest,
-    ) -> Result<ironclaw_turns::TurnRunState, TurnError> {
-        Err(TurnError::Unavailable {
-            reason: "backend unavailable".to_string(),
-        })
-    }
-}
 
 fn turn_scope(thread: &str) -> TurnScope {
     TurnScope::new(
@@ -155,8 +112,19 @@ async fn active_run_ref_state_treats_missing_lookup_as_missing() {
 
 #[tokio::test]
 async fn active_run_ref_state_propagates_non_scope_not_found_errors() {
+    // The real row store over a `FaultInjecting` backend armed to fail its first
+    // durable read: `get_run_state` now runs the store's genuine
+    // `load_snapshot_from_rows` and its `FilesystemError::Backend -> TurnError`
+    // mapping (`fs_error` -> `TurnError::Unavailable`), which the former
+    // whole-trait `FailingTurnStateStore` fake short-circuited. A non-scope
+    // (not `ScopeNotFound`) error must propagate through `active_run_ref_state`.
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::ReadFile).backend("injected turn-state read failure"),
+    ));
+    let store = FilesystemTurnStateRowStore::new(scoped_turns_filesystem(backend));
+
     let result = ironclaw_turns::active_run_ref_state(
-        &FailingTurnStateStore,
+        &store,
         turn_scope("active-run-ref-error"),
         Some(TurnRunId::new()),
     )

--- a/crates/ironclaw_turns/tests/row_store_crash_consistency.rs
+++ b/crates/ironclaw_turns/tests/row_store_crash_consistency.rs
@@ -127,6 +127,34 @@ struct FaultConfig {
 /// `RootFilesystem` wrapper over `InMemoryBackend` with write-fault injection
 /// and mutation recording (for byte-state forks). Concrete over
 /// `InMemoryBackend` because that is the only backend under test.
+///
+/// # Why this is NOT `ironclaw_filesystem::FaultInjecting`
+///
+/// The pure I/O-fault half (fail the Nth / a path-matching mutating write)
+/// *could* be expressed with `FaultInjecting`, but this backend is kept whole
+/// because its crash-consistency machinery needs three things `FaultInjecting`
+/// structurally cannot provide, and they are inseparably interleaved with the
+/// fault injection in the same `put`/`append`/`delete` methods:
+///
+/// 1. **Byte-state reconstruction** ([`FaultBackend::fork_durable_bytes`]) —
+///    records the full [`Entry`]/[`CasExpectation`]/payloads of every applied
+///    mutation and replays them into a fresh backend to rebuild a
+///    byte-identical durable state "at moment T" (the crash primitive).
+///    `FaultInjecting::recorded()` records only `{operation, path}`, so it
+///    cannot reconstruct durable bytes.
+/// 2. **Append stall barrier** ([`FaultBackend::append_gate`]) — a
+///    `tokio::sync::Mutex` a test holds to freeze the flusher so pending
+///    write-behind acks never resolve. `FaultInjecting` is not a
+///    synchronization primitive.
+/// 3. **Relative / countdown one-shot fault triggers** (`fail_next_appends`
+///    countdown, `fail_at_relative_write` = current-count + n).
+///    `FaultInjecting`'s `Nth` is absolute-from-construction, not
+///    relative-from-now.
+///
+/// Folding only the write-fault part would strand the recording (needed for the
+/// fork primitive) in a second wrapper while losing the relative triggers, so
+/// there is no clean sub-part to migrate. Kept as the purpose-named
+/// crash-consistency harness per the fault-fake migration STRICT SCOPE RULE.
 struct FaultBackend {
     inner: InMemoryBackend,
     write_count: AtomicUsize,


### PR DESCRIPTION
Stacked on #6400 (needs `FaultInjecting`, not yet on `main`). Extends the fault-fake→real-store migration across the remaining filesystem-backed domains, plus folds the hand-rolled `impl RootFilesystem for …Failing…` decorators (literal `FaultInjecting` duplicates) into the shared decorator.

## Migrated onto the real store over `FaultInjecting`
- **`ironclaw_approvals`** — `FailingApproveApprovalStore`, `FailingIssueLeaseStore` → real `FilesystemApprovalRequestStore` / `FilesystemCapabilityLeaseStore`.
- **`ironclaw_turns`** — `FailingTurnStateStore`, `FailingProjectionSource` → real `FilesystemTurnStateRowStore`.
- **`ironclaw_event_projections`** — `FailingDurableEventLog` → real `FilesystemDurableEventLog` (**stronger**: now proves the projection boundary strips a *real* backend host-path+reason, not a fake's canned string).
- **`ironclaw_authorization`** — `CountingFilesystem` observer → `FaultInjecting` recorder.

## `RootFilesystem`-decorator folds (into the shared `FaultInjecting`)
- **`ironclaw_threads`** ×4, **`ironclaw_skills`** ×2, **`ironclaw_filesystem`** cas ×2, **`ironclaw_reborn_composition`** extension_host/factory ×6, **`ironclaw_host_runtime`** first_party_coding_tools ×2.

## Kept + documented (correctly not migrated)
- **Domain doubles / sync primitives** — 5 capability-lease doubles (domain errors like `InactiveLease`, `Barrier`/`Notify` interleavers), turns `RetryOnlyStore`/`MemoryProjectionSource`, 4 `DurableEventLog` doubles (call-shape observations, default `append_batch` loop, typed-sanitizer bypass).
- **`FaultInjecting` can't express it** — turns crash-consistency `FaultBackend` (byte-state reconstruction + append barrier + relative triggers), skills `CleanupDeleteDenyingFilesystem` (`PermissionDenied` ≠ a `FaultKind`), host_runtime `WriteFailureFilesystem` (real flow calls `create_dir_all`, left at `FaultInjecting`'s trait-default `Unsupported`) and `ReadInfrastructureFailureFilesystem` (`BackendInfrastructure` variant).

## Findings corrected (not papered over)
A turns projection test asserted a fake's fiction `reason == "event store offline"` — repointed to the real store's production reason.

## Verified non-migratable
`TriggerRepository` is SQL-backed (Postgres/libSQL) — no filesystem store to drive; left as-is.

## Decorator-gap note (follow-up candidate)
`FaultInjecting` doesn't delegate the legacy `create_dir_all`/`append_file` ops to its inner backend (trait-default `Unsupported`), which blocked one host_runtime fold. Teaching it to delegate those would close the gap.

## Verification
- **1684 tests pass** across the touched crates (approvals, threads, turns, events, authz, capabilities, skills, filesystem, composition, host_runtime)
- clippy clean (`-D warnings`), both feature lanes on `ironclaw_filesystem`

Net reduction across both commits (~−630 LOC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
