### PR TITLE
fix(live-canary): scrub verified static runtime artifacts

### DIFF
--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -149,9 +149,12 @@ managed marker, stable content hash, file set, and bytes match the
 source-controlled bundle from the tested commit. Unverified or unmanaged system
 skills and all other run-specific artifacts remain present and are scanned for
 secret material. Non-strict scrubbing is report-only and does not prune them.
-Strict scrubbing also removes byte-verified first-party extension manifests,
-whose static credential schema fields otherwise look like live secrets; changed
-or unrecognized manifests remain subject to the fail-closed scanner.
+Strict scrubbing also removes source-byte-verified first-party extension
+manifests, whose static credential schema fields otherwise look like live
+secrets. The dynamically rendered NEAR AI manifest is instead verified against
+a trusted runtime template after normalizing only the repository-owned
+`cloud-api.near.ai` and `private.near.ai` MCP endpoints. Changed or unrecognized
+manifests remain subject to the fail-closed scanner.
 
 ## Secrets And Account Material
 

--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -144,6 +144,11 @@ Artifacts are written under:
 artifacts/live-canary/<lane>/<provider>/<timestamp>/
 ```
 
+Before upload, strict scrubbing removes only marker-owned copies of bundled
+system skills from staged Reborn homes. Those files are reproducible from the
+tested commit; unmanaged system skills and all other run-specific artifacts
+remain present and are scanned for secret material.
+
 ## Secrets And Account Material
 
 Public live LLM lane secrets and variables are documented in

--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -144,10 +144,11 @@ Artifacts are written under:
 artifacts/live-canary/<lane>/<provider>/<timestamp>/
 ```
 
-Before upload, strict scrubbing removes only marker-owned copies of bundled
-system skills from staged Reborn homes. Those files are reproducible from the
-tested commit; unmanaged system skills and all other run-specific artifacts
-remain present and are scanned for secret material.
+Before upload, strict scrubbing removes only bundled system-skill copies whose
+managed marker, stable content hash, file set, and bytes match the
+source-controlled bundle from the tested commit. Unverified or unmanaged system
+skills and all other run-specific artifacts remain present and are scanned for
+secret material. Non-strict scrubbing is report-only and does not prune them.
 
 ## Secrets And Account Material
 

--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -149,6 +149,9 @@ managed marker, stable content hash, file set, and bytes match the
 source-controlled bundle from the tested commit. Unverified or unmanaged system
 skills and all other run-specific artifacts remain present and are scanned for
 secret material. Non-strict scrubbing is report-only and does not prune them.
+Strict scrubbing also removes byte-verified first-party extension manifests,
+whose static credential schema fields otherwise look like live secrets; changed
+or unrecognized manifests remain subject to the fail-closed scanner.
 
 ## Secrets And Account Material
 

--- a/scripts/live-canary/fixtures/nearai-runtime-manifest.toml
+++ b/scripts/live-canary/fixtures/nearai-runtime-manifest.toml
@@ -1,0 +1,49 @@
+description = "NEAR AI MCP tools for web search and hosted agent capabilities."
+id = "nearai"
+name = "NEAR AI"
+schema_version = "reborn.extension_manifest.v3"
+trust = "first_party_requested"
+version = "0.1.0"
+
+[auth.nearai]
+display_name = "NEAR AI API key"
+method = "api_key"
+
+[[auth.nearai.fields]]
+handle = "llm_nearai_api_key"
+label = "NEAR AI API key"
+secret = true
+
+[mcp]
+default_permission = "ask"
+effects = ["network", "use_secret"]
+max_tools = 64
+namespace = "nearai"
+server = "__LIVE_CANARY_NEARAI_MCP_SERVER__"
+
+[[mcp.credentials]]
+handle = "llm_nearai_api_key"
+scopes = []
+vendor = "nearai"
+
+[mcp.credentials.injection]
+name = "authorization"
+prefix = "Bearer "
+type = "header"
+
+[mcp.origin_gate_matrix]
+automation = "forbidden"
+loop_run = "gated_unless_granted"
+product = "forbidden"
+
+[[tools]]
+default_permission = "ask"
+description = "Search through the NEAR AI MCP server."
+id = "nearai.web_search"
+input_schema_ref = "schemas/nearai/web_search.input.v1.json"
+prompt_doc_ref = "prompts/nearai/web_search.md"
+
+[tools.origin_gate_matrix]
+automation = "forbidden"
+loop_run = "gated_unless_granted"
+product = "forbidden"

--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -7,11 +7,37 @@ set -euo pipefail
 
 ARTIFACT_DIR="${1:-${RUN_DIR:-artifacts/live-canary}}"
 STRICT_ARTIFACT_SCRUB="${STRICT_ARTIFACT_SCRUB:-false}"
+BUNDLED_SKILL_MARKER=".ironclaw-reborn-bundled.json"
+BUNDLED_SKILL_OWNER="ironclaw_reborn_composition_bundled_skill"
 
 if [[ ! -d "${ARTIFACT_DIR}" ]]; then
   echo "Artifact directory does not exist: ${ARTIFACT_DIR}" >&2
   exit 2
 fi
