### PR TITLE
fix(telegram): enable Telegram channel host by default

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/serve_telegram.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_telegram.rs
@@ -30,7 +30,7 @@ fn telegram_enabled(
         Ok(value) => {
             crate::commands::parse_channel_enabled_bool(TELEGRAM_ENABLED_ENV, value.as_str())
         }
-        Err(std::env::VarError::NotPresent) => Ok(section.and_then(|s| s.enabled).unwrap_or(false)),
+        Err(std::env::VarError::NotPresent) => Ok(section.and_then(|s| s.enabled).unwrap_or(true)),
         Err(std::env::VarError::NotUnicode(_)) => {
             anyhow::bail!("{TELEGRAM_ENABLED_ENV} must be valid UTF-8 when set")
         }
@@ -87,7 +87,7 @@ mod tests {
     }
 
     #[test]
-    fn telegram_host_config_is_absent_without_section() {
+    fn telegram_host_config_is_present_without_section_default_enabled() {
         let resolved = resolve_telegram_config_for_serve(
             None,
             &tenant_id("tenant"),
@@ -97,6 +97,26 @@ mod tests {
             None,
         )
         .expect("Telegram config resolves without section");
+
+        assert!(
+            resolved.is_some(),
+            "Telegram must be enabled by default when no [telegram] section is configured"
+        );
+    }
+
+    #[test]
+    fn telegram_host_config_is_absent_when_explicitly_disabled() {
+        let section = ironclaw_reborn_config::TelegramSection::default().set_enabled(false);
+
+        let resolved = resolve_telegram_config_for_serve(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            None,
+        )
+        .expect("Telegram config resolves with explicit disable");
 
         assert!(resolved.is_none());
     }

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -446,17 +446,19 @@ pub struct SlackChannelRouteSection {
 
 /// Telegram channel host enablement.
 ///
-/// `enabled = true` or `IRONCLAW_REBORN_TELEGRAM_ENABLED=true` mounts the
-/// Telegram updates route and the WebUI setup/pairing surface. The env var
+/// Enabled by default — an absent `[telegram]` section, or one that omits
+/// `enabled`, still mounts the Telegram updates route and the WebUI
+/// setup/pairing surface. Set `enabled = false` (or
+/// `IRONCLAW_REBORN_TELEGRAM_ENABLED=false`) to opt out. The env var
 /// overrides only this enablement gate. The bot token, webhook registration,
 /// and pairing are configured at runtime through the WebUI channel setup
 /// surface; no Telegram identifiers or secrets live in this file.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TelegramSection {
-    /// Explicit enablement gate. Omitted/false means the Telegram routes are
-    /// not mounted by `ironclaw-reborn serve` unless
-    /// `IRONCLAW_REBORN_TELEGRAM_ENABLED` overrides it.
+    /// Enablement gate. Omitted/true means the Telegram routes are mounted
+    /// by `ironclaw serve` by default; set explicitly to `false` (or
+    /// override via `IRONCLAW_REBORN_TELEGRAM_ENABLED`) to disable.
     pub enabled: Option<bool>,
 }
 

--- a/docs/reborn/contracts/telegram-v2.md
+++ b/docs/reborn/contracts/telegram-v2.md
@@ -1,8 +1,9 @@
 # Telegram Channel (Reborn host)
 
-**Status:** Shipped host wiring, compiled into every build. The CLI requires
-runtime Telegram enablement — `[telegram].enabled = true` /
-`IRONCLAW_REBORN_TELEGRAM_ENABLED=true` — before the routes are mounted.
+**Status:** Shipped host wiring, compiled into every build. Telegram is
+enabled by default — `ironclaw serve` mounts the routes unless an operator
+opts out with `[telegram].enabled = false` /
+`IRONCLAW_REBORN_TELEGRAM_ENABLED=false`.
 Supersedes the issue #3285 webhook-only
 tracer bullet this document previously described (see "What changed from the
 tracer-bullet contract" below).


### PR DESCRIPTION
Closes #6522.

## Bug (verified live)

`ironclaw serve` never mounted the Telegram webhook/setup/pairing routes unless an operator explicitly opted in via `[telegram].enabled = true` or `IRONCLAW_REBORN_TELEGRAM_ENABLED=true`. The account-setup descriptor for the `telegram` extension is always declared at composition time, so a deployment that never touched `[telegram]` presented Telegram as installable, but any attempt to use it (`extension_activate`) failed closed with a non-actionable "the account setup host for extension telegram is not enabled on this deployment" — no instructions, no path forward. #6522's own root-cause comment traced this to `telegram_enabled()` defaulting `unwrap_or(false)`.

## Fix

Flip the default so Telegram is enabled unless explicitly turned off — the same posture Google/Gmail already has (no equivalent gate):

- `crates/ironclaw_reborn_cli/src/commands/serve_telegram.rs::telegram_enabled()` — `unwrap_or(false)` → `unwrap_or(true)` for the "no env var, no explicit `section.enabled`" case. Explicit `enabled = false` and the `IRONCLAW_REBORN_TELEGRAM_ENABLED` env var override both still work unchanged in both directions.
- Doc-comment updates on `TelegramSection`/`TelegramSection::enabled` (`crates/ironclaw_reborn_config/src/config_file.rs`) and the contract doc's status line (`docs/reborn/contracts/telegram-v2.md`) to describe the new default.

## Regression tests

`crates/ironclaw_reborn_cli/src/commands/serve_telegram.rs`:
- `telegram_host_config_is_present_without_section_default_enabled` — pins the fix: no `[telegram]` section, no env var → host config resolves `Some` (previously `None`). Red on the pre-fix code, green after.
- `telegram_host_config_is_absent_when_explicitly_disabled` — explicit `enabled = false` still resolves `None`, so opt-out keeps working.

4/4 tests in the module pass; 443/443 crate tests for the `ironclaw` binary pass; `cargo fmt` clean; `cargo clippy -p ironclaw -p ironclaw_reborn_config --all-targets --all-features -- -D warnings` clean.

## Review

Passed thermo-nuclear-code-quality-review (SHIP, no structural blockers; confirmed the resolver — not a custom `TelegramSection::default()` impl — is the correct layer, since the primary case is `section: None` itself, which a `Default` impl can't reach) and an 8-agent code-review pass. One real finding from that pass was fixed: a doc comment I wrote said `ironclaw-reborn serve` instead of the actual binary name `ironclaw serve` — corrected.

**Known, accepted scope limits** (mirrors the pattern in #6533 for this same frozen release line):
- **Coverage tier:** this CLI-level enablement gate is unit-tested at crate tier only, matching the sibling Slack gate (`resolve_slack_config_for_serve`/`serve_slack.rs`), which has the same shape and the same crate-tier-only coverage — no integration test drives either channel's CLI config-resolution through a live `ironclaw serve` process. The route-mounting behavior itself (once a `TelegramHostRuntimeConfig` exists) is already covered by `tests/integration/telegram_journeys/*`.
- **Env-var-override mutation tests:** deliberately not added. `std::env::set_var` in `#[test]` would race other tests in the same process (`cargo test` runs the binary's tests in parallel threads); the existing Slack tests avoid this for the identical reason and only unit-test the pure `parse_channel_enabled_bool` parser, which this PR's tests already do for Telegram too.
- **Narrower scope than the full issue:** #6522's own comment named two follow-ups — making the `extension_activate` error name the specific flag, and adding `telegram.enabled` to `ironclaw config set` for parity with `slack.enabled`. Neither is in this PR; this PR only makes the default match Google's no-gate posture. Both follow-ups remain open and are good candidates for a fast-follow.
- **Attack-surface note:** flipping the default does mean the Telegram webhook (`POST /webhooks/extensions/telegram/updates`) and WebUI setup/pairing routes become reachable without operator action on upgrade. The webhook fails closed (401) until a bot is actually configured via WebUI setup, so this does not expose any capability — only a new, rate-limited, auth-gated endpoint becomes network-visible by default, matching Google's existing no-gate posture for its own OAuth surface.

## Base branch

Targets `release-fix-1.0.0-rc.1` (frozen `1.0.0-rc.1` release line), not `main`, per the same pattern PR #6533 used — will forward-port to `main` separately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>