### PR TITLE
feat(reborn): opt-in BENCHMARKING_MODE system-prompt addendum for unattended eval

### DIFF
--- a/crates/ironclaw_reborn_composition/assets/prompts/benchmarking-mode.md
+++ b/crates/ironclaw_reborn_composition/assets/prompts/benchmarking-mode.md
@@ -1,0 +1,5 @@
+## Automated Evaluation Mode
+
+This session is part of an automated evaluation with no human on the other end. There is no one to answer a clarifying question, approve a next step, or make a product decision — the "ask the user" escape valve in Tool Continuation above does not apply here.
+
+Never end a turn with a question, a menu of options, or a description of what you could do next. If you have gathered enough information to attempt the request, produce the actual deliverable it asks for (the file, the answer, the analysis) using your best judgment on any ambiguous details, and state the assumption you made in passing rather than pausing to ask about it.

--- a/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
+++ b/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
@@ -35,6 +35,15 @@ const TOOL_DISCLOSURE_PROTOCOL_EMBEDDED: &str =
 /// protocol uses.
 const SELF_KNOWLEDGE_PROTOCOL_EMBEDDED: &str =
     include_str!("../../assets/prompts/self-knowledge.md");
+/// Appended only when benchmarking mode is active (see
+/// `DefaultSystemPromptIdentitySource::benchmarking_mode_active`). Tells the
+/// model there is no human to ask, overriding the "ask the user...a product
+/// decision" escape valve in the base prompt's Tool Continuation section —
+/// that escape valve is correct for real product usage but causes an agent
+/// running unattended dataset evaluation to stall a turn on a clarifying
+/// question no one will ever answer.
+const BENCHMARKING_MODE_PROTOCOL_EMBEDDED: &str =
+    include_str!("../../assets/prompts/benchmarking-mode.md");
 const MAX_DEFAULT_SYSTEM_PROMPT_BYTES: u64 = 64 * 1024;
 
 #[derive(Debug, thiserror::Error)]
@@ -63,6 +72,11 @@ pub(crate) struct DefaultSystemPromptIdentitySource {
     /// off ⇒ the prompt carries the file plus the unconditional self-knowledge
     /// section, and nothing that references the bridge tools.
     disclosure_protocol_active: bool,
+    /// When true, the benchmarking-mode protocol is appended, telling the
+    /// model no human is available to answer clarifying questions. Set from
+    /// the `BENCHMARKING_MODE` env var at build time (see `runtime.rs`); off
+    /// by default, so normal product usage is unaffected.
+    benchmarking_mode_active: bool,
     loaded_identity_content: Arc<RwLock<HashMap<LoopMessageRef, HostIdentityMessageContent>>>,
 }
 
@@ -71,12 +85,14 @@ impl DefaultSystemPromptIdentitySource {
         storage_root: PathBuf,
         prompt_path: PathBuf,
         disclosure_protocol_active: bool,
+        benchmarking_mode_active: bool,
     ) -> Result<Self, DefaultSystemPromptError> {
         read_default_system_prompt(&storage_root, &prompt_path)?;
         Ok(Self {
             storage_root,
             prompt_path,
             disclosure_protocol_active,
+            benchmarking_mode_active,
             loaded_identity_content: Arc::new(RwLock::new(HashMap::new())),
         })
     }
@@ -89,6 +105,9 @@ impl DefaultSystemPromptIdentitySource {
         append_section(&mut content, SELF_KNOWLEDGE_PROTOCOL_EMBEDDED);
         if self.disclosure_protocol_active {
             append_section(&mut content, TOOL_DISCLOSURE_PROTOCOL_EMBEDDED);
+        }
+        if self.benchmarking_mode_active {
+            append_section(&mut content, BENCHMARKING_MODE_PROTOCOL_EMBEDDED);
         }
         Ok(content)
     }
