### PR TITLE
feat(composition): run the trigger poller on production-shaped runtimes (opt-in) (#5013)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1174,6 +1174,14 @@ where
     /// filesystem. Backs the WebUI project surface for production profiles where
     /// `local_runtime` is None; mirrors the local substrate's `project_service`.
     pub(crate) project_service: Arc<dyn ProjectService>,
+    /// Trigger conversation services over the production scoped filesystem.
+    /// Mirrors the local substrate's `trigger_conversation_services`: it backs
+    /// the production trigger poller's prompt materializer and trusted-ingress
+    /// submitter (binding + session-thread + actor-pairing roles). Built eagerly
+    /// in `build_backend_production` — production is always durable, so there is
+    /// no `OnceCell` lazy-init arm like the local substrate carries.
+    pub(crate) trigger_conversation_services:
+        ironclaw_conversations::RebornFilesystemConversationServices,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -5320,6 +5328,18 @@ where
         ));
     let project_service: Arc<dyn ProjectService> =
         Arc::new(RebornProjectService::new(project_repository));
+    // Trigger conversation services over the production scoped filesystem —
+    // the substrate-agnostic trigger poller (`runtime.rs`) sources the
+    // materializer/submitter/pairing roles from here for production profiles,
+    // exactly as the local substrate serves them from its own conversation
+    // services. Built eagerly (production is always durable); the underlying
+    // `InboundTurnError` cause is preserved in the mapped build error.
+    let trigger_conversation_services =
+        RebornFilesystemConversationServices::new(Arc::clone(&stores.scoped_filesystem))
+            .await
+            .map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("trigger conversation services unavailable: {error}"),
+            })?;
     let production_runtime_graph = Arc::new(RebornProductionRuntimeStoreGraph {
         scoped_filesystem: Arc::clone(&stores.scoped_filesystem),
         extension_registry: Arc::clone(&extension_registry),
@@ -5334,6 +5354,7 @@ where
         audit_log,
         admin_secret_provisioner,
         project_service,
+        trigger_conversation_services,
     });
     let production_runtime = production_runtime_services(production_runtime_graph);
     // Same store-backed lookup the WebUI automations panel builds via

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -41,7 +41,7 @@ use ironclaw_first_party_extension_ports::{
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AgentId, ApprovalRequestId, AuditEnvelope, AuditEventId,
     AuditStage, CapabilityId, CorrelationId, DecisionSummary, EffectKind, ExtensionId,
-    InvocationId, Principal, ResourceScope, TenantId, ThreadId, UserId,
+    InvocationId, Principal, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
 };
 use ironclaw_loop_host::{
     AwaitEdgeSettler, AwaitEdgeWriter, CapabilityAllowSet, CapabilityResolveError,
@@ -219,6 +219,12 @@ struct RuntimeStoreParts<'a> {
     subagent_await_edge_settler: Arc<dyn AwaitEdgeSettler>,
     subagent_await_edge_evidence: Arc<dyn AwaitDependentRunEvidenceStore>,
     trigger_repository: Option<Arc<dyn ironclaw_triggers::TriggerRepository>>,
+    /// Unified turn-run snapshot source for the substrate-agnostic trigger
+    /// poller's active-run lookup. Local sets it from `local_runtime.turn_state`;
+    /// production from `graph.turn_state`. Both back
+    /// `SnapshotActiveRunLookup` identically, so the poller-launch block no
+    /// longer reaches into the concrete local substrate for it.
+    turn_run_snapshot_source: Arc<dyn TurnRunSnapshotSource>,
 }
 
 /// Non-durable await-edge fallback for the composition profile with neither
@@ -366,6 +372,8 @@ fn local_runtime_parts(
         subagent_await_edge_settler,
         subagent_await_edge_evidence,
         trigger_repository: Some(Arc::clone(&local_runtime.trigger_repository)),
+        turn_run_snapshot_source: Arc::clone(&local_runtime.turn_state)
+            as Arc<dyn TurnRunSnapshotSource>,
     }
 }
 
@@ -411,6 +419,7 @@ where
         subagent_await_edge_settler: await_edge_resolver as Arc<dyn AwaitEdgeSettler>,
         subagent_await_edge_evidence: await_edge_store as Arc<dyn AwaitDependentRunEvidenceStore>,
         trigger_repository: Some(Arc::clone(&graph.trigger_repository)),
+        turn_run_snapshot_source: Arc::clone(&graph.turn_state) as Arc<dyn TurnRunSnapshotSource>,
     }
 }
 
@@ -849,73 +858,51 @@ struct TriggerPollerServices {
     pairing_service: Arc<dyn ironclaw_conversations::ConversationActorPairingService>,
 }
 
