### PR TITLE
ci(reborn): discover nested manifest integration tests

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -529,15 +529,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
-    # This is the ONLY execution of the 27 flat reborn_integration_* suites
+    # This is the ONLY execution of the flat reborn_integration_* suites
     # (there is no separate uninstrumented pass/fail run of them — `cargo
     # llvm-cov ... test` has the same pass/fail semantics as `cargo test`, just
-    # instrumented) plus one more, instrumented, run of the 7 reborn_group_*
+    # instrumented) plus one more, instrumented, run of the reborn_group_*
     # suites already covered uninstrumented by reborn-group-tests above.
     # Generous backstop: a cold-cache instrumented build of the Reborn closure
     # is heavier than a plain build (see the retired reborn-coverage.yml's
     # 180m budget for the same closure, run as a single job); each of these 5
-    # lanes only carries a slice of the 34 int-tier suites, so 120m is ample.
+    # lanes only carries a slice of the discovered int-tier suites, so 120m is ample.
     timeout-minutes: 120
     env:
       ANTHROPIC_API_KEY: ""
@@ -865,7 +865,7 @@ jobs:
             exit 1
           fi
 
-          # This is the ONLY execution of the 27 flat reborn_integration_*
+          # This is the ONLY execution of the flat reborn_integration_*
           # suites (see the reborn-integration-coverage job), so it gates like
           # every other test job above — real pass/fail, not the coverage
           # percentage (that's coverage-report below).

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -529,7 +529,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
-    # This is the ONLY execution of the flat reborn_integration_* suites
+    # This is the ONLY execution of the non-group integration-tier suites
     # (there is no separate uninstrumented pass/fail run of them — `cargo
     # llvm-cov ... test` has the same pass/fail semantics as `cargo test`, just
     # instrumented) plus one more, instrumented, run of the reborn_group_*
@@ -865,7 +865,7 @@ jobs:
             exit 1
           fi
 
-          # This is the ONLY execution of the flat reborn_integration_*
+          # This is the ONLY execution of the non-group integration-tier
           # suites (see the reborn-integration-coverage job), so it gates like
           # every other test job above — real pass/fail, not the coverage
           # percentage (that's coverage-report below).

--- a/.github/workflows/regression-test-check.yml
+++ b/.github/workflows/regression-test-check.yml
@@ -193,6 +193,11 @@ jobs:
             exit 0
           fi
 
+          if grep -qE '(^|/)test[-_][^/]*\.sh$|(^|/)[^/]*[-_]test\.sh$' <<< "$CHANGED_FILES"; then
+            echo "Shell test file changes found."
+            exit 0
+          fi
+
           if grep -qE '^crates/ironclaw_webui/frontend/src/.*\.test\.(ts|mts)$' <<< "$CHANGED_FILES"; then
             echo "Reborn WebUI v2 JS test file changes found."
             exit 0

--- a/scripts/ci/reborn-coverage-int-tier-tests.sh
+++ b/scripts/ci/reborn-coverage-int-tier-tests.sh
@@ -3,51 +3,39 @@
 # Print the cargo `--test <name>` arguments for the Reborn in-process
 # integration-tier test binaries, one per line.
 #
-# Integration-tier (task T0-COV) is the set of in-process suites under
-# tests/integration/ (post-restructure home of the roadmap integration suite;
-# see docs/superpowers/specs/2026-06-26-reborn-integration-test-framework-design.md):
-#   - tests/integration/<name>.rs   (flat [[test]] binaries; Cargo `name` is
-#                                    reborn_integration_<name>)
-#   - tests/integration/group_<x>/  ([[test]] binaries; Cargo `name` is
-#                                    reborn_group_<x>)
+# Integration-tier (task T0-COV) is every test target Cargo resolves from the
+# root manifest whose source path is under tests/integration/ (the
+# post-restructure home of the roadmap integration suite; see
+# docs/superpowers/specs/2026-06-26-reborn-integration-test-framework-design.md).
+# This includes flat, group, and other nested targets such as auth/*.rs.
 #