@@ -350,9 +369,13 @@ mod tests {
         let storage_root = root.path().canonicalize().expect("canonical root");
         let prompt_path = storage_root.join("system/prompts/default-system.md");
         seed_default_system_prompt(&storage_root, &prompt_path).expect("prompt seeds");
-        let source =
-            DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path.clone(), false)
-                .expect("prompt loads");
+        let source = DefaultSystemPromptIdentitySource::try_new(
+            storage_root,
+            prompt_path.clone(),
+            false,
+            false,
+        )
+        .expect("prompt loads");
         let context = test_run_context().await;
 
         let candidates = source
@@ -423,10 +446,12 @@ mod tests {
             storage_root.clone(),
             prompt_path.clone(),
             false,
+            false,
         )
         .expect("off source loads");
-        let on = DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path, true)
-            .expect("on source loads");
+        let on =
+            DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path, true, false)
+                .expect("on source loads");
         let context = test_run_context().await;
 
         async fn resolve_content(
@@ -466,6 +491,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn benchmarking_mode_active_appends_no_human_protocol_to_system_prompt() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let storage_root = root.path().canonicalize().expect("canonical root");
+        let prompt_path = storage_root.join("system/prompts/default-system.md");
+        seed_default_system_prompt(&storage_root, &prompt_path).expect("prompt seeds");
+
+        let off = DefaultSystemPromptIdentitySource::try_new(
+            storage_root.clone(),
+            prompt_path.clone(),
+            false,
+            false,
+        )
+        .expect("off source loads");
+        let on =
+            DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path, false, true)
+                .expect("on source loads");
+        let context = test_run_context().await;
+
+        async fn resolve_content(
+            source: &DefaultSystemPromptIdentitySource,
+            context: &LoopRunContext,
+        ) -> String {
+            let candidates = source
+                .load_identity_candidates(context, PromptMode::TextOnly)
+                .await
+                .expect("candidates load");
+            source
+                .resolve_identity_message_content(
+                    context,
+                    candidates[0]
+                        .message_ref
+                        .as_ref()
+                        .expect("trusted identity has ref"),
+                )
+                .await
+                .expect("resolve content")
+                .expect("content exists")
+                .content
+        }
+
+        let off_content = resolve_content(&off, &context).await;
+        let on_content = resolve_content(&on, &context).await;
+
+        // The base prompt is preserved verbatim, and only the active source
+        // adds the no-human protocol — real product usage (mode off) is
+        // byte-identical to today's prompt.
+        assert!(on_content.starts_with(off_content.trim_end()));
+        assert!(!off_content.contains("Automated Evaluation Mode"));
+        assert!(on_content.contains("Automated Evaluation Mode"));
+        assert!(on_content.contains("no one to answer a clarifying question"));
+    }
+
+    #[tokio::test]
     async fn default_system_prompt_reloads_edited_prompt_for_new_candidates() {
         let root = tempfile::tempdir().expect("tempdir");
         let storage_root = root.path().canonicalize().expect("canonical root");
@@ -474,6 +552,7 @@ mod tests {
         let source = DefaultSystemPromptIdentitySource::try_new(
             storage_root.clone(),
             prompt_path.clone(),
+            false,
             false,
         )
         .expect("prompt loads");

--- a/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
+++ b/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
@@ -449,9 +449,8 @@ mod tests {
             false,
         )
         .expect("off source loads");
-        let on =
-            DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path, true, false)
-                .expect("on source loads");
+        let on = DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path, true, false)
+            .expect("on source loads");
         let context = test_run_context().await;
 
         async fn resolve_content(
@@ -504,9 +503,8 @@ mod tests {
             false,
         )
         .expect("off source loads");
-        let on =
-            DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path, false, true)
-                .expect("on source loads");
+        let on = DefaultSystemPromptIdentitySource::try_new(storage_root, prompt_path, false, true)
+            .expect("on source loads");
         let context = test_run_context().await;
 
         async fn resolve_content(

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -4204,6 +4204,7 @@ pub async fn build_runtime(input: RebornRuntimeInput) -> Result<RebornRuntime, R
                         local_dev_storage_root,
                         default_system_prompt_path,
                         resolved_tool_disclosure.is_bridged(),
+                        bool_env_flag("BENCHMARKING_MODE"),
                     )
                     .map_err(|error| RebornRuntimeError::InvalidArgument {
                         reason: error.to_string(),
@@ -4899,6 +4900,18 @@ struct ComposedSkillContextSource {
 }
 
 const LOCAL_DEV_MAX_SKILL_CONTEXT_TOKENS: usize = 6000;
+
+/// Reads a boolean feature flag from the environment. Absent or unrecognized
+/// values are treated as off — this gates an opt-in prompt addendum for
+/// unattended dataset evaluation (see `default_system_prompt.rs`), not a
+/// required config value, so we default closed rather than erroring on a
+/// typo'd value.
+fn bool_env_flag(key: &'static str) -> bool {
+    match std::env::var(key) {
+        Ok(value) => matches!(value.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes"),
+        Err(_) => false,
+    }
+}
 
 fn optional_nonzero_u32_env(
     key: &'static str,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -4908,7 +4908,10 @@ const LOCAL_DEV_MAX_SKILL_CONTEXT_TOKENS: usize = 6000;
 /// typo'd value.
 fn bool_env_flag(key: &'static str) -> bool {
     match std::env::var(key) {
-        Ok(value) => matches!(value.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes"),
+        Ok(value) => matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "true" | "1" | "yes"
+        ),
         Err(_) => false,
     }
 }


### PR DESCRIPTION
## Summary
- The default system prompt's **Tool Continuation** section already says: *"Ask the user only when progress requires external information, approval, or a product decision."* That's correct guidance for real product usage, but it gives the model an escape valve to stall a turn asking a clarifying question in automated/unattended evaluation contexts, where no human is ever coming back to answer.
- Observed concretely in a downstream benchmark harness (nearai/benchmarks, PinchBench suite): on long-document tasks (large meeting transcripts, ~500K-2M cumulative tokens across several tool calls), the agent read the file correctly, then ended its turn with *"I've finished reading through the transcript... What would you like me to do with this?"* instead of delivering the requested analysis. Same pattern recurred across several structurally similar tasks.
- Adds an opt-in system-prompt addendum, appended only when the `BENCHMARKING_MODE` env var is set truthy (`true`/`1`/`yes`, case-insensitive), telling the model explicitly that the "ask" escape valve does not apply in this session and it should complete the deliverable using its best judgment on ambiguous details rather than pause to ask.
- **Off by default** — real product usage is byte-identical to today's prompt. Mirrors the existing `disclosure_protocol_active` pattern used for the tool-disclosure-protocol addendum (`default_system_prompt.rs`), including a matching unit test.

## Why not just rely on the existing Tool Continuation guidance?
That guidance already exists and is close, but it explicitly carves out "a product decision" as a valid reason to ask — which a model can (and did) interpret loosely enough to justify asking "what should I do with this transcript" on a well-specified, single-turn task. `BENCHMARKING_MODE` removes that carve-out entirely for sessions that opt in, rather than weakening it for everyone.

## How this was validated
- New unit test `benchmarking_mode_active_appends_no_human_protocol_to_system_prompt` (mirrors `disclosure_active_appends_tool_search_protocol_to_system_prompt`): confirms the addendum is appended only when the flag is on, and the flag-off prompt is byte-identical to today's.
- The underlying instruction was previously A/B tested as a benchmark-adapter-level prompt addition (before being relocated here) against the exact tasks that showed this stalling pattern: `task_financial_ratio_calculation` (0.00→1.00), `task_csv_finance_report` (0.17→1.00), `task_email_search` (0.08→1.00), plus partial improvement on several others. A live end-to-end rerun through this specific commit wasn't performed for this PR, since the downstream harness's ironclaw pin doesn't yet track this recent a `main` (unrelated pin-lag issue on that side, not a limitation of this change).

## Test plan
- [x] `cargo test -p ironclaw_reborn_composition --lib default_system_prompt` — 8/8 pass
- [x] `cargo test -p ironclaw_reborn_composition --lib runtime::default_system_prompt_tests` — 3/3 pass
- [x] `cargo check -p ironclaw_reborn_composition` — clean
- [ ] Live end-to-end verification once a downstream harness picks up this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
