### PR TITLE
Harden legacy migration against real data

### DIFF
--- a/crates/ironclaw_reborn_migration/src/convert/identities.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/identities.rs
@@ -20,13 +20,6 @@ use crate::report::{Domain, LossReason, MigrationReport};
 use crate::source::V1Source;
 use crate::target::RebornTarget;
 
-#[cfg(feature = "postgres")]
-fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
-    error
-        .as_db_error()
-        .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)
-}
-
 pub(crate) async fn run(
     src: &V1Source,
     tgt: &mut RebornTarget,
@@ -240,7 +233,7 @@ async fn read_channel_identities(
         let client = pool.get().await.map_err(|e| read_err(&e))?;
         let rows = match client.query(sql, &[]).await {
             Ok(rows) => rows,
-            Err(e) if is_missing_postgres_table_error(&e) => return Ok(Vec::new()),
+            Err(e) if crate::source::is_missing_postgres_table_error(&e) => return Ok(Vec::new()),
             Err(e) => return Err(read_err(&e)),
         };
         let mut out = Vec::new();

--- a/crates/ironclaw_reborn_migration/src/convert/identities.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/identities.rs
@@ -20,6 +20,13 @@ use crate::report::{Domain, LossReason, MigrationReport};
 use crate::source::V1Source;
 use crate::target::RebornTarget;
 
+#[cfg(feature = "postgres")]
+fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
+    error
+        .as_db_error()
+        .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)
+}
+
 pub(crate) async fn run(
     src: &V1Source,
     tgt: &mut RebornTarget,
@@ -58,12 +65,16 @@ async fn migrate_user_identities(
     users.extend(src.distinct_users().await?);
 
     for user in users {
-        let identities = src.db.list_identities_for_user(&user).await.map_err(|e| {
-            MigrationError::ReadSource {
-                domain: "user_identities".into(),
-                reason: e.to_string(),
+        let identities = match src.db.list_identities_for_user(&user).await {
+            Ok(identities) => identities,
+            Err(e) if crate::source::is_missing_table_error(&e.to_string()) => Vec::new(),
+            Err(e) => {
+                return Err(MigrationError::ReadSource {
+                    domain: "user_identities".into(),
+                    reason: e.to_string(),
+                });
             }
-        })?;
+        };
         if identities.is_empty() {
             continue;
         }
@@ -229,9 +240,7 @@ async fn read_channel_identities(
         let client = pool.get().await.map_err(|e| read_err(&e))?;
         let rows = match client.query(sql, &[]).await {
             Ok(rows) => rows,
-            Err(e) if crate::source::is_missing_table_error(&e.to_string()) => {
-                return Ok(Vec::new());
-            }
+            Err(e) if is_missing_postgres_table_error(&e) => return Ok(Vec::new()),
             Err(e) => return Err(read_err(&e)),
         };
         let mut out = Vec::new();

--- a/crates/ironclaw_reborn_migration/src/convert/memory.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/memory.rs
@@ -10,7 +10,10 @@
 //! and is recorded as a loss.
 
 use ironclaw_host_api::{CorrelationId, InvocationId, ResourceScope};
-use ironclaw_memory::{DocumentMetadata, MemoryInvocation, MemoryServiceWriteRequest};
+use ironclaw_memory::{DocumentMetadata, MemoryInvocation};
+use ironclaw_memory_native::{
+    MemoryBackendWriteOptions, MemoryContext, MemoryDocumentPath, MemoryDocumentScope,
+};
 
 use crate::error::MigrationError;
 use crate::options::MigrationOptions;
@@ -63,29 +66,66 @@ pub(crate) async fn run(
                 invocation_id: InvocationId::new(),
             };
             let invocation = MemoryInvocation {
-                scope,
+                scope: scope.clone(),
                 correlation_id: CorrelationId::new(),
             };
             let metadata = DocumentMetadata::from_value(&doc.metadata);
-            let request = MemoryServiceWriteRequest {
-                target: doc.path.clone(),
-                content: doc.content.clone(),
-                append: false,
-                old_string: None,
-                new_string: None,
-                replace_all: false,
-                metadata: Some(metadata),
-                timezone: None,
+            let memory_scope = match MemoryDocumentScope::new_with_agent(
+                invocation.scope.tenant_id.as_str(),
+                invocation.scope.user_id.as_str(),
+                invocation.scope.agent_id.as_ref().map(|id| id.as_str()),
+                invocation.scope.project_id.as_ref().map(|id| id.as_str()),
+            ) {
+                Ok(scope) => scope,
+                Err(error) => {
+                    report.record_loss(
+                        Domain::Memory,
+                        memory_source_id(&doc.user_id, &doc.path),
+                        "scope",
+                        LossReason::Unparseable,
+                        format!("legacy memory document scope is not a valid Reborn memory scope (record skipped): {error}"),
+                    );
+                    continue;
+                }
             };
+            let path = match MemoryDocumentPath::from_scope(memory_scope.clone(), doc.path.clone())
+            {
+                Ok(path) => path,
+                Err(error) => {
+                    report.record_loss(
+                        Domain::Memory,
+                        memory_source_id(&doc.user_id, &doc.path),
+                        "path",
+                        LossReason::Unparseable,
+                        format!("legacy memory document path is not a valid Reborn memory path (record skipped): {error}"),
+                    );
+                    continue;
+                }
+            };
+            let context = MemoryContext::new(memory_scope)
+                .with_audit_context(invocation.scope, invocation.correlation_id);
+            let write_options = MemoryBackendWriteOptions::with_metadata_overlay(Some(metadata));
 
-            tgt.memory_service
-                .write(invocation, request)
+            match tgt
+                .memory_backend
+                .write_document_with_backend_options(
+                    &context,
+                    &path,
+                    doc.content.as_bytes(),
+                    &write_options,
+                )
                 .await
-                .map_err(|e| MigrationError::WriteTarget {
-                    domain: format!("memory document {}", doc.path),
-                    reason: e.to_string(),
-                })?;
-            report.stats.memory_documents += 1;
+            {
+                Ok(_) => {
+                    report.stats.memory_documents += 1;
+                }
+                Err(error) => {
+                    return Err(MigrationError::WriteTarget {
+                        domain: format!("memory document {}", doc.path),
+                        reason: error.to_string(),
+                    });
+                }
+            }
         }
     }
 
@@ -99,4 +139,8 @@ pub(crate) async fn run(
             .to_string(),
     );
     Ok(())
+}
+
+fn memory_source_id(user_id: &str, path: &str) -> String {
+    format!("{user_id}:{path}")
 }

--- a/crates/ironclaw_reborn_migration/src/convert/threads.rs
+++ b/crates/ironclaw_reborn_migration/src/convert/threads.rs
@@ -246,11 +246,15 @@ fn build_metadata_json(import: &ThreadImport) -> Result<String, MigrationError> 
         .messages
         .iter()
         .map(|m| {
-            json!({
+            let mut message = json!({
                 "role": m.raw_role,
                 "created_at": m.created_at.to_rfc3339(),
                 "orig_id": m.orig_id,
-            })
+            });
+            if m.role == ImportRole::Other {
+                message["content"] = json!(m.content);
+            }
+            message
         })
         .collect();
     serde_json::to_string(&json!({

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/queries.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/queries.rs
@@ -22,6 +22,18 @@ use super::types::{
 };
 use super::types::{Routine, RoutineAction};
 
+#[cfg(feature = "libsql")]
+fn is_missing_libsql_table_error(message: &str) -> bool {
+    message.to_ascii_lowercase().contains("no such table")
+}
+
+#[cfg(feature = "postgres")]
+fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
+    error
+        .as_db_error()
+        .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)
+}
+
 /// Explicit column list for the `routines` table — libSQL positional reads
 /// match this order 1:1; Postgres reads `SELECT *` by name, so this is
 /// libSQL-only (see [`super::connect::ensure_schema_current`] for the
@@ -394,7 +406,7 @@ async fn libsql_identities_for_user(
     user_id: &str,
 ) -> Result<Vec<UserIdentityRecord>, LegacyError> {
     let conn = libsql_connect(db).await?;
-    let mut rows = conn
+    let mut rows = match conn
         .query(
             "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
              display_name, avatar_url, raw_profile, created_at, updated_at \
@@ -402,7 +414,11 @@ async fn libsql_identities_for_user(
             libsql::params![user_id],
         )
         .await
-        .map_err(|e| LegacyError::Query(e.to_string()))?;
+    {
+        Ok(rows) => rows,
+        Err(e) if is_missing_libsql_table_error(&e.to_string()) => return Ok(Vec::new()),
+        Err(e) => return Err(LegacyError::Query(e.to_string())),
+    };
 
     let mut result = Vec::new();
     while let Some(row) = rows
@@ -701,7 +717,7 @@ async fn postgres_identities_for_user(
     user_id: &str,
 ) -> Result<Vec<UserIdentityRecord>, LegacyError> {
     let client = pg_client(pool).await?;
-    let rows = client
+    let rows = match client
         .query(
             "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
              display_name, avatar_url, raw_profile, created_at, updated_at \
@@ -709,7 +725,11 @@ async fn postgres_identities_for_user(
             &[&user_id],
         )
         .await
-        .map_err(|e| LegacyError::Query(e.to_string()))?;
+    {
+        Ok(rows) => rows,
+        Err(e) if is_missing_postgres_table_error(&e) => return Ok(Vec::new()),
+        Err(e) => return Err(LegacyError::Query(e.to_string())),
+    };
 
     Ok(rows
         .iter()

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/queries.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/queries.rs
@@ -22,17 +22,10 @@ use super::types::{
 };
 use super::types::{Routine, RoutineAction};
 
-#[cfg(feature = "libsql")]
-fn is_missing_libsql_table_error(message: &str) -> bool {
-    message.to_ascii_lowercase().contains("no such table")
-}
-
 #[cfg(feature = "postgres")]
-fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
-    error
-        .as_db_error()
-        .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)
-}
+use crate::source::is_missing_postgres_table_error;
+#[cfg(feature = "libsql")]
+use crate::source::is_missing_table_error;
 
 /// Explicit column list for the `routines` table — libSQL positional reads
 /// match this order 1:1; Postgres reads `SELECT *` by name, so this is
@@ -416,7 +409,7 @@ async fn libsql_identities_for_user(
         .await
     {
         Ok(rows) => rows,
-        Err(e) if is_missing_libsql_table_error(&e.to_string()) => return Ok(Vec::new()),
+        Err(e) if is_missing_table_error(&e.to_string()) => return Ok(Vec::new()),
         Err(e) => return Err(LegacyError::Query(e.to_string())),
     };
 

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/wasm_stores.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/wasm_stores.rs
@@ -15,6 +15,19 @@ pub(crate) enum WasmStorageError {
     Database(String),
 }
 
+fn is_missing_table_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("no such table")
+        || (lower.contains("relation") && lower.contains("does not exist"))
+}
+
+#[cfg(feature = "postgres")]
+fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
+    error
+        .as_db_error()
+        .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)
+}
+
 /// Frozen mirror of `ironclaw::tools::wasm::ToolStatus`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolStatus {
@@ -116,10 +129,10 @@ impl WasmToolStore for LibSqlWasmToolStore {
     async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmTool>, WasmStorageError> {
         use super::libsql_helpers::{get_text, get_ts};
         let conn = self.connect().await?;
-        let mut rows = conn
+        let mut rows = match conn
             .query(
                 r#"
-                SELECT id, user_id, name, version, wit_version, description, parameters_schema,
+                SELECT id, user_id, name, version, description, parameters_schema,
                        source_url, trust_level, status, created_at, updated_at
                 FROM wasm_tools
                 WHERE user_id = ?1
@@ -128,7 +141,11 @@ impl WasmToolStore for LibSqlWasmToolStore {
                 libsql::params![user_id],
             )
             .await
-            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        {
+            Ok(rows) => rows,
+            Err(e) if is_missing_table_error(&e.to_string()) => return Ok(Vec::new()),
+            Err(e) => return Err(WasmStorageError::Database(e.to_string())),
+        };
 
         let mut tools = Vec::new();
         while let Some(row) = rows
@@ -137,16 +154,16 @@ impl WasmToolStore for LibSqlWasmToolStore {
             .map_err(|e| WasmStorageError::Database(e.to_string()))?
         {
             let id_str = get_text(&row, 0);
-            let status_str = get_text(&row, 9);
+            let status_str = get_text(&row, 8);
             tools.push(StoredWasmTool {
                 id: id_str
                     .parse()
                     .map_err(|e: uuid::Error| WasmStorageError::Database(e.to_string()))?,
                 name: get_text(&row, 2),
                 version: get_text(&row, 3),
-                description: get_text(&row, 5),
+                description: get_text(&row, 4),
                 status: status_str.parse().map_err(WasmStorageError::Database)?,
-                updated_at: get_ts(&row, 11),
+                updated_at: get_ts(&row, 10),
             });
         }
         Ok(tools)
@@ -157,7 +174,7 @@ impl WasmToolStore for LibSqlWasmToolStore {
         tool_id: Uuid,
     ) -> Result<Option<StoredCapabilities>, WasmStorageError> {
         let conn = self.connect().await?;
-        let mut rows = conn
+        let mut rows = match conn
             .query(
                 r#"
                 SELECT allowed_secrets
@@ -167,7 +184,11 @@ impl WasmToolStore for LibSqlWasmToolStore {
                 libsql::params![tool_id.to_string()],
             )
             .await
-            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        {
+            Ok(rows) => rows,
+            Err(e) if is_missing_table_error(&e.to_string()) => return Ok(None),
+            Err(e) => return Err(WasmStorageError::Database(e.to_string())),
+        };
 
         match rows
             .next()
@@ -214,10 +235,10 @@ impl WasmChannelStore for LibSqlWasmChannelStore {
     async fn list(&self, user_id: &str) -> Result<Vec<StoredWasmChannel>, WasmStorageError> {
         use super::libsql_helpers::{get_text, parse_timestamp};
         let conn = self.connect().await?;
-        let mut rows = conn
+        let mut rows = match conn
             .query(
                 r#"
-                SELECT id, user_id, name, version, wit_version, description,
+                SELECT id, user_id, name, version, description,
                        capabilities_json, status, created_at, updated_at
                 FROM wasm_channels
                 WHERE user_id = ?1
@@ -226,7 +247,11 @@ impl WasmChannelStore for LibSqlWasmChannelStore {
                 libsql::params![user_id],
             )
             .await
-            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        {
+            Ok(rows) => rows,
+            Err(e) if is_missing_table_error(&e.to_string()) => return Ok(Vec::new()),
+            Err(e) => return Err(WasmStorageError::Database(e.to_string())),
+        };
 
         let mut channels = Vec::new();
         while let Some(row) = rows
@@ -234,12 +259,12 @@ impl WasmChannelStore for LibSqlWasmChannelStore {
             .await
             .map_err(|e| WasmStorageError::Database(e.to_string()))?
         {
-            let updated_at_str = get_text(&row, 9);
+            let updated_at_str = get_text(&row, 8);
             channels.push(StoredWasmChannel {
                 name: get_text(&row, 2),
                 version: get_text(&row, 3),
-                description: get_text(&row, 5),
-                status: get_text(&row, 7),
+                description: get_text(&row, 4),
+                status: get_text(&row, 6),
                 updated_at: parse_timestamp(&updated_at_str).map_err(WasmStorageError::Database)?,
             });
         }
@@ -270,11 +295,11 @@ impl WasmToolStore for PostgresWasmToolStore {
             .get()
             .await
             .map_err(|e| WasmStorageError::Database(e.to_string()))?;
-        let rows = client
+        let rows = match client
             .query(
                 r#"
-                SELECT id, user_id, name, version, wit_version, description,
-                       parameters_schema, source_url, trust_level, status, created_at, updated_at
+                SELECT id, user_id, name, version, description, parameters_schema, source_url,
+                       trust_level, status, created_at, updated_at
                 FROM wasm_tools
                 WHERE user_id = $1
                 ORDER BY name
@@ -282,7 +307,11 @@ impl WasmToolStore for PostgresWasmToolStore {
                 &[&user_id],
             )
             .await
-            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        {
+            Ok(rows) => rows,
+            Err(e) if is_missing_postgres_table_error(&e) => return Ok(Vec::new()),
+            Err(e) => return Err(WasmStorageError::Database(e.to_string())),
+        };
 
         rows.iter()
             .map(|r| {
@@ -308,13 +337,17 @@ impl WasmToolStore for PostgresWasmToolStore {
             .get()
             .await
             .map_err(|e| WasmStorageError::Database(e.to_string()))?;
-        let row = client
+        let row = match client
             .query_opt(
                 "SELECT allowed_secrets FROM tool_capabilities WHERE wasm_tool_id = $1",
                 &[&tool_id],
             )
             .await
-            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        {
+            Ok(row) => row,
+            Err(e) if is_missing_postgres_table_error(&e) => return Ok(None),
+            Err(e) => return Err(WasmStorageError::Database(e.to_string())),
+        };
         Ok(row.map(|r| StoredCapabilities {
             allowed_secrets: r.get("allowed_secrets"),
         }))
@@ -342,11 +375,11 @@ impl WasmChannelStore for PostgresWasmChannelStore {
             .get()
             .await
             .map_err(|e| WasmStorageError::Database(e.to_string()))?;
-        let rows = client
+        let rows = match client
             .query(
                 r#"
-                SELECT id, user_id, name, version, wit_version, description,
-                       capabilities_json, status, created_at, updated_at
+                SELECT id, user_id, name, version, description, capabilities_json, status,
+                       created_at, updated_at
                 FROM wasm_channels
                 WHERE user_id = $1
                 ORDER BY name
@@ -354,7 +387,11 @@ impl WasmChannelStore for PostgresWasmChannelStore {
                 &[&user_id],
             )
             .await
-            .map_err(|e| WasmStorageError::Database(e.to_string()))?;
+        {
+            Ok(rows) => rows,
+            Err(e) if is_missing_postgres_table_error(&e) => return Ok(Vec::new()),
+            Err(e) => return Err(WasmStorageError::Database(e.to_string())),
+        };
 
         Ok(rows
             .iter()

--- a/crates/ironclaw_reborn_migration/src/legacy_snapshot/wasm_stores.rs
+++ b/crates/ironclaw_reborn_migration/src/legacy_snapshot/wasm_stores.rs
@@ -15,18 +15,10 @@ pub(crate) enum WasmStorageError {
     Database(String),
 }
 
-fn is_missing_table_error(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    lower.contains("no such table")
-        || (lower.contains("relation") && lower.contains("does not exist"))
-}
-
 #[cfg(feature = "postgres")]
-fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
-    error
-        .as_db_error()
-        .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)
-}
+use crate::source::is_missing_postgres_table_error;
+#[cfg(feature = "libsql")]
+use crate::source::is_missing_table_error;
 
 /// Frozen mirror of `ironclaw::tools::wasm::ToolStatus`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ironclaw_reborn_migration/src/main.rs
+++ b/crates/ironclaw_reborn_migration/src/main.rs
@@ -99,20 +99,18 @@ impl Cli {
         };
         let tenant_id = TenantId::new(self.tenant_id)?;
         let agent_id = AgentId::new(self.agent_id)?;
-        let secret_master_key = match (self.secret_master_key, self.resolve_secret_master_key) {
-            (Some(key), false) => Some(SecretString::from(key)),
-            (None, true) => match ironclaw_secrets::keychain::resolve_master_key_material().await {
-                Ok(key) => key,
-                Err(error) => {
-                    tracing::warn!(
-                        "failed to resolve secrets master key; secrets will be reported as unmigrated: {error}"
-                    );
-                    None
-                }
-            },
-            (None, false) => None,
-            (Some(_), true) => unreachable!("clap conflict prevents both secret key sources"),
+        // Only touch the env/keychain when the user asked us to resolve; an
+        // explicit `--secret-master-key` (or neither flag) never consults it.
+        let resolved = if self.resolve_secret_master_key {
+            ironclaw_secrets::keychain::resolve_master_key_material().await
+        } else {
+            Ok(None)
         };
+        let secret_master_key = select_secret_master_key(
+            self.secret_master_key,
+            self.resolve_secret_master_key,
+            resolved,
+        )?;
         let options = MigrationOptions {
             source,
             target,
@@ -122,6 +120,31 @@ impl Cli {
             dry_run: self.dry_run,
         };
         Ok((options, self.report))
+    }
+}
+
+/// Resolve the effective secrets master key from the two mutually-exclusive CLI
+/// inputs (`--secret-master-key` vs `--resolve-secret-master-key`) and the
+/// outcome of the keychain/env lookup.
+///
+/// Fail-loud: when the user explicitly asked us to resolve the key and the
+/// lookup **errored**, the migration aborts. Swallowing that error and
+/// returning `None` would silently skip every secret and leave the target in a
+/// broken half-migrated state, violating the crate's "nothing is silently
+/// dropped" invariant (see `.claude/rules/error-handling.md`). A successful
+/// lookup that simply found no key (`Ok(None)`) is a legitimate absence — the
+/// secrets converter records it as a reported loss, not a swallowed failure.
+fn select_secret_master_key(
+    explicit: Option<String>,
+    resolve: bool,
+    resolved: Result<Option<SecretString>, ironclaw_secrets::SecretError>,
+) -> anyhow::Result<Option<SecretString>> {
+    match (explicit, resolve) {
+        (Some(key), false) => Ok(Some(SecretString::from(key))),
+        (None, true) => resolved
+            .map_err(|error| anyhow::anyhow!("failed to resolve secrets master key: {error}")),
+        (None, false) => Ok(None),
+        (Some(_), true) => unreachable!("clap conflict prevents both secret key sources"),
     }
 }
 
@@ -171,4 +194,62 @@ async fn emit_report(
         None => println!("{json}"),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_secrets::SecretError;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    fn explicit_key_resolution_failure_aborts_rather_than_silently_skipping() {
+        // User asked us to resolve the key (`--resolve-secret-master-key`) and
+        // the lookup errored. This must surface as an error, not a silent
+        // `None` that would skip every secret. Regression for the swallowed
+        // `tracing::warn!` + `return None` fail-loud violation.
+        let result = select_secret_master_key(
+            None,
+            true,
+            Err(SecretError::KeychainError(
+                "keychain unavailable".to_string(),
+            )),
+        );
+        let error = result.expect_err("resolution failure must abort the migration");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to resolve secrets master key"),
+            "error should name the resolution failure, got: {error}"
+        );
+    }
+
+    #[test]
+    fn explicit_key_resolution_success_carries_the_resolved_key() {
+        let result = select_secret_master_key(
+            None,
+            true,
+            Ok(Some(SecretString::from("resolved-key".to_string()))),
+        );
+        let key = result.expect("successful resolution should not error");
+        assert_eq!(key.expect("key present").expose_secret(), "resolved-key");
+    }
+
+    #[test]
+    fn absent_resolved_key_is_a_legitimate_none_not_an_error() {
+        // A successful lookup that found nothing is not a failure — secrets are
+        // reported as unmigrated by the converter, not swallowed here.
+        let result = select_secret_master_key(None, true, Ok(None));
+        assert!(
+            result.expect("Ok(None) is not an error").is_none(),
+            "no key found must flow through as None"
+        );
+    }
+
+    #[test]
+    fn explicit_master_key_flag_never_consults_resolution() {
+        let result = select_secret_master_key(Some("literal-key".to_string()), false, Ok(None));
+        let key = result.expect("explicit key path must not error");
+        assert_eq!(key.expect("key present").expose_secret(), "literal-key");
+    }
 }

--- a/crates/ironclaw_reborn_migration/src/main.rs
+++ b/crates/ironclaw_reborn_migration/src/main.rs
@@ -68,6 +68,10 @@ struct Cli {
     #[arg(long, env = "MIGRATION_SECRET_MASTER_KEY")]
     secret_master_key: Option<String>,
 
+    /// Resolve the v1 secrets master key from SECRETS_MASTER_KEY or OS keychain.
+    #[arg(long, conflicts_with = "secret_master_key")]
+    resolve_secret_master_key: bool,
+
     /// Report what would be migrated without writing to the Reborn store.
     #[arg(long)]
     dry_run: bool,
@@ -78,7 +82,7 @@ struct Cli {
 }
 
 impl Cli {
-    fn into_options(self) -> anyhow::Result<(MigrationOptions, Option<PathBuf>)> {
+    async fn into_options(self) -> anyhow::Result<(MigrationOptions, Option<PathBuf>)> {
         let source = match (self.source_libsql, self.source_postgres) {
             (Some(path), None) => SourceDb::LibSql { path },
             (None, Some(url)) => SourceDb::Postgres {
@@ -95,12 +99,26 @@ impl Cli {
         };
         let tenant_id = TenantId::new(self.tenant_id)?;
         let agent_id = AgentId::new(self.agent_id)?;
+        let secret_master_key = match (self.secret_master_key, self.resolve_secret_master_key) {
+            (Some(key), false) => Some(SecretString::from(key)),
+            (None, true) => match ironclaw_secrets::keychain::resolve_master_key_material().await {
+                Ok(key) => key,
+                Err(error) => {
+                    tracing::warn!(
+                        "failed to resolve secrets master key; secrets will be reported as unmigrated: {error}"
+                    );
+                    None
+                }
+            },
+            (None, false) => None,
+            (Some(_), true) => unreachable!("clap conflict prevents both secret key sources"),
+        };
         let options = MigrationOptions {
             source,
             target,
             tenant_id,
             agent_id,
-            secret_master_key: self.secret_master_key.map(SecretString::from),
+            secret_master_key,
             dry_run: self.dry_run,
         };
         Ok((options, self.report))
@@ -128,7 +146,7 @@ async fn main() -> ExitCode {
 
 async fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let (options, report_path) = cli.into_options()?;
+    let (options, report_path) = cli.into_options().await?;
     let dry_run = options.dry_run;
 
     let report = run_migration(options).await?;

--- a/crates/ironclaw_reborn_migration/src/source.rs
+++ b/crates/ironclaw_reborn_migration/src/source.rs
@@ -12,6 +12,13 @@ use crate::error::MigrationError;
 use crate::legacy_snapshot::{self, LegacyDb, LegacyHandles};
 use crate::options::SourceDb;
 
+#[cfg(feature = "postgres")]
+fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
+    error
+        .as_db_error()
+        .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)
+}
+
 /// A live handle to the v1 source database.
 ///
 /// Crate-internal: the only public entry point is [`crate::run_migration`], and
@@ -94,7 +101,7 @@ impl V1Source {
             let client = pool.get().await.map_err(|e| read_err(&e))?;
             let stmt_rows = match client.query(sql.as_str(), &[]).await {
                 Ok(rows) => rows,
-                Err(e) if is_missing_table_error(&e.to_string()) => return Ok(Vec::new()),
+                Err(e) if is_missing_postgres_table_error(&e) => return Ok(Vec::new()),
                 Err(e) => return Err(read_err(&e)),
             };
             return stmt_rows

--- a/crates/ironclaw_reborn_migration/src/source.rs
+++ b/crates/ironclaw_reborn_migration/src/source.rs
@@ -12,8 +12,13 @@ use crate::error::MigrationError;
 use crate::legacy_snapshot::{self, LegacyDb, LegacyHandles};
 use crate::options::SourceDb;
 
+/// True when a PostgreSQL error is the "table/relation does not exist" class,
+/// the one case the read paths tolerate as "nothing here" (see
+/// [`is_missing_table_error`] for the string-based libSQL counterpart). Shared
+/// across every read site in the crate (source discovery, the frozen legacy
+/// queries, the wasm stores, and the identity converter).
 #[cfg(feature = "postgres")]
-fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
+pub(crate) fn is_missing_postgres_table_error(error: &tokio_postgres::Error) -> bool {
     error
         .as_db_error()
         .is_some_and(|db| db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE)

--- a/crates/ironclaw_reborn_migration/src/target.rs
+++ b/crates/ironclaw_reborn_migration/src/target.rs
@@ -16,8 +16,11 @@ use ironclaw_host_api::{AgentId, TenantId, UserId};
 use ironclaw_reborn_identity::{FilesystemRebornIdentityStore, RebornUserDirectory};
 
 use ironclaw_host_api::ProjectId;
-use ironclaw_memory::MemoryService;
-use ironclaw_memory_native::NativeMemoryService;
+use ironclaw_memory_native::{
+    ChunkingMemoryDocumentIndexer, DefaultPromptWriteSafetyPolicy,
+    FilesystemMemoryDocumentRepository, MemoryBackend, MemoryBackendCapabilities,
+    PromptProtectedPathRegistry, PromptSafetyPolicyVersion, RepositoryMemoryBackend,
+};
 use ironclaw_reborn_identity::RebornIdentityResolver;
 use ironclaw_secrets::{FilesystemSecretStore, SecretStore, SecretsCrypto};
 use ironclaw_threads::{FilesystemSessionThreadService, SessionThreadService};
@@ -57,7 +60,7 @@ pub(crate) struct RebornTarget {
     pub(crate) tenant_id: TenantId,
     pub(crate) agent_id: AgentId,
     pub(crate) thread_service: Arc<dyn SessionThreadService>,
-    pub(crate) memory_service: Arc<dyn MemoryService>,
+    pub(crate) memory_backend: Arc<dyn MemoryBackend>,
     pub(crate) trigger_repo: Arc<dyn TriggerRepository>,
     pub(crate) extension_store: Arc<dyn ExtensionInstallationStore>,
     /// Present only when a secrets master key was supplied.
@@ -119,11 +122,11 @@ impl RebornTarget {
         };
 
         let backend = open_backend(&options.target).await?;
-        let (thread_service, memory_service, secret_store) = match &backend {
+        let (thread_service, memory_backend, secret_store) = match &backend {
             #[cfg(feature = "libsql")]
-            Backend::LibSql { root, .. } => build_kv_services(root.clone(), crypto.clone()),
+            Backend::LibSql { root, .. } => build_kv_services(root.clone(), crypto.clone())?,
             #[cfg(feature = "postgres")]
-            Backend::Postgres { root, .. } => build_kv_services(root.clone(), crypto.clone()),
+            Backend::Postgres { root, .. } => build_kv_services(root.clone(), crypto.clone())?,
         };
         let trigger_repo = build_trigger_repo(&backend).await?;
 
@@ -147,7 +150,7 @@ impl RebornTarget {
             tenant_id: options.tenant_id.clone(),
             agent_id: options.agent_id.clone(),
             thread_service,
-            memory_service,
+            memory_backend,
             trigger_repo,
             extension_store,
             secret_store,
@@ -182,13 +185,16 @@ fn build_crypto(key: &SecretString) -> Result<SecretsCrypto, MigrationError> {
 /// The KV-substrate write services built over one backend.
 type KvServices = (
     Arc<dyn SessionThreadService>,
-    Arc<dyn MemoryService>,
+    Arc<dyn MemoryBackend>,
     Option<Arc<dyn SecretStore>>,
 );
 
 /// Build the filesystem-backed KV services over one concrete backend, returning
 /// them as trait objects.
-fn build_kv_services<F>(root: Arc<F>, crypto: Option<Arc<SecretsCrypto>>) -> KvServices
+fn build_kv_services<F>(
+    root: Arc<F>,
+    crypto: Option<Arc<SecretsCrypto>>,
+) -> Result<KvServices, MigrationError>
 where
     F: RootFilesystem + 'static,
 {
@@ -200,8 +206,7 @@ where
         Arc::new(FilesystemSessionThreadService::new(threads_scoped));
 
     let root_dyn: Arc<dyn RootFilesystem> = root.clone();
-    let memory_service: Arc<dyn MemoryService> =
-        Arc::new(NativeMemoryService::from_filesystem(root_dyn, None));
+    let memory_backend = build_memory_backend(root_dyn)?;
 
     let secret_store: Option<Arc<dyn SecretStore>> = crypto.map(|crypto| {
         let secrets_scoped = Arc::new(ScopedFilesystem::new(
@@ -213,7 +218,38 @@ where
         store
     });
 
-    (thread_service, memory_service, secret_store)
+    Ok((thread_service, memory_backend, secret_store))
+}
+
+fn build_memory_backend(
+    filesystem: Arc<dyn RootFilesystem>,
+) -> Result<Arc<dyn MemoryBackend>, MigrationError> {
+    let repository = Arc::new(FilesystemMemoryDocumentRepository::new(filesystem));
+    let indexer = Arc::new(ChunkingMemoryDocumentIndexer::new(repository.clone()));
+    let empty_protected_paths = PromptProtectedPathRegistry::new(
+        PromptSafetyPolicyVersion::new("migration-empty-prompt-protected-paths:v1")
+            .map_err(|error| MigrationError::OpenTarget(error.to_string()))?,
+        std::iter::empty::<String>(),
+    )
+    .map_err(|error| MigrationError::OpenTarget(error.to_string()))?;
+    Ok(Arc::new(
+        RepositoryMemoryBackend::new(repository)
+            .with_indexer(indexer)
+            .with_prompt_write_safety_policy(Arc::new(
+                DefaultPromptWriteSafetyPolicy::with_registry(empty_protected_paths.clone()),
+            ))
+            .with_prompt_protected_path_registry(empty_protected_paths)
+            .with_capabilities(
+                MemoryBackendCapabilities::default()
+                    .set_file_documents(true)
+                    .set_metadata(true)
+                    .set_versioning(true)
+                    .set_prompt_write_safety(true)
+                    .set_full_text_search(true)
+                    .set_delete(true)
+                    .set_transactions(true),
+            ),
+    ))
 }
 
 #[allow(dead_code)] // wired for the identity row-by-row follow-up

--- a/crates/ironclaw_reborn_migration/src/target.rs
+++ b/crates/ironclaw_reborn_migration/src/target.rs
@@ -226,6 +226,15 @@ fn build_memory_backend(
 ) -> Result<Arc<dyn MemoryBackend>, MigrationError> {
     let repository = Arc::new(FilesystemMemoryDocumentRepository::new(filesystem));
     let indexer = Arc::new(ChunkingMemoryDocumentIndexer::new(repository.clone()));
+    // Intentionally empty, and load-bearing: the migration must be able to
+    // import legacy content into paths that are normally prompt-protected (e.g.
+    // BOOTSTRAP.md). Because `MemoryBackendWriteOptions` leaves
+    // `prompt_safety_already_enforced: false`, the backend consults this
+    // registry on every write and is fail-closed by default; an empty registry
+    // is what makes it match nothing, so no legacy write is blocked. This
+    // bypass is deliberately scoped to this ephemeral, one-shot migration-only
+    // backend — do NOT "fix" it by populating protected paths here, or you will
+    // silently reintroduce write failures for protected legacy documents.
     let empty_protected_paths = PromptProtectedPathRegistry::new(
         PromptSafetyPolicyVersion::new("migration-empty-prompt-protected-paths:v1")
             .map_err(|error| MigrationError::OpenTarget(error.to_string()))?,

--- a/crates/ironclaw_reborn_migration/tests/migration_roundtrip.rs
+++ b/crates/ironclaw_reborn_migration/tests/migration_roundtrip.rs
@@ -1182,7 +1182,10 @@ async fn migration_reads_older_optional_tables_without_wit_version() {
     drop(conn);
     drop(db);
 
-    let report = run_migration(options(path, dst, true))
+    // Run a real (non-dry) migration so the write path is genuinely exercised:
+    // a dry run only counts in memory and would not prove the older schema lets
+    // real writes through.
+    let report = run_migration(options(path, dst.clone(), false))
         .await
         .expect("older wasm schema should not block migration");
 
@@ -1190,6 +1193,20 @@ async fn migration_reads_older_optional_tables_without_wit_version() {
     assert_eq!(
         report.stats.extensions, 1,
         "installed tools must still migrate when the optional capabilities table is absent"
+    );
+
+    // Assert the migrated content is actually persisted on disk (the point of
+    // dropping dry-run): the memory document and the extension installation
+    // record must be readable back through a fresh connection.
+    assert!(
+        reborn_entry_count_by_path_and_content(&dst, "%old-wasm.md", "%old schema still migrates%")
+            .await
+            >= 1,
+        "the migrated memory document must be persisted on disk, not just counted"
+    );
+    assert!(
+        reborn_entry_count(&dst, "%/system/extensions/.installations/state.json").await >= 1,
+        "the installed tool must be persisted as an extension installation on disk"
     );
 }
 

--- a/crates/ironclaw_reborn_migration/tests/migration_roundtrip.rs
+++ b/crates/ironclaw_reborn_migration/tests/migration_roundtrip.rs
@@ -378,6 +378,7 @@ async fn seed_v1_fixture(dir: &std::path::Path) -> PathBuf {
     let c2 = insert_conversation(&conn, "telegram", USER).await;
     insert_conversation_message(&conn, c2, "user", "what's on my calendar?").await;
     insert_conversation_message(&conn, c2, "assistant", "you have 2 meetings").await;
+    insert_conversation_message(&conn, c2, "tool_calls", "[{\"name\":\"calendar.list\"}]").await;
 
     // ── routines: every trigger variant × both actions ──
     insert_routine(
@@ -501,6 +502,8 @@ async fn seed_v1_fixture(dir: &std::path::Path) -> PathBuf {
 
     // ── a non-engine memory document ──
     insert_memory_document(&conn, USER, "context/vision.md", "# Vision\nbe helpful").await;
+    insert_memory_document(&conn, USER, ".system/gateway/.config", "").await;
+    insert_memory_document(&conn, USER, "BOOTSTRAP.md", "# Legacy bootstrap\nkeep me").await;
 
     // ── settings ──
     insert_setting(&conn, USER, "model", &serde_json::json!("gpt-4")).await;
@@ -581,6 +584,17 @@ fn options(src: PathBuf, dst: PathBuf, dry_run: bool) -> MigrationOptions {
     }
 }
 
+fn options_without_secret_key(src: PathBuf, dst: PathBuf, dry_run: bool) -> MigrationOptions {
+    MigrationOptions {
+        source: SourceDb::LibSql { path: src },
+        target: TargetStore::LibSql { path: dst },
+        tenant_id: TenantId::new(TENANT).unwrap(),
+        agent_id: ironclaw_host_api::AgentId::new(AGENT).unwrap(),
+        secret_master_key: None,
+        dry_run,
+    }
+}
+
 /// Count rows in the Reborn store whose resolved path matches a LIKE pattern,
 /// via a fresh connection — proves on-disk durability of a domain's documents.
 async fn reborn_entry_count(path: &Path, like: &str) -> i64 {
@@ -596,6 +610,27 @@ async fn reborn_entry_count(path: &Path, like: &str) -> i64 {
         )
         .await
         .expect("query entries");
+    let row = rows.next().await.expect("row").expect("some row");
+    row.get::<i64>(0).expect("count")
+}
+
+async fn reborn_entry_count_by_path_and_content(
+    path: &Path,
+    path_like: &str,
+    content_like: &str,
+) -> i64 {
+    let db = libsql::Builder::new_local(path)
+        .build()
+        .await
+        .expect("open reborn db");
+    let conn = db.connect().expect("connect");
+    let mut rows = conn
+        .query(
+            "SELECT count(*) FROM root_filesystem_entries WHERE path LIKE ?1 AND CAST(contents AS TEXT) LIKE ?2",
+            libsql::params![path_like, content_like],
+        )
+        .await
+        .expect("query entries by path and content");
     let row = rows.next().await.expect("row").expect("some row");
     row.get::<i64>(0).expect("count")
 }
@@ -618,6 +653,27 @@ async fn reborn_entry_content(path: &Path, like: &str) -> String {
     let row = rows.next().await.expect("row").expect("some row");
     let blob = row.get::<Vec<u8>>(0).expect("contents blob");
     String::from_utf8(blob).expect("utf-8 contents")
+}
+
+async fn reborn_entry_contents(path: &Path, like: &str) -> Vec<String> {
+    let db = libsql::Builder::new_local(path)
+        .build()
+        .await
+        .expect("open reborn db");
+    let conn = db.connect().expect("connect");
+    let mut rows = conn
+        .query(
+            "SELECT contents FROM root_filesystem_entries WHERE path LIKE ?1 ORDER BY path",
+            [like],
+        )
+        .await
+        .expect("query entry contents");
+    let mut contents = Vec::new();
+    while let Some(row) = rows.next().await.expect("row") {
+        let blob = row.get::<Vec<u8>>(0).expect("contents blob");
+        contents.push(String::from_utf8(blob).expect("utf-8 contents"));
+    }
+    contents
 }
 
 async fn reborn_triggers(path: &Path) -> Vec<ironclaw_triggers::TriggerRecord> {
@@ -673,7 +729,7 @@ async fn migrates_v1_and_engine_v2_state_without_loss() {
     // user+assistant messages: conv1 (2) + conv2 (2) + mission thread (2) = 6.
     assert_eq!(report.stats.messages, 6, "messages: {:?}", report.stats);
     assert_eq!(
-        report.stats.memory_documents, 1,
+        report.stats.memory_documents, 3,
         "memory: {:?}",
         report.stats
     );
@@ -684,8 +740,9 @@ async fn migrates_v1_and_engine_v2_state_without_loss() {
     let expected_losses = [
         // owner/thread/mission ids are all valid → no thread-identity losses.
         (Domain::Thread, 0),
-        // conv1's single "system" transcript message (no first-class append path).
-        (Domain::Message, 1),
+        // conv1 system + conv2 tool_calls transcript messages are retained in
+        // thread metadata because they have no first-class append path.
+        (Domain::Message, 2),
         // 6 routines: each cron routine records 3 field losses
         // (action + guardrails/notify/counters + routine_runs); each non-cron
         // routine records 1 trigger-source loss + 2 field losses. 6 × 3 = 18.
@@ -824,6 +881,20 @@ async fn migrates_v1_and_engine_v2_state_without_loss() {
         reborn_thread_doc_count(&dst).await >= 3,
         "expected >=3 persisted thread.json docs"
     );
+    assert!(
+        reborn_entry_count_by_path_and_content(&dst, "%/thread.json", "%session started%").await
+            >= 1,
+        "system transcript content must be retained in thread metadata"
+    );
+    assert!(
+        reborn_entry_count_by_path_and_content(&dst, "%/thread.json", "%calendar.list%").await >= 1,
+        "tool_calls transcript content must be retained in thread metadata"
+    );
+    assert!(
+        reborn_entry_count_by_path_and_content(&dst, "%/BOOTSTRAP.md", "%Legacy bootstrap%").await
+            >= 1,
+        "protected legacy memory documents must be preserved by the migration backend"
+    );
 
     // ── idempotency: re-running the migration into the same target re-adopts
     // identities (first-writer-wins) and upserts the extension installation by
@@ -878,6 +949,109 @@ async fn migrates_all_active_duplicate_users_as_enabled() {
     assert_eq!(
         installations[0]["owner"]["user_ids"],
         serde_json::json!([USER, USER_BOB])
+    );
+}
+
+#[tokio::test]
+async fn migration_preserves_empty_and_prompt_protected_memory_documents() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("v1_memory_edges.db");
+    let dst = dir.path().join("reborn.db");
+
+    let db = open_v1_fixture_db(&src).await;
+    let conn = db.connect().expect("connect");
+    insert_memory_document(&conn, USER, "context/vision.md", "# Vision\nbe helpful").await;
+    insert_memory_document(&conn, USER, ".system/gateway/.config", "").await;
+    insert_memory_document(&conn, USER, "BOOTSTRAP.md", "# Legacy bootstrap\nkeep me").await;
+    drop(conn);
+    drop(db);
+
+    let report = run_migration(options(src, dst.clone(), false))
+        .await
+        .expect("migration runs");
+
+    assert_eq!(report.stats.memory_documents, 3);
+    assert_eq!(report.losses_in(Domain::Memory), 1);
+    assert_eq!(
+        reborn_entry_contents(&dst, "%/.system/gateway/.config").await,
+        vec![String::new()],
+        "empty legacy memory documents must remain present, not disappear as no-op writes"
+    );
+    assert_eq!(
+        reborn_entry_content(&dst, "%/BOOTSTRAP.md").await,
+        "# Legacy bootstrap\nkeep me",
+        "prompt-protected legacy paths must be imported by the migration backend"
+    );
+}
+
+#[tokio::test]
+async fn migration_retains_non_first_class_transcript_content_in_thread_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("v1_transcript_edges.db");
+    let dst = dir.path().join("reborn.db");
+
+    let db = open_v1_fixture_db(&src).await;
+    let conn = db.connect().expect("connect");
+    let conversation = insert_conversation(&conn, "gateway", USER).await;
+    insert_conversation_message(&conn, conversation, "system", "session started").await;
+    insert_conversation_message(
+        &conn,
+        conversation,
+        "tool_calls",
+        "[{\"name\":\"calendar.list\"}]",
+    )
+    .await;
+    insert_conversation_message(&conn, conversation, "tool", "{\"result\":\"ok\"}").await;
+    drop(conn);
+    drop(db);
+
+    let report = run_migration(options(src, dst.clone(), false))
+        .await
+        .expect("migration runs");
+
+    assert_eq!(report.stats.threads, 1);
+    assert_eq!(report.stats.messages, 0);
+    assert_eq!(report.losses_in(Domain::Message), 3);
+    let thread_doc = reborn_entry_content(&dst, "%/thread.json").await;
+    assert!(thread_doc.contains("session started"));
+    assert!(thread_doc.contains("calendar.list"));
+    assert!(thread_doc.contains("result"));
+    assert!(thread_doc.contains("ok"));
+}
+
+#[tokio::test]
+async fn migration_reports_secrets_as_unmigrated_without_master_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("v1_secret_edges.db");
+    let dst = dir.path().join("reborn.db");
+
+    let db = open_v1_fixture_db(&src).await;
+    let conn = db.connect().expect("connect");
+    let now = Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap();
+    seed_secret(&conn, now).await;
+    drop(conn);
+    drop(db);
+
+    let report = run_migration(options_without_secret_key(src, dst.clone(), false))
+        .await
+        .expect("migration runs");
+
+    assert_eq!(report.stats.secrets, 0);
+    assert_eq!(report.losses_in(Domain::Secret), 1);
+    assert!(
+        report.lossy.iter().any(|loss| {
+            loss.domain == Domain::Secret
+                && loss.source_id == "secrets"
+                && loss.field == "*"
+                && loss.detail.contains("secret-master-key")
+        }),
+        "missing master key must be explicit in the report: {:#?}",
+        report.lossy
+    );
+    assert_eq!(
+        reborn_entry_count(&dst, "%/secrets/%openai_api_key.json").await,
+        0,
+        "a skipped v1 secret must not create an empty Reborn secret document"
     );
 }
 
@@ -968,6 +1142,54 @@ async fn dry_run_reports_without_writing() {
         reborn_thread_doc_count(&dst).await,
         0,
         "dry run wrote thread docs"
+    );
+}
+
+#[tokio::test]
+async fn migration_reads_older_optional_tables_without_wit_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("v1_old_wasm.db");
+    let dst = dir.path().join("reborn.db");
+
+    let db = open_v1_fixture_db(&path).await;
+    let conn = db.connect().expect("connect");
+    seed_wasm_tool(&conn, Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap()).await;
+    conn.execute("ALTER TABLE wasm_tools DROP COLUMN wit_version", ())
+        .await
+        .expect("drop wasm_tools.wit_version");
+    conn.execute("ALTER TABLE wasm_channels DROP COLUMN wit_version", ())
+        .await
+        .expect("drop wasm_channels.wit_version");
+    conn.execute("DROP TABLE wasm_channels", ())
+        .await
+        .expect("drop optional wasm_channels table");
+    conn.execute("DROP TABLE tool_capabilities", ())
+        .await
+        .expect("drop optional tool_capabilities table");
+    conn.execute("DROP TABLE user_identities", ())
+        .await
+        .expect("drop optional user_identities table");
+    conn.execute("DROP TABLE channel_identities", ())
+        .await
+        .expect("drop optional channel_identities table");
+    insert_memory_document(
+        &conn,
+        USER,
+        "context/old-wasm.md",
+        "old schema still migrates",
+    )
+    .await;
+    drop(conn);
+    drop(db);
+
+    let report = run_migration(options(path, dst, true))
+        .await
+        .expect("older wasm schema should not block migration");
+
+    assert_eq!(report.stats.memory_documents, 1);
+    assert_eq!(
+        report.stats.extensions, 1,
+        "installed tools must still migrate when the optional capabilities table is absent"
     );
 }
 


### PR DESCRIPTION
## Summary

- Preserve legacy memory documents that are empty or use prompt-protected paths like `BOOTSTRAP.md` by writing through the migration backend path.
- Retain non-first-class legacy transcript roles (`system`, `tool_calls`, `tool`) in thread metadata so content is reported as degraded, not lost.
- Tolerate older optional legacy tables across libSQL/Postgres (`wasm_channels`, `tool_capabilities`, `user_identities`, `channel_identities`) while still failing on real schema/query errors.
- Add `--resolve-secret-master-key` support and explicit reporting when secrets cannot be migrated without a usable legacy key.
- Add regression tests from the local `~/.ironclaw*` migration matrix.

## Root Cause

Real legacy stores had schema and data shapes that the migration tests did not cover: empty memory docs, prompt-protected memory paths, non-user/assistant transcript roles, older WASM table layouts, and optional identity tables missing in Postgres-backed installs. Some Postgres missing-table errors were also reduced to generic text before the converter could classify them safely.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_reborn_migration --features libsql --test migration_roundtrip`
- `cargo clippy -p ironclaw_reborn_migration --all-targets --all-features -- -D warnings`
- Local migration matrix over `~/.ironclaw`, `~/.ironclaw-2`, `~/.ironclaw-3`, `~/.ironclaw-4`, `~/.ironclaw-5`, `~/.ironclaw-6`, and `~/.ironclaw-psql`
- Verified libSQL source DB hashes matched before/after, order-insensitive, so originals were preserved

## Notes

Secrets are now explicitly reported instead of silently skipped, but preserving secret values still requires the correct legacy master key or working keychain access. The local Postgres-backed store still reported decrypt/expiry losses for its existing secret rows.