-# Discovery is dynamic so coverage automatically picks up new int-tier suites
-# as they land (mirrors scripts/ci/run-reborn-group-tests.sh's dir->name
-# rewrite and scripts/ci/run-reborn-root-partition.sh's overall shape).
-#
-# Candidate names are filtered against Cargo.toml's `[[test]] name = "..."`
-# entries: not every flat tests/integration/<name>.rs file is its own binary
-# — a file can be a #[path]-mounted shared-fixture sibling included by two or
-# more real suites instead (see slack_pairing_fixtures.rs, mounted by
-# slack_pairing_redeem.rs / slack_pairing_actor_resolution.rs), and such
-# siblings have no `[[test]]` entry of their own. Without this filter, a bare
-# directory scan derives a nonexistent `--test reborn_integration_<sibling>`
-# arg and `cargo llvm-cov ... test` fails outright with "no test target
-# named" before running anything in the lane.
+# Cargo metadata is authoritative for target names and paths. This avoids
+# deriving names from directory conventions and naturally excludes shared
+# fixtures that are mounted by real suites but are not test targets themselves.
 
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo_root}"
 
-mapfile -t names < <(
-  {
-    find tests/integration -maxdepth 1 -type f -name '*.rs' \
-      | sed -E 's#^tests/integration/#reborn_integration_#; s#\.rs$##'
-    find tests/integration -mindepth 1 -maxdepth 1 -type d -name 'group_*' \
-      -exec sh -c 'test -f "$1/main.rs"' _ {} ';' -print \
-      | sed -E 's#^tests/integration/group_#reborn_group_#'
-  } | LC_ALL=C sort -u | while IFS= read -r candidate; do
-    if awk -v name="${candidate}" '
-      /^\[\[test\]\]/ { in_test=1; next }
-      /^\[/ { in_test=0 }
-      in_test && $0 == "name = \"" name "\"" { found=1; exit }
-      END { exit !found }
-    ' Cargo.toml; then
-      printf '%s\n' "${candidate}"
-    fi
-  done
-)
+metadata="$(cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml)"
+names_output="$(
+  printf '%s\n' "${metadata}" | jq -r '
+    .workspace_root as $root
+    | .packages[]
+    | select(.manifest_path == ($root + "/Cargo.toml"))
+    | .targets[]
+    | select(.kind | index("test"))
+    | select(.src_path | startswith($root + "/tests/integration/"))
+    | .name
+  ' | LC_ALL=C sort -u
+)"
+names=()
+while IFS= read -r name; do
+  if [ -n "${name}" ]; then
+    names+=("${name}")
+  fi
+done <<< "${names_output}"
 
 if [ "${#names[@]}" -eq 0 ]; then
   echo "No Reborn integration-tier test binaries discovered" >&2

--- a/scripts/ci/reborn-coverage-lane-run.sh
+++ b/scripts/ci/reborn-coverage-lane-run.sh
@@ -3,16 +3,16 @@
 # Run one instrumented Reborn integration-tier coverage lane and produce that
 # lane's lcov tracefile.
 #
-# The 34 tests/integration/ suites (see reborn-coverage-int-tier-tests.sh for
-# the canonical enumeration) are split across 5 lanes in
+# The tests/integration/ suites (see reborn-coverage-int-tier-tests.sh for the
+# canonical enumeration) are split across 5 lanes in
 # .github/workflows/reborn-tests.yml's `reborn-integration-coverage` matrix
-# job: 4 modulo-partitions of the 27 flat `reborn_integration_*` suites, plus
-# one dedicated lane for all 7 `reborn_group_*` suites.
+# job: 4 modulo-partitions of the flat `reborn_integration_*` suites, plus
+# one dedicated lane for all `reborn_group_*` suites.
 #
-# This script is the SINGLE execution of the 34 int-tier suites for pass/fail
+# This script is the SINGLE execution of the discovered int-tier suites for pass/fail
 # purposes too: `cargo llvm-cov ... test` has the same pass/fail semantics as
-# `cargo test`, so there is no separate uninstrumented run of the 27 flat
-# suites. (The 7 group suites also still have their own uninstrumented
+# `cargo test`, so there is no separate uninstrumented run of the flat
+# suites. (The group suites also still have their own uninstrumented
 # `reborn-group-tests` job via run-reborn-group-tests.sh, which stays as the
 # fast low-contention pass/fail signal for that suite; this lane additionally
 # runs them once more, instrumented, for coverage.)