+
+# Reborn live QA copies each case's full home into the artifact staging tree.
+# System skills carrying this marker are byte-for-byte runtime installations of
+# source-controlled bundles, so retaining them adds no run-specific evidence.
+# Some bundles intentionally contain dummy credential examples, which strict
+# scanning must not mistake for leaked live material. Remove only directories
+# with Ironclaw's managed-bundle marker; unmanaged/operator system skills remain
+# in the artifact tree and are scanned normally.
+while IFS= read -r -d '' marker; do
+  if ! grep -qE "\"owner\"[[:space:]]*:[[:space:]]*\"${BUNDLED_SKILL_OWNER}\"" "${marker}"; then
+    continue
+  fi
+  skill_dir="$(dirname "${marker}")"
+  case "${skill_dir}" in
+    "${ARTIFACT_DIR}"/*/reborn-home/*/local-dev/system/skills/*|\
+    "${ARTIFACT_DIR}"/reborn-home/*/local-dev/system/skills/*)
+      rm -rf -- "${skill_dir}"
+      ;;
+  esac
+done < <(
+  find "${ARTIFACT_DIR}" -type f \
+    -path '*/reborn-home/*/local-dev/system/skills/*/.ironclaw-reborn-bundled.json' \
+    -print0
+)
 
 patterns=(
   'bearer[[:space:]]+[A-Za-z0-9._~+/=-]+'

--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -9,6 +9,8 @@ ARTIFACT_DIR="${1:-${RUN_DIR:-artifacts/live-canary}}"
 STRICT_ARTIFACT_SCRUB="${STRICT_ARTIFACT_SCRUB:-false}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BUNDLED_SKILLS_ROOT="${LIVE_CANARY_BUNDLED_SKILLS_ROOT:-${REPO_ROOT}/skills}"
+FIRST_PARTY_EXTENSIONS_ROOT="${LIVE_CANARY_FIRST_PARTY_EXTENSIONS_ROOT:-${REPO_ROOT}/crates/ironclaw_first_party_extensions/assets}"
+NEARAI_MANIFEST_TEMPLATE="${REPO_ROOT}/scripts/live-canary/fixtures/nearai-runtime-manifest.toml"
 BUNDLED_SKILL_MARKER=".ironclaw-reborn-bundled.json"
 BUNDLED_SKILL_OWNER="ironclaw_reborn_composition_bundled_skill"
 
@@ -127,6 +129,26 @@ except (OSError, UnicodeError, ValueError):
 PY
 }
 
+is_verified_first_party_extension_manifest() {
+  local manifest="$1"
+  local extension_dir
+  local extension_id
+  local trusted_manifest
+  extension_dir="$(dirname "${manifest}")"
+  extension_id="$(basename "${extension_dir}")"
+  trusted_manifest="${FIRST_PARTY_EXTENSIONS_ROOT}/${extension_id}/manifest.toml"
+
+  if [[ -f "${trusted_manifest}" ]] && cmp -s -- "${trusted_manifest}" "${manifest}"; then
+    return 0
+  fi
+  if [[ "${extension_id}" != "nearai" || ! -f "${NEARAI_MANIFEST_TEMPLATE}" ]]; then
+    return 1
+  fi
+  sed -E \
+    's#^server = "https://(cloud-api|private)\.near\.ai/mcp"$#server = "__LIVE_CANARY_NEARAI_MCP_SERVER__"#' \
+    "${manifest}" | cmp -s -- "${NEARAI_MANIFEST_TEMPLATE}" -
+}
+
 # Reborn live QA copies each case's full home into the artifact staging tree.
 # In strict mode, remove only managed system-skill installations whose marker,
 # stable content hash, file set, and bytes all match the source-controlled
@@ -145,6 +167,23 @@ if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" || "${STRICT_ARTIFACT_SCRUB}" == "1" 
   done < <(
     find "${ARTIFACT_DIR}" -type f \
       -path '*/reborn-home/*/local-dev/system/skills/*/.ironclaw-reborn-bundled.json' \
+      -print0
+  )
+
+  # Installed first-party extension manifests are also source-controlled
+  # package metadata. Their credential declarations contain secret-shaped
+  # field names and OAuth response paths, but no credential values. Remove a
+  # manifest only when every byte matches its trusted source. NEAR AI's
+  # bootstrap rewrites and deterministically re-serializes the configured MCP
+  # endpoint, so compare it to the pinned runtime template after normalizing
+  # only the two repository-owned endpoints.
+  while IFS= read -r -d '' manifest; do
+    if is_verified_first_party_extension_manifest "${manifest}"; then
+      rm -f -- "${manifest}"
+    fi
+  done < <(
+    find "${ARTIFACT_DIR}" -type f \
+      -path '*/reborn-home/*/local-dev/system/extensions/*/manifest.toml' \
       -print0
   )
 fi

--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 ARTIFACT_DIR="${1:-${RUN_DIR:-artifacts/live-canary}}"
 STRICT_ARTIFACT_SCRUB="${STRICT_ARTIFACT_SCRUB:-false}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUNDLED_SKILLS_ROOT="${LIVE_CANARY_BUNDLED_SKILLS_ROOT:-${REPO_ROOT}/skills}"
 BUNDLED_SKILL_MARKER=".ironclaw-reborn-bundled.json"
 BUNDLED_SKILL_OWNER="ironclaw_reborn_composition_bundled_skill"
 
@@ -15,29 +17,137 @@ if [[ ! -d "${ARTIFACT_DIR}" ]]; then
   exit 2
 fi
 
