### PR TITLE
test(e2e): route retained Python scenarios through ironclaw serve

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -32,6 +32,7 @@ on:
       - "crates/ironclaw_*/**"
       - "docs/reborn/**"
       - "scripts/reborn-e2e-rust.sh"
+      - "scripts/ci/check-ironclaw-serve-e2e-manifest.py"
       - "tests/e2e/**"
       - "build.rs"
       - "providers.json"
@@ -73,7 +74,7 @@ jobs:
 
           # Keep this pattern in sync with the push `paths:` filter in the
           # `on:` block above.
-          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/ironclaw_[^/]+/|docs/reborn/|scripts/reborn-e2e-rust\.sh$|tests/e2e/|build\.rs$|providers\.json$|Cargo\.toml$|Cargo\.lock$|\.github/workflows/reborn-e2e\.yml$)'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/ironclaw_[^/]+/|docs/reborn/|scripts/reborn-e2e-rust\.sh$|scripts/ci/check-ironclaw-serve-e2e-manifest\.py$|tests/e2e/|build\.rs$|providers\.json$|Cargo\.toml$|Cargo\.lock$|\.github/workflows/reborn-e2e\.yml$)'; then
             echo "has_e2e_scope=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_e2e_scope=false" >> "$GITHUB_OUTPUT"
@@ -163,6 +164,9 @@ jobs:
       - name: Check Reborn Responses API E2E inventory
         run: python3 scripts/ci/check-reborn-responses-e2e-manifest.py
 
+      - name: Check retained IronClaw serve E2E inventory
+        run: python3 scripts/ci/check-ironclaw-serve-e2e-manifest.py
+
       - name: Install WebUI frontend dependencies
         run: |
           cd crates/ironclaw_webui/frontend
@@ -227,6 +231,17 @@ jobs:
             exit 1
           fi
           pytest "${responses_tests[@]}" -v --timeout=120