@@ -36,7 +36,7 @@
 # reborn_group_* rewrite rules), so this script never re-derives that mapping.
 #
 # Modes (REBORN_COV_LANE_MODE):
-#   flat-partition  Modulo-partitions the 27 reborn_integration_* suites
+#   flat-partition  Modulo-partitions the reborn_integration_* suites
 #                   across REBORN_COV_LANE_PARTITIONS lanes; REBORN_COV_LANE_INDEX
 #                   (0-based) selects this lane's slice — mirrors
 #                   scripts/ci/run-reborn-root-partition.sh's partitioning.

--- a/scripts/ci/reborn-coverage-lane-run.sh
+++ b/scripts/ci/reborn-coverage-lane-run.sh
@@ -6,12 +6,12 @@
 # The tests/integration/ suites (see reborn-coverage-int-tier-tests.sh for the
 # canonical enumeration) are split across 5 lanes in
 # .github/workflows/reborn-tests.yml's `reborn-integration-coverage` matrix
-# job: 4 modulo-partitions of the flat `reborn_integration_*` suites, plus
-# one dedicated lane for all `reborn_group_*` suites.
+# job: 4 modulo-partitions of every non-`reborn_group_*` suite, plus one
+# dedicated lane for all `reborn_group_*` suites.
 #
 # This script is the SINGLE execution of the discovered int-tier suites for pass/fail
 # purposes too: `cargo llvm-cov ... test` has the same pass/fail semantics as
-# `cargo test`, so there is no separate uninstrumented run of the flat
+# `cargo test`, so there is no separate uninstrumented run of the non-group
 # suites. (The group suites also still have their own uninstrumented
 # `reborn-group-tests` job via run-reborn-group-tests.sh, which stays as the
 # fast low-contention pass/fail signal for that suite; this lane additionally
@@ -32,16 +32,16 @@
 # other workspace crates' coverage.
 #
 # Reuses reborn-coverage-int-tier-tests.sh as the single source of truth for
-# suite discovery/naming (the tests/integration/ -> reborn_integration_*/
-# reborn_group_* rewrite rules), so this script never re-derives that mapping.
+# manifest-resolved suite discovery and names. Group targets retain their
+# dedicated lane; every other discovered target is modulo-partitioned.
 #
 # Modes (REBORN_COV_LANE_MODE):
-#   flat-partition  Modulo-partitions the reborn_integration_* suites
+#   flat-partition  Modulo-partitions every non-reborn_group_* suite
 #                   across REBORN_COV_LANE_PARTITIONS lanes; REBORN_COV_LANE_INDEX
 #                   (0-based) selects this lane's slice — mirrors
 #                   scripts/ci/run-reborn-root-partition.sh's partitioning.
-#   group           Runs all reborn_group_* suites (7 total) — the one
-#                   dedicated group coverage lane.
+#   group           Runs all reborn_group_* suites in the dedicated group
+#                   coverage lane.
 #
 # Usage: REBORN_COV_LANE_MODE=... [other env] reborn-coverage-lane-run.sh <output-lcov-path>
 
@@ -87,7 +87,7 @@ case "${mode}" in
       exit 1
     fi
 
-    mapfile -t flat_names < <(printf '%s\n' "${all_names[@]}" | grep '^reborn_integration_' | LC_ALL=C sort)
+    mapfile -t flat_names < <(printf '%s\n' "${all_names[@]}" | grep -v '^reborn_group_' | LC_ALL=C sort)
 
     for index in "${!flat_names[@]}"; do
       if (( index % partition_count_int != partition_index_int )); then

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -347,6 +347,14 @@ has_legacy_tests=false
 has_reborn_tests=true"
 
 assert_scope \
+  "reborn coverage regression suite, sourced sibling (lane cases)" \
+  "scripts/ci/test-reborn-coverage-lane-cases.sh" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
   "test suite boundaries checker script" \
   "scripts/ci/check-test-suite-boundaries.sh" \
   "docs_only=false

