### PR TITLE
fix(composition): make outbound delivery-target registry caller-scoping structural

### DIFF
--- a/crates/ironclaw_channel_delivery/src/tests.rs
+++ b/crates/ironclaw_channel_delivery/src/tests.rs
@@ -140,7 +140,7 @@ mod tests {
     // `RebornRuntime` for that purpose.
 
     use ironclaw_channel_host::outbound_targets::{
-        OutboundDeliveryTargetEntry, OutboundDeliveryTargetProvider,
+        OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner, OutboundDeliveryTargetProvider,
     };
     use ironclaw_outbound::{
         CommunicationPreferenceRecord, DeliveryDefaultScope,
@@ -1233,6 +1233,13 @@ mod tests {
                 },
                 reply_target_binding_ref: ReplyTargetBindingRef::new(format!("reply:{raw}"))
                     .expect("shared target binding ref"),
+                // channel_delivery consumes providers directly and does not
+                // apply the composition registry's caller-scoping filter, so
+                // this owner is informational; it mirrors `personal_turn_scope`.
+                owner: OutboundDeliveryTargetOwner::new(
+                    ironclaw_host_api::TenantId::new("test-tenant").expect("tenant"),
+                    ironclaw_host_api::UserId::new("creator-user").expect("user"),
+                ),
             }],
         })
     }

--- a/crates/ironclaw_channel_host/src/outbound_targets.rs
+++ b/crates/ironclaw_channel_host/src/outbound_targets.rs
@@ -7,17 +7,59 @@
 //! its entry shape live here so channel host crates can implement them.
 
 use async_trait::async_trait;
+use ironclaw_host_api::{TenantId, UserId};
 use ironclaw_product_workflow::{
     RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
     RebornOutboundDeliveryTargetSummary, RebornServicesError, WebUiAuthenticatedCaller,
 };
 use ironclaw_turns::ReplyTargetBindingRef;
 