+
+      - name: Run retained IronClaw serve E2E scenarios
+        run: |
+          mapfile -t serve_tests < <(
+            sed -e 's/#.*//' -e '/^[[:space:]]*$/d' tests/e2e/ironclaw_serve_e2e_tests.txt
+          )
+          if ((${#serve_tests[@]} == 0)); then
+            echo "No retained IronClaw serve E2E tests selected"
+            exit 1
+          fi
+          pytest "${serve_tests[@]}" -v --timeout=120
 
       - name: Package live-canary binary
         id: live_canary_binary

--- a/scripts/ci/check-ironclaw-serve-e2e-manifest.py
+++ b/scripts/ci/check-ironclaw-serve-e2e-manifest.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate the retained Python E2E inventory for ``ironclaw serve``."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "tests/e2e/ironclaw_serve_e2e_tests.txt"
+REQUIRED_CATEGORIES = {
+    "auth-oauth",
+    "conversation-thread",
+    "engine-tool-extension",
+}
+FORBIDDEN_FIXTURES = {
+    "auth_matrix_server",
+    "hosted_oauth_refresh_server",
+    "ironclaw_binary",
+    "ironclaw_server",
+}
+SERVE_FIXTURE_PREFIX = "reborn_v2_"
+
+
+@dataclass(frozen=True)
+class Selection:
+    category: str
+    selector: str
+
+
+def selections() -> list[Selection]:
+    selected: list[Selection] = []
+    category: str | None = None
+    for raw_line in MANIFEST.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("# category:"):
+            category = line.partition(":")[2].strip()
+            continue
+        selector = line.split("#", 1)[0].strip()
+        if not selector:
+            continue
+        if category is None:
+            raise SystemExit(f"selector has no category: {selector}")
+        selected.append(Selection(category=category, selector=selector))
+    return selected
+
+
+def test_functions(path: Path) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+
+
+def selected_tests(
+    selection: Selection,
+) -> tuple[Path, dict[str, ast.FunctionDef | ast.AsyncFunctionDef]]:
+    path_text, separator, test_name = selection.selector.partition("::")
+    path = ROOT / path_text
+    if not path.is_file():
+        raise SystemExit(f"selected scenario does not exist: {path_text}")
+    tests = test_functions(path)
+    if separator:
+        try:
+            return path, {test_name: tests[test_name]}
+        except KeyError as exc:
+            raise SystemExit(
+                f"selected test does not exist: {selection.selector}"
+            ) from exc
+    if not tests:
+        raise SystemExit(f"selected scenario has no tests: {path_text}")
+    return path, tests
+
+
+def fixture_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    return {
+        argument.arg
+        for argument in (
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+        )
+    }
+
+
+def main() -> int:
+    manifest = selections()
+    errors: list[str] = []
+    categories = {selection.category for selection in manifest}
+    missing_categories = sorted(REQUIRED_CATEGORIES - categories)
+    extra_categories = sorted(categories - REQUIRED_CATEGORIES)
+    if missing_categories:
+        errors.append(
+            "missing retained coverage categories: "
+            + ", ".join(missing_categories)
+        )
+    if extra_categories:
+        errors.append(
+            "unknown retained coverage categories: "
+            + ", ".join(extra_categories)
+        )
+
+    duplicates = sorted(
+        selector
+        for selector, count in Counter(
+            selection.selector for selection in manifest
+        ).items()
+        if count > 1
+    )
+    if duplicates:
+        errors.append(
+            "duplicate retained selectors:\n  " + "\n  ".join(duplicates)
+        )
+
+    selected_count = 0
+    for selection in manifest:
+        path, tests = selected_tests(selection)
+        for test_name, node in tests.items():
+            selected_count += 1
+            fixtures = fixture_names(node)
+            forbidden = sorted(fixtures & FORBIDDEN_FIXTURES)
+            if forbidden:
+                errors.append(
+                    f"{path.relative_to(ROOT)}::{test_name} uses deleted-binary "
+                    f"fixture(s): {', '.join(forbidden)}"
+                )
+            if not any(
+                fixture.startswith(SERVE_FIXTURE_PREFIX)
+                for fixture in fixtures
+            ):
+                errors.append(
+                    f"{path.relative_to(ROOT)}::{test_name} is not routed "
+                    "through a reborn_v2_* serve fixture"
+                )
+
+    if errors:
+        raise SystemExit("\n".join(errors))
+
+    print(
+        "IronClaw serve E2E manifest is complete "
+        f"({len(manifest)} selectors, {selected_count} tests)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/classify-test-scope.sh
+++ b/scripts/ci/classify-test-scope.sh
@@ -66,7 +66,7 @@ is_shared_test_path() {
 is_reborn_test_path() {
   local path="$1"
   case "$path" in
-    docs/reborn/*|scripts/reborn-e2e-rust.sh|scripts/ci/run-reborn-root-partition.sh|scripts/ci/run-reborn-group-tests.sh|scripts/ci/check-reborn-responses-e2e-manifest.py|tests/reborn_*|tests/integration/*|tests/support/reborn_parity_qa/*|tests/fixtures/llm_traces/reborn_qa/*|tests/e2e/reborn_coverage_tests.txt|tests/e2e/reborn_responses_e2e_tests.txt|tests/e2e/scenarios/test_reborn_*)
+    docs/reborn/*|scripts/reborn-e2e-rust.sh|scripts/ci/run-reborn-root-partition.sh|scripts/ci/run-reborn-group-tests.sh|scripts/ci/check-reborn-responses-e2e-manifest.py|scripts/ci/check-ironclaw-serve-e2e-manifest.py|tests/reborn_*|tests/integration/*|tests/support/reborn_parity_qa/*|tests/fixtures/llm_traces/reborn_qa/*|tests/e2e/reborn_coverage_tests.txt|tests/e2e/reborn_responses_e2e_tests.txt|tests/e2e/ironclaw_serve_e2e_tests.txt|tests/e2e/scenarios/test_reborn_*)
       return 0
       ;;
     crates/ironclaw_architecture/*)

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -244,6 +244,14 @@ has_legacy_tests=false
 has_reborn_tests=true"
 
 assert_scope \
+  "IronClaw serve E2E manifest" \
+  "tests/e2e/ironclaw_serve_e2e_tests.txt" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
   "shared reborn tests workflow" \
   ".github/workflows/reborn-tests.yml" \
   "docs_only=false

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -107,6 +107,13 @@ Emulate provider-contract tests are also excluded from the Reborn coverage gate
 because they primarily validate the fixture provider, while current hosted
 full-path Emulate tests still start the legacy gateway binary.
 
+The retained Python product scenarios that must survive legacy-fixture removal
+are listed separately in `ironclaw_serve_e2e_tests.txt`. Every selected test
+must use a `reborn_v2_*` fixture backed by the shipping `ironclaw serve`
+binary. Keep the auth/OAuth, conversation/thread, and engine/tool/extension
+category markers complete; CI validates the inventory with
+`scripts/ci/check-ironclaw-serve-e2e-manifest.py` before executing it.
+
 **Provider-contract / full-path (Emulate-backed):**
 
 | File | What it tests |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -72,6 +72,15 @@ in the E2E suite, but they are not part of the Reborn coverage gate. Manifest
 entries may be pytest node IDs when only part of a broader scenario file belongs
 in this gate.
 
+The narrower `tests/e2e/ironclaw_serve_e2e_tests.txt` inventory owns retained
+Python product coverage while the deleted-binary fixtures are removed. It
+groups served scenarios by auth/OAuth, conversation/thread, and
+engine/tool/extension behavior. Validate it with:
+
+```bash
+python3 scripts/ci/check-ironclaw-serve-e2e-manifest.py
+```
+
 ## Adding new scenarios
 
 1. Create `tests/e2e/scenarios/test_<name>.py`

--- a/tests/e2e/ironclaw_serve_e2e_tests.txt
+++ b/tests/e2e/ironclaw_serve_e2e_tests.txt
@@ -1,0 +1,22 @@
+# Retained Python E2E scenarios for the shipping `ironclaw serve` harness.
+#
+# Category markers are validated by
+# scripts/ci/check-ironclaw-serve-e2e-manifest.py. Keep the selectors focused
+# on product contracts that survive removal of the legacy gateway fixtures.
+
+# category: auth-oauth
+# replaces: test_v2_auth_oauth_matrix.py and legacy hosted auth fixtures
+tests/e2e/scenarios/test_reborn_webui_v2_product_auth_api.py
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_auth_flows.py
+
+# category: conversation-thread
+# replaces: legacy conversation, history, and gateway SSE scenarios
+tests/e2e/scenarios/test_reborn_webui_v2_session_api.py
+tests/e2e/scenarios/test_reborn_webui_v2_streaming_run_control_api.py
+
+# category: engine-tool-extension
+# replaces: legacy engine-v2, tool lifecycle, and extension lifecycle scenarios
+tests/e2e/scenarios/test_reborn_webui_v2_extensions_api.py::test_reborn_v2_extension_routes_require_auth_served
+tests/e2e/scenarios/test_reborn_webui_v2_extensions_api.py::test_reborn_v2_extension_routes_reject_invalid_input_served
+tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_execution.py
+tests/e2e/scenarios/test_reborn_private_tool_installs.py

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_auth_flows.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_auth_flows.py
@@ -382,7 +382,7 @@ async def test_reborn_legacy_manual_token_cancel_resolves_gate_without_token_sub
         assert f"/threads/{THREAD_ID}/runs/{RUN_ID}/gates/manual-token-cancel-gate/resolve" in (
             resolve_requests[0]["url"]
         )
-        assert resolve_requests[0]["body"]["resolution"] == "cancelled"
+        assert resolve_requests[0]["body"]["resolution"] == "declined"
         assert resolve_requests[0]["body"]["always"] is False
         assert resolve_requests[0]["body"]["client_action_id"]
     finally:
@@ -643,12 +643,14 @@ async def test_reborn_legacy_oauth_prompt_opens_https_authorization_only(
                 "url": auth_url,
             }
         ]
-        await expect(gate).to_contain_text("Waiting for GitHub")
+        await expect(gate).to_contain_text(
+            re.compile(r"Waiting for GitHub", re.IGNORECASE)
+        )
 
         await gate.get_by_role("button", name="Cancel").click()
         await expect(gate).to_be_hidden(timeout=5000)
         assert len(resolve_requests) == 1
-        assert resolve_requests[0]["body"]["resolution"] == "cancelled"
+        assert resolve_requests[0]["body"]["resolution"] == "declined"
     finally:
         await context.close()
 


### PR DESCRIPTION
## Summary

- define a reviewed inventory of 39 retained Python E2E tests
- group replacement coverage into auth/OAuth, conversation/thread, and engine/tool/extension contracts
- require every retained test to run through a `reborn_v2_*` fixture backed by `ironclaw serve`
- add manifest validation and execute the inventory in Reborn E2E CI
- update two stale assertions to match current product behavior

## Linked Issue

Closes #6561
Part of #6369

## Validation

- 39/39 retained E2E tests passed
- manifest and category validation passed
- scope-classifier regression tests passed
- workflow YAML parsing passed
- diff check and pre-commit safety passed

## Security Impact

No security policy changes. Auth and OAuth behavior is exercised through the shipping serve boundary.

## Database Impact

None.

## Blast Radius

Python E2E inventory and CI only. Expected CI runtime increase is approximately 40 seconds.

## Rollback Plan

Revert commit `df98bd623`.