### PR TITLE
fix(reborn): cover Slack OAuth and restore Telegram routine targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Automation delivery:** honor each trigger's creator-selected outbound
   target at fire time instead of silently falling back to the user-wide
   default.
+- **Telegram automation delivery:** expose paired Telegram DMs as caller-owned
+  outbound targets so routines can select and persist Telegram delivery.
 - **Channel removal:** revoke caller-owned OAuth or proof-code pairing state
   through the shared lifecycle before deleting any channel installation, so
   removing Telegram, Slack, or a future channel unpairs it on every surface.

--- a/crates/ironclaw_reborn_cli/src/runtime/native_extensions.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/native_extensions.rs
@@ -11,7 +11,7 @@ use ironclaw_extension_host::{
     NativeExtensionFactory,
 };
 use ironclaw_reborn_composition::ChannelExtensionBinding;
-use ironclaw_telegram_extension::TelegramChannelAdapter;
+use ironclaw_telegram_extension::{TelegramChannelAdapter, TelegramPreferenceTargetCodec};
 
 /// Every native factory the binary assembles (`first_party`-runtime
 /// extensions bind their adapters through these).
@@ -42,7 +42,7 @@ pub(crate) fn bundled_channel_extension_bindings() -> Vec<ChannelExtensionBindin
             extension_id: "telegram".to_string(),
             adapter: Arc::new(TelegramChannelAdapter::default()),
             inbound_payload_classifier: None,
-            preference_target_codec: None,
+            preference_target_codec: Some(Arc::new(TelegramPreferenceTargetCodec)),
         },
     ]
 }