+is_verified_bundled_skill() {
+  local marker="$1"
+  local skill_dir="$2"
+  local skill_name
+  skill_name="$(basename "${skill_dir}")"
+
+  python3 - "${marker}" "${BUNDLED_SKILLS_ROOT}/${skill_name}" "${skill_dir}" \
+    "${skill_name}" "${BUNDLED_SKILL_OWNER}" "${BUNDLED_SKILL_MARKER}" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+
+marker_path = Path(sys.argv[1])
+trusted_dir = Path(sys.argv[2])
+staged_dir = Path(sys.argv[3])
+skill_name = sys.argv[4]
+expected_owner = sys.argv[5]
+marker_name = sys.argv[6]
+
+
+def regular_files(root: Path, *, omit_marker: bool) -> list[tuple[str, Path]]:
+    if not root.is_dir() or root.is_symlink():
+        raise ValueError("bundle root is not a real directory")
+    files: list[tuple[str, Path]] = []
+    for current, directories, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for directory in directories:
+            if (current_path / directory).is_symlink():
+                raise ValueError("bundle contains a symlinked directory")
+        for filename in filenames:
+            path = current_path / filename
+            relative = path.relative_to(root).as_posix()
+            if omit_marker and relative == marker_name:
+                continue
+            if not stat.S_ISREG(path.lstat().st_mode):
+                raise ValueError("bundle contains a non-regular file")
+            files.append((relative, path))
+    return sorted(files)
+
+
+def update_fnv64(value: int, data: bytes) -> int:
+    for byte in data:
+        value ^= byte
+        value = (value * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return value
+
+
+def trusted_content_hash(files: list[tuple[str, Path]]) -> str:
+    value = update_fnv64(0xCBF29CE484222325, skill_name.encode())
+    for relative, path in files:
+        value = update_fnv64(value, relative.encode())
+        value = update_fnv64(value, b"\0")
+        with path.open("rb") as source:
+            while chunk := source.read(1024 * 1024):
+                value = update_fnv64(value, chunk)
+        value = update_fnv64(value, b"\0")
+    return f"{value:016x}"
+
+
+def files_equal(left: Path, right: Path) -> bool:
+    if left.stat().st_size != right.stat().st_size:
+        return False
+    with left.open("rb") as left_file, right.open("rb") as right_file:
+        while True:
+            left_chunk = left_file.read(1024 * 1024)
+            right_chunk = right_file.read(1024 * 1024)
+            if left_chunk != right_chunk:
+                return False
+            if not left_chunk:
+                return True
+
+
+try:
+    if marker_path.stat().st_size > 4096:
+        raise ValueError("bundle marker is too large")
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    if not isinstance(marker, dict):
+        raise ValueError("bundle marker is not an object")
+    content_hash = marker.get("content_hash")
+    if (
+        marker.get("owner") != expected_owner
+        or type(marker.get("format")) is not int
+        or marker.get("format") != 1
+        or not isinstance(content_hash, str)
+        or re.fullmatch(r"[0-9a-f]{16}", content_hash) is None
+    ):
+        raise ValueError("bundle marker is invalid")
+
+    trusted_files = regular_files(trusted_dir, omit_marker=False)
+    staged_files = regular_files(staged_dir, omit_marker=True)
+    if any(relative == marker_name for relative, _ in trusted_files):
+        raise ValueError("trusted source contains a runtime marker")
+    if content_hash != trusted_content_hash(trusted_files):
+        raise ValueError("bundle marker hash does not match trusted source")
+    if [relative for relative, _ in trusted_files] != [relative for relative, _ in staged_files]:
+        raise ValueError("staged bundle file set differs from trusted source")
+    if not all(
+        files_equal(trusted_path, staged_path)
+        for (_, trusted_path), (_, staged_path) in zip(trusted_files, staged_files)
+    ):
+        raise ValueError("staged bundle content differs from trusted source")
+except (OSError, UnicodeError, ValueError):
+    sys.exit(1)
+PY
+}
+
 # Reborn live QA copies each case's full home into the artifact staging tree.
-# System skills carrying this marker are byte-for-byte runtime installations of
-# source-controlled bundles, so retaining them adds no run-specific evidence.
-# Some bundles intentionally contain dummy credential examples, which strict
-# scanning must not mistake for leaked live material. Remove only directories
-# with Ironclaw's managed-bundle marker; unmanaged/operator system skills remain
-# in the artifact tree and are scanned normally.
-while IFS= read -r -d '' marker; do
-  if ! grep -qE "\"owner\"[[:space:]]*:[[:space:]]*\"${BUNDLED_SKILL_OWNER}\"" "${marker}"; then
-    continue
-  fi
-  skill_dir="$(dirname "${marker}")"
-  case "${skill_dir}" in
-    "${ARTIFACT_DIR}"/*/reborn-home/*/local-dev/system/skills/*|\
-    "${ARTIFACT_DIR}"/reborn-home/*/local-dev/system/skills/*)
-      rm -rf -- "${skill_dir}"
-      ;;
-  esac
-done < <(
-  find "${ARTIFACT_DIR}" -type f \
-    -path '*/reborn-home/*/local-dev/system/skills/*/.ironclaw-reborn-bundled.json' \
-    -print0
-)
+# In strict mode, remove only managed system-skill installations whose marker,
+# stable content hash, file set, and bytes all match the source-controlled
+# bundle. Unverified and operator-owned skills remain in scope for scanning.
+if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" || "${STRICT_ARTIFACT_SCRUB}" == "1" ]]; then
+  while IFS= read -r -d '' marker; do
+    skill_dir="$(dirname "${marker}")"
+    case "${skill_dir}" in
+      "${ARTIFACT_DIR}"/*/reborn-home/*/local-dev/system/skills/*|\
+      "${ARTIFACT_DIR}"/reborn-home/*/local-dev/system/skills/*)
+        if is_verified_bundled_skill "${marker}" "${skill_dir}"; then
+          rm -rf -- "${skill_dir}"
+        fi
+        ;;
+    esac
+  done < <(
+    find "${ARTIFACT_DIR}" -type f \
+      -path '*/reborn-home/*/local-dev/system/skills/*/.ironclaw-reborn-bundled.json' \
+      -print0
+  )
+fi
 
 patterns=(
   'bearer[[:space:]]+[A-Za-z0-9._~+/=-]+'

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -13,6 +13,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "live-canary" / "scrub-artifacts.sh"
+NEARAI_MANIFEST_TEMPLATE = (
+    ROOT / "scripts" / "live-canary" / "fixtures" / "nearai-runtime-manifest.toml"
+)
 
 
 class ScrubArtifactsTests(unittest.TestCase):
@@ -22,11 +25,16 @@ class ScrubArtifactsTests(unittest.TestCase):
         *,
         strict: bool,
         bundled_skills_root: Path | None = None,
+        first_party_extensions_root: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["STRICT_ARTIFACT_SCRUB"] = "true" if strict else "false"
         if bundled_skills_root is not None:
             env["LIVE_CANARY_BUNDLED_SKILLS_ROOT"] = str(bundled_skills_root)
+        if first_party_extensions_root is not None:
+            env["LIVE_CANARY_FIRST_PARTY_EXTENSIONS_ROOT"] = str(
+                first_party_extensions_root
+            )
         runner_temp = artifact_dir.parent / f"{artifact_dir.name}-runner-temp"
         runner_temp.mkdir(parents=True, exist_ok=True)
         env["RUNNER_TEMP"] = str(runner_temp)
@@ -102,6 +110,37 @@ class ScrubArtifactsTests(unittest.TestCase):
             encoding="utf-8",
         )
         return trusted_root, staged_skill
