### PR TITLE
Fix generic extension activation and channel delivery regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hosted MCP discovery:** bound overlong valid tool descriptions at the
+  generic MCP boundary instead of rejecting the provider's entire catalog.
+- **Channel delivery:** keep live source-route observers attached for normal
+  long-running turns so every channel receives the durable final reply.
+- **Automation delivery:** honor each trigger's creator-selected outbound
+  target at fire time instead of silently falling back to the user-wide
+  default.
+- **Channel removal:** revoke caller-owned OAuth or proof-code pairing state
+  through the shared lifecycle before deleting any channel installation, so
+  removing Telegram, Slack, or a future channel unpairs it on every surface.
+
+### Removed
+
+- **Slack compatibility route:** retire the one-release
+  `/webhooks/slack/events` forwarding alias. Slack Event Subscriptions must use
+  `/webhooks/extensions/slack/events`; generic product-auth OAuth callbacks are
+  unchanged.
+
 ## [1.0.0-rc.1] - 2026-07-20
 
 First release candidate of the rearchitected IronClaw, internally called

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, targeted catalog parsing fix remains beside the existing MCP protocol parser pending the adapter module split, plan #4088
 //! MCP adapter contracts for IronClaw Reborn.
 //!
 //! `ironclaw_mcp` adapts manifest-declared MCP tools into IronClaw
@@ -1069,11 +1070,8 @@ fn parse_tools_list_result(value: &Value) -> Result<Vec<HostedMcpDiscoveredTool>
                 .get("description")
                 .and_then(Value::as_str)
                 .unwrap_or("");
-            if description.len() > MAX_TOOL_DESCRIPTION_BYTES
-                || description.chars().any(is_unsupported_description_char)
-            {
-                return Err(invalid_tool_list());
-            }
+            let description = bound_mcp_tool_description(description, MAX_TOOL_DESCRIPTION_BYTES)
+                .ok_or_else(invalid_tool_list)?;
             let input_schema = tool
                 .get("inputSchema")
                 .filter(|schema| schema.is_object())
@@ -1160,6 +1158,34 @@ fn validate_mcp_schema_value(
 
 fn is_unsupported_description_char(value: char) -> bool {
     value.is_control() && !matches!(value, '\n' | '\r' | '\t')
+}
+
+/// Preserve a provider's otherwise-valid tool catalog when only descriptive
+/// prose exceeds the host display/prompt budget. Names and schemas remain
+/// fail-closed because truncating either could change capability semantics;
+/// descriptions are presentation metadata and can be safely bounded.
+fn bound_mcp_tool_description(value: &str, max_bytes: usize) -> Option<String> {
+    if value.chars().any(is_unsupported_description_char) {
+        return None;
+    }
+    if value.len() <= max_bytes {
+        return Some(value.to_string());
+    }
+
+    const TRUNCATION_MARKER: &str = "...";
+    if max_bytes <= TRUNCATION_MARKER.len() {
+        return Some(".".repeat(max_bytes));
+    }
+
+    let mut end = max_bytes - TRUNCATION_MARKER.len();
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    let prefix = value.get(..end)?;
+    let mut bounded = String::with_capacity(max_bytes);
+    bounded.push_str(prefix);
+    bounded.push_str(TRUNCATION_MARKER);
+    Some(bounded)
 }
 
 fn parse_tool_annotations(
@@ -1741,6 +1767,20 @@ mod tests {
             .expect_err("unsupported description control characters must fail");
 
         assert_eq!(error, "mcp_invalid_tool_list");
+    }
+
+    #[test]
+    fn parse_tools_list_result_bounds_utf8_description_at_character_boundary() {
+        let mut tool = valid_tool("search", json!({"type": "object"}));
+        tool["description"] = json!("🔧".repeat(600));
+
+        let tools = parse_tools_list_result(&json!({ "tools": [tool] }))
+            .expect("descriptive prose must not invalidate the catalog");
+        let description = &tools[0].description;
+
+        assert!(description.len() <= 2_048);
+        assert!(description.ends_with("..."));
+        assert!(description.is_char_boundary(description.len()));
     }
 
     #[test]

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, whole-handshake catalog regression reuses the existing mediated HTTP fixture, plan #4088
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -799,6 +800,46 @@ async fn concrete_mcp_http_client_discovers_tool_schemas_through_shared_egress()
     );
 }
 
+#[tokio::test]
+async fn concrete_mcp_http_client_bounds_long_provider_descriptions_without_dropping_catalog() {
+    let egress = RecordingRuntimeEgress::long_tool_description();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let output = client
+        .discover_tools(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({}),
+            max_output_bytes: 16_384,
+        })
+        .await
+        .expect("a valid provider catalog must survive an overlong description");
+
+    assert_eq!(output.tools.len(), 2);
+    assert_eq!(output.tools[0].name, "search");
+    assert_eq!(output.tools[0].description.len(), 2_048);
+    assert!(
+        output.tools[0].description.ends_with("..."),
+        "bounded descriptions must make truncation explicit"
+    );
+    assert_eq!(
+        egress
+            .requests()
+            .iter()
+            .map(|request| json_rpc_method(&request.body))
+            .collect::<Vec<_>>(),
+        vec!["initialize", "notifications/initialized", "tools/list"]
+    );
+}
+
 /// Coverage gap noted in review of the SSE contract tests: the loopback MCP
 /// path predeclares its tool schemas, so `discover_tools` (host-mediated HTTP
 /// path) is only ever exercised over JSON-framed `tools/list` responses
@@ -1308,6 +1349,7 @@ enum RecordedResponseMode {
     Json,
     AuthRequired,
     JsonMissingProtocolVersion,
+    LongToolDescription,
     Sse,
 }
 