@@ -101,5 +101,6 @@ mod tests {
             .find(|binding| binding.extension_id == "telegram")
             .expect("the binary supplies the telegram deployment channel binding");
         assert!(telegram.inbound_payload_classifier.is_none());
+        assert!(telegram.preference_target_codec.is_some());
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -667,6 +667,33 @@ impl RebornServices {
             .map(|status| status.connected)
     }
 
+    /// Caller-scoped ids from the production outbound-target registry — tests
+    /// only. This is the same registry `builtin.outbound_delivery_targets_list`
+    /// and per-trigger target validation use; the accessor avoids replacing it
+    /// with an integration harness's synthetic outbound facade.
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn outbound_delivery_target_ids_for_test(
+        &self,
+        caller: ironclaw_product_workflow::WebUiAuthenticatedCaller,
+    ) -> Result<Vec<String>, String> {
+        let local_runtime = self
+            .local_runtime
+            .as_ref()
+            .ok_or_else(|| "local runtime is unavailable".to_string())?;
+        use crate::outbound::OutboundDeliveryTargetProvider as _;
+        local_runtime
+            .outbound_delivery_targets
+            .list_outbound_delivery_targets(&caller)
+            .await
+            .map(|entries| {
+                entries
+                    .into_iter()
+                    .map(|entry| entry.summary.target_id.as_str().to_string())
+                    .collect()
+            })
+            .map_err(|error| error.to_string())
+    }
+
     /// The generic delivery coordinator (extension-runtime §5.4), when this
     /// composition path built the channel egress transport.
     pub fn delivery_coordinator(
@@ -771,11 +798,12 @@ impl RebornServices {
     /// channel-config secret storage, workflow state substrate, delivery
     /// coordinator + outbound stores) is the production wiring.
     #[cfg(any(test, feature = "test-support"))]
-    pub fn start_channel_host_assembly_for_test(
+    pub async fn start_channel_host_assembly_for_test(
         &self,
         wiring: ChannelHostAssemblyTestWiring,
     ) -> Option<Arc<crate::extension_host::channel_host::GenericChannelHostAssembly>> {
-        self.start_channel_host_assembly(ChannelHostAssemblyWiring {
+        let identity = wiring.identity.clone();
+        let assembly = self.start_channel_host_assembly(ChannelHostAssemblyWiring {
             thread_service: wiring.thread_service,
             turn_coordinator: wiring.turn_coordinator,
             approval_interaction: None,
@@ -785,7 +813,45 @@ impl RebornServices {
             blocked_auth_prompts: None,
             auth_flow_cancel: None,
             run_delivery_settings: wiring.run_delivery_settings,
-        })
+        })?;
+
+        for binding in &self.channel_extension_bindings {
+            assembly
+                .register_extras(
+                    &binding.extension_id,
+                    crate::extension_host::channel_host::ChannelExtras {
+                        classifier: binding.inbound_payload_classifier.clone(),
+                        preference_target_codec: binding.preference_target_codec.clone(),
+                        subject_route_resolver: None,
+                        storage_roots: None,
+                    },
+                )
+                .await;
+        }
+
+        if let Some(local_runtime) = self.local_runtime.as_ref()
+            && let (Some(channel_config), Some(dm_targets)) = (
+                local_runtime.channel_config.clone(),
+                local_runtime.channel_dm_target_store.clone(),
+            )
+        {
+            crate::extension_host::channel_outbound_targets::register_generic_channel_outbound_targets(
+                &local_runtime.outbound_delivery_targets,
+                crate::extension_host::channel_outbound_targets::GenericChannelOutboundTargetDeps {
+                    watch: assembly.snapshot_watch(),
+                    assembly: Arc::clone(&assembly),
+                    channel_config,
+                    dm_targets,
+                    identity: crate::extension_host::channel_outbound_targets::ChannelOutboundTargetIdentity {
+                        tenant_id: identity.tenant_id,
+                        agent_id: identity.agent_id,
+                        project_id: identity.project_id,
+                    },
+                },
+            );
+        }
+
+        Some(assembly)
     }
 
     /// The deployment-first channel delivery resolver behind the coordinator.

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -16,17 +16,21 @@
 
 #![cfg(feature = "test-support")]
 
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use axum::body::{Body, to_bytes};
+use axum::extract::ConnectInfo;
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
+use chrono::Utc;
 use http_body_util::BodyExt;
 use ironclaw_auth::{
-    AuthProductScope, AuthSurface, CredentialAccountLabel, CredentialAccountStatus,
-    CredentialOwnership, NewCredentialAccount, ProviderScope,
+    AuthProductScope, AuthProviderId, AuthSurface, CredentialAccountLabel,
+    CredentialAccountListRequest, CredentialAccountStatus, CredentialOwnership,
+    NewCredentialAccount, ProviderScope,
 };
 use ironclaw_host_api::runtime_policy::{
     ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
@@ -42,13 +46,14 @@ use ironclaw_loop_host::{
     HostManagedModelStreamSink,
 };
 use ironclaw_reborn_composition::{
-    OAuthClientConfig, PollSettings, RebornBuildInput, RebornRuntime, RebornRuntimeIdentity,
-    RebornRuntimeInput, build_reborn_runtime, build_webui_services,
+    ChannelExtensionBinding, OAuthClientConfig, PollSettings, RebornBuildInput, RebornRuntime,
+    RebornRuntimeIdentity, RebornRuntimeInput, build_reborn_runtime, build_webui_services,
 };
 use ironclaw_turns::run_profile::{
     CapabilityCallCandidate, LoopCapabilityPort, ProviderToolCall, RegisterProviderToolCallRequest,
 };
 use ironclaw_webui::{WebuiAuthentication, WebuiAuthenticator, WebuiServeConfig, webui_v2_app};
+use secrecy::SecretString;
 use serde_json::{Value, json};
 use tokio::sync::oneshot;
 use tower::ServiceExt;
@@ -63,6 +68,78 @@ const USER_B: &str = "e2e-viewer-b";
 const AGENT: &str = "e2e-agent";
 const SENSITIVE_TOOL_SENTINEL: &str = "sk-e2e-progress-secret";
 const MEMORY_ISOLATION_MARKER: &str = "webui-memory-owner-a-secret-5460";
+const SLACK_TEAM_ID: &str = "T-E2E-SLACK";
+const SLACK_APP_ID: &str = "A-E2E-SLACK";
+const SLACK_USER_ID: &str = "U-E2E-SLACK";
+const SLACK_BOT_TOKEN: &str = "xoxb-e2e-slack-bot";
+
+const SLACK_SCOPES: &[&str] = &[
+    "search:read",
+    "channels:history",
+    "groups:history",
+    "im:history",
+    "mpim:history",
+    "channels:read",
+    "groups:read",
+    "im:read",
+    "mpim:read",
+    "users:read",
+    "chat:write",
+];
+
+#[derive(Default)]
+struct SlackOAuthNetworkEgress {
+    urls: StdMutex<Vec<String>>,
+}
+
+impl SlackOAuthNetworkEgress {
+    fn urls(&self) -> Vec<String> {
+        self.urls.lock().expect("Slack egress lock").clone()
+    }
+}
+
+#[async_trait]
+impl ironclaw_network::NetworkHttpEgress for SlackOAuthNetworkEgress {
+    async fn execute(
+        &self,
+        request: ironclaw_network::NetworkHttpRequest,
+    ) -> Result<ironclaw_network::NetworkHttpResponse, ironclaw_network::NetworkHttpError> {
+        self.urls
+            .lock()
+            .expect("Slack egress lock")
+            .push(request.url.clone());
+        let body = if request.url.ends_with("/api/oauth.v2.access") {
+            json!({
+                "ok": true,
+                "authed_user": {
+                    "id": SLACK_USER_ID,
+                    "access_token": "xoxp-e2e-slack-user",
+                    "scope": SLACK_SCOPES.join(",")
+                },
+                "team": {"id": SLACK_TEAM_ID},
+                "app_id": SLACK_APP_ID
+            })
+            .to_string()
+            .into_bytes()
+        } else if request.url.ends_with("/api/conversations.open") {
+            json!({"ok": true, "channel": {"id": "D-E2E-SLACK"}})
+                .to_string()
+                .into_bytes()
+        } else {
+            panic!("unexpected Slack OAuth test request: {}", request.url);
+        };
+        Ok(ironclaw_network::NetworkHttpResponse {
+            status: 200,
+            headers: vec![("content-type".to_string(), "application/json".to_string())],
+            usage: ironclaw_network::NetworkUsage {
+                request_bytes: request.body.len() as u64,
+                response_bytes: body.len() as u64,
+                resolved_ip: None,
+            },
+            body,
+        })
+    }
+}
 
 // ─── auth stub ────────────────────────────────────────────────────────
 
@@ -644,6 +721,67 @@ fn test_google_oauth_backend() -> OAuthClientConfig {
     .expect("valid test google oauth client config")
 }
 
+fn test_slack_oauth_backend() -> OAuthClientConfig {
+    OAuthClientConfig::new(
+        "e2e-slack-client-id",
+        "http://127.0.0.1:3000/api/reborn/product-auth/oauth/slack/callback",
+        Some(SecretString::from("e2e-slack-client-secret".to_string())),
+    )
+    .expect("valid test Slack OAuth client config")
+}
+
+async fn build_slack_oauth_harness() -> (Harness, Arc<SlackOAuthNetworkEgress>) {
+    let root = tempfile::tempdir().expect("tempdir");
+    let storage_root = root.path().join("local-dev");
+    std::fs::create_dir_all(&storage_root).expect("create Slack e2e storage root");
+    std::fs::write(
+        storage_root.join(".reborn-local-dev-secrets-master-key"),
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    )
+    .expect("seed hermetic Slack e2e secrets master key");
+    let network_egress = Arc::new(SlackOAuthNetworkEgress::default());
+    let build_input = RebornBuildInput::local_dev(USER, storage_root)
+        .with_runtime_policy(local_dev_effective_policy())
+        .with_vendor_oauth_client("slack", test_slack_oauth_backend())
+        .with_network_http_egress_for_test(network_egress.clone())
+        .with_channel_extension_bindings(vec![ChannelExtensionBinding {
+            extension_id: "slack".to_string(),
+            adapter: Arc::new(ironclaw_slack_extension::SlackChannelAdapter),
+            inbound_payload_classifier: None,
+            preference_target_codec: None,
+        }]);
+    let input = RebornRuntimeInput::from_services(build_input)
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: TENANT.to_string(),
+            agent_id: AGENT.to_string(),
+            source_binding_id: "e2e-slack-source".to_string(),
+            reply_target_binding_id: "e2e-slack-reply".to_string(),
+        })
+        .with_model_gateway_override(Arc::new(ToolCallingGateway::default()));
+    let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+    let channel_identity_binding = runtime
+        .channel_identity_binding_config()
+        .expect("Slack runtime exposes channel identity binding");
+    let bundle = build_webui_services(&runtime, None).expect("webui bundle");
+    let config = WebuiServeConfig::new(
+        TenantId::new(TENANT).expect("tenant"),
+        Arc::new(ValidTokenForUser::new(USER)),
+        vec![HeaderValue::from_static("http://localhost:0")],
+    )
+    .with_default_agent_id(AgentId::new(AGENT).expect("agent"))
+    .with_channel_identity_binding(channel_identity_binding);
+    let router = webui_v2_app(bundle, config).expect("webui v2 app");
+
+    (
+        Harness {
+            runtime,
+            router,
+            _root: Some(root),
+        },
+        network_egress,
+    )
+}
+
 async fn build_harness_at_with_runtime_owner_and_auth_user(
     storage_root: PathBuf,
     root: Option<tempfile::TempDir>,
@@ -849,6 +987,18 @@ fn bearer_get_with_last_event_id(uri: &str, last_event_id: Option<&str>) -> Requ
         builder = builder.header("Last-Event-ID", last_event_id);
     }
     builder.body(Body::empty()).expect("bearer GET request")
+}
+
+fn public_callback_get(uri: &str) -> Request<Body> {
+    let mut request = Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .expect("public callback GET request");
+    request
+        .extensions_mut()
+        .insert(ConnectInfo(SocketAddr::from(([203, 0, 113, 10], 443))));
+    request
 }
 
 #[derive(Default, Debug)]
@@ -1617,6 +1767,191 @@ async fn webui_v2_gmail_oauth_setup_complete_allows_activation() {
         "activation should succeed after setup completion: {activate_body}"
     );
     assert_eq!(activate_body["activated"], true);
+}
+
+/// Regression coverage for the shipped Slack personal-connect journey. This
+/// deliberately starts at the authenticated WebUI extension card and returns
+/// through the public provider callback; no direct credential seeding or
+/// channel-identity helper is allowed in the path.
+#[tokio::test]
+async fn webui_v2_slack_personal_oauth_callback_persists_connected_projection() {
+    let (harness, network_egress) = build_slack_oauth_harness().await;
+    let package_ref = json!({"kind": "extension", "id": "slack"});
+    let oauth_invocation_id = InvocationId::new();
+
+    let install = harness
+        .router
+        .clone()
+        .oneshot(bearer_post(
+            "/api/webchat/v2/extensions/install",
+            json!({"package_ref": package_ref}),
+        ))
+        .await
+        .expect("install Slack oneshot");
+    assert_eq!(install.status(), StatusCode::OK);
+
+    let configure = harness
+        .router
+        .clone()
+        .oneshot(bearer_post(
+            "/api/webchat/v2/extensions/slack/setup",
+            json!({
+                "action": "submit",
+                "payload": {
+                    "fields": {
+                        "slack_team_id": SLACK_TEAM_ID,
+                        "slack_api_app_id": SLACK_APP_ID
+                    },
+                    "secrets": {
+                        "slack_bot_token": SLACK_BOT_TOKEN,
+                        "slack_signing_secret": "e2e-slack-signing-secret"
+                    }
+                }
+            }),
+        ))
+        .await
+        .expect("configure Slack oneshot");
+    assert_eq!(configure.status(), StatusCode::OK);
+
+    let start = harness
+        .router
+        .clone()
+        .oneshot(bearer_post(
+            "/api/webchat/v2/extensions/slack/setup/oauth/start",
+            json!({
+                "provider": "slack",
+                "account_label": "Personal Slack",
+                "scopes": SLACK_SCOPES,
+                "expires_at": (Utc::now() + chrono::Duration::minutes(5)).to_rfc3339(),
+                "invocation_id": oauth_invocation_id.to_string()
+            }),
+        ))
+        .await
+        .expect("start Slack OAuth oneshot");
+    assert_eq!(start.status(), StatusCode::OK);
+    let start_body = read_json(start).await;
+    let authorization_url = url::Url::parse(
+        start_body["authorization_url"]
+            .as_str()
+            .expect("Slack authorization URL"),
+    )
+    .expect("valid Slack authorization URL");
+    assert_eq!(authorization_url.host_str(), Some("slack.com"));
+    let state = authorization_url
+        .query_pairs()
+        .find_map(|(name, value)| (name == "state").then(|| value.into_owned()))
+        .expect("Slack OAuth state");
+    let callback_scopes = SLACK_SCOPES.join("%20");
+    let callback = harness
+        .router
+        .clone()
+        .oneshot(public_callback_get(&format!(
+            "/api/reborn/product-auth/oauth/slack/callback?state={state}&code=e2e-slack-code&scope={callback_scopes}"
+        )))
+        .await
+        .expect("Slack OAuth callback oneshot");
+    assert_eq!(callback.status(), StatusCode::OK);
+    let callback_body = read_json(callback).await;
+    assert_eq!(callback_body["status"], "completed");
+
+    let product_auth = harness
+        .runtime
+        .services()
+        .product_auth
+        .as_ref()
+        .expect("local-dev runtime wires product auth");
+    let accounts = product_auth
+        .credential_account_service()
+        .list_accounts(CredentialAccountListRequest::new(
+            AuthProductScope::new(
+                ResourceScope {
+                    tenant_id: TenantId::new(TENANT).expect("tenant"),
+                    user_id: UserId::new(USER).expect("user"),
+                    agent_id: Some(AgentId::new(AGENT).expect("agent")),
+                    project_id: None,
+                    mission_id: None,
+                    thread_id: None,
+                    invocation_id: oauth_invocation_id,
+                },
+                AuthSurface::Callback,
+            ),
+            AuthProviderId::new("slack").expect("Slack provider id"),
+        ))
+        .await
+        .expect("list persisted Slack accounts");
+    assert_eq!(accounts.accounts.len(), 1);
+    assert_eq!(
+        accounts.accounts[0].status,
+        CredentialAccountStatus::Configured
+    );
+
+    // The Extensions UI follows a completed first-time OAuth callback with
+    // the ordinary activation route. Keep that caller step in this journey:
+    // setup OAuth flows are intentionally SetupOnly, while activation makes
+    // the configured channel live and publishes its ready projection.
+    let activate = harness
+        .router
+        .clone()
+        .oneshot(bearer_post(
+            "/api/webchat/v2/extensions/slack/activate",
+            json!({}),
+        ))
+        .await
+        .expect("activate Slack oneshot");
+    assert_eq!(activate.status(), StatusCode::OK);
+    let activate_body = read_json(activate).await;
+    assert_eq!(
+        activate_body["success"], true,
+        "activation: {activate_body}"
+    );
+    assert_eq!(
+        activate_body["activated"], true,
+        "activation: {activate_body}"
+    );
+
+    let extensions = harness
+        .router
+        .clone()
+        .oneshot(bearer_get("/api/webchat/v2/extensions"))
+        .await
+        .expect("list extensions oneshot");
+    assert_eq!(extensions.status(), StatusCode::OK);
+    let extensions_body = read_json(extensions).await;
+    let slack = extensions_body["extensions"]
+        .as_array()
+        .expect("extensions array")
+        .iter()
+        .find(|extension| extension["package_ref"]["id"] == "slack")
+        .expect("installed Slack projection");
+    assert_eq!(slack["authenticated"], true, "Slack projection: {slack}");
+    assert_eq!(slack["needs_setup"], false, "Slack projection: {slack}");
+    assert_eq!(
+        slack["auth_accounts"][0]["accounts"][0]["state"],
+        "connected",
+        "Slack projection must expose the persisted connected account: {slack}"
+    );
+
+    let urls = network_egress.urls();
+    assert_eq!(
+        urls.iter()
+            .filter(|url| url.ends_with("/api/oauth.v2.access"))
+            .count(),
+        1,
+        "the real callback must perform exactly one Slack token exchange: {urls:?}"
+    );
+    assert_eq!(
+        urls.iter()
+            .filter(|url| url.ends_with("/api/conversations.open"))
+            .count(),
+        1,
+        "the identity bind must provision exactly one personal Slack DM target: {urls:?}"
+    );
+
+    harness
+        .runtime
+        .shutdown()
+        .await
+        .expect("runtime shutdown clean");
 }
 
 /// The provider-instance readiness map's 400 path

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -1926,8 +1926,7 @@ async fn webui_v2_slack_personal_oauth_callback_persists_connected_projection() 
     assert_eq!(slack["authenticated"], true, "Slack projection: {slack}");
     assert_eq!(slack["needs_setup"], false, "Slack projection: {slack}");
     assert_eq!(
-        slack["auth_accounts"][0]["accounts"][0]["state"],
-        "connected",
+        slack["auth_accounts"][0]["accounts"][0]["state"], "connected",
         "Slack projection must expose the persisted connected account: {slack}"
     );
 

--- a/crates/ironclaw_telegram_extension/src/lib.rs
+++ b/crates/ironclaw_telegram_extension/src/lib.rs
@@ -14,8 +14,10 @@
 #![forbid(unsafe_code)]
 
 mod channel;
+mod preference_targets;
 
 pub use channel::{
     TELEGRAM_BOT_TOKEN_HANDLE, TELEGRAM_WEBHOOK_SECRET_HANDLE, TELEGRAM_WEBHOOK_URL_CONFIG,
     TelegramChannelAdapter,
 };
+pub use preference_targets::TelegramPreferenceTargetCodec;

--- a/crates/ironclaw_telegram_extension/src/preference_targets.rs
+++ b/crates/ironclaw_telegram_extension/src/preference_targets.rs
@@ -173,5 +173,4 @@ mod tests {
         assert!(codec.direct_message_actor_for_target(&target).is_none());
         assert_eq!(codec.conversation_for_target(&target), Some(conversation));
     }
-
 }

--- a/crates/ironclaw_telegram_extension/src/preference_targets.rs
+++ b/crates/ironclaw_telegram_extension/src/preference_targets.rs
@@ -1,0 +1,177 @@
+//! Telegram reply-target binding-ref grammar for proactive delivery.
+//!
+//! Reactive replies keep using the compact `tg:` grammar owned by the
+//! protocol renderer. Stored preferences need one additional authority bit:
+//! the proven Telegram actor for a personal DM. The generic outbound-target
+//! registry compares that actor with its caller-scoped DM record before it
+//! resolves a target, so this grammar must preserve it.
+
+use ironclaw_product_adapters::{
+    ExternalConversationRef, PreferenceTargetCodec, PreferenceTargetEncodeRequest,
+};
+use ironclaw_turns::ReplyTargetBindingRef;
+
+const TELEGRAM_PREFERENCE_PREFIX: &str = "reply:telegram:";
+
+pub struct TelegramPreferenceTargetCodec;
+
+impl PreferenceTargetCodec for TelegramPreferenceTargetCodec {
+    fn conversation_for_target(
+        &self,
+        target: &ReplyTargetBindingRef,
+    ) -> Option<ExternalConversationRef> {
+        let decoded = decode_target(target)?;
+        ExternalConversationRef::new(None, decoded.chat_id, decoded.topic_id.as_deref(), None).ok()
+    }
+
+    fn is_personal_direct_message(&self, target: &ReplyTargetBindingRef) -> bool {
+        decode_target(target).is_some_and(|decoded| decoded.actor_id.is_some())
+    }
+
+    fn direct_message_actor_for_target(&self, target: &ReplyTargetBindingRef) -> Option<String> {
+        decode_target(target)?.actor_id
+    }
+
+    fn encode_shared_conversation_target(
+        &self,
+        request: PreferenceTargetEncodeRequest<'_>,
+    ) -> Option<ReplyTargetBindingRef> {
+        encode_target(request.conversation, None)
+    }
+
+    fn encode_personal_direct_message_target(
+        &self,
+        request: PreferenceTargetEncodeRequest<'_>,
+        external_actor_id: &str,
+    ) -> Option<ReplyTargetBindingRef> {
+        external_actor_id.parse::<i64>().ok()?;
+        encode_target(request.conversation, Some(external_actor_id))
+    }
+}
+
+struct DecodedTarget {
+    chat_id: String,
+    topic_id: Option<String>,
+    actor_id: Option<String>,
+}
+
+fn encode_target(
+    conversation: &ExternalConversationRef,
+    actor_id: Option<&str>,
+) -> Option<ReplyTargetBindingRef> {
+    if conversation.space_id().is_some() || conversation.reply_target_message_id().is_some() {
+        return None;
+    }
+    let chat_id = conversation.conversation_id();
+    chat_id.parse::<i64>().ok()?;
+    let topic_id = conversation.topic_id().unwrap_or("_");
+    if topic_id != "_" {
+        topic_id.parse::<i64>().ok()?;
+    }
+    let actor_id = actor_id.unwrap_or("_");
+    ReplyTargetBindingRef::new(format!(
+        "{TELEGRAM_PREFERENCE_PREFIX}{chat_id}:{topic_id}:{actor_id}"
+    ))
+    .ok()
+}
+
+fn decode_target(target: &ReplyTargetBindingRef) -> Option<DecodedTarget> {
+    let raw = target.as_str().strip_prefix(TELEGRAM_PREFERENCE_PREFIX)?;
+    let mut segments = raw.split(':');
+    let chat_id = segments.next()?;
+    let topic_id = segments.next()?;
+    let actor_id = segments.next()?;
+    if segments.next().is_some() || chat_id.parse::<i64>().is_err() {
+        return None;
+    }
+    let topic_id = match topic_id {
+        "_" => None,
+        value if value.parse::<i64>().is_ok() => Some(value.to_string()),
+        _ => return None,
+    };
+    let actor_id = match actor_id {
+        "_" => None,
+        value if value.parse::<i64>().is_ok() => Some(value.to_string()),
+        _ => return None,
+    };
+    Some(DecodedTarget {
+        chat_id: chat_id.to_string(),
+        topic_id,
+        actor_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::AgentId;
+    use ironclaw_product_adapters::{AdapterInstallationId, PreferenceTargetEncodeRequest};
+
+    use super::*;
+
+    fn request<'a>(
+        installation_id: &'a AdapterInstallationId,
+        agent_id: &'a AgentId,
+        conversation: &'a ExternalConversationRef,
+    ) -> PreferenceTargetEncodeRequest<'a> {
+        PreferenceTargetEncodeRequest {
+            installation_id,
+            agent_id,
+            project_id: None,
+            conversation,
+        }
+    }
+
+    #[test]
+    fn personal_dm_round_trips_with_the_proven_actor() {
+        let codec = TelegramPreferenceTargetCodec;
+        let installation = AdapterInstallationId::new("telegram").expect("installation");
+        let agent = AgentId::new("agent").expect("agent");
+        let conversation =
+            ExternalConversationRef::new(None, "-100123", Some("42"), None).expect("conversation");
+
+        let target = codec
+            .encode_personal_direct_message_target(
+                request(&installation, &agent, &conversation),
+                "987654",
+            )
+            .expect("personal target");
+
+        assert!(codec.is_personal_direct_message(&target));
+        assert_eq!(
+            codec.direct_message_actor_for_target(&target).as_deref(),
+            Some("987654")
+        );
+        assert_eq!(codec.conversation_for_target(&target), Some(conversation));
+    }
+
+    #[test]
+    fn malformed_or_non_telegram_actor_targets_fail_closed() {
+        let codec = TelegramPreferenceTargetCodec;
+        let malformed =
+            ReplyTargetBindingRef::new("reply:telegram:123:_:not-a-telegram-user".to_string())
+                .expect("bounded ref");
+        let reactive = ironclaw_telegram_v2_adapter::build_reply_target_binding(123, None, None);
+
+        assert!(codec.conversation_for_target(&malformed).is_none());
+        assert!(!codec.is_personal_direct_message(&malformed));
+        assert!(codec.conversation_for_target(&reactive).is_none());
+    }
+
+    #[test]
+    fn shared_conversation_round_trips_without_claiming_a_personal_actor() {
+        let codec = TelegramPreferenceTargetCodec;
+        let installation = AdapterInstallationId::new("telegram").expect("installation");
+        let agent = AgentId::new("agent").expect("agent");
+        let conversation =
+            ExternalConversationRef::new(None, "-100456", None, None).expect("conversation");
+
+        let target = codec
+            .encode_shared_conversation_target(request(&installation, &agent, &conversation))
+            .expect("shared target");
+
+        assert!(!codec.is_personal_direct_message(&target));
+        assert!(codec.direct_message_actor_for_target(&target).is_none());
+        assert_eq!(codec.conversation_for_target(&target), Some(conversation));
+    }
+
+}

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -687,7 +687,7 @@ async fn assert_extension_has_no_user_installation(services: &RebornServices, ex
     );
 }
 