--- a/scripts/ci/test-reborn-coverage-lane-cases.sh
+++ b/scripts/ci/test-reborn-coverage-lane-cases.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# E-section cases for reborn-coverage-lane-run.sh, sourced by
+# test-reborn-coverage.sh so these caller-path checks can reuse its capture and
+# assertion helpers. Running this file directly does nothing useful.
+#
+# shellcheck disable=SC2154 # lane_sh/tmp_root/PATH and the assertion helpers
+# are assigned by the sourcing parent.
+
+# E1: every discovered non-group target reaches cargo, even when its manifest
+# name does not follow the historical reborn_integration_* convention. The
+# fake timeout records the production caller's complete command instead of
+# launching cargo llvm-cov.
+e1="${tmp_root}/e1"
+e1_bin="${e1}/bin"
+e1_scripts="${e1}/scripts/ci"
+e1_timeout_log="${e1}/timeout.log"
+mkdir -p "${e1_bin}" "${e1_scripts}"
+cp "${lane_sh}" "${e1_scripts}/reborn-coverage-lane-run.sh"
+chmod +x "${e1_scripts}/reborn-coverage-lane-run.sh"
+
+cat > "${e1_scripts}/reborn-coverage-int-tier-tests.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' \
+  --test reborn_group_bar \
+  --test manifest_named_target \
+  --test reborn_integration_alpha
+EOF
+chmod +x "${e1_scripts}/reborn-coverage-int-tier-tests.sh"
+
+cat > "${e1_bin}/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${FAKE_TIMEOUT_LOG:?FAKE_TIMEOUT_LOG must be set}"
+printf '%s\n' "$@" > "${FAKE_TIMEOUT_LOG}"
+EOF
+chmod +x "${e1_bin}/timeout"
+
+capture env \
+  PATH="${e1_bin}:${PATH}" \
+  FAKE_TIMEOUT_LOG="${e1_timeout_log}" \
+  REBORN_COV_LANE_MODE=flat-partition \
+  REBORN_COV_LANE_PARTITIONS=1 \
+  REBORN_COV_LANE_INDEX=0 \
+  "${e1_scripts}/reborn-coverage-lane-run.sh" "${e1}/part-0.lcov"
+assert_exit_code "E1: non-group lane execution exits 0" 0 "${CAP_RC}"
+
+e1_timeout_args="$(cat "${e1_timeout_log}")"
+assert_contains "E1: arbitrary manifest target reaches cargo llvm-cov" \
+  "${e1_timeout_args}" "$(printf -- '--test\nmanifest_named_target')"
+assert_contains "E1: conventional integration target still reaches cargo llvm-cov" \
+  "${e1_timeout_args}" "$(printf -- '--test\nreborn_integration_alpha')"
+assert_not_contains "E1: group target stays out of the non-group lane" \
+  "${e1_timeout_args}" "reborn_group_bar"

--- a/scripts/ci/test-reborn-coverage-lane-cases.sh
+++ b/scripts/ci/test-reborn-coverage-lane-cases.sh
@@ -46,9 +46,14 @@ capture env \
 assert_exit_code "E1: non-group lane execution exits 0" 0 "${CAP_RC}"
 
 e1_timeout_args="$(cat "${e1_timeout_log}")"
-assert_contains "E1: arbitrary manifest target reaches cargo llvm-cov" \
-  "${e1_timeout_args}" "$(printf -- '--test\nmanifest_named_target')"
-assert_contains "E1: conventional integration target still reaches cargo llvm-cov" \
-  "${e1_timeout_args}" "$(printf -- '--test\nreborn_integration_alpha')"
+assert_contains "E1: selected targets reach cargo llvm-cov" \
+  "${e1_timeout_args}" "$(printf -- 'cargo\nllvm-cov')"
+e1_selected_targets="$(awk '
+  take_next { print; take_next=0; next }
+  $0 == "--test" { take_next=1 }
+' "${e1_timeout_log}")"
+assert_eq "E1: complete non-group target list reaches cargo exactly once" \
+  "$(printf -- 'manifest_named_target\nreborn_integration_alpha')" \
+  "${e1_selected_targets}"
 assert_not_contains "E1: group target stays out of the non-group lane" \
