### PR TITLE
test(live-canary): migrate lanes to the IronClaw serve harness

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -3,8 +3,8 @@ run-name: ${{ inputs.trigger_context || github.workflow }}
 
 on:
   # Scheduled runs are intentionally limited to Reborn WebUI v2 live QA.
-  # Legacy canary lanes remain available through workflow_dispatch for
-  # manual diagnosis, but do not run on cron.
+  # Retired legacy-gateway lanes and their replacement coverage are recorded
+  # in scripts/live-canary/MIGRATION.md.
   schedule:
     # Every 3 hours. Only reborn-webui-v2-live-qa has a matching guard.
     - cron: "0 */3 * * *"
@@ -24,12 +24,6 @@ on:
           - provider-matrix
           - release-public-full
           - upgrade-canary
-          - auth-smoke
-          - auth-full
-          - auth-channels
-          - auth-live-seeded
-          - auth-browser-consent
-          - workflow-canary
           - reborn-webui-v2-live-qa
       scenario:
         description: "Optional scenario/test filter. Use auto for rotating persona."
@@ -94,8 +88,8 @@ env:
 jobs:
   auth-smoke:
     name: Auth Smoke
-    if: >
-      github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'auth-smoke')
+    # Retained temporarily as migration input for #6561; unreachable from CI.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -125,8 +119,8 @@ jobs:
 
   auth-full:
     name: Auth Full
-    if: >
-      github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'auth-full')
+    # Retained temporarily as migration input for #6561; unreachable from CI.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:
@@ -156,8 +150,8 @@ jobs:
 
   auth-channels:
     name: Auth Channels
-    if: >
-      github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'auth-channels')
+    # Retained temporarily as migration input for #6561; unreachable from CI.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -187,8 +181,8 @@ jobs:
 
   auth-live-seeded:
     name: Auth Live Seeded
-    if: >
-      github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'auth-live-seeded')
+    # Retained temporarily as migration input for #6561; unreachable from CI.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:
@@ -276,8 +270,8 @@ jobs:
 
   auth-browser-consent:
     name: Auth Browser Consent
-    if: >
-      github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'auth-browser-consent')
+    # Retained temporarily as migration input for #6561; unreachable from CI.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -377,8 +371,8 @@ jobs:
 
   workflow-canary:
     name: Workflow Canary
-    if: >
-      github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'workflow-canary')
+    # Retained temporarily as migration input for #6561; unreachable from CI.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/docs/internal/live-canary.md
+++ b/docs/internal/live-canary.md
@@ -141,29 +141,21 @@ Run a private OAuth lane on the dedicated runner:
 LANE=private-oauth scripts/live-canary/run.sh
 ```
 
-Run the auth smoke lane:
+The former `auth-smoke`, `auth-full`, and `auth-channels` lanes are retired.
+Run their `ironclaw serve` replacement scenarios from
+`tests/e2e/scenarios/`; see `scripts/live-canary/MIGRATION.md`.
 
-```bash
-LANE=auth-smoke scripts/live-canary/run.sh
-```
+Live product-auth coverage now runs through the
+`reborn-webui-v2-live-qa` lane; see `scripts/live-canary/MIGRATION.md`.
 
-Run the seeded auth live lane:
-
-```bash
-LANE=auth-live-seeded scripts/live-canary/run.sh
-```
-
-Run the browser-consent auth lane:
-
-```bash
-LANE=auth-browser-consent scripts/live-canary/run.sh
-```
+Browser-consent coverage now runs through the
+`reborn-webui-v2-live-qa` lane; see `scripts/live-canary/MIGRATION.md`.
 
 Run selected auth provider cases only:
 
 ```bash
