### PR TITLE
add run failure classification facade

### DIFF
--- a/crates/ironclaw_runner/src/failure_categories.rs
+++ b/crates/ironclaw_runner/src/failure_categories.rs
@@ -38,3 +38,74 @@ pub(crate) fn host_stage_unavailable_category(reason: &str) -> &'static str {
         _ => HOST_STAGE_UNAVAILABLE_UNKNOWN_CATEGORY,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_agent_loop::executor::HostStage;
+
+    #[test]
+    fn host_stage_unavailable_categories_cover_every_host_stage() {
+        use HostStage as S;
+
+        let stage_reason_and_category = |stage| match stage {
+            S::Prompt => ("prompt", HOST_STAGE_UNAVAILABLE_PROMPT_CATEGORY),
+            S::Model => ("model", HOST_STAGE_UNAVAILABLE_MODEL_CATEGORY),
+            S::Capability => ("capability", HOST_STAGE_UNAVAILABLE_CAPABILITY_CATEGORY),
+            S::Transcript => ("transcript", HOST_STAGE_UNAVAILABLE_TRANSCRIPT_CATEGORY),
+            S::Checkpoint => ("checkpoint", HOST_STAGE_UNAVAILABLE_CHECKPOINT_CATEGORY),
+            S::Input => ("input", HOST_STAGE_UNAVAILABLE_INPUT_CATEGORY),
+        };
+
+        for stage in [
+            S::Prompt,
+            S::Model,
+            S::Capability,
+            S::Transcript,
+            S::Checkpoint,
+            S::Input,
+        ] {
+            let (reason_prefix, category) = stage_reason_and_category(stage);
+            let reason = format!("{reason_prefix}: unavailable");
+            assert_eq!(
+                host_stage_unavailable_category(&reason),
+                category,
+                "host stage {stage:?} must map to its unavailable category"
+            );
+        }
+    }
+
+    #[test]
+    fn host_stage_unavailable_reason_prefixes_are_classified() {
+        for (reason, expected) in [
+            (
+                "prompt: unavailable",
+                HOST_STAGE_UNAVAILABLE_PROMPT_CATEGORY,
+            ),
+            ("model: unavailable", HOST_STAGE_UNAVAILABLE_MODEL_CATEGORY),
+            (
+                "capability: unavailable",
+                HOST_STAGE_UNAVAILABLE_CAPABILITY_CATEGORY,
+            ),
+            (
+                "transcript: unavailable",
+                HOST_STAGE_UNAVAILABLE_TRANSCRIPT_CATEGORY,
+            ),
+            (
+                "checkpoint: unavailable",
+                HOST_STAGE_UNAVAILABLE_CHECKPOINT_CATEGORY,
+            ),
+            ("input: unavailable", HOST_STAGE_UNAVAILABLE_INPUT_CATEGORY),
+            (
+                "unexpected: unavailable",
+                HOST_STAGE_UNAVAILABLE_UNKNOWN_CATEGORY,
+            ),
+        ] {
+            assert_eq!(
+                host_stage_unavailable_category(reason),
+                expected,
+                "{reason}"
+            );
+        }
+    }
+}

