### PR TITLE
fix(composition): fail closed on unreachable endpoint in test_connection (fixes #6099)

### DIFF
--- a/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
@@ -687,11 +687,28 @@ impl LlmConfigService for RebornLlmConfigService {
             // discovery is unsupported or default returned Ok([]) without I/O),
             // connectivity is not yet verified. Run a fallback completion probe.
             Ok(_) => {
+                let model = request
+                    .model
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|model| !model.is_empty());
+
+                let Some(model) = model else {
+                    return Ok(LlmProbeResult {
+                        ok: false,
+                        message: format!(
+                            "could not verify {endpoint}: model is required when model discovery is unavailable"
+                        ),
+                    });
+                };
+
                 let probe_req =
                     ironclaw_llm::CompletionRequest::new(vec![ironclaw_llm::ChatMessage::user(
                         "ping",
                     )])
+                    .with_model(model)
                     .with_max_tokens(1);
+
                 match provider.complete(probe_req).await {
                     Ok(_) => Ok(LlmProbeResult {
                         ok: true,
@@ -706,7 +723,7 @@ impl LlmConfigService for RebornLlmConfigService {
                         );
                         Ok(LlmProbeResult {
                             ok: false,
-                            message: format!("could not reach {endpoint} with these settings"),
+                            message: format!("probe failed for {endpoint}: {error}"),
                         })
                     }
                 }

--- a/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
@@ -683,12 +683,34 @@ impl LlmConfigService for RebornLlmConfigService {
                 ok: true,
                 message: format!("connection ok — {} models available", models.len()),
             }),
-            // The endpoint answered but advertised no models. Connectivity is
-            // confirmed, but don't overstate it as a verified model list.
-            Ok(_) => Ok(LlmProbeResult {
-                ok: true,
-                message: format!("connected to {endpoint}, but it reported no models"),
-            }),
+            // When `list_models()` returns an empty model list (because model
+            // discovery is unsupported or default returned Ok([]) without I/O),
+            // connectivity is not yet verified. Run a fallback completion probe.
+            Ok(_) => {
+                let probe_req =
+                    ironclaw_llm::CompletionRequest::new(vec![ironclaw_llm::ChatMessage::user(
+                        "ping",
+                    )])
+                    .with_max_tokens(1);
+                match provider.complete(probe_req).await {
+                    Ok(_) => Ok(LlmProbeResult {
+                        ok: true,
+                        message: format!("connection ok — verified {endpoint}"),
+                    }),
+                    Err(error) => {
+                        tracing::debug!(
+                            provider_id = %request.provider_id,
+                            adapter = %request.adapter,
+                            error = %error,
+                            "test_connection fallback completion probe failed"
+                        );
+                        Ok(LlmProbeResult {
+                            ok: false,
+                            message: format!("could not reach {endpoint} with these settings"),
+                        })
+                    }
+                }
+            }
             // A failed `list_models` is the connectivity signal: the discovery
             // request never reached a live endpoint. Name the address so the
             // operator can see which host was unreachable.
@@ -2298,6 +2320,41 @@ mod tests {
         assert!(
             !result.ok,
             "an unreachable endpoint must not report success, got {result:?}"
+        );
+        assert!(
+            result.message.contains("127.0.0.1:1"),
+            "failure message must name the unreachable endpoint, got: {}",
+            result.message
+        );
+    }
+
+    /// Regression for #6099: Probing an unreachable endpoint for a provider
+    /// whose list_models() returns empty without I/O (e.g. OpenAI/Anthropic/custom)
+    /// must fail closed and name the unreachable endpoint, rather than returning
+    /// a false positive success.
+    #[tokio::test]
+    async fn test_connection_reports_unreachable_openai_endpoint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        let boot = boot_for_home(&reborn_home);
+        let service = RebornLlmConfigService::new(boot, key_store());
+
+        let request = LlmProbeRequest {
+            provider_id: "openai".to_string(),
+            adapter: "open_ai_completions".to_string(),
+            base_url: Some("http://127.0.0.1:1".to_string()),
+            model: Some("gpt-4o".to_string()),
+            api_key: Some(secrecy::SecretString::from("sk-invalid-key")),
+        };
+
+        let result = service
+            .test_connection(caller(), request)
+            .await
+            .expect("probe completes");
+
+        assert!(
+            !result.ok,
+            "an unreachable OpenAI endpoint must not report success, got {result:?}"
         );
         assert!(
             result.message.contains("127.0.0.1:1"),


### PR DESCRIPTION
## Summary

- Fixed `POST /api/webchat/v2/llm/test-connection` returning a false positive `ok: true` when probing an unreachable endpoint or invalid credentials for providers whose `list_models()` returns an empty list without performing network I/O.
- When `list_models()` returns an empty model list, `test_connection` now falls back to executing a 1-token probe completion request (`provider.complete(...)`) to verify host reachability and authorization over HTTP.
- Added unit regression test `test_connection_reports_unreachable_openai_endpoint` in `llm_config_service.rs` ensuring probes to unreachable custom/OpenAI endpoints fail closed with `ok: false`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #6099

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_composition llm_config_service`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: Tested probing an unreachable endpoint (`http://127.0.0.1:1`) for custom OpenAI adapter and verified response returns `ok: false` with the unreachable address in the message.
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior:
Testing LLM provider connection settings in WebUI or via `POST /api/webchat/v2/llm/test-connection` when configuring custom endpoints or API keys.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: `test_connection_reports_unreachable_openai_endpoint` in `llm_config_service.rs`
- Reborn integration: Not applicable: Unit test in `llm_config_service` exercises the composition probe boundary directly.
- Recorded fixture: Not applicable: No recorded model fixtures needed.
- Browser E2E: Not applicable: Wire response tested via unit contract.
- Backend or runtime: `ironclaw_reborn_composition::llm_admin::llm_config_service::tests`
- Live canary: Not applicable: Tested with local loopback mock endpoint.

What the tests prove:
Probing an unreachable endpoint for a provider without model discovery (or where `list_models()` returns empty without network I/O) fails closed with `ok: false` and includes the target host address in the error message instead of returning a false `ok: true`.

Commands run:
`cargo test -p ironclaw_reborn_composition llm_config_service`

## Security Impact

None. Probes target only user-specified provider base URLs and do not log secret API keys.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? Handled behind `RebornServicesApi` with operator-token capability checks.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: Handled via standard `LlmProbeResult`.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent).
- [x] Sandbox/native/host names accurately describe trust boundary.

## Database Impact

None.

## Blast Radius

Touches `RebornLlmConfigService::test_connection` in `ironclaw_reborn_composition`. Replaces a false-positive success with a real network connectivity probe when model discovery is unavailable.

## Rollback Plan

Revert commit `7fdf030e7` (`fix(composition): fail closed on unreachable endpoint in test_connection (fixes #6099)`).

## Review Follow-Through

None.

---

**Review track**: Track B (feature/maintainer-requested refactor)