+
+    @staticmethod
+    def write_extension_manifest_fixture(
+        artifact_dir: Path,
+        *,
+        source_body: str,
+        staged_body: str | None = None,
+        extension_id: str = "gmail",
+    ) -> tuple[Path, Path]:
+        trusted_root = artifact_dir.parent / "trusted-extensions"
+        trusted_extension = trusted_root / extension_id
+        trusted_extension.mkdir(parents=True)
+        (trusted_extension / "manifest.toml").write_text(source_body, encoding="utf-8")
+
+        staged_manifest = (
+            artifact_dir
+            / "lane"
+            / "reborn-home"
+            / "case-a"
+            / "local-dev"
+            / "system"
+            / "extensions"
+            / extension_id
+            / "manifest.toml"
+        )
+        staged_manifest.parent.mkdir(parents=True)
+        staged_manifest.write_text(
+            source_body if staged_body is None else staged_body,
+            encoding="utf-8",
+        )
+        return trusted_root, staged_manifest
 
     def test_strict_scrub_redacts_diagnostics_and_preserves_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -286,6 +325,69 @@ class ScrubArtifactsTests(unittest.TestCase):
             self.assertFalse(bundled.exists())
             self.assertFalse(unsafe.exists())
 
+    def test_strict_scrub_prunes_verified_first_party_extension_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, manifest = self.write_extension_manifest_fixture(
+                root,
+                source_body=(
+                    'secret = true\naccess_token = "/access_token"\n'
+                    'refresh_token = "/refresh_token"\n'
+                ),
+            )
+
+            result = self.run_scrub(
+                root,
+                strict=True,
+                first_party_extensions_root=trusted_root,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertFalse(manifest.exists())
+
+    def test_strict_scrub_rejects_modified_first_party_extension_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, manifest = self.write_extension_manifest_fixture(
+                root,
+                source_body='secret = true\naccess_token = "/access_token"\n',
+                staged_body=(
+                    'secret = true\naccess_token = "/access_token"\n'
+                    "api_key: live-secret-value\n"
+                ),
+            )
+
+            result = self.run_scrub(
+                root,
+                strict=True,
+                first_party_extensions_root=trusted_root,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertFalse(manifest.exists())
+
+    def test_strict_scrub_prunes_verified_nearai_runtime_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            runtime_manifest = NEARAI_MANIFEST_TEMPLATE.read_text(encoding="utf-8").replace(
+                "__LIVE_CANARY_NEARAI_MCP_SERVER__",
+                "https://cloud-api.near.ai/mcp",
+            )
+            _, manifest = self.write_extension_manifest_fixture(
+                root,
+                extension_id="nearai",
+                source_body="not used for the dynamic nearai manifest\n",
+                staged_body=runtime_manifest,
+            )
+
+            result = self.run_scrub(root, strict=True)
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertFalse(manifest.exists())
+
     def test_non_strict_scrub_is_report_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir) / "artifacts"
@@ -294,6 +396,10 @@ class ScrubArtifactsTests(unittest.TestCase):
                 root,
                 source_body="docker run -e NEARAI_API_KEY=dummy ironclaw-test\n",
             )
