### PR TITLE
refactor(reborn): sole-witness dispatch input + HIGH review fixes that missed the #6432 merge (§5.3.2/§9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,6 +3498,7 @@ name = "ironclaw_dispatcher"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "ironclaw_events",
  "ironclaw_host_api",
  "ironclaw_resources",

--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -140,6 +140,7 @@ impl From<DispatchError> for CapabilityInvocationError {
             | DispatchError::RuntimeMismatch { .. }
             | DispatchError::MissingRuntimeBackend { .. }
             | DispatchError::UnsupportedRuntime { .. }
+            | DispatchError::LaneMismatch { .. }
             | DispatchError::Mcp { .. }
             | DispatchError::Script { .. }
             | DispatchError::Wasm { .. }
@@ -181,7 +182,8 @@ fn dispatch_error_model_visible_cause(error: &DispatchError) -> Option<String> {
         | DispatchError::UnknownProvider { .. }
         | DispatchError::RuntimeMismatch { .. }
         | DispatchError::MissingRuntimeBackend { .. }
-        | DispatchError::UnsupportedRuntime { .. } => Some(error.to_string()),
+        | DispatchError::UnsupportedRuntime { .. }
+        | DispatchError::LaneMismatch { .. } => Some(error.to_string()),
         // Auth-required carries redacted secret handles; keep it summary-free.
         DispatchError::AuthRequired { .. } => None,
     }

--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -141,6 +141,7 @@ impl From<DispatchError> for CapabilityInvocationError {
             | DispatchError::MissingRuntimeBackend { .. }
             | DispatchError::UnsupportedRuntime { .. }
             | DispatchError::LaneMismatch { .. }
+            | DispatchError::AuthorizationExpired { .. }
             | DispatchError::Mcp { .. }
             | DispatchError::Script { .. }
             | DispatchError::Wasm { .. }
@@ -183,7 +184,8 @@ fn dispatch_error_model_visible_cause(error: &DispatchError) -> Option<String> {
         | DispatchError::RuntimeMismatch { .. }
         | DispatchError::MissingRuntimeBackend { .. }
         | DispatchError::UnsupportedRuntime { .. }
-        | DispatchError::LaneMismatch { .. } => Some(error.to_string()),
+        | DispatchError::LaneMismatch { .. }
+        | DispatchError::AuthorizationExpired { .. } => Some(error.to_string()),
         // Auth-required carries redacted secret handles; keep it summary-free.
         DispatchError::AuthRequired { .. } => None,
     }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -4801,4 +4801,217 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
             "an expired resume witness must fail the run"
         );
     }
+
+    // Finding (§5.2.1/§5.3.2): an ALLOWED but origin-less invocation (no `origin`
+    // AND no `run_id`, so `resolved_origin()` is `None`) must fail CLOSED at the
+    // authorize fold — deny with `InternalInvariantViolation`, mint no witness,
+    // dispatch NOTHING, and fail the run. Every production ingress stamps an
+    // origin (the loop stamps `run_id` → `LoopRun`), so an origin-less allowed
+    // context is not a real ingress and an un-attributable dispatch must not
+    // proceed. Drives the production `invoke_json` caller so the invariant cannot
+    // silently regress.
+    #[tokio::test]
+    async fn origin_less_invoke_denied_dispatches_nothing_and_fails_run() {
+        let registry = echo_registry();
+        // A recording dispatcher that must never fire on the origin-less path. Its
+        // responder returns an error so a regression (dispatch actually firing) is
+        // caught by the `call_count() == 0` assertion, not masked by a success.
+        let dispatcher =
+            ironclaw_host_api::dispatch_test_support::TestDispatcher::responding(|req, _| {
+                Err(DispatchError::UnknownCapability {
+                    capability: req.capability_id.clone(),
+                })
+            });
+        let authorizer = AllowAuthorizer;
+        let trust_policy = StaticTrustPolicy;
+        let runtime_policy = permissive_runtime_policy();
+        let policy_facts = SatisfiedPolicyFacts;
+        let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+        let host = CapabilityHost::new(
+            &registry,
+            &dispatcher,
+            &authorizer,
+            &trust_policy,
+            &runtime_policy,
+            &policy_facts,
+        )
+        .with_run_state(&run_state);
+
+        // An otherwise-allowed request stripped of every ingress origin fact: no
+        // `origin` and no `run_id`, so `resolved_origin()` is `None`. The
+        // membrane-sealed actor is deliberately left set to prove the deny is the
+        // origin-less fail-close, not a missing actor.
+        let mut request = allow_request();
+        request.context.origin = None;
+        request.context.run_id = None;
+        assert!(
+            request.context.resolved_origin().is_none(),
+            "test fixture must be origin-less for this to exercise the fail-close"
+        );
+        let scope = request.context.resource_scope.clone();
+        let invocation_id = request.context.invocation_id;
+
+        let error = host.invoke_json(request).await.unwrap_err();
+
+        // Terminal fail-closed denial carrying the internal-invariant reason.
+        assert!(
+            matches!(
+                error,
+                CapabilityInvocationError::AuthorizationDenied {
+                    reason: DenyReason::InternalInvariantViolation,
+                    ..
+                }
+            ),
+            "origin-less invoke must fail closed with InternalInvariantViolation, got {error:?}"
+        );
+        // The side effect must NOT be dispatched — no witness was minted.
+        assert_eq!(
+            dispatcher.call_count(),
+            0,
+            "an origin-less invoke must NOT dispatch the side effect"
+        );
+        // The run record started by the authorize fold transitioned to Failed.
+        let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+        assert_eq!(
+            run.status,
+            ironclaw_run_state::RunStatus::Failed,
+            "an origin-less invoke must fail the run"
+        );
+        assert_eq!(
+            run.error_kind.as_deref(),
+            Some("AuthorizationDenied"),
+            "the origin-less fail-close records the AuthorizationDenied error kind"
+        );
+    }
+
+    // Finding (§5.2.1/§5.3.2), auth-resume claimed-lease cleanup path: an ALLOWED
+    // but origin-less resume that carries an already-`Claimed` approval lease
+    // (`AlreadyClaimed`, advanced to `Dispatching` in the `auth_resume_json`
+    // preamble) must fail CLOSED at the authorize fold — deny with
+    // `InternalInvariantViolation`, dispatch NOTHING, fail the run, AND revoke the
+    // already-claimed lease so a terminal refusal does not strand it. Drives the
+    // whole resume tail (`dispatch_resumed_capability`) so the fail-close and the
+    // lease revoke cannot silently regress; the `Deny`-arm lease cleanup the
+    // neighboring resume tests assert is mirrored here for the origin-less arm.
+    #[tokio::test]
+    async fn origin_less_resume_denies_dispatches_nothing_fails_run_and_revokes_claimed_lease() {
+        let registry = echo_registry();
+        // A recording dispatcher that must never fire on the origin-less path.
+        let dispatcher =
+            ironclaw_host_api::dispatch_test_support::TestDispatcher::responding(|req, _| {
+                Err(DispatchError::UnknownCapability {
+                    capability: req.capability_id.clone(),
+                })
+            });
+        let authorizer = AllowAuthorizer;
+        let trust_policy = StaticTrustPolicy;
+        let runtime_policy = permissive_runtime_policy();
+        let policy_facts = SatisfiedPolicyFacts;
+        let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+
+        // Origin-less: strip both `origin` and `run_id` from an otherwise-allowed
+        // request so `resolved_origin()` is `None`.
+        let mut request = allow_request();
+        request.context.origin = None;
+        request.context.run_id = None;
+        assert!(request.context.resolved_origin().is_none());
+        let capability_id = request.capability_id.clone();
+        let estimate = request.estimate.clone();
+        let input = request.input.clone();
+        let context = request.context.clone();
+        let scope = context.resource_scope.clone();
+        let invocation_id = context.invocation_id;
+
+        // Start + block the run so the terminal fail transition has a record to
+        // move to `Failed` (the auth-resume preamble leaves it BlockedAuth).
+        run_state
+            .start(RunStart {
+                invocation_id,
+                scope: scope.clone(),
+                capability_id: capability_id.clone(),
+                authenticated_actor_user_id: context.authenticated_actor_user_id.clone(),
+            })
+            .await
+            .unwrap();
+        run_state
+            .block_auth(&scope, invocation_id, "AuthRequired".to_string())
+            .await
+            .unwrap();
+
+        let host = CapabilityHost::new(
+            &registry,
+            &dispatcher,
+            &authorizer,
+            &trust_policy,
+            &runtime_policy,
+            &policy_facts,
+        )
+        .with_run_state(&run_state);
+
+        let descriptor = registry
+            .get_capability(&capability_id)
+            .expect("echo.say is registered");
+        // A prior approval lease already `Claimed` in the preamble, with a future
+        // expiry so the deny is unambiguously the origin-less fail-close, not an
+        // expiry-based one.
+        let leases = ClaimRecordingLeaseStore {
+            grant_id: CapabilityGrantId::new(),
+            expires_at: chrono::Utc::now() + chrono::Duration::minutes(5),
+            capability_id: capability_id.clone(),
+            claimed: std::sync::Mutex::new(false),
+            revoked: std::sync::Mutex::new(None),
+        };
+        let expected_grant_id = leases.grant_id;
+        let claimed_lease = leases.lease(&scope);
+
+        let params = ResumedDispatchParams {
+            run_state: &run_state,
+            scope: scope.clone(),
+            invocation_id,
+            capability_id,
+            estimate,
+            input,
+            authorized_context: context,
+            descriptor,
+            lease_state: ResumedLeaseState::AlreadyClaimed(&leases, Box::new(claimed_lease)),
+        };
+
+        let error = host.dispatch_resumed_capability(params).await.unwrap_err();
+
+        // Terminal fail-closed denial carrying the internal-invariant reason.
+        assert!(
+            matches!(
+                error,
+                CapabilityInvocationError::AuthorizationDenied {
+                    reason: DenyReason::InternalInvariantViolation,
+                    ..
+                }
+            ),
+            "origin-less resume must fail closed with InternalInvariantViolation, got {error:?}"
+        );
+        // No side effect, and the deferred lease claim never ran (the fail-close
+        // returns before the claim-before-dispatch tail).
+        assert_eq!(
+            dispatcher.call_count(),
+            0,
+            "an origin-less resume must NOT dispatch the side effect"
+        );
+        assert!(
+            !*leases.claimed.lock().unwrap(),
+            "the fail-close returns before the resume claim-before-dispatch tail"
+        );
+        // The already-claimed lease is revoked (terminal), not stranded Dispatching.
+        assert_eq!(
+            *leases.revoked.lock().unwrap(),
+            Some(expected_grant_id),
+            "an origin-less resume must REVOKE the already-claimed lease"
+        );
+        // The run failed.
+        let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+        assert_eq!(
+            run.status,
+            ironclaw_run_state::RunStatus::Failed,
+            "an origin-less resume must fail the run"
+        );
+    }
 }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -354,7 +354,7 @@ where
         // S6 (§5.3.2/§9): dispatch routes through the always-present sealed
         // witness (consumed single-use, failing closed on expiry). See
         // [`Self::dispatch_inputs_from_witness`].
-        let (dispatch_mounts, dispatch_reservation, pinned_lane) = self
+        let (dispatch_mounts, dispatch_reservation, pinned_lane, deadline) = self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Invoke,
                 witness,
@@ -378,6 +378,10 @@ where
                 mounts: dispatch_mounts,
                 resource_reservation: dispatch_reservation,
                 pinned_lane,
+                // Carry the witness deadline so the dispatcher revalidates it
+                // immediately before the executor, past its pre-execution event
+                // awaits (§5.3.2, finding #6436).
+                deadline,
                 input: request.input,
             })
             .await
@@ -2002,7 +2006,7 @@ where
             origin,
             frozen_deadline,
         );
-        let (witness_mounts, witness_reservation, _pinned_lane) = match self
+        let (witness_mounts, witness_reservation, _pinned_lane, deadline) = match self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Spawn,
                 witness,
@@ -2038,6 +2042,45 @@ where
         let resource_reservation_id = witness_reservation
             .as_ref()
             .map(|reservation| reservation.id);
+
+        // Revalidate the authorization deadline IMMEDIATELY before process start
+        // (§5.3.2, IronLoop finding #6436), mirroring `spawn_json`. The claimed
+        // approval lease bounds this witness; `dispatch_inputs_from_witness` failed
+        // closed on expiry when it consumed the witness and there is no meaningful
+        // `await` before `ProcessManager::spawn` here, so this is defense-in-depth.
+        // On expiry, revoke the claimed lease too (mirror the witness-expiry arm
+        // above) so it is not stranded, and no process starts. `None` skips it.
+        if let Some(deadline) = deadline
+            && chrono::Utc::now() >= deadline
+        {
+            self.abort_obligations(
+                CapabilityObligationPhase::Spawn,
+                &authorized_context,
+                &capability_id,
+                &request.estimate,
+                obligations.as_slice(),
+                &obligation_outcome,
+            )
+            .await;
+            fail_run_if_configured(Some(run_state), &scope, invocation_id, "WitnessExpired").await;
+            if let Err(revoke_error) = capability_leases
+                .revoke(&scope, claimed_lease.grant.id)
+                .await
+            {
+                warn!(
+                    lease_id = %claimed_lease.grant.id,
+                    invocation_id = %invocation_id,
+                    capability_id = %capability_id,
+                    revoke_error_kind = capability_lease_error_kind(&revoke_error),
+                    "capability lease revoke failed after resume-spawn deadline re-check; lease may remain claimed",
+                );
+            }
+            return Err(CapabilityInvocationError::AuthorizationDenied {
+                capability: request.capability_id,
+                reason: DenyReason::InternalInvariantViolation,
+                detail: None,
+            });
+        }
 
         let process = match process_manager
             .spawn(ProcessStart {
@@ -2156,7 +2199,7 @@ where
         // to carry a pinned lane — the witness's lane binding (finding C) is a
         // dispatcher-path concern, so the lane it yields is unused here. See
         // [`Self::dispatch_inputs_from_witness`].
-        let (witness_mounts, witness_reservation, _pinned_lane) = self
+        let (witness_mounts, witness_reservation, _pinned_lane, deadline) = self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Spawn,
                 witness,
@@ -2201,6 +2244,34 @@ where
         let resource_reservation_id = witness_reservation
             .as_ref()
             .map(|reservation| reservation.id);
+
+        // Revalidate the authorization deadline IMMEDIATELY before process start
+        // (§5.3.2, IronLoop finding #6436). `dispatch_inputs_from_witness` already
+        // failed closed on expiry when it consumed the witness, and there is no
+        // meaningful `await` between that consumption and `ProcessManager::spawn`
+        // on this path — so this re-check is defense-in-depth (cheap): it makes the
+        // "no side effect after the authorization deadline" invariant local to the
+        // spawn site, matching the dispatcher's execution-boundary re-check. `None`
+        // (witness-free/legacy) skips it.
+        if let Some(deadline) = deadline
+            && chrono::Utc::now() >= deadline
+        {
+            self.abort_obligations(
+                CapabilityObligationPhase::Spawn,
+                &request.context,
+                &request.capability_id,
+                &request.estimate,
+                obligations.as_slice(),
+                &obligation_outcome,
+            )
+            .await;
+            fail_run_if_configured(self.run_state, &scope, invocation_id, "WitnessExpired").await;
+            return Err(CapabilityInvocationError::AuthorizationDenied {
+                capability: request.capability_id,
+                reason: DenyReason::InternalInvariantViolation,
+                detail: None,
+            });
+        }
 
         let process = match process_manager
             .spawn(ProcessStart {
@@ -3048,7 +3119,7 @@ where
             obligation_outcome.mounts.clone(),
             obligation_outcome.resource_reservation.clone(),
         ));
-        let (dispatch_mounts, dispatch_reservation, pinned_lane) = match self
+        let (dispatch_mounts, dispatch_reservation, pinned_lane, deadline) = match self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Resume,
                 witness,
@@ -3096,6 +3167,10 @@ where
                 mounts: dispatch_mounts,
                 resource_reservation: dispatch_reservation,
                 pinned_lane,
+                // Carry the witness deadline so the dispatcher revalidates it
+                // immediately before the executor, past its pre-execution event
+                // awaits (§5.3.2, finding #6436).
+                deadline,
                 input,
             })
             .await
@@ -3320,14 +3395,27 @@ where
             Option<ironclaw_host_api::MountView>,
             Option<ironclaw_host_api::ResourceReservation>,
             Option<RuntimeLane>,
+            Option<Timestamp>,
         ),
         CapabilityInvocationError,
     > {
+        // Capture the witness deadline BEFORE `into_parts` consumes it. The
+        // consumption fails closed on expiry (below), but the callers still need
+        // the deadline as expiry evidence carried through the final handoff: the
+        // dispatcher revalidates it immediately before the executor (past the
+        // pre-execution event-emission awaits), and the spawn paths revalidate it
+        // immediately before `ProcessManager::spawn` (§5.3.2, IronLoop finding
+        // #6436).
+        let deadline = witness.deadline();
         match witness.into_parts(chrono::Utc::now()) {
             // `lane` is the descriptor-resolved lane the authorization pinned:
             // threaded into the dispatch request so the dispatcher fails closed
             // if the hot registry re-resolves a different lane (§5.3.2, finding C).
-            Ok((_invocation, lane, mounts, reservation)) => Ok((mounts, reservation, lane)),
+            // `deadline` rides alongside as the expiry evidence the final
+            // execution-boundary re-check enforces (finding #6436).
+            Ok((_invocation, lane, mounts, reservation)) => {
+                Ok((mounts, reservation, lane, Some(deadline)))
+            }
             Err(expired) => {
                 self.abort_obligations(
                     phase,

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -1029,9 +1029,13 @@ where
             Some(user_id) => Actor::Sealed(user_id),
             None => Actor::System,
         };
-        // Lane resolved from the descriptor's runtime kind; `System` runtimes
-        // have no untrusted execution lane (`None`) and are not sealed here.
-        let lane = RuntimeLane::from_runtime_kind(descriptor.runtime)?;
+        // Lane resolved from the descriptor's runtime kind. `System` runtimes
+        // have no untrusted execution lane (`None`) — they dispatch on the
+        // process axis, not a lane — but the witness is STILL minted for them
+        // (carrying `lane == None`), so a witness is present for every
+        // dispatchable/spawnable invocation. No `?` here: the lane's absence no
+        // longer suppresses the whole witness.
+        let lane = RuntimeLane::from_runtime_kind(descriptor.runtime);
         let scope = &context.resource_scope;
         // Origin is the ingress-stamped authority fact (§5.2.1). The loop path
         // also carries `run_id`, so a context that stamped only `run_id` still
@@ -4103,7 +4107,7 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
         let Some(AuthorizeResult::Authorized(authorized)) = &fold.result else {
             panic!("allow path with a sealed actor must mint an Authorized witness");
         };
-        assert_eq!(authorized.lane(), RuntimeLane::Wasm);
+        assert_eq!(authorized.lane(), Some(RuntimeLane::Wasm));
         let invocation = authorized.invocation();
         assert_eq!(
             invocation.capability,

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -358,7 +358,7 @@ where
         // single-use, failing closed on expiry), or falls back to the fold's
         // obligation-derived inputs when no witness was sealed. See
         // [`Self::dispatch_inputs_from_witness`].
-        let (dispatch_mounts, dispatch_reservation) = self
+        let (dispatch_mounts, dispatch_reservation, pinned_lane) = self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Invoke,
                 witness,
@@ -381,6 +381,7 @@ where
                 estimate: request.estimate.clone(),
                 mounts: dispatch_mounts,
                 resource_reservation: dispatch_reservation,
+                pinned_lane,
                 input: request.input,
             })
             .await
@@ -1924,12 +1925,101 @@ where
                 return Err(error);
             }
         };
-        let effective_mounts = obligation_outcome
-            .mounts
-            .clone()
-            .unwrap_or_else(|| authorized_context.mounts.clone());
-        let resource_reservation_id = obligation_outcome
-            .resource_reservation
+        // Finding (IronLoop, §5.3.2): gate the resumed SPAWN through the same
+        // sealed-witness checks as resumed dispatch. Without this, an origin-less
+        // resume could start an unattributable process, and an approval lease that
+        // expired during preparation could still spawn (the expiry would only be
+        // noticed on a later consume). Resolve the origin (fail closed if absent)
+        // and seal a witness bounded by the claimed lease's approval expiry, then
+        // consume it so the deadline is enforced BEFORE `ProcessManager::spawn`.
+        // Both terminal failures revoke the claimed lease so it is not stranded.
+        let Some(origin) = authorized_context.resolved_origin() else {
+            // `prepare_obligations` already ran, so abort the prepared Spawn
+            // obligations before returning — otherwise an origin-less denial
+            // leaks the reservation / staged handoff. Mirrors the expired-witness
+            // (via `dispatch_inputs_from_witness`) and process-spawn-failure paths.
+            self.abort_obligations(
+                CapabilityObligationPhase::Spawn,
+                &authorized_context,
+                &capability_id,
+                &request.estimate,
+                obligations.as_slice(),
+                &obligation_outcome,
+            )
+            .await;
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "AuthorizationDenied",
+            )
+            .await;
+            if let Err(revoke_error) = capability_leases
+                .revoke(&scope, claimed_lease.grant.id)
+                .await
+            {
+                warn!(
+                    lease_id = %claimed_lease.grant.id,
+                    invocation_id = %invocation_id,
+                    capability_id = %capability_id,
+                    revoke_error_kind = capability_lease_error_kind(&revoke_error),
+                    "capability lease revoke failed after origin-less resume-spawn fail-close; lease may remain claimed",
+                );
+            }
+            return Err(CapabilityInvocationError::AuthorizationDenied {
+                capability: request.capability_id,
+                reason: DenyReason::InternalInvariantViolation,
+                detail: None,
+            });
+        };
+        // The claimed approval lease's expiry is the frozen fact bounding the
+        // witness deadline (mirrors `authorize_resumed`); `seal_authorization`
+        // min's it with the default TTL.
+        let frozen_deadline = claimed_lease.grant.constraints.expires_at;
+        let witness = self.seal_authorization(
+            &authorized_context,
+            &capability_id,
+            &request.estimate,
+            &request.input,
+            descriptor,
+            &obligation_outcome,
+            origin,
+            frozen_deadline,
+        );
+        let (witness_mounts, witness_reservation, _pinned_lane) = match self
+            .dispatch_inputs_from_witness(
+                CapabilityObligationPhase::Spawn,
+                witness,
+                &authorized_context,
+                &capability_id,
+                &request.estimate,
+                &obligations,
+                &obligation_outcome,
+            )
+            .await
+        {
+            Ok(parts) => parts,
+            Err(error) => {
+                // Witness expired: `dispatch_inputs_from_witness` already aborted
+                // the prepared obligations and failed the run; revoke the claimed
+                // lease too so it does not remain stuck claimed. No process starts.
+                if let Err(revoke_error) = capability_leases
+                    .revoke(&scope, claimed_lease.grant.id)
+                    .await
+                {
+                    warn!(
+                        lease_id = %claimed_lease.grant.id,
+                        invocation_id = %invocation_id,
+                        capability_id = %capability_id,
+                        revoke_error_kind = capability_lease_error_kind(&revoke_error),
+                        "capability lease revoke failed after resume-spawn witness expiry; lease may remain claimed",
+                    );
+                }
+                return Err(error);
+            }
+        };
+        let effective_mounts = witness_mounts.unwrap_or_else(|| authorized_context.mounts.clone());
+        let resource_reservation_id = witness_reservation
             .as_ref()
             .map(|reservation| reservation.id);
 
