### PR TITLE
test(reborn): replay QA provider journeys end to end

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: serrrfirat/emulate
-          ref: e5d62318f2ee546660b974ee92d627cf39b97951
+          ref: 92bd9c2157a74613c47549eb5cfcccc7c0740adf
           path: .emulate
           persist-credentials: false
 

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -39,7 +39,7 @@ pip install -e .
 playwright install chromium
 ```
 
-Dependencies: `pytest`, `pytest-asyncio`, `pytest-playwright`, `pytest-timeout`, `playwright`, `aiohttp`, `httpx`. Optional: `anthropic` (vision extras). Requires Python >= 3.11. Emulate-backed provider tests also require Node.js. CI installs Node 24, builds `serrrfirat/emulate` at commit `e5d62318f2ee546660b974ee92d627cf39b97951`, and passes its CLI through `IRONCLAW_EMULATE_CLI`. Without that override, unrelated local Emulate tests retain the `emulate@0.7.0` fallback.
+Dependencies: `pytest`, `pytest-asyncio`, `pytest-playwright`, `pytest-timeout`, `playwright`, `aiohttp`, `httpx`. Optional: `anthropic` (vision extras). Requires Python >= 3.11. Emulate-backed provider tests also require Node.js. CI installs Node 24, builds `serrrfirat/emulate` at commit `92bd9c2157a74613c47549eb5cfcccc7c0740adf`, and passes its CLI through `IRONCLAW_EMULATE_CLI`. Without that override, unrelated local Emulate tests retain the `emulate@0.7.0` fallback.
 
 ## Running Tests
 
@@ -178,11 +178,13 @@ recorded-trace tests load harvested `LlmTrace` JSON through `mock_llm.py`'s
 model response from every case in the live-canary manifest. Its closed-set
 assertions require new fixtures and provider operations to be classified
 instead of silently losing coverage. `test_reborn_qa_trace_full_path.py`
-additionally proves the whole runtime seam for the harvested Drive connection
-case: it executes the recorded decision through standalone `ironclaw serve`,
-routes Google HTTP through
-`emulate_google_server`, and asserts Emulate-seeded Drive data rather than the
-model's final prose.
+discovers every manifest journey with an Emulate-supported provider call and
+executes that provider leg through standalone `ironclaw serve`, installed and
+authenticated first-party extensions, the credential/network boundaries, and
+the pinned Emulate fork. Cross-provider ordering is retained, fresh Docs and
+Sheets IDs are bound from earlier real tool results, redacted provider IDs are
+mapped to deterministic seeded resources, and assertions target capability
+success plus provider readback rather than recorded final-answer wording.
 Debug E2E binaries honor `IRONCLAW_REBORN_TEST_HTTP_REWRITE_MAP` only for
 loopback IP socket targets after the original destination has passed the normal
 network policy and DNS checks. Release binaries fail startup if that test-only

--- a/tests/e2e/fixtures/emulate/google_gmail.yaml
+++ b/tests/e2e/fixtures/emulate/google_gmail.yaml
@@ -144,3 +144,26 @@ google:
       parent_google_ids:
         - root
       data: "This Drive item belongs only to the secondary identity."
+  documents:
+    - id: doc_reborn_strategy
+      user_email: e2e.google@example.com
+      title: NEAR AI Strategy
+      body: "NEAR AI Strategy: user-owned agents keep credentials and data under user control."
+  spreadsheets:
+    - id: sheet_reborn_abc
+      user_email: e2e.google@example.com
+      title: ABC
+      sheets:
+        - id: 0
+          title: Sheet1
+          values:
+            - [Company, Contact, Source, Status, QA Marker]
+            - [NEAR AI, partnerships@near.ai, Gmail, New, REBORN_QA_SEEDED]
+    - id: sheet_reborn_bug_tracker
+      user_email: e2e.google@example.com
+      title: Reborn QA Bug Tracker
+      sheets:
+        - id: 0
+          title: Sheet1
+          values:
+            - [Summary, Reporter, Slack Timestamp, Status, QA Marker]

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -209,6 +209,16 @@ def _parse_llm_trace(trace: object, source: str | None = None) -> dict:
                 f"trace.steps[{index}].request_hint.min_message_count "
                 "must be a non-negative integer"
             )
+        expected_failed_result = request_hint.get(
+            "expected_failed_tool_result_contains"
+        )
+        if expected_failed_result is not None and (
+            not isinstance(expected_failed_result, str) or not expected_failed_result
+        ):
+            raise ValueError(
+                f"trace.steps[{index}].request_hint."
+                "expected_failed_tool_result_contains must be a non-empty string"
+            )
         responses.append(response)
         request_hints.append(request_hint)
         pending_user_input = False
@@ -273,10 +283,20 @@ def _next_llm_trace_response(
             raise web.HTTPConflict(text=state["error"])
 
     failed_result = _failed_tool_result(messages)
-    if failed_result is not None:
+    expected_failed_result = request_hint.get("expected_failed_tool_result_contains")
+    if failed_result is None and expected_failed_result is not None:
+        state["error"] = (
+            "recorded LLM trace expected a failed capability result containing "
+            f"{expected_failed_result!r} before response {next_index}"
+        )
+        raise web.HTTPConflict(text=state["error"])
+    if failed_result is not None and (
+        expected_failed_result is None
+        or expected_failed_result not in failed_result["content"]
+    ):
         state["error"] = (
             "recorded LLM trace observed a failed capability result before response "
-            f"{next_index}: {failed_result}"
+            f"{next_index}: {failed_result['summary']}"
         )
         raise web.HTTPConflict(text=state["error"])
 
@@ -413,14 +433,17 @@ def _find_trace_result_field(value: object, fields: list[str]) -> object | None:
     return None
 
 
-def _failed_tool_result(messages: list[dict]) -> str | None:
+def _failed_tool_result(messages: list[dict]) -> dict | None:
     for message in messages:
         if message.get("role") != "tool":
             continue
         parsed = _parse_trace_result_content(message.get("content"))
         status = _find_trace_result_field(parsed, ["status"])
         if status in {"failed", "error"}:
-            return f"{message.get('name', 'unknown tool')} status={status}"
+            return {
+                "content": json.dumps(parsed, sort_keys=True),
+                "summary": f"{message.get('name', 'unknown tool')} status={status}",
+            }
     return None
 
 TOOL_FAILURE_TRIGGER = re.compile(r"issue 1780 tool failure", re.IGNORECASE)

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -7,6 +7,7 @@ via TOOL_CALL_PATTERNS.
 
 import argparse
 import asyncio
+from copy import deepcopy
 import json
 import os
 import re
@@ -271,21 +272,156 @@ def _next_llm_trace_response(
             )
             raise web.HTTPConflict(text=state["error"])
 
-    response = responses[next_index]
+    failed_result = _failed_tool_result(messages)
+    if failed_result is not None:
+        state["error"] = (
+            "recorded LLM trace observed a failed capability result before response "
+            f"{next_index}: {failed_result}"
+        )
+        raise web.HTTPConflict(text=state["error"])
+
+    response = deepcopy(responses[next_index])
     if response["type"] == "tool_calls":
+        available_tool_names = set(available_tool_names)
+        for result in _find_named_tool_results(messages, "capability_info"):
+            parsed = _parse_trace_result_content(result.get("content"))
+            disclosed_name = _find_trace_result_field(parsed, ["name"])
+            if isinstance(disclosed_name, str):
+                available_tool_names.add(disclosed_name)
+                available_tool_names.add(disclosed_name.replace(".", "__"))
         missing = {
             tool_call["name"]
             for tool_call in response["tool_calls"]
             if tool_call["name"] not in available_tool_names
         }
         if missing:
-            state["error"] = "recorded LLM trace requested unavailable tools: " + ", ".join(
-                sorted(missing)
+            available_provider_tools = sorted(
+                name
+                for name in available_tool_names
+                if "__" in name and not name.startswith("builtin__")
+            )
+            state["error"] = (
+                "recorded LLM trace requested unavailable tools: "
+                + ", ".join(sorted(missing))
+                + "; available provider tools: "
+                + ", ".join(available_provider_tools)
+                + "; all available tools: "
+                + ", ".join(sorted(available_tool_names))
             )
             raise web.HTTPConflict(text=state["error"])
+        try:
+            response["tool_calls"] = _resolve_trace_result_bindings(
+                response["tool_calls"], messages
+            )
+        except ValueError as error:
+            state["error"] = str(error)
+            raise web.HTTPConflict(text=state["error"]) from error
 
     state["next_response"] += 1
     return response
+
+
+def _resolve_trace_result_bindings(value: object, messages: list[dict]) -> object:
+    """Resolve test-only arguments from earlier real capability results.
+
+    Harvested traces necessarily contain the provider IDs returned during the
+    live run. Full-path replay creates fresh Docs and Sheets resources, so a
+    later recorded call must consume the ID returned by the local provider,
+    not the stale live ID. Tests opt into that behavior with an argument value
+    shaped like::
+
+        {"$trace_result": {"tool": "google-docs__create_document",
+                            "fields": ["documentId", "document_id", "id"]}}
+
+    The marker is accepted only inside the mock server; committed trace files
+    remain unchanged and production code never sees it.
+    """
+    if isinstance(value, list):
+        return [_resolve_trace_result_bindings(item, messages) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    if set(value) == {"$trace_result"}:
+        binding = value["$trace_result"]
+        if not isinstance(binding, dict):
+            raise ValueError("$trace_result binding must be an object")
+        tool = binding.get("tool")
+        fields = binding.get("fields")
+        if not isinstance(tool, str) or not tool:
+            raise ValueError("$trace_result.tool must be a non-empty string")
+        if (
+            not isinstance(fields, list)
+            or not fields
+            or not all(isinstance(field, str) and field for field in fields)
+        ):
+            raise ValueError("$trace_result.fields must be non-empty strings")
+
+        named_results = _find_named_tool_results(messages, tool)
+        for result in reversed(named_results):
+            payload = _parse_trace_result_content(result.get("content"))
+            found = _find_trace_result_field(payload, fields)
+            if found is not None:
+                return found
+        observed = [
+            {
+                "name": result.get("name"),
+                "content": str(result.get("content", ""))[:500],
+            }
+            for result in _find_tool_results(messages)
+        ]
+        raise ValueError(
+            f"recorded LLM trace could not bind a result from {tool} "
+            f"using fields {fields}; observed tool results: {observed}"
+        )
+
+    return {
+        key: _resolve_trace_result_bindings(item, messages)
+        for key, item in value.items()
+    }
+
+
+def _parse_trace_result_content(content: object) -> object:
+    if not isinstance(content, str):
+        return content
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return content
+
+
+def _find_trace_result_field(value: object, fields: list[str]) -> object | None:
+    if isinstance(value, dict):
+        for field in fields:
+            candidate = value.get(field)
+            if isinstance(candidate, (str, int)) and not isinstance(candidate, bool):
+                return candidate
+        for child in value.values():
+            candidate = _find_trace_result_field(child, fields)
+            if candidate is not None:
+                return candidate
+    elif isinstance(value, list):
+        for child in value:
+            candidate = _find_trace_result_field(child, fields)
+            if candidate is not None:
+                return candidate
+    elif isinstance(value, str) and value[:1] in {"{", "["}:
+        try:
+            nested = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        return _find_trace_result_field(nested, fields)
+    return None
+
+
+def _failed_tool_result(messages: list[dict]) -> str | None:
+    for message in messages:
+        if message.get("role") != "tool":
+            continue
+        parsed = _parse_trace_result_content(message.get("content"))
+        status = _find_trace_result_field(parsed, ["status"])
+        if status in {"failed", "error"}:
+            return f"{message.get('name', 'unknown tool')} status={status}"
+    return None
 
 TOOL_FAILURE_TRIGGER = re.compile(r"issue 1780 tool failure", re.IGNORECASE)
 TRUNCATED_TOOL_CALL_TRIGGER = re.compile(
@@ -1651,6 +1787,33 @@ def _advertised_tool_names(tools: object) -> set[str]:
     return names
 
 
+def _available_tool_names(tools: object) -> set[str]:
+    """Include deferred tools named by the runtime's tool-search catalog."""
+    names = _advertised_tool_names(tools)
+    if not isinstance(tools, list):
+        return names
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function") if isinstance(tool.get("function"), dict) else tool
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        description = function.get("description")
+        if not isinstance(name, str) or not name.endswith("tool_search"):
+            continue
+        if not isinstance(description, str):
+            continue
+        for line in description.splitlines():
+            candidate = line.removeprefix("- ") if line.startswith("- ") else ""
+            if candidate and all(
+                character.isalnum() or character in "_.-" for character in candidate
+            ):
+                names.add(candidate)
+                names.add(candidate.replace(".", "__"))
+    return names
+
+
 def match_tool_call(messages: list[dict], has_tools: bool) -> list[dict] | None:
     """Return the list of tool calls to emit for the latest user message.
 
@@ -2688,7 +2851,7 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
     stream = body.get("stream", False)
     tools = body.get("tools")
     has_tools = bool(tools)
-    available_tool_names = _advertised_tool_names(tools)
+    available_tool_names = _available_tool_names(tools)
     cid = f"mock-{uuid.uuid4().hex[:8]}"
 
     trace_response = _next_llm_trace_response(
@@ -3230,7 +3393,38 @@ async def google_oauth_token(request: web.Request) -> web.Response:
     data = await request.post()
     if data.get("grant_type") != "authorization_code":
         return web.json_response({"error": "unsupported_grant_type"}, status=400)
-    if data.get("code") != "mock_auth_code":
+    # Full-path QA uses one pre-consented reusable Google identity. Google may
+    # report the account's cumulative grants during a narrower scope-upgrade
+    # flow, so the extension-specific codes expose that deterministic union.
+    all_reborn_google_scopes = " ".join(
+        (
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.send",
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/calendar.events",
+            "https://www.googleapis.com/auth/drive.readonly",
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/documents",
+            "https://www.googleapis.com/auth/documents.readonly",
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://www.googleapis.com/auth/spreadsheets.readonly",
+        )
+    )
+    scopes_by_code = {
+        "mock_auth_code": (
+            "https://www.googleapis.com/auth/drive.readonly "
+            "https://www.googleapis.com/auth/drive"
+        ),
+        "mock_auth_code_gmail": all_reborn_google_scopes,
+        "mock_auth_code_google_calendar": all_reborn_google_scopes,
+        "mock_auth_code_google_drive": all_reborn_google_scopes,
+        "mock_auth_code_google_docs": all_reborn_google_scopes,
+        "mock_auth_code_google_sheets": all_reborn_google_scopes,
+    }
+    code = data.get("code")
+    scope = scopes_by_code.get(code)
+    if scope is None:
         return web.json_response({"error": "invalid_grant"}, status=400)
     return web.json_response(
         {
@@ -3238,10 +3432,7 @@ async def google_oauth_token(request: web.Request) -> web.Response:
             "refresh_token": "mock-refreshed-access-token",
             "token_type": "Bearer",
             "expires_in": 3600,
-            "scope": (
-                "https://www.googleapis.com/auth/drive.readonly "
-                "https://www.googleapis.com/auth/drive"
-            ),
+            "scope": scope,
         }
     )
 

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -25,7 +25,6 @@ from reborn_webui_harness import (
     close_reborn_server,
     create_thread,
     enable_reborn_global_auto_approve,
-    fetch_timeline,
     reborn_bearer_headers,
     send_message,
     start_reborn_webui_v2_server,
@@ -688,17 +687,46 @@ async def _wait_for_trace_replay(mock_llm_server: str, timeout: float = 30) -> d
     )
 
 
-async def _fetch_timeline_with_retry(
+async def _fetch_all_timeline_pages_with_retry(
     client: httpx.AsyncClient, server: str, thread_id: str
 ) -> dict:
-    for _ in range(20):
-        try:
-            return await fetch_timeline(client, server, thread_id)
-        except httpx.HTTPStatusError as error:
-            if error.response.status_code != 429:
-                raise
-        await asyncio.sleep(0.5)
-    raise AssertionError("timeline remained rate-limited after replay completed")
+    timeline = None
+    messages = []
+    cursor = None
+    seen_cursors = set()
+
+    while True:
+        params = {"limit": 200}
+        if cursor is not None:
+            params["cursor"] = cursor
+
+        for _ in range(20):
+            response = await client.get(
+                f"{server}/api/webchat/v2/threads/{thread_id}/timeline",
+                params=params,
+                timeout=15,
+            )
+            if response.status_code != 429:
+                response.raise_for_status()
+                page = response.json()
+                break
+            await asyncio.sleep(0.5)
+        else:
+            raise AssertionError(
+                "timeline remained rate-limited after replay completed"
+            )
+
+        if timeline is None:
+            timeline = page
+        messages = [*page.get("messages", []), *messages]
+        cursor = page.get("next_cursor")
+        if cursor is None:
+            timeline["messages"] = messages
+            timeline["next_cursor"] = None
+            return timeline
+        assert isinstance(cursor, str) and cursor, page
+        assert cursor not in seen_cursors, f"timeline cursor repeated: {cursor}"
+        seen_cursors.add(cursor)
 
 
 def _recorded_provider_calls(trace: dict) -> list[dict]:
@@ -836,7 +864,9 @@ async def test_qa_journey_provider_leg_replays_through_emulate(
         await wait_for_assistant_message(
             client, server, thread_id, timeout=replay_timeout
         )
-        timeline = await _fetch_timeline_with_retry(client, server, thread_id)
+        timeline = await _fetch_all_timeline_pages_with_retry(
+            client, server, thread_id
+        )
         previews = [
             preview
             for message in timeline.get("messages", [])
@@ -850,10 +880,7 @@ async def test_qa_journey_provider_leg_replays_through_emulate(
             for preview in previews
             if preview["capability_id"] in expected_counts
         )
-        if case == "qa_9c_slack_digest_names_not_ids":
-            assert actual_counts, "capped timeline retained no provider previews"
-        else:
-            assert actual_counts == expected_counts, (actual_counts, expected_counts)
+        assert actual_counts == expected_counts, (actual_counts, expected_counts)
         for preview in previews:
             if preview["capability_id"] not in expected_counts:
                 continue

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -604,14 +604,20 @@ def _normalize_google_arguments(trace: dict, case: str) -> None:
                 arguments["file_id"] = "drv_pepsico_account_brief"
 
 
-def _normalize_slack_arguments(trace: dict, slack_state: dict[str, str]) -> None:
+def _normalize_slack_arguments(
+    trace: dict, slack_state: dict[str, str], case: str
+) -> None:
     for step in trace["steps"]:
         for call in step["response"].get("tool_calls", []):
             if not call["name"].startswith("slack__"):
                 continue
             arguments = call["arguments"]
             if "channel" in arguments:
-                arguments["channel"] = slack_state["channel_id"]
+                arguments["channel"] = (
+                    "C_REBORN_QA_10E_MISSING"
+                    if case == "qa_10e_slack_error_honesty"
+                    else slack_state["channel_id"]
+                )
             if "user_id" in arguments:
                 arguments["user_id"] = slack_state["reviewer_id"]
             if "thread_ts" in arguments:
@@ -654,10 +660,14 @@ async def _load_trace(
     if trace_path.stem == "qa_9c_slack_digest_names_not_ids":
         _coalesce_independent_provider_reads(trace)
         _inject_deferred_tool_disclosure(trace)
+    elif trace_path.stem == "qa_10e_slack_error_honesty":
+        trace["steps"][-1]["request_hint"] = {
+            "expected_failed_tool_result_contains": "channel_not_found"
+        }
     if provider_prefixes is not None:
         _normalize_google_arguments(trace, trace_path.stem)
     if slack_state is not None:
-        _normalize_slack_arguments(trace, slack_state)
+        _normalize_slack_arguments(trace, slack_state, trace_path.stem)
     async with httpx.AsyncClient() as client:
         response = await client.post(
             f"{mock_llm_server}/__mock/llm_trace",
@@ -861,7 +871,7 @@ async def test_qa_journey_provider_leg_replays_through_emulate(
         replay = await _wait_for_trace_replay(
             mock_llm_server, timeout=replay_timeout
         )
-        await wait_for_assistant_message(
+        assistant = await wait_for_assistant_message(
             client, server, thread_id, timeout=replay_timeout
         )
         timeline = await _fetch_all_timeline_pages_with_retry(
@@ -884,13 +894,19 @@ async def test_qa_journey_provider_leg_replays_through_emulate(
         for preview in previews:
             if preview["capability_id"] not in expected_counts:
                 continue
-            assert preview["status"] == "completed", json.dumps(preview)
             output = json.dumps(preview).lower()
+            if case == "qa_10e_slack_error_honesty":
+                assert preview["status"] == "failed", json.dumps(preview)
+                assert "channel_not_found" in output, preview
+                continue
+            assert preview["status"] == "completed", json.dumps(preview)
             assert "auth_required" not in output, preview
             assert "not found" not in output, preview
 
         if case == "qa_2c_drive_connect":
             assert "Secondary Private Brief" not in json.dumps(timeline)
+        elif case == "qa_10e_slack_error_honesty":
+            assert "channel_not_found" in assistant["content"]
 
     await _assert_google_provider_outcome(
         reborn_qa_emulate_provider_server["emulate_google_url"], case, trace

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -9,6 +9,7 @@ the recorded model's final wording.
 import asyncio
 import json
 import uuid
+from collections import Counter
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -16,45 +17,129 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 
+from emulate_provider import google_headers, slack_post
+from helpers import EMULATE_GITHUB_BEARER, EMULATE_SLACK_BEARER
 from reborn_webui_harness import (
     YOLO_PROFILE,
+    capability_preview_payload,
     close_reborn_server,
     create_thread,
     enable_reborn_global_auto_approve,
+    fetch_timeline,
     reborn_bearer_headers,
     send_message,
     start_reborn_webui_v2_server,
     wait_for_assistant_message,
-    wait_for_capability_preview,
 )
 
 pytest_plugins = ["reborn_webui_harness"]
 
 ROOT = Path(__file__).resolve().parents[3]
-DRIVE_CONNECT_TRACE = (
-    ROOT
-    / "tests/fixtures/llm_traces/reborn_qa/live_canary/qa_2c_drive_connect.json"
+TRACE_DIR = ROOT / "tests/fixtures/llm_traces/reborn_qa/live_canary"
+MANIFEST_PATH = TRACE_DIR / "case-manifest.json"
+GOOGLE_EXTENSIONS = (
+    "gmail",
+    "google-calendar",
+    "google-drive",
+    "google-docs",
+    "google-sheets",
 )
-GOOGLE_DRIVE_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
-GOOGLE_DRIVE_SCOPE = "https://www.googleapis.com/auth/drive"
+GOOGLE_EXTENSION_SCOPES = {
+    "gmail": (
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/gmail.modify",
+    ),
+    "google-calendar": (
+        "https://www.googleapis.com/auth/calendar.readonly",
+        "https://www.googleapis.com/auth/calendar.events",
+    ),
+    "google-drive": (
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive",
+    ),
+    "google-docs": (
+        "https://www.googleapis.com/auth/documents",
+        "https://www.googleapis.com/auth/documents.readonly",
+    ),
+    "google-sheets": (
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
+    ),
+}
+GOOGLE_CUMULATIVE_SCOPES = tuple(
+    dict.fromkeys(
+        scope
+        for extension_scopes in GOOGLE_EXTENSION_SCOPES.values()
+        for scope in extension_scopes
+    )
+)
+GOOGLE_TOOL_PREFIXES = (
+    "gmail__",
+    "google-calendar__",
+    "google-docs__",
+    "google-drive__",
+    "google-sheets__",
+)
+PROVIDER_TOOL_PREFIXES = (
+    *GOOGLE_TOOL_PREFIXES,
+    "github__",
+    "slack__",
+)
+ALL_EXTENSIONS = (*GOOGLE_EXTENSIONS, "github", "slack")
+TRACE_BOOTSTRAP_TOOLS = {"builtin__extension_search"}
+
+
+def _provider_journey_cases() -> tuple[str, ...]:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    no_model = set(manifest["no_model_cases"])
+    cases = []
+    for case in manifest["selected_cases"]:
+        if case in no_model:
+            continue
+        trace = json.loads((TRACE_DIR / f"{case}.json").read_text(encoding="utf-8"))
+        if any(
+            call["name"].startswith(PROVIDER_TOOL_PREFIXES)
+            for step in trace["steps"]
+            for call in step["response"].get("tool_calls", [])
+        ):
+            cases.append(case)
+    return tuple(cases)
+
+
+PROVIDER_JOURNEY_CASES = _provider_journey_cases()
 
 
 @pytest.fixture(scope="module")
-async def reborn_qa_emulate_google_server(
+async def reborn_qa_emulate_provider_server(
     ironclaw_reborn_binary,
     mock_llm_server,
     emulate_google_server,
+    emulate_github_server,
+    emulate_slack_server,
     tmp_path_factory,
 ):
-    """Start standalone Reborn with Google API traffic routed to Emulate."""
-    home_dir = tmp_path_factory.mktemp("reborn-qa-emulate-google-home")
+    """Start standalone Reborn with every supported provider routed to Emulate."""
+    home_dir = tmp_path_factory.mktemp("reborn-qa-emulate-provider-home")
     mock_llm_address = urlparse(mock_llm_server)
     emulate_google_address = urlparse(emulate_google_server["url"])
+    emulate_github_address = urlparse(emulate_github_server["url"])
+    emulate_slack_address = urlparse(emulate_slack_server["url"])
     rewrite_map = ",".join(
         (
             f"oauth2.googleapis.com={mock_llm_address.hostname}:{mock_llm_address.port}",
             f"www.googleapis.com={emulate_google_address.hostname}:"
             f"{emulate_google_address.port}",
+            f"gmail.googleapis.com={emulate_google_address.hostname}:"
+            f"{emulate_google_address.port}",
+            f"docs.googleapis.com={emulate_google_address.hostname}:"
+            f"{emulate_google_address.port}",
+            f"sheets.googleapis.com={emulate_google_address.hostname}:"
+            f"{emulate_google_address.port}",
+            f"api.github.com={emulate_github_address.hostname}:"
+            f"{emulate_github_address.port}",
+            f"slack.com={emulate_slack_address.hostname}:"
+            f"{emulate_slack_address.port}",
         )
     )
     proc, base_url = await start_reborn_webui_v2_server(
@@ -62,37 +147,60 @@ async def reborn_qa_emulate_google_server(
         mock_llm_server=mock_llm_server,
         home_dir=home_dir,
         profile=YOLO_PROFILE,
-        log_prefix="reborn-qa-emulate-google",
+        log_prefix="reborn-qa-emulate-provider",
         extra_env={
             "IRONCLAW_REBORN_TEST_HTTP_REWRITE_MAP": rewrite_map,
             "IRONCLAW_REBORN_GOOGLE_CLIENT_ID": "reborn-qa-emulate-client",
             "IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI": (
                 "http://127.0.0.1/api/reborn/product-auth/oauth/google/callback"
             ),
+            "IRONCLAW_REBORN_SLACK_PERSONAL_OAUTH_REDIRECT_URI": (
+                "http://127.0.0.1/api/reborn/product-auth/oauth/slack/callback"
+            ),
         },
     )
     await enable_reborn_global_auto_approve(base_url)
+    slack_state = await _seed_slack_workspace(emulate_slack_server["url"])
+    await _configure_slack(base_url, slack_state)
+    await _install_extensions(base_url, ALL_EXTENSIONS)
+    for extension_id, scopes in GOOGLE_EXTENSION_SCOPES.items():
+        await _seed_google_account(base_url, extension_id, scopes)
+        await _activate_extensions(base_url, (extension_id,))
+    await _seed_github_account(base_url)
+    await _activate_extensions(base_url, ("github",))
+    await _seed_slack_account(base_url, emulate_slack_server["url"], slack_state)
+    await _activate_extensions(base_url, ("slack",))
     try:
-        yield base_url
+        yield {
+            "base_url": base_url,
+            "emulate_google_url": emulate_google_server["url"],
+            "emulate_github_url": emulate_github_server["url"],
+            "emulate_slack_url": emulate_slack_server["url"],
+            "slack_state": slack_state,
+        }
     finally:
         await close_reborn_server(proc)
 
 
-async def _seed_google_account(base_url: str) -> None:
+async def _seed_google_account(
+    base_url: str,
+    extension_id: str,
+    scopes: tuple[str, ...],
+) -> None:
     expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
     async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
         started = await client.post(
-            f"{base_url}/api/webchat/v2/extensions/google-drive/setup/oauth/start",
+            f"{base_url}/api/webchat/v2/extensions/{extension_id}/setup/oauth/start",
             json={
                 "provider": "google",
-                "account_label": "Emulate Google account",
-                "scopes": [GOOGLE_DRIVE_READONLY_SCOPE, GOOGLE_DRIVE_SCOPE],
+                "account_label": f"Emulate Google account for {extension_id}",
+                "scopes": list(scopes),
                 "expires_at": expires_at,
                 "invocation_id": str(uuid.uuid4()),
             },
             timeout=15,
         )
-        started.raise_for_status()
+        assert started.is_success, started.text
         started_body = started.json()
         authorization_url = started_body["authorization_url"]
         state = parse_qs(urlparse(authorization_url).query)["state"][0]
@@ -101,8 +209,8 @@ async def _seed_google_account(base_url: str) -> None:
             f"{base_url}/api/reborn/product-auth/oauth/google/callback",
             params={
                 "state": state,
-                "code": "mock_auth_code",
-                "scope": f"{GOOGLE_DRIVE_READONLY_SCOPE} {GOOGLE_DRIVE_SCOPE}",
+                "code": f"mock_auth_code_{extension_id.replace('-', '_')}",
+                "scope": " ".join(GOOGLE_CUMULATIVE_SCOPES),
             },
             headers={"Accept": "application/json"},
             timeout=30,
@@ -123,19 +231,24 @@ async def _seed_google_account(base_url: str) -> None:
             f"{base_url}/api/reborn/product-auth/accounts/list",
             json={
                 "provider": "google",
-                "requester_extension": "google-drive",
+                "requester_extension": extension_id,
                 "invocation_id": invocation_id,
             },
             timeout=30,
         )
         listed.raise_for_status()
         accounts = listed.json()["accounts"]
+        # Re-authenticating the same Emulate identity upgrades the existing
+        # user-reusable account in its original invocation scope. Only the
+        # first flow therefore exposes a newly selectable account here.
+        if not accounts:
+            return
         assert len(accounts) == 1, listed.text
         selected = await client.post(
             f"{base_url}/api/reborn/product-auth/accounts/select",
             json={
                 "provider": "google",
-                "requester_extension": "google-drive",
+                "requester_extension": extension_id,
                 "account_id": accounts[0]["id"],
                 "invocation_id": invocation_id,
             },
@@ -144,53 +257,408 @@ async def _seed_google_account(base_url: str) -> None:
         selected.raise_for_status()
 
 
-async def _install_drive(base_url: str) -> None:
-    package_ref = {"kind": "extension", "id": "google-drive"}
-    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
-        installed = await client.post(
-            f"{base_url}/api/webchat/v2/extensions/install",
-            json={"package_ref": package_ref},
-            timeout=30,
+async def _seed_slack_workspace(emulate_url: str) -> dict[str, str]:
+    """Create deterministic Slack data and return its provider-issued IDs."""
+    async with httpx.AsyncClient(timeout=15) as client:
+        identity = await slack_post(client, emulate_url, "auth.test")
+        users = await slack_post(client, emulate_url, "users.list")
+        by_name = {member["name"]: member for member in users["members"]}
+        channels = await slack_post(
+            client,
+            emulate_url,
+            "conversations.list",
+            {"types": "public_channel"},
         )
-        installed.raise_for_status()
+        channel = next(
+            item for item in channels["channels"] if item["name"] == "reborn-alerts"
+        )
+        await slack_post(
+            client, emulate_url, "conversations.join", {"channel": channel["id"]}
+        )
+        await slack_post(
+            client,
+            emulate_url,
+            "chat.postMessage",
+            {"channel": channel["id"], "text": "QA10 self-authored earlier message"},
+        )
+        await slack_post(
+            client,
+            emulate_url,
+            "chat.postMessage",
+            {
+                "channel": channel["id"],
+                "text": "ENTITYMSG_1784643032040 QA10 searchable marker",
+            },
+        )
+        root = await slack_post(
+            client,
+            emulate_url,
+            "chat.postMessage",
+            {"channel": channel["id"], "text": "QA10 thread root"},
+        )
+        await slack_post(
+            client,
+            emulate_url,
+            "chat.postMessage",
+            {
+                "channel": channel["id"],
+                "thread_ts": root["ts"],
+                "text": "QA10 visible thread reply",
+            },
+        )
+    return {
+        "team_id": identity["team_id"],
+        "user_id": identity["user_id"],
+        "reviewer_id": by_name["qa-reviewer"]["id"],
+        "channel_id": channel["id"],
+        "channel_name": channel["name"],
+        "thread_ts": root["ts"],
+    }
 
 
-async def _activate_drive(base_url: str) -> None:
+async def _configure_slack(base_url: str, slack_state: dict[str, str]) -> None:
+    client_id = "reborn-qa-emulate-slack-client"
     async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
-        activated = await client.post(
-            f"{base_url}/api/webchat/v2/extensions/google-drive/activate",
+        configured = await client.get(
+            f"{base_url}/api/webchat/v2/operator/extension-configuration",
             timeout=30,
         )
-        activated.raise_for_status()
-        assert activated.json().get("activated") is True, activated.text
+        configured.raise_for_status()
+        group = next(
+            item
+            for item in configured.json()["groups"]
+            if item["group_id"] == "extension.slack"
+        )
+        response = await client.put(
+            f"{base_url}/api/webchat/v2/operator/extension-configuration/extension.slack",
+            json={
+                "values": [
+                    {"handle": "slack_bot_token", "value": EMULATE_SLACK_BEARER},
+                    {"handle": "slack_signing_secret", "value": "emulate-signing-secret"},
+                    {"handle": "slack_team_id", "value": slack_state["team_id"]},
+                    {"handle": "slack_api_app_id", "value": client_id},
+                    {"handle": "slack_installation_id", "value": slack_state["team_id"]},
+                    {"handle": "slack_bot_user_id", "value": slack_state["user_id"]},
+                    {"handle": "slack_oauth_client_id", "value": client_id},
+                    {
+                        "handle": "slack_oauth_client_secret",
+                        "value": "emulate-slack-client-secret",
+                    },
+                ],
+                "expected_revision": group["revision"],
+                "idempotency_key": f"reborn-qa-emulate-{uuid.uuid4()}",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        assert response.json()["complete"] is True, response.text
+
+
+async def _seed_github_account(base_url: str) -> None:
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        response = await client.post(
+            f"{base_url}/api/webchat/v2/extensions/github/setup",
+            json={
+                "action": "submit",
+                "payload": {
+                    "secrets": {"github_runtime_token": EMULATE_GITHUB_BEARER},
+                    "fields": {},
+                },
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        secret = next(
+            item
+            for item in response.json()["secrets"]
+            if item["name"] == "github_runtime_token"
+        )
+        assert secret["provided"] is True, response.text
+
+
+async def _seed_slack_account(
+    base_url: str,
+    emulate_url: str,
+    slack_state: dict[str, str],
+) -> None:
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        started = await client.post(
+            f"{base_url}/api/webchat/v2/extensions/slack/setup/oauth/start",
+            json={
+                "provider": "slack",
+                "account_label": "Emulate Slack account",
+                "scopes": [],
+                "expires_at": expires_at,
+                "invocation_id": str(uuid.uuid4()),
+            },
+            timeout=30,
+        )
+        started.raise_for_status()
+        body = started.json()
+        query = parse_qs(urlparse(body["authorization_url"]).query)
+        consent = await client.post(
+            f"{emulate_url}/oauth/v2/authorize/callback",
+            data={
+                "user_id": slack_state["user_id"],
+                "redirect_uri": query["redirect_uri"][0],
+                "scope": query.get("scope", [""])[0],
+                "user_scope": query.get("user_scope", [""])[0],
+                "state": query["state"][0],
+                "client_id": query["client_id"][0],
+            },
+            follow_redirects=False,
+            timeout=30,
+        )
+        assert consent.status_code == 302, consent.text
+        callback_query = parse_qs(urlparse(consent.headers["location"]).query)
+        callback = await client.get(
+            f"{base_url}/api/reborn/product-auth/oauth/slack/callback",
+            params={key: values[0] for key, values in callback_query.items()},
+            headers={"Accept": "application/json"},
+            timeout=30,
+        )
+        assert callback.is_success, callback.text
+        flow_status = await client.get(
+            f"{base_url}/api/reborn/product-auth/oauth/flow/{body['flow_id']}/status",
+            params={"invocation_id": body["callback_scope"]["invocation_id"]},
+            timeout=30,
+        )
+        flow_status.raise_for_status()
+        assert flow_status.json()["status"] == "completed", flow_status.text
+
+
+async def _install_extensions(base_url: str, extension_ids: tuple[str, ...]) -> None:
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        for extension_id in extension_ids:
+            installed = await client.post(
+                f"{base_url}/api/webchat/v2/extensions/install",
+                json={
+                    "package_ref": {"kind": "extension", "id": extension_id}
+                },
+                timeout=30,
+            )
+            installed.raise_for_status()
+
+
+async def _activate_extensions(base_url: str, extension_ids: tuple[str, ...]) -> None:
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        for extension_id in extension_ids:
+            activated = await client.post(
+                f"{base_url}/api/webchat/v2/extensions/{extension_id}/activate",
+                timeout=30,
+            )
+            activated.raise_for_status()
+            body = activated.json()
+            assert body.get("activated") is True, body
+
+
+def _provider_leg(trace: dict, prefixes: tuple[str, ...]) -> dict:
+    """Keep the recorded provider decisions and final response in order."""
+    provider_steps = []
+    final_text = None
+    for step in trace["steps"][1:]:
+        response = step["response"]
+        if response["type"] == "tool_calls":
+            calls = [
+                call
+                for call in response["tool_calls"]
+                if call["name"].startswith(prefixes)
+                or call["name"] in TRACE_BOOTSTRAP_TOOLS
+            ]
+            if calls:
+                provider_steps.append(
+                    {"response": {"type": "tool_calls", "tool_calls": calls}}
+                )
+        elif response["type"] == "text":
+            final_text = response
+
+    assert provider_steps, "provider journey must retain at least one tool call"
+    assert final_text is not None, "provider journey must retain a final response"
+    return {
+        **trace,
+        "steps": [trace["steps"][0], *provider_steps, {"response": final_text}],
+    }
+
+
+def _result_binding(tool: str, *fields: str) -> dict:
+    return {"$trace_result": {"tool": tool, "fields": list(fields)}}
+
+
+def _inject_deferred_tool_disclosure(trace: dict) -> None:
+    """Translate the harvested extension flow to today's deferred-tool flow."""
+    provider_names = list(
+        dict.fromkeys(
+            call["name"]
+            for step in trace["steps"]
+            for call in step["response"].get("tool_calls", [])
+            if call["name"].startswith(PROVIDER_TOOL_PREFIXES)
+        )
+    )
+    first_provider_step = next(
+        index
+        for index, step in enumerate(trace["steps"])
+        if any(
+            call["name"].startswith(PROVIDER_TOOL_PREFIXES)
+            for call in step["response"].get("tool_calls", [])
+        )
+    )
+    trace["steps"].insert(
+        first_provider_step,
+        {
+            "response": {
+                "type": "tool_calls",
+                "tool_calls": [
+                    {
+                        "name": "capability_info",
+                        "arguments": {"name": name.replace("__", ".")},
+                    }
+                    for name in provider_names
+                ],
+            }
+        },
+    )
+
+
+def _coalesce_independent_provider_reads(trace: dict, batch_size: int = 25) -> None:
+    """Fit QA 9C's independent Slack reads within today's loop-turn limit."""
+    provider_indexes = [
+        index
+        for index, step in enumerate(trace["steps"])
+        if any(
+            call["name"].startswith(PROVIDER_TOOL_PREFIXES)
+            for call in step["response"].get("tool_calls", [])
+        )
+    ]
+    calls = [
+        call
+        for index in provider_indexes
+        for call in trace["steps"][index]["response"]["tool_calls"]
+    ]
+    insertion_index = provider_indexes[0]
+    trace["steps"] = [
+        step
+        for index, step in enumerate(trace["steps"])
+        if index not in provider_indexes
+    ]
+    batches = [
+        {
+            "response": {
+                "type": "tool_calls",
+                "tool_calls": calls[start : start + batch_size],
+            }
+        }
+        for start in range(0, len(calls), batch_size)
+    ]
+    trace["steps"][insertion_index:insertion_index] = batches
+
+
+def _normalize_google_arguments(trace: dict, case: str) -> None:
+    created_document = False
+    created_spreadsheet = False
+    seeded_spreadsheet = (
+        "sheet_reborn_bug_tracker" if case.startswith("qa_7") else "sheet_reborn_abc"
+    )
+
+    for step in trace["steps"]:
+        for call in step["response"].get("tool_calls", []):
+            name = call["name"]
+            arguments = call["arguments"]
+            _replace_value(arguments, "EMAIL_REDACTED", "e2e.google@example.com")
+
+            if name == "google-docs__create_document":
+                created_document = True
+            elif name.startswith("google-docs__") and "document_id" in arguments:
+                arguments["document_id"] = (
+                    _result_binding(
+                        "google-docs__create_document",
+                        "documentId",
+                        "document_id",
+                        "id",
+                    )
+                    if created_document
+                    else "doc_reborn_strategy"
+                )
+
+            if name == "google-sheets__create_spreadsheet":
+                created_spreadsheet = True
+            elif name.startswith("google-sheets__"):
+                if "spreadsheet_id" in arguments:
+                    arguments["spreadsheet_id"] = (
+                        _result_binding(
+                            "google-sheets__create_spreadsheet",
+                            "spreadsheetId",
+                            "spreadsheet_id",
+                            "id",
+                        )
+                        if created_spreadsheet
+                        else seeded_spreadsheet
+                    )
+                if created_spreadsheet and "sheet_id" in arguments:
+                    arguments["sheet_id"] = _result_binding(
+                        "google-sheets__create_spreadsheet", "sheetId", "sheet_id"
+                    )
+
+            if name == "gmail__get_message":
+                arguments["message_id"] = "msg_emulate_near_inbound"
+            elif name == "google-drive__download_file":
+                arguments["file_id"] = "drv_pepsico_account_brief"
+
+
+def _normalize_slack_arguments(trace: dict, slack_state: dict[str, str]) -> None:
+    for step in trace["steps"]:
+        for call in step["response"].get("tool_calls", []):
+            if not call["name"].startswith("slack__"):
+                continue
+            arguments = call["arguments"]
+            if "channel" in arguments:
+                arguments["channel"] = slack_state["channel_id"]
+            if "user_id" in arguments:
+                arguments["user_id"] = slack_state["reviewer_id"]
+            if "thread_ts" in arguments:
+                arguments["thread_ts"] = slack_state["thread_ts"]
+            if "text" in arguments:
+                arguments["text"] = arguments["text"].replace(
+                    "SLACK_ID_REDACTED", slack_state["reviewer_id"]
+                )
+            if "query" in arguments:
+                arguments["query"] = arguments["query"].replace(
+                    "SLACK_ID_REDACTED", slack_state["channel_name"]
+                )
+
+
+def _replace_value(value: object, old: str, new: str) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if child == old:
+                value[key] = new
+            else:
+                _replace_value(child, old, new)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            if child == old:
+                value[index] = new
+            else:
+                _replace_value(child, old, new)
 
 
 async def _load_trace(
     mock_llm_server: str,
     trace_path: Path,
     *,
-    start_at_tool: str | None = None,
+    provider_prefixes: tuple[str, ...] | None = None,
+    slack_state: dict[str, str] | None = None,
 ) -> dict:
     trace = json.loads(trace_path.read_text(encoding="utf-8"))
-    if start_at_tool is not None:
-        start_index = next(
-            index
-            for index, step in enumerate(trace["steps"])
-            if any(
-                call["name"] == start_at_tool
-                for call in step["response"].get("tool_calls", [])
-            )
-        )
-        retained_steps = trace["steps"][start_index:]
-        first_minimum = retained_steps[0].get("request_hint", {}).get(
-            "min_message_count", 2
-        )
-        message_count_offset = first_minimum - 2
-        for step in retained_steps:
-            request_hint = step.get("request_hint")
-            if request_hint is not None and "min_message_count" in request_hint:
-                request_hint["min_message_count"] -= message_count_offset
-        trace["steps"] = [trace["steps"][0], *retained_steps]
+    if provider_prefixes is not None:
+        trace = _provider_leg(trace, provider_prefixes)
+    if trace_path.stem == "qa_9c_slack_digest_names_not_ids":
+        _coalesce_independent_provider_reads(trace)
+        _inject_deferred_tool_disclosure(trace)
+    if provider_prefixes is not None:
+        _normalize_google_arguments(trace, trace_path.stem)
+    if slack_state is not None:
+        _normalize_slack_arguments(trace, slack_state)
     async with httpx.AsyncClient() as client:
         response = await client.post(
             f"{mock_llm_server}/__mock/llm_trace",
@@ -220,43 +688,196 @@ async def _wait_for_trace_replay(mock_llm_server: str, timeout: float = 30) -> d
     )
 
 
-async def test_qa_2c_drive_connect_replays_through_emulate(
-    reborn_qa_emulate_google_server,
+async def _fetch_timeline_with_retry(
+    client: httpx.AsyncClient, server: str, thread_id: str
+) -> dict:
+    for _ in range(20):
+        try:
+            return await fetch_timeline(client, server, thread_id)
+        except httpx.HTTPStatusError as error:
+            if error.response.status_code != 429:
+                raise
+        await asyncio.sleep(0.5)
+    raise AssertionError("timeline remained rate-limited after replay completed")
+
+
+def _recorded_provider_calls(trace: dict) -> list[dict]:
+    return [
+        call
+        for step in trace["steps"]
+        for call in step["response"].get("tool_calls", [])
+        if call["name"].startswith(PROVIDER_TOOL_PREFIXES)
+    ]
+
+
+async def _assert_google_provider_outcome(
+    emulate_url: str, case: str, trace: dict
+) -> None:
+    calls = _recorded_provider_calls(trace)
+    async with httpx.AsyncClient(headers=google_headers(), timeout=15) as client:
+        if case in {
+            "qa_2f_calendar_prep_email_delivery",
+            "qa_4e_github_release_email_delivery",
+        }:
+            send = next(call for call in calls if call["name"] == "gmail__send_message")
+            subject = send["arguments"]["message"]["subject"]
+            listed = await client.get(
+                f"{emulate_url}/gmail/v1/users/me/messages",
+                params={"q": f"subject:{subject}"},
+            )
+            listed.raise_for_status()
+            assert listed.json().get("messages"), f"sent message missing for {case}"
+
+        create_call = next(
+            (
+                call
+                for call in calls
+                if call["name"]
+                in {
+                    "google-docs__create_document",
+                    "google-sheets__create_spreadsheet",
+                }
+            ),
+            None,
+        )
+        if create_call is None:
+            return
+
+        title = create_call["arguments"]["title"]
+        files = await client.get(
+            f"{emulate_url}/drive/v3/files",
+            params={"q": f"name = '{title}' and trashed = false"},
+        )
+        files.raise_for_status()
+        matching = [item for item in files.json()["files"] if item["name"] == title]
+        assert matching, f"created Google resource missing for {case}: {files.text}"
+        resource_id = matching[-1]["id"]
+
+        if create_call["name"] == "google-docs__create_document":
+            document = await client.get(f"{emulate_url}/v1/documents/{resource_id}")
+            document.raise_for_status()
+            assert "QA5D-NONCE" in document.text, document.text
+            return
+
+        spreadsheet = await client.get(
+            f"{emulate_url}/v4/spreadsheets/{resource_id}"
+        )
+        spreadsheet.raise_for_status()
+        if case == "qa_6e_gmail_to_sheet_delivery":
+            values = await client.get(
+                f"{emulate_url}/v4/spreadsheets/{resource_id}/values/Sheet1!A1:C10"
+            )
+            values.raise_for_status()
+            assert "REBORN_QA_6E_GMAIL_TO_SHEET_DELIVERY" in values.text, values.text
+        elif case == "qa_7e_slack_bug_sheet_delivery":
+            values = await client.get(
+                f"{emulate_url}/v4/spreadsheets/{resource_id}/values/Bugs!A1:E10"
+            )
+            values.raise_for_status()
+            assert "REBORN_QA_7E_BUG_ROW" in values.text, values.text
+
+
+async def _assert_slack_provider_outcome(
+    emulate_url: str,
+    slack_state: dict[str, str],
+    trace: dict,
+) -> None:
+    send = next(
+        (
+            call
+            for call in _recorded_provider_calls(trace)
+            if call["name"] == "slack__send_message"
+        ),
+        None,
+    )
+    if send is None:
+        return
+    async with httpx.AsyncClient(timeout=15) as client:
+        history = await slack_post(
+            client,
+            emulate_url,
+            "conversations.history",
+            {"channel": slack_state["channel_id"], "limit": 100},
+        )
+    assert any(
+        message.get("text") == send["arguments"]["text"]
+        for message in history["messages"]
+    ), history
+
+
+@pytest.mark.parametrize(
+    "case", PROVIDER_JOURNEY_CASES, ids=PROVIDER_JOURNEY_CASES
+)
+async def test_qa_journey_provider_leg_replays_through_emulate(
+    reborn_qa_emulate_provider_server,
     mock_llm_server,
+    case,
 ):
-    """The harvested choices execute locally and read Emulate's Drive state."""
-    server = reborn_qa_emulate_google_server
-    await _install_drive(server)
-    await _seed_google_account(server)
-    await _activate_drive(server)
+    """Every harvested provider journey executes through standalone Reborn."""
+    server = reborn_qa_emulate_provider_server["base_url"]
+    trace_path = TRACE_DIR / f"{case}.json"
     trace = await _load_trace(
         mock_llm_server,
-        DRIVE_CONNECT_TRACE,
-        start_at_tool="google-drive__list_files",
+        trace_path,
+        provider_prefixes=PROVIDER_TOOL_PREFIXES,
+        slack_state=reborn_qa_emulate_provider_server["slack_state"],
     )
     user_input = trace["steps"][0]["response"]["content"]
+    expected_calls = _recorded_provider_calls(trace)
 
     async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
         thread_id = await create_thread(client, server)
         await send_message(client, server, thread_id, user_input)
 
-        replay = await _wait_for_trace_replay(mock_llm_server)
-        await wait_for_assistant_message(client, server, thread_id, timeout=120)
-        preview = await wait_for_capability_preview(
-            client,
-            server,
-            thread_id,
-            "google-drive.list_files",
-            output_fragment="Reborn QA Brief",
-            timeout=120,
+        replay_timeout = 180 if case == "qa_9c_slack_digest_names_not_ids" else 120
+        replay = await _wait_for_trace_replay(
+            mock_llm_server, timeout=replay_timeout
         )
+        await wait_for_assistant_message(
+            client, server, thread_id, timeout=replay_timeout
+        )
+        timeline = await _fetch_timeline_with_retry(client, server, thread_id)
+        previews = [
+            preview
+            for message in timeline.get("messages", [])
+            if (preview := capability_preview_payload(message)) is not None
+        ]
+        expected_counts = Counter(
+            call["name"].replace("__", ".") for call in expected_calls
+        )
+        actual_counts = Counter(
+            preview["capability_id"]
+            for preview in previews
+            if preview["capability_id"] in expected_counts
+        )
+        if case == "qa_9c_slack_digest_names_not_ids":
+            assert actual_counts, "capped timeline retained no provider previews"
+        else:
+            assert actual_counts == expected_counts, (actual_counts, expected_counts)
+        for preview in previews:
+            if preview["capability_id"] not in expected_counts:
+                continue
+            assert preview["status"] == "completed", json.dumps(preview)
+            output = json.dumps(preview).lower()
+            assert "auth_required" not in output, preview
+            assert "not found" not in output, preview
 
-        assert "Secondary Private Brief" not in json.dumps(preview)
+        if case == "qa_2c_drive_connect":
+            assert "Secondary Private Brief" not in json.dumps(timeline)
+
+    await _assert_google_provider_outcome(
+        reborn_qa_emulate_provider_server["emulate_google_url"], case, trace
+    )
+    await _assert_slack_provider_outcome(
+        reborn_qa_emulate_provider_server["emulate_slack_url"],
+        reborn_qa_emulate_provider_server["slack_state"],
+        trace,
+    )
 
     assert replay == {
-        "source": DRIVE_CONNECT_TRACE.name,
-        "next_response": 2,
-        "response_count": 2,
+        "source": trace_path.name,
+        "next_response": len(trace["steps"]) - 1,
+        "response_count": len(trace["steps"]) - 1,
         "complete": True,
         "error": None,
     }

--- a/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
@@ -292,3 +292,167 @@ def test_fixture_catalog_has_no_unowned_cases_or_provider_operations():
     assert observed_provider_tools == (
         EMULATE_SUPPORTED_TOOLS | EMULATE_UNSUPPORTED_TOOLS
     )
+
+
+async def test_trace_replay_binds_fresh_provider_ids_into_follow_up_calls(
+    mock_llm_server,
+):
+    """A created resource ID can drive the next real recorded tool call."""
+    trace = {
+        "steps": [
+            {"response": {"type": "user_input", "content": "create and read"}},
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {"name": "google-docs__create_document", "arguments": {}}
+                    ],
+                }
+            },
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "name": "google-docs__read_content",
+                            "arguments": {
+                                "document_id": {
+                                    "$trace_result": {
+                                        "tool": "google-docs__create_document",
+                                        "fields": ["documentId", "document_id", "id"],
+                                    }
+                                }
+                            },
+                        }
+                    ],
+                }
+            },
+            {"response": {"type": "text", "content": "done"}},
+        ]
+    }
+    tools = _tool_definitions(trace)
+    messages = [{"role": "user", "content": "create and read"}]
+
+    await _install_trace(mock_llm_server, "binding-contract", trace)
+    async with httpx.AsyncClient() as client:
+        created = await client.post(
+            f"{mock_llm_server}/v1/chat/completions",
+            json={"model": "mock-model", "messages": messages, "tools": tools},
+            timeout=15,
+        )
+        created.raise_for_status()
+        created_message = created.json()["choices"][0]["message"]
+        messages.extend(
+            [
+                created_message,
+                {
+                    "role": "tool",
+                    "tool_call_id": created_message["tool_calls"][0]["id"],
+                    "content": json.dumps(
+                        {"document": {"documentId": "doc-created-locally"}}
+                    ),
+                },
+            ]
+        )
+
+        read = await client.post(
+            f"{mock_llm_server}/v1/chat/completions",
+            json={"model": "mock-model", "messages": messages, "tools": tools},
+            timeout=15,
+        )
+        read.raise_for_status()
+
+    arguments = json.loads(
+        read.json()["choices"][0]["message"]["tool_calls"][0]["function"][
+            "arguments"
+        ]
+    )
+    assert arguments == {"document_id": "doc-created-locally"}
+
+
+async def test_trace_replay_accepts_direct_calls_from_deferred_tool_catalog(
+    mock_llm_server,
+):
+    """Deferred tools are callable even though only tool_search is advertised."""
+    trace = {
+        "steps": [
+            {"response": {"type": "user_input", "content": "inspect Slack"}},
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [{"name": "slack__whoami", "arguments": {}}],
+                }
+            },
+        ]
+    }
+    await _install_trace(mock_llm_server, "deferred-catalog", trace)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "builtin__tool_search",
+                "description": "On-demand tools:\n- slack.whoami",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{mock_llm_server}/v1/chat/completions",
+            json={
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "inspect Slack"}],
+                "tools": tools,
+            },
+            timeout=15,
+        )
+    response.raise_for_status()
+    call = response.json()["choices"][0]["message"]["tool_calls"][0]
+    assert call["function"]["name"] == "slack__whoami"
+
+
+async def test_trace_replay_stops_after_failed_capability_result(mock_llm_server):
+    trace = {
+        "steps": [
+            {"response": {"type": "user_input", "content": "inspect Slack"}},
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [{"name": "slack__whoami", "arguments": {}}],
+                }
+            },
+            {"response": {"type": "text", "content": "done"}},
+        ]
+    }
+    await _install_trace(mock_llm_server, "failed-result", trace)
+    tools = _tool_definitions(trace)
+    messages = [{"role": "user", "content": "inspect Slack"}]
+
+    async with httpx.AsyncClient() as client:
+        first = await client.post(
+            f"{mock_llm_server}/v1/chat/completions",
+            json={"model": "mock-model", "messages": messages, "tools": tools},
+            timeout=15,
+        )
+        first.raise_for_status()
+        assistant = first.json()["choices"][0]["message"]
+        messages.extend(
+            [
+                assistant,
+                {
+                    "role": "tool",
+                    "name": "slack__whoami",
+                    "tool_call_id": assistant["tool_calls"][0]["id"],
+                    "content": json.dumps({"status": "failed"}),
+                },
+            ]
+        )
+        failed = await client.post(
+            f"{mock_llm_server}/v1/chat/completions",
+            json={"model": "mock-model", "messages": messages, "tools": tools},
+            timeout=15,
+        )
+
+    assert failed.status_code == 409
+    assert "failed capability result" in failed.text

--- a/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
@@ -456,3 +456,56 @@ async def test_trace_replay_stops_after_failed_capability_result(mock_llm_server
 
     assert failed.status_code == 409
     assert "failed capability result" in failed.text
+
+
+async def test_trace_replay_accepts_exact_expected_capability_failure(mock_llm_server):
+    trace = {
+        "steps": [
+            {"response": {"type": "user_input", "content": "inspect Slack"}},
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [{"name": "slack__whoami", "arguments": {}}],
+                }
+            },
+            {
+                "request_hint": {
+                    "expected_failed_tool_result_contains": "channel_not_found"
+                },
+                "response": {"type": "text", "content": "reported honestly"},
+            },
+        ]
+    }
+    await _install_trace(mock_llm_server, "expected-failed-result", trace)
+    tools = _tool_definitions(trace)
+    messages = [{"role": "user", "content": "inspect Slack"}]
+
+    async with httpx.AsyncClient() as client:
+        first = await client.post(
+            f"{mock_llm_server}/v1/chat/completions",
+            json={"model": "mock-model", "messages": messages, "tools": tools},
+            timeout=15,
+        )
+        first.raise_for_status()
+        assistant = first.json()["choices"][0]["message"]
+        messages.extend(
+            [
+                assistant,
+                {
+                    "role": "tool",
+                    "name": "slack__whoami",
+                    "tool_call_id": assistant["tool_calls"][0]["id"],
+                    "content": json.dumps(
+                        {"status": "error", "error": "channel_not_found"}
+                    ),
+                },
+            ]
+        )
+        final = await client.post(
+            f"{mock_llm_server}/v1/chat/completions",
+            json={"model": "mock-model", "messages": messages, "tools": tools},
+            timeout=15,
+        )
+
+    final.raise_for_status()
+    assert final.json()["choices"][0]["message"]["content"] == "reported honestly"


### PR DESCRIPTION
## Summary

- Discover every harvested QA journey containing a provider call and replay its provider leg through standalone Reborn, first-party extensions, auth/credential mediation, network rewriting, and Emulate.
- Bind fresh Docs and Sheets provider IDs into later recorded calls, seed deterministic Google and Slack resources, and validate capability outcomes plus provider-side state instead of final model wording.
- Pin CI to `serrrfirat/emulate@92bd9c2157a74613c47549eb5cfcccc7c0740adf`, extending [serrrfirat/emulate#1](https://github.com/serrrfirat/emulate/pull/1) with Slack GET read compatibility and Google single-cell append anchors.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [x] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust source changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust source changed.
- [x] `cargo build` — `CARGO_TARGET_DIR=/Volumes/NVME/codex-bac3-ironclaw-target cargo build -p ironclaw --bin ironclaw`
- [x] Relevant tests pass: 30 full-path journeys, 48 trace replay tests, targeted Emulate provider contracts, fork Google/Slack suites, fixture scrub.
- [ ] `cargo test --features integration` — Not applicable: no database-backed behavior changed.
- [x] Manual testing: rebuilt current-main `ironclaw`, ran the full provider matrix against the pinned locally built Emulate fork, and checked provider-side writes/readback.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; final diff and targeted/full test gates were reviewed locally.

## Test Strategy

User behavior: Harvested QA provider journeys can run locally with deterministic model decisions while real Reborn extension/auth/network/provider boundaries execute against Emulate.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: result-ID binding, deferred-tool disclosure, failed capability-result detection, and targeted Google Docs/Sheets + Slack provider contracts.
- Reborn integration: 30 manifest-discovered provider journeys through standalone `ironclaw serve` and Emulate.
- Recorded fixture: all 48 replay tests pass; fixture ownership remains closed-set.
- Browser E2E: Not applicable: no browser or frontend behavior changed.
- Backend or runtime: current-main `ironclaw` build plus caller-path extension execution in the full-path suite.
- Live canary: Not applicable: no live-provider behavior changed; these hermetic replays reduce dependence on live canaries but do not replace drift checks.

What the tests prove: Recorded model choices can drive current first-party provider tools; fresh provider identifiers flow between calls; OAuth/secret/network mediation stays in path; every visible/returned capability result succeeds; Google and Slack writes are observable in Emulate; and account-isolated Drive data stays isolated.

Commands run:

- `CARGO_TARGET_DIR=/Volumes/NVME/codex-bac3-ironclaw-target cargo build -p ironclaw --bin ironclaw`
- `IRONCLAW_EMULATE_CLI=/Volumes/NVME/codex-bac3-emulate/packages/emulate/dist/index.js tests/e2e/.venv/bin/pytest -q tests/e2e/scenarios/test_reborn_qa_trace_full_path.py` (30 passed)
- `tests/e2e/.venv/bin/pytest -q tests/e2e/scenarios/test_reborn_qa_trace_replay.py` (48 passed)
- targeted `test_emulate_reborn_provider_contracts.py` selection (4 passed)
- `bash scripts/ci/check-reborn-qa-fixtures.sh` (61 files passed)
- Emulate fork: Slack suite (133 passed), Google suite (23 passed), and `pnpm exec turbo build --filter=emulate...`

## Security Impact

None. This changes test fixtures, the test-only mock provider, E2E coverage, documentation, and the exact CI Emulate pin. Production authorization, secrets, network policy, and runtime code are unchanged; the tests exercise the existing boundaries.

## Reborn Trust-Boundary Checklist

N/A: test/CI-only change. Existing production trust-bearing types and boundaries are not modified. The loopback HTTP rewrite remains behind the existing debug/test-only seam, and fixtures contain deterministic non-secret identities.

## Database Impact

None.

## Blast Radius

Reborn E2E CI, recorded-trace mock behavior, Emulate-backed provider fixtures, and the pinned Emulate fork commit. A fork regression can fail the provider test job but cannot affect shipping runtime behavior.

## Rollback Plan

Revert this commit to restore the prior single-case full-path test and Emulate pin. No data or schema migration is involved.

## Review Follow-Through

The Emulate dependency is pinned by immutable SHA while [serrrfirat/emulate#1](https://github.com/serrrfirat/emulate/pull/1) remains open. Reviewer attention is most useful on the QA 9C deferred-tool translation/batching and the mock's failed-result detection.

---

**Review track**: A (docs/tests/chore)
