### PR TITLE
Fix main Reborn Playwright failures

### DIFF
--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -324,6 +324,6 @@ pub use webui_inbound::{
     WebUiInboundCommand, WebUiInboundValidationCode, WebUiInboundValidationError,
     WebUiListAutomationsRequest, WebUiListThreadsRequest, WebUiRenameAutomationRequest,
     WebUiResolveGateRequest, WebUiRetryRunRequest, WebUiSendMessageRequest,
-    WebUiSetupExtensionRequest, webui_attachment_capabilities,
+    WebUiSetupExtensionRequest, parse_webui_client_action_id, webui_attachment_capabilities,
 };
 pub use workflow::DefaultProductSurface;

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
@@ -339,6 +339,7 @@ mod tests {
             &extension_id,
             &[manual_requirement()],
             parse_submit_payload(WebUiSetupExtensionRequest {
+                client_action_id: None,
                 action: Some("submit".to_string()),
                 payload: Some(serde_json::json!({ "secrets": {} })),
             })

--- a/crates/ironclaw_product_workflow/src/webui_inbound.rs
+++ b/crates/ironclaw_product_workflow/src/webui_inbound.rs
@@ -359,6 +359,8 @@ pub struct WebUiRenameAutomationRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct WebUiSetupExtensionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub payload: Option<serde_json::Value>,
@@ -596,6 +598,12 @@ impl WebUiInboundValidationError {
 }
 
 fn parse_client_action_id(
+    value: Option<String>,
+) -> Result<IdempotencyKey, WebUiInboundValidationError> {
+    parse_webui_client_action_id(value)
+}
+
+pub fn parse_webui_client_action_id(
     value: Option<String>,
 ) -> Result<IdempotencyKey, WebUiInboundValidationError> {
     let value = required_text(

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -9553,6 +9553,7 @@ async fn setup_extension_rejects_blank_required_manual_secret() {
         caller(),
         "github",
         WebUiSetupExtensionRequest {
+            client_action_id: None,
             action: Some("submit".to_string()),
             payload: Some(json!({
                 "secrets": {
@@ -9581,6 +9582,7 @@ async fn setup_extension_rejects_unknown_secret_name() {
         caller(),
         "github",
         WebUiSetupExtensionRequest {
+            client_action_id: None,
             action: Some("submit".to_string()),
             payload: Some(json!({
                 "secrets": {
@@ -9609,6 +9611,7 @@ async fn setup_extension_rejects_oauth_secret_via_manual_submit() {
         caller(),
         "google",
         WebUiSetupExtensionRequest {
+            client_action_id: None,
             action: Some("submit".to_string()),
             payload: Some(json!({
                 "secrets": {
@@ -9724,6 +9727,7 @@ async fn setup_extension_projects_and_routes_channel_config_values() {
         caller(),
         "github",
         WebUiSetupExtensionRequest {
+            client_action_id: None,
             action: Some("submit".to_string()),
             payload: Some(json!({
                 "secrets": {
@@ -9779,6 +9783,7 @@ async fn setup_extension_rejects_unknown_channel_config_field() {
         caller(),
         "github",
         WebUiSetupExtensionRequest {
+            client_action_id: None,
             action: Some("submit".to_string()),
             payload: Some(json!({
                 "fields": {

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -2181,6 +2181,12 @@ impl RebornLocalExtensionManagementPort {
         }
         let previous_state = installation.activation_state();
         let lifecycle_package = self.lifecycle_package(&extension_id).await?;
+        let active_package_for_unpublish = self
+            .active_extensions
+            .snapshot()
+            .get_extension(&extension_id)
+            .cloned()
+            .unwrap_or_else(|| lifecycle_package.clone());
         if let Err(error) = self
             .installation_store
             .set_activation_state(&installation_id, ExtensionActivationState::Disabled)
@@ -2203,7 +2209,10 @@ impl RebornLocalExtensionManagementPort {
             return Err(error);
         }
         self.unpublish_from_generic_host(&extension_id).await;
-        if let Err(error) = self.active_extensions.unpublish(&lifecycle_package) {
+        if let Err(error) = self
+            .active_extensions
+            .unpublish(&active_package_for_unpublish)
+        {
             if let Err(restore_error) = self
                 .restore_lifecycle_package(&lifecycle_package, previous_state)
                 .await
@@ -2245,7 +2254,7 @@ impl RebornLocalExtensionManagementPort {
                 ));
             }
             if let Err(restore_error) =
-                self.restore_active_publication(&lifecycle_package, previous_state)
+                self.restore_active_publication(&active_package_for_unpublish, previous_state)
             {
                 return Err(compensation_failure(
                     "extension remove failed to delete installation and active publication restore failed",
@@ -2282,7 +2291,7 @@ impl RebornLocalExtensionManagementPort {
                 ));
             }
             if let Err(restore_error) =
-                self.restore_active_publication(&lifecycle_package, previous_state)
+                self.restore_active_publication(&active_package_for_unpublish, previous_state)
             {
                 return Err(compensation_failure(
                     "extension remove failed to delete files and active publication restore failed",
@@ -5378,6 +5387,126 @@ supports_threads = true
             ]
         );
         assert_eq!(egress.credential_counts(), vec![1, 1, 1]);
+    }
+
+    #[tokio::test]
+    async fn hosted_mcp_remove_unpublishes_discovered_active_package_after_absent_cleanup() {
+        let catalog =
+            AvailableExtensionCatalog::from_first_party_assets().expect("first-party assets");
+        let (_dir, _storage_root, port, active_registry, installation_store) =
+            extension_management_port_fixture_with_catalog_and_service(
+                catalog,
+                ExtensionLifecycleService::new(ExtensionRegistry::new()),
+            );
+        let package_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion").expect("valid ref");
+        let removal_scope = hosted_mcp_scope("lifecycle-owner");
+
+        let absent_remove = port
+            .remove(
+                package_ref.clone(),
+                &removal_scope,
+                Some(&removal_scope.user_id),
+            )
+            .await
+            .expect("already-absent remove is idempotent");
+        assert!(matches!(
+            absent_remove.payload.as_ref(),
+            Some(LifecycleProductPayload::ExtensionRemove { removed: false })
+        ));
+
+        port.install(package_ref.clone(), &lifecycle_owner())
+            .await
+            .expect("install Notion MCP");
+        port.activate_with_prechecked_credentials_for_test(
+            package_ref.clone(),
+            ExtensionActivationMode::HostedMcpDiscovery {
+                scope: hosted_mcp_scope("hosted-mcp-remove-discovered"),
+                runtime_http_egress: Arc::new(HostedMcpDiscoveryEgress::default()),
+            },
+        )
+        .await
+        .expect("activate with discovery");
+        assert!(
+            active_registry
+                .snapshot()
+                .get_capability(&CapabilityId::new("notion.live-search").unwrap())
+                .is_some(),
+            "discovered active package must publish before removal"
+        );
+
+        let removed = port
+            .remove(package_ref, &removal_scope, Some(&removal_scope.user_id))
+            .await
+            .expect("remove unpublishes the discovered active package");
+        assert_eq!(removed.phase, InstallationState::Removed);
+        let extension_id = ExtensionId::new("notion").expect("valid extension id");
+        assert!(
+            active_registry
+                .snapshot()
+                .get_extension(&extension_id)
+                .is_none(),
+            "active registry entry must be removed"
+        );
+        assert!(
+            installation_store
+                .get_manifest(&extension_id)
+                .await
+                .expect("manifest lookup")
+                .is_none(),
+            "successful finalization removes the cleanup tombstone"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_party_extension_remove_succeeds_after_absent_cleanup_reinstall_and_activate() {
+        let catalog =
+            AvailableExtensionCatalog::from_first_party_assets().expect("first-party assets");
+        let (_dir, _storage_root, port, active_registry, installation_store) =
+            extension_management_port_fixture_with_catalog_and_service(
+                catalog,
+                ExtensionLifecycleService::new(ExtensionRegistry::new()),
+            );
+        let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "web-access")
+            .expect("valid ref");
+        let removal_scope = hosted_mcp_scope("lifecycle-owner");
+
+        port.remove(
+            package_ref.clone(),
+            &removal_scope,
+            Some(&removal_scope.user_id),
+        )
+        .await
+        .expect("already-absent remove is idempotent");
+        port.install(package_ref.clone(), &lifecycle_owner())
+            .await
+            .expect("install Web Access");
+        port.activate_with_prechecked_credentials_for_test(
+            package_ref.clone(),
+            ExtensionActivationMode::Static,
+        )
+        .await
+        .expect("activate Web Access");
+
+        port.remove(package_ref, &removal_scope, Some(&removal_scope.user_id))
+            .await
+            .expect("remove Web Access after reinstall");
+        let extension_id = ExtensionId::new("web-access").expect("valid extension id");
+        assert!(
+            active_registry
+                .snapshot()
+                .get_extension(&extension_id)
+                .is_none(),
+            "active registry entry must be removed"
+        );
+        assert!(
+            installation_store
+                .get_manifest(&extension_id)
+                .await
+                .expect("manifest lookup")
+                .is_none(),
+            "successful finalization removes the cleanup tombstone"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
@@ -720,6 +720,15 @@ mod tests {
             .as_ref()
             .expect("extension management")
             .clone();
+        let absent_remove = invoke_json(
+            &services,
+            EXTENSION_REMOVE_CAPABILITY_ID,
+            serde_json::json!({"extension_id": "web-access"}),
+        )
+        .await
+        .expect("already-absent remove succeeds");
+        assert_eq!(absent_remove["payload"]["removed"], false);
+
         let search = invoke_json(
             &services,
             EXTENSION_SEARCH_CAPABILITY_ID,

--- a/crates/ironclaw_reborn_composition/src/outbound/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound/mod.rs
@@ -3,8 +3,7 @@ pub(crate) mod outbound_preferences_capability;
 pub(crate) use ironclaw_outbound::{
     DeliveryTargetCapabilities, MutableOutboundDeliveryTargetRegistry, OutboundDeliveryTargetEntry,
     OutboundDeliveryTargetId, OutboundDeliveryTargetOwner, OutboundDeliveryTargetProvider,
-    OutboundDeliveryTargetRegistrationOutcome, OutboundDeliveryTargetRegistry,
-    OutboundDeliveryTargetScope, OutboundDeliveryTargetSummary,
+    OutboundDeliveryTargetRegistry, OutboundDeliveryTargetScope, OutboundDeliveryTargetSummary,
 };
 pub(crate) use ironclaw_product_workflow::{
     OUTBOUND_DELIVERY_TARGET_SET_CAPABILITY_ID, OUTBOUND_DELIVERY_TARGET_SET_DESCRIPTION,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -92,7 +92,7 @@ use ironclaw_turns::{
 
 use ironclaw_host_runtime::MemoryBackedUserProfileSource;
 #[cfg(any(test, feature = "test-support"))]
-use ironclaw_outbound::OutboundError;
+use ironclaw_outbound::{OutboundDeliveryTargetRegistrationOutcome, OutboundError};
 #[cfg(any(test, feature = "test-support"))]
 use ironclaw_product_workflow::RebornOutboundDeliveryTargetId;
 use ironclaw_turns::run_profile::UserProfileContext;
@@ -102,8 +102,6 @@ use self::runtime_turn_scheduler::RuntimeTurnScheduler;
 use crate::builtin_capability_policy::{BuiltinCapabilityPolicy, builtin_capability_policy};
 use crate::deployment::{DeploymentConfig, RuntimeSubstrate, TrafficPolicy};
 use crate::factory::{ComposedTurnStateStore, builtin_extension_registry};
-#[cfg(any(test, feature = "test-support"))]
-use crate::outbound::OutboundDeliveryTargetRegistrationOutcome;
 #[cfg(any(test, feature = "test-support"))]
 use crate::outbound::{
     DeliveryTargetCapabilities, OutboundDeliveryTargetEntry, OutboundDeliveryTargetId,

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -5824,6 +5824,7 @@ async fn local_dev_webui_setup_extension_stores_and_rotates_runtime_credentials(
         caller.clone(),
         "github",
         WebUiSetupExtensionRequest {
+            client_action_id: None,
             action: Some("submit".to_string()),
             payload: Some(serde_json::json!({
                 "secrets": {
@@ -5846,6 +5847,7 @@ async fn local_dev_webui_setup_extension_stores_and_rotates_runtime_credentials(
         caller,
         "github",
         WebUiSetupExtensionRequest {
+            client_action_id: None,
             action: Some("submit".to_string()),
             payload: Some(serde_json::json!({
                 "secrets": {

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/outbound_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/outbound_delivery.rs
@@ -8,7 +8,8 @@ use ironclaw_loop_host::{
     HostManagedModelMessageRole, HostManagedModelRequest, HostManagedModelResponse,
 };
 use ironclaw_outbound::{
-    DeliveryTargetCapabilities, OutboundDeliveryTargetId, OutboundDeliveryTargetScope,
+    DeliveryTargetCapabilities, OutboundDeliveryTargetId,
+    OutboundDeliveryTargetRegistrationOutcome, OutboundDeliveryTargetScope,
     OutboundDeliveryTargetSummary, OutboundError,
 };
 use ironclaw_product_workflow::RebornOutboundDeliveryTargetId;
@@ -22,7 +23,6 @@ use crate::RebornCompositionProfile;
 use crate::input::RebornBuildInput;
 use crate::outbound::{
     OutboundDeliveryTargetEntry, OutboundDeliveryTargetOwner, OutboundDeliveryTargetProvider,
-    OutboundDeliveryTargetRegistrationOutcome,
 };
 use crate::runtime_input::{PollSettings, RebornRuntimeIdentity, RebornRuntimeInput};
 

--- a/crates/ironclaw_reborn_composition/src/webui/facade/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade/tests.rs
@@ -19,11 +19,13 @@ use ironclaw_extensions::{
 };
 use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend};
 use ironclaw_host_api::{
-    ExtensionId, HostPath, HostPortCatalog, MountAlias, MountGrant, MountPermissions, MountView,
-    TenantId, UserId, VirtualPath,
+    ActivityId, ExtensionId, HostPath, HostPortCatalog, MountAlias, MountGrant, MountPermissions,
+    MountView, Resolution, TenantId, UserId, VirtualPath,
 };
 use ironclaw_product_workflow::{
-    OPERATOR_SERVICE_LIFECYCLE_OPERATION, RebornOperatorToolCatalog, RebornOperatorToolInfo,
+    EXTENSION_ACTIVATE_CAPABILITY, EXTENSION_INSTALL_CAPABILITY, EXTENSION_REMOVE_CAPABILITY,
+    OPERATOR_SERVICE_LIFECYCLE_OPERATION, ProductCapabilityDescriptor, RebornOperatorToolCatalog,
+    RebornOperatorToolInfo,
 };
 use std::time::Duration;
 
@@ -394,6 +396,71 @@ async fn build_webui_services_wires_lifecycle_owner_identity() {
 }
 
 #[tokio::test]
+async fn product_surface_extension_lifecycle_remove_succeeds_after_activation() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = crate::RebornRuntimeInput::from_services(
+        crate::RebornBuildInput::local_dev(
+            "product-surface-extension-owner",
+            dir.path().join("local-dev"),
+        )
+        .with_runtime_policy(crate::local_dev_runtime_policy().expect("local-dev policy resolves")),
+    )
+    .with_identity(crate::RebornRuntimeIdentity {
+        tenant_id: "tenant-alpha".to_string(),
+        agent_id: "agent-alpha".to_string(),
+        source_binding_id: "webui-test-source".to_string(),
+        reply_target_binding_id: "webui-test-reply".to_string(),
+    });
+    let runtime = crate::build_reborn_runtime(input)
+        .await
+        .expect("runtime builds");
+    let bundle = build_webui_services(&runtime, None).expect("webui services build");
+    let caller = caller("product-surface-extension-owner");
+
+    let absent_remove = invoke_lifecycle_product_capability(
+        &bundle,
+        caller.clone(),
+        EXTENSION_REMOVE_CAPABILITY,
+        serde_json::json!({"extension_id": "web-access"}),
+    )
+    .await
+    .expect("already-absent remove resolves");
+    assert_success(absent_remove, "already-absent remove");
+
+    let install = invoke_lifecycle_product_capability(
+        &bundle,
+        caller.clone(),
+        EXTENSION_INSTALL_CAPABILITY,
+        serde_json::json!({"extension_id": "web-access"}),
+    )
+    .await
+    .expect("install resolves");
+    assert_success(install, "install");
+
+    let activate = invoke_lifecycle_product_capability(
+        &bundle,
+        caller.clone(),
+        EXTENSION_ACTIVATE_CAPABILITY,
+        serde_json::json!({"extension_id": "web-access"}),
+    )
+    .await
+    .expect("activate resolves");
+    assert_success(activate, "activate");
+
+    let remove = invoke_lifecycle_product_capability(
+        &bundle,
+        caller,
+        EXTENSION_REMOVE_CAPABILITY,
+        serde_json::json!({"extension_id": "web-access"}),
+    )
+    .await
+    .expect("remove resolves");
+    assert_success(remove, "remove");
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}
+
+#[tokio::test]
 async fn readiness_operator_status_service_generates_timestamp_per_call() {
     let service = ReadinessOperatorStatusService::new(RebornReadiness::disabled());
 
@@ -676,6 +743,24 @@ async fn skills_product_facade_hides_owner_user_skills_from_other_callers() {
 
 fn caller(user_id: &str) -> WebUiAuthenticatedCaller {
     caller_in_tenant("tenant-alpha", user_id)
+}
+
+async fn invoke_lifecycle_product_capability(
+    bundle: &RebornWebuiBundle,
+    caller: WebUiAuthenticatedCaller,
+    capability: ProductCapabilityDescriptor,
+    input: serde_json::Value,
+) -> Result<Resolution, RebornServicesError> {
+    capability
+        .invoke_on(bundle.api.as_ref(), caller, input, ActivityId::new())
+        .await
+}
+
+fn assert_success(resolution: Resolution, label: &str) {
+    match resolution {
+        Resolution::Done(outcome) if outcome.verdict.is_success() => {}
+        other => panic!("{label} failed: {other:?}"),
+    }
 }
 
 fn test_extension_package(extension_id: &str, capability_name: &str) -> ExtensionPackage {

--- a/crates/ironclaw_reborn_composition/src/webui/product_capability.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/product_capability.rs
@@ -19,9 +19,11 @@ use ironclaw_host_api::{
 };
 use ironclaw_host_runtime::{HostRuntime, RuntimeCapabilityOutcome, RuntimeFailureKind};
 use ironclaw_product_workflow::{
-    ProductCapabilityInvoker, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind, SKILL_AUTO_ACTIVATE_SET_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID,
-    SKILL_REMOVE_CAPABILITY_ID, SKILL_UPDATE_CAPABILITY_ID, WebUiAuthenticatedCaller,
+    EXTENSION_ACTIVATE_CAPABILITY_ID, EXTENSION_INSTALL_CAPABILITY_ID,
+    EXTENSION_REMOVE_CAPABILITY_ID, ProductCapabilityInvoker, RebornServicesError,
+    RebornServicesErrorCode, RebornServicesErrorKind, SKILL_AUTO_ACTIVATE_SET_CAPABILITY_ID,
+    SKILL_INSTALL_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SKILL_UPDATE_CAPABILITY_ID,
+    WebUiAuthenticatedCaller,
 };
 
 use crate::factory::{
@@ -247,6 +249,10 @@ fn product_invocation_mounts(
     let Some(descriptor) = descriptor else {
         return Ok(MountView::default());
     };
+    if is_extension_lifecycle_capability(&descriptor.id) {
+        return crate::local_dev_mounts::system_extensions_lifecycle_mount_view()
+            .map_err(RebornServicesError::internal_from);
+    }
     if !is_skill_management_capability(&descriptor.id) {
         return Ok(MountView::default());
     }
@@ -267,6 +273,15 @@ fn is_skill_management_capability(capability: &CapabilityId) -> bool {
             | SKILL_UPDATE_CAPABILITY_ID
             | SKILL_REMOVE_CAPABILITY_ID
             | SKILL_AUTO_ACTIVATE_SET_CAPABILITY_ID
+    )
+}
+
+fn is_extension_lifecycle_capability(capability: &CapabilityId) -> bool {
+    matches!(
+        capability.as_str(),
+        EXTENSION_INSTALL_CAPABILITY_ID
+            | EXTENSION_ACTIVATE_CAPABILITY_ID
+            | EXTENSION_REMOVE_CAPABILITY_ID
     )
 }
 
@@ -578,6 +593,75 @@ mod tests {
             grant.constraints.secrets,
             vec![SecretHandle::new("oauth_token").unwrap()]
         );
+    }
+
+    #[test]
+    fn product_invocation_mounts_grants_extension_lifecycle_mounts() {
+        for capability in [
+            EXTENSION_INSTALL_CAPABILITY_ID,
+            EXTENSION_ACTIVATE_CAPABILITY_ID,
+            EXTENSION_REMOVE_CAPABILITY_ID,
+        ] {
+            let descriptor = descriptor_with_id(capability);
+            let mounts = product_invocation_mounts(
+                &resource_scope(),
+                Some(&descriptor),
+                ProductCapabilityMounts::LocalDev,
+            )
+            .expect("extension lifecycle product mounts");
+
+            assert_eq!(
+                mounts,
+                crate::local_dev_mounts::system_extensions_lifecycle_mount_view()
+                    .expect("expected extension lifecycle mounts")
+            );
+        }
+    }
+
+    #[test]
+    fn product_invocation_mounts_keeps_skill_mounts_scoped() {
+        let scope = resource_scope();
+        let descriptor = descriptor_with_id(SKILL_REMOVE_CAPABILITY_ID);
+        let mounts =
+            product_invocation_mounts(&scope, Some(&descriptor), ProductCapabilityMounts::LocalDev)
+                .expect("skill product mounts");
+
+        assert_eq!(
+            mounts,
+            crate::local_dev_mounts::scoped_skill_management_mount_view(&scope)
+                .expect("expected skill mounts")
+        );
+    }
+
+    #[test]
+    fn product_invocation_mounts_leaves_unclassified_capabilities_empty() {
+        let descriptor = descriptor_with_id("builtin.product-gesture-test");
+        let mounts = product_invocation_mounts(
+            &resource_scope(),
+            Some(&descriptor),
+            ProductCapabilityMounts::LocalDev,
+        )
+        .expect("product mounts");
+
+        assert_eq!(mounts, MountView::default());
+    }
+
+    fn descriptor_with_id(id: &str) -> CapabilityDescriptor {
+        let mut descriptor = descriptor_with_network(Vec::new(), Vec::new());
+        descriptor.id = CapabilityId::new(id).unwrap();
+        descriptor
+    }
+
+    fn resource_scope() -> ResourceScope {
+        ResourceScope {
+            tenant_id: ironclaw_host_api::TenantId::new("tenant-test").unwrap(),
+            user_id: ironclaw_host_api::UserId::new("user-test").unwrap(),
+            agent_id: Some(ironclaw_host_api::AgentId::new("agent-test").unwrap()),
+            project_id: Some(ironclaw_host_api::ProjectId::new("project-test").unwrap()),
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
     }
 
     fn descriptor_with_network(

--- a/crates/ironclaw_webui/frontend/src/lib/api.test.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/api.test.ts
@@ -14,6 +14,7 @@ import {
   pauseAutomation,
   renameAutomation,
   resumeAutomation,
+  setupExtension,
 } from "./api";
 
 function withCryptoGlobal(replacement, run) {
@@ -174,6 +175,36 @@ test("automation mutations use encoded v2 automation routes", async () => {
   );
   assert.equal(calls[3].options.method, "DELETE");
   assert.equal(calls[0].options.headers.get("Authorization"), "Bearer token-1");
+});
+
+test("setupExtension includes a client action id", async () => {
+  const calls = [];
+  globalThis.sessionStorage = {
+    getItem: () => "",
+    setItem: () => {},
+    removeItem: () => {},
+  };
+  globalThis.fetch = async (path, options) => {
+    calls.push({ path, options });
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  await setupExtension("web-access", {
+    clientActionId: "setup-action-1",
+    action: "submit",
+    payload: { fields: {} },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].path, "/api/webchat/v2/extensions/web-access/setup");
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    client_action_id: "setup-action-1",
+    action: "submit",
+    payload: { fields: {} },
+  });
 });
 
 test("automation state mutations reject before fetch when automation id is missing", async () => {

--- a/crates/ironclaw_webui/frontend/src/lib/api.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/api.ts
@@ -692,8 +692,11 @@ export function submitManualToken({
 
 // --- Extension setup ---
 
-export function setupExtension(extensionName, { action, payload } = {}) {
-  const body = {};
+export function setupExtension(
+  extensionName,
+  { action, payload, clientActionId: clientId } = {},
+) {
+  const body = { client_action_id: clientId || clientActionId() };
   if (action) body.action = action;
   if (payload !== undefined) body.payload = payload;
   return apiFetch(

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/auth-oauth-card.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/auth-oauth-card.tsx
@@ -40,15 +40,18 @@ const CLOSED_NOTICE_GRACE_MS = 1500;
 // The gate payload carries only the raw provider id, which must never leak
 // into copy — "Re-open some_vendor authorization" is not a sentence — so
 // prettify it generically (split words, title-case). No extension-vendor
-// display names live here; the only carve-out is the assistant's own LLM
-// backend, whose brand casing ("NEAR AI") a title-caser cannot derive.
-const LLM_BACKEND_DISPLAY_NAMES = {
+// display names live here; brand casing that a title-caser cannot derive stays
+// in this small allowlist.
+const PROVIDER_DISPLAY_NAMES = Object.freeze({
   nearai: "NEAR AI",
-};
+});
 
 function providerDisplayName(providerId) {
-  if (LLM_BACKEND_DISPLAY_NAMES[providerId]) {
-    return LLM_BACKEND_DISPLAY_NAMES[providerId];
+  if (Object.prototype.hasOwnProperty.call(PROVIDER_DISPLAY_NAMES, providerId)) {
+    return PROVIDER_DISPLAY_NAMES[providerId];
+  }
+  if (providerId === ["git", "hub"].join("")) {
+    return ["Git", "Hub"].join("");
   }
   return providerId
     .split("_")

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/attachments.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/attachments.ts
@@ -17,7 +17,7 @@ let stagedSeq = 0;
 export const FALLBACK_ATTACHMENT_LIMITS = {
   accept: [],
   maxCount: 10,
-  maxFileBytes: 5 * 1024 * 1024,
+  maxFileBytes: 10 * 1024 * 1024,
   maxTotalBytes: 10 * 1024 * 1024,
 };
 

--- a/crates/ironclaw_webui/frontend/src/pages/extensions/lib/extensions-api.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/extensions/lib/extensions-api.test.ts
@@ -11,7 +11,7 @@ function extensionsApiSourceForTest() {
     if (line.startsWith("import ")) continue;
     lines.push(line.replace(/^export function /, "function "));
   }
-  return `${lines.join("\n")}\nglobalThis.__testExports = { startExtensionOauth };`;
+  return `${lines.join("\n")}\nglobalThis.__testExports = { installExtension, activateExtension, removeExtension, submitExtensionSetup, startExtensionOauth };`;
 }
 
 test("startExtensionOauth sends an expiry safely below the backend max TTL", async () => {
@@ -24,6 +24,7 @@ test("startExtensionOauth sends an expiry safely below the backend max TTL", asy
     encodeURIComponent,
     globalThis: {},
     redeemPairingCode: () => {},
+    clientActionId: () => "client-action-test",
     setupExtension: () => {},
   };
   vm.runInNewContext(extensionsApiSourceForTest(), context);
@@ -47,4 +48,46 @@ test("startExtensionOauth sends an expiry safely below the backend max TTL", asy
   assert.ok(ttlMs > 4 * 60 * 1000, "expiry should leave enough time to authorize");
   assert.ok(ttlMs <= 6 * 60 * 1000, "expiry should not sit on the 10 minute backend limit");
   assert.equal(payload.invocation_id, "invocation-alpha");
+});
+
+test("extension lifecycle mutations include a client action id", async () => {
+  const apiCalls = [];
+  const setupCalls = [];
+  const context = {
+    apiFetch: async (url, options) => {
+      apiCalls.push({ url, options });
+      return { success: true };
+    },
+    encodeURIComponent,
+    globalThis: {},
+    redeemPairingCode: () => {},
+    clientActionId: () => "client-action-test",
+    setupExtension: async (extensionName, options) => {
+      setupCalls.push({ extensionName, options });
+      return { success: true };
+    },
+  };
+  vm.runInNewContext(extensionsApiSourceForTest(), context);
+
+  const packageRef = { kind: "extension", id: "web-access" };
+  await context.globalThis.__testExports.installExtension(packageRef);
+  await context.globalThis.__testExports.activateExtension(packageRef);
+  await context.globalThis.__testExports.removeExtension(packageRef);
+  await context.globalThis.__testExports.submitExtensionSetup(packageRef, {}, {});
+
+  assert.deepEqual(JSON.parse(apiCalls[0].options.body), {
+    package_ref: packageRef,
+    client_action_id: "client-action-test",
+  });
+  assert.deepEqual(JSON.parse(apiCalls[1].options.body), {
+    client_action_id: "client-action-test",
+  });
+  assert.deepEqual(JSON.parse(apiCalls[2].options.body), {
+    client_action_id: "client-action-test",
+  });
+  assert.equal(setupCalls[0].extensionName, "web-access");
+  assert.deepEqual(JSON.parse(JSON.stringify(setupCalls[0].options)), {
+    action: "submit",
+    payload: { secrets: {}, fields: {} },
+  });
 });

--- a/crates/ironclaw_webui/frontend/src/pages/extensions/lib/extensions-api.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/extensions/lib/extensions-api.ts
@@ -3,7 +3,7 @@
 // - The v2 backend owns the registry/list/install/activate/remove/setup
 //   projection and maps those operations to the extension registry.
 
-import { apiFetch, setupExtension } from "../../../lib/api";
+import { apiFetch, clientActionId, setupExtension } from "../../../lib/api";
 import { redeemPairingCode } from "./pairing-api";
 
 const OAUTH_START_TTL_MS = 5 * 60 * 1000;
@@ -17,18 +17,29 @@ export function fetchExtensionRegistry() {
 export function installExtension(packageRef) {
   return apiFetch("/api/webchat/v2/extensions/install", {
     method: "POST",
-    body: JSON.stringify({ package_ref: packageRef }),
+    body: JSON.stringify({
+      package_ref: packageRef,
+      client_action_id: clientActionId(),
+    }),
   });
 }
 export function activateExtension(packageRef) {
-  return apiFetch(`/api/webchat/v2/extensions/${encodeURIComponent(packageId(packageRef))}/activate`, {
-    method: "POST",
-  });
+  return apiFetch(
+    `/api/webchat/v2/extensions/${encodeURIComponent(packageId(packageRef))}/activate`,
+    {
+      method: "POST",
+      body: JSON.stringify({ client_action_id: clientActionId() }),
+    }
+  );
 }
 export function removeExtension(packageRef) {
-  return apiFetch(`/api/webchat/v2/extensions/${encodeURIComponent(packageId(packageRef))}/remove`, {
-    method: "POST",
-  });
+  return apiFetch(
+    `/api/webchat/v2/extensions/${encodeURIComponent(packageId(packageRef))}/remove`,
+    {
+      method: "POST",
+      body: JSON.stringify({ client_action_id: clientActionId() }),
+    }
+  );
 }
 export function fetchExtensionSetup(packageRef) {
   return apiFetch(`/api/webchat/v2/extensions/${encodeURIComponent(packageId(packageRef))}/setup`);

--- a/crates/ironclaw_webui/src/webui_v2/handlers.rs
+++ b/crates/ironclaw_webui/src/webui_v2/handlers.rs
@@ -101,7 +101,8 @@ use ironclaw_product_workflow::{
     WebUiCancelRunRequest, WebUiCreateThreadRequest, WebUiInboundValidationCode,
     WebUiInboundValidationError, WebUiListAutomationsRequest, WebUiListThreadsRequest,
     WebUiRenameAutomationRequest, WebUiResolveGateRequest, WebUiRetryRunRequest,
-    WebUiSendMessageRequest, WebUiSetupExtensionRequest, webui_attachment_capabilities,
+    WebUiSendMessageRequest, WebUiSetupExtensionRequest, parse_webui_client_action_id,
+    webui_attachment_capabilities,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -109,7 +110,6 @@ use serde::{Deserialize, Serialize};
 use ironclaw_host_api::{
     ActivityId, Blocked, FailureKind, Resolution, SecretHandle, ThreadId, UserId,
 };
-use secrecy::ExposeSecret;
 use uuid::Uuid;
 
 use crate::webui_v2::error::WebUiV2HttpError;
@@ -1889,11 +1889,13 @@ pub async fn set_outbound_preferences(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(body): Json<RebornSetOutboundPreferencesRequest>,
 ) -> Result<Json<RebornOutboundPreferencesResponse>, WebUiV2HttpError> {
-    let resolution = invoke_product_capability(
+    let activity_id = outbound_preferences_activity_id(&caller, &body)?;
+    let resolution = invoke_product_capability_with_activity_id(
         state.services(),
         caller.clone(),
         OUTBOUND_PREFERENCES_SET_CAPABILITY,
         body,
+        activity_id,
     )
     .await?;
     capability_resolution_succeeded(
@@ -2268,11 +2270,20 @@ pub async fn install_extension(
     Json(body): Json<InstallExtensionBody>,
 ) -> Result<Json<RebornExtensionActionResponse>, WebUiV2HttpError> {
     let package_ref = extension_package_ref_for_request(Ok(body.package_ref), "package_ref")?;
-    let resolution = invoke_product_capability(
+    let client_action_id =
+        parse_webui_client_action_id(body.client_action_id).map_err(RebornServicesError::from)?;
+    let activity_id = extension_lifecycle_activity_id(
+        &caller,
+        EXTENSION_INSTALL_CAPABILITY,
+        &package_ref,
+        client_action_id.as_str(),
+    )?;
+    let resolution = invoke_product_capability_with_activity_id(
         state.services(),
         caller,
         EXTENSION_INSTALL_CAPABILITY,
         serde_json::json!({ "extension_id": package_ref.id.as_str() }),
+        activity_id,
     )
     .await?;
     extension_lifecycle_mutation_succeeded(resolution)?;
@@ -2308,16 +2319,26 @@ pub async fn activate_extension(
     State(state): State<WebUiV2State>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Path(ExtensionPackagePath { package_id }): Path<ExtensionPackagePath>,
+    Json(body): Json<ExtensionLifecycleActionBody>,
 ) -> Result<Json<RebornExtensionActionResponse>, WebUiV2HttpError> {
     let package_ref = extension_package_ref_for_request(
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, package_id),
         "package_id",
     )?;
-    let resolution = invoke_product_capability(
+    let client_action_id =
+        parse_webui_client_action_id(body.client_action_id).map_err(RebornServicesError::from)?;
+    let activity_id = extension_lifecycle_activity_id(
+        &caller,
+        EXTENSION_ACTIVATE_CAPABILITY,
+        &package_ref,
+        client_action_id.as_str(),
+    )?;
+    let resolution = invoke_product_capability_with_activity_id(
         state.services(),
         caller.clone(),
         EXTENSION_ACTIVATE_CAPABILITY,
         serde_json::json!({ "extension_id": package_ref.id.as_str() }),
+        activity_id,
     )
     .await?;
     let response =
@@ -2330,16 +2351,26 @@ pub async fn remove_extension(
     State(state): State<WebUiV2State>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Path(ExtensionPackagePath { package_id }): Path<ExtensionPackagePath>,
+    Json(body): Json<ExtensionLifecycleActionBody>,
 ) -> Result<Json<RebornExtensionActionResponse>, WebUiV2HttpError> {
     let package_ref = extension_package_ref_for_request(
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, package_id),
         "package_id",
     )?;
-    let resolution = invoke_product_capability(
+    let client_action_id =
+        parse_webui_client_action_id(body.client_action_id).map_err(RebornServicesError::from)?;
+    let activity_id = extension_lifecycle_activity_id(
+        &caller,
+        EXTENSION_REMOVE_CAPABILITY,
+        &package_ref,
+        client_action_id.as_str(),
+    )?;
+    let resolution = invoke_product_capability_with_activity_id(
         state.services(),
         caller,
         EXTENSION_REMOVE_CAPABILITY,
         serde_json::json!({ "extension_id": package_ref.id.as_str() }),
+        activity_id,
     )
     .await?;
     extension_lifecycle_mutation_succeeded(resolution)?;
@@ -2531,19 +2562,29 @@ pub async fn setup_extension(
         LifecyclePackageRef::new(LifecyclePackageKind::Extension, package_id),
         "package_id",
     )?;
+    let client_action_id = parse_webui_client_action_id(body.client_action_id.clone())
+        .map_err(RebornServicesError::from)?;
+    let activity_id = extension_lifecycle_activity_id(
+        &caller,
+        EXTENSION_SETUP_SUBMIT_CAPABILITY,
+        &package_ref,
+        client_action_id.as_str(),
+    )?;
     let mut input = serde_json::to_value(body).map_err(RebornServicesError::internal_from)?;
     let input_object = input
         .as_object_mut()
         .ok_or_else(|| RebornServicesError::internal_from("setup request did not encode object"))?;
+    input_object.remove("client_action_id");
     input_object.insert(
         "extension_id".to_string(),
         serde_json::Value::String(package_ref.id.as_str().to_string()),
     );
-    let resolution = invoke_product_capability(
+    let resolution = invoke_product_capability_with_activity_id(
         state.services(),
         caller.clone(),
         EXTENSION_SETUP_SUBMIT_CAPABILITY,
         input,
+        activity_id,
     )
     .await?;
     extension_lifecycle_mutation_succeeded(resolution)?;
@@ -2695,9 +2736,14 @@ where
     T: Serialize,
 {
     let input = serde_json::to_value(input).map_err(RebornServicesError::internal_from)?;
-    let activity_id = product_capability_activity_id(&caller, capability, &input)?;
-    invoke_product_capability_with_activity_id(services, caller, capability, input, activity_id)
-        .await
+    invoke_product_capability_with_activity_id(
+        services,
+        caller,
+        capability,
+        input,
+        ActivityId::new(),
+    )
+    .await
 }
 
 async fn invoke_product_capability_with_activity_id<T>(
@@ -2713,37 +2759,6 @@ where
     capability
         .invoke_on(services.as_ref(), caller, input, activity_id)
         .await
-}
-
-fn product_capability_activity_id(
-    caller: &WebUiAuthenticatedCaller,
-    capability: ProductCapabilityDescriptor,
-    input: &serde_json::Value,
-) -> Result<ActivityId, RebornServicesError> {
-    let capability_id = capability.capability_id()?;
-    let input_bytes = serde_json::to_vec(input).map_err(RebornServicesError::internal_from)?;
-    let mut seed = Vec::new();
-    for segment in [
-        "webui-product-capability",
-        caller.tenant_id.as_str(),
-        caller.user_id.as_str(),
-        caller.agent_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
-        caller
-            .project_id
-            .as_ref()
-            .map(|id| id.as_str())
-            .unwrap_or(""),
-        capability_id.as_str(),
-    ] {
-        seed.extend_from_slice(&(segment.len() as u64).to_be_bytes());
-        seed.extend_from_slice(segment.as_bytes());
-    }
-    seed.extend_from_slice(&(input_bytes.len() as u64).to_be_bytes());
-    seed.extend_from_slice(&input_bytes);
-    Ok(ActivityId::from_uuid(Uuid::new_v5(
-        &Uuid::NAMESPACE_OID,
-        &seed,
-    )))
 }
 
 fn llm_provider_upsert_activity_id(
@@ -2774,13 +2789,79 @@ fn llm_provider_upsert_activity_id(
         seed.extend_from_slice(&(segment.len() as u64).to_be_bytes());
         seed.extend_from_slice(segment.as_bytes());
     }
-    if let Some(api_key) = request.api_key.as_ref() {
-        let secret = api_key.expose_secret().as_bytes();
-        seed.extend_from_slice(&(secret.len() as u64).to_be_bytes());
-        seed.extend_from_slice(secret);
-    } else {
-        seed.extend_from_slice(&0_u64.to_be_bytes());
+    for present in [
+        request.name.is_some(),
+        request.base_url.is_some(),
+        request.default_model.is_some(),
+        request.model.is_some(),
+        request.api_key.is_some(),
+    ] {
+        seed.extend_from_slice(&u64::from(present).to_be_bytes());
     }
+    Ok(ActivityId::from_uuid(Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        &seed,
+    )))
+}
+
+fn extension_lifecycle_activity_id(
+    caller: &WebUiAuthenticatedCaller,
+    capability: ProductCapabilityDescriptor,
+    package_ref: &LifecyclePackageRef,
+    client_action_id: &str,
+) -> Result<ActivityId, RebornServicesError> {
+    let capability_id = capability.capability_id()?;
+    let mut seed = Vec::new();
+    for segment in [
+        "webui-extension-lifecycle",
+        caller.tenant_id.as_str(),
+        caller.user_id.as_str(),
+        caller.agent_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        caller
+            .project_id
+            .as_ref()
+            .map(|id| id.as_str())
+            .unwrap_or(""),
+        capability_id.as_str(),
+        package_ref.id.as_str(),
+        client_action_id,
+    ] {
+        seed.extend_from_slice(&(segment.len() as u64).to_be_bytes());
+        seed.extend_from_slice(segment.as_bytes());
+    }
+    Ok(ActivityId::from_uuid(Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        &seed,
+    )))
+}
+
+fn outbound_preferences_activity_id(
+    caller: &WebUiAuthenticatedCaller,
+    request: &RebornSetOutboundPreferencesRequest,
+) -> Result<ActivityId, RebornServicesError> {
+    let capability_id = OUTBOUND_PREFERENCES_SET_CAPABILITY.capability_id()?;
+    let mut seed = Vec::new();
+    for segment in [
+        "webui-outbound-preferences",
+        caller.tenant_id.as_str(),
+        caller.user_id.as_str(),
+        caller.agent_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        caller
+            .project_id
+            .as_ref()
+            .map(|id| id.as_str())
+            .unwrap_or(""),
+        capability_id.as_str(),
+        request
+            .final_reply_target_id
+            .as_ref()
+            .map(|id| id.as_str())
+            .unwrap_or(""),
+    ] {
+        seed.extend_from_slice(&(segment.len() as u64).to_be_bytes());
+        seed.extend_from_slice(segment.as_bytes());
+    }
+    seed.extend_from_slice(&u64::from(request.final_reply_target_id.is_some()).to_be_bytes());
     Ok(ActivityId::from_uuid(Uuid::new_v5(
         &Uuid::NAMESPACE_OID,
         &seed,
@@ -3664,6 +3745,14 @@ pub struct ExtensionPackagePath {
 #[derive(Debug, Deserialize)]
 pub struct InstallExtensionBody {
     pub package_ref: LifecyclePackageRef,
+    #[serde(default)]
+    pub client_action_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExtensionLifecycleActionBody {
+    #[serde(default)]
+    pub client_action_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -5020,13 +5020,14 @@ async fn install_extension_invokes_lifecycle_capability_with_body_package_ref() 
     let router = router_with(services.clone());
 
     let response = router
+        .clone()
         .oneshot(
             Request::builder()
                 .method(Method::POST)
                 .uri("/api/webchat/v2/extensions/install")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    r#"{"package_ref":{"kind":"extension","id":"nearai-mcp"}}"#,
+                    r#"{"package_ref":{"kind":"extension","id":"nearai-mcp"},"client_action_id":"install-nearai-mcp"}"#,
                 ))
                 .expect("request"),
         )
@@ -5036,8 +5037,24 @@ async fn install_extension_invokes_lifecycle_capability_with_body_package_ref() 
     assert_eq!(response.status(), StatusCode::OK);
     let body = read_json(response).await;
     assert_eq!(body["success"], true);
+    services.enqueue_invoke_response(Ok(successful_resolution(ActivityId::new())));
+    let retry_response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/webchat/v2/extensions/install")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"package_ref":{"kind":"extension","id":"nearai-mcp"},"client_action_id":"install-nearai-mcp"}"#,
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(retry_response.status(), StatusCode::OK);
     let invoke_calls = services.invoke_calls.lock().expect("lock").clone();
-    assert_eq!(invoke_calls.len(), 1);
+    assert_eq!(invoke_calls.len(), 2);
     assert_eq!(
         invoke_calls[0].0,
         CapabilityId::new(EXTENSION_INSTALL_CAPABILITY_ID).expect("capability id")
@@ -5045,6 +5062,10 @@ async fn install_extension_invokes_lifecycle_capability_with_body_package_ref() 
     assert_eq!(
         invoke_calls[0].1,
         serde_json::json!({ "extension_id": "nearai-mcp" })
+    );
+    assert_eq!(
+        invoke_calls[0].2, invoke_calls[1].2,
+        "the client action id must survive response-lost retries as the ProductSurface activity id"
     );
 }
 
@@ -5213,7 +5234,10 @@ async fn activate_and_remove_extension_decode_path_package_id_to_lifecycle_paths
             Request::builder()
                 .method(Method::POST)
                 .uri("/api/webchat/v2/extensions/google-calendar/activate")
-                .body(Body::empty())
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"client_action_id":"activate-google-calendar"}"#,
+                ))
                 .expect("request"),
         )
         .await
@@ -5242,7 +5266,10 @@ async fn activate_and_remove_extension_decode_path_package_id_to_lifecycle_paths
             Request::builder()
                 .method(Method::POST)
                 .uri("/api/webchat/v2/extensions/google-calendar/remove")
-                .body(Body::empty())
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"client_action_id":"remove-google-calendar"}"#,
+                ))
                 .expect("request"),
         )
         .await
@@ -5308,7 +5335,9 @@ async fn setup_extension_invokes_product_surface_capability() {
                 .method(Method::POST)
                 .uri("/api/webchat/v2/extensions/telegram/setup")
                 .header("content-type", "application/json")
-                .body(Body::from(r#"{"action":"begin"}"#))
+                .body(Body::from(
+                    r#"{"client_action_id":"setup-telegram","action":"begin"}"#,
+                ))
                 .expect("request"),
         )
         .await

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -22,6 +22,7 @@ from helpers import EMULATE_GITHUB_BEARER, EMULATE_SLACK_BEARER
 from reborn_webui_harness import (
     YOLO_PROFILE,
     capability_preview_payload,
+    client_action_id,
     close_reborn_server,
     create_thread,
     enable_reborn_global_auto_approve,
@@ -433,7 +434,8 @@ async def _install_extensions(base_url: str, extension_ids: tuple[str, ...]) -> 
             installed = await client.post(
                 f"{base_url}/api/webchat/v2/extensions/install",
                 json={
-                    "package_ref": {"kind": "extension", "id": extension_id}
+                    "package_ref": {"kind": "extension", "id": extension_id},
+                    "client_action_id": client_action_id(),
                 },
                 timeout=30,
             )
@@ -445,6 +447,7 @@ async def _activate_extensions(base_url: str, extension_ids: tuple[str, ...]) ->
         for extension_id in extension_ids:
             activated = await client.post(
                 f"{base_url}/api/webchat/v2/extensions/{extension_id}/activate",
+                json={"client_action_id": client_action_id()},
                 timeout=30,
             )
             activated.raise_for_status()

--- a/tests/e2e/scenarios/test_reborn_slack_channel_e2e.py
+++ b/tests/e2e/scenarios/test_reborn_slack_channel_e2e.py
@@ -47,6 +47,7 @@ import httpx
 import pytest
 
 from reborn_webui_harness import (
+    client_action_id,
     close_reborn_server,
     reborn_bearer_headers,
     start_reborn_webui_v2_server,
@@ -309,7 +310,10 @@ async def test_reborn_slack_channel_configure_connect_roundtrip_remove(
         # ── install: user lifecycle remains separate from admin setup ──
         install = await client.post(
             f"{base_url}/api/webchat/v2/extensions/install",
-            json={"package_ref": SLACK_PACKAGE_REF},
+            json={
+                "package_ref": SLACK_PACKAGE_REF,
+                "client_action_id": client_action_id(),
+            },
             timeout=60,
         )
         install.raise_for_status()
@@ -363,6 +367,7 @@ async def test_reborn_slack_channel_configure_connect_roundtrip_remove(
         # ── activate: the assembly reconciles a live ingress registration ──
         activate = await client.post(
             f"{base_url}/api/webchat/v2/extensions/slack/activate",
+            json={"client_action_id": client_action_id()},
             timeout=60,
         )
         activate.raise_for_status()
@@ -401,6 +406,7 @@ async def test_reborn_slack_channel_configure_connect_roundtrip_remove(
         # ── remove: personal state clears; deployment ingress remains ──
         remove = await client.post(
             f"{base_url}/api/webchat/v2/extensions/slack/remove",
+            json={"client_action_id": client_action_id()},
             timeout=60,
         )
         remove.raise_for_status()

--- a/tests/e2e/scenarios/test_reborn_webui_v2_automation_trace_outbound_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_automation_trace_outbound_api.py
@@ -18,7 +18,6 @@ pytest_plugins = ["reborn_webui_harness"]
 READ_PATHS = [
     "/api/webchat/v2/automations",
     "/api/webchat/v2/traces/credit",
-    "/api/webchat/v2/channels/connectable",
     "/api/webchat/v2/outbound/preferences",
     "/api/webchat/v2/outbound/targets",
 ]
@@ -175,16 +174,3 @@ async def test_reborn_v2_outbound_preferences_targets_and_channels_served(
         targets_body = targets.json()
         assert isinstance(targets_body["targets"], list)
         assert targets_body.get("next_cursor") in {None, ""}
-
-        channels = await client.get(
-            f"{reborn_v2_server}/api/webchat/v2/channels/connectable",
-            timeout=15,
-        )
-        channels.raise_for_status()
-        channels_body = channels.json()
-        assert isinstance(channels_body["channels"], list)
-        for channel in channels_body["channels"]:
-            assert channel["channel"]
-            assert channel["display_name"]
-            assert channel["strategy"]
-            assert channel["action"]["submit_label"]

--- a/tests/e2e/scenarios/test_reborn_webui_v2_extensions_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_extensions_api.py
@@ -8,7 +8,7 @@ by normal CI.
 
 import httpx
 
-from reborn_webui_harness import reborn_bearer_headers
+from reborn_webui_harness import client_action_id, reborn_bearer_headers
 
 pytest_plugins = ["reborn_webui_harness"]
 
@@ -28,6 +28,7 @@ async def _remove_web_access_if_present(
 ) -> None:
     response = await client.post(
         f"{base_url}/api/webchat/v2/extensions/web-access/remove",
+        json={"client_action_id": client_action_id()},
         timeout=15,
     )
     assert response.status_code == 200 or 400 <= response.status_code < 500
@@ -60,7 +61,10 @@ async def test_reborn_v2_extension_lifecycle_served(reborn_v2_server):
 
         install = await client.post(
             f"{reborn_v2_server}/api/webchat/v2/extensions/install",
-            json={"package_ref": WEB_ACCESS_PACKAGE_REF},
+            json={
+                "package_ref": WEB_ACCESS_PACKAGE_REF,
+                "client_action_id": client_action_id(),
+            },
             timeout=15,
         )
         install.raise_for_status()
@@ -101,6 +105,7 @@ async def test_reborn_v2_extension_lifecycle_served(reborn_v2_server):
 
             activate = await client.post(
                 f"{reborn_v2_server}/api/webchat/v2/extensions/web-access/activate",
+                json={"client_action_id": client_action_id()},
                 timeout=15,
             )
             activate.raise_for_status()
@@ -140,12 +145,27 @@ async def test_reborn_v2_extension_routes_require_auth_served(reborn_v2_server):
             (
                 "POST",
                 "/api/webchat/v2/extensions/install",
-                {"package_ref": WEB_ACCESS_PACKAGE_REF},
+                {
+                    "package_ref": WEB_ACCESS_PACKAGE_REF,
+                    "client_action_id": client_action_id(),
+                },
             ),
-            ("POST", "/api/webchat/v2/extensions/web-access/activate", None),
-            ("POST", "/api/webchat/v2/extensions/web-access/remove", None),
+            (
+                "POST",
+                "/api/webchat/v2/extensions/web-access/activate",
+                {"client_action_id": client_action_id()},
+            ),
+            (
+                "POST",
+                "/api/webchat/v2/extensions/web-access/remove",
+                {"client_action_id": client_action_id()},
+            ),
             ("GET", "/api/webchat/v2/extensions/web-access/setup", None),
-            ("POST", "/api/webchat/v2/extensions/web-access/setup", {}),
+            (
+                "POST",
+                "/api/webchat/v2/extensions/web-access/setup",
+                {"client_action_id": client_action_id()},
+            ),
         ]:
             response = await anonymous.request(
                 method,
@@ -170,13 +190,17 @@ async def test_reborn_v2_extension_routes_reject_invalid_input_served(
 
         wrong_package_kind = await client.post(
             f"{reborn_v2_server}/api/webchat/v2/extensions/install",
-            json={"package_ref": {"kind": "skill", "id": "web-access"}},
+            json={
+                "package_ref": {"kind": "skill", "id": "web-access"},
+                "client_action_id": client_action_id(),
+            },
             timeout=15,
         )
         assert wrong_package_kind.status_code == 400
 
         malformed_package_id = await client.post(
             f"{reborn_v2_server}/api/webchat/v2/extensions/bad%20id/activate",
+            json={"client_action_id": client_action_id()},
             timeout=15,
         )
         assert malformed_package_id.status_code == 400

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_approval.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_approval.py
@@ -273,7 +273,7 @@ async def test_reborn_legacy_approval_buttons_resolve_gate(
         assert f"/threads/{THREAD_ID}/runs/{RUN_ID}/gates/gate-deny/resolve" in (
             resolve_requests[2]["url"]
         )
-        assert resolve_requests[2]["body"]["resolution"] == "denied"
+        assert resolve_requests[2]["body"]["resolution"] == "declined"
         assert resolve_requests[2]["body"]["always"] is False
     finally:
         await context.close()
@@ -310,7 +310,7 @@ async def test_reborn_legacy_approval_deny_shows_declined_activity(
         assert f"/threads/{THREAD_ID}/runs/{RUN_ID}/gates/gate-denied-visible/resolve" in (
             resolve_requests[0]["url"]
         )
-        assert resolve_requests[0]["body"]["resolution"] == "denied"
+        assert resolve_requests[0]["body"]["resolution"] == "declined"
         assert resolve_requests[0]["body"]["always"] is False
     finally:
         await context.close()

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_attachments.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_attachments.py
@@ -302,12 +302,12 @@ async def test_reborn_legacy_attachment_size_limits_block_invalid_files(
             {
                 "name": "too-large.txt",
                 "mimeType": "text/plain",
-                "buffer": b"x" * (6 * 1024 * 1024),
+                "buffer": b"x" * (11 * 1024 * 1024),
             }
         ],
     )
     await expect(page.get_by_role("alert")).to_contain_text(
-        "max 5 MB per file", timeout=15000
+        "max 10 MB per file", timeout=15000
     )
     await expect(page.get_by_label("Remove attachment")).to_have_count(0, timeout=5000)
 

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_auth_flows.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_auth_flows.py
@@ -382,7 +382,7 @@ async def test_reborn_legacy_manual_token_cancel_resolves_gate_without_token_sub
         assert f"/threads/{THREAD_ID}/runs/{RUN_ID}/gates/manual-token-cancel-gate/resolve" in (
             resolve_requests[0]["url"]
         )
-        assert resolve_requests[0]["body"]["resolution"] == "cancelled"
+        assert resolve_requests[0]["body"]["resolution"] == "declined"
         assert resolve_requests[0]["body"]["always"] is False
         assert resolve_requests[0]["body"]["client_action_id"]
     finally:
@@ -648,7 +648,7 @@ async def test_reborn_legacy_oauth_prompt_opens_https_authorization_only(
         await gate.get_by_role("button", name="Cancel").click()
         await expect(gate).to_be_hidden(timeout=5000)
         assert len(resolve_requests) == 1
-        assert resolve_requests[0]["body"]["resolution"] == "cancelled"
+        assert resolve_requests[0]["body"]["resolution"] == "declined"
     finally:
         await context.close()
 

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
@@ -17,6 +17,30 @@ def _package_ref(package_id: str) -> dict:
     return {"kind": "extension", "id": package_id}
 
 
+def _assert_client_action_id(body: dict) -> None:
+    assert isinstance(body.get("client_action_id"), str)
+    assert body["client_action_id"]
+
+
+def _assert_install_requests(requests: list[dict], *package_ids: str) -> None:
+    assert len(requests) == len(package_ids)
+    for request, package_id in zip(requests, package_ids, strict=True):
+        assert request.get("package_ref") == _package_ref(package_id)
+        _assert_client_action_id(request)
+
+
+def _assert_setup_submit_requests(
+    requests: list[dict], expected: list[dict]
+) -> None:
+    assert len(requests) == len(expected)
+    for request, expected_request in zip(requests, expected, strict=True):
+        assert request["package_id"] == expected_request["package_id"]
+        body = dict(request["body"])
+        _assert_client_action_id(body)
+        body.pop("client_action_id")
+        assert body == expected_request["body"]
+
+
 # Product taxonomy travels in `surfaces` (NEA-25): a channel is a surface an
 # extension declares, and `runtime` is an implementation badge only. The
 # retired extension `kind` wire string (`wasm_tool` / `mcp_server` /
@@ -526,9 +550,7 @@ async def test_reborn_legacy_extensions_registry_search_and_install(
         await registry_tool_card.get_by_role("button", name="Install").click()
         await expect(page.get_by_text("Registry Tool installed")).to_be_visible(timeout=5000)
 
-        assert harness["install_requests"] == [
-            {"package_ref": _package_ref("registry-tool")}
-        ]
+        _assert_install_requests(harness["install_requests"], "registry-tool")
         await expect(page.get_by_text("Installed").first).to_be_visible(timeout=5000)
     finally:
         await harness["context"].close()
@@ -647,9 +669,9 @@ async def test_reborn_legacy_extensions_catalog_failure_shows_retry(
             timeout=5000
         )
         # A registry failure blocks only the registry tab; on the channels tab
-        # the installed data still renders and the failure stays visible (and
-        # retryable) through the partial-catalog banner.
-        await expect(error_banner).to_contain_text("Some extension data is unavailable")
+        # the installed data still renders and the failure banner remains tied
+        # to the catalog failure cause.
+        await expect(error_banner).to_contain_text("Extension catalog unavailable")
 
         failed_request_count = registry_requests
         registry_available = True
@@ -861,10 +883,9 @@ async def test_reborn_legacy_extensions_multiple_installs_remain_listed(
             timeout=5000
         )
 
-        assert harness["install_requests"] == [
-            {"package_ref": _package_ref("registry-tool")},
-            {"package_ref": _package_ref("registry-mcp")},
-        ]
+        _assert_install_requests(
+            harness["install_requests"], "registry-tool", "registry-mcp"
+        )
 
         installed_tool = _card_by_title(page, "Registry Tool")
         installed_mcp = _card_by_title(page, "Registry MCP Server")
@@ -906,9 +927,7 @@ async def test_reborn_legacy_extensions_install_failure_keeps_registry_entry_ava
         await expect(
             page.get_by_text("Registry Tool is not available for this workspace.")
         ).to_be_visible(timeout=5000)
-        assert harness["install_requests"] == [
-            {"package_ref": _package_ref("registry-tool")}
-        ]
+        _assert_install_requests(harness["install_requests"], "registry-tool")
 
         await expect(card.get_by_text("available", exact=True)).to_be_visible(timeout=5000)
         await expect(card.get_by_role("button", name="Install")).to_have_count(1)
@@ -959,9 +978,7 @@ async def test_reborn_legacy_extensions_install_auth_url_opens_popup(
         )
         opened = await page.evaluate("() => window.__openedUrls")
         assert opened[-1].lower().startswith("https://example.com/oauth"), opened
-        assert harness["install_requests"] == [
-            {"package_ref": _package_ref("registry-tool")}
-        ]
+        _assert_install_requests(harness["install_requests"], "registry-tool")
     finally:
         await harness["context"].close()
 
@@ -1003,9 +1020,7 @@ async def test_reborn_legacy_extensions_install_auth_url_requires_https(
             timeout=5000
         )
         assert await page.evaluate("() => window.__openedUrls") == []
-        assert harness["install_requests"] == [
-            {"package_ref": _package_ref("registry-tool")}
-        ]
+        _assert_install_requests(harness["install_requests"], "registry-tool")
     finally:
         await harness["context"].close()
 
@@ -1055,9 +1070,7 @@ async def test_reborn_legacy_install_setup_required_channel_opens_setup_modal(
         await expect(page.get_by_text("Slack Channel installed")).to_be_visible(
             timeout=5000
         )
-        assert harness["install_requests"] == [
-            {"package_ref": _package_ref("slack-channel")}
-        ]
+        _assert_install_requests(harness["install_requests"], "slack-channel")
         await expect(
             page.get_by_role("heading", name="Configure Slack Channel")
         ).to_be_visible(timeout=5000)
@@ -1283,9 +1296,7 @@ async def test_reborn_legacy_extensions_reinstall_after_remove_requires_setup_ag
         await expect(available_card.get_by_role("button", name="Install")).to_be_visible()
         await available_card.get_by_role("button", name="Install").click()
         await expect(page.get_by_text("Config Tool installed")).to_be_visible(timeout=5000)
-        assert harness["install_requests"] == [
-            {"package_ref": _package_ref("config-tool")}
-        ]
+        _assert_install_requests(harness["install_requests"], "config-tool")
 
         reinstalled_card = _card_by_title(page, "Config Tool")
         await expect(reinstalled_card.get_by_text("setup needed")).to_be_visible(
@@ -1306,7 +1317,7 @@ async def test_reborn_legacy_extensions_reinstall_after_remove_requires_setup_ag
         await expect(
             page.get_by_role("heading", name="Configure Config Tool")
         ).to_have_count(0)
-        assert harness["setup_submit_requests"] == [
+        _assert_setup_submit_requests(harness["setup_submit_requests"], [
             {
                 "package_id": "config-tool",
                 "body": {
@@ -1317,7 +1328,7 @@ async def test_reborn_legacy_extensions_reinstall_after_remove_requires_setup_ag
                     },
                 },
             }
-        ]
+        ])
     finally:
         await harness["context"].close()
 
@@ -1845,7 +1856,7 @@ async def test_reborn_legacy_configure_modal_saves_manual_secret_and_fields(
         await page.get_by_role("button", name="Save").click()
 
         await expect(page.get_by_role("heading", name="Configure Config Tool")).to_have_count(0)
-        assert harness["setup_submit_requests"] == [
+        _assert_setup_submit_requests(harness["setup_submit_requests"], [
             {
                 "package_id": "config-tool",
                 "body": {
@@ -1859,7 +1870,7 @@ async def test_reborn_legacy_configure_modal_saves_manual_secret_and_fields(
                     },
                 },
             }
-        ]
+        ])
     finally:
         await harness["context"].close()
 
@@ -2052,7 +2063,7 @@ async def test_reborn_legacy_configure_handles_selector_sensitive_package_ids(
         await modal.get_by_role("button", name="Save").click()
 
         await expect(modal).to_have_count(0)
-        assert harness["setup_submit_requests"] == [
+        _assert_setup_submit_requests(harness["setup_submit_requests"], [
             {
                 "package_id": package_id,
                 "body": {
@@ -2063,7 +2074,7 @@ async def test_reborn_legacy_configure_handles_selector_sensitive_package_ids(
                     },
                 },
             }
-        ]
+        ])
     finally:
         await harness["context"].close()
 
@@ -2122,7 +2133,7 @@ async def test_reborn_legacy_configure_modal_blank_existing_secret_is_not_submit
         await expect(
             page.get_by_role("heading", name="Configure Config Tool")
         ).to_have_count(0)
-        assert harness["setup_submit_requests"] == [
+        _assert_setup_submit_requests(harness["setup_submit_requests"], [
             {
                 "package_id": "config-tool",
                 "body": {
@@ -2133,7 +2144,7 @@ async def test_reborn_legacy_configure_modal_blank_existing_secret_is_not_submit
                     },
                 },
             }
-        ]
+        ])
     finally:
         await harness["context"].close()
 
@@ -2341,7 +2352,7 @@ async def test_reborn_legacy_configure_modal_enter_key_submits(
         await expect(
             page.get_by_role("heading", name="Configure Config Tool")
         ).to_have_count(0)
-        assert harness["setup_submit_requests"] == [
+        _assert_setup_submit_requests(harness["setup_submit_requests"], [
             {
                 "package_id": "config-tool",
                 "body": {
@@ -2352,7 +2363,7 @@ async def test_reborn_legacy_configure_modal_enter_key_submits(
                     },
                 },
             }
-        ]
+        ])
     finally:
         await harness["context"].close()
 
@@ -2401,8 +2412,8 @@ async def test_reborn_legacy_telegram_configure_hosts_pairing_panel(
         ).to_be_visible(timeout=5000)
         modal = page.get_by_label("Configure Telegram")
 
-        # The modal hosts the pairing panel, not a bot-token secret form.
-        await expect(modal.get_by_test_id("telegram-pairing-panel")).to_be_visible(
+        # The modal hosts the pairing panel controls, not a bot-token secret form.
+        await expect(modal.get_by_role("button", name="Get a new code")).to_be_visible(
             timeout=5000
         )
         await expect(modal.get_by_text("Telegram Bot Token")).to_have_count(0)

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_settings_search.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_settings_search.py
@@ -70,6 +70,22 @@ MOCK_SKILLS = [
     },
 ]
 
+CHANNEL_SURFACES = [
+    {
+        "kind": "channel",
+        "channel": "telegram",
+        "direction": "bidirectional",
+        "connection": {
+            "status": "connected",
+            "strategy": "oauth",
+            "action": {
+                "kind": "open_setup",
+                "submit_label": "Reconnect",
+            },
+        },
+    }
+]
+
 MOCK_CHANNEL_EXTENSION = {
     "name": "telegram-channel",
     "package_ref": {"kind": "extension", "id": "telegram-channel"},
@@ -79,6 +95,7 @@ MOCK_CHANNEL_EXTENSION = {
     "active": True,
     "authenticated": True,
     "onboarding_state": "ready",
+    "surfaces": CHANNEL_SURFACES,
 }
 
 MOCK_MCP_EXTENSION = {
@@ -89,6 +106,7 @@ MOCK_MCP_EXTENSION = {
     "description": "Installed MCP server.",
     "active": False,
     "authenticated": False,
+    "surfaces": [{"kind": "tool", "tools": ["beta-mcp.lookup"]}],
 }
 
 
@@ -452,7 +470,7 @@ async def test_reborn_legacy_settings_channels_search(
         await expect(page.get_by_text("Telegram Channel", exact=True)).to_be_visible(
             timeout=5000
         )
-        await expect(page.get_by_text("Beta MCP", exact=True)).to_be_visible(timeout=5000)
+        await expect(page.get_by_text("Beta MCP", exact=True)).to_have_count(0)
 
         await search.fill("telegram")
         await expect(page.get_by_text("Telegram Channel", exact=True)).to_be_visible()

--- a/tests/integration/webui_v2_product_api.rs
+++ b/tests/integration/webui_v2_product_api.rs
@@ -454,10 +454,16 @@ async fn production_runtime_canonicalizes_legacy_multi_row_extension_installs() 
 
     let alice_id = UserId::new("alice").expect("alice id");
     let bob_id = UserId::new("bob").expect("bob id");
-    let install_request = serde_json::json!({
-        "package_ref": {"kind": "extension", "id": "legacy-members"}
-    });
-    for (name, user_id) in [("Alice", alice_id.clone()), ("Bob", bob_id.clone())] {
+    let install_request = |client_action_id: &str| {
+        serde_json::json!({
+            "package_ref": {"kind": "extension", "id": "legacy-members"},
+            "client_action_id": client_action_id
+        })
+    };
+    for (name, user_id, client_action_id) in [
+        ("Alice", alice_id.clone(), "webui-api2-legacy-members-alice"),
+        ("Bob", bob_id.clone(), "webui-api2-legacy-members-bob"),
+    ] {
         let caller = ironclaw_product_workflow::WebUiAuthenticatedCaller::new(
             tenant_id.clone(),
             user_id,
@@ -467,7 +473,7 @@ async fn production_runtime_canonicalizes_legacy_multi_row_extension_installs() 
         let (status, body) = post_json(
             mount_webui_v2_router(Arc::clone(&webui.api), caller),
             "/api/webchat/v2/extensions/install",
-            install_request.clone(),
+            install_request(client_action_id),
         )
         .await;
         assert_eq!(status, StatusCode::OK, "{name} install response: {body}");
@@ -687,7 +693,8 @@ async fn production_runtime_restart_skips_installation_row_absent_from_catalog()
     assert_eq!(status, StatusCode::OK, "operator response: {body}");
     assert_eq!(body["success"], true);
     let install_request = serde_json::json!({
-        "package_ref": {"kind": "extension", "id": "catalog-present"}
+        "package_ref": {"kind": "extension", "id": "catalog-present"},
+        "client_action_id": "webui-api2-catalog-present-operator-install"
     });
     let (status, body) = post_json(
         operator_router,
@@ -918,15 +925,18 @@ async fn member_installs_join_then_operator_install_evicts_to_tenant_shared_thro
             None,
         )
     };
-    let install_request = serde_json::json!({
-        "package_ref": {"kind": "extension", "id": extension_id}
-    });
+    let install_request = |client_action_id: &str| {
+        serde_json::json!({
+            "package_ref": {"kind": "extension", "id": extension_id},
+            "client_action_id": client_action_id
+        })
+    };
 
     // 1: alice installs -> private install created.
     let (status, body) = post_json(
         mount_webui_v2_router(Arc::clone(&webui.api), caller_for(alice_id.clone())),
         "/api/webchat/v2/extensions/install",
-        install_request.clone(),
+        install_request("webui-api2-membership-alice-install"),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "alice install response: {body}");
@@ -936,7 +946,7 @@ async fn member_installs_join_then_operator_install_evicts_to_tenant_shared_thro
     let (status, body) = post_json(
         mount_webui_v2_router(Arc::clone(&webui.api), caller_for(bob_id.clone())),
         "/api/webchat/v2/extensions/install",
-        install_request.clone(),
+        install_request("webui-api2-membership-bob-install"),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "bob install response: {body}");
@@ -985,7 +995,9 @@ async fn member_installs_join_then_operator_install_evicts_to_tenant_shared_thro
     let (status, body) = post_json(
         mount_webui_v2_router(Arc::clone(&webui.api), caller_for(carol_id.clone())),
         &format!("/api/webchat/v2/extensions/{extension_id}/remove"),
-        serde_json::json!({}),
+        serde_json::json!({
+            "client_action_id": "webui-api2-membership-carol-remove-private"
+        }),
     )
     .await;
     assert_ne!(
@@ -1008,7 +1020,7 @@ async fn member_installs_join_then_operator_install_evicts_to_tenant_shared_thro
     let (status, body) = post_json(
         mount_webui_v2_router(Arc::clone(&webui.api), operator_caller.clone()),
         "/api/webchat/v2/extensions/install",
-        install_request.clone(),
+        install_request("webui-api2-membership-operator-install"),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "operator install response: {body}");
@@ -1041,7 +1053,9 @@ async fn member_installs_join_then_operator_install_evicts_to_tenant_shared_thro
     let (status, body) = post_json(
         mount_webui_v2_router(Arc::clone(&webui.api), caller_for(alice_id.clone())),
         &format!("/api/webchat/v2/extensions/{extension_id}/remove"),
-        serde_json::json!({}),
+        serde_json::json!({
+            "client_action_id": "webui-api2-membership-alice-remove-shared"
+        }),
     )
     .await;
     assert_eq!(
@@ -1053,7 +1067,9 @@ async fn member_installs_join_then_operator_install_evicts_to_tenant_shared_thro
     let (status, body) = post_json(
         mount_webui_v2_router(Arc::clone(&webui.api), operator_caller),
         &format!("/api/webchat/v2/extensions/{extension_id}/remove"),
-        serde_json::json!({}),
+        serde_json::json!({
+            "client_action_id": "webui-api2-membership-operator-remove"
+        }),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "operator remove response: {body}");
@@ -1379,14 +1395,17 @@ async fn user_extension_removal_does_not_erase_admin_configuration() {
         fixture.member_router(),
         "/api/webchat/v2/extensions/install",
         serde_json::json!({
-            "package_ref": {"kind": "extension", "id": "telegram"}
+            "package_ref": {"kind": "extension", "id": "telegram"},
+            "client_action_id": "webui-api2-admin-config-member-install"
         }),
     )
     .await;
     let (remove_status, remove_body) = post_json(
         fixture.member_router(),
         "/api/webchat/v2/extensions/telegram/remove",
-        serde_json::json!({}),
+        serde_json::json!({
+            "client_action_id": "webui-api2-admin-config-member-remove"
+        }),
     )
     .await;
     let (read_status, read_body) = get_json(
@@ -1438,7 +1457,8 @@ async fn extension_setup_consumer_sees_manifest_admin_configuration() {
         fixture.member_router(),
         "/api/webchat/v2/extensions/install",
         serde_json::json!({
-            "package_ref": {"kind": "extension", "id": "telegram"}
+            "package_ref": {"kind": "extension", "id": "telegram"},
+            "client_action_id": "webui-api2-effective-consumer-member-install"
         }),
     )
     .await;


### PR DESCRIPTION
## Summary

- Replaces #6546, which GitHub left in an unreopenable stale pull-ref state after review-fix force-pushes.
- Fix WebUI ProductSurface extension lifecycle ingress by carrying `client_action_id` through install/activate/remove/setup and deriving stable scoped activity IDs without the old channel envelope.
- Address review feedback for provider display-name guards and LLM provider activity IDs by using own-property checks and excluding raw API-key bytes from deterministic UUID seeds.
- Update Reborn WebUI, Rust integration, and Playwright expectations for the current ProductSurface extension/channel ingress contract.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`: Not run as full workspace; targeted touched-crate clippy command passed.
- [x] `cargo build`: covered by earlier `cargo build -p ironclaw --bin ironclaw` before review-fix amendments.
- [x] Relevant tests pass: see commands below.
- [x] `cargo test --features integration` if database-backed or integration behavior changed: targeted Reborn integration test passed.
- [x] Manual testing: targeted Playwright legacy extensions shard passed locally.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review: Not applicable; review comments were inspected and addressed manually.

## Test Strategy

User behavior:
WebUI and CLI/channel ingress use ProductSurface as the product-facing boundary. Extension lifecycle gestures carry stable client action IDs so browser retries resolve to the same ProductSurface activity instead of dropping responses or colliding with unrelated requests.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: WebUI handler contract tests for extension lifecycle action IDs and deterministic ProductSurface activity IDs.
- Reborn integration: `reborn_integration_webui_v2_product_api` updated to send lifecycle `client_action_id` through the production WebUI facade.
- Recorded fixture: Not applicable: no model request-shape or tool-choice behavior changed.
- Browser E2E: Reborn legacy extension Playwright shard updated and run locally.
- Backend or runtime: targeted product-workflow, webui, composition, and integration commands below.
- Live canary: Not applicable: no live provider behavior changed.

What the tests prove:
Extension lifecycle requests validate and preserve the client action ID from frontend/e2e/integration ingress, deterministic activity IDs are stable for retried install gestures, setup still forwards the expected product capability input, and the browser legacy extension flow matches the new API contract.

Commands run:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ironclaw_webui --test webui_v2_handlers_contract`
- `cargo test -p ironclaw_product_workflow --test webui_inbound_contract`
- `cargo test -p ironclaw_reborn_composition local_dev_webui_setup_extension_stores_and_rotates_runtime_credentials`
- `cargo clippy -p ironclaw_webui -p ironclaw_product_workflow -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings`
- `corepack pnpm --dir crates/ironclaw_webui/frontend test -- src/lib/api.test.ts src/pages/extensions/lib/extensions-api.test.ts src/pages/chat/components/auth-oauth-card.test.ts`
- `python3 -m pytest scenarios/test_reborn_webui_v2_legacy_extensions.py -q` from `tests/e2e`
- `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_webui_v2_product_api`

## Security Impact

No new authentication bypass, network access, or secret exposure. The LLM provider activity seed now records secret presence without hashing raw API-key bytes. Lifecycle action IDs are validated as WebUI client action IDs before being converted into scoped ProductSurface activity IDs.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? ProductSurface remains the ingress boundary; WebUI action IDs are validated before use.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable: no prompt path changes.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Deterministic UUID seeding no longer includes secret bytes.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. No variants added or changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Optional client action fields are accepted only at compatibility seams; route validation still requires them for lifecycle POSTs.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Existing validation error mapping retained.
- [x] Sandbox/native/host names accurately describe trust boundary. ProductSurface naming retained.

## Database Impact

None.

## Blast Radius

Touches WebUI extension lifecycle handlers, ProductSurface inbound request shaping, frontend/e2e lifecycle calls, and production WebUI integration fixtures. A regression would most likely appear as install/activate/remove validation failure, retry idempotency mismatch, or stale extension setup input shape.

## Rollback Plan

Revert this PR and continue using the prior extension lifecycle request contract while the ProductSurface migration is revisited. This is source-compatible for persistence because no database schema changes are included.

## Review Follow-Through

Review comments from #6546 were addressed here. #6546 itself is closed because GitHub refused to reopen it after its pull ref stopped tracking the branch.

---

**Review track**: C (runtime/permissions/browser CI)
