### PR TITLE
Remove advisory runtime idempotency DTO field

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -334,19 +334,6 @@ pub struct RuntimeCapabilityRequest {
     /// and must not trust caller estimates as binding limits or actual usage.
     pub estimate: ResourceEstimate,
     pub input: Value,
-    /// Caller-supplied dedup hint.
-    ///
-    /// **This field is currently advisory at this layer.** The composed
-    /// capability host does not yet implement caller-driven idempotent
-    /// retries, so two `invoke_capability` calls carrying the same key will
-    /// both execute. Upper turn/loop services that need at-most-once
-    /// semantics must dedupe themselves until idempotency lands in the
-    /// capability host. The field is kept on the contract surface so that
-    /// shape doesn't break when dedup is wired through downstream.
-    ///
-    /// The host runtime still validates and forwards the key into
-    /// observability spans for audit/tracing.
-    pub idempotency_key: Option<IdempotencyKey>,
 }
 
 impl RuntimeCapabilityRequest {
@@ -366,13 +353,7 @@ impl RuntimeCapabilityRequest {
             capability_id,
             estimate,
             input,
-            idempotency_key: None,
         }
-    }
-
-    pub fn with_idempotency_key(mut self, key: IdempotencyKey) -> Self {
-        self.idempotency_key = Some(key);
-        self
     }
 }
 
@@ -389,7 +370,6 @@ pub struct RuntimeCapabilityResumeRequest {
     pub capability_id: CapabilityId,
     pub estimate: ResourceEstimate,
     pub input: Value,
-    pub idempotency_key: Option<IdempotencyKey>,
 }
 
 impl RuntimeCapabilityResumeRequest {
@@ -406,13 +386,7 @@ impl RuntimeCapabilityResumeRequest {
             capability_id,
             estimate,
             input,
-            idempotency_key: None,
         }
-    }
-
-    pub fn with_idempotency_key(mut self, key: IdempotencyKey) -> Self {
-        self.idempotency_key = Some(key);
-        self
     }
 }
 