-  "${e1_timeout_args}" "reborn_group_bar"
+  "${e1_selected_targets}" "reborn_group_bar"

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -5,6 +5,7 @@
 #   - reborn-coverage-summary.sh        (report + --zero-crates modes)
 #   - reborn-coverage-comment.sh        (sticky PR comment upsert via `gh api`)
 #   - reborn-coverage-int-tier-tests.sh (int-tier suite discovery)
+#   - reborn-coverage-lane-run.sh       (int-tier lane assignment/execution)
 #   - reborn-coverage-ratchet.sh        (coverage-floor ratchet gate)
 #
 # Mirrors test-classify-test-scope.sh: self-contained, locates the
@@ -12,8 +13,7 @@
 # fixtures in a mktemp dir, and reports PASS/FAIL per case. Unlike that
 # precedent (which exits on the first failure), this suite runs every case
 # and prints a final summary, exiting non-zero only if something failed —
-# with five scripts and 50 cases (M/A/B/C/D/R sections), seeing the full
-# picture in one run beats stopping at the first mismatch.
+# seeing the full picture in one run beats stopping at the first mismatch.
 #
 # reborn-coverage-summary.sh and reborn-coverage-ratchet.sh share one lcov-
 # parsing + exemption-filtering + by-crate-aggregation implementation
@@ -23,8 +23,8 @@
 #
 # The R section (reborn-coverage-ratchet.sh cases) lives in the sibling
 # test-reborn-coverage-ratchet-cases.sh, `source`d near the end of this file —
-# split out to keep this file under 1000 lines once a fifth script's cases
-# joined the suite. That file is not standalone; it shares this script's
+# split out to keep this file under 1000 lines as the suite grew. That file is
+# not standalone; it shares this script's
 # helpers, fixtures, and PASS_COUNT/FAIL_COUNT counters.
 #
 # reborn-coverage-summary.sh and reborn-coverage-comment.sh consume a merged,
@@ -55,6 +55,7 @@ merge_sh="${script_dir}/reborn-coverage-merge-lcov.sh"
 summary_sh="${script_dir}/reborn-coverage-summary.sh"
 comment_sh="${script_dir}/reborn-coverage-comment.sh"
 int_tier_sh="${script_dir}/reborn-coverage-int-tier-tests.sh"
+lane_sh="${script_dir}/reborn-coverage-lane-run.sh"
 ratchet_sh="${script_dir}/reborn-coverage-ratchet.sh"
 
 tmp_root="$(mktemp -d)"
@@ -944,6 +945,13 @@ assert_exit_code "D6: nested auth targets exit 0" 0 "${CAP_RC}"
 assert_eq "D6: all nested auth targets are emitted exactly once and shared fixtures are excluded" \
   "$(printf -- '--test\nreborn_integration_auth_failure\n--test\nreborn_integration_auth_gate\n--test\nreborn_integration_oauth_connect\n--test\nreborn_integration_oauth_popup_journeys\n--test\nreborn_integration_oauth_refresh\n--test\nreborn_integration_reopen_resume_through_gate')" \
   "${CAP_OUT}"
+
+# ---------------------------------------------------------------------------
+# E. reborn-coverage-lane-run.sh (coverage-lane assignment/execution)
+# ---------------------------------------------------------------------------
+
+# shellcheck source=./test-reborn-coverage-lane-cases.sh
+source "${script_dir}/test-reborn-coverage-lane-cases.sh"
 
 # ---------------------------------------------------------------------------
 # R. reborn-coverage-ratchet.sh (coverage-floor ratchet gate)

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -828,33 +828,46 @@ fi
 #
 # The script derives its repo root from its own path and `cd`s there, so
 # each case copies it into a fresh temp tree's scripts/ci/ and builds a