-LANE=auth-live-seeded CASES=gmail,github scripts/live-canary/run.sh
-LANE=auth-browser-consent CASES=google,github scripts/live-canary/run.sh
+LANE=reborn-webui-v2-live-qa CASES=qa_2a_gmail_connect,qa_4b_github_connect \
+  scripts/live-canary/run.sh
 ```
 
 ## Artifact Policy

--- a/scripts/live-canary/MIGRATION.md
+++ b/scripts/live-canary/MIGRATION.md
@@ -1,0 +1,34 @@
+# Live-canary migration inventory
+
+This inventory is the source of truth for the live-canary lanes after the
+`ironclaw-legacy` binary was removed. A retained lane either exercises Rust
+integration tests directly or starts the shipping `ironclaw serve` binary. A
+retired lane is no longer selectable in the dispatcher or GitHub workflow and
+names the coverage that replaces it.
+
+| Lane | Disposition | Runtime | Replacement or evidence |
+| --- | --- | --- | --- |
+| `deterministic-replay` | Retained | Rust integration test | `tests/e2e_live.rs` |
+| `public-smoke` | Retained | Rust integration test | `tests/e2e_live.rs`, `tests/e2e_live_mission.rs` |
+| `persona-rotating` | Retained | Rust integration test | `tests/e2e_live_personas.rs` |
+| `private-oauth` | Retained | Rust integration test | `tests/e2e_live.rs::drive_transparent_oauth_refresh` |
+| `provider-matrix` | Retained | Rust integration test | Operator-selected live integration target |
+| `release-public-full` | Retained | Rust integration test | Full public live integration set |
+| `upgrade-canary` | Retained | Shipping `ironclaw` CLI | `scripts/live-canary/upgrade-canary.sh` |
+| `reborn-webui-v2-live-qa` | Retained | Shipping `ironclaw serve` | `scripts/reborn_webui_v2_live_qa/run_live_qa.py` |
+| `auth-smoke` | Retired | — | `tests/e2e/scenarios/test_reborn_webui_v2_product_auth_api.py` |
+| `auth-full` | Retired | — | `tests/e2e/scenarios/test_v2_auth_oauth_matrix.py` plus the retained-scenario migration tracked by #6561 |
+| `auth-channels` | Retired | — | `tests/e2e/scenarios/test_reborn_slack_channel_e2e.py` plus the retained-scenario migration tracked by #6561 |
+| `auth-live-seeded` | Retired | — | Product-auth cases in `scripts/reborn_webui_v2_live_qa/run_live_qa.py` |
+| `auth-browser-consent` | Retired | — | Product-auth OAuth cases in `scripts/reborn_webui_v2_live_qa/run_live_qa.py` |
+| `workflow-canary` | Retired | — | Workflow/routine cases in `scripts/reborn_webui_v2_live_qa/run_live_qa.py` |
+
+The Reborn WebUI v2 runner is the live launcher contract. It creates an
+isolated home and workspace per run, binds loopback only, injects credentials
+only into the child environment, waits on `/api/health`, bounds startup, and
+captures stdout/stderr under the lane artifact directory. Its launcher tests
+live in `scripts/reborn_webui_v2_live_qa/test_run_live_qa.py`.
+
+The retired Python runners remain temporarily as migration input for #6561 and
+are deleted with the rest of the obsolete infrastructure by #6562. They are
+not reachable from the operator entrypoint or CI.

--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -1,19 +1,25 @@
 # Live Canary Local and GitHub Setup
 
-This directory contains the unified entrypoints for the live regression lanes:
+This directory contains the unified entrypoints for the retained live
+regression lanes:
 
 - `run.sh` dispatches named lanes and writes artifacts
 - `scrub-artifacts.sh` scans artifacts before upload
 - `upgrade-canary.sh` checks previous-release DB compatibility
 
-The auth-focused Python runners remain the executors behind the auth lanes:
+The former auth-focused Python runners remain temporarily as migration input
+for #6561:
 
 - `scripts/auth_canary/run_canary.py` — mock-backed pytest matrix (fresh-machine)
 - `scripts/auth_live_canary/run_live_canary.py` — live-provider runner with two
   modes: `--mode seeded` (token persistence and refresh) and `--mode browser`
   (OAuth consent in Playwright)
 
-Their shared auth canary setup, provider registry, and runtime helpers live in:
+They are no longer selectable through `run.sh` or the GitHub workflow. Their
+replacement coverage is recorded in [MIGRATION.md](MIGRATION.md), and #6562
+removes the obsolete infrastructure after the retained scenarios migrate.
+
+Their shared setup, provider registry, and runtime helpers live in:
 
 - `scripts/live_canary/common.py`
 - `scripts/live_canary/auth_registry.py`
@@ -41,17 +47,13 @@ Run commands from the repository root.
 - `release-public-full`
 - `upgrade-canary`
 
-### Auth lanes added on this branch
-
-- `auth-smoke`
-- `auth-full`
-- `auth-channels`
-- `auth-live-seeded`
-- `auth-browser-consent`
-
 ### Reborn WebUI v2 QA lane
 
 - `reborn-webui-v2-live-qa`
+
+This is the retained Python live lane. It launches the shipping
+`ironclaw serve` binary with an isolated home and workspace, loopback-only
+listener, bounded readiness check, child-only credentials, and captured logs.
 
 PR-targeted runs execute the reviewed PR binary with live integration secrets.
 They must pass the `reborn-live-canary-pr` GitHub environment gate and have an
@@ -76,33 +78,6 @@ SCENARIO=mission_daily_news_digest_with_followup \
 scripts/live-canary/run.sh
 ```
 