-fn start_channel_host_assembly(
+async fn start_channel_host_assembly(
     services: &RebornServices,
     inbound: &RebornIntegrationHarness,
 ) -> Arc<GenericChannelHostAssembly> {
@@ -709,6 +709,7 @@ fn start_channel_host_assembly(
             },
             run_delivery_settings: fast_delivery_settings(),
         })
+        .await
         .expect("production channel host assembly starts")
 }
 
@@ -725,7 +726,7 @@ async fn admin_configured_slack_unconnected_dm_gets_connect_notice_without_insta
         .await
         .expect("inbound thread builds");
     assert_extension_has_no_user_installation(services, "slack").await;
-    let assembly = start_channel_host_assembly(services, &inbound);
+    let assembly = start_channel_host_assembly(services, &inbound).await;
     let _binding = wait_for_production_registration(&assembly, services, "slack").await;
     let ingress = VendorIngress::production(
         services
@@ -837,7 +838,7 @@ async fn admin_configured_telegram_unconnected_dm_gets_connect_notice_without_in
         .await
         .expect("inbound thread builds");
     assert_extension_has_no_user_installation(services, "telegram").await;
-    let assembly = start_channel_host_assembly(services, &inbound);
+    let assembly = start_channel_host_assembly(services, &inbound).await;
     let _binding = wait_for_production_registration(&assembly, services, "telegram").await;
     let ingress = VendorIngress::production(
         services
@@ -1124,6 +1125,7 @@ async fn telegram_update_becomes_a_turn_and_a_coordinated_reply(#[case] storage:
             },
             run_delivery_settings: fast_delivery_settings(),
         })
