### PR TITLE
test(e2e): add typed provider operation cases

### DIFF
--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -191,9 +191,10 @@ Cross-provider ordering is retained, fresh Docs and
 Sheets IDs are bound from earlier real tool results, redacted provider IDs are
 mapped to deterministic seeded resources, and assertions target capability
 success plus provider readback rather than recorded final-answer wording.
-`ProviderOperationCase` adds typed capability, argument, baseline, and readback
-cases for operations not yet present in harvested journeys. These cases reuse
-the same Reborn process and reset only their mutable provider world.
+`ProviderOperationCase` adds typed provider service, capability, argument,
+baseline, and readback cases for operations not yet present in harvested
+journeys. These cases reuse the same Reborn process and reset only their mutable
+provider world.
 Debug E2E binaries honor `IRONCLAW_REBORN_TEST_HTTP_REWRITE_MAP` only for
 loopback IP socket targets after the original destination has passed the normal
 network policy and DNS checks. Release binaries fail startup if that test-only

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -191,6 +191,9 @@ Cross-provider ordering is retained, fresh Docs and
 Sheets IDs are bound from earlier real tool results, redacted provider IDs are
 mapped to deterministic seeded resources, and assertions target capability
 success plus provider readback rather than recorded final-answer wording.
+`ProviderOperationCase` adds typed capability, argument, baseline, and readback
+cases for operations not yet present in harvested journeys. These cases reuse
+the same Reborn process and reset only their mutable provider world.
 Debug E2E binaries honor `IRONCLAW_REBORN_TEST_HTTP_REWRITE_MAP` only for
 loopback IP socket targets after the original destination has passed the normal
 network policy and DNS checks. Release binaries fail startup if that test-only

--- a/tests/e2e/fixtures/provider_capability_coverage.toml
+++ b/tests/e2e/fixtures/provider_capability_coverage.toml
@@ -1,22 +1,26 @@
 schema_version = 1
 