-async fn build_trigger_poller_services(
-    local_runtime: &crate::factory::RebornRuntimeSubstrate,
+/// Build the trigger-poller services from already-resolved conversation
+/// services. Substrate-agnostic: the caller resolves the concrete conversation
+/// services type per substrate (local `RebornFilesystemConversationServices` /
+/// `InMemoryConversationServices`, or the production graph's
+/// `RebornFilesystemConversationServices`) and hands it in by value, so this
+/// function no longer reaches into the local substrate or branches on the
+/// durable-backend cfg.
+fn build_trigger_poller_services<C>(
+    conversation_services: C,
     turn_coordinator: Arc<dyn TurnCoordinator>,
     thread_service: Arc<dyn SessionThreadService>,
     authorizer_config: TriggerPollerAuthorizerConfig,
     access_checker: Option<Arc<dyn crate::runtime_input::TriggerFireAccessChecker>>,
     tenant_id: TenantId,
     default_agent_id: AgentId,
-) -> Result<TriggerPollerServices, RebornRuntimeError> {
+) -> Result<TriggerPollerServices, RebornRuntimeError>
+where
+    C: ironclaw_conversations::ConversationBindingService
+        + ironclaw_conversations::SessionThreadService
+        + ironclaw_conversations::ConversationActorPairingService
+        + Clone
+        + 'static,
+{
     let authorizer = build_trigger_fire_authorizer(authorizer_config, access_checker, tenant_id)?;
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
-    {
-        let conversations = local_runtime
-            .durable_trigger_conversation_services()
-            .await
-            .map_err(|error| RebornRuntimeError::InvalidArgument {
-                reason: format!("trigger conversation services unavailable: {error}"),
-            })?;
+    #[cfg(any(test, feature = "test-support"))]
+    let pairing_service: Arc<dyn ironclaw_conversations::ConversationActorPairingService> =
+        Arc::new(conversation_services.clone());
+    let TriggerPollerServicesInner {
+        materializer,
+        trusted_submitter,
+    } = build_trigger_poller_services_from_conversation_services(
+        conversation_services.clone(),
+        conversation_services,
+        turn_coordinator,
+        thread_service,
+        default_agent_id,
+        authorizer,
+    );
+    Ok(TriggerPollerServices {
+        materializer,
+        trusted_submitter,
+        post_submit_hook_slot: Arc::new(std::sync::OnceLock::new()),
         #[cfg(any(test, feature = "test-support"))]
-        let pairing_service: Arc<
-            dyn ironclaw_conversations::ConversationActorPairingService,
-        > = Arc::new(conversations.clone());
-        let TriggerPollerServicesInner {
-            materializer,
-            trusted_submitter,
-        } = build_trigger_poller_services_from_conversation_services(
-            conversations.clone(),
-            conversations,
-            turn_coordinator,
-            thread_service,
-            default_agent_id,
-            authorizer,
-        );
-        Ok(TriggerPollerServices {
-            materializer,
-            trusted_submitter,
-            post_submit_hook_slot: Arc::new(std::sync::OnceLock::new()),
-            #[cfg(any(test, feature = "test-support"))]
-            pairing_service,
-        })
-    }
-    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-    {
-        let conversations = local_runtime.trigger_conversation_services.clone();
-        #[cfg(any(test, feature = "test-support"))]
-        let pairing_service: Arc<
-            dyn ironclaw_conversations::ConversationActorPairingService,
-        > = Arc::new(conversations.clone());
-        let TriggerPollerServicesInner {
-            materializer,
-            trusted_submitter,
-        } = build_trigger_poller_services_from_conversation_services(
-            conversations.clone(),
-            conversations,
-            turn_coordinator,
-            thread_service,
-            default_agent_id,
-            authorizer,
-        );
-        Ok(TriggerPollerServices {
-            materializer,
-            trusted_submitter,
-            post_submit_hook_slot: Arc::new(std::sync::OnceLock::new()),
-            #[cfg(any(test, feature = "test-support"))]
-            pairing_service,
-        })
-    }
+        pairing_service,
+    })
 }
 
 fn trigger_poller_authorization_required_error() -> RebornRuntimeError {
@@ -1002,10 +989,69 @@ where
 }
 
 fn build_trigger_active_run_lookup(
-    turn_state_store: Arc<ComposedTurnStateStore>,
+    snapshot_source: Arc<dyn TurnRunSnapshotSource>,
 ) -> Arc<dyn ironclaw_triggers::TriggerActiveRunLookup> {
-    let snapshot_source = turn_state_store as Arc<dyn TurnRunSnapshotSource>;
     Arc::new(SnapshotActiveRunLookup::new(snapshot_source))
+}
+
+/// Resolve the fire-time `TenantMembership` user directory from either
+/// substrate. Mirrors [`RebornRuntime::reborn_user_directory`] but as a free
+/// function usable during `build_reborn_runtime` (before a `RebornRuntime`
+/// exists): local builds it over the local substrate's identity filesystem;
+/// production-shaped builds match the production store graph and build it over
+/// the same scoped filesystem the identity resolver uses. Returns `None` only
+/// when no substrate is present, in which case a `TenantMembership` grant
+/// cannot be honored and the caller fails closed.
+fn poller_user_directory(
+    services: &RebornServices,
+    local_runtime: Option<&crate::factory::RebornRuntimeSubstrate>,
+    tenant_id: &TenantId,
+    actor_user_id: &UserId,
+    agent_id: &AgentId,
+    project_id: Option<&ProjectId>,
+) -> Option<Arc<dyn ironclaw_reborn_identity::RebornUserDirectory>> {
+    if let Some(local) = local_runtime {
+        let store = ironclaw_reborn_identity::FilesystemRebornIdentityStore::new(
+            Arc::clone(&local.identity_filesystem),
+            tenant_id.clone(),
+            actor_user_id.clone(),
+            agent_id.clone(),
+            project_id.cloned(),
+        );
+        return Some(Arc::new(store) as Arc<dyn ironclaw_reborn_identity::RebornUserDirectory>);
+    }
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    {
+        if let Some(production) = services.production_runtime.as_ref() {
+            let directory: Arc<dyn ironclaw_reborn_identity::RebornUserDirectory> = match production
+            {
+                #[cfg(feature = "libsql")]
+                crate::factory::RebornProductionRuntimeServices::LibSql(graph) => Arc::new(
+                    ironclaw_reborn_identity::FilesystemRebornIdentityStore::new(
+                        Arc::clone(&graph.scoped_filesystem),
+                        tenant_id.clone(),
+                        actor_user_id.clone(),
+                        agent_id.clone(),
+                        project_id.cloned(),
+                    ),
+                ),
+                #[cfg(feature = "postgres")]
+                crate::factory::RebornProductionRuntimeServices::Postgres(graph) => Arc::new(
+                    ironclaw_reborn_identity::FilesystemRebornIdentityStore::new(
+                        Arc::clone(&graph.scoped_filesystem),
+                        tenant_id.clone(),
+                        actor_user_id.clone(),
+                        agent_id.clone(),
+                        project_id.cloned(),
+                    ),
+                ),
+            };
+            return Some(directory);
+        }
+    }
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    let _ = services;
+    None
 }
 
 struct SnapshotApprovalTurnRunLocator {
@@ -1532,6 +1578,28 @@ impl RebornRuntime {
             .local_runtime
             .as_ref()
             .map(|local_runtime| Arc::clone(&local_runtime.trigger_repository))
+    }
+
+    /// Test-only accessor for the trigger repository backing a
+    /// production-shaped runtime (where `local_runtime` is `None`, so
+    /// [`Self::trigger_repository`] returns `None`). Mirrors the production
+    /// call site `RebornProductionRuntimeServices::trigger_repository`, which
+    /// the WebUI automations facade uses. Integration tests use this to seed
+    /// due `TriggerRecord` rows on a production runtime before driving the
+    /// poller. Returns `None` when no production store graph is present. Gated
+    /// behind `test-support` so the substrate handle never leaks into
+    /// production builds. For tests only.
+    #[cfg(all(
+        any(test, feature = "test-support"),
+        any(feature = "libsql", feature = "postgres")
+    ))]
+    pub fn production_trigger_repository_for_test(
+        &self,
+    ) -> Option<Arc<dyn ironclaw_triggers::TriggerRepository>> {
+        self.services
+            .production_runtime
+            .as_ref()
+            .map(|production| production.trigger_repository())
     }
 
     /// Test-only accessor for the SAME `ConversationActorPairingService`
