### PR TITLE
docs(reborn): audit and guard explicit deployment profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GCP container deployment:** route PostgreSQL through a scoped Cloud SQL
+  Proxy Unix socket, persist the Reborn home on the VM, and reject unset,
+  placeholder, or `latest` image versions before Docker starts.
 - **Hosted MCP discovery:** bound overlong valid tool descriptions at the
   generic MCP boundary instead of rejecting the provider's entire catalog.
 - **Channel delivery:** keep live source-route observers attached for normal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 # Multi-stage Dockerfile for the standalone Reborn CLI HTTP service.
 #
 # Build:
-#   docker build -f Dockerfile.reborn -t ironclaw-reborn:latest .
+#   docker build -t ironclaw:latest .
 #
 # Run locally:
-#   docker run --rm --env-file .env.reborn -p 127.0.0.1:3000:3000 ironclaw-reborn:latest
+#   docker run --rm --env-file .env.reborn -p 127.0.0.1:3000:3000 ironclaw:latest
 #
 # Railway:
-#   Set Dockerfile path to Dockerfile.reborn and IRONCLAW_REBORN_SERVE_HOST=0.0.0.0.
-#   Railway supplies PORT. Set IRONCLAW_REBORN_PROFILE=hosted-single-tenant for
-#   Postgres-backed hosted storage, or hosted-single-tenant-volume for a
-#   Railway volume-backed single-tenant preview.
+#   Use this root Dockerfile and set IRONCLAW_REBORN_SERVE_HOST=0.0.0.0.
+#   Railway supplies PORT. IRONCLAW_REBORN_PROFILE must be set explicitly;
+#   see docs/reborn/deployment-profile-operator-checklist.md for the profile
+#   matching the service's storage and tenancy topology.
 
 FROM node:22.23.1-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS node_toolchain
 

--- a/deploy/cloud-sql-proxy.service
+++ b/deploy/cloud-sql-proxy.service
@@ -6,8 +6,8 @@ After=network.target
 Type=simple
 DynamicUser=yes
 # Keep the database handoff off TCP entirely. The runtime directory is shared
-# only with the IronClaw container, whose supplementary group is derived from
-# this directory when docker run starts.
+# with the IronClaw container, whose supplementary group is derived from this
+# directory when docker run starts.
 RuntimeDirectory=cloud-sql-proxy
 RuntimeDirectoryMode=0770
 RuntimeDirectoryPreserve=restart

--- a/deploy/cloud-sql-proxy.service
+++ b/deploy/cloud-sql-proxy.service
@@ -5,7 +5,14 @@ After=network.target
 [Service]
 Type=simple
 DynamicUser=yes
-ExecStart=/usr/local/bin/cloud-sql-proxy ironclaw-prod:us-central1:ironclaw-db --port=5432
+# Keep the database handoff off TCP entirely. The runtime directory is shared
+# only with the IronClaw container, whose supplementary group is derived from
+# this directory when docker run starts.
+RuntimeDirectory=cloud-sql-proxy
+RuntimeDirectoryMode=0770
+RuntimeDirectoryPreserve=restart
+UMask=0007
+ExecStart=/usr/local/bin/cloud-sql-proxy ironclaw-prod:us-central1:ironclaw-db --unix-socket=/run/cloud-sql-proxy
 Restart=always
 RestartSec=5
 

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -9,8 +9,9 @@
 # checklist. Never copy observed secret values into an issue or deployment log.
 
 # Pin the Docker image version for deterministic deployments.
-# Update this value when deploying a new release.
-# IRONCLAW_VERSION=v1.0.0
+# Replace this placeholder with a release tag before starting the unit. The
+# systemd service rejects an unset or empty value and never falls back to latest.
+IRONCLAW_VERSION=CHANGE_ME
 
 # --- Reborn serve binding ---
 # 0.0.0.0 binds to all interfaces (required so the published Docker port is
@@ -23,10 +24,14 @@ IRONCLAW_REBORN_SERVE_PORT=3000
 # (docker/reborn/config.production.toml). Requires the Postgres URL and a
 # secret master key below.
 IRONCLAW_REBORN_PROFILE=production