--- a/crates/ironclaw_runner/src/failure_classification.rs
+++ b/crates/ironclaw_runner/src/failure_classification.rs
@@ -1,0 +1,83 @@
+//! Run-failure classification facade.
+//!
+//! This joins the runner-owned failure category, user-facing summary, retry
+//! disposition, and lane into one pure classifier. Producers still emit the
+//! narrow category string; consumers that need policy should use this module
+//! instead of independently recomputing lane and retry behavior.
+
+use crate::{
+    failure_lane::{FailureLane, failure_lane},
+    failure_summary::reborn_failure_summary_for_category,
+    retry_disposition::{RetryDisposition, retry_disposition},
+};
+
+/// Full policy classification for a terminal run failure category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunFailureClassification {
+    pub lane: FailureLane,
+    pub retry: RetryDisposition,
+    pub user_message: &'static str,
+}
+
+/// Classify a terminal run failure category.
+///
+/// `retryable` is the host-derived signal: the failed run has a resumable
+/// checkpoint. `None` or an unknown category remains explainable via the generic
+/// failure summary; if a checkpoint exists it is still user-retriable.
+pub fn classify_run_failure(category: Option<&str>, retryable: bool) -> RunFailureClassification {
+    let category = category.unwrap_or("unknown_failure");
+    let retry = retry_disposition(category, retryable);
+    RunFailureClassification {
+        lane: failure_lane(category, retryable),
+        retry,
+        user_message: reborn_failure_summary_for_category(Some(category)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::failure_lane::ALL_RUN_FAILURE_CATEGORIES;
+
+    #[test]
+    fn classifier_combines_lane_retry_and_summary_for_every_known_category() {
+        for category in ALL_RUN_FAILURE_CATEGORIES {
+            let retryable = classify_run_failure(Some(category), true);
+            assert_eq!(retryable.lane, FailureLane::Retriable, "{category}");
+            assert_ne!(retryable.retry, RetryDisposition::NoRetry, "{category}");
+            assert!(
+                !retryable.user_message.trim().is_empty(),
+                "{category} must carry a user-facing explanation"
+            );
+
+            let non_retryable = classify_run_failure(Some(category), false);
+            assert_eq!(non_retryable.lane, FailureLane::Explainable, "{category}");
+            assert_eq!(non_retryable.retry, RetryDisposition::NoRetry, "{category}");
+            assert_eq!(non_retryable.user_message, retryable.user_message);
+        }
+    }
+
+    #[test]
+    fn unknown_category_stays_explainable_and_user_retriable_with_checkpoint() {
+        let classification = classify_run_failure(Some("__unknown__"), true);
+
+        assert_eq!(classification.lane, FailureLane::Retriable);
+        assert_eq!(classification.retry, RetryDisposition::UserInitiated);
+        assert_eq!(
+            classification.user_message,
+            "The run failed before producing a reply. Retry the run, and contact support if it keeps happening."
+        );
+    }
+
+    #[test]
+    fn missing_category_uses_generic_explainable_summary() {
+        let classification = classify_run_failure(None, false);
+
+        assert_eq!(classification.lane, FailureLane::Explainable);
+        assert_eq!(classification.retry, RetryDisposition::NoRetry);
+        assert_eq!(
+            classification.user_message,
+            "The run failed before producing a reply. Retry the run, and contact support if it keeps happening."
+        );
+    }
+}

--- a/crates/ironclaw_runner/src/lib.rs
+++ b/crates/ironclaw_runner/src/lib.rs
@@ -20,6 +20,7 @@ pub mod app_loop_family;
 mod context_shadow;
 pub mod driver_registry;
 pub mod failure_categories;
+pub mod failure_classification;
 pub mod failure_lane;
 pub mod failure_summary;
 pub mod hook_gate_refs;

--- a/crates/ironclaw_runner/src/model_failure_mapping.rs
+++ b/crates/ironclaw_runner/src/model_failure_mapping.rs
@@ -25,3 +25,88 @@ pub(crate) fn model_stage_failure_category(
     (kind == AgentLoopHostErrorKind::CredentialUnavailable)
         .then_some(MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_stage_host_error_kind_category_matrix_is_exhaustive() {
+        use AgentLoopHostErrorKind as K;
+
+        let expected_without_reason = |kind| match kind {
+            K::CredentialUnavailable => Some(MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY),
+            K::BudgetAccountingFailed => Some(BUDGET_ACCOUNTING_FAILED_CATEGORY),
+            K::Unauthorized
+            | K::ScopeMismatch
+            | K::StaleSurface
+            | K::InvalidInvocation
+            | K::Invalid
+            | K::InvalidOutput
+            | K::PolicyDenied
+            | K::BudgetExceeded
+            | K::BudgetApprovalRequired
+            | K::Unavailable
+            | K::Cancelled
+            | K::CheckpointRejected
+            | K::TranscriptWriteFailed
+            | K::Internal => None,
+        };
+
+        for kind in [
+            K::Unauthorized,
+            K::CredentialUnavailable,
+            K::ScopeMismatch,
+            K::StaleSurface,
+            K::InvalidInvocation,
+            K::Invalid,
+            K::InvalidOutput,
+            K::PolicyDenied,
+            K::BudgetExceeded,
+            K::BudgetApprovalRequired,
+            K::BudgetAccountingFailed,
+            K::Unavailable,
+            K::Cancelled,
+            K::CheckpointRejected,
+            K::TranscriptWriteFailed,
+            K::Internal,
+        ] {
+            assert_eq!(
+                model_stage_failure_category(true, kind, None),
+                expected_without_reason(kind),
+                "model-stage category for {kind:?} changed"
+            );
+            assert_eq!(
+                model_stage_failure_category(false, kind, None),
+                None,
+                "non-model stage must not produce model-specific category for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn model_credits_reason_overrides_model_stage_error_kind() {
+        let reason = Some(AgentLoopHostErrorReasonKind::ModelCreditsExhausted);
+
+        assert_eq!(
+            model_stage_failure_category(
+                true,
+                AgentLoopHostErrorKind::CredentialUnavailable,
+                reason
+            ),
+            Some(MODEL_CREDITS_EXHAUSTED_CATEGORY)
+        );
+        assert_eq!(
+            model_stage_failure_category(true, AgentLoopHostErrorKind::Internal, reason),
+            Some(MODEL_CREDITS_EXHAUSTED_CATEGORY)
+        );
+        assert_eq!(
+            model_stage_failure_category(
+                false,
+                AgentLoopHostErrorKind::CredentialUnavailable,
+                reason
+            ),
+            None
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a runner-owned `failure_classification` facade that returns lane, retry disposition, and user-facing message from a terminal run failure category.
- Add typed ratchets for host-stage unavailable category mapping and model-stage host-error category mapping.
- Keep recoverability classification scoped to `ironclaw_runner`; no composition/runtime wiring changes.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_runner`; `cargo test -p ironclaw_architecture`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable: pure classifier/test ratchet change.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior:
Run failures continue to surface the same summaries and retry behavior; this PR centralizes the classification so future consumers can use one policy function.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added runner unit tests for `classify_run_failure`, host-stage unavailable category mapping, and model-stage host-error category matrix.
- Reborn integration: Not applicable: no runtime path or persistence behavior changed.
- Recorded fixture: Not applicable: no model request/response fixture changed.
- Browser E2E: Not applicable: no frontend/browser behavior changed.
- Backend or runtime: `cargo test -p ironclaw_runner`; `cargo test -p ironclaw_architecture`.
- Live canary: Not applicable: no external provider/live path changed.

What the tests prove:
Every known run failure category combines into a lane, retry disposition, and non-empty user message; every public host stage maps to a host-stage unavailable category; model-stage diagnostic categories remain explicit for credentials, credits, and budget accounting.

Commands run:
- `cargo fmt -p ironclaw_runner`
- `cargo test -p ironclaw_runner failure_classification --lib`
- `cargo test -p ironclaw_runner model_stage_host_error_kind_category_matrix_is_exhaustive --lib`
- `cargo test -p ironclaw_runner host_stage_unavailable_categories_cover_every_host_stage --lib`
- `cargo test -p ironclaw_runner model_credits_reason_overrides_model_stage_error_kind --lib`
- `cargo test -p ironclaw_runner`
- `cargo clippy -p ironclaw_runner --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture`

## Security Impact

None. This is a pure classification facade and test ratchet; it does not change permissions, secrets, network, file access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? `RunFailureClassification` is derived from already-sanitized failure categories plus the host-derived retryable flag; it carries no authority or evidence.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable: no prompt content changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable: no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: no variants added; added typed matrix tests for `HostStage` and `AgentLoopHostErrorKind` producer mappings.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Not applicable: no serde persistence fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable: no queues/maps/buffers/counters changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Added classifier facade and typed ratchets around existing stable category semantics.
- [x] Sandbox/native/host names accurately describe trust boundary. Not applicable: no sandbox/native host names changed.

## Database Impact

None.

## Blast Radius

Touches only `ironclaw_runner` failure classification helpers and unit tests. Possible breakage is limited to consumers of the new module or changed assumptions in category tests; existing runtime classification behavior is unchanged.

## Rollback Plan

Revert commit `381d9ec38` to remove the facade and added ratchet tests. No migration or compatibility cleanup required.

## Review Follow-Through

Draft PR for the recoverability classification slice. Follow-up scheduler/UI work can consume `classify_run_failure` instead of recomputing lane and retry policy.

---

**Review track**: B (feature/maintainer-requested refactor)