-Run the auth smoke lane:
-
-```bash
-LANE=auth-smoke scripts/live-canary/run.sh
-```
-
-Run the seeded auth live lane:
-
-```bash
-LANE=auth-live-seeded scripts/live-canary/run.sh
-```
-
-Run the browser-consent auth lane:
-
-```bash
-LANE=auth-browser-consent scripts/live-canary/run.sh
-```
-
-Run selected auth provider cases:
-
-```bash
-LANE=auth-live-seeded CASES=gmail,github scripts/live-canary/run.sh
-LANE=auth-browser-consent CASES=google,notion scripts/live-canary/run.sh
-# Browser cases: google, notion only. github is PAT-only (not OAuth) so
-# it lives in auth-live-seeded instead — see scripts/live_canary/auth_registry.py.
-```
-
 Run the Reborn WebUI v2 live QA lane against the local copied Reborn home:
 
 ```bash
@@ -117,16 +92,16 @@ Run the full QA-sheet-backed Reborn suite:
 LANE=reborn-webui-v2-live-qa CASES=all scripts/live-canary/run.sh
 ```
 
-Use CI-style browser installation for auth browser lanes:
+Use CI-style browser installation:
 
 ```bash
-LANE=auth-browser-consent PLAYWRIGHT_INSTALL=with-deps scripts/live-canary/run.sh
+LANE=reborn-webui-v2-live-qa PLAYWRIGHT_INSTALL=with-deps scripts/live-canary/run.sh
 ```
 
 Reuse an existing build and Python environment:
 
 ```bash
-LANE=auth-smoke SKIP_BUILD=1 SKIP_PYTHON_BOOTSTRAP=1 scripts/live-canary/run.sh
+LANE=reborn-webui-v2-live-qa SKIP_BUILD=1 SKIP_PYTHON_BOOTSTRAP=1 scripts/live-canary/run.sh
 ```
 
 Run an upgrade canary:
@@ -168,5 +143,5 @@ Seeded auth live-provider credentials:
 ## GitHub Workflow
 
 GitHub Actions uses `.github/workflows/live-canary.yml` as the single scheduled
-and manual entrypoint. That workflow now contains both the upstream live LLM
-jobs and the auth-specific canary jobs.
+and manual entrypoint. Retired legacy-gateway jobs are statically disabled
+until #6562 removes their definitions.

--- a/scripts/live-canary/run.sh
+++ b/scripts/live-canary/run.sh
@@ -13,8 +13,9 @@ set -euo pipefail
 
 # Unified live-canary dispatcher.
 #
-# This branch carries the upstream live LLM lanes plus the auth-focused lanes
-# added here. Lanes write artifacts under artifacts/live-canary/.
+# Lanes write artifacts under artifacts/live-canary/. Retired legacy-gateway
+# lanes are intentionally not dispatched here; their replacement coverage is
+# recorded in MIGRATION.md.
 
 if [[ -n "${LANE:-}" ]]; then
   lane_value="${LANE}"
@@ -287,56 +288,14 @@ main() {
     upgrade-canary)
       run_with_timeout scripts/live-canary/upgrade-canary.sh
       ;;