+            extensions_root, extension_manifest = self.write_extension_manifest_fixture(
+                root,
+                source_body='secret = true\naccess_token = "/access_token"\n',
+            )
             artifact = root / "raw.html"
             artifact.write_text("api_key: secret-value\n", encoding="utf-8")
 
@@ -301,10 +407,12 @@ class ScrubArtifactsTests(unittest.TestCase):
                 root,
                 strict=False,
                 bundled_skills_root=trusted_root,
+                first_party_extensions_root=extensions_root,
             )
 
             self.assertEqual(result.returncode, 0, result.stdout)
             self.assertTrue((bundled / "SKILL.md").exists())
+            self.assertTrue(extension_manifest.exists())
             self.assertTrue(artifact.exists())
             matches = (root / "scrub-matches.txt").read_text(encoding="utf-8")
             self.assertIn("<REDACTED>", matches)

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -264,6 +264,28 @@ class ScrubArtifactsTests(unittest.TestCase):
             self.assertFalse(bundled.exists())
             self.assertTrue((unmanaged / "SKILL.md").exists())
 
+    def test_strict_scrub_still_scans_unmanaged_system_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            unmanaged = (
+                root
+                / "lane"
+                / "reborn-home"
+                / "case-a"
+                / "local-dev"
+                / "system"
+                / "skills"
+                / "operator-skill"
+                / "SKILL.md"
+            )
+            unmanaged.parent.mkdir(parents=True)
+            unmanaged.write_text("api_key: live-secret-value\n", encoding="utf-8")
+
+            result = self.run_scrub(root, strict=True)
+
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertFalse(unmanaged.exists())
+
     def test_strict_scrub_rejects_malformed_bundled_marker_content(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir) / "artifacts"
@@ -369,24 +391,31 @@ class ScrubArtifactsTests(unittest.TestCase):
             self.assertFalse(manifest.exists())
 
     def test_strict_scrub_prunes_verified_nearai_runtime_manifest(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir) / "artifacts"
-            root.mkdir()
-            runtime_manifest = NEARAI_MANIFEST_TEMPLATE.read_text(encoding="utf-8").replace(
-                "__LIVE_CANARY_NEARAI_MCP_SERVER__",
-                "https://cloud-api.near.ai/mcp",
-            )
-            _, manifest = self.write_extension_manifest_fixture(
-                root,
-                extension_id="nearai",
-                source_body="not used for the dynamic nearai manifest\n",
-                staged_body=runtime_manifest,
-            )
+        for endpoint in (
+            "https://cloud-api.near.ai/mcp",
+            "https://private.near.ai/mcp",
+        ):
+            with self.subTest(endpoint=endpoint):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir) / "artifacts"
+                    root.mkdir()
+                    runtime_manifest = NEARAI_MANIFEST_TEMPLATE.read_text(
+                        encoding="utf-8"
+                    ).replace(
+                        "__LIVE_CANARY_NEARAI_MCP_SERVER__",
+                        endpoint,
+                    )
+                    _, manifest = self.write_extension_manifest_fixture(
+                        root,
+                        extension_id="nearai",
+                        source_body="not used for the dynamic nearai manifest\n",
+                        staged_body=runtime_manifest,
+                    )
 
-            result = self.run_scrub(root, strict=True)
+                    result = self.run_scrub(root, strict=True)
 
-            self.assertEqual(result.returncode, 0, result.stdout)
-            self.assertFalse(manifest.exists())
+                    self.assertEqual(result.returncode, 0, result.stdout)
+                    self.assertFalse(manifest.exists())
 
     def test_non_strict_scrub_is_report_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -395,27 +395,29 @@ class ScrubArtifactsTests(unittest.TestCase):
             "https://cloud-api.near.ai/mcp",
             "https://private.near.ai/mcp",
         ):
-            with self.subTest(endpoint=endpoint):
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    root = Path(tmpdir) / "artifacts"
-                    root.mkdir()
-                    runtime_manifest = NEARAI_MANIFEST_TEMPLATE.read_text(
-                        encoding="utf-8"
-                    ).replace(
-                        "__LIVE_CANARY_NEARAI_MCP_SERVER__",
-                        endpoint,
-                    )
-                    _, manifest = self.write_extension_manifest_fixture(
-                        root,
-                        extension_id="nearai",
-                        source_body="not used for the dynamic nearai manifest\n",
-                        staged_body=runtime_manifest,
-                    )
+            with (
+                self.subTest(endpoint=endpoint),
+                tempfile.TemporaryDirectory() as tmpdir,
+            ):
+                root = Path(tmpdir) / "artifacts"
+                root.mkdir()
+                runtime_manifest = NEARAI_MANIFEST_TEMPLATE.read_text(
+                    encoding="utf-8"
+                ).replace(
+                    "__LIVE_CANARY_NEARAI_MCP_SERVER__",
+                    endpoint,
+                )
+                _, manifest = self.write_extension_manifest_fixture(
+                    root,
+                    extension_id="nearai",
+                    source_body="not used for the dynamic nearai manifest\n",
+                    staged_body=runtime_manifest,
+                )
 
-                    result = self.run_scrub(root, strict=True)
+                result = self.run_scrub(root, strict=True)
 
