### PR TITLE
Mask ambient NEARAI env in tests

### DIFF
--- a/crates/ironclaw_common/src/env_helpers.rs
+++ b/crates/ironclaw_common/src/env_helpers.rs
@@ -22,10 +22,24 @@ pub fn lock_env() -> std::sync::MutexGuard<'static, ()> {
     ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner())
 }
 
-static RUNTIME_ENV_OVERRIDES: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RuntimeEnvOverride {
+    Value(String),
+    Mask,
+}
 
-fn runtime_overrides() -> &'static Mutex<HashMap<String, String>> {
+static RUNTIME_ENV_OVERRIDES: OnceLock<Mutex<HashMap<String, RuntimeEnvOverride>>> =
+    OnceLock::new();
+
+fn runtime_overrides() -> &'static Mutex<HashMap<String, RuntimeEnvOverride>> {
     RUNTIME_ENV_OVERRIDES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Exact saved runtime-overlay state for one env var.
+#[derive(Clone, Debug)]
+pub struct RuntimeEnvSnapshot {
+    key: String,
+    value: Option<RuntimeEnvOverride>,
 }
 
 /// Optional secondary env lookup registered by the main crate at startup.
@@ -52,7 +66,22 @@ pub fn set_runtime_env(key: &str, value: &str) {
     runtime_overrides()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .insert(key.to_string(), value.to_string());
+        .insert(
+            key.to_string(),
+            RuntimeEnvOverride::Value(value.to_string()),
+        );
+}
+
+/// Mask an env var for callers of [`env_or_override`].
+///
+/// This is primarily useful for tests that need hermetic "env var absent"
+/// behavior even when a developer shell exports the variable. Call
+/// [`remove_runtime_env`] to clear the mask.
+pub fn mask_runtime_env(key: &str) {
+    runtime_overrides()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(key.to_string(), RuntimeEnvOverride::Mask);
 }
 
 /// Remove a runtime env override.
@@ -63,24 +92,62 @@ pub fn remove_runtime_env(key: &str) {
         .remove(key);
 }
 