@@ -3387,7 +3455,8 @@ pub async fn build_reborn_runtime(
         subagent_await_edge_writer,
         subagent_await_edge_settler,
         subagent_await_edge_evidence,
-        trigger_repository: _trigger_repository,
+        trigger_repository,
+        turn_run_snapshot_source,
     } = runtime_parts;
     let (skill_context_source, skill_activation_source, skill_execution_adapter) =
         match (configured_skill_context_source, local_runtime) {
@@ -4089,9 +4158,6 @@ pub async fn build_reborn_runtime(
         Arc<dyn ironclaw_conversations::ConversationActorPairingService>,
     >;
     if trigger_poller.enabled {
-        let local_runtime = local_runtime.ok_or(RebornRuntimeError::InvalidArgument {
-            reason: "trigger poller is not wired for production runtime launch".to_string(),
-        })?;
         // Fire-time authorizer: an explicit override wins (tests/advanced),
         // otherwise build one from the deployment's `TriggerFireAccessPolicy`
         // (arch-simplification §4.4 — the former `local_trigger_access` store is
@@ -4117,17 +4183,22 @@ pub async fn build_reborn_runtime(
                 TriggerFireAccessGrant::TenantMembership { agent, project } => {
                     // Membership is resolved against the canonical identity
                     // directory the SSO login path populates — the same store
-                    // `reborn_user_directory` opens, built here from the
-                    // runtime's own identity filesystem.
-                    let store = ironclaw_reborn_identity::FilesystemRebornIdentityStore::new(
-                        Arc::clone(&local_runtime.identity_filesystem),
-                        thread_scope.tenant_id.clone(),
-                        actor_user_id.clone(),
-                        thread_scope.agent_id.clone(),
-                        thread_scope.project_id.clone(),
-                    );
-                    let directory: Arc<dyn ironclaw_reborn_identity::RebornUserDirectory> =
-                        Arc::new(store);
+                    // `reborn_user_directory` opens, built here from whichever
+                    // substrate (local or production-shaped) backs this runtime.
+                    // Fail closed if no substrate can provide the directory.
+                    let directory = poller_user_directory(
+                        &services,
+                        local_runtime,
+                        &thread_scope.tenant_id,
+                        &actor_user_id,
+                        &thread_scope.agent_id,
+                        thread_scope.project_id.as_ref(),
+                    )
+                    .ok_or(RebornRuntimeError::InvalidArgument {
+                        reason: "trigger poller TenantMembership grant requires an identity \
+                                 directory, but no runtime substrate is present"
+                            .to_string(),
+                    })?;
                     let checker: Arc<dyn TriggerFireAccessChecker> =
                         Arc::new(IdentityMembershipTriggerFireChecker::new(
                             directory,
@@ -4153,18 +4224,64 @@ pub async fn build_reborn_runtime(
             &trigger_poller,
             effective_trigger_fire_access_checker.as_ref(),
         )?;
+        // Resolve the trigger conversation services from whichever substrate
+        // backs this runtime — the local substrate's (lazily-built durable /
+        // in-memory) services, or the production store graph's eagerly-built
+        // filesystem services. The poller launch is otherwise identical for
+        // both, so there is a single substrate-agnostic path below.
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let conversation_services = match local_runtime {
+            Some(local) => local
+                .durable_trigger_conversation_services()
+                .await
+                .map_err(|error| RebornRuntimeError::InvalidArgument {
+                    reason: format!("trigger conversation services unavailable: {error}"),
+                })?,
+            None => match services.production_runtime.as_ref() {
+                #[cfg(feature = "libsql")]
+                Some(crate::factory::RebornProductionRuntimeServices::LibSql(graph)) => {
+                    graph.trigger_conversation_services.clone()
+                }
+                #[cfg(feature = "postgres")]
+                Some(crate::factory::RebornProductionRuntimeServices::Postgres(graph)) => {
+                    graph.trigger_conversation_services.clone()
+                }
+                None => {
+                    return Err(RebornRuntimeError::InvalidArgument {
+                        reason: "trigger poller enabled but no runtime substrate present"
+                            .to_string(),
+                    });
+                }
+            },
+        };
+        #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+        let conversation_services = local_runtime
+            .ok_or(RebornRuntimeError::InvalidArgument {
+                reason: "trigger poller enabled but no runtime substrate present".to_string(),
+            })?
+            .trigger_conversation_services
+            .clone();
         let trigger_poller_services = build_trigger_poller_services(
-            local_runtime,
+            conversation_services,
             Arc::clone(&planned_turn_coordinator),
             Arc::clone(&thread_service),
             trigger_poller.authorizer,
             effective_trigger_fire_access_checker.clone(),
             thread_scope.tenant_id.clone(),
             validated_identity.agent_id.clone(),
-        )
-        .await?;
+        )?;
         let active_run_lookup =
-            build_trigger_active_run_lookup(Arc::clone(&local_runtime.turn_state));
+            build_trigger_active_run_lookup(Arc::clone(&turn_run_snapshot_source));
+        // Fail closed if the substrate produced no trigger repository (both the
+        // local and production parts always set `Some`; a `None` here means the
+        // runtime was assembled without a substrate, which the poller cannot
+        // service).
+        let trigger_repository =
+            trigger_repository
+                .clone()
+                .ok_or(RebornRuntimeError::InvalidArgument {
+                    reason: "trigger poller enabled but no trigger repository present".to_string(),
+                })?;
         #[cfg(any(test, feature = "test-support"))]
         {
             trigger_conversation_pairing_value =
@@ -4180,7 +4297,7 @@ pub async fn build_reborn_runtime(
         trigger_poller_handle = spawn_trigger_poller(
             trigger_poller,
             TriggerPollerCompositionDeps {
-                repository: Arc::clone(&local_runtime.trigger_repository),
+                repository: trigger_repository,
                 materializer: trigger_poller_services.materializer,
                 trusted_submitter: trigger_poller_services.trusted_submitter,
                 active_run_lookup,

--- a/crates/ironclaw_reborn_composition/tests/production_runtime_trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/tests/production_runtime_trigger_poller.rs
@@ -1,0 +1,339 @@
+//! Full-path integration test for the composition-owned trigger poller on a
+//! **production-shaped** `RebornRuntime` (`local_runtime: None`,
+//! `production_runtime: Some(...)`).
+//!
+//! Before #5013 the poller launch hard-errored for any production-shaped
+//! runtime ("trigger poller is not wired for production runtime launch"), so
+//! `build_reborn_runtime` returned `Err` the moment `trigger_poller.enabled`
+//! was set on a production profile — that is the RED state this test pins.
+//! After the launch-collapse the poller runs on the same substrate-agnostic
+//! path the local runtime uses, sourcing its trigger repository, conversation
+//! services, identity directory, and turn-run snapshot source from the
+//! production store graph. This test drives the whole path: it builds the
+//! production runtime with the poller enabled, seeds a due `TriggerRecord`
+//! through the production trigger repository, pairs the trigger creator's
+//! external actor through the production conversation services, and asserts
+//! the poller claims + materializes + submits + settles the trigger against
+//! the production substrate.
+//!
+//! Assertion seam: the trigger record. `mark_fire_accepted` (→ `last_status =
+//! Ok`, `last_run_at`, `last_fired_slot`) is written only after the trusted
+//! submitter returns `Accepted { run_id, .. }` — i.e. a real trusted-ingress
+//! turn was materialized (via the production conversation services) and
+//! submitted to the coordinator. `clear_active_fire` (→ `state = Completed`
+//! for a once-schedule, `active_run_ref`/`active_fire_slot` cleared) is written
+//! only after the run engine signals the run terminal. So the settled record
+//! proves claim → materialize → submit → run-terminal → settle, all against
+//! the production store graph — a trigger/run-seam assertion, not
+//! `wait_for_status(Completed)` alone.
+//!
+//! Scope note: the model gateway override IS honored on production under
+//! `test-support`, but the fired trusted-ingress run terminates before the
+//! first model call in this minimal secure-default / tenant-sandbox production
+//! harness (no real conversational agent-loop environment), so this tier
+//! cannot assert "the trigger prompt reached the model" the way the local
+//! `trigger_poller_e2e` suite does. That is a turn-execution-environment limit,
+//! not a poller-wiring gap — the poller's claim/materialize/submit/settle path
+//! is fully exercised here. Delivery likewise stays downstream: the poller runs
+//! without a post-submit delivery hook (production gets no channel driver yet).
+//!
+//! Gated on `libsql` because the production-runtime path under test requires
+//! the libsql substrate.
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_conversations::{AdapterInstallationId, AdapterKind, ExternalActorRef};
+use ironclaw_host_api::{
+    AgentId, TenantId, UserId,
+    runtime_policy::{
+        ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
+        NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+    },
+};
+use ironclaw_host_runtime::{
+    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandTransport,
+    TenantSandboxProcessPort,
+};
+use ironclaw_loop_host::{
+    HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
+    HostManagedModelResponse,
+};
+use ironclaw_reborn_composition::{
+    RebornBuildInput, RebornCompositionProfile, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProcessBinding, TriggerPollerSettings, build_reborn_runtime,
+    builtin_first_party_trust_policy,
+};
+use ironclaw_triggers::{
+    TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
+    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerId, TriggerPollerWorkerConfig, TriggerRecord,
+    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+};
+use tokio::sync::Mutex as TokioMutex;
+
+const TENANT: &str = "trigger-prod-tenant";
+const USER: &str = "trigger-prod-owner";
+const AGENT: &str = "trigger-prod-agent";
+const TRIGGER_PROMPT: &str = "trigger-prod-prompt-marker-do-not-rephrase";
+
+/// Deterministic model gateway: records every request and returns a plain
+/// assistant reply so the fired run terminates without touching a real LLM,
+/// process backend, or network.
+#[derive(Debug, Default)]
+struct RecordingGateway {
+    requests: Arc<TokioMutex<Vec<HostManagedModelRequest>>>,
+}
+
+impl RecordingGateway {
+    async fn captured_message_contents(&self) -> Vec<String> {
+        let guard = self.requests.lock().await;
+        guard
+            .iter()
+            .flat_map(|req| req.messages.iter().map(|m| m.content.clone()))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl HostManagedModelGateway for RecordingGateway {
+    async fn stream_model(
+        &self,
+        request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        self.requests.lock().await.push(request);
+        Ok(HostManagedModelResponse::assistant_reply(
+            "trigger prod e2e ok".to_string(),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct RecordingSandboxTransport;
+
+#[async_trait]
+impl SandboxCommandTransport for RecordingSandboxTransport {
+    async fn run_command(
+        &self,
+        _request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        Ok(CommandExecutionOutput {
+            output: String::new(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: Duration::ZERO,
+        })
+    }
+}
+
+/// Builds a production-shaped runtime with the trigger poller enabled.
+/// Mirrors `production_runtime_automations.rs`'s recipe (Production profile,
+/// first-party trust policy, secure-default runtime policy, tenant-sandbox
+/// process binding) and additionally opts the poller in via the existing
+/// `trigger_poller.enabled` input flag, using the tenant-scoped placeholder
+/// authorizer so no fire-time access checker is required for the test.
+async fn build_production_runtime_with_poller(
+    dir: &tempfile::TempDir,
+    model_gateway: Arc<RecordingGateway>,
+) -> ironclaw_reborn_composition::RebornRuntime {
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.path().join("reborn.db"))
+            .build()
+            .await
+            .expect("libsql db"),
+    );
+
+    let input = RebornRuntimeInput::from_services(
+        RebornBuildInput::libsql(
+            RebornCompositionProfile::Production,
+            USER,
+            db,
+            dir.path().join("events.db").to_string_lossy(),
+            None,
+            ironclaw_secrets::SecretMaterial::from("01234567890123456789012345678901"),
+        )
+        .with_production_trust_policy(Arc::new(
+            builtin_first_party_trust_policy().expect("trust policy"),
+        ))
+        .with_runtime_policy(EffectiveRuntimePolicy {
+            deployment: DeploymentMode::HostedMultiTenant,
+            requested_profile: RuntimeProfile::SecureDefault,
+            resolved_profile: RuntimeProfile::SecureDefault,
+            filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+            process_backend: ProcessBackendKind::TenantSandbox,
+            network_mode: NetworkMode::Deny,
+            secret_mode: SecretMode::BrokeredHandles,
+            approval_policy: ApprovalPolicy::AskAlways,
+            audit_mode: AuditMode::Standard,
+        })
+        .with_runtime_process_binding(RebornRuntimeProcessBinding::tenant_sandbox(Arc::new(
+            TenantSandboxProcessPort::new(Arc::new(RecordingSandboxTransport)),
+        ))),
+    )
+    .with_identity(RebornRuntimeIdentity {
+        tenant_id: TENANT.to_string(),
+        agent_id: AGENT.to_string(),
+        source_binding_id: "trigger-prod-source".to_string(),
+        reply_target_binding_id: "trigger-prod-reply".to_string(),
+    })
+    .with_trigger_poller_settings(
+        TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
+            TriggerPollerWorkerConfig::default().set_poll_interval(Duration::from_millis(20)),
+        ),
+    )
+    .with_model_gateway_override(model_gateway);
+
+    // RED before #5013: this errored with "trigger poller is not wired for
+    // production runtime launch". GREEN after the launch-collapse.
+    build_reborn_runtime(input)
+        .await
+        .expect("production runtime builds with the trigger poller enabled")
+}
+
+/// End-to-end: a production-shaped runtime with the poller enabled claims and
+/// fires a due one-shot trigger, driving a run to the model gateway and
+/// settling the record `Completed`/`Ok`.
+#[tokio::test]
+async fn production_runtime_trigger_poller_fires_due_scheduled_trigger() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway::default());
+
+    let runtime = build_production_runtime_with_poller(&dir, Arc::clone(&recording_gateway)).await;
+
+    // The production-shaped runtime exposes its trigger repository only through
+    // the test-support production accessor (`trigger_repository()` covers the
+    // local substrate, which production does not have).
+    assert!(
+        runtime.trigger_repository().is_none(),
+        "production runtime has no local-substrate trigger repository"
+    );
+    let repo = runtime
+        .production_trigger_repository_for_test()
+        .expect("production runtime exposes its store-graph trigger repository");
+    let pairing = runtime
+        .trigger_conversation_pairing()
+        .expect("poller-enabled production runtime exposes conversation pairing service");
+
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let agent_id = AgentId::new(AGENT).expect("agent id");
+    let trigger_id = TriggerId::new();
+
+    // Seed the trigger creator's actor pairing through the production
+    // `ConversationActorPairingService`. The trusted trigger submission path
+    // fails closed for unpaired actors by design; the constants must match the
+    // trusted trigger fire constants.
+    pairing
+        .pair_external_actor(
+            tenant_id.clone(),
+            AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("adapter kind"),
+            AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                .expect("installation id"),
+            ExternalActorRef::new(TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, user_id.as_str())
+                .expect("actor ref"),
+            user_id.clone(),
+        )
+        .await
+        .expect("pair external actor for trigger creator");
+
+    let record = TriggerRecord {
+        trigger_id,
+        tenant_id: tenant_id.clone(),
+        creator_user_id: user_id,
+        agent_id: Some(agent_id),
+        project_id: None,
+        name: "trigger-prod-test".to_string(),
+        source: TriggerSourceKind::Schedule,
+        // One-shot, already due: fires once then becomes Completed.
+        schedule: TriggerSchedule::once(Utc::now() - chrono::Duration::seconds(120), "UTC")
+            .expect("valid once schedule"),
+        prompt: TRIGGER_PROMPT.to_string(),
+        delivery_target: None,
+        state: TriggerState::Scheduled,
+        next_run_at: Utc::now() - chrono::Duration::seconds(120),
+        last_run_at: None,
+        last_fired_slot: None,
+        last_status: None,
+        active_fire_slot: None,
+        active_run_ref: None,
+        created_at: Utc::now(),
+    };
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("upsert trigger record on the production repository");
+
+    // Poll until the once-schedule trigger settles: `last_status = Ok`
+    // (accepted trusted submit) and `state = Completed` (run reached terminal,
+    // `clear_active_fire` ran). The production poller runs at a 20ms interval,
+    // so this is well within the deadline.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut final_record = repo
+        .get_trigger(tenant_id.clone(), record.trigger_id)
+        .await
+        .expect("get_trigger")
+        .expect("record present");
+    while Instant::now() < deadline {
+        if final_record.last_fired_slot.is_some()
+            && final_record.last_run_at.is_some()
+            && final_record.last_status.is_some()
+            && final_record.state == TriggerState::Completed
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        final_record = repo
+            .get_trigger(tenant_id.clone(), record.trigger_id)
+            .await
+            .expect("get_trigger")
+            .expect("record present");
+    }
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    // Trigger/run-seam assertions (see module docs): the production poller
+    // claimed the due trigger, materialized its prompt through the production
+    // conversation services, submitted a trusted-ingress turn that the
+    // coordinator ACCEPTED (returning a run_id — the precondition for
+    // `mark_fire_accepted`), and the run reached terminal so the once-schedule
+    // trigger settled `Completed`. All settle writes landed on the production
+    // store-graph trigger repository read back here.
+    assert!(
+        final_record.last_fired_slot.is_some(),
+        "once schedule: last_fired_slot should be set after the production poller fires — \
+         record: {final_record:?}",
+    );
+    assert!(
+        final_record.last_run_at.is_some(),
+        "once schedule: last_run_at should be set after the production poller fires — \
+         record: {final_record:?}",
+    );
+    assert_eq!(
+        final_record.last_status,
+        Some(TriggerRunStatus::Ok),
+        "once schedule: last_status must be Ok after an accepted trusted submit — \
+         record: {final_record:?}",
+    );
+    assert_eq!(
+        final_record.state,
+        TriggerState::Completed,
+        "once schedule: state must be Completed after the run reaches terminal and \
+         clear_active_fire runs — record: {final_record:?}",
+    );
+    assert!(
+        final_record.active_run_ref.is_none() && final_record.active_fire_slot.is_none(),
+        "the settled once-schedule fire must clear its active run/fire claim — \
+         record: {final_record:?}",
+    );
+
+    // The model gateway is wired (so no real LLM is ever contacted) but is not
+    // asserted on: the fired trusted-ingress run terminates before the first
+    // model call in this minimal production harness. See the module docs — this
+    // is a turn-execution-environment limit, not a poller-wiring gap. The
+    // captured-request snapshot is read purely to keep the gateway on the run's
+    // wiring path.
+    let _captured_contents = recording_gateway.captured_message_contents().await;
+}


### PR DESCRIPTION
## What

Make the composition-owned **trigger poller run on production-shaped runtimes** (`local_runtime: None`, `production_runtime: Some(..)`), not just local-dev. This is the keystone for **production proactive/scheduled execution** — before this change the poller launch hard-errored `"trigger poller is not wired for production runtime launch"` for any production-shaped runtime.

**Enablement is unchanged and opt-in**: the existing `trigger_poller.enabled` input flag (`TriggerPollerSettings.enabled`). No new config axis.

## How — collapse, not duplicate

The `if trigger_poller.enabled { … }` launch block no longer branches on the concrete local substrate. It became **one substrate-agnostic path** sourcing its deps from the unified `RuntimeStoreParts` plus two small both-path resolver helpers for the concrete-`F` pieces:

**Unified `RuntimeStoreParts` fields used by the collapsed path:**
- `turn_run_snapshot_source: Arc<dyn TurnRunSnapshotSource>` — **new field**; set from `local_runtime.turn_state` (local) / `graph.turn_state` (production). Backs the active-run lookup (`build_trigger_active_run_lookup` now takes the snapshot source directly).
- `trigger_repository: Option<Arc<dyn TriggerRepository>>` — **now bound** (was `_trigger_repository`, unused). Backs the poller spawn; fail-closed if `None`.

**Two concrete-`F` resolver helpers (both-path):**
- `poller_user_directory(services, local_runtime, tenant, user, agent, project) -> Option<Arc<dyn RebornUserDirectory>>` — resolves the `TenantMembership` fire-checker's identity directory from either substrate (mirrors `RebornRuntime::reborn_user_directory`; production matches the store-graph arms → `FilesystemRebornIdentityStore::new(graph.scoped_filesystem, …)`).
- Trigger **conversation services** resolve inline from either the local substrate (`durable_trigger_conversation_services()` / in-memory) or the production store graph's **new eager** `RebornProductionRuntimeStoreGraph.trigger_conversation_services` field (built in `build_backend_production` from `scoped_filesystem`; production is always durable, so no `OnceCell` arm).

`build_trigger_poller_services` is now **generic over the conversation-services type and synchronous** — the caller resolves the concrete type per substrate (`RebornFilesystemConversationServices` durable / `InMemoryConversationServices` non-durable), so there is no `#[cfg]` split inside it.

## Delivery stays downstream

The poller runs with an **empty post-submit delivery hook** until a channel driver fills it (production gets no driver yet). Triggered runs **execute + persist**; no external send. This is intended.

## `readiness_for` intentionally unchanged

`workers.trigger_poller` in `readiness_for` stays `false` — it is a services-build-time flag that predates knowing the runtime input's poller setting, and local-dev already reports `false` there. Out of scope.

## Test (red→green, integration tier, `libsql`)

New `crates/ironclaw_reborn_composition/tests/production_runtime_trigger_poller.rs`: builds a `Production`-profile runtime with the poller enabled, seeds a **due one-shot `TriggerRecord`** through the production store graph's trigger repository (new `RebornRuntime::production_trigger_repository_for_test` `test-support` accessor), pairs the creator's external actor via the **production** conversation services, and asserts the poller **claims → materializes → submits (accepted, `run_id`) → settles** the once-schedule to `Completed`/`Ok` on the production repository (`mark_fire_accepted` requires an accepted trusted submit; `clear_active_fire` → `Completed` requires run-terminal). That is a trigger/run-**seam** assertion, not `wait_for_status(Completed)` alone.

- **Red→green confirmed**: with the pre-change hard-error restored, the test panics at build with `"trigger poller is not wired for production runtime launch"`; after the collapse it passes.

**Assertion reduced vs. local (why):** the model-gateway override *is* honored on production under `test-support`, but the fired trusted-ingress run terminates **before the first model call** in this minimal secure-default / tenant-sandbox production harness (no real conversational agent-loop environment). So this tier cannot assert "the trigger prompt reached the model" the way local `trigger_poller_e2e` does — that is a turn-execution-environment limit, not a poller-wiring gap. The poller's full claim/materialize/submit/settle path against the production substrate **is** exercised. The local `trigger_poller_e2e` suite (9 tests, incl. the prompt-reaches-model happy path) still passes unchanged, confirming the local execution path is preserved by the refactor.

## Verification gate

- `cargo fmt` — clean
- `cargo test -p ironclaw_reborn_composition --features libsql,test-support --test production_runtime_trigger_poller` — pass (red→green verified)
- `cargo test -p ironclaw_reborn_composition --features libsql,test-support --test trigger_poller_e2e` — 9 pass (no regression)
- `cargo test -p ironclaw_reborn_composition --features libsql,test-support trigger` — 0 failures
- clippy `-D warnings` (`--all-targets`) on all three lanes: `libsql,test-support`; `--all-features`; `--no-default-features --features postgres,test-support` — clean
- `scripts/pre-commit-safety.sh` — pass

Refs #6389 (design). Stacked-independent: branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)