+/// The `(tenant, user)` an outbound delivery-target entry belongs to.
+///
+/// Providers stamp this with the identity of the resource they resolved — the
+/// route's subject user, the DM target's paired user — so the aggregating
+/// registry can drop any entry that does not belong to the querying caller.
+/// Populating it from the resolved resource (not merely echoing the caller) is
+/// what makes registry scoping a genuine defense-in-depth layer: a provider
+/// that fails to filter by caller yields an owner that no longer matches the
+/// caller, so the registry drops the leaked entry regardless.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboundDeliveryTargetOwner {
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+}
+
+impl OutboundDeliveryTargetOwner {
+    pub fn new(tenant_id: TenantId, user_id: UserId) -> Self {
+        Self { tenant_id, user_id }
+    }
+
+    /// The owner scope for the authenticated caller. Static test fixtures that
+    /// intentionally answer whichever caller asks claim ownership this way;
+    /// real providers derive the owner from the resolved resource instead.
+    pub fn for_caller(caller: &WebUiAuthenticatedCaller) -> Self {
+        Self {
+            tenant_id: caller.tenant_id.clone(),
+            user_id: caller.user_id.clone(),
+        }
+    }
+
+    /// Whether this owner is the querying caller's `(tenant, user)`.
+    pub fn matches_caller(&self, caller: &WebUiAuthenticatedCaller) -> bool {
+        self.tenant_id == caller.tenant_id && self.user_id == caller.user_id
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutboundDeliveryTargetEntry {
     pub summary: RebornOutboundDeliveryTargetSummary,
     pub capabilities: RebornOutboundDeliveryTargetCapabilities,
     pub reply_target_binding_ref: ReplyTargetBindingRef,
+    /// The `(tenant, user)` this entry belongs to. The aggregating registry
+    /// drops any fanned-out entry whose owner does not match the querying
+    /// caller, so cross-caller isolation is structural rather than a
+    /// per-provider convention.
+    pub owner: OutboundDeliveryTargetOwner,
 }
 
 #[async_trait]

--- a/crates/ironclaw_reborn_composition/src/factory/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/tests.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, pre-existing >1500-line factory test module; this PR only adds the mandatory `owner` field to an outbound-target entry fixture for the registry caller-scoping hardening, plan #6389
 use super::*;
 use ironclaw_approvals::{AutoApproveSettingInput, AutoApproveSettingStore};
 use ironclaw_auth::{
@@ -266,7 +267,9 @@ impl RootFilesystem for FailingConversationStateFilesystem {
 /// closed as `DeliveryTargetInvalid`.
 #[tokio::test]
 async fn trigger_delivery_target_validation_resolves_through_the_outbound_registry() {
-    use crate::outbound::outbound_preferences::OutboundDeliveryTargetEntry;
+    use crate::outbound::outbound_preferences::{
+        OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner,
+    };
     use crate::outbound::{MutableOutboundDeliveryTargetRegistry, OutboundDeliveryTargetProvider};
     use ironclaw_product_workflow::{
         RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
@@ -281,12 +284,15 @@ async fn trigger_delivery_target_validation_resolves_through_the_outbound_regist
     impl OutboundDeliveryTargetProvider for OneTargetProvider {
         async fn list_outbound_delivery_targets(
             &self,
-            _caller: &WebUiAuthenticatedCaller,
+            caller: &WebUiAuthenticatedCaller,
         ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+            // Fixture available to whichever caller asks: claim the querying
+            // caller as owner so it survives the registry caller-scoping filter.
             Ok(vec![OutboundDeliveryTargetEntry {
                 summary: self.entry.summary.clone(),
                 capabilities: self.entry.capabilities.clone(),
                 reply_target_binding_ref: self.entry.reply_target_binding_ref.clone(),
+                owner: OutboundDeliveryTargetOwner::for_caller(caller),
             }])
         }
     }
@@ -334,6 +340,12 @@ async fn trigger_delivery_target_validation_resolves_through_the_outbound_regist
             "reply:registry-validation",
         )
         .expect("binding ref"),
+        // Overwritten with the querying caller by `OneTargetProvider::list`;
+        // set to the scope identity here for clarity.
+        owner: OutboundDeliveryTargetOwner::new(
+            TenantId::new("registry-validation-tenant").expect("tenant"),
+            UserId::new("registry-validation-user").expect("user"),
+        ),
     };
     registry
         .register_provider("test", Arc::new(OneTargetProvider { entry }))

--- a/crates/ironclaw_reborn_composition/src/outbound/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound/outbound_preferences.rs
@@ -26,9 +26,26 @@ use ironclaw_turns::ReplyTargetBindingRef;
 // re-imported here so the registries and facade below keep their one
 // canonical composition-internal path.
 pub(crate) use ironclaw_channel_host::outbound_targets::{
-    OutboundDeliveryTargetEntry, OutboundDeliveryTargetProvider,
+    OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner, OutboundDeliveryTargetProvider,
     OutboundDeliveryTargetRegistrationOutcome,
 };
+
+/// Caller-ownership predicate the aggregating registry applies to every
+/// fanned-out entry.
+///
+/// The registry is a single process-global instance shared across every
+/// caller/tenant, so it must not trust each provider to have scoped its own
+/// results. Dropping entries whose `owner` is not the querying caller makes
+/// cross-caller isolation structural: a provider that fails to filter (or
+/// scopes by tenant but not user) cannot leak another caller's delivery
+/// target past this predicate. Provider-side filtering stays intact as the
+/// first layer of defense in depth.
+fn entry_owned_by_caller(
+    entry: &OutboundDeliveryTargetEntry,
+    caller: &WebUiAuthenticatedCaller,
+) -> bool {
+    entry.owner.matches_caller(caller)
+}
 
 pub(crate) struct OutboundDeliveryTargetRegistry {
     providers: Vec<Arc<dyn OutboundDeliveryTargetProvider>>,
@@ -180,7 +197,11 @@ impl OutboundDeliveryTargetProvider for OutboundDeliveryTargetRegistry {
                 .map(|provider| provider.list_outbound_delivery_targets(caller)),
         )
         .await?;
-        Ok(target_groups.into_iter().flatten().collect())
+        Ok(target_groups
+            .into_iter()
+            .flatten()
+            .filter(|entry| entry_owned_by_caller(entry, caller))
+            .collect())
     }
 
     async fn resolve_outbound_delivery_target(
@@ -199,7 +220,7 @@ impl OutboundDeliveryTargetProvider for OutboundDeliveryTargetRegistry {
         Ok(target_groups
             .into_iter()
             .flatten()
-            .find(|entry| entry.capabilities.final_replies))
+            .find(|entry| entry_owned_by_caller(entry, caller) && entry.capabilities.final_replies))
     }
 
     async fn resolve_reply_target_binding(
@@ -218,7 +239,7 @@ impl OutboundDeliveryTargetProvider for OutboundDeliveryTargetRegistry {
         Ok(target_groups
             .into_iter()
             .flatten()
-            .find(|entry| entry.capabilities.final_replies))
+            .find(|entry| entry_owned_by_caller(entry, caller) && entry.capabilities.final_replies))
     }
 }
 
@@ -1315,6 +1336,124 @@ mod tests {
         );
     }
 
+    /// A provider that ignores caller scoping: it returns one entry owned by a
+    /// different `(tenant, user)` and one owned by the querying caller, for
+    /// every caller. Models a provider whose own filtering is buggy or absent.
+    struct MisbehavingUnscopedProvider {
+        foreign: OutboundDeliveryTargetEntry,
+        owned: OutboundDeliveryTargetEntry,
+    }
+
+    #[async_trait]
+    impl OutboundDeliveryTargetProvider for MisbehavingUnscopedProvider {
+        async fn list_outbound_delivery_targets(
+            &self,
+            _caller: &WebUiAuthenticatedCaller,
+        ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+            Ok(vec![self.foreign.clone(), self.owned.clone()])
+        }
+        // resolve_* deliberately use the trait defaults (list-then-find), which
+        // filter only on capability/id — NOT on owner. This is the leak the
+        // registry must close on top of the provider.
+    }
+
+    /// The registry must drop any fanned-out entry that does not belong to the
+    /// querying caller, regardless of provider behavior — cross-caller
+    /// isolation is structural at the registry, not a per-provider convention.
+    /// (#6389 bucket-2 multi-tenant-safety hardening.)
+    ///
+    /// Red→green check: commenting out the `entry_owned_by_caller` guard in the
+    /// two registry impls surfaces the tenant-B/user-B `foreign` entry through
+    /// `list`/`resolve_*`, failing this test.
+    #[tokio::test]
+    async fn target_registry_drops_entries_not_owned_by_querying_caller() {
+        let foreign = target_entry_owned_by(
+            "slack-foreign",
+            "reply:slack-foreign",
+            "tenant-bravo",
+            "user-bravo",
+        );
+        let owned = target_entry_owned_by(
+            "slack-owned",
+            "reply:slack-owned",
+            "tenant-alpha",
+            "user-alpha",
+        );
+
+        // Cover both registry implementations behind the shared provider trait.
+        let mutable = MutableOutboundDeliveryTargetRegistry::default();
+        mutable
+            .register_provider(
+                "misbehaving",
+                Arc::new(MisbehavingUnscopedProvider {
+                    foreign: foreign.clone(),
+                    owned: owned.clone(),
+                }),
+            )
+            .expect("register misbehaving provider");
+        let immutable =
+            OutboundDeliveryTargetRegistry::new(vec![Arc::new(MisbehavingUnscopedProvider {
+                foreign: foreign.clone(),
+                owned: owned.clone(),
+            })]);
+
+        let caller = caller("tenant-alpha", "user-alpha");
+        let registries: [&dyn OutboundDeliveryTargetProvider; 2] = [&mutable, &immutable];
+        for registry in registries {
+            // list: only the caller-owned entry survives; the B-owned entry is
+            // dropped by the registry even though the provider returned it.
+            let listed = registry
+                .list_outbound_delivery_targets(&caller)
+                .await
+                .expect("list");
+            assert_eq!(
+                listed
+                    .iter()
+                    .map(|entry| entry.summary.target_id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["slack-owned"],
+                "only the querying caller's entry may surface from list"
+            );
+
+            // resolve by target id: the caller-owned id resolves; the foreign id
+            // does not, even though the provider would return it.
+            assert_eq!(
+                registry
+                    .resolve_outbound_delivery_target(&caller, &target_id("slack-owned"))
+                    .await
+                    .expect("resolve owned")
+                    .map(|entry| entry.summary.target_id.as_str().to_string()),
+                Some("slack-owned".to_string())
+            );
+            assert!(
+                registry
+                    .resolve_outbound_delivery_target(&caller, &target_id("slack-foreign"))
+                    .await
+                    .expect("resolve foreign")
+                    .is_none(),
+                "a target owned by another (tenant, user) must not resolve"
+            );
+
+            // resolve by reply-target binding: same asymmetry.
+            assert_eq!(
+                registry
+                    .resolve_reply_target_binding(&caller, &reply_ref("reply:slack-owned"))
+                    .await
+                    .expect("resolve owned binding")
+                    .map(|entry| entry.summary.target_id.as_str().to_string()),
+                Some("slack-owned".to_string())
+            );
+            assert!(
+                registry
+                    .resolve_reply_target_binding(&caller, &reply_ref("reply:slack-foreign"))
+                    .await
+                    .expect("resolve foreign binding")
+                    .is_none(),
+                "a binding owned by another (tenant, user) must not resolve"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn target_registry_propagates_provider_failure() {
         let registry = OutboundDeliveryTargetRegistry::new(vec![Arc::new(FailingTargetProvider)]);
@@ -1433,6 +1572,21 @@ mod tests {
                 auth_prompts: true,
             },
             reply_target_binding_ref: reply_ref(reply_target),
+            // Existing registry-path tests query as tenant-alpha/user-alpha, so
+            // fixtures claim that owner and survive the caller-scoping filter.
+            owner: OutboundDeliveryTargetOwner::new(tenant("tenant-alpha"), user("user-alpha")),
+        }
+    }
+
+    fn target_entry_owned_by(
+        target_id_value: &str,
+        reply_target: &str,
+        owner_tenant: &str,
+        owner_user: &str,
+    ) -> OutboundDeliveryTargetEntry {
+        OutboundDeliveryTargetEntry {
+            owner: OutboundDeliveryTargetOwner::new(tenant(owner_tenant), user(owner_user)),
+            ..target_entry(target_id_value, reply_target, true)
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -109,7 +109,9 @@ use crate::builtin_capability_policy::{BuiltinCapabilityPolicy, builtin_capabili
 use crate::deployment::{DeploymentConfig, RuntimeSubstrate, TrafficPolicy};
 use crate::factory::{ComposedTurnStateStore, builtin_extension_registry};
 #[cfg(any(test, feature = "test-support"))]
-use crate::outbound::outbound_preferences::OutboundDeliveryTargetEntry;
+use crate::outbound::outbound_preferences::{
+    OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner,
+};
 use crate::outbound::{
     MutableOutboundDeliveryTargetRegistry, OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID,
     OutboundDeliveryTargetProvider, OutboundDeliveryTargetRegistrationOutcome,
@@ -123,7 +125,9 @@ use ironclaw_filesystem::CompositeRootFilesystem;
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Clone)]
 struct StaticOutboundDeliveryTargetProvider {
-    entry: OutboundDeliveryTargetEntry,
+    summary: RebornOutboundDeliveryTargetSummary,
+    capabilities: RebornOutboundDeliveryTargetCapabilities,
+    reply_target_binding_ref: ReplyTargetBindingRef,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -131,9 +135,18 @@ struct StaticOutboundDeliveryTargetProvider {
 impl OutboundDeliveryTargetProvider for StaticOutboundDeliveryTargetProvider {
     async fn list_outbound_delivery_targets(
         &self,
-        _caller: &WebUiAuthenticatedCaller,
+        caller: &WebUiAuthenticatedCaller,
     ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        Ok(vec![self.entry.clone()])
+        // Static test/QA fixture available to whichever caller asks: it claims
+        // the querying caller as owner so it always survives the registry's
+        // caller-scoping filter. Real providers derive the owner from the
+        // resolved resource instead.
+        Ok(vec![OutboundDeliveryTargetEntry {
+            summary: self.summary.clone(),
+            capabilities: self.capabilities.clone(),
+            reply_target_binding_ref: self.reply_target_binding_ref.clone(),
+            owner: OutboundDeliveryTargetOwner::for_caller(caller),
+        }])
     }
 }
 #[cfg(any(test, feature = "test-support"))]
@@ -1870,15 +1883,13 @@ impl RebornRuntime {
         self.register_outbound_delivery_target_provider(
             provider_key,
             Arc::new(StaticOutboundDeliveryTargetProvider {
-                entry: OutboundDeliveryTargetEntry {
-                    summary,
-                    capabilities: RebornOutboundDeliveryTargetCapabilities {
-                        final_replies: true,
-                        gate_prompts: false,
-                        auth_prompts: false,
-                    },
-                    reply_target_binding_ref,
+                summary,
+                capabilities: RebornOutboundDeliveryTargetCapabilities {
+                    final_replies: true,
+                    gate_prompts: false,
+                    auth_prompts: false,
                 },
+                reply_target_binding_ref,
             }),
         )
         .map(|_| ())

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -59,7 +59,9 @@ mod tests {
         EXTENSION_ACTIVATE_CAPABILITY_ID, EXTENSION_INSTALL_CAPABILITY_ID,
         EXTENSION_REMOVE_CAPABILITY_ID, EXTENSION_SEARCH_CAPABILITY_ID,
     };
-    use crate::outbound::outbound_preferences::OutboundDeliveryTargetEntry;
+    use crate::outbound::outbound_preferences::{
+        OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner,
+    };
     use crate::outbound::{
         OutboundDeliveryTargetProvider, OutboundDeliveryTargetRegistry,
         RebornOutboundPreferencesFacade,
@@ -354,7 +356,11 @@ mod tests {
             {
                 return Ok(Vec::new());
             }
-            Ok(vec![self.entry.clone()])
+            // Fixture answers a single expected caller; claim that caller as
+            // owner so the entry survives the registry caller-scoping filter.
+            let mut entry = self.entry.clone();
+            entry.owner = OutboundDeliveryTargetOwner::for_caller(caller);
+            Ok(vec![entry])
         }
     }
 
@@ -3639,6 +3645,11 @@ mod tests {
                 summary: slack_target_summary,
                 capabilities: slack_target_capabilities,
                 reply_target_binding_ref: slack_reply_target.clone(),
+                // Overwritten with the querying caller at list-time.
+                owner: OutboundDeliveryTargetOwner::new(
+                    TenantId::new("tenant-outbound-delivery").expect("tenant id"),
+                    UserId::new("outbound-delivery-owner").expect("user id"),
+                ),
             },
         ));
         let slack_provider_delegate: Arc<dyn OutboundDeliveryTargetProvider> =
@@ -4359,6 +4370,11 @@ mod tests {
                     auth_prompts: false,
                 },
                 reply_target_binding_ref: slack_reply_target.clone(),
+                // Overwritten with the querying caller at list-time.
+                owner: OutboundDeliveryTargetOwner::new(
+                    TenantId::new("tenant-outbound-delivery").expect("tenant id"),
+                    UserId::new("outbound-delivery-owner").expect("user id"),
+                ),
             },
         ));
         let slack_provider_delegate: Arc<dyn OutboundDeliveryTargetProvider> =

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/outbound_delivery.rs
@@ -19,7 +19,9 @@ use ironclaw_turns::{
 
 use crate::RebornCompositionProfile;
 use crate::input::RebornBuildInput;
-use crate::outbound::outbound_preferences::OutboundDeliveryTargetEntry;
+use crate::outbound::outbound_preferences::{
+    OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner,
+};
 use crate::outbound::{OutboundDeliveryTargetProvider, OutboundDeliveryTargetRegistrationOutcome};
 use crate::runtime_input::{PollSettings, RebornRuntimeIdentity, RebornRuntimeInput};
 
@@ -35,16 +37,25 @@ struct OutboundDeliveryTriggerGateway {
 
 #[derive(Clone)]
 struct StaticOutboundDeliveryTargetProvider {
-    entry: OutboundDeliveryTargetEntry,
+    summary: RebornOutboundDeliveryTargetSummary,
+    capabilities: RebornOutboundDeliveryTargetCapabilities,
+    reply_target_binding_ref: ReplyTargetBindingRef,
 }
 
 #[async_trait]
 impl OutboundDeliveryTargetProvider for StaticOutboundDeliveryTargetProvider {
     async fn list_outbound_delivery_targets(
         &self,
-        _caller: &WebUiAuthenticatedCaller,
+        caller: &WebUiAuthenticatedCaller,
     ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        Ok(vec![self.entry.clone()])
+        // Fixture available to whichever caller asks: claim the querying caller
+        // as owner so it survives the registry's caller-scoping filter.
+        Ok(vec![OutboundDeliveryTargetEntry {
+            summary: self.summary.clone(),
+            capabilities: self.capabilities.clone(),
+            reply_target_binding_ref: self.reply_target_binding_ref.clone(),
+            owner: OutboundDeliveryTargetOwner::for_caller(caller),
+        }])
     }
 }
 
@@ -202,22 +213,20 @@ async fn local_dev_runtime_selects_outbound_delivery_target_before_trigger_creat
     let registered = runtime.register_outbound_delivery_target_provider(
         "slack:test",
         Arc::new(StaticOutboundDeliveryTargetProvider {
-            entry: OutboundDeliveryTargetEntry {
-                summary: RebornOutboundDeliveryTargetSummary::new(
-                    slack_target_id,
-                    "slack",
-                    "Slack DM",
-                    Some("Personal Slack direct message".to_string()),
-                )
-                .expect("target summary"),
-                capabilities: RebornOutboundDeliveryTargetCapabilities {
-                    final_replies: true,
-                    gate_prompts: false,
-                    auth_prompts: false,
-                },
-                reply_target_binding_ref: ReplyTargetBindingRef::new("reply:test:slack-dm")
-                    .expect("reply target"),
+            summary: RebornOutboundDeliveryTargetSummary::new(
+                slack_target_id,
+                "slack",
+                "Slack DM",
+                Some("Personal Slack direct message".to_string()),
+            )
+            .expect("target summary"),
+            capabilities: RebornOutboundDeliveryTargetCapabilities {
+                final_replies: true,
+                gate_prompts: false,
+                auth_prompts: false,
             },
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply:test:slack-dm")
+                .expect("reply target"),
         }),
     );
     assert_eq!(

--- a/crates/ironclaw_reborn_composition/src/slack/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack/slack_outbound_targets.rs
@@ -23,7 +23,9 @@ use ironclaw_turns::ReplyTargetBindingRef;
 use thiserror::Error;
 
 use crate::outbound::OutboundDeliveryTargetProvider;
-use crate::outbound::outbound_preferences::OutboundDeliveryTargetEntry;
+use crate::outbound::outbound_preferences::{
+    OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner,
+};
 use crate::slack::slack_channel_routes::{
     SlackChannelRouteError, SlackChannelRouteKey, SlackChannelRouteStore,
 };
@@ -466,6 +468,14 @@ impl SlackHostBetaOutboundTargetProvider {
                 &self.team_id,
                 &route.channel_id,
             )?,
+            // Owner is the route's resolved subject user in this provider's
+            // configured tenant — the identity the shared channel is bound to,
+            // not merely the caller. The registry drops this entry if it ever
+            // does not match the querying caller.
+            owner: OutboundDeliveryTargetOwner::new(
+                self.tenant_id.clone(),
+                route.subject_user_id.clone(),
+            ),
         })
     }
 
@@ -495,6 +505,13 @@ impl SlackHostBetaOutboundTargetProvider {
                 &target.dm_channel_id,
                 &target.slack_user_id,
             )?,
+            // Owner is the Reborn identity the DM target is keyed to, carried
+            // from the stored target key rather than the caller, so the
+            // registry drops the entry if resolution ever crosses users.
+            owner: OutboundDeliveryTargetOwner::new(
+                target.key.tenant_id.clone(),
+                target.key.user_id.clone(),
+            ),
         })
     }
 

--- a/crates/ironclaw_telegram_extension/src/delivery/targets.rs
+++ b/crates/ironclaw_telegram_extension/src/delivery/targets.rs
@@ -25,6 +25,7 @@ use crate::pairing::{TelegramDmTarget, TelegramPairingError};
 use crate::setup::{TelegramSetupError, TelegramSetupService};
 use crate::state::FilesystemTelegramHostState;
 use ironclaw_channel_host::outbound_targets::OutboundDeliveryTargetEntry;
+use ironclaw_channel_host::outbound_targets::OutboundDeliveryTargetOwner;
 use ironclaw_channel_host::outbound_targets::OutboundDeliveryTargetProvider;
 
 /// Outbound delivery targets for the Telegram channel host: exactly one
@@ -84,6 +85,10 @@ impl TelegramOutboundTargetProvider {
             // threading for proactive DM delivery), built by the adapter crate
             // so it always round-trips through its render-time parser.
             reply_target_binding_ref: build_reply_target_binding(target.chat_id, None, None),
+            // Owner is the paired DM target's user in this provider's tenant,
+            // taken from the stored target rather than the caller, so the
+            // registry drops the entry if a lookup ever crosses users.
+            owner: OutboundDeliveryTargetOwner::new(self.tenant_id.clone(), target.user_id.clone()),
         })
     }
 }


### PR DESCRIPTION
## The gap

The outbound delivery-target registry (`crates/ironclaw_reborn_composition/src/outbound/outbound_preferences.rs`) aggregated every provider's results with **no caller-scoping of its own**. Both `impl OutboundDeliveryTargetProvider` for `MutableOutboundDeliveryTargetRegistry` and for `OutboundDeliveryTargetRegistry` fanned the `WebUiAuthenticatedCaller` out to each registered provider and concatenated the returned `Vec<OutboundDeliveryTargetEntry>`, filtering only on `entry.capabilities.final_replies` — **never on the caller's tenant/user**.

Multi-tenant isolation was therefore an un-enforced per-provider convention:

- a provider that failed to filter by `caller` (or scoped by tenant but not user) would leak another caller's delivery targets, and
- `resolve_outbound_delivery_target` returns the first `final_replies`-capable match across **all** providers, so one buggy provider could poison resolution globally.

The registry is a single process-global instance (one per runtime), so this matters for the eventual multi-tenant production build. Today the only real providers (Slack host-beta, Telegram) *do* filter correctly, so there is no live leak — this is defense-in-depth hardening to make the isolation **structural at the registry**, not merely conventional.

## Mechanism

- Added `owner: OutboundDeliveryTargetOwner { tenant_id: TenantId, user_id: UserId }` to `OutboundDeliveryTargetEntry` (`crates/ironclaw_channel_host/src/outbound_targets.rs`), using the existing identity newtypes — no stringly-typed fields. The entry is an internal port type (the browser sees `RebornOutboundDeliveryTargetSummary`) and is **not serialized across any wire boundary** (no `Serialize`/`Deserialize` derive; verified before adding the field), so the addition is safe.
- **Real providers stamp the owner from the resolved resource, not the caller:** Slack shared-channel from the route's `subject_user_id`, Slack/Telegram personal-DM from the stored target's user identity. Deriving the owner from the resource (rather than echoing the caller) is what makes the registry filter genuine defense in depth — a provider whose own filtering is buggy yields an owner that no longer matches the caller, so the registry drops the leaked entry.
- **Both registry impls now drop any fanned-out entry not owned by the querying caller**, via a single shared `entry_owned_by_caller` predicate applied in `list_outbound_delivery_targets` and in both `resolve_*` paths (the `resolve_*` methods are overridden on the registry, so the filter is applied there explicitly, not only inherited).
- **Provider-side caller filtering is preserved intact** — the Slack `tenant_id` early-return and user-scoped lookups, and the Telegram tenant/user guards, are unchanged. The two layers are defense in depth.

For correctly-behaving providers the registry filter is a no-op (resolved owner always equals the caller), so there is **no behavior change on the live path** — confirmed by the full existing composition suite (1685 lib tests) staying green.

## Adversarial test (test-first, red → green)

`target_registry_drops_entries_not_owned_by_querying_caller` (in the composition crate, next to the registry): a deliberately-unscoped fake provider returns, for **every** caller, one entry owned by tenant-B/user-B and one owned by the querying tenant-A/user-A (its `resolve_*` uses the trait defaults, which filter only on capability/id — not owner). Registered in **both** `MutableOutboundDeliveryTargetRegistry` and `OutboundDeliveryTargetRegistry`, queried as tenant-A/user-A, it asserts the B-owned entry is dropped from `list`, `resolve_outbound_delivery_target`, and `resolve_reply_target_binding`, while the A-owned entry passes.

**Red → green verified:** with the `entry_owned_by_caller` predicate temporarily forced to `true`, the test fails —
```
assertion `left == right` failed: only the querying caller's entry may surface from list
  left: ["slack-foreign", "slack-owned"]
 right: ["slack-owned"]
```
— i.e. the tenant-B entry surfaced through the registry. With the real predicate in place it passes.

## Verification

- `cargo fmt`
- `cargo test -p ironclaw_reborn_composition --features libsql --lib` — 1685 passed (incl. the new test)
- `cargo test -p ironclaw_channel_host -p ironclaw_channel_delivery -p ironclaw_telegram_extension` — all pass
- `cargo test -p ironclaw_architecture` — pass
- `cargo clippy -p ironclaw_channel_host -p ironclaw_channel_delivery -p ironclaw_telegram_extension -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings` — clean (no `#[cfg(feature)]` gates added, so no feature-lane divergence)
- `scripts/pre-commit-safety.sh` — clean

Relates to the bucket-2 / multi-tenant-safety audit in #6389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)