-# A capability is "tested" only when a harvested journey executes the real
-# first-party extension boundary against Emulate and observes the provider.
+# A capability is "tested" only when a harvested journey or typed operation
+# case executes the real extension boundary and observes Emulate.
 [classifications]
 tested = [
   "github.get_authenticated_user",
   "github.get_repo",
   "github.list_releases",
+  "gmail.create_draft",
   "gmail.get_message",
   "gmail.list_messages",
   "gmail.send_message",
+  "gmail.trash_message",
   "google-calendar.list_calendars",
   "google-calendar.list_events",
   "google-docs.create_document",
   "google-docs.insert_text",
   "google-docs.read_content",
   "google-drive.download_file",
+  "google-drive.get_file",
   "google-drive.list_files",
+  "google-drive.update_file",
   "google-sheets.append_values",
   "google-sheets.create_spreadsheet",
   "google-sheets.get_spreadsheet",
@@ -88,9 +92,7 @@ capabilities = [
   "github.unresolve_review_thread",
   "github.update_issue",
   "github.update_pull_request",
-  "gmail.create_draft",
   "gmail.reply_to_message",
-  "gmail.trash_message",
   "google-calendar.add_attendees",
   "google-calendar.create_event",
   "google-calendar.delete_event",
@@ -108,13 +110,11 @@ capabilities = [
   "google-docs.replace_text",
   "google-drive.create_folder",
   "google-drive.delete_file",
-  "google-drive.get_file",
   "google-drive.list_permissions",
   "google-drive.list_shared_drives",
   "google-drive.remove_permission",
   "google-drive.share_file",
   "google-drive.trash_file",
-  "google-drive.update_file",
   "google-drive.upload_file",
   "google-sheets.add_sheet",
   "google-sheets.batch_read_values",

--- a/tests/e2e/provider_operation_cases.py
+++ b/tests/e2e/provider_operation_cases.py
@@ -3,6 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import json
+from typing import Literal
 
 import httpx
 
@@ -10,6 +11,7 @@ from emulate_provider import gmail_header, google_headers, raw_mime
 
 BaselineAssertion = Callable[[str], Awaitable[None]]
 OutcomeAssertion = Callable[[str, dict], Awaitable[None]]
+ProviderService = Literal["google", "github", "slack"]
 
 
 @dataclass(frozen=True)
@@ -17,6 +19,7 @@ class ProviderOperationCase:
     """One capability invocation with provider-observable proof."""
 
     case_id: str
+    provider_service: ProviderService
     capability_id: str
     arguments: dict
     assert_baseline: BaselineAssertion
@@ -102,6 +105,7 @@ async def _assert_gmail_trash_outcome(emulate_url: str, preview: dict) -> None:
 PROVIDER_OPERATION_CASES = (
     ProviderOperationCase(
         case_id="google_drive_get_file",
+        provider_service="google",
         capability_id="google-drive.get_file",
         arguments={"file_id": "drv_reborn_qa_brief"},
         assert_baseline=_assert_drive_get_baseline,
@@ -109,6 +113,7 @@ PROVIDER_OPERATION_CASES = (
     ),
     ProviderOperationCase(
         case_id="gmail_create_draft",
+        provider_service="google",
         capability_id="gmail.create_draft",
         arguments={
             "draft": {
@@ -126,6 +131,7 @@ PROVIDER_OPERATION_CASES = (
     ),
     ProviderOperationCase(
         case_id="google_drive_update_file",
+        provider_service="google",
         capability_id="google-drive.update_file",
         arguments={
             "file_id": "drv_reborn_qa_brief",
@@ -136,6 +142,7 @@ PROVIDER_OPERATION_CASES = (
     ),
     ProviderOperationCase(
         case_id="gmail_trash_message",
+        provider_service="google",
         capability_id="gmail.trash_message",
         arguments={"message_id": "msg_emulate_unread"},
         assert_baseline=_assert_gmail_trash_baseline,

--- a/tests/e2e/provider_operation_cases.py
+++ b/tests/e2e/provider_operation_cases.py
@@ -1,0 +1,144 @@
+"""Typed full-path provider operation cases and provider-side oracles."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import json
+
+import httpx
+
+from emulate_provider import gmail_header, google_headers, raw_mime
+
+BaselineAssertion = Callable[[str], Awaitable[None]]
+OutcomeAssertion = Callable[[str, dict], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ProviderOperationCase:
+    """One capability invocation with provider-observable proof."""
+
+    case_id: str
+    capability_id: str
+    arguments: dict
+    assert_baseline: BaselineAssertion
+    assert_outcome: OutcomeAssertion
+
+
+async def _drive_file(emulate_url: str, file_id: str) -> dict:
+    async with httpx.AsyncClient(headers=google_headers(), timeout=15) as client:
+        response = await client.get(f"{emulate_url}/drive/v3/files/{file_id}")
+    response.raise_for_status()
+    return response.json()
+
+
+async def _assert_drive_get_baseline(emulate_url: str) -> None:
+    file = await _drive_file(emulate_url, "drv_reborn_qa_brief")
+    assert file["name"] == "Reborn QA Brief", file
+
+
+async def _assert_drive_get_outcome(emulate_url: str, preview: dict) -> None:
+    await _assert_drive_get_baseline(emulate_url)
+    assert "Reborn QA Brief" in json.dumps(preview), preview
+
+
+async def _assert_drive_update_baseline(emulate_url: str) -> None:
+    await _assert_drive_get_baseline(emulate_url)
+
+
+async def _assert_drive_update_outcome(emulate_url: str, preview: dict) -> None:
+    file = await _drive_file(emulate_url, "drv_reborn_qa_brief")
+    assert file["name"] == "REBORN_PROVIDER_CASE_UPDATED_FILE", file
+    assert "REBORN_PROVIDER_CASE_UPDATED_FILE" in json.dumps(preview), preview
+
+
+async def _drafts(emulate_url: str) -> list[dict]:
+    async with httpx.AsyncClient(headers=google_headers(), timeout=15) as client:
+        response = await client.get(
+            f"{emulate_url}/gmail/v1/users/me/drafts",
+            params={"maxResults": 100},
+        )
+    response.raise_for_status()
+    return response.json().get("drafts", [])
+
+
+async def _assert_gmail_draft_baseline(emulate_url: str) -> None:
+    assert not await _drafts(emulate_url), "seeded provider unexpectedly has drafts"
+
+
+async def _assert_gmail_draft_outcome(emulate_url: str, preview: dict) -> None:
+    drafts = await _drafts(emulate_url)
+    assert len(drafts) == 1, drafts
+    async with httpx.AsyncClient(headers=google_headers(), timeout=15) as client:
+        response = await client.get(
+            f"{emulate_url}/gmail/v1/users/me/drafts/{drafts[0]['id']}",
+            params={"format": "full"},
+        )
+    response.raise_for_status()
+    draft = response.json()
+    assert gmail_header(draft["message"], "Subject") == "REBORN_PROVIDER_CASE_DRAFT"
+    assert "REBORN_PROVIDER_CASE_DRAFT" in json.dumps(preview), preview
+
+
+async def _gmail_message(emulate_url: str, message_id: str) -> dict:
+    async with httpx.AsyncClient(headers=google_headers(), timeout=15) as client:
+        response = await client.get(
+            f"{emulate_url}/gmail/v1/users/me/messages/{message_id}",
+            params={"format": "full"},
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+async def _assert_gmail_trash_baseline(emulate_url: str) -> None:
+    message = await _gmail_message(emulate_url, "msg_emulate_unread")
+    assert "TRASH" not in message["labelIds"], message
+
+
+async def _assert_gmail_trash_outcome(emulate_url: str, preview: dict) -> None:
+    message = await _gmail_message(emulate_url, "msg_emulate_unread")
+    assert "TRASH" in message["labelIds"], message
+    assert "msg_emulate_unread" in json.dumps(preview), preview
+
+
+PROVIDER_OPERATION_CASES = (
+    ProviderOperationCase(
+        case_id="google_drive_get_file",
+        capability_id="google-drive.get_file",
+        arguments={"file_id": "drv_reborn_qa_brief"},
+        assert_baseline=_assert_drive_get_baseline,
+        assert_outcome=_assert_drive_get_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="gmail_create_draft",
+        capability_id="gmail.create_draft",
+        arguments={
+            "draft": {
+                "message": {
+                    "raw": raw_mime(
+                        to="draft-recipient@example.com",
+                        subject="REBORN_PROVIDER_CASE_DRAFT",
+                        body="Created through the reusable provider operation runner.",
+                    )
+                }
+            }
+        },
+        assert_baseline=_assert_gmail_draft_baseline,
+        assert_outcome=_assert_gmail_draft_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_drive_update_file",
+        capability_id="google-drive.update_file",
+        arguments={
+            "file_id": "drv_reborn_qa_brief",
+            "name": "REBORN_PROVIDER_CASE_UPDATED_FILE",
+        },
+        assert_baseline=_assert_drive_update_baseline,
+        assert_outcome=_assert_drive_update_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="gmail_trash_message",
+        capability_id="gmail.trash_message",
+        arguments={"message_id": "msg_emulate_unread"},
+        assert_baseline=_assert_gmail_trash_baseline,
+        assert_outcome=_assert_gmail_trash_outcome,
+    ),
+)

--- a/tests/e2e/scenarios/test_provider_capability_inventory.py
+++ b/tests/e2e/scenarios/test_provider_capability_inventory.py
@@ -8,7 +8,9 @@ from provider_capability_inventory import (
     ALL_CLASSIFIED_CAPABILITY_IDS,
     EMULATE_SUPPORTED_TOOLS,
     INVENTORY,
+    capability_id_to_wire_name,
 )
+from provider_operation_cases import PROVIDER_OPERATION_CASES
 
 ROOT = Path(__file__).resolve().parents[3]
 ASSET_ROOT = ROOT / "crates/ironclaw_first_party_extensions/assets"
@@ -67,5 +69,12 @@ def test_every_shipped_provider_capability_has_an_owned_classification():
 def test_tested_capabilities_have_recorded_full_path_evidence():
     """A tested label must point to an exercised hermetic journey."""
     evidence = _recorded_tool_evidence()
-    missing_tested = sorted(EMULATE_SUPPORTED_TOOLS - evidence.keys())
+    operation_case_tools = {
+        capability_id_to_wire_name(case.capability_id)
+        for case in PROVIDER_OPERATION_CASES
+    }
+    missing_tested = sorted(
+        EMULATE_SUPPORTED_TOOLS - evidence.keys() - operation_case_tools
+    )
     assert not missing_tested, f"tested capabilities lack journey evidence: {missing_tested}"
+    assert operation_case_tools <= EMULATE_SUPPORTED_TOOLS

--- a/tests/e2e/scenarios/test_provider_capability_inventory.py
+++ b/tests/e2e/scenarios/test_provider_capability_inventory.py
@@ -66,8 +66,8 @@ def test_every_shipped_provider_capability_has_an_owned_classification():
         assert waiver["capabilities"], f"waiver has no capabilities: {waiver}"
 
 
-def test_tested_capabilities_have_recorded_full_path_evidence():
-    """A tested label must point to an exercised hermetic journey."""
+def test_tested_capabilities_have_full_path_evidence():
+    """A tested label must point to a harvested journey or typed operation case."""
     evidence = _recorded_tool_evidence()
     operation_case_tools = {
         capability_id_to_wire_name(case.capability_id)
@@ -76,5 +76,7 @@ def test_tested_capabilities_have_recorded_full_path_evidence():
     missing_tested = sorted(
         EMULATE_SUPPORTED_TOOLS - evidence.keys() - operation_case_tools
     )
-    assert not missing_tested, f"tested capabilities lack journey evidence: {missing_tested}"
+    assert not missing_tested, (
+        f"tested capabilities lack full-path evidence: {missing_tested}"
+    )
     assert operation_case_tools <= EMULATE_SUPPORTED_TOOLS

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -20,6 +20,7 @@ import pytest
 from emulate_provider import google_headers, slack_post
 from helpers import EMULATE_GITHUB_BEARER, EMULATE_SLACK_BEARER
 from provider_capability_inventory import EMULATE_SUPPORTED_TOOLS
+from provider_operation_cases import PROVIDER_OPERATION_CASES, ProviderOperationCase
 from reborn_webui_harness import (
     YOLO_PROFILE,
     capability_preview_payload,
@@ -236,6 +237,18 @@ async def reborn_qa_emulate_provider_server(
             )
         if reset_services:
             await resettable_emulate_provider_world.reset(reset_services)
+
+
+@pytest.fixture
+async def reborn_provider_operation_server(
+    reborn_qa_emulate_runtime,
+    resettable_emulate_provider_world,
+):
+    """Reuse Reborn but restore Google after each operation case."""
+    try:
+        yield reborn_qa_emulate_runtime
+    finally:
+        await resettable_emulate_provider_world.reset({"google"})
 
 
 async def _seed_google_account(
@@ -735,6 +748,64 @@ async def _load_trace(
     return trace
 
 
+async def _install_inline_trace(
+    mock_llm_server: str,
+    source: str,
+    trace: dict,
+) -> None:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{mock_llm_server}/__mock/llm_trace",
+            json={"source": source, "trace": trace},
+            timeout=15,
+        )
+    response.raise_for_status()
+
+
+def _provider_operation_trace(case: ProviderOperationCase) -> dict:
+    wire_name = case.capability_id.replace(".", "__")
+    return {
+        "steps": [
+            {
+                "response": {
+                    "type": "user_input",
+                    "content": f"Execute provider contract {case.case_id}",
+                }
+            },
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "id": f"disclose_{case.case_id}",
+                            "name": "capability_info",
+                            "arguments": {"name": case.capability_id},
+                        }
+                    ],
+                }
+            },
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "id": f"execute_{case.case_id}",
+                            "name": wire_name,
+                            "arguments": case.arguments,
+                        }
+                    ],
+                }
+            },
+            {
+                "response": {
+                    "type": "text",
+                    "content": "Provider operation completed.",
+                }
+            },
+        ]
+    }
+
+
 async def _wait_for_trace_replay(mock_llm_server: str, timeout: float = 30) -> dict:
     state = {}
     async with httpx.AsyncClient() as client:
@@ -1101,6 +1172,56 @@ async def test_qa_journey_provider_leg_replays_through_emulate(
         "source": trace_path.name,
         "next_response": len(trace["steps"]) - 1,
         "response_count": len(trace["steps"]) - 1,
+        "complete": True,
+        "error": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "operation_case",
+    PROVIDER_OPERATION_CASES,
+    ids=lambda case: case.case_id,
+)
+async def test_provider_operation_case_executes_with_provider_readback(
+    reborn_provider_operation_server,
+    mock_llm_server,
+    operation_case,
+):
+    """Typed operation cases cross Reborn and prove provider-observable results."""
+    server = reborn_provider_operation_server["base_url"]
+    emulate_url = reborn_provider_operation_server["emulate_google_url"]
+    source = f"provider-operation-{operation_case.case_id}.json"
+    trace = _provider_operation_trace(operation_case)
+    await operation_case.assert_baseline(emulate_url)
+    await _install_inline_trace(mock_llm_server, source, trace)
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, server)
+        await send_message(
+            client,
+            server,
+            thread_id,
+            trace["steps"][0]["response"]["content"],
+        )
+        replay = await _wait_for_trace_replay(mock_llm_server, timeout=120)
+        await wait_for_assistant_message(client, server, thread_id, timeout=120)
+        timeline = await _fetch_all_timeline_pages_with_retry(
+            client, server, thread_id
+        )
+
+    matches = [
+        preview
+        for message in timeline.get("messages", [])
+        if (preview := capability_preview_payload(message)) is not None
+        and preview["capability_id"] == operation_case.capability_id
+    ]
+    assert len(matches) == 1, matches
+    assert matches[0]["status"] == "completed", matches[0]
+    await operation_case.assert_outcome(emulate_url, matches[0])
+    assert replay == {
+        "source": source,
+        "next_response": 3,
+        "response_count": 3,
         "complete": True,
         "error": None,
     }

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -19,7 +19,10 @@ import pytest
 
 from emulate_provider import google_headers, slack_post
 from helpers import EMULATE_GITHUB_BEARER, EMULATE_SLACK_BEARER
-from provider_capability_inventory import EMULATE_SUPPORTED_TOOLS
+from provider_capability_inventory import (
+    EMULATE_SUPPORTED_TOOLS,
+    capability_id_to_wire_name,
+)
 from provider_operation_cases import PROVIDER_OPERATION_CASES, ProviderOperationCase
 from reborn_webui_harness import (
     YOLO_PROFILE,
@@ -243,12 +246,15 @@ async def reborn_qa_emulate_provider_server(
 async def reborn_provider_operation_server(
     reborn_qa_emulate_runtime,
     resettable_emulate_provider_world,
+    operation_case,
 ):
-    """Reuse Reborn but restore Google after each operation case."""
+    """Reuse Reborn but restore the case's provider after execution."""
     try:
         yield reborn_qa_emulate_runtime
     finally:
-        await resettable_emulate_provider_world.reset({"google"})
+        await resettable_emulate_provider_world.reset(
+            {operation_case.provider_service}
+        )
 
 
 async def _seed_google_account(
@@ -763,7 +769,7 @@ async def _install_inline_trace(
 
 
 def _provider_operation_trace(case: ProviderOperationCase) -> dict:
-    wire_name = case.capability_id.replace(".", "__")
+    wire_name = capability_id_to_wire_name(case.capability_id)
     return {
         "steps": [
             {
@@ -1189,7 +1195,9 @@ async def test_provider_operation_case_executes_with_provider_readback(
 ):
     """Typed operation cases cross Reborn and prove provider-observable results."""
     server = reborn_provider_operation_server["base_url"]
-    emulate_url = reborn_provider_operation_server["emulate_google_url"]
+    emulate_url = reborn_provider_operation_server[
+        f"emulate_{operation_case.provider_service}_url"
+    ]
     source = f"provider-operation-{operation_case.case_id}.json"
     trace = _provider_operation_trace(operation_case)
     await operation_case.assert_baseline(emulate_url)

--- a/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
@@ -258,13 +258,10 @@ def test_fixture_catalog_has_no_unowned_cases_or_provider_operations():
         capability_id_to_wire_name(capability_id)
         for capability_id in ALL_CLASSIFIED_CAPABILITY_IDS
     }
-    required_evidence = EMULATE_SUPPORTED_TOOLS | LIVE_ONLY_TOOLS
     assert observed_provider_tools <= classified_tools, (
         f"unclassified={sorted(observed_provider_tools - classified_tools)}"
     )
-    assert required_evidence <= observed_provider_tools, (
-        f"unobserved={sorted(required_evidence - observed_provider_tools)}"
-    )
+    assert LIVE_ONLY_TOOLS <= observed_provider_tools
 
 
 async def test_trace_replay_binds_fresh_provider_ids_into_follow_up_calls(


### PR DESCRIPTION
## Summary

- Add a typed `ProviderOperationCase` registry with capability arguments, clean-baseline assertions, and provider-side outcome oracles.
- Execute four operations through standalone Reborn, the real first-party extension boundary, credential/network mediation, and Emulate: Drive get/update and Gmail draft/trash.
- Reset each case's declared provider world while reusing the existing binary and module-scoped Reborn process; the initial four cases all target Google.
- Move those four capabilities from waived to tested, bringing hermetic provider coverage from 27/123 to 31/123.

This is stacked on #6526 and should be reviewed/merged after it.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Part of #6524

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust files changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust files changed.
- [ ] `cargo build` — Not applicable: no build inputs changed; this reuses the parent lane's single binary build.
- [x] Relevant tests pass: 101 inventory, provider-contract, recorded-replay, full-path journey, and typed operation tests.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: no product/database behavior changed.
- [x] Manual testing: ran the exact stacked Emulate selection against the pinned fork and verified all four provider readbacks.
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — forced eight-lens `code-review-multi` completed; all three low-severity findings were fixed in `d46d4935e`.

## Test Strategy

User behavior: Developers can add deterministic provider-operation coverage without waiting for a harvested model trace, while still proving the real IronClaw extension path and provider-observable outcome.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: The inventory gate requires every tested capability to have harvested full-path evidence or a collected typed operation case.
- Reborn integration: Four typed cases execute through served Reborn, installed/authenticated first-party extensions, capability dispatch, and network mediation.
- Recorded fixture: No recorded fixture added; inline deterministic traces drive the operation runner without claiming model-behavior coverage.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Provider baselines and readbacks verify Drive metadata and Gmail draft/trash state in Emulate.
- Live canary: Not applicable: these operations are fully hermetic.

What the tests prove: Each operation begins from a known provider baseline, executes exactly once through the real capability boundary, completes successfully, produces the expected provider state or response, and cannot leak mutation state into the next case.

Commands run:

```bash
./tests/e2e/.venv/bin/python -m py_compile \
  tests/e2e/provider_operation_cases.py \
  tests/e2e/scenarios/test_provider_capability_inventory.py \
  tests/e2e/scenarios/test_reborn_qa_trace_replay.py \
  tests/e2e/scenarios/test_reborn_qa_trace_full_path.py

IRONCLAW_EMULATE_CLI=/tmp/emulate-6528/packages/emulate/dist/index.js \
  ./tests/e2e/.venv/bin/pytest -q \
  tests/e2e/scenarios/test_provider_capability_inventory.py \
  tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py \
  tests/e2e/scenarios/test_reborn_qa_trace_replay.py \
  tests/e2e/scenarios/test_reborn_qa_trace_full_path.py \
  --timeout=240

git diff --check
python3 /Users/firatsertgoz/.codex/skills/autoreview/scripts/autoreview \
  --mode local --stream-engine-output
```

Result after review fixes, using the exact CI-pinned Emulate commit `92bd9c2`: `101 passed in 57.32s`. The forced multi-agent review found three low-severity maintainability issues; all were fixed and the focused 4-case operation selection also passed.

## Security Impact

None. Test-only capability calls use seeded local credentials and loopback Emulate services; production permission, credential, network, and sandbox behavior is unchanged.

## Reborn Trust-Boundary Checklist

N/A: test-harness-only change. The tests exercise existing trust boundaries but do not change their construction, policy, errors, serialization, or runtime behavior.

## Database Impact

None.

## Blast Radius

Limited to the Emulate-backed E2E lane and provider coverage metadata. The four cases add approximately five seconds to the combined local selection and do not add a Rust build, Reborn process, or CI lane.

## Rollback Plan

Revert this commit to remove the operation registry/cases and return the four capabilities to the owned waiver list. No migration or compatibility step is required.

## Review Follow-Through

`google-drive.share_file` remains waived because the pinned Emulate fork does not expose Drive permissions routes. Future provider-family PRs can add cases by declaring the Emulate provider service, capability arguments, and provider-owned baseline/readback oracles.

---

**Review track**: C (CI/test infrastructure)