-/// Read an env var, checking real env first, then runtime overrides, then any
-/// secondary fallback registered by the embedding application.
+/// Capture the current runtime overlay or mask for one env var.
+///
+/// This does not capture the real process environment. It is intended for
+/// tests that temporarily set or mask a runtime env override and then need to
+/// restore the exact prior overlay state.
+pub fn snapshot_runtime_env(key: &str) -> RuntimeEnvSnapshot {
+    let value = runtime_overrides()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(key)
+        .cloned();
+    RuntimeEnvSnapshot {
+        key: key.to_string(),
+        value,
+    }
+}
+
+/// Restore an exact runtime overlay or mask captured by [`snapshot_runtime_env`].
+pub fn restore_runtime_env(snapshot: RuntimeEnvSnapshot) {
+    let mut overrides = runtime_overrides()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    match snapshot.value {
+        Some(value) => {
+            overrides.insert(snapshot.key, value);
+        }
+        None => {
+            overrides.remove(&snapshot.key);
+        }
+    }
+}
+
+/// Read an env var, honoring a runtime mask first, then checking real env,
+/// runtime overrides, and any secondary fallback registered by the embedding
+/// application.
 ///
 /// Empty values are treated as unset at every layer.
 pub fn env_or_override(key: &str) -> Option<String> {
+    let runtime_value = {
+        let overrides = runtime_overrides()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        match overrides.get(key) {
+            Some(RuntimeEnvOverride::Mask) => return None,
+            Some(RuntimeEnvOverride::Value(value)) if !value.is_empty() => Some(value.clone()),
+            _ => None,
+        }
+    };
+
     if let Ok(val) = std::env::var(key)
         && !val.is_empty()
     {
         return Some(val);
     }
 
-    if let Some(val) = runtime_overrides()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .get(key)
-        .filter(|v| !v.is_empty())
-        .cloned()
-    {
+    if let Some(val) = runtime_value {
         return Some(val);
     }
 
@@ -120,5 +187,29 @@ mod tests {
         set_runtime_env("IRONCLAW_TEST_REMOVE", "1");
         remove_runtime_env("IRONCLAW_TEST_REMOVE");
         assert_eq!(env_or_override("IRONCLAW_TEST_REMOVE"), None);
+    }
+
+    #[test]
+    fn runtime_mask_hides_real_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_RUNTIME_MASK";
+        let original = std::env::var_os(key);
+        remove_runtime_env(key);
+        unsafe {
+            std::env::set_var(key, "real-env-value");
+        }
+
+        assert_eq!(env_or_override(key), Some("real-env-value".to_string()));
+
+        mask_runtime_env(key);
+        assert_eq!(env_or_override(key), None);
+
+        remove_runtime_env(key);
+        unsafe {
+            match original {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/llm_config_service.rs
@@ -1427,26 +1427,30 @@ mod tests {
             .expect("nearai provider in snapshot")
     }
 
-    /// Clear the runtime-overlay NEARAI_* entries so overlay state from other
-    /// tests cannot leak into snapshot assertions. A real `NEARAI_API_KEY`
-    /// exported by the developer shell is deliberately tolerated: the
-    /// snapshot assertions below only depend on the base URL, and this
-    /// `#![forbid(unsafe_code)]` crate cannot remove real process env vars.
-    /// `NEARAI_BASE_URL` would change the asserted base URL, so its absence
-    /// from the real env is still checked loudly.
-    fn clear_nearai_snapshot_env() {
-        for key in ["NEARAI_API_KEY", "NEARAI_BASE_URL"] {
-            ironclaw_common::env_helpers::remove_runtime_env(key);
+    struct NearAiSnapshotEnvGuard {
+        snapshots: Vec<ironclaw_common::env_helpers::RuntimeEnvSnapshot>,
+    }
+
+    impl Drop for NearAiSnapshotEnvGuard {
+        fn drop(&mut self) {
+            for snapshot in self.snapshots.drain(..).rev() {
+                ironclaw_common::env_helpers::restore_runtime_env(snapshot);
+            }
         }
-        // An EMPTY value is semantically unset to `env_or_override`, so only a
-        // non-empty real value can change the asserted base URL — treat empty
-        // as absent to keep the precondition environment-independent.
-        assert!(
-            std::env::var_os("NEARAI_BASE_URL")
-                .map(|value| value.is_empty())
-                .unwrap_or(true),
-            "NEARAI_BASE_URL must be unset (or empty) in the real environment for this snapshot test"
-        );
+    }
+
+    /// Mask NEARAI_* entries so developer shell env cannot leak into snapshot
+    /// assertions. The guard restores the exact prior runtime overlay state.
+    fn clear_nearai_snapshot_env() -> NearAiSnapshotEnvGuard {
+        let keys = ["NEARAI_API_KEY", "NEARAI_BASE_URL"];
+        let snapshots = keys
+            .iter()
+            .map(|key| ironclaw_common::env_helpers::snapshot_runtime_env(key))
+            .collect::<Vec<_>>();
+        for key in keys {
+            ironclaw_common::env_helpers::mask_runtime_env(key);
+        }
+        NearAiSnapshotEnvGuard { snapshots }
     }
 
     /// nearai has exactly one default now — cloud — regardless of whether an
@@ -2159,7 +2163,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     async fn nearai_snapshot_exposes_effective_default_base_url() {
         let _env_lock = ironclaw_common::env_helpers::lock_env();
-        clear_nearai_snapshot_env();
+        let _snapshot_env = clear_nearai_snapshot_env();
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         let boot = boot_for_home(&reborn_home);
@@ -2183,7 +2187,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     async fn nearai_snapshot_uses_cloud_default_with_stored_api_key() {
         let _env_lock = ironclaw_common::env_helpers::lock_env();
-        clear_nearai_snapshot_env();
+        let _snapshot_env = clear_nearai_snapshot_env();
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         let boot = boot_for_home(&reborn_home);

--- a/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_admin/nearai_mcp.rs
@@ -95,12 +95,8 @@ pub fn nearai_mcp_bootstrap_config_from_env()
 }
 
 /// Env-shape parsing behind [`nearai_mcp_bootstrap_config_from_env`], with the
-/// variable lookup injected so tests stay hermetic. `env_or_override` consults
-/// the real process environment before the runtime overlay, so a developer
-/// shell exporting a real `NEARAI_API_KEY` cannot be masked by overlay
-/// mutation, and this `#![forbid(unsafe_code)]` crate cannot call
-/// `std::env::remove_var`. Tests therefore drive this function with an
-/// in-memory lookup instead of mutating process state.
+/// variable lookup injected so tests stay hermetic without mutating process
+/// state.
 fn nearai_mcp_bootstrap_config_from_lookup(
     lookup: impl Fn(&str) -> Option<String>,
 ) -> Result<Option<NearAiMcpBootstrapConfig>, NearAiMcpBootstrapConfigError> {
@@ -470,8 +466,7 @@ mod tests {
 
     /// Hermetic stand-in for the env lookup injected into
     /// [`nearai_mcp_bootstrap_config_from_lookup`]: tests must not depend on
-    /// (or mutate) the process environment, where a developer shell may
-    /// legitimately export a real `NEARAI_API_KEY`.
+    /// or mutate the process environment.
     fn lookup_from<'a>(entries: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
         move |key| {
             entries

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -1225,13 +1225,19 @@ fn model_capability_error(error: impl std::fmt::Display) -> HostManagedModelErro
 
 static RUNTIME_ENV_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+struct RuntimeEnvGuardEntry {
+    name: &'static str,
+    effective: Option<String>,
+    snapshot: ironclaw_common::env_helpers::RuntimeEnvSnapshot,
+}
+
 struct RuntimeEnvGuard {
     // Serializes tokio tests that mutate the runtime env overlay. The
     // set/remove helpers lock only the separate override map, not
     // ENV_MUTEX, so restoration can safely run while this guard is held.
     _async_lock: tokio::sync::MutexGuard<'static, ()>,
     _env_lock: std::sync::MutexGuard<'static, ()>,
-    previous: Vec<(&'static str, Option<String>)>,
+    previous: Vec<RuntimeEnvGuardEntry>,
 }
 
 impl RuntimeEnvGuard {
@@ -1244,12 +1250,16 @@ impl RuntimeEnvGuard {
         let env_lock = ironclaw_common::env_helpers::lock_env();
         let previous = vars
             .iter()
-            .map(|(name, _)| (*name, ironclaw_common::env_helpers::env_or_override(name)))
+            .map(|(name, _)| RuntimeEnvGuardEntry {
+                name,
+                effective: ironclaw_common::env_helpers::env_or_override(name),
+                snapshot: ironclaw_common::env_helpers::snapshot_runtime_env(name),
+            })
             .collect::<Vec<_>>();
         for (name, value) in vars {
             match value {
                 Some(value) => ironclaw_common::env_helpers::set_runtime_env(name, value),
-                None => ironclaw_common::env_helpers::remove_runtime_env(name),
+                None => ironclaw_common::env_helpers::mask_runtime_env(name),
             }
         }
         Self {
@@ -1262,16 +1272,14 @@ impl RuntimeEnvGuard {
 
 impl Drop for RuntimeEnvGuard {
     fn drop(&mut self) {
-        for (name, previous) in self.previous.iter().rev() {
-            match previous {
-                Some(value) => ironclaw_common::env_helpers::set_runtime_env(name, value),
-                None => ironclaw_common::env_helpers::remove_runtime_env(name),
-            }
+        for previous in self.previous.iter().rev() {
+            ironclaw_common::env_helpers::restore_runtime_env(previous.snapshot.clone());
             if !std::thread::panicking() {
                 debug_assert_eq!(
-                    ironclaw_common::env_helpers::env_or_override(name),
-                    previous.clone(),
-                    "RuntimeEnvGuard failed to restore {name}"
+                    ironclaw_common::env_helpers::env_or_override(previous.name),
+                    previous.effective.clone(),
+                    "RuntimeEnvGuard failed to restore {}",
+                    previous.name
                 );
             }
         }
@@ -1963,8 +1971,12 @@ async fn runtime_nearai_mcp_bootstraps_from_nearai_session_token() {
 
 #[tokio::test]
 async fn runtime_nearai_mcp_bootstraps_from_stored_nearai_api_key() {
-    let _env_guard =
-        RuntimeEnvGuard::with([("NEARAI_SESSION_TOKEN", None), ("NEARAI_API_KEY", None)]).await;
+    let _env_guard = RuntimeEnvGuard::with([
+        ("NEARAI_SESSION_TOKEN", None),
+        ("NEARAI_API_KEY", None),
+        ("NEARAI_BASE_URL", None),
+    ])
+    .await;
     let root = tempfile::tempdir().expect("tempdir");
     let local_dev_root = root.path().join("local-dev");
     let session_dir = tempfile::tempdir().expect("session tempdir");
@@ -2114,8 +2126,12 @@ async fn nearai_mcp_runtime_access_secret(
 
 #[tokio::test]
 async fn runtime_nearai_mcp_prebuild_api_key_is_not_replaced_by_stored_key() {
-    let _env_guard =
-        RuntimeEnvGuard::with([("NEARAI_SESSION_TOKEN", None), ("NEARAI_API_KEY", None)]).await;
+    let _env_guard = RuntimeEnvGuard::with([
+        ("NEARAI_SESSION_TOKEN", None),
+        ("NEARAI_API_KEY", None),
+        ("NEARAI_BASE_URL", None),
+    ])
+    .await;
     let root = tempfile::tempdir().expect("tempdir");
     let local_dev_root = root.path().join("local-dev");
     let session_dir = tempfile::tempdir().expect("session tempdir");
@@ -2604,8 +2620,12 @@ async fn local_dev_runtime_startup_uses_stored_nearai_api_key_after_restart() {
     // by `RebornLlmReloadAdapter::reload`) sets exactly that field from the
     // seeded key below. So the session/auth-url defaults are constructed but
     // never read from disk or contacted over the network.
-    let _env_guard =
-        RuntimeEnvGuard::with([("NEARAI_SESSION_TOKEN", None), ("NEARAI_API_KEY", None)]).await;
+    let _env_guard = RuntimeEnvGuard::with([
+        ("NEARAI_SESSION_TOKEN", None),
+        ("NEARAI_API_KEY", None),
+        ("NEARAI_BASE_URL", None),
+    ])
+    .await;
     let (base_url, auth_rx) = start_nearai_auth_capture_server().await;
 
     let root = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- Add a runtime env mask to `ironclaw_common::env_helpers` so tests can make `env_or_override` behave as if an ambient variable is absent.
- Update NearAI snapshot/runtime test guards to mask `NEARAI_API_KEY`, `NEARAI_SESSION_TOKEN`, and relevant `NEARAI_BASE_URL` entries instead of relying on developer shell state.
- Remove stale comments that described ambient `NEARAI_API_KEY` masking as impossible.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `NEARAI_API_KEY=ambient-test cargo test -p ironclaw_common env_helpers -- --nocapture`; `NEARAI_API_KEY=ambient-test NEARAI_BASE_URL=https://private.near.ai cargo test -p ironclaw_reborn_composition nearai_snapshot -- --nocapture`; `NEARAI_API_KEY=ambient-test NEARAI_BASE_URL=https://private.near.ai cargo test -p ironclaw_reborn_composition runtime_nearai_mcp -- --nocapture`; `cargo clippy -p ironclaw_common --all-targets --all-features -- -D warnings`; `git diff --check`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable: covered by targeted env-isolation tests with ambient NearAI env set.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior:

Developers can keep `NEARAI_API_KEY` and `NEARAI_BASE_URL` exported locally without NearAI snapshot/runtime tests inheriting that ambient configuration.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: added `runtime_mask_hides_real_env` in `ironclaw_common::env_helpers`.
- Reborn integration: updated NearAI snapshot/runtime test guards to mask ambient env.
- Recorded fixture: Not applicable: no model request-shape or replay fixture behavior changed.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: `runtime_nearai_mcp` filter under fake ambient NearAI env.
- Live canary: Not applicable: this is test isolation and does not require live provider calls.

What the tests prove:

`env_or_override` can be explicitly masked even when a real process env var exists, and the NearAI composition tests that require hermetic env assumptions pass with ambient `NEARAI_API_KEY` and `NEARAI_BASE_URL` set.

Commands run:

- `cargo fmt --check`
- `NEARAI_API_KEY=ambient-test cargo test -p ironclaw_common env_helpers -- --nocapture`
- `NEARAI_API_KEY=ambient-test NEARAI_BASE_URL=https://private.near.ai cargo test -p ironclaw_reborn_composition nearai_snapshot -- --nocapture`
- `NEARAI_API_KEY=ambient-test NEARAI_BASE_URL=https://private.near.ai cargo test -p ironclaw_reborn_composition runtime_nearai_mcp -- --nocapture`
- `cargo clippy -p ironclaw_common --all-targets --all-features -- -D warnings`
- `git diff --check`

## Security Impact

None. This adds an explicit in-process env mask for callers already using the runtime env overlay; it does not expose secrets, change credential lookup from external input, or alter network behavior.

## Reborn Trust-Boundary Checklist

N/A: test isolation/runtime-env helper change; no public trust-bearing types, prompt ingress, status variants, durable serde fields, queues, or sandbox/native boundary names changed.

## Database Impact

None.

## Blast Radius

Touches shared env helper lookup semantics and NearAI-related composition tests. The main risk is a caller unexpectedly using `mask_runtime_env` in production, but existing callers are unchanged unless they opt into the new function.

## Rollback Plan

Revert the commit to restore previous runtime env overlay behavior and the previous NearAI test preconditions.

## Review Follow-Through

No known follow-up. Review should focus on whether `mask_runtime_env` belongs in the shared helper API or should be narrowed behind a test-only seam.

---

**Review track**: B (bug fix / cross-component test isolation)