### PR TITLE
ci: run full Reborn test/E2E gates on release-fix-* PR branches

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -16,6 +16,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-fix-*"
   # The merge queue is the production gate: the deterministic Reborn contract
   # and smoke coverage must pass on the merged state before it reaches main.
   # merge_group does not support `paths:` filters, so scope is resolved by the

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -16,6 +16,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-fix-*"
   merge_group:
     branches:
       - main


### PR DESCRIPTION
## Problem

PR #6533 (targeting `release-fix-1.0.0-rc.1`) only got Code Style, smoke/lint checks, and regression-test-check — the two heavy gates, **Tests (Reborn)** and **Reborn E2E**, never ran at all:

```
$ gh pr checks 6533
Clippy (all-features)                pass
Code Style (fmt + clippy)            pass
Reborn CLI smoke tests               pass
Regression test enforcement          pass
...
(no "Tests (Reborn)" or "Reborn E2E" entries)
```

## Root cause

Both `reborn-tests.yml` and `reborn-e2e.yml` restrict their `pull_request` trigger to `branches: [main]`. A PR against any other base branch — including a release line's fix branch — silently never triggers them, and CI still goes green because a check that never reports isn't required.

## Fix

Add a `release-fix-*` branch pattern to both workflows' `pull_request.branches`, so PRs against a release branch (this line, and any future one following the same naming convention) get the same test/E2E coverage as PRs against `main`.

`merge_group` and `push` triggers are left untouched — those are the production merge queue and the main-branch rust-cache refresh, both genuinely main-specific.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>