-                    self.assertEqual(result.returncode, 0, result.stdout)
-                    self.assertFalse(manifest.exists())
+                self.assertEqual(result.returncode, 0, result.stdout)
+                self.assertFalse(manifest.exists())
 
     def test_non_strict_scrub_is_report_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -16,9 +16,17 @@ SCRIPT = ROOT / "scripts" / "live-canary" / "scrub-artifacts.sh"
 
 
 class ScrubArtifactsTests(unittest.TestCase):
-    def run_scrub(self, artifact_dir: Path, *, strict: bool) -> subprocess.CompletedProcess[str]:
+    def run_scrub(
+        self,
+        artifact_dir: Path,
+        *,
+        strict: bool,
+        bundled_skills_root: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["STRICT_ARTIFACT_SCRUB"] = "true" if strict else "false"
+        if bundled_skills_root is not None:
+            env["LIVE_CANARY_BUNDLED_SKILLS_ROOT"] = str(bundled_skills_root)
         runner_temp = artifact_dir.parent / f"{artifact_dir.name}-runner-temp"
         runner_temp.mkdir(parents=True, exist_ok=True)
         env["RUNNER_TEMP"] = str(runner_temp)
@@ -31,6 +39,69 @@ class ScrubArtifactsTests(unittest.TestCase):
             stderr=subprocess.STDOUT,
             check=False,
         )
+
+    @staticmethod
+    def bundle_hash(name: str, source_dir: Path) -> str:
+        value = 0xCBF29CE484222325
+
+        def update(data: bytes) -> None:
+            nonlocal value
+            for byte in data:
+                value ^= byte
+                value = (value * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+
+        update(name.encode())
+        source_files = sorted(path for path in source_dir.rglob("*") if path.is_file())
+        for source_file in source_files:
+            update(source_file.relative_to(source_dir).as_posix().encode())
+            update(b"\0")
+            update(source_file.read_bytes())
+            update(b"\0")
+        return f"{value:016x}"
+
+    def write_bundled_skill_fixture(
+        self,
+        artifact_dir: Path,
+        *,
+        source_body: str,
+        staged_body: str | None = None,
+        marker: dict[str, object] | str | None = None,
+    ) -> tuple[Path, Path]:
+        trusted_root = artifact_dir.parent / "trusted-skills"
+        trusted_skill = trusted_root / "local-test"
+        trusted_skill.mkdir(parents=True)
+        (trusted_skill / "SKILL.md").write_text(source_body, encoding="utf-8")
+
+        staged_skill = (
+            artifact_dir
+            / "lane"
+            / "reborn-home"
+            / "case-a"
+            / "local-dev"
+            / "system"
+            / "skills"
+            / "local-test"
+        )
+        staged_skill.mkdir(parents=True)
+        (staged_skill / "SKILL.md").write_text(
+            source_body if staged_body is None else staged_body,
+            encoding="utf-8",
+        )
+        marker_payload = marker or {
+            "owner": "ironclaw_reborn_composition_bundled_skill",
+            "format": 1,
+            "content_hash": self.bundle_hash("local-test", trusted_skill),
+        }
+        marker_text = (
+            marker_payload
+            if isinstance(marker_payload, str)
+            else json.dumps(marker_payload)
+        )
+        (staged_skill / ".ironclaw-reborn-bundled.json").write_text(
+            marker_text,
+            encoding="utf-8",
+        )
+        return trusted_root, staged_skill
 
     def test_strict_scrub_redacts_diagnostics_and_preserves_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -128,34 +199,15 @@ class ScrubArtifactsTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1, result.stdout)
             self.assertFalse(unsafe.exists())
 