-# tests/integration/ subtree alongside it, then invokes the copy. It also
-# filters candidates against a `[[test]] name = "..."` entry in Cargo.toml
-# (see that script's header comment), so every case seeds a fake Cargo.toml
-# with one `[[test]]` block per fixture suite the case constructs — mirrors
-# the real repo root always having a `[[test]]` entry per suite.
+# tests/integration/ subtree alongside it, then invokes the copy. Each fixture
+# is a minimal Cargo package whose `[[test]]` targets exercise Cargo metadata as
+# the discovery authority.
 
 setup_int_tier_case() {
   local case_dir="$1"
-  shift
-  mkdir -p "${case_dir}/scripts/ci" "${case_dir}/tests/integration"
+  mkdir -p "${case_dir}/scripts/ci" "${case_dir}/src" "${case_dir}/tests/integration"
   cp "${int_tier_sh}" "${case_dir}/scripts/ci/reborn-coverage-int-tier-tests.sh"
   chmod +x "${case_dir}/scripts/ci/reborn-coverage-int-tier-tests.sh"
-  : > "${case_dir}/Cargo.toml"
-  local candidate
-  for candidate in "$@"; do
-    cat >>"${case_dir}/Cargo.toml" <<EOF
-[[test]]
-name = "${candidate}"
-path = "tests/integration/${candidate}.rs"
+  : > "${case_dir}/src/lib.rs"
+  cat >"${case_dir}/Cargo.toml" <<'TOML'
+[package]
+name = "int-tier-discovery-fixture"
+version = "0.0.0"
+edition = "2024"
+publish = false
+autotests = false
 
-EOF
-  done
+[lib]
+path = "src/lib.rs"
+TOML
 }
 
-# D1: empty tests/integration/ -> non-zero exit + discovery error.
+add_int_tier_target() {
+  local case_dir="$1" name="$2" path="$3"
+  mkdir -p "$(dirname "${case_dir}/${path}")"
+  : > "${case_dir}/${path}"
+  cat >>"${case_dir}/Cargo.toml" <<EOF
+
+[[test]]
+name = "${name}"
+path = "${path}"
+EOF
+}
+
+# D1: no tests/integration/ targets -> non-zero exit + discovery error, even
+# when the root package declares a test target elsewhere.
 d1="${tmp_root}/d1"
 setup_int_tier_case "${d1}"
+add_int_tier_target "${d1}" root_helper tests/root_helper.rs
 capture "${d1}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D1: empty tests/integration/ exits non-zero" 1 "${CAP_RC}"
 assert_contains "D1: empty tests/integration/ prints the discovery error" "${CAP_ERR}" \
@@ -862,8 +875,8 @@ assert_contains "D1: empty tests/integration/ prints the discovery error" "${CAP
 
 # D2: one tests/integration/foo.rs -> --test / reborn_integration_foo.
 d2="${tmp_root}/d2"
-setup_int_tier_case "${d2}" reborn_integration_foo
-: > "${d2}/tests/integration/foo.rs"
+setup_int_tier_case "${d2}"
+add_int_tier_target "${d2}" reborn_integration_foo tests/integration/foo.rs
 capture "${d2}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D2: single flat integration file exits 0" 0 "${CAP_RC}"
 assert_eq "D2: single flat integration file emits its --test pair" \
@@ -871,51 +884,66 @@ assert_eq "D2: single flat integration file emits its --test pair" \
 
 # D3: one tests/integration/group_bar/main.rs -> --test / reborn_group_bar.
 d3="${tmp_root}/d3"
-setup_int_tier_case "${d3}" reborn_group_bar
-mkdir -p "${d3}/tests/integration/group_bar"
-: > "${d3}/tests/integration/group_bar/main.rs"
+setup_int_tier_case "${d3}"
+add_int_tier_target "${d3}" reborn_group_bar tests/integration/group_bar/main.rs
 capture "${d3}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D3: single group dir exits 0" 0 "${CAP_RC}"
-assert_eq "D3: single group dir emits its --test pair, dir->name rewrite applied" \
+assert_eq "D3: single group target emits its manifest-declared --test pair" \
   "$(printf -- '--test\nreborn_group_bar')" "${CAP_OUT}"
 
-# D3b: a half-scaffolded group dir (no main.rs yet) is skipped, not errored.
+# D3b: a half-scaffolded group dir with no manifest target is ignored.
 d3b="${tmp_root}/d3b"
-setup_int_tier_case "${d3b}" reborn_group_bar
-mkdir -p "${d3b}/tests/integration/group_bar" "${d3b}/tests/integration/group_incomplete"
-: > "${d3b}/tests/integration/group_bar/main.rs"
+setup_int_tier_case "${d3b}"
+add_int_tier_target "${d3b}" reborn_group_bar tests/integration/group_bar/main.rs
+mkdir -p "${d3b}/tests/integration/group_incomplete"
 capture "${d3b}/scripts/ci/reborn-coverage-int-tier-tests.sh"