@@ -429,7 +403,6 @@ pub struct RuntimeCapabilityAuthResumeRequest {
     pub capability_id: CapabilityId,
     pub estimate: ResourceEstimate,
     pub input: Value,
-    pub idempotency_key: Option<IdempotencyKey>,
     /// Present when the invocation previously passed an approval gate.
     /// Used to locate and claim the matching fingerprinted approval lease
     /// so the re-dispatch does not require a second approval.
@@ -449,14 +422,8 @@ impl RuntimeCapabilityAuthResumeRequest {
             capability_id,
             estimate,
             input,
-            idempotency_key: None,
             approval_request_id,
         }
-    }
-
-    pub fn with_idempotency_key(mut self, key: IdempotencyKey) -> Self {
-        self.idempotency_key = Some(key);
-        self
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -484,22 +484,10 @@ impl HostRuntime for DefaultHostRuntime {
             capability_id,
             estimate,
             input,
-            idempotency_key,
         } = request;
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
         let total_started_at = live_latency_started_at();
-        // Forward the (currently advisory) idempotency key into spans for
-        // audit/tracing only — dedupe enforcement is not yet implemented at
-        // this layer (see `RuntimeCapabilityRequest::idempotency_key`).
-        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
-        if let Some(key) = idempotency_key.as_deref() {
-            tracing::debug!(
-                capability_id = %capability_id,
-                idempotency_key = %key,
-                "capability invocation accepted advisory idempotency key (not yet enforced)"
-            );
-        }
 
         let trust_decision = match self.open_pre_authorization(&mut context, &capability_id) {
             Ok(trust_decision) => trust_decision,
@@ -623,7 +611,6 @@ impl HostRuntime for DefaultHostRuntime {
                 tracing::debug!(
                     capability_id = %capability_id,
                     error_kind = failure_kind_from(&error).as_str(),
-                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability invocation failed"
                 );
                 let translated = self
@@ -663,7 +650,6 @@ impl HostRuntime for DefaultHostRuntime {
             capability_id,
             estimate,
             input,
-            idempotency_key,
         } = request;
         let input = match host_runtime_spawn_input_for_capability(&capability_id, input)? {
             SpawnInputPreparation::Ready(input) => input,
@@ -677,14 +663,6 @@ impl HostRuntime for DefaultHostRuntime {
         };
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
-        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
-        if let Some(key) = idempotency_key.as_deref() {
-            tracing::debug!(
-                capability_id = %capability_id,
-                idempotency_key = %key,
-                "capability spawn accepted advisory idempotency key (not yet enforced)"
-            );
-        }
 
         let trust_decision = match self.open_pre_authorization(&mut context, &capability_id) {
             Ok(trust_decision) => trust_decision,
@@ -741,7 +719,6 @@ impl HostRuntime for DefaultHostRuntime {
                 tracing::debug!(
                     capability_id = %capability_id,
                     error_kind = failure_kind_from(&error).as_str(),
-                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability spawn failed"
                 );
                 self.translate_invocation_error(error, capability_id, scope, invocation_id)
@@ -760,22 +737,12 @@ impl HostRuntime for DefaultHostRuntime {
             capability_id,
             estimate,
             input,
-            idempotency_key,
         } = request;
         if let Some(outcome) = self
             .resume_actor_preflight_guard(&context, &capability_id)
             .await?
         {
             return Ok(outcome);
-        }
-        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
-        if let Some(key) = idempotency_key.as_deref() {
-            tracing::debug!(
-                capability_id = %capability_id,
-                approval_request_id = %approval_request_id,
-                idempotency_key = %key,
-                "capability resume accepted advisory idempotency key (not yet enforced)"
-            );
         }
 
         let trust_decision = match self.open_pre_authorization(&mut context, &capability_id) {
@@ -823,7 +790,6 @@ impl HostRuntime for DefaultHostRuntime {
                 tracing::debug!(
                     capability_id = %capability_id,
                     error_kind = failure_kind_from(&error).as_str(),
-                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability resume failed"
                 );
                 match error {
@@ -854,7 +820,6 @@ impl HostRuntime for DefaultHostRuntime {
             capability_id,
             estimate,
             input,
-            idempotency_key,
             approval_request_id,
         } = request;
         if let Some(outcome) = self
@@ -862,15 +827,6 @@ impl HostRuntime for DefaultHostRuntime {
             .await?
         {
             return Ok(outcome);
-        }
-        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
-        if let Some(key) = idempotency_key.as_deref() {
-            tracing::debug!(
-                capability_id = %capability_id,
-                approval_request_id = approval_request_id.map(|id| id.to_string()).as_deref().unwrap_or("none"),
-                idempotency_key = %key,
-                "capability auth-resume accepted advisory idempotency key (not yet enforced)"
-            );
         }
 
         let trust_decision = match self.open_pre_authorization(&mut context, &capability_id) {
@@ -934,7 +890,6 @@ impl HostRuntime for DefaultHostRuntime {
                 tracing::debug!(
                     capability_id = %capability_id,
                     error_kind = failure_kind_from(&error).as_str(),
-                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability auth-resume failed"
                 );
                 match error {
@@ -966,7 +921,6 @@ impl HostRuntime for DefaultHostRuntime {
             capability_id,
             estimate,
             input,
-            idempotency_key,
         } = request;
         if let Some(outcome) = self
             .resume_actor_preflight_guard(&context, &capability_id)
@@ -984,15 +938,6 @@ impl HostRuntime for DefaultHostRuntime {
                 return Ok(RuntimeCapabilityOutcome::Failed(failure));
             }
         };
-        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
-        if let Some(key) = idempotency_key.as_deref() {
-            tracing::debug!(
-                capability_id = %capability_id,
-                approval_request_id = %approval_request_id,
-                idempotency_key = %key,
-                "capability spawn resume accepted advisory idempotency key (not yet enforced)"
-            );
-        }
 
         if let Err(error) = self.enforce_runtime_policy(&capability_id) {
             tracing::debug!(
@@ -1049,7 +994,6 @@ impl HostRuntime for DefaultHostRuntime {
                 tracing::debug!(
                     capability_id = %capability_id,
                     error_kind = failure_kind_from(&error).as_str(),
-                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability spawn resume failed"
                 );
                 // Mirror resume_capability: AuthorizationRequiresAuth must return

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -94,8 +94,7 @@ async fn default_runtime_returns_completed_outcome_for_authorized_dispatch() {
         capability_id(),
         ResourceEstimate::default(),
         json!({"message": "hello"}),
-    )
-    .with_idempotency_key(IdempotencyKey::new("turn-1/tool-1").unwrap());
+    );
 
     let outcome = runtime.invoke_capability(request).await.unwrap();
 
@@ -355,11 +354,10 @@ async fn default_runtime_surfaces_authorization_failure_when_authorizer_denies()
 }
 
 #[tokio::test]
-async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
-    // Pins the documented limitation: idempotency_key is advisory only at
-    // this layer. Two invocations carrying the same key both reach dispatch.
-    // If a future change wires dedupe through the capability host, this test
-    // is the canary that flags the contract change.
+async fn default_runtime_repeated_invocations_are_not_deduped_by_host_runtime_request_shape() {
+    // Host-runtime requests no longer carry a caller-provided idempotency key.
+    // Loop-host owns invocation replay/dedup before this boundary; repeated
+    // host-runtime invocations are ordinary independent dispatches.
     let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(CountingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
@@ -372,16 +370,13 @@ async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
     )
     .with_trust_policy(Arc::new(local_manifest_trust_policy()));
 
-    let key = IdempotencyKey::new("turn-1/tool-1").unwrap();
-
     let context_a = execution_context_with_dispatch_grant();
     let request_a = RuntimeCapabilityRequest::new(
         context_a,
         capability_id(),
         ResourceEstimate::default(),
         json!({"n": 1}),
-    )
-    .with_idempotency_key(key.clone());
+    );
     let _ = runtime.invoke_capability(request_a).await.unwrap();
 
     let context_b = execution_context_with_dispatch_grant();
@@ -390,14 +385,13 @@ async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
         capability_id(),
         ResourceEstimate::default(),
         json!({"n": 2}),
-    )
-    .with_idempotency_key(key);
+    );
     let _ = runtime.invoke_capability(request_b).await.unwrap();
 
     assert_eq!(
         dispatcher.count(),
         2,
-        "idempotency_key is advisory only — dedupe is not enforced at this layer"
+        "dedupe is enforced by loop-host before the host-runtime request boundary"
     );
 }
 

--- a/crates/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/ironclaw_loop_host/src/capability_port.rs
@@ -2531,8 +2531,7 @@ impl HostRuntimeLoopCapabilityPort {
                     request.capability_id,
                     estimate.clone(),
                     input.clone(),
-                )
-                .with_idempotency_key(idempotency_key.clone());
+                );
                 dispatch_runtime_capability_resume(self.runtime.as_ref(), runtime_request).await
             }
             ResolvedResumeMode::Auth {
@@ -2555,8 +2554,7 @@ impl HostRuntimeLoopCapabilityPort {
                     estimate.clone(),
                     input.clone(),
                     prior_approval_id,
-                )
-                .with_idempotency_key(idempotency_key.clone());
+                );
                 dispatch_runtime_capability_auth_resume(self.runtime.as_ref(), runtime_request)
                     .await
             }
@@ -2566,8 +2564,7 @@ impl HostRuntimeLoopCapabilityPort {
                     request.capability_id,
                     estimate.clone(),
                     input.clone(),
-                )
-                .with_idempotency_key(idempotency_key.clone());
+                );
                 dispatch_runtime_capability(self.runtime.as_ref(), runtime_request).await
             }
         };

--- a/crates/ironclaw_runner/tests/loop_driver_host.rs
+++ b/crates/ironclaw_runner/tests/loop_driver_host.rs
@@ -7029,7 +7029,6 @@ async fn text_only_host_does_not_reinvoke_runtime_after_failed_outcome_retry() {
     assert_eq!(first, second);
     let invocations = runtime.invocations();
     assert_eq!(invocations.len(), 1);
-    assert!(invocations[0].idempotency_key.is_some());
     assert!(io.results().is_empty());
 }
 
@@ -7357,7 +7356,6 @@ async fn text_only_host_does_not_reinvoke_runtime_after_result_write_failure_ret
     assert!(matches!(second, Resolution::Done(ref o) if o.verdict.is_success()));
     let invocations = runtime.invocations();
     assert_eq!(invocations.len(), 1);
-    assert!(invocations[0].idempotency_key.is_some());
     assert_eq!(
         io.results(),
         vec![(capability_id, json!({"write": "fails"}))]


### PR DESCRIPTION
## Summary

- Remove the unused advisory `idempotency_key` field from host-runtime capability invoke/resume/auth-resume request DTOs.
- Drop the corresponding no-op builder methods and tracing-only pass-through logging in the production host runtime.
- Keep actual invocation replay/dedup ownership in loop-host, and update contract/runner tests to assert behavior rather than the deleted DTO shape.

## Why

The host-runtime layer never enforced caller-provided idempotency. Carrying the field through the runtime request DTOs made the hot path look like it had a dedupe contract that did not exist. Loop-host already owns the real reservation/replay behavior before this boundary, so this removes dead shape padding instead of adding another mirror.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_loop_host --lib`
- `cargo test -p ironclaw_host_runtime --lib --no-run`
- `cargo test -p ironclaw_host_runtime --test host_runtime_contract default_runtime_repeated_invocations_are_not_deduped_by_host_runtime_request_shape`
- `cargo test -p ironclaw_runner --test loop_driver_host text_only_host_does_not_reinvoke_runtime_after_failed_outcome_retry`
- `cargo test -p ironclaw_runner --test loop_driver_host text_only_host_does_not_reinvoke_runtime_after_result_write_failure_retry`
- `cargo test -p ironclaw_architecture`
- `cargo clippy -p ironclaw_host_runtime -p ironclaw_loop_host --all-targets --all-features -- -D warnings`
- `SKIP_FRONTEND_BUILD=1 cargo clippy --all --benches --tests --examples --all-features -- -D warnings`

## Notes

`cargo test -p ironclaw_host_runtime --lib` still has three unrelated Docker-socket failures locally because `/var/run/docker.sock` is unavailable. Full workspace clippy without `SKIP_FRONTEND_BUILD=1` fails before Rust checks because the `ironclaw_webui` build script cannot run the frontend build path in this environment.