-IRONCLAW_REBORN_POSTGRES_URL=postgres://ironclaw:CHANGE_ME@localhost:5432/ironclaw?sslmode=require
+# The percent-encoded host is the Cloud SQL Auth Proxy Unix socket directory
+# mounted at /cloudsql inside the container. sslmode=disable applies only to
+# this local socket; the proxy encrypts the connection to Cloud SQL.
+IRONCLAW_REBORN_POSTGRES_URL=postgres://ironclaw:CHANGE_ME@%2Fcloudsql%2Fironclaw-prod%3Aus-central1%3Aironclaw-db/ironclaw?sslmode=disable
 IRONCLAW_REBORN_SECRET_MASTER_KEY=CHANGE_ME
 
-# Persistent home for config.toml and any volume-backed state.
+# Persistent home for config.toml and any volume-backed state. The systemd unit
+# bind-mounts the host's /opt/ironclaw/data directory at this path.
 IRONCLAW_REBORN_HOME=/data/ironclaw-reborn
 
 # --- Logging ---

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -4,7 +4,9 @@
 # This is the deploy-target env file for the Reborn `ironclaw` image
 # (docker/reborn/entrypoint.sh). With no CLI arguments the entrypoint runs
 # `serve --host $IRONCLAW_REBORN_SERVE_HOST --port $PORT`. See the repo-root
-# `.env.example` for the exhaustive list of IRONCLAW_REBORN_* variables.
+# `.env.example` for the exhaustive list of IRONCLAW_REBORN_* variables and
+# `docs/reborn/deployment-profile-operator-checklist.md` for the GCP verification
+# checklist. Never copy observed secret values into an issue or deployment log.
 
 # Pin the Docker image version for deterministic deployments.
 # Update this value when deploying a new release.

--- a/deploy/ironclaw.service
+++ b/deploy/ironclaw.service
@@ -16,6 +16,8 @@ ExecStartPre=/bin/bash -c 'docker pull us-central1-docker.pkg.dev/ironclaw-prod/
 # the published port is reachable, and IRONCLAW_REBORN_PROFILE=production to
 # select Postgres-backed hosted storage. Do NOT pass legacy v1 flags such as
 # `--no-onboard` here — they are not accepted by the Reborn `ironclaw` binary.
+# Before enabling or restarting this unit, follow
+# docs/reborn/deployment-profile-operator-checklist.md without recording secrets.
 ExecStart=/bin/bash -c 'docker run --rm \
   --name ironclaw \
   --env-file /opt/ironclaw/.env \

--- a/deploy/ironclaw.service
+++ b/deploy/ironclaw.service
@@ -6,10 +6,10 @@ Requires=cloud-sql-proxy.service
 [Service]
 Type=simple
 EnvironmentFile=/opt/ironclaw/.env
-# Pin to a specific version tag or digest instead of :latest to prevent
-# uncontrolled deployments. Update IRONCLAW_VERSION in /opt/ironclaw/.env
-# or replace the tag below when deploying a new release.
-ExecStartPre=/bin/bash -c 'docker pull us-central1-docker.pkg.dev/ironclaw-prod/ironclaw/agent:${IRONCLAW_VERSION:-latest}'
+# Pin to a specific release tag instead of :latest to prevent uncontrolled
+# deployments. Update IRONCLAW_VERSION in /opt/ironclaw/.env when deploying a
+# new release. Empty, placeholder, and latest values fail before Docker runs.
+ExecStartPre=/bin/bash -c ': "${IRONCLAW_VERSION:?IRONCLAW_VERSION must be set in /opt/ironclaw/.env}"; case "${IRONCLAW_VERSION}" in latest|CHANGE_ME) echo "IRONCLAW_VERSION must be a pinned release tag" >&2; exit 1 ;; esac; exec docker pull "us-central1-docker.pkg.dev/ironclaw-prod/ironclaw/agent:${IRONCLAW_VERSION}"'
 # The Reborn image entrypoint (docker/reborn/entrypoint.sh) defaults to
 # `serve --host $IRONCLAW_REBORN_SERVE_HOST --port $PORT` when invoked with no
 # arguments. Set IRONCLAW_REBORN_SERVE_HOST=0.0.0.0 in /opt/ironclaw/.env so