@@ -1342,6 +1384,14 @@ impl RecordingRuntimeEgress {
     fn json_rpc_without_protocol_version() -> Self {
         Self {
             mode: RecordedResponseMode::JsonMissingProtocolVersion,
+            protocol_version: "2025-06-18",
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn long_tool_description() -> Self {
+        Self {
+            mode: RecordedResponseMode::LongToolDescription,
             protocol_version: "2025-06-18",
             requests: Arc::new(Mutex::new(Vec::new())),
         }
@@ -1411,13 +1461,12 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                 let id = json_rpc_id(&request.body);
                 match self.mode {
                     RecordedResponseMode::Json
-                    | RecordedResponseMode::JsonMissingProtocolVersion => {
-                        Ok(runtime_json_response(
-                            id,
-                            json!({"content":[{"type":"text","text":"ok"}],"isError":false}),
-                            vec![],
-                        ))
-                    }
+                    | RecordedResponseMode::JsonMissingProtocolVersion
+                    | RecordedResponseMode::LongToolDescription => Ok(runtime_json_response(
+                        id,
+                        json!({"content":[{"type":"text","text":"ok"}],"isError":false}),
+                        vec![],
+                    )),
                     RecordedResponseMode::Sse => Ok(runtime_sse_response(
                         id,
                         json!({"content":[{"type":"text","text":"ok from sse"}],"isError":false}),
@@ -1429,11 +1478,16 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
             }
             "tools/list" => {
                 let id = json_rpc_id(&request.body);
+                let search_description = if self.mode == RecordedResponseMode::LongToolDescription {
+                    "x".repeat(7_115)
+                } else {
+                    "Search GitHub issues\nacross repositories".to_string()
+                };
                 let result = json!({
                     "tools": [
                         {
                             "name": "search",
-                            "description": "Search GitHub issues\nacross repositories",
+                            "description": search_description,
                             "inputSchema": {
                                 "type": "object",
                                 "properties": {
@@ -1462,7 +1516,8 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                 });
                 match self.mode {
                     RecordedResponseMode::Json
-                    | RecordedResponseMode::JsonMissingProtocolVersion => {
+                    | RecordedResponseMode::JsonMissingProtocolVersion
+                    | RecordedResponseMode::LongToolDescription => {
                         Ok(runtime_json_response(id, result, vec![]))
                     }
                     RecordedResponseMode::Sse => Ok(runtime_sse_response(id, result)),

--- a/crates/ironclaw_outbound/src/delivery_resolution.rs
+++ b/crates/ironclaw_outbound/src/delivery_resolution.rs
@@ -141,6 +141,14 @@ pub enum RunNotificationOrigin {
     Triggered {
         trigger: TriggerCommunicationContext,
     },
+    /// A triggered run whose creator selected a durable per-trigger target.
+    /// Ordinary notifications use this exact binding; authority-bearing
+    /// approval/auth prompts still resolve through the creator's dedicated
+    /// preference fields.
+    TriggeredWithTarget {
+        trigger: TriggerCommunicationContext,
+        target: ReplyTargetBindingRef,
+    },
     TriggeredFromSourceRoute {
         trigger: TriggerCommunicationContext,
         source_route: SourceRouteContext,
@@ -292,6 +300,14 @@ mod tests {
     fn run_notification_origin_round_trips_triggered() {
         assert_json_round_trip(RunNotificationOrigin::Triggered {
             trigger: trigger_context(),
+        });
+    }
+
+    #[test]
+    fn run_notification_origin_round_trips_triggered_with_target() {
+        assert_json_round_trip(RunNotificationOrigin::TriggeredWithTarget {
+            trigger: trigger_context(),
+            target: ReplyTargetBindingRef::new("reply:trigger-target").expect("target"),
         });
     }
 

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -75,6 +75,10 @@ impl<'a> OutboundResolutionEngine<'a> {
             RunNotificationOrigin::Triggered { .. } => {
                 self.resolve_triggered_target(scope, actor, kind).await?
             }
+            RunNotificationOrigin::TriggeredWithTarget { target, .. } => {
+                self.resolve_triggered_explicit_target(kind, target, scope, actor)
+                    .await?
+            }
             RunNotificationOrigin::TriggeredFromSourceRoute { source_route, .. } => {
                 self.resolve_triggered_from_source_route_target(
                     kind,
@@ -101,6 +105,17 @@ impl<'a> OutboundResolutionEngine<'a> {
         scope: &ironclaw_turns::TurnScope,
         actor: &ironclaw_turns::TurnActor,
     ) -> Result<ReplyTargetBindingRef, OutboundError> {
+        self.resolve_triggered_explicit_target(kind, source_route_target, scope, actor)
+            .await
+    }
+
+    async fn resolve_triggered_explicit_target(
+        &self,
+        kind: CommunicationDeliveryKind,
+        ordinary_notification_target: &ReplyTargetBindingRef,
+        scope: &ironclaw_turns::TurnScope,
+        actor: &ironclaw_turns::TurnActor,
+    ) -> Result<ReplyTargetBindingRef, OutboundError> {
         match kind {
             CommunicationDeliveryKind::ApprovalPrompt => {
                 self.load_preference_target(scope, actor, PreferenceTargetKind::ApprovalPrompt)
@@ -112,7 +127,7 @@ impl<'a> OutboundResolutionEngine<'a> {
             }
             CommunicationDeliveryKind::FinalReply
             | CommunicationDeliveryKind::ProgressUpdate
-            | CommunicationDeliveryKind::DeliveryStatus => Ok(source_route_target.clone()),
+            | CommunicationDeliveryKind::DeliveryStatus => Ok(ordinary_notification_target.clone()),
         }
     }
 
@@ -683,6 +698,51 @@ mod tests {
 
         assert_eq!(candidate.target, reply_ref("reply:owner-default"));
         assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_with_target_routes_ordinary_result_without_global_preference() {
+        let store = in_memory_backed_outbound_state_store();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::FinalReplyReady,
+            RunNotificationOrigin::TriggeredWithTarget {
+                trigger: trigger_context(),
+                target: reply_ref("reply:per-trigger"),
+            },
+            "reply:per-trigger",
+            CommunicationDeliveryKind::FinalReply,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn triggered_with_target_does_not_select_authority_prompt_destination() {
+        let store = in_memory_backed_outbound_state_store();
+        let engine = OutboundResolutionEngine::new(&store);
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                None,
+                Some("reply:approval"),
+                None,
+            ))
+            .await
+            .expect("seed preference");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ApprovalNeeded,
+            RunNotificationOrigin::TriggeredWithTarget {
+                trigger: trigger_context(),
+                target: reply_ref("reply:per-trigger"),
+            },
+            "reply:approval",
+            CommunicationDeliveryKind::ApprovalPrompt,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -80,7 +80,7 @@ ironclaw_product_adapters = { path = "../ironclaw_product_adapters", features = 
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0", features = ["test-support"] }
 ironclaw_telegram_extension = { path = "../ironclaw_telegram_extension" }
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "test-util", "time"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 # Durable-ledger contract tests drive the libSQL/Postgres RootFilesystem
 # backends directly; the Postgres leg builds its own pool. libSQL leg runs

--- a/crates/ironclaw_product_workflow/src/run_delivery.rs
+++ b/crates/ironclaw_product_workflow/src/run_delivery.rs
@@ -60,7 +60,7 @@ pub use triggered::{
 };
 
 const MAX_RUN_POLL_INTERVAL: Duration = Duration::from_secs(5);
-const DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT: Duration = Duration::from_secs(30 * 60);
+const DEFAULT_RUN_DELIVERY_MAX_WAIT: Duration = Duration::from_secs(30 * 60);
 const RUN_POLL_JITTER_BUCKETS: u32 = 5;
 
 /// Maximum number of (conversation, external_event_id) pairs remembered for
@@ -93,20 +93,18 @@ impl Default for RunDeliverySettings {
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_millis(250),
-            max_wait: Duration::from_secs(120),
+            max_wait: DEFAULT_RUN_DELIVERY_MAX_WAIT,
             max_concurrent_deliveries: NonZeroUsize::new(64).expect("non-zero literal"), // safety: static default literal is non-zero.
             max_pending_deliveries: NonZeroUsize::new(256).expect("non-zero literal"), // safety: static default literal is non-zero.
         }
     }
 }
 
-/// Triggered-path default: proactive runs may legitimately take far longer
-/// than a live conversational turn before parking or completing.
+/// Compatibility constructor for the triggered path. Live and proactive runs
+/// share the same long-running watcher budget because either may legitimately
+/// exceed the former two-minute cutoff before parking or completing.
 pub fn triggered_run_delivery_settings() -> RunDeliverySettings {
-    RunDeliverySettings {
-        max_wait: DEFAULT_TRIGGERED_RUN_DELIVERY_MAX_WAIT,
-        ..RunDeliverySettings::default()
-    }
+    RunDeliverySettings::default()
 }
 
 /// Approval-gate context enrichment: resolves WHAT is being approved
@@ -261,7 +259,7 @@ pub(crate) async fn wait_for_actionable_state(
     settings: &RunDeliverySettings,
     delivered_blocked_marker: Option<&BlockedActionableMarker>,
 ) -> Result<TurnRunState, RunDeliveryError> {
-    let start = std::time::Instant::now();
+    let start = tokio::time::Instant::now();
     let mut poll_interval = settings.poll_interval;
     loop {
         let state = turn_coordinator

--- a/crates/ironclaw_product_workflow/src/run_delivery/observer.rs
+++ b/crates/ironclaw_product_workflow/src/run_delivery/observer.rs
@@ -4,7 +4,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use tokio::time::Instant;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -516,7 +516,7 @@ impl RunDeliveryObserver {
         delivered_blocked_marker: Option<&BlockedActionableMarker>,
         working_message: &mut Option<DeliveredChannelMessage>,
     ) -> Result<TurnRunState, RunDeliveryError> {
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         let mut poll_interval = self.settings.poll_interval;
         loop {
             let state = self

--- a/crates/ironclaw_product_workflow/src/run_delivery/triggered.rs
+++ b/crates/ironclaw_product_workflow/src/run_delivery/triggered.rs
@@ -55,6 +55,10 @@ pub struct TriggeredRunDeliveryRequest {
     pub project_scoped: bool,
     /// The trigger prompt; its first line becomes the short footer label.
     pub prompt: String,
+    /// Optional per-trigger target resolved from the creator-scoped outbound
+    /// target registry. When present, ordinary results route here instead of
+    /// consulting the user's mutable global default.
+    pub delivery_target: Option<ironclaw_turns::ReplyTargetBindingRef>,
     pub trigger_context: TriggerCommunicationContext,
 }
 
@@ -67,6 +71,17 @@ struct TriggeredNotification {
     /// AuthPrompt payloads carrying an OAuth URL must only land in a
     /// personal DM; enforced by the resolver at send time.
     require_direct_message_target: bool,
+}
+
+/// Stable run and routing inputs shared by each notification attempt for one
+/// triggered run.
+struct TriggeredNotificationContext<'a> {
+    scope: &'a TurnScope,
+    actor: &'a TurnActor,
+    run_id: TurnRunId,
+    trigger_context: &'a TriggerCommunicationContext,
+    delivery_target: Option<&'a ironclaw_turns::ReplyTargetBindingRef>,
+    authority: &'a TriggeredReplyTargetAuthority<'a>,
 }
 
 /// Typed failure classification for a single triggered-run notification
@@ -276,6 +291,7 @@ async fn deliver_triggered_run(
         creator_user_id,
         project_scoped: _,
         prompt,
+        delivery_target,
         trigger_context,
     } = request;
     let actor = TurnActor::new(creator_user_id);
@@ -378,16 +394,16 @@ async fn deliver_triggered_run(
         let event_kind = notification.event_kind;
         let gate_ref_for_routing = notification.gate_ref_for_routing.clone();
 
-        let delivery_result = deliver_triggered_notification(
-            services,
-            &scope,
-            &actor,
+        let notification_context = TriggeredNotificationContext {
+            scope: &scope,
+            actor: &actor,
             run_id,
-            &trigger_context,
-            &authority,
-            notification,
-        )
-        .await;
+            trigger_context: &trigger_context,
+            delivery_target: delivery_target.as_ref(),
+            authority: &authority,
+        };
+        let delivery_result =
+            deliver_triggered_notification(services, &notification_context, notification).await;
 
         match delivery_result {
             Ok(delivered_messages) => {
@@ -475,29 +491,22 @@ async fn deliver_triggered_run(
                     gate_ref_for_routing: None,
                     require_direct_message_target: false,
                 };
-                let outcome = match deliver_triggered_notification(
-                    services,
-                    &scope,
-                    &actor,
-                    run_id,
-                    &trigger_context,
-                    &authority,
-                    notice,
-                )
-                .await
-                {
-                    Ok(_) => TriggeredRunDeliveryOutcomeKind::Delivered,
-                    Err(TriggeredNotificationFailure::NoDefaultConfigured) => {
-                        TriggeredRunDeliveryOutcomeKind::NoDefaultConfigured
-                    }
-                    Err(TriggeredNotificationFailure::Denied) => {
-                        TriggeredRunDeliveryOutcomeKind::Denied
-                    }
-                    Err(TriggeredNotificationFailure::OAuthTargetNotDm)
-                    | Err(TriggeredNotificationFailure::Other(_)) => {
-                        TriggeredRunDeliveryOutcomeKind::Failed
-                    }
-                };
+                let outcome =
+                    match deliver_triggered_notification(services, &notification_context, notice)
+                        .await
+                    {
+                        Ok(_) => TriggeredRunDeliveryOutcomeKind::Delivered,
+                        Err(TriggeredNotificationFailure::NoDefaultConfigured) => {
+                            TriggeredRunDeliveryOutcomeKind::NoDefaultConfigured
+                        }
+                        Err(TriggeredNotificationFailure::Denied) => {
+                            TriggeredRunDeliveryOutcomeKind::Denied
+                        }
+                        Err(TriggeredNotificationFailure::OAuthTargetNotDm)
+                        | Err(TriggeredNotificationFailure::Other(_)) => {
+                            TriggeredRunDeliveryOutcomeKind::Failed
+                        }
+                    };
                 // Only after a successful cancel and the replacement notice:
                 // remove the now-stale OAuth prompts.
                 for message in messages_to_delete_after_final.drain(..) {
@@ -693,36 +702,39 @@ async fn triggered_notification_for_state(
 /// returning the delivered channel messages.
 async fn deliver_triggered_notification(
     services: &RunDeliveryServices,
-    scope: &TurnScope,
-    actor: &TurnActor,
-    run_id: TurnRunId,
-    trigger_context: &TriggerCommunicationContext,
-    authority: &TriggeredReplyTargetAuthority<'_>,
+    context: &TriggeredNotificationContext<'_>,
     notification: TriggeredNotification,
 ) -> Result<Vec<DeliveredChannelMessage>, TriggeredNotificationFailure> {
     let projection_access_policy = AllowNoProjectionAccess;
     let outbound_policy = OutboundPolicyService::new(
         services.outbound_store.as_ref(),
         &projection_access_policy,
-        authority,
+        context.authority,
     );
-    let projection_id = prompts::run_notification_projection_id(run_id, notification.event_kind);
+    let projection_id =
+        prompts::run_notification_projection_id(context.run_id, notification.event_kind);
     let projection_ref = ProjectionUpdateRef::new(projection_id).map_err(|reason| {
         TriggeredNotificationFailure::Other(format!("invalid_projection_ref: {reason}"))
     })?;
     let delivery = PrepareCommunicationDeliveryRequest {
         resolution_request: CommunicationDeliveryResolutionRequest {
-            scope: scope.clone(),
-            actor: actor.clone(),
+            scope: context.scope.clone(),
+            actor: context.actor.clone(),
             modality: CommunicationModality::Text,
             intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
                 event_kind: notification.event_kind,
-                origin: RunNotificationOrigin::Triggered {
-                    trigger: trigger_context.clone(),
+                origin: match context.delivery_target {
+                    Some(target) => RunNotificationOrigin::TriggeredWithTarget {
+                        trigger: context.trigger_context.clone(),
+                        target: target.clone(),
+                    },
+                    None => RunNotificationOrigin::Triggered {
+                        trigger: context.trigger_context.clone(),
+                    },
                 },
             }),
         },
-        turn_run_id: Some(run_id),
+        turn_run_id: Some(context.run_id),
         projection_ref,
         attempted_at: Utc::now(),
     };
@@ -732,7 +744,7 @@ async fn deliver_triggered_notification(
         .deliver(
             &outbound_policy,
             services.communication_preferences.as_ref(),
-            authority,
+            context.authority,
             CoordinatedDeliveryRequest {
                 intent: notification.intent,
                 delivery,

--- a/crates/ironclaw_product_workflow/tests/run_delivery_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/run_delivery_contract.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, channel-neutral timeout and trigger-target regressions reuse the shared delivery harness, plan #4088
 //! Contract rows for the generic run-delivery components (§5.4, 9b): the
 //! live observer and the triggered driver, driven with scripted run states
 //! and a scripted channel adapter, asserting at the coordinator/store seam.
@@ -543,6 +544,26 @@ fn build_harness(
     auth_url: Option<&str>,
     max_wait: Duration,
 ) -> Harness {
+    build_harness_with_settings(
+        states,
+        bind_fails,
+        auth_url,
+        RunDeliverySettings {
+            poll_interval: Duration::from_millis(1),
+            max_wait,
+            max_concurrent_deliveries: NonZeroUsize::new(4).expect("nz"),
+            max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_harness_with_settings(
+    states: Vec<ScriptedRunState>,
+    bind_fails: bool,
+    auth_url: Option<&str>,
+    settings: RunDeliverySettings,
+) -> Harness {
     let adapter = Arc::new(RecordingChannelAdapter::new());
     let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
     let route_store =
@@ -584,12 +605,7 @@ fn build_harness(
     let connection_notices = ChannelConnectionNoticePolicy::generic("Acme");
     let observer = Arc::new(RunDeliveryObserver::with_settings_and_connection_notices(
         services,
-        RunDeliverySettings {
-            poll_interval: Duration::from_millis(1),
-            max_wait,
-            max_concurrent_deliveries: NonZeroUsize::new(4).expect("nz"),
-            max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
-        },
+        settings,
         connection_notices.clone(),
     ));
     Harness {
@@ -780,6 +796,48 @@ async fn observer_posts_working_indicator_and_retracts_it_after_final_reply() {
             .iter()
             .all(|a| a.status == ironclaw_outbound::OutboundDeliveryStatus::Delivered)
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn observer_keeps_watching_a_healthy_run_past_the_previous_two_minute_cutoff() {
+    let settings = RunDeliverySettings::default();
+    assert!(
+        settings.max_wait > Duration::from_secs(2 * 60),
+        "the live channel watcher must outlive a healthy run that exceeds the old two-minute cutoff"
+    );
+
+    // The foreign-run existence guard consumes the first state. The wait
+    // loop then remains Running for more than two minutes of virtual time
+    // before observing Completed. This is channel-neutral: every adapter
+    // reaches final replies through this observer.
+    let mut states = vec![scripted_state(TurnStatus::Running, None)];
+    states.extend(std::iter::repeat_with(|| scripted_state(TurnStatus::Running, None)).take(32));
+    states.push(scripted_state(TurnStatus::Completed, None));
+    let harness = build_harness_with_settings(states, false, None, settings);
+    let run_id = TurnRunId::new();
+    seed_final_message(&harness.threads, run_id, "slow run finished").await;
+
+    let started = tokio::time::Instant::now();
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-slow-run"),
+            accepted_ack(run_id),
+        )
+        .await;
+
+    assert!(
+        tokio::time::Instant::now().duration_since(started) > Duration::from_secs(2 * 60),
+        "the scripted run must cross the previous delivery deadline"
+    );
+    assert_eq!(
+        harness.adapter.texts(),
+        vec![
+            "Ironclaw is thinking...".to_string(),
+            "slow run finished".to_string()
+        ]
+    );
+    assert_eq!(harness.adapter.retracted_refs().len(), 1);
 }
 
 #[tokio::test]
@@ -1263,6 +1321,7 @@ fn triggered_request(run_id: TurnRunId, project_scoped: bool) -> TriggeredRunDel
         creator_user_id: user(),
         project_scoped,
         prompt: "watch the deploys".to_string(),
+        delivery_target: None,
         trigger_context: trigger_context(),
     }
 }
@@ -1440,6 +1499,26 @@ async fn triggered_final_reply_reaches_the_preference_target_with_footer() {
         "dm-creator",
         "delivered to the decoded preference target"
     );
+}
+
+#[tokio::test]
+async fn triggered_final_reply_honors_per_trigger_target_without_global_default() {
+    let harness = build_triggered_harness(
+        vec![scripted_state(TurnStatus::Completed, None)],
+        None,
+        true,
+    );
+    let run_id = TurnRunId::new();
+    seed_final_message(&harness.threads, run_id, "pinned route complete").await;
+    let mut request = triggered_request(run_id, false);
+    request.delivery_target =
+        Some(ReplyTargetBindingRef::new("reply:pinned-trigger").expect("target"));
+
+    harness.driver.on_trigger_submitted(request).await;
+
+    let outcome = wait_for_outcome(&harness.delivery_store, run_id).await;
+    assert_eq!(outcome, TriggeredRunDeliveryOutcomeKind::Delivered);
+    assert_eq!(harness.adapter.texts().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -35,24 +35,6 @@ const DEFAULT_ENV_USER_ID_VAR: &str = "IRONCLAW_REBORN_WEBUI_USER_ID";
 /// year: this is a long-lived programmatic credential, not a browser session.
 const ADMIN_API_TOKEN_LIFETIME_DAYS: i64 = 365;
 
-struct LegacyExtensionIngressAlias {
-    legacy_path: &'static str,
-    route_id: &'static str,
-    extension_id: &'static str,
-    route_suffix: &'static str,
-}
-
-/// REMOVAL NOTE (extension-runtime MIG-5): delete this binary-edge
-/// compatibility entry in the first release after operators have moved their
-/// Slack Events API URL to `/webhooks/extensions/slack/events`.
-const LEGACY_EXTENSION_INGRESS_ALIASES: &[LegacyExtensionIngressAlias] =
-    &[LegacyExtensionIngressAlias {
-        legacy_path: "/webhooks/slack/events",
-        route_id: "slack.events.compat",
-        extension_id: "slack",
-        route_suffix: "events",
-    }];
-
 /// Read an env var, distinguishing "unset" from "set but not valid UTF-8".
 ///
 /// `std::env::var(name).ok()` collapses both `VarError::NotPresent` and
@@ -592,18 +574,6 @@ impl ServeCommand {
                     ironclaw_reborn_composition::extension_ingress_route_mount(&ingress_parts)
                         .context("failed to compose the extension ingress route mount")?;
                 serve_config = serve_config.with_public_route_mount(ingress_mount);
-                for alias in LEGACY_EXTENSION_INGRESS_ALIASES {
-                    let alias_mount =
-                        ironclaw_reborn_composition::extension_ingress_alias_route_mount(
-                            &ingress_parts,
-                            alias.route_id,
-                            alias.legacy_path,
-                            alias.extension_id,
-                            alias.route_suffix,
-                        )
-                        .context("failed to compose legacy extension ingress alias")?;
-                    serve_config = serve_config.with_public_route_mount(alias_mount);
-                }
             }
             // The generic post-OAuth channel identity binding: installed
             // channel extensions bind through generic discovery over the

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_connection.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_connection.rs
@@ -1,13 +1,12 @@
 //! Generic per-user channel connection facade (extension-runtime §6.4).
 //!
 //! One vendor-blind [`ChannelConnectionFacade`] replaces the per-vendor
-//! facades: for every installed extension whose manifest declares a channel
-//! surface and an auth vendor, the caller's connection state is derived from
-//! the identity-binding store — connected iff the caller holds a binding for
-//! the extension's vendor under the extension's current installation-scoped
-//! prefix. Disconnect runs the fixed order: revoke the caller's personal
-//! vendor credential → per-extension vendor cleanup (lane-supplied residue,
-//! e.g. personal delivery targets) → delete the caller's identity bindings.
+//! facades: every installed extension whose manifest declares a channel
+//! surface is discovered. OAuth connection state is derived from the
+//! identity-binding store; proof-code connection state comes from the generic
+//! pairing registry. Disconnect runs the owner-specific cleanup before the
+//! installation disappears: revoke any personal vendor credential → pairing
+//! or per-extension residue cleanup → delete the caller's identity bindings.
 //! The binding is the "connected" signal and deletes last (commit point);
 //! the credential revokes first so a mid-sequence failure leaves the caller
 //! visibly connected with every step retryable.
@@ -1087,6 +1086,115 @@ team_id = "/team/id"
                 Some("install-alpha:".to_string())
             )],
             "bindings delete last, prefix-scoped to the installation"
+        );
+    }
+
+    /// Proof-code channels have no auth vendor, but the connection facade
+    /// still has to discover them so its pairing registry can own status and
+    /// disconnect. This mirrors Telegram's manifest shape without naming a
+    /// provider in production code.
+    #[tokio::test]
+    async fn connection_discovery_includes_channel_without_auth_vendor() {
+        use ironclaw_extensions::{
+            ExtensionActivationState, ExtensionInstallation, ExtensionInstallationId,
+            ExtensionManifestRecord, ExtensionManifestRef, ManifestSource,
+        };
+
+        const PAIRING_CHANNEL_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v3"
+id = "pairchat"
+name = "PairChat"
+version = "0.1.0"
+description = "proof-code channel discovery fixture"
+trust = "first_party_requested"
+
+[runtime]
+kind = "first_party"
+service = "pairchat.extension/v1"
+
+[channel]
+id = "messages"
+display_name = "PairChat messages"
+inbound = true
+outbound = true
+conversation_model = "continuous"
+
+[channel.ingress]
+route_suffix = "updates"
+method = "post"
+body_limit_bytes = 1048576
+
+[channel.ingress.verification]
+kind = "shared_secret_header"
+secret_handle = "pairchat_webhook_secret"
+header = "X-PairChat-Secret"
+
+[channel.config]
+fields = [
+  { handle = "pairchat_bot_token", label = "Bot token", secret = true },
+  { handle = "pairchat_webhook_secret", label = "Webhook secret", secret = true },
+]
+
+[[channel.egress]]
+scheme = "https"
+host = "api.pairchat.example"
+methods = ["post"]
+credential_handle = "pairchat_bot_token"
+injection = { type = "header", name = "authorization", prefix = "Bearer " }
+"#;
+
+        let installation_store =
+            Arc::new(crate::extension_host::filesystem_installation_store_for_test().await);
+        let record = ExtensionManifestRecord::from_toml(
+            PAIRING_CHANNEL_MANIFEST,
+            ManifestSource::HostBundled,
+            &ironclaw_host_runtime::default_host_port_catalog().expect("catalog"),
+            None,
+            &product_extension_host_api_contract_registry().expect("contracts"),
+        )
+        .expect("pairing channel manifest parses");
+        let extension_id = ExtensionId::new("pairchat").expect("extension id");
+        installation_store
+            .upsert_manifest_and_installation(
+                record,
+                ExtensionInstallation::new(
+                    ExtensionInstallationId::new("pairchat-install").expect("installation id"),
+                    extension_id.clone(),
+                    ExtensionActivationState::Enabled,
+                    ExtensionManifestRef::new(extension_id, None),
+                    Vec::new(),
+                    chrono::Utc::now(),
+                    ironclaw_extensions::InstallationOwner::Tenant,
+                )
+                .expect("installation"),
+            )
+            .await
+            .expect("persist install");
+
+        let identity_store = bound_identity_store("pairchat-install");
+        let facade = GenericChannelConnectionFacade::new(
+            tenant(),
+            Vec::new(),
+            Some(installation_store as Arc<dyn ExtensionInstallationStore>),
+            identity_store.clone(),
+            identity_store,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let entries = facade
+            .connection_entries()
+            .await
+            .expect("discover channels");
+        let pairchat = entries
+            .iter()
+            .find(|entry| entry.extension_id == "pairchat")
+            .expect("channel-only extension is discoverable");
+        assert!(
+            pairchat.providers.is_empty(),
+            "proof-code pairing does not invent an OAuth vendor"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_host/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_host/e2e_tests.rs
@@ -1049,6 +1049,7 @@ fn triggered_request_from_fire(
         creator_user_id: fire.creator_user_id.clone(),
         project_scoped: fire.project_id.is_some(),
         prompt: fire.prompt.clone(),
+        delivery_target: None,
         trigger_context: ironclaw_outbound::TriggerCommunicationContext {
             trigger_origin_ref: ironclaw_outbound::TriggerOriginRef::new(
                 fire.identity.trigger_id().to_string(),
@@ -4259,6 +4260,7 @@ async fn generic_triggered_hook_routes_fire_to_the_owning_extension_driver() {
         Arc::clone(&harness.assembly),
         Arc::clone(&delivery_store) as Arc<dyn TriggeredRunDeliveryStore>,
         harness.outbound.clone() as Arc<dyn CommunicationPreferenceRepository>,
+        Arc::new(crate::outbound::MutableOutboundDeliveryTargetRegistry::default()),
     );
 
     let fire = TriggerFire {
@@ -4343,6 +4345,115 @@ async fn generic_triggered_hook_routes_fire_to_the_owning_extension_driver() {
         record.outcome,
         ironclaw_outbound::TriggeredRunDeliveryOutcomeKind::Failed,
         "an undecodable stored target fails closed"
+    );
+}
+
+/// A trigger's own target id is resolved at fire time through the same
+/// creator-scoped registry used during creation, then delivered without a
+/// user-global preference. This is the whole composition path used by
+/// Telegram, Slack, and future manifest-driven channel providers.
+#[tokio::test]
+async fn generic_triggered_hook_honors_per_trigger_target_without_global_default() {
+    let harness = build_harness(TurnMode::Running).await;
+    save_outbound_target_config(&harness).await;
+    let dm_targets = generic_dm_target_store();
+    let user = UserId::new(USER).expect("user"); // safety: static test user id is valid.
+    dm_targets
+        .upsert(
+            ADAPTER,
+            &user,
+            SLACK_USER.to_string(),
+            dm_target_payload(Some(TEAM), CHANNEL),
+        )
+        .await
+        .expect("provision DM target");
+    let provider = Arc::new(generic_outbound_target_provider(&harness, dm_targets));
+    let listed = provider
+        .list_outbound_delivery_targets(&operator_caller())
+        .await
+        .expect("list targets");
+    let target_id = listed
+        .iter()
+        .find(|entry| entry.summary.target_id.as_str().contains("personal-dm"))
+        .expect("personal target")
+        .summary
+        .target_id
+        .as_str()
+        .to_string();
+    let registry = Arc::new(crate::outbound::MutableOutboundDeliveryTargetRegistry::default());
+    registry
+        .register_provider(
+            "channel",
+            provider as Arc<dyn OutboundDeliveryTargetProvider>,
+        )
+        .expect("register target provider");
+
+    let scope = foreign_run_scope();
+    harness.ensure_scope_thread(&scope).await;
+    let run_id = TurnRunId::new();
+    harness
+        .coordinator
+        .complete_run(
+            scope.clone(),
+            TurnActor::new(user.clone()),
+            run_id,
+            "scheduled result",
+        )
+        .await
+        .expect("seed completed trigger run");
+
+    let delivery_store = Arc::new(in_memory_backed_outbound_state_store());
+    let hook = GenericTriggeredRunDeliveryHook::new(
+        Arc::clone(&harness.assembly),
+        Arc::clone(&delivery_store) as Arc<dyn TriggeredRunDeliveryStore>,
+        harness.outbound.clone() as Arc<dyn CommunicationPreferenceRepository>,
+        registry,
+    );
+    let fire = TriggerFire {
+        identity: TriggerFireIdentity::new(
+            TenantId::new(TENANT).expect("tenant"), // safety: static test tenant id is valid.
+            TriggerId::new(),
+            chrono::Utc::now(),
+        ),
+        creator_user_id: user,
+        agent_id: Some(AgentId::new(AGENT).expect("agent")), // safety: static test agent id is valid.
+        project_id: None,
+        prompt: "scheduled result to this DM".to_string(),
+        delivery_target: Some(
+            ironclaw_triggers::TriggerDeliveryTargetId::new(target_id).expect("target id"),
+        ),
+    };
+    use crate::automation::trigger_poller::PostSubmitDeliveryHook as _;
+    hook.on_trigger_submitted(fire, run_id, scope).await;
+
+    for _ in 0..200 {
+        if delivery_store
+            .load_triggered_run_delivery(run_id)
+            .await
+            .expect("load outcome")
+            .is_some()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let record = delivery_store
+        .load_triggered_run_delivery(run_id)
+        .await
+        .expect("load outcome")
+        .expect("delivery outcome");
+    assert_eq!(
+        record.outcome,
+        ironclaw_outbound::TriggeredRunDeliveryOutcomeKind::Delivered
+    );
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 1, "one per-trigger result: {messages:?}");
+    assert_eq!(messages[0]["channel"], CHANNEL);
+    assert!(
+        messages[0]["text"]
+            .as_str()
+            .is_some_and(|text| text.starts_with("scheduled result")),
+        "final result reaches the selected target: {messages:?}"
     );
 }
 // arch-exempt: large_file, channel host end-to-end coverage remains centralized, plan #6175

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_identity.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_identity.rs
@@ -294,9 +294,11 @@ pub(crate) struct DiscoveredChannelExtension {
     pub(crate) providers: Vec<String>,
 }
 
-/// Installed extensions whose manifest declares a channel surface and at
-/// least one auth vendor, excluding `overridden` extension ids (their lane
-/// owns identity binding).
+/// Installed extensions whose manifest declares a channel surface, excluding
+/// `overridden` extension ids (their lane owns identity binding). OAuth
+/// channels expose one or more auth vendors; proof-code paired channels expose
+/// none but must still be discoverable by the generic connection facade so
+/// removal can revoke their pairing-owned state.
 pub(crate) async fn discover_channel_extensions(
     installation_store: &Arc<dyn ExtensionInstallationStore>,
     overridden: &BTreeSet<String>,
@@ -308,7 +310,7 @@ pub(crate) async fn discover_channel_extensions(
     let mut discovered = Vec::new();
     for record in manifests {
         let resolved = record.resolved();
-        if resolved.channel.is_none() || resolved.auth.is_empty() {
+        if resolved.channel.is_none() {
             continue;
         }
         let extension_id = resolved.id.as_str().to_string();

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_triggered_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_triggered_delivery.rs
@@ -2,12 +2,12 @@
 //! (extension-runtime §5.4, P6 c-rest).
 //!
 //! One composition-owned [`PostSubmitDeliveryHook`] serves every channel
-//! extension: on a settled trigger fire it reads the creator's personal
-//! communication preference, routes the stored reply-target binding ref to
-//! the extension whose registered [`PreferenceTargetCodec`] decodes it, and
-//! drives that extension's generic [`TriggeredRunDeliveryDriver`]. The
-//! single poller hook slot stays — multiplexing happens inside this hook,
-//! by extension id.
+//! extension: on a settled trigger fire it resolves the fire's optional
+//! creator-owned target id, otherwise reads the creator's personal
+//! communication preference, routes that reply-target binding ref to the
+//! extension whose registered [`PreferenceTargetCodec`] decodes it, and drives
+//! that extension's generic [`TriggeredRunDeliveryDriver`]. The single poller
+//! hook slot stays — multiplexing happens inside this hook, by extension id.
 //!
 //! Fail-closed routing: with no stored preference the fire routes to the
 //! only active codec-bearing channel extension when exactly one exists (its
@@ -23,14 +23,15 @@ use ironclaw_outbound::{
     TriggeredRunDeliveryOutcomeKind, TriggeredRunDeliveryRecord, TriggeredRunDeliveryStore,
 };
 use ironclaw_product_workflow::{
-    PreferenceTargetCodec, TriggeredRunDeliveryDriver, TriggeredRunDeliveryRequest,
-    triggered_run_delivery_settings,
+    PreferenceTargetCodec, RebornOutboundDeliveryTargetId, TriggeredRunDeliveryDriver,
+    TriggeredRunDeliveryRequest, WebUiAuthenticatedCaller, triggered_run_delivery_settings,
 };
 use ironclaw_triggers::TriggerFire;
 use ironclaw_turns::{ReplyTargetBindingRef, TurnRunId, TurnScope};
 
 use crate::automation::trigger_poller::PostSubmitDeliveryHook;
 use crate::extension_host::channel_host::GenericChannelHostAssembly;
+use crate::outbound::{MutableOutboundDeliveryTargetRegistry, OutboundDeliveryTargetProvider};
 
 /// The generic post-submit delivery hook: routes each settled trigger fire
 /// to the owning extension's triggered-delivery driver.
@@ -38,6 +39,7 @@ pub(crate) struct GenericTriggeredRunDeliveryHook {
     assembly: Arc<GenericChannelHostAssembly>,
     delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
     preferences: Arc<dyn CommunicationPreferenceRepository>,
+    delivery_targets: Arc<MutableOutboundDeliveryTargetRegistry>,
     drivers: tokio::sync::Mutex<HashMap<String, Arc<TriggeredRunDeliveryDriver>>>,
 }
 
@@ -46,11 +48,13 @@ impl GenericTriggeredRunDeliveryHook {
         assembly: Arc<GenericChannelHostAssembly>,
         delivery_store: Arc<dyn TriggeredRunDeliveryStore>,
         preferences: Arc<dyn CommunicationPreferenceRepository>,
+        delivery_targets: Arc<MutableOutboundDeliveryTargetRegistry>,
     ) -> Self {
         Self {
             assembly,
             delivery_store,
             preferences,
+            delivery_targets,
             drivers: tokio::sync::Mutex::new(HashMap::new()),
         }
     }
@@ -64,12 +68,17 @@ impl GenericTriggeredRunDeliveryHook {
         &self,
         scope: &TurnScope,
         creator: &ironclaw_host_api::UserId,
+        per_trigger_target: Option<&ReplyTargetBindingRef>,
     ) -> Result<(String, Arc<dyn PreferenceTargetCodec>), String> {
         let codecs = self.assembly.active_preference_codecs();
         if codecs.is_empty() {
             return Err("no active channel extension registered a preference codec".to_string());
         }
-        if let Some(target) = self.stored_preference_target(scope, creator).await? {
+        let target = match per_trigger_target {
+            Some(target) => Some(target.clone()),
+            None => self.stored_preference_target(scope, creator).await?,
+        };
+        if let Some(target) = target {
             for (extension_id, codec) in &codecs {
                 if codec.conversation_for_target(&target).is_some() {
                     return Ok((extension_id.clone(), Arc::clone(codec)));
@@ -89,6 +98,37 @@ impl GenericTriggeredRunDeliveryHook {
              delivery routing is ambiguous"
                 .to_string(),
         )
+    }
+
+    /// Resolve the fire's durable opaque target id at fire time through the
+    /// same creator-scoped registry used at trigger creation. This both turns
+    /// the public id into a transport binding and revalidates ownership and
+    /// current availability after any intervening channel disconnect/remove.
+    async fn resolve_per_trigger_target(
+        &self,
+        fire: &TriggerFire,
+        scope: &TurnScope,
+    ) -> Result<Option<ReplyTargetBindingRef>, String> {
+        let Some(target) = fire.delivery_target.as_ref() else {
+            return Ok(None);
+        };
+        let target_id = RebornOutboundDeliveryTargetId::new(target.as_str())
+            .map_err(|error| format!("invalid per-trigger delivery target id: {error}"))?;
+        let caller = WebUiAuthenticatedCaller::new(
+            scope.tenant_id.clone(),
+            fire.creator_user_id.clone(),
+            fire.agent_id.clone(),
+            fire.project_id.clone(),
+        );
+        let entry = self
+            .delivery_targets
+            .resolve_outbound_delivery_target(&caller, &target_id)
+            .await
+            .map_err(|error| format!("per-trigger delivery target lookup failed: {error}"))?
+            .ok_or_else(|| {
+                "per-trigger delivery target is no longer available to its creator".to_string()
+            })?;
+        Ok(Some(entry.reply_target_binding_ref))
     }
 
     /// The creator's first configured personal preference target, in
@@ -180,7 +220,22 @@ impl PostSubmitDeliveryHook for GenericTriggeredRunDeliveryHook {
                 return;
             }
         };
-        let (extension_id, codec) = match self.route_extension(&scope, &fire.creator_user_id).await
+        let delivery_target = match self.resolve_per_trigger_target(&fire, &scope).await {
+            Ok(target) => target,
+            Err(reason) => {
+                tracing::warn!(
+                    target = "ironclaw::reborn::channel_triggered_delivery",
+                    %run_id,
+                    %reason,
+                    "triggered run delivery skipped: per-trigger target could not be resolved"
+                );
+                self.record_failed(run_id).await;
+                return;
+            }
+        };
+        let (extension_id, codec) = match self
+            .route_extension(&scope, &fire.creator_user_id, delivery_target.as_ref())
+            .await
         {
             Ok(routed) => routed,
             Err(reason) => {
@@ -215,6 +270,7 @@ impl PostSubmitDeliveryHook for GenericTriggeredRunDeliveryHook {
                 creator_user_id: fire.creator_user_id.clone(),
                 project_scoped: fire.project_id.is_some(),
                 prompt: fire.prompt.clone(),
+                delivery_target,
                 trigger_context,
             })
             .await;

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_ingress.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_ingress.rs
@@ -634,10 +634,7 @@ pub(crate) fn build_extension_ingress(
     }
 }
 
-pub use serve_mount::{
-    EXTENSION_INGRESS_ROUTE_PATTERN, extension_ingress_alias_route_mount,
-    extension_ingress_route_mount, forward_alias_request,
-};
+pub use serve_mount::{EXTENSION_INGRESS_ROUTE_PATTERN, extension_ingress_route_mount};
 
 mod serve_mount {
     use std::num::{NonZeroU32, NonZeroU64};
@@ -739,26 +736,6 @@ mod serve_mount {
         })
     }
 
-    /// Build a fixed-path compatibility alias over the same generic router and
-    /// public-webhook policy as the canonical manifest route.
-    pub fn extension_ingress_alias_route_mount(
-        parts: &ExtensionIngressParts,
-        route_id: &'static str,
-        legacy_path: &'static str,
-        extension_id: &'static str,
-        route_suffix: &'static str,
-    ) -> Result<PublicRouteMount, crate::RebornBuildError> {
-        let descriptor = ingress_route_descriptor(route_id, legacy_path)?;
-        let router = Router::new()
-            .route(legacy_path, post(alias_handler))
-            .with_state(AliasState {
-                router: Arc::clone(&parts.router),
-                extension_id,
-                route_suffix,
-            });
-        Ok(PublicRouteMount::new(router, vec![descriptor]))
-    }
-
     struct RegistryDrain {
         registry: Arc<ExtensionIngressRegistry>,
     }
@@ -781,49 +758,6 @@ mod serve_mount {
                 extension_id,
                 route_suffix,
                 &headers,
-                body,
-            ))
-            .await;
-        into_axum_response(response)
-    }
-
-    #[derive(Clone)]
-    struct AliasState {
-        router: Arc<ExtensionIngressRouter>,
-        extension_id: &'static str,
-        route_suffix: &'static str,
-    }
-
-    async fn alias_handler(
-        State(state): State<AliasState>,
-        headers: HeaderMap,
-        body: Bytes,
-    ) -> Response {
-        forward_alias_request(
-            &state.router,
-            state.extension_id,
-            state.route_suffix,
-            &headers,
-            body,
-        )
-        .await
-    }
-
-    /// Drive the generic router for a legacy fixed-path alias
-    /// (one-release forwarding shims, migration MIG-5).
-    pub async fn forward_alias_request(
-        router: &ExtensionIngressRouter,
-        extension_id: &str,
-        route_suffix: &str,
-        headers: &HeaderMap,
-        body: Bytes,
-    ) -> Response {
-        let response = router
-            .handle(ingress_request(
-                "POST",
-                extension_id.to_string(),
-                route_suffix.to_string(),
-                headers,
                 body,
             ))
             .await;

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -158,11 +158,11 @@ pub(crate) struct RebornLocalExtensionManagementPort {
     /// Late-binding slot for the generic per-user channel-connection facade
     /// (extension-runtime §6.4), shared with
     /// `RebornLocalRuntimeServices::channel_disconnect_slot`. Removing
-    /// an extension whose manifest declares a channel surface backed by an
-    /// auth vendor disconnects the authenticated caller through it (revoke
-    /// personal vendor credential → vendor cleanup → delete identity
-    /// bindings) at this single convergence point, so `builtin.extension_remove`
-    /// and the WebUI remove route cannot drift apart (issue #6091 shape).
+    /// an extension whose manifest declares a channel surface disconnects the
+    /// authenticated caller through it (revoke any personal vendor credential
+    /// → vendor/pairing cleanup → delete identity bindings) at this single
+    /// convergence point, so `builtin.extension_remove` and the WebUI remove
+    /// route cannot drift apart (issue #6091 shape).
     /// Fail-closed contract: removing such an extension with an authenticated
     /// actor while the slot is still empty FAILS the removal with a typed
     /// retryable error instead of skipping the disconnect — an unobservable
@@ -1698,14 +1698,15 @@ impl RebornLocalExtensionManagementPort {
             let removed_providers =
                 Self::removed_extension_providers_from_manifest(&removal_manifest)?;
             let cleanup_requirements = removal_manifest.removal_cleanup_requirements().to_vec();
-            // §6.4: a channel surface backed by an auth vendor holds
-            // per-caller identity bindings; removal runs the real per-caller
-            // disconnect (below) while the installation still exists. Same
-            // predicate the generic facade's discovery uses
-            // (`discover_channel_extensions`).
+            // §6.4: every channel surface can hold per-caller connection state.
+            // OAuth channels own vendor credentials/identity bindings, while
+            // proof-code channels own pairing records, identity bindings, DM
+            // targets, and conversation-actor bindings. Removal runs the real
+            // per-caller disconnect below while the installation still exists.
+            // The generic facade discovers the same manifest-derived set.
             let removes_connectable_channel = {
                 let resolved = removal_manifest.resolved();
-                resolved.channel.is_some() && !resolved.auth.is_empty()
+                resolved.channel.is_some()
             };
             // Deliberately validate cleanup actors only after caller
             // authorization and manifest/provider preflight. Hoisting this
@@ -1749,10 +1750,10 @@ impl RebornLocalExtensionManagementPort {
             // retryable, mirroring the credential cleanup below.
             if removes_connectable_channel && let Some(actor_user_id) = authenticated_actor_user_id
             {
-                // Fail closed on an empty slot: a channel surface backed by
-                // an auth vendor may hold per-caller identity bindings, and a
-                // composition that gives this path no facade to disconnect
-                // them through must not report the removal as successful.
+                // Fail closed on an empty slot: a channel surface may hold
+                // per-caller OAuth or pairing state, and a composition that
+                // gives this path no facade to disconnect it through must not
+                // report the removal as successful.
                 // Surface the same typed retryable error a failing disconnect
                 // does; compositions that legitimately remove channel
                 // extensions fill the slot (runtime composition in
@@ -4189,6 +4190,77 @@ team_id = "/team/id"
         )
     }
 
+    /// A channel-only v3 fixture mirroring Telegram's manifest shape: the
+    /// user's connection is owned by proof-code pairing, so there is no
+    /// `[auth.*]` vendor even though removal must still disconnect the caller.
+    fn fixture_pairing_channel_package() -> AvailableExtensionPackage {
+        let manifest_toml = r#"
+schema_version = "reborn.extension_manifest.v3"
+id = "pairchat"
+name = "PairChat"
+version = "0.1.0"
+description = "proof-code paired channel removal fixture"
+trust = "first_party_requested"
+
+[runtime]
+kind = "first_party"
+service = "pairchat.extension/v1"
+
+[channel]
+id = "messages"
+display_name = "PairChat messages"
+inbound = true
+outbound = true
+conversation_model = "continuous"
+
+[channel.ingress]
+route_suffix = "updates"
+method = "post"
+body_limit_bytes = 1048576
+
+[channel.ingress.verification]
+kind = "shared_secret_header"
+secret_handle = "pairchat_webhook_secret"
+header = "X-PairChat-Secret"
+
+[channel.config]
+fields = [
+  { handle = "pairchat_bot_token", label = "Bot token", secret = true },
+  { handle = "pairchat_webhook_secret", label = "Webhook secret", secret = true },
+]
+
+[[channel.egress]]
+scheme = "https"
+host = "api.pairchat.example"
+methods = ["post"]
+credential_handle = "pairchat_bot_token"
+injection = { type = "header", name = "authorization", prefix = "Bearer " }
+
+[channel.presentation]
+supports_markdown = false
+supports_threads = true
+"#;
+        let record = ExtensionManifestRecord::from_toml(
+            manifest_toml,
+            ManifestSource::HostBundled,
+            &ironclaw_host_runtime::default_host_port_catalog().expect("host port catalog"),
+            None,
+            &product_extension_host_api_contract_registry().expect("host API contracts"),
+        )
+        .expect("pairing channel fixture manifest");
+        let manifest: ExtensionManifest = record
+            .manifest()
+            .clone()
+            .try_into()
+            .expect("pairing channel fixture manifest lowers to a package manifest");
+        fixture_extension_package_from_parsed_manifest(
+            manifest_toml,
+            "pairchat",
+            manifest,
+            Arc::new(record.resolved().clone()),
+        )
+    }
+
     /// Recording double for the §6.4 per-caller disconnect the removal path
     /// dispatches through the late-bound facade slot. `fail_next(n)` scripts
     /// the next `n` disconnects to fail so retry convergence can be pinned.
@@ -4352,6 +4424,61 @@ team_id = "/team/id"
                 .expect("installation lookup")
                 .is_some(),
             "fail-closed removal must keep the installation for a retry"
+        );
+    }
+
+    /// Channel removal cleanup is keyed by the manifest's channel surface,
+    /// not by OAuth. Proof-code paired channels hold the same caller-owned
+    /// identity and conversation bindings and must cross the shared
+    /// disconnect boundary before their installation row is deleted.
+    #[tokio::test]
+    async fn extension_remove_of_pairing_channel_disconnects_the_caller() {
+        let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "pairchat")
+            .expect("valid ref");
+        let channel_connection = Arc::new(RecordingChannelConnectionFacade::default());
+        let slot: Arc<std::sync::OnceLock<Arc<dyn ChannelConnectionFacade>>> =
+            Arc::new(std::sync::OnceLock::new());
+        slot.set(channel_connection.clone() as Arc<dyn ChannelConnectionFacade>)
+            .ok();
+        let (_dir, _storage_root, facade, _active_registry, installation_store) =
+            extension_lifecycle_fixture_with_all_cleanup(
+                AvailableExtensionCatalog::from_packages(vec![fixture_pairing_channel_package()]),
+                ExtensionLifecycleService::new(ExtensionRegistry::new()),
+                None,
+                Arc::new(ExtensionRemovalCleanupRegistry::empty()),
+                Some(slot),
+            );
+
+        facade
+            .execute(
+                lifecycle_surface_context_for_user("alice"),
+                LifecycleProductAction::ExtensionInstall {
+                    package_ref: package_ref.clone(),
+                },
+            )
+            .await
+            .expect("alice installs pairchat");
+        facade
+            .execute(
+                lifecycle_surface_context_for_user("alice"),
+                LifecycleProductAction::ExtensionRemove { package_ref },
+            )
+            .await
+            .expect("alice removes pairchat");
+
+        let disconnects = channel_connection.disconnects();
+        assert_eq!(disconnects.len(), 1, "removal runs exactly one disconnect");
+        assert_eq!(disconnects[0].1, "pairchat");
+        assert_eq!(disconnects[0].0.user_id.as_str(), "alice");
+        assert!(
+            installation_store
+                .get_installation(
+                    &ExtensionInstallationId::new("pairchat").expect("valid installation id")
+                )
+                .await
+                .expect("installation lookup")
+                .is_none(),
+            "the installation is deleted only after disconnect succeeds"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/hosted_mcp_test_support.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle/hosted_mcp_test_support.rs
@@ -170,6 +170,7 @@ fn runtime_json_response(
 /// JSON-RPC call carried an `authorization` header on the wire.
 pub(crate) struct HostedMcpDiscoveryNetworkScript {
     tool_name: String,
+    tool_description: String,
     authorized_methods: std::sync::Mutex<Vec<(String, bool)>>,
 }
 
@@ -177,8 +178,14 @@ impl HostedMcpDiscoveryNetworkScript {
     pub(crate) fn with_tool_name(tool_name: &str) -> Self {
         Self {
             tool_name: tool_name.to_string(),
+            tool_description: format!("Scripted hosted MCP tool {tool_name}"),
             authorized_methods: std::sync::Mutex::new(Vec::new()),
         }
+    }
+
+    pub(crate) fn with_tool_description(mut self, tool_description: impl Into<String>) -> Self {
+        self.tool_description = tool_description.into();
+        self
     }
 
     /// `(json_rpc_method, authorization_header_present)` per call, in order.
@@ -226,7 +233,7 @@ impl ironclaw_network::NetworkHttpEgress for HostedMcpDiscoveryNetworkScript {
             "tools/list" => serde_json::json!({
                 "tools": [{
                     "name": self.tool_name,
-                    "description": format!("Scripted hosted MCP tool {}", self.tool_name),
+                    "description": self.tool_description,
                     "inputSchema": {
                         "type": "object",
                         "properties": {"query": {"type": "string"}},

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
@@ -1350,7 +1350,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let storage_root = dir.path().join("local-dev");
         let discovery_script = std::sync::Arc::new(
-            crate::extension_host::extension_lifecycle::hosted_mcp_test_support::HostedMcpDiscoveryNetworkScript::with_tool_name("notion-search"),
+            crate::extension_host::extension_lifecycle::hosted_mcp_test_support::HostedMcpDiscoveryNetworkScript::with_tool_name("notion-search")
+                // Real hosted MCP providers may return verbose prose. The
+                // generic MCP boundary must bound it without dropping the
+                // entire catalog or preventing activation.
+                .with_tool_description("provider documentation ".repeat(320)),
         );
         let services = build_reborn_services(
             RebornBuildInput::local_dev("extension-tools-hosted-mcp-owner", storage_root.clone())

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1409,8 +1409,8 @@ pub(crate) struct RebornRuntimeSubstrate {
     /// `RebornRuntime::generic_channel_connection_facade`) or by the
     /// channel-connection test bundle over a services-only harness.
     /// Fail-closed contract: a composition that leaves the slot empty cannot
-    /// remove a channel+auth extension — the removal path surfaces a typed
-    /// retryable error instead of skipping the per-caller disconnect (see
+    /// remove a channel extension — the removal path surfaces a typed
+    /// retryable error instead of skipping OAuth or pairing cleanup (see
     /// `RebornLocalExtensionManagementPort::channel_disconnect_slot`).
     pub(crate) channel_disconnect_slot:
         Arc<std::sync::OnceLock<Arc<dyn ironclaw_product_workflow::ChannelConnectionFacade>>>,
@@ -2270,9 +2270,10 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         .with_account_setup_registry(account_setups.clone())
         .with_removal_cleanup_registry(removal_cleanup)
         .with_provider_instance_readiness(provider_instance_readiness)
-        // Removal of a channel+auth extension disconnects the caller through
-        // the facade this late-bound slot carries once composition (runtime
-        // build or the channel-connection test bundle) fills it.
+        // Removal of any channel extension disconnects the caller through the
+        // facade this late-bound slot carries once composition (runtime build
+        // or the channel-connection test bundle) fills it. The facade chooses
+        // OAuth cleanup or proof-code unpairing from its generic registries.
         .with_channel_disconnect_slot(Arc::clone(
             &store_graph.local_runtime.channel_disconnect_slot,
         )),

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -71,8 +71,7 @@ pub use extension_host::extension_ingress::{
     InboundPayloadClassifier, PostAdmissionObserver, StaticIngressSecrets, VerifiedEvidenceMint,
 };
 pub use extension_host::extension_ingress::{
-    EXTENSION_INGRESS_ROUTE_PATTERN, extension_ingress_alias_route_mount,
-    extension_ingress_route_mount, forward_alias_request,
+    EXTENSION_INGRESS_ROUTE_PATTERN, extension_ingress_route_mount,
 };
 pub use extension_host::extension_lifecycle_command::{
     RebornExtensionLifecycleCommand, RebornExtensionLifecycleCommandError,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -4105,6 +4105,7 @@ pub async fn build_reborn_runtime(
                 Arc::clone(assembly),
                 Arc::clone(&local_runtime.triggered_run_delivery),
                 Arc::clone(&local_runtime.outbound_preferences),
+                Arc::clone(&local_runtime.outbound_delivery_targets),
             ),
         );
         if slot.set(generic_trigger_hook).is_err() {

--- a/docs/plans/composition-pubuse.snapshot
+++ b/docs/plans/composition-pubuse.snapshot
@@ -12,8 +12,7 @@ pub use extension_host::extension_ingress::{
     InboundPayloadClassifier, PostAdmissionObserver, StaticIngressSecrets, VerifiedEvidenceMint,
 };
 pub use extension_host::extension_ingress::{
-    EXTENSION_INGRESS_ROUTE_PATTERN, extension_ingress_alias_route_mount,
-    extension_ingress_route_mount, forward_alias_request,
+    EXTENSION_INGRESS_ROUTE_PATTERN, extension_ingress_route_mount,
 };
 pub use extension_host::extension_lifecycle_command::{
     RebornExtensionLifecycleCommand, RebornExtensionLifecycleCommandError,

--- a/docs/reborn/contracts/communication-delivery-resolution.md
+++ b/docs/reborn/contracts/communication-delivery-resolution.md
@@ -131,6 +131,10 @@ pub struct RunNotificationContext {
 pub enum RunNotificationOrigin {
     LiveSourceRoute { source_route: SourceRouteContext },
     Triggered { trigger: TriggerCommunicationContext },
+    TriggeredWithTarget {
+        trigger: TriggerCommunicationContext,
+        target: ReplyTargetBindingRef,
+    },
     TriggeredFromSourceRoute {
         trigger: TriggerCommunicationContext,
         source_route: SourceRouteContext,
@@ -140,10 +144,15 @@ pub enum RunNotificationOrigin {
 ```
 
 `SourceRouteContext` carries the validated reply target for a live inbound
-conversation. `TriggerCommunicationContext` identifies the trigger fire without
-turning that trigger into a communication destination. The trigger reference is
-an outbound-local correlation value; the canonical trigger identity belongs to
-the future `ironclaw_triggers::TriggerId` in PR 9.
+conversation. `TriggeredWithTarget` carries the creator-owned binding resolved
+at fire time from the trigger's durable opaque target id; it routes ordinary
+results without changing the creator's global default. Approval and auth prompts
+continue to use their dedicated preference fields, so an ordinary delivery
+target cannot select an authority-bearing prompt destination.
+`TriggerCommunicationContext` identifies the trigger fire without turning that
+trigger into a communication destination. The trigger reference is an
+outbound-local correlation value; the canonical trigger identity belongs to the
+future `ironclaw_triggers::TriggerId` in PR 9.
 
 `SystemEventReasonCode` is a stable, redacted enum/code. Human-readable backend
 details, raw tool input, prompt material, OAuth state, approval payloads, and

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -144,6 +144,7 @@ TriggerFire {
     agent_id,
     project_id,
     prompt,
+    delivery_target,
 }
 ```
 
@@ -483,16 +484,25 @@ the outbound delivery track. Product-facing outbound preference APIs and
 explicit provider-backed target tooling own discovery and approval-gated
 selection. Local-dev Reborn exposes model-visible outbound target
 discovery/selection capabilities that write the caller's final-reply
-preference. When a user asks to send routine or trigger results through a
-delivery product/channel, model-visible trigger surfaces must steer the model to
-discover and select an outbound delivery target before calling
-`trigger_create`; durable selection remains product-owned and trigger records
-still do not embed delivery targets.
+preference. A trigger may also persist an optional opaque `delivery_target` id
+selected from that creator-scoped registry; the fire carries the id without
+placing it in `TriggerFireIdentity`. At fire time, composition re-resolves the
+id for the creator, obtains the current typed reply-target binding, and sends
+ordinary results through the outbound delivery-resolution path. Missing,
+foreign, disconnected, or removed targets fail closed. Triggers without an
+explicit target retain the user-wide preference fallback.
+
+When a user asks to send routine or trigger results through a delivery
+product/channel, model-visible trigger surfaces must steer the model to discover
+and select an outbound delivery target before calling `trigger_create`.
 
 - Trigger ingress identity must not include delivery targets.
 - Trigger record identity must not include delivery targets.
 - Trigger fire identity must not include delivery targets.
-- When delivery is added, it must flow through the delivery-resolution/outbound contract track, not through trigger ingress identity.
+- A trigger record and fire may carry the optional opaque target id outside
+  their identity fields.
+- Delivery flows through the delivery-resolution/outbound contract track, not
+  through trigger ingress identity.
 
 V1 acceptance does not require external delivery. A valid V1 trigger fire is one that submits a cron-backed synthetic inbound turn and persists through the normal Reborn turn path.
 

--- a/docs/reborn/extension-runtime/checklist.md
+++ b/docs/reborn/extension-runtime/checklist.md
@@ -1038,7 +1038,7 @@ Rules — kept short on purpose:
   setup POST → real product-auth OAuth connect against the fake vendor
   through the loopback-only rewrite seam → credential-gated activation →
   v0-signed inbound DM on the canonical generic route → coordinated
-  reply on `chat.postMessage` (+ the MIG-5 alias round trip) → remove
+  reply on `chat.postMessage` (while proving the retired MIG-5 alias is 404) → remove
   (no further admission, no further delivery). Green on the standard
   `webui-v2-beta` binary.
 
@@ -1086,15 +1086,11 @@ Rules — kept short on purpose:
   durable Enabled → an Active record in the first published generation
   (snapshot presence + capability resolves); durable Disabled → inactive
   after restart.
-- [x] MIG-5 `/webhooks/slack/events` forwards to the canonical route for one
-  release; a removal note names the release that deletes it. — The legacy
-  path is an internal forwarding alias into the generic router, homed in the
-  sanctioned compatibility table
-  (`composition/src/extension_host/legacy_ingress_aliases.rs`; the whole
-  ported `extension_host/channel_host/e2e_tests.rs` suite posts to it).
-  REMOVAL NOTE: delete the slack alias entry (and the module when the table
-  empties) in the first release after the P4 cutover ships; vendors
-  reconfigure their Events URL to `/webhooks/extensions/slack/events`.
+- [x] MIG-5 `/webhooks/slack/events` forwarded to the canonical route for the
+  cutover release and is now retired. The whole-path Slack E2E pins the legacy
+  path at 404 while the canonical
+  `/webhooks/extensions/slack/events` route remains live. Operators must use
+  the canonical Events URL.
 - [x] MIG-6 OAuth callback URLs are unchanged (no vendor reconfiguration
   needed) — verified by the route tests. — The
   `/api/reborn/product-auth/oauth/{provider}/callback` shape is unchanged

--- a/docs/reborn/extension-runtime/implementation.md
+++ b/docs/reborn/extension-runtime/implementation.md
@@ -461,9 +461,10 @@ possible.
    keys / installation config. After migration no `slack`-named state root is
    read outside migration code.
 5. **Installation lifecycle records** → standard state enum backfill.
-6. **Webhook URL:** `/webhooks/slack/events` becomes a forwarding alias to
-   `/webhooks/extensions/slack/events` for **one release**, then is deleted.
-   OAuth callback paths are unchanged — no vendor reconfiguration.
+6. **Webhook URL:** `/webhooks/slack/events` forwarded to
+   `/webhooks/extensions/slack/events` for the cutover release and is now
+   deleted. OAuth callback paths remain on the generic product-auth route;
+   operators must configure the canonical Events URL.
 7. **First-party manifests:** rewrite all 11 packages v2 → v3 in one PR, with
    a projection-equality test (derived surfaces, capability ids, scopes,
    credentials identical before/after) — plus the new explicit `[auth.*]` and

--- a/docs/reborn/setup-slack-for-reborn-binary.md
+++ b/docs/reborn/setup-slack-for-reborn-binary.md
@@ -37,7 +37,7 @@ Slack is disabled unless the mounted or seeded Reborn config enables it.
 Slack Events API must reach the Reborn listener over a public HTTPS URL:
 
 ```text
-https://<public-host>/webhooks/slack/events
+https://<public-host>/webhooks/extensions/slack/events
 ```
 
 Slack personal OAuth must also redirect back to the Reborn product-auth
@@ -106,7 +106,7 @@ enabled = true
 overrides only the route enablement gate: `true`/`1` mounts Slack, while
 `false`/`0` acts as a deployment kill switch.
 
-Slack enablement mounts `POST /webhooks/slack/events`, exposes Slack channel
+Slack enablement mounts `POST /webhooks/extensions/slack/events`, exposes Slack channel
 setup in WebUI, and makes personal Slack connection available through the Slack
 extension's OAuth configuration flow.
 Slack installation ids, team/app ids, the bot token, the signing secret,
@@ -168,7 +168,7 @@ Event Subscriptions:
 - Set Request URL to:
 
 ```text
-https://<public-host>/webhooks/slack/events
+https://<public-host>/webhooks/extensions/slack/events
 ```
 
 - Subscribe to bot events:
@@ -213,7 +213,7 @@ oauth_config:
       - users:read
 settings:
   event_subscriptions:
-    request_url: https://<public-host>/webhooks/slack/events
+    request_url: https://<public-host>/webhooks/extensions/slack/events
     bot_events:
       - app_mention
       - message.im
@@ -252,7 +252,7 @@ docker run --rm \
 Verification checklist:
 
 - Slack Event Subscriptions shows the Request URL as verified.
-- `POST /webhooks/slack/events` returns the Slack URL-verification challenge
+- `POST /webhooks/extensions/slack/events` returns the Slack URL-verification challenge
   during setup.
 - After the user installs and configures the Slack extension, the OAuth callback
   binds that Slack user to the authenticated Reborn user.
@@ -268,7 +268,7 @@ Confirm the Reborn config sets [slack].enabled = true, or that the deployment en
 
 ### Slack route never receives events
 
-Confirm the Slack Request URL is exactly https://<public-host>/webhooks/slack/events, the public URL reaches the Reborn listener, and Socket Mode is disabled for this host path.
+Confirm the Slack Request URL is exactly https://<public-host>/webhooks/extensions/slack/events, the public URL reaches the Reborn listener, and Socket Mode is disabled for this host path.
 
 ### Slack URL verification fails
 

--- a/tests/e2e/scenarios/test_reborn_slack_channel_e2e.py
+++ b/tests/e2e/scenarios/test_reborn_slack_channel_e2e.py
@@ -22,8 +22,8 @@ lane routes (`/api/webchat/v2/channels/slack/*`):
                `/webhooks/extensions/slack/events` admits a real turn.
   reply out  — the coordinated reply reaches `chat.postMessage` on the fake
                Slack API (`/__mock/sent_messages`), via the delivery
-               coordinator and host-side credential injection. The MIG-5
-               legacy alias `/webhooks/slack/events` round-trips too.
+               coordinator and host-side credential injection. The retired
+               `/webhooks/slack/events` compatibility alias stays unmounted.
   remove     — after `/api/webchat/v2/extensions/slack/remove`, deployment
                ingress remains live, the user's personal connection is gone,
                and a subsequent DM gets the static connect notice without a
@@ -65,7 +65,7 @@ TEAM_ID = "T0001"
 DM_CHANNEL = f"D{OWNER_USER_ID}"
 
 CANONICAL_EVENTS_PATH = "/webhooks/extensions/slack/events"
-ALIAS_EVENTS_PATH = "/webhooks/slack/events"
+RETIRED_EVENTS_PATH = "/webhooks/slack/events"
 
 
 @pytest.fixture(scope="module")
@@ -388,16 +388,15 @@ async def test_reborn_slack_channel_configure_connect_roundtrip_remove(
         replies = await wait_for_final_replies(client, fake_slack_server, 1)
         assert replies[0]["channel"] == DM_CHANNEL, replies
 
-        # ── MIG-5 alias: the legacy path forwards into the same router ──
-        alias_inbound = await post_signed_event(
+        # ── retired compatibility alias: only the manifest route remains ──
+        retired_inbound = await post_signed_event(
             client,
             base_url,
-            ALIAS_EVENTS_PATH,
-            dm_event("Ev-alias-dm", "hello via the alias path"),
+            RETIRED_EVENTS_PATH,
+            dm_event("Ev-retired-path", "this route must stay retired"),
         )
-        assert alias_inbound.status_code == 200, alias_inbound.text
-        replies = await wait_for_final_replies(client, fake_slack_server, 2)
-        assert replies[1]["channel"] == DM_CHANNEL, replies
+        assert retired_inbound.status_code == 404, retired_inbound.text
+        assert len(await wait_for_final_replies(client, fake_slack_server, 1)) == 1
 
         # ── remove: personal state clears; deployment ingress remains ──
         remove = await client.post(
@@ -416,6 +415,6 @@ async def test_reborn_slack_channel_configure_connect_roundtrip_remove(
             client, fake_slack_server, "connect it in the Ironclaw web app", 2
         )
         final_messages = await fake_sent_messages(client, fake_slack_server)
-        assert len(final_replies(final_messages)) == 2, (
+        assert len(final_replies(final_messages)) == 1, (
             f"no model reply may be delivered after removal: {final_messages}"
         )


### PR DESCRIPTION
## Summary

- Keep hosted MCP catalogs usable when a provider returns valid but oversized descriptive metadata, while continuing to reject unsafe names, schemas, and control characters.
- Standardize channel delivery and removal: long-running turns retain their watcher, per-trigger targets are honored, and every channel removal revokes the caller's OAuth or pairing state before deleting the installation.
- Retire the legacy Slack `/webhooks/slack/events` alias; the manifest-derived `/webhooks/extensions/slack/events` route remains canonical and the generic OAuth callback is unchanged.
- Add caller-level regressions for the MCP handshake, pairing-only removal, per-trigger delivery, delayed final replies, and the canonical Slack ingress route.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6116

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo build` — not run separately; the complete package tests, Reborn E2E gate, and workspace clippy compiled all affected targets.
- [x] Relevant tests pass: MCP, outbound, product-workflow, composition, CLI, architecture, Slack channel E2E, and the complete deterministic Reborn E2E gate.
- [ ] `cargo test --features integration` — not applicable: no database schema or feature-gated database behavior changed; production-wired filesystem/composition contracts cover the modified persistence seams.
- [ ] Manual testing — pending deployment of this follow-up branch; deterministic whole-path tests are green.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not available in this harness; final diff, architecture ratchets, and safety gate were reviewed directly.

## Test Strategy

User behavior:

- A configured hosted MCP such as Notion activates even when its provider publishes long, valid tool descriptions.
- Slack and Telegram final replies are still delivered after runs exceed the old two-minute observer cutoff.
- An automation created for a specific chat posts back to that chat without requiring a mutable global default.
- Removing a channel from any user surface removes the caller's installation and caller-owned pairing/OAuth state, while preserving administrator bot configuration.
- The retired Slack webhook alias returns 404 and the canonical manifest-derived route continues to ingest events.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: UTF-8-safe MCP description bounding; explicit trigger-target resolution; delayed run observation; pairing-only channel discovery and removal cleanup.
- Reborn integration: real composition lifecycle, target registry, pairing registry, and triggered-delivery hooks are exercised through caller-facing facades.
- Recorded fixture: Not applicable: model tool selection and request shape did not change.
- Browser E2E: Not applicable: no frontend rendering or browser interaction changed.
- Backend or runtime: complete MCP initialize -> initialized -> tools/list exchange, full deterministic Reborn runtime gate, and Slack HTTP channel E2E.
- Live canary: [full exact-head run 29889454703](https://github.com/nearai/ironclaw/actions/runs/29889454703) is in progress against `8b613678a6faaf4923aa4f2458c01e535ae12a90`; trusted PR authorization and Google OAuth preflight passed.

What the tests prove:

- The fixes are manifest- and contract-driven rather than provider-specific. Pairing-only and OAuth channels converge through the same lifecycle removal path; hosted MCP behavior is shared by all HTTP MCP extensions; per-trigger routing is channel-neutral.
- Disconnect fails closed before installation deletion, and explicit per-trigger targets remain creator-scoped and are revalidated at fire time.
- Admin/deployment configuration is not deleted by a user's extension removal.

Commands run:

```text
cargo test -p ironclaw_mcp --no-fail-fast
cargo test -p ironclaw_outbound --no-fail-fast
cargo test -p ironclaw_product_workflow --no-fail-fast
cargo test -p ironclaw_reborn_composition --no-fail-fast
cargo test -p ironclaw --no-fail-fast
cargo test -p ironclaw_architecture --no-fail-fast
tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_reborn_slack_channel_e2e.py -q --tb=short
bash scripts/reborn-e2e-rust.sh
scripts/pre-commit-safety.sh
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
git diff --check
```

## Security Impact

Channel removal now revokes all caller-owned channel connection state, including proof-code pairing records that previously survived removal. OAuth prompt delivery remains constrained by the existing send-time personal-DM validation. No authentication, origin, rate-limit, network mediation, or secret boundary is weakened.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: `RunNotificationOrigin::TriggeredWithTarget` carries a typed binding reference only; the creator-scoped registry and existing authority validator revalidate the target before delivery.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable to new inputs; existing trigger prompt handling is unchanged.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable: no hashing changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. The new run-notification origin is handled in the shared resolution engine and serialization/resolution contracts.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. No durable schema or defaulted field was added.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Existing bounded delivery semaphores remain; the observer deadline is finite at 30 minutes.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Existing typed lifecycle and delivery classifications are preserved.
- [x] Sandbox/native/host names accurately describe trust boundary. No runtime lane or trust-boundary naming changed.

## Database Impact

None. No migration or schema change. Removal uses the existing generic stores and cleanup contracts for both libSQL and PostgreSQL-backed filesystem deployments.

## Blast Radius

Hosted HTTP MCP discovery, channel connection discovery/removal, run-notification resolution, triggered-run delivery, Slack ingress route registration, and their composition wiring. Triggers without an explicit target still use the user's global default. Administrator channel configuration is preserved.

## Rollback Plan

Revert commit `8b613678a`. If an operator still depends on the retired Slack alias, the alias-only route deletion can be reverted independently while keeping the generic lifecycle, MCP, and delivery fixes. No data migration is required.

## Review Follow-Through

The live canary result will be added after the exact branch run completes. Reviewer judgment is requested on the intentional compatibility break for the retired Slack webhook alias; all other changes preserve existing defaults and use shared manifest-driven paths.

---

**Review track**: C (runtime, persistence cleanup, and external-provider behavior)
