### PR TITLE
fix(service): add container-supervised mode for hosted deployments

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/service/container.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/container.rs
@@ -1,0 +1,372 @@
+//! Container-supervised flavor of `ironclaw service`.
+//!
+//! Hosted deployments run the Reborn binary as the container's foreground
+//! process: the image entrypoint (`docker/reborn/entrypoint.sh`) `exec`s
+//! `ironclaw serve`, so PID 1 is the container init (e.g. `docker-init`) and
+//! the container runtime's restart policy — not systemd or launchd — is the
+//! supervisor. There is no service manager to install into: `systemctl`
+//! does not exist in the image, so before this module existed every
+//! `ironclaw service` verb on such a host died with a confusing
+//! "failed to spawn command for systemctl …" or "Service not installed"
+//! error, while our own setup docs tell users to finish with
+//! `ironclaw service restart`.
+//!
+//! [`super::ServicePlatform::detect`] resolves to `Container` on Linux when
+//! systemd is not the running init (no `/run/systemd/system`). In that mode:
+//!
+//! - `restart` terminates the running `serve` process. The container's main
+//!   process exiting makes the container exit, and the restart policy
+//!   relaunches it through the entrypoint — that *is* the restart primitive
+//!   for this deployment shape.
+//! - `status` reports whether a `serve` process is running.
+//! - `install`/`uninstall`/`start`/`stop` fail with one actionable message:
+//!   there is no service manager to act on, and a `stop` would be undone by
+//!   the restart policy immediately.
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use super::{ServiceCommandRunner, ServiceState};
+
+/// The serve process is found by argv shape, not by pid-1 parentage: the
+/// entrypoint `exec`s `ironclaw serve --host … --port …`, so argv0's
+/// basename is `ironclaw` and argv1 is exactly `serve`.
+const SERVE_SUBCOMMAND: &str = "serve";
+
+/// Scan `<proc_root>/<pid>/cmdline` for running `ironclaw serve` processes,
+/// excluding this process itself. `proc_root` is `/proc` in production and a
+/// fake tree under a tempdir in tests (which lets the scan logic run on
+/// macOS test hosts too, where the Container variant is otherwise
+/// unreachable).
+fn find_serve_pids(proc_root: &Path) -> Result<Vec<u32>> {
+    let entries = std::fs::read_dir(proc_root)
+        .with_context(|| format!("read process table at {}", proc_root.display()))?;
+    let own_pid = std::process::id();
+    let mut pids = Vec::new();
+    for entry in entries {
+        // silent-ok: a process may exit between readdir and stat; a vanished
+        // entry is normal churn, not a scan failure.
+        let Ok(entry) = entry else { continue };
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid == own_pid {
+            continue;
+        }
+        // silent-ok: same readdir/read race — the process can exit before we
+        // read its cmdline; skip rather than fail the whole scan.
+        let Ok(cmdline) = std::fs::read(entry.path().join("cmdline")) else {
+            continue;
+        };
+        let mut argv = cmdline.split(|byte| *byte == 0);
+        let argv0_is_ironclaw = argv
+            .next()
+            .map(String::from_utf8_lossy)
+            .map(|argv0| {
+                Path::new(argv0.as_ref())
+                    .file_name()
+                    .is_some_and(|name| name == "ironclaw")
+            })
+            .unwrap_or(false);
+        let argv1_is_serve = argv
+            .next()
+            .map(String::from_utf8_lossy)
+            .is_some_and(|argv1| argv1 == SERVE_SUBCOMMAND);
+        if argv0_is_ironclaw && argv1_is_serve {
+            pids.push(pid);
+        }
+    }
+    pids.sort_unstable();
+    Ok(pids)
+}
+
+/// Runner-injectable service-state query behind
+/// [`super::ServicePlatform::current_state_with_runner`] — see that method's
+/// doc. "Installed" doesn't apply to a container-supervised deployment (the
+/// container itself is the installation), so state is purely running/stopped
+/// based on whether a `serve` process is found.
+pub(super) fn current_state(proc_root: &Path) -> Result<ServiceState> {
+    Ok(if find_serve_pids(proc_root)?.is_empty() {
+        ServiceState::Stopped
+    } else {
+        ServiceState::Running
+    })
+}
+
+/// Runner-injectable `status` behind [`super::ServicePlatform::status_with_runner`]
+/// — see that method's doc. Delegates message-building to [`status_message`]
+/// (a pure fn) so the text is testable without capturing stdout.
+pub(super) fn status(proc_root: &Path) -> Result<()> {
+    let pids = find_serve_pids(proc_root)?;
+    println!("{}", status_message(&pids));
+    Ok(())
+}
+
+/// Builds the `service status` line for the given serve pids. Reuses
+/// [`super::status_label`] (not a hand-rolled "running"/"stopped" string) so
+/// the vocabulary can't drift from launchd/systemd's.
+fn status_message(pids: &[u32]) -> String {
+    let label = super::status_label(true, !pids.is_empty());
+    if pids.is_empty() {
+        format!("Service: {label} (container-supervised; no `ironclaw serve` process found)")
+    } else {
+        let pid_list = pids
+            .iter()
+            .map(|pid| pid.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("Service: {label} (container-supervised, pid {pid_list})")
+    }
+}
+
+/// Runner-injectable `restart` behind [`super::ServicePlatform::restart_with_runner`]
+/// — see that method's doc. Unlike launchd/systemd's stop-then-start, this
+/// signals the running `serve` process and relies on the container runtime's
+/// restart policy to relaunch it — see the module doc for why that is the
+/// correct restart primitive for this deployment shape.
+pub(super) fn restart_with_runner(
+    runner: &mut dyn ServiceCommandRunner,
+    proc_root: &Path,
+) -> Result<()> {
+    let pids = find_serve_pids(proc_root)?;
+    if pids.is_empty() {
+        bail!(
+            "no running `ironclaw serve` process found. This instance is supervised by its \
+             container runtime (no systemd available); if serve is down, restart the container \
+             from your hosting platform."
+        );
+    }
+    let pid_list = pids
+        .iter()
+        .map(|pid| pid.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    // Print before signaling: terminating serve makes the container's main
+    // process exit, which ends this session too — this line may be the last
+    // output the operator sees before reconnecting.
+    println!(
+        "Terminating `ironclaw serve` (pid {pid_list}). The container will exit and be \
+         relaunched by its restart policy; active sessions (including SSH) will disconnect. \
+         Reconnect once the container is back up."
+    );
+    // Direct `kill` invocation, matching launchd.rs/systemd.rs's convention
+    // of calling the target binary directly rather than through a shell —
+    // no shell parsing is involved since every argument is a bare pid.
+    runner.run_checked(
+        "terminate serve process",
+        Command::new("kill")
+            .arg("-TERM")
+            .args(pids.iter().map(u32::to_string)),
+    )
+}
+
+/// Shared bail for the verbs that require a service manager. One message so
+/// the guidance can't drift between verbs.
+pub(super) fn unsupported_in_container(verb: &str) -> Result<()> {
+    bail!(
+        "`ironclaw service {verb}` is not available here: this instance runs as the container's \
+         main process, supervised by the container runtime's restart policy (systemd is not \
+         running). Use `ironclaw service restart` to restart serve, or manage the instance from \
+         your hosting platform."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build `<root>/<pid>/cmdline` with NUL-joined argv, mirroring the real
+    /// procfs encoding.
+    fn write_proc_entry(root: &Path, pid: u32, argv: &[&str]) {
+        let dir = root.join(pid.to_string());
+        std::fs::create_dir_all(&dir).expect("create fake proc pid dir");
+        std::fs::write(dir.join("cmdline"), argv.join("\0").as_bytes() as &[u8])
+            .expect("write fake cmdline");
+    }
+
+    fn fake_proc(entries: &[(u32, &[&str])]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for (pid, argv) in entries {
+            write_proc_entry(tmp.path(), *pid, argv);
+        }
+        tmp
+    }
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        commands: Vec<(String, String)>,
+    }
+
+    impl ServiceCommandRunner for RecordingRunner {
+        fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()> {
+            self.commands
+                .push((label.to_string(), format!("{command:?}")));
+            Ok(())
+        }
+
+        fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String> {
+            self.commands
+                .push((label.to_string(), format!("{command:?}")));
+            Ok(String::new())
+        }
+    }
+
+    #[test]
+    fn find_serve_pids_matches_only_ironclaw_serve_argv() {
+        let proc = fake_proc(&[
+            (
+                1,
+                &["/sbin/docker-init", "--", "ironclaw-reborn-entrypoint"],
+            ),
+            (
+                71,
+                &[
+                    "/usr/local/bin/ironclaw",
+                    "serve",
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "3000",
+                ],
+            ),
+            (87, &["sshd: /usr/sbin/sshd"]),
+            // Same binary, different subcommand — must not match.
+            (90, &["/usr/local/bin/ironclaw", "status"]),
+            // `serve` argv1 under a different binary — must not match.
+            (91, &["/usr/local/bin/other", "serve"]),
+        ]);
+        assert_eq!(
+            find_serve_pids(proc.path()).expect("scan must succeed"),
+            vec![71]
+        );
+    }
+
+    #[test]
+    fn find_serve_pids_skips_non_numeric_and_unreadable_entries() {
+        let proc = fake_proc(&[(42, &["/usr/local/bin/ironclaw", "serve"])]);
+        std::fs::create_dir_all(proc.path().join("self")).expect("non-numeric proc entry");
+        // Numeric dir with no cmdline file: the readdir/read race shape.
+        std::fs::create_dir_all(proc.path().join("99")).expect("raced proc entry");
+        assert_eq!(
+            find_serve_pids(proc.path()).expect("scan must succeed"),
+            vec![42]
+        );
+    }
+
+    #[test]
+    fn find_serve_pids_skips_empty_and_argv0_only_cmdline() {
+        // Real /proc races: a process caught mid-exec (or already exited)
+        // can leave a 0-byte cmdline, or a cmdline with only argv0 and no
+        // argv1 yet — neither is a serve match, and neither should error
+        // the scan.
+        let proc = fake_proc(&[(42, &["/usr/local/bin/ironclaw", "serve"])]);
+        std::fs::create_dir_all(proc.path().join("50")).expect("create pid dir");
+        std::fs::write(proc.path().join("50/cmdline"), b"").expect("empty cmdline");
+        std::fs::create_dir_all(proc.path().join("51")).expect("create pid dir");
+        std::fs::write(proc.path().join("51/cmdline"), b"/usr/local/bin/ironclaw\0")
+            .expect("argv0-only cmdline");
+        assert_eq!(
+            find_serve_pids(proc.path()).expect("scan must succeed"),
+            vec![42]
+        );
+    }
+
+    #[test]
+    fn find_serve_pids_returns_ascending_order_regardless_of_readdir_order() {
+        // pids.sort_unstable() must actually run: entries are created with
+        // pid 200 before 3 and 45, so a directory-order scan (readdir isn't
+        // numerically ordered) would return them out of order without the
+        // sort.
+        let proc = fake_proc(&[
+            (200, &["/usr/local/bin/ironclaw", "serve"]),
+            (3, &["/usr/local/bin/ironclaw", "serve"]),
+            (45, &["/usr/local/bin/ironclaw", "serve"]),
+        ]);
+        assert_eq!(
+            find_serve_pids(proc.path()).expect("scan must succeed"),
+            vec![3, 45, 200]
+        );
+    }
+
+    #[test]
+    fn status_message_reuses_the_shared_running_stopped_vocabulary() {
+        assert_eq!(
+            status_message(&[]),
+            "Service: stopped (container-supervised; no `ironclaw serve` process found)"
+        );
+        assert_eq!(
+            status_message(&[71, 72]),
+            "Service: running (container-supervised, pid 71, 72)"
+        );
+    }
+
+    #[test]
+    fn current_state_maps_presence_to_running_and_absence_to_stopped() {
+        let running = fake_proc(&[(7, &["/usr/local/bin/ironclaw", "serve"])]);
+        assert_eq!(
+            current_state(running.path()).expect("state"),
+            ServiceState::Running
+        );
+        let stopped = fake_proc(&[(1, &["/sbin/docker-init"])]);
+        assert_eq!(
+            current_state(stopped.path()).expect("state"),
+            ServiceState::Stopped
+        );
+    }
+
+    #[test]
+    fn restart_signals_every_serve_pid_through_the_runner() {
+        let proc = fake_proc(&[
+            (71, &["/usr/local/bin/ironclaw", "serve"]),
+            (72, &["/usr/local/bin/ironclaw", "serve", "--port", "3001"]),
+        ]);
+        let mut runner = RecordingRunner::default();
+        restart_with_runner(&mut runner, proc.path()).expect("restart must succeed");
+        assert_eq!(runner.commands.len(), 1);
+        let (label, command) = &runner.commands[0];
+        assert_eq!(label, "terminate serve process");
+        assert!(
+            command.starts_with("\"kill\""),
+            "must invoke kill directly, not a shell: {command}"
+        );
+        assert!(command.contains("\"-TERM\""), "{command}");
+        assert!(command.contains("\"71\""), "{command}");
+        assert!(command.contains("\"72\""), "{command}");
+    }
+
+    #[test]
+    fn restart_without_a_serve_process_names_container_supervision() {
+        let proc = fake_proc(&[(1, &["/sbin/docker-init"])]);
+        let mut runner = RecordingRunner::default();
+        let error = restart_with_runner(&mut runner, proc.path())
+            .expect_err("restart without serve must fail");
+        assert!(
+            error.to_string().contains("container runtime"),
+            "error must explain the supervision model: {error:#}"
+        );
+        assert!(
+            runner.commands.is_empty(),
+            "no signal may be sent when no serve process exists"
+        );
+    }
+
+    #[test]
+    fn unsupported_verbs_share_one_actionable_message() {
+        for verb in ["install", "uninstall", "start", "stop"] {
+            let error = unsupported_in_container(verb).expect_err("verb must be rejected");
+            let text = error.to_string();
+            assert!(
+                text.contains(&format!("`ironclaw service {verb}`")),
+                "{text}"
+            );
+            assert!(text.contains("container"), "{text}");
+            assert!(text.contains("ironclaw service restart"), "{text}");
+        }
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/service/container.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/container.rs
@@ -12,11 +12,14 @@
 //! `ironclaw service restart`.
 //!
 //! [`super::ServicePlatform::detect`] resolves to `Container` on Linux when
-//! systemd is not the running init (no `/run/systemd/system`) AND `/.dockerenv`
-//! is present — systemd-absence alone is not enough (WSL2, OpenRC distros, a
-//! plain VM running `ironclaw onboard` directly all lack systemd too, and
-//! `restart`'s kill-and-trust-a-restart-policy behavior would be destructive
-//! on them without a positive container signal; see
+//! systemd is not the running init (no `/run/systemd/system`) AND the
+//! deployment has explicitly declared a managed restart policy via
+//! `IRONCLAW_REBORN_CONTAINER_SUPERVISED` — systemd-absence alone is not
+//! enough, and neither is merely being *a* container (WSL2, OpenRC distros,
+//! a plain VM running `ironclaw onboard` directly, or a real Docker
+//! container started with no restart policy at all, e.g. the documented
+//! `docker run --rm ...` local-run command, all lack a guarantee that
+//! anything relaunches `serve` after `restart` kills it; see
 //! [`super::ServicePlatform::linux_platform`]'s doc). In `Container` mode:
 //!
 //! - `restart` terminates the running `serve` process. The container's main

--- a/crates/ironclaw_reborn_cli/src/commands/service/container.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/container.rs
@@ -14,9 +14,8 @@
 //! [`super::ServicePlatform::detect`] resolves to `Container` on Linux when
 //! systemd is not the running init (no `/run/systemd/system`) AND the
 //! deployment has explicitly declared a managed restart policy via
-//! `IRONCLAW_REBORN_CONTAINER_SUPERVISED`, or is Railway (whose deployment
-//! markers identify its managed restart policy) — systemd-absence alone is
-//! not enough, and neither is merely being *a* container (WSL2, OpenRC distros,
+//! `IRONCLAW_CONTAINER_SUPERVISE=true` — systemd-absence alone is not enough,
+//! and neither is merely being *a* container (WSL2, OpenRC distros,
 //! a plain VM running `ironclaw onboard` directly, or a real Docker
 //! container started with no restart policy at all, e.g. the documented
 //! `docker run --rm ...` local-run command, all lack a guarantee that

--- a/crates/ironclaw_reborn_cli/src/commands/service/container.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/container.rs
@@ -14,8 +14,9 @@
 //! [`super::ServicePlatform::detect`] resolves to `Container` on Linux when
 //! systemd is not the running init (no `/run/systemd/system`) AND the
 //! deployment has explicitly declared a managed restart policy via
-//! `IRONCLAW_REBORN_CONTAINER_SUPERVISED` — systemd-absence alone is not
-//! enough, and neither is merely being *a* container (WSL2, OpenRC distros,
+//! `IRONCLAW_REBORN_CONTAINER_SUPERVISED`, or is Railway (whose deployment
+//! markers identify its managed restart policy) — systemd-absence alone is
+//! not enough, and neither is merely being *a* container (WSL2, OpenRC distros,
 //! a plain VM running `ironclaw onboard` directly, or a real Docker
 //! container started with no restart policy at all, e.g. the documented
 //! `docker run --rm ...` local-run command, all lack a guarantee that

--- a/crates/ironclaw_reborn_cli/src/commands/service/container.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/container.rs
@@ -12,7 +12,12 @@
 //! `ironclaw service restart`.
 //!
 //! [`super::ServicePlatform::detect`] resolves to `Container` on Linux when
-//! systemd is not the running init (no `/run/systemd/system`). In that mode:
+//! systemd is not the running init (no `/run/systemd/system`) AND `/.dockerenv`
+//! is present — systemd-absence alone is not enough (WSL2, OpenRC distros, a
+//! plain VM running `ironclaw onboard` directly all lack systemd too, and
+//! `restart`'s kill-and-trust-a-restart-policy behavior would be destructive
+//! on them without a positive container signal; see
+//! [`super::ServicePlatform::linux_platform`]'s doc). In `Container` mode:
 //!
 //! - `restart` terminates the running `serve` process. The container's main
 //!   process exiting makes the container exit, and the restart policy
@@ -142,7 +147,7 @@ pub(super) fn restart_with_runner(
              from your hosting platform."
         );
     }
-    let pid_list = pids
+    let display_pids = pids
         .iter()
         .map(|pid| pid.to_string())
         .collect::<Vec<_>>()
@@ -151,18 +156,27 @@ pub(super) fn restart_with_runner(
     // process exit, which ends this session too — this line may be the last
     // output the operator sees before reconnecting.
     println!(
-        "Terminating `ironclaw serve` (pid {pid_list}). The container will exit and be \
+        "Terminating `ironclaw serve` (pid {display_pids}). The container will exit and be \
          relaunched by its restart policy; active sessions (including SSH) will disconnect. \
          Reconnect once the container is back up."
     );
-    // Direct `kill` invocation, matching launchd.rs/systemd.rs's convention
-    // of calling the target binary directly rather than through a shell —
-    // no shell parsing is involved since every argument is a bare pid.
+    // Through `sh -c`, not a direct `Command::new("kill")`: unlike
+    // `systemctl`/`launchctl`, `kill` is a shell BUILTIN on the shipped
+    // image (debian:bookworm-slim has no `procps`, the only package
+    // providing a standalone `/bin/kill`) — spawning "kill" directly fails
+    // with ENOENT. `/bin/sh` is guaranteed present; it's what boots this
+    // container (the image entrypoint is a `#!/bin/sh` script). Every
+    // argument is a bare numeric pid, so no shell-injection surface.
+    let shell_command = format!(
+        "kill -TERM {}",
+        pids.iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
     runner.run_checked(
         "terminate serve process",
-        Command::new("kill")
-            .arg("-TERM")
-            .args(pids.iter().map(u32::to_string)),
+        Command::new("sh").arg("-c").arg(shell_command),
     )
 }
 
@@ -201,19 +215,30 @@ mod tests {
     #[derive(Default)]
     struct RecordingRunner {
         commands: Vec<(String, String)>,
+        /// When set, `run_checked`/`run_capture_checked` still record the
+        /// call, then return this error instead of `Ok` — used to prove
+        /// `restart_with_runner` propagates a signal-send failure rather
+        /// than reporting success.
+        fail_with: Option<String>,
     }
 
     impl ServiceCommandRunner for RecordingRunner {
         fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()> {
             self.commands
                 .push((label.to_string(), format!("{command:?}")));
-            Ok(())
+            match &self.fail_with {
+                Some(message) => bail!("{message}"),
+                None => Ok(()),
+            }
         }
 
         fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String> {
             self.commands
                 .push((label.to_string(), format!("{command:?}")));
-            Ok(String::new())
+            match &self.fail_with {
+                Some(message) => bail!("{message}"),
+                None => Ok(String::new()),
+            }
         }
     }
 
@@ -295,6 +320,20 @@ mod tests {
     }
 
     #[test]
+    fn find_serve_pids_propagates_missing_proc_root_error() {
+        let missing = tempfile::tempdir()
+            .expect("tempdir")
+            .path()
+            .join("does-not-exist");
+        let err = find_serve_pids(&missing).expect_err("missing proc root must error");
+        assert!(
+            err.to_string()
+                .contains(&format!("read process table at {}", missing.display())),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
     fn status_message_reuses_the_shared_running_stopped_vocabulary() {
         assert_eq!(
             status_message(&[]),
@@ -331,13 +370,38 @@ mod tests {
         assert_eq!(runner.commands.len(), 1);
         let (label, command) = &runner.commands[0];
         assert_eq!(label, "terminate serve process");
+        // Through `sh -c`, not a direct `Command::new("kill")` — `kill` is a
+        // shell builtin on the shipped image (no `procps`), not a spawnable
+        // binary; see the comment on `restart_with_runner`.
         assert!(
-            command.starts_with("\"kill\""),
-            "must invoke kill directly, not a shell: {command}"
+            command.starts_with("\"sh\" \"-c\""),
+            "must invoke kill through a shell, since kill has no standalone binary on the \
+             shipped image: {command}"
         );
-        assert!(command.contains("\"-TERM\""), "{command}");
-        assert!(command.contains("\"71\""), "{command}");
-        assert!(command.contains("\"72\""), "{command}");
+        assert!(command.contains("kill -TERM 71 72"), "{command}");
+    }
+
+    #[test]
+    fn restart_propagates_terminate_runner_error() {
+        // The success-path test above only proves the happy path. A failure
+        // to spawn or execute the signal command is the operational failure
+        // this command exists to surface — it must not be swallowed.
+        let proc = fake_proc(&[(71, &["/usr/local/bin/ironclaw", "serve"])]);
+        let mut runner = RecordingRunner {
+            fail_with: Some("spawn failed: No such file or directory".to_string()),
+            ..Default::default()
+        };
+        let error = restart_with_runner(&mut runner, proc.path())
+            .expect_err("a runner failure must propagate, not be reported as success");
+        assert!(
+            error.to_string().contains("spawn failed"),
+            "the underlying runner error must survive: {error:#}"
+        );
+        assert_eq!(
+            runner.commands.len(),
+            1,
+            "the attempt must still have been recorded"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -171,16 +171,13 @@ impl ServicePlatform {
     /// trusts an external restart policy to relaunch it — no signal
     /// observable from inside the container (not `/.dockerenv`, not a
     /// cgroup, not any other ambient marker) can actually prove that policy
-    /// exists; only the party that configured the deployment knows. So this
-    /// is not auto-detected: it must be explicitly declared, matching this
-    /// same script's existing opt-in convention (`IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY`,
-    /// `IRONCLAW_REBORN_CONFIRM_HOST_ACCESS`). `docker/reborn/entrypoint.sh`
-    /// sets it automatically for the platform this PR targets (Railway,
-    /// already detected there for other purposes); anyone else opts in
-    /// deliberately. When it isn't declared, fall back to `Linux`: that host
-    /// gets the old systemd-manager path, which fails loud (a plain
-    /// `systemctl` ENOENT) rather than guessing and taking a destructive
-    /// action with no recovery guarantee.
+    /// exists. The one platform-specific exception is Railway: its
+    /// deployment markers identify a platform which provides the restart
+    /// policy, matching `docker/reborn/entrypoint.sh`. Elsewhere, the policy
+    /// must be declared explicitly. When neither applies, fall back to
+    /// `Linux`: that host gets the old systemd-manager path, which fails loud
+    /// (a plain `systemctl` ENOENT) rather than guessing and taking a
+    /// destructive action with no recovery guarantee.
     fn linux_platform(systemd_booted: bool, container_supervised_declared: bool) -> Self {
         if systemd_booted {
             Self::Linux
@@ -268,10 +265,21 @@ impl ServicePlatform {
 
     /// Runner-injectable `restart` — see [`Self::start_with_runner`].
     fn restart_with_runner(&self, runner: &mut dyn ServiceCommandRunner) -> Result<()> {
+        self.restart_with_runner_at_proc_root(runner, Path::new(PROC_ROOT))
+    }
+
+    /// Testable restart dispatch with an injectable procfs root. Production
+    /// uses [`PROC_ROOT`]; tests use a fake process table to prove the
+    /// `Container` arm reaches the same signal command as a real restart.
+    fn restart_with_runner_at_proc_root(
+        &self,
+        runner: &mut dyn ServiceCommandRunner,
+        proc_root: &Path,
+    ) -> Result<()> {
         match self {
             Self::MacOs => launchd::restart_with_runner(runner),
             Self::Linux => systemd::restart_with_runner(runner),
-            Self::Container => container::restart_with_runner(runner, Path::new(PROC_ROOT)),
+            Self::Container => container::restart_with_runner(runner, proc_root),
         }
     }
 
@@ -336,22 +344,53 @@ fn systemd_booted_under(root: &Path) -> bool {
 }
 
 /// Env var a deployment sets to explicitly declare "I run under a managed
-/// restart policy" — see [`ServicePlatform::linux_platform`]'s doc for why
-/// this must be an explicit opt-in rather than inferred from the
-/// environment. `docker/reborn/entrypoint.sh` sets it automatically on
-/// Railway; anyone else opts in deliberately.
+/// restart policy". An explicit value always wins; otherwise Railway's
+/// deployment markers imply its managed restart policy, matching
+/// `docker/reborn/entrypoint.sh`.
 const CONTAINER_SUPERVISED_ENV_VAR: &str = "IRONCLAW_REBORN_CONTAINER_SUPERVISED";
+const RAILWAY_ENVIRONMENT_ENV_VAR: &str = "RAILWAY_ENVIRONMENT";
+const RAILWAY_PROJECT_ID_ENV_VAR: &str = "RAILWAY_PROJECT_ID";
+const RAILWAY_SERVICE_ID_ENV_VAR: &str = "RAILWAY_SERVICE_ID";
 
-/// Whether [`CONTAINER_SUPERVISED_ENV_VAR`] is set. Combined with
+/// Whether a deployment declares a managed restart policy. Combined with
 /// [`systemd_booted`] absence, this is [`ServicePlatform::linux_platform`]'s
 /// second signal for `Container` mode.
 fn container_supervised_declared() -> bool {
-    is_truthy_env(std::env::var(CONTAINER_SUPERVISED_ENV_VAR).ok().as_deref())
+    container_supervised_declared_from_signals(
+        std::env::var_os(CONTAINER_SUPERVISED_ENV_VAR).as_deref(),
+        railway_runtime_detected(),
+    )
 }
 
-/// `container_supervised_declared`'s actual check, parameterized on the raw
-/// value so tests don't need to touch real process env vars — mirrors
-/// [`systemd_booted_under`]'s injectable-root pattern for the same reason.
+/// Matches `docker/reborn/entrypoint.sh`'s `railway_runtime_detected()`.
+fn railway_runtime_detected() -> bool {
+    railway_runtime_detected_from_signals([
+        std::env::var_os(RAILWAY_ENVIRONMENT_ENV_VAR).as_deref(),
+        std::env::var_os(RAILWAY_PROJECT_ID_ENV_VAR).as_deref(),
+        std::env::var_os(RAILWAY_SERVICE_ID_ENV_VAR).as_deref(),
+    ])
+}
+
+fn railway_runtime_detected_from_signals(signals: [Option<&std::ffi::OsStr>; 3]) -> bool {
+    signals
+        .into_iter()
+        .any(|signal| signal.is_some_and(|value| !value.is_empty()))
+}
+
+/// The actual supervision decision, parameterized so tests do not mutate the
+/// process environment. Explicit supervision settings, including explicit
+/// false values, override Railway's ambient deployment markers.
+fn container_supervised_declared_from_signals(
+    explicit_supervision: Option<&std::ffi::OsStr>,
+    railway_detected: bool,
+) -> bool {
+    match explicit_supervision {
+        Some(value) => is_truthy_env(value.to_str()),
+        None => railway_detected,
+    }
+}
+
+/// `container_supervised_declared_from_signals`' explicit-value check.
 /// Matches `docker/reborn/entrypoint.sh`'s `is_truthy()` shell helper
 /// exactly, so a value that's truthy in the entrypoint script is truthy
 /// here too.
@@ -717,6 +756,30 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct RecordingServiceCommandRunner {
+        commands: Vec<(String, String, Vec<String>)>,
+    }
+
+    impl ServiceCommandRunner for RecordingServiceCommandRunner {
+        fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()> {
+            self.commands.push((
+                label.to_string(),
+                command.get_program().to_string_lossy().into_owned(),
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect(),
+            ));
+            Ok(())
+        }
+
+        fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String> {
+            self.run_checked(label, command)?;
+            Ok(String::new())
+        }
+    }
+
     #[test]
     fn status_label_covers_running_stopped_and_not_installed() {
         assert_eq!(status_label(false, false), "not installed");
@@ -774,6 +837,76 @@ mod tests {
         assert_eq!(
             ServicePlatform::linux_platform(false, false),
             ServicePlatform::Linux
+        );
+    }
+
+    #[test]
+    fn railway_markers_select_container_when_supervision_is_not_explicitly_set() {
+        let railway_detected = railway_runtime_detected_from_signals([
+            Some(std::ffi::OsStr::new("production")),
+            None,
+            None,
+        ]);
+        assert!(railway_detected);
+        assert!(container_supervised_declared_from_signals(
+            None,
+            railway_detected,
+        ));
+        assert_eq!(
+            ServicePlatform::linux_platform(
+                false,
+                container_supervised_declared_from_signals(None, railway_detected),
+            ),
+            ServicePlatform::Container
+        );
+    }
+
+    #[test]
+    fn explicit_false_supervision_overrides_railway_markers() {
+        let railway_detected = railway_runtime_detected_from_signals([
+            None,
+            Some(std::ffi::OsStr::new("project-id")),
+            None,
+        ]);
+        assert!(!container_supervised_declared_from_signals(
+            Some(std::ffi::OsStr::new("false")),
+            railway_detected,
+        ));
+        assert_eq!(
+            ServicePlatform::linux_platform(
+                false,
+                container_supervised_declared_from_signals(
+                    Some(std::ffi::OsStr::new("false")),
+                    railway_detected,
+                ),
+            ),
+            ServicePlatform::Linux
+        );
+    }
+
+    #[test]
+    fn container_restart_dispatches_the_serve_signal_through_the_runner() {
+        let proc = tempfile::tempdir().expect("tempdir");
+        let serve_dir = proc.path().join("71");
+        std::fs::create_dir_all(&serve_dir).expect("create fake proc entry");
+        std::fs::write(
+            serve_dir.join("cmdline"),
+            b"/usr/local/bin/ironclaw\0serve\0--host\0",
+        )
+        .expect("write fake serve command line");
+        let mut runner = RecordingServiceCommandRunner::default();
+
+        ServicePlatform::Container
+            .restart_with_runner_at_proc_root(&mut runner, proc.path())
+            .expect("container restart must dispatch through the runner");
+
+        assert_eq!(
+            runner.commands,
+            vec![(
+                "terminate serve process".to_string(),
+                "sh".to_string(),
+                vec!["-c".to_string(), "kill -TERM 71".to_string()],
+            )]
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -147,20 +147,34 @@ impl ServicePlatform {
         if cfg!(target_os = "macos") {
             Ok(Self::MacOs)
         } else if cfg!(target_os = "linux") {
-            Ok(Self::linux_platform(systemd_booted()))
+            Ok(Self::linux_platform(systemd_booted(), dockerenv_present()))
         } else {
             bail!(UNSUPPORTED_OS_MESSAGE);
         }
     }
 
-    /// The one runtime decision [`Self::detect`] makes: a Linux host manages
-    /// services through systemd only when systemd is actually the running
-    /// init; otherwise this is a container-supervised deployment.
-    fn linux_platform(systemd_booted: bool) -> Self {
+    /// The one runtime decision [`Self::detect`] makes on Linux.
+    /// `Container` requires BOTH signals — systemd absent AND `/.dockerenv`
+    /// present — not systemd-absence alone: a Linux host can lack systemd
+    /// for reasons that have nothing to do with container supervision (WSL2,
+    /// an OpenRC distro like Alpine/Gentoo, a SysV-init host, a plain VM
+    /// running `ironclaw onboard` directly). `restart` in `Container` mode
+    /// kills the running `serve` process and trusts an external restart
+    /// policy to relaunch it — misclassifying one of those hosts as
+    /// `Container` would make `restart` silently kill `serve` with no
+    /// recovery guarantee, which is worse than the old behavior (a clear
+    /// "not installed" error) it replaces for exactly that host. When
+    /// systemd is absent but `/.dockerenv` is too, fall back to `Linux`:
+    /// that host isn't identifiably a container, so it gets the old
+    /// systemd-manager path, which fails loud (a plain `systemctl` ENOENT)
+    /// rather than guessing and taking a destructive action.
+    fn linux_platform(systemd_booted: bool, dockerenv_present: bool) -> Self {
         if systemd_booted {
             Self::Linux
-        } else {
+        } else if dockerenv_present {
             Self::Container
+        } else {
+            Self::Linux
         }
     }
 
@@ -306,6 +320,21 @@ fn systemd_booted() -> bool {
 /// tests can point it at a fake tree instead of the host's real `/run`.
 fn systemd_booted_under(root: &Path) -> bool {
     root.join("run/systemd/system").is_dir()
+}
+
+/// `/.dockerenv` is a file Docker creates unconditionally in the root of
+/// every container it starts, regardless of base image — the standard
+/// external convention for "am I in a Docker container" detection. Combined
+/// with [`systemd_booted`] absence, this is [`ServicePlatform::linux_platform`]'s
+/// second signal for `Container` mode.
+fn dockerenv_present() -> bool {
+    dockerenv_present_under(Path::new("/"))
+}
+
+/// `dockerenv_present`'s actual check, parameterized on the filesystem root
+/// so tests can point it at a fake tree — mirrors [`systemd_booted_under`].
+fn dockerenv_present_under(root: &Path) -> bool {
+    root.join(".dockerenv").is_file()
 }
 
 /// Install then start the OS service in one call — used by `onboard`'s
@@ -687,7 +716,7 @@ mod tests {
     }
 
     #[test]
-    fn linux_without_systemd_resolves_to_container_not_linux() {
+    fn linux_without_systemd_and_with_dockerenv_resolves_to_container() {
         // Regression: hosted containers (image entrypoint execs `ironclaw
         // serve`, PID 1 = docker-init, no systemctl binary) used to resolve
         // to `Linux`, so every service verb died spawning `systemctl`
@@ -695,21 +724,40 @@ mod tests {
         // `restart` reported "Service not installed" — while the setup docs
         // tell users to finish with `ironclaw service restart`.
         assert_eq!(
-            ServicePlatform::linux_platform(false),
+            ServicePlatform::linux_platform(false, true),
             ServicePlatform::Container
         );
         assert_eq!(
-            ServicePlatform::linux_platform(true),
+            ServicePlatform::linux_platform(true, true),
+            ServicePlatform::Linux
+        );
+        assert_eq!(
+            ServicePlatform::linux_platform(true, false),
+            ServicePlatform::Linux
+        );
+    }
+
+    #[test]
+    fn linux_without_systemd_and_without_dockerenv_falls_back_to_linux() {
+        // Systemd-absence alone must NOT resolve to Container: a host that
+        // is neither systemd-managed nor identifiably a Docker container
+        // (WSL2, an OpenRC distro, a SysV-init host, a plain VM running
+        // `ironclaw onboard` directly) must NOT get Container's destructive
+        // restart (kill + trust an external restart policy) — it falls back
+        // to the old Linux/systemd path, which fails loud (a plain
+        // `systemctl` ENOENT) instead of guessing and taking a destructive
+        // action with no recovery guarantee.
+        assert_eq!(
+            ServicePlatform::linux_platform(false, false),
             ServicePlatform::Linux
         );
     }
 
     #[test]
     fn systemd_booted_under_reads_run_systemd_system_from_the_given_root() {
-        // The detection `linux_without_systemd_resolves_to_container_not_linux`
-        // exercises only the pre-computed bool; this proves the actual
-        // filesystem check that feeds it (the real bug-fix logic) reads the
-        // right path and both directions.
+        // The detection tests above exercise only the pre-computed bools;
+        // this proves the actual filesystem check that feeds one of them
+        // (the real bug-fix logic) reads the right path and both directions.
         let tmp = tempfile::tempdir().expect("tempdir");
         assert!(
             !systemd_booted_under(tmp.path()),
@@ -720,6 +768,20 @@ mod tests {
         assert!(
             systemd_booted_under(tmp.path()),
             "run/systemd/system dir must read as booted"
+        );
+    }
+
+    #[test]
+    fn dockerenv_present_under_reads_dockerenv_from_the_given_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            !dockerenv_present_under(tmp.path()),
+            "no .dockerenv file must read as not present"
+        );
+        std::fs::write(tmp.path().join(".dockerenv"), "").expect("create .dockerenv");
+        assert!(
+            dockerenv_present_under(tmp.path()),
+            ".dockerenv file must read as present"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -171,13 +171,11 @@ impl ServicePlatform {
     /// trusts an external restart policy to relaunch it — no signal
     /// observable from inside the container (not `/.dockerenv`, not a
     /// cgroup, not any other ambient marker) can actually prove that policy
-    /// exists. The one platform-specific exception is Railway: its
-    /// deployment markers identify a platform which provides the restart
-    /// policy, matching `docker/reborn/entrypoint.sh`. Elsewhere, the policy
-    /// must be declared explicitly. When neither applies, fall back to
-    /// `Linux`: that host gets the old systemd-manager path, which fails loud
-    /// (a plain `systemctl` ENOENT) rather than guessing and taking a
-    /// destructive action with no recovery guarantee.
+    /// exists. Every container host, including Railway, must declare that
+    /// policy explicitly. When it is not declared, fall back to `Linux`: that
+    /// host gets the old systemd-manager path, which fails loud (a plain
+    /// `systemctl` ENOENT) rather than guessing and taking a destructive
+    /// action with no recovery guarantee.
     fn linux_platform(systemd_booted: bool, container_supervised_declared: bool) -> Self {
         if systemd_booted {
             Self::Linux
@@ -344,56 +342,23 @@ fn systemd_booted_under(root: &Path) -> bool {
 }
 
 /// Env var a deployment sets to explicitly declare "I run under a managed
-/// restart policy". An explicit value always wins; otherwise Railway's
-/// deployment markers imply its managed restart policy, matching
-/// `docker/reborn/entrypoint.sh`.
-const CONTAINER_SUPERVISED_ENV_VAR: &str = "IRONCLAW_REBORN_CONTAINER_SUPERVISED";
-const RAILWAY_ENVIRONMENT_ENV_VAR: &str = "RAILWAY_ENVIRONMENT";
-const RAILWAY_PROJECT_ID_ENV_VAR: &str = "RAILWAY_PROJECT_ID";
-const RAILWAY_SERVICE_ID_ENV_VAR: &str = "RAILWAY_SERVICE_ID";
+/// restart policy". This deployment contract is provider-neutral: Docker,
+/// Railway, Kubernetes, and other container hosts must opt in explicitly.
+const CONTAINER_SUPERVISED_ENV_VAR: &str = "IRONCLAW_CONTAINER_SUPERVISE";
 
 /// Whether a deployment declares a managed restart policy. Combined with
 /// [`systemd_booted`] absence, this is [`ServicePlatform::linux_platform`]'s
 /// second signal for `Container` mode.
 fn container_supervised_declared() -> bool {
-    container_supervised_declared_from_signals(
-        std::env::var_os(CONTAINER_SUPERVISED_ENV_VAR).as_deref(),
-        railway_runtime_detected(),
+    is_truthy_env(
+        std::env::var_os(CONTAINER_SUPERVISED_ENV_VAR)
+            .as_deref()
+            .and_then(std::ffi::OsStr::to_str),
     )
 }
 
-/// Matches `docker/reborn/entrypoint.sh`'s `railway_runtime_detected()`.
-fn railway_runtime_detected() -> bool {
-    railway_runtime_detected_from_signals([
-        std::env::var_os(RAILWAY_ENVIRONMENT_ENV_VAR).as_deref(),
-        std::env::var_os(RAILWAY_PROJECT_ID_ENV_VAR).as_deref(),
-        std::env::var_os(RAILWAY_SERVICE_ID_ENV_VAR).as_deref(),
-    ])
-}
-
-fn railway_runtime_detected_from_signals(signals: [Option<&std::ffi::OsStr>; 3]) -> bool {
-    signals
-        .into_iter()
-        .any(|signal| signal.is_some_and(|value| !value.is_empty()))
-}
-
-/// The actual supervision decision, parameterized so tests do not mutate the
-/// process environment. Explicit supervision settings, including explicit
-/// false values, override Railway's ambient deployment markers.
-fn container_supervised_declared_from_signals(
-    explicit_supervision: Option<&std::ffi::OsStr>,
-    railway_detected: bool,
-) -> bool {
-    match explicit_supervision {
-        Some(value) => is_truthy_env(value.to_str()),
-        None => railway_detected,
-    }
-}
-
-/// `container_supervised_declared_from_signals`' explicit-value check.
-/// Matches `docker/reborn/entrypoint.sh`'s `is_truthy()` shell helper
-/// exactly, so a value that's truthy in the entrypoint script is truthy
-/// here too.
+/// Parses [`CONTAINER_SUPERVISED_ENV_VAR`] without mutating the process
+/// environment in tests.
 fn is_truthy_env(value: Option<&str>) -> bool {
     matches!(value, Some("1" | "true" | "TRUE" | "yes" | "YES"))
 }
@@ -841,47 +806,16 @@ mod tests {
     }
 
     #[test]
-    fn railway_markers_select_container_when_supervision_is_not_explicitly_set() {
-        let railway_detected = railway_runtime_detected_from_signals([
-            Some(std::ffi::OsStr::new("production")),
-            None,
-            None,
-        ]);
-        assert!(railway_detected);
-        assert!(container_supervised_declared_from_signals(
-            None,
-            railway_detected,
-        ));
-        assert_eq!(
-            ServicePlatform::linux_platform(
-                false,
-                container_supervised_declared_from_signals(None, railway_detected),
-            ),
-            ServicePlatform::Container
-        );
-    }
-
-    #[test]
-    fn explicit_false_supervision_overrides_railway_markers() {
-        let railway_detected = railway_runtime_detected_from_signals([
-            None,
-            Some(std::ffi::OsStr::new("project-id")),
-            None,
-        ]);
-        assert!(!container_supervised_declared_from_signals(
-            Some(std::ffi::OsStr::new("false")),
-            railway_detected,
-        ));
-        assert_eq!(
-            ServicePlatform::linux_platform(
-                false,
-                container_supervised_declared_from_signals(
-                    Some(std::ffi::OsStr::new("false")),
-                    railway_detected,
-                ),
-            ),
-            ServicePlatform::Linux
-        );
+    fn container_supervision_requires_an_explicit_truthy_declaration() {
+        for truthy in ["1", "true", "TRUE", "yes", "YES"] {
+            assert!(is_truthy_env(Some(truthy)), "{truthy} must opt in");
+        }
+        for falsey in [None, Some(""), Some("false"), Some("railway")] {
+            assert!(
+                !is_truthy_env(falsey),
+                "{falsey:?} must not opt in without an explicit truthy value"
+            );
+        }
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -147,31 +147,44 @@ impl ServicePlatform {
         if cfg!(target_os = "macos") {
             Ok(Self::MacOs)
         } else if cfg!(target_os = "linux") {
-            Ok(Self::linux_platform(systemd_booted(), dockerenv_present()))
+            Ok(Self::linux_platform(
+                systemd_booted(),
+                container_supervised_declared(),
+            ))
         } else {
             bail!(UNSUPPORTED_OS_MESSAGE);
         }
     }
 
-    /// The one runtime decision [`Self::detect`] makes on Linux.
-    /// `Container` requires BOTH signals — systemd absent AND `/.dockerenv`
-    /// present — not systemd-absence alone: a Linux host can lack systemd
-    /// for reasons that have nothing to do with container supervision (WSL2,
-    /// an OpenRC distro like Alpine/Gentoo, a SysV-init host, a plain VM
-    /// running `ironclaw onboard` directly). `restart` in `Container` mode
-    /// kills the running `serve` process and trusts an external restart
-    /// policy to relaunch it — misclassifying one of those hosts as
-    /// `Container` would make `restart` silently kill `serve` with no
-    /// recovery guarantee, which is worse than the old behavior (a clear
-    /// "not installed" error) it replaces for exactly that host. When
-    /// systemd is absent but `/.dockerenv` is too, fall back to `Linux`:
-    /// that host isn't identifiably a container, so it gets the old
-    /// systemd-manager path, which fails loud (a plain `systemctl` ENOENT)
-    /// rather than guessing and taking a destructive action.
-    fn linux_platform(systemd_booted: bool, dockerenv_present: bool) -> Self {
+    /// The one runtime decision [`Self::detect`] makes on Linux. `Container`
+    /// requires BOTH signals — systemd absent AND `container_supervised`
+    /// explicitly declared — not systemd-absence alone: a Linux host can
+    /// lack systemd for reasons that have nothing to do with a managed
+    /// restart policy (WSL2, an OpenRC distro like Alpine/Gentoo, a
+    /// SysV-init host, a plain VM running `ironclaw onboard` directly, or
+    /// even a real Docker container started with no restart policy at all —
+    /// e.g. the documented `docker run --rm ...` local-run command in
+    /// `docs/reborn/deploy-reborn-cli-docker.md`, which is a real container
+    /// but has nothing to relaunch `serve` if `restart` kills it).
+    ///
+    /// `restart` in `Container` mode kills the running `serve` process and
+    /// trusts an external restart policy to relaunch it — no signal
+    /// observable from inside the container (not `/.dockerenv`, not a
+    /// cgroup, not any other ambient marker) can actually prove that policy
+    /// exists; only the party that configured the deployment knows. So this
+    /// is not auto-detected: it must be explicitly declared, matching this
+    /// same script's existing opt-in convention (`IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY`,
+    /// `IRONCLAW_REBORN_CONFIRM_HOST_ACCESS`). `docker/reborn/entrypoint.sh`
+    /// sets it automatically for the platform this PR targets (Railway,
+    /// already detected there for other purposes); anyone else opts in
+    /// deliberately. When it isn't declared, fall back to `Linux`: that host
+    /// gets the old systemd-manager path, which fails loud (a plain
+    /// `systemctl` ENOENT) rather than guessing and taking a destructive
+    /// action with no recovery guarantee.
+    fn linux_platform(systemd_booted: bool, container_supervised_declared: bool) -> Self {
         if systemd_booted {
             Self::Linux
-        } else if dockerenv_present {
+        } else if container_supervised_declared {
             Self::Container
         } else {
             Self::Linux
@@ -322,19 +335,28 @@ fn systemd_booted_under(root: &Path) -> bool {
     root.join("run/systemd/system").is_dir()
 }
 
-/// `/.dockerenv` is a file Docker creates unconditionally in the root of
-/// every container it starts, regardless of base image — the standard
-/// external convention for "am I in a Docker container" detection. Combined
-/// with [`systemd_booted`] absence, this is [`ServicePlatform::linux_platform`]'s
+/// Env var a deployment sets to explicitly declare "I run under a managed
+/// restart policy" — see [`ServicePlatform::linux_platform`]'s doc for why
+/// this must be an explicit opt-in rather than inferred from the
+/// environment. `docker/reborn/entrypoint.sh` sets it automatically on
+/// Railway; anyone else opts in deliberately.
+const CONTAINER_SUPERVISED_ENV_VAR: &str = "IRONCLAW_REBORN_CONTAINER_SUPERVISED";
+
+/// Whether [`CONTAINER_SUPERVISED_ENV_VAR`] is set. Combined with
+/// [`systemd_booted`] absence, this is [`ServicePlatform::linux_platform`]'s
 /// second signal for `Container` mode.
-fn dockerenv_present() -> bool {
-    dockerenv_present_under(Path::new("/"))
+fn container_supervised_declared() -> bool {
+    is_truthy_env(std::env::var(CONTAINER_SUPERVISED_ENV_VAR).ok().as_deref())
 }
 
-/// `dockerenv_present`'s actual check, parameterized on the filesystem root
-/// so tests can point it at a fake tree — mirrors [`systemd_booted_under`].
-fn dockerenv_present_under(root: &Path) -> bool {
-    root.join(".dockerenv").is_file()
+/// `container_supervised_declared`'s actual check, parameterized on the raw
+/// value so tests don't need to touch real process env vars — mirrors
+/// [`systemd_booted_under`]'s injectable-root pattern for the same reason.
+/// Matches `docker/reborn/entrypoint.sh`'s `is_truthy()` shell helper
+/// exactly, so a value that's truthy in the entrypoint script is truthy
+/// here too.
+fn is_truthy_env(value: Option<&str>) -> bool {
+    matches!(value, Some("1" | "true" | "TRUE" | "yes" | "YES"))
 }
 
 /// Install then start the OS service in one call — used by `onboard`'s
@@ -716,7 +738,7 @@ mod tests {
     }
 
     #[test]
-    fn linux_without_systemd_and_with_dockerenv_resolves_to_container() {
+    fn linux_without_systemd_and_with_supervision_declared_resolves_to_container() {
         // Regression: hosted containers (image entrypoint execs `ironclaw
         // serve`, PID 1 = docker-init, no systemctl binary) used to resolve
         // to `Linux`, so every service verb died spawning `systemctl`
@@ -738,15 +760,17 @@ mod tests {
     }
 
     #[test]
-    fn linux_without_systemd_and_without_dockerenv_falls_back_to_linux() {
+    fn linux_without_systemd_and_without_supervision_declared_falls_back_to_linux() {
         // Systemd-absence alone must NOT resolve to Container: a host that
-        // is neither systemd-managed nor identifiably a Docker container
-        // (WSL2, an OpenRC distro, a SysV-init host, a plain VM running
-        // `ironclaw onboard` directly) must NOT get Container's destructive
-        // restart (kill + trust an external restart policy) — it falls back
-        // to the old Linux/systemd path, which fails loud (a plain
-        // `systemctl` ENOENT) instead of guessing and taking a destructive
-        // action with no recovery guarantee.
+        // is neither systemd-managed nor has explicitly declared a managed
+        // restart policy (WSL2, an OpenRC distro, a SysV-init host, a plain
+        // VM running `ironclaw onboard` directly, or even a real Docker
+        // container started with no restart policy at all — e.g. the
+        // documented `docker run --rm ...` local-run command) must NOT get
+        // Container's destructive restart (kill + trust an external restart
+        // policy) — it falls back to the old Linux/systemd path, which
+        // fails loud (a plain `systemctl` ENOENT) instead of guessing and
+        // taking a destructive action with no recovery guarantee.
         assert_eq!(
             ServicePlatform::linux_platform(false, false),
             ServicePlatform::Linux
@@ -772,17 +796,23 @@ mod tests {
     }
 
     #[test]
-    fn dockerenv_present_under_reads_dockerenv_from_the_given_root() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        assert!(
-            !dockerenv_present_under(tmp.path()),
-            "no .dockerenv file must read as not present"
-        );
-        std::fs::write(tmp.path().join(".dockerenv"), "").expect("create .dockerenv");
-        assert!(
-            dockerenv_present_under(tmp.path()),
-            ".dockerenv file must read as present"
-        );
+    fn is_truthy_env_matches_entrypoint_sh_is_truthy_exactly() {
+        // Must stay in sync with docker/reborn/entrypoint.sh's is_truthy():
+        // a value the entrypoint treats as true (e.g. when auto-declaring
+        // supervision on Railway) must read as true here too.
+        for truthy in ["1", "true", "TRUE", "yes", "YES"] {
+            assert!(is_truthy_env(Some(truthy)), "{truthy} must be truthy");
+        }
+        for falsy in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("garbage"),
+        ] {
+            assert!(!is_truthy_env(falsy), "{falsy:?} must not be truthy");
+        }
     }
 
     #[test]

--- a/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/mod.rs
@@ -3,8 +3,12 @@
 //!
 //! - **macOS**: launchd user agent at
 //!   `~/Library/LaunchAgents/com.ironclaw.reborn.plist`.
-//! - **Linux**: systemd user unit at
+//! - **Linux (systemd)**: systemd user unit at
 //!   `~/.config/systemd/user/ironclaw-reborn.service`.
+//! - **Linux (container, no systemd)**: no unit to install — `serve` runs
+//!   as the container's own supervised process; `restart` signals it
+//!   directly and the container runtime's restart policy relaunches it.
+//!   See the `container` module doc.
 //!
 //! The installed service runs `<current_exe> serve`, restarting
 //! automatically on failure. Mirrors v1's `src/service.rs` shape with
@@ -14,8 +18,8 @@
 //! Platform dispatch happens once, in [`ServicePlatform::detect`], called
 //! a single time from [`ServiceCommand::execute`]. Each verb is a method
 //! on [`ServicePlatform`] that `match self`es to delegate into the
-//! OS-specific implementation (`launchd` or `systemd`), rather than every
-//! verb re-checking `cfg!(target_os)`.
+//! OS-specific implementation (`launchd`, `systemd`, or `container`),
+//! rather than every verb re-checking `cfg!(target_os)`.
 //!
 //! ## Canonical service identity, shared with the WebUI operator facade
 //!
@@ -50,6 +54,7 @@ use clap::{Args, Subcommand};
 use crate::context::RebornCliContext;
 use crate::serve_invocation::serve_invocation;
 
+mod container;
 mod launchd;
 mod systemd;
 
@@ -112,9 +117,16 @@ impl ServiceCommand {
 
 // ── Platform dispatch ───────────────────────────────────────────
 
-/// The two supported service-management targets. Detected once per
+/// The supported service-management targets. Detected once per
 /// invocation via [`ServicePlatform::detect`]; every verb dispatches
 /// off the resolved variant instead of re-checking `cfg!(target_os)`.
+///
+/// `Container` is Linux without systemd as the running init: hosted
+/// deployments where the image entrypoint `exec`s `ironclaw serve` as the
+/// container's main process and the container runtime's restart policy is
+/// the supervisor (see the `container` module doc). Before this variant,
+/// such hosts resolved to `Linux` and every verb died spawning the
+/// nonexistent `systemctl`.
 ///
 /// pub(super): `commands::status` queries [`Self::current_state`] to check
 /// whether the installed service is actually running, not just present.
@@ -122,16 +134,33 @@ impl ServiceCommand {
 pub(super) enum ServicePlatform {
     MacOs,
     Linux,
+    Container,
 }
+
+/// Production procfs root for [`ServicePlatform::Container`] dispatch.
+/// `container`'s functions take it as a parameter so tests can point them at
+/// a fake proc tree (see `container::tests`).
+const PROC_ROOT: &str = "/proc";
 
 impl ServicePlatform {
     pub(super) fn detect() -> Result<Self> {
         if cfg!(target_os = "macos") {
             Ok(Self::MacOs)
         } else if cfg!(target_os = "linux") {
-            Ok(Self::Linux)
+            Ok(Self::linux_platform(systemd_booted()))
         } else {
             bail!(UNSUPPORTED_OS_MESSAGE);
+        }
+    }
+
+    /// The one runtime decision [`Self::detect`] makes: a Linux host manages
+    /// services through systemd only when systemd is actually the running
+    /// init; otherwise this is a container-supervised deployment.
+    fn linux_platform(systemd_booted: bool) -> Self {
+        if systemd_booted {
+            Self::Linux
+        } else {
+            Self::Container
         }
     }
 
@@ -155,6 +184,11 @@ impl ServicePlatform {
         context: &RebornCliContext,
         runner: &mut dyn ServiceCommandRunner,
     ) -> Result<Vec<String>> {
+        // Bail before preflight: warnings about onboarding/config are noise
+        // when there is no service manager to install into at all.
+        if matches!(self, Self::Container) {
+            container::unsupported_in_container("install")?;
+        }
         let warnings = preflight_warnings(context)?;
         for warning in &warnings {
             eprintln!("warning: {warning}");
@@ -167,6 +201,7 @@ impl ServicePlatform {
             Self::Linux => {
                 systemd::install_with_runner(context, &invocation, runner).map(|_replaced| ())?
             }
+            Self::Container => unreachable!("container installs bail before preflight"),
         }
         Ok(warnings)
     }
@@ -183,6 +218,7 @@ impl ServicePlatform {
         match self {
             Self::MacOs => launchd::start_with_runner(runner),
             Self::Linux => systemd::start_with_runner(runner),
+            Self::Container => container::unsupported_in_container("start"),
         }
     }
 
@@ -195,6 +231,7 @@ impl ServicePlatform {
         match self {
             Self::MacOs => launchd::stop_with_runner(runner),
             Self::Linux => systemd::stop_with_runner(runner),
+            Self::Container => container::unsupported_in_container("stop"),
         }
     }
 
@@ -207,6 +244,7 @@ impl ServicePlatform {
         match self {
             Self::MacOs => launchd::restart_with_runner(runner),
             Self::Linux => systemd::restart_with_runner(runner),
+            Self::Container => container::restart_with_runner(runner, Path::new(PROC_ROOT)),
         }
     }
 
@@ -219,6 +257,7 @@ impl ServicePlatform {
         match self {
             Self::MacOs => launchd::status_with_runner(runner),
             Self::Linux => systemd::status_with_runner(runner),
+            Self::Container => container::status(Path::new(PROC_ROOT)),
         }
     }
 
@@ -231,6 +270,7 @@ impl ServicePlatform {
         match self {
             Self::MacOs => launchd::uninstall_with_runner(runner),
             Self::Linux => systemd::uninstall_with_runner(runner),
+            Self::Container => container::unsupported_in_container("uninstall"),
         }
     }
 
@@ -249,8 +289,23 @@ impl ServicePlatform {
         match self {
             Self::MacOs => launchd::current_state_with_runner(runner),
             Self::Linux => systemd::current_state_with_runner(runner),
+            Self::Container => container::current_state(Path::new(PROC_ROOT)),
         }
     }
+}
+
+/// systemd is the running init exactly when `/run/systemd/system` exists —
+/// the documented `sd_booted(3)` check. A Linux host where it is absent
+/// (hosted containers, minimal images) has no systemd to manage services
+/// with, regardless of what unit files are baked into the filesystem.
+fn systemd_booted() -> bool {
+    systemd_booted_under(Path::new("/"))
+}
+
+/// `systemd_booted`'s actual check, parameterized on the filesystem root so
+/// tests can point it at a fake tree instead of the host's real `/run`.
+fn systemd_booted_under(root: &Path) -> bool {
+    root.join("run/systemd/system").is_dir()
 }
 
 /// Install then start the OS service in one call — used by `onboard`'s
@@ -621,13 +676,51 @@ mod tests {
 
     #[test]
     fn detect_returns_a_supported_platform_on_this_test_host() {
-        // This test only runs in CI/dev on macOS or Linux, so detect()
-        // must resolve to one of the two supported variants, never bail.
+        // This test only runs in CI/dev on macOS or Linux (possibly inside a
+        // systemd-less container), so detect() must resolve to one of the
+        // supported variants, never bail.
         let platform = ServicePlatform::detect().expect("detect must resolve on macOS/Linux");
         assert!(matches!(
             platform,
-            ServicePlatform::MacOs | ServicePlatform::Linux
+            ServicePlatform::MacOs | ServicePlatform::Linux | ServicePlatform::Container
         ));
+    }
+
+    #[test]
+    fn linux_without_systemd_resolves_to_container_not_linux() {
+        // Regression: hosted containers (image entrypoint execs `ironclaw
+        // serve`, PID 1 = docker-init, no systemctl binary) used to resolve
+        // to `Linux`, so every service verb died spawning `systemctl`
+        // ("failed to spawn command for systemctl show unit state") and
+        // `restart` reported "Service not installed" — while the setup docs
+        // tell users to finish with `ironclaw service restart`.
+        assert_eq!(
+            ServicePlatform::linux_platform(false),
+            ServicePlatform::Container
+        );
+        assert_eq!(
+            ServicePlatform::linux_platform(true),
+            ServicePlatform::Linux
+        );
+    }
+
+    #[test]
+    fn systemd_booted_under_reads_run_systemd_system_from_the_given_root() {
+        // The detection `linux_without_systemd_resolves_to_container_not_linux`
+        // exercises only the pre-computed bool; this proves the actual
+        // filesystem check that feeds it (the real bug-fix logic) reads the
+        // right path and both directions.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            !systemd_booted_under(tmp.path()),
+            "no run/systemd/system dir must read as not booted"
+        );
+        std::fs::create_dir_all(tmp.path().join("run/systemd/system"))
+            .expect("create run/systemd/system");
+        assert!(
+            systemd_booted_under(tmp.path()),
+            "run/systemd/system dir must read as booted"
+        );
     }
 
     #[test]
@@ -764,6 +857,37 @@ mod tests {
                 "{verb_name} must reach the injected runner, not bail out before calling it"
             );
         }
+    }
+
+    #[test]
+    fn container_platform_dispatches_service_manager_verbs_into_container_module() {
+        // Covers the install/start/stop/uninstall match arms only — these
+        // reject unconditionally with no I/O, so they're safe to drive
+        // directly against `ServicePlatform::Container` here. Proves wiring
+        // only: `container::unsupported_verbs_share_one_actionable_message`
+        // already pins the message content; this just proves each arm
+        // actually reaches `container::` instead of falling through to
+        // launchd/systemd, and that the runner is never touched.
+        //
+        // NOT covered here: the restart/status/current_state match arms,
+        // which route through the hardcoded `PROC_ROOT = "/proc"` constant
+        // and so aren't independently fakeable at this dispatch layer
+        // without threading a proc root through `ServicePlatform` itself.
+        // Their underlying logic is fully covered directly against a fake
+        // proc tree in `container::tests`; only the one-line match arms
+        // that route to it are unverified here.
+        let (_tmp, context) = RebornCliContext::test_context();
+        let platform = ServicePlatform::Container;
+        let mut runner = SuccessfulServiceCommandRunner::default();
+        for result in [
+            platform.install_with_runner(&context, &mut runner).err(),
+            platform.start_with_runner(&mut runner).err(),
+            platform.stop_with_runner(&mut runner).err(),
+            platform.uninstall_with_runner(&mut runner).err(),
+        ] {
+            assert!(result.is_some_and(|e| e.to_string().contains("container runtime")));
+        }
+        assert!(runner.labels.is_empty(), "must never reach the runner");
     }
 
     #[cfg(unix)]

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -14,6 +14,20 @@ railway_runtime_detected() {
     || [ -n "${RAILWAY_SERVICE_ID:-}" ]
 }
 
+# `ironclaw service restart` (see crates/ironclaw_reborn_cli's service/mod.rs
+# `ServicePlatform::Container`) signals the running `serve` process and
+# trusts an external restart policy to relaunch it — that's only safe when
+# one actually exists, which no signal observable from inside the container
+# can prove (not even being a container at all: a bare `docker run --rm`
+# with no `--restart` is a real container with nothing to relaunch `serve`).
+# So it's an explicit opt-in, not auto-detected. Declare it here for
+# Railway, which manages its own restart policy by default, so operators on
+# that platform don't have to configure it themselves; an operator who has
+# already set the var (in either direction) is left untouched.
+if railway_runtime_detected && [ -z "${IRONCLAW_REBORN_CONTAINER_SUPERVISED:-}" ]; then
+  export IRONCLAW_REBORN_CONTAINER_SUPERVISED=true
+fi
+
 railway_volume_mount=""
 if [ -n "${RAILWAY_VOLUME_MOUNT_PATH:-}" ]; then
   railway_volume_mount="${RAILWAY_VOLUME_MOUNT_PATH%/}"

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -14,20 +14,6 @@ railway_runtime_detected() {
     || [ -n "${RAILWAY_SERVICE_ID:-}" ]
 }
 
-# `ironclaw service restart` (see crates/ironclaw_reborn_cli's service/mod.rs
-# `ServicePlatform::Container`) signals the running `serve` process and
-# trusts an external restart policy to relaunch it — that's only safe when
-# one actually exists, which no signal observable from inside the container
-# can prove (not even being a container at all: a bare `docker run --rm`
-# with no `--restart` is a real container with nothing to relaunch `serve`).
-# So it's an explicit opt-in, not auto-detected. Declare it here for
-# Railway, which manages its own restart policy by default, so operators on
-# that platform don't have to configure it themselves; an operator who has
-# already set the var (in either direction) is left untouched.
-if railway_runtime_detected && [ -z "${IRONCLAW_REBORN_CONTAINER_SUPERVISED:-}" ]; then
-  export IRONCLAW_REBORN_CONTAINER_SUPERVISED=true
-fi
-
 railway_volume_mount=""
 if [ -n "${RAILWAY_VOLUME_MOUNT_PATH:-}" ]; then
   railway_volume_mount="${RAILWAY_VOLUME_MOUNT_PATH%/}"

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -44,6 +44,20 @@ The bundled Docker config selects NearAI in `[llm.default]`; set
 `NEARAI_API_KEY` for that provider. To change provider or model, mount a custom
 config and point `IRONCLAW_REBORN_DEFAULT_CONFIG` at it for the first start.
 
+## Managed Container Deployments
+
+For a container host that restarts the container when its main process exits,
+set this variable in the deployment configuration (not the shared image):
+
+```bash
+IRONCLAW_CONTAINER_SUPERVISE=true
+```
+
+This enables `ironclaw service status` and `ironclaw service restart` inside
+the container. `restart` terminates `ironclaw serve`; the external restart
+policy must recreate the container. Do not set it for an ad-hoc
+`docker run --rm` session; manage that container from Docker instead.
+
 Google product-auth setup:
 
 ```bash
@@ -87,6 +101,7 @@ Minimum Railway variables for the hosted single-tenant Postgres profile:
 
 ```bash
 IRONCLAW_REBORN_PROFILE=hosted-single-tenant
+IRONCLAW_CONTAINER_SUPERVISE=true
 IRONCLAW_REBORN_POSTGRES_URL=<postgres-url>
 IRONCLAW_REBORN_SECRET_MASTER_KEY=<random-secret-master-key>
 IRONCLAW_REBORN_WEBUI_TOKEN=<random-hex-32-bytes-or-longer>
@@ -98,6 +113,7 @@ Minimum Railway variables for the hosted single-tenant volume profile:
 
 ```bash
 IRONCLAW_REBORN_PROFILE=hosted-single-tenant-volume
+IRONCLAW_CONTAINER_SUPERVISE=true
 IRONCLAW_REBORN_WEBUI_TOKEN=<random-hex-32-bytes-or-longer>
 IRONCLAW_REBORN_WEBUI_USER_ID=reborn-cli
 NEARAI_API_KEY=<nearai-api-key>


### PR DESCRIPTION
Relates to #6534 (partial fix: addresses the container-appropriate restart/apply path and the raw-`os error 2`-instead-of-clear-message UX from that issue's "Secondary cleanup" and part of "Core problem 1"; does not cover the WebUI config path, the saved-but-unread config-consumption question, or layer (B) account connection — those remain open in #6534).

## Bug (verified live)

Hosted Docker containers (`sakethare/ironclaw-reborn:1.0.0-rc.5`, binary `1.0.0-rc.1`) run `ironclaw serve` directly as the container's main process — the image entrypoint `exec`s it, so PID 1 is `docker-init` and there is no systemd. Verified on a staging instance:

- `ironclaw service restart` → `Error: Service not installed. Run 'ironclaw service install' first.`
- `ironclaw service status` → `Error: failed to spawn command for systemctl show unit state / No such file or directory (os error 2)`

`ironclaw service` is a systemd/launchd wrapper with no fallback for a systemd-less container, even though `serve` is running and healthy. This blocks any setup flow (e.g. Gmail/Google OAuth) whose final step is `ironclaw service restart`.

## Root cause

`ServicePlatform::detect()` resolved every Linux host to `Self::Linux` unconditionally, so a systemd-less container spawned `systemctl` and failed with a confusing OS error instead of a clear "no service manager here" message.

## Fix

Add `ServicePlatform::Container`, detected via `/run/systemd/system` absence on Linux (the documented `sd_booted(3)` check):

- `restart` scans `/proc` for the running `ironclaw serve` process and sends `SIGTERM` — the container's restart policy relaunching it through the entrypoint is the correct restart primitive for this deployment shape (verified `serve` installs its own `SIGTERM` handler via tokio, so signal delivery is fine even without a full init).
- `status`/`current_state` report from the same scan, reusing the existing `status_label` helper so the running/stopped vocabulary can't drift from launchd/systemd's.
- `install`/`uninstall`/`start`/`stop` fail with one shared, actionable message — there is no service manager to act on.

## Regression tests

- `linux_without_systemd_resolves_to_container_not_linux` — pins the exact bug (Linux-without-systemd must resolve to `Container`, not `Linux`).
- `systemd_booted_under_reads_run_systemd_system_from_the_given_root` — covers the actual filesystem probe feeding that decision.
- `container::tests` — 9 tests covering the `/proc` scan (argv matching, non-numeric/unreadable/empty/argv0-only entries, ordering), `restart`/`status`/`current_state`, and the shared unsupported-verb message.
- `container_platform_dispatches_service_manager_verbs_into_container_module` — proves the `ServicePlatform` dispatch wiring reaches `container::` for install/start/stop/uninstall.

107/107 crate tests pass (103 pre-existing + new coverage), `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt` applied.

## Review

Passed thermo-nuclear-code-quality-review and an 8-agent code-review pass (security, bugs, performance, tests, conventions, local-patterns, maintainability, approach). Findings applied:
- `sh -c "kill -TERM ..."` → direct `Command::new("kill")` (matches launchd.rs/systemd.rs's convention of invoking the target binary directly, no shell).
- `container::status` now reuses `status_label` instead of hand-writing the running/stopped strings.
- Added doc comments matching the sibling launchd/systemd convention; updated the module-level doc to mention the container case.
- Closed a test-coverage gap on the actual `systemd` detection logic (previously only the pure decision function was tested).

**Known, accepted limitation:** two reviewers independently flagged a PID-reuse TOCTOU between the `/proc` scan and the `kill -TERM` call (an in-container process could theoretically be reused between scan and signal). Low severity/confidence — requires an attacker already running code inside the same container, at which point the instance is already compromised. Not fixed in this hotfix; every sibling verb in this file has the same shape (signal by identity resolved earlier in time).

**Deferred to the main forward-port:** full `ServicePlatform`-dispatch-layer test coverage for the `restart`/`status`/`current_state` Container arms would need `PROC_ROOT` to be injectable through public signatures — real churn for a frozen release branch. The underlying logic is fully covered directly in `container::tests` against a fake proc tree; only the one-line match arms that route to it are unverified at the dispatch layer.

## Base branch

Targets `release-fix-1.0.0-rc.1` (frozen `1.0.0-rc.1` release line), not `main` — this line already has a tag (`ironclaw-v1.0.0-rc.1`) and hosted images running from it. Will forward-port to `main` separately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
