### PR TITLE
feat(signing): NEAR redirect provider (Reborn-only, replaces #3993)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4887,6 +4887,7 @@ name = "ironclaw_wallet_external"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "ed25519-dalek",
  "hex",
  "ironclaw_attestation",

--- a/crates/ironclaw_wallet_external/Cargo.toml
+++ b/crates/ironclaw_wallet_external/Cargo.toml
@@ -34,6 +34,12 @@ k256 = { version = "0.13", features = ["ecdsa"] }
 ed25519-dalek = { version = "2.2.0", features = ["std"] }
 sha3 = "0.10"
 sha2 = "0.10"
+# NEAR redirect (PR8): the unsigned tx and gate-bound `state` ride the redirect
+# URL as URL-safe base64. Already vendored in the workspace lockfile; no heavy
+# near-primitives / near-crypto SDK is pulled — ed25519 verification reuses the
+# vendored ed25519-dalek above and the full borsh Transaction roundtrip is a
+# deferred follow-up (matching PR6).
+base64 = "0.22"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/ironclaw_wallet_external/src/lib.rs
+++ b/crates/ironclaw_wallet_external/src/lib.rs
@@ -1,12 +1,15 @@
 //! External-wallet signing providers for the IronClaw attested-signing
 //! substrate.
 //!
-//! This is **PR7 of a 10-PR stack** (see
-//! `docs/plans/2026-05-23-attested-signing-substrate.md`). It implements the
+//! This crate spans **PR7 and PR8 of a 10-PR stack** (see
+//! `docs/plans/2026-05-23-attested-signing-substrate.md`). PR7 implements the
 //! **browser injected provider** backend — `window.ethereum` (EVM) and
-//! `window.solana` (Solana) — as a [`SigningProvider`]. The wallet holds the
-//! keys and renders + signs natively (true wallet-side WYSIWYS); IronClaw never
-//! has custody.
+//! `window.solana` (Solana). PR8 adds the **NEAR browser-wallet redirect
+//! provider** ([`NearRedirectSigningProvider`]): the user is redirected to a
+//! NEAR wallet that signs the bound approved-tx hash with the account's ed25519
+//! access key and redirects back with the signature. In every case the wallet
+//! holds the keys and renders + signs natively (true wallet-side WYSIWYS);
+//! IronClaw never has custody.
 //!
 //! ## Trust model
 //!
@@ -46,7 +49,7 @@
 //!
 //! ## Dependency boundary
 //!
-//! May depend on `k256` / `ed25519-dalek` / `sha3` / `sha2` /
+//! May depend on `k256` / `ed25519-dalek` / `sha3` / `sha2` / `base64` /
 //! `ironclaw_signing_provider` / `ironclaw_attestation` — but NOT on
 //! `solana-sdk`, `near-primitives`, or `ironclaw_secrets` (it holds no keys).
 //! The architecture boundary test
@@ -56,8 +59,14 @@
 #![forbid(unsafe_code)]
 
 mod injected;
+mod near_redirect;
 
 pub use injected::{
     InjectedProofPayload, InjectedScheme, InjectedSigningProvider, decode_injected_proof,
     encode_injected_proof,
+};
+pub use near_redirect::{
+    NearAccessKeyScope, NearBoundOperation, NearRedirectProofPayload, NearRedirectSigningProvider,
+    NearRedirectState, decode_near_redirect_proof, decode_state, derive_state,
+    encode_near_redirect_proof, encode_state, verify_state,
 };

--- a/crates/ironclaw_wallet_external/src/near_redirect/mod.rs
+++ b/crates/ironclaw_wallet_external/src/near_redirect/mod.rs
@@ -1,0 +1,640 @@
+//! The NEAR browser-wallet redirect [`SigningProvider`] backend.
+//!
+//! NEAR wallets (NEAR Wallet / Wallet Selector compatible) sign in the user's
+//! browser after a redirect: IronClaw sends the user to a wallet URL embedding
+//! the unsigned transaction and a `state` parameter cryptographically bound to
+//! the gate, the user approves and signs in the wallet, and the wallet
+//! redirects back with the signature material. This module builds that redirect
+//! ([`NearRedirectSigningProvider::initiate`]) and verifies the proof carried
+//! back ([`NearRedirectSigningProvider::verify_resume`]), fail-closed, against
+//! the bound [`ApprovedTxHash`], the bound NEAR account / access key, the echoed
+//! `state`, and the one-shot grant.
+//!
+//! NEAR accounts authorize with ed25519 access keys. The wallet attests to the
+//! *bound* [`ApprovedTxHash`] (the WYSIWYS digest IronClaw rendered and the
+//! wallet UI mirrors) by signing over its raw 32 bytes, exactly as the Solana
+//! injected provider does — no `near-primitives` borsh `Transaction` roundtrip
+//! is pulled in. The full borsh `Transaction` decode/roundtrip is a deferred
+//! follow-up (PR6 made the same deferral); the transaction bytes ride the
+//! redirect URL as an opaque base64 payload here.
+
+mod state;
+mod verify;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use ironclaw_attestation::{GrantError, GrantKey, SealedGrantStore};
+use ironclaw_signing_provider::{
+    ApprovedTxHash, DecodedTransaction, InitiationOutcome, ProviderId, RenderedTx, SigningContext,
+    SigningProof, SigningProvider, SigningProviderError, TrustModel, VerifiedProof,
+};
+
+pub use state::{NearRedirectState, decode_state, derive_state, encode_state, verify_state};
+
+/// The NEAR access-key permission scope a proof claims it signed under.
+///
+/// `#[serde(rename_all = "snake_case", tag = "kind")]` pins the wire form: these
+/// tags ride in the persisted gate proof, so they must not drift. The scope is
+/// validated against the bound operation in
+/// [`NearRedirectSigningProvider::verify_resume`] (threat #22: NEAR access-key
+/// scope).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum NearAccessKeyScope {
+    /// A full-access key: authorizes any action on the account. Always covers
+    /// the bound operation.
+    FullAccess,
+    /// A function-call access key: restricted to calling specific methods on a
+    /// single receiver, optionally with a gas allowance. The bound receiver and
+    /// method must fall within these limits.
+    FunctionCall {
+        /// The single contract account the key may call.
+        receiver_id: String,
+        /// The method names the key may call. Empty means "any method on
+        /// `receiver_id`" (NEAR's convention for an unrestricted method list).
+        method_names: Vec<String>,
+    },
+}
+
+/// The operation a NEAR redirect proof is bound to, used to validate the
+/// declared access-key scope (threat #22).
+///
+/// This is recomputed by the verifier from the bound transaction; it is never
+/// taken from caller-supplied proof fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NearBoundOperation {
+    /// The receiver (contract) account the bound transaction calls, if it is a
+    /// function call. `None` for a plain transfer / full-access-only operation.
+    pub receiver_id: Option<String>,
+    /// The method the bound transaction calls, if it is a function call.
+    pub method_name: Option<String>,
+}
+
+/// The structured payload a NEAR wallet carries back on the redirect callback,
+/// serialized into the opaque [`SigningProof::NearRedirectProof`] byte body.
+///
+/// The wallet attests to the *bound* [`ApprovedTxHash`] by signing over its raw
+/// 32 bytes with the account's ed25519 access key. The payload echoes that hash,
+/// the claimed NEAR account, the access-key public key, the declared key scope,
+/// and the `state` parameter so the verifier can re-check every binding without
+/// trusting any caller-supplied chain bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NearRedirectProofPayload {
+    /// The approved-tx hash the wallet attests to. MUST equal the bound hash;
+    /// re-checked in [`NearRedirectSigningProvider::verify_resume`] (threat #3).
+    pub approved_tx_hash: ApprovedTxHash,
+    /// The NEAR account id the wallet claims signed (e.g. `alice.near`).
+    /// Compared to the bound account; the claim itself is never trusted
+    /// (threat #4).
+    pub account_id: String,
+    /// The ed25519 access-key public key bytes (32 bytes) the signature verifies
+    /// against. Lowercase hex on the wire.
+    #[serde(with = "hex_bytes")]
+    pub public_key: Vec<u8>,
+    /// The raw 64-byte ed25519 signature over the 32-byte approved hash.
+    #[serde(with = "hex_bytes")]
+    pub signature: Vec<u8>,
+    /// The access-key scope the wallet signed under. Validated against the bound
+    /// operation (threat #22).
+    pub access_key_scope: NearAccessKeyScope,
+    /// The opaque `state` parameter echoed back from the redirect. Re-derived
+    /// and compared by the verifier to defeat callback / deep-link interception
+    /// (threat #20).
+    pub state: String,
+}
+
+/// Serialize a [`NearRedirectProofPayload`] into opaque proof bytes for
+/// [`SigningProof::NearRedirectProof`].
+pub fn encode_near_redirect_proof(
+    payload: &NearRedirectProofPayload,
+) -> Result<Vec<u8>, SigningProviderError> {
+    // serde_json keeps the encoding self-describing and stable across the wire;
+    // the opaque-bytes contract of `SigningProof::NearRedirectProof` is satisfied
+    // by any deterministic round-trippable encoding. Propagate the error rather
+    // than silently returning empty bytes (which would only surface as an opaque
+    // decode failure later); `.unwrap()`/`.expect()` is banned in production.
+    serde_json::to_vec(payload).map_err(|e| SigningProviderError::ProofInvalid {
+        reason: format!("failed to encode near redirect proof payload: {e}"),
+    })
+}
+
+/// Decode opaque [`SigningProof::NearRedirectProof`] bytes into a structured
+/// [`NearRedirectProofPayload`].
+pub fn decode_near_redirect_proof(
+    bytes: &[u8],
+) -> Result<NearRedirectProofPayload, SigningProviderError> {
+    // The payload is a small fixed-shape record; a generous 64 KiB ceiling
+    // rejects attacker-inflated callback bodies before the serde allocator.
+    const MAX_PROOF_BYTES: usize = 64 * 1024;
+    if bytes.len() > MAX_PROOF_BYTES {
+        return Err(SigningProviderError::ProofInvalid {
+            reason: format!(
+                "near redirect proof payload too large: {} bytes (max {MAX_PROOF_BYTES})",
+                bytes.len()
+            ),
+        });
+    }
+    serde_json::from_slice(bytes).map_err(|e| SigningProviderError::ProofInvalid {
+        reason: format!("malformed near redirect proof payload: {e}"),
+    })
+}
+
+/// The NEAR browser-wallet redirect signing backend.
+///
+/// Holds the wallet base URL (where the user is redirected to sign), the
+/// callback URL the wallet redirects back to, a server-side secret used to bind
+/// the `state` parameter to the gate, and a handle to the sealed-grant store so
+/// [`Self::verify_resume`] can claim the one-shot grant atomically. Holds **no
+/// signing key material** — the wallet owns the account's keys.
+pub struct NearRedirectSigningProvider {
+    wallet_base_url: String,
+    callback_url: String,
+    state_secret: Vec<u8>,
+    grants: Arc<dyn SealedGrantStore>,
+}
+
+impl NearRedirectSigningProvider {
+    /// Construct over the wallet redirect/callback URLs, a server-side
+    /// `state_secret` (used to MAC-bind the `state` parameter to the gate), and
+    /// a sealed-grant store.
+    pub fn new(
+        wallet_base_url: impl Into<String>,
+        callback_url: impl Into<String>,
+        state_secret: impl Into<Vec<u8>>,
+        grants: Arc<dyn SealedGrantStore>,
+    ) -> Self {
+        Self {
+            wallet_base_url: wallet_base_url.into(),
+            callback_url: callback_url.into(),
+            state_secret: state_secret.into(),
+            grants,
+        }
+    }
+
+    /// Build the NEAR wallet redirect URL for a bound transaction.
+    ///
+    /// Embeds the opaque (base64) transaction bytes, the callback URL, and the
+    /// gate-bound `state` parameter. This is the directive surfaced to the user
+    /// in [`InitiationOutcome::AwaitingUserAction`].
+    fn build_redirect_url(
+        &self,
+        context: &SigningContext,
+        decoded: &DecodedTransaction,
+        approved_tx_hash: &ApprovedTxHash,
+    ) -> String {
+        use base64::Engine as _;
+        let tx_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(decoded.as_opaque());
+        let state = derive_state(&self.state_secret, context, approved_tx_hash);
+        let sep = if self.wallet_base_url.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        format!(
+            "{base}{sep}transactions={tx}&callbackUrl={cb}&state={state}",
+            base = self.wallet_base_url,
+            tx = url_encode(&tx_b64),
+            cb = url_encode(&self.callback_url),
+            state = url_encode(&state),
+        )
+    }
+}
+
+#[async_trait]
+impl SigningProvider for NearRedirectSigningProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::NearRedirect
+    }
+
+    fn trust_model(&self) -> TrustModel {
+        TrustModel::ExternalWallet
+    }
+
+    async fn initiate(
+        &self,
+        context: &SigningContext,
+        decoded: &DecodedTransaction,
+        _rendered: &RenderedTx,
+        approved_tx_hash: &ApprovedTxHash,
+    ) -> Result<InitiationOutcome, SigningProviderError> {
+        // The NEAR wallet signs after a browser redirect, so the user must be
+        // sent to an external surface. The directive is the redirect URL; the
+        // owning channel (web gateway) delivers it outbound to the user.
+        let url = self.build_redirect_url(context, decoded, approved_tx_hash);
+        Ok(InitiationOutcome::AwaitingUserAction {
+            directive: url.into_bytes(),
+        })
+    }
+
+    async fn verify_resume(
+        &self,
+        context: &SigningContext,
+        approved_tx_hash: &ApprovedTxHash,
+        proof: &SigningProof,
+    ) -> Result<VerifiedProof, SigningProviderError> {
+        // Only NEAR redirect proofs are accepted by this provider; anything else
+        // is a routing error and fails closed.
+        let SigningProof::NearRedirectProof(bytes) = proof else {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "near redirect provider received a non-near-redirect proof".to_string(),
+            });
+        };
+        let payload = decode_near_redirect_proof(bytes)?;
+
+        // 1. Hash binding (threat #3): the wallet must have attested to the
+        //    exact bound hash. Reject before any signature work.
+        if &payload.approved_tx_hash != approved_tx_hash {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof approved-tx hash does not match the bound hash".to_string(),
+            });
+        }
+
+        // 2. State echo (threat #20): re-derive the gate-bound state and require
+        //    the callback to echo it. Defeats redirect / deep-link interception:
+        //    a callback for a different gate carries a different state.
+        if !verify_state(
+            &self.state_secret,
+            context,
+            approved_tx_hash,
+            &payload.state,
+        ) {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "state parameter does not match the gate-bound state".to_string(),
+            });
+        }
+
+        // 3. Account + key binding (threat #4): parse the gate-bound NEAR
+        //    identity into its account id and its expected access-key public key.
+        //    BOTH are fixed at gate-raise (from Wallet Selector) and MUST match
+        //    the callback — the public key in particular is NEVER trusted from
+        //    the callback, exactly as the Solana injected provider binds the
+        //    signer pubkey. Binding only the account would let an attacker who
+        //    knows the (public) account id supply their own keypair and forge an
+        //    approval, since a NEAR account may hold many access keys.
+        let bound = BoundNearIdentity::parse(context.key_or_account_id.as_str())?;
+        if payload.account_id != bound.account_id {
+            return Err(SigningProviderError::SignerMismatch);
+        }
+        if payload.public_key != bound.public_key {
+            return Err(SigningProviderError::SignerMismatch);
+        }
+
+        // 4. Signed-bytes binding (threat #2): verify the ed25519 signature over
+        //    the bound 32 hash bytes against the GATE-BOUND access-key public key
+        //    (`bound.public_key`, NOT the callback-supplied one — they are now
+        //    proven equal above). Because the signed message *is* the approved
+        //    canonical hash, a valid signature proves the bound wallet signed
+        //    exactly the approved bytes.
+        verify::verify_signature_over_hash(
+            approved_tx_hash.as_bytes(),
+            &payload.signature,
+            &bound.public_key,
+        )?;
+
+        // 5. Access-key scope (threat #22): the declared scope must cover the
+        //    bound operation. A function-call key restricted to a different
+        //    receiver / method cannot authorize this transaction.
+        let bound_op = decode_bound_operation(context, approved_tx_hash);
+        validate_access_key_scope(&payload.access_key_scope, &bound_op)?;
+
+        // 6. One-shot grant (threat #1): claim the sealed grant atomically. A
+        //    replay of an already-claimed grant fails closed here.
+        let key = GrantKey::from_context(context, *approved_tx_hash);
+        self.grants.claim(&key).await.map_err(map_grant_error)?;
+
+        Ok(VerifiedProof::new(
+            ProviderId::NearRedirect,
+            *approved_tx_hash,
+            proof.clone(),
+        ))
+    }
+}
+
+/// The gate-bound NEAR identity, parsed from [`SigningContext::key_or_account_id`].
+///
+/// A NEAR account (`alice.near`) is public and may hold many access keys, so the
+/// account id alone cannot authenticate a signature: the gate must also bind the
+/// specific access-key public key the user signs with (captured at gate-raise
+/// from Wallet Selector). The wire form is `account_id:<64-char lowercase-hex
+/// 32-byte ed25519 pubkey>`. The bound key — never the callback-supplied one —
+/// is what [`NearRedirectSigningProvider::verify_resume`] verifies against
+/// (threat #4: signer/key binding, mirroring the Solana injected provider).
+struct BoundNearIdentity {
+    account_id: String,
+    public_key: Vec<u8>,
+}
+
+impl BoundNearIdentity {
+    fn parse(bound: &str) -> Result<Self, SigningProviderError> {
+        // Split on the LAST ':' so account ids that themselves contain ':' (none
+        // do in NEAR, but be defensive) keep the key as the final field.
+        let (account_id, key_hex) =
+            bound
+                .rsplit_once(':')
+                .ok_or_else(|| SigningProviderError::ProofInvalid {
+                    reason: "bound NEAR identity must be `account_id:<hex ed25519 pubkey>`"
+                        .to_string(),
+                })?;
+        if account_id.is_empty() {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "bound NEAR identity has an empty account id".to_string(),
+            });
+        }
+        let public_key =
+            hex_bytes::hex_decode(key_hex).map_err(|e| SigningProviderError::ProofInvalid {
+                reason: format!("bound NEAR access-key pubkey is not valid hex: {e}"),
+            })?;
+        if public_key.len() != 32 {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: format!(
+                    "bound NEAR access-key pubkey must be 32 bytes, got {}",
+                    public_key.len()
+                ),
+            });
+        }
+        Ok(Self {
+            account_id: account_id.to_string(),
+            public_key,
+        })
+    }
+}
+
+/// Recompute the bound NEAR operation from authoritative context.
+///
+/// PR6 deferred the full `near-primitives` borsh `Transaction` decode, so the
+/// per-action receiver/method are not yet recoverable from the transaction bytes
+/// at this layer. Until that decode lands, the bound operation is treated as
+/// unconstrained (`None`/`None`): a `FullAccess` key always passes, and a
+/// `FunctionCall` key is accepted as long as it is internally well-formed (the
+/// scope still cannot be *escalated* beyond what the wallet declares). The
+/// receiver/method cross-check against the decoded transaction is wired once the
+/// borsh decode follow-up lands.
+fn decode_bound_operation(
+    _context: &SigningContext,
+    _approved_tx_hash: &ApprovedTxHash,
+) -> NearBoundOperation {
+    // PR-followup(near-borsh): recover receiver_id/method_name from the decoded
+    // borsh Transaction once the heavy-SDK-free decode lands, and cross-check
+    // them against the FunctionCall scope below.
+    NearBoundOperation {
+        receiver_id: None,
+        method_name: None,
+    }
+}
+
+/// Validate that the declared access-key scope covers the bound operation
+/// (threat #22).
+fn validate_access_key_scope(
+    scope: &NearAccessKeyScope,
+    bound: &NearBoundOperation,
+) -> Result<(), SigningProviderError> {
+    match scope {
+        // A full-access key authorizes any action on the account.
+        NearAccessKeyScope::FullAccess => Ok(()),
+        NearAccessKeyScope::FunctionCall {
+            receiver_id,
+            method_names,
+        } => {
+            if receiver_id.is_empty() {
+                return Err(SigningProviderError::ScopeViolation {
+                    reason: "function-call access key declares an empty receiver".to_string(),
+                });
+            }
+            // Fail-closed (threat #22): a FunctionCall key is restricted to a
+            // single receiver, so we MUST be able to prove the key covers the
+            // bound operation's receiver. Until the borsh transaction decode
+            // lands, `decode_bound_operation` returns `None`, meaning we cannot
+            // recover the tx's actual receiver — so we cannot prove the
+            // restricted key authorizes THIS operation. Accepting it would let a
+            // key scoped to receiver A authorize a transaction to receiver B
+            // (the verifier can't tell them apart yet). Refuse rather than
+            // fail open; a FullAccess key (or the post-decode follow-up) is the
+            // supported path.
+            let Some(bound_receiver) = &bound.receiver_id else {
+                return Err(SigningProviderError::ScopeViolation {
+                    reason: "function-call access-key scope cannot be verified against the bound \
+                             operation (NEAR transaction receiver decode not yet available); \
+                             refuse fail-closed"
+                        .to_string(),
+                });
+            };
+            if receiver_id != bound_receiver {
+                return Err(SigningProviderError::ScopeViolation {
+                    reason: format!(
+                        "access key receiver `{receiver_id}` does not match bound receiver \
+                         `{bound_receiver}`"
+                    ),
+                });
+            }
+            if let Some(bound_method) = &bound.method_name
+                && !method_names.is_empty()
+                && !method_names.iter().any(|m| m == bound_method)
+            {
+                return Err(SigningProviderError::ScopeViolation {
+                    reason: format!(
+                        "bound method `{bound_method}` is not in the access key's method list"
+                    ),
+                });
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
+fn map_grant_error(err: GrantError) -> SigningProviderError {
+    match err {
+        // Replay / missing / lost-CAS all collapse to a single fail-closed
+        // grant-claim failure; the distinction is not safe to leak to a caller.
+        GrantError::AlreadyClaimed
+        | GrantError::NotFound
+        | GrantError::AlreadySealed
+        | GrantError::InvalidTimestamp { .. }
+        | GrantError::InvalidExpiry { .. } => SigningProviderError::GrantClaimFailed,
+        GrantError::Backend { reason } => SigningProviderError::Provider { reason },
+    }
+}
+
+/// Percent-encode a URL query component (the small, dependency-free subset we
+/// need: keeps unreserved chars, escapes everything else).
+fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => {
+                out.push('%');
+                out.push(
+                    char::from_digit((b >> 4) as u32, 16)
+                        .unwrap_or('0')
+                        .to_ascii_uppercase(),
+                );
+                out.push(
+                    char::from_digit((b & 0x0f) as u32, 16)
+                        .unwrap_or('0')
+                        .to_ascii_uppercase(),
+                );
+            }
+        }
+    }
+    out
+}
+
+/// Hex (de)serialization helper for `Vec<u8>` proof fields.
+mod hex_bytes {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(bytes: &[u8], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&hex_encode(bytes))
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(d)?;
+        hex_decode(&s).map_err(serde::de::Error::custom)
+    }
+
+    pub(super) fn hex_encode(bytes: &[u8]) -> String {
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            out.push(char::from_digit((b >> 4) as u32, 16).unwrap_or('0'));
+            out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap_or('0'));
+        }
+        out
+    }
+
+    pub(super) fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        // Decode over BYTES, not `&str` char slices: `&s[i..i+2]` panics when the
+        // input contains a multi-byte (non-ASCII) char straddling an odd byte
+        // offset, and proof payloads come from external wallets (callback DoS).
+        let bytes = s.as_bytes();
+        if !bytes.len().is_multiple_of(2) {
+            return Err("odd-length hex".to_string());
+        }
+        bytes
+            .chunks_exact(2)
+            .map(|pair| {
+                let hi = decode_nibble(pair[0])?;
+                let lo = decode_nibble(pair[1])?;
+                Ok((hi << 4) | lo)
+            })
+            .collect()
+    }
+
+    fn decode_nibble(b: u8) -> Result<u8, String> {
+        match b {
+            b'0'..=b'9' => Ok(b - b'0'),
+            b'a'..=b'f' => Ok(b - b'a' + 10),
+            b'A'..=b'F' => Ok(b - b'A' + 10),
+            other => Err(format!("invalid hex byte: {other:#x}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(receiver: Option<&str>, method: Option<&str>) -> NearBoundOperation {
+        NearBoundOperation {
+            receiver_id: receiver.map(str::to_string),
+            method_name: method.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn full_access_scope_always_covers_bound_operation() {
+        assert!(
+            validate_access_key_scope(&NearAccessKeyScope::FullAccess, &op(None, None)).is_ok()
+        );
+        assert!(
+            validate_access_key_scope(
+                &NearAccessKeyScope::FullAccess,
+                &op(Some("c.near"), Some("transfer")),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn function_call_scope_rejects_empty_receiver() {
+        let scope = NearAccessKeyScope::FunctionCall {
+            receiver_id: String::new(),
+            method_names: vec![],
+        };
+        let err = validate_access_key_scope(&scope, &op(None, None)).expect_err("empty receiver");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn function_call_scope_with_unknown_bound_operation_fails_closed() {
+        // Until the borsh tx decode lands, the bound receiver is `None`. A
+        // restricted FunctionCall key cannot be proven to cover the bound
+        // operation, so it MUST be refused fail-closed (threat #22) rather than
+        // accepted on the wallet's word.
+        let scope = NearAccessKeyScope::FunctionCall {
+            receiver_id: "a.near".to_string(),
+            method_names: vec!["foo".to_string()],
+        };
+        let err = validate_access_key_scope(&scope, &op(None, None))
+            .expect_err("unknown bound operation must fail closed for a function-call key");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn function_call_scope_rejects_mismatched_bound_receiver() {
+        let scope = NearAccessKeyScope::FunctionCall {
+            receiver_id: "a.near".to_string(),
+            method_names: vec![],
+        };
+        let err = validate_access_key_scope(&scope, &op(Some("b.near"), None))
+            .expect_err("receiver mismatch");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn function_call_scope_rejects_method_not_in_list() {
+        let scope = NearAccessKeyScope::FunctionCall {
+            receiver_id: "a.near".to_string(),
+            method_names: vec!["foo".to_string()],
+        };
+        let err = validate_access_key_scope(&scope, &op(Some("a.near"), Some("bar")))
+            .expect_err("method mismatch");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn function_call_scope_accepts_matching_receiver_and_method() {
+        let scope = NearAccessKeyScope::FunctionCall {
+            receiver_id: "a.near".to_string(),
+            method_names: vec!["foo".to_string()],
+        };
+        assert!(validate_access_key_scope(&scope, &op(Some("a.near"), Some("foo"))).is_ok());
+    }
+
+    #[test]
+    fn url_encode_escapes_reserved_and_keeps_unreserved() {
+        assert_eq!(url_encode("a-b_c.d~e"), "a-b_c.d~e");
+        assert_eq!(url_encode("a b&c=d"), "a%20b%26c%3Dd");
+    }
+
+    #[test]
+    fn proof_payload_round_trips_through_opaque_bytes() {
+        let payload = NearRedirectProofPayload {
+            approved_tx_hash: ApprovedTxHash::from_bytes([4u8; 32]),
+            account_id: "alice.near".to_string(),
+            public_key: vec![3u8; 32],
+            signature: vec![9u8; 64],
+            access_key_scope: NearAccessKeyScope::FullAccess,
+            state: "abc".to_string(),
+        };
+        let bytes = encode_near_redirect_proof(&payload).expect("encode");
+        let back = decode_near_redirect_proof(&bytes).expect("decode");
+        assert_eq!(back, payload);
+    }
+}

--- a/crates/ironclaw_wallet_external/src/near_redirect/state.rs
+++ b/crates/ironclaw_wallet_external/src/near_redirect/state.rs
@@ -1,0 +1,231 @@
+//! The gate-bound `state` parameter for the NEAR wallet redirect (threat #20).
+//!
+//! When IronClaw redirects the user to the NEAR wallet it embeds a `state`
+//! parameter. The wallet echoes it back on the callback. To defeat redirect /
+//! deep-link interception — an attacker pasting a callback for a *different*
+//! gate, or replaying a callback against a different request — the `state` is
+//! deterministically derived from the gate-identifying context plus the bound
+//! [`ApprovedTxHash`], MAC'd with a server-side secret. The verifier
+//! re-derives it from the authoritative context and requires an exact,
+//! constant-time match; nothing in the callback is trusted to *carry* the
+//! binding, only to echo it.
+//!
+//! The MAC is HMAC-SHA256 over the canonical context tuple, built on the `sha2`
+//! primitive the crate already depends on (no new crypto dependency).
+
+use sha2::{Digest, Sha256};
+
+use ironclaw_signing_provider::{ApprovedTxHash, SigningContext};
+
+/// Domain separation tag so this MAC can never collide with another use of the
+/// same secret.
+const STATE_DOMAIN: &[u8] = b"ironclaw.near_redirect.state.v1";
+
+/// The decoded view of a state parameter (currently just the opaque MAC hex).
+///
+/// Kept as a named type so the wire shape can grow (e.g. an explicit nonce)
+/// without churning call sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NearRedirectState {
+    /// Lowercase-hex HMAC-SHA256 binding the gate context + approved hash.
+    pub mac_hex: String,
+}
+
+/// Derive the gate-bound `state` parameter string.
+///
+/// Deterministic in `(secret, context, approved_tx_hash)`: the same gate always
+/// produces the same state, and any change to who/which-run/which-gate/which-
+/// chain/which-account/which-hash changes it.
+pub fn derive_state(
+    secret: &[u8],
+    context: &SigningContext,
+    approved_tx_hash: &ApprovedTxHash,
+) -> String {
+    let mac = hmac_sha256(secret, &state_message(context, approved_tx_hash));
+    hex_encode(&mac)
+}
+
+/// Re-derive and constant-time compare the gate-bound state against the echoed
+/// `candidate`. Returns `true` iff they match.
+pub fn verify_state(
+    secret: &[u8],
+    context: &SigningContext,
+    approved_tx_hash: &ApprovedTxHash,
+    candidate: &str,
+) -> bool {
+    let expected = derive_state(secret, context, approved_tx_hash);
+    constant_time_eq(expected.as_bytes(), candidate.as_bytes())
+}
+
+/// Encode a [`NearRedirectState`] to its wire string.
+pub fn encode_state(state: &NearRedirectState) -> String {
+    state.mac_hex.clone()
+}
+
+/// Decode a wire string into a [`NearRedirectState`]. Validation of the binding
+/// happens in [`verify_state`]; this is only the shape parse.
+pub fn decode_state(s: &str) -> NearRedirectState {
+    NearRedirectState {
+        mac_hex: s.to_string(),
+    }
+}
+
+/// Build the canonical, length-prefixed message the MAC is computed over. Each
+/// field is length-prefixed so no two distinct field tuples can collide.
+fn state_message(context: &SigningContext, approved_tx_hash: &ApprovedTxHash) -> Vec<u8> {
+    let mut msg = Vec::new();
+    push_field(&mut msg, STATE_DOMAIN);
+    push_field(&mut msg, context.tenant.as_str().as_bytes());
+    push_field(&mut msg, context.user.as_str().as_bytes());
+    push_field(&mut msg, context.run_id.as_str().as_bytes());
+    push_field(&mut msg, context.gate_ref.as_str().as_bytes());
+    push_field(&mut msg, context.chain_id.as_str().as_bytes());
+    push_field(&mut msg, context.key_or_account_id.as_str().as_bytes());
+    push_field(&mut msg, approved_tx_hash.as_bytes());
+    msg
+}
+
+/// Length-prefix (8-byte big-endian) then append a field.
+fn push_field(buf: &mut Vec<u8>, field: &[u8]) {
+    buf.extend_from_slice(&(field.len() as u64).to_be_bytes());
+    buf.extend_from_slice(field);
+}
+
+/// HMAC-SHA256 (RFC 2104) over `sha2::Sha256`. Implemented inline to avoid
+/// pulling an `hmac` crate for this single use.
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK: usize = 64;
+    let mut block_key = [0u8; BLOCK];
+    if key.len() > BLOCK {
+        let digest = Sha256::digest(key);
+        block_key[..32].copy_from_slice(&digest);
+    } else {
+        block_key[..key.len()].copy_from_slice(key);
+    }
+
+    let mut ipad = [0x36u8; BLOCK];
+    let mut opad = [0x5cu8; BLOCK];
+    for i in 0..BLOCK {
+        ipad[i] ^= block_key[i];
+        opad[i] ^= block_key[i];
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(ipad);
+    inner.update(message);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(opad);
+    outer.update(inner_digest);
+    let out = outer.finalize();
+
+    let mut mac = [0u8; 32];
+    mac.copy_from_slice(&out);
+    mac
+}
+
+/// Constant-time byte-slice equality (length-independent short-circuit only on
+/// length, which is not secret here — the state is fixed-length hex).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(char::from_digit((b >> 4) as u32, 16).unwrap_or('0'));
+        out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap_or('0'));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_signing_provider::{
+        ActorId, ChainId, GateRef, KeyOrAccountId, RunId, ScopeId, TenantId, UserId,
+    };
+
+    fn ctx(account: &str, gate: &str) -> SigningContext {
+        SigningContext {
+            tenant: TenantId::new("tenant-a"),
+            user: UserId::new("user-1"),
+            scope: ScopeId::new("scope-x"),
+            actor: ActorId::new("actor-7"),
+            run_id: RunId::new("run-42"),
+            gate_ref: GateRef::new(gate),
+            chain_id: ChainId::new("near:mainnet"),
+            key_or_account_id: KeyOrAccountId::new(account),
+        }
+    }
+
+    #[test]
+    fn hmac_sha256_matches_rfc_test_vector() {
+        // RFC 4231 test case 1: key = 0x0b * 20, data = "Hi There".
+        let key = [0x0bu8; 20];
+        let mac = hmac_sha256(&key, b"Hi There");
+        assert_eq!(
+            hex_encode(&mac),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+    }
+
+    #[test]
+    fn derive_is_deterministic() {
+        let c = ctx("alice.near", "gate:1");
+        let h = ApprovedTxHash::from_bytes([7u8; 32]);
+        assert_eq!(
+            derive_state(b"secret", &c, &h),
+            derive_state(b"secret", &c, &h)
+        );
+    }
+
+    #[test]
+    fn verify_accepts_matching_state() {
+        let c = ctx("alice.near", "gate:1");
+        let h = ApprovedTxHash::from_bytes([7u8; 32]);
+        let s = derive_state(b"secret", &c, &h);
+        assert!(verify_state(b"secret", &c, &h, &s));
+    }
+
+    #[test]
+    fn verify_rejects_different_gate() {
+        let c1 = ctx("alice.near", "gate:1");
+        let c2 = ctx("alice.near", "gate:2");
+        let h = ApprovedTxHash::from_bytes([7u8; 32]);
+        let s = derive_state(b"secret", &c1, &h);
+        // A callback echoing gate:1's state must not validate against gate:2.
+        assert!(!verify_state(b"secret", &c2, &h, &s));
+    }
+
+    #[test]
+    fn verify_rejects_different_hash() {
+        let c = ctx("alice.near", "gate:1");
+        let h1 = ApprovedTxHash::from_bytes([7u8; 32]);
+        let h2 = ApprovedTxHash::from_bytes([8u8; 32]);
+        let s = derive_state(b"secret", &c, &h1);
+        assert!(!verify_state(b"secret", &c, &h2, &s));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_secret() {
+        let c = ctx("alice.near", "gate:1");
+        let h = ApprovedTxHash::from_bytes([7u8; 32]);
+        let s = derive_state(b"secret-a", &c, &h);
+        assert!(!verify_state(b"secret-b", &c, &h, &s));
+    }
+
+    #[test]
+    fn state_round_trips_through_wire_string() {
+        let st = decode_state("deadbeef");
+        assert_eq!(encode_state(&st), "deadbeef");
+    }
+}

--- a/crates/ironclaw_wallet_external/src/near_redirect/verify.rs
+++ b/crates/ironclaw_wallet_external/src/near_redirect/verify.rs
@@ -1,0 +1,85 @@
+//! NEAR redirect-proof ed25519 signature verification.
+//!
+//! A NEAR wallet attests to the bound [`ApprovedTxHash`] by signing over the raw
+//! 32 hash bytes with the account's ed25519 access key, producing a 64-byte
+//! signature. We verify it with the vendored `ed25519-dalek` (no
+//! `near-primitives` / `near-crypto`). Binding the verifying key to the bound
+//! NEAR account happens in the caller (the account id is the bound identity;
+//! the public key authenticates the signature under it).
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+use ironclaw_signing_provider::SigningProviderError;
+
+/// Verify a 64-byte ed25519 `signature` over the 32 `hash_bytes` against the
+/// 32-byte ed25519 `public_key`. Fails closed on any malformed input or
+/// verification failure.
+pub(super) fn verify_signature_over_hash(
+    hash_bytes: &[u8; 32],
+    signature: &[u8],
+    public_key: &[u8],
+) -> Result<(), SigningProviderError> {
+    let pk_bytes: [u8; 32] =
+        public_key
+            .try_into()
+            .map_err(|_| SigningProviderError::ProofInvalid {
+                reason: format!("near public key must be 32 bytes, got {}", public_key.len()),
+            })?;
+    let sig_bytes: [u8; 64] =
+        signature
+            .try_into()
+            .map_err(|_| SigningProviderError::ProofInvalid {
+                reason: format!("near signature must be 64 bytes, got {}", signature.len()),
+            })?;
+
+    let verifying_key =
+        VerifyingKey::from_bytes(&pk_bytes).map_err(|e| SigningProviderError::ProofInvalid {
+            reason: format!("invalid near ed25519 public key: {e}"),
+        })?;
+    let sig = Signature::from_bytes(&sig_bytes);
+
+    verifying_key
+        .verify(hash_bytes, &sig)
+        .map_err(|e| SigningProviderError::ProofInvalid {
+            reason: format!("near ed25519 verification failed: {e}"),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    #[test]
+    fn valid_signature_verifies() {
+        let key = SigningKey::from_bytes(&[0x44u8; 32]);
+        let pk = key.verifying_key().to_bytes();
+        let hash = [9u8; 32];
+        let sig = key.sign(&hash).to_bytes();
+        assert!(verify_signature_over_hash(&hash, &sig, &pk).is_ok());
+    }
+
+    #[test]
+    fn signature_over_other_message_fails() {
+        let key = SigningKey::from_bytes(&[0x44u8; 32]);
+        let pk = key.verifying_key().to_bytes();
+        let sig = key.sign(&[0u8; 32]).to_bytes();
+        let err =
+            verify_signature_over_hash(&[9u8; 32], &sig, &pk).expect_err("wrong message must fail");
+        assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+    }
+
+    #[test]
+    fn wrong_length_public_key_fails() {
+        let err = verify_signature_over_hash(&[0u8; 32], &[0u8; 64], &[0u8; 31])
+            .expect_err("short pubkey");
+        assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+    }
+
+    #[test]
+    fn wrong_length_signature_fails() {
+        let err =
+            verify_signature_over_hash(&[0u8; 32], &[0u8; 63], &[0u8; 32]).expect_err("short sig");
+        assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+    }
+}

--- a/crates/ironclaw_wallet_external/tests/near_redirect.rs
+++ b/crates/ironclaw_wallet_external/tests/near_redirect.rs
@@ -1,0 +1,375 @@
+//! End-to-end verification tests for the NEAR redirect
+//! [`NearRedirectSigningProvider`] (attested-signing PR8).
+//!
+//! These drive the provider behind `Arc<dyn SigningProvider>` (object-safety)
+//! and through the sealed-grant store, exercising both halves of the contract:
+//!
+//! * `initiate` builds an `AwaitingUserAction` redirect directive embedding the
+//!   base64 transaction, the callback URL, and the gate-bound `state`.
+//! * `verify_resume` is fail-closed: a valid signature from the bound account
+//!   with a matching state + covering scope succeeds; a wrong account is
+//!   `SignerMismatch`; a tampered hash, a bad signature, or a mismatched state
+//!   is `ProofInvalid`; a function-call key with an empty receiver is a
+//!   `ScopeViolation`; a replayed (already-claimed) grant fails closed.
+
+use std::sync::Arc;
+
+use ironclaw_attestation::{
+    ApprovedTxHash, AttestedSigningGrant, GrantKey, InMemorySealedGrantStore, SealedGrantStore,
+};
+use ironclaw_signing_provider::{
+    ActorId, ChainId, DecodedTransaction, GateRef, InitiationOutcome, KeyOrAccountId, RenderedTx,
+    RunId, ScopeId, SigningContext, SigningProof, SigningProvider, SigningProviderError, TenantId,
+    UserId,
+};
+use ironclaw_wallet_external::{
+    NearAccessKeyScope, NearRedirectProofPayload, NearRedirectSigningProvider, derive_state,
+    encode_near_redirect_proof,
+};
+
+use ed25519_dalek::{Signer as _, SigningKey as EdSigningKey};
+
+const WALLET_URL: &str = "https://wallet.near.org/sign";
+const CALLBACK_URL: &str = "https://ironclaw.example/api/chat/gate/resolve";
+const STATE_SECRET: &[u8] = b"server-side-state-secret";
+
+fn near_key() -> EdSigningKey {
+    EdSigningKey::from_bytes(&[0x55u8; 32])
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+    }
+    out
+}
+
+/// The gate-bound NEAR identity is `account_id:<64-hex ed25519 pubkey>`. The
+/// access-key public key is bound at gate-raise (from Wallet Selector), exactly
+/// as the Solana injected provider binds the signer pubkey, so a callback that
+/// carries an attacker's own key cannot pass verification (threat #4).
+fn bound_identity(account: &str, key: &EdSigningKey) -> String {
+    format!("{account}:{}", lower_hex(&key.verifying_key().to_bytes()))
+}
+
+fn ctx_for(account: &str) -> SigningContext {
+    SigningContext {
+        tenant: TenantId::new("tenant-a"),
+        user: UserId::new("user-1"),
+        scope: ScopeId::new("scope-x"),
+        actor: ActorId::new("actor-7"),
+        run_id: RunId::new("run-42"),
+        gate_ref: GateRef::new("gate:near-1"),
+        chain_id: ChainId::new("near:mainnet"),
+        key_or_account_id: KeyOrAccountId::new(account),
+    }
+}
+
+fn provider(store: Arc<InMemorySealedGrantStore>) -> NearRedirectSigningProvider {
+    NearRedirectSigningProvider::new(WALLET_URL, CALLBACK_URL, STATE_SECRET, store)
+}
+
+async fn seal_grant(store: &InMemorySealedGrantStore, ctx: &SigningContext, hash: ApprovedTxHash) {
+    let key = GrantKey::from_context(ctx, hash);
+    store
+        .seal(AttestedSigningGrant::new(key, 1_000, None).expect("valid grant"))
+        .await
+        .expect("seal");
+}
+
+/// Build a valid proof: the key signs the bound hash, the state is gate-derived.
+fn valid_proof(
+    key: &EdSigningKey,
+    account: &str,
+    ctx: &SigningContext,
+    hash: ApprovedTxHash,
+    scope: NearAccessKeyScope,
+) -> SigningProof {
+    let sig = key.sign(hash.as_bytes());
+    let payload = NearRedirectProofPayload {
+        approved_tx_hash: hash,
+        account_id: account.to_string(),
+        public_key: key.verifying_key().to_bytes().to_vec(),
+        signature: sig.to_bytes().to_vec(),
+        access_key_scope: scope,
+        state: derive_state(STATE_SECRET, ctx, &hash),
+    };
+    SigningProof::NearRedirectProof(encode_near_redirect_proof(&payload).expect("encode"))
+}
+
+#[tokio::test]
+async fn initiate_returns_redirect_directive_with_state_and_callback() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = provider(store.clone());
+    let ctx = ctx_for("alice.near");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let decoded = DecodedTransaction::from_opaque(vec![0xab, 0xcd, 0xef]);
+    let rendered = RenderedTx::from_opaque(vec![1]);
+
+    let outcome = provider
+        .initiate(&ctx, &decoded, &rendered, &hash)
+        .await
+        .expect("initiate");
+    let InitiationOutcome::AwaitingUserAction { directive } = outcome else {
+        panic!("near redirect must require a user redirect");
+    };
+    let url = String::from_utf8(directive).expect("utf8 url");
+    assert!(url.starts_with(WALLET_URL), "url: {url}");
+    assert!(url.contains("transactions="), "url: {url}");
+    assert!(url.contains("callbackUrl="), "url: {url}");
+    // The gate-bound state must be embedded so the callback can be matched.
+    let state = derive_state(STATE_SECRET, &ctx, &hash);
+    assert!(url.contains(&format!("state={state}")), "url: {url}");
+}
+
+#[tokio::test]
+async fn valid_signature_from_bound_account_verifies() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p: Arc<dyn SigningProvider> = Arc::new(provider(store.clone()));
+    let key = near_key();
+    let account = "alice.near";
+    let ctx = ctx_for(&bound_identity(account, &key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    let proof = valid_proof(&key, account, &ctx, hash, NearAccessKeyScope::FullAccess);
+    let verified = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("valid near proof must verify");
+    assert_eq!(verified.proof(), &proof);
+}
+
+/// Threat #4 (signer/key binding): an attacker who knows the bound account but
+/// NOT its bound access key supplies their own keypair in the callback. The
+/// claimed `account_id` matches the bound account, and they can sign over the
+/// bound hash with their own key, but the signature must be verified against the
+/// GATE-BOUND access key — not the callback-supplied one — so it fails closed.
+#[tokio::test]
+async fn attacker_supplied_key_is_signer_mismatch() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p: Arc<dyn SigningProvider> = Arc::new(provider(store.clone()));
+    let legit_key = near_key();
+    let attacker_key = EdSigningKey::from_bytes(&[0x99u8; 32]);
+    let account = "alice.near";
+    // The gate binds alice.near's LEGITIMATE access key.
+    let ctx = ctx_for(&bound_identity(account, &legit_key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    // Attacker forges a proof: correct account, correct hash, valid state (state
+    // only binds the account), a self-signed signature, and THEIR OWN pubkey.
+    let sig = attacker_key.sign(hash.as_bytes());
+    let payload = NearRedirectProofPayload {
+        approved_tx_hash: hash,
+        account_id: account.to_string(),
+        public_key: attacker_key.verifying_key().to_bytes().to_vec(),
+        signature: sig.to_bytes().to_vec(),
+        access_key_scope: NearAccessKeyScope::FullAccess,
+        state: derive_state(STATE_SECRET, &ctx, &hash),
+    };
+    let proof =
+        SigningProof::NearRedirectProof(encode_near_redirect_proof(&payload).expect("encode"));
+    let err = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("attacker-supplied key must fail closed");
+    assert!(matches!(err, SigningProviderError::SignerMismatch));
+}
+
+#[tokio::test]
+async fn wrong_account_is_signer_mismatch() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store.clone());
+    let key = near_key();
+    // Bind a different account than the proof claims.
+    let ctx = ctx_for(&bound_identity("bob.near", &key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    // The proof claims `alice.near` (state derived for the bound bob.near ctx
+    // would mismatch, so derive the proof for its own claimed account but bind
+    // bob.near) — account binding check fires first via the bound ctx account.
+    let proof = valid_proof(
+        &key,
+        "alice.near",
+        &ctx,
+        hash,
+        NearAccessKeyScope::FullAccess,
+    );
+    let err = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("mismatched account must reject");
+    assert!(matches!(err, SigningProviderError::SignerMismatch));
+}
+
+#[tokio::test]
+async fn tampered_hash_is_proof_invalid() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store.clone());
+    let key = near_key();
+    let account = "alice.near";
+    let ctx = ctx_for(&bound_identity(account, &key));
+    let bound_hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, bound_hash).await;
+
+    // Wallet attests to a DIFFERENT hash than the gate bound.
+    let attested = ApprovedTxHash::from_bytes([9u8; 32]);
+    let proof = valid_proof(
+        &key,
+        account,
+        &ctx,
+        attested,
+        NearAccessKeyScope::FullAccess,
+    );
+    let err = p
+        .verify_resume(&ctx, &bound_hash, &proof)
+        .await
+        .expect_err("tampered hash must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn mismatched_state_is_proof_invalid() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store.clone());
+    let key = near_key();
+    let account = "alice.near";
+    let ctx = ctx_for(&bound_identity(account, &key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    let sig = key.sign(hash.as_bytes());
+    let payload = NearRedirectProofPayload {
+        approved_tx_hash: hash,
+        account_id: account.to_string(),
+        public_key: key.verifying_key().to_bytes().to_vec(),
+        signature: sig.to_bytes().to_vec(),
+        access_key_scope: NearAccessKeyScope::FullAccess,
+        // Forged / intercepted state that was not derived for this gate.
+        state: "deadbeef".to_string(),
+    };
+    let proof =
+        SigningProof::NearRedirectProof(encode_near_redirect_proof(&payload).expect("encode"));
+    let err = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("bad state must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn bad_signature_is_proof_invalid() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store.clone());
+    let key = near_key();
+    let account = "alice.near";
+    let ctx = ctx_for(&bound_identity(account, &key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    // Signature over a different message.
+    let sig = key.sign(&[0u8; 32]);
+    let payload = NearRedirectProofPayload {
+        approved_tx_hash: hash,
+        account_id: account.to_string(),
+        public_key: key.verifying_key().to_bytes().to_vec(),
+        signature: sig.to_bytes().to_vec(),
+        access_key_scope: NearAccessKeyScope::FullAccess,
+        state: derive_state(STATE_SECRET, &ctx, &hash),
+    };
+    let proof =
+        SigningProof::NearRedirectProof(encode_near_redirect_proof(&payload).expect("encode"));
+    let err = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("bad signature must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn empty_receiver_function_call_scope_is_scope_violation() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store.clone());
+    let key = near_key();
+    let account = "alice.near";
+    let ctx = ctx_for(&bound_identity(account, &key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    let scope = NearAccessKeyScope::FunctionCall {
+        receiver_id: String::new(),
+        method_names: vec![],
+    };
+    let proof = valid_proof(&key, account, &ctx, hash, scope);
+    let err = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("empty receiver must be a scope violation");
+    assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+}
+
+#[tokio::test]
+async fn replay_after_claim_fails_closed() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store.clone());
+    let key = near_key();
+    let account = "alice.near";
+    let ctx = ctx_for(&bound_identity(account, &key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    let proof = valid_proof(&key, account, &ctx, hash, NearAccessKeyScope::FullAccess);
+    p.verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("first resume succeeds");
+    let err = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("replay must fail closed");
+    assert!(matches!(err, SigningProviderError::GrantClaimFailed));
+}
+
+#[tokio::test]
+async fn unsealed_grant_fails_closed() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store.clone());
+    let key = near_key();
+    let account = "alice.near";
+    let ctx = ctx_for(&bound_identity(account, &key));
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    // No grant sealed.
+
+    let proof = valid_proof(&key, account, &ctx, hash, NearAccessKeyScope::FullAccess);
+    let err = p
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("no grant must fail closed");
+    assert!(matches!(err, SigningProviderError::GrantClaimFailed));
+}
+
+#[tokio::test]
+async fn non_near_redirect_proof_is_rejected() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store);
+    let ctx = ctx_for("alice.near");
+    let hash = ApprovedTxHash::from_bytes([1u8; 32]);
+
+    let err = p
+        .verify_resume(&ctx, &hash, &SigningProof::InjectedProof(vec![1, 2, 3]))
+        .await
+        .expect_err("non-near-redirect proof must be rejected");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn provider_reports_near_redirect_identity() {
+    use ironclaw_signing_provider::{ProviderId, TrustModel};
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let p = provider(store);
+    assert_eq!(p.provider_id(), ProviderId::NearRedirect);
+    assert_eq!(p.trust_model(), TrustModel::ExternalWallet);
+}

--- a/crates/ironclaw_wallet_external/tests/near_redirect_binding.rs
+++ b/crates/ironclaw_wallet_external/tests/near_redirect_binding.rs
@@ -1,0 +1,160 @@
+//! Edge-case coverage for the canonical NEAR signer-binding format
+//! (`account_id:<64-char lowercase-hex 32-byte ed25519 pubkey>`) parsed from
+//! [`SigningContext::key_or_account_id`] in `verify_resume`.
+//!
+//! `BoundNearIdentity::parse` is a crate-private helper, so these drive it
+//! through the public `verify_resume` surface: a malformed bound identity
+//! string must fail closed as `ProofInvalid` before any signature is trusted.
+//! These supplement the byte-identical `tests/near_redirect.rs` (which mirrors
+//! `attested-signing-10-reborn-runtime`) with the parse failure modes, and are
+//! kept in a separate file so the shared test file stays identical across the
+//! stack for clean rebase-cascade dedup.
+
+use std::sync::Arc;
+
+use ironclaw_attestation::{
+    ApprovedTxHash, AttestedSigningGrant, GrantKey, InMemorySealedGrantStore, SealedGrantStore,
+};
+use ironclaw_signing_provider::{
+    ActorId, ChainId, GateRef, KeyOrAccountId, RunId, ScopeId, SigningContext, SigningProof,
+    SigningProvider, SigningProviderError, TenantId, UserId,
+};
+use ironclaw_wallet_external::{
+    NearAccessKeyScope, NearRedirectProofPayload, NearRedirectSigningProvider, derive_state,
+    encode_near_redirect_proof,
+};
+
+use ed25519_dalek::{Signer as _, SigningKey as EdSigningKey};
+
+const WALLET_URL: &str = "https://wallet.near.org/sign";
+const CALLBACK_URL: &str = "https://ironclaw.example/api/chat/gate/resolve";
+const STATE_SECRET: &[u8] = b"server-side-state-secret";
+
+fn near_key() -> EdSigningKey {
+    EdSigningKey::from_bytes(&[0x55u8; 32])
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(char::from_digit((b >> 4) as u32, 16).unwrap_or('0'));
+        out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap_or('0'));
+    }
+    out
+}
+
+/// Build a context whose `key_or_account_id` is set to an arbitrary (possibly
+/// malformed) bound-identity string, so we can exercise `BoundNearIdentity::parse`.
+fn ctx_with_bound(bound: &str) -> SigningContext {
+    SigningContext {
+        tenant: TenantId::new("tenant-a"),
+        user: UserId::new("user-1"),
+        scope: ScopeId::new("scope-x"),
+        actor: ActorId::new("actor-7"),
+        run_id: RunId::new("run-42"),
+        gate_ref: GateRef::new("gate:near-1"),
+        chain_id: ChainId::new("near:mainnet"),
+        key_or_account_id: KeyOrAccountId::new(bound),
+    }
+}
+
+async fn seal_grant(store: &InMemorySealedGrantStore, ctx: &SigningContext, hash: ApprovedTxHash) {
+    let key = GrantKey::from_context(ctx, hash);
+    store
+        .seal(AttestedSigningGrant::new(key, 1_000, None).expect("valid grant"))
+        .await
+        .expect("seal");
+}
+
+/// Build an otherwise-valid proof (good hash, good state, real signature) so the
+/// ONLY thing that can fail is parsing the bound identity from the context.
+fn valid_proof(
+    key: &EdSigningKey,
+    account: &str,
+    ctx: &SigningContext,
+    hash: ApprovedTxHash,
+) -> SigningProof {
+    let sig = key.sign(hash.as_bytes());
+    let payload = NearRedirectProofPayload {
+        approved_tx_hash: hash,
+        account_id: account.to_string(),
+        public_key: key.verifying_key().to_bytes().to_vec(),
+        signature: sig.to_bytes().to_vec(),
+        access_key_scope: NearAccessKeyScope::FullAccess,
+        state: derive_state(STATE_SECRET, ctx, &hash),
+    };
+    SigningProof::NearRedirectProof(encode_near_redirect_proof(&payload).expect("encode"))
+}
+
+/// Drive `verify_resume` with a malformed bound identity and assert it fails
+/// closed as `ProofInvalid` (the `parse` error class).
+async fn assert_bound_identity_rejected(bound: &str) {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider =
+        NearRedirectSigningProvider::new(WALLET_URL, CALLBACK_URL, STATE_SECRET, store.clone());
+    let key = near_key();
+    let ctx = ctx_with_bound(bound);
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    let proof = valid_proof(&key, "alice.near", &ctx, hash);
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("malformed bound identity must fail closed");
+    assert!(
+        matches!(err, SigningProviderError::ProofInvalid { .. }),
+        "expected ProofInvalid for bound `{bound}`, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn bound_identity_without_colon_is_rejected() {
+    // No `:` separator at all — cannot split account from key.
+    assert_bound_identity_rejected("alice.near").await;
+}
+
+#[tokio::test]
+async fn bound_identity_with_empty_account_is_rejected() {
+    let key = near_key();
+    let bound = format!(":{}", lower_hex(&key.verifying_key().to_bytes()));
+    assert_bound_identity_rejected(&bound).await;
+}
+
+#[tokio::test]
+async fn bound_identity_with_non_hex_pubkey_is_rejected() {
+    // 64 chars but not valid hex (`z` is not a hex digit).
+    let bound = format!("alice.near:{}", "z".repeat(64));
+    assert_bound_identity_rejected(&bound).await;
+}
+
+#[tokio::test]
+async fn bound_identity_with_wrong_length_pubkey_is_rejected() {
+    // Valid hex, but only 16 bytes (32 hex chars) instead of the required 32.
+    let bound = format!("alice.near:{}", "ab".repeat(16));
+    assert_bound_identity_rejected(&bound).await;
+}
+
+#[tokio::test]
+async fn bound_identity_account_with_colon_keeps_key_as_final_field() {
+    // `rsplit_once(':')` splits on the LAST colon, so an account id that itself
+    // contains a colon keeps the trailing 64-hex field as the key. A correctly
+    // formed identity (real key bytes) with such an account verifies cleanly.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider =
+        NearRedirectSigningProvider::new(WALLET_URL, CALLBACK_URL, STATE_SECRET, store.clone());
+    let key = near_key();
+    let account = "weird:account.near";
+    let bound = format!("{account}:{}", lower_hex(&key.verifying_key().to_bytes()));
+    let ctx = ctx_with_bound(&bound);
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    seal_grant(&store, &ctx, hash).await;
+
+    // The proof's account_id must echo the full account (everything before the
+    // final colon), and the key must be the bound key.
+    let proof = valid_proof(&key, account, &ctx, hash);
+    provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("colon-containing account with a valid final key field verifies");
+}


### PR DESCRIPTION
Replaces #3993, which was closed on 2026-07-20 because it modified the legacy top-level `src/` web ingress. **`src/` has since been deleted entirely** (`b6da0272a`, #6375 — "delete v1 legacy monolith (src/) and cut deploy over to Reborn"), so this branch has been rebased onto current `main` with all `src/` hunks excised. The crate-side work is unchanged.

Part of the attested-signing revival — see the tracking issue #6532 for the full plan.

## What this PR is

NEAR browser-wallet redirect signing provider (`ironclaw_wallet_external::near_redirect`): the user is redirected to a NEAR wallet that signs the bound `ApprovedTxHash` with the account's ed25519 access key and redirects back with the signature. The wallet holds the keys and renders/signs natively (wallet-side WYSIWYS); IronClaw never has custody.

## Cascade changes (vs the closed #3993)

- **Rebased onto current `main`** (the stack was 1184 commits behind; merge base was 2026-05-24).
- **`src/` excised**: dropped the legacy `src/channels/web/features/chat/attested.rs` proof-ingress hunks (+696 lines across 3 files). The Reborn-side replacement lands in the gate/resolve ingress PR (#3995).
- **Adopted the hardened round-2 attestation API** (these are the security fixes the lower PRs gained after this branch forked, and they must not regress):
  - `AttestedSigningGrant::seal` → fallible `::new` (timestamp/expiry validation)
  - `map_grant_error` now maps `GrantError::InvalidTimestamp`/`InvalidExpiry` fail-closed to `GrantClaimFailed`

## Verification

`cargo build`/`cargo test -p ironclaw_wallet_external` green (19 + 12 + 5 + 20 tests); `attested_signing_boundaries` boundary test green (incl. `workspace_graph_is_openssl_free`); clippy clean.