@@ -21,8 +21,11 @@ ExecStartPre=/bin/bash -c 'docker pull us-central1-docker.pkg.dev/ironclaw-prod/
 ExecStart=/bin/bash -c 'docker run --rm \
   --name ironclaw \
   --env-file /opt/ironclaw/.env \
+  --mount type=bind,src=/opt/ironclaw/data,dst=/data/ironclaw-reborn \
+  --mount type=bind,src=/run/cloud-sql-proxy,dst=/cloudsql \
+  --group-add "$(stat -c %g /run/cloud-sql-proxy)" \
   -p 3000:3000 \
-  us-central1-docker.pkg.dev/ironclaw-prod/ironclaw/agent:${IRONCLAW_VERSION:-latest}'
+  "us-central1-docker.pkg.dev/ironclaw-prod/ironclaw/agent:${IRONCLAW_VERSION:?IRONCLAW_VERSION must be set in /opt/ironclaw/.env}"'
 ExecStop=/usr/bin/docker stop ironclaw
 Restart=always
 RestartSec=10

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -48,11 +48,11 @@ echo "==> Configuring Docker registry auth"
 # The VM service account provides Artifact Registry access
 gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
-echo "==> Creating config directory"
-# Owned by root, readable only by root. Docker reads --env-file as root
-# before dropping to uid 1000 (ironclaw) inside the container.
-mkdir -p /opt/ironclaw
-chmod 700 /opt/ironclaw
+echo "==> Creating config and persistent data directories"
+# The config remains root-only. The data directory is bind-mounted into the
+# image and therefore uses the image's fixed ironclaw uid/gid (1000:1000).
+install -d -m 0700 -o root -g root /opt/ironclaw
+install -d -m 0700 -o 1000 -g 1000 /opt/ironclaw/data
 
 if [ ! -f /opt/ironclaw/.env ]; then
   echo "WARNING: /opt/ironclaw/.env does not exist."
@@ -61,6 +61,7 @@ if [ ! -f /opt/ironclaw/.env ]; then
   echo ""
   echo "Then run: systemctl enable ironclaw && systemctl start ironclaw"
 else
+  chown root:root /opt/ironclaw/.env
   chmod 600 /opt/ironclaw/.env
   echo "==> Starting IronClaw"
   systemctl enable ironclaw

--- a/docs/reborn/README.md
+++ b/docs/reborn/README.md
@@ -12,6 +12,8 @@ This repo exposes Reborn structure primarily through implementation crates, crat
 | --- | --- |
 | Standalone Reborn binary | `docs/reborn-binary.md` |
 | Standalone Reborn onboarding | `docs/reborn/onboarding.md` |
+| Docker/Railway/GCP deployment | `docs/reborn/deploy-reborn-cli-docker.md` |
+| Deployment profile operator checklist | `docs/reborn/deployment-profile-operator-checklist.md` |
 | Production cutover readiness closeout | `docs/reborn/production-cutover-readiness-closeout.md` |
 | Standalone Reborn Slack setup | `docs/reborn/setup-slack-for-reborn-binary.md` |
 | Porting v1 channels to Reborn surfaces/ProductAdapters | `docs/reborn/how-to-port-channel-to-reborn.md` |

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -1,7 +1,7 @@
 # Reborn CLI Docker Deployment
 
-`Dockerfile.reborn` builds the standalone `ironclaw` binary with the
-WebUI v2 and Slack host-beta features enabled. The image defaults to:
+The root `Dockerfile` builds the standalone `ironclaw` binary with the WebUI v2
+and Slack host-beta features enabled. The image defaults to:
 
 ```text
 ironclaw serve --host ${IRONCLAW_REBORN_SERVE_HOST:-127.0.0.1} --port ${PORT:-3000}
@@ -11,10 +11,15 @@ Railway supplies `PORT`; set `IRONCLAW_REBORN_SERVE_HOST=0.0.0.0` for
 Railway/public deployments. Local Docker runs can keep the loopback default and
 set `IRONCLAW_REBORN_SERVE_PORT=3000`.
 
+Before changing an external environment, follow the
+[deployment profile operator checklist](deployment-profile-operator-checklist.md).
+The profile must be explicit for public Railway and GCP deployments; do not
+infer it from the image's local-development seed.
+
 ## Build
 
 ```bash
-docker build -f Dockerfile.reborn -t ironclaw-reborn:local .
+docker build -t ironclaw:local .
 ```
 
 ## Local Run
@@ -25,7 +30,7 @@ Create an env file outside git, then run:
 docker run --rm \
   --env-file .env.reborn \
   -p 127.0.0.1:3000:3000 \
-  ironclaw-reborn:local
+  ironclaw:local
 ```
 
 Minimum local env shape:
@@ -74,9 +79,11 @@ https://<public-host>/auth/callback/google
 
 ## Railway
 
-Set the service Dockerfile path to `Dockerfile.reborn`. Railway sets `PORT`;
-keep `IRONCLAW_REBORN_SERVE_HOST=0.0.0.0`. The Reborn WebUI service serves
-`/api/health` for Railway's healthcheck.
+Use the repository root `Dockerfile` (the checked-in `railway.toml` already
+selects it). Railway sets `PORT`; keep
+`IRONCLAW_REBORN_SERVE_HOST=0.0.0.0`. The Reborn WebUI service serves
+`/api/health` for Railway's healthcheck. Set `IRONCLAW_REBORN_PROFILE`
+explicitly in Railway service variables.
 
 Leave Railway's Start Command empty for the Docker image. The image entrypoint
 builds the `ironclaw serve` arguments from `PORT` and
@@ -188,6 +195,22 @@ the agent connect a Google credential:
 ```bash
 IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI=https://<railway-domain>/api/reborn/product-auth/oauth/google/callback
 ```
+
+## GCP Compute Engine with systemd
+
+The checked-in GCP unit reads `/opt/ironclaw/.env` through
+`deploy/ironclaw.service`. Start from `deploy/env.example` and keep this active
+assignment:
+
+```bash
+IRONCLAW_REBORN_PROFILE=production
+```
+
+The production profile requires `IRONCLAW_REBORN_POSTGRES_URL` and
+`IRONCLAW_REBORN_SECRET_MASTER_KEY`; the example routes PostgreSQL through the
+Cloud SQL Auth Proxy. Keep the secret values only in the root-readable external
+environment file. Before enabling or restarting the unit, complete the GCP
+section of the [operator checklist](deployment-profile-operator-checklist.md).
 
 ## Slack
 

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -207,10 +207,24 @@ IRONCLAW_REBORN_PROFILE=production
 ```
 
 The production profile requires `IRONCLAW_REBORN_POSTGRES_URL` and
-`IRONCLAW_REBORN_SECRET_MASTER_KEY`; the example routes PostgreSQL through the
-Cloud SQL Auth Proxy. Keep the secret values only in the root-readable external
-environment file. Before enabling or restarting the unit, complete the GCP
-section of the [operator checklist](deployment-profile-operator-checklist.md).
+`IRONCLAW_REBORN_SECRET_MASTER_KEY`. The checked-in services route PostgreSQL
+through a Cloud SQL Auth Proxy Unix socket: `cloud-sql-proxy.service` creates the
+socket below `/run/cloud-sql-proxy`, and `ironclaw.service` mounts that directory
+at `/cloudsql` inside the container. The percent-encoded socket path in
+`deploy/env.example` is parsed as a local Unix socket; `sslmode=disable` applies
+only to that local hop, while the proxy encrypts the connection to Cloud SQL.
+No PostgreSQL TCP port is exposed to the VM or its network.
+
+The unit also bind-mounts the host directory `/opt/ironclaw/data` at
+`/data/ironclaw-reborn`. `deploy/setup.sh` creates it as UID/GID `1000:1000`
+with mode `0700`, matching the non-root user baked into the image. Back up this
+host directory, and verify a restore before treating the deployment as durable.
+
+Keep secret values only in the root-readable external environment file, and
+replace `IRONCLAW_VERSION=CHANGE_ME` with a pinned release tag; the unit fails
+closed instead of falling back to `latest`. Before enabling or restarting the
+unit, complete the GCP section of the
+[operator checklist](deployment-profile-operator-checklist.md).
 
 ## Slack
 

--- a/docs/reborn/deployment-profile-operator-checklist.md
+++ b/docs/reborn/deployment-profile-operator-checklist.md
@@ -65,19 +65,28 @@ Before enabling or restarting `ironclaw.service`:
 
 - [ ] Start from `deploy/env.example`; replace every `CHANGE_ME` value in the
   root-readable `/opt/ironclaw/.env` without committing that file.
+- [ ] Confirm `IRONCLAW_VERSION` is an explicit immutable release tag and is
+  neither empty nor `latest`; an unset value must prevent the unit from starting.
 - [ ] Confirm the file contains exactly one active
   `IRONCLAW_REBORN_PROFILE=production` assignment.
-- [ ] Confirm the PostgreSQL URL points at the intended Cloud SQL Auth Proxy
-  endpoint and the independent secret master key is present, without printing
-  either value.
+- [ ] Confirm the PostgreSQL URL uses the intended percent-encoded `/cloudsql/`
+  Unix socket path and the independent secret master key is present, without
+  printing either value. Do not expose a Cloud SQL Proxy TCP port.
 - [ ] Confirm `IRONCLAW_REBORN_SERVE_HOST=0.0.0.0`, the WebUI authentication
   variables are present, and the image version is pinned.
 - [ ] Confirm `/opt/ironclaw/.env` remains root-owned and mode `0600`.
+- [ ] Confirm `/opt/ironclaw/data` is owned by UID/GID `1000:1000`, has mode
+  `0700`, and is included in a tested backup/restore procedure.
 - [ ] Confirm `cloud-sql-proxy.service` is active before starting IronClaw.
+- [ ] Confirm the GCP firewall or trusted reverse proxy exposes only the intended
+  WebUI port; `docker inspect ironclaw` must show no published PostgreSQL port.
 
 After a safe deployment or restart:
 
 - [ ] Confirm `systemctl is-active cloud-sql-proxy ironclaw` succeeds.
+- [ ] Confirm the proxy socket exists below
+  `/run/cloud-sql-proxy/ironclaw-prod:us-central1:ironclaw-db/` and the IronClaw
+  container has both `/cloudsql` and `/data/ironclaw-reborn` bind mounts.
 - [ ] Confirm `curl --fail http://127.0.0.1:3000/api/health` succeeds from the
   VM.
 - [ ] Inspect the bounded, redacted service logs for the intended profile and