-    auth-smoke)
-      run_python_lane scripts/auth_canary/run_canary.py --profile smoke --playwright-install "${PLAYWRIGHT_INSTALL}"
-      ;;
-    auth-full)
-      run_python_lane scripts/auth_canary/run_canary.py --profile full --playwright-install "${PLAYWRIGHT_INSTALL}"
-      ;;
-    auth-channels)
-      run_python_lane scripts/auth_canary/run_canary.py --profile channels --playwright-install "${PLAYWRIGHT_INSTALL}"
-      ;;
-    auth-live-seeded)
-      run_python_lane scripts/auth_live_canary/run_live_canary.py --mode seeded --playwright-install "${PLAYWRIGHT_INSTALL}"
-      ;;
-    auth-browser-consent)
-      run_python_lane scripts/auth_live_canary/run_live_canary.py --mode browser --playwright-install "${PLAYWRIGHT_INSTALL}"
-      ;;
-    workflow-canary)
-      # Translate SCENARIO into one or more --scenario flags so targeted
-      # reruns (LANE=workflow-canary SCENARIO=telegram_round_trip) hit
-      # only that probe instead of the full 21-probe suite. Comma-list
-      # is supported so multiple probes can be chained:
-      # SCENARIO=bug_logger,telegram_round_trip.
-      workflow_canary_scenario_args=()
-      if [[ -n "${SCENARIO:-}" && "${SCENARIO}" != "auto" ]]; then
-        IFS=',' read -ra raw_scenarios <<< "${SCENARIO}"
-        for scenario_name in "${raw_scenarios[@]}"; do
-          trimmed="$(echo "$scenario_name" | xargs)"
-          if [[ -n "${trimmed}" ]]; then
-            workflow_canary_scenario_args+=(--scenario "${trimmed}")
-          fi
-        done
-      fi
-      # Empty-array expansion under `set -u` is fine on bash 4.4+ but
-      # historically explodes on macOS bash 3.2 — guard the splat the
-      # same way `run_python_lane` guards `case_args` / `passthrough_args`.
-      if [[ ${#workflow_canary_scenario_args[@]} -gt 0 ]]; then
-        run_python_lane scripts/workflow_canary/run_workflow_canary.py \
-          --playwright-install "${PLAYWRIGHT_INSTALL}" \
-          "${workflow_canary_scenario_args[@]}"
-      else
-        run_python_lane scripts/workflow_canary/run_workflow_canary.py \
-          --playwright-install "${PLAYWRIGHT_INSTALL}"
-      fi
-      ;;
     reborn-webui-v2-live-qa)
       run_python_lane scripts/reborn_webui_v2_live_qa/run_live_qa.py \
         --playwright-install "${PLAYWRIGHT_INSTALL}"
       ;;
     *)
       echo "Unknown live canary lane: ${LANE}" >&2
-      echo "Known lanes: deterministic-replay, public-smoke, persona-rotating, private-oauth, provider-matrix, release-public-full, upgrade-canary, auth-smoke, auth-full, auth-channels, auth-live-seeded, auth-browser-consent, workflow-canary, reborn-webui-v2-live-qa" >&2
+      echo "Known lanes: deterministic-replay, public-smoke, persona-rotating, private-oauth, provider-matrix, release-public-full, upgrade-canary, reborn-webui-v2-live-qa" >&2
+      echo "Retired lane replacements: scripts/live-canary/MIGRATION.md" >&2
       return 2
       ;;
   esac

--- a/scripts/live-canary/test_common.py
+++ b/scripts/live-canary/test_common.py
@@ -64,5 +64,23 @@ class InstallPlaywrightTests(unittest.TestCase):
                 common.install_playwright(Path("/venv/bin/python"), "plain")
 
 
+class CargoBuildTests(unittest.TestCase):
+    def test_builds_the_shipping_ironclaw_binary(self):
+        with patch.object(common, "run") as run:
+            common.cargo_build()
+
+        run.assert_called_once_with(
+            [
+                "cargo",
+                "build",
+                "-p",
+                "ironclaw",
+                "--bin",
+                "ironclaw",
+            ],
+            cwd=common.ROOT,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/live-canary/test_run_dispatch.py
+++ b/scripts/live-canary/test_run_dispatch.py
@@ -63,6 +63,62 @@ class RunShDispatchTests(unittest.TestCase):
         self.assertIn("--case qa_8b_hn_keyword_live_chat", result.stdout)
         self.assertNotIn("--all-cases", result.stdout)
 
+    def test_retired_legacy_gateway_lanes_are_not_dispatchable(self):
+        retired_lanes = (
+            "auth-smoke",
+            "auth-full",
+            "auth-channels",
+            "auth-live-seeded",
+            "auth-browser-consent",
+            "workflow-canary",
+        )
+
+        for lane in retired_lanes:
+            with self.subTest(lane=lane), tempfile.TemporaryDirectory() as tmpdir:
+                env = {
+                    **os.environ,
+                    "ARTIFACT_ROOT": tmpdir,
+                    "LANE": lane,
+                    "PROVIDER": "mock",
+                    "PYTHON_BIN": "echo",
+                    "TIMESTAMP": "dispatch-test",
+                }
+                result = subprocess.run(
+                    [str(RUN_SH)],
+                    cwd=ROOT,
+                    env=env,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    check=False,
+                )
+
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(f"Unknown live canary lane: {lane}", result.stdout)
+                self.assertIn("MIGRATION.md", result.stdout)
+                self.assertNotIn("scripts/auth_canary/", result.stdout)
+                self.assertNotIn("scripts/auth_live_canary/", result.stdout)
+                self.assertNotIn("scripts/workflow_canary/", result.stdout)
+
+    def test_workflow_exposes_only_retained_dispatch_choices(self):
+        workflow = (ROOT / ".github" / "workflows" / "live-canary.yml").read_text(
+            encoding="utf-8"
+        )
+        choices = workflow.split("options:", 1)[1].split("scenario:", 1)[0]
+
+        for lane in (
+            "auth-smoke",
+            "auth-full",
+            "auth-channels",
+            "auth-live-seeded",
+            "auth-browser-consent",
+            "workflow-canary",
+        ):
+            with self.subTest(lane=lane):
+                self.assertNotIn(f"- {lane}", choices)
+
+        self.assertIn("- reborn-webui-v2-live-qa", choices)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/live-canary/test_serve_harness.py
+++ b/scripts/live-canary/test_serve_harness.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Unit tests for the shared ``ironclaw serve`` live-canary launcher."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "live_canary_serve_harness",
+    ROOT / "scripts" / "live_canary" / "serve_harness.py",
+)
+serve_harness = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = serve_harness
+_SPEC.loader.exec_module(serve_harness)
+
+
+class ServeHarnessTests(unittest.TestCase):
+    def test_command_uses_shipping_serve_cli_on_loopback(self):
+        self.assertEqual(
+            serve_harness.serve_command(Path("/tmp/ironclaw"), 43121),
+            [
+                "/tmp/ironclaw",
+                "serve",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "43121",
+            ],
+        )
+
+    def test_launcher_captures_logs_and_waits_for_health(self):
+        proc = Mock(spec=subprocess.Popen)
+        proc.poll.return_value = None
+
+        async def run_test() -> tuple[object, str, list[str], str, bool, bool]:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output_dir = Path(tmpdir)
+                with (
+                    patch.object(
+                        serve_harness.subprocess,
+                        "Popen",
+                        return_value=proc,
+                    ) as popen,
+                    patch.object(
+                        serve_harness,
+                        "wait_for_ready",
+                    ) as wait_for_ready,
+                ):
+                    launched_proc, base_url = await serve_harness.start_serve(
+                        binary=Path("/opt/ironclaw"),
+                        port=43122,
+                        env={"PATH": "/usr/bin:/bin"},
+                        output_dir=output_dir,
+                    )
+                    command = popen.call_args.args[0]
+                    readiness_url = wait_for_ready.call_args.args[0]
+                    stdout_exists = (output_dir / "ironclaw-serve.stdout.log").exists()
+                    stderr_exists = (output_dir / "ironclaw-serve.stderr.log").exists()
+                return (
+                    launched_proc,
+                    base_url,
+                    command,
+                    readiness_url,
+                    stdout_exists,
+                    stderr_exists,
+                )
+
+        (
+            launched_proc,
+            base_url,
+            command,
+            readiness_url,
+            stdout_exists,
+            stderr_exists,
+        ) = asyncio.run(run_test())
+        self.assertIs(launched_proc, proc)
+        self.assertEqual(base_url, "http://127.0.0.1:43122")
+        self.assertIn("serve", command)
+        self.assertEqual(readiness_url, "http://127.0.0.1:43122/api/health")
+        self.assertTrue(stdout_exists)
+        self.assertTrue(stderr_exists)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/live_canary/common.py
+++ b/scripts/live_canary/common.py
@@ -103,9 +103,9 @@ def cargo_build() -> None:
             "cargo",
             "build",
             "-p",
-            "ironclaw_legacy",
+            "ironclaw",
             "--bin",
-            "ironclaw-legacy",
+            "ironclaw",
         ],
         cwd=ROOT,
     )
