### PR TITLE
test(e2e): retry any transient 5xx cold-start in the legacy Responses smoke

### DIFF
--- a/tests/e2e/reborn_responses_e2e_tests.txt
+++ b/tests/e2e/reborn_responses_e2e_tests.txt
@@ -17,3 +17,12 @@ tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_reborn_le
 tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_reborn_legacy_responses_rejects_missing_auth
 tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_reborn_legacy_responses_rejects_empty_input_items
 tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_reborn_legacy_responses_rejects_empty_text_input
+# Mocked-client unit coverage for the shared `_create_response` retry helper
+# (no served binary needed; runs standalone in this lane). Pins the retry
+# contract the served tests above depend on: transient retry, non-transient
+# stop, attempt cap, single reused idempotency key, per-attempt budget bound.
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_create_response_retries_transient_then_succeeds
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_create_response_succeeds_without_retry_or_sleep
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_create_response_does_not_retry_non_transient_status
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_create_response_caps_attempts_without_trailing_sleep
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py::test_create_response_bounds_each_attempt_by_remaining_budget

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
@@ -1,9 +1,22 @@
 """Legacy Responses API coverage ported to standalone Reborn."""
 
 import asyncio
+import time
+import uuid
 
 import httpx
 import pytest
+
+# Retry statuses that indicate a transient/cold-start condition worth resending.
+# 429 = under load; 502/503/504 = the first request racing the backend/LLM
+# warm-up (a cold-start 503 flaked this smoke).
+_TRANSIENT_STATUSES = {429, 502, 503, 504}
+_MAX_ATTEMPTS = 6
+# Cap the WHOLE retry sequence well under the 120s E2E test timeout. Each attempt
+# is given only the remaining budget as its timeout, so even a hung backend
+# cannot blow past this deadline — the test fails fast instead of being killed by
+# the outer pytest timeout with a less useful error.
+_RETRY_DEADLINE_SECONDS = 100.0
 
 from reborn_webui_harness import (
     close_reborn_server,
@@ -54,25 +67,120 @@ def _response_output_text(response: dict) -> str:
 
 
 async def _create_response(client: httpx.AsyncClient, path="/v1/responses", **payload):
+    # One idempotency key per logical create, reused on every retry. A transient
+    # 5xx can be returned AFTER the Responses handler has already accepted the run,
+    # so a keyless resend would create a duplicate run; the Responses API dedupes
+    # on the `Idempotency-Key` header (see `create_response` → `idempotency_key_
+    # from_headers`), making the resend safe.
+    headers = {"Idempotency-Key": str(uuid.uuid4())}
     response = None
-    # Retry transient statuses: 429 under load, and 502/503/504 when the first
-    # request races the backend/LLM warm-up (a cold-start 503 was flaking this
-    # smoke). Any non-transient status breaks immediately.
-    transient_statuses = {429, 502, 503, 504}
-    attempts = 6
-    for attempt in range(attempts):
-        response = await client.post(path, json={"model": "default", **payload})
-        # Break on a non-transient status, or after the final attempt (no point
-        # sleeping when no further request will be made).
-        if response.status_code not in transient_statuses or attempt == attempts - 1:
+    deadline = time.monotonic() + _RETRY_DEADLINE_SECONDS
+    for attempt in range(_MAX_ATTEMPTS):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             break
-        await asyncio.sleep(1 + attempt * 0.5)
+        response = await client.post(
+            path,
+            json={"model": "default", **payload},
+            headers=headers,
+            timeout=remaining,
+        )
+        # Break on a non-transient status; retrying would not change the outcome.
+        if response.status_code not in _TRANSIENT_STATUSES:
+            break
+        # No point sleeping after the final attempt, or once the budget is spent.
+        backoff = 1 + attempt * 0.5
+        if attempt == _MAX_ATTEMPTS - 1 or time.monotonic() + backoff >= deadline:
+            break
+        await asyncio.sleep(backoff)
     assert response is not None
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["id"].startswith("resp_")
     assert body["object"] == "response"
     return body
+
+
+# --- `_create_response` retry-semantics unit coverage (mocked client) ----------
+# These exercise the helper's retry contract without a live server: transient
+# statuses retry, non-transient statuses stop immediately, retries are capped and
+# never sleep after the final attempt, a single idempotency key is reused across
+# attempts, and each attempt is bounded by the remaining budget.
+
+
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.text = f"status {status_code}"
+
+    def json(self):
+        return {"id": "resp_mock", "object": "response"}
+
+
+class _RecordingClient:
+    """Minimal `httpx.AsyncClient` stand-in that replays scripted statuses."""
+
+    def __init__(self, statuses):
+        self._statuses = list(statuses)
+        self.posts = []
+
+    async def post(self, path, json, headers, timeout):
+        index = min(len(self.posts), len(self._statuses) - 1)
+        self.posts.append({"headers": dict(headers), "timeout": timeout})
+        return _FakeResponse(self._statuses[index])
+
+
+@pytest.fixture()
+def _recorded_sleeps(monkeypatch):
+    sleeps = []
+
+    async def _fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+    return sleeps
+
+
+async def test_create_response_retries_transient_then_succeeds(_recorded_sleeps):
+    client = _RecordingClient([503, 502, 429, 200])
+    body = await _create_response(client, input="hi")
+    assert body["object"] == "response"
+    assert len(client.posts) == 4  # three transient retries, then success
+    assert len(_recorded_sleeps) == 3  # one backoff between each retry, none after 200
+    # A single idempotency key is reused on every attempt so an accepted-then-5xx
+    # run is deduped rather than duplicated.
+    keys = {post["headers"]["Idempotency-Key"] for post in client.posts}
+    assert len(keys) == 1
+
+
+async def test_create_response_succeeds_without_retry_or_sleep(_recorded_sleeps):
+    client = _RecordingClient([200])
+    await _create_response(client, input="hi")
+    assert len(client.posts) == 1
+    assert _recorded_sleeps == []
+
+
+async def test_create_response_does_not_retry_non_transient_status(_recorded_sleeps):
+    client = _RecordingClient([400])
+    with pytest.raises(AssertionError):  # helper asserts a 200
+        await _create_response(client, input="hi")
+    assert len(client.posts) == 1  # a 4xx is not retried
+    assert _recorded_sleeps == []
+
+
+async def test_create_response_caps_attempts_without_trailing_sleep(_recorded_sleeps):
+    client = _RecordingClient([503] * (_MAX_ATTEMPTS + 2))
+    with pytest.raises(AssertionError):  # never reaches a 200
+        await _create_response(client, input="hi")
+    assert len(client.posts) == _MAX_ATTEMPTS  # capped at the attempt ceiling
+    assert len(_recorded_sleeps) == _MAX_ATTEMPTS - 1  # no sleep after the last try
+
+
+async def test_create_response_bounds_each_attempt_by_remaining_budget(_recorded_sleeps):
+    client = _RecordingClient([200])
+    await _create_response(client, input="hi")
+    timeout = client.posts[0]["timeout"]
+    assert 0 < timeout <= _RETRY_DEADLINE_SECONDS  # never an unbounded per-call wait
 
 
 async def test_reborn_legacy_responses_non_streaming_text_input(

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
@@ -142,11 +142,13 @@ def _recorded_sleeps(monkeypatch):
 
 
 async def test_create_response_retries_transient_then_succeeds(_recorded_sleeps):
-    client = _RecordingClient([503, 502, 429, 200])
+    # Every transient status (503/502/504/429) must be retried — a sequence that
+    # exercises all four fails if any is dropped from `_TRANSIENT_STATUSES`.
+    client = _RecordingClient([503, 502, 504, 429, 200])
     body = await _create_response(client, input="hi")
     assert body["object"] == "response"
-    assert len(client.posts) == 4  # three transient retries, then success
-    assert len(_recorded_sleeps) == 3  # one backoff between each retry, none after 200
+    assert len(client.posts) == 5  # four transient retries, then success
+    assert len(_recorded_sleeps) == 4  # one backoff between each retry, none after 200
     # A single idempotency key is reused on every attempt so an accepted-then-5xx
     # run is deduped rather than duplicated.
     keys = {post["headers"]["Idempotency-Key"] for post in client.posts}

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_responses_api.py
@@ -55,9 +55,16 @@ def _response_output_text(response: dict) -> str:
 
 async def _create_response(client: httpx.AsyncClient, path="/v1/responses", **payload):
     response = None
-    for attempt in range(6):
+    # Retry transient statuses: 429 under load, and 502/503/504 when the first
+    # request races the backend/LLM warm-up (a cold-start 503 was flaking this
+    # smoke). Any non-transient status breaks immediately.
+    transient_statuses = {429, 502, 503, 504}
+    attempts = 6
+    for attempt in range(attempts):
         response = await client.post(path, json={"model": "default", **payload})
-        if response.status_code != 429 and not _is_retryable_service_unavailable(response):
+        # Break on a non-transient status, or after the final attempt (no point
+        # sleeping when no further request will be made).
+        if response.status_code not in transient_statuses or attempt == attempts - 1:
             break
         await asyncio.sleep(1 + attempt * 0.5)
     assert response is not None
@@ -66,21 +73,6 @@ async def _create_response(client: httpx.AsyncClient, path="/v1/responses", **pa
     assert body["id"].startswith("resp_")
     assert body["object"] == "response"
     return body
-
-
-def _is_retryable_service_unavailable(response: httpx.Response) -> bool:
-    if response.status_code != 503:
-        return False
-    try:
-        body = response.json()
-    except ValueError:
-        return False
-    if not isinstance(body, dict):
-        return False
-    error = body.get("error")
-    if isinstance(error, dict) and error.get("code") == "service_unavailable":
-        return True
-    return error == "service_unavailable" or body.get("kind") == "service_unavailable"
 
 
 async def test_reborn_legacy_responses_non_streaming_text_input(


### PR DESCRIPTION
## What

Broaden the legacy Responses E2E smoke's retry to cover any transient status `{429, 502, 503, 504}`, and skip the backoff sleep after the final attempt.

## Why

The smoke flaked when the first `/v1/responses` request raced the backend/LLM warm-up and got a cold-start 5xx. The existing retry only covered `429` and a `503` carrying a specific `service_unavailable` body marker (`_is_retryable_service_unavailable`), so a bare cold-start `502`/`503`/`504` (no marker yet) still failed the test.

## Change

- Retry any status in `{429, 502, 503, 504}` with the same bounded backoff.
- Break without sleeping on the final attempt (no further request is made — saves ~3.5s on an exhausted sequence).
- Remove the now-subsumed `_is_retryable_service_unavailable` helper.

A genuinely persistent 5xx still fails the `status_code == 200` assertion once the attempts are exhausted — the broader retry only smooths warm-up races, it does not mask a real failure.

## Provenance

Salvaged from the now-closed #6436 (superseded by #6438, "Seal process redispatch authority"). This E2E hardening is independent of that PR's dispatch changes and stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)