--- a/docs/reborn/deployment-profile-operator-checklist.md
+++ b/docs/reborn/deployment-profile-operator-checklist.md
@@ -1,0 +1,117 @@
+# Deployment Profile Operator Checklist
+
+**Issue:** #6454
+
+**Parent Epic:** #6369
+
+Use this checklist to verify deployment variables that live outside the
+repository. It is an operator procedure, not authorization to modify a live
+Railway or GCP environment. Record profile names and verification results, but
+never copy database URLs, tokens, master keys, OAuth secrets, or other secret
+values into issues, pull requests, logs, or screenshots.
+
+## Checked-in profile contract
+
+| Target | Profile source | Required profile |
+| --- | --- | --- |
+| Local Docker | `docker/reborn/config.toml` | `local-dev` |
+| Railway, Postgres-backed single tenant | Railway service variable | `hosted-single-tenant` |
+| Railway, volume-backed single tenant | Railway service variable | `hosted-single-tenant-volume` |
+| Railway, production multi-tenant | Railway service variable | `production` |
+| GCP Compute Engine systemd unit | `/opt/ironclaw/.env` created from `deploy/env.example` | `production` |
+| Production-shaped validation without traffic | Explicit operator invocation | `migration-dry-run` |
+
+Public Railway and GCP deployments must set `IRONCLAW_REBORN_PROFILE`
+explicitly. Do not use `local-dev-yolo` on a public listener. Do not use
+`migration-dry-run` as a serving profile.
+
+The image ships an explicit local `local-dev` seed so a loopback-only local
+Docker run remains usable without PostgreSQL. That seed is not a public
+deployment default.
+
+## Railway checklist
+
+Before deploying:
+
+- [ ] Confirm `railway.toml` uses the repository root `Dockerfile` and has no
+  custom Start Command that bypasses the image entrypoint.
+- [ ] Confirm `IRONCLAW_REBORN_PROFILE` is present in Railway service variables
+  and matches the intended row in the table above.
+- [ ] Confirm `IRONCLAW_REBORN_SERVE_HOST=0.0.0.0` and let Railway supply
+  `PORT`.
+- [ ] For `hosted-single-tenant`, confirm the PostgreSQL URL and independent
+  secret master key variables are present without displaying their values.
+- [ ] For a volume-backed profile, confirm a persistent Railway volume is
+  attached and `IRONCLAW_REBORN_HOME` resolves beneath its mount.
+- [ ] Confirm WebUI authentication variables and the selected LLM provider's
+  credential variables are present without displaying their values.
+- [ ] Confirm the service does not set
+  `IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true` unless it is explicitly a
+  disposable test deployment.
+
+After a safe deployment or restart:
+
+- [ ] Confirm Railway reports `/api/health` healthy.
+- [ ] Confirm non-health routes leave the temporary startup `503` state after
+  runtime assembly completes.
+- [ ] Inspect redacted startup logs for the intended profile and absence of
+  blocking readiness diagnostics; do not paste raw environment output.
+- [ ] Record only the target, profile name, image tag/digest, timestamp, and
+  pass/fail result in the deployment record.
+
+## GCP Compute Engine checklist
+
+Before enabling or restarting `ironclaw.service`:
+
+- [ ] Start from `deploy/env.example`; replace every `CHANGE_ME` value in the
+  root-readable `/opt/ironclaw/.env` without committing that file.
+- [ ] Confirm the file contains exactly one active
+  `IRONCLAW_REBORN_PROFILE=production` assignment.
+- [ ] Confirm the PostgreSQL URL points at the intended Cloud SQL Auth Proxy
+  endpoint and the independent secret master key is present, without printing
+  either value.
+- [ ] Confirm `IRONCLAW_REBORN_SERVE_HOST=0.0.0.0`, the WebUI authentication
+  variables are present, and the image version is pinned.
+- [ ] Confirm `/opt/ironclaw/.env` remains root-owned and mode `0600`.
+- [ ] Confirm `cloud-sql-proxy.service` is active before starting IronClaw.
+
+After a safe deployment or restart:
+
+- [ ] Confirm `systemctl is-active cloud-sql-proxy ironclaw` succeeds.
+- [ ] Confirm `curl --fail http://127.0.0.1:3000/api/health` succeeds from the
+  VM.
+- [ ] Inspect the bounded, redacted service logs for the intended profile and
+  absence of blocking readiness diagnostics.
+- [ ] Record only the target, profile name, image tag/digest, timestamp, and
+  pass/fail result.
+
+## Local Docker checklist
+
+- [ ] Keep the listener on `127.0.0.1` unless a trusted external proxy requires
+  a different bind.
+- [ ] Use the shipped `local-dev` seed or set `IRONCLAW_REBORN_PROFILE`
+  explicitly when testing another profile.
+- [ ] Supply the storage and secret variables required by the selected profile.
+- [ ] Do not treat a successful local `local-dev` start as production-profile
+  readiness evidence.
+
+## Rollback and evidence
+
+This audit does not change runtime defaults. Rollback for documentation or
+static-test corrections is a normal source revert. A live deployment rollback
+must use the platform's previously verified image tag/digest and its matching
+profile/config contract; never fall back to an uncontrolled `latest` tag.
+
+For issue evidence, record:
+
+```text
+Target: Railway | GCP | local Docker
+Profile: <non-secret profile name>
+Image: <version tag or digest>
+Checked at: <UTC timestamp>
+Health: pass | fail
+Readiness: pass | blocking diagnostic id only
+Operator: <GitHub handle or team>
+```
+
+Do not attach complete environment dumps or unredacted logs.

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,12 @@
 builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