@@ -2046,7 +2136,12 @@ where
         // fold's obligation-derived inputs when no witness was sealed
         // (`system.process_sandbox` is System-runtime with no lane, so it seals
         // none yet spawns legitimately). See [`Self::dispatch_inputs_from_witness`].
-        let (witness_mounts, witness_reservation) = self
+        // Spawn starts a process through the `ProcessManager`, not the runtime
+        // dispatcher's `dispatch_json`, so there is no `CapabilityDispatchRequest`
+        // to carry a pinned lane on — the witness's lane binding (finding C) is a
+        // dispatcher-path concern. The witness is still consumed here for its
+        // single-use + expiry semantics; the lane it yields is unused on this path.
+        let (witness_mounts, witness_reservation, _pinned_lane) = self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Spawn,
                 witness,
@@ -2769,10 +2864,14 @@ where
             lease_state,
         } = params;
 
-        let obligations = match fold {
+        let (witness, obligations) = match fold {
             AuthorizeFold::Authorized(fold) => {
-                let AuthorizedFold { obligations, .. } = *fold;
-                obligations
+                let AuthorizedFold {
+                    result,
+                    obligations,
+                    ..
+                } = *fold;
+                (result, obligations)
             }
             AuthorizeFold::Denied { reason, .. } => {
                 return Err(CapabilityInvocationError::AuthorizationDenied {
@@ -2868,6 +2967,65 @@ where
             }
         };
 
+        // Finding B (§5.3.2): the witness sealed in `authorize_resumed` froze the
+        // approval/grant deadline BEFORE the lease claim, but against a provisional
+        // (empty) obligation outcome — the authoritative outcome is only prepared
+        // above, post-claim, to keep the resume paths' claim-before-dispatch
+        // ordering. Re-seal that witness against the ACTUAL prepared outcome
+        // (preserving its invocation/lane/deadline verbatim) so the witness the
+        // tail consumes carries the real dispatch inputs, then consume it through
+        // the shared `dispatch_inputs_from_witness` helper exactly like
+        // invoke/spawn — enforcing the deadline and failing CLOSED on expiry
+        // BEFORE the side effect. An approval lease that expired during the async
+        // authorization/obligation gap (after `begin_dispatch_claimed` advanced it)
+        // is caught here, not after dispatch when the later consume observes it.
+        let witness = match witness {
+            Some(AuthorizeResult::Authorized(authorized)) => Some(AuthorizeResult::Authorized(
+                Box::new(authorized.reseal_with_outcome(
+                    self.authorization_grant(),
+                    obligation_outcome.mounts.clone(),
+                    obligation_outcome.resource_reservation.clone(),
+                )),
+            )),
+            other => other,
+        };
+        let (dispatch_mounts, dispatch_reservation, pinned_lane) = match self
+            .dispatch_inputs_from_witness(
+                CapabilityObligationPhase::Resume,
+                witness,
+                &authorized_context,
+                &capability_id,
+                &estimate,
+                obligations.as_slice(),
+                &obligation_outcome,
+            )
+            .await
+        {
+            Ok(inputs) => inputs,
+            Err(error) => {
+                // Witness expired: `dispatch_inputs_from_witness` already aborted
+                // the prepared obligations, aborted the witness, and failed the
+                // run. The resume preamble additionally advanced the lease to
+                // Dispatching/claimed it, so expiry is terminal — REVOKE it so it
+                // does not stay stuck (mirror the `Decision::Deny` arm in
+                // `authorize_resumed`); a non-terminal revert would leave a
+                // dead-but-Claimed lease reusable against an expired approval.
+                if let Some((capability_leases, ref claimed)) = claimed_lease
+                    && let Err(revoke_error) =
+                        capability_leases.revoke(&scope, claimed.grant.id).await
+                {
+                    warn!(
+                        lease_id = %claimed.grant.id,
+                        invocation_id = %invocation_id,
+                        capability_id = %capability_id,
+                        revoke_error_kind = capability_lease_error_kind(&revoke_error),
+                        "capability lease revoke failed after resume witness expiry; lease may remain claimed",
+                    );
+                }
+                return Err(error);
+            }
+        };
+
         let dispatch = match self
             .dispatcher
             .dispatch_json(CapabilityDispatchRequest {
@@ -2876,8 +3034,9 @@ where
                 authenticated_actor_user_id: authorized_context.authenticated_actor_user_id.clone(),
                 run_id: authorized_context.run_id,
                 estimate: estimate.clone(),
-                mounts: obligation_outcome.mounts.clone(),
-                resource_reservation: obligation_outcome.resource_reservation.clone(),
+                mounts: dispatch_mounts,
+                resource_reservation: dispatch_reservation,
+                pinned_lane,
                 input,
             })
             .await
@@ -3074,8 +3233,10 @@ where
     /// lifecycle), consuming the witness via `abort` (never `Drop`), failing the
     /// run, and returning a terminal denial. The sealed `mounts`/`reservation`
     /// are the fold's `obligation_outcome` values verbatim, so dispatch inputs
-    /// are byte-identical to the pre-S6 path; the sealed `lane` is dropped here
-    /// (the dispatcher re-derives the identical descriptor lane it owns).
+    /// are byte-identical to the pre-S6 path; the sealed `lane` is returned as the
+    /// pinned lane so the caller can bind dispatch to it — the dispatcher
+    /// re-resolves the descriptor lane from its hot registry and fails closed if
+    /// it no longer matches this pinned lane (§5.3.2, mutable-registry TOCTOU).
     ///
     /// A `None` witness is NOT an error: the seal mints none for a host-internal
     /// `System`-runtime descriptor (no untrusted lane — `system.process_sandbox`
@@ -3099,17 +3260,26 @@ where
         (
             Option<ironclaw_host_api::MountView>,
             Option<ironclaw_host_api::ResourceReservation>,
+            Option<RuntimeLane>,
         ),
         CapabilityInvocationError,
     > {
         let Some(AuthorizeResult::Authorized(witness)) = witness else {
+            // No witness (host-internal `System` runtime with no lane, or a
+            // defensively origin-less context): no lane to pin, so dispatch keeps
+            // the obligation-derived inputs and the dispatcher's lane check is
+            // skipped — byte-identical to the pre-pinning path.
             return Ok((
                 obligation_outcome.mounts.clone(),
                 obligation_outcome.resource_reservation.clone(),
+                None,
             ));
         };
         match witness.into_parts(chrono::Utc::now()) {
-            Ok((_invocation, _lane, mounts, reservation)) => Ok((mounts, reservation)),
+            // `lane` is the descriptor-resolved lane the authorization pinned:
+            // threaded into the dispatch request so the dispatcher fails closed
+            // if the hot registry re-resolves a different lane (§5.3.2, finding C).
+            Ok((_invocation, lane, mounts, reservation)) => Ok((mounts, reservation, Some(lane))),
             Err(expired) => {
                 self.abort_obligations(
                     phase,
@@ -4352,6 +4522,243 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
             authorized.deadline(),
             lease_expiry,
             "the sealed witness deadline must be bounded by the approval lease expiry, not the default TTL"
+        );
+    }
+
+    // Lease store double for the resume-tail expiry test. Records the single
+    // `claim` (the PendingClaim tail claims here) and the single `revoke` (the
+    // terminal expiry cleanup), returning a Claimed lease carrying the expired
+    // grant. Every other method is unreachable on this path.
+    struct ClaimRecordingLeaseStore {
+        grant_id: CapabilityGrantId,
+        expires_at: Timestamp,
+        capability_id: CapabilityId,
+        claimed: std::sync::Mutex<bool>,
+        revoked: std::sync::Mutex<Option<CapabilityGrantId>>,
+    }
+
+    impl ClaimRecordingLeaseStore {
+        fn lease(&self, scope: &ResourceScope) -> CapabilityLease {
+            use ironclaw_host_api::{
+                CapabilityGrant, GrantConstraints, MountView, NetworkPolicy, Principal,
+            };
+            CapabilityLease {
+                scope: scope.clone(),
+                grant: CapabilityGrant {
+                    id: self.grant_id,
+                    capability: self.capability_id.clone(),
+                    grantee: Principal::User(scope.user_id.clone()),
+                    issued_by: Principal::HostRuntime,
+                    constraints: GrantConstraints {
+                        allowed_effects: Vec::new(),
+                        mounts: MountView::default(),
+                        network: NetworkPolicy::default(),
+                        secrets: Vec::new(),
+                        resource_ceiling: None,
+                        expires_at: Some(self.expires_at),
+                        max_invocations: Some(1),
+                    },
+                },
+                invocation_fingerprint: None,
+                status: ironclaw_authorization::CapabilityLeaseStatus::Claimed,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CapabilityLeaseStore for ClaimRecordingLeaseStore {
+        async fn issue(
+            &self,
+            _lease: CapabilityLease,
+        ) -> Result<CapabilityLease, ironclaw_authorization::CapabilityLeaseError> {
+            unimplemented!("resume tail does not issue leases")
+        }
+
+        async fn revoke(
+            &self,
+            scope: &ResourceScope,
+            lease_id: CapabilityGrantId,
+        ) -> Result<CapabilityLease, ironclaw_authorization::CapabilityLeaseError> {
+            *self.revoked.lock().unwrap() = Some(lease_id);
+            Ok(self.lease(scope))
+        }
+
+        async fn get(
+            &self,
+            _scope: &ResourceScope,
+            _lease_id: CapabilityGrantId,
+        ) -> Option<CapabilityLease> {
+            unimplemented!("resume tail does not read leases here")
+        }
+
+        async fn claim(
+            &self,
+            scope: &ResourceScope,
+            _lease_id: CapabilityGrantId,
+            _invocation_fingerprint: &InvocationFingerprint,
+        ) -> Result<CapabilityLease, ironclaw_authorization::CapabilityLeaseError> {
+            *self.claimed.lock().unwrap() = true;
+            Ok(self.lease(scope))
+        }
+
+        async fn consume(
+            &self,
+            _scope: &ResourceScope,
+            _lease_id: CapabilityGrantId,
+        ) -> Result<CapabilityLease, ironclaw_authorization::CapabilityLeaseError> {
+            unimplemented!("expired resume must not consume the lease")
+        }
+
+        async fn begin_dispatch_claimed(
+            &self,
+            _scope: &ResourceScope,
+            _lease_id: CapabilityGrantId,
+            _invocation_fingerprint: &InvocationFingerprint,
+        ) -> Result<CapabilityLease, ironclaw_authorization::CapabilityLeaseError> {
+            unimplemented!("driving the tail directly bypasses the preamble")
+        }
+
+        async fn abort_dispatch_claimed(
+            &self,
+            _scope: &ResourceScope,
+            _lease_id: CapabilityGrantId,
+        ) -> Result<CapabilityLease, ironclaw_authorization::CapabilityLeaseError> {
+            unimplemented!("expired resume revokes, not aborts-dispatch")
+        }
+
+        async fn leases_for_scope(&self, _scope: &ResourceScope) -> Vec<CapabilityLease> {
+            unimplemented!("resume tail does not enumerate leases")
+        }
+
+        async fn active_leases_for_context(
+            &self,
+            _context: &ExecutionContext,
+        ) -> Vec<CapabilityLease> {
+            unimplemented!("resume tail does not enumerate leases")
+        }
+    }
+
+    // Finding B (§5.3.2): a resume whose sealed witness deadline has already
+    // passed must dispatch NOTHING, fail the run, and revoke the claimed lease —
+    // it must not dispatch the side effect and only observe expiry at the later
+    // lease consume. Drives `dispatch_resumed_capability` (the whole resume tail:
+    // claim → prepare obligations → re-seal witness → consume witness → dispatch)
+    // through a `PendingClaim` whose approval-lease expiry is in the past, so the
+    // witness `into_parts(now)` fails closed before the dispatcher is ever called.
+    #[tokio::test]
+    async fn expired_resume_witness_dispatches_nothing_fails_run_and_revokes_lease() {
+        let past_expiry = chrono::Utc::now() - chrono::Duration::minutes(1);
+
+        let registry = echo_registry();
+        // A recording dispatcher that must never fire on the expired path. Its
+        // responder returns an error so a regression (dispatch actually firing)
+        // is caught by the `call_count() == 0` assertion, not masked by a success.
+        let dispatcher =
+            ironclaw_host_api::dispatch_test_support::TestDispatcher::responding(|req, _| {
+                Err(DispatchError::UnknownCapability {
+                    capability: req.capability_id.clone(),
+                })
+            });
+        let authorizer = AllowAuthorizer;
+        let trust_policy = StaticTrustPolicy;
+        let runtime_policy = permissive_runtime_policy();
+        let policy_facts = SatisfiedPolicyFacts;
+        let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+
+        let request = allow_request();
+        let capability_id = request.capability_id.clone();
+        let estimate = request.estimate.clone();
+        let input = request.input.clone();
+        let context = request.context.clone();
+        let scope = context.resource_scope.clone();
+        let invocation_id = context.invocation_id;
+
+        // Start + block the run so the terminal fail transition has a record to
+        // move to `Failed`.
+        run_state
+            .start(RunStart {
+                invocation_id,
+                scope: scope.clone(),
+                capability_id: capability_id.clone(),
+                authenticated_actor_user_id: context.authenticated_actor_user_id.clone(),
+            })
+            .await
+            .unwrap();
+        run_state
+            .block_auth(&scope, invocation_id, "AuthRequired".to_string())
+            .await
+            .unwrap();
+
+        let host = CapabilityHost::new(
+            &registry,
+            &dispatcher,
+            &authorizer,
+            &trust_policy,
+            &runtime_policy,
+            &policy_facts,
+        )
+        .with_run_state(&run_state);
+
+        let descriptor = registry
+            .get_capability(&capability_id)
+            .expect("echo.say is registered");
+        let fingerprint =
+            InvocationFingerprint::for_dispatch(&scope, &capability_id, &estimate, &input).unwrap();
+        let leases = ClaimRecordingLeaseStore {
+            grant_id: CapabilityGrantId::new(),
+            expires_at: past_expiry,
+            capability_id: capability_id.clone(),
+            claimed: std::sync::Mutex::new(false),
+            revoked: std::sync::Mutex::new(None),
+        };
+        let expected_grant_id = leases.grant_id;
+
+        let params = ResumedDispatchParams {
+            run_state: &run_state,
+            scope: scope.clone(),
+            invocation_id,
+            capability_id,
+            estimate,
+            input,
+            authorized_context: context,
+            descriptor,
+            lease_state: ResumedLeaseState::PendingClaim(PendingClaimAfterAuth {
+                leases: &leases,
+                grant_id: expected_grant_id,
+                fingerprint,
+                grant_expiry: Some(past_expiry),
+            }),
+        };
+
+        let error = host.dispatch_resumed_capability(params).await.unwrap_err();
+
+        // Terminal fail-closed denial, no side effect.
+        assert!(
+            matches!(error, CapabilityInvocationError::AuthorizationDenied { .. }),
+            "expired resume witness must fail closed with a terminal denial, got {error:?}"
+        );
+        assert_eq!(
+            dispatcher.call_count(),
+            0,
+            "the side effect must NOT be dispatched on an expired resume witness"
+        );
+        // The lease was claimed (claim-before-dispatch ordering) and then revoked
+        // by the terminal expiry cleanup.
+        assert!(
+            *leases.claimed.lock().unwrap(),
+            "the PendingClaim tail must have claimed the lease before the witness check"
+        );
+        assert_eq!(
+            *leases.revoked.lock().unwrap(),
+            Some(expected_grant_id),
+            "the expired resume must REVOKE the claimed lease (terminal), not leave it Claimed"
+        );
+        // The run failed.
+        let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+        assert_eq!(
+            run.status,
+            ironclaw_run_state::RunStatus::Failed,
+            "an expired resume witness must fail the run"
         );
     }
 }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -8,8 +8,8 @@ use ironclaw_host_api::{
     CapabilityAuthorizer, CapabilityDescriptor, CapabilityDispatchRequest,
     CapabilityDispatchResult, CapabilityDispatcher, CapabilityGrantId, CapabilityId, Decision,
     DenyReason, DenyRef, DispatchError, EffectiveRuntimePolicy, ExecutionContext, GateRef,
-    GateWaypoint, Invocation, InvocationFingerprint, InvocationId, Obligation, PermissionMode,
-    ProcessId, ResourceEstimate, ResourceScope, RuntimeLane, Timestamp,
+    GateWaypoint, Invocation, InvocationFingerprint, InvocationId, InvocationOrigin, Obligation,
+    PermissionMode, ProcessId, ResourceEstimate, ResourceScope, RuntimeLane, Timestamp,
 };
 use ironclaw_processes::{ProcessManager, ProcessStart};
 use ironclaw_run_state::{
@@ -182,18 +182,16 @@ enum AuthorizeFold {
 
 /// Payload of [`AuthorizeFold::Authorized`] — the allowed-dispatch side-band.
 ///
-/// `result` is `Some(AuthorizeResult::Authorized(..))` for every allowed,
-/// dispatchable invocation: the actor is always resolved (`Actor::System` for an
-/// actor-less/host-internal context) and the origin is the real ingress fact, so
-/// the seal no longer skips actor-less invocations. `result` is `None` only when
-/// the descriptor resolves to no untrusted [`RuntimeLane`] (a host-internal
-/// `System` runtime is not dispatched to a lane). A `None` witness does not
-/// regress dispatch: this slice mints the witness as a forward-looking seal
-/// artifact but still builds dispatch from `obligation_outcome`, so a lane-less
-/// invocation dispatches exactly as it does today. The hard witness-routed
-/// dispatch requirement lands in a later slice (§9).
+/// `witness` is the sealed [`Authorized`] minted for **every** allowed,
+/// dispatchable invocation on the Allow path: the actor is always resolved
+/// (`Actor::System` for an actor-less/host-internal context), the origin is the
+/// real ingress fact (an origin-less context fails closed at the fold before it
+/// reaches here — see the `Decision::Allow` arms), and a host-internal `System`
+/// runtime still seals a witness carrying `lane == None`. The witness is
+/// therefore non-optional: the Allow path always has one, and dispatch routes
+/// through it in [`Self::dispatch_inputs_from_witness`].
 struct AuthorizedFold {
-    result: Option<AuthorizeResult>,
+    witness: Box<Authorized>,
     obligations: Vec<Obligation>,
     obligation_outcome: CapabilityObligationOutcome,
 }
@@ -320,16 +318,15 @@ where
         let (witness, obligations, obligation_outcome) = match self.authorize(&request).await? {
             AuthorizeFold::Authorized(fold) => {
                 let AuthorizedFold {
-                    result,
+                    witness,
                     obligations,
                     obligation_outcome,
                 } = *fold;
                 debug!(
-                    authorize_result = ?result.as_ref().map(AuthorizeResult::kind),
                     obligation_count = obligations.len(),
                     "capability authorization allowed dispatch"
                 );
-                (result, obligations, obligation_outcome)
+                (witness, obligations, obligation_outcome)
             }
             AuthorizeFold::Denied { result, reason } => {
                 debug!(
@@ -354,9 +351,8 @@ where
             }
         };
 
-        // S6 (§5.3.2/§9): dispatch routes through the sealed witness (consumed
-        // single-use, failing closed on expiry), or falls back to the fold's
-        // obligation-derived inputs when no witness was sealed. See
+        // S6 (§5.3.2/§9): dispatch routes through the always-present sealed
+        // witness (consumed single-use, failing closed on expiry). See
         // [`Self::dispatch_inputs_from_witness`].
         let (dispatch_mounts, dispatch_reservation, pinned_lane) = self
             .dispatch_inputs_from_witness(
@@ -735,6 +731,28 @@ where
             Decision::Allow {
                 obligations: allowed_obligations,
             } => {
+                // Fail closed on an origin-less context (§5.2.1/§5.3.2): the
+                // sealed witness is now always-present on the Allow path, and
+                // `Invocation` requires an [`InvocationOrigin`]. Every production
+                // ingress stamps one (the loop stamps `run_id` → `LoopRun`), so a
+                // context that resolves to no origin is not a real ingress and an
+                // un-attributable dispatch must not proceed. Deny with the
+                // internal-invariant reason, using the same run-state transition
+                // the `Decision::Deny` arm uses.
+                let Some(origin) = authorize_context.resolved_origin() else {
+                    debug!("capability authorization denied dispatch: origin-less context");
+                    fail_run_if_configured(
+                        self.run_state,
+                        &scope,
+                        invocation_id,
+                        "AuthorizationDenied",
+                    )
+                    .await;
+                    return Ok(AuthorizeFold::Denied {
+                        result: AuthorizeResult::Denied(DenyRef::new()),
+                        reason: DenyReason::InternalInvariantViolation,
+                    });
+                };
                 let allowed_obligations = allowed_obligations.into_vec();
                 debug!(
                     obligation_count = allowed_obligations.len(),
@@ -769,17 +787,18 @@ where
                         return Err(error);
                     }
                 };
-                let result = self.seal_authorization(
+                let witness = self.seal_authorization(
                     &authorize_context,
                     &request.capability_id,
                     &request.estimate,
                     &request.input,
                     descriptor,
                     &obligation_outcome,
+                    origin,
                     frozen_deadline,
                 );
                 Ok(AuthorizeFold::Authorized(Box::new(AuthorizedFold {
-                    result,
+                    witness,
                     obligations: allowed_obligations,
                     obligation_outcome,
                 })))
@@ -989,24 +1008,19 @@ where
     /// Mint the sealed [`Authorized`] witness for an allowed invoke, spawn, or
     /// resume (arch-simplification §5.3.2).
     ///
-    /// `actor` and `origin` are now always resolvable, so the witness is minted
-    /// for **every** dispatchable invocation: an actor-less/host-internal context
-    /// seals [`Actor::System`] (never a stand-in user, never a skipped seal), and
-    /// `origin` is sealed from the ingress-stamped [`ExecutionContext::origin`]
-    /// (authoritative, §5.2.1), falling back to reconstructing
-    /// [`InvocationOrigin::LoopRun`] from `run_id` for the loop path. There is no
-    /// `"provisional"` placeholder — every production ingress stamps its true
-    /// origin (the loop via `run_id`/`LoopRun`).
+    /// `actor` and `origin` are always resolved, so the witness is minted for
+    /// **every** dispatchable invocation on the Allow path: an
+    /// actor-less/host-internal context seals [`Actor::System`] (never a stand-in
+    /// user, never a skipped seal), and `origin` is the authoritative ingress
+    /// fact resolved by the caller (§5.2.1) — the origin-less fail-close lives in
+    /// each fold's `Decision::Allow` arm, so this function receives a resolved
+    /// [`InvocationOrigin`] and never has to skip the seal. A host-internal
+    /// `System` runtime seals a witness carrying `lane == None` (it dispatches on
+    /// the process axis, not a lane); the lane's absence no longer suppresses the
+    /// witness.
     ///
-    /// Returns `None` only when the descriptor's runtime maps to no untrusted
-    /// [`RuntimeLane`] (a host-internal `System` runtime is not dispatched to a
-    /// lane at all), or, defensively, when a context carries neither an `origin`
-    /// nor a `run_id` — a shape no production ingress produces. This slice mints
-    /// the witness as a forward-looking seal artifact (it does not yet gate
-    /// dispatch), so the lane-less `None` must not regress today's path.
-    ///
-    /// Shared by the invoke, spawn, and resume authorize folds so the same six
-    /// frozen facts seal every path (§9 step 2). `scope` is derived from
+    /// Shared by the invoke, spawn, and resume authorize folds so the same frozen
+    /// facts seal every path (§9 step 2). `scope` is derived from
     /// `context.resource_scope` — every caller's `scope` local is exactly that
     /// value (`request.context.resource_scope.clone()`), so passing it separately
     /// would only duplicate it.
@@ -1020,8 +1034,9 @@ where
         input: &serde_json::Value,
         descriptor: &CapabilityDescriptor,
         obligation_outcome: &CapabilityObligationOutcome,
+        origin: InvocationOrigin,
         frozen_deadline: Option<Timestamp>,
-    ) -> Option<AuthorizeResult> {
+    ) -> Box<Authorized> {
         // Actor is sealed at the membrane; NO fallback to `user_id`. An
         // actor-less (system service / one-shot) context seals `Actor::System`
         // as its own class — never a stand-in user, and never a skipped seal.
@@ -1037,12 +1052,9 @@ where
         // longer suppresses the whole witness.
         let lane = RuntimeLane::from_runtime_kind(descriptor.runtime);
         let scope = &context.resource_scope;
-        // Origin is the ingress-stamped authority fact (§5.2.1). The loop path
-        // also carries `run_id`, so a context that stamped only `run_id` still
-        // reconstructs `LoopRun` (transitional compat). No `"provisional"`
-        // fallback: a context that carries neither is not a real production
-        // ingress, so it is not sealed here (Option `?`, not a placeholder).
-        let origin = context.resolved_origin()?;
+        // Origin is the ingress-stamped authority fact (§5.2.1), resolved and
+        // fail-closed by the caller's `Decision::Allow` arm, so it arrives here
+        // as a plain value — never re-derived and never a placeholder.
         let invocation = Invocation {
             activity_id: ActivityId::from_uuid(context.invocation_id.as_uuid()),
             capability: capability_id.clone(),
@@ -1078,14 +1090,14 @@ where
         // candidates into `frozen_deadline`), or a bounded default TTL. See
         // [`witness_deadline`].
         let deadline = witness_deadline([frozen_deadline]);
-        Some(AuthorizeResult::Authorized(Box::new(Authorized::seal(
+        Box::new(Authorized::seal(
             self.authorization_grant(),
             invocation,
             lane,
             mounts,
             reservation,
             deadline,
-        ))))
+        ))
     }
 
     pub async fn resume_json(
@@ -2115,11 +2127,11 @@ where
             match self.authorize_spawn(&request).await? {
                 AuthorizeFold::Authorized(fold) => {
                     let AuthorizedFold {
-                        result,
+                        witness,
                         obligations,
                         obligation_outcome,
                     } = *fold;
-                    (result, obligations, obligation_outcome)
+                    (witness, obligations, obligation_outcome)
                 }
                 AuthorizeFold::Denied { reason, .. } => {
                     return Err(CapabilityInvocationError::AuthorizationDenied {
@@ -2136,15 +2148,14 @@ where
             };
 
         // S6 (§5.3.2/§9): the process start's mounts/reservation come from the
-        // sealed witness (consumed single-use, failing closed on expiry), or the
-        // fold's obligation-derived inputs when no witness was sealed
-        // (`system.process_sandbox` is System-runtime with no lane, so it seals
-        // none yet spawns legitimately). See [`Self::dispatch_inputs_from_witness`].
-        // Spawn starts a process through the `ProcessManager`, not the runtime
+        // always-present sealed witness (consumed single-use, failing closed on
+        // expiry). `system.process_sandbox` is System-runtime with no lane, so it
+        // seals a witness carrying `lane == None` yet spawns legitimately. Spawn
+        // starts a process through the `ProcessManager`, not the runtime
         // dispatcher's `dispatch_json`, so there is no `CapabilityDispatchRequest`
-        // to carry a pinned lane on — the witness's lane binding (finding C) is a
-        // dispatcher-path concern. The witness is still consumed here for its
-        // single-use + expiry semantics; the lane it yields is unused on this path.
+        // to carry a pinned lane — the witness's lane binding (finding C) is a
+        // dispatcher-path concern, so the lane it yields is unused here. See
+        // [`Self::dispatch_inputs_from_witness`].
         let (witness_mounts, witness_reservation, _pinned_lane) = self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Spawn,
@@ -2374,6 +2385,23 @@ where
             Decision::Allow {
                 obligations: allowed_obligations,
             } => {
+                // Fail closed on an origin-less context (§5.2.1/§5.3.2), mirroring
+                // `authorize()`: the witness is always-present on the Allow path
+                // and `Invocation` requires an origin, so a context resolving to
+                // none is not a real ingress and must not spawn un-attributably.
+                let Some(origin) = authorize_context.resolved_origin() else {
+                    fail_run_if_configured(
+                        self.run_state,
+                        &scope,
+                        invocation_id,
+                        "AuthorizationDenied",
+                    )
+                    .await;
+                    return Ok(AuthorizeFold::Denied {
+                        result: AuthorizeResult::Denied(DenyRef::new()),
+                        reason: DenyReason::InternalInvariantViolation,
+                    });
+                };
                 let allowed_obligations = allowed_obligations.into_vec();
                 let obligation_outcome = match self
                     .prepare_obligations(
@@ -2397,17 +2425,18 @@ where
                         return Err(error);
                     }
                 };
-                let result = self.seal_authorization(
+                let witness = self.seal_authorization(
                     &authorize_context,
                     &request.capability_id,
                     &request.estimate,
                     &request.input,
                     descriptor,
                     &obligation_outcome,
+                    origin,
                     frozen_deadline,
                 );
                 Ok(AuthorizeFold::Authorized(Box::new(AuthorizedFold {
-                    result,
+                    witness,
                     obligations: allowed_obligations,
                     obligation_outcome,
                 })))
@@ -2749,6 +2778,36 @@ where
             Decision::Allow {
                 obligations: allowed_obligations,
             } => {
+                // Fail closed on an origin-less context (§5.2.1/§5.3.2), mirroring
+                // `authorize()`: the witness is always-present on the Allow path
+                // and `Invocation` requires an origin, so a context resolving to
+                // none is not a real ingress and must not re-dispatch
+                // un-attributably. As in the `Deny` arm below, a reused
+                // `AlreadyClaimed` lease was already advanced to `Dispatching` in
+                // the `auth_resume_json` preamble, so revoke it here too rather
+                // than strand it.
+                let Some(origin) = params.authorized_context.resolved_origin() else {
+                    fail_run_if_configured(
+                        Some(params.run_state),
+                        &params.scope,
+                        params.invocation_id,
+                        "AuthorizationDenied",
+                    )
+                    .await;
+                    if let ResumedLeaseState::AlreadyClaimed(store, lease) = &params.lease_state
+                        && let Err(error) = store.revoke(&params.scope, lease.grant.id).await
+                    {
+                        warn!(
+                            lease_id = %lease.grant.id,
+                            revoke_error_kind = capability_lease_error_kind(&error),
+                            "failed to revoke reused approval lease after origin-less auth-resume fail-close; lease may remain Dispatching",
+                        );
+                    }
+                    return Ok(AuthorizeFold::Denied {
+                        result: AuthorizeResult::Denied(DenyRef::new()),
+                        reason: DenyReason::InternalInvariantViolation,
+                    });
+                };
                 let allowed_obligations = allowed_obligations.into_vec();
                 // PROVISIONAL (Slice C): the authoritative obligation outcome is
                 // prepared post-claim in `dispatch_resumed_capability` to keep the
@@ -2758,17 +2817,18 @@ where
                 // the tail), so an empty seal outcome does not regress today's
                 // path.
                 let provisional_outcome = CapabilityObligationOutcome::default();
-                let result = self.seal_authorization(
+                let witness = self.seal_authorization(
                     &params.authorized_context,
                     &params.capability_id,
                     &params.estimate,
                     &params.input,
                     params.descriptor,
                     &provisional_outcome,
+                    origin,
                     frozen_deadline,
                 );
                 Ok(AuthorizeFold::Authorized(Box::new(AuthorizedFold {
-                    result,
+                    witness,
                     obligations: allowed_obligations,
                     obligation_outcome: provisional_outcome,
                 })))
@@ -2871,11 +2931,11 @@ where
         let (witness, obligations) = match fold {
             AuthorizeFold::Authorized(fold) => {
                 let AuthorizedFold {
-                    result,
+                    witness,
                     obligations,
                     ..
                 } = *fold;
-                (result, obligations)
+                (witness, obligations)
             }
             AuthorizeFold::Denied { reason, .. } => {
                 return Err(CapabilityInvocationError::AuthorizationDenied {
@@ -2983,16 +3043,11 @@ where
         // BEFORE the side effect. An approval lease that expired during the async
         // authorization/obligation gap (after `begin_dispatch_claimed` advanced it)
         // is caught here, not after dispatch when the later consume observes it.
-        let witness = match witness {
-            Some(AuthorizeResult::Authorized(authorized)) => Some(AuthorizeResult::Authorized(
-                Box::new(authorized.reseal_with_outcome(
-                    self.authorization_grant(),
-                    obligation_outcome.mounts.clone(),
-                    obligation_outcome.resource_reservation.clone(),
-                )),
-            )),
-            other => other,
-        };
+        let witness = Box::new(witness.reseal_with_outcome(
+            self.authorization_grant(),
+            obligation_outcome.mounts.clone(),
+            obligation_outcome.resource_reservation.clone(),
+        ));
         let (dispatch_mounts, dispatch_reservation, pinned_lane) = match self
             .dispatch_inputs_from_witness(
                 CapabilityObligationPhase::Resume,
@@ -3230,31 +3285,31 @@ where
     /// Resolve the mounts/reservation dispatch inputs from the fold's sealed
     /// witness (S6, §5.3.2/§9), shared by the invoke and spawn paths.
     ///
-    /// When the fold sealed an `Authorized`, dispatch routes through IT: the
-    /// witness is consumed single-use (`into_parts` moves it, so a second
-    /// dispatch is a compile error) and fails closed on expiry — aborting the
-    /// prepared obligations (releasing the reservation through the obligation
-    /// lifecycle), consuming the witness via `abort` (never `Drop`), failing the
-    /// run, and returning a terminal denial. The sealed `mounts`/`reservation`
-    /// are the fold's `obligation_outcome` values verbatim, so dispatch inputs
-    /// are byte-identical to the pre-S6 path; the sealed `lane` is returned as the
-    /// pinned lane so the caller can bind dispatch to it — the dispatcher
-    /// re-resolves the descriptor lane from its hot registry and fails closed if
-    /// it no longer matches this pinned lane (§5.3.2, mutable-registry TOCTOU).
+    /// Dispatch always routes through the always-present witness: it is consumed
+    /// single-use (`into_parts` moves it, so a second dispatch is a compile
+    /// error) and fails closed on expiry — aborting the prepared obligations
+    /// (releasing the reservation through the obligation lifecycle), consuming
+    /// the witness via `abort` (never `Drop`), failing the run, and returning a
+    /// terminal denial. The sealed `mounts`/`reservation` are the fold's
+    /// `obligation_outcome` values verbatim, so dispatch inputs are byte-identical
+    /// to the pre-S6 path; the sealed `lane` is returned as the pinned lane so the
+    /// caller can bind dispatch to it — the dispatcher re-resolves the descriptor
+    /// lane from its hot registry and fails closed if it no longer matches this
+    /// pinned lane (§5.3.2, mutable-registry TOCTOU). `None` for a host-internal
+    /// `System` witness (no lane), which skips the dispatcher's lane check.
     ///
-    /// A `None` witness is NOT an error: the seal mints none for a host-internal
-    /// `System`-runtime descriptor (no untrusted lane — `system.process_sandbox`
-    /// on the spawn path) or, defensively, an origin-less context. Those keep the
-    /// obligation-derived inputs — exactly the values a witness would have
-    /// carried — rather than failing closed, which would break process-sandbox
-    /// dispatch. Expiry cannot occur in a synchronous authorize→dispatch today;
-    /// the fail-closed arm is new-behavior-by-design for a held witness.
+    /// The witness is non-optional: every allowed invoke/spawn seals one
+    /// (including a host-internal `System`-runtime descriptor, whose witness
+    /// carries `lane == None`), and an origin-less context fails closed at the
+    /// authorize fold before dispatch — so there is no obligation-derived
+    /// fallback here. Expiry cannot occur in a synchronous authorize→dispatch
+    /// today; the fail-closed arm is new-behavior-by-design for a held witness.
     // arch-exempt: too_many_args, the witness plus the `abort_obligations` arg set (context/capability_id/estimate/obligations/obligation_outcome) — invoke's `CapabilityInvocationRequest` and spawn's `CapabilitySpawnRequest` are distinct types, so no shared request bundle unifies them (same reason `seal_authorization` is exempt); folds into a prepared-invocation bundle with the capability-path collapse, plan #6175
     #[allow(clippy::too_many_arguments)]
     async fn dispatch_inputs_from_witness(
         &self,
         phase: CapabilityObligationPhase,
-        witness: Option<AuthorizeResult>,
+        witness: Box<Authorized>,
         context: &ExecutionContext,
         capability_id: &ironclaw_host_api::CapabilityId,
         estimate: &ResourceEstimate,
@@ -3268,22 +3323,11 @@ where
         ),
         CapabilityInvocationError,
     > {
-        let Some(AuthorizeResult::Authorized(witness)) = witness else {
-            // No witness (host-internal `System` runtime with no lane, or a
-            // defensively origin-less context): no lane to pin, so dispatch keeps
-            // the obligation-derived inputs and the dispatcher's lane check is
-            // skipped — byte-identical to the pre-pinning path.
-            return Ok((
-                obligation_outcome.mounts.clone(),
-                obligation_outcome.resource_reservation.clone(),
-                None,
-            ));
-        };
         match witness.into_parts(chrono::Utc::now()) {
             // `lane` is the descriptor-resolved lane the authorization pinned:
             // threaded into the dispatch request so the dispatcher fails closed
             // if the hot registry re-resolves a different lane (§5.3.2, finding C).
-            Ok((_invocation, lane, mounts, reservation)) => Ok((mounts, reservation, Some(lane))),
+            Ok((_invocation, lane, mounts, reservation)) => Ok((mounts, reservation, lane)),
             Err(expired) => {
                 self.abort_obligations(
                     phase,
@@ -4104,9 +4148,7 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
         let AuthorizeFold::Authorized(fold) = fold else {
             panic!("expected an allowed authorization");
         };
-        let Some(AuthorizeResult::Authorized(authorized)) = &fold.result else {
-            panic!("allow path with a sealed actor must mint an Authorized witness");
-        };
+        let authorized = &fold.witness;
         assert_eq!(authorized.lane(), Some(RuntimeLane::Wasm));
         let invocation = authorized.invocation();
         assert_eq!(
@@ -4169,9 +4211,7 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
         let AuthorizeFold::Authorized(fold) = fold else {
             panic!("expected an allowed authorization");
         };
-        let Some(AuthorizeResult::Authorized(authorized)) = &fold.result else {
-            panic!("allow path must mint an Authorized witness");
-        };
+        let authorized = &fold.witness;
         assert_eq!(
             authorized.deadline(),
             expiry,
@@ -4270,9 +4310,7 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
             let AuthorizeFold::Authorized(fold) = fold else {
                 panic!("expected an allowed authorization for {expected_origin:?}");
             };
-            let Some(AuthorizeResult::Authorized(authorized)) = &fold.result else {
-                panic!("every allowed invocation must mint a witness ({expected_origin:?})");
-            };
+            let authorized = &fold.witness;
             let invocation = authorized.invocation();
             assert_eq!(
                 invocation.actor, expected_actor,
@@ -4519,9 +4557,7 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
         let AuthorizeFold::Authorized(fold) = fold else {
             panic!("expected an allowed resume authorization");
         };
-        let Some(AuthorizeResult::Authorized(authorized)) = &fold.result else {
-            panic!("a sealable resume must mint an Authorized witness");
-        };
+        let authorized = &fold.witness;
         assert_eq!(
             authorized.deadline(),
             lease_expiry,

--- a/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
@@ -295,6 +295,10 @@ fn execution_context_with_mounts_and_parent(
     )
     .unwrap();
     context.process_id = parent_process_id;
+    // Stamp a real loop-run origin (production always has one — the loop stamps
+    // `run_id` → `LoopRun`) so the kernel's origin-less fail-close does not deny
+    // this spawn. Production-faithful scaffolding, not a behavior relaxation.
+    context.run_id = Some(RunId::new());
     context.validate().unwrap();
     context
 }

--- a/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_process_integration.rs
@@ -194,6 +194,82 @@ async fn capability_host_spawn_fails_closed_on_unsupported_obligations_before_pr
     assert_eq!(run.error_kind.as_deref(), Some("UnsupportedObligations"));
 }
 
+// Finding (§5.2.1/§5.3.2), spawn path: an ALLOWED but origin-less spawn (no
+// `origin` AND no `run_id`, so `resolved_origin()` is `None`) must fail CLOSED at
+// the authorize-spawn fold — deny with `InternalInvariantViolation`, mint no
+// witness, start NO process, and fail the run. Every production ingress stamps an
+// origin, so an origin-less allowed context is not a real ingress and an
+// un-attributable process start must not proceed. Drives the production
+// `spawn_json` caller so the invariant cannot silently regress.
+#[tokio::test]
+async fn origin_less_spawn_denied_starts_no_process_and_fails_run() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = recording_dispatcher();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let process_services = ProcessServices::in_memory();
+    let executor = Arc::new(RecordingSuccessExecutor::default());
+    let process_manager = process_services.background_manager(Arc::clone(&executor));
+    let authorizer = SpawnOnlyAuthorizer;
+    let host = capability_host(&registry, &dispatcher, &authorizer)
+        .with_run_state(&run_state)
+        .with_process_manager(&process_manager);
+
+    // An otherwise-allowed spawn context stripped of every ingress origin fact:
+    // `execution_context` stamps a `run_id`, so removing it (and leaving `origin`
+    // unset) makes `resolved_origin()` return `None`.
+    let mut context = execution_context(CapabilitySet {
+        grants: vec![spawn_grant()],
+    });
+    context.run_id = None;
+    assert!(
+        context.resolved_origin().is_none(),
+        "test fixture must be origin-less for this to exercise the fail-close"
+    );
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+
+    let err = host
+        .spawn_json(CapabilitySpawnRequest {
+            context,
+            capability_id: capability_id(),
+            estimate: ResourceEstimate::default(),
+            input: json!({"message":"must not spawn"}),
+        })
+        .await
+        .unwrap_err();
+
+    // Terminal fail-closed denial carrying the internal-invariant reason.
+    assert!(
+        matches!(
+            err,
+            CapabilityInvocationError::AuthorizationDenied {
+                reason: DenyReason::InternalInvariantViolation,
+                ..
+            }
+        ),
+        "origin-less spawn must fail closed with InternalInvariantViolation, got {err:?}"
+    );
+    // No runtime dispatch and no process start.
+    assert_eq!(dispatcher.call_count(), 0);
+    assert!(
+        executor.take_request_opt().is_none(),
+        "an origin-less spawn must NOT start a process"
+    );
+    assert!(
+        process_services
+            .process_store()
+            .records_for_scope(&scope)
+            .await
+            .unwrap()
+            .is_empty(),
+        "no ProcessStart may be issued on the origin-less fail-close"
+    );
+    // The run record started by the authorize-spawn fold transitioned to Failed.
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.error_kind.as_deref(), Some("AuthorizationDenied"));
+}
+
 #[derive(Default)]
 struct RecordingSuccessExecutor {
     request: Mutex<Option<ProcessExecutionRequest>>,

--- a/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
@@ -1,4 +1,7 @@
-use std::sync::Mutex;
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 
 use async_trait::async_trait;
 use ironclaw_approvals::*;
@@ -298,6 +301,306 @@ async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
     assert_eq!(consumed.status, CapabilityLeaseStatus::Consumed);
 }
 
+// Finding (IronLoop, §5.3.2), resume-SPAWN path: an approved spawn whose lease
+// expired between approval and resume must fail CLOSED at the witness-consume
+// gate — the sealed witness is bounded by the claimed lease's `expires_at`, so a
+// past expiry makes `dispatch_inputs_from_witness` fail before `ProcessManager::
+// spawn`. Previously the expiry was only noticed on the later lease consume, so
+// an expired-lease resume-spawn could start a process. Drives the production
+// `resume_spawn_json` caller. The real filesystem lease store rejects an expired
+// lease at match/claim (so the path is unreachable through it); an
+// `ExpiredApprovalLeaseStore` double bypasses that gate — exactly as the
+// in-`host.rs` `expired_resume_witness_dispatches_nothing_fails_run_and_revokes_lease`
+// unit does — so the witness-consume fail-close is what is exercised.
+#[tokio::test]
+async fn capability_host_resume_spawn_fails_closed_on_expired_lease_witness() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = recording_dispatcher();
+    let process_manager = RecordingProcessManager::default();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
+    let leases = ExpiredApprovalLeaseStore::default();
+    let block_host = capability_host(&registry, &dispatcher, &SpawnApprovalAuthorizer)
+        .with_process_manager(&process_manager)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests);
+    let mut context = execution_context(CapabilitySet::default());
+    context.authenticated_actor_user_id = Some(UserId::new("slack-alice").unwrap());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "approved background"});
+
+    block_host
+        .spawn_json(CapabilitySpawnRequest {
+            context: context.clone(),
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+        })
+        .await
+        .unwrap_err();
+    let approval_id = run_state
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .approval_request_id
+        .unwrap();
+
+    // Approve with an already-past `expires_at`: the issued lease's expiry is the
+    // frozen fact the sealed witness deadline is bounded by, so the witness is
+    // expired the moment it is consumed on the resume.
+    let past_expiry = chrono::Utc::now() - chrono::Duration::minutes(1);
+    let lease = ApprovalResolver::new(&approval_requests, &leases)
+        .approve_spawn(
+            &scope,
+            approval_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                constraints: GrantConstraints {
+                    allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: Some(past_expiry),
+                    max_invocations: Some(1),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    // Always-allow spawn authorizer that ALSO obliges a resource reservation, so
+    // authorization passes and the resume reaches the witness-consume gate under
+    // test with a non-empty prepared `obligation_outcome` (a grant-aware
+    // authorizer would deny the expired lease grant one step earlier — a
+    // different fail-close). Mirrors the in-`host.rs` unit's `AllowAuthorizer`.
+    let reservation_id = ResourceReservationId::new();
+    let resume_authorizer =
+        ObligatingSpawnAuthorizer::new(vec![Obligation::ReserveResources { reservation_id }]);
+    // Recording handler so the witness-expiry cleanup's `abort_obligations` is
+    // observable: `prepare` stages a reservation, `abort` records the release.
+    let handler = RecordingSpawnObligationHandler::with_reservation(ResourceReservation {
+        id: reservation_id,
+        scope: scope.clone(),
+        estimate: ResourceEstimate::default(),
+    });
+    let resume_host = capability_host(&registry, &dispatcher, &resume_authorizer)
+        .with_process_manager(&process_manager)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests)
+        .with_capability_leases(&leases)
+        .with_obligation_handler(&handler);
+
+    let error = resume_host
+        .resume_spawn_json(CapabilityResumeRequest {
+            context,
+            approval_request_id: approval_id,
+            capability_id: capability_id(),
+            estimate,
+            input,
+        })
+        .await
+        .unwrap_err();
+
+    // Terminal fail-closed denial carrying the internal-invariant reason.
+    assert!(
+        matches!(
+            error,
+            CapabilityInvocationError::AuthorizationDenied {
+                reason: DenyReason::InternalInvariantViolation,
+                ..
+            }
+        ),
+        "expired-lease resume-spawn must fail closed with InternalInvariantViolation, got {error:?}"
+    );
+    // No process was ever started, and the runtime was not dispatched inline.
+    assert!(dispatcher.call_count() == 0);
+    assert!(
+        !process_manager.has_start(),
+        "an expired-lease resume-spawn must NOT start a process"
+    );
+    // The run transitioned to Failed with the witness-expiry error kind.
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.error_kind.as_deref(), Some("WitnessExpired"));
+    // The lease was claimed (claim-before-witness ordering) and then REVOKED by
+    // the terminal expiry cleanup — never consumed.
+    assert!(
+        *leases.claimed.lock().unwrap(),
+        "the resume-spawn tail must claim the lease before the witness check"
+    );
+    assert_eq!(
+        *leases.revoked.lock().unwrap(),
+        Some(lease.grant.id),
+        "an expired-lease resume-spawn must REVOKE the claimed lease (terminal), not consume it"
+    );
+    // The prepared reservation was staged and then RELEASED via the obligation
+    // abort path (`dispatch_inputs_from_witness` → `abort_obligations`), not
+    // leaked.
+    assert!(
+        handler.prepared(),
+        "the resume-spawn tail must prepare the reservation obligation before the witness check"
+    );
+    assert!(
+        handler.aborted(),
+        "an expired-lease resume-spawn must ABORT the prepared reservation obligation, not leak it"
+    );
+}
+
+// Finding (IronLoop, §5.3.2), resume-SPAWN path: an approved, non-expired
+// spawn-resume whose `ExecutionContext` carries neither `origin` nor `run_id`
+// (so `resolved_origin()` is `None`) must fail CLOSED at the spawn gate — deny
+// with `InternalInvariantViolation`, start NO process, fail the run, AND revoke
+// the already-claimed lease so a terminal refusal does not strand it. Every
+// production ingress stamps an origin, so an origin-less resume is not a real
+// ingress and an un-attributable process start must not proceed. Drives the
+// production `resume_spawn_json` caller. Uses the SAME setup as
+// `capability_host_resumes_approved_spawn_and_consumes_matching_lease` (the
+// control shape, whose context resolves an origin) with the origin/run_id
+// stripped from the resume context.
+#[tokio::test]
+async fn capability_host_resume_spawn_fails_closed_on_origin_less_context() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = recording_dispatcher();
+    let process_manager = RecordingProcessManager::default();
+    let run_state = ironclaw_run_state::in_memory_backed_run_state_store();
+    let approval_requests = ironclaw_run_state::in_memory_backed_approval_request_store();
+    let leases = in_memory_backed_capability_lease_store();
+    let block_host = capability_host(&registry, &dispatcher, &SpawnApprovalAuthorizer)
+        .with_process_manager(&process_manager)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests);
+    let mut context = execution_context(CapabilitySet::default());
+    context.authenticated_actor_user_id = Some(UserId::new("slack-alice").unwrap());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "approved background"});
+
+    block_host
+        .spawn_json(CapabilitySpawnRequest {
+            context: context.clone(),
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+        })
+        .await
+        .unwrap_err();
+    let approval_id = run_state
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .approval_request_id
+        .unwrap();
+    // Approve with no expiry so the deny is unambiguously the origin-less
+    // fail-close, not an expiry-based one.
+    let lease = ApprovalResolver::new(&approval_requests, &leases)
+        .approve_spawn(
+            &scope,
+            approval_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                constraints: GrantConstraints {
+                    allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: Some(1),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    // Always-allow spawn authorizer that ALSO obliges a resource reservation, so
+    // the resume claims the lease, prepares a non-empty `obligation_outcome`, and
+    // reaches the origin-less fail-close with a staged reservation to release.
+    let reservation_id = ResourceReservationId::new();
+    let resume_authorizer =
+        ObligatingSpawnAuthorizer::new(vec![Obligation::ReserveResources { reservation_id }]);
+    // Recording handler so the fail-close's `abort_obligations` is observable:
+    // `prepare` stages a reservation, `abort` records the release.
+    let handler = RecordingSpawnObligationHandler::with_reservation(ResourceReservation {
+        id: reservation_id,
+        scope: scope.clone(),
+        estimate: ResourceEstimate::default(),
+    });
+    let resume_host = capability_host(&registry, &dispatcher, &resume_authorizer)
+        .with_process_manager(&process_manager)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests)
+        .with_capability_leases(&leases)
+        .with_obligation_handler(&handler);
+
+    // Strip every ingress origin fact from the resume context: no `origin` and no
+    // `run_id`, so `resolved_origin()` is `None`. The membrane-sealed actor is
+    // left set to prove the deny is the origin-less fail-close, not a missing
+    // actor or an actor mismatch.
+    let mut origin_less = context.clone();
+    origin_less.origin = None;
+    origin_less.run_id = None;
+    assert!(
+        origin_less.resolved_origin().is_none(),
+        "test fixture must be origin-less for this to exercise the fail-close"
+    );
+
+    let error = resume_host
+        .resume_spawn_json(CapabilityResumeRequest {
+            context: origin_less,
+            approval_request_id: approval_id,
+            capability_id: capability_id(),
+            estimate,
+            input,
+        })
+        .await
+        .unwrap_err();
+
+    // Terminal fail-closed denial carrying the internal-invariant reason.
+    assert!(
+        matches!(
+            error,
+            CapabilityInvocationError::AuthorizationDenied {
+                reason: DenyReason::InternalInvariantViolation,
+                ..
+            }
+        ),
+        "origin-less resume-spawn must fail closed with InternalInvariantViolation, got {error:?}"
+    );
+    // No process was ever started, and the runtime was not dispatched inline.
+    assert!(dispatcher.call_count() == 0);
+    assert!(
+        !process_manager.has_start(),
+        "an origin-less resume-spawn must NOT start a process"
+    );
+    // The run transitioned to Failed with the authorization-denied error kind.
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.error_kind.as_deref(), Some("AuthorizationDenied"));
+    // The claimed lease is revoked (terminal), not left Claimed or consumed.
+    assert_eq!(
+        leases.get(&scope, lease.grant.id).await.unwrap().status,
+        CapabilityLeaseStatus::Revoked,
+        "an origin-less resume-spawn must REVOKE the claimed lease"
+    );
+    // The prepared reservation was staged and then RELEASED via the fail-close's
+    // `abort_obligations` call (MEDIUM finding #4) — the origin-less denial must
+    // not leak the reservation / staged handoff.
+    assert!(
+        handler.prepared(),
+        "the resume-spawn tail must prepare the reservation obligation before the origin check"
+    );
+    assert!(
+        handler.aborted(),
+        "the origin-less fail-close must ABORT the prepared reservation obligation, not leak it"
+    );
+}
+
 #[tokio::test]
 async fn capability_host_denies_spawn_when_trust_ceiling_omits_spawn_effect() {
     let registry = registry_with_echo_capability();
@@ -395,6 +698,226 @@ async fn capability_host_spawns_authorized_process_without_dispatching_inline() 
     assert_eq!(start.runtime, RuntimeKind::Wasm);
     assert_eq!(start.input, json!({"message": "background"}));
     assert_eq!(result.process.process_id, start.process_id);
+}
+
+/// Lease-store double for the expired-witness resume-spawn test. Unlike the real
+/// filesystem store, it does NOT filter or reject on expiry: it returns the
+/// issued lease from `active_leases_for_context` and lets `claim` succeed even
+/// though `expires_at` is in the past, so `resume_spawn_json` reaches the
+/// witness-consume gate that is the code under test (the real store rejects an
+/// expired lease at match/claim, hiding that gate). Records the single `claim`
+/// and the single terminal `revoke`; `consume` must never be reached on the
+/// expiry path. Mirrors `ClaimRecordingLeaseStore` in `host.rs`, extended with
+/// `issue`/`active_leases_for_context` so the full `resume_spawn_json` caller can
+/// find and claim the lease.
+#[derive(Default)]
+struct ExpiredApprovalLeaseStore {
+    lease: Mutex<Option<CapabilityLease>>,
+    claimed: Mutex<bool>,
+    revoked: Mutex<Option<CapabilityGrantId>>,
+}
+
+impl ExpiredApprovalLeaseStore {
+    fn stored(&self) -> CapabilityLease {
+        self.lease
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .expect("lease must be issued before it is read")
+    }
+
+    fn stored_as_vec(&self) -> Vec<CapabilityLease> {
+        self.lease
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .into_iter()
+            .collect()
+    }
+}
+
+#[async_trait]
+impl CapabilityLeaseStore for ExpiredApprovalLeaseStore {
+    async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError> {
+        *self
+            .lease
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(lease.clone());
+        Ok(lease)
+    }
+
+    async fn revoke(
+        &self,
+        _scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        *self
+            .revoked
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(lease_id);
+        let mut lease = self.stored();
+        lease.status = CapabilityLeaseStatus::Revoked;
+        Ok(lease)
+    }
+
+    async fn get(
+        &self,
+        _scope: &ResourceScope,
+        _lease_id: CapabilityGrantId,
+    ) -> Option<CapabilityLease> {
+        Some(self.stored())
+    }
+
+    async fn claim(
+        &self,
+        _scope: &ResourceScope,
+        _lease_id: CapabilityGrantId,
+        _invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        *self
+            .claimed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+        let mut lease = self.stored();
+        // Bypass the real store's expiry gate: the whole point is to reach the
+        // witness-consume check with a claimed-but-expired lease.
+        lease.status = CapabilityLeaseStatus::Claimed;
+        Ok(lease)
+    }
+
+    async fn consume(
+        &self,
+        _scope: &ResourceScope,
+        _lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        unimplemented!("an expired resume-spawn witness must fail before the lease consume")
+    }
+
+    async fn begin_dispatch_claimed(
+        &self,
+        _scope: &ResourceScope,
+        _lease_id: CapabilityGrantId,
+        _invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        unimplemented!("resume-spawn does not use dispatch-claimed transitions")
+    }
+
+    async fn abort_dispatch_claimed(
+        &self,
+        _scope: &ResourceScope,
+        _lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        unimplemented!("resume-spawn does not use dispatch-claimed transitions")
+    }
+
+    async fn leases_for_scope(&self, _scope: &ResourceScope) -> Vec<CapabilityLease> {
+        self.stored_as_vec()
+    }
+
+    async fn active_leases_for_context(&self, _context: &ExecutionContext) -> Vec<CapabilityLease> {
+        // Deliberately ignores expiry so the expired lease is still matched by
+        // `matching_approval_lease` — the real store would filter it out.
+        self.stored_as_vec()
+    }
+}
+
+/// Always-allow spawn authorizer that attaches a fixed obligation set on the
+/// spawn path, so `prepare_obligations` produces a non-empty `obligation_outcome`
+/// the fail-close branches then abort. Dispatch is denied (unused on this path).
+/// Mirrors `ObligatingAuthorizer` in `capability_obligation_handler_contract.rs`,
+/// scoped to the spawn arm the resume-spawn fail-close tests exercise.
+struct ObligatingSpawnAuthorizer {
+    obligations: Vec<Obligation>,
+}
+
+impl ObligatingSpawnAuthorizer {
+    fn new(obligations: Vec<Obligation>) -> Self {
+        Self { obligations }
+    }
+}
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for ObligatingSpawnAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        _context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+        _trust_decision: &ironclaw_trust::TrustDecision,
+    ) -> Decision {
+        Decision::Deny {
+            reason: DenyReason::MissingGrant,
+        }
+    }
+
+    async fn authorize_spawn_with_trust(
+        &self,
+        _context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+        _trust_decision: &ironclaw_trust::TrustDecision,
+    ) -> Decision {
+        Decision::Allow {
+            obligations: Obligations::new(self.obligations.clone()).unwrap(),
+        }
+    }
+}
+
+/// Obligation handler that stages a reservation on `prepare` and records the
+/// `abort` release, so the resume-spawn fail-close paths can PROVE the prepared
+/// obligation was aborted (not leaked). Models `EffectObligationHandler` in
+/// `capability_obligation_handler_contract.rs`, adding a `prepared` flag.
+struct RecordingSpawnObligationHandler {
+    reservation: Option<ResourceReservation>,
+    prepared: AtomicBool,
+    aborted: AtomicBool,
+}
+
+impl RecordingSpawnObligationHandler {
+    fn with_reservation(reservation: ResourceReservation) -> Self {
+        Self {
+            reservation: Some(reservation),
+            prepared: AtomicBool::new(false),
+            aborted: AtomicBool::new(false),
+        }
+    }
+
+    fn prepared(&self) -> bool {
+        self.prepared.load(Ordering::SeqCst)
+    }
+
+    fn aborted(&self) -> bool {
+        self.aborted.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl CapabilityObligationHandler for RecordingSpawnObligationHandler {
+    async fn satisfy(
+        &self,
+        _request: CapabilityObligationRequest<'_>,
+    ) -> Result<(), CapabilityObligationError> {
+        Ok(())
+    }
+
+    async fn prepare(
+        &self,
+        _request: CapabilityObligationRequest<'_>,
+    ) -> Result<CapabilityObligationOutcome, CapabilityObligationError> {
+        self.prepared.store(true, Ordering::SeqCst);
+        Ok(CapabilityObligationOutcome {
+            mounts: None,
+            resource_reservation: self.reservation.clone(),
+        })
+    }
+
+    async fn abort(
+        &self,
+        _request: CapabilityObligationAbortRequest<'_>,
+    ) -> Result<(), CapabilityObligationError> {
+        self.aborted.store(true, Ordering::SeqCst);
+        Ok(())
+    }
 }
 
 #[derive(Default)]

--- a/crates/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/ironclaw_capabilities/tests/support/mod.rs
@@ -458,7 +458,7 @@ pub fn registry_with_github_comment_capability() -> ExtensionRegistry {
 }
 
 pub fn execution_context(grants: CapabilitySet) -> ExecutionContext {
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Wasm,
@@ -466,7 +466,14 @@ pub fn execution_context(grants: CapabilitySet) -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Stamp a real loop-run origin so the context resolves to an
+    // `InvocationOrigin` — production ingress always stamps one (the loop stamps
+    // `run_id` → `LoopRun`), and the capability kernel now fails closed on an
+    // origin-less context. This is production-faithful scaffolding, not a
+    // behavior relaxation.
+    context.run_id = Some(RunId::new());
+    context
 }
 
 pub fn dispatch_grant() -> CapabilityGrant {

--- a/crates/ironclaw_dispatcher/Cargo.toml
+++ b/crates/ironclaw_dispatcher/Cargo.toml
@@ -9,6 +9,7 @@ layer = "kernel"
 
 [dependencies]
 async-trait = "0.1"
+chrono = "0.4"
 ironclaw_events = { path = "../ironclaw_events" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_resources = { path = "../ironclaw_resources" }

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -200,6 +200,35 @@ where
         let provider = resolved.provider.clone();
         let runtime = resolved.runtime;
 
+        // Bind dispatch to the lane the authorization pinned into the witness
+        // (§5.3.2, mutable-registry TOCTOU). The descriptor + lane resolved above
+        // came from a FRESH `self.registry.snapshot()`, so an extension update
+        // between authorize and dispatch can move the descriptor onto a different
+        // runtime lane. If the authorization pinned a lane, fail closed on a
+        // mismatch — never execute a replacement runtime on mounts, a reservation,
+        // and trust prepared for the old lane. A `None` pin (witness-free/legacy
+        // dispatch, or a host-internal `System` descriptor with no lane) skips the
+        // check, so the common path is byte-identical. Same-lane descriptor-content
+        // swaps (which keep this lane equal) are the residual gap tracked in #6434.
+        if let Some(pinned) = request.pinned_lane
+            && pinned != lane
+        {
+            let error = DispatchError::LaneMismatch {
+                capability: capability_id.clone(),
+                authorized: pinned,
+                resolved: lane,
+            };
+            self.emit_dispatch_failure(
+                scope,
+                capability_id,
+                Some(descriptor.provider.clone()),
+                Some(runtime),
+                &error,
+            )
+            .await?;
+            return Err(error);
+        }
+
         self.emit_event(RuntimeEvent::runtime_selected(
             scope.clone(),
             capability_id.clone(),

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -20,7 +20,7 @@ pub use ironclaw_host_api::{
 };
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, ResourceReceipt, ResourceReservation, ResourceScope, ResourceUsage,
-    RuntimeKind,
+    RuntimeKind, RuntimeLane,
 };
 use ironclaw_resources::ResourceGovernor;
 use serde_json::Value;
@@ -200,28 +200,45 @@ where
         let provider = resolved.provider.clone();
         let runtime = resolved.runtime;
 
+        // Resolve the lane the capability's runtime executes on. A runtime that
+        // maps to no untrusted lane (host-internal `System`) is NOT dispatchable
+        // through a runtime adapter — fail closed with `MissingRuntimeBackend`,
+        // never default to a lane or reach the adapter (§4.2). This is
+        // UNCONDITIONAL: it does not depend on whether the caller pinned a lane, so
+        // a `System` dispatch carrying `pinned_lane: None` still fails closed here.
+        let Some(resolved_lane) = RuntimeLane::from_runtime_kind(runtime) else {
+            let error = DispatchError::MissingRuntimeBackend { runtime };
+            self.emit_dispatch_failure(
+                scope,
+                capability_id,
+                Some(provider.clone()),
+                Some(runtime),
+                &error,
+            )
+            .await?;
+            return Err(error);
+        };
+
         // Bind dispatch to the lane the authorization pinned into the witness
-        // (§5.3.2, mutable-registry TOCTOU). The descriptor + lane resolved above
-        // came from a FRESH `self.registry.snapshot()`, so an extension update
-        // between authorize and dispatch can move the descriptor onto a different
-        // runtime lane. If the authorization pinned a lane, fail closed on a
-        // mismatch — never execute a replacement runtime on mounts, a reservation,
-        // and trust prepared for the old lane. A `None` pin (witness-free/legacy
-        // dispatch, or a host-internal `System` descriptor with no lane) skips the
-        // check, so the common path is byte-identical. Same-lane descriptor-content
-        // swaps (which keep this lane equal) are the residual gap tracked in #6434.
+        // (§5.3.2, mutable-registry TOCTOU). `resolve()` above returns a fresh
+        // snapshot-shaped binding, so if the freshly-resolved lane no longer
+        // matches the lane the authorization pinned, fail closed — never execute a
+        // replacement runtime on mounts, a reservation, and trust prepared for the
+        // old lane. A `None` pin (witness-free/legacy dispatch) skips the
+        // comparison, so the common path is byte-identical. Same-lane content swaps
+        // (which keep this lane equal) are the residual gap tracked in #6434.
         if let Some(pinned) = request.pinned_lane
-            && pinned != lane
+            && pinned != resolved_lane
         {
             let error = DispatchError::LaneMismatch {
                 capability: capability_id.clone(),
                 authorized: pinned,
-                resolved: lane,
+                resolved: resolved_lane,
             };
             self.emit_dispatch_failure(
                 scope,
                 capability_id,
-                Some(descriptor.provider.clone()),
+                Some(provider.clone()),
                 Some(runtime),
                 &error,
             )
@@ -236,6 +253,31 @@ where
             runtime,
         ))
         .await?;
+
+        // Revalidate the authorization deadline IMMEDIATELY before execution
+        // (§5.3.2, IronLoop finding #6436). The caller checked the witness
+        // deadline once when it consumed the `Authorized` (`into_parts`), but the
+        // `DispatchRequested`/`RuntimeSelected` emissions above are `await`s — a
+        // claimed approval lease can expire during either, which would let the
+        // side effect run AFTER its authorization deadline. Fail closed here so
+        // the adapter is never invoked past the deadline. `None` (a witness-free/
+        // legacy dispatch) skips the check, so the common path is byte-identical.
+        if let Some(deadline) = request.deadline
+            && chrono::Utc::now() >= deadline
+        {
+            let error = DispatchError::AuthorizationExpired {
+                capability: capability_id.clone(),
+            };
+            self.emit_dispatch_failure(
+                scope,
+                capability_id,
+                Some(provider.clone()),
+                Some(runtime),
+                &error,
+            )
+            .await?;
+            return Err(error);
+        }
 
         let execution = match resolved
             .adapter

--- a/crates/ironclaw_dispatcher/tests/deadline_revalidation_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/deadline_revalidation_contract.rs
@@ -1,0 +1,309 @@
+//! IronLoop finding #6436 (§5.3.2): the authorization deadline must be
+//! revalidated at the EXECUTION boundary, not only when the caller consumes the
+//! `Authorized` witness.
+//!
+//! `dispatch_inputs_from_witness` checks the witness deadline once (via
+//! `Authorized::into_parts`) and hands the dispatcher `(mounts, reservation,
+//! lane)` plus the deadline. `RuntimeDispatcher::dispatch_json` then `await`s the
+//! `DispatchRequested` and `RuntimeSelected` event emissions BEFORE calling the
+//! resolved binding. A claimed approval lease can expire during either await, so
+//! without a re-check the binding side effect could run AFTER its authorization
+//! deadline. This contract forces that race with a DELAYED event sink whose
+//! `emit` sleeps past a near-future deadline, and asserts the binding is NEVER
+//! invoked and dispatch fails closed with `AuthorizationExpired`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::*;
+use ironclaw_events::{EventError, EventSink, InMemoryEventSink, RuntimeEvent, RuntimeEventKind};
+use ironclaw_host_api::*;
+use ironclaw_resources::{
+    InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceLimits,
+};
+use serde_json::{Value, json};
+
+/// An event sink whose `emit` sleeps `delay` before recording — modelling the
+/// real dispatcher's pre-execution event-emission awaits taking long enough for a
+/// claimed approval lease to expire mid-dispatch. Wraps an `InMemoryEventSink` so
+/// the emitted kinds are still inspectable.
+#[derive(Clone)]
+struct DelayedEventSink {
+    inner: InMemoryEventSink,
+    delay: Duration,
+}
+
+impl DelayedEventSink {
+    fn new(delay: Duration) -> Self {
+        Self {
+            inner: InMemoryEventSink::new(),
+            delay,
+        }
+    }
+
+    fn events(&self) -> Vec<RuntimeEvent> {
+        self.inner.events()
+    }
+}
+
+#[async_trait]
+impl EventSink for DelayedEventSink {
+    async fn emit(&self, event: RuntimeEvent) -> Result<(), EventError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.emit(event).await
+    }
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn dispatch_request(
+    scope: &ResourceScope,
+    deadline: Option<Timestamp>,
+) -> CapabilityDispatchRequest {
+    CapabilityDispatchRequest {
+        run_id: None,
+        capability_id: CapabilityId::new("echo.say").unwrap(),
+        scope: scope.clone(),
+        authenticated_actor_user_id: None,
+        estimate: ResourceEstimate {
+            concurrency_slots: Some(1),
+            output_bytes: Some(10_000),
+            ..ResourceEstimate::default()
+        },
+        mounts: None,
+        resource_reservation: None,
+        pinned_lane: None,
+        deadline,
+        input: json!({"message": "hello"}),
+    }
+}
+
+fn set_limit(governor: &InMemoryResourceGovernor, scope: &ResourceScope) {
+    governor
+        .set_limit(
+            ResourceAccount::tenant(scope.tenant_id.clone()),
+            ResourceLimits::default()
+                .set_max_concurrency_slots(1)
+                .set_max_output_bytes(10_000),
+        )
+        .unwrap();
+}
+
+fn echo_resolver(governor: &Arc<InMemoryResourceGovernor>) -> (ScriptedResolver, RecordingBinding) {
+    let binding = RecordingBinding::new(json!({"message": "echo"}), Arc::clone(governor));
+    let resolver = ScriptedResolver::from_entries([(
+        "echo.say",
+        resolved("echo", RuntimeKind::Wasm, binding.clone()),
+    )]);
+    (resolver, binding)
+}
+
+// A witness deadline crossed by the dispatcher's pre-execution event-emission
+// awaits must fail closed with `AuthorizationExpired` and execute NOTHING — the
+// side effect must never run after its authorization deadline.
+#[tokio::test]
+async fn deadline_crossed_during_pre_execution_awaits_fails_closed_and_never_executes() {
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let scope = sample_scope();
+    set_limit(&governor, &scope);
+
+    // The binding is fully executable, so if the deadline re-check were absent the
+    // dispatch would happily execute — the test proves the re-check fails closed
+    // BEFORE the binding, not that the lane is merely unconfigured.
+    let (resolver, binding) = echo_resolver(&governor);
+    // Each emit sleeps 60ms; the deadline is only 5ms out, so it is already past
+    // by the time the dispatcher reaches the pre-execution re-check.
+    let events = DelayedEventSink::new(Duration::from_millis(60));
+    let dispatcher = RuntimeDispatcher::new(&resolver, governor.as_ref())
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let deadline = chrono::Utc::now() + chrono::Duration::milliseconds(5);
+    let error = dispatcher
+        .dispatch_json(dispatch_request(&scope, Some(deadline)))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(error, DispatchError::AuthorizationExpired { .. }),
+        "an expired witness deadline must fail closed with AuthorizationExpired, got {error:?}"
+    );
+    assert_eq!(
+        error.failure_kind(),
+        DispatchFailureKind::AuthorizationExpired
+    );
+
+    // The binding must NEVER have run — no side effect after the deadline.
+    assert!(
+        binding.requests().is_empty(),
+        "the binding must not run after the authorization deadline"
+    );
+
+    // The redacted failure event is emitted; a DispatchSucceeded never is.
+    let kinds: Vec<_> = events.events().iter().map(|event| event.kind).collect();
+    assert!(
+        kinds.contains(&RuntimeEventKind::DispatchFailed),
+        "an expired deadline must emit DispatchFailed, got {kinds:?}"
+    );
+    assert!(
+        !kinds.contains(&RuntimeEventKind::DispatchSucceeded),
+        "an expired deadline must never emit DispatchSucceeded, got {kinds:?}"
+    );
+    let failed = events
+        .events()
+        .into_iter()
+        .find(|event| event.kind == RuntimeEventKind::DispatchFailed)
+        .unwrap();
+    assert_eq!(failed.error_kind.as_deref(), Some("authorization_expired"));
+}
+
+// Behavior-neutrality control: a deadline comfortably in the future still
+// dispatches normally even through the delayed sink — the re-check is a no-op on
+// the common path.
+#[tokio::test]
+async fn future_deadline_dispatches_normally_through_delayed_sink() {
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let scope = sample_scope();
+    set_limit(&governor, &scope);
+
+    let (resolver, binding) = echo_resolver(&governor);
+    let events = DelayedEventSink::new(Duration::from_millis(5));
+    let dispatcher = RuntimeDispatcher::new(&resolver, governor.as_ref())
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let deadline = chrono::Utc::now() + chrono::Duration::seconds(60);
+    let result = dispatcher
+        .dispatch_json(dispatch_request(&scope, Some(deadline)))
+        .await
+        .unwrap();
+
+    assert_eq!(result.runtime, RuntimeKind::Wasm);
+    assert_eq!(binding.requests().len(), 1);
+}
+
+// A `None` deadline (witness-free/legacy dispatch) skips the re-check entirely —
+// even through the delayed sink, the binding still runs. Byte-identical to the
+// pre-#6436 path.
+#[tokio::test]
+async fn none_deadline_skips_recheck_and_executes() {
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let scope = sample_scope();
+    set_limit(&governor, &scope);
+
+    let (resolver, binding) = echo_resolver(&governor);
+    let events = DelayedEventSink::new(Duration::from_millis(60));
+    let dispatcher = RuntimeDispatcher::new(&resolver, governor.as_ref())
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let result = dispatcher
+        .dispatch_json(dispatch_request(&scope, None))
+        .await
+        .unwrap();
+
+    assert_eq!(result.runtime, RuntimeKind::Wasm);
+    assert_eq!(binding.requests().len(), 1);
+}
+
+fn resolved(provider: &str, runtime: RuntimeKind, binding: RecordingBinding) -> ResolvedCapability {
+    ResolvedCapability {
+        provider: ExtensionId::new(provider).unwrap(),
+        runtime,
+        adapter: Arc::new(binding),
+    }
+}
+
+struct ScriptedResolver {
+    bindings: HashMap<CapabilityId, ResolvedCapability>,
+}
+
+impl ScriptedResolver {
+    fn from_entries<const N: usize>(entries: [(&str, ResolvedCapability); N]) -> Self {
+        Self {
+            bindings: entries
+                .into_iter()
+                .map(|(id, resolved)| (CapabilityId::new(id).unwrap(), resolved))
+                .collect(),
+        }
+    }
+}
+
+impl ToolResolver for ScriptedResolver {
+    fn resolve(&self, capability_id: &CapabilityId) -> Option<ResolvedCapability> {
+        self.bindings.get(capability_id).cloned()
+    }
+}
+
+/// Records every dispatch it receives (the COMPLETE request, so forwarding
+/// regressions in `deadline`/`pinned_lane`/mounts/reservation stay observable),
+/// then reserves-and-reconciles through the governor so a routed request produces
+/// a real receipt.
+#[derive(Clone)]
+struct RecordingBinding {
+    output: Value,
+    governor: Arc<InMemoryResourceGovernor>,
+    requests: Arc<Mutex<Vec<CapabilityDispatchRequest>>>,
+}
+
+impl RecordingBinding {
+    fn new(output: Value, governor: Arc<InMemoryResourceGovernor>) -> Self {
+        Self {
+            output,
+            governor,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<CapabilityDispatchRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl BoundCapabilityAdapter for RecordingBinding {
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        self.requests.lock().unwrap().push(request.clone());
+        let output_bytes = serde_json::to_vec(&self.output).unwrap().len() as u64;
+        let usage = ResourceUsage {
+            output_bytes,
+            ..ResourceUsage::default()
+        };
+        let reservation = match request.resource_reservation {
+            Some(reservation) => reservation,
+            None => self
+                .governor
+                .reserve(request.scope.clone(), request.estimate.clone())
+                .map_err(|_| DispatchError::Wasm {
+                    kind: RuntimeDispatchErrorKind::Resource,
+                    model_visible_cause: None,
+                })?,
+        };
+        let receipt = self
+            .governor
+            .reconcile(reservation.id, usage.clone())
+            .map_err(|_| DispatchError::Wasm {
+                kind: RuntimeDispatchErrorKind::Resource,
+                model_visible_cause: None,
+            })?;
+        Ok(RuntimeAdapterResult {
+            output: self.output.clone(),
+            display_preview: None,
+            output_bytes,
+            usage,
+            receipt,
+        })
+    }
+}

--- a/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
@@ -49,6 +49,8 @@ async fn dispatcher_routes_capability_through_resolved_binding() {
             },
             mounts: None,
             resource_reservation: None,
+            pinned_lane: None,
+            deadline: None,
             input: json!({"message": "hello dispatcher"}),
         })
         .await
@@ -126,6 +128,8 @@ async fn dispatcher_fails_unknown_capability_before_any_binding_work() {
             estimate: ResourceEstimate::default().set_concurrency_slots(1),
             mounts: None,
             resource_reservation: None,
+            pinned_lane: None,
+            deadline: None,
             input: json!({"message": "nope"}),
         })
         .await
@@ -157,6 +161,8 @@ async fn dispatcher_releases_prepared_reservation_when_resolution_fails() {
             estimate,
             mounts: None,
             resource_reservation: Some(reservation),
+            pinned_lane: None,
+            deadline: None,
             input: json!({"message": "release on resolution failure"}),
         })
         .await
@@ -194,6 +200,8 @@ async fn dispatcher_hands_prepared_reservation_to_the_binding() {
             estimate,
             mounts: None,
             resource_reservation: Some(reservation),
+            pinned_lane: None,
+            deadline: None,
             input: json!({}),
         })
         .await
@@ -410,6 +418,8 @@ fn sample_request(capability_id: &str, input: Value) -> CapabilityDispatchReques
         },
         mounts: None,
         resource_reservation: None,
+        pinned_lane: None,
+        deadline: None,
         input,
     }
 }

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -147,6 +147,8 @@ async fn dispatcher_logs_release_failure_without_masking_dispatch_error() {
             },
             mounts: None,
             resource_reservation: Some(reservation.clone()),
+            pinned_lane: None,
+            deadline: None,
             input: json!({"message": "unknown capability"}),
         })
         .instrument(tracing::info_span!(
@@ -230,6 +232,8 @@ async fn dispatcher_emits_failed_event_for_unknown_capability_without_reserving(
             },
             mounts: None,
             resource_reservation: None,
+            pinned_lane: None,
+            deadline: None,
             input: json!({"message": "blocked"}),
         })
         .await
@@ -381,6 +385,8 @@ fn sample_request(capability_id: &str, input: Value) -> CapabilityDispatchReques
         },
         mounts: None,
         resource_reservation: None,
+        pinned_lane: None,
+        deadline: None,
         input,
     }
 }

--- a/crates/ironclaw_dispatcher/tests/lane_pinning_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/lane_pinning_contract.rs
@@ -92,8 +92,7 @@ async fn resolver_lane_differs_from_pinned_lane_fails_closed() {
         resolved("echo", RuntimeKind::Script, binding.clone()),
     )]);
     let events = InMemoryEventSink::new();
-    let dispatcher =
-        RuntimeDispatcher::new(&resolver, governor.as_ref()).with_event_sink(&events);
+    let dispatcher = RuntimeDispatcher::new(&resolver, governor.as_ref()).with_event_sink(&events);
 
     let error = dispatcher
         .dispatch_json(dispatch_request(&scope, Some(RuntimeLane::Wasm)))

--- a/crates/ironclaw_dispatcher/tests/lane_pinning_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/lane_pinning_contract.rs
@@ -1,0 +1,247 @@
+//! Finding C (§5.3.2, mutable-registry TOCTOU): dispatch must bind to the lane
+//! the authorization pinned into the witness, not to whatever the hot registry
+//! re-resolves at dispatch time.
+//!
+//! An extension update between authorize and dispatch can replace a descriptor's
+//! runtime — moving it onto a DIFFERENT execution lane — while the mounts,
+//! reservation, and trust prepared for the OLD descriptor still ride the request.
+//! The dispatcher re-derives the descriptor + lane from a fresh
+//! `SharedExtensionRegistry::snapshot()`, so it must compare that freshly-resolved
+//! lane against the request's `pinned_lane` and fail CLOSED on a mismatch —
+//! never executing a replacement runtime under authorization it did not receive.
+//!
+//! Full descriptor-content pinning (a same-lane descriptor swap) is tracked
+//! separately in #6434; this contract locks the lane (runtime/executor) binding.
+
+mod support;
+
+use std::sync::Arc;
+
+use crate::support::RecordingExecutor;
+
+use ironclaw_dispatcher::*;
+use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
+use ironclaw_extensions::{
+    ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource, SharedExtensionRegistry,
+};
+use ironclaw_filesystem::DiskFilesystem;
+use ironclaw_host_api::*;
+use ironclaw_resources::{
+    InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceLimits,
+};
+use serde_json::json;
+
+// Same extension id ("echo") and capability id ("echo.say") across both
+// registries — only the `[runtime]` differs. This is exactly an extension
+// update: the descriptor the authorization saw (WASM → lane Wasm) is replaced
+// by a descriptor on a different lane (Script → lane Process).
+const WASM_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "echo"
+name = "Echo"
+version = "0.1.0"
+description = "Echo test extension"
+trust = "untrusted"
+
+[runtime]
+kind = "wasm"
+module = "echo.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echoes input"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/echo/say.input.v1.json"
+output_schema_ref = "schemas/echo/say.output.v1.json"
+"#;
+
+const SWAPPED_SCRIPT_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "echo"
+name = "Echo"
+version = "0.2.0"
+description = "Echo test extension (updated to a script runtime)"
+trust = "untrusted"
+
+[runtime]
+kind = "script"
+runner = "docker"
+image = "example/echo:latest"
+command = "cat"
+args = []
+
+[[capabilities]]
+id = "echo.say"
+description = "Echoes input"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/echo/say.input.v1.json"
+output_schema_ref = "schemas/echo/say.output.v1.json"
+"#;
+
+fn registry(manifest: &str) -> ExtensionRegistry {
+    let manifest = ExtensionManifest::parse(
+        manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    let package = ExtensionPackage::from_manifest(manifest, root).unwrap();
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+    registry
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn dispatch_request(
+    scope: &ResourceScope,
+    pinned_lane: Option<RuntimeLane>,
+) -> CapabilityDispatchRequest {
+    CapabilityDispatchRequest {
+        run_id: None,
+        capability_id: CapabilityId::new("echo.say").unwrap(),
+        scope: scope.clone(),
+        authenticated_actor_user_id: None,
+        estimate: ResourceEstimate::default()
+            .set_concurrency_slots(1)
+            .set_output_bytes(10_000),
+        mounts: None,
+        resource_reservation: None,
+        pinned_lane,
+        input: json!({"message": "hello"}),
+    }
+}
+
+// A registry update that swaps the descriptor's runtime onto a DIFFERENT lane
+// after the authorization pinned the original lane must fail closed with
+// `LaneMismatch` and execute nothing.
+#[tokio::test]
+async fn registry_update_between_authorize_and_dispatch_fails_closed_on_lane_mismatch() {
+    let shared = Arc::new(SharedExtensionRegistry::new(registry(WASM_MANIFEST)));
+    let filesystem = Arc::new(DiskFilesystem::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    // The executor supports BOTH lanes, so if the pinned-lane check were absent
+    // the dispatch would happily execute on the swapped-in Process lane — the
+    // test proves the check fails closed BEFORE that execution, not that the
+    // lane merely happens to be unconfigured.
+    let executor = RecordingExecutor::new()
+        .echo(RuntimeKind::Wasm)
+        .echo(RuntimeKind::Script);
+    let events = InMemoryEventSink::new();
+
+    let scope = sample_scope();
+    governor
+        .set_limit(
+            ResourceAccount::tenant(scope.tenant_id.clone()),
+            ResourceLimits::default()
+                .set_max_concurrency_slots(1)
+                .set_max_output_bytes(10_000),
+        )
+        .unwrap();
+
+    let dispatcher = RuntimeDispatcher::from_shared_registry(
+        Arc::clone(&shared),
+        Arc::clone(&filesystem),
+        Arc::clone(&governor),
+        executor.clone(),
+    )
+    .with_event_sink_arc(Arc::new(events.clone()));
+
+    // Authorization pinned the WASM lane; now an extension update swaps echo.say
+    // onto the Script runtime (Process lane) behind the shared registry.
+    shared.replace(registry(SWAPPED_SCRIPT_MANIFEST));
+
+    let error = dispatcher
+        .dispatch_json(dispatch_request(&scope, Some(RuntimeLane::Wasm)))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            error,
+            DispatchError::LaneMismatch {
+                authorized: RuntimeLane::Wasm,
+                resolved: RuntimeLane::Process,
+                ..
+            }
+        ),
+        "swapped runtime lane must fail closed with LaneMismatch(Wasm→Process), got {error:?}"
+    );
+    assert_eq!(error.failure_kind(), DispatchFailureKind::LaneMismatch);
+
+    // The executor must NOT have run the replacement runtime.
+    assert!(
+        executor.requests().is_empty(),
+        "no execution may occur on a lane the authorization did not name"
+    );
+
+    // The dispatcher must have emitted the redacted failure event and NEVER a
+    // RuntimeSelected/DispatchSucceeded for the swapped lane.
+    let recorded = events.events();
+    let kinds: Vec<_> = recorded.iter().map(|event| event.kind).collect();
+    assert!(
+        kinds.contains(&RuntimeEventKind::DispatchFailed),
+        "a lane mismatch must emit DispatchFailed, got {kinds:?}"
+    );
+    assert!(
+        !kinds.contains(&RuntimeEventKind::RuntimeSelected),
+        "a lane mismatch must fail before RuntimeSelected, got {kinds:?}"
+    );
+    let failed = recorded
+        .iter()
+        .find(|event| event.kind == RuntimeEventKind::DispatchFailed)
+        .unwrap();
+    assert_eq!(failed.error_kind.as_deref(), Some("lane_mismatch"));
+}
+
+// Control: when no registry update happens, a request whose pinned lane matches
+// the freshly-resolved lane dispatches normally — the pinning check does not
+// break the common path.
+#[tokio::test]
+async fn matching_pinned_lane_dispatches_normally() {
+    let shared = Arc::new(SharedExtensionRegistry::new(registry(WASM_MANIFEST)));
+    let filesystem = Arc::new(DiskFilesystem::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let executor = RecordingExecutor::new().echo(RuntimeKind::Wasm);
+
+    let scope = sample_scope();
+    governor
+        .set_limit(
+            ResourceAccount::tenant(scope.tenant_id.clone()),
+            ResourceLimits::default()
+                .set_max_concurrency_slots(1)
+                .set_max_output_bytes(10_000),
+        )
+        .unwrap();
+
+    let dispatcher = RuntimeDispatcher::from_shared_registry(
+        Arc::clone(&shared),
+        Arc::clone(&filesystem),
+        Arc::clone(&governor),
+        executor.clone(),
+    );
+
+    let result = dispatcher
+        .dispatch_json(dispatch_request(&scope, Some(RuntimeLane::Wasm)))
+        .await
+        .unwrap();
+
+    assert_eq!(result.runtime, RuntimeKind::Wasm);
+    assert_eq!(executor.requests().len(), 1);
+    assert_eq!(executor.requests()[0].lane, RuntimeLane::Wasm);
+}

--- a/crates/ironclaw_dispatcher/tests/lane_pinning_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/lane_pinning_contract.rs
@@ -1,100 +1,31 @@
 //! Finding C (§5.3.2, mutable-registry TOCTOU): dispatch must bind to the lane
-//! the authorization pinned into the witness, not to whatever the hot registry
-//! re-resolves at dispatch time.
+//! the authorization pinned into the witness, not to whatever the resolver
+//! returns at dispatch time.
 //!
-//! An extension update between authorize and dispatch can replace a descriptor's
+//! An extension update between authorize and dispatch can replace a capability's
 //! runtime — moving it onto a DIFFERENT execution lane — while the mounts,
-//! reservation, and trust prepared for the OLD descriptor still ride the request.
-//! The dispatcher re-derives the descriptor + lane from a fresh
-//! `SharedExtensionRegistry::snapshot()`, so it must compare that freshly-resolved
+//! reservation, and trust prepared for the OLD binding still ride the request.
+//! The dispatcher resolves the capability through the injected [`ToolResolver`]
+//! (a fresh snapshot-shaped binding), so it must compare that freshly-resolved
 //! lane against the request's `pinned_lane` and fail CLOSED on a mismatch —
 //! never executing a replacement runtime under authorization it did not receive.
+//! Modeling the swap at the resolver seam is exactly the post-swap observation:
+//! the resolver now hands back a binding on a lane the authorization never named.
 //!
-//! Full descriptor-content pinning (a same-lane descriptor swap) is tracked
+//! Full capability-content pinning (a same-lane binding swap) is tracked
 //! separately in #6434; this contract locks the lane (runtime/executor) binding.
 
-mod support;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
-use std::sync::Arc;
-
-use crate::support::RecordingExecutor;
-
+use async_trait::async_trait;
 use ironclaw_dispatcher::*;
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
-use ironclaw_extensions::{
-    ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource, SharedExtensionRegistry,
-};
-use ironclaw_filesystem::DiskFilesystem;
 use ironclaw_host_api::*;
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceLimits,
 };
-use serde_json::json;
-
-// Same extension id ("echo") and capability id ("echo.say") across both
-// registries — only the `[runtime]` differs. This is exactly an extension
-// update: the descriptor the authorization saw (WASM → lane Wasm) is replaced
-// by a descriptor on a different lane (Script → lane Process).
-const WASM_MANIFEST: &str = r#"
-schema_version = "reborn.extension_manifest.v2"
-id = "echo"
-name = "Echo"
-version = "0.1.0"
-description = "Echo test extension"
-trust = "untrusted"
-
-[runtime]
-kind = "wasm"
-module = "echo.wasm"
-
-[[capabilities]]
-id = "echo.say"
-description = "Echoes input"
-effects = ["dispatch_capability"]
-default_permission = "allow"
-visibility = "model"
-input_schema_ref = "schemas/echo/say.input.v1.json"
-output_schema_ref = "schemas/echo/say.output.v1.json"
-"#;
-
-const SWAPPED_SCRIPT_MANIFEST: &str = r#"
-schema_version = "reborn.extension_manifest.v2"
-id = "echo"
-name = "Echo"
-version = "0.2.0"
-description = "Echo test extension (updated to a script runtime)"
-trust = "untrusted"
-
-[runtime]
-kind = "script"
-runner = "docker"
-image = "example/echo:latest"
-command = "cat"
-args = []
-
-[[capabilities]]
-id = "echo.say"
-description = "Echoes input"
-effects = ["dispatch_capability"]
-default_permission = "allow"
-visibility = "model"
-input_schema_ref = "schemas/echo/say.input.v1.json"
-output_schema_ref = "schemas/echo/say.output.v1.json"
-"#;
-
-fn registry(manifest: &str) -> ExtensionRegistry {
-    let manifest = ExtensionManifest::parse(
-        manifest,
-        ManifestSource::InstalledLocal,
-        &HostPortCatalog::empty(),
-    )
-    .unwrap();
-    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
-    let package = ExtensionPackage::from_manifest(manifest, root).unwrap();
-    let mut registry = ExtensionRegistry::new();
-    registry.insert(package).unwrap();
-    registry
-}
+use serde_json::{Value, json};
 
 fn sample_scope() -> ResourceScope {
     ResourceScope {
@@ -117,34 +48,20 @@ fn dispatch_request(
         capability_id: CapabilityId::new("echo.say").unwrap(),
         scope: scope.clone(),
         authenticated_actor_user_id: None,
-        estimate: ResourceEstimate::default()
-            .set_concurrency_slots(1)
-            .set_output_bytes(10_000),
+        estimate: ResourceEstimate {
+            concurrency_slots: Some(1),
+            output_bytes: Some(10_000),
+            ..ResourceEstimate::default()
+        },
         mounts: None,
         resource_reservation: None,
         pinned_lane,
+        deadline: None,
         input: json!({"message": "hello"}),
     }
 }
 
-// A registry update that swaps the descriptor's runtime onto a DIFFERENT lane
-// after the authorization pinned the original lane must fail closed with
-// `LaneMismatch` and execute nothing.
-#[tokio::test]
-async fn registry_update_between_authorize_and_dispatch_fails_closed_on_lane_mismatch() {
-    let shared = Arc::new(SharedExtensionRegistry::new(registry(WASM_MANIFEST)));
-    let filesystem = Arc::new(DiskFilesystem::new());
-    let governor = Arc::new(InMemoryResourceGovernor::new());
-    // The executor supports BOTH lanes, so if the pinned-lane check were absent
-    // the dispatch would happily execute on the swapped-in Process lane — the
-    // test proves the check fails closed BEFORE that execution, not that the
-    // lane merely happens to be unconfigured.
-    let executor = RecordingExecutor::new()
-        .echo(RuntimeKind::Wasm)
-        .echo(RuntimeKind::Script);
-    let events = InMemoryEventSink::new();
-
-    let scope = sample_scope();
+fn set_tenant_limit(governor: &InMemoryResourceGovernor, scope: &ResourceScope) {
     governor
         .set_limit(
             ResourceAccount::tenant(scope.tenant_id.clone()),
@@ -153,18 +70,30 @@ async fn registry_update_between_authorize_and_dispatch_fails_closed_on_lane_mis
                 .set_max_output_bytes(10_000),
         )
         .unwrap();
+}
 
-    let dispatcher = RuntimeDispatcher::from_shared_registry(
-        Arc::clone(&shared),
-        Arc::clone(&filesystem),
-        Arc::clone(&governor),
-        executor.clone(),
-    )
-    .with_event_sink_arc(Arc::new(events.clone()));
+// A capability update that resolves the descriptor onto a DIFFERENT lane than
+// the authorization pinned must fail closed with `LaneMismatch` and execute
+// nothing. Here the authorization pinned the WASM lane, but the resolver now
+// returns a Script (Process-lane) binding — exactly the post-swap observation.
+#[tokio::test]
+async fn resolver_lane_differs_from_pinned_lane_fails_closed() {
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let scope = sample_scope();
+    set_tenant_limit(&governor, &scope);
 
-    // Authorization pinned the WASM lane; now an extension update swaps echo.say
-    // onto the Script runtime (Process lane) behind the shared registry.
-    shared.replace(registry(SWAPPED_SCRIPT_MANIFEST));
+    // The binding is fully executable, so if the pinned-lane check were absent
+    // the dispatch would happily run on the swapped-in Process lane — the test
+    // proves the check fails closed BEFORE that execution, not that the lane
+    // merely happens to be unconfigured.
+    let binding = RecordingBinding::new(json!({"message": "echo"}), Arc::clone(&governor));
+    let resolver = ScriptedResolver::from_entries([(
+        "echo.say",
+        resolved("echo", RuntimeKind::Script, binding.clone()),
+    )]);
+    let events = InMemoryEventSink::new();
+    let dispatcher =
+        RuntimeDispatcher::new(&resolver, governor.as_ref()).with_event_sink(&events);
 
     let error = dispatcher
         .dispatch_json(dispatch_request(&scope, Some(RuntimeLane::Wasm)))
@@ -184,9 +113,9 @@ async fn registry_update_between_authorize_and_dispatch_fails_closed_on_lane_mis
     );
     assert_eq!(error.failure_kind(), DispatchFailureKind::LaneMismatch);
 
-    // The executor must NOT have run the replacement runtime.
+    // The binding must NOT have run the replacement runtime.
     assert!(
-        executor.requests().is_empty(),
+        binding.requests().is_empty(),
         "no execution may occur on a lane the authorization did not name"
     );
 
@@ -209,32 +138,20 @@ async fn registry_update_between_authorize_and_dispatch_fails_closed_on_lane_mis
     assert_eq!(failed.error_kind.as_deref(), Some("lane_mismatch"));
 }
 
-// Control: when no registry update happens, a request whose pinned lane matches
-// the freshly-resolved lane dispatches normally — the pinning check does not
-// break the common path.
+// Control: a request whose pinned lane matches the freshly-resolved lane
+// dispatches normally — the pinning check does not break the common path.
 #[tokio::test]
 async fn matching_pinned_lane_dispatches_normally() {
-    let shared = Arc::new(SharedExtensionRegistry::new(registry(WASM_MANIFEST)));
-    let filesystem = Arc::new(DiskFilesystem::new());
     let governor = Arc::new(InMemoryResourceGovernor::new());
-    let executor = RecordingExecutor::new().echo(RuntimeKind::Wasm);
-
     let scope = sample_scope();
-    governor
-        .set_limit(
-            ResourceAccount::tenant(scope.tenant_id.clone()),
-            ResourceLimits::default()
-                .set_max_concurrency_slots(1)
-                .set_max_output_bytes(10_000),
-        )
-        .unwrap();
+    set_tenant_limit(&governor, &scope);
 
-    let dispatcher = RuntimeDispatcher::from_shared_registry(
-        Arc::clone(&shared),
-        Arc::clone(&filesystem),
-        Arc::clone(&governor),
-        executor.clone(),
-    );
+    let binding = RecordingBinding::new(json!({"message": "echo"}), Arc::clone(&governor));
+    let resolver = ScriptedResolver::from_entries([(
+        "echo.say",
+        resolved("echo", RuntimeKind::Wasm, binding.clone()),
+    )]);
+    let dispatcher = RuntimeDispatcher::new(&resolver, governor.as_ref());
 
     let result = dispatcher
         .dispatch_json(dispatch_request(&scope, Some(RuntimeLane::Wasm)))
@@ -242,6 +159,150 @@ async fn matching_pinned_lane_dispatches_normally() {
         .unwrap();
 
     assert_eq!(result.runtime, RuntimeKind::Wasm);
-    assert_eq!(executor.requests().len(), 1);
-    assert_eq!(executor.requests()[0].lane, RuntimeLane::Wasm);
+    assert_eq!(
+        binding.requests().len(),
+        1,
+        "a matching pinned lane must dispatch through the resolved binding"
+    );
+}
+
+// A resolved runtime that maps to NO untrusted lane (host-internal `System`)
+// must fail closed with `MissingRuntimeBackend` and execute nothing — even when
+// no lane was pinned (`pinned_lane: None`). `System` is host-internal and is
+// never dispatched through a runtime adapter (§4.2).
+#[tokio::test]
+async fn system_runtime_fails_closed_even_without_a_pinned_lane() {
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let scope = sample_scope();
+    set_tenant_limit(&governor, &scope);
+
+    let binding = RecordingBinding::new(json!({"message": "echo"}), Arc::clone(&governor));
+    let resolver = ScriptedResolver::from_entries([(
+        "echo.say",
+        resolved("echo", RuntimeKind::System, binding.clone()),
+    )]);
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::new(&resolver, governor.as_ref()).with_event_sink(&events);
+
+    // No lane pinned — the fail-close must NOT depend on a pin being present.
+    let error = dispatcher
+        .dispatch_json(dispatch_request(&scope, None))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            error,
+            DispatchError::MissingRuntimeBackend {
+                runtime: RuntimeKind::System
+            }
+        ),
+        "a host-internal System runtime must fail closed with MissingRuntimeBackend, got {error:?}"
+    );
+    assert_eq!(
+        error.failure_kind(),
+        DispatchFailureKind::MissingRuntimeBackend
+    );
+    assert!(
+        binding.requests().is_empty(),
+        "System must never reach the runtime adapter"
+    );
+    let kinds: Vec<_> = events.events().iter().map(|event| event.kind).collect();
+    assert!(
+        !kinds.contains(&RuntimeEventKind::RuntimeSelected),
+        "an unmappable runtime must fail before RuntimeSelected, got {kinds:?}"
+    );
+}
+
+fn resolved(provider: &str, runtime: RuntimeKind, binding: RecordingBinding) -> ResolvedCapability {
+    ResolvedCapability {
+        provider: ExtensionId::new(provider).unwrap(),
+        runtime,
+        adapter: Arc::new(binding),
+    }
+}
+
+struct ScriptedResolver {
+    bindings: HashMap<CapabilityId, ResolvedCapability>,
+}
+
+impl ScriptedResolver {
+    fn from_entries<const N: usize>(entries: [(&str, ResolvedCapability); N]) -> Self {
+        Self {
+            bindings: entries
+                .into_iter()
+                .map(|(id, resolved)| (CapabilityId::new(id).unwrap(), resolved))
+                .collect(),
+        }
+    }
+}
+
+impl ToolResolver for ScriptedResolver {
+    fn resolve(&self, capability_id: &CapabilityId) -> Option<ResolvedCapability> {
+        self.bindings.get(capability_id).cloned()
+    }
+}
+
+/// Records every dispatch it receives (the COMPLETE request, so forwarding
+/// regressions in `pinned_lane`/`deadline`/mounts/reservation stay observable),
+/// then reserves-and-reconciles through the governor so a routed request produces
+/// a real receipt.
+#[derive(Clone)]
+struct RecordingBinding {
+    output: Value,
+    governor: Arc<InMemoryResourceGovernor>,
+    requests: Arc<Mutex<Vec<CapabilityDispatchRequest>>>,
+}
+
+impl RecordingBinding {
+    fn new(output: Value, governor: Arc<InMemoryResourceGovernor>) -> Self {
+        Self {
+            output,
+            governor,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<CapabilityDispatchRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl BoundCapabilityAdapter for RecordingBinding {
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        self.requests.lock().unwrap().push(request.clone());
+        let output_bytes = serde_json::to_vec(&self.output).unwrap().len() as u64;
+        let usage = ResourceUsage {
+            output_bytes,
+            ..ResourceUsage::default()
+        };
+        let reservation = match request.resource_reservation {
+            Some(reservation) => reservation,
+            None => self
+                .governor
+                .reserve(request.scope.clone(), request.estimate.clone())
+                .map_err(|_| DispatchError::Wasm {
+                    kind: RuntimeDispatchErrorKind::Resource,
+                    model_visible_cause: None,
+                })?,
+        };
+        let receipt = self
+            .governor
+            .reconcile(reservation.id, usage.clone())
+            .map_err(|_| DispatchError::Wasm {
+                kind: RuntimeDispatchErrorKind::Resource,
+                model_visible_cause: None,
+            })?;
+        Ok(RuntimeAdapterResult {
+            output: self.output.clone(),
+            display_preview: None,
+            output_bytes,
+            usage,
+            receipt,
+        })
+    }
 }

--- a/crates/ironclaw_extension_host/tests/lifecycle_contract.rs
+++ b/crates/ironclaw_extension_host/tests/lifecycle_contract.rs
@@ -356,6 +356,8 @@ async fn snapshot_resolver_serves_activated_tools_and_stops_after_deactivate() {
             estimate: ironclaw_host_api::ResourceEstimate::default(),
             mounts: None,
             resource_reservation: None,
+            pinned_lane: None,
+            deadline: None,
             authenticated_actor_user_id: None,
             input: serde_json::json!({"message": "in flight"}),
         })
@@ -417,6 +419,8 @@ async fn snapshot_resolver_maps_tool_auth_required_to_the_generic_gate() {
             estimate: ironclaw_host_api::ResourceEstimate::default(),
             mounts: None,
             resource_reservation: None,
+            pinned_lane: None,
+            deadline: None,
             authenticated_actor_user_id: None,
             input: serde_json::json!({}),
         })

--- a/crates/ironclaw_host_api/src/authorized.rs
+++ b/crates/ironclaw_host_api/src/authorized.rs
@@ -64,11 +64,13 @@ pub trait CapabilityAuthorizer {
 pub struct AuthorizationGrant(());
 
 /// The dispatch-lane parts a consumed [`Authorized`] yields: the exact
-/// invocation, the descriptor-resolved lane, the fold's `Option<MountView>`, and
-/// the fold's `Option<ResourceReservation>` — all verbatim, never re-derived.
+/// invocation, the descriptor-resolved lane (`None` for a host-internal
+/// `System`-runtime invocation that maps to no untrusted lane), the fold's
+/// `Option<MountView>`, and the fold's `Option<ResourceReservation>` — all
+/// verbatim, never re-derived.
 pub type AuthorizedParts = (
     Invocation,
-    RuntimeLane,
+    Option<RuntimeLane>,
     Option<MountView>,
     Option<ResourceReservation>,
 );
@@ -80,7 +82,10 @@ pub type AuthorizedParts = (
 ///   [`AuthorizationGrant`]. No forging, no repairing to a different invocation.
 /// - **Lane-bound:** it carries the exact [`RuntimeLane`] resolved from the
 ///   descriptor; `dispatch()` routes by that, never to a lane the descriptor did
-///   not name.
+///   not name. `None` for a host-internal `System`-runtime invocation, which
+///   maps to no untrusted lane and is dispatched on the process axis instead —
+///   the witness is still minted (so it is always present for a dispatchable
+///   invocation), it simply carries no lane.
 /// - **Single-use:** not `Clone`; `dispatch()` consumes it. The not-dispatched
 ///   path calls [`Authorized::abort`] explicitly — never `Drop` (destructors do
 ///   no async I/O; a leaked witness is reclaimed by lease-expiry, §5.3.2).
@@ -90,7 +95,11 @@ pub type AuthorizedParts = (
 #[derive(Debug)]
 pub struct Authorized {
     invocation: Invocation,
-    lane: RuntimeLane,
+    /// The descriptor-resolved untrusted lane, or `None` for a host-internal
+    /// `System`-runtime invocation (dispatched on the process axis, not a lane).
+    /// The witness is minted either way — always present for a dispatchable
+    /// invocation.
+    lane: Option<RuntimeLane>,
     /// The filesystem mounts the fold's `UseScopedMounts` obligation produced
     /// (`Some`), or `None` when the capability declares no mount obligation.
     /// Kept as an `Option` — never collapsed to a default `MountView` — so the
@@ -123,7 +132,7 @@ impl Authorized {
     pub fn seal(
         _grant: AuthorizationGrant,
         invocation: Invocation,
-        lane: RuntimeLane,
+        lane: Option<RuntimeLane>,
         mounts: Option<MountView>,
         reservation: Option<ResourceReservation>,
         deadline: Timestamp,
@@ -142,8 +151,10 @@ impl Authorized {
         &self.invocation
     }
 
-    /// The runtime lane resolved from the descriptor — where `dispatch()` routes.
-    pub fn lane(&self) -> RuntimeLane {
+    /// The runtime lane resolved from the descriptor — where `dispatch()`
+    /// routes — or `None` for a host-internal `System`-runtime invocation that
+    /// maps to no untrusted lane.
+    pub fn lane(&self) -> Option<RuntimeLane> {
         self.lane
     }
 

--- a/crates/ironclaw_host_api/src/authorized.rs
+++ b/crates/ironclaw_host_api/src/authorized.rs
@@ -169,8 +169,15 @@ impl Authorized {
 
     /// Whether the witness has outlived its facts. `dispatch()` after this must
     /// fail closed with `HostFailure::Permanent` (§5.3.2).
+    ///
+    /// Expiry is **inclusive** (`now >= deadline`): the witness is expired at the
+    /// exact deadline instant, not one tick past it. The deadline is derived from
+    /// the shortest-lived frozen fact — an approval/credential lease — and leases
+    /// expire inclusively (`expires_at <= now`). An exclusive check here would let
+    /// a resume dispatch the side effect at `now == deadline` and only observe the
+    /// already-expired lease on the later `consume` (IronLoop finding, #6436).
     pub fn is_expired(&self, now: Timestamp) -> bool {
-        now > self.deadline
+        now >= self.deadline
     }
 
     /// Consume the witness into its parts for the dispatch lane, failing closed
@@ -198,6 +205,31 @@ impl Authorized {
     /// Never `Drop`.
     pub fn abort(self) -> Option<ResourceReservation> {
         self.reservation
+    }
+
+    /// Re-seal this witness against the authoritative obligation outcome the
+    /// resume tail prepares *after* the approval lease is claimed, preserving the
+    /// invocation, lane, and deadline it was originally sealed with.
+    ///
+    /// The resume fold (`authorize_resumed`) seals a *provisional* (empty) outcome
+    /// before the claim because the resume paths' claim-before-dispatch ordering
+    /// prepares the real mounts/reservation only post-claim (§5.3.2). The tail
+    /// then calls this to swap in the actual prepared outcome so the witness it
+    /// consumes carries the real dispatch inputs — matching the invoke/spawn
+    /// witnesses, which seal the real outcome in place. Kernel-only (it needs an
+    /// [`AuthorizationGrant`]); the deadline is preserved verbatim, never extended,
+    /// so a re-seal cannot lengthen a held witness's validity window.
+    pub fn reseal_with_outcome(
+        self,
+        _grant: AuthorizationGrant,
+        mounts: Option<MountView>,
+        reservation: Option<ResourceReservation>,
+    ) -> Self {
+        Self {
+            mounts,
+            reservation,
+            ..self
+        }
     }
 }
 

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use crate::{
     CapabilityId, ExtensionId, HostRemediation, MountView, ResourceEstimate, ResourceReceipt,
     ResourceReservation, ResourceScope, ResourceUsage, RunId, RuntimeCredentialAuthRequirement,
-    RuntimeKind, SecretHandle, UserId,
+    RuntimeKind, RuntimeLane, SecretHandle, UserId,
 };
 
 /// Request for one already-authorized declared capability dispatch.
@@ -29,6 +29,20 @@ pub struct CapabilityDispatchRequest {
     pub estimate: ResourceEstimate,
     pub mounts: Option<MountView>,
     pub resource_reservation: Option<ResourceReservation>,
+    /// The runtime lane the authorization pinned into the `Authorized` witness
+    /// (`authorized.lane()`), threaded through so the dispatcher can bind
+    /// execution to the lane the authorization named (§5.3.2, mutable-registry
+    /// TOCTOU): the dispatcher re-resolves the descriptor's lane from the hot
+    /// registry and MUST fail closed with [`DispatchError::LaneMismatch`] when the
+    /// freshly-resolved lane differs from this pinned lane — an extension update
+    /// between authorize and dispatch must never execute a replacement runtime on
+    /// authority prepared for the old one.
+    ///
+    /// `None` means no lane was pinned (a witness-free/legacy dispatch or a
+    /// host-internal `System` descriptor that resolved to no lane); the dispatcher
+    /// skips the check and behaves exactly as before. Full descriptor-content
+    /// pinning (a same-lane descriptor swap) is tracked separately in #6434.
+    pub pinned_lane: Option<RuntimeLane>,
     pub input: Value,
 }
 
@@ -303,6 +317,7 @@ pub enum DispatchFailureKind {
     MissingRuntimeBackend,
     UnsupportedRuntime,
     AuthRequired,
+    LaneMismatch,
     Runtime(RuntimeDispatchErrorKind),
 }
 
@@ -315,6 +330,7 @@ impl DispatchFailureKind {
             Self::MissingRuntimeBackend => "MissingRuntimeBackend",
             Self::UnsupportedRuntime => "UnsupportedRuntime",
             Self::AuthRequired => "AuthRequired",
+            Self::LaneMismatch => "LaneMismatch",
             Self::Runtime(kind) => kind.as_str(),
         }
     }
@@ -329,6 +345,9 @@ impl DispatchFailureKind {
             Self::MissingRuntimeBackend => "the tool runtime backend is unavailable",
             Self::UnsupportedRuntime => "the tool runtime is not supported",
             Self::AuthRequired => "the tool requires authentication",
+            Self::LaneMismatch => {
+                "the tool runtime changed and no longer matches its authorization"
+            }
             Self::Runtime(kind) => kind.human_summary(),
         }
     }
@@ -360,6 +379,20 @@ pub enum DispatchError {
     },
     #[error("runtime backend {runtime:?} is not configured")]
     MissingRuntimeBackend { runtime: RuntimeKind },
+    /// The lane the dispatcher freshly resolved for this capability does not
+    /// match the lane the authorization pinned into the witness — an extension
+    /// update between authorize and dispatch moved the descriptor onto a
+    /// different runtime lane. Fail closed: never execute a replacement runtime
+    /// on authority (mounts/reservation/trust) prepared for the old lane
+    /// (§5.3.2). Full descriptor-content pinning is tracked in #6434.
+    #[error(
+        "capability {capability} resolved to runtime lane {resolved} but the authorization pinned lane {authorized}"
+    )]
+    LaneMismatch {
+        capability: CapabilityId,
+        authorized: RuntimeLane,
+        resolved: RuntimeLane,
+    },
     #[error(
         "runtime {runtime:?} is recognized but not supported by this dispatcher yet for capability {capability}"
     )]
@@ -443,6 +476,16 @@ impl fmt::Debug for DispatchError {
                 .debug_struct("MissingRuntimeBackend")
                 .field("runtime", runtime)
                 .finish(),
+            Self::LaneMismatch {
+                capability,
+                authorized,
+                resolved,
+            } => f
+                .debug_struct("LaneMismatch")
+                .field("capability", capability)
+                .field("authorized", authorized)
+                .field("resolved", resolved)
+                .finish(),
             Self::UnsupportedRuntime {
                 capability,
                 runtime,
@@ -504,6 +547,7 @@ impl DispatchError {
             Self::MissingRuntimeBackend { .. } => DispatchFailureKind::MissingRuntimeBackend,
             Self::UnsupportedRuntime { .. } => DispatchFailureKind::UnsupportedRuntime,
             Self::AuthRequired { .. } => DispatchFailureKind::AuthRequired,
+            Self::LaneMismatch { .. } => DispatchFailureKind::LaneMismatch,
             Self::Mcp { kind, .. }
             | Self::Script { kind, .. }
             | Self::Wasm { kind, .. }
@@ -523,6 +567,7 @@ impl DispatchError {
             Self::MissingRuntimeBackend { .. } => "missing_runtime_backend",
             Self::UnsupportedRuntime { .. } => "unsupported_runtime",
             Self::AuthRequired { .. } => "auth_required",
+            Self::LaneMismatch { .. } => "lane_mismatch",
             Self::Mcp { kind, .. }
             | Self::Script { kind, .. }
             | Self::Wasm { kind, .. }

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use crate::{
     CapabilityId, ExtensionId, HostRemediation, MountView, ResourceEstimate, ResourceReceipt,
     ResourceReservation, ResourceScope, ResourceUsage, RunId, RuntimeCredentialAuthRequirement,
-    RuntimeKind, RuntimeLane, SecretHandle, UserId,
+    RuntimeKind, RuntimeLane, SecretHandle, Timestamp, UserId,
 };
 
 /// Request for one already-authorized declared capability dispatch.
@@ -38,11 +38,29 @@ pub struct CapabilityDispatchRequest {
     /// between authorize and dispatch must never execute a replacement runtime on
     /// authority prepared for the old one.
     ///
-    /// `None` means no lane was pinned (a witness-free/legacy dispatch or a
-    /// host-internal `System` descriptor that resolved to no lane); the dispatcher
-    /// skips the check and behaves exactly as before. Full descriptor-content
-    /// pinning (a same-lane descriptor swap) is tracked separately in #6434.
+    /// `None` means no lane was pinned (a witness-free/legacy dispatch); the
+    /// dispatcher skips the pin comparison and behaves exactly as before. This is
+    /// independent of the runtime→lane resolution: a resolved runtime that maps to
+    /// no lane (host-internal `System`) fails closed with `MissingRuntimeBackend`
+    /// regardless of this field. Full descriptor-content pinning (a same-lane
+    /// descriptor swap) is tracked separately in #6434.
     pub pinned_lane: Option<RuntimeLane>,
+    /// The `Authorized` witness's frozen expiry deadline (`authorized.deadline()`),
+    /// threaded through so the dispatcher can revalidate `now >= deadline`
+    /// IMMEDIATELY before it invokes the executor (§5.3.2, IronLoop finding
+    /// #6436). The witness deadline is checked once when the caller consumes the
+    /// witness (`Authorized::into_parts`), but the dispatcher then `await`s
+    /// `DispatchRequested`/`RuntimeSelected` event emissions before the executor
+    /// runs — a claimed approval lease can expire during those awaits, letting a
+    /// side effect execute AFTER its authorization deadline. The dispatcher fails
+    /// closed with [`DispatchError::AuthorizationExpired`] when this deadline is
+    /// `Some(d)` and `d` has passed by the time it reaches the executor.
+    ///
+    /// `None` means the dispatch carries no deadline (a witness-free/legacy
+    /// dispatch: the process executor forwarding an already-authorized long-running
+    /// process, or a test double); the dispatcher skips the re-check and the common
+    /// path is byte-identical.
+    pub deadline: Option<Timestamp>,
     pub input: Value,
 }
 
@@ -318,6 +336,7 @@ pub enum DispatchFailureKind {
     UnsupportedRuntime,
     AuthRequired,
     LaneMismatch,
+    AuthorizationExpired,
     Runtime(RuntimeDispatchErrorKind),
 }
 
@@ -331,6 +350,7 @@ impl DispatchFailureKind {
             Self::UnsupportedRuntime => "UnsupportedRuntime",
             Self::AuthRequired => "AuthRequired",
             Self::LaneMismatch => "LaneMismatch",
+            Self::AuthorizationExpired => "AuthorizationExpired",
             Self::Runtime(kind) => kind.as_str(),
         }
     }
@@ -348,6 +368,7 @@ impl DispatchFailureKind {
             Self::LaneMismatch => {
                 "the tool runtime changed and no longer matches its authorization"
             }
+            Self::AuthorizationExpired => "the tool's authorization expired before it could run",
             Self::Runtime(kind) => kind.human_summary(),
         }
     }
@@ -393,6 +414,15 @@ pub enum DispatchError {
         authorized: RuntimeLane,
         resolved: RuntimeLane,
     },
+    /// The authorization deadline the `Authorized` witness froze had already
+    /// passed by the time the dispatcher reached the executor. A claimed approval
+    /// lease can expire during the pre-execution `DispatchRequested`/
+    /// `RuntimeSelected` event-emission awaits, so the witness deadline is
+    /// revalidated immediately before execution and fails closed here — never
+    /// running the side effect AFTER its authorization deadline (§5.3.2, IronLoop
+    /// finding #6436).
+    #[error("capability {capability} authorization deadline expired before dispatch")]
+    AuthorizationExpired { capability: CapabilityId },
     #[error(
         "runtime {runtime:?} is recognized but not supported by this dispatcher yet for capability {capability}"
     )]
@@ -486,6 +516,10 @@ impl fmt::Debug for DispatchError {
                 .field("authorized", authorized)
                 .field("resolved", resolved)
                 .finish(),
+            Self::AuthorizationExpired { capability } => f
+                .debug_struct("AuthorizationExpired")
+                .field("capability", capability)
+                .finish(),
             Self::UnsupportedRuntime {
                 capability,
                 runtime,
@@ -548,6 +582,7 @@ impl DispatchError {
             Self::UnsupportedRuntime { .. } => DispatchFailureKind::UnsupportedRuntime,
             Self::AuthRequired { .. } => DispatchFailureKind::AuthRequired,
             Self::LaneMismatch { .. } => DispatchFailureKind::LaneMismatch,
+            Self::AuthorizationExpired { .. } => DispatchFailureKind::AuthorizationExpired,
             Self::Mcp { kind, .. }
             | Self::Script { kind, .. }
             | Self::Wasm { kind, .. }
@@ -568,6 +603,7 @@ impl DispatchError {
             Self::UnsupportedRuntime { .. } => "unsupported_runtime",
             Self::AuthRequired { .. } => "auth_required",
             Self::LaneMismatch { .. } => "lane_mismatch",
+            Self::AuthorizationExpired { .. } => "authorization_expired",
             Self::Mcp { kind, .. }
             | Self::Script { kind, .. }
             | Self::Wasm { kind, .. }

--- a/crates/ironclaw_host_api/src/dispatch_test_support.rs
+++ b/crates/ironclaw_host_api/src/dispatch_test_support.rs
@@ -155,6 +155,7 @@ mod tests {
             mounts: None,
             resource_reservation: None,
             pinned_lane: None,
+            deadline: None,
             input: json!({}),
         }
     }

--- a/crates/ironclaw_host_api/src/dispatch_test_support.rs
+++ b/crates/ironclaw_host_api/src/dispatch_test_support.rs
@@ -154,6 +154,7 @@ mod tests {
             estimate: ResourceEstimate::default(),
             mounts: None,
             resource_reservation: None,
+            pinned_lane: None,
             input: json!({}),
         }
     }

--- a/crates/ironclaw_host_api/tests/authorized_seal.rs
+++ b/crates/ironclaw_host_api/tests/authorized_seal.rs
@@ -61,7 +61,7 @@ fn seal_with_mounts_and_reservation(
     Authorized::seal(
         grant,
         invocation(),
-        RuntimeLane::Process,
+        Some(RuntimeLane::Process),
         mounts,
         reservation,
         deadline,
@@ -75,8 +75,24 @@ fn ts(secs: i64) -> Timestamp {
 #[test]
 fn authorized_is_lane_bound_and_carries_its_invocation() {
     let auth = seal_one(ts(1000));
-    assert_eq!(auth.lane(), RuntimeLane::Process);
+    assert_eq!(auth.lane(), Some(RuntimeLane::Process));
     assert_eq!(auth.invocation().capability.as_str(), "shell.exec");
+}
+
+#[test]
+fn host_internal_invocation_seals_a_witness_with_no_lane() {
+    // A host-internal `System`-runtime invocation maps to no untrusted lane, but
+    // the witness is STILL minted (lane `None`) — the witness is present for
+    // every dispatchable/spawnable invocation, not only lane-routed ones. This
+    // is what lets the kernel stop suppressing the whole witness when the lane
+    // is absent.
+    let grant = TestAuthorizer.authorization_grant();
+    let auth = Authorized::seal(grant, invocation(), None, None, None, ts(1000));
+    assert_eq!(auth.lane(), None);
+    let (_inv, lane, _mounts, _res) = auth
+        .into_parts(ts(999))
+        .expect("unexpired witness must consume");
+    assert_eq!(lane, None);
 }
 
 #[test]
@@ -98,7 +114,7 @@ fn single_use_consumes_into_parts_before_deadline() {
         .into_parts(ts(999))
         .expect("unexpired witness must consume");
     // `auth` is moved — a second dispatch is a compile error, not a runtime bug.
-    assert_eq!(lane, RuntimeLane::Process);
+    assert_eq!(lane, Some(RuntimeLane::Process));
     assert_eq!(inv.capability.as_str(), "shell.exec");
     // The real obligation-produced reservation flows through consumption.
     assert!(res.is_some());

--- a/crates/ironclaw_host_api/tests/authorized_seal.rs
+++ b/crates/ironclaw_host_api/tests/authorized_seal.rs
@@ -83,7 +83,11 @@ fn authorized_is_lane_bound_and_carries_its_invocation() {
 fn deadline_fails_closed_past_the_frozen_facts() {
     let auth = seal_one(ts(1000));
     assert!(!auth.is_expired(ts(999)));
-    assert!(!auth.is_expired(ts(1000))); // boundary: not yet expired at the deadline
+    // Boundary: expiry is INCLUSIVE — the witness is expired at the exact
+    // deadline instant, matching approval-lease `expires_at <= now` semantics
+    // (the deadline is derived from the lease). An exclusive check would let a
+    // resume dispatch at `now == deadline` and only see the expired lease after.
+    assert!(auth.is_expired(ts(1000)));
     assert!(auth.is_expired(ts(1001)));
 }
 

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -2198,6 +2198,17 @@ mod tests {
                 DispatchFailureKind::AuthRequired,
                 RuntimeFailureKind::Authorization,
             ),
+            // The registry-swap (§5.3.2 finding C) and execution-boundary
+            // deadline (finding #5) fail-closed arms must classify as
+            // Authorization, so a later remapping cannot silently weaken them.
+            (
+                DispatchFailureKind::LaneMismatch,
+                RuntimeFailureKind::Authorization,
+            ),
+            (
+                DispatchFailureKind::AuthorizationExpired,
+                RuntimeFailureKind::Authorization,
+            ),
         ];
         for (kind, expected) in cases {
             assert_eq!(RuntimeFailureKind::from(*kind), *expected, "kind {kind:?}");

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -1823,6 +1823,11 @@ impl From<DispatchFailureKind> for RuntimeFailureKind {
             DispatchFailureKind::MissingRuntimeBackend
             | DispatchFailureKind::UnsupportedRuntime => RuntimeFailureKind::MissingRuntime,
             DispatchFailureKind::AuthRequired => RuntimeFailureKind::Authorization,
+            // The dispatcher resolved a lane the authorization did not name (an
+            // extension update between authorize and dispatch). Fail closed as an
+            // authorization failure — the run must not execute on unauthorized
+            // authority (§5.3.2, finding C).
+            DispatchFailureKind::LaneMismatch => RuntimeFailureKind::Authorization,
             DispatchFailureKind::RuntimeMismatch => RuntimeFailureKind::Backend,
             DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExtensionRuntimeMismatch) => {
                 RuntimeFailureKind::MissingRuntime

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -1828,6 +1828,11 @@ impl From<DispatchFailureKind> for RuntimeFailureKind {
             // authorization failure — the run must not execute on unauthorized
             // authority (§5.3.2, finding C).
             DispatchFailureKind::LaneMismatch => RuntimeFailureKind::Authorization,
+            // The witness deadline passed during the dispatcher's pre-execution
+            // event-emission awaits (a claimed approval lease expired). Fail closed
+            // as an authorization failure — the side effect must not run after its
+            // authorization deadline (§5.3.2, IronLoop finding #6436).
+            DispatchFailureKind::AuthorizationExpired => RuntimeFailureKind::Authorization,
             DispatchFailureKind::RuntimeMismatch => RuntimeFailureKind::Backend,
             DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExtensionRuntimeMismatch) => {
                 RuntimeFailureKind::MissingRuntime

--- a/crates/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/ironclaw_host_runtime/src/services/process_executor.rs
@@ -1,7 +1,9 @@
 use std::{sync::Arc, time::Instant};
 
 use async_trait::async_trait;
-use ironclaw_host_api::{CapabilityDispatchRequest, CapabilityDispatcher, RuntimeKind};
+use ironclaw_host_api::{
+    CapabilityDispatchRequest, CapabilityDispatcher, RuntimeKind, RuntimeLane,
+};
 use ironclaw_observability::live_latency_started_at;
 use ironclaw_processes::{
     ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult, ProcessExecutor,
@@ -224,6 +226,17 @@ impl ProcessExecutor for RuntimeDispatchProcessExecutor {
                 estimate: request.estimate,
                 mounts: Some(request.mounts),
                 resource_reservation: request.resource_reservation,
+                // Bind the detached process dispatch to the lane the spawn
+                // authorization approved (§5.3.2, finding C — mutable-registry
+                // TOCTOU). This executor holds no `Authorized` witness (it
+                // forwards an already-authorized, long-running process request),
+                // but `request.runtime` is the `RuntimeKind` captured in the
+                // `ProcessStart` from the authorized descriptor at spawn time, so
+                // the pinned lane is derivable from it. The dispatcher re-resolves
+                // the descriptor lane from its hot registry and fails closed if an
+                // extension update moved the capability onto a different lane
+                // between spawn authorization and this detached run.
+                pinned_lane: RuntimeLane::from_runtime_kind(request.runtime),
                 input: request.input,
             })
             .await
@@ -454,6 +467,69 @@ mod tests {
         assert_eq!(calls[0].authenticated_actor_user_id, Some(actor));
         assert_eq!(calls[0].scope, expected_scope);
         assert_eq!(calls[0].capability_id, expected_capability_id);
+    }
+
+    #[tokio::test]
+    async fn runtime_dispatch_executor_pins_authorized_lane_for_toctou_guard() {
+        // Finding (IronLoop, §5.3.2 finding C): the detached process re-dispatch
+        // must pin the lane the SPAWN AUTHORIZED — derived from `request.runtime`,
+        // the `RuntimeKind` captured in the `ProcessStart` from the authorized
+        // descriptor — not `None`. Otherwise the dispatcher's lane check is a
+        // no-op on this path, and an extension update between spawn authorization
+        // and this detached run could move the capability onto a different lane
+        // that then executes under the original mounts/reservation/trust.
+        // safety: in-memory test dispatcher, no external capability executed.
+        let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
+        let executor = RuntimeDispatchProcessExecutor::new(dispatcher.clone());
+        // Script runtime → `RuntimeLane::Process` is the authorized lane.
+        let request = sample_process_request("demo.background", RuntimeKind::Script);
+
+        executor.execute(request).await.unwrap();
+
+        let calls = dispatcher.recorded();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].pinned_lane,
+            Some(RuntimeLane::Process),
+            "detached process dispatch must pin the authorized lane, not None"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_dispatch_executor_fails_closed_on_registry_lane_swap() {
+        // With the lane pinned (above), a post-spawn registry update that moves
+        // the capability to a different lane makes the dispatcher return
+        // `LaneMismatch` — no replacement executor runs. The detached process
+        // must surface that as a failure (fail closed), not swallow it.
+        // safety: in-memory test dispatcher; the closure returns before any
+        // capability executes.
+        let dispatcher = Arc::new(TestDispatcher::responding(|req, _| {
+            // The process path pins the authorized (Script → Process) lane; model
+            // the dispatcher detecting that the hot registry now resolves Wasm.
+            let authorized = req
+                .pinned_lane
+                .expect("detached process dispatch must pin a lane for the TOCTOU guard");
+            Err(DispatchError::LaneMismatch {
+                capability: req.capability_id.clone(),
+                authorized,
+                resolved: RuntimeLane::Wasm,
+            })
+        }));
+        let executor = RuntimeDispatchProcessExecutor::new(dispatcher);
+        let request = sample_process_request("demo.background", RuntimeKind::Script);
+
+        let error = executor.execute(request).await.unwrap_err();
+
+        assert_eq!(
+            error.kind,
+            DispatchError::LaneMismatch {
+                capability: CapabilityId::new("demo.background").unwrap(),
+                authorized: RuntimeLane::Process,
+                resolved: RuntimeLane::Wasm,
+            }
+            .event_kind(),
+            "a post-authorization lane swap must fail the detached process closed"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/ironclaw_host_runtime/src/services/process_executor.rs
@@ -237,6 +237,11 @@ impl ProcessExecutor for RuntimeDispatchProcessExecutor {
                 // extension update moved the capability onto a different lane
                 // between spawn authorization and this detached run.
                 pinned_lane: RuntimeLane::from_runtime_kind(request.runtime),
+                // Witness-free: this executor forwards an already-authorized,
+                // long-running process request and holds no `Authorized` witness,
+                // so it carries no deadline and the dispatcher skips the
+                // execution-boundary re-check (§5.3.2, finding #6436).
+                deadline: None,
                 input: request.input,
             })
             .await

--- a/crates/ironclaw_host_runtime/src/services/tests/registry_lane_tool_resolver.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/registry_lane_tool_resolver.rs
@@ -108,6 +108,8 @@ fn wasm_capability_request(input: Value) -> CapabilityDispatchRequest {
         },
         mounts: None,
         resource_reservation: None,
+        pinned_lane: None,
+        deadline: None,
         input,
     }
 }
@@ -201,6 +203,8 @@ async fn unconfigured_lane_fails_missing_backend_and_releases_prepared_reservati
             estimate,
             mounts: None,
             resource_reservation: Some(reservation),
+            pinned_lane: None,
+            deadline: None,
             input: json!({"message":"blocked"}),
         })
         .await
@@ -322,6 +326,8 @@ async fn resolved_binding_survives_registry_swap_mid_flight() {
             },
             mounts: None,
             resource_reservation: None,
+            pinned_lane: None,
+            deadline: None,
             authenticated_actor_user_id: None,
             input: json!({"in":"flight"}),
         })

--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -1219,7 +1219,9 @@ fn execution_context(grants: CapabilitySet) -> ExecutionContext {
         invocation_id,
     };
     ExecutionContext {
-        run_id: None,
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        run_id: Some(ironclaw_host_api::RunId::new()),
         origin: None,
         invocation_id,
         correlation_id: CorrelationId::new(),

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -119,6 +119,7 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
             estimate: estimate.clone(),
             mounts: None,
             resource_reservation: Some(reservation),
+            pinned_lane: None,
             input: json!({"message":"hello"}),
         })
         .await

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -120,6 +120,7 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
             mounts: None,
             resource_reservation: Some(reservation),
             pinned_lane: None,
+            deadline: None,
             input: json!({"message":"hello"}),
         })
         .await

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -9718,7 +9718,7 @@ where
             .map(|grant| dispatch_grant(grant.as_ref()))
             .collect(),
     };
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -9726,7 +9726,11 @@ where
         capability_set,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn execution_context_with_mounts<I>(grants: I, mounts: MountView) -> ExecutionContext
@@ -9740,7 +9744,7 @@ where
             .map(|grant| dispatch_grant_with_mounts(grant.as_ref(), mounts.clone()))
             .collect(),
     };
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -9748,7 +9752,11 @@ where
         capability_set,
         mounts,
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn execution_context_with_network<I>(grants: I, network: NetworkPolicy) -> ExecutionContext
@@ -9780,7 +9788,7 @@ where
             })
             .collect(),
     };
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -9788,7 +9796,11 @@ where
         capability_set,
         mounts,
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn set_context_scope(

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -2011,7 +2011,7 @@ fn execution_context_with_mounts<const N: usize>(
             .map(|grant| dispatch_grant_with_mounts(grant, mounts.clone()))
             .collect(),
     };
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -2019,7 +2019,11 @@ fn execution_context_with_mounts<const N: usize>(
         capability_set,
         mounts,
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn dispatch_grant_with_mounts(capability: &str, mounts: MountView) -> CapabilityGrant {

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -818,7 +818,7 @@ async fn invoke_http_fixture(
 }
 
 fn execution_context(grants: CapabilitySet) -> ExecutionContext {
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -826,7 +826,11 @@ fn execution_context(grants: CapabilitySet) -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn dispatch_grant() -> CapabilityGrant {

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -2312,7 +2312,9 @@ fn execution_context_with_dispatch_grant_for_scope(
     scope: ResourceScope,
 ) -> ExecutionContext {
     let context = ExecutionContext {
-        run_id: None,
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        run_id: Some(ironclaw_host_api::RunId::new()),
         origin: None,
         invocation_id: scope.invocation_id,
         correlation_id: CorrelationId::new(),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -1495,7 +1495,7 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
             max_invocations: None,
         },
     });
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Wasm,
@@ -1503,7 +1503,11 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn visible_capability_request(context: ExecutionContext) -> VisibleCapabilityRequest {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -920,7 +920,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
 }
 
 fn execution_context_without_grants() -> ExecutionContext {
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Wasm,
@@ -928,7 +928,11 @@ fn execution_context_without_grants() -> ExecutionContext {
         CapabilitySet::default(),
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn scoped_approval_fs() -> Arc<ScopedFilesystem<InMemoryBackend>> {

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -326,7 +326,7 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
             max_invocations: None,
         },
     });
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Wasm,
@@ -334,7 +334,11 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn capability_id() -> CapabilityId {

--- a/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
@@ -226,7 +226,7 @@ fn execution_context_with_dispatch_grant(trust: TrustClass) -> ExecutionContext 
             max_invocations: None,
         },
     });
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Wasm,
@@ -234,7 +234,11 @@ fn execution_context_with_dispatch_grant(trust: TrustClass) -> ExecutionContext 
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn capability_id() -> CapabilityId {

--- a/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
@@ -906,7 +906,9 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
 
 fn execution_context_without_grants_for_scope(scope: ResourceScope) -> ExecutionContext {
     let context = ExecutionContext {
-        run_id: None,
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        run_id: Some(ironclaw_host_api::RunId::new()),
         origin: None,
         invocation_id: scope.invocation_id,
         correlation_id: CorrelationId::new(),
@@ -935,7 +937,9 @@ fn execution_context_with_dispatch_grant_for_scope(
     scope: ResourceScope,
 ) -> ExecutionContext {
     let context = ExecutionContext {
-        run_id: None,
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        run_id: Some(ironclaw_host_api::RunId::new()),
         origin: None,
         invocation_id: scope.invocation_id,
         correlation_id: CorrelationId::new(),

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -890,7 +890,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
 fn execution_context_with_dispatch_grant() -> ExecutionContext {
     let mut grants = CapabilitySet::default();
     grants.grants.push(dispatch_grant());
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Script,
@@ -898,11 +898,15 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn execution_context_without_grants() -> ExecutionContext {
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Script,
@@ -910,7 +914,11 @@ fn execution_context_without_grants() -> ExecutionContext {
         CapabilitySet::default(),
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn dispatch_grant() -> CapabilityGrant {

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -347,7 +347,7 @@ fn parse_manifest(manifest: &str) -> ExtensionManifest {
 }
 
 fn execution_context(grants: CapabilitySet) -> ExecutionContext {
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Wasm,
@@ -355,7 +355,11 @@ fn execution_context(grants: CapabilitySet) -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn dispatch_grant() -> CapabilityGrant {

--- a/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
+++ b/crates/ironclaw_host_runtime/tests/support/host_runtime_harness.rs
@@ -1652,7 +1652,7 @@ pub(crate) fn parse_manifest_from_source(
 }
 
 pub(crate) fn execution_context_without_grants() -> ExecutionContext {
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Script,
@@ -1660,12 +1660,18 @@ pub(crate) fn execution_context_without_grants() -> ExecutionContext {
         CapabilitySet::default(),
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(RunId::new());
+    context
 }
 
 pub(crate) fn execution_context_without_grants_for_scope(scope: ResourceScope) -> ExecutionContext {
     let context = ExecutionContext {
-        run_id: None,
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        run_id: Some(RunId::new()),
         origin: None,
         invocation_id: scope.invocation_id,
         correlation_id: CorrelationId::new(),
@@ -1691,7 +1697,7 @@ pub(crate) fn execution_context_without_grants_for_scope(scope: ResourceScope) -
 
 pub(crate) fn execution_context_with_dispatch_grant(capability: CapabilityId) -> ExecutionContext {
     let grants = capability_grants(capability);
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::Wasm,
@@ -1699,7 +1705,11 @@ pub(crate) fn execution_context_with_dispatch_grant(capability: CapabilityId) ->
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(RunId::new());
+    context
 }
 
 pub(crate) fn execution_context_with_dispatch_grant_for_scope(
@@ -1719,7 +1729,9 @@ pub(crate) fn execution_context_with_effect_grants_for_scope(
     allowed_effects: Vec<EffectKind>,
 ) -> ExecutionContext {
     let context = ExecutionContext {
-        run_id: None,
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        run_id: Some(RunId::new()),
         origin: None,
         invocation_id: scope.invocation_id,
         correlation_id: CorrelationId::new(),

--- a/crates/ironclaw_host_runtime/tests/support/trace_commons_dispatch.rs
+++ b/crates/ironclaw_host_runtime/tests/support/trace_commons_dispatch.rs
@@ -254,7 +254,7 @@ pub fn execution_context_with_network(
             network,
         )],
     };
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new(user_id).unwrap(),
         ExtensionId::new(caller_extension_id).unwrap(),
         RuntimeKind::FirstParty,
@@ -262,7 +262,11 @@ pub fn execution_context_with_network(
         capability_set,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 /// Execution context granting a read-only capability (no network needed).

--- a/crates/ironclaw_host_runtime/tests/user_profile_roundtrip.rs
+++ b/crates/ironclaw_host_runtime/tests/user_profile_roundtrip.rs
@@ -181,6 +181,9 @@ fn agent_scoped_context(
     ctx.resource_scope.user_id = UserId::new(user_id).unwrap();
     ctx.resource_scope.agent_id = Some(AgentId::new(agent_id).unwrap());
     ctx.resource_scope.project_id = Some(ProjectId::new(project_id).unwrap());
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    ctx.run_id = Some(ironclaw_host_api::RunId::new());
     ctx
 }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
@@ -1603,6 +1603,9 @@ mod tests {
         )
         .expect("valid execution context");
         context.authenticated_actor_user_id = Some(user_id);
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        context.run_id = Some(ironclaw_host_api::RunId::new());
         context
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities_auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities_auth_tests.rs
@@ -305,7 +305,9 @@ fn execution_context_for_scope<'a>(
 ) -> ExecutionContext {
     let caller = ExtensionId::new("extension-tool-test-caller").expect("valid extension id"); // safety: static test extension id is valid.
     let context = ExecutionContext {
-        run_id: None,
+        // Production-faithful loop-run origin (the loop stamps `run_id` →
+        // `LoopRun`); the kernel now fails closed on an origin-less context.
+        run_id: Some(ironclaw_host_api::RunId::new()),
         origin: None,
         invocation_id: resource_scope.invocation_id,
         correlation_id: ironclaw_host_api::CorrelationId::new(),

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -883,6 +883,9 @@ fn shell_execution_context(user_id: &str, thread_id: &str) -> ExecutionContext {
     let thread_id = ThreadId::new(thread_id).expect("thread id"); // safety: callers pass static valid test ids.
     context.thread_id = Some(thread_id.clone());
     context.resource_scope.thread_id = Some(thread_id);
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
     context.validate().expect("thread-scoped context"); // safety: fixed test context should validate.
     context
 }
@@ -1241,6 +1244,9 @@ fn echo_spawn_execution_context(user_id: &str, thread_id: &str) -> ExecutionCont
     let thread_id = ThreadId::new(thread_id).expect("thread id"); // safety: callers pass static valid test ids.
     context.thread_id = Some(thread_id.clone());
     context.resource_scope.thread_id = Some(thread_id);
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
     context.validate().expect("thread-scoped context"); // safety: fixed test context should validate.
     context
 }

--- a/crates/ironclaw_reborn_composition/src/factory/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/tests.rs
@@ -2518,7 +2518,7 @@ fn memory_context(capability_id: &str) -> ExecutionContext {
 
 fn gsuite_context(capability_id: &str) -> ExecutionContext {
     let extension_id = ExtensionId::new("caller").expect("valid extension id");
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("local-dev-test-user").expect("valid user id"),
         extension_id.clone(),
         RuntimeKind::FirstParty,
@@ -2547,7 +2547,11 @@ fn gsuite_context(capability_id: &str) -> ExecutionContext {
         },
         MountView::new(Vec::new()).expect("valid empty mount view"),
     )
-    .expect("valid execution context")
+    .expect("valid execution context");
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 /// Turn on the global auto-approve switch for `context`'s actor scope so a
@@ -2574,7 +2578,7 @@ use crate::approval_test_support::disable_global_auto_approve;
 
 fn notion_mcp_context(capability_id: &str) -> ExecutionContext {
     let extension_id = ExtensionId::new("caller").expect("valid extension id");
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("local-dev-test-user").expect("valid user id"),
         extension_id.clone(),
         RuntimeKind::Mcp,
@@ -2598,12 +2602,16 @@ fn notion_mcp_context(capability_id: &str) -> ExecutionContext {
         },
         MountView::new(Vec::new()).expect("valid empty mount view"),
     )
-    .expect("valid execution context")
+    .expect("valid execution context");
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn web_access_context(capability_id: &str) -> ExecutionContext {
     let extension_id = ExtensionId::new("caller").expect("valid extension id");
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("local-dev-test-user").expect("valid user id"),
         extension_id.clone(),
         RuntimeKind::FirstParty,
@@ -2627,7 +2635,11 @@ fn web_access_context(capability_id: &str) -> ExecutionContext {
         },
         MountView::new(Vec::new()).expect("valid empty mount view"),
     )
-    .expect("valid execution context")
+    .expect("valid execution context");
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn web_access_network_policy() -> NetworkPolicy {
@@ -2644,7 +2656,7 @@ fn web_access_network_policy() -> NetworkPolicy {
 
 fn execution_context(capability_id: &str, mounts: MountView) -> ExecutionContext {
     let extension_id = ExtensionId::new("caller").expect("valid extension id");
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("local-dev-test-user").expect("valid user id"),
         extension_id.clone(),
         RuntimeKind::FirstParty,
@@ -2658,7 +2670,11 @@ fn execution_context(capability_id: &str, mounts: MountView) -> ExecutionContext
         },
         mounts,
     )
-    .expect("valid execution context")
+    .expect("valid execution context");
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn capability_grant(

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -196,7 +196,7 @@ fn local_dev_builtin_visible_request() -> VisibleCapabilityRequest {
             ),
         ],
     };
-    let context = ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -205,6 +205,9 @@ fn local_dev_builtin_visible_request() -> VisibleCapabilityRequest {
         MountView::default(),
     )
     .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
 
     let mut provider_trust = BTreeMap::new();
     provider_trust.insert(
@@ -257,7 +260,7 @@ fn production_process_capability_execution_context() -> ExecutionContext {
             ),
         ],
     };
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("production-user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -265,7 +268,11 @@ fn production_process_capability_execution_context() -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn production_builtin_provider_trust() -> BTreeMap<ExtensionId, TrustDecision> {
@@ -439,7 +446,7 @@ fn trigger_management_execution_context() -> ExecutionContext {
             ),
         ],
     };
-    ExecutionContext::local_default(
+    let mut context = ExecutionContext::local_default(
         UserId::new("trigger-user").unwrap(),
         ExtensionId::new("caller").unwrap(),
         RuntimeKind::FirstParty,
@@ -447,7 +454,11 @@ fn trigger_management_execution_context() -> ExecutionContext {
         grants,
         MountView::default(),
     )
-    .unwrap()
+    .unwrap();
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
+    context
 }
 
 fn empty_trust_policy() -> Arc<HostTrustPolicy> {

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -534,6 +534,9 @@ fn trigger_management_execution_context() -> ExecutionContext {
     context.resource_scope.tenant_id = tenant_id;
     context.resource_scope.agent_id = Some(agent_id);
     context.resource_scope.project_id = None;
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
     context
 }
 

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -958,6 +958,7 @@ fn dispatch_request(capability: &str, input: Value) -> CapabilityDispatchRequest
         mounts: None,
         resource_reservation: None,
         pinned_lane: None,
+        deadline: None,
         input,
     }
 }

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -957,6 +957,7 @@ fn dispatch_request(capability: &str, input: Value) -> CapabilityDispatchRequest
             .set_output_bytes(10_000),
         mounts: None,
         resource_reservation: None,
+        pinned_lane: None,
         input,
     }
 }

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
@@ -55,9 +55,13 @@ def _response_output_text(response: dict) -> str:
 
 async def _create_response(client: httpx.AsyncClient, path="/v1/responses", **payload):
     response = None
+    # Retry transient statuses: 429 under load, and 502/503/504 when the first
+    # request races the backend/LLM warm-up (a cold-start 503 was flaking this
+    # smoke). Any non-transient status breaks immediately.
+    transient_statuses = {429, 502, 503, 504}
     for attempt in range(6):
         response = await client.post(path, json={"model": "default", **payload})
-        if response.status_code != 429:
+        if response.status_code not in transient_statuses:
             break
         await asyncio.sleep(1 + attempt * 0.5)
     assert response is not None

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
@@ -59,9 +59,12 @@ async def _create_response(client: httpx.AsyncClient, path="/v1/responses", **pa
     # request races the backend/LLM warm-up (a cold-start 503 was flaking this
     # smoke). Any non-transient status breaks immediately.
     transient_statuses = {429, 502, 503, 504}
-    for attempt in range(6):
+    attempts = 6
+    for attempt in range(attempts):
         response = await client.post(path, json={"model": "default", **payload})
-        if response.status_code not in transient_statuses:
+        # Break on a non-transient status, or after the final attempt (no point
+        # sleeping when no further request will be made).
+        if response.status_code not in transient_statuses or attempt == attempts - 1:
             break
         await asyncio.sleep(1 + attempt * 0.5)
     assert response is not None

--- a/tests/reborn_qa_routines.rs
+++ b/tests/reborn_qa_routines.rs
@@ -663,5 +663,8 @@ fn trigger_management_execution_context() -> ExecutionContext {
     context.resource_scope.tenant_id = tenant_id;
     context.resource_scope.agent_id = Some(agent_id);
     context.resource_scope.project_id = None;
+    // Production-faithful loop-run origin (the loop stamps `run_id` → `LoopRun`);
+    // the kernel now fails closed on an origin-less context.
+    context.run_id = Some(ironclaw_host_api::RunId::new());
     context
 }


### PR DESCRIPTION
**Now targets `main`** (rebased after #6432 merged). #6432 merged **without** its two HIGH review fixes (they raced past the merge), so this PR now carries them in addition to the deletions.

## Contents (4 commits on main)

### The two HIGH review fixes that missed the #6432 merge
1. **Resume witness-deadline enforcement.** The resumed-dispatch tail dropped the sealed `Authorized` and never enforced its deadline, so an approval lease expiring between claim and dispatch could still execute. The tail now re-seals the witness against the authoritative post-claim outcome (grant-gated `Authorized::reseal_with_outcome`, preserving invocation/lane/deadline) and consumes it through the shared `dispatch_inputs_from_witness` helper — `into_parts` fails closed on expiry **before** the side effect (abort obligations, abort witness, revoke claimed lease, fail run). Test: `expired_resume_witness_dispatches_nothing_fails_run_and_revokes_lease`.
2. **Dispatch bound to the authorized lane (mutable-registry TOCTOU).** The dispatcher re-resolved the descriptor/lane from the hot registry, so an extension update between authorize and dispatch could execute a replacement runtime under the old authorization. The witness's authorized lane is threaded as `CapabilityDispatchRequest.pinned_lane`; `RuntimeDispatcher::dispatch_json` fails closed with `DispatchError::LaneMismatch` (→ `RuntimeFailureKind::Authorization`) before `RuntimeSelected`/execution. `None` pin (witness-free / host-internal System) = byte-identical common path. Residual same-lane descriptor-content swaps → #6434. Test: `registry_update_between_authorize_and_dispatch_fails_closed_on_lane_mismatch` (+ matching-lane control).

### The deletions (turning the #6396 scaffold into net removal)
3. **Mint the witness for `System`-runtime invocations** (`Authorized.lane: Option<RuntimeLane>`). `System` maps to no untrusted lane, so the seal `?`-ed it and dispatched a `None`-witness fallback; now it mints a witness with `lane == None`, so the witness is present for every dispatchable invocation. Touches no exhaustive `RuntimeLane` match.
4. **Delete the `None`-fallback + `Option` chain.** With the witness always-present, an origin-less `ExecutionContext` (test-only; production always stamps an origin) now **fails closed** at the authorize fold, and the `dispatch_inputs_from_witness` fallback arm, `seal_authorization`'s `Option` return, and `AuthorizedFold.result`'s `Option` are deleted — the sealed witness is the sole Allow-path dispatch input. Tests: `origin_less_{invoke,spawn,resume}_...` (invoke/spawn/resume-lease-revoke).

## Behavior-neutrality
Production-neutral: `resolved_origin()` is always `Some` in production; sealed mounts/reservation are byte-identical. The new fail-closed behaviors fire only on the racy conditions (held-witness expiry, registry lane swap, un-attributable origin-less dispatch). 24 test contexts stamp the `LoopRun` origin production would have — no assertion weakened.

## Testing
Full **unfiltered** gate (`--no-fail-fast`) on merged main: capabilities/host_api/dispatcher **356 passed / 0 failed**; host_runtime/reborn_composition/architecture **3121 passed / 0 failed** (env vars unset). `clippy --all-targets --all-features -D warnings` clean; `fmt` clean.

## Deferred → #6434
Full dispatcher-consumes-`Authorized` (deleting `CapabilityDispatchRequest.mounts`/`.resource_reservation` + the `from_runtime_kind` re-derivation, and same-lane descriptor pinning) is blocked by long-running process re-dispatch being witness-free (witness lifetime ≠ process lifetime) — the continuation-model process authority, scoped in #6434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