@@ -436,7 +436,9 @@ async def start_gateway_stack(
     oauth_proxy: bool = False,
     log_dir: Path | None = None,
 ) -> GatewayStack:
-    secrets_master_key = secrets_master_key or generate_secrets_master_key()
+    # Kept in the compatibility signature until #6562 removes the retired
+    # callers. The shipping runtime owns its encrypted filesystem key.
+    _ = secrets_master_key or generate_secrets_master_key()
     python = venv_python(venv_dir)
     # Race-free port acquisition: `mock_llm.py --port 0` binds the
     # kernel-assigned port itself and prints `MOCK_LLM_PORT=<N>` on
@@ -486,50 +488,73 @@ async def start_gateway_stack(
             }
             extra_gateway_env = {**(extra_gateway_env or {}), **proxy_env}
 
-        gateway_port = reserve_loopback_port()
+        serve_port = reserve_loopback_port()
         http_port = reserve_loopback_port()
         gateway_token = f"{gateway_token_prefix}-{uuid.uuid4().hex[:12]}"
-        db_path = Path(db_tmp.name) / "canary.db"
-        home_dir = Path(home_tmp.name)
-        env = build_gateway_env(
-            owner_user_id=owner_user_id,
-            gateway_port=gateway_port,
-            http_port=http_port,
-            gateway_token=gateway_token,
-            db_path=db_path,
-            home_dir=home_dir,
-            tools_dir=Path(tools_tmp.name),
-            channels_dir=Path(channels_tmp.name),
-            mock_llm_url=mock_llm_url,
-            secrets_master_key=secrets_master_key,
-            extra_env=extra_gateway_env,
-        )
-        gateway_proc = subprocess.Popen(
-            [str(ROOT / "target" / "debug" / "ironclaw-legacy"), "--no-onboard"],
-            cwd=ROOT,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-            env=env,
-        )
-        # Same deadlock guard as mock_llm above — drain ironclaw's
-        # stdout/stderr so a chatty `RUST_LOG=info` doesn't fill the pipe
-        # buffer and freeze the request handler mid-response.
-        if log_dir is not None and gateway_proc.stdout is not None:
-            log_dir.mkdir(parents=True, exist_ok=True)
-            _drain_to_file(gateway_proc.stdout, log_dir / "gateway.log")
-        base_url = f"http://127.0.0.1:{gateway_port}"
-        await wait_for_ready(f"{base_url}/api/health", timeout=60.0)
+        process_home = Path(home_tmp.name)
+        ironclaw_home = process_home / "ironclaw-home"
+        ironclaw_home.mkdir(parents=True, exist_ok=True)
+        (ironclaw_home / "config.toml").write_text(
+            f"""api_version = "ironclaw.runtime/v1"
 
-        # Pin the LLM provider via the settings API. Setting LLM_BACKEND /
-        # LLM_BASE_URL / LLM_MODEL via env is not enough — IronClaw's DB
-        # setting takes priority over env, and the freshly-seeded DB
-        # defaults llm_backend to `nearai`, so the env config is ignored
-        # and the agent attempts an interactive NearAI auth flow that
-        # never completes in CI. Mirrors the pattern documented in
-        # tests/e2e/CLAUDE.md.
-        await _pin_mock_llm_settings(base_url, gateway_token, mock_llm_url)
+[boot]
+profile = "local-dev"
+
+[identity]
+default_owner = "{owner_user_id}"
+tenant = "live-canary"
+default_agent = "live-canary-agent"
+
+[webui]
+env_token_var = "IRONCLAW_REBORN_WEBUI_TOKEN"
+env_user_id_var = "IRONCLAW_REBORN_WEBUI_USER_ID"
+
+[llm.default]
+provider_id = "openai"
+model = "mock-model"
+api_key_env = "MOCK_LLM_API_KEY"
+base_url = "{mock_llm_url}/v1"
+""",
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(process_home),
+                "IRONCLAW_REBORN_HOME": str(ironclaw_home),
+                "IRONCLAW_REBORN_PROFILE": "local-dev",
+                "IRONCLAW_REBORN_WEBUI_TOKEN": gateway_token,
+                "IRONCLAW_REBORN_WEBUI_USER_ID": owner_user_id,
+                "MOCK_LLM_API_KEY": "mock-api-key",
+                "NO_PROXY": "127.0.0.1,localhost,::1",
+                "no_proxy": "127.0.0.1,localhost,::1",
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG": os.environ.get(
+                    "RUST_LOG",
+                    "ironclaw=warn,ironclaw_runner=warn",
+                ),
+            }
+        )
+        if extra_gateway_env:
+            env.update(
+                {
+                    key: value
+                    for key, value in extra_gateway_env.items()
+                    if value
+                }
+            )
+
+        from scripts.live_canary.serve_harness import start_serve
+
+        serve_log_dir = log_dir or process_home / "logs"
+        gateway_proc, base_url = await start_serve(
+            binary=ROOT / "target" / "debug" / "ironclaw",
+            port=serve_port,
+            env=env,
+            output_dir=serve_log_dir,
+            readiness_timeout=60.0,
+        )
+        db_path = ironclaw_home / "local-dev" / "reborn-local-dev.db"
         return GatewayStack(
             base_url=base_url,
             gateway_token=gateway_token,

--- a/scripts/live_canary/serve_harness.py
+++ b/scripts/live_canary/serve_harness.py
@@ -1,0 +1,87 @@
+"""Hermetic launcher for live-canary ``ironclaw serve`` processes."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+from scripts.live_canary.common import stop_process, wait_for_ready
+
+
+class ServeLaunchError(RuntimeError):
+    """Raised when a serve process does not become ready within its bound."""
+
+
+def serve_command(binary: Path, port: int) -> list[str]:
+    """Return the shipping CLI invocation used by retained Python canaries."""
+    return [
+        str(binary),
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+
+
+async def start_serve(
+    *,
+    binary: Path,
+    port: int,
+    env: dict[str, str],
+    output_dir: Path,
+    workspace_dir: Path | None = None,
+    readiness_timeout: float = 90.0,
+    log_stem: str = "ironclaw-serve",
+) -> tuple[subprocess.Popen[str], str]:
+    """Start ``ironclaw serve`` with bounded readiness and captured logs."""
+    base_url = f"http://127.0.0.1:{port}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    workspace = workspace_dir or output_dir / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    stdout_path = output_dir / f"{log_stem}.stdout.log"
+    stderr_path = output_dir / f"{log_stem}.stderr.log"
+    separator = (
+        f"\n--- ironclaw serve start "
+        f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} ---\n"
+    )
+
+    with (
+        stdout_path.open("a", encoding="utf-8") as stdout,
+        stderr_path.open("a", encoding="utf-8") as stderr,
+    ):
+        stdout.write(separator)
+        stderr.write(separator)
+        stdout.flush()
+        stderr.flush()
+        proc = subprocess.Popen(
+            serve_command(binary, port),
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=stderr,
+            text=True,
+            env=env,
+            cwd=workspace,
+        )
+
+    try:
+        await wait_for_ready(
+            f"{base_url}/api/health",
+            timeout=readiness_timeout,
+        )
+    except Exception as exc:
+        stop_process(proc)
+        tail = ""
+        if stderr_path.exists():
+            tail = "\n".join(
+                stderr_path.read_text(
+                    encoding="utf-8",
+                    errors="replace",
+                ).splitlines()[-80:]
+            )
+        raise ServeLaunchError(
+            f"ironclaw serve did not become healthy at {base_url}: {exc}\n{tail}"
+        ) from exc
+
+    return proc, base_url

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -43,6 +43,10 @@ from scripts.live_canary.common import (  # noqa: E402
     wait_for_ready,
     write_results,
 )
+from scripts.live_canary.serve_harness import (  # noqa: E402
+    ServeLaunchError,
+    start_serve,
+)
 from scripts.reborn_webui_v2_live_qa.case_matrix import (  # noqa: E402
     CaseFn,
     CaseSpec,
@@ -850,44 +854,21 @@ async def start_reborn_server(
         process_extra_env["IRONCLAW_REBORN_SLACK_PERSONAL_OAUTH_REDIRECT_URI"] = (
             f"{base_url}/api/reborn/product-auth/oauth/{_slack_auth_provider()}/callback"
         )
-    stdout_path = output_dir / "ironclaw-reborn-serve.stdout.log"
-    stderr_path = output_dir / "ironclaw-reborn-serve.stderr.log"
-    workspace_dir = output_dir / "workspace"
-    workspace_dir.mkdir(parents=True, exist_ok=True)
-    out = stdout_path.open("a", encoding="utf-8")
-    err = stderr_path.open("a", encoding="utf-8")
-    separator = f"\n--- ironclaw serve start {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} ---\n"
-    out.write(separator)
-    err.write(separator)
-    out.flush()
-    err.flush()
-    proc = subprocess.Popen(
-        [
-            str(binary),
-            "serve",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-        ],
-        stdin=subprocess.DEVNULL,
-        stdout=out,
-        stderr=err,
-        text=True,
-        env=server_env(reborn_home, output_dir / "os-home", process_extra_env),
-        cwd=workspace_dir,
-    )
     try:
-        await wait_for_ready(f"{base_url}/api/health", timeout=90.0)
-    except Exception as exc:
-        stop_process(proc)
-        tail = ""
-        if stderr_path.exists():
-            tail = "\n".join(stderr_path.read_text(encoding="utf-8", errors="replace").splitlines()[-80:])
-        raise LiveQaError(
-            f"ironclaw serve did not become healthy at {base_url}: {exc}\n{tail}"
-        ) from exc
-    return proc, base_url
+        return await start_serve(
+            binary=binary,
+            port=port,
+            env=server_env(
+                reborn_home,
+                output_dir / "os-home",
+                process_extra_env,
+            ),
+            output_dir=output_dir,
+            readiness_timeout=90.0,
+            log_stem="ironclaw-reborn-serve",
+        )
+    except ServeLaunchError as exc:
+        raise LiveQaError(str(exc)) from exc
 
 
 def _extension_setup_submission(

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -3894,23 +3894,20 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         class FakeProcess:
             pass
 
-        def fake_popen(*_args, **kwargs):
+        async def fake_start_serve(**kwargs):
             captured["env"] = kwargs["env"]
-            captured["cwd"] = kwargs["cwd"]
-            kwargs["stdout"].close()
-            kwargs["stderr"].close()
-            return FakeProcess()
-
-        async def fake_wait_for_ready(url: str, *, timeout: float) -> None:
-            captured["health_url"] = url
-            captured["timeout"] = timeout
+            captured["port"] = kwargs["port"]
+            return FakeProcess(), f"http://127.0.0.1:{kwargs['port']}"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             with (
                 patch.object(run_live_qa, "reserve_loopback_port", return_value=38555),
-                patch.object(run_live_qa.subprocess, "Popen", side_effect=fake_popen),
-                patch.object(run_live_qa, "wait_for_ready", side_effect=fake_wait_for_ready),
+                patch.object(
+                    run_live_qa,
+                    "start_serve",
+                    side_effect=fake_start_serve,
+                ),
             ):
                 proc, base_url = asyncio.run(
                     run_live_qa.start_reborn_server(
@@ -3926,7 +3923,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
         self.assertIsInstance(proc, FakeProcess)
         self.assertEqual(base_url, "http://127.0.0.1:38555")
-        self.assertEqual(captured["health_url"], "http://127.0.0.1:38555/api/health")
+        self.assertEqual(captured["port"], 38555)
         env = captured["env"]
         self.assertIsInstance(env, dict)
         self.assertEqual(
@@ -3943,15 +3940,9 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         class FakeProcess:
             pass
 
-        def fake_popen(*_args, **kwargs):
+        async def fake_start_serve(**kwargs):
             captured["env"] = kwargs["env"]
-            kwargs["stdout"].close()
-            kwargs["stderr"].close()
-            return FakeProcess()
-
-        async def fake_wait_for_ready(url: str, *, timeout: float) -> None:
-            captured["health_url"] = url
-            captured["timeout"] = timeout
+            return FakeProcess(), f"http://127.0.0.1:{kwargs['port']}"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -3982,8 +3973,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             with (
                 patch.dict(os.environ, env, clear=False),
                 patch.object(run_live_qa, "reserve_loopback_port", return_value=38555),
-                patch.object(run_live_qa.subprocess, "Popen", side_effect=fake_popen),
-                patch.object(run_live_qa, "wait_for_ready", side_effect=fake_wait_for_ready),
+                patch.object(
+                    run_live_qa,
+                    "start_serve",
+                    side_effect=fake_start_serve,
+                ),
             ):
                 proc, base_url = asyncio.run(
                     run_live_qa.start_reborn_server(


### PR DESCRIPTION
## Summary

- add a shared hermetic launcher for live-canary tests using the shipping `ironclaw serve` binary
- route retained Reborn WebUI live QA through isolated home, workspace, loopback listener, and bounded readiness checks
- retire six obsolete gateway-only lanes from workflow and dispatcher selection
- document the retained, migrated, and retired lane inventory

## Linked Issue

Closes #6560
Part of #6369

## Validation

- 207 related Python tests passed
- workflow YAML parsing passed
- Python compilation passed
- live-canary dispatcher tests passed
- diff check and pre-commit safety passed

## Security Impact

No authentication or authorization behavior changed. The new launcher keeps credentials child-only and binds services to loopback.

## Database Impact

None.

## Blast Radius

Test, CI, live-canary launcher, and documentation paths only.

## Rollback Plan

Revert commit `c1ecde010`.