+# Railway service variables are managed outside this repository.
+# IRONCLAW_REBORN_PROFILE must be set explicitly to the profile matching the
+# service's storage and tenancy topology. Do not rely on the image's local-dev
+# seed for a public deployment. Follow the pre-deploy and verification checklist:
+# docs/reborn/deployment-profile-operator-checklist.md
+
 [deploy]
 healthcheckPath = "/api/health"
 healthcheckTimeout = 300

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -287,6 +287,77 @@ fn reborn_deployment_docs_keep_webui_sso_separate_from_product_auth() {
 }
 
 #[test]
+fn checked_in_deployments_require_explicit_reborn_profiles() {
+    let railway = read_repo_file("railway.toml");
+    assert!(
+        railway.contains("dockerfilePath = \"Dockerfile\"")
+            && railway.contains("IRONCLAW_REBORN_PROFILE must be set explicitly")
+            && railway.contains("docs/reborn/deployment-profile-operator-checklist.md"),
+        "Railway must use the canonical image and document its external profile requirement"
+    );
+
+    let systemd = read_repo_file("deploy/ironclaw.service");
+    let gcp_env = read_repo_file("deploy/env.example");
+    assert!(
+        systemd.contains("EnvironmentFile=/opt/ironclaw/.env")
+            && systemd.contains("IRONCLAW_REBORN_PROFILE=production")
+            && systemd.contains("docs/reborn/deployment-profile-operator-checklist.md"),
+        "the GCP systemd unit must document its external production profile contract"
+    );
+    assert_eq!(
+        gcp_env
+            .lines()
+            .filter(|line| line.trim() == "IRONCLAW_REBORN_PROFILE=production")
+            .count(),
+        1,
+        "the GCP environment example must contain exactly one active production profile assignment"
+    );
+
+    for (path, profile) in [
+        ("docker/reborn/config.toml", "local-dev"),
+        (
+            "docker/reborn/config.hosted-single-tenant.toml",
+            "hosted-single-tenant",
+        ),
+        (
+            "docker/reborn/config.hosted-single-tenant-volume.toml",
+            "hosted-single-tenant-volume",
+        ),
+        ("docker/reborn/config.production.toml", "production"),
+    ] {
+        let config = read_repo_file(path);
+        let assignment = format!("profile = \"{profile}\"");
+        assert_eq!(
+            config
+                .lines()
+                .filter(|line| line.trim() == assignment)
+                .count(),
+            1,
+            "{path} must contain exactly one explicit {profile} profile assignment"
+        );
+    }
+
+    let checklist = read_repo_file("docs/reborn/deployment-profile-operator-checklist.md");
+    for required in [
+        "## Railway checklist",
+        "## GCP Compute Engine checklist",
+        "## Local Docker checklist",
+        "IRONCLAW_REBORN_PROFILE",
+        "Do not attach complete environment dumps or unredacted logs.",
+    ] {
+        assert!(
+            checklist.contains(required),
+            "deployment profile checklist must retain `{required}`"
+        );
+    }
+    assert!(
+        read_repo_file("docs/reborn/README.md")
+            .contains("docs/reborn/deployment-profile-operator-checklist.md"),
+        "the Reborn documentation map must keep the operator checklist discoverable"
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn reborn_entrypoint_copies_config_and_builds_default_serve_args() {
     let fake = setup_fake_entrypoint();

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -298,11 +298,14 @@ fn checked_in_deployments_require_explicit_reborn_profiles() {
 
     let systemd = read_repo_file("deploy/ironclaw.service");
     let gcp_env = read_repo_file("deploy/env.example");
+    let cloud_sql_proxy = read_repo_file("deploy/cloud-sql-proxy.service");
+    let setup = read_repo_file("deploy/setup.sh");
     assert!(
         systemd.contains("EnvironmentFile=/opt/ironclaw/.env")
+            && systemd.contains("--env-file /opt/ironclaw/.env")
             && systemd.contains("IRONCLAW_REBORN_PROFILE=production")
             && systemd.contains("docs/reborn/deployment-profile-operator-checklist.md"),
-        "the GCP systemd unit must document its external production profile contract"
+        "the GCP systemd unit must hand the external production profile environment to Docker"
     );
     assert_eq!(
         gcp_env
@@ -311,6 +314,63 @@ fn checked_in_deployments_require_explicit_reborn_profiles() {
             .count(),
         1,
         "the GCP environment example must contain exactly one active production profile assignment"
+    );
+    assert_eq!(
+        gcp_env
+            .lines()
+            .filter(|line| line.trim() == "IRONCLAW_VERSION=CHANGE_ME")
+            .count(),
+        1,
+        "the GCP environment example must require an explicit image version"
+    );
+    assert!(
+        !systemd.contains(":-latest")
+            && systemd.matches("${IRONCLAW_VERSION:?").count() == 2
+            && systemd.contains("latest|CHANGE_ME"),
+        "the GCP systemd unit must fail closed when IRONCLAW_VERSION is unset"
+    );
+    assert!(
+        cloud_sql_proxy.contains("--unix-socket=/run/cloud-sql-proxy")
+            && cloud_sql_proxy.contains("RuntimeDirectoryMode=0770")
+            && cloud_sql_proxy.contains("RuntimeDirectoryPreserve=restart")
+            && cloud_sql_proxy.contains("UMask=0007")
+            && systemd.contains("--mount type=bind,src=/run/cloud-sql-proxy,dst=/cloudsql")
+            && systemd.contains("--group-add \"$(stat -c %g /run/cloud-sql-proxy)\"")
+            && gcp_env.contains("@%2Fcloudsql%2Fironclaw-prod%3Aus-central1%3Aironclaw-db/")
+            && gcp_env.contains("sslmode=disable")
+            && !systemd.contains("--network=host")
+            && !systemd.contains("-p 5432")
+            && !cloud_sql_proxy.contains("--port"),
+        "the GCP container must reach Cloud SQL through the scoped Unix socket without host networking"
+    );
+    #[cfg(unix)]
+    {
+        use tokio_postgres::config::{Host, SslMode};
+
+        let postgres_url = gcp_env
+            .lines()
+            .find_map(|line| line.strip_prefix("IRONCLAW_REBORN_POSTGRES_URL="))
+            .expect("the GCP environment example must define a Postgres URL");
+        let postgres_config = postgres_url
+            .parse::<tokio_postgres::Config>()
+            .expect("the GCP Postgres URL must parse");
+        assert_eq!(
+            postgres_config.get_hosts(),
+            &[Host::Unix(PathBuf::from(
+                "/cloudsql/ironclaw-prod:us-central1:ironclaw-db"
+            ))],
+            "the GCP Postgres URL must resolve to the mounted proxy socket directory"
+        );
+        assert_eq!(
+            postgres_config.get_ssl_mode(),
+            SslMode::Disable,
+            "the local proxy socket must not attempt a second TLS handshake"
+        );
+    }
+    assert!(
+        systemd.contains("--mount type=bind,src=/opt/ironclaw/data,dst=/data/ironclaw-reborn")
+            && setup.contains("install -d -m 0700 -o 1000 -g 1000 /opt/ironclaw/data"),
+        "the GCP deployment must persist Reborn home with ownership matching the image user"
     );
 
     for (path, profile) in [

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -330,7 +330,8 @@ fn checked_in_deployments_require_explicit_reborn_profiles() {
         "the GCP systemd unit must fail closed when IRONCLAW_VERSION is unset"
     );
     assert!(
-        cloud_sql_proxy.contains("--unix-socket=/run/cloud-sql-proxy")
+        cloud_sql_proxy.contains("RuntimeDirectory=cloud-sql-proxy")
+            && cloud_sql_proxy.contains("--unix-socket=/run/cloud-sql-proxy")
             && cloud_sql_proxy.contains("RuntimeDirectoryMode=0770")
             && cloud_sql_proxy.contains("RuntimeDirectoryPreserve=restart")
             && cloud_sql_proxy.contains("UMask=0007")


### PR DESCRIPTION
## Summary

- Audits the checked-in Railway, GCP systemd, and Docker deployment profiles after the Tier B cutover.
- Documents the required explicit `IRONCLAW_REBORN_PROFILE` values for Railway, GCP, and local Docker deployments.
- Adds an operator checklist for verifying externally managed environment variables without exposing secrets.
- Corrects active deployment documentation that still referenced the retired `Dockerfile.reborn` path.
- Adds a static regression contract covering Railway configuration, GCP environment wiring, shipped Docker profiles, and checklist discoverability.
- Does not change composition defaults, entrypoint behavior, runtime behavior, or live deployment environments.

## Linked Issue

Closes #6454

Part of #6369

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test --test dockerfile_runtime_home` — 20 passed
- [x] `cargo test -p ironclaw --test smoke dockerfile_reborn_builds_without_backend_feature_flags` — 1 passed
- [x] `cargo clippy --test dockerfile_runtime_home -- -D warnings`
- [x] `scripts/pre-commit-safety.sh`

## Security Impact

No runtime security changes. The operator checklist reinforces that database URLs, tokens, master keys, OAuth secrets, environment dumps, and unredacted logs must not be copied into issues, pull requests, or deployment records.

## Database Impact

No schema, migration, storage, or database behavior changes.

## Blast Radius

Limited to checked-in deployment documentation, Dockerfile comments, Railway/GCP configuration guidance, and a static deployment contract test. No production execution path is modified.

External Railway and GCP environment verification remains operator-owned and was not performed by this PR.

## Rollback Plan

Revert this PR to restore the previous documentation and static-test contract. No live environment or persisted state requires rollback.

---

**Review track**: A