### PR TITLE
ci(reborn): restore sub-10-minute test runs

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -219,6 +219,7 @@ jobs:
           scripts/ci/test-check-hermetic-env.sh
           scripts/ci/test-classify-test-scope.sh
           scripts/ci/test-package-feature-flags.sh
+          scripts/ci/test-reborn-crate-test-buckets.sh
           bash .github/scripts/test-pr-labeler.sh
 
   clippy:

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -348,7 +348,7 @@ jobs:
             echo "::endgroup::"
           done < <(printf '%s\n' "${BUCKET_PACKAGES}" | jq -r '.[]')
 
-          # Concat per-package lcov into one artifact per bucket (keeps artifact count at ~12, not ~60); merge script parses end_of_record blocks per file already, so `cat` is sufficient.
+          # Concat per-package lcov into one artifact per bucket (keeps artifact count bounded by the matrix, not ~60); merge script parses end_of_record blocks per file already, so `cat` is sufficient.
           cat coverage/*.lcov > "bucket-${BUCKET_NAME}.lcov"
 
       - name: Upload bucket lcov artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "hex",
+ "ironclaw_common",
  "ironclaw_events",
  "ironclaw_filesystem",
  "ironclaw_host_api",

--- a/crates/ironclaw_reborn_event_store/Cargo.toml
+++ b/crates/ironclaw_reborn_event_store/Cargo.toml
@@ -37,5 +37,6 @@ webpki-roots = "1.0"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+ironclaw_common = { path = "../ironclaw_common", version = "0.4.2" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
@@ -4,6 +4,68 @@ use ironclaw_reborn_event_store::{
 };
 use secrecy::SecretString;
 
+const POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV: &str =
+    "IRONCLAW_FILESYSTEM_POSTGRES_MIGRATION_CONNECT_MAX_WAIT_SECS";
+static POSTGRES_MIGRATION_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct ShortMigrationConnectWait {
+    _lock: tokio::sync::MutexGuard<'static, ()>,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ShortMigrationConnectWait {
+    async fn install() -> Self {
+        let lock = POSTGRES_MIGRATION_ENV_LOCK.lock().await;
+        let previous = std::env::var_os(POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV);
+        // SAFETY: the two tests that exercise a failed migration connection
+        // serialize access through POSTGRES_MIGRATION_ENV_LOCK. No other test
+        // in this integration-test process reads this variable.
+        unsafe { std::env::set_var(POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV, "1") };
+        Self {
+            _lock: lock,
+            previous,
+        }
+    }
+}
+
+impl Drop for ShortMigrationConnectWait {
+    fn drop(&mut self) {
+        // SAFETY: the lock remains held until after this restoration, so the
+        // environment cannot be changed concurrently within this process.
+        unsafe {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV, previous);
+            } else {
+                std::env::remove_var(POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV);
+            }
+        }
+    }
+}
+
+fn rejecting_remote_postgres_url(database: &str, ssl_mode: &str) -> SecretString {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind loopback listener for deterministic connection failure");
+    let port = listener
+        .local_addr()
+        .expect("loopback listener address")
+        .port();
+
+    // Keep `host` remote so the production TLS policy is exercised, while
+    // `hostaddr` bypasses DNS and routes the attempted connection to this
+    // hermetic endpoint. Closing the accepted socket makes the backend fail
+    // immediately after policy validation instead of waiting on DNS retries.
+    let _rejector = std::thread::spawn(move || {
+        let _ = listener.accept();
+    });
+
+    SecretString::new(
+        format!(
+            "host=example.invalid hostaddr=127.0.0.1 port={port} user=event_user password=RAW_PASSWORD_SENTINEL_3162 dbname={database} sslmode={ssl_mode}"
+        )
+        .into_boxed_str(),
+    )
+}
+
 #[tokio::test]
 async fn production_profile_rejects_in_memory_before_returning_service_graph() {
     let result =
@@ -103,14 +165,11 @@ async fn production_postgres_rejects_remote_sslmode_disable_before_connecting() 
 }
 #[tokio::test]
 async fn production_postgres_event_store_honors_explicit_remote_cleartext_opt_in() {
+    let _short_wait = ShortMigrationConnectWait::install().await;
     let result = build_reborn_event_stores(
         RebornProfile::Production,
         RebornEventStoreConfig::Postgres {
-            url: SecretString::new(
-                "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@example.invalid/events?sslmode=disable"
-                    .to_string()
-                    .into_boxed_str(),
-            ),
+            url: rejecting_remote_postgres_url("events", "disable"),
             tls_options: PostgresPoolTlsOptions {
                 ssl_mode_override: None,
                 allow_remote_cleartext: true,
@@ -136,14 +195,11 @@ async fn production_postgres_event_store_honors_explicit_remote_cleartext_opt_in
 }
 #[tokio::test]
 async fn postgres_connection_failure_does_not_fall_back_or_leak_secret_config() {
+    let _short_wait = ShortMigrationConnectWait::install().await;
     let result = build_reborn_event_stores(
         RebornProfile::Production,
         RebornEventStoreConfig::Postgres {
-            url: SecretString::new(
-                "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@example.invalid/db"
-                    .to_string()
-                    .into_boxed_str(),
-            ),
+            url: rejecting_remote_postgres_url("db", "require"),
             tls_options: Default::default(),
         },
     )

--- a/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/profile_contract.rs
@@ -6,20 +6,18 @@ use secrecy::SecretString;
 
 const POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV: &str =
     "IRONCLAW_FILESYSTEM_POSTGRES_MIGRATION_CONNECT_MAX_WAIT_SECS";
-static POSTGRES_MIGRATION_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 struct ShortMigrationConnectWait {
-    _lock: tokio::sync::MutexGuard<'static, ()>,
+    _lock: std::sync::MutexGuard<'static, ()>,
     previous: Option<std::ffi::OsString>,
 }
 
 impl ShortMigrationConnectWait {
-    async fn install() -> Self {
-        let lock = POSTGRES_MIGRATION_ENV_LOCK.lock().await;
+    fn install() -> Self {
+        let lock = ironclaw_common::env_helpers::lock_env();
         let previous = std::env::var_os(POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV);
-        // SAFETY: the two tests that exercise a failed migration connection
-        // serialize access through POSTGRES_MIGRATION_ENV_LOCK. No other test
-        // in this integration-test process reads this variable.
+        // SAFETY: env-mutating tests serialize through the canonical
+        // workspace lock for the lifetime of this guard.
         unsafe { std::env::set_var(POSTGRES_MIGRATION_CONNECT_MAX_WAIT_ENV, "1") };
         Self {
             _lock: lock,
@@ -164,8 +162,9 @@ async fn production_postgres_rejects_remote_sslmode_disable_before_connecting() 
     assert!(!displayed.contains("postgres://"));
 }
 #[tokio::test]
+#[allow(clippy::await_holding_lock, reason = "serializes process env mutation")]
 async fn production_postgres_event_store_honors_explicit_remote_cleartext_opt_in() {
-    let _short_wait = ShortMigrationConnectWait::install().await;
+    let _short_wait = ShortMigrationConnectWait::install();
     let result = build_reborn_event_stores(
         RebornProfile::Production,
         RebornEventStoreConfig::Postgres {
@@ -194,8 +193,9 @@ async fn production_postgres_event_store_honors_explicit_remote_cleartext_opt_in
     assert!(!displayed.contains("postgres://"));
 }
 #[tokio::test]
+#[allow(clippy::await_holding_lock, reason = "serializes process env mutation")]
 async fn postgres_connection_failure_does_not_fall_back_or_leak_secret_config() {
-    let _short_wait = ShortMigrationConnectWait::install().await;
+    let _short_wait = ShortMigrationConnectWait::install();
     let result = build_reborn_event_stores(
         RebornProfile::Production,
         RebornEventStoreConfig::Postgres {

--- a/scripts/ci/classify-test-scope.sh
+++ b/scripts/ci/classify-test-scope.sh
@@ -87,7 +87,7 @@ is_reborn_test_path() {
     crates/ironclaw_conversations/*|crates/ironclaw_outbound/*|crates/ironclaw_triggers/*)
       return 0
       ;;
-    scripts/ci/reborn-coverage-*.sh|scripts/ci/test-reborn-coverage.sh|scripts/ci/test-reborn-coverage-*.sh|scripts/ci/lib/reborn_coverage_lcov.py|scripts/ci/check-test-suite-boundaries.sh|scripts/ci/classify-test-scope.sh|scripts/ci/test-classify-test-scope.sh)
+    scripts/ci/reborn-coverage-*.sh|scripts/ci/test-reborn-coverage.sh|scripts/ci/test-reborn-coverage-*.sh|scripts/ci/lib/reborn_coverage_lcov.py|scripts/ci/reborn-crate-test-buckets.sh|scripts/ci/test-reborn-crate-test-buckets.sh|scripts/ci/check-test-suite-boundaries.sh|scripts/ci/classify-test-scope.sh|scripts/ci/test-classify-test-scope.sh)
       return 0
       ;;
     *)

--- a/scripts/ci/reborn-crate-test-buckets.sh
+++ b/scripts/ci/reborn-crate-test-buckets.sh
@@ -26,6 +26,10 @@ jq -c -n --argjson packages "${packages_json}" '
     "events-conversations",
     "auth-security",
     "memory-skills",
+    "channel-delivery",
+    "channel-host",
+    "reborn-migration",
+    "telegram-extension",
     "adapters-misc"
   ];
 
@@ -98,6 +102,14 @@ jq -c -n --argjson packages "${packages_json}" '
       ironclaw_scripts: "memory-skills",
       ironclaw_skill_learning: "memory-skills",
       ironclaw_skills: "memory-skills",
+
+      # These packages dominate cold/partial-cache wall time. Keep each in its
+      # own matrix lane so compilation overlaps instead of serializing behind
+      # the miscellaneous adapters bucket.
+      ironclaw_channel_delivery: "channel-delivery",
+      ironclaw_channel_host: "channel-host",
+      ironclaw_reborn_migration: "reborn-migration",
+      ironclaw_telegram_extension: "telegram-extension",
 
       ironclaw_architecture: "adapters-misc",
       ironclaw_common: "adapters-misc",

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -212,6 +212,22 @@ has_legacy_tests=true
 has_reborn_tests=true"
 
 assert_scope \
+  "Reborn crate bucket script" \
+  "scripts/ci/reborn-crate-test-buckets.sh" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "Reborn crate bucket regression suite" \
+  "scripts/ci/test-reborn-crate-test-buckets.sh" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
   "Reborn Responses E2E manifest checker" \
   "scripts/ci/check-reborn-responses-e2e-manifest.py" \
   "docs_only=false

--- a/scripts/ci/test-reborn-crate-test-buckets.sh
+++ b/scripts/ci/test-reborn-crate-test-buckets.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bucket_script="${script_dir}/reborn-crate-test-buckets.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+packages='[
+  "ironclaw_telegram_extension",
+  "ironclaw_common",
+  "ironclaw_reborn_migration",
+  "ironclaw_channel_host",
+  "ironclaw_channel_delivery",
+  "ironclaw_future_adapter"
+]'
+
+actual="$("${bucket_script}" "${packages}")"
+expected='[
+  {"name":"channel-delivery","packages":["ironclaw_channel_delivery"]},
+  {"name":"channel-host","packages":["ironclaw_channel_host"]},
+  {"name":"reborn-migration","packages":["ironclaw_reborn_migration"]},
+  {"name":"telegram-extension","packages":["ironclaw_telegram_extension"]},
+  {"name":"adapters-misc","packages":["ironclaw_common","ironclaw_future_adapter"]}
+]'
+
+if ! jq -e --argjson expected "${expected}" '. == $expected' <<< "${actual}" >/dev/null; then
+  fail "heavy packages were not isolated into the expected ordered buckets: ${actual}"
+fi
+
+if ! jq -e --argjson packages "${packages}" '
+  [.[].packages[]] as $assigned
+  | ($assigned | length) == ($packages | length)
+    and ($assigned | unique | length) == ($assigned | length)
+    and (($assigned | sort) == ($packages | sort))
+' <<< "${actual}" >/dev/null; then
+  fail "every input package must be assigned exactly once: ${actual}"
+fi
+
+if [ "$("${bucket_script}" '[]')" != '[]' ]; then
+  fail "an empty package list must produce an empty matrix"
+fi
+
+echo "PASS Reborn crate bucket assignments"


### PR DESCRIPTION
## Summary

- split channel delivery, channel host, Reborn migration, and Telegram extension coverage out of the serial `adapters-misc` lane
- make failed-Postgres profile contracts hermetic and fast while preserving the production 300-second migration retry
- add exact-once bucket assignment and test-scope regression coverage

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [x] Dependencies — dev-only `ironclaw_common` for the canonical test environment lock

## Linked Issue

None.

## Timing Evidence

- PR #6408 run 29809380134: **24m04s** overall; `adapters-misc` test step **19m34s**
- recurring cold-cache outliers reached **31m09s** and **33m57s**
- validation run 29817130153: **9m26s** overall
  - slowest newly split target: **4m13s**
  - `reborn-core` test step: **7m50s → 2m56s**
  - event-store `profile_contract`: **300.04s → 2.04s**

Validation run: https://github.com/nearai/ironclaw/actions/runs/29817130153

## Validation

- [ ] `cargo fmt --all -- --check` — focused test file was formatted
- [ ] workspace-wide Clippy — owning crate passed `cargo clippy -p ironclaw_reborn_event_store --all-targets --all-features -- -D warnings`; PR Clippy check passed
- [ ] `cargo build` — covered by passing PR build/test matrix
- [x] Relevant tests pass:
  - `cargo test -p ironclaw_reborn_event_store`
  - `cargo test -p ironclaw_architecture`
  - `scripts/ci/test-check-hermetic-env.sh`
  - `scripts/ci/test-reborn-crate-test-buckets.sh`
  - `scripts/ci/test-classify-test-scope.sh`
  - `scripts/ci/test-package-feature-flags.sh`
  - `scripts/pre-commit-safety.sh`
- [ ] `cargo test --features integration` — no database behavior or schema changed
- [x] Manual testing: GitHub Actions completed with 60 passing checks and zero source failures
- [x] Review follow-through audit performed; every inline thread received an evidence-based reply

## Security Impact

None. Production network, TLS, secret-redaction, and retry behavior are unchanged. Test environment mutation now uses the canonical workspace lock, eliminating the private lock domain flagged by the hermetic-env gate.

## Reborn Trust-Boundary Checklist

N/A: this changes CI partitioning and test-only failure setup; no production trust-bearing types, ingress, prompts, status variants, serialization, queues, errors, or sandbox boundaries changed.

## Database Impact

None. No migration, schema, PostgreSQL/libSQL behavior, or production timeout changed.

## Blast Radius

Reborn coverage job partitioning and the event-store profile-contract test process. The operational tradeoff is four additional parallel coverage jobs; incorrect bucket assignment is guarded by an exact-once matrix regression test.

## Rollback Plan

Revert the PR merge commit to restore the prior bucket layout and test helper. The canonical-lock follow-up can be retained independently because it is dev-only and preserves test semantics.

## Review Follow-Through

- Gemini canonical-lock finding: fixed in `b00365fd5` and replied inline.
- CodeRabbit deadlock claim: investigated and rejected; CodeRabbit verified the current-thread runtime evidence, withdrew the finding, and auto-resolved its thread.
- IronLoop’s earlier review found no actionable defects. A post-merge retry failed fetching GitHub’s removed PR merge ref, after the PR had already merged; this was an external lifecycle failure, not a code verdict.
- GitHub Actions: 60 passed, zero failed. Railway preview was cancelled during post-merge environment teardown.

---

**Review track**: C (CI)