-    def test_strict_scrub_prunes_only_managed_bundled_skill_snapshots(self) -> None:
+    def test_strict_scrub_prunes_only_verified_bundled_skill_snapshots(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            skills_root = (
-                root
-                / "lane"
-                / "reborn-home"
-                / "case-a"
-                / "local-dev"
-                / "system"
-                / "skills"
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, bundled = self.write_bundled_skill_fixture(
+                root,
+                source_body="docker run -e NEARAI_API_KEY=dummy ironclaw-test\n",
             )
-            bundled = skills_root / "local-test"
-            bundled.mkdir(parents=True)
-            (bundled / ".ironclaw-reborn-bundled.json").write_text(
-                json.dumps(
-                    {
-                        "owner": "ironclaw_reborn_composition_bundled_skill",
-                        "format": 1,
-                        "content_hash": "fixture-hash",
-                    }
-                ),
-                encoding="utf-8",
-            )
-            (bundled / "SKILL.md").write_text(
-                "docker run -e NEARAI_API_KEY=dummy ironclaw-test\n",
-                encoding="utf-8",
-            )
+            skills_root = bundled.parent
             unmanaged = skills_root / "operator-skill"
             unmanaged.mkdir()
             (unmanaged / "SKILL.md").write_text(
@@ -163,38 +215,72 @@ class ScrubArtifactsTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            result = self.run_scrub(root, strict=True)
+            result = self.run_scrub(
+                root,
+                strict=True,
+                bundled_skills_root=trusted_root,
+            )
 
             self.assertEqual(result.returncode, 0, result.stdout)
             self.assertFalse(bundled.exists())
             self.assertTrue((unmanaged / "SKILL.md").exists())
 
+    def test_strict_scrub_rejects_malformed_bundled_marker_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, bundled = self.write_bundled_skill_fixture(
+                root,
+                source_body="api_key: live-secret-value\n",
+                marker='{"owner":"ironclaw_reborn_composition_bundled_skill"',
+            )
+
+            result = self.run_scrub(
+                root,
+                strict=True,
+                bundled_skills_root=trusted_root,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertTrue(bundled.exists())
+            self.assertFalse((bundled / "SKILL.md").exists())
+
+    def test_strict_scrub_rejects_spoofed_bundled_skill_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, bundled = self.write_bundled_skill_fixture(
+                root,
+                source_body="safe source-controlled instructions\n",
+                staged_body="api_key: live-secret-value\n",
+            )
+
+            result = self.run_scrub(
+                root,
+                strict=True,
+                bundled_skills_root=trusted_root,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertTrue(bundled.exists())
+            self.assertFalse((bundled / "SKILL.md").exists())
+
     def test_strict_scrub_still_rejects_secret_outside_bundled_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            bundled = (
-                root
-                / "lane"
-                / "reborn-home"
-                / "case-a"
-                / "local-dev"
-                / "system"
-                / "skills"
-                / "local-test"
-            )
-            bundled.mkdir(parents=True)
-            (bundled / ".ironclaw-reborn-bundled.json").write_text(
-                '{"owner": "ironclaw_reborn_composition_bundled_skill"}',
-                encoding="utf-8",
-            )
-            (bundled / "SKILL.md").write_text(
-                "NEARAI_API_KEY=dummy\n",
-                encoding="utf-8",
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, bundled = self.write_bundled_skill_fixture(
+                root,
+                source_body="docker run -e NEARAI_API_KEY=dummy ironclaw-test\n",
             )
             unsafe = root / "operator-state.txt"
             unsafe.write_text("api_key: live-secret-value\n", encoding="utf-8")
 
-            result = self.run_scrub(root, strict=True)
+            result = self.run_scrub(
+                root,
+                strict=True,
+                bundled_skills_root=trusted_root,
+            )
 
             self.assertEqual(result.returncode, 1, result.stdout)
             self.assertFalse(bundled.exists())
@@ -202,13 +288,23 @@ class ScrubArtifactsTests(unittest.TestCase):
 
     def test_non_strict_scrub_is_report_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, bundled = self.write_bundled_skill_fixture(
+                root,
+                source_body="docker run -e NEARAI_API_KEY=dummy ironclaw-test\n",
+            )
             artifact = root / "raw.html"
             artifact.write_text("api_key: secret-value\n", encoding="utf-8")
 
-            result = self.run_scrub(root, strict=False)
+            result = self.run_scrub(
+                root,
+                strict=False,
+                bundled_skills_root=trusted_root,
+            )
 
             self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertTrue((bundled / "SKILL.md").exists())
             self.assertTrue(artifact.exists())
             matches = (root / "scrub-matches.txt").read_text(encoding="utf-8")
             self.assertIn("<REDACTED>", matches)

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -128,6 +128,78 @@ class ScrubArtifactsTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1, result.stdout)
             self.assertFalse(unsafe.exists())
 
+    def test_strict_scrub_prunes_only_managed_bundled_skill_snapshots(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            skills_root = (
+                root
+                / "lane"
+                / "reborn-home"
+                / "case-a"
+                / "local-dev"
+                / "system"
+                / "skills"
+            )
+            bundled = skills_root / "local-test"
+            bundled.mkdir(parents=True)
+            (bundled / ".ironclaw-reborn-bundled.json").write_text(
+                json.dumps(
+                    {
+                        "owner": "ironclaw_reborn_composition_bundled_skill",
+                        "format": 1,
+                        "content_hash": "fixture-hash",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (bundled / "SKILL.md").write_text(
+                "docker run -e NEARAI_API_KEY=dummy ironclaw-test\n",
+                encoding="utf-8",
+            )
+            unmanaged = skills_root / "operator-skill"
+            unmanaged.mkdir()
+            (unmanaged / "SKILL.md").write_text(
+                "operator-owned diagnostic context\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_scrub(root, strict=True)
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertFalse(bundled.exists())
+            self.assertTrue((unmanaged / "SKILL.md").exists())
+
+    def test_strict_scrub_still_rejects_secret_outside_bundled_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bundled = (
+                root
+                / "lane"
+                / "reborn-home"
+                / "case-a"
+                / "local-dev"
+                / "system"
+                / "skills"
+                / "local-test"
+            )
+            bundled.mkdir(parents=True)
+            (bundled / ".ironclaw-reborn-bundled.json").write_text(
+                '{"owner": "ironclaw_reborn_composition_bundled_skill"}',
+                encoding="utf-8",
+            )
+            (bundled / "SKILL.md").write_text(
+                "NEARAI_API_KEY=dummy\n",
+                encoding="utf-8",
+            )
+            unsafe = root / "operator-state.txt"
+            unsafe.write_text("api_key: live-secret-value\n", encoding="utf-8")
+
+            result = self.run_scrub(root, strict=True)
+
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertFalse(bundled.exists())
+            self.assertFalse(unsafe.exists())
+
     def test_non_strict_scrub_is_report_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Remove bundled system-skill snapshots from staged Reborn homes only after validating the complete managed marker, its source-derived stable hash, and an exact source/staged file-set and byte match.
- Remove first-party extension manifests only when they exactly match the tested commit's source manifest, or the pinned deterministic NEAR AI runtime template after normalizing its repository-owned endpoint.
- Keep non-strict scrubbing report-only and leave malformed, modified, unmanaged, or unrecognized content in scope for the existing fail-closed secret scan.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Related #6437. Its full PR canary exposed this default-branch infrastructure regression; this PR does not change #6437 runtime behavior.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust changed.
- [ ] `cargo build` — Not applicable: shell/Python artifact tooling only.
- [x] Relevant tests pass: `python3 scripts/live-canary/test_scrub_artifacts.py` (14/14).
- [ ] `cargo test --features integration` — Not applicable: no database-backed or product integration behavior changed.
- [x] Manual testing: `bash -n scripts/live-canary/scrub-artifacts.sh`, `scripts/pre-commit-safety.sh`, and `git diff --check` pass.
- [x] Real-artifact replay: the strict scrubber returns 0 over a previously uploaded full QA 2 artifact after isolating the separately covered managed-skill snapshot; actual Gmail, Calendar, Drive, and dynamically rendered NEAR AI manifests produce no false positive.
- [x] Exact-head live canary: full target-harness run [29919847987](https://github.com/nearai/ironclaw/actions/runs/29919847987) exercised `a0c687ecba1f6778a65c08d0cd0fd12fb7ad2929`. Strict scrub and artifact upload passed on all 12 lanes; 46/47 live cases passed, while `qa_10a_slack_self_attribution` timed out after the model remained in a working/pagination state. A same-SHA targeted retry, [29921566607](https://github.com/nearai/ironclaw/actions/runs/29921566607), passed that case 1/1 together with strict scrub, upload, and the final report. Thus every live case has a passing exact-head result, although the first full matrix was not a one-shot 47/47.
- [x] Runtime-change baseline: full target-harness run [29918384467](https://github.com/nearai/ironclaw/actions/runs/29918384467) passed 12/12 lanes and 47/47 live cases on `bf93ff16811d795292adef839f482c61855c9ccc`; the only later commits change tests and documentation, not the production scrubber. Final PR head 1774d1814 differs from this canary-validated head only by Ruff-required formatting in the deterministic test.

## Test Strategy

User behavior: Live-canary lanes should preserve model and runtime evidence without failing strict artifact scrubbing on verified source-controlled package metadata, while any modified or unrecognized secret-shaped content still blocks upload.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Extended `scripts/live-canary/test_scrub_artifacts.py` through the real scrub entrypoint (14 tests).
- Reborn integration: Not applicable: runtime behavior is unchanged.
- Recorded fixture: Not applicable: no model request or choice changed.
- Browser E2E: Not applicable: no UI behavior changed.
- Backend or runtime: Real uploaded canary-artifact replay covers actual runtime package materialization output.
- Live canary: Full and targeted exact-head target-harness evidence is recorded under Validation.

What the tests prove:

- Valid managed skill snapshots are pruned only in strict mode and only with trusted marker/hash/tree provenance.
- Malformed markers and spoofed or modified skill contents remain scanned and fail closed.
- Unmanaged system skills remain present when safe and are still scanned and rejected when they contain secret-shaped content.
- Byte-identical first-party extension manifests are pruned; the NEAR AI runtime manifest is pruned only after trusted-template comparison with narrowly scoped normalization for both repository-owned endpoints.
- Modified or unrecognized manifests remain scanned and fail closed.
- Non-strict mode does not delete managed skills, manifests, or other artifacts.
- Secret material outside verified static snapshots still makes strict scrub delete the unsafe file and return failure.

Commands run:

- `python3 scripts/live-canary/test_scrub_artifacts.py`
- `bash -n scripts/live-canary/scrub-artifacts.sh`
- `scripts/pre-commit-safety.sh`
- `git diff --check`
- `STRICT_ARTIFACT_SCRUB=true scripts/live-canary/scrub-artifacts.sh <downloaded-QA-2-artifact>` after removing only the separately covered managed-skill directories

## Security Impact

Strict secret scanning remains enabled. Pre-scan deletion is limited to artifact copies proven equal to trusted source-controlled content from the tested commit. Skill directories require a valid runtime marker, matching source-derived hash, identical file set, and identical bytes. Extension handling removes only a verified static `manifest.toml`, or the trusted NEAR AI template after narrow endpoint normalization; sibling runtime evidence remains scanned. Any failed provenance check leaves the content in scope for fail-closed scanning.

## Reborn Trust-Boundary Checklist

N/A: this changes CI artifact staging only; no Reborn runtime, authority, prompt, persistence, status, or execution contract changes.

## Database Impact

None.

## Blast Radius

Live-canary artifact staging and upload preparation. A changed package format can retain redundant static files and fail the canary safely; it cannot bypass scanning without matching reviewed trusted content exactly.

## Rollback Plan

Revert this PR. Strict scrub then returns to rejecting copied bundled skills and first-party extension metadata that contain dummy credential examples or credential schema fields; no runtime or persisted-data rollback is required.

## Review Follow-Through

After merge, update #6437 from `main` and rerun `/canary` so its exact PR binary uses the corrected canonical artifact harness.

---

**Review track**: C (CI artifact security)

