### PR TITLE
fix(webui): restore SSE streams across navigation

### DIFF
--- a/crates/ironclaw_event_streams/src/manager.rs
+++ b/crates/ironclaw_event_streams/src/manager.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use ironclaw_event_projections::{
     EventCursor, EventProjectionService, ProjectionCursor, ProjectionError, ProjectionRequest,
@@ -21,7 +21,8 @@ use crate::{
     types::{
         LagReason, ProductProjectionEnvelope, ProjectionFetchRequest, ProjectionFetchResponse,
         ProjectionStreamItem, ProjectionSubscribeRequest, ProjectionSubscription, ProjectionTarget,
-        ProjectionViewClass, PushCandidatesForUpdateRequest,
+        ProjectionViewClass, PushCandidatesForUpdateRequest, ThreadLiveProjectionItem,
+        ThreadLiveProjectionUpdate,
     },
     update_source::{ProjectionLiveUpdateRequest, ProjectionUpdateSource},
 };
@@ -220,7 +221,8 @@ impl EventStreamManager {
                 Err(error) => return Err(map_projection_error(error)),
             },
         };
-        let buffered_live = self
+        let is_fresh_subscription = request.after_cursor.is_none();
+        let mut buffered_live = self
             .update_source
             .replay_after(
                 ProjectionLiveUpdateRequest {
@@ -233,6 +235,9 @@ impl EventStreamManager {
                 request.limit,
             )
             .await?;
+        if is_fresh_subscription {
+            buffered_live = compact_live_replay_to_current_state(buffered_live);
+        }
         for envelope in buffered_live {
             validate_stream_envelope(
                 envelope.as_ref(),
@@ -379,6 +384,83 @@ impl EventStreamManager {
             .map(ProductProjectionEnvelope::ThreadSnapshot)
             .map_err(map_projection_error)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum LiveProjectionItemKey {
+    Text(String),
+    Thinking(String),
+    CapabilityActivity(String),
+    WorkSummary(String),
+    SkillActivation(String),
+}
+
+fn live_projection_item_key(item: &ThreadLiveProjectionItem) -> LiveProjectionItemKey {
+    match item {
+        ThreadLiveProjectionItem::Text { id, .. } => LiveProjectionItemKey::Text(id.clone()),
+        ThreadLiveProjectionItem::Thinking { id, .. } => {
+            LiveProjectionItemKey::Thinking(id.clone())
+        }
+        ThreadLiveProjectionItem::CapabilityActivity { invocation_id, .. } => {
+            LiveProjectionItemKey::CapabilityActivity(invocation_id.to_string())
+        }
+        ThreadLiveProjectionItem::WorkSummary { id, .. } => {
+            LiveProjectionItemKey::WorkSummary(id.clone())
+        }
+        ThreadLiveProjectionItem::SkillActivation { id, .. } => {
+            LiveProjectionItemKey::SkillActivation(id.clone())
+        }
+    }
+}
+
+/// A new subscriber needs current live projection state, not the sequence of
+/// cumulative values that built it. Cursor-based subscribers retain normal
+/// incremental replay; only an origin subscription compacts the retained live
+/// window to the latest value for each stable projection identity.
+fn compact_live_replay_to_current_state(
+    replay: Vec<Arc<ProductProjectionEnvelope>>,
+) -> Vec<Arc<ProductProjectionEnvelope>> {
+    let mut passthrough = Vec::new();
+    let mut latest_items = HashMap::new();
+    let mut live_item_order = 0_usize;
+    let mut latest_live_position = None;
+    let mut latest_live_update = None;
+
+    for (position, envelope) in replay.into_iter().enumerate() {
+        match envelope.as_ref() {
+            ProductProjectionEnvelope::ThreadLiveUpdate(update) => {
+                latest_live_position = Some(position);
+                latest_live_update = Some((update.cursor.clone(), update.thread_id.clone()));
+                for item in update.items.iter().cloned() {
+                    latest_items.insert(live_projection_item_key(&item), (live_item_order, item));
+                    live_item_order = live_item_order.saturating_add(1);
+                }
+            }
+            _ => passthrough.push((position, envelope)),
+        }
+    }
+
+    if let (Some(position), Some((cursor, thread_id))) = (latest_live_position, latest_live_update)
+    {
+        let mut items = latest_items.into_values().collect::<Vec<_>>();
+        items.sort_by_key(|(position, _)| *position);
+        passthrough.push((
+            position,
+            Arc::new(ProductProjectionEnvelope::ThreadLiveUpdate(
+                ThreadLiveProjectionUpdate {
+                    cursor,
+                    thread_id,
+                    items: items.into_iter().map(|(_, item)| item).collect(),
+                },
+            )),
+        ));
+    }
+
+    passthrough.sort_by_key(|(position, _)| *position);
+    passthrough
+        .into_iter()
+        .map(|(_, envelope)| envelope)
+        .collect()
 }
 
 impl std::fmt::Debug for EventStreamManager {

--- a/crates/ironclaw_event_streams/src/manager.rs
+++ b/crates/ironclaw_event_streams/src/manager.rs
@@ -432,8 +432,13 @@ fn compact_live_replay_to_current_state(
                 latest_live_position = Some(position);
                 latest_live_update = Some((update.cursor.clone(), update.thread_id.clone()));
                 for item in update.items.iter().cloned() {
-                    latest_items.insert(live_projection_item_key(&item), (live_item_order, item));
-                    live_item_order = live_item_order.saturating_add(1);
+                    let key = live_projection_item_key(&item);
+                    if let Some((_, latest_item)) = latest_items.get_mut(&key) {
+                        *latest_item = item;
+                    } else {
+                        latest_items.insert(key, (live_item_order, item));
+                        live_item_order = live_item_order.saturating_add(1);
+                    }
                 }
             }
             _ => passthrough.push((position, envelope)),

--- a/crates/ironclaw_event_streams/tests/event_stream_manager_contract/redaction_live.rs
+++ b/crates/ironclaw_event_streams/tests/event_stream_manager_contract/redaction_live.rs
@@ -1,6 +1,73 @@
 use super::*;
 
 #[tokio::test]
+async fn fresh_subscription_hydrates_latest_live_state_then_tails_new_updates() {
+    let scope = projection_scope("thread-a");
+    let source = Arc::new(InMemoryProjectionUpdateSource::new(8));
+    let manager = manager_with_source(scope.clone(), Arc::clone(&source));
+    let run_id = TurnRunId::new();
+    let thread_id = scope.read_scope.thread_id.clone().unwrap();
+    let live_update = |cursor, body: &str| {
+        ProductProjectionEnvelope::ThreadLiveUpdate(ThreadLiveProjectionUpdate {
+            cursor: ProjectionCursor::for_scope(scope.clone(), EventCursor::new(cursor)),
+            thread_id: thread_id.clone(),
+            items: vec![ThreadLiveProjectionItem::Text {
+                id: "text:active-run".to_string(),
+                run_id,
+                body: body.to_string(),
+            }],
+        })
+    };
+
+    for (cursor, body) in [(100, "partial"), (101, "current partial")] {
+        let error = source
+            .publish(live_update(cursor, body))
+            .expect_err("an update without a subscriber is retained but not broadcast");
+        assert!(matches!(error, ProjectionStreamError::Source));
+    }
+
+    let mut subscription = manager
+        .subscribe(subscribe_request(scope.clone(), None))
+        .await
+        .expect("fresh subscription");
+    assert!(matches!(
+        subscription.next().await,
+        Some(ProjectionStreamItem::Snapshot(_))
+    ));
+    let current = subscription.next().await.expect("current live state");
+    let ProjectionStreamItem::Update(current) = current else {
+        panic!("expected current live update, got {current:?}");
+    };
+    let ProductProjectionEnvelope::ThreadLiveUpdate(current) = current.as_ref() else {
+        panic!("expected thread live update, got {current:?}");
+    };
+    assert_eq!(
+        current.items,
+        vec![ThreadLiveProjectionItem::Text {
+            id: "text:active-run".to_string(),
+            run_id,
+            body: "current partial".to_string(),
+        }],
+        "origin subscribers must receive one current value rather than cumulative replay history"
+    );
+
+    source
+        .publish(live_update(102, "next partial"))
+        .expect("active subscriber receives the next update");
+    let next = subscription.next().await.expect("next live update");
+    let ProjectionStreamItem::Update(next) = next else {
+        panic!("expected next live update, got {next:?}");
+    };
+    let ProductProjectionEnvelope::ThreadLiveUpdate(next) = next.as_ref() else {
+        panic!("expected thread live update, got {next:?}");
+    };
+    assert!(matches!(
+        next.items.as_slice(),
+        [ThreadLiveProjectionItem::Text { body, .. }] if body == "next partial"
+    ));
+}
+
+#[tokio::test]
 async fn no_exposure_validator_rejects_sentinel_payloads() {
     let scope = projection_scope("thread-a");
     let source = Arc::new(InMemoryProjectionUpdateSource::new(8));

--- a/crates/ironclaw_event_streams/tests/event_stream_manager_contract/redaction_live.rs
+++ b/crates/ironclaw_event_streams/tests/event_stream_manager_contract/redaction_live.rs
@@ -7,21 +7,30 @@ async fn fresh_subscription_hydrates_latest_live_state_then_tails_new_updates() 
     let manager = manager_with_source(scope.clone(), Arc::clone(&source));
     let run_id = TurnRunId::new();
     let thread_id = scope.read_scope.thread_id.clone().unwrap();
-    let live_update = |cursor, body: &str| {
+    let text_item = |body: &str| ThreadLiveProjectionItem::Text {
+        id: "text:active-run".to_string(),
+        run_id,
+        body: body.to_string(),
+    };
+    let thinking_item = ThreadLiveProjectionItem::Thinking {
+        id: "thinking:active-run".to_string(),
+        run_id,
+        body: "current reasoning".to_string(),
+    };
+    let live_update = |cursor, items| {
         ProductProjectionEnvelope::ThreadLiveUpdate(ThreadLiveProjectionUpdate {
             cursor: ProjectionCursor::for_scope(scope.clone(), EventCursor::new(cursor)),
             thread_id: thread_id.clone(),
-            items: vec![ThreadLiveProjectionItem::Text {
-                id: "text:active-run".to_string(),
-                run_id,
-                body: body.to_string(),
-            }],
+            items,
         })
     };
 
-    for (cursor, body) in [(100, "partial"), (101, "current partial")] {
+    for update in [
+        live_update(100, vec![text_item("partial"), thinking_item.clone()]),
+        live_update(101, vec![text_item("current partial")]),
+    ] {
         let error = source
-            .publish(live_update(cursor, body))
+            .publish(update)
             .expect_err("an update without a subscriber is retained but not broadcast");
         assert!(matches!(error, ProjectionStreamError::Source));
     }
@@ -43,16 +52,12 @@ async fn fresh_subscription_hydrates_latest_live_state_then_tails_new_updates() 
     };
     assert_eq!(
         current.items,
-        vec![ThreadLiveProjectionItem::Text {
-            id: "text:active-run".to_string(),
-            run_id,
-            body: "current partial".to_string(),
-        }],
-        "origin subscribers must receive one current value rather than cumulative replay history"
+        vec![text_item("current partial"), thinking_item],
+        "origin subscribers must receive the latest payload at its first-seen position rather than cumulative replay history"
     );
 
     source
-        .publish(live_update(102, "next partial"))
+        .publish(live_update(102, vec![text_item("next partial")]))
         .expect("active subscriber receives the next update");
     let next = subscription.next().await.expect("next live update");
     let ProjectionStreamItem::Update(next) = next else {

--- a/crates/ironclaw_event_streams/tests/event_stream_manager_contract/support/imports.rs
+++ b/crates/ironclaw_event_streams/tests/event_stream_manager_contract/support/imports.rs
@@ -15,7 +15,7 @@ use ironclaw_event_streams::{
     ProjectionStreamAdmissionPolicy, ProjectionStreamAdmissionRequest, ProjectionStreamError,
     ProjectionStreamItem, ProjectionStreamLimits, ProjectionSubscribeRequest, ProjectionTarget,
     ProjectionUpdateSource, ProjectionViewClass, PushCandidatesForUpdateRequest,
-    SubscriberCapabilities, keep_alive_item,
+    SubscriberCapabilities, ThreadLiveProjectionItem, ThreadLiveProjectionUpdate, keep_alive_item,
 };
 use ironclaw_events::{EventCursor, EventStreamKey, ReadScope};
 use ironclaw_filesystem::{
@@ -33,7 +33,7 @@ use ironclaw_outbound::{
     ProjectionUpdateRef, ThreadNotificationPolicy, ThreadNotificationTarget,
     UpdateDeliveryStatusRequest,
 };
-use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnScope};
+use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
 use tokio::{
     sync::Barrier,
     time::{Duration, timeout},

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -401,7 +401,8 @@ The opaque WebUI projection cursor stamps its process-local live position with
 the projection-services epoch. On an epoch mismatch, resume preserves durable
 runtime and turn positions but clears the volatile live position so a browser
 cursor retained across a deployment cannot suppress the restarted process's
-interim updates.
+interim updates. This is enforced by
+`WebuiRuntimeProjectionStream::runtime_subscription` in `src/projection.rs`.
 
 ```rust
 // Inside a host-owned ingress crate / binary (NOT in this crate —

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -397,6 +397,12 @@ before that milestone is projected. Reasoning, capability, and lifecycle
 milestones remain ordered and uncoalesced. The in-memory source still records
 the latest projection for replay when no browser subscriber is active.
 
+The opaque WebUI projection cursor stamps its process-local live position with
+the projection-services epoch. On an epoch mismatch, resume preserves durable
+runtime and turn positions but clears the volatile live position so a browser
+cursor retained across a deployment cannot suppress the restarted process's
+interim updates.
+
 ```rust
 // Inside a host-owned ingress crate / binary (NOT in this crate —
 // `reborn_product_api_crates_do_not_bind_http_ingress` forbids

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -40,6 +40,7 @@ use ironclaw_turns::{
     TurnRunId, TurnScope, TurnStatus, run_profile::LoopHostMilestoneSink,
 };
 use tokio::sync::{broadcast, mpsc};
+use uuid::Uuid;
 
 mod display_preview;
 mod live_progress;
@@ -80,6 +81,7 @@ pub(crate) struct RebornProjectionServices {
     event_stream_manager: Arc<EventStreamManager>,
     live_updates: Arc<InMemoryProjectionUpdateSource>,
     live_sequence: Arc<AtomicU64>,
+    live_epoch: Arc<str>,
     turn_event_wake_source: Arc<TurnEventWakeSource>,
     turn_events: TurnEventBridge,
     approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
@@ -157,6 +159,7 @@ impl RebornProjectionServices {
             auth_challenges: self.auth_challenges.clone(),
             display_previews: Arc::clone(&self.display_previews),
             reply_target_binding_ref: self.webui_reply_target_binding_ref.clone(),
+            live_epoch: Arc::clone(&self.live_epoch),
         })
     }
 
@@ -204,6 +207,7 @@ pub(crate) fn build_reborn_projection_services(
     // the same SSE cursor space; per-publisher counters can collide after a
     // durable cursor has advanced.
     let live_sequence = Arc::new(AtomicU64::new(0));
+    let live_epoch: Arc<str> = Arc::from(Uuid::new_v4().to_string());
     let event_stream_manager = Arc::new(EventStreamManager::from_services(
         projection,
         Arc::new(AllowAllProjectionAccessPolicy),
@@ -227,6 +231,7 @@ pub(crate) fn build_reborn_projection_services(
         event_stream_manager,
         live_updates,
         live_sequence,
+        live_epoch,
         turn_event_wake_source: Arc::new(TurnEventWakeSource::new()),
         turn_events: TurnEventBridge::default(),
         approval_requests: None,
@@ -301,6 +306,7 @@ struct WebuiRuntimeProjectionStream {
     auth_challenges: Option<Arc<dyn AuthChallengeProvider>>,
     display_previews: Arc<dyn CapabilityDisplayPreviewSource>,
     reply_target_binding_ref: ReplyTargetBindingRef,
+    live_epoch: Arc<str>,
 }
 
 #[async_trait]
@@ -379,13 +385,26 @@ impl WebuiRuntimeProjectionStream {
         request: &ProjectionSubscriptionRequest,
     ) -> Result<(EventProjectionSubscription, WebuiProjectionCursor), ProductAdapterError> {
         let projection_scope = runtime_projection_scope(&request.actor, &request.scope);
-        let origin_cursor = request
+        let mut origin_cursor = request
             .after_cursor
             .clone()
             .map(|cursor| parse_webui_projection_cursor(cursor.as_str()))
             .transpose()?
             .unwrap_or_default();
         validate_webui_projection_cursor_scope(&origin_cursor, &request.scope, &projection_scope)?;
+        // Live projection updates are process-local and their numeric sequence
+        // restarts from zero with each projection-services bundle. A browser
+        // can retain an otherwise valid composite cursor across a deployment;
+        // carrying that prior process's live floor forward would suppress new
+        // live updates until the restarted counter overtook it. Keep the
+        // durable runtime/turn positions, but rebase only the volatile live
+        // component when the producing process changes.
+        if origin_cursor.live.is_some()
+            && origin_cursor.live_epoch.as_deref() != Some(self.live_epoch.as_ref())
+        {
+            origin_cursor.live = None;
+        }
+        origin_cursor.live_epoch = Some(self.live_epoch.to_string());
         let subscription = self
             .manager
             .subscribe(ProjectionSubscribeRequest {
@@ -1060,6 +1079,8 @@ struct WebuiProjectionCursor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     live: Option<EventProjectionCursor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    live_epoch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     runtime_item: Option<EventCursor>,
     turn: Option<TurnEventProjectionCursor>,
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -1096,6 +1117,7 @@ fn parse_webui_projection_cursor(
     Ok(WebuiProjectionCursor {
         runtime: Some(runtime),
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 0,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/cursor_validation.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/cursor_validation.rs
@@ -54,6 +54,7 @@ async fn webui_event_stream_rejects_runtime_delivery_offset_above_payload_limit(
             runtime_projection_scope(&actor, &scope),
         )),
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: WEBUI_RUNTIME_ITEM_MAX_PAYLOADS + 2,
@@ -107,6 +108,7 @@ async fn webui_event_stream_rejects_runtime_delivery_offset_above_item_payload_c
             runtime_projection_scope(&actor, &scope),
         )),
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 3,
@@ -158,6 +160,7 @@ async fn webui_event_stream_rejects_legacy_partial_snapshot_offset_above_item_pa
     let cursor = product_cursor_from_webui_cursor(&WebuiProjectionCursor {
         runtime: None,
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 3,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
@@ -41,6 +41,113 @@ fn live_projection_fixture(label: &str) -> LiveProjectionFixture {
     }
 }
 
+// A browser keeps its opaque SSE cursor when Chat unmounts during route
+// navigation. Live cursors are process-local, however, so a deployment can
+// reset the sequence and produce the same numeric cursor again. The restarted
+// stream must discard only that stale live floor while preserving the durable
+// cursor components; otherwise all new interim text is silently filtered until
+// a full page refresh clears the browser cache.
+#[tokio::test]
+async fn webui_event_stream_rebases_live_cursor_from_prior_process_epoch() {
+    let tenant_id = TenantId::new("webui-live-restart-tenant").unwrap();
+    let user_id = UserId::new("webui-live-restart-user").unwrap();
+    let agent_id = AgentId::new("webui-live-restart-agent").unwrap();
+    let thread_id = ThreadId::new("webui-live-restart-thread").unwrap();
+    let scope = TurnScope::new(tenant_id, Some(agent_id), None, thread_id);
+    let actor = TurnActor::new(user_id.clone());
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+
+    let services_before_restart = build_reborn_projection_services(
+        Arc::clone(&event_log),
+        ReplyTargetBindingRef::new("webui-live-restart-before").unwrap(),
+    );
+    let sink_before_restart = services_before_restart
+        .with_live_progress_milestone_sink_for_publisher(
+            Arc::new(InMemoryLoopHostMilestoneSink::default()),
+            services_before_restart.live_projection_publisher(user_id.clone()),
+        );
+    let run_id = TurnRunId::new();
+    let reasoning = |body: &str| LoopHostMilestone {
+        scope: scope.clone(),
+        actor: None,
+        turn_id: TurnId::new(),
+        run_id,
+        loop_driver_id: LoopDriverId::new("test_loop").unwrap(),
+        kind: LoopHostMilestoneKind::ModelReasoningDelta {
+            safe_delta: body.to_string(),
+        },
+    };
+    sink_before_restart
+        .publish_loop_milestone(reasoning("before restart"))
+        .await
+        .unwrap();
+    let before_restart = services_before_restart
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: actor.clone(),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+    let cached_cursor = before_restart
+        .iter()
+        .find(|event| {
+            matches!(
+                event.payload(),
+                ProductOutboundPayload::ProjectionUpdate { state }
+                    if state.items.iter().any(|item| matches!(
+                        item,
+                        ProductProjectionItem::Thinking { body, .. }
+                            if body == "before restart"
+                    ))
+            )
+        })
+        .expect("first process must emit live reasoning")
+        .projection_cursor()
+        .clone();
+
+    // A fresh services bundle models a new server process: it shares the
+    // durable log but owns a new live-update source, sequence, and epoch.
+    let services_after_restart = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-live-restart-after").unwrap(),
+    );
+    let sink_after_restart = services_after_restart
+        .with_live_progress_milestone_sink_for_publisher(
+            Arc::new(InMemoryLoopHostMilestoneSink::default()),
+            services_after_restart.live_projection_publisher(user_id),
+        );
+    sink_after_restart
+        .publish_loop_milestone(reasoning("after restart"))
+        .await
+        .unwrap();
+
+    let resumed = services_after_restart
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: Some(cached_cursor),
+        })
+        .await
+        .unwrap();
+    assert!(
+        resumed.iter().any(|event| {
+            matches!(
+                event.payload(),
+                ProductOutboundPayload::ProjectionUpdate { state }
+                    if state.items.iter().any(|item| matches!(
+                        item,
+                        ProductProjectionItem::Thinking { body, .. }
+                            if body == "after restart"
+                    ))
+            )
+        }),
+        "a stale process-local live cursor must not suppress the restarted process's updates: {resumed:#?}"
+    );
+}
+
 #[tokio::test]
 async fn webui_event_stream_drains_live_reasoning_projection_from_update_source() {
     let fixture = live_projection_fixture("webui-thinking");

--- a/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/live_progress_stream.rs
@@ -202,7 +202,7 @@ async fn webui_event_stream_drains_live_reasoning_projection_from_update_source(
 }
 
 #[tokio::test]
-async fn webui_event_stream_drains_live_assistant_text_projection_from_update_source() {
+async fn fresh_webui_event_stream_compacts_buffered_assistant_text_to_latest_state() {
     let fixture = live_projection_fixture("webui-text");
     let user_id = fixture.user_id.clone();
     let thread_id = fixture.thread_id.clone();
@@ -277,11 +277,8 @@ async fn webui_event_stream_drains_live_assistant_text_projection_from_update_so
 
     assert_eq!(
         text_bodies,
-        vec![
-            "partial answer".to_string(),
-            "partial answer with [redacted]".to_string()
-        ],
-        "assistant text should drain as incremental updates to one stable text item"
+        vec!["partial answer with [redacted]".to_string()],
+        "a fresh route attach must hydrate the latest text state without replaying its growth history"
     );
     let wire = serde_json::to_string(&events).unwrap();
     assert!(!wire.contains(secret_like_token));
@@ -649,6 +646,16 @@ async fn live_publishers_from_same_services_share_monotonic_sequence() {
     let user_id = fixture.user_id.clone();
     let scope = fixture.scope.clone();
     let run_id = TurnRunId::new();
+    let mut subscription = fixture
+        .services
+        .webui_event_stream()
+        .subscribe(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id.clone()),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
 
     let reasoning = |body: &str| LoopHostMilestone {
         scope: scope.clone(),
@@ -681,38 +688,34 @@ async fn live_publishers_from_same_services_share_monotonic_sequence() {
         .await
         .unwrap();
 
-    let events = fixture
-        .services
-        .webui_event_stream()
-        .drain(ProjectionSubscriptionRequest {
-            actor: TurnActor::new(user_id),
-            scope,
-            after_cursor: None,
-        })
-        .await
-        .unwrap();
-
-    let thinking_cursors = events
-        .iter()
-        .filter(|event| {
-            matches!(
-                event.payload(),
-                ProductOutboundPayload::ProjectionUpdate { state }
-                    if state.items.iter().any(|item| matches!(
-                        item,
-                        ProductProjectionItem::Thinking { body, .. }
-                            if body == "from publisher A" || body == "from publisher B"
-                    ))
-            )
-        })
-        .map(|event| event.projection_cursor().clone())
-        .collect::<Vec<_>>();
+    let mut thinking_cursors = Vec::new();
+    for _ in 0..4 {
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), subscription.next())
+            .await
+            .expect("live projection event")
+            .expect("live projection subscription remains open")
+            .expect("live projection event remains valid");
+        if matches!(
+            event.payload(),
+            ProductOutboundPayload::ProjectionUpdate { state }
+                if state.items.iter().any(|item| matches!(
+                    item,
+                    ProductProjectionItem::Thinking { body, .. }
+                        if body == "from publisher A" || body == "from publisher B"
+                ))
+        ) {
+            thinking_cursors.push(event.projection_cursor().clone());
+        }
+        if thinking_cursors.len() == 2 {
+            break;
+        }
+    }
 
     assert_eq!(
         thinking_cursors.len(),
         2,
         "both publishers' live reasoning items must reach the stream on their \
-         own cursor: {events:#?}"
+         own cursor"
     );
     assert_ne!(
         thinking_cursors[0], thinking_cursors[1],
@@ -786,9 +789,9 @@ async fn webui_event_stream_preserves_live_reasoning_and_tool_start_order() {
 
     let live_items = events
         .iter()
-        .filter_map(|event| match event.payload() {
-            ProductOutboundPayload::ProjectionUpdate { state } => state.items.first(),
-            _ => None,
+        .flat_map(|event| match event.payload() {
+            ProductOutboundPayload::ProjectionUpdate { state } => state.items.iter(),
+            _ => [].iter(),
         })
         .map(|item| match item {
             ProductProjectionItem::Thinking { body, .. } => format!("thinking:{body}"),

--- a/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
@@ -1828,6 +1828,7 @@ async fn webui_event_stream_accepts_legacy_partial_origin_cursor() {
     let legacy_cursor = product_cursor_from_webui_cursor(&WebuiProjectionCursor {
         runtime: None,
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 1,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -976,6 +976,7 @@ async fn webui_event_stream_recovers_from_turn_event_rebase_on_reconnect() {
             runtime_projection_scope(&actor, &scope),
         )),
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: Some(TurnEventProjectionCursor::for_scope(
             scope.clone(),
@@ -1025,6 +1026,7 @@ async fn webui_event_stream_rejects_foreign_composite_turn_cursor() {
     let cursor = product_cursor_from_webui_cursor(&WebuiProjectionCursor {
         runtime: None,
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: Some(TurnEventProjectionCursor::for_scope(
             scope_a,
@@ -1078,6 +1080,7 @@ async fn webui_event_stream_rejects_foreign_composite_runtime_cursor() {
             runtime_projection_scope(&actor, &scope_a),
         )),
         live: None,
+        live_epoch: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 1,

--- a/crates/ironclaw_webui/CLAUDE.md
+++ b/crates/ironclaw_webui/CLAUDE.md
@@ -134,6 +134,12 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
   (default 3 concurrent; override via `WebUiV2State::with_sse_concurrency_limit`)
   — a caller cannot bypass the cap by mixing SSE and WS. Exhaustion returns
   `429` with `retryable: true`.
+- The SPA also sends a bounded, random `connection_id` that is stable for one
+  loaded browser tab. A new stream with the same caller and connection id
+  supersedes and cancels its prior stream without consuming another slot. This
+  prevents a proxy-delayed close during thread navigation from stranding the
+  replacement stream behind the cap; distinct tabs still consume distinct
+  slots.
 - Every stream is closed after a max lifetime (5 min) and every `socket.send` /
   drain await is `timeout`-bounded, so a back-pressuring client or a stalled
   facade cannot pin a slot past the budget. Slots are RAII (`SseSlot`), released

--- a/crates/ironclaw_webui/CLAUDE.md
+++ b/crates/ironclaw_webui/CLAUDE.md
@@ -135,11 +135,22 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
   — a caller cannot bypass the cap by mixing SSE and WS. Exhaustion returns
   `429` with `retryable: true`.
 - The SPA also sends a bounded, random `connection_id` that is stable for one
-  loaded browser tab. A new stream with the same caller and connection id
-  supersedes and cancels its prior stream without consuming another slot. This
-  prevents a proxy-delayed close during thread navigation from stranding the
+  loaded browser tab plus a monotonically increasing `connection_generation`
+  for each EventSource it creates. A same-caller, same-id stream supersedes its
+  prior generation without consuming another slot; a delayed older generation
+  receives `204` and cannot cancel the current stream. This prevents
+  proxy-reordered closes/opens during thread navigation from stranding the
   replacement stream behind the cap; distinct tabs still consume distinct
   slots.
+- A successful facade subscription emits an application-level `keep_alive`
+  frame immediately after admission. Browser connection state uses that frame
+  as proof that the projection tail is ready instead of waiting for a model
+  delta or the periodic transport keep-alive.
+- `after_cursor` is retained only within one mounted Chat route (including
+  native EventSource retries and visibility recovery). A route/thread remount
+  starts at the projection origin so the server returns durable state plus the
+  compacted current live state; it does not persist process-local live cursors
+  across SPA navigation.
 - Every stream is closed after a max lifetime (5 min) and every `socket.send` /
   drain await is `timeout`-bounded, so a back-pressuring client or a stalled
   facade cannot pin a slot past the budget. Slots are RAII (`SseSlot`), released

--- a/crates/ironclaw_webui/frontend/src/lib/api.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/api.ts
@@ -577,7 +577,7 @@ export async function fetchAttachmentDataUrl(path) {
 // `EventSource` cannot set request headers, so the token rides as a
 // query param. The composition middleware accepts `?token=` for this
 // route specifically (in-scope "SSE query-token exception" from #3886).
-export function openEventStream({ threadId, afterCursor } = {}) {
+export function openEventStream({ threadId, afterCursor, connectionId } = {}) {
   const url = new URL(
     `${V2_BASE}/threads/${encodeURIComponent(threadId)}/events`,
     window.location.origin,
@@ -585,6 +585,7 @@ export function openEventStream({ threadId, afterCursor } = {}) {
   const token = readStoredToken();
   if (token) url.searchParams.set("token", token);
   if (afterCursor) url.searchParams.set("after_cursor", afterCursor);
+  if (connectionId) url.searchParams.set("connection_id", connectionId);
   return new EventSource(url.toString());
 }
 

--- a/crates/ironclaw_webui/frontend/src/lib/api.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/api.ts
@@ -577,7 +577,12 @@ export async function fetchAttachmentDataUrl(path) {
 // `EventSource` cannot set request headers, so the token rides as a
 // query param. The composition middleware accepts `?token=` for this
 // route specifically (in-scope "SSE query-token exception" from #3886).
-export function openEventStream({ threadId, afterCursor, connectionId } = {}) {
+export function openEventStream({
+  threadId,
+  afterCursor,
+  connectionId,
+  connectionGeneration,
+} = {}) {
   const url = new URL(
     `${V2_BASE}/threads/${encodeURIComponent(threadId)}/events`,
     window.location.origin,
@@ -586,6 +591,9 @@ export function openEventStream({ threadId, afterCursor, connectionId } = {}) {
   if (token) url.searchParams.set("token", token);
   if (afterCursor) url.searchParams.set("after_cursor", afterCursor);
   if (connectionId) url.searchParams.set("connection_id", connectionId);
+  if (connectionGeneration != null) {
+    url.searchParams.set("connection_generation", String(connectionGeneration));
+  }
   return new EventSource(url.toString());
 }
 

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -1,6 +1,5 @@
 import React from "react";
 import { openEventStream } from "../../../lib/api";
-import { authScope } from "../../../lib/auth-scope";
 import {
   CONNECTION_STATUS,
   type ConnectionStatus,
@@ -33,8 +32,6 @@ const V2_EVENT_NAMES = [
 
 const EVENT_SOURCE_CLOSED = 2;
 const EVENT_SOURCE_OPEN = 1;
-const MAX_CACHED_CURSORS = 30;
-const lastEventIdByThread = new Map<string, string>();
 // Stable for this browser tab's loaded SPA. Reusing it across Chat route
 // mounts lets the server supersede a proxy-held stream from the prior thread
 // instead of rejecting the replacement against the per-user connection cap.
@@ -42,28 +39,14 @@ const SSE_CONNECTION_ID =
   typeof globalThis.crypto?.randomUUID === "function"
     ? globalThis.crypto.randomUUID()
     : undefined;
+let nextConnectionGeneration = 0;
 
-function cursorKey(threadId: string) {
-  return `${authScope()}:${threadId}`;
-}
-
-function getLastEventId(threadId: string) {
-  return lastEventIdByThread.get(cursorKey(threadId));
-}
-
-function setLastEventId(threadId: string, eventId: string) {
-  const key = cursorKey(threadId);
-  lastEventIdByThread.delete(key);
-  lastEventIdByThread.set(key, eventId);
-  while (lastEventIdByThread.size > MAX_CACHED_CURSORS) {
-    const oldestKey = lastEventIdByThread.keys().next().value;
-    if (oldestKey === undefined) break;
-    lastEventIdByThread.delete(oldestKey);
-  }
-}
-
-function deleteLastEventId(threadId: string) {
-  lastEventIdByThread.delete(cursorKey(threadId));
+function connectionGeneration() {
+  nextConnectionGeneration =
+    nextConnectionGeneration >= Number.MAX_SAFE_INTEGER
+      ? 1
+      : nextConnectionGeneration + 1;
+  return nextConnectionGeneration;
 }
 
 function eventSourceReadyStateConstant(staticValue: unknown, fallback: number) {
@@ -105,6 +88,12 @@ export function useSSE({ threadId, onEvent, enabled }) {
     let reconnectAttempts = 0;
     let disposed = false;
     let terminalErrorReceived = false;
+    // This cursor belongs to this mounted route only. A route remount must
+    // hydrate current state from the projection origin because the composite
+    // cursor contains a process-local live rail. Native EventSource retries
+    // still carry Last-Event-ID automatically, and explicit retries within
+    // this effect may resume from the latest frame observed here.
+    let lastEventId = null;
     const maxReconnectDelay = 30_000;
     const reconnectOpenDeadline = 10_000;
 
@@ -169,8 +158,9 @@ export function useSSE({ threadId, onEvent, enabled }) {
 
       es = openEventStream({
         threadId,
-        afterCursor: getLastEventId(threadId) || undefined,
+        afterCursor: lastEventId || undefined,
         connectionId: SSE_CONNECTION_ID,
+        connectionGeneration: connectionGeneration(),
       });
       const source = es;
 
@@ -195,7 +185,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
         }
         if (!frame || typeof frame !== "object") return;
         if (event.lastEventId) {
-          setLastEventId(threadId, event.lastEventId);
+          lastEventId = event.lastEventId;
         }
         const rawType = frame.type || fallbackType;
         const type = rawType === "stream_error" ? "error" : rawType;
@@ -240,7 +230,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
           frame.retryable === true &&
           es === source
         ) {
-          deleteLastEventId(threadId);
+          lastEventId = null;
           reconnectWithTimer(CONNECTION_STATUS.RECONNECTING);
         }
       };

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -35,6 +35,13 @@ const EVENT_SOURCE_CLOSED = 2;
 const EVENT_SOURCE_OPEN = 1;
 const MAX_CACHED_CURSORS = 30;
 const lastEventIdByThread = new Map<string, string>();
+// Stable for this browser tab's loaded SPA. Reusing it across Chat route
+// mounts lets the server supersede a proxy-held stream from the prior thread
+// instead of rejecting the replacement against the per-user connection cap.
+const SSE_CONNECTION_ID =
+  typeof globalThis.crypto?.randomUUID === "function"
+    ? globalThis.crypto.randomUUID()
+    : undefined;
 
 function cursorKey(threadId: string) {
   return `${authScope()}:${threadId}`;
@@ -163,6 +170,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
       es = openEventStream({
         threadId,
         afterCursor: getLastEventId(threadId) || undefined,
+        connectionId: SSE_CONNECTION_ID,
       });
       const source = es;
 

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { openEventStream } from "../../../lib/api";
+import { clientActionId, openEventStream } from "../../../lib/api";
 import {
   CONNECTION_STATUS,
   type ConnectionStatus,
@@ -35,10 +35,7 @@ const EVENT_SOURCE_OPEN = 1;
 // Stable for this browser tab's loaded SPA. Reusing it across Chat route
 // mounts lets the server supersede a proxy-held stream from the prior thread
 // instead of rejecting the replacement against the per-user connection cap.
-const SSE_CONNECTION_ID =
-  typeof globalThis.crypto?.randomUUID === "function"
-    ? globalThis.crypto.randomUUID()
-    : undefined;
+const SSE_CONNECTION_ID = clientActionId();
 let nextConnectionGeneration = 0;
 
 function connectionGeneration() {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -46,6 +46,7 @@ function createHarness({
   const context = {
     CONNECTION_STATUS,
     authScope: () => "tenant:user",
+    clientActionId: () => "browser-tab-connection",
     EventSource,
     JSON,
     Math,

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -49,7 +49,9 @@ function createHarness({
     EventSource,
     JSON,
     Math,
-    globalThis: {},
+    globalThis: {
+      crypto: { randomUUID: () => "browser-tab-connection" },
+    },
     openEventStream: (args) => {
       const listeners = new Map();
       const stream = {
@@ -348,6 +350,7 @@ test("useSSE resumes each thread from its own cursor after switching", () => {
   render("thread-2");
   assert.equal(streams[1].args.threadId, "thread-2");
   assert.equal(streams[1].args.afterCursor, undefined);
+  assert.equal(streams[1].args.connectionId, "browser-tab-connection");
 
   streams[1].listener("projection_update")({
     data: JSON.stringify({
@@ -360,6 +363,11 @@ test("useSSE resumes each thread from its own cursor after switching", () => {
   render("thread-1");
   assert.equal(streams[2].args.threadId, "thread-1");
   assert.equal(streams[2].args.afterCursor, "thread-1-cursor");
+  assert.equal(
+    streams[2].args.connectionId,
+    streams[1].args.connectionId,
+    "thread switches must reuse the tab connection id so the server can supersede the old stream",
+  );
 
   render("thread-2");
   assert.equal(streams[3].args.threadId, "thread-2");

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -336,7 +336,7 @@ test("useSSE does not reconnect after a non-retryable server error", () => {
   assert.deepEqual(statuses, ["connecting", "disconnected"]);
 });
 
-test("useSSE resumes each thread from its own cursor after switching", () => {
+test("useSSE starts each thread route from a fresh projection", () => {
   const { cleanup, render, streams } = createHarness();
 
   streams[0].listener("projection_update")({
@@ -351,6 +351,7 @@ test("useSSE resumes each thread from its own cursor after switching", () => {
   assert.equal(streams[1].args.threadId, "thread-2");
   assert.equal(streams[1].args.afterCursor, undefined);
   assert.equal(streams[1].args.connectionId, "browser-tab-connection");
+  assert.equal(streams[1].args.connectionGeneration, 2);
 
   streams[1].listener("projection_update")({
     data: JSON.stringify({
@@ -362,7 +363,8 @@ test("useSSE resumes each thread from its own cursor after switching", () => {
 
   render("thread-1");
   assert.equal(streams[2].args.threadId, "thread-1");
-  assert.equal(streams[2].args.afterCursor, "thread-1-cursor");
+  assert.equal(streams[2].args.afterCursor, undefined);
+  assert.equal(streams[2].args.connectionGeneration, 3);
   assert.equal(
     streams[2].args.connectionId,
     streams[1].args.connectionId,
@@ -371,12 +373,13 @@ test("useSSE resumes each thread from its own cursor after switching", () => {
 
   render("thread-2");
   assert.equal(streams[3].args.threadId, "thread-2");
-  assert.equal(streams[3].args.afterCursor, "thread-2-cursor");
+  assert.equal(streams[3].args.afterCursor, undefined);
+  assert.equal(streams[3].args.connectionGeneration, 4);
 
   cleanup();
 });
 
-test("useSSE keeps a thread cursor when the chat page remounts", () => {
+test("useSSE discards a volatile live cursor when the chat page remounts", () => {
   const { cleanup, remount, streams } = createHarness();
 
   streams[0].listener("projection_update")({
@@ -388,7 +391,8 @@ test("useSSE keeps a thread cursor when the chat page remounts", () => {
   });
 
   remount("thread-1");
-  assert.equal(streams[1].args.afterCursor, "before-navigation");
+  assert.equal(streams[1].args.afterCursor, undefined);
+  assert.equal(streams[1].args.connectionGeneration, 2);
 
   cleanup();
 });

--- a/crates/ironclaw_webui/src/webui_v2/handlers.rs
+++ b/crates/ironclaw_webui/src/webui_v2/handlers.rs
@@ -896,14 +896,21 @@ pub async fn stream_events(
     headers: HeaderMap,
     Query(query): Query<StreamEventsQuery>,
 ) -> Result<Response, WebUiV2HttpError> {
-    let slot = state
-        .sse_capacity()
-        .try_acquire(
-            &caller.tenant_id,
-            &caller.user_id,
-            stream_connection_id(query.connection_id.as_deref()),
-        )
-        .ok_or_else(sse_concurrency_exhausted)?;
+    let connection_id = stream_connection_id(query.connection_id.as_deref());
+    let slot = match state.sse_capacity().try_acquire_ordered(
+        &caller.tenant_id,
+        &caller.user_id,
+        connection_id,
+        connection_id.and(query.connection_generation),
+    ) {
+        crate::webui_v2::sse_capacity::SseAcquireResult::Acquired(slot) => slot,
+        crate::webui_v2::sse_capacity::SseAcquireResult::AtCapacity => {
+            return Err(sse_concurrency_exhausted());
+        }
+        crate::webui_v2::sse_capacity::SseAcquireResult::StaleGeneration => {
+            return Ok(StatusCode::NO_CONTENT.into_response());
+        }
+    };
     let services = state.services().clone();
     let initial_cursor = headers
         .get(LAST_EVENT_ID_HEADER)
@@ -951,6 +958,8 @@ pub struct StreamEventsQuery {
     pub after_cursor: Option<String>,
     #[serde(default)]
     pub connection_id: Option<String>,
+    #[serde(default)]
+    pub connection_generation: Option<u64>,
 }
 
 fn stream_connection_id(connection_id: Option<&str>) -> Option<&str> {
@@ -1023,6 +1032,12 @@ fn sse_error_event(error: RebornServicesError) -> Event {
     }
 }
 
+fn sse_ready_event() -> Event {
+    Event::default()
+        .event("keep_alive")
+        .data(r#"{"type":"keep_alive"}"#)
+}
+
 fn build_sse_stream(
     services: std::sync::Arc<dyn RebornServicesApi>,
     caller: WebUiAuthenticatedCaller,
@@ -1074,6 +1089,12 @@ fn build_sse_stream(
                     return;
                 }
             };
+            // Axum can complete the HTTP handshake before the facade has
+            // admitted its projection subscription. This application frame
+            // proves the stream is actually ready, so a route switch can clear
+            // a stale reconnecting state without waiting for the next model
+            // delta or the transport keep-alive interval.
+            yield Ok(sse_ready_event());
             loop {
                 let remaining = SSE_MAX_LIFETIME.saturating_sub(started_at.elapsed());
                 if remaining.is_zero() {

--- a/crates/ironclaw_webui/src/webui_v2/handlers.rs
+++ b/crates/ironclaw_webui/src/webui_v2/handlers.rs
@@ -1032,10 +1032,12 @@ fn sse_error_event(error: RebornServicesError) -> Event {
     }
 }
 
+const STREAM_READY_PAYLOAD: &str = r#"{"type":"keep_alive"}"#;
+
 fn sse_ready_event() -> Event {
     Event::default()
         .event("keep_alive")
-        .data(r#"{"type":"keep_alive"}"#)
+        .data(STREAM_READY_PAYLOAD)
 }
 
 fn build_sse_stream(
@@ -2425,6 +2427,19 @@ async fn ws_drain_loop(
                 return;
             }
         };
+        let send_budget = SSE_MAX_LIFETIME.saturating_sub(started_at.elapsed());
+        if ws_send_with_timeout(
+            &mut socket,
+            Some(axum::extract::ws::Message::Text(
+                STREAM_READY_PAYLOAD.into(),
+            )),
+            send_budget,
+        )
+        .await
+        .is_err()
+        {
+            return;
+        }
         loop {
             let remaining = SSE_MAX_LIFETIME.saturating_sub(started_at.elapsed());
             if remaining.is_zero() {

--- a/crates/ironclaw_webui/src/webui_v2/handlers.rs
+++ b/crates/ironclaw_webui/src/webui_v2/handlers.rs
@@ -898,7 +898,11 @@ pub async fn stream_events(
 ) -> Result<Response, WebUiV2HttpError> {
     let slot = state
         .sse_capacity()
-        .try_acquire(&caller.tenant_id, &caller.user_id)
+        .try_acquire(
+            &caller.tenant_id,
+            &caller.user_id,
+            stream_connection_id(query.connection_id.as_deref()),
+        )
         .ok_or_else(sse_concurrency_exhausted)?;
     let services = state.services().clone();
     let initial_cursor = headers
@@ -945,6 +949,18 @@ fn sse_concurrency_exhausted() -> WebUiV2HttpError {
 pub struct StreamEventsQuery {
     #[serde(default)]
     pub after_cursor: Option<String>,
+    #[serde(default)]
+    pub connection_id: Option<String>,
+}
+
+fn stream_connection_id(connection_id: Option<&str>) -> Option<&str> {
+    connection_id.filter(|connection_id| {
+        !connection_id.is_empty()
+            && connection_id.len() <= 64
+            && connection_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    })
 }
 
 /// Redacted SSE error payload. Defined as a typed struct (not built with
@@ -1019,7 +1035,7 @@ fn build_sse_stream(
         // the lifetime of this stream. It drops automatically when the
         // generator is dropped (client disconnect, max-lifetime expiry,
         // or facade error), releasing the per-caller concurrency slot.
-        let _slot_guard = slot;
+        let mut slot_guard = slot;
         let started_at = tokio::time::Instant::now();
         let mut after_cursor = initial_cursor.and_then(parse_cursor_token);
         if services.supports_stream_events_subscription() {
@@ -1031,12 +1047,15 @@ fn build_sse_stream(
                 thread_id: thread_id.clone(),
                 after_cursor: after_cursor.clone(),
             };
-            let mut subscription = match tokio::time::timeout(
-                remaining,
-                services.subscribe_events(caller.clone(), request),
-            )
-            .await
-            {
+            let subscription_result = tokio::select! {
+                biased;
+                _ = slot_guard.cancelled() => return,
+                result = tokio::time::timeout(
+                    remaining,
+                    services.subscribe_events(caller.clone(), request),
+                ) => result,
+            };
+            let mut subscription = match subscription_result {
                 Err(_elapsed) => {
                     tracing::debug!(
                         target = "ironclaw_webui_v2::sse",
@@ -1060,7 +1079,12 @@ fn build_sse_stream(
                 if remaining.is_zero() {
                     return;
                 }
-                match tokio::time::timeout(remaining, subscription.next()).await {
+                let next = tokio::select! {
+                    biased;
+                    _ = slot_guard.cancelled() => return,
+                    result = tokio::time::timeout(remaining, subscription.next()) => result,
+                };
+                match next {
                     Err(_elapsed) => {
                         tracing::debug!(
                             target = "ironclaw_webui_v2::sse",
@@ -1102,12 +1126,15 @@ fn build_sse_stream(
                 thread_id: thread_id.clone(),
                 after_cursor: after_cursor.clone(),
             };
-            match tokio::time::timeout(
-                remaining,
-                services.stream_events(caller.clone(), request),
-            )
-            .await
-            {
+            let drain = tokio::select! {
+                biased;
+                _ = slot_guard.cancelled() => return,
+                result = tokio::time::timeout(
+                    remaining,
+                    services.stream_events(caller.clone(), request),
+                ) => result,
+            };
+            match drain {
                 Err(_elapsed) => {
                     // The facade drain was still pending when SSE_MAX_LIFETIME
                     // ran out. Returning here drops the generator (and the
@@ -1147,7 +1174,11 @@ fn build_sse_stream(
                     if sleep_for.is_zero() {
                         return;
                     }
-                    tokio::time::sleep(sleep_for).await;
+                    tokio::select! {
+                        biased;
+                        _ = slot_guard.cancelled() => return,
+                        _ = tokio::time::sleep(sleep_for) => {}
+                    }
                 }
                 Ok(Err(error)) => {
                     // Surface a redacted error event and close the stream.
@@ -2277,7 +2308,11 @@ pub async fn stream_events_ws(
 ) -> Result<axum::response::Response, WebUiV2HttpError> {
     let slot = state
         .sse_capacity()
-        .try_acquire(&caller.tenant_id, &caller.user_id)
+        .try_acquire(
+            &caller.tenant_id,
+            &caller.user_id,
+            stream_connection_id(query.connection_id.as_deref()),
+        )
         .ok_or_else(sse_concurrency_exhausted)?;
     let services = state.services().clone();
     let initial_cursor = headers
@@ -2314,7 +2349,7 @@ async fn ws_drain_loop(
     //    leave bytes queued indefinitely. Each `socket.send().await`
     //    runs under `ws_send_with_timeout` so the per-caller slot
     //    is released within the lifetime budget regardless.
-    let _slot_guard = slot;
+    let mut slot_guard = slot;
     let started_at = tokio::time::Instant::now();
     let mut after_cursor = initial_cursor.and_then(parse_cursor_token);
     if services.supports_stream_events_subscription() {
@@ -2328,38 +2363,47 @@ async fn ws_drain_loop(
             thread_id: thread_id.clone(),
             after_cursor: after_cursor.clone(),
         };
-        let mut subscription =
-            match tokio::time::timeout(remaining, services.subscribe_events(caller, request)).await
-            {
-                Err(_elapsed) => {
-                    let _ = socket.close().await;
-                    return;
+        let subscription_result = tokio::select! {
+            biased;
+            _ = slot_guard.cancelled() => {
+                let _ = socket.close().await;
+                return;
+            }
+            result = tokio::time::timeout(
+                remaining,
+                services.subscribe_events(caller, request),
+            ) => result,
+        };
+        let mut subscription = match subscription_result {
+            Err(_elapsed) => {
+                let _ = socket.close().await;
+                return;
+            }
+            Ok(Ok(subscription)) => subscription,
+            Ok(Err(error)) => {
+                tracing::debug!(
+                    target = "ironclaw_webui_v2::ws",
+                    error = ?error,
+                    "facade rejected WS subscription; closing stream",
+                );
+                let payload = SseErrorPayload {
+                    error: error.code,
+                    kind: error.kind,
+                    retryable: error.retryable,
+                };
+                if let Ok(text) = serde_json::to_string(&payload) {
+                    let send_budget = SSE_MAX_LIFETIME.saturating_sub(started_at.elapsed());
+                    let _ = ws_send_with_timeout(
+                        &mut socket,
+                        Some(axum::extract::ws::Message::Text(text.into())),
+                        send_budget,
+                    )
+                    .await;
                 }
-                Ok(Ok(subscription)) => subscription,
-                Ok(Err(error)) => {
-                    tracing::debug!(
-                        target = "ironclaw_webui_v2::ws",
-                        error = ?error,
-                        "facade rejected WS subscription; closing stream",
-                    );
-                    let payload = SseErrorPayload {
-                        error: error.code,
-                        kind: error.kind,
-                        retryable: error.retryable,
-                    };
-                    if let Ok(text) = serde_json::to_string(&payload) {
-                        let send_budget = SSE_MAX_LIFETIME.saturating_sub(started_at.elapsed());
-                        let _ = ws_send_with_timeout(
-                            &mut socket,
-                            Some(axum::extract::ws::Message::Text(text.into())),
-                            send_budget,
-                        )
-                        .await;
-                    }
-                    let _ = socket.close().await;
-                    return;
-                }
-            };
+                let _ = socket.close().await;
+                return;
+            }
+        };
         loop {
             let remaining = SSE_MAX_LIFETIME.saturating_sub(started_at.elapsed());
             if remaining.is_zero() {
@@ -2368,6 +2412,10 @@ async fn ws_drain_loop(
             }
             let outcome = tokio::select! {
                 biased;
+                _ = slot_guard.cancelled() => {
+                    let _ = socket.close().await;
+                    return;
+                }
                 incoming = socket.recv() => {
                     match incoming {
                         None | Some(Err(_)) => return,
@@ -2454,6 +2502,10 @@ async fn ws_drain_loop(
         let facade_call = services.stream_events(caller.clone(), request);
         let outcome = tokio::select! {
             biased;
+            _ = slot_guard.cancelled() => {
+                let _ = socket.close().await;
+                return;
+            }
             // Peer close / socket error wins over the facade poll —
             // if the browser already dropped the connection we want
             // to free the slot immediately, not wait for stream_events
@@ -2532,6 +2584,10 @@ async fn ws_drain_loop(
                 // slot immediately.
                 tokio::select! {
                     biased;
+                    _ = slot_guard.cancelled() => {
+                        let _ = socket.close().await;
+                        return;
+                    }
                     incoming = socket.recv() => match incoming {
                         None | Some(Err(_)) => return,
                         Some(Ok(axum::extract::ws::Message::Close(_))) => return,

--- a/crates/ironclaw_webui/src/webui_v2/sse_capacity.rs
+++ b/crates/ironclaw_webui/src/webui_v2/sse_capacity.rs
@@ -55,7 +55,15 @@ struct CapacityState {
 #[derive(Debug)]
 struct NamedSlot {
     generation: u64,
+    client_generation: Option<u64>,
     cancel: watch::Sender<bool>,
+}
+
+#[derive(Debug)]
+pub(crate) enum SseAcquireResult {
+    Acquired(SseSlot),
+    AtCapacity,
+    StaleGeneration,
 }
 
 impl SseCapacity {
@@ -76,13 +84,29 @@ impl SseCapacity {
         user_id: &UserId,
         connection_id: Option<&str>,
     ) -> Option<SseSlot> {
+        match self.try_acquire_ordered(tenant_id, user_id, connection_id, None) {
+            SseAcquireResult::Acquired(slot) => Some(slot),
+            SseAcquireResult::AtCapacity | SseAcquireResult::StaleGeneration => None,
+        }
+    }
+
+    /// Reserve a slot using the browser tab's monotonically increasing stream
+    /// generation. A delayed request from an older route must not cancel the
+    /// newer route merely because it reached the server later.
+    pub(crate) fn try_acquire_ordered(
+        self: &Arc<Self>,
+        tenant_id: &TenantId,
+        user_id: &UserId,
+        connection_id: Option<&str>,
+        client_generation: Option<u64>,
+    ) -> SseAcquireResult {
         // Reject before touching the HashMap so a configured cap of 0
         // (SSE disabled) does not leak a zero-count entry per rejected
         // open. With the insert-before-check order we used to use, every
         // 429 under a configured cap of 0 would
         // store the caller's `(tenant, user)` key indefinitely.
         if self.max_per_caller == 0 {
-            return None;
+            return SseAcquireResult::AtCapacity;
         }
         let key = CallerKey {
             tenant_id: tenant_id.clone(),
@@ -93,12 +117,24 @@ impl SseCapacity {
         if let Some(connection_id) = connection_id {
             let named_key = (key.clone(), connection_id.to_string());
             if let Some(previous) = state.named_slots.get(&named_key) {
+                match (client_generation, previous.client_generation) {
+                    (Some(incoming), Some(current)) if incoming < current => {
+                        return SseAcquireResult::StaleGeneration;
+                    }
+                    (None, Some(_)) => return SseAcquireResult::StaleGeneration,
+                    _ => {}
+                }
                 let _ = previous.cancel.send(true);
                 let (cancel, cancellation) = watch::channel(false);
-                state
-                    .named_slots
-                    .insert(named_key, NamedSlot { generation, cancel });
-                return Some(SseSlot {
+                state.named_slots.insert(
+                    named_key,
+                    NamedSlot {
+                        generation,
+                        client_generation,
+                        cancel,
+                    },
+                );
+                return SseAcquireResult::Acquired(SseSlot {
                     capacity: Arc::clone(self),
                     key,
                     connection_id: Some(connection_id.to_string()),
@@ -109,20 +145,24 @@ impl SseCapacity {
         }
         let entry = state.open_by_caller.entry(key.clone()).or_insert(0);
         if *entry >= self.max_per_caller {
-            return None;
+            return SseAcquireResult::AtCapacity;
         }
         *entry += 1;
         let (connection_id, cancellation) = if let Some(connection_id) = connection_id {
             let (cancel, cancellation) = watch::channel(false);
             state.named_slots.insert(
                 (key.clone(), connection_id.to_string()),
-                NamedSlot { generation, cancel },
+                NamedSlot {
+                    generation,
+                    client_generation,
+                    cancel,
+                },
             );
             (Some(connection_id.to_string()), Some(cancellation))
         } else {
             (None, None)
         };
-        Some(SseSlot {
+        SseAcquireResult::Acquired(SseSlot {
             capacity: Arc::clone(self),
             key,
             connection_id,
@@ -374,5 +414,32 @@ mod tests {
         );
         drop(replacement);
         assert_eq!(cap.open_count(&tenant(), &alice), 0);
+    }
+
+    #[test]
+    fn ordered_named_slot_rejects_a_late_older_client_generation() {
+        let cap = Arc::new(SseCapacity::new(1));
+        let alice = user("alice");
+        let first = match cap.try_acquire_ordered(&tenant(), &alice, Some("browser-tab"), Some(1)) {
+            SseAcquireResult::Acquired(slot) => slot,
+            result => panic!("first generation must be admitted: {result:?}"),
+        };
+        let current = match cap.try_acquire_ordered(&tenant(), &alice, Some("browser-tab"), Some(2))
+        {
+            SseAcquireResult::Acquired(slot) => slot,
+            result => panic!("newer generation must be admitted: {result:?}"),
+        };
+
+        assert!(first.is_cancelled());
+        assert!(!current.is_cancelled());
+        assert!(matches!(
+            cap.try_acquire_ordered(&tenant(), &alice, Some("browser-tab"), Some(1)),
+            SseAcquireResult::StaleGeneration
+        ));
+        assert!(
+            !current.is_cancelled(),
+            "a late older request must not cancel the current route stream"
+        );
+        assert_eq!(cap.open_count(&tenant(), &alice), 1);
     }
 }

--- a/crates/ironclaw_webui/src/webui_v2/sse_capacity.rs
+++ b/crates/ironclaw_webui/src/webui_v2/sse_capacity.rs
@@ -15,9 +15,11 @@
 //! [`RateLimitPolicy`]: ironclaw_host_api::ingress::RateLimitPolicy
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use ironclaw_host_api::{TenantId, UserId};
+use tokio::sync::watch;
 
 /// Default concurrent SSE streams per (tenant, user). Sized to cover a
 /// normal browser tab plus brief reconnect overlap; sustained abuse hits
@@ -39,15 +41,29 @@ struct CallerKey {
 
 #[derive(Debug)]
 pub(crate) struct SseCapacity {
-    state: Mutex<HashMap<CallerKey, usize>>,
+    state: Mutex<CapacityState>,
     max_per_caller: usize,
+    next_generation: AtomicU64,
+}
+
+#[derive(Debug, Default)]
+struct CapacityState {
+    open_by_caller: HashMap<CallerKey, usize>,
+    named_slots: HashMap<(CallerKey, String), NamedSlot>,
+}
+
+#[derive(Debug)]
+struct NamedSlot {
+    generation: u64,
+    cancel: watch::Sender<bool>,
 }
 
 impl SseCapacity {
     pub(crate) fn new(max_per_caller: usize) -> Self {
         Self {
-            state: Mutex::new(HashMap::new()),
+            state: Mutex::new(CapacityState::default()),
             max_per_caller,
+            next_generation: AtomicU64::new(1),
         }
     }
 
@@ -58,6 +74,7 @@ impl SseCapacity {
         self: &Arc<Self>,
         tenant_id: &TenantId,
         user_id: &UserId,
+        connection_id: Option<&str>,
     ) -> Option<SseSlot> {
         // Reject before touching the HashMap so a configured cap of 0
         // (SSE disabled) does not leak a zero-count entry per rejected
@@ -72,23 +89,65 @@ impl SseCapacity {
             user_id: user_id.clone(),
         };
         let mut state = lock_state(&self.state);
-        let entry = state.entry(key.clone()).or_insert(0);
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        if let Some(connection_id) = connection_id {
+            let named_key = (key.clone(), connection_id.to_string());
+            if let Some(previous) = state.named_slots.get(&named_key) {
+                let _ = previous.cancel.send(true);
+                let (cancel, cancellation) = watch::channel(false);
+                state
+                    .named_slots
+                    .insert(named_key, NamedSlot { generation, cancel });
+                return Some(SseSlot {
+                    capacity: Arc::clone(self),
+                    key,
+                    connection_id: Some(connection_id.to_string()),
+                    generation,
+                    cancellation: Some(cancellation),
+                });
+            }
+        }
+        let entry = state.open_by_caller.entry(key.clone()).or_insert(0);
         if *entry >= self.max_per_caller {
             return None;
         }
         *entry += 1;
+        let (connection_id, cancellation) = if let Some(connection_id) = connection_id {
+            let (cancel, cancellation) = watch::channel(false);
+            state.named_slots.insert(
+                (key.clone(), connection_id.to_string()),
+                NamedSlot { generation, cancel },
+            );
+            (Some(connection_id.to_string()), Some(cancellation))
+        } else {
+            (None, None)
+        };
         Some(SseSlot {
             capacity: Arc::clone(self),
             key,
+            connection_id,
+            generation,
+            cancellation,
         })
     }
 
-    fn release(&self, key: &CallerKey) {
+    fn release(&self, key: &CallerKey, connection_id: Option<&str>, generation: u64) {
         let mut state = lock_state(&self.state);
-        if let Some(count) = state.get_mut(key) {
+        if let Some(connection_id) = connection_id {
+            let named_key = (key.clone(), connection_id.to_string());
+            let is_current = state
+                .named_slots
+                .get(&named_key)
+                .is_some_and(|slot| slot.generation == generation);
+            if !is_current {
+                return;
+            }
+            state.named_slots.remove(&named_key);
+        }
+        if let Some(count) = state.open_by_caller.get_mut(key) {
             *count = count.saturating_sub(1);
             if *count == 0 {
-                state.remove(key);
+                state.open_by_caller.remove(key);
             }
         }
     }
@@ -100,7 +159,7 @@ impl SseCapacity {
             user_id: user_id.clone(),
         };
         let state = lock_state(&self.state);
-        state.get(&key).copied().unwrap_or(0)
+        state.open_by_caller.get(&key).copied().unwrap_or(0)
     }
 }
 
@@ -121,9 +180,7 @@ impl SseCapacity {
 /// break. The worst case is a single caller's count being off by one,
 /// which `SSE_MAX_LIFETIME`-driven slot recycling self-heals within
 /// minutes.
-fn lock_state(
-    mutex: &Mutex<HashMap<CallerKey, usize>>,
-) -> std::sync::MutexGuard<'_, HashMap<CallerKey, usize>> {
+fn lock_state(mutex: &Mutex<CapacityState>) -> std::sync::MutexGuard<'_, CapacityState> {
     mutex
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -138,11 +195,40 @@ fn lock_state(
 pub(crate) struct SseSlot {
     capacity: Arc<SseCapacity>,
     key: CallerKey,
+    connection_id: Option<String>,
+    generation: u64,
+    cancellation: Option<watch::Receiver<bool>>,
+}
+
+impl SseSlot {
+    pub(crate) async fn cancelled(&mut self) {
+        let Some(cancellation) = self.cancellation.as_mut() else {
+            std::future::pending::<()>().await;
+            return;
+        };
+        if *cancellation.borrow() {
+            return;
+        }
+        while cancellation.changed().await.is_ok() {
+            if *cancellation.borrow() {
+                return;
+            }
+        }
+        std::future::pending::<()>().await;
+    }
+
+    #[cfg(test)]
+    fn is_cancelled(&self) -> bool {
+        self.cancellation
+            .as_ref()
+            .is_some_and(|cancellation| *cancellation.borrow())
+    }
 }
 
 impl Drop for SseSlot {
     fn drop(&mut self) {
-        self.capacity.release(&self.key);
+        self.capacity
+            .release(&self.key, self.connection_id.as_deref(), self.generation);
     }
 }
 
@@ -162,17 +248,21 @@ mod tests {
     fn acquires_up_to_cap_then_refuses() {
         let cap = Arc::new(SseCapacity::new(2));
         let alice = user("alice");
-        let s1 = cap.try_acquire(&tenant(), &alice).expect("first slot");
-        let s2 = cap.try_acquire(&tenant(), &alice).expect("second slot");
+        let s1 = cap
+            .try_acquire(&tenant(), &alice, None)
+            .expect("first slot");
+        let s2 = cap
+            .try_acquire(&tenant(), &alice, None)
+            .expect("second slot");
         assert!(
-            cap.try_acquire(&tenant(), &alice).is_none(),
+            cap.try_acquire(&tenant(), &alice, None).is_none(),
             "third slot must be refused"
         );
         assert_eq!(cap.open_count(&tenant(), &alice), 2);
         drop(s1);
         // After release, a new slot is available again.
         let s3 = cap
-            .try_acquire(&tenant(), &alice)
+            .try_acquire(&tenant(), &alice, None)
             .expect("slot after release");
         drop(s2);
         drop(s3);
@@ -188,7 +278,7 @@ mod tests {
         // return the rejected open touches no state.
         let cap = Arc::new(SseCapacity::new(0));
         let alice = user("alice");
-        assert!(cap.try_acquire(&tenant(), &alice).is_none());
+        assert!(cap.try_acquire(&tenant(), &alice, None).is_none());
         assert_eq!(
             cap.open_count(&tenant(), &alice),
             0,
@@ -207,7 +297,9 @@ mod tests {
     fn poisoned_lock_does_not_double_panic_on_release_or_acquire() {
         let cap = Arc::new(SseCapacity::new(2));
         let alice = user("alice");
-        let slot = cap.try_acquire(&tenant(), &alice).expect("first slot");
+        let slot = cap
+            .try_acquire(&tenant(), &alice, None)
+            .expect("first slot");
 
         // Poison the mutex by panicking while holding the guard. We
         // catch the panic so the test process survives — the goal is
@@ -238,7 +330,7 @@ mod tests {
         // rather than panic; this is the call-site that runs on every
         // new SSE open.
         let recovered = cap
-            .try_acquire(&tenant(), &alice)
+            .try_acquire(&tenant(), &alice, None)
             .expect("try_acquire must recover from a poisoned lock");
         drop(recovered);
     }
@@ -248,9 +340,39 @@ mod tests {
         let cap = Arc::new(SseCapacity::new(1));
         let alice = user("alice");
         let bob = user("bob");
-        let _alice_slot = cap.try_acquire(&tenant(), &alice).expect("alice");
-        let _bob_slot = cap.try_acquire(&tenant(), &bob).expect("bob");
-        assert!(cap.try_acquire(&tenant(), &alice).is_none());
-        assert!(cap.try_acquire(&tenant(), &bob).is_none());
+        let _alice_slot = cap.try_acquire(&tenant(), &alice, None).expect("alice");
+        let _bob_slot = cap.try_acquire(&tenant(), &bob, None).expect("bob");
+        assert!(cap.try_acquire(&tenant(), &alice, None).is_none());
+        assert!(cap.try_acquire(&tenant(), &bob, None).is_none());
+    }
+
+    #[test]
+    fn named_slot_replaces_its_prior_generation_without_consuming_capacity() {
+        let cap = Arc::new(SseCapacity::new(1));
+        let alice = user("alice");
+        let first = cap
+            .try_acquire(&tenant(), &alice, Some("browser-tab"))
+            .expect("first named slot");
+        let replacement = cap
+            .try_acquire(&tenant(), &alice, Some("browser-tab"))
+            .expect("same browser tab replaces its stale stream");
+
+        assert!(first.is_cancelled(), "the prior stream must be cancelled");
+        assert!(!replacement.is_cancelled());
+        assert_eq!(cap.open_count(&tenant(), &alice), 1);
+        assert!(
+            cap.try_acquire(&tenant(), &alice, Some("different-tab"))
+                .is_none(),
+            "a different browser tab still respects the per-caller cap"
+        );
+
+        drop(first);
+        assert_eq!(
+            cap.open_count(&tenant(), &alice),
+            1,
+            "dropping the superseded generation must not release the replacement"
+        );
+        drop(replacement);
+        assert_eq!(cap.open_count(&tenant(), &alice), 0);
     }
 }

--- a/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -6305,7 +6305,7 @@ async fn stream_events_ws_uses_subscription_when_facade_supports_it() {
 
     let mut text_frames: Vec<String> = Vec::new();
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while std::time::Instant::now() < deadline && text_frames.len() < 2 {
+    while std::time::Instant::now() < deadline && text_frames.len() < 3 {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         match tokio::time::timeout(remaining, ws.next()).await {
             Ok(Some(Ok(WsMessage::Text(text)))) => text_frames.push(text.to_string()),
@@ -6319,19 +6319,22 @@ async fn stream_events_ws_uses_subscription_when_facade_supports_it() {
     serve_handle.abort();
 
     assert!(
-        text_frames.len() >= 2,
-        "expected subscription projection frames; got {} text frame(s): {:?}",
+        text_frames.len() >= 3,
+        "expected readiness + subscription projection frames; got {} text frame(s): {:?}",
         text_frames.len(),
         text_frames,
     );
 
-    let envelope_a_json: Value = serde_json::from_str(&text_frames[0]).expect("envelope a parses");
+    let ready_json: Value = serde_json::from_str(&text_frames[0]).expect("ready frame parses");
+    assert_eq!(ready_json, serde_json::json!({ "type": "keep_alive" }));
+
+    let envelope_a_json: Value = serde_json::from_str(&text_frames[1]).expect("envelope a parses");
     let expected_a: Value = serde_json::to_value(&envelope_a).expect("envelope a value");
     assert_eq!(
         envelope_a_json, expected_a,
-        "first WS frame must carry the first subscription envelope",
+        "first projection WS frame must carry the first subscription envelope",
     );
-    let envelope_b_json: Value = serde_json::from_str(&text_frames[1]).expect("envelope b parses");
+    let envelope_b_json: Value = serde_json::from_str(&text_frames[2]).expect("envelope b parses");
     let expected_b: Value = serde_json::to_value(&envelope_b).expect("envelope b value");
     assert_eq!(
         envelope_b_json, expected_b,

--- a/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -4984,6 +4984,125 @@ fn url_encode(value: &str) -> String {
     out
 }
 
+// A browser tab reuses one connection_id while navigating between threads.
+// The replacement must cancel the prior response even when a proxy has not
+// propagated the browser's close yet; otherwise stale streams consume the
+// per-caller cap and the new thread remains disconnected until refresh.
+#[tokio::test]
+async fn stream_events_same_connection_id_supersedes_stale_stream() {
+    let services: Arc<dyn RebornServicesApi> = Arc::new(StubServices::default());
+    let router = webui_v2_router(WebUiV2State::new(services, 1)).layer(axum::Extension(caller()));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let serve_handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut first = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("first tcp");
+    first
+        .write_all(
+            b"GET /api/webchat/v2/threads/thread-a/events?connection_id=browser-tab HTTP/1.1\r\n\
+              Host: localhost\r\n\
+              Accept: text/event-stream\r\n\
+              Connection: close\r\n\
+              \r\n",
+        )
+        .await
+        .expect("first request");
+    let mut first_headers = [0_u8; 512];
+    let first_read = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        first.read(&mut first_headers),
+    )
+    .await
+    .expect("first headers within timeout")
+    .expect("first headers");
+    assert!(
+        std::str::from_utf8(&first_headers[..first_read])
+            .expect("first headers utf8")
+            .starts_with("HTTP/1.1 200"),
+        "first stream must be admitted"
+    );
+
+    let mut replacement = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("replacement tcp");
+    replacement
+        .write_all(
+            b"GET /api/webchat/v2/threads/thread-b/events?connection_id=browser-tab HTTP/1.1\r\n\
+              Host: localhost\r\n\
+              Accept: text/event-stream\r\n\
+              Connection: close\r\n\
+              \r\n",
+        )
+        .await
+        .expect("replacement request");
+    let mut replacement_headers = [0_u8; 512];
+    let replacement_read = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        replacement.read(&mut replacement_headers),
+    )
+    .await
+    .expect("replacement headers within timeout")
+    .expect("replacement headers");
+    assert!(
+        std::str::from_utf8(&replacement_headers[..replacement_read])
+            .expect("replacement headers utf8")
+            .starts_with("HTTP/1.1 200"),
+        "same-tab replacement must bypass its own stale slot"
+    );
+
+    let first_closed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut buffer = [0_u8; 512];
+        loop {
+            if first.read(&mut buffer).await.expect("read first stream") == 0 {
+                return;
+            }
+        }
+    })
+    .await;
+    assert!(
+        first_closed.is_ok(),
+        "superseded stream must close promptly instead of retaining a slot"
+    );
+
+    let mut different_tab = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("different-tab tcp");
+    different_tab
+        .write_all(
+            b"GET /api/webchat/v2/threads/thread-c/events?connection_id=other-tab HTTP/1.1\r\n\
+              Host: localhost\r\n\
+              Accept: text/event-stream\r\n\
+              Connection: close\r\n\
+              \r\n",
+        )
+        .await
+        .expect("different-tab request");
+    let mut rejected_headers = [0_u8; 512];
+    let rejected_read = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        different_tab.read(&mut rejected_headers),
+    )
+    .await
+    .expect("rejection headers within timeout")
+    .expect("rejection headers");
+    assert!(
+        std::str::from_utf8(&rejected_headers[..rejected_read])
+            .expect("rejection headers utf8")
+            .starts_with("HTTP/1.1 429"),
+        "a distinct tab must still respect the per-caller cap"
+    );
+
+    drop(replacement);
+    serve_handle.abort();
+}
+
 // Regression for the WS-shares-SSE-pool review (Medium): the WS
 // transport must draw from the same `SseCapacity` pool as the SSE
 // transport for the same `(tenant, user)`. If they kept independent

--- a/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -5006,7 +5006,7 @@ async fn stream_events_same_connection_id_supersedes_stale_stream() {
         .expect("first tcp");
     first
         .write_all(
-            b"GET /api/webchat/v2/threads/thread-a/events?connection_id=browser-tab HTTP/1.1\r\n\
+            b"GET /api/webchat/v2/threads/thread-a/events?connection_id=browser-tab&connection_generation=1 HTTP/1.1\r\n\
               Host: localhost\r\n\
               Accept: text/event-stream\r\n\
               Connection: close\r\n\
@@ -5034,7 +5034,7 @@ async fn stream_events_same_connection_id_supersedes_stale_stream() {
         .expect("replacement tcp");
     replacement
         .write_all(
-            b"GET /api/webchat/v2/threads/thread-b/events?connection_id=browser-tab HTTP/1.1\r\n\
+            b"GET /api/webchat/v2/threads/thread-b/events?connection_id=browser-tab&connection_generation=2 HTTP/1.1\r\n\
               Host: localhost\r\n\
               Accept: text/event-stream\r\n\
               Connection: close\r\n\
@@ -5069,6 +5069,34 @@ async fn stream_events_same_connection_id_supersedes_stale_stream() {
     assert!(
         first_closed.is_ok(),
         "superseded stream must close promptly instead of retaining a slot"
+    );
+
+    let mut late_stale = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("late stale tcp");
+    late_stale
+        .write_all(
+            b"GET /api/webchat/v2/threads/thread-a/events?connection_id=browser-tab&connection_generation=1 HTTP/1.1\r\n\
+              Host: localhost\r\n\
+              Accept: text/event-stream\r\n\
+              Connection: close\r\n\
+              \r\n",
+        )
+        .await
+        .expect("late stale request");
+    let mut stale_headers = [0_u8; 512];
+    let stale_read = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        late_stale.read(&mut stale_headers),
+    )
+    .await
+    .expect("stale response within timeout")
+    .expect("stale response");
+    assert!(
+        std::str::from_utf8(&stale_headers[..stale_read])
+            .expect("stale response utf8")
+            .starts_with("HTTP/1.1 204"),
+        "a delayed older route request must stop without replacing the current stream"
     );
 
     let mut different_tab = tokio::net::TcpStream::connect(addr)
@@ -5808,21 +5836,23 @@ async fn stream_events_uses_subscription_when_facade_supports_it() {
 
     let mut body = response.into_body();
     let bytes = collect_sse_until(&mut body, Duration::from_millis(750), |buf| {
-        parse_sse_events(buf).len() >= 2
+        parse_sse_events(buf).len() >= 3
     })
     .await;
     drop(body);
 
     let events = parse_sse_events(&bytes);
     assert!(
-        events.len() >= 2,
+        events.len() >= 3,
         "subscription events must reach SSE without facade polling; got {events:?}; raw: {}",
         String::from_utf8_lossy(&bytes)
     );
     let cursor_a_json =
         serde_json::to_string(envelope_a.projection_cursor()).expect("cursor-a json");
-    assert_eq!(events[0].event.as_deref(), Some("projection_update"));
-    assert_eq!(events[0].id.as_deref(), Some(cursor_a_json.as_str()));
+    assert_eq!(events[0].event.as_deref(), Some("keep_alive"));
+    assert_eq!(events[0].data.as_deref(), Some(r#"{"type":"keep_alive"}"#));
+    assert_eq!(events[1].event.as_deref(), Some("projection_update"));
+    assert_eq!(events[1].id.as_deref(), Some(cursor_a_json.as_str()));
 
     assert_eq!(
         services.stream_events_calls.lock().expect("lock").len(),

--- a/docs/reborn/contracts/events-projections.md
+++ b/docs/reborn/contracts/events-projections.md
@@ -202,6 +202,11 @@ subscription visibility.
 Rules:
 
 - event ids are scoped; a user cannot replay another user's stream
+- an origin subscription receives the durable snapshot plus the latest
+  retained value for each stable live projection identity; it does not replay
+  cumulative live UI hint history such as every partial-text growth step
+- a cursor-based reconnect remains incremental and replays available events
+  after that cursor before resuming the live tail
 - replay gaps produce an explicit snapshot/rebase, not silent data loss
 - truncated snapshot/replay pages produce an explicit lag signal before live tailing, not a cursor treated as complete
 - access policy runs before snapshot, replay, or live subscription


### PR DESCRIPTION
## Summary

Fixes the WebUI SSE lifecycle when navigating between threads, tabs, or extensions while a run is active.

- keep replay cursors local to one mounted thread route instead of caching volatile live cursors across routes
- hydrate a fresh route with the latest retained partial state, then tail new updates without replaying every cumulative text fragment
- order same-tab connection replacement with a monotonic client generation so a delayed old request cannot cancel the current route
- emit an immediate application-level `keep_alive` after projection subscription admission so an idle, caught-up stream is visibly connected
- retain the existing live-publisher epoch guard for process restarts

## Root cause

The previous fix combined a durable projection cursor with a process-local live cursor and cached that composite cursor per thread in a module-global frontend map. On route changes, a new component could resume from a volatile cursor instead of performing a fresh state hydration. At the same time, same-tab replacement was ordered by server arrival, so a delayed request from the previous route could supersede the newer stream. A caught-up stream also emitted no application event until the next delta or periodic keepalive, leaving the client in `Reconnecting` even when the server had admitted the subscription.

This change separates the two modes:

- browser-native reconnects within one mounted route resume incrementally from that route's local cursor
- route/thread remounts subscribe from origin and receive a compact current-state projection before live deltas

## Test card

### User behavior

Switching to a running thread immediately restores its current partial text, does not animate the retained text from the beginning, reports the SSE connection as ready, and continues receiving subsequent deltas without a page refresh.

### Risk areas

- [ ] model behavior
- [x] browser lifecycle
- [ ] persistent side effects
- [x] security / authenticated connection ownership
- [x] external provider interruptions
- [x] cross-component behavior

### Coverage

- Frontend lifecycle contracts verify route-local cursors, a stable tab connection ID, and increasing connection generations across retries/remounts.
- Event-stream manager contracts verify fresh subscriptions compact retained partial history to current state and then tail new updates; cursor-based resumes remain incremental.
- Composition caller-path coverage verifies current partial-text hydration through the real projection subscription boundary.
- WebUI handler contracts use a real Axum TCP server to verify newer generations supersede older streams, delayed older requests receive HTTP 204 without canceling the current stream, distinct connections still respect capacity, and subscription admission emits an immediate ready frame.
- No recorded LLM fixture was added: this changes deterministic transport/projection behavior, not model selection or request shape.
- No new browser E2E fixture was added; the socket-level handler contract covers the request-ordering race hermetically. A live preview canary remains the final deployment check.

### Commands run

- `npm test -- --run src/pages/chat/lib/useSSE.test.ts` (13 passed after rebase)
- full frontend test suite (104 files, 850 tests), lint, conventions, typecheck, and Vite build
- `cargo test -p ironclaw_event_streams --locked` (68 contract tests plus unit tests passed after rebase)
- focused composition fresh-hydration and live-order tests
- `cargo test -p ironclaw_webui --all-features` (all WebUI unit and integration suites passed)
- focused real-TCP generation replacement and ready-frame contracts passed after rebase
- clippy for `ironclaw_event_streams`, `ironclaw_reborn_composition`, and `ironclaw_webui --all-features --all-targets`
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `bash scripts/reborn-e2e-rust.sh`
- `git diff --check`

The broad composition run reached 1,682 passing tests. Two unrelated existing/environment-sensitive tests failed locally (environment LLM detection and a trace-queue fixture leak); the environment detection test passed with the relevant variables unset, and all changed composition contracts pass in isolation.

## Docs and compatibility

- documents fresh-state hydration versus cursor-based incremental resume in the events/projections contract
- documents route-local cursor and connection-generation behavior in the WebUI subsystem guide
- checked `FEATURE_PARITY.md`; this fixes existing behavior and does not change feature status
- does not change the conversation unlimited setting

## Security and rollback

Connection generations are scoped to the already-authenticated caller plus an opaque bounded connection ID. They do not bypass caller capacity or authorization. Stale generations receive HTTP 204 so EventSource stops reconnecting; legacy generation-less clients remain compatible unless a newer generated client has already taken ownership of the same slot.

Rollback is the three commits in this PR; no schema or persistent-data migration is involved.