+        .await
         .expect("the production channel host assembly starts over the composed runtime");
 
     // Install through the production lifecycle tool (same handshake as the
@@ -1586,6 +1588,7 @@ async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_t
             },
             run_delivery_settings: fast_delivery_settings(),
         })
+        .await
         .expect("the production channel host assembly starts over the composed runtime");
 
     let lifecycle = group
@@ -1802,6 +1805,30 @@ async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_t
             .await,
         Some(true),
         "consuming the minted code must durably connect the caller"
+    );
+
+    // Routine creation discovers destinations through this caller-scoped
+    // production registry before passing a target id to trigger_create. Keep
+    // the assertion in the real Telegram pairing journey: a connected DM
+    // without a registered vendor codec used to disappear here, making
+    // Telegram routine delivery impossible even though reactive replies
+    // worked. The synthetic capability facade used by the integration harness
+    // is deliberately bypassed so this reads the real composed registry.
+    let telegram_target_id = format!("telegram:personal-dm::{}", paired_user.as_str());
+    let target_ids = services
+        .outbound_delivery_target_ids_for_test(
+            ironclaw_product_workflow::WebUiAuthenticatedCaller::new(
+                inbound.binding.tenant_id.clone(),
+                paired_user.clone(),
+                inbound.binding.agent_id.clone(),
+                inbound.binding.project_id.clone(),
+            ),
+        )
+        .await
+        .expect("paired caller's production outbound targets list");
+    assert!(
+        target_ids.contains(&telegram_target_id),
+        "paired Telegram DM must be caller-visible for routine delivery: {target_ids:?}"
     );
     for intercepted_text in [
         "hello, are you there?",

--- a/tests/integration/support/harness/profiles/extension.rs
+++ b/tests/integration/support/harness/profiles/extension.rs
@@ -784,7 +784,9 @@ fn telegram_channel_extension_binding() -> ironclaw_reborn_composition::ChannelE
         extension_id: "telegram".to_string(),
         adapter: Arc::new(ironclaw_telegram_extension::TelegramChannelAdapter::default()),
         inbound_payload_classifier: None,
-        preference_target_codec: None,
+        preference_target_codec: Some(Arc::new(
+            ironclaw_telegram_extension::TelegramPreferenceTargetCodec,
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

- Add a hermetic WebUI v2 Slack personal OAuth journey through install/configure, public callback, credential and identity binding, activation, and caller-visible connected projection.
- Restore paired Telegram DMs as caller-owned routine targets by wiring a fail-closed Telegram preference-target codec in production.
- Extend the real Telegram pairing journey to read the production outbound-target registry used by routine creation.
- Diagnose the named Telegram deny scenario as retired during the generic extension-runtime migration and validate its current generic deny equivalents.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (repository-required superset)
- [ ] `cargo build` (not separate; changed CLI wiring compiled in tests)
- [x] Relevant tests pass: Slack OAuth, Telegram codec/pairing/target, CLI wiring, generic deny paths, architecture
- [ ] `cargo test --features integration` (targeted Reborn binaries passed)
- [ ] Manual testing: Not applicable; provider paths use hermetic doubles.
- [ ] Agent review workflow: not run

## Test Strategy

User behavior:
- Slack personal OAuth completes through the current extension UI route graph and projects connected.
- A paired Telegram user can select the personal DM as a routine delivery target.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Telegram codec round trips personal/shared targets and rejects malformed, non-numeric, and reactive-only refs; CLI assembly supplies it.
- Reborn integration: WebUI v2 Slack route/callback/persistence/projection; Telegram pairing reads the caller-scoped production target registry.
- Recorded fixture: Not applicable: no model choice/request-shape change; merged QA fixture work is untouched.
- Browser E2E: Not applicable: the regression seam is server-side WebUI v2 HTTP and callback routing, exercised in-process.
- Backend or runtime: libSQL local-dev runtime, real lifecycle/identity stores, callback binding hook, and target registry. PostgreSQL not repeated because no schema/backend-specific code changed.
- Live canary: Not applicable: hermetic protocol-faithful provider doubles need no live credential.

What the tests prove:
- Slack exchanges one OAuth code, persists a configured account, binds the proven Slack user, provisions one personal DM, activates via the UI follow-up route, and projects `connected`.
- Telegram pairing exposes `telegram:personal-dm::<user>` through the registry used by routine creation/target validation.
- Scheduled-trigger denial does not execute its side effect; OAuth links aimed at non-DM targets are suppressed and the blocked run is cancelled.

Commands run:
- `bash scripts/codebase-graph.sh status` (unavailable; documented fallback used)
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_composition --test webui_v2_e2e --features test-support webui_v2_slack_personal_oauth_callback_persists_connected_projection -- --exact --nocapture`
- `SECRETS_MASTER_KEY=<test-key> cargo test --test reborn_integration_extension_delivery unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_to_the_paired_user::case_1_libsql -- --exact --nocapture`
- `cargo test -p ironclaw_telegram_extension`
- `cargo test -p ironclaw --bin ironclaw runtime::native_extensions::tests -- --nocapture`
- `SECRETS_MASTER_KEY=<test-key> cargo test --test reborn_group_triggers triggered_gate_group -- --exact --nocapture`
- `cargo test -p ironclaw_reborn_composition --lib extension_host::channel_host::e2e_tests::triggered_auth_prompt_oauth_target_not_dm_suppresses_setup_link_and_cancels_run -- --exact --nocapture`
- `cargo test -p ironclaw_architecture`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `scripts/pre-commit-safety.sh`

## Security Impact

The Slack test exercises public callback state validation, scoped credential persistence, and channel identity binding with a hermetic provider. Production security behavior is unchanged. Telegram refs preserve the proven numeric actor in bounded storage; the generic registry still validates it against caller-scoped durable DM state.

## Reborn Trust-Boundary Checklist

- [x] Public trust-bearing types: no new evidence type; codec consumes host-proven DM records.
- [x] Untrusted content enters prompts only through an envelope. No prompt change.
- [x] Hashes declare purpose. No hashing change.
- [x] Status/error variants audited: none changed; workspace clippy passed.
- [x] Security/durability serde defaults: no schema fields changed.
- [x] Bounds: existing bounded `ReplyTargetBindingRef`; malformed/oversized refs fail closed.
- [x] Stable driver error semantics: no error class changed.
- [x] Trust-boundary naming remains accurate.

## Database Impact

None. No migration or schema change. Existing Telegram pairings need no migration.

## Blast Radius

Slack WebUI OAuth coverage, channel-host test-support parity, Telegram preference encoding, CLI native assembly, and Telegram integration setup. A codec bug would hide or fail-close Telegram routine targets; reactive replies are unchanged.

## Rollback Plan

Revert the commit. No migration or provider cleanup is required; Telegram routine discovery returns to the prior missing state.

## Review Follow-Through

Remaining gap: the integration harness cannot synchronously join the detached trigger-to-channel push hook. This PR covers real target discovery and relies on existing generic channel-host triggered-delivery E2E for the push leg. PostgreSQL and live canaries were not run as documented above.

---

**Review track**: B
