### PR TITLE
test(dispatch): consolidate ~24 CapabilityDispatcher test doubles into one shared TestDispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ dependencies = [
  "sha2 0.11.0",
  "static_assertions",
  "thiserror 2.0.18",
+ "tokio",
  "uuid",
  "zeroize",
 ]

--- a/crates/ironclaw_approvals/Cargo.toml
+++ b/crates/ironclaw_approvals/Cargo.toml
@@ -31,6 +31,8 @@ tracing = "0.1"
 [dev-dependencies]
 # Enables the in-memory-backed capability-lease store constructor for tests only.
 ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test-support"] }
+# FaultInjecting decorator: test store fault paths through the real store
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 # Enables the in-memory-backed run-state/approval store constructors for tests only.
 ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 tempfile = "3"

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -1,9 +1,71 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use ironclaw_approvals::*;
 use ironclaw_authorization::*;
 use ironclaw_events::{AuditSink, EventError, InMemoryAuditSink};
+use ironclaw_filesystem::{
+    Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, ScopedFilesystem,
+};
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
+
+/// The production `FilesystemApprovalRequestStore` over a [`FaultInjecting`]
+/// backend armed to fail the approval-status write. On the `/approvals` mount,
+/// `save_pending` is the 1st `WriteFile` and `approve` is the 2nd, so failing the
+/// 2nd lets the pending record persist and then faults the status transition.
+/// Replaces the former whole-trait `FailingApproveApprovalStore` fake: the real
+/// store now runs its genuine CAS read-modify-write and
+/// `FilesystemError -> RunStateError::Filesystem` mapping under the injected
+/// backend fault, so the test exercises the production store path instead of a
+/// hand-rolled stand-in that reimplemented the trait.
+fn approval_store_failing_status_write()
+-> FilesystemApprovalRequestStore<FaultInjecting<InMemoryBackend>> {
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("approvals")
+                .nth(2)
+                .backend("injected approval write failure"),
+        ),
+    );
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/approvals").unwrap(),
+        VirtualPath::new("/engine/approvals").unwrap(),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .unwrap();
+    FilesystemApprovalRequestStore::new(Arc::new(ScopedFilesystem::with_fixed_view(
+        backend, mounts,
+    )))
+}
+
+/// The production `FilesystemCapabilityLeaseStore` over a [`FaultInjecting`]
+/// backend armed to fail every write on the `/authorization` mount, so
+/// `issue(...)` fails at its first backend write. Replaces the former
+/// whole-trait `FailingIssueLeaseStore` fake: the real store now runs its
+/// genuine lease serialization and `FilesystemError -> CapabilityLeaseError`
+/// mapping (`Backend -> Persistence`) under the injected fault, proving the
+/// mapping the fake short-circuited.
+fn lease_store_failing_issue_write()
+-> FilesystemCapabilityLeaseStore<FaultInjecting<InMemoryBackend>> {
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("authorization")
+                .backend("injected lease write failure"),
+        ),
+    );
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/authorization").unwrap(),
+        VirtualPath::new("/engine/authorization").unwrap(),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .unwrap();
+    FilesystemCapabilityLeaseStore::new(Arc::new(ScopedFilesystem::with_fixed_view(
+        backend, mounts,
+    )))
+}
 
 #[tokio::test]
 async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
@@ -146,7 +208,7 @@ async fn approving_pending_request_marks_request_approved_even_when_lease_issue_
     // the system can surface the error to the caller and re-attempt
     // lease issuance later.
     let approvals = ironclaw_run_state::in_memory_backed_approval_request_store();
-    let leases = FailingIssueLeaseStore;
+    let leases = lease_store_failing_issue_write();
     let resolver = ApprovalResolver::new(&approvals, &leases);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -201,13 +263,13 @@ async fn approving_pending_request_issues_no_lease_when_approval_update_fails() 
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
     let request_id = approval.id;
-    let approvals = FailingApproveApprovalStore {
-        record: ApprovalRecord {
-            scope: scope.clone(),
-            request: approval,
-            status: ApprovalStatus::Pending,
-        },
-    };
+    let approvals = approval_store_failing_status_write();
+    // 1st `/approvals` write persists the pending record; the armed fault fires
+    // on the 2nd write (the `approve` status transition below).
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
     let leases = in_memory_backed_capability_lease_store();
     let resolver = ApprovalResolver::new(&approvals, &leases);
 
@@ -231,8 +293,22 @@ async fn approving_pending_request_issues_no_lease_when_approval_update_fails() 
         .await
         .unwrap_err();
 
+    // The real store mapped the injected `FilesystemError::Backend` through its
+    // CAS write path to `RunStateError::Filesystem` (which the old whole-trait
+    // fake short-circuited), surfaced as `ApprovalResolutionError::RunState`.
     assert!(matches!(err, ApprovalResolutionError::RunState(_)));
     assert_eq!(leases.leases_for_scope(&scope).await, Vec::new());
+    // The faulted status write left the record `Pending` — the real store's CAS
+    // behavior the old whole-trait fake could not prove.
+    assert_eq!(
+        approvals
+            .get(&scope, request_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ApprovalStatus::Pending
+    );
 }
 
 #[tokio::test]
@@ -753,62 +829,6 @@ impl AuditSink for FailingAuditSink {
     }
 }
 
-struct FailingApproveApprovalStore {
-    record: ApprovalRecord,
-}
-
-#[async_trait]
-impl ApprovalRequestStore for FailingApproveApprovalStore {
-    async fn save_pending(
-        &self,
-        _scope: ResourceScope,
-        _request: ApprovalRequest,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        Ok(self.record.clone())
-    }
-
-    async fn get(
-        &self,
-        scope: &ResourceScope,
-        request_id: ApprovalRequestId,
-    ) -> Result<Option<ApprovalRecord>, RunStateError> {
-        if self.record.scope == *scope && self.record.request.id == request_id {
-            Ok(Some(self.record.clone()))
-        } else {
-            Ok(None)
-        }
-    }
-
-    async fn approve(
-        &self,
-        _scope: &ResourceScope,
-        _request_id: ApprovalRequestId,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        Err(RunStateError::Filesystem(
-            "injected approval write failure".to_string(),
-        ))
-    }
-
-    async fn deny(
-        &self,
-        _scope: &ResourceScope,
-        _request_id: ApprovalRequestId,
-    ) -> Result<ApprovalRecord, RunStateError> {
-        Ok(self.record.clone())
-    }
-
-    async fn records_for_scope(
-        &self,
-        scope: &ResourceScope,
-    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
-        if same_tenant_user_for_test(&self.record.scope, scope) {
-            Ok(vec![self.record.clone()])
-        } else {
-            Ok(Vec::new())
-        }
-    }
-}
-
 struct AlreadyResolvedOnApproveStore {
     record: ApprovalRecord,
     resolved_status: ApprovalStatus,
@@ -867,78 +887,6 @@ impl ApprovalRequestStore for AlreadyResolvedOnApproveStore {
         } else {
             Ok(Vec::new())
         }
-    }
-}
-
-struct FailingIssueLeaseStore;
-
-#[async_trait]
-impl CapabilityLeaseStore for FailingIssueLeaseStore {
-    async fn issue(
-        &self,
-        _lease: CapabilityLease,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::Persistence {
-            reason: "injected lease write failure".to_string(),
-        })
-    }
-
-    async fn revoke(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn get(
-        &self,
-        _scope: &ResourceScope,
-        _lease_id: CapabilityGrantId,
-    ) -> Option<CapabilityLease> {
-        None
-    }
-
-    async fn claim(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-        _invocation_fingerprint: &InvocationFingerprint,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn consume(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn begin_dispatch_claimed(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-        _invocation_fingerprint: &InvocationFingerprint,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn abort_dispatch_claimed(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: CapabilityGrantId,
-    ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        Err(CapabilityLeaseError::UnknownLease { lease_id })
-    }
-
-    async fn leases_for_scope(&self, _scope: &ResourceScope) -> Vec<CapabilityLease> {
-        Vec::new()
-    }
-
-    async fn active_leases_for_context(&self, _context: &ExecutionContext) -> Vec<CapabilityLease> {
-        Vec::new()
     }
 }
 

--- a/crates/ironclaw_authorization/Cargo.toml
+++ b/crates/ironclaw_authorization/Cargo.toml
@@ -26,5 +26,8 @@ thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
+# FaultInjecting decorator: fold the hand-rolled `CountingFilesystem` op-recorder
+# onto the real backend seam so tests assert on genuine `list_dir` traffic.
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -1,13 +1,9 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
-};
+use std::sync::Arc;
 
-use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::*;
 use ironclaw_filesystem::{
-    DirEntry, DiskFilesystem, FileStat, FilesystemError, InMemoryBackend, RootFilesystem,
+    DiskFilesystem, FaultInjecting, FilesystemOperation, InMemoryBackend, RootFilesystem,
     ScopedFilesystem,
 };
 use ironclaw_host_api::*;
@@ -740,14 +736,17 @@ async fn filesystem_lease_store_persists_and_reloads_issued_leases() {
 
 #[tokio::test]
 async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocation_roots() {
-    // Wrap the underlying [`DiskFilesystem`] in a [`CountingFilesystem`]
-    // so we can assert that `leases_for_scope` reads the owner index
-    // rather than fanning out to `list_dir` per invocation. The
-    // [`ScopedFilesystem`] layer on top binds the `/authorization` alias
-    // to a tenant/user-scoped target — same as `engine_filesystem()`.
-    let counting = Arc::new(CountingFilesystem::new(local_filesystem_with_engine_mount()));
+    // Wrap the underlying [`DiskFilesystem`] in
+    // [`ironclaw_filesystem::FaultInjecting`] (op-recorder mode, no faults armed)
+    // so we can assert that `leases_for_scope` reads the owner index rather than
+    // fanning out to `list_dir` per invocation. Folds the former hand-rolled
+    // `CountingFilesystem` observer onto the shared decorator, exercising the
+    // real backend traffic instead of a bespoke counting wrapper. The
+    // [`ScopedFilesystem`] layer on top binds the `/authorization` alias to a
+    // tenant/user-scoped target — same as `engine_filesystem()`.
+    let backend = Arc::new(FaultInjecting::new(local_filesystem_with_engine_mount()));
     let fs = build_scoped_fs(
-        Arc::clone(&counting),
+        Arc::clone(&backend),
         "/engine/tenants/test/users/test/authorization",
     );
     let context = execution_context(CapabilitySet::default());
@@ -769,7 +768,7 @@ async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocati
         store.issue(lease).await.unwrap();
     }
 
-    counting.reset_list_dir_calls();
+    let list_dir_before = backend.count(FilesystemOperation::ListDir);
     let leases = store.leases_for_scope(&context.resource_scope).await;
 
     let mut actual = leases
@@ -780,7 +779,7 @@ async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocati
     expected.sort_by_key(|lease_id| lease_id.as_uuid());
     assert_eq!(actual, expected);
     assert_eq!(
-        counting.list_dir_calls(),
+        backend.count(FilesystemOperation::ListDir) - list_dir_before,
         0,
         "indexed lease listing should not scan every invocation directory"
     );
@@ -1161,81 +1160,6 @@ async fn revoked_lease_no_longer_authorizes_dispatch() {
             reason: DenyReason::MissingGrant
         }
     ));
-}
-
-struct CountingFilesystem {
-    inner: DiskFilesystem,
-    list_dir_calls: Arc<AtomicUsize>,
-}
-
-impl CountingFilesystem {
-    fn new(inner: DiskFilesystem) -> Self {
-        Self {
-            inner,
-            list_dir_calls: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-
-    fn reset_list_dir_calls(&self) {
-        self.list_dir_calls.store(0, Ordering::SeqCst);
-    }
-
-    fn list_dir_calls(&self) -> usize {
-        self.list_dir_calls.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for CountingFilesystem {
-    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        self.inner.read_file(path).await
-    }
-
-    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.write_file(path, bytes).await
-    }
-
-    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.append_file(path, bytes).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.list_dir_calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-
-    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.create_dir_all(path).await
-    }
-
-    // After PR #3659 the trait default `get`/`put` are `Unsupported`.
-    // Forward to the inner DiskFilesystem (which implements them
-    // natively) so this counting wrapper keeps participating in the
-    // unified surface used by FilesystemCapabilityLeaseStore's read_lease
-    // / write_lease / read_lease_index / write_lease_index ops.
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: ironclaw_filesystem::Entry,
-        cas: ironclaw_filesystem::CasExpectation,
-    ) -> Result<ironclaw_filesystem::RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(
-        &self,
-        path: &VirtualPath,
-    ) -> Result<Option<ironclaw_filesystem::VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
 }
 
 fn trust_decision(

--- a/crates/ironclaw_capabilities/Cargo.toml
+++ b/crates/ironclaw_capabilities/Cargo.toml
@@ -41,5 +41,7 @@ ironclaw_processes = { path = "../ironclaw_processes", features = ["test-support
 ironclaw_run_state = { path = "../ironclaw_run_state", features = ["test-support"] }
 ironclaw_dispatcher = { path = "../ironclaw_dispatcher" }
 ironclaw_events = { path = "../ironclaw_events" }
+# Enables the shared TestDispatcher CapabilityDispatcher double for tests only.
+ironclaw_host_api = { path = "../ironclaw_host_api", features = ["test-support"] }
 ironclaw_resources = { path = "../ironclaw_resources" }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -2933,20 +2933,6 @@ mod tests {
 
     // `authorize()` never dispatches; this satisfies the `CapabilityHost` type
     // parameter without pulling in the integration-tier recording dispatcher.
-    struct UnusedDispatcher;
-
-    #[async_trait::async_trait]
-    impl CapabilityDispatcher for UnusedDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            Err(DispatchError::UnknownCapability {
-                capability: request.capability_id,
-            })
-        }
-    }
-
     const ECHO_MANIFEST_FIXTURE: &str = r#"
 schema_version = "reborn.extension_manifest.v2"
 id = "echo"
@@ -3027,7 +3013,14 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
         use ironclaw_host_api::UserId;
 
         let registry = echo_registry();
-        let dispatcher = UnusedDispatcher;
+        // Never dispatched on this authorize-only path; errors if it ever is.
+        let dispatcher = ironclaw_host_api::dispatch_test_support::TestDispatcher::responding(
+            |req, _| {
+                Err(DispatchError::UnknownCapability {
+                    capability: req.capability_id.clone(),
+                })
+            },
+        );
         let authorizer = AllowAuthorizer;
         let host = CapabilityHost::new(&registry, &dispatcher, &authorizer);
 

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
@@ -76,27 +76,9 @@ impl CapabilityObligationHandler for PassthroughObligationHandler {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Stub: dispatcher that always returns AuthRequired with an empty
-// credential_requirements list, simulating a WASM adapter that only knows the
-// error string and has no access to the obligation list.
-// ---------------------------------------------------------------------------
-
-struct AuthRequiredDispatcher;
-
-#[async_trait]
-impl CapabilityDispatcher for AuthRequiredDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        Err(DispatchError::AuthRequired {
-            capability: request.capability_id,
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-        })
-    }
-}
+// The dispatcher double that always returns AuthRequired with an empty
+// credential_requirements list (simulating a WASM adapter that only knows the
+// error string) is `TestDispatcher::auth_required()`.
 
 // ---------------------------------------------------------------------------
 // Test: invoke_json enriches empty credential_requirements from obligations
@@ -112,7 +94,7 @@ async fn invoke_json_enriches_auth_required_credential_requirements_from_obligat
         setup: RuntimeCredentialAccountSetup::ManualToken,
         requester_extension: requester,
     };
-    let dispatcher = AuthRequiredDispatcher;
+    let dispatcher = TestDispatcher::auth_required();
     let handler = PassthroughObligationHandler;
     let host =
         CapabilityHost::new(&registry, &dispatcher, &authorizer).with_obligation_handler(&handler);
@@ -163,29 +145,6 @@ async fn invoke_json_enriches_auth_required_credential_requirements_from_obligat
 async fn invoke_json_preserves_non_empty_credential_requirements_from_dispatcher() {
     // When the runtime already supplies requirements (e.g. MCP), the enrichment
     // must not replace them.
-    struct AuthRequiredWithRequirementsDispatcher;
-
-    #[async_trait]
-    impl CapabilityDispatcher for AuthRequiredWithRequirementsDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            let mcp_provider = RuntimeCredentialAccountProviderId::new("mcp_provider").unwrap();
-            let mcp_ext = ExtensionId::new("mcp_ext").unwrap();
-            Err(DispatchError::AuthRequired {
-                capability: request.capability_id,
-                required_secrets: Vec::new(),
-                credential_requirements: vec![RuntimeCredentialAuthRequirement {
-                    provider: mcp_provider,
-                    setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
-                    requester_extension: mcp_ext,
-                    provider_scopes: Vec::new(),
-                }],
-            })
-        }
-    }
-
     let registry = registry_with_echo_capability();
     let obligation_provider = RuntimeCredentialAccountProviderId::new("github").unwrap();
     let requester = ExtensionId::new("github").unwrap();
@@ -194,7 +153,18 @@ async fn invoke_json_preserves_non_empty_credential_requirements_from_dispatcher
         setup: RuntimeCredentialAccountSetup::ManualToken,
         requester_extension: requester,
     };
-    let dispatcher = AuthRequiredWithRequirementsDispatcher;
+    let dispatcher = TestDispatcher::responding(|request, _| {
+        Err(DispatchError::AuthRequired {
+            capability: request.capability_id.clone(),
+            required_secrets: Vec::new(),
+            credential_requirements: vec![RuntimeCredentialAuthRequirement {
+                provider: RuntimeCredentialAccountProviderId::new("mcp_provider").unwrap(),
+                setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
+                requester_extension: ExtensionId::new("mcp_ext").unwrap(),
+                provider_scopes: Vec::new(),
+            }],
+        })
+    });
     let handler = PassthroughObligationHandler;
     let host =
         CapabilityHost::new(&registry, &dispatcher, &authorizer).with_obligation_handler(&handler);
@@ -250,22 +220,6 @@ async fn auth_resume_json_enriches_auth_required_credential_requirements_from_ob
 
     // A dispatcher that returns AuthRequired with an empty credential_requirements
     // list on every call (simulating a WASM adapter at both invoke and resume time).
-    struct AlwaysAuthRequiredDispatcher;
-
-    #[async_trait]
-    impl CapabilityDispatcher for AlwaysAuthRequiredDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            Err(DispatchError::AuthRequired {
-                capability: request.capability_id,
-                required_secrets: Vec::new(),
-                credential_requirements: Vec::new(),
-            })
-        }
-    }
-
     let registry = registry_with_echo_capability();
     let provider = RuntimeCredentialAccountProviderId::new("github").unwrap();
     let requester = ExtensionId::new("github").unwrap();
@@ -274,7 +228,7 @@ async fn auth_resume_json_enriches_auth_required_credential_requirements_from_ob
         setup: RuntimeCredentialAccountSetup::ManualToken,
         requester_extension: requester,
     };
-    let dispatcher = AlwaysAuthRequiredDispatcher;
+    let dispatcher = TestDispatcher::auth_required();
     let handler = PassthroughObligationHandler;
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
@@ -393,7 +347,7 @@ async fn invoke_json_does_not_enrich_when_multiple_credential_obligations_declar
 
     let registry = registry_with_echo_capability();
     let authorizer = MultiObligationAuthorizer;
-    let dispatcher = AuthRequiredDispatcher;
+    let dispatcher = TestDispatcher::auth_required();
     let handler = PassthroughObligationHandler;
     let host =
         CapabilityHost::new(&registry, &dispatcher, &authorizer).with_obligation_handler(&handler);
@@ -446,22 +400,6 @@ async fn invoke_json_does_not_enrich_when_multiple_credential_obligations_declar
 async fn invoke_json_preserves_required_secrets_from_dispatcher() {
     // A dispatcher that returns AuthRequired with required_secrets POPULATED
     // and credential_requirements EMPTY — the raw-secret-handle gate case.
-    struct AuthRequiredWithSecretsDispatcher;
-
-    #[async_trait]
-    impl CapabilityDispatcher for AuthRequiredWithSecretsDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            Err(DispatchError::AuthRequired {
-                capability: request.capability_id,
-                required_secrets: vec![SecretHandle::new("raw_secret_handle").unwrap()],
-                credential_requirements: Vec::new(),
-            })
-        }
-    }
-
     let registry = registry_with_echo_capability();
     let obligation_provider = RuntimeCredentialAccountProviderId::new("github").unwrap();
     let requester = ExtensionId::new("github").unwrap();
@@ -473,7 +411,13 @@ async fn invoke_json_preserves_required_secrets_from_dispatcher() {
         setup: RuntimeCredentialAccountSetup::ManualToken,
         requester_extension: requester,
     };
-    let dispatcher = AuthRequiredWithSecretsDispatcher;
+    let dispatcher = TestDispatcher::responding(|request, _| {
+        Err(DispatchError::AuthRequired {
+            capability: request.capability_id.clone(),
+            required_secrets: vec![SecretHandle::new("raw_secret_handle").unwrap()],
+            credential_requirements: Vec::new(),
+        })
+    });
     let handler = PassthroughObligationHandler;
     let host =
         CapabilityHost::new(&registry, &dispatcher, &authorizer).with_obligation_handler(&handler);

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -1346,6 +1346,10 @@ async fn concurrent_auth_resume_claim_loser_returns_lease_error_without_failing_
     // A lease store that delegates everything to an inner FilesystemCapabilityLeaseStore<InMemoryBackend>
     // except `claim()`, which returns InactiveLease { status: Claimed } once the
     // `fail_next_claim` flag is set — simulating the loser of a concurrent claim race.
+    // domain-state fake, not an I/O fault — cannot move to
+    // ironclaw_filesystem::FaultInjecting: it returns a domain
+    // `CapabilityLeaseError::InactiveLease{Claimed}` (the concurrent winner already
+    // claimed) that no backend fault (which only yields `Persistence`) can produce.
     struct ClaimFailingLeaseStore {
         inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         fail_next_claim: AtomicBool,
@@ -1792,6 +1796,10 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
     // `begin_dispatch_claimed`, creating the real data race on the state
     // machine transition: one wins (Claimed→Dispatching), the other loses
     // (sees Dispatching → InactiveLease{Dispatching}).
+    // Synchronization primitive, not an I/O fault — cannot move to
+    // ironclaw_filesystem::FaultInjecting: FaultInjecting injects errors + records
+    // ops but is explicitly NOT a read/write-interleaving barrier (see
+    // ironclaw_filesystem/CLAUDE.md). The Barrier(2) interleave is the whole test.
     struct BarrierLeaseStore {
         inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         /// Both concurrent auth_resume_json callers rendezvous here after
@@ -2948,6 +2956,10 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
     // store, suspends the caller until `claim_release` is notified.  Any other
     // caller that runs `matching_approval_lease` during this window finds None
     // (lease is Claimed, not Active) and falls into the REUSE branch.
+    // Synchronization primitive, not an I/O fault — cannot move to
+    // ironclaw_filesystem::FaultInjecting: the Notify gate suspends a caller
+    // mid-`claim` to force an interleaving; FaultInjecting only injects errors +
+    // records ops and is explicitly not a synchronization barrier.
     struct GatedLeaseStore {
         inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
         claim_entered: StdArc<Notify>,

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -43,7 +43,7 @@ fn dispatch_lease_approval() -> LeaseApproval {
 async fn auth_resume_json_accepts_blocked_auth_run_and_dispatches() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     // Simulate a run that was previously blocked at an auth gate.
@@ -85,7 +85,7 @@ async fn auth_resume_json_accepts_blocked_auth_run_and_dispatches() {
         .unwrap();
 
     assert_eq!(result.dispatch.output, json!({"ok": true}));
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::Completed);
 }
@@ -94,7 +94,7 @@ async fn auth_resume_json_accepts_blocked_auth_run_and_dispatches() {
 async fn auth_resume_preserves_original_actor_and_rejects_forged_actor() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let mut alice_context = execution_context(CapabilitySet {
@@ -144,7 +144,7 @@ async fn auth_resume_preserves_original_actor_and_rejects_forged_actor() {
         ),
         "changed authenticated actor must fail closed, got {forged_error:?}"
     );
-    assert_eq!(dispatcher.dispatch_count(), 0);
+    assert_eq!(dispatcher.call_count(), 0);
 
     host.auth_resume_json(CapabilityAuthResumeRequest {
         context: alice_context,
@@ -157,7 +157,7 @@ async fn auth_resume_preserves_original_actor_and_rejects_forged_actor() {
     .await
     .expect("the original authenticated actor can resume");
 
-    let dispatched = dispatcher.take_request();
+    let dispatched = dispatcher.last_request().unwrap();
     assert_eq!(
         dispatched
             .authenticated_actor_user_id
@@ -174,7 +174,7 @@ async fn auth_resume_preserves_original_actor_and_rejects_forged_actor() {
 #[tokio::test]
 async fn auth_resume_json_rejects_run_in_blocked_approval_status() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
 
@@ -227,7 +227,7 @@ async fn auth_resume_json_rejects_run_in_blocked_approval_status() {
         "expected ResumeNotBlocked(BlockedApproval), got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "auth_resume must not dispatch when run is not in BlockedAuth"
     );
@@ -237,7 +237,7 @@ async fn auth_resume_json_rejects_run_in_blocked_approval_status() {
 async fn auth_resume_json_rejects_run_in_running_status() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let context = execution_context(CapabilitySet {
@@ -280,7 +280,7 @@ async fn auth_resume_json_rejects_run_in_running_status() {
         ),
         "expected ResumeNotBlocked(Running), got {err:?}"
     );
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -292,7 +292,7 @@ async fn auth_resume_json_rejects_fingerprint_mismatch_on_approval_request() {
     // Build an invocation, approve it (fingerprinted to original input), then
     // attempt auth_resume with different input — should reject before lease claim.
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -364,7 +364,7 @@ async fn auth_resume_json_rejects_fingerprint_mismatch_on_approval_request() {
         "mutated input must be rejected as fingerprint mismatch, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when fingerprint mismatches"
     );
@@ -388,7 +388,7 @@ async fn auth_resume_json_with_approval_request_id_claims_active_lease_and_dispa
     // Clean-ordering path: approve → manual block_auth (skipping resume_json) →
     // auth_resume_json → finds Active lease, claims it, dispatches.
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -464,7 +464,7 @@ async fn auth_resume_json_with_approval_request_id_claims_active_lease_and_dispa
         json!({"ok": true}),
         "auth_resume with original invocation_id must complete dispatch"
     );
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
     // Run must be completed.
     let run = run_state
         .get(&scope, original_invocation_id)
@@ -493,7 +493,7 @@ async fn auth_resume_json_with_approval_request_id_claims_active_lease_and_dispa
 async fn auth_resume_json_rejects_capability_id_mismatch_against_run_record() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     // Start the run with the canonical capability_id.
@@ -538,7 +538,7 @@ async fn auth_resume_json_rejects_capability_id_mismatch_against_run_record() {
         "capability_id mismatch against run record must be rejected, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire on capability_id mismatch"
     );
@@ -563,7 +563,7 @@ async fn auth_resume_json_rejects_approval_not_yet_approved() {
     // and leave the run in its original BlockedAuth status.
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -638,7 +638,7 @@ async fn auth_resume_json_rejects_approval_not_yet_approved() {
         "expected ApprovalNotApproved(Pending), got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when approval is still Pending"
     );
@@ -663,7 +663,7 @@ async fn auth_resume_json_returns_store_missing_when_approval_requests_absent() 
     // Err(ResumeStoreMissing { store: "approval_requests" }) immediately.
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let context = execution_context(CapabilitySet {
@@ -711,7 +711,7 @@ async fn auth_resume_json_returns_store_missing_when_approval_requests_absent() 
         "expected ResumeStoreMissing {{ store: \"approval_requests\" }}, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when approval_requests store is absent"
     );
@@ -728,7 +728,7 @@ async fn auth_resume_json_without_approval_request_id_skips_lease_path_and_dispa
     // validation entirely and proceed directly to dispatch.
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
 
     let context = execution_context(CapabilitySet {
@@ -769,7 +769,7 @@ async fn auth_resume_json_without_approval_request_id_skips_lease_path_and_dispa
         .unwrap();
 
     assert_eq!(result.dispatch.output, json!({"ok": true}));
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::Completed);
 }
@@ -795,49 +795,22 @@ async fn auth_resume_json_without_approval_request_id_skips_lease_path_and_dispa
 
 #[tokio::test]
 async fn auth_resume_after_real_approval_bounce_reuses_claimed_lease() {
-    use async_trait::async_trait;
-
     // A dispatcher that returns AuthRequired on the first call and succeeds on
     // the second, so we can drive the real resume_json → auth bounce → auth_resume_json flow.
-    struct FirstCallAuthRequiredDispatcher {
-        inner: RecordingDispatcher,
-        call_count: std::sync::atomic::AtomicUsize,
-    }
-
-    impl Default for FirstCallAuthRequiredDispatcher {
-        fn default() -> Self {
-            Self {
-                inner: RecordingDispatcher::default(),
-                call_count: std::sync::atomic::AtomicUsize::new(0),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl CapabilityDispatcher for FirstCallAuthRequiredDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            let count = self
-                .call_count
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            if count == 0 {
-                // First dispatch: return AuthRequired to trigger the auth bounce.
-                Err(DispatchError::AuthRequired {
-                    capability: request.capability_id,
-                    required_secrets: vec![],
-                    credential_requirements: vec![],
-                })
-            } else {
-                // Second dispatch (from auth_resume_json): succeed.
-                self.inner.dispatch_json(request).await
-            }
-        }
-    }
-
     let registry = registry_with_echo_capability();
-    let dispatcher = FirstCallAuthRequiredDispatcher::default();
+    let dispatcher = TestDispatcher::responding(|request, call_index| {
+        if call_index == 0 {
+            // First dispatch: return AuthRequired to trigger the auth bounce.
+            Err(DispatchError::AuthRequired {
+                capability: request.capability_id.clone(),
+                required_secrets: vec![],
+                credential_requirements: vec![],
+            })
+        } else {
+            // Second dispatch (from auth_resume_json): succeed.
+            Ok(ok_dispatch_result(request))
+        }
+    });
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -1006,9 +979,8 @@ async fn auth_resume_after_real_approval_bounce_reuses_claimed_lease() {
     );
 
     // ── Assertion (e): dispatch was called with the SAME invocation_id ────────
-    // The dispatcher is FirstCallAuthRequiredDispatcher; the second call
-    // went through inner.dispatch_json which recorded the request.
-    let dispatched_request = dispatcher.inner.take_request();
+    // The second (successful) dispatch is the most recently recorded request.
+    let dispatched_request = dispatcher.last_request().unwrap();
     assert_eq!(
         dispatched_request.scope.invocation_id, original_invocation_id,
         "(e) capability must be dispatched with the original invocation_id"
@@ -1030,51 +1002,23 @@ async fn auth_resume_after_real_approval_bounce_reuses_claimed_lease() {
 
 #[tokio::test]
 async fn auth_resume_json_terminal_dispatch_failure_revokes_claimed_lease() {
-    use async_trait::async_trait;
-
     // Phase 1+2 use an auth-bounce dispatcher (AuthRequired on first call
     // so resume_json bounces and leaves the lease Claimed).
     // Phase 3 (auth_resume_json) uses a terminal-fail dispatcher
     // (UnknownCapability on first call so auth_resume_json errors terminally).
-    struct TerminalFailDispatcher {
-        call_count: std::sync::atomic::AtomicUsize,
-    }
-
-    impl Default for TerminalFailDispatcher {
-        fn default() -> Self {
-            Self {
-                call_count: std::sync::atomic::AtomicUsize::new(0),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl CapabilityDispatcher for TerminalFailDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            let count = self
-                .call_count
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            if count == 0 {
-                // First call (from resume_json): auth bounce → lease stays Claimed.
-                Err(DispatchError::AuthRequired {
-                    capability: request.capability_id,
-                    required_secrets: vec![],
-                    credential_requirements: vec![],
-                })
-            } else {
-                // Second call (from auth_resume_json): terminal failure.
-                Err(DispatchError::UnknownCapability {
-                    capability: request.capability_id,
-                })
-            }
-        }
-    }
-
     let registry = registry_with_echo_capability();
-    let dispatcher = TerminalFailDispatcher::default();
+    let dispatcher = TestDispatcher::scripted(vec![
+        // First call (from resume_json): auth bounce → lease stays Claimed.
+        Err(DispatchError::AuthRequired {
+            capability: capability_id(),
+            required_secrets: vec![],
+            credential_requirements: vec![],
+        }),
+        // Second call (from auth_resume_json): terminal failure.
+        Err(DispatchError::UnknownCapability {
+            capability: capability_id(),
+        }),
+    ]);
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -1195,27 +1139,9 @@ async fn auth_resume_json_terminal_dispatch_failure_revokes_claimed_lease() {
 
 #[tokio::test]
 async fn auth_resume_json_non_terminal_auth_bounce_leaves_lease_claimed() {
-    use async_trait::async_trait;
-
     // A dispatcher that always returns AuthRequired (non-terminal BlockAuth path).
-    struct AlwaysAuthRequiredDispatcher;
-
-    #[async_trait]
-    impl CapabilityDispatcher for AlwaysAuthRequiredDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            Err(DispatchError::AuthRequired {
-                capability: request.capability_id,
-                required_secrets: vec![],
-                credential_requirements: vec![],
-            })
-        }
-    }
-
     let registry = registry_with_echo_capability();
-    let dispatcher = AlwaysAuthRequiredDispatcher;
+    let dispatcher = TestDispatcher::auth_required();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -1452,7 +1378,7 @@ async fn concurrent_auth_resume_claim_loser_returns_lease_error_without_failing_
     }
 
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = ClaimFailingLeaseStore::new();
@@ -1540,7 +1466,7 @@ async fn concurrent_auth_resume_claim_loser_returns_lease_error_without_failing_
 
     // Dispatch must not have been called (claim failed before dispatch).
     assert!(
-        !dispatcher.has_request(),
+        dispatcher.call_count() == 0,
         "concurrent claim loser must not dispatch"
     );
 }
@@ -1563,7 +1489,7 @@ async fn concurrent_auth_resume_claim_loser_returns_lease_error_without_failing_
 async fn auth_resume_json_returns_store_missing_when_capability_leases_absent() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
 
@@ -1616,7 +1542,7 @@ async fn auth_resume_json_returns_store_missing_when_capability_leases_absent() 
         "expected ResumeStoreMissing {{ store: \"capability_leases\" }}, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when capability_leases store is absent"
     );
@@ -1648,7 +1574,7 @@ async fn auth_resume_json_returns_store_missing_when_capability_leases_absent() 
 async fn auth_resume_json_rejected_prior_approval_fails_blocked_auth_run() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -1738,7 +1664,7 @@ async fn auth_resume_json_rejected_prior_approval_fails_blocked_auth_run() {
         "expected ApprovalNotApproved(Denied), got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when prior approval is Denied"
     );
@@ -1914,7 +1840,7 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
     // Call 1: winner auth_resume_json → signals `in_dispatch`, blocks on
     //         `release`, then succeeds.  Holds Dispatching while loser runs.
     struct GatingDispatcher {
-        inner: RecordingDispatcher,
+        inner: TestDispatcher,
         call_count: std::sync::atomic::AtomicUsize,
         in_dispatch: StdArc<Notify>,
         release: StdArc<Notify>,
@@ -1949,7 +1875,7 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
 
     let registry = StdArc::new(registry_with_echo_capability());
     let gating_dispatcher = StdArc::new(GatingDispatcher {
-        inner: RecordingDispatcher::default(),
+        inner: recording_dispatcher(),
         call_count: std::sync::atomic::AtomicUsize::new(0),
         in_dispatch: StdArc::clone(&in_dispatch),
         release: StdArc::clone(&release),
@@ -2154,11 +2080,11 @@ async fn concurrent_auth_resume_reuse_loser_does_not_double_dispatch() {
 
     // The inner RecordingDispatcher sees exactly one successful dispatch.
     assert!(
-        gating_dispatcher.inner.has_request(),
+        gating_dispatcher.inner.call_count() > 0,
         "exactly one successful dispatch must have been recorded by the winner"
     );
     assert_eq!(
-        gating_dispatcher.inner.dispatch_count(),
+        gating_dispatcher.inner.call_count(),
         1,
         "exactly one successful dispatch (loser never reached the dispatcher)"
     );
@@ -2205,29 +2131,14 @@ async fn auth_resume_json_authorization_deny_revokes_dispatching_lease() {
 
     // Dispatcher: first call (resume_json) → AuthRequired bounce; second call
     // (auth_resume_json) is never reached because the authorizer denies first.
-    struct AuthRequiredOnFirstCall;
-
-    #[async_trait]
-    impl CapabilityDispatcher for AuthRequiredOnFirstCall {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            Err(DispatchError::AuthRequired {
-                capability: request.capability_id,
-                required_secrets: vec![],
-                credential_requirements: vec![],
-            })
-        }
-    }
-
+    // `auth_required()` returns AuthRequired on every call, which covers this.
     let registry = registry_with_echo_capability();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke → BlockedApproval ──────────────────────────────────
-    let block_dispatcher = AuthRequiredOnFirstCall;
+    let block_dispatcher = TestDispatcher::auth_required();
     let block_host = CapabilityHost::new(&registry, &block_dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -2270,7 +2181,7 @@ async fn auth_resume_json_authorization_deny_revokes_dispatching_lease() {
         grants: vec![dispatch_grant()],
     };
     let resume_authorizer = GrantAuthorizer::new();
-    let resume_dispatcher = AuthRequiredOnFirstCall;
+    let resume_dispatcher = TestDispatcher::auth_required();
     let resume_host = CapabilityHost::new(&registry, &resume_dispatcher, &resume_authorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests)
@@ -2302,7 +2213,7 @@ async fn auth_resume_json_authorization_deny_revokes_dispatching_lease() {
     // Pre-fix: lease stuck in Dispatching.
     // Post-fix: lease revoked → Revoked.
     let deny_authorizer = DenyingAuthorizer;
-    let deny_dispatcher = RecordingDispatcher::default();
+    let deny_dispatcher = recording_dispatcher();
     let deny_host = CapabilityHost::new(&registry, &deny_dispatcher, &deny_authorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests)
@@ -2325,7 +2236,7 @@ async fn auth_resume_json_authorization_deny_revokes_dispatching_lease() {
         "expected AuthorizationDenied, got {err:?}"
     );
     assert_eq!(
-        deny_dispatcher.dispatch_count(),
+        deny_dispatcher.call_count(),
         0,
         "dispatch must not fire when authorization is denied"
     );
@@ -2356,24 +2267,8 @@ async fn auth_resume_json_authorization_deny_revokes_dispatching_lease() {
 
 #[tokio::test]
 async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lease() {
-    use async_trait::async_trait;
-
     // Dispatcher: always returns AuthRequired (used for the resume_json bounce).
-    struct AlwaysAuthRequired;
-
-    #[async_trait]
-    impl CapabilityDispatcher for AlwaysAuthRequired {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            Err(DispatchError::AuthRequired {
-                capability: request.capability_id,
-                required_secrets: vec![],
-                credential_requirements: vec![],
-            })
-        }
-    }
+    let always_auth_required = TestDispatcher::auth_required();
 
     let registry = registry_with_echo_capability();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
@@ -2381,7 +2276,7 @@ async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lea
     let leases = in_memory_backed_capability_lease_store();
 
     // ── Phase 1: invoke → BlockedApproval ──────────────────────────────────
-    let block_host = CapabilityHost::new(&registry, &AlwaysAuthRequired, &ApprovalAuthorizer)
+    let block_host = CapabilityHost::new(&registry, &always_auth_required, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
 
@@ -2423,7 +2318,7 @@ async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lea
         grants: vec![dispatch_grant()],
     };
     let resume_grant_authorizer = GrantAuthorizer::new();
-    let resume_host = CapabilityHost::new(&registry, &AlwaysAuthRequired, &resume_grant_authorizer)
+    let resume_host = CapabilityHost::new(&registry, &always_auth_required, &resume_grant_authorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests)
         .with_capability_leases(&leases);
@@ -2453,7 +2348,7 @@ async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lea
     // Pre-fix: lease stuck Dispatching.
     // Post-fix: lease → Revoked.
     let approval_authorizer_for_resume = ApprovalAuthorizer;
-    let recording_dispatcher = RecordingDispatcher::default();
+    let recording_dispatcher = recording_dispatcher();
     let req_approval_host = CapabilityHost::new(
         &registry,
         &recording_dispatcher,
@@ -2483,7 +2378,7 @@ async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lea
         "expected AuthorizationRequiresApproval, got {err:?}"
     );
     assert_eq!(
-        recording_dispatcher.dispatch_count(),
+        recording_dispatcher.call_count(),
         0,
         "dispatch must not fire when authorization requires approval"
     );
@@ -2514,7 +2409,7 @@ async fn auth_resume_json_authorization_require_approval_revokes_dispatching_lea
 async fn auth_resume_json_returns_store_missing_when_run_state_absent() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
 
     // Host has NO run_state store — only the bare minimum.
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer);
@@ -2543,7 +2438,7 @@ async fn auth_resume_json_returns_store_missing_when_run_state_absent() {
         "expected ResumeStoreMissing {{ store: \"run_state\" }}, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when run_state store is absent"
     );
@@ -2564,7 +2459,7 @@ async fn auth_resume_json_returns_store_missing_when_run_state_absent() {
 async fn auth_resume_json_unknown_invocation_when_run_record_missing() {
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     // No run record seeded — the store is empty.
 
@@ -2595,7 +2490,7 @@ async fn auth_resume_json_unknown_invocation_when_run_record_missing() {
         "expected RunState(UnknownInvocation), got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when no run record exists"
     );
@@ -2651,7 +2546,7 @@ async fn auth_resume_json_approval_request_mismatch_action() {
     // Approval references a DIFFERENT capability than the one being invoked.
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -2717,7 +2612,7 @@ async fn auth_resume_json_approval_request_mismatch_action() {
         "expected ApprovalRequestMismatch {{ field: \"action\" }}, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire on action mismatch"
     );
@@ -2735,7 +2630,7 @@ async fn auth_resume_json_approval_request_mismatch_correlation_id() {
     // Approval has a DIFFERENT correlation_id than the current invocation context.
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -2806,7 +2701,7 @@ async fn auth_resume_json_approval_request_mismatch_correlation_id() {
         "expected ApprovalRequestMismatch {{ field: \"correlation_id\" }}, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire on correlation_id mismatch"
     );
@@ -2825,7 +2720,7 @@ async fn auth_resume_json_approval_request_mismatch_requested_by() {
     // must mismatch.
     let registry = registry_with_echo_capability();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -2890,7 +2785,7 @@ async fn auth_resume_json_approval_request_mismatch_requested_by() {
         "expected ApprovalRequestMismatch {{ field: \"requested_by\" }}, got {err:?}"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire on requested_by mismatch"
     );
@@ -3070,7 +2965,7 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
     let claim_release = StdArc::new(Notify::new());
 
     let registry = StdArc::new(registry_with_echo_capability());
-    let dispatcher = StdArc::new(RecordingDispatcher::default());
+    let dispatcher = StdArc::new(recording_dispatcher());
     let run_state = StdArc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests =
         StdArc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -3195,7 +3090,7 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
         "lease must be Consumed after winner B dispatched"
     );
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         1,
         "exactly one dispatch after winner B — before releasing A"
     );
@@ -3223,7 +3118,7 @@ async fn concurrent_auth_resume_fresh_active_lease_loser_does_not_double_dispatc
 
     // A must NOT have dispatched.
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         1,
         "exactly one dispatch must be recorded — A must not have dispatched \
          (pre-fix: dispatch_count would be 2)"
@@ -3278,7 +3173,7 @@ async fn auth_resume_json_unknown_capability_does_not_strand_active_approval_lea
     // the auth resume.
     let empty_registry = ironclaw_extensions::ExtensionRegistry::new();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -3399,7 +3294,7 @@ async fn auth_resume_json_unknown_capability_does_not_strand_active_approval_lea
 
     // 3. No dispatch must have been attempted.
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when capability is unknown"
     );
@@ -3412,7 +3307,7 @@ async fn auth_resume_json_unknown_capability_does_not_strand_claimed_approval_le
     // (as it would be after a prior resume_json auth bounce left it Claimed).
     let empty_registry = ironclaw_extensions::ExtensionRegistry::new();
     let authorizer = GrantAuthorizer::new();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -3541,7 +3436,7 @@ async fn auth_resume_json_unknown_capability_does_not_strand_claimed_approval_le
 
     // 3. No dispatch.
     assert_eq!(
-        dispatcher.dispatch_count(),
+        dispatcher.call_count(),
         0,
         "dispatch must not fire when capability is unknown"
     );

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
@@ -12,7 +12,7 @@ use support::*;
 #[tokio::test]
 async fn capability_host_blocks_auth_when_obligation_requires_secret_recovery() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let handler = AuthRequiredObligationHandler;
     let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
@@ -37,7 +37,7 @@ async fn capability_host_blocks_auth_when_obligation_requires_secret_recovery() 
         err,
         CapabilityInvocationError::AuthorizationRequiresAuth { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::BlockedAuth);
     assert_eq!(run.error_kind.as_deref(), Some("AuthRequired"));
@@ -48,7 +48,7 @@ async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
     // P1 regression: dispatch-path DispatchError::AuthRequired must transition
     // the run to BlockedAuth, not Failed, so auth-resume can pick it up.
     let registry = registry_with_echo_capability();
-    let dispatcher = AuthRequiredDispatcher;
+    let dispatcher = TestDispatcher::auth_required();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let authorizer = PlainAllowAuthorizer;
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
@@ -86,7 +86,7 @@ async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
 #[tokio::test]
 async fn capability_host_fails_post_dispatch_auth_required_without_retryable_gate() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let handler = PostDispatchAuthRequiredObligationHandler;
     let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
@@ -114,7 +114,7 @@ async fn capability_host_fails_post_dispatch_auth_required_without_retryable_gat
             ..
         }
     ));
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::Failed);
     assert_eq!(run.error_kind.as_deref(), Some("ObligationFailed"));
@@ -190,18 +190,3 @@ impl TrustAwareCapabilityDispatchAuthorizer for PlainAllowAuthorizer {
     }
 }
 
-struct AuthRequiredDispatcher;
-
-#[async_trait]
-impl CapabilityDispatcher for AuthRequiredDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        Err(DispatchError::AuthRequired {
-            capability: request.capability_id,
-            required_secrets: vec![],
-            credential_requirements: Vec::new(),
-        })
-    }
-}

--- a/crates/ironclaw_capabilities/tests/capability_host_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_contract.rs
@@ -9,7 +9,7 @@ use support::*;
 #[tokio::test]
 async fn capability_host_denies_missing_grant_before_dispatch() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = GrantAuthorizer::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer);
     let context = execution_context(CapabilitySet::default());
@@ -32,13 +32,13 @@ async fn capability_host_denies_missing_grant_before_dispatch() {
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_denies_dispatch_when_trust_ceiling_omits_capability_effect() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = GrantAuthorizer::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer);
     let context = execution_context(CapabilitySet {
@@ -63,13 +63,13 @@ async fn capability_host_denies_dispatch_when_trust_ceiling_omits_capability_eff
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_authorized_dispatch_uses_neutral_dispatch_port() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = GrantAuthorizer::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer);
     let context = execution_context(CapabilitySet {
@@ -89,7 +89,7 @@ async fn capability_host_authorized_dispatch_uses_neutral_dispatch_port() {
         .unwrap();
 
     assert_eq!(result.dispatch.output, json!({"ok": true}));
-    let recorded = dispatcher.take_request();
+    let recorded = dispatcher.last_request().unwrap();
     assert_eq!(recorded.capability_id, capability_id());
     assert_eq!(recorded.scope, scope);
     assert_eq!(recorded.input, json!({"message": "authorized"}));
@@ -100,7 +100,7 @@ async fn capability_host_authorized_dispatch_uses_neutral_dispatch_port() {
 #[tokio::test]
 async fn capability_host_returns_approval_store_missing_when_approval_cannot_be_persisted() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer);
     let context = execution_context(CapabilitySet::default());
 
@@ -119,13 +119,13 @@ async fn capability_host_returns_approval_store_missing_when_approval_cannot_be_
         err,
         CapabilityInvocationError::ApprovalStoreMissing { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_fails_closed_on_unsupported_obligations_before_dispatch() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = ObligatingAuthorizer;
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer);
     let context = execution_context(CapabilitySet::default());
@@ -145,5 +145,5 @@ async fn capability_host_fails_closed_on_unsupported_obligations_before_dispatch
         err,
         CapabilityInvocationError::UnsupportedObligations { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }

--- a/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
@@ -14,8 +14,8 @@ use support::*;
 async fn capability_host_blocks_github_comment_issue_before_dispatch() {
     let fixture = blocked_github_comment_fixture().await;
 
-    assert_eq!(fixture.dispatcher.dispatch_count(), 0);
-    assert!(!fixture.dispatcher.has_request());
+    assert_eq!(fixture.dispatcher.call_count(), 0);
+    assert!(fixture.dispatcher.call_count() == 0);
     let run = fixture
         .run_state
         .get(&fixture.scope, fixture.invocation_id)
@@ -69,8 +69,8 @@ async fn capability_host_resumes_approved_github_comment_issue_and_dispatches_on
         .unwrap();
 
     assert_eq!(result.dispatch.output, json!({"ok": true}));
-    assert_eq!(fixture.dispatcher.dispatch_count(), 1);
-    let request = fixture.dispatcher.take_request();
+    assert_eq!(fixture.dispatcher.call_count(), 1);
+    let request = fixture.dispatcher.last_request().unwrap();
     assert_eq!(request.capability_id, github_comment_capability_id());
     assert_eq!(request.input, fixture.input);
     let run = fixture
@@ -124,8 +124,8 @@ async fn capability_host_rejects_mutated_github_comment_issue_replay_before_disp
         err,
         CapabilityInvocationError::ApprovalFingerprintMismatch { .. }
     ));
-    assert_eq!(fixture.dispatcher.dispatch_count(), 0);
-    assert!(!fixture.dispatcher.has_request());
+    assert_eq!(fixture.dispatcher.call_count(), 0);
+    assert!(fixture.dispatcher.call_count() == 0);
     let active = fixture
         .leases
         .get(
@@ -139,7 +139,7 @@ async fn capability_host_rejects_mutated_github_comment_issue_replay_before_disp
 
 struct GitHubCommentApprovalFixture {
     registry: ironclaw_extensions::ExtensionRegistry,
-    dispatcher: RecordingDispatcher,
+    dispatcher: TestDispatcher,
     run_state: ironclaw_run_state::FilesystemRunStateStore<ironclaw_filesystem::InMemoryBackend>,
     approval_requests:
         ironclaw_run_state::FilesystemApprovalRequestStore<ironclaw_filesystem::InMemoryBackend>,
@@ -155,7 +155,7 @@ struct GitHubCommentApprovalFixture {
 
 async fn blocked_github_comment_fixture() -> GitHubCommentApprovalFixture {
     let registry = registry_with_github_comment_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();

--- a/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
@@ -17,7 +17,7 @@ use support::*;
 #[tokio::test]
 async fn capability_host_spawn_runs_background_process_through_process_host() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let process_services = ProcessServices::in_memory();
     let executor = Arc::new(RecordingSuccessExecutor::default());
@@ -57,7 +57,7 @@ async fn capability_host_spawn_runs_background_process_through_process_host() {
         .await
         .unwrap();
 
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert_eq!(spawned.process.status, ProcessStatus::Running);
     assert_eq!(spawned.process.parent_process_id, Some(parent_process_id));
     assert_eq!(spawned.process.invocation_id, invocation_id);
@@ -111,7 +111,7 @@ async fn capability_host_spawn_runs_background_process_through_process_host() {
 #[tokio::test]
 async fn capability_spawn_process_host_hides_cross_scope_status_and_output() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let process_services = ProcessServices::in_memory();
     let executor = Arc::new(RecordingSuccessExecutor::default());
     let process_manager = process_services.background_manager(Arc::clone(&executor));
@@ -153,7 +153,7 @@ async fn capability_spawn_process_host_hides_cross_scope_status_and_output() {
 #[tokio::test]
 async fn capability_host_spawn_fails_closed_on_unsupported_obligations_before_process_start() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let process_services = ProcessServices::in_memory();
     let executor = Arc::new(RecordingSuccessExecutor::default());
@@ -182,7 +182,7 @@ async fn capability_host_spawn_fails_closed_on_unsupported_obligations_before_pr
         err,
         CapabilityInvocationError::UnsupportedObligations { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert!(executor.take_request_opt().is_none());
     assert!(
         process_services

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -19,7 +19,7 @@ use support::*;
 #[tokio::test]
 async fn capability_host_blocks_for_approval_without_dispatch() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -46,7 +46,7 @@ async fn capability_host_blocks_for_approval_without_dispatch() {
         err,
         CapabilityInvocationError::AuthorizationRequiresApproval { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::BlockedApproval);
     let approval_id = run.approval_request_id.unwrap();
@@ -101,7 +101,7 @@ output_schema_ref = "schemas/shell.output.v1.json"
     .unwrap();
     let mut registry = ExtensionRegistry::new();
     registry.insert(package).unwrap();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -162,7 +162,7 @@ output_schema_ref = "schemas/shell.output.v1.json"
 #[tokio::test]
 async fn capability_host_uses_combined_store_for_atomic_approval_block() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let store = RecordingCombinedRunStateApprovalStore::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
         .with_run_state_approval_store(&store);
@@ -212,7 +212,7 @@ async fn capability_host_uses_combined_store_for_atomic_approval_block() {
 #[tokio::test]
 async fn capability_host_separate_store_setters_clear_combined_atomic_path() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let combined = RecordingCombinedRunStateApprovalStore::new();
     let separate_run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -255,7 +255,7 @@ async fn capability_host_separate_store_setters_clear_combined_atomic_path() {
 #[tokio::test]
 async fn capability_host_leaves_run_blocked_when_resume_is_attempted_before_approval_resolves() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -310,7 +310,7 @@ async fn capability_host_leaves_run_blocked_when_resume_is_attempted_before_appr
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::BlockedApproval);
     assert_eq!(run.approval_request_id, Some(approval_id));
@@ -351,7 +351,7 @@ async fn assert_mismatched_approval_request_rejected(
     expected_field: &'static str,
 ) {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let authorizer = MismatchedApprovalRequestAuthorizer { mismatch };
@@ -379,7 +379,7 @@ async fn assert_mismatched_approval_request_rejected(
         }
         other => panic!("expected ApprovalRequestMismatch, got {other:?}"),
     }
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert!(
         approval_requests
             .records_for_scope(&scope)
@@ -395,7 +395,7 @@ async fn assert_mismatched_approval_request_rejected(
 #[tokio::test]
 async fn capability_host_does_not_point_run_at_approval_before_approval_is_persisted() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = HangingSaveApprovalRequestStore::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -444,7 +444,7 @@ async fn capability_host_does_not_point_run_at_approval_before_approval_is_persi
 #[tokio::test]
 async fn capability_host_marks_run_failed_when_obligations_are_unsupported() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
         .with_run_state(&run_state);
@@ -467,7 +467,7 @@ async fn capability_host_marks_run_failed_when_obligations_are_unsupported() {
         err,
         CapabilityInvocationError::UnsupportedObligations { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::Failed);
     assert_eq!(run.error_kind.as_deref(), Some("UnsupportedObligations"));
@@ -476,7 +476,7 @@ async fn capability_host_marks_run_failed_when_obligations_are_unsupported() {
 #[tokio::test]
 async fn capability_host_returns_business_error_when_run_state_fail_transition_fails() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = GrantAuthorizer::new();
     let run_state = FailOnFailRunStateStore::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
@@ -500,13 +500,13 @@ async fn capability_host_returns_business_error_when_run_state_fail_transition_f
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_returns_resume_business_error_when_run_state_fail_transition_fails() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = FailOnFailRunStateStore::new();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -561,13 +561,13 @@ async fn capability_host_returns_resume_business_error_when_run_state_fail_trans
         }
         other => panic!("expected ResumeContextMismatch, got {other:?}"),
     }
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_does_not_orphan_approval_when_run_block_fails() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = FailBlockApprovalRunStateStore::new();
     let approval_requests = RecordingApprovalStore::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
@@ -589,7 +589,7 @@ async fn capability_host_does_not_orphan_approval_when_run_block_fails() {
         .unwrap_err();
 
     assert!(matches!(err, CapabilityInvocationError::RunState(_)));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert!(
         approval_requests
             .records_for_scope(&scope)
@@ -635,7 +635,7 @@ async fn capability_host_does_not_orphan_approval_when_run_block_fails() {
 #[tokio::test]
 async fn capability_host_returns_specific_error_for_authorizer_fingerprint_mismatch() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let host = CapabilityHost::new(&registry, &dispatcher, &MismatchedApprovalAuthorizer)
@@ -658,13 +658,13 @@ async fn capability_host_returns_specific_error_for_authorizer_fingerprint_misma
         err,
         CapabilityInvocationError::ApprovalFingerprintMismatch { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_returns_dispatch_result_when_run_completion_fails_after_invoke() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = GrantAuthorizer::new();
     let run_state = FailCompleteRunStateStore::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
@@ -684,13 +684,13 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
         .unwrap();
 
     assert_eq!(result.dispatch.output, json!({"ok": true}));
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 #[tokio::test]
 async fn capability_host_resumes_approved_invocation_and_consumes_matching_lease() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -766,7 +766,7 @@ async fn capability_host_resumes_approved_invocation_and_consumes_matching_lease
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert_eq!(
         run_state
             .get(&scope, invocation_id)
@@ -796,7 +796,7 @@ async fn capability_host_resumes_approved_invocation_and_consumes_matching_lease
     assert_eq!(result.dispatch.output, json!({"ok": true}));
     assert_eq!(
         dispatcher
-            .take_request()
+            .last_request().unwrap()
             .authenticated_actor_user_id
             .as_ref()
             .map(UserId::as_str),
@@ -811,7 +811,7 @@ async fn capability_host_resumes_approved_invocation_and_consumes_matching_lease
 #[tokio::test]
 async fn capability_host_returns_dispatch_result_when_run_completion_fails_after_resume() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = FailCompleteRunStateStore::new();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -884,7 +884,7 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
 #[tokio::test]
 async fn capability_host_denies_resume_when_trust_ceiling_omits_capability_effect() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -958,7 +958,7 @@ async fn capability_host_denies_resume_when_trust_ceiling_omits_capability_effec
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let active = leases.get(&scope, lease.grant.id).await.unwrap();
     assert_eq!(active.status, CapabilityLeaseStatus::Active);
 }
@@ -966,11 +966,16 @@ async fn capability_host_denies_resume_when_trust_ceiling_omits_capability_effec
 #[tokio::test]
 async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume() {
     let registry = registry_with_echo_capability();
-    let dispatcher = FailingDispatcher;
+    let dispatcher = TestDispatcher::responding(|_, _| {
+        Err(DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::Backend,
+            safe_summary: None,
+        })
+    });
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
-    let block_dispatcher = RecordingDispatcher::default();
+    let block_dispatcher = recording_dispatcher();
     let block_host = CapabilityHost::new(&registry, &block_dispatcher, &ApprovalAuthorizer)
         .with_run_state(&run_state)
         .with_approval_requests(&approval_requests);
@@ -1057,7 +1062,7 @@ async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume(
 #[tokio::test]
 async fn capability_host_returns_dispatch_result_when_lease_consume_fails_after_dispatch() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = ConsumeFailingLeaseStore::new();
@@ -1134,7 +1139,7 @@ async fn capability_host_returns_dispatch_result_when_lease_consume_fails_after_
 #[tokio::test]
 async fn capability_host_does_not_overwrite_completed_run_when_concurrent_resume_loses_claim() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let complete_notify = Arc::new(tokio::sync::Notify::new());
     let run_state = CompleteNotifyingRunStateStore::new(complete_notify.clone());
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
@@ -1221,7 +1226,7 @@ async fn capability_host_does_not_overwrite_completed_run_when_concurrent_resume
 #[tokio::test]
 async fn capability_host_rejects_resume_with_mismatched_capability_id() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -1279,7 +1284,7 @@ async fn capability_host_rejects_resume_with_mismatched_capability_id() {
         }
         other => panic!("expected ResumeContextMismatch, got {other:?}"),
     }
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::Failed);
     assert_eq!(run.error_kind.as_deref(), Some("ResumeContextMismatch"));
@@ -1288,7 +1293,7 @@ async fn capability_host_rejects_resume_with_mismatched_capability_id() {
 #[tokio::test]
 async fn capability_host_rejects_resume_with_mismatched_approval_request_id() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -1348,13 +1353,13 @@ async fn capability_host_rejects_resume_with_mismatched_approval_request_id() {
         }
         other => panic!("expected ResumeContextMismatch, got {other:?}"),
     }
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_rejects_resume_with_mutated_input_before_lease_claim_or_dispatch() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
     let leases = in_memory_backed_capability_lease_store();
@@ -1424,7 +1429,7 @@ async fn capability_host_rejects_resume_with_mutated_input_before_lease_claim_or
         err,
         CapabilityInvocationError::ApprovalFingerprintMismatch { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let active = leases.get(&scope, lease.grant.id).await.unwrap();
     assert_eq!(active.status, CapabilityLeaseStatus::Active);
 }
@@ -1435,21 +1440,6 @@ enum ApprovalRequestMismatch {
     Estimate,
     RequestedBy,
     CorrelationId,
-}
-
-struct FailingDispatcher;
-
-#[async_trait]
-impl CapabilityDispatcher for FailingDispatcher {
-    async fn dispatch_json(
-        &self,
-        _request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        Err(DispatchError::Wasm {
-            kind: RuntimeDispatchErrorKind::Backend,
-            safe_summary: None,
-        })
-    }
 }
 
 struct MismatchedApprovalRequestAuthorizer {

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -2106,6 +2106,11 @@ impl RunStateStore for FailOnFailRunStateStore {
     }
 }
 
+// Synchronization primitive + domain-state fake, not an I/O fault — cannot move
+// to ironclaw_filesystem::FaultInjecting: it uses `tokio::sync::Notify` to
+// interleave two concurrent `claim` calls and returns a domain
+// `CapabilityLeaseError::InactiveLease{Consumed}` for the loser. FaultInjecting
+// is neither a synchronization barrier nor able to produce that domain error.
 struct CoordinatedClaimConflictLeaseStore {
     inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
     claim_calls: AtomicUsize,
@@ -2204,6 +2209,13 @@ impl CapabilityLeaseStore for CoordinatedClaimConflictLeaseStore {
     }
 }
 
+// I/O-shaped (returns `CapabilityLeaseError::Persistence` on `consume`), but kept:
+// FaultInjecting gates by FilesystemOperation + path only, and `consume`'s CAS
+// write is indistinguishable — same op (WriteFile) and same lease-file path — from
+// the `claim`/`begin_dispatch_claimed` CAS writes in the same `resume_json` call,
+// so a backend fault cannot isolate the consume failure this test needs. This is
+// the documented FaultInjecting limitation ("can't fault only versioned writes";
+// ironclaw_filesystem/CLAUDE.md), not a domain-double.
 struct ConsumeFailingLeaseStore {
     inner: FilesystemCapabilityLeaseStore<InMemoryBackend>,
 }

--- a/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
@@ -16,7 +16,7 @@ use support::*;
 #[tokio::test]
 async fn capability_host_blocks_spawn_for_approval_without_starting_process() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let process_manager = RecordingProcessManager::default();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
@@ -45,7 +45,7 @@ async fn capability_host_blocks_spawn_for_approval_without_starting_process() {
         err,
         CapabilityInvocationError::AuthorizationRequiresApproval { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert!(!process_manager.has_start());
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::BlockedApproval);
@@ -100,7 +100,7 @@ output_schema_ref = "schemas/shell.output.v1.json"
     .unwrap();
     let mut registry = ExtensionRegistry::new();
     registry.insert(package).unwrap();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let process_manager = RecordingProcessManager::default();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
@@ -163,7 +163,7 @@ output_schema_ref = "schemas/shell.output.v1.json"
 #[tokio::test]
 async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let process_manager = RecordingProcessManager::default();
     let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
     let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
@@ -242,7 +242,7 @@ async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert!(!process_manager.has_start());
     assert_eq!(
         run_state
@@ -270,7 +270,7 @@ async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
         .await
         .unwrap();
 
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let start = process_manager.take_start();
     assert_eq!(start.scope, context.resource_scope);
     assert_eq!(
@@ -299,7 +299,7 @@ async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
 #[tokio::test]
 async fn capability_host_denies_spawn_when_trust_ceiling_omits_spawn_effect() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let process_manager = RecordingProcessManager::default();
     let authorizer = GrantAuthorizer::new();
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer)
@@ -326,14 +326,14 @@ async fn capability_host_denies_spawn_when_trust_ceiling_omits_spawn_effect() {
             ..
         }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert!(!process_manager.has_start());
 }
 
 #[tokio::test]
 async fn capability_host_returns_spawn_result_when_run_completion_fails_after_spawn() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let process_manager = RecordingProcessManager::default();
     let run_state = FailCompleteRunStateStore::new();
     let authorizer = SpawnAuthorizer;
@@ -355,7 +355,7 @@ async fn capability_host_returns_spawn_result_when_run_completion_fails_after_sp
         .await
         .unwrap();
 
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let start = process_manager.take_start();
     assert_eq!(result.process.process_id, start.process_id);
 }
@@ -363,7 +363,7 @@ async fn capability_host_returns_spawn_result_when_run_completion_fails_after_sp
 #[tokio::test]
 async fn capability_host_spawns_authorized_process_without_dispatching_inline() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let process_manager = RecordingProcessManager::default();
     let authorizer = SpawnAuthorizer;
     let host = CapabilityHost::new(&registry, &dispatcher, &authorizer)
@@ -383,7 +383,7 @@ async fn capability_host_spawns_authorized_process_without_dispatching_inline() 
         .await
         .unwrap();
 
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     let start = process_manager.take_start();
     assert_eq!(start.scope, context.resource_scope);
     assert_eq!(start.capability_id, capability_id());

--- a/crates/ironclaw_capabilities/tests/capability_obligation_handler_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_obligation_handler_contract.rs
@@ -18,7 +18,7 @@ use support::*;
 #[tokio::test]
 async fn capability_host_uses_obligation_handler_before_dispatch() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = ObligatingAuthorizer::new(vec![Obligation::AuditBefore]);
     let handler = RecordingObligationHandler::default();
     let host =
@@ -36,7 +36,7 @@ async fn capability_host_uses_obligation_handler_before_dispatch() {
         .unwrap();
 
     assert_eq!(result.dispatch.output, json!({"ok": true}));
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
     assert_eq!(
         handler.records(),
         vec![ObligationRecord {
@@ -49,7 +49,7 @@ async fn capability_host_uses_obligation_handler_before_dispatch() {
 #[tokio::test]
 async fn capability_host_still_fails_closed_when_handler_rejects_obligations() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = ObligatingAuthorizer::new(vec![Obligation::RedactOutput]);
     let handler = RecordingObligationHandler::default();
     let host =
@@ -70,7 +70,7 @@ async fn capability_host_still_fails_closed_when_handler_rejects_obligations() {
         err,
         CapabilityInvocationError::UnsupportedObligations { .. }
     ));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
     assert_eq!(handler.records().len(), 1);
 }
 
@@ -83,7 +83,7 @@ async fn capability_host_passes_prepared_effects_to_dispatch() {
         "/projects/demo",
         MountPermissions::read_only(),
     );
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let mut context = execution_context(CapabilitySet::default());
     context.mounts = mount_view(
         "/workspace",
@@ -120,7 +120,7 @@ async fn capability_host_passes_prepared_effects_to_dispatch() {
     .await
     .unwrap();
 
-    let request = dispatcher.take_request();
+    let request = dispatcher.last_request().unwrap();
     assert_eq!(request.scope, scope);
     assert_eq!(request.estimate, estimate);
     assert_eq!(request.mounts, Some(narrowed_mounts));
@@ -136,7 +136,12 @@ async fn capability_host_passes_prepared_effects_to_dispatch() {
 #[tokio::test]
 async fn capability_host_completes_post_dispatch_obligations_before_returning() {
     let registry = registry_with_echo_capability();
-    let dispatcher = OutputDispatcher::new(json!({"token": "secret-token"}));
+    let dispatcher = TestDispatcher::responding(|request, _| {
+        Ok(dispatch_result_with_output(
+            request,
+            json!({"token": "secret-token"}),
+        ))
+    });
     let authorizer = ObligatingAuthorizer::new(vec![Obligation::RedactOutput]);
     let handler = RedactingObligationHandler;
     let host =
@@ -159,7 +164,9 @@ async fn capability_host_completes_post_dispatch_obligations_before_returning() 
 #[tokio::test]
 async fn capability_host_aborts_staged_obligations_when_completion_fails() {
     let registry = registry_with_echo_capability();
-    let dispatcher = OutputDispatcher::new(json!({"oversized": true}));
+    let dispatcher = TestDispatcher::responding(|request, _| {
+        Ok(dispatch_result_with_output(request, json!({"oversized": true})))
+    });
     let aborted_outcome = Arc::new(Mutex::new(None));
     let reservation_id = ResourceReservationId::new();
     let context = execution_context(CapabilitySet::default());
@@ -201,7 +208,7 @@ async fn capability_host_aborts_staged_obligations_when_completion_fails() {
 #[tokio::test]
 async fn capability_host_passes_prepared_mounts_to_process_start() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let narrowed_mounts = mount_view(
         "/workspace",
         "/projects/demo",
@@ -242,7 +249,7 @@ async fn capability_host_passes_prepared_mounts_to_process_start() {
 #[tokio::test]
 async fn capability_host_aborts_prepared_obligations_when_process_start_fails() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let context = execution_context(CapabilitySet::default());
     let estimate = ResourceEstimate::default();
     let aborted = Arc::new(AtomicBool::new(false));
@@ -276,13 +283,13 @@ async fn capability_host_aborts_prepared_obligations_when_process_start_fails() 
 
     assert!(matches!(err, CapabilityInvocationError::Process { .. }));
     assert!(aborted.load(Ordering::SeqCst));
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
 async fn capability_host_rejects_post_output_obligations_for_spawn_before_handler_or_process() {
     let registry = registry_with_echo_capability();
-    let dispatcher = RecordingDispatcher::default();
+    let dispatcher = recording_dispatcher();
     let authorizer = ObligatingAuthorizer::new(vec![Obligation::RedactOutput]);
     let observed = Arc::new(AtomicBool::new(false));
     let handler = FlaggingObligationHandler {
@@ -539,40 +546,6 @@ struct PanicProcessManager;
 impl ProcessManager for PanicProcessManager {
     async fn spawn(&self, _start: ProcessStart) -> Result<ProcessRecord, ProcessError> {
         panic!("process manager must not be called for unsupported post-output spawn obligations")
-    }
-}
-
-struct OutputDispatcher {
-    output: serde_json::Value,
-}
-
-impl OutputDispatcher {
-    fn new(output: serde_json::Value) -> Self {
-        Self { output }
-    }
-}
-
-#[async_trait]
-impl CapabilityDispatcher for OutputDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: extension_id(),
-            runtime: RuntimeKind::Wasm,
-            output: self.output.clone(),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: ResourceReservationId::new(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
     }
 }
 

--- a/crates/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/ironclaw_capabilities/tests/support/mod.rs
@@ -1,10 +1,5 @@
 #![allow(dead_code)]
 
-use std::sync::{
-    Mutex,
-    atomic::{AtomicUsize, Ordering},
-};
-
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::*;
@@ -13,60 +8,45 @@ use ironclaw_host_api::*;
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use serde_json::json;
 
-#[derive(Default)]
-pub struct RecordingDispatcher {
-    request: Mutex<Option<CapabilityDispatchRequest>>,
-    dispatch_count: AtomicUsize,
+// The shared `CapabilityDispatcher` double. Re-exported so every test file that
+// does `use support::*` gets it without importing the feature-gated module path.
+pub use ironclaw_host_api::dispatch_test_support::TestDispatcher;
+
+/// The standard success dispatch result, echoing the request's capability id,
+/// scope, and estimate — the exact shape the retired hand-rolled
+/// `RecordingDispatcher` returned.
+pub fn ok_dispatch_result(request: &CapabilityDispatchRequest) -> CapabilityDispatchResult {
+    dispatch_result_with_output(request, json!({"ok": true}))
 }
 
-impl RecordingDispatcher {
-    pub fn take_request(&self) -> CapabilityDispatchRequest {
-        self.request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take()
-            .unwrap()
-    }
-
-    pub fn has_request(&self) -> bool {
-        self.request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .is_some()
-    }
-
-    pub fn dispatch_count(&self) -> usize {
-        self.dispatch_count.load(Ordering::SeqCst)
+/// Like [`ok_dispatch_result`] but with a caller-supplied output payload — the
+/// replacement for the retired `OutputDispatcher`.
+pub fn dispatch_result_with_output(
+    request: &CapabilityDispatchRequest,
+    output: serde_json::Value,
+) -> CapabilityDispatchResult {
+    CapabilityDispatchResult {
+        capability_id: request.capability_id.clone(),
+        provider: extension_id(),
+        runtime: RuntimeKind::Wasm,
+        output,
+        display_preview: None,
+        usage: ResourceUsage::default(),
+        receipt: ResourceReceipt {
+            id: ResourceReservationId::new(),
+            scope: request.scope.clone(),
+            status: ReservationStatus::Reconciled,
+            estimate: request.estimate.clone(),
+            actual: Some(ResourceUsage::default()),
+        },
     }
 }
 
-#[async_trait]
-impl CapabilityDispatcher for RecordingDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        self.dispatch_count.fetch_add(1, Ordering::SeqCst);
-        *self
-            .request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(request.clone());
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: extension_id(),
-            runtime: RuntimeKind::Wasm,
-            output: json!({"ok": true}),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: ResourceReservationId::new(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
-    }
+/// Drop-in replacement for the retired `RecordingDispatcher`: records every
+/// dispatched request and returns the standard success result. Assert on it via
+/// `.recorded()` / `.call_count()` / `.last_request()`.
+pub fn recording_dispatcher() -> TestDispatcher {
+    TestDispatcher::responding(|request, _| Ok(ok_dispatch_result(request)))
 }
 
 pub struct ApprovalAuthorizer;

--- a/crates/ironclaw_event_projections/Cargo.toml
+++ b/crates/ironclaw_event_projections/Cargo.toml
@@ -19,7 +19,8 @@ thiserror = "2"
 
 [dev-dependencies]
 ironclaw_extensions = { path = "../ironclaw_extensions" }
-ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+# FaultInjecting decorator: test the projection source-error path through the real store
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 ironclaw_memory = { path = "../ironclaw_memory" }
 ironclaw_memory_native = { path = "../ironclaw_memory_native" }
 ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -14,12 +14,16 @@ use ironclaw_events::{
     EventStreamKey, InMemoryDurableAuditLog, InMemoryDurableEventLog, ReadScope, RuntimeEvent,
     RuntimeEventId, RuntimeEventKind, UNCLASSIFIED_ERROR_KIND,
 };
+use ironclaw_filesystem::{
+    Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, ScopedFilesystem,
+};
 use ironclaw_host_api::{
     Action, ActionResultSummary, ActionSummary, AgentId, AuditEnvelope, AuditEventId, AuditStage,
-    CapabilityId, CapabilitySet, CorrelationId, DenyReason, ExtensionId, InvocationId, MountView,
-    ProcessId, ProjectId, ResourceScope, RuntimeKind, ScopedPath, TenantId, ThreadId, TrustClass,
-    UserId,
+    CapabilityId, CapabilitySet, CorrelationId, DenyReason, ExtensionId, InvocationId, MountAlias,
+    MountGrant, MountPermissions, MountView, ProcessId, ProjectId, ResourceScope, RuntimeKind,
+    ScopedPath, TenantId, ThreadId, TrustClass, UserId, VirtualPath,
 };
+use ironclaw_reborn_event_store::FilesystemDurableEventLog;
 
 #[test]
 fn audit_projection_stage_wire_strings_stay_compatible_with_audit_stage() {
@@ -1901,7 +1905,7 @@ async fn replay_projection_output_does_not_expose_raw_runtime_details() {
 
 #[tokio::test]
 async fn replay_projection_errors_do_not_expose_backend_details() {
-    let service = ReplayEventProjectionService::new(Arc::new(FailingDurableEventLog));
+    let service = ReplayEventProjectionService::new(projection_source_failing_with_sentinels());
     let scope = scope_for_thread(ThreadId::new("thread-a").unwrap());
 
     let error = service
@@ -1927,42 +1931,49 @@ async fn replay_projection_errors_do_not_expose_backend_details() {
     assert!(message.contains("projection source failed"));
 }
 
-struct FailingDurableEventLog;
-
-#[async_trait]
-impl DurableEventLog for FailingDurableEventLog {
-    async fn append(
-        &self,
-        _event: RuntimeEvent,
-    ) -> Result<EventLogEntry<RuntimeEvent>, EventError> {
-        Err(EventError::DurableLog {
-            reason: "DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live".to_string(),
-        })
-    }
-
-    async fn read_after_cursor(
-        &self,
-        _stream: &EventStreamKey,
-        _filter: &ReadScope,
-        _after: Option<EventCursor>,
-        _limit: usize,
-    ) -> Result<EventReplay<RuntimeEvent>, EventError> {
-        Err(EventError::DurableLog {
-            reason: "DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live".to_string(),
-        })
-    }
-
-    async fn head_cursor(
-        &self,
-        _stream: &EventStreamKey,
-        _after: EventCursor,
-    ) -> Result<EventCursor, EventError> {
-        Err(EventError::DurableLog {
-            reason: "DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live".to_string(),
-        })
-    }
+/// The real [`FilesystemDurableEventLog`] over a [`FaultInjecting`] backend
+/// armed to fail the replay `Tail` op with a backend reason that embeds
+/// sentinel tokens (a fake DB marker, a private host path, a secret-shaped
+/// string). Replaces the former whole-trait `FailingDurableEventLog` fake:
+/// the projection service now sanitizes an error produced by the *real*
+/// store's `FilesystemError -> EventError` mapping, whose `Backend` Display
+/// (`"filesystem backend error during {operation} at {path}: {reason}"`)
+/// threads the injected reason through `map_filesystem_tail_error` verbatim.
+/// This proves the projection boundary strips genuine backend detail the store
+/// actually surfaces, not just a fake's hand-returned string.
+fn projection_source_failing_with_sentinels()
+-> Arc<FilesystemDurableEventLog<FaultInjecting<InMemoryBackend>>> {
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::Tail)
+                .backend("DATABASE_PROJECTION_SENTINEL /tmp/backend-private-path sk_live"),
+        ),
+    );
+    // The filesystem log routes every stream through scoped paths under
+    // `/events`; grant the read/tail permissions the replay path needs.
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/events").expect("alias"),
+        VirtualPath::new("/events").expect("target"),
+        MountPermissions {
+            read: true,
+            write: true,
+            delete: false,
+            list: true,
+            execute: false,
+        },
+    )])
+    .expect("mount view");
+    Arc::new(FilesystemDurableEventLog::new(Arc::new(
+        ScopedFilesystem::with_fixed_view(backend, mounts),
+    )))
 }
 
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. Serves canned `entries` at fixed cursors
+// and records the `after` cursor of each `read_after_cursor` call to assert the
+// projection service's pagination/cursor-advance behavior. Those are
+// above-the-store observations (cursor arguments, not filesystem ops) that
+// FaultInjecting — which records only op+path — cannot reproduce.
 struct CountingDurableEventLog {
     entries: Vec<EventLogEntry<RuntimeEvent>>,
     reads: Mutex<Vec<Option<EventCursor>>>,
@@ -2435,6 +2446,12 @@ async fn replay_projection_updates_with_small_limit_handles_long_prefix() {
 /// the first `read_after_cursor(after=None, ..)` call and an empty page
 /// otherwise. Used for regressions that need to inject hand-built
 /// `RuntimeEvent`s that bypass the typed sanitizing constructors.
+//
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. Its whole purpose is to feed the
+// projection service hand-built events that bypass the typed sanitizing
+// constructors; the real store serializes/deserializes through that sanitizer,
+// so it structurally cannot carry these unsanitized records.
 struct StaticDurableEventLog {
     entries: Vec<EventLogEntry<RuntimeEvent>>,
 }

--- a/crates/ironclaw_events/tests/durable_log_contract.rs
+++ b/crates/ironclaw_events/tests/durable_log_contract.rs
@@ -1013,6 +1013,13 @@ async fn read_scope_filter_isolates_project_within_same_stream() {
 /// `succeed_count` calls and fails for every subsequent call.  `append_batch`
 /// is deliberately NOT overridden so the test exercises the default
 /// implementation in [`DurableEventLog`].
+//
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. It exists to exercise the trait's
+// *default* `append_batch` loop, which the filesystem-backed store overrides
+// (so the real store never runs this path); and the filesystem store lives in
+// the downstream `ironclaw_reborn_event_store` crate, unreachable from
+// `ironclaw_events` without a circular dependency.
 struct PartialFailLog {
     call_count: std::sync::atomic::AtomicUsize,
     succeed_count: usize,

--- a/crates/ironclaw_filesystem/src/cas/tests.rs
+++ b/crates/ironclaw_filesystem/src/cas/tests.rs
@@ -22,6 +22,14 @@ use crate::{
     FilesystemOperation, InMemoryBackend, RecordKind, RecordVersion, RootFilesystem,
     ScopedFilesystem, VersionedEntry,
 };
+// The generic get/put backend-error regressions inject a `Backend` fault below
+// the real CAS-capable `InMemoryBackend` via the shared `FaultInjecting`
+// decorator instead of hand-rolling a whole-trait fake. `FaultInjecting` lives
+// behind the `test-support` feature, so the import and the two tests that use
+// it are gated to keep the default `cargo test` lane compiling with the feature
+// off.
+#[cfg(feature = "test-support")]
+use crate::{Fault, FaultInjecting};
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────
 
@@ -611,54 +619,6 @@ async fn unsupported_write_file_maps_to_cas_unsupported() {
     );
 }
 
-// ─── A CAS-capable backend whose `get` returns a generic error ────────────────
-
-/// CAS-capable backend whose `get` always returns a [`FilesystemError::Backend`]
-/// error — not a not-found / `Ok(None)`, not a `VersionMismatch`. Used to
-/// exercise the `get`-error arm of `cas_update_loop` — the
-/// `Err(error) => return Err(CasUpdateError::Backend(error))` branch of the
-/// `match filesystem.get(...)` — when the read itself fails. The pre-flight
-/// gate passes because full capabilities are declared; `get` then fails before any
-/// decode or apply runs.
-struct GetErrorBackend;
-
-#[async_trait]
-impl RootFilesystem for GetErrorBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        // Full CAS-capable shape — pre-flight gate passes and the loop enters.
-        BackendCapabilities::in_memory_full()
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        // A plain infrastructure error on the read path. Not a not-found
-        // (`Ok(None)`) and not a `VersionMismatch` — a backend that is simply
-        // broken or temporarily unavailable. The loop's get-error arm must
-        // forward it unchanged as `CasUpdateError::Backend`.
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::ReadFile,
-            reason: "simulated backend read failure".to_string(),
-        })
-    }
-
-    async fn put(
-        &self,
-        _path: &VirtualPath,
-        _entry: Entry,
-        _cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        unimplemented!("GetErrorBackend::put is unreachable in this test")
-    }
-
-    async fn list_dir(&self, _path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        unimplemented!("GetErrorBackend::list_dir is unreachable in this test")
-    }
-
-    async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        unimplemented!("GetErrorBackend::stat is unreachable in this test")
-    }
-}
-
 // ─── A backend whose `get` returns a record with an unparseable body ──────────
 
 /// CAS-capable backend whose `get` always returns a [`VersionedEntry`] whose
@@ -758,57 +718,17 @@ impl RootFilesystem for PutTrackingBackend {
     }
 }
 
-// ─── A CAS-capable backend whose `put` returns a generic non-CAS error ────────
+// ─── Generic backend get/put errors, injected via `FaultInjecting` ────────────
+//
+// `GetErrorBackend` and `GenericPutErrorBackend` (hand-rolled whole-trait
+// `RootFilesystem` fakes) folded into `ironclaw_filesystem::FaultInjecting`:
+// each test now wraps the real CAS-capable `InMemoryBackend` and injects a
+// `Backend` fault on the read / write op, so the regression exercises the
+// genuine backend under the injected fault rather than a bespoke stand-in.
+// Gated on `test-support` because `FaultInjecting` is (the default `cargo test`
+// lane keeps compiling this module with the feature off).
 
-/// CAS-capable backend whose `get` returns `Ok(None)` and whose `put` returns
-/// a plain [`FilesystemError::Backend`] — neither `VersionMismatch` nor
-/// `Unsupported { operation: WriteFile }`. Used to exercise the catch-all
-/// `Err(error) => Err(CasUpdateError::Backend(error))` arm in `cas_update_loop`
-/// — the fallback after the `VersionMismatch` and `Unsupported { operation:
-/// WriteFile, .. }` arms on the `match filesystem.put(...)`. The pre-flight gate
-/// passes because full capabilities are declared; `get` returns absent so the
-/// loop attempts a first write; `put` then returns the generic error the loop
-/// must forward as-is.
-struct GenericPutErrorBackend;
-
-#[async_trait]
-impl RootFilesystem for GenericPutErrorBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        // Full CAS-capable shape — pre-flight gate passes and the loop enters.
-        BackendCapabilities::in_memory_full()
-    }
-
-    async fn get(&self, _path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        // No existing record — loop takes the first-write path and reaches `put`.
-        Ok(None)
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        _entry: Entry,
-        _cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        // A plain backend failure that is neither `VersionMismatch` (which
-        // would trigger a retry) nor `Unsupported { WriteFile }` (which maps
-        // to `CasUnsupported`). The loop's catch-all arm must forward it as
-        // `CasUpdateError::Backend`.
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::WriteFile,
-            reason: "simulated generic backend failure".to_string(),
-        })
-    }
-
-    async fn list_dir(&self, _path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        unimplemented!("GenericPutErrorBackend::list_dir is unreachable in this test")
-    }
-
-    async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        unimplemented!("GenericPutErrorBackend::stat is unreachable in this test")
-    }
-}
-
+#[cfg(feature = "test-support")]
 #[tokio::test]
 async fn backend_put_error_maps_to_backend() {
     // Regression for the catch-all `Err(error) => Err(CasUpdateError::Backend(error))`
@@ -816,14 +736,17 @@ async fn backend_put_error_maps_to_backend() {
     // after the `VersionMismatch` (retry) and `Unsupported { operation: WriteFile,
     // .. }` (CasUnsupported) arms.
     //
-    // The backend advertises full CAS capability so the pre-flight gate passes
-    // and the helper enters the loop. `get` returns `Ok(None)` so the loop
+    // `InMemoryBackend` advertises full CAS capability so the pre-flight gate
+    // passes and the helper enters the loop. The record is absent so the loop
     // takes the first-write (`CasExpectation::Absent`) path and calls `put`.
-    // `put` returns `FilesystemError::Backend` — a generic infrastructure
-    // failure that is neither `VersionMismatch` (retry) nor
-    // `Unsupported { WriteFile }` (maps to CasUnsupported). The helper must
+    // `FaultInjecting` faults that write with `FilesystemError::Backend` — a
+    // generic infrastructure failure that is neither `VersionMismatch` (retry)
+    // nor `Unsupported { WriteFile }` (maps to CasUnsupported). The helper must
     // forward it unchanged as `CasUpdateError::Backend(_)`.
-    let fs = Arc::new(scoped(Arc::new(GenericPutErrorBackend)));
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::WriteFile).backend("simulated generic backend failure"),
+    ));
+    let fs = Arc::new(scoped(backend));
     let scope = ResourceScope::system();
 
     let result: Result<u64, CasUpdateError<TestError>> = cas_update(
@@ -843,17 +766,22 @@ async fn backend_put_error_maps_to_backend() {
     );
 }
 
+#[cfg(feature = "test-support")]
 #[tokio::test]
 async fn backend_get_error_maps_to_backend() {
     // Regression for the `get`-error arm in `cas_update_loop`:
     // `Err(error) => return Err(CasUpdateError::Backend(error))` on the
     // `match filesystem.get(...)`.
     //
-    // The backend advertises full CAS capability so the pre-flight gate passes
-    // and the helper enters the loop. `get` then returns a plain infrastructure
-    // error (not `Ok(None)` and not a `VersionMismatch`). The helper must
-    // forward it unchanged as `CasUpdateError::Backend(_)`.
-    let fs = Arc::new(scoped(Arc::new(GetErrorBackend)));
+    // `InMemoryBackend` advertises full CAS capability so the pre-flight gate
+    // passes and the helper enters the loop. `FaultInjecting` faults the read
+    // with a plain infrastructure `Backend` error (not `Ok(None)` and not a
+    // `VersionMismatch`). The helper must forward it unchanged as
+    // `CasUpdateError::Backend(_)`.
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::ReadFile).backend("simulated backend read failure"),
+    ));
+    let fs = Arc::new(scoped(backend));
     let scope = ResourceScope::system();
 
     let result: Result<u64, CasUpdateError<TestError>> = cas_update(

--- a/crates/ironclaw_host_api/Cargo.toml
+++ b/crates/ironclaw_host_api/Cargo.toml
@@ -14,6 +14,13 @@ publish = false
 [package.metadata.ironclaw]
 layer = "contracts"
 
+[features]
+# Dev-only seam (rule: cargo-features.md bar #4 — the sanctioned `test-support`
+# name). Compiles the shared `TestDispatcher` `CapabilityDispatcher` double so
+# downstream crates stop hand-rolling ~25 one-method dispatcher fakes. Never
+# enabled by a shipped artifact.
+test-support = []
+
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -28,3 +35,5 @@ zeroize = "1"
 [dev-dependencies]
 rust_decimal_macros = "1"
 static_assertions = "1"
+# `#[tokio::test]` for the async `dispatch_test_support::TestDispatcher` tests.
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_host_api/src/dispatch_test_support.rs
+++ b/crates/ironclaw_host_api/src/dispatch_test_support.rs
@@ -1,0 +1,244 @@
+//! Shared [`CapabilityDispatcher`] test double (`test-support`).
+//!
+//! [`CapabilityDispatcher`](crate::dispatch::CapabilityDispatcher) is a
+//! one-method port ([`dispatch_json`](crate::dispatch::CapabilityDispatcher::dispatch_json)),
+//! so the ~25 hand-rolled `impl CapabilityDispatcher for …Dispatcher` doubles
+//! that used to live across `ironclaw_capabilities` and `ironclaw_host_runtime`
+//! tests differed only in what that single method returned and whether they
+//! recorded the request. [`TestDispatcher`] is the one configurable double that
+//! covers all of them:
+//!
+//! - `RecordingDispatcher` / `CountingDispatcher` → recording is always on
+//!   ([`TestDispatcher::recorded`] / [`TestDispatcher::call_count`]).
+//! - `OutputDispatcher` → [`TestDispatcher::ok`].
+//! - `AuthRequiredDispatcher` / `AlwaysAuthRequired[Dispatcher]` →
+//!   [`TestDispatcher::auth_required`].
+//! - `FailingDispatcher` / `TerminalFailDispatcher` / `PanicDispatcher` and
+//!   any request-dependent response → [`TestDispatcher::responding`].
+//! - `GatingDispatcher` / `FirstCallAuthRequiredDispatcher` /
+//!   `AuthRequiredOnFirstCall` (X on the first call, Y after) →
+//!   [`TestDispatcher::scripted`].
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, MutexGuard};
+
+use async_trait::async_trait;
+
+use crate::dispatch::{
+    CapabilityDispatchRequest, CapabilityDispatchResult, CapabilityDispatcher, DispatchError,
+};
+
+type ResponderFn = dyn Fn(&CapabilityDispatchRequest, usize) -> Result<CapabilityDispatchResult, DispatchError>
+    + Send
+    + Sync;
+
+/// A configurable [`CapabilityDispatcher`] test double.
+///
+/// Records every dispatched request and returns a response computed by its
+/// responder — a fixed `Ok` value ([`Self::ok`]), an `AuthRequired` failure
+/// ([`Self::auth_required`]), a scripted per-call sequence ([`Self::scripted`]),
+/// or an arbitrary closure of `(request, call_index)` ([`Self::responding`]).
+/// Recording is always on, so a test asserts on [`Self::recorded`] /
+/// [`Self::call_count`] regardless of the response mode.
+pub struct TestDispatcher {
+    calls: Mutex<Vec<CapabilityDispatchRequest>>,
+    responder: Box<ResponderFn>,
+}
+
+impl std::fmt::Debug for TestDispatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestDispatcher")
+            .field("calls", &self.call_count())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TestDispatcher {
+    /// Core constructor: the response for each dispatch is
+    /// `f(&request, zero_based_call_index)`.
+    pub fn responding<F>(f: F) -> Self
+    where
+        F: Fn(&CapabilityDispatchRequest, usize) -> Result<CapabilityDispatchResult, DispatchError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            responder: Box::new(f),
+        }
+    }
+
+    /// Always returns `Ok(result)`.
+    pub fn ok(result: CapabilityDispatchResult) -> Self {
+        Self::responding(move |_, _| Ok(result.clone()))
+    }
+
+    /// Always fails with [`DispatchError::AuthRequired`] for the request's
+    /// capability and no secret/credential requirements — the common auth-gate
+    /// double. For non-empty requirements, use [`Self::responding`].
+    pub fn auth_required() -> Self {
+        Self::responding(|request, _| {
+            Err(DispatchError::AuthRequired {
+                capability: request.capability_id.clone(),
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+            })
+        })
+    }
+
+    /// Returns each queued response once, in order. Panics if dispatched more
+    /// times than the queue length — a scripted double is expected to be
+    /// exhausted exactly, so an over-dispatch is a test-authoring error, not a
+    /// silent last-value repeat.
+    pub fn scripted(responses: Vec<Result<CapabilityDispatchResult, DispatchError>>) -> Self {
+        let queue = Mutex::new(VecDeque::from(responses));
+        Self::responding(move |_, _| {
+            queue
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .pop_front()
+                .expect("TestDispatcher scripted queue exhausted")
+        })
+    }
+
+    /// Every request dispatched so far, in call order.
+    pub fn recorded(&self) -> Vec<CapabilityDispatchRequest> {
+        self.lock().clone()
+    }
+
+    /// Number of dispatches so far.
+    pub fn call_count(&self) -> usize {
+        self.lock().len()
+    }
+
+    /// The most recent dispatched request, if any.
+    pub fn last_request(&self) -> Option<CapabilityDispatchRequest> {
+        self.lock().last().cloned()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Vec<CapabilityDispatchRequest>> {
+        self.calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[async_trait]
+impl CapabilityDispatcher for TestDispatcher {
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        let index = {
+            let mut calls = self.lock();
+            calls.push(request.clone());
+            calls.len() - 1
+        };
+        (self.responder)(&request, index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CapabilityId, ResourceEstimate, ResourceScope};
+    use serde_json::json;
+
+    fn request(cap: &str) -> CapabilityDispatchRequest {
+        CapabilityDispatchRequest {
+            capability_id: CapabilityId::new(cap).unwrap(),
+            scope: ResourceScope::system(),
+            authenticated_actor_user_id: None,
+            run_id: None,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        }
+    }
+
+    fn auth_required_err(cap: &str) -> DispatchError {
+        DispatchError::AuthRequired {
+            capability: CapabilityId::new(cap).unwrap(),
+            required_secrets: Vec::new(),
+            credential_requirements: Vec::new(),
+        }
+    }
+
+    // Recording is always on, so it is asserted here via the error path — the
+    // `Ok`-returning `ok()` responder is a one-liner (`Ok(result.clone())`) and
+    // is exercised by the downstream migrations that carry a real result.
+
+    #[tokio::test]
+    async fn records_every_request_in_call_order() {
+        let d = TestDispatcher::auth_required();
+        let _ = d.dispatch_json(request("test.a")).await;
+        let _ = d.dispatch_json(request("test.b")).await;
+
+        assert_eq!(d.call_count(), 2);
+        let recorded = d.recorded();
+        assert_eq!(recorded[0].capability_id.as_str(), "test.a");
+        assert_eq!(recorded[1].capability_id.as_str(), "test.b");
+        assert_eq!(d.last_request().unwrap().capability_id.as_str(), "test.b");
+    }
+
+    #[tokio::test]
+    async fn auth_required_fails_with_the_requests_capability() {
+        let d = TestDispatcher::auth_required();
+        let err = d.dispatch_json(request("test.gated")).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DispatchError::AuthRequired { capability, .. } if capability.as_str() == "test.gated"
+        ));
+    }
+
+    #[tokio::test]
+    async fn scripted_returns_each_response_once_in_order() {
+        let d = TestDispatcher::scripted(vec![
+            Err(auth_required_err("test.first")),
+            Err(DispatchError::UnknownCapability { capability: CapabilityId::new("test.other").unwrap() }),
+        ]);
+        assert!(matches!(
+            d.dispatch_json(request("test.x")).await,
+            Err(DispatchError::AuthRequired { .. })
+        ));
+        assert!(matches!(
+            d.dispatch_json(request("test.x")).await,
+            Err(DispatchError::UnknownCapability { .. })
+        ));
+        assert_eq!(d.call_count(), 2);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "scripted queue exhausted")]
+    async fn scripted_panics_when_over_dispatched() {
+        let d = TestDispatcher::scripted(vec![Err(auth_required_err("test.only"))]);
+        let _ = d.dispatch_json(request("test.x")).await;
+        let _ = d.dispatch_json(request("test.x")).await; // one too many
+    }
+
+    #[tokio::test]
+    async fn responding_can_branch_on_request_and_call_index() {
+        let d = TestDispatcher::responding(|req, idx| {
+            // Fail only the first call for capability "first".
+            if idx == 0 && req.capability_id.as_str() == "test.first" {
+                Err(DispatchError::AuthRequired {
+                    capability: req.capability_id.clone(),
+                    required_secrets: Vec::new(),
+                    credential_requirements: Vec::new(),
+                })
+            } else {
+                Err(DispatchError::UnknownCapability { capability: CapabilityId::new("test.other").unwrap() })
+            }
+        });
+        assert!(matches!(
+            d.dispatch_json(request("test.first")).await,
+            Err(DispatchError::AuthRequired { .. })
+        ));
+        assert!(matches!(
+            d.dispatch_json(request("test.first")).await,
+            Err(DispatchError::UnknownCapability { .. })
+        ));
+    }
+}

--- a/crates/ironclaw_host_api/src/lib.rs
+++ b/crates/ironclaw_host_api/src/lib.rs
@@ -39,6 +39,8 @@ pub mod capability;
 pub mod capability_profile;
 pub mod decision;
 pub mod dispatch;
+#[cfg(feature = "test-support")]
+pub mod dispatch_test_support;
 mod dotted_id;
 pub mod error;
 pub mod failure;

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -80,6 +80,8 @@ ironclaw_authorization = { path = "../ironclaw_authorization", features = ["test
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 # FaultInjecting decorator: drive store fault paths through the real store.
 ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
+# shared TestDispatcher double
+ironclaw_host_api = { path = "../ironclaw_host_api", features = ["test-support"] }
 # Enables the in-memory-backed process store constructors for tests only.
 ironclaw_processes = { path = "../ironclaw_processes", features = ["test-support"] }
 # Enables the in-memory-backed run-state/approval store constructors for tests only.

--- a/crates/ironclaw_host_runtime/src/egress/credential.rs
+++ b/crates/ironclaw_host_runtime/src/egress/credential.rs
@@ -678,7 +678,10 @@ mod tests {
         let error = lease_secret_for_injection(&store, &request, &sample_injection(handle))
             .expect_err("absent required credential must error");
 
-        assert_eq!(credential_reason(&error), "required credential is unavailable");
+        assert_eq!(
+            credential_reason(&error),
+            "required credential is unavailable"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/ironclaw_host_runtime/src/services/process_executor.rs
@@ -254,6 +254,7 @@ mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
 
+    use ironclaw_host_api::dispatch_test_support::TestDispatcher;
     use ironclaw_host_api::{
         AgentId, CapabilityDispatchResult, CapabilityId, DispatchError, ExtensionId, InvocationId,
         MountView, ProcessId, ProjectId, ReservationStatus, ResourceEstimate, ResourceReceipt,
@@ -301,75 +302,21 @@ mod tests {
         }
     }
 
-    #[derive(Clone)]
-    struct CancellingDispatcher {
-        cancellation: ProcessCancellationToken,
-    }
-
-    #[derive(Clone, Default)]
-    struct RecordingCapabilityDispatcher {
-        calls: Arc<Mutex<Vec<CapabilityDispatchRequest>>>,
-    }
-
-    impl RecordingCapabilityDispatcher {
-        fn calls(&self) -> Vec<CapabilityDispatchRequest> {
-            self.calls
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .clone()
-        }
-    }
-
-    #[async_trait]
-    impl CapabilityDispatcher for RecordingCapabilityDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            self.calls
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .push(request.clone());
-            Ok(CapabilityDispatchResult {
-                capability_id: request.capability_id,
-                provider: ExtensionId::new("demo").unwrap(),
-                runtime: RuntimeKind::Script,
-                output: json!({"ok": true}),
-                display_preview: None,
-                usage: ResourceUsage::default(),
-                receipt: ResourceReceipt {
-                    id: ResourceReservationId::new(),
-                    scope: request.scope,
-                    status: ReservationStatus::Reconciled,
-                    estimate: ResourceEstimate::default(),
-                    actual: Some(ResourceUsage::default()),
-                },
-            })
-        }
-    }
-
-    #[async_trait]
-    impl CapabilityDispatcher for CancellingDispatcher {
-        async fn dispatch_json(
-            &self,
-            request: CapabilityDispatchRequest,
-        ) -> Result<CapabilityDispatchResult, DispatchError> {
-            self.cancellation.cancel();
-            Ok(CapabilityDispatchResult {
-                capability_id: request.capability_id,
-                provider: ExtensionId::new("demo").unwrap(),
-                runtime: RuntimeKind::Script,
-                output: json!({"ok": true}),
-                display_preview: None,
-                usage: ResourceUsage::default(),
-                receipt: ResourceReceipt {
-                    id: ResourceReservationId::new(),
-                    scope: request.scope,
-                    status: ReservationStatus::Reconciled,
-                    estimate: ResourceEstimate::default(),
-                    actual: Some(ResourceUsage::default()),
-                },
-            })
+    fn dispatch_result() -> CapabilityDispatchResult {
+        CapabilityDispatchResult {
+            capability_id: CapabilityId::new("demo.background").unwrap(),
+            provider: ExtensionId::new("demo").unwrap(),
+            runtime: RuntimeKind::Script,
+            output: json!({"ok": true}),
+            display_preview: None,
+            usage: ResourceUsage::default(),
+            receipt: ResourceReceipt {
+                id: ResourceReservationId::new(),
+                scope: ResourceScope::system(),
+                status: ReservationStatus::Reconciled,
+                estimate: ResourceEstimate::default(),
+                actual: Some(ResourceUsage::default()),
+            },
         }
     }
 
@@ -475,9 +422,11 @@ mod tests {
     async fn runtime_dispatch_executor_returns_cancelled_after_dispatch() {
         // safety: test executor call is an in-memory process executor call, not a DB write.
         let cancellation = ProcessCancellationToken::new();
-        let dispatcher = Arc::new(CancellingDispatcher {
-            cancellation: cancellation.clone(),
-        });
+        let signal = cancellation.clone();
+        let dispatcher = Arc::new(TestDispatcher::responding(move |_, _| {
+            signal.cancel();
+            Ok(dispatch_result())
+        }));
         let executor = RuntimeDispatchProcessExecutor::new(dispatcher);
         let mut request = sample_process_request("demo.background", RuntimeKind::Script);
         request.cancellation = cancellation;
@@ -490,7 +439,7 @@ mod tests {
     #[tokio::test]
     async fn runtime_dispatch_executor_preserves_authenticated_actor() {
         // safety: test dispatcher call is in-memory and does not execute an external capability.
-        let dispatcher = Arc::new(RecordingCapabilityDispatcher::default());
+        let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
         let executor = RuntimeDispatchProcessExecutor::new(dispatcher.clone());
         let mut request = sample_process_request("demo.background", RuntimeKind::Script);
         let actor = UserId::new("slack-alice").unwrap();
@@ -500,7 +449,7 @@ mod tests {
 
         executor.execute(request).await.unwrap();
 
-        let calls = dispatcher.calls();
+        let calls = dispatcher.recorded();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].authenticated_actor_user_id, Some(actor));
         assert_eq!(calls[0].scope, expected_scope);

--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -15,6 +15,7 @@ use ironclaw_capabilities::{
 use ironclaw_events::InMemoryAuditSink;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 use ironclaw_filesystem::InMemoryBackend;
+use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     BuiltinObligationHandler, BuiltinObligationServices, CapabilitySurfaceVersion,
@@ -981,7 +982,9 @@ async fn builtin_obligation_handler_reserves_requested_resources_and_releases_on
 #[tokio::test]
 async fn default_host_runtime_fails_closed_when_resource_ceiling_lacks_required_estimate() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(PanicDispatcher);
+    let dispatcher = Arc::new(TestDispatcher::responding(|_, _| {
+        panic!("dispatcher must not be called for unsupported resource-ceiling obligations")
+    }));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(ObligatingAuthorizer::new(vec![
             Obligation::EnforceResourceCeiling {
@@ -1018,7 +1021,7 @@ async fn default_host_runtime_fails_closed_when_resource_ceiling_lacks_required_
 #[tokio::test]
 async fn default_host_runtime_dispatches_when_resource_ceiling_is_satisfied() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher);
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(ObligatingAuthorizer::new(vec![
             Obligation::EnforceResourceCeiling {
@@ -1057,7 +1060,7 @@ async fn default_host_runtime_dispatches_when_resource_ceiling_is_satisfied() {
 #[tokio::test]
 async fn default_host_runtime_installs_configured_obligation_handler() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher);
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
         Arc::new(ObligatingAuthorizer::new(vec![Obligation::AuditBefore]));
     let audit = Arc::new(InMemoryAuditSink::new());
@@ -1112,46 +1115,21 @@ impl TrustAwareCapabilityDispatchAuthorizer for ObligatingAuthorizer {
     }
 }
 
-#[derive(Default)]
-struct RecordingDispatcher;
-
-struct PanicDispatcher;
-
-#[async_trait]
-impl CapabilityDispatcher for PanicDispatcher {
-    async fn dispatch_json(
-        &self,
-        _request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        panic!("dispatcher must not be called for unsupported resource-ceiling obligations")
-    }
-}
-
-#[async_trait]
-impl CapabilityDispatcher for RecordingDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: ExtensionId::new("echo").unwrap(),
-            runtime: RuntimeKind::Wasm,
-            output: json!({"ok": true}),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: request
-                    .resource_reservation
-                    .as_ref()
-                    .map(|reservation| reservation.id)
-                    .unwrap_or_default(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
+fn dispatch_result() -> CapabilityDispatchResult {
+    CapabilityDispatchResult {
+        capability_id: capability_id(),
+        provider: ExtensionId::new("echo").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        output: json!({"ok": true}),
+        display_preview: None,
+        usage: ResourceUsage::default(),
+        receipt: ResourceReceipt {
+            id: ResourceReservationId::new(),
+            scope: ResourceScope::system(),
+            status: ReservationStatus::Reconciled,
+            estimate: ResourceEstimate::default(),
+            actual: Some(ResourceUsage::default()),
+        },
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::{
-    DirEntry, DiskFilesystem, FileStat, FileType, FilesystemError, FilesystemOperation,
-    RootFilesystem,
+    DirEntry, DiskFilesystem, Fault, FaultInjecting, FileStat, FileType, FilesystemError,
+    FilesystemOperation, RootFilesystem,
 };
 use ironclaw_host_api::runtime_policy::{
     ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
@@ -142,10 +142,13 @@ async fn builtin_coding_list_and_grep_skip_entries_when_stat_fails() {
     std::fs::write(temp.path().join("skip.rs"), "needle\n").unwrap();
 
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
-    let runtime = runtime_with_filesystem(StatFailureFilesystem {
-        inner: filesystem,
-        fail_suffix: "/skip.rs",
-    });
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::Stat)
+                .path("/skip.rs")
+                .backend("injected stat failure"),
+        ),
+    );
     let context = execution_context_with_mounts(coding_capability_ids(), mounts);
 
     let listed = invoke_with_context(
@@ -176,10 +179,13 @@ async fn builtin_coding_grep_skips_entries_when_read_fails_during_directory_sear
     std::fs::write(temp.path().join("skip.rs"), "needle\n").unwrap();
 
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
-    let runtime = runtime_with_filesystem(ReadFailureFilesystem {
-        inner: filesystem,
-        fail_suffix: "/skip.rs",
-    });
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/skip.rs")
+                .backend("injected read failure"),
+        ),
+    );
     let context = execution_context_with_mounts(coding_capability_ids(), mounts);
 
     let grepped = invoke_with_context(
@@ -200,10 +206,13 @@ async fn builtin_coding_grep_fails_on_explicit_file_read_error() {
     std::fs::write(temp.path().join("fail.rs"), "needle\n").unwrap();
 
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
-    let runtime = runtime_with_filesystem(ReadFailureFilesystem {
-        inner: filesystem,
-        fail_suffix: "/fail.rs",
-    });
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/fail.rs")
+                .backend("injected read failure"),
+        ),
+    );
     let context = execution_context_with_mounts(coding_capability_ids(), mounts);
 
     let error = invoke_with_context(
@@ -1820,41 +1829,6 @@ fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (DiskFilesy
     (filesystem, mounts)
 }
 
-struct StatFailureFilesystem {
-    inner: DiskFilesystem,
-    fail_suffix: &'static str,
-}
-
-#[async_trait]
-impl RootFilesystem for StatFailureFilesystem {
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        if path.as_str().ends_with(self.fail_suffix) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::Stat,
-                reason: "injected stat failure".to_string(),
-            });
-        }
-        self.inner.stat(path).await
-    }
-
-    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        self.inner.read_file(path).await
-    }
-
-    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.write_file(path, bytes).await
-    }
-
-    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.create_dir_all(path).await
-    }
-}
-
 struct StatLenOverrideFilesystem {
     inner: DiskFilesystem,
     suffix: &'static str,
@@ -1888,41 +1862,15 @@ impl RootFilesystem for StatLenOverrideFilesystem {
     }
 }
 
-struct ReadFailureFilesystem {
-    inner: DiskFilesystem,
-    fail_suffix: &'static str,
-}
-
-#[async_trait]
-impl RootFilesystem for ReadFailureFilesystem {
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        if path.as_str().ends_with(self.fail_suffix) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "injected read failure".to_string(),
-            });
-        }
-        self.inner.read_file(path).await
-    }
-
-    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        self.inner.write_file(path, bytes).await
-    }
-
-    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.create_dir_all(path).await
-    }
-}
-
+/// KEPT (not folded to `ironclaw_filesystem::FaultInjecting`): the coding
+/// `write_file`/`apply_patch` tools call `create_dir_all` on the target's parent
+/// before writing (see `coding::paths::create_parent_dir_unless_sensitive`).
+/// `FaultInjecting` gates only the unified entry/event ops and leaves the legacy
+/// `create_dir_all` at its trait default, which returns `Unsupported` instead of
+/// delegating to the inner `DiskFilesystem` — the tool maps that to
+/// `FilesystemDenied`/`Authorization`, masking the injected write fault. This
+/// delegator forwards `create_dir_all` to the real backend and faults only
+/// `write_file`, preserving the `Backend` assertion.
 struct WriteFailureFilesystem {
     inner: DiskFilesystem,
     fail_suffix: &'static str,
@@ -1942,7 +1890,7 @@ impl RootFilesystem for WriteFailureFilesystem {
         self.inner.read_file(path).await
     }
 
-    async fn write_file(&self, path: &VirtualPath, _bytes: &[u8]) -> Result<(), FilesystemError> {
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         if path.as_str().ends_with(self.fail_suffix) {
             return Err(FilesystemError::Backend {
                 path: path.clone(),
@@ -1950,7 +1898,7 @@ impl RootFilesystem for WriteFailureFilesystem {
                 reason: "disk full".to_string(),
             });
         }
-        self.inner.write_file(path, _bytes).await
+        self.inner.write_file(path, bytes).await
     }
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
@@ -1958,6 +1906,11 @@ impl RootFilesystem for WriteFailureFilesystem {
     }
 }
 
+/// KEPT (not folded to `ironclaw_filesystem::FaultInjecting`): this fake returns
+/// [`FilesystemError::BackendInfrastructure`], a variant `FaultKind` cannot
+/// express (it covers only `Backend`/`BackendBusy`/`NotFound`/`Unsupported`).
+/// Folding it would change the injected error and lose the
+/// `BackendInfrastructure -> Backend` mapping this test pins.
 struct ReadInfrastructureFailureFilesystem {
     inner: DiskFilesystem,
     fail_suffix: &'static str,

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -6,7 +6,7 @@ use support::legacy_capability_fixture_to_v2;
 use std::{
     collections::BTreeMap,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicUsize, Ordering},
     },
 };
@@ -23,6 +23,7 @@ use ironclaw_extensions::{
 use ironclaw_filesystem::{
     Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, ScopedFilesystem,
 };
+use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CancelReason, CancelRuntimeWorkRequest, CapabilitySurfacePolicy, CapabilitySurfaceVersion,
@@ -74,7 +75,7 @@ fn bounded_contract_strings_share_validation_semantics() {
 #[tokio::test]
 async fn default_runtime_returns_completed_outcome_for_authorized_dispatch() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -108,13 +109,13 @@ async fn default_runtime_returns_completed_outcome_for_authorized_dispatch() {
         }
         other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 #[tokio::test]
 async fn default_runtime_surfaces_approval_required_with_persisted_request_id() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -159,7 +160,7 @@ async fn default_runtime_surfaces_approval_required_with_persisted_request_id() 
 #[tokio::test]
 async fn default_runtime_uses_combined_store_for_atomic_approval_block() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
     let combined_store = Arc::new(RecordingCombinedRunStateApprovalStore::new());
     let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
@@ -223,7 +224,7 @@ async fn default_runtime_propagates_unavailable_when_run_state_lookup_fails_duri
     // `HostRuntimeError::Unavailable` so callers can distinguish between a
     // missing record and a broken backend.
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
     let inner_run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let run_state: Arc<dyn RunStateStore> = Arc::new(FailingGetRunStateStore {
@@ -269,7 +270,7 @@ async fn default_runtime_propagates_unavailable_when_run_state_lookup_fails_duri
 #[tokio::test]
 async fn default_runtime_returns_failed_for_unknown_capability() {
     let registry = Arc::new(ExtensionRegistry::new());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let runtime = DefaultHostRuntime::new(
@@ -302,8 +303,9 @@ async fn default_runtime_returns_failed_for_unknown_capability() {
         }
         other => panic!("expected Failed outcome, got {:?}", other),
     }
-    assert!(
-        !dispatcher.has_request(),
+    assert_eq!(
+        dispatcher.call_count(),
+        0,
         "unknown capabilities must fail during trust evaluation before dispatch"
     );
     assert!(
@@ -322,7 +324,7 @@ async fn default_runtime_surfaces_authorization_failure_when_authorizer_denies()
     // as Failed with kind=Authorization, not bubble up as a HostRuntimeError
     // or get swallowed.
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(DenyAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -353,7 +355,7 @@ async fn default_runtime_surfaces_authorization_failure_when_authorizer_denies()
         other => panic!("expected Failed(Authorization), got {:?}", other),
     }
     // Deny must short-circuit before dispatch runs.
-    assert!(!dispatcher.has_request());
+    assert_eq!(dispatcher.call_count(), 0);
 }
 
 #[tokio::test]
@@ -363,7 +365,7 @@ async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
     // If a future change wires dedupe through the capability host, this test
     // is the canary that flags the contract change.
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(CountingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -397,7 +399,7 @@ async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
     let _ = runtime.invoke_capability(request_b).await.unwrap();
 
     assert_eq!(
-        dispatcher.count(),
+        dispatcher.call_count(),
         2,
         "idempotency_key is advisory only — dedupe is not enforced at this layer"
     );
@@ -408,7 +410,7 @@ async fn default_runtime_status_returns_default_when_no_run_state_attached() {
     // Pins the no-run-state branch: callers must get an empty status rather
     // than a panic or an Unavailable error.
     let registry = Arc::new(ExtensionRegistry::new());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -436,7 +438,7 @@ async fn default_runtime_status_propagates_unavailable_on_run_state_error() {
     // surface as HostRuntimeError::Unavailable with a redacted reason, not
     // leak the underlying filesystem string.
     let registry = Arc::new(ExtensionRegistry::new());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let inner = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let run_state: Arc<dyn RunStateStore> = Arc::new(FailingRecordsRunStateStore { inner });
@@ -473,16 +475,18 @@ async fn default_runtime_status_propagates_unavailable_on_run_state_error() {
 #[tokio::test]
 async fn default_runtime_status_redacts_process_filesystem_errors() {
     let registry = Arc::new(ExtensionRegistry::new());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     // Real process store over a fault backend armed to fail `records_for_scope`
     // (its `query` op) with a leaky reason, so the test proves the host-runtime
     // path maps `ProcessError::Filesystem` to the sanitized, path-free
     // "process filesystem unavailable" through the production store.
-    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
-        Fault::on(FilesystemOperation::Query)
-            .backend("simulated read failure: /tmp/processes.db connection refused"),
-    ));
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::Query)
+                .backend("simulated read failure: /tmp/processes.db connection refused"),
+        ),
+    );
     let mounts = MountView::new(vec![MountGrant::new(
         MountAlias::new("/processes").unwrap(),
         VirtualPath::new("/engine/processes").unwrap(),
@@ -527,7 +531,7 @@ async fn default_runtime_status_filters_to_running_records_only() {
     // active_work. Surfacing terminal records as "active" would mislead
     // upper services about which work to wait on.
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
 
@@ -590,7 +594,7 @@ async fn default_runtime_visible_capabilities_returns_empty_descriptors_for_empt
     // Pins the empty-registry path: the surface still carries a deterministic
     // version derived from the configured base version and request policy.
     let registry = Arc::new(ExtensionRegistry::new());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -617,7 +621,7 @@ async fn default_runtime_visible_capabilities_returns_empty_descriptors_for_empt
 #[tokio::test]
 async fn default_runtime_returns_versioned_visible_surface_with_registry_descriptors() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry.clone(),
@@ -643,7 +647,7 @@ async fn default_runtime_returns_versioned_visible_surface_with_registry_descrip
 #[tokio::test]
 async fn default_runtime_visible_surface_tracks_shared_registry_mutations() {
     let registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::from_shared_registry(
         Arc::clone(&registry),
@@ -694,7 +698,7 @@ async fn default_runtime_visible_surface_tracks_shared_registry_mutations() {
 #[tokio::test]
 async fn default_runtime_status_reports_running_invocations_only() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
 
@@ -738,7 +742,7 @@ async fn default_runtime_status_reports_running_invocations_only() {
 #[tokio::test]
 async fn default_runtime_cancel_reports_running_invocations_as_unsupported() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let runtime = DefaultHostRuntime::new(
@@ -781,7 +785,7 @@ async fn default_runtime_cancel_reports_running_invocations_as_unsupported() {
 #[tokio::test]
 async fn default_runtime_cancel_kills_running_processes_and_cancels_tokens() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let process_store = Arc::new(ironclaw_processes::in_memory_backed_process_store());
     let cancellation_registry = Arc::new(ProcessCancellationRegistry::new());
@@ -827,7 +831,7 @@ async fn default_runtime_cancel_kills_running_processes_and_cancels_tokens() {
 #[tokio::test]
 async fn spawn_process_returns_unavailable_when_process_manager_is_none() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -852,7 +856,7 @@ async fn spawn_process_returns_unavailable_when_process_manager_is_none() {
 #[tokio::test]
 async fn default_runtime_status_includes_running_processes_from_process_store() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let process_store = Arc::new(ironclaw_processes::in_memory_backed_process_store());
     let runtime = DefaultHostRuntime::new(
@@ -891,7 +895,7 @@ async fn default_runtime_status_includes_running_processes_from_process_store() 
 #[tokio::test]
 async fn default_runtime_cancel_writes_killed_process_result_record() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let processes_filesystem = ironclaw_processes::in_memory_backed_processes_filesystem();
     let process_store = Arc::new(FilesystemProcessStore::new(Arc::clone(
@@ -942,7 +946,7 @@ async fn default_runtime_cancel_writes_killed_process_result_record() {
 #[tokio::test]
 async fn default_runtime_status_does_not_duplicate_process_backed_invocations() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let process_store = Arc::new(ironclaw_processes::in_memory_backed_process_store());
@@ -990,7 +994,7 @@ async fn default_runtime_status_does_not_duplicate_process_backed_invocations() 
 #[tokio::test]
 async fn default_runtime_health_reports_ready_when_registry_requires_no_backends() {
     let registry = Arc::new(ExtensionRegistry::new());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -1009,7 +1013,7 @@ async fn default_runtime_health_reports_ready_when_registry_requires_no_backends
 #[tokio::test]
 async fn default_runtime_health_without_probe_reports_required_runtimes_missing() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -1028,7 +1032,7 @@ async fn default_runtime_health_without_probe_reports_required_runtimes_missing(
 #[tokio::test]
 async fn default_runtime_health_uses_configured_backend_probe() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         registry,
@@ -1370,39 +1374,21 @@ impl RunStateApprovalStore for RecordingCombinedRunStateApprovalStore {
     }
 }
 
-#[derive(Default)]
-struct CountingDispatcher {
-    count: Mutex<usize>,
-}
-
-impl CountingDispatcher {
-    fn count(&self) -> usize {
-        *self.count.lock().unwrap_or_else(|p| p.into_inner())
-    }
-}
-
-#[async_trait]
-impl CapabilityDispatcher for CountingDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        *self.count.lock().unwrap_or_else(|p| p.into_inner()) += 1;
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: extension_id(),
-            runtime: RuntimeKind::Wasm,
-            output: json!({"ok": true}),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: ResourceReservationId::new(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
+fn dispatch_result() -> CapabilityDispatchResult {
+    CapabilityDispatchResult {
+        capability_id: capability_id(),
+        provider: extension_id(),
+        runtime: RuntimeKind::Wasm,
+        output: json!({"ok": true}),
+        display_preview: None,
+        usage: ResourceUsage::default(),
+        receipt: ResourceReceipt {
+            id: ResourceReservationId::new(),
+            scope: ResourceScope::system(),
+            status: ReservationStatus::Reconciled,
+            estimate: ResourceEstimate::default(),
+            actual: Some(ResourceUsage::default()),
+        },
     }
 }
 
@@ -1420,48 +1406,6 @@ impl TrustAwareCapabilityDispatchAuthorizer for DenyAuthorizer {
         Decision::Deny {
             reason: DenyReason::PolicyDenied,
         }
-    }
-}
-
-#[derive(Default)]
-struct RecordingDispatcher {
-    request: Mutex<Option<CapabilityDispatchRequest>>,
-}
-
-impl RecordingDispatcher {
-    fn has_request(&self) -> bool {
-        self.request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .is_some()
-    }
-}
-
-#[async_trait]
-impl CapabilityDispatcher for RecordingDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        *self
-            .request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(request.clone());
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: extension_id(),
-            runtime: RuntimeKind::Wasm,
-            output: json!({"ok": true}),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: ResourceReservationId::new(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -2,7 +2,7 @@ mod support;
 
 use support::legacy_capability_fixture_to_v2;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -14,6 +14,7 @@ use ironclaw_approvals::{
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
 use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime, RuntimeCapabilityAuthResumeRequest,
@@ -29,7 +30,7 @@ use serde_json::json;
 #[tokio::test]
 async fn default_runtime_uses_persistent_policy_as_dispatch_authority() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -86,7 +87,7 @@ async fn default_runtime_uses_persistent_policy_as_dispatch_authority() {
         }
         other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 // Regression: an auth-resume (BlockedAuth → credential supplied → resume) for a
@@ -102,7 +103,7 @@ async fn default_runtime_uses_persistent_policy_as_dispatch_authority() {
 #[tokio::test]
 async fn default_runtime_uses_persistent_policy_as_auth_resume_authority() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -183,7 +184,7 @@ async fn default_runtime_uses_persistent_policy_as_auth_resume_authority() {
             other
         ),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 
     let resumed = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(
@@ -196,7 +197,7 @@ async fn default_runtime_uses_persistent_policy_as_auth_resume_authority() {
 #[tokio::test]
 async fn default_runtime_uses_user_grantee_persistent_policy_as_dispatch_authority() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -253,13 +254,13 @@ async fn default_runtime_uses_user_grantee_persistent_policy_as_dispatch_authori
         }
         other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 #[tokio::test]
 async fn default_runtime_uses_threadless_filesystem_policy_after_thread_change() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -328,13 +329,13 @@ async fn default_runtime_uses_threadless_filesystem_policy_after_thread_change()
         }
         other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 #[tokio::test]
 async fn default_runtime_does_not_replay_tenant_grantee_persistent_policy() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -391,13 +392,13 @@ async fn default_runtime_does_not_replay_tenant_grantee_persistent_policy() {
         }
         other => panic!("expected authorization failure, got {:?}", other),
     }
-    assert!(!dispatcher.has_request());
+    assert_eq!(dispatcher.call_count(), 0);
 }
 
 #[tokio::test]
 async fn default_runtime_skips_unusable_persistent_policy_for_later_match() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -474,13 +475,13 @@ async fn default_runtime_skips_unusable_persistent_policy_for_later_match() {
         }
         other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 #[tokio::test]
 async fn default_runtime_falls_back_when_persistent_policy_lookup_fails() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -517,13 +518,13 @@ async fn default_runtime_falls_back_when_persistent_policy_lookup_fails() {
         }
         other => panic!("expected authorization failure, got {:?}", other),
     }
-    assert!(!dispatcher.has_request());
+    assert_eq!(dispatcher.call_count(), 0);
 }
 
 #[tokio::test]
 async fn default_runtime_reuses_persistent_policy_for_manifest_ask() {
     let registry = Arc::new(registry_with_echo_capability_permission("ask"));
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -580,13 +581,13 @@ async fn default_runtime_reuses_persistent_policy_for_manifest_ask() {
         }
         other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 #[tokio::test]
 async fn default_runtime_skips_expired_persistent_policy() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -643,7 +644,7 @@ async fn default_runtime_skips_expired_persistent_policy() {
         }
         other => panic!("expected authorization failure, got {:?}", other),
     }
-    assert!(!dispatcher.has_request());
+    assert_eq!(dispatcher.call_count(), 0);
 }
 
 #[tokio::test]
@@ -652,7 +653,7 @@ async fn default_runtime_uses_persistent_policy_for_no_project_no_thread_scope()
     // (tenant, user, agent) persistent approval scope: the lookup proceeds and a
     // seeded "always allow" policy authorizes dispatch without a gate.
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -714,13 +715,13 @@ async fn default_runtime_uses_persistent_policy_for_no_project_no_thread_scope()
         }
         other => panic!("expected Completed outcome, got {:?}", other),
     }
-    assert!(dispatcher.has_request());
+    assert!(dispatcher.call_count() > 0);
 }
 
 #[tokio::test]
 async fn default_runtime_uses_persistent_policy_as_spawn_capability_authority() {
     let registry = Arc::new(registry_with_echo_capability());
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let run_state = Arc::new(ironclaw_run_state::in_memory_backed_run_state_store());
     let approval_requests = Arc::new(ironclaw_run_state::in_memory_backed_approval_request_store());
@@ -791,45 +792,21 @@ fn local_test_runtime_policy() -> ironclaw_host_api::runtime_policy::EffectiveRu
     .unwrap()
 }
 
-#[derive(Default)]
-struct RecordingDispatcher {
-    request: Mutex<Option<CapabilityDispatchRequest>>,
-}
-
-impl RecordingDispatcher {
-    fn has_request(&self) -> bool {
-        self.request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .is_some()
-    }
-}
-
-#[async_trait]
-impl CapabilityDispatcher for RecordingDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        *self
-            .request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(request.clone());
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: extension_id(),
-            runtime: RuntimeKind::Wasm,
-            output: json!({"ok": true}),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: ResourceReservationId::new(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
+fn dispatch_result() -> CapabilityDispatchResult {
+    CapabilityDispatchResult {
+        capability_id: capability_id(),
+        provider: extension_id(),
+        runtime: RuntimeKind::Wasm,
+        output: json!({"ok": true}),
+        display_preview: None,
+        usage: ResourceUsage::default(),
+        receipt: ResourceReceipt {
+            id: ResourceReservationId::new(),
+            scope: ResourceScope::system(),
+            status: ReservationStatus::Reconciled,
+            estimate: ResourceEstimate::default(),
+            actual: Some(ResourceUsage::default()),
+        },
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -24,11 +24,11 @@ use ironclaw_events::{
     InMemoryEventSink, ReadScope, RuntimeEventKind,
 };
 use ironclaw_extensions::ExtensionRegistry;
-use ironclaw_filesystem::{DiskFilesystem, FilesystemOperation};
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::RootFilesystem;
+use ironclaw_filesystem::{DiskFilesystem, FilesystemOperation};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     BuiltinObligationServices, CancelReason, CancelRuntimeWorkRequest, CapabilitySurfaceVersion,

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -190,6 +190,12 @@ impl NetworkHttpEgress for RecordingNetwork {
     }
 }
 
+// KEPT (not `TestDispatcher`): this double does real work inside `dispatch_json`
+// that a `TestDispatcher` responder cannot express — it awaits `egress.execute`
+// with the staged credential injection, releases the resource reservation via the
+// governor, and records whether the staged handoffs were present. A `responding`
+// closure is synchronous and cannot `.await`; `ok`/`scripted` only return canned
+// values.
 struct ObligationAwareDispatcher {
     egress: Arc<dyn RuntimeHttpEgress>,
     resource_governor: Arc<InMemoryResourceGovernor>,

--- a/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
@@ -2,11 +2,11 @@ mod support;
 
 use support::legacy_capability_fixture_to_v2;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use async_trait::async_trait;
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
+use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime, RuntimeCapabilityOutcome,
@@ -35,7 +35,7 @@ fn local_test_runtime_policy() -> ironclaw_host_api::runtime_policy::EffectiveRu
 #[tokio::test]
 async fn production_runtime_uses_host_policy_decision_instead_of_request_claims() {
     let registry = Arc::new(registry_with_manifest(LOCAL_INSTALLED_MANIFEST));
-    let dispatcher = Arc::new(CountingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let runtime = DefaultHostRuntime::new(
         Arc::clone(&registry),
@@ -63,7 +63,7 @@ async fn production_runtime_uses_host_policy_decision_instead_of_request_claims(
         other => panic!("expected Completed outcome, got {other:?}"),
     }
     assert_eq!(
-        dispatcher.count(),
+        dispatcher.call_count(),
         1,
         "host-owned trust policy should supply the effective decision before authorization"
     );
@@ -72,7 +72,7 @@ async fn production_runtime_uses_host_policy_decision_instead_of_request_claims(
 #[tokio::test]
 async fn trust_downgrade_denies_future_invocation_before_dispatch_side_effects() {
     let registry = Arc::new(registry_with_manifest(LOCAL_INSTALLED_MANIFEST));
-    let dispatcher = Arc::new(CountingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
     let policy = Arc::new(privileged_local_manifest_policy());
     let runtime = DefaultHostRuntime::new(
@@ -96,7 +96,7 @@ async fn trust_downgrade_denies_future_invocation_before_dispatch_side_effects()
         matches!(first_outcome, RuntimeCapabilityOutcome::Completed(_)),
         "first invocation should use the host policy's privileged decision"
     );
-    assert_eq!(dispatcher.count(), 1);
+    assert_eq!(dispatcher.call_count(), 1);
 
     policy
         .mutate_with(
@@ -124,7 +124,7 @@ async fn trust_downgrade_denies_future_invocation_before_dispatch_side_effects()
 
     assert_authorization_failed(second_outcome);
     assert_eq!(
-        dispatcher.count(),
+        dispatcher.call_count(),
         1,
         "downgraded trust must fail closed before any second dispatch side effect"
     );
@@ -140,45 +140,21 @@ fn assert_authorization_failed(outcome: RuntimeCapabilityOutcome) {
     }
 }
 
-#[derive(Default)]
-struct CountingDispatcher {
-    count: Mutex<usize>,
-}
-
-impl CountingDispatcher {
-    fn count(&self) -> usize {
-        *self
-            .count
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-}
-
-#[async_trait]
-impl CapabilityDispatcher for CountingDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        *self
-            .count
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) += 1;
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: extension_id(),
-            runtime: RuntimeKind::Wasm,
-            output: json!({"ok": true}),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: ResourceReservationId::new(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
+fn dispatch_result() -> CapabilityDispatchResult {
+    CapabilityDispatchResult {
+        capability_id: capability_id(),
+        provider: extension_id(),
+        runtime: RuntimeKind::Wasm,
+        output: json!({"ok": true}),
+        display_preview: None,
+        usage: ResourceUsage::default(),
+        receipt: ResourceReceipt {
+            id: ResourceReservationId::new(),
+            scope: ResourceScope::system(),
+            status: ReservationStatus::Reconciled,
+            estimate: ResourceEstimate::default(),
+            actual: Some(ResourceUsage::default()),
+        },
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -32,6 +32,7 @@ use ironclaw_filesystem::{
     DiskFilesystem, Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, RootFilesystem,
     ScopedFilesystem,
 };
+use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     BuiltinObligationHandler, BuiltinObligationServices, CapabilitySurfaceVersion,
@@ -1003,7 +1004,7 @@ pub(crate) async fn stage_process_handoffs(
 
 pub(crate) struct SpawnObligationFixture {
     pub(crate) registry: Arc<ExtensionRegistry>,
-    pub(crate) dispatcher: Arc<NoopDispatcher>,
+    pub(crate) dispatcher: Arc<TestDispatcher>,
     pub(crate) authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
     pub(crate) handler: Arc<BuiltinObligationHandler>,
     pub(crate) process_manager: Arc<BackgroundProcessManager>,
@@ -1082,7 +1083,9 @@ where
     R: ProcessResultStore + 'static,
 {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
-    let dispatcher = Arc::new(NoopDispatcher);
+    let dispatcher = Arc::new(TestDispatcher::responding(|_, _| {
+        panic!("spawn tests must not invoke the foreground dispatcher")
+    }));
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let secret_store = Arc::new(FilesystemSecretStore::ephemeral());
     let obligation_services = BuiltinObligationServices::new(
@@ -1294,11 +1297,13 @@ pub(crate) fn secret_store_failing_reads() -> (
     Arc<FilesystemSecretStore<FaultInjecting<InMemoryBackend>>>,
     Arc<FaultInjecting<InMemoryBackend>>,
 ) {
-    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
-        Fault::on(FilesystemOperation::ReadFile)
-            .path("secrets")
-            .backend("injected secret read failure"),
-    ));
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("secrets")
+                .backend("injected secret read failure"),
+        ),
+    );
     let store = Arc::new(FilesystemSecretStore::ephemeral_over(backend.clone()));
     (store, backend)
 }
@@ -1397,18 +1402,6 @@ impl ironclaw_processes::ProcessManager for FailingSpawnManager {
         Err(ProcessError::InvalidStoredRecord {
             reason: "start failed".to_string(),
         })
-    }
-}
-
-pub(crate) struct NoopDispatcher;
-
-#[async_trait]
-impl CapabilityDispatcher for NoopDispatcher {
-    async fn dispatch_json(
-        &self,
-        _request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        panic!("spawn tests must not invoke the foreground dispatcher")
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -6,7 +6,7 @@ use support::legacy_capability_fixture_to_v2_with_schema_suffix as legacy_capabi
 use std::{
     collections::BTreeMap,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
@@ -22,6 +22,7 @@ use ironclaw_filesystem::{
     DirEntry, DiskFilesystem, FileStat, FileType, FilesystemError, FilesystemOperation,
     RootFilesystem,
 };
+use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HTTP_CAPABILITY_ID,
@@ -1037,7 +1038,7 @@ async fn visible_surface_marks_askable_capabilities_without_granting_authority()
 
 #[tokio::test]
 async fn hidden_capability_direct_invoke_still_fails_closed_through_authorization() {
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let runtime = DefaultHostRuntime::new(
         Arc::new(registry_from_manifests([(
             ECHO_MANIFEST,
@@ -1077,7 +1078,7 @@ async fn hidden_capability_direct_invoke_still_fails_closed_through_authorizatio
         }
         other => panic!("expected authorization failure, got {other:?}"),
     }
-    assert!(!dispatcher.has_request());
+    assert!(dispatcher.call_count() == 0);
 }
 
 #[tokio::test]
@@ -1542,7 +1543,7 @@ async fn visible_surface_hides_secret_when_policy_denies_secrets() {
 
 #[tokio::test]
 async fn runtime_policy_denied_extension_invoke_does_not_dispatch() {
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let dispatcher_for_runtime: Arc<dyn CapabilityDispatcher> = dispatcher.clone();
     let runtime = runtime_with_dispatcher(
         registry_from_manifests([(ECHO_NETWORK_MANIFEST, "/system/extensions/echo")]),
@@ -1582,14 +1583,14 @@ async fn runtime_policy_denied_extension_invoke_does_not_dispatch() {
             .contains("NetworkMode::Deny")
     );
     assert!(
-        !dispatcher.has_request(),
+        dispatcher.call_count() == 0,
         "runtime-policy denial must happen before generic extension dispatch"
     );
 }
 
 #[tokio::test]
 async fn runtime_policy_denied_secret_invoke_does_not_dispatch() {
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let dispatcher_for_runtime: Arc<dyn CapabilityDispatcher> = dispatcher.clone();
     let runtime = runtime_with_dispatcher(
         registry_from_manifests([(SECRET_MANIFEST, "/system/extensions/secret-tool")]),
@@ -1626,14 +1627,14 @@ async fn runtime_policy_denied_secret_invoke_does_not_dispatch() {
             .contains("SecretMode::Deny")
     );
     assert!(
-        !dispatcher.has_request(),
+        dispatcher.call_count() == 0,
         "runtime-policy secret denial must happen before generic extension dispatch"
     );
 }
 
 #[tokio::test]
 async fn runtime_policy_denied_mcp_http_invoke_does_not_dispatch_when_effect_underdeclared() {
-    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
     let dispatcher_for_runtime: Arc<dyn CapabilityDispatcher> = dispatcher.clone();
     let runtime = runtime_with_dispatcher(
         registry_from_manifests([(MCP_UNDERDECLARED_NETWORK_MANIFEST, "/system/extensions/mcp")]),
@@ -1673,7 +1674,7 @@ async fn runtime_policy_denied_mcp_http_invoke_does_not_dispatch_when_effect_und
             .contains("NetworkMode::Deny")
     );
     assert!(
-        !dispatcher.has_request(),
+        dispatcher.call_count() == 0,
         "runtime-policy denial must happen before MCP dispatch"
     );
 }
@@ -1982,7 +1983,7 @@ fn runtime_with(
     runtime_with_dispatcher(
         registry,
         authorizer,
-        Arc::new(RecordingDispatcher::default()),
+        Arc::new(TestDispatcher::ok(dispatch_result())),
     )
 }
 
@@ -2114,45 +2115,21 @@ impl TrustPolicy for PanicTrustPolicy {
     }
 }
 
-#[derive(Default)]
-struct RecordingDispatcher {
-    request: Mutex<Option<CapabilityDispatchRequest>>,
-}
-
-impl RecordingDispatcher {
-    fn has_request(&self) -> bool {
-        self.request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .is_some()
-    }
-}
-
-#[async_trait]
-impl CapabilityDispatcher for RecordingDispatcher {
-    async fn dispatch_json(
-        &self,
-        request: CapabilityDispatchRequest,
-    ) -> Result<CapabilityDispatchResult, DispatchError> {
-        *self
-            .request
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(request.clone());
-        Ok(CapabilityDispatchResult {
-            capability_id: request.capability_id,
-            provider: ExtensionId::new("echo").unwrap(),
-            runtime: RuntimeKind::Wasm,
-            output: json!({"ok": true}),
-            display_preview: None,
-            usage: ResourceUsage::default(),
-            receipt: ResourceReceipt {
-                id: ResourceReservationId::new(),
-                scope: request.scope,
-                status: ReservationStatus::Reconciled,
-                estimate: request.estimate,
-                actual: Some(ResourceUsage::default()),
-            },
-        })
+fn dispatch_result() -> CapabilityDispatchResult {
+    CapabilityDispatchResult {
+        capability_id: capability_id("echo.say"),
+        provider: ExtensionId::new("echo").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        output: json!({"ok": true}),
+        display_preview: None,
+        usage: ResourceUsage::default(),
+        receipt: ResourceReceipt {
+            id: ResourceReservationId::new(),
+            scope: ResourceScope::system(),
+            status: ReservationStatus::Reconciled,
+            estimate: ResourceEstimate::default(),
+            actual: Some(ResourceUsage::default()),
+        },
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/available_extensions.rs
@@ -1808,8 +1808,8 @@ mod tests {
     use async_trait::async_trait;
     use ironclaw_extensions::{ExtensionManifest, ManifestSource};
     use ironclaw_filesystem::{
-        BackendCapabilities, DirEntry, FileStat, FilesystemError, FilesystemOperation,
-        InMemoryBackend,
+        BackendCapabilities, DirEntry, Fault, FaultInjecting, FileStat, FilesystemError,
+        FilesystemOperation, InMemoryBackend,
     };
     use ironclaw_host_api::{
         EffectKind, HostPortCatalog, PermissionMode, RuntimeCredentialAccountSetup,
@@ -2867,7 +2867,15 @@ handle = "web_token"
 
     #[tokio::test]
     async fn materialize_fails_on_filesystem_error_and_rolls_back_written_assets() {
-        let fs = FailingWriteFilesystem::default();
+        // The wasm write is faulted at the backend; the real materialize path
+        // then rolls back the manifest write it already committed. `recorded_*`
+        // proves the true op stream (writes include the faulted wasm write; the
+        // rollback deletes the one prior committed asset).
+        let fs = FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("fixture.wasm")
+                .backend("write rejected"),
+        );
         let extension = test_extension_package();
 
         let error = materialize_available_extension(&fs, &extension)
@@ -2875,16 +2883,25 @@ handle = "web_token"
             .expect_err("second write fails");
 
         assert!(matches!(error, ProductWorkflowError::Transient { .. }));
-        let state = fs.state.lock().unwrap();
+        let writes = fs
+            .recorded_paths(FilesystemOperation::WriteFile)
+            .iter()
+            .map(|path| path.as_str().to_string())
+            .collect::<Vec<_>>();
         assert_eq!(
-            state.writes,
+            writes,
             vec![
                 "/system/extensions/fixture/manifest.toml".to_string(),
                 "/system/extensions/fixture/wasm/fixture.wasm".to_string()
             ]
         );
+        let deletes = fs
+            .recorded_paths(FilesystemOperation::Delete)
+            .iter()
+            .map(|path| path.as_str().to_string())
+            .collect::<Vec<_>>();
         assert_eq!(
-            state.deletes,
+            deletes,
             vec!["/system/extensions/fixture/manifest.toml".to_string()]
         );
     }
@@ -2985,17 +3002,6 @@ credential_handle = "channel_ext_token"
     }
 
     #[derive(Default)]
-    struct FailingWriteFilesystem {
-        state: Arc<Mutex<FailingWriteState>>,
-    }
-
-    #[derive(Default)]
-    struct FailingWriteState {
-        writes: Vec<String>,
-        deletes: Vec<String>,
-    }
-
-    #[derive(Default)]
     struct RecordingMaterializeFilesystem {
         files: Arc<Mutex<HashMap<String, Vec<u8>>>>,
         writes: Arc<Mutex<Vec<String>>>,
@@ -3053,56 +3059,6 @@ credential_handle = "channel_ext_token"
                 .lock()
                 .unwrap()
                 .insert(path.as_str().to_string(), bytes.to_vec());
-            Ok(())
-        }
-    }
-
-    #[async_trait]
-    impl RootFilesystem for FailingWriteFilesystem {
-        fn capabilities(&self) -> BackendCapabilities {
-            BackendCapabilities::default()
-        }
-
-        async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-            Err(FilesystemError::Unsupported {
-                path: path.clone(),
-                operation: FilesystemOperation::ListDir,
-            })
-        }
-
-        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-            Err(FilesystemError::NotFound {
-                path: path.clone(),
-                operation: FilesystemOperation::Stat,
-            })
-        }
-
-        async fn write_file(
-            &self,
-            path: &VirtualPath,
-            _bytes: &[u8],
-        ) -> Result<(), FilesystemError> {
-            self.state
-                .lock()
-                .unwrap()
-                .writes
-                .push(path.as_str().to_string());
-            if path.as_str().ends_with("fixture.wasm") {
-                return Err(FilesystemError::Backend {
-                    path: path.clone(),
-                    operation: FilesystemOperation::WriteFile,
-                    reason: "write rejected".to_string(),
-                });
-            }
-            Ok(())
-        }
-
-        async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-            self.state
-                .lock()
-                .unwrap()
-                .deletes
-                .push(path.as_str().to_string());
             Ok(())
         }
     }

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_installation_store/tests.rs
@@ -8,8 +8,7 @@ use ironclaw_extensions::{
     ExtensionManifestRef, InstallationOwner, MANIFEST_SCHEMA_VERSION,
 };
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemOperation,
-    InMemoryBackend, RecordVersion, RootFilesystem, VersionedEntry,
+    Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, RootFilesystem,
 };
 use ironclaw_host_api::{HostPortCatalog, SecretHandle};
 
@@ -58,7 +57,10 @@ async fn load_at_treats_not_found_as_empty_state() {
 
 #[tokio::test]
 async fn load_at_sanitizes_filesystem_read_errors() {
-    let filesystem: Arc<dyn RootFilesystem> = Arc::new(ReadFailureFilesystem::new());
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(
+        FaultInjecting::new(InMemoryBackend::new())
+            .with_fault(Fault::on(FilesystemOperation::ReadFile).backend("raw backend detail")),
+    );
     let state_path = VirtualPath::new("/tenants/acme/system/extensions/.installations/state.json")
         .expect("valid state path");
 
@@ -446,7 +448,7 @@ async fn load_at_rejects_credential_conflicts_without_rewriting_state() {
 
 #[tokio::test]
 async fn load_at_returns_rewrite_failure_without_exposing_normalized_store() {
-    let backend = Arc::new(InMemoryBackend::new());
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
     let seed_filesystem: Arc<dyn RootFilesystem> = backend.clone();
     let state_path = test_state_path();
     let original = seed_state(
@@ -468,9 +470,14 @@ async fn load_at_returns_rewrite_failure_without_exposing_normalized_store() {
         ],
     )
     .await;
-    let failing_filesystem: Arc<dyn RootFilesystem> = Arc::new(WriteFailureFilesystem {
-        inner: backend.clone(),
-    });
+    // Arm the write fault only after seeding, so the store's canonical rewrite
+    // during load fails at the backend and flows through the real store's
+    // `FilesystemError -> ExtensionInstallationError` mapping.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .backend("injected extension installation write failure"),
+    );
+    let failing_filesystem: Arc<dyn RootFilesystem> = backend.clone();
 
     let error =
         match FilesystemExtensionInstallationStore::load_at(failing_filesystem, state_path.clone())
@@ -684,70 +691,9 @@ fn stored_installation_with_bindings(
     .unwrap()
 }
 
-struct FailNextWriteFilesystem {
-    inner: Arc<InMemoryBackend>,
-    fail_next: std::sync::atomic::AtomicBool,
-}
-
-impl FailNextWriteFilesystem {
-    fn new() -> Self {
-        Self {
-            inner: Arc::new(InMemoryBackend::new()),
-            fail_next: std::sync::atomic::AtomicBool::new(false),
-        }
-    }
-
-    fn fail_next_write(&self) {
-        self.fail_next
-            .store(true, std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for FailNextWriteFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        if self
-            .fail_next
-            .swap(false, std::sync::atomic::Ordering::SeqCst)
-        {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::WriteFile,
-                reason: "injected one-shot write failure".to_string(),
-            });
-        }
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
 #[tokio::test]
 async fn failed_snapshot_write_rolls_back_the_in_memory_mutation_so_retry_converges() {
-    let filesystem = Arc::new(FailNextWriteFilesystem::new());
+    let filesystem = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
     let state_path = test_state_path();
     let store = FilesystemExtensionInstallationStore::load_at(
         Arc::clone(&filesystem) as Arc<dyn RootFilesystem>,
@@ -762,7 +708,14 @@ async fn failed_snapshot_write_rolls_back_the_in_memory_mutation_so_retry_conver
         .await
         .expect("seed installation");
 
-    filesystem.fail_next_write();
+    // One-shot: fault the next write (the delete's snapshot rewrite) only; the
+    // retry's write passes through so the delete converges. `nth(1)` on a freshly
+    // added fault fires on the first matching write after arming, then is spent.
+    filesystem.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .nth(1)
+            .backend("injected one-shot write failure"),
+    );
     let error = store
         .delete_installation(&installation_id)
         .await
@@ -802,90 +755,3 @@ async fn failed_snapshot_write_rolls_back_the_in_memory_mutation_so_retry_conver
     );
 }
 
-struct WriteFailureFilesystem {
-    inner: Arc<InMemoryBackend>,
-}
-
-#[async_trait]
-impl RootFilesystem for WriteFailureFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        _entry: Entry,
-        _cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::WriteFile,
-            reason: "injected extension installation write failure".to_string(),
-        })
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
-struct ReadFailureFilesystem {
-    inner: InMemoryBackend,
-}
-
-impl ReadFailureFilesystem {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for ReadFailureFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::ReadFile,
-            reason: "raw backend detail".to_string(),
-        })
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -2657,9 +2657,7 @@ mod tests {
         ExtensionManifest, ExtensionRegistry, InMemoryExtensionInstallationStore,
         SharedExtensionRegistry,
     };
-    use ironclaw_filesystem::{
-        DirEntry, DiskFilesystem, FileStat, FilesystemError, FilesystemOperation,
-    };
+    use ironclaw_filesystem::{DiskFilesystem, Fault, FaultInjecting, FilesystemOperation};
     use ironclaw_host_api::{
         AgentId, CapabilityId, ExtensionLifecycleOperation, HostPath, HostPortCatalog,
         InvocationId, MountAlias, MountGrant, MountPermissions, MountView, NetworkMethod,
@@ -8045,9 +8043,10 @@ output_schema_ref = "schemas/run.output.json"
                 HostPath::from_path_buf(storage_root.join("system/extensions")),
             )
             .expect("mount system extensions");
-        let filesystem: Arc<dyn RootFilesystem> = Arc::new(filesystem);
-        let root_filesystem: Arc<dyn RootFilesystem> =
-            Arc::new(DeleteFailingRootFilesystem { inner: filesystem });
+        let root_filesystem: Arc<dyn RootFilesystem> = Arc::new(
+            FaultInjecting::new(filesystem)
+                .with_fault(Fault::on(FilesystemOperation::Delete).backend("delete failed")),
+        );
         let active_registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
         let trust_policy = test_extension_trust_policy();
         let installation_store = Arc::new(InMemoryExtensionInstallationStore::default());
@@ -8320,45 +8319,6 @@ output_schema_ref = "schemas/run.output.json"
             .expect("read fixture installation")
             .expect("fixture installation remains")
             .activation_state()
-    }
-
-    struct DeleteFailingRootFilesystem {
-        inner: Arc<dyn RootFilesystem>,
-    }
-
-    #[async_trait]
-    impl RootFilesystem for DeleteFailingRootFilesystem {
-        fn capabilities(&self) -> ironclaw_filesystem::BackendCapabilities {
-            self.inner.capabilities()
-        }
-
-        async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-            self.inner.list_dir(path).await
-        }
-
-        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-            self.inner.stat(path).await
-        }
-
-        async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-            self.inner.read_file(path).await
-        }
-
-        async fn write_file(
-            &self,
-            path: &VirtualPath,
-            bytes: &[u8],
-        ) -> Result<(), FilesystemError> {
-            self.inner.write_file(path, bytes).await
-        }
-
-        async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-            Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::Delete,
-                reason: "delete failed".to_string(),
-            })
-        }
     }
 
     async fn assert_enabled_active_extension_state<S>(

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -5602,10 +5602,8 @@ mod tests {
     };
     use ironclaw_authorization::{CapabilityLeaseStatus, CapabilityLeaseStore, GrantAuthorizer};
     use ironclaw_filesystem::FilesystemError;
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
-    use ironclaw_filesystem::{
-        DirEntry, FileStat, FilesystemOperation, RootFilesystem, VersionedEntry,
-    };
+    #[cfg(feature = "libsql")]
+    use ironclaw_filesystem::RootFilesystem;
     use ironclaw_host_api::{
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
         ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias, MountGrant,
@@ -5835,32 +5833,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
-    struct FailingConversationStateFilesystem;
-
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
-    #[async_trait::async_trait]
-    impl RootFilesystem for FailingConversationStateFilesystem {
-        async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-            Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "conversation state load failed".to_string(),
-            })
-        }
-
-        async fn list_dir(&self, _path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-            Ok(Vec::new())
-        }
-
-        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-            Err(FilesystemError::NotFound {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-            })
-        }
-    }
-
     /// Per-trigger delivery targets validate against the SAME registry the
     /// outbound target surface publishes from: an id a provider resolves for
     /// the caller is accepted; an unknown id (or an empty registry) fails
@@ -6017,7 +5989,17 @@ mod tests {
                     BackendCapabilities::default(),
                 )
                 .expect("mount descriptor"),
-                Arc::new(FailingConversationStateFilesystem),
+                Arc::new(
+                    ironclaw_filesystem::FaultInjecting::new(
+                        ironclaw_filesystem::InMemoryBackend::new(),
+                    )
+                    .with_fault(
+                        ironclaw_filesystem::Fault::on(
+                            ironclaw_filesystem::FilesystemOperation::ReadFile,
+                        )
+                        .backend("conversation state load failed"),
+                    ),
+                ),
             )
             .expect("mount failing backend");
         Arc::new(RebornRuntimeSubstrate {

--- a/crates/ironclaw_reborn_event_store/tests/coalescing_sink_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/coalescing_sink_contract.rs
@@ -43,6 +43,16 @@ fn scope_for(user: &str, project: &str) -> ResourceScope {
 /// partial-failure result vector: the first event succeeds (committed to the
 /// inner log) and the remaining events fail with an injected error. This lets
 /// tests verify that `flush()` propagates a per-event rejection as `Err`.
+//
+// domain-state fake, not an I/O fault — cannot move to
+// ironclaw_filesystem::FaultInjecting. This is a double for the log dependency
+// while the *sink* (`CoalescingEventSink`) is under test, and its assertions
+// observe the sink->log call shape *above* the store: it distinguishes single
+// `append` from `append_batch`, records each batch's size (`batch_sizes`), and
+// returns a partial-failure results vector (`[Ok, Err, ..]`). FaultInjecting
+// records only one `Append` op per call (no single-vs-batch distinction, no
+// size) and faults whole ops, so the real `FilesystemDurableEventLog` over it
+// could reproduce none of those observations without dropping coverage.
 struct CountingEventLog {
     inner: InMemoryDurableEventLog,
     append_calls: AtomicUsize,

--- a/crates/ironclaw_skills/Cargo.toml
+++ b/crates/ironclaw_skills/Cargo.toml
@@ -46,5 +46,7 @@ urlencoding = { version = "2", optional = true }
 tempfile = { version = "3", optional = true }
 
 [dev-dependencies]
+# FaultInjecting decorator: test store fault paths through the real store.
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{
-    BackendCapabilities, DirEntry, FileStat, FilesystemError, FilesystemOperation, InMemoryBackend,
-    RootFilesystem,
+    BackendCapabilities, DirEntry, Fault, FaultInjecting, FileStat, FilesystemError,
+    FilesystemOperation, InMemoryBackend, RootFilesystem,
 };
 use ironclaw_host_api::{
     MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, ScopedPath, VirtualPath,
@@ -394,13 +394,18 @@ async fn install_rejects_invalid_bundle_files() {
 
 #[tokio::test]
 async fn install_bundle_failure_cleans_up_partial_directory() {
-    let inner = Arc::new(InMemoryBackend::default());
-    let filesystem = Arc::new(FailingBundleWriteFilesystem {
-        inner: inner.clone(),
-        fail_suffix: "/scripts/run.py",
-        fail_delete: false,
-    });
-    let context = skill_management_context_with_root(filesystem, skill_mounts());
+    // The real byte-write path faulted at the backend seam via the shared
+    // `FaultInjecting` decorator: the `scripts/run.py` bundle write (routed
+    // through the entry-plane `put`) surfaces `FilesystemError::Backend`
+    // (→ `InvalidSkill`), triggering the partial-directory cleanup.
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::default()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("scripts/run.py")
+                .backend("injected bundle write failure"),
+        ),
+    );
+    let context = skill_management_context_with_root(backend.clone(), skill_mounts());
 
     let error = install_skill(
         &context,
@@ -425,9 +430,9 @@ async fn install_bundle_failure_cleans_up_partial_directory() {
     .unwrap_err();
     assert_eq!(error.kind(), SkillManagementErrorKind::InvalidSkill);
 
-    assert_missing(&inner, "/projects/skills/partial-helper/SKILL.md").await;
+    assert_missing(backend.as_ref(), "/projects/skills/partial-helper/SKILL.md").await;
     assert_missing(
-        &inner,
+        backend.as_ref(),
         "/projects/skills/partial-helper/references/guide.md",
     )
     .await;
@@ -463,14 +468,18 @@ async fn install_rejects_preexisting_skill_directory_without_deleting_contents()
 
     assert_eq!(error.kind(), SkillManagementErrorKind::Conflict);
     assert_file_contents(
-        &filesystem,
+        filesystem.as_ref(),
         "/projects/skills/existing-helper/references/guide.md",
         b"# Keep\n",
     )
     .await;
-    assert_missing(&filesystem, "/projects/skills/existing-helper/SKILL.md").await;
     assert_missing(
-        &filesystem,
+        filesystem.as_ref(),
+        "/projects/skills/existing-helper/SKILL.md",
+    )
+    .await;
+    assert_missing(
+        filesystem.as_ref(),
         "/projects/skills/existing-helper/scripts/run.py",
     )
     .await;
@@ -507,7 +516,7 @@ async fn install_serializes_concurrent_same_name_requests() {
     let results = [first, second];
     assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 2);
     assert_file_contents(
-        &filesystem,
+        filesystem.as_ref(),
         "/projects/skills/shared-helper/SKILL.md",
         content.as_bytes(),
     )
@@ -516,13 +525,18 @@ async fn install_serializes_concurrent_same_name_requests() {
 
 #[tokio::test]
 async fn install_metadata_write_failure_cleans_up_partial_directory() {
-    let inner = Arc::new(InMemoryBackend::default());
-    let filesystem = Arc::new(FailingBundleWriteFilesystem {
-        inner: inner.clone(),
-        fail_suffix: "/.ironclaw-install.json",
-        fail_delete: false,
-    });
-    let context = skill_management_context_with_root(filesystem, skill_mounts());
+    // The install-metadata write (`.ironclaw-install.json`) faulted at the
+    // backend seam via `FaultInjecting`: the entry-plane `put` for that path
+    // surfaces `FilesystemError::Backend` (→ `InvalidSkill`), triggering the
+    // partial-directory cleanup after the earlier bundle file already landed.
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::default()).with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path(".ironclaw-install.json")
+                .backend("injected bundle write failure"),
+        ),
+    );
+    let context = skill_management_context_with_root(backend.clone(), skill_mounts());
 
     let error = install_skill(
         &context,
@@ -541,9 +555,9 @@ async fn install_metadata_write_failure_cleans_up_partial_directory() {
     .unwrap_err();
     assert_eq!(error.kind(), SkillManagementErrorKind::InvalidSkill);
 
-    assert_missing(&inner, "/projects/skills/metadata-helper/SKILL.md").await;
+    assert_missing(backend.as_ref(), "/projects/skills/metadata-helper/SKILL.md").await;
     assert_missing(
-        &inner,
+        backend.as_ref(),
         "/projects/skills/metadata-helper/references/guide.md",
     )
     .await;
@@ -552,10 +566,8 @@ async fn install_metadata_write_failure_cleans_up_partial_directory() {
 #[tokio::test]
 async fn install_cleanup_failure_is_reported() {
     let inner = Arc::new(InMemoryBackend::default());
-    let filesystem = Arc::new(FailingBundleWriteFilesystem {
+    let filesystem = Arc::new(CleanupDeleteDenyingFilesystem {
         inner: inner.clone(),
-        fail_suffix: "/scripts/run.py",
-        fail_delete: true,
     });
     let context = skill_management_context_with_root(filesystem, skill_mounts());
 
@@ -583,7 +595,7 @@ async fn install_cleanup_failure_is_reported() {
 
     assert_eq!(error.kind(), SkillManagementErrorKind::FilesystemDenied);
     assert_file_contents(
-        &inner,
+        inner.as_ref(),
         "/projects/skills/cleanup-helper/references/guide.md",
         b"# Guide\n",
     )
@@ -734,8 +746,14 @@ async fn search_skills_returns_bounded_matches_with_truncation() {
 
 #[tokio::test]
 async fn search_skills_propagates_filesystem_error() {
-    let context =
-        skill_management_context_with_root(Arc::new(FailingListFilesystem), skill_mounts());
+    // The directory listing faulted at the backend seam via `FaultInjecting`:
+    // `list_dir_bounded` routes through the entry-plane `list_dir`, which
+    // surfaces `FilesystemError::Backend` (→ `InvalidSkill`).
+    let backend = Arc::new(
+        FaultInjecting::new(InMemoryBackend::default())
+            .with_fault(Fault::on(FilesystemOperation::ListDir).backend("injected list failure")),
+    );
+    let context = skill_management_context_with_root(backend, skill_mounts());
 
     let error = search_skills(
         &context,
@@ -933,13 +951,13 @@ async fn skill_management_root_filesystem_delete_if_version_delegates_to_inner_b
     assert!(inner.get(&path).await.unwrap().is_none());
 }
 
-async fn write_file(root: &InMemoryBackend, path: &str, body: String) {
+async fn write_file<R: RootFilesystem + ?Sized>(root: &R, path: &str, body: String) {
     root.write_file(&VirtualPath::new(path).unwrap(), body.as_bytes())
         .await
         .unwrap();
 }
 
-async fn read_file(root: &InMemoryBackend, path: &str) -> String {
+async fn read_file<R: RootFilesystem + ?Sized>(root: &R, path: &str) -> String {
     let bytes = root
         .read_file_bounded(
             &VirtualPath::new(path).unwrap(),
@@ -951,7 +969,7 @@ async fn read_file(root: &InMemoryBackend, path: &str) -> String {
     String::from_utf8(bytes).unwrap()
 }
 
-async fn assert_missing(root: &InMemoryBackend, path: &str) {
+async fn assert_missing<R: RootFilesystem + ?Sized>(root: &R, path: &str) {
     match root
         .read_file_bounded(&VirtualPath::new(path).unwrap(), 1024)
         .await
@@ -962,7 +980,7 @@ async fn assert_missing(root: &InMemoryBackend, path: &str) {
     }
 }
 
-async fn assert_file_contents(root: &InMemoryBackend, path: &str, expected: &[u8]) {
+async fn assert_file_contents<R: RootFilesystem + ?Sized>(root: &R, path: &str, expected: &[u8]) {
     let bytes = root
         .read_file_bounded(&VirtualPath::new(path).unwrap(), 1024)
         .await
@@ -971,15 +989,22 @@ async fn assert_file_contents(root: &InMemoryBackend, path: &str, expected: &[u8
     assert_eq!(bytes, expected);
 }
 
+/// KEPT (not folded into `ironclaw_filesystem::FaultInjecting`):
+/// `install_cleanup_failure_is_reported` needs the cleanup `delete` to fail
+/// with `FilesystemError::PermissionDenied` (→ `FilesystemDenied`).
+/// `FaultInjecting` can only inject `Backend`/`BackendBusy`/`NotFound`/
+/// `Unsupported` errors, so it cannot reproduce the specific
+/// `PermissionDenied → FilesystemDenied` mapping this test pins. Faults the
+/// `/scripts/run.py` bundle write (to trigger the cleanup path) and denies the
+/// subsequent cleanup `delete` with `PermissionDenied`; every other op
+/// delegates to the real `InMemoryBackend`.
 #[derive(Clone)]
-struct FailingBundleWriteFilesystem {
+struct CleanupDeleteDenyingFilesystem {
     inner: Arc<InMemoryBackend>,
-    fail_suffix: &'static str,
-    fail_delete: bool,
 }
 
 #[async_trait]
-impl RootFilesystem for FailingBundleWriteFilesystem {
+impl RootFilesystem for CleanupDeleteDenyingFilesystem {
     fn capabilities(&self) -> BackendCapabilities {
         self.inner.capabilities()
     }
@@ -1001,7 +1026,7 @@ impl RootFilesystem for FailingBundleWriteFilesystem {
     }
 
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        if path.as_str().ends_with(self.fail_suffix) {
+        if path.as_str().ends_with("/scripts/run.py") {
             return Err(FilesystemError::Backend {
                 operation: FilesystemOperation::WriteFile,
                 path: path.clone(),
@@ -1016,46 +1041,9 @@ impl RootFilesystem for FailingBundleWriteFilesystem {
     }
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        if self.fail_delete {
-            return Err(FilesystemError::PermissionDenied {
-                path: ScopedPath::new(path.as_str().to_string()).unwrap(),
-                operation: FilesystemOperation::Delete,
-            });
-        }
-        self.inner.delete(path).await
-    }
-}
-
-#[derive(Clone)]
-struct FailingListFilesystem;
-
-#[async_trait]
-impl RootFilesystem for FailingListFilesystem {
-    fn capabilities(&self) -> BackendCapabilities {
-        BackendCapabilities::default()
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        Err(FilesystemError::Backend {
-            operation: FilesystemOperation::ListDir,
-            path: path.clone(),
-            reason: "injected list failure".to_string(),
-        })
-    }
-
-    async fn list_dir_bounded(
-        &self,
-        path: &VirtualPath,
-        _max_entries: usize,
-    ) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.list_dir(path).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        Err(FilesystemError::Backend {
-            operation: FilesystemOperation::Stat,
-            path: path.clone(),
-            reason: "injected stat failure".to_string(),
+        Err(FilesystemError::PermissionDenied {
+            path: ScopedPath::new(path.as_str().to_string()).unwrap(),
+            operation: FilesystemOperation::Delete,
         })
     }
 }

--- a/crates/ironclaw_threads/Cargo.toml
+++ b/crates/ironclaw_threads/Cargo.toml
@@ -37,5 +37,7 @@ test-support = []
 
 [dev-dependencies]
 ironclaw_threads = { path = ".", features = ["test-support"] }
+# FaultInjecting decorator: test store fault paths through the real store
+ironclaw_filesystem = { path = "../ironclaw_filesystem", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -12,15 +12,15 @@ use std::{
     collections::HashMap,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, FileStat,
-    FilesystemError, FilesystemOperation, Filter, InMemoryBackend, Page, RecordVersion,
+    BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, Fault, FaultInjecting,
+    FileStat, FilesystemError, FilesystemOperation, Filter, InMemoryBackend, Page, RecordVersion,
     RootFilesystem, ScopedFilesystem, SeqNo, StorageTxn, TxnCapability, VersionedEntry,
 };
 use ironclaw_host_api::{
@@ -1055,7 +1055,7 @@ async fn filesystem_redacts_append_only_finalized_assistant_message() {
 
 #[tokio::test]
 async fn filesystem_lookup_index_write_failure_does_not_fail_message_contract() {
-    let backend = Arc::new(LookupIndexWriteFailureBackend::new());
+    let backend = Arc::new(lookup_index_write_failure_backend());
     let scoped = scoped_threads_fs_at(backend, "tenant-lookup-index-failure", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("lookup-index-failure");
@@ -1105,7 +1105,7 @@ async fn filesystem_lookup_index_write_failure_does_not_fail_message_contract() 
 
 #[tokio::test]
 async fn filesystem_lookup_index_read_failure_falls_back_to_transcript_scan() {
-    let backend = Arc::new(LookupIndexReadFailureBackend::new());
+    let backend = Arc::new(lookup_index_read_failure_backend());
     let scoped = scoped_threads_fs_at(backend, "tenant-lookup-index-read-failure", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("lookup-index-read-failure");
@@ -2270,7 +2270,7 @@ async fn filesystem_list_threads_does_not_treat_partial_source_cache_as_complete
 async fn filesystem_list_threads_retries_bootstrap_after_source_read_error() {
     use ironclaw_threads::ListThreadsForScopeRequest;
 
-    let backend = Arc::new(FailOnceThreadRecordReadBackend::new("legacy-flaky-read"));
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
     let scoped = scoped_threads_fs_at(
         Arc::clone(&backend),
         "tenant-index-bootstrap-retry",
@@ -2299,7 +2299,16 @@ async fn filesystem_list_threads_retries_bootstrap_after_source_read_error() {
         )
         .await
         .expect("test setup removes one derived index row");
-    backend.fail_next_thread_record_read();
+    // Arm the fault mid-test through the shared `Arc`: `.nth(1)` counts only
+    // matching reads that occur AFTER `add_fault`, so the first `thread.json`
+    // read for `legacy-flaky-read` during the following list fails exactly
+    // once — the same one-shot semantics the old `fail_next_read` flag had.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::ReadFile)
+            .path("/threads/legacy-flaky-read/thread.json")
+            .nth(1)
+            .backend("thread record reads disabled once by contract test"),
+    );
     service.clear_thread_index_cache_for_scope(&scope);
 
     let first = service
@@ -3128,33 +3137,41 @@ where
     Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts))
 }
 
-struct LookupIndexWriteFailureBackend {
-    inner: InMemoryBackend,
+/// Real thread store backend that fails every write to a message lookup-index
+/// row (`/indexes/assistant-runs/…`, `/indexes/tool-results/…`) so the store
+/// runs its genuine "lookup-index backfill is best-effort, fall back to a
+/// transcript scan" path. Folds the former hand-rolled
+/// `LookupIndexWriteFailureBackend` onto `FaultInjecting` — two path-scoped
+/// `WriteFile` faults, one per lookup-index family.
+fn lookup_index_write_failure_backend() -> FaultInjecting<InMemoryBackend> {
+    FaultInjecting::new(InMemoryBackend::new())
+        .with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("/indexes/assistant-runs/")
+                .backend("lookup index writes disabled by contract test"),
+        )
+        .with_fault(
+            Fault::on(FilesystemOperation::WriteFile)
+                .path("/indexes/tool-results/")
+                .backend("lookup index writes disabled by contract test"),
+        )
 }
 
-impl LookupIndexWriteFailureBackend {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
-
-    fn is_lookup_index_path(path: &VirtualPath) -> bool {
-        path.as_str().contains("/indexes/assistant-runs/")
-            || path.as_str().contains("/indexes/tool-results/")
-    }
-}
-
-struct LookupIndexReadFailureBackend {
-    inner: InMemoryBackend,
-}
-
-impl LookupIndexReadFailureBackend {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
+/// As [`lookup_index_write_failure_backend`], but fails every lookup-index
+/// *read* so the store must fall back to a transcript scan. Folds the former
+/// hand-rolled `LookupIndexReadFailureBackend`.
+fn lookup_index_read_failure_backend() -> FaultInjecting<InMemoryBackend> {
+    FaultInjecting::new(InMemoryBackend::new())
+        .with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/indexes/assistant-runs/")
+                .backend("lookup index reads disabled by contract test"),
+        )
+        .with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/indexes/tool-results/")
+                .backend("lookup index reads disabled by contract test"),
+        )
 }
 
 struct QueryCountingBackend {
@@ -3178,31 +3195,6 @@ impl QueryCountingBackend {
 
     fn get_count(&self) -> usize {
         self.get_count.load(Ordering::SeqCst)
-    }
-}
-
-struct FailOnceThreadRecordReadBackend {
-    inner: InMemoryBackend,
-    thread_id: String,
-    fail_next_read: AtomicBool,
-}
-
-impl FailOnceThreadRecordReadBackend {
-    fn new(thread_id: &str) -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-            thread_id: thread_id.to_string(),
-            fail_next_read: AtomicBool::new(false),
-        }
-    }
-
-    fn fail_next_thread_record_read(&self) {
-        self.fail_next_read.store(true, Ordering::SeqCst);
-    }
-
-    fn is_target_thread_record_path(&self, path: &VirtualPath) -> bool {
-        path.as_str()
-            .contains(&format!("/threads/{}/thread.json", self.thread_id))
     }
 }
 
@@ -3308,102 +3300,6 @@ impl TransactionalRaceTxn {
 }
 
 #[async_trait]
-impl RootFilesystem for LookupIndexWriteFailureBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        if Self::is_lookup_index_path(path) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::WriteFile,
-                reason: "lookup index writes disabled by contract test".to_string(),
-            });
-        }
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for LookupIndexReadFailureBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        if LookupIndexWriteFailureBackend::is_lookup_index_path(path) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "lookup index reads disabled by contract test".to_string(),
-            });
-        }
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
-}
-
-#[async_trait]
 impl RootFilesystem for QueryCountingBackend {
     fn capabilities(&self) -> BackendCapabilities {
         self.inner.capabilities()
@@ -3451,56 +3347,6 @@ impl RootFilesystem for QueryCountingBackend {
 
     async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
         self.inner.reserve_sequence(path).await
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for FailOnceThreadRecordReadBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        if self.is_target_thread_record_path(path)
-            && self.fail_next_read.swap(false, Ordering::SeqCst)
-        {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "thread record reads disabled once by contract test".to_string(),
-            });
-        }
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
     }
 }
 
@@ -4078,79 +3924,25 @@ async fn filesystem_summary_spanning_interior_draft_is_not_applied() {
     assert_eq!(context.messages[1].content, "third");
 }
 
-// Backend that fails only the summary-artifact write, so all prior reads in
-// `create_summary_artifact` succeed and only the final CAS `put` errors —
-// the shape `persist_summary` (ironclaw_loop_host::compaction_task) hits
-// in production (#5838).
-struct SummaryWriteFailureBackend {
-    inner: InMemoryBackend,
-}
-
-impl SummaryWriteFailureBackend {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryBackend::new(),
-        }
-    }
-
-    fn is_summary_path(path: &VirtualPath) -> bool {
-        path.as_str().contains("/summaries/")
-    }
-}
-
-#[async_trait]
-impl RootFilesystem for SummaryWriteFailureBackend {
-    fn capabilities(&self) -> BackendCapabilities {
-        self.inner.capabilities()
-    }
-
-    async fn put(
-        &self,
-        path: &VirtualPath,
-        entry: Entry,
-        cas: CasExpectation,
-    ) -> Result<RecordVersion, FilesystemError> {
-        if Self::is_summary_path(path) {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::WriteFile,
-                reason: "synthetic summary artifact write failure (contract test)".to_string(),
-            });
-        }
-        self.inner.put(path, entry, cas).await
-    }
-
-    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        self.inner.get(path).await
-    }
-
-    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        self.inner.list_dir(path).await
-    }
-
-    async fn query(
-        &self,
-        path: &VirtualPath,
-        filter: &Filter,
-        page: Page,
-    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
-        self.inner.query(path, filter, page).await
-    }
-
-    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        self.inner.stat(path).await
-    }
-
-    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.inner.delete(path).await
-    }
+// Real thread store backend that fails only the summary-artifact write, so all
+// prior reads in `create_summary_artifact` succeed and only the final CAS `put`
+// errors — the shape `persist_summary` (ironclaw_loop_host::compaction_task)
+// hits in production (#5838). Folds the former hand-rolled
+// `SummaryWriteFailureBackend` onto `FaultInjecting`: an always-firing
+// path-scoped `WriteFile` fault on `/summaries/`.
+fn summary_write_failure_backend() -> FaultInjecting<InMemoryBackend> {
+    FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path("/summaries/")
+            .backend("synthetic summary artifact write failure (contract test)"),
+    )
 }
 
 #[tokio::test]
 async fn create_summary_artifact_surfaces_backend_error_on_storage_write_failure() {
     // Regression for #5838: the backend cause must survive to the caller
     // instead of being collapsed away before it reaches `persist_summary`.
-    let backend = Arc::new(SummaryWriteFailureBackend::new());
+    let backend = Arc::new(summary_write_failure_backend());
     let scoped = scoped_threads_fs_at(backend, "tenant-summary-write-fail", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("fs-summary-write-fail");

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -41,6 +41,11 @@ uuid = { version = "1", features = ["v4", "serde"] }
 [dev-dependencies]
 # Self-reference so the crate's own integration tests see `test_support`.
 ironclaw_turns = { path = ".", features = ["test-support"] }
+# FaultInjecting decorator: drive store fault paths through the real
+# `FilesystemTurnStateRowStore` instead of a hand-rolled whole-trait fake.
+ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0", features = [
+    "test-support",
+] }
 rand = "0.10"
 static_assertions = "1"
 tempfile = "3"

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -622,23 +622,6 @@ mod tests {
         }
     }
 
-    struct FailingProjectionSource;
-
-    #[async_trait]
-    impl TurnEventProjectionSource for FailingProjectionSource {
-        async fn read_turn_events_after(
-            &self,
-            _scope: &TurnScope,
-            _owner_user_id: Option<&UserId>,
-            _after: Option<EventCursor>,
-            _limit: usize,
-        ) -> Result<TurnEventPage, TurnError> {
-            Err(TurnError::Unavailable {
-                reason: "event store offline".to_string(),
-            })
-        }
-    }
-
     #[test]
     fn blocked_gate_kind_from_status_ignores_non_blocked_statuses() {
         for status in [
@@ -834,7 +817,23 @@ mod tests {
 
     #[tokio::test]
     async fn projection_service_preserves_source_read_error_cause() {
-        let service = TurnEventProjectionService::new(std::sync::Arc::new(FailingProjectionSource));
+        use ironclaw_filesystem::{Fault, FaultInjecting, FilesystemOperation, InMemoryBackend};
+
+        // The projection source is the real `FilesystemTurnStateRowStore` (which
+        // implements `TurnEventProjectionSource`) over a `FaultInjecting` backend
+        // armed to fail its first durable read. `read_turn_events_after` now runs
+        // the store's genuine durable-row read and its
+        // `FilesystemError::Backend -> TurnError::Unavailable` mapping, replacing
+        // the former hand-rolled `FailingProjectionSource` fake. The service must
+        // still wrap and preserve that read-error cause under the same
+        // `read_turn_events_after` operation label.
+        let backend = std::sync::Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+            Fault::on(FilesystemOperation::ReadFile).backend("injected turn-state read failure"),
+        ));
+        let source = std::sync::Arc::new(crate::FilesystemTurnStateRowStore::new(
+            crate::test_support::scoped_turns_filesystem(backend),
+        ));
+        let service = TurnEventProjectionService::new(source);
         let error = service
             .snapshot(crate::events::TurnEventProjectionRequest {
                 scope: scope("thread-source-error"),
@@ -845,12 +844,14 @@ mod tests {
             .await
             .expect_err("source error should propagate");
 
+        // The cause is the real store's mapped error (`fs_error`), not the fake's
+        // former "event store offline" string.
         assert!(matches!(
             error,
             TurnEventProjectionError::Source {
                 operation: "read_turn_events_after",
                 reason: TurnError::Unavailable { reason }
-            } if reason == "event store offline"
+            } if reason == "turn state row-store persistence temporarily unavailable"
         ));
     }
 

--- a/crates/ironclaw_turns/src/test_support.rs
+++ b/crates/ironclaw_turns/src/test_support.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_filesystem::{InMemoryBackend, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
 
 use crate::FilesystemTurnStateRowStore;
@@ -41,11 +41,14 @@ pub fn in_memory_turns_filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
     scoped_turns_filesystem(Arc::new(InMemoryBackend::new()))
 }
 
-/// Wrap a specific [`InMemoryBackend`] in the scoped `/turns` mount the row
-/// store expects. Handy when a test needs to hold the backend itself.
-pub fn scoped_turns_filesystem(
-    backend: Arc<InMemoryBackend>,
-) -> Arc<ScopedFilesystem<InMemoryBackend>> {
+/// Wrap a specific backend in the scoped `/turns` mount the row store expects.
+/// Handy when a test needs to hold the backend itself — e.g. a bare
+/// [`InMemoryBackend`], or an
+/// [`ironclaw_filesystem::FaultInjecting`]`<InMemoryBackend>` so a store fault
+/// path runs through the real store's `FilesystemError -> TurnError` mapping.
+pub fn scoped_turns_filesystem<F: RootFilesystem>(
+    backend: Arc<F>,
+) -> Arc<ScopedFilesystem<F>> {
     let mounts = MountView::new(vec![MountGrant::new(
         MountAlias::new("/turns").expect("turns alias"),
         VirtualPath::new("/turns").expect("turns target"),

--- a/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
+++ b/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
@@ -1,57 +1,14 @@
+use std::sync::Arc;
+
 use chrono::{TimeZone, Utc};
+use ironclaw_filesystem::{Fault, FaultInjecting, FilesystemOperation, InMemoryBackend};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_turns::test_support::scoped_turns_filesystem;
 use ironclaw_turns::{
-    AcceptedMessageRef, AllowAllTurnAdmissionPolicy, IdempotencyKey, InMemoryRunProfileResolver,
-    ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef, TurnActiveRunRefState, TurnActor,
-    TurnError, TurnRunId, TurnScope, TurnStateStore, TurnStatus,
+    AcceptedMessageRef, AllowAllTurnAdmissionPolicy, FilesystemTurnStateRowStore, IdempotencyKey,
+    InMemoryRunProfileResolver, ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef,
+    TurnActiveRunRefState, TurnActor, TurnError, TurnRunId, TurnScope, TurnStateStore, TurnStatus,
 };
-
-struct FailingTurnStateStore;
-
-#[async_trait::async_trait]
-impl TurnStateStore for FailingTurnStateStore {
-    async fn submit_turn(
-        &self,
-        _request: ironclaw_turns::SubmitTurnRequest,
-        _admission_policy: &dyn ironclaw_turns::TurnAdmissionPolicy,
-        _run_profile_resolver: &dyn ironclaw_turns::RunProfileResolver,
-    ) -> Result<ironclaw_turns::SubmitTurnResponse, TurnError> {
-        unreachable!("active_run_ref_state only calls get_run_state")
-    }
-
-    async fn resume_turn(
-        &self,
-        _request: ironclaw_turns::ResumeTurnRequest,
-    ) -> Result<ironclaw_turns::ResumeTurnResponse, TurnError> {
-        unreachable!("active_run_ref_state only calls get_run_state")
-    }
-
-    async fn retry_turn(
-        &self,
-        request: ironclaw_turns::RetryTurnRequest,
-    ) -> Result<ironclaw_turns::RetryTurnResponse, TurnError> {
-        // WS-3 implements this.
-        Err(TurnError::RunNotRetryable {
-            run_id: request.run_id,
-        })
-    }
-
-    async fn request_cancel(
-        &self,
-        _request: ironclaw_turns::CancelRunRequest,
-    ) -> Result<ironclaw_turns::CancelRunResponse, TurnError> {
-        unreachable!("active_run_ref_state only calls get_run_state")
-    }
-
-    async fn get_run_state(
-        &self,
-        _request: ironclaw_turns::GetRunStateRequest,
-    ) -> Result<ironclaw_turns::TurnRunState, TurnError> {
-        Err(TurnError::Unavailable {
-            reason: "backend unavailable".to_string(),
-        })
-    }
-}
 
 fn turn_scope(thread: &str) -> TurnScope {
     TurnScope::new(
@@ -155,8 +112,19 @@ async fn active_run_ref_state_treats_missing_lookup_as_missing() {
 
 #[tokio::test]
 async fn active_run_ref_state_propagates_non_scope_not_found_errors() {
+    // The real row store over a `FaultInjecting` backend armed to fail its first
+    // durable read: `get_run_state` now runs the store's genuine
+    // `load_snapshot_from_rows` and its `FilesystemError::Backend -> TurnError`
+    // mapping (`fs_error` -> `TurnError::Unavailable`), which the former
+    // whole-trait `FailingTurnStateStore` fake short-circuited. A non-scope
+    // (not `ScopeNotFound`) error must propagate through `active_run_ref_state`.
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::ReadFile).backend("injected turn-state read failure"),
+    ));
+    let store = FilesystemTurnStateRowStore::new(scoped_turns_filesystem(backend));
+
     let result = ironclaw_turns::active_run_ref_state(
-        &FailingTurnStateStore,
+        &store,
         turn_scope("active-run-ref-error"),
         Some(TurnRunId::new()),
     )

--- a/crates/ironclaw_turns/tests/row_store_crash_consistency.rs
+++ b/crates/ironclaw_turns/tests/row_store_crash_consistency.rs
@@ -127,6 +127,34 @@ struct FaultConfig {
 /// `RootFilesystem` wrapper over `InMemoryBackend` with write-fault injection
 /// and mutation recording (for byte-state forks). Concrete over
 /// `InMemoryBackend` because that is the only backend under test.
+///
+/// # Why this is NOT `ironclaw_filesystem::FaultInjecting`
+///
+/// The pure I/O-fault half (fail the Nth / a path-matching mutating write)
+/// *could* be expressed with `FaultInjecting`, but this backend is kept whole
+/// because its crash-consistency machinery needs three things `FaultInjecting`
+/// structurally cannot provide, and they are inseparably interleaved with the
+/// fault injection in the same `put`/`append`/`delete` methods:
+///
+/// 1. **Byte-state reconstruction** ([`FaultBackend::fork_durable_bytes`]) —
+///    records the full [`Entry`]/[`CasExpectation`]/payloads of every applied
+///    mutation and replays them into a fresh backend to rebuild a
+///    byte-identical durable state "at moment T" (the crash primitive).
+///    `FaultInjecting::recorded()` records only `{operation, path}`, so it
+///    cannot reconstruct durable bytes.
+/// 2. **Append stall barrier** ([`FaultBackend::append_gate`]) — a
+///    `tokio::sync::Mutex` a test holds to freeze the flusher so pending
+///    write-behind acks never resolve. `FaultInjecting` is not a
+///    synchronization primitive.
+/// 3. **Relative / countdown one-shot fault triggers** (`fail_next_appends`
+///    countdown, `fail_at_relative_write` = current-count + n).
+///    `FaultInjecting`'s `Nth` is absolute-from-construction, not
+///    relative-from-now.
+///
+/// Folding only the write-fault part would strand the recording (needed for the
+/// fork primitive) in a second wrapper while losing the relative triggers, so
+/// there is no clean sub-part to migrate. Kept as the purpose-named
+/// crash-consistency harness per the fault-fake migration STRICT SCOPE RULE.
 struct FaultBackend {
     inner: InMemoryBackend,
     write_count: AtomicUsize,


### PR DESCRIPTION
Stacked on #6403. A **test-double consolidation** (the "narrow win" from the Tier-3 discussion) — touches only test code, no `dyn`/trait/production change.

## The problem
`CapabilityDispatcher` is a **one-method** port (`dispatch_json`), yet ~25 hand-rolled `impl CapabilityDispatcher for …Dispatcher` doubles were spread across `ironclaw_capabilities` and `ironclaw_host_runtime` tests, wasting effort two ways:
- **Verbatim duplication** — `RecordingDispatcher` ×5, `CountingDispatcher` ×2, `AuthRequiredDispatcher` ×2, `AlwaysAuthRequiredDispatcher` ×2 copy-pasted across files (drift-prone).
- **Variant explosion** — every double differed only in what the single method returned.

## The fix
- **New:** `ironclaw_host_api::dispatch_test_support::TestDispatcher` (feature `test-support`) — one configurable double. `ok(result)` / `auth_required()` / `scripted(vec![…])` / `responding(|req, idx| …)`; recording always on (`recorded()` / `call_count()` / `last_request()`).
- **Migrated** every dispatcher double in both crates onto it (~24), including the shared `RecordingDispatcher` + its 8 users and `UnusedDispatcher`. Recording/Counting/Output/AuthRequired*/Failing/TerminalFail/Panic/Noop/Gating/FirstCall* all become a constructor call.
- **Kept** two doubles that do real async side effects a synchronous responder can't express: `GatingDispatcher` (notify/await interleave) and `ObligationAwareDispatcher` (awaits egress + releases the reservation) — each with a documenting comment.

## Note
The migration caught a real behavior detail: `NoopDispatcher` actually **panics** ("spawn tests must not invoke the foreground dispatcher"), not returns `Ok` — mapped faithfully to a panicking responder rather than the wrong `ok()`.

## Verification
- `TestDispatcher` unit tests (5) pass; host_api clippy clean on **both** feature lanes.
- Full `ironclaw_capabilities` + `ironclaw_host_runtime` suites pass; `cargo clippy --tests -D warnings` clean.

Net **−177 LOC**, and the copy-paste-drift class of bug is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)