-assert_exit_code "D3b: half-scaffolded group dir does not error the whole discovery" 0 "${CAP_RC}"
-assert_eq "D3b: half-scaffolded group dir (no main.rs) is skipped" \
+assert_exit_code "D3b: unmanifested group dir does not error the whole discovery" 0 "${CAP_RC}"
+assert_eq "D3b: unmanifested group dir is skipped" \
   "$(printf -- '--test\nreborn_group_bar')" "${CAP_OUT}"
 
-# D4: multiple files + dirs, created out of alphabetical order -> sorted,
-# deduped output. Group dirs ('g') sort before integration files ('i').
+# D4: multiple targets declared out of alphabetical order produce sorted output.
+# Group names ('g') sort before integration names ('i').
 d4="${tmp_root}/d4"
-setup_int_tier_case "${d4}" reborn_group_beta reborn_group_omega reborn_integration_alpha reborn_integration_zeta
-: > "${d4}/tests/integration/zeta.rs"
-: > "${d4}/tests/integration/alpha.rs"
-mkdir -p "${d4}/tests/integration/group_omega" "${d4}/tests/integration/group_beta"
-: > "${d4}/tests/integration/group_omega/main.rs"
-: > "${d4}/tests/integration/group_beta/main.rs"
+setup_int_tier_case "${d4}"
+add_int_tier_target "${d4}" reborn_integration_zeta tests/integration/zeta.rs
+add_int_tier_target "${d4}" reborn_group_omega tests/integration/group_omega/main.rs
+add_int_tier_target "${d4}" reborn_integration_alpha tests/integration/alpha.rs
+add_int_tier_target "${d4}" reborn_group_beta tests/integration/group_beta/main.rs
 capture "${d4}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D4: multiple suites exits 0" 0 "${CAP_RC}"
-assert_eq "D4: multiple suites sorted+deduped in expected order" \
+assert_eq "D4: multiple suites sorted in expected order" \
   "$(printf -- '--test\nreborn_group_beta\n--test\nreborn_group_omega\n--test\nreborn_integration_alpha\n--test\nreborn_integration_zeta')" \
   "${CAP_OUT}"
 
-# D5: a `support/` subdirectory alongside the flat files must not be
-# mistaken for a suite (no main.rs, and doesn't match the `group_*` name
-# pattern either) — mirrors the real tests/integration/support/ harness tree.
+# D5: a shared file with no manifest target must not be mistaken for a suite;
+# this mirrors the real tests/integration/support/ harness tree.
 d5="${tmp_root}/d5"
-setup_int_tier_case "${d5}" reborn_integration_only
-: > "${d5}/tests/integration/only.rs"
+setup_int_tier_case "${d5}"
+add_int_tier_target "${d5}" reborn_integration_only tests/integration/only.rs
 mkdir -p "${d5}/tests/integration/support"
 : > "${d5}/tests/integration/support/mod.rs"
 capture "${d5}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D5: support/ dir alongside flat suites exits 0" 0 "${CAP_RC}"
 assert_eq "D5: support/ dir is not discovered as a suite" \
   "$(printf -- '--test\nreborn_integration_only')" "${CAP_OUT}"
+
+# D6: nested manifest targets are selected by their declared target names;
+# an adjacent shared fixture with no [[test]] entry is excluded. These mirror
+# the six auth binaries that directory-based discovery missed in the real repo.
+d6="${tmp_root}/d6"
+setup_int_tier_case "${d6}"
+add_int_tier_target "${d6}" reborn_integration_oauth_refresh tests/integration/auth/oauth_refresh.rs
+add_int_tier_target "${d6}" reborn_integration_auth_failure tests/integration/auth/auth_failure.rs
+add_int_tier_target "${d6}" reborn_integration_auth_gate tests/integration/auth/auth_gate.rs
+add_int_tier_target "${d6}" reborn_integration_oauth_connect tests/integration/auth/oauth_connect.rs
+add_int_tier_target "${d6}" reborn_integration_oauth_popup_journeys tests/integration/auth/oauth_popup_journeys.rs
+add_int_tier_target "${d6}" reborn_integration_reopen_resume_through_gate tests/integration/auth/reopen_resume_through_gate.rs
+: > "${d6}/tests/integration/auth/common.rs"
+capture "${d6}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+assert_exit_code "D6: nested auth targets exit 0" 0 "${CAP_RC}"
+assert_eq "D6: all nested auth targets are emitted exactly once and shared fixtures are excluded" \
+  "$(printf -- '--test\nreborn_integration_auth_failure\n--test\nreborn_integration_auth_gate\n--test\nreborn_integration_oauth_connect\n--test\nreborn_integration_oauth_popup_journeys\n--test\nreborn_integration_oauth_refresh\n--test\nreborn_integration_reopen_resume_through_gate')" \
+  "${CAP_OUT}"
 
 # ---------------------------------------------------------------------------
 # R. reborn-coverage-ratchet.sh (coverage-floor ratchet gate)


### PR DESCRIPTION
## Summary

- derive Reborn integration-tier test targets from Cargo metadata instead of directory naming conventions
- discover all 52 manifest-resolved targets under `tests/integration/`, including the six previously missed nested auth binaries
- exclude shared fixture files that are not Cargo test targets
- add hermetic coverage for flat, group, nested, empty, and shared-fixture discovery
- remove stale hard-coded suite counts from coverage workflow comments
- partition every non-group manifest target into a coverage lane and test the caller path
- recognize shell regression tests in regression enforcement

## Linked Issue

Closes #6456
Part of #6369

## Validation

- hermetic discovery cases D1–D6 — 14 assertions passed
- caller-path lane assignment case E1 — 4 assertions passed under Linux Bash
- shell-test detector matched the PR regression test and rejected a non-test shell script
- all six newly discovered auth binaries — 67 tests passed
- exact-once discovery check — 52 unique targets
- complete 52-target argument list accepted by:
  `cargo llvm-cov --workspace --no-report test ... -- --list`
- Bash syntax checks passed
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`

Local validation note: the unrelated PR-comment cases in the complete coverage
helper suite require Bash 4+ because of an existing `mapfile` use. macOS Bash
3.2 cannot run those cases; the changed discovery section passed locally and CI
runs on Ubuntu.

## Test Strategy

User behavior:

Not applicable: CI-only integration coverage selection; no product-facing behavior changes.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: caller-path shell regression captures the real lane runner's `cargo llvm-cov` arguments.
- Reborn integration: Not applicable: this changes CI test selection, not Reborn runtime behavior.
- Recorded fixture: Not applicable: no model behavior or request shape changes.
- Browser E2E: Not applicable: no UI behavior changes.
- Backend or runtime: Not applicable: no backend/runtime behavior changes.
- Live canary: Not applicable: hermetic CI helper behavior.

What the tests prove:

Every Cargo-resolved non-`reborn_group_*` target, including an arbitrary manifest name, reaches a partitioned coverage lane exactly once; group targets remain isolated in the dedicated group lane. Regression enforcement recognizes the shell caller-path test without misclassifying the lane runner.

Commands run:

- regression shell-test detector probe against the PR changed-file set
- `scripts/ci/test-classify-test-scope.sh`
- `bash -n scripts/ci/reborn-coverage-lane-run.sh scripts/ci/test-reborn-coverage.sh scripts/ci/test-reborn-coverage-lane-cases.sh`
- Linux Bash E1 caller-path fixture — 4 assertions passed
- exact assignment check — 52 discovered = 45 non-group + 7 group
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`

## Security Impact

None. No runtime, credentials, permissions, or application behavior changes.

## Database Impact

None.

## Blast Radius

CI integration coverage discovery only. Six additional existing auth test
binaries will now run in the partitioned coverage lanes.

## Risk Assessment

Low. The primary risks are slightly longer coverage lanes and dependency on
Cargo metadata parsing. All newly selected tests passed, the complete generated
argument list was accepted by cargo-llvm-cov, and `jq`/Cargo metadata are already
used by the same CI workflow.

## Rollback Plan

Revert commits `0c8a281a5`, `877fdb53c`, and `3c972f813` to restore the previous regression detector, lane selector, and directory-based discovery.

---

**Review track**: A