### PR TITLE
test(reborn): complete capability evidence

### DIFF
--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -112,7 +112,7 @@ full-path Emulate tests still start the legacy gateway binary.
 | File | What it tests |
 |------|--------------|
 | `test_emulate_reborn_provider_contracts.py` | Reborn Emulate fixture contracts: Google account isolation and stateful reads/writes, Slack QA 9/10 provider shapes and strict-scope failures, and GitHub identity plus positive/negative state transitions |
-| `test_provider_capability_inventory.py` | Fast completeness gate derived from shipped first-party manifests. Every static provider capability must be tested, live-only, unsupported, or covered by an owned waiver in `fixtures/provider_capability_coverage.toml`. |
+| `test_provider_capability_inventory.py` | Fast completeness gate derived from shipped first-party manifests. Every static provider capability must be tested, live-only, unsupported, or covered by an owned waiver in `fixtures/provider_capability_coverage.toml`; non-Emulate evidence names its exact Cargo target, source, and executable test. |
 | `test_reborn_emulate_full_path.py` | Install/auth a first-party extension, drive scripted Gmail/Calendar/Drive/GitHub tool calls, assert provider state and cleanup via Emulate |
 | `test_oauth_refresh.py` | Hosted Gmail OAuth refresh: expire token, real tool call, refresh via mock proxy without leaking `client_secret` |
 | `test_extension_uninstall_cleanup.py` | Install/remove for WASM tools/channels, shared Google tools, MCP; uninstall deletes secrets, preserves shared creds |
@@ -214,13 +214,15 @@ routing, tool execution, and provider mutation together.
 The pinned `serrrfirat/emulate` fork adds the Google Calendar, Docs, Drive,
 Sheets, and Slides operations; Slack `search.messages`; and GitHub Contents,
 GraphQL review threads, and seeded Actions workflows used by the provider
-contract catalog. Of 123 shipped static provider capabilities, 119 now have
-full-path Emulate-backed evidence. The remaining four are intentionally outside
-this runner: `github.handle_webhook` is local ingress normalization, while
-`nearai.web_search`, `web-access.get_content`, and `web-access.search` need a
-separate hermetic web-search/content double. Manual QA rows that mention
-Telegram or Twitter/X also remain model-replay-only unless paired with their own
-provider fixture.
+contract catalog. All 123 shipped static provider capabilities now have
+executable hermetic evidence: 119 cross the standalone Reborn + Emulate path,
+while `github.handle_webhook`, `nearai.web_search`,
+`web-access.get_content`, and `web-access.search` use Reborn integration tests
+at their actual local-WASM or hosted-MCP seams. The inventory records the exact
+Cargo target, source, and test for those non-Emulate cases and fails if that
+evidence stops being executable. Manual QA rows that mention Telegram or
+Twitter/X remain model-replay-only unless paired with their own provider
+fixture.
 
 ### Environment passed to ironclaw in tests
 

--- a/tests/e2e/fixtures/provider_capability_coverage.toml
+++ b/tests/e2e/fixtures/provider_capability_coverage.toml
@@ -29,6 +29,7 @@ tested = [
   "github.get_workflow_run_artifacts",
   "github.get_workflow_run_jobs",
   "github.get_workflow_runs",
+  "github.handle_webhook",
   "github.list_branches",
   "github.list_issue_comments",
   "github.list_issues",
@@ -115,6 +116,7 @@ tested = [
   "google-slides.insert_text",
   "google-slides.replace_all_text",
   "google-slides.replace_shapes_with_image",
+  "nearai.web_search",
   "slack.get_conversation_history",
   "slack.get_conversation_info",
   "slack.get_thread_replies",
@@ -123,27 +125,37 @@ tested = [
   "slack.search_messages",
   "slack.send_message",
   "slack.whoami",
+  "web-access.get_content",
+  "web-access.search",
 ]
 
 live_only = []
 unsupported = []
 
-[[waivers]]
-owner = "@serrrfirat"
-reason = "Webhook normalization is local logic and does not cross a provider boundary."
-issue = "#6524"
-review_condition = "Add a caller-path webhook ingress contract outside the Emulate provider runner."
-capabilities = [
-  "github.handle_webhook",
-]
+[[integration_evidence]]
+capability = "github.handle_webhook"
+kind = "reborn_integration"
+target = "reborn_integration_tool_call"
+source = "tests/integration/tool_call.rs"
+test = "github_webhook_normalization_dispatches_through_bundled_wasm"
 
-[[waivers]]
-owner = "@serrrfirat"
-reason = "These search tools need a separate hermetic web-search/content provider double."
-issue = "#6524"
-review_condition = "Replace with tested when the non-Emulate provider fixture exists."
-capabilities = [
-  "nearai.web_search",
-  "web-access.get_content",
-  "web-access.search",
-]
+[[integration_evidence]]
+capability = "nearai.web_search"
+kind = "reborn_integration"
+target = "reborn_integration_mcp"
+source = "tests/integration/mcp.rs"
+test = "nearai_web_search_dispatches_through_bundled_hosted_mcp"
+
+[[integration_evidence]]
+capability = "web-access.get_content"
+kind = "reborn_integration"
+target = "reborn_integration_web_access"
+source = "tests/integration/web_access.rs"
+test = "get_content_dispatches_through_scripted_exa_mcp"
+
+[[integration_evidence]]
+capability = "web-access.search"
+kind = "reborn_integration"
+target = "reborn_integration_web_access"
+source = "tests/integration/web_access.rs"
+test = "web_search_dispatches_through_scripted_exa_mcp"

--- a/tests/e2e/fixtures/provider_capability_coverage.toml
+++ b/tests/e2e/fixtures/provider_capability_coverage.toml
@@ -1,7 +1,8 @@
 schema_version = 1
 
 # A capability is "tested" only when a harvested journey or typed operation
-# case executes the real extension boundary and observes Emulate.
+# case observes Emulate, or an integration_evidence entry names its executable
+# test at the real local-WASM or hosted-MCP seam.
 [classifications]
 tested = [
   "github.add_issue_assignees",
@@ -134,28 +135,24 @@ unsupported = []
 
 [[integration_evidence]]
 capability = "github.handle_webhook"
-kind = "reborn_integration"
 target = "reborn_integration_tool_call"
 source = "tests/integration/tool_call.rs"
 test = "github_webhook_normalization_dispatches_through_bundled_wasm"
 
 [[integration_evidence]]
 capability = "nearai.web_search"
-kind = "reborn_integration"
 target = "reborn_integration_mcp"
 source = "tests/integration/mcp.rs"
 test = "nearai_web_search_dispatches_through_bundled_hosted_mcp"
 
 [[integration_evidence]]
 capability = "web-access.get_content"
-kind = "reborn_integration"
 target = "reborn_integration_web_access"
 source = "tests/integration/web_access.rs"
 test = "get_content_dispatches_through_scripted_exa_mcp"
 
 [[integration_evidence]]
 capability = "web-access.search"
-kind = "reborn_integration"
 target = "reborn_integration_web_access"
 source = "tests/integration/web_access.rs"
 test = "web_search_dispatches_through_scripted_exa_mcp"

--- a/tests/e2e/provider_capability_inventory.py
+++ b/tests/e2e/provider_capability_inventory.py
@@ -20,8 +20,12 @@ LIVE_ONLY_CAPABILITY_IDS = frozenset(CLASSIFICATIONS["live_only"])
 UNSUPPORTED_CAPABILITY_IDS = frozenset(CLASSIFICATIONS["unsupported"])
 WAIVED_CAPABILITY_IDS = frozenset(
     capability
-    for waiver in INVENTORY["waivers"]
+    for waiver in INVENTORY.get("waivers", [])
     for capability in waiver["capabilities"]
+)
+INTEGRATION_EVIDENCE = tuple(INVENTORY.get("integration_evidence", []))
+INTEGRATION_EVIDENCE_CAPABILITY_IDS = frozenset(
+    evidence["capability"] for evidence in INTEGRATION_EVIDENCE
 )
 ALL_CLASSIFIED_CAPABILITY_IDS = (
     TESTED_CAPABILITY_IDS
@@ -55,6 +59,7 @@ def capability_id_to_wire_name(capability_id: str) -> str:
 EMULATE_SUPPORTED_TOOLS = frozenset(
     capability_id_to_wire_name(capability_id)
     for capability_id in TESTED_CAPABILITY_IDS
+    - INTEGRATION_EVIDENCE_CAPABILITY_IDS
 )
 LIVE_ONLY_TOOLS = frozenset(
     capability_id_to_wire_name(capability_id)

--- a/tests/e2e/scenarios/test_provider_capability_inventory.py
+++ b/tests/e2e/scenarios/test_provider_capability_inventory.py
@@ -2,12 +2,16 @@
 
 import json
 from pathlib import Path
+import re
 import tomllib
 
 from provider_capability_inventory import (
     ALL_CLASSIFIED_CAPABILITY_IDS,
     EMULATE_SUPPORTED_TOOLS,
+    INTEGRATION_EVIDENCE,
+    INTEGRATION_EVIDENCE_CAPABILITY_IDS,
     INVENTORY,
+    TESTED_CAPABILITY_IDS,
     capability_id_to_wire_name,
 )
 from provider_operation_cases import PROVIDER_OPERATION_CASES
@@ -47,7 +51,7 @@ def test_every_shipped_provider_capability_has_an_owned_classification():
     classified_lists = [
         INVENTORY["classifications"][classification]
         for classification in ("tested", "live_only", "unsupported")
-    ] + [waiver["capabilities"] for waiver in INVENTORY["waivers"]]
+    ] + [waiver["capabilities"] for waiver in INVENTORY.get("waivers", [])]
     flattened = [capability for group in classified_lists for capability in group]
     duplicates = sorted(
         capability for capability in set(flattened) if flattened.count(capability) > 1
@@ -60,19 +64,74 @@ def test_every_shipped_provider_capability_has_an_owned_classification():
         f"stale={sorted(ALL_CLASSIFIED_CAPABILITY_IDS - production)}"
     )
 
-    for waiver in INVENTORY["waivers"]:
+    for waiver in INVENTORY.get("waivers", []):
         for field in ("owner", "reason", "issue", "review_condition"):
             assert waiver.get(field), f"waiver is missing {field}: {waiver}"
         assert waiver["capabilities"], f"waiver has no capabilities: {waiver}"
 
 
+def _cargo_test_targets() -> dict[str, str]:
+    with (ROOT / "Cargo.toml").open("rb") as cargo_file:
+        manifest = tomllib.load(cargo_file)
+    return {
+        target["name"]: target["path"]
+        for target in manifest.get("test", [])
+    }
+
+
+def _assert_integration_evidence_is_executable(
+    evidence: dict, targets: dict[str, str]
+) -> None:
+    required = {"capability", "kind", "target", "source", "test"}
+    assert set(evidence) == required, (
+        f"integration evidence fields must be exactly {sorted(required)}: "
+        f"{evidence}"
+    )
+    assert evidence["kind"] == "reborn_integration", evidence
+
+    assert evidence["target"] in targets, (
+        f"unknown Cargo test target {evidence['target']!r}: {evidence}"
+    )
+    assert targets[evidence["target"]] == evidence["source"], (
+        f"Cargo target {evidence['target']!r} points to "
+        f"{targets[evidence['target']]!r}, not {evidence['source']!r}"
+    )
+
+    source = ROOT / evidence["source"]
+    assert source.is_file(), f"integration evidence source is missing: {source}"
+    test_pattern = re.compile(
+        rf"#\s*\[\s*(?:tokio::)?test(?:\s*\([^]]*\))?\s*\]\s*"
+        rf"(?:pub\s+)?(?:async\s+)?fn\s+{re.escape(evidence['test'])}\s*\("
+    )
+    assert test_pattern.search(source.read_text()), (
+        f"integration test {evidence['test']!r} is missing from "
+        f"{evidence['source']}"
+    )
+
+
 def test_tested_capabilities_have_full_path_evidence():
-    """A tested label must point to a harvested journey or typed operation case."""
+    """A tested label must point to executable evidence at the correct seam."""
     evidence = _recorded_tool_evidence()
     operation_case_tools = {
         capability_id_to_wire_name(case.capability_id)
         for case in PROVIDER_OPERATION_CASES
     }
+    integration_capabilities = [
+        entry["capability"] for entry in INTEGRATION_EVIDENCE
+    ]
+    duplicates = sorted(
+        capability
+        for capability in set(integration_capabilities)
+        if integration_capabilities.count(capability) > 1
+    )
+    assert not duplicates, f"duplicate integration evidence: {duplicates}"
+    assert INTEGRATION_EVIDENCE_CAPABILITY_IDS <= TESTED_CAPABILITY_IDS
+    cargo_targets = _cargo_test_targets()
+    for integration_evidence in INTEGRATION_EVIDENCE:
+        _assert_integration_evidence_is_executable(
+            integration_evidence, cargo_targets
+        )
+
     missing_tested = sorted(
         EMULATE_SUPPORTED_TOOLS - evidence.keys() - operation_case_tools
     )

--- a/tests/e2e/scenarios/test_provider_capability_inventory.py
+++ b/tests/e2e/scenarios/test_provider_capability_inventory.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import re
 import tomllib
 
+import pytest
+
 from provider_capability_inventory import (
     ALL_CLASSIFIED_CAPABILITY_IDS,
     EMULATE_SUPPORTED_TOOLS,
@@ -82,12 +84,11 @@ def _cargo_test_targets() -> dict[str, str]:
 def _assert_integration_evidence_is_executable(
     evidence: dict, targets: dict[str, str]
 ) -> None:
-    required = {"capability", "kind", "target", "source", "test"}
+    required = {"capability", "target", "source", "test"}
     assert set(evidence) == required, (
         f"integration evidence fields must be exactly {sorted(required)}: "
         f"{evidence}"
     )
-    assert evidence["kind"] == "reborn_integration", evidence
 
     assert evidence["target"] in targets, (
         f"unknown Cargo test target {evidence['target']!r}: {evidence}"
@@ -99,17 +100,65 @@ def _assert_integration_evidence_is_executable(
 
     source = ROOT / evidence["source"]
     assert source.is_file(), f"integration evidence source is missing: {source}"
-    test_pattern = re.compile(
-        rf"#\s*\[\s*(?:tokio::)?test(?:\s*\([^]]*\))?\s*\]\s*"
-        rf"(?:pub\s+)?(?:async\s+)?fn\s+{re.escape(evidence['test'])}\s*\("
-    )
-    assert test_pattern.search(source.read_text()), (
-        f"integration test {evidence['test']!r} is missing from "
-        f"{evidence['source']}"
+    _assert_executable_test_declaration(
+        source.read_text(), evidence["test"], evidence["source"]
     )
 
 
-def test_tested_capabilities_have_full_path_evidence():
+def _assert_executable_test_declaration(
+    source: str, test_name: str, source_label: str
+) -> None:
+    declaration = re.compile(
+        rf"(?P<attributes>(?:^[ \t]*#\s*\[[^\n]+\][ \t]*\n)+)"
+        rf"^[ \t]*(?:pub\s+)?(?:async\s+)?fn\s+{re.escape(test_name)}\s*\(",
+        re.MULTILINE,
+    ).search(source)
+    assert declaration, (
+        f"integration test {test_name!r} is missing from {source_label}"
+    )
+
+    attributes = set(
+        re.findall(
+            r"#\s*\[\s*([A-Za-z_][A-Za-z0-9_:]*)",
+            declaration.group("attributes"),
+        )
+    )
+    assert attributes & {"test", "tokio::test"}, (
+        f"integration test {test_name!r} lacks a test attribute in "
+        f"{source_label}"
+    )
+    disabling_attributes = sorted(attributes & {"cfg", "cfg_attr", "ignore"})
+    assert not disabling_attributes, (
+        f"integration test {test_name!r} is disabled by test-level attributes "
+        f"{disabling_attributes} in {source_label}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("disabling_attribute", "expected_attribute"),
+    [
+        ("#[ignore]", "ignore"),
+        ('#[cfg(feature = "disabled-evidence")]', "cfg"),
+    ],
+)
+def test_executable_evidence_rejects_disabled_tests(
+    disabling_attribute: str, expected_attribute: str
+):
+    source = (
+        f"{disabling_attribute}\n"
+        "#[tokio::test]\n"
+        "async fn disabled_evidence() {}\n"
+    )
+    with pytest.raises(
+        AssertionError,
+        match=rf"disabled by test-level attributes .*{expected_attribute}",
+    ):
+        _assert_executable_test_declaration(
+            source, "disabled_evidence", "synthetic.rs"
+        )
+
+
+def test_tested_capabilities_have_executable_evidence_at_the_correct_seam():
     """A tested label must point to executable evidence at the correct seam."""
     evidence = _recorded_tool_evidence()
     operation_case_tools = {
@@ -125,7 +174,10 @@ def test_tested_capabilities_have_full_path_evidence():
         if integration_capabilities.count(capability) > 1
     )
     assert not duplicates, f"duplicate integration evidence: {duplicates}"
-    assert INTEGRATION_EVIDENCE_CAPABILITY_IDS <= TESTED_CAPABILITY_IDS
+    assert INTEGRATION_EVIDENCE_CAPABILITY_IDS <= TESTED_CAPABILITY_IDS, (
+        "integration evidence for untested capabilities: "
+        f"{sorted(INTEGRATION_EVIDENCE_CAPABILITY_IDS - TESTED_CAPABILITY_IDS)}"
+    )
     cargo_targets = _cargo_test_targets()
     for integration_evidence in INTEGRATION_EVIDENCE:
         _assert_integration_evidence_is_executable(
@@ -136,6 +188,6 @@ def test_tested_capabilities_have_full_path_evidence():
         EMULATE_SUPPORTED_TOOLS - evidence.keys() - operation_case_tools
     )
     assert not missing_tested, (
-        f"tested capabilities lack full-path evidence: {missing_tested}"
+        f"Emulate-backed capabilities lack executable evidence: {missing_tested}"
     )
     assert operation_case_tools <= EMULATE_SUPPORTED_TOOLS

--- a/tests/integration/mcp.rs
+++ b/tests/integration/mcp.rs
@@ -15,6 +15,7 @@ mod support;
 
 use reborn_support::assertions::ToolErrorClass;
 use reborn_support::builder::RebornIntegrationHarness;
+use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
 use support::mock_mcp_server::{MockMcpServer, MockToolResponse, start_mock_mcp_server};
 
@@ -46,6 +47,126 @@ fn assert_recorded_tools_call(server: &MockMcpServer, expected_tool: &str, expec
             .and_then(|a| a.get("query"))
             .and_then(|q| q.as_str()),
         Some(expected_query)
+    );
+}
+
+/// The bundled `nearai` package is hosted MCP rather than Emulate-backed.
+/// Install and activate the real first-party manifest, then prove its static
+/// search capability crosses the mediated MCP boundary with its credential
+/// and returns the hermetic server result to the model.
+#[tokio::test]
+async fn nearai_web_search_dispatches_through_bundled_hosted_mcp() {
+    let group = RebornIntegrationGroup::extension_lifecycle()
+        .await
+        .expect("extension-lifecycle group builds");
+    let installer = group
+        .thread("nearai-hosted-mcp-install")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                serde_json::json!({"extension_id": "nearai"}),
+            ),
+            RebornScriptedReply::text("NEAR AI search is installed."),
+        ])
+        .build()
+        .await
+        .expect("installer thread builds");
+
+    installer
+        .seed_capability_credential_account("nearai", "NEAR AI integration account", &[])
+        .await
+        .expect("NEAR AI account is seeded under the dispatching user");
+    installer
+        .submit_turn("install NEAR AI search")
+        .await
+        .expect("install turn completes");
+    installer
+        .assert_tool_result_contains(r#""installed":true"#)
+        .await
+        .expect("NEAR AI package installed");
+
+    let activator = group
+        .thread("nearai-hosted-mcp-activate")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_activate",
+                serde_json::json!({"extension_id": "nearai"}),
+            ),
+            RebornScriptedReply::text("NEAR AI search is ready."),
+        ])
+        .build()
+        .await
+        .expect("activator thread builds");
+
+    activator
+        .submit_turn("activate NEAR AI search")
+        .await
+        .expect("activation turn completes");
+    activator
+        .assert_tool_result_contains(r#""activated":true"#)
+        .await
+        .expect("NEAR AI package activated");
+
+    let search = group
+        .thread("nearai-hosted-mcp-search")
+        .script([
+            RebornScriptedReply::tool_call(
+                "nearai.web_search",
+                serde_json::json!({"query": "IronClaw capability evidence"}),
+            ),
+            RebornScriptedReply::text("search complete"),
+        ])
+        .build()
+        .await
+        .expect("search thread builds");
+
+    search
+        .submit_turn("search for IronClaw capability evidence")
+        .await
+        .expect("search turn completes");
+    search
+        .assert_model_tools_contains("nearai__web_search")
+        .await
+        .expect("activated NEAR AI capability is disclosed to the model");
+    search
+        .assert_tool_invoked("nearai.web_search")
+        .await
+        .expect("canonical NEAR AI capability dispatched");
+    search
+        .assert_tool_result_contains("REBORN_NEARAI_WEB_SEARCH_RESULT")
+        .await
+        .expect("hosted MCP response reached the model-facing result");
+
+    let requests = search.captured_network_requests_for_test();
+    let tools_call = requests
+        .iter()
+        .find(|request| {
+            serde_json::from_slice::<serde_json::Value>(&request.body)
+                .ok()
+                .and_then(|body| body["method"].as_str().map(str::to_owned))
+                .as_deref()
+                == Some("tools/call")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "no hosted MCP tools/call captured across {} redacted request(s)",
+                requests.len()
+            )
+        });
+    let body: serde_json::Value =
+        serde_json::from_slice(&tools_call.body).expect("tools/call body is JSON");
+    assert_eq!(body["params"]["name"], "web_search");
+    assert_eq!(
+        body["params"]["arguments"]["query"],
+        "IronClaw capability evidence"
+    );
+    assert!(
+        tools_call.headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("authorization")
+                && value.starts_with("Bearer ")
+                && value.len() > "Bearer ".len()
+        }),
+        "hosted MCP tools/call must carry a mediated bearer credential"
     );
 }
 

--- a/tests/integration/mcp.rs
+++ b/tests/integration/mcp.rs
@@ -59,57 +59,19 @@ async fn nearai_web_search_dispatches_through_bundled_hosted_mcp() {
     let group = RebornIntegrationGroup::extension_lifecycle()
         .await
         .expect("extension-lifecycle group builds");
-    let installer = group
-        .thread("nearai-hosted-mcp-install")
+    let h = group
+        .thread("nearai-hosted-mcp-lifecycle")
         .script([
             RebornScriptedReply::tool_call(
                 "builtin.extension_install",
                 serde_json::json!({"extension_id": "nearai"}),
             ),
             RebornScriptedReply::text("NEAR AI search is installed."),
-        ])
-        .build()
-        .await
-        .expect("installer thread builds");
-
-    installer
-        .seed_capability_credential_account("nearai", "NEAR AI integration account", &[])
-        .await
-        .expect("NEAR AI account is seeded under the dispatching user");
-    installer
-        .submit_turn("install NEAR AI search")
-        .await
-        .expect("install turn completes");
-    installer
-        .assert_tool_result_contains(r#""installed":true"#)
-        .await
-        .expect("NEAR AI package installed");
-
-    let activator = group
-        .thread("nearai-hosted-mcp-activate")
-        .script([
             RebornScriptedReply::tool_call(
                 "builtin.extension_activate",
                 serde_json::json!({"extension_id": "nearai"}),
             ),
             RebornScriptedReply::text("NEAR AI search is ready."),
-        ])
-        .build()
-        .await
-        .expect("activator thread builds");
-
-    activator
-        .submit_turn("activate NEAR AI search")
-        .await
-        .expect("activation turn completes");
-    activator
-        .assert_tool_result_contains(r#""activated":true"#)
-        .await
-        .expect("NEAR AI package activated");
-
-    let search = group
-        .thread("nearai-hosted-mcp-search")
-        .script([
             RebornScriptedReply::tool_call(
                 "nearai.web_search",
                 serde_json::json!({"query": "IronClaw capability evidence"}),
@@ -118,26 +80,37 @@ async fn nearai_web_search_dispatches_through_bundled_hosted_mcp() {
         ])
         .build()
         .await
-        .expect("search thread builds");
+        .expect("NEAR AI lifecycle thread builds");
 
-    search
-        .submit_turn("search for IronClaw capability evidence")
+    h.seed_capability_credential_account("nearai", "NEAR AI integration account", &[])
+        .await
+        .expect("NEAR AI account is seeded under the dispatching user");
+    h.submit_turn("install NEAR AI search")
+        .await
+        .expect("install turn completes");
+    h.assert_tool_result_contains(r#""installed":true"#)
+        .await
+        .expect("NEAR AI package installed");
+    h.submit_turn("activate NEAR AI search")
+        .await
+        .expect("activation turn completes");
+    h.assert_tool_result_contains(r#""activated":true"#)
+        .await
+        .expect("NEAR AI package activated");
+    h.submit_turn("search for IronClaw capability evidence")
         .await
         .expect("search turn completes");
-    search
-        .assert_model_tools_contains("nearai__web_search")
+    h.assert_model_tools_contains("nearai__web_search")
         .await
         .expect("activated NEAR AI capability is disclosed to the model");
-    search
-        .assert_tool_invoked("nearai.web_search")
+    h.assert_tool_invoked("nearai.web_search")
         .await
         .expect("canonical NEAR AI capability dispatched");
-    search
-        .assert_tool_result_contains("REBORN_NEARAI_WEB_SEARCH_RESULT")
+    h.assert_tool_result_contains("REBORN_NEARAI_WEB_SEARCH_RESULT")
         .await
         .expect("hosted MCP response reached the model-facing result");
 
-    let requests = search.captured_network_requests_for_test();
+    let requests = h.captured_network_requests_for_test();
     let tools_call = requests
         .iter()
         .find(|request| {

--- a/tests/integration/support/extension_surface.rs
+++ b/tests/integration/support/extension_surface.rs
@@ -165,9 +165,9 @@ pub const BUNDLED_EXTENSION_CAPABILITY_IDS: &[&str] = &[
     "google-slides.format_paragraph",
     "google-slides.replace_shapes_with_image",
     "google-slides.batch_update",
-    // `nearai` and `notion` are hosted-MCP packages: their v3 manifests
-    // declare no static tools (the former v2 placeholder tools became live
-    // discovery), so they contribute nothing to this static grant list.
+    // NEAR AI pins its core search capability so it is available before live
+    // discovery. Notion remains discovery-only.
+    "nearai.web_search",
 ];
 
 /// Bundled first-party extension asset directories under

--- a/tests/integration/support/harness/profiles/extension.rs
+++ b/tests/integration/support/harness/profiles/extension.rs
@@ -11,8 +11,9 @@ use ironclaw_host_api::{
 use std::sync::Arc;
 
 use super::super::super::extension_surface::{
-    BUNDLED_EXTENSION_CAPABILITY_IDS, EXTENSION_LIFECYCLE_CAPABILITY_IDS,
+    EXTENSION_LIFECYCLE_CAPABILITY_IDS, bundled_extension_manifest_capability_ids,
 };
+use super::super::super::github;
 use super::super::options::{HostRuntimeHarnessOptions, ToolsProfile};
 use super::super::{
     HarnessResult, HostRuntimeCapabilityHarness, RecordingNetworkHttpEgress,
@@ -38,7 +39,8 @@ pub(crate) fn extension_lifecycle_tools_profile_for_user(
     user_id: &str,
 ) -> HarnessResult<ToolsProfile> {
     let mut capability_ids = capability_ids_from_strs(EXTENSION_LIFECYCLE_CAPABILITY_IDS)?;
-    capability_ids.extend(capability_ids_from_strs(BUNDLED_EXTENSION_CAPABILITY_IDS)?);
+    capability_ids.extend(github::capability_ids()?);
+    capability_ids.extend(bundled_extension_manifest_capability_ids()?);
     // Hermetic guard: without a test egress, `build_local_runtime` defaults to
     // a REAL `ReqwestNetworkTransport`, and this profile's scenarios dispatch a
     // bundled extension capability post-activation, which crosses HTTP. The
@@ -78,6 +80,7 @@ fn hosted_mcp_discovery_fixture_response(
 ) -> Option<(u16, Vec<u8>)> {
     let body: serde_json::Value = serde_json::from_slice(&request.body).ok()?;
     let method = body.get("method")?.as_str()?;
+    let is_nearai = request.url.contains(".near.ai/");
     let result = match method {
         "initialize" => serde_json::json!({
             "protocolVersion": "2025-06-18",
@@ -87,7 +90,7 @@ fn hosted_mcp_discovery_fixture_response(
         "notifications/initialized" => serde_json::json!({}),
         "tools/list" => serde_json::json!({
             "tools": [{
-                "name": "live-search",
+                "name": if is_nearai { "web_search" } else { "live-search" },
                 "description": "Hermetic hosted MCP search tool",
                 "inputSchema": {
                     "type": "object",
@@ -95,6 +98,12 @@ fn hosted_mcp_discovery_fixture_response(
                     "required": ["query"]
                 },
                 "annotations": {"readOnlyHint": true}
+            }]
+        }),
+        "tools/call" if is_nearai => serde_json::json!({
+            "content": [{
+                "type": "text",
+                "text": "REBORN_NEARAI_WEB_SEARCH_RESULT"
             }]
         }),
         _ => return None,

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -29,6 +29,34 @@ const SLACK_PERSONAL_SCOPES: &[&str] = &[
     "chat:write",
 ];
 
+fn github_webhook_normalization_call() -> RebornScriptedReply {
+    RebornScriptedReply::tool_call(
+        "github.handle_webhook",
+        json!({
+            "webhook": {
+                "headers": {
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-capability-evidence"
+                },
+                "body_json": {
+                    "action": "opened",
+                    "repository": {
+                        "full_name": "nearai/ironclaw",
+                        "owner": {"login": "nearai"}
+                    },
+                    "pull_request": {
+                        "number": 6573,
+                        "state": "open",
+                        "base": {"ref": "main"},
+                        "head": {"ref": "codex/provider-evidence"}
+                    },
+                    "sender": {"login": "serrrfirat"}
+                }
+            }
+        }),
+    )
+}
+
 #[tokio::test]
 async fn runs_numeric_time_input_through_builtin_tools_group() {
     let g = RebornIntegrationGroup::builtin_tools()
@@ -117,31 +145,7 @@ async fn github_webhook_normalization_dispatches_through_bundled_wasm() {
     let h = RebornIntegrationHarness::test_default()
         .with_github_issue_tools()
         .script([
-            RebornScriptedReply::tool_call(
-                "github.handle_webhook",
-                json!({
-                    "webhook": {
-                        "headers": {
-                            "X-GitHub-Event": "pull_request",
-                            "X-GitHub-Delivery": "delivery-capability-evidence"
-                        },
-                        "body_json": {
-                            "action": "opened",
-                            "repository": {
-                                "full_name": "nearai/ironclaw",
-                                "owner": {"login": "nearai"}
-                            },
-                            "pull_request": {
-                                "number": 6573,
-                                "state": "open",
-                                "base": {"ref": "main"},
-                                "head": {"ref": "codex/provider-evidence"}
-                            },
-                            "sender": {"login": "serrrfirat"}
-                        }
-                    }
-                }),
-            ),
+            github_webhook_normalization_call(),
             RebornScriptedReply::text("webhook normalized"),
         ])
         .build()

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -109,6 +109,62 @@ async fn runs_http_tool_call_through_recorded_egress() {
         .expect("final reply finalized");
 }
 
+/// `github.handle_webhook` is local normalization rather than a provider API
+/// call. Drive it through the real bundled GitHub WASM capability and assert
+/// the emitted event plus the absence of network egress.
+#[tokio::test]
+async fn github_webhook_normalization_dispatches_through_bundled_wasm() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_github_issue_tools()
+        .script([
+            RebornScriptedReply::tool_call(
+                "github.handle_webhook",
+                json!({
+                    "webhook": {
+                        "headers": {
+                            "X-GitHub-Event": "pull_request",
+                            "X-GitHub-Delivery": "delivery-capability-evidence"
+                        },
+                        "body_json": {
+                            "action": "opened",
+                            "repository": {
+                                "full_name": "nearai/ironclaw",
+                                "owner": {"login": "nearai"}
+                            },
+                            "pull_request": {
+                                "number": 6573,
+                                "state": "open",
+                                "base": {"ref": "main"},
+                                "head": {"ref": "codex/provider-evidence"}
+                            },
+                            "sender": {"login": "serrrfirat"}
+                        }
+                    }
+                }),
+            ),
+            RebornScriptedReply::text("webhook normalized"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    h.submit_turn("normalize this GitHub webhook")
+        .await
+        .expect("turn completes");
+    h.assert_tool_invoked("github.handle_webhook")
+        .await
+        .expect("bundled GitHub WASM capability ran");
+    h.assert_tool_result_contains(r#""event_type":"pr.opened""#)
+        .await
+        .expect("normalized event type reached the model-facing result");
+    h.assert_tool_result_contains(r#""delivery_id":"delivery-capability-evidence""#)
+        .await
+        .expect("delivery identity survived normalization");
+    h.assert_network_egress_count(0)
+        .await
+        .expect("local webhook normalization made no provider request");
+}
+
 const HTTP_TOOL_URL: &str = "https://api.example.test/v1/items";
 
 /// A prior assistant refusal is conversation history, not capability truth.

--- a/tests/integration/wiring_parity.rs
+++ b/tests/integration/wiring_parity.rs
@@ -369,14 +369,13 @@ fn profile_capability_ids_by_domain() -> HarnessResult<Vec<(&'static str, Vec<St
                 .collect(),
         ),
         // extension_lifecycle_tools_profile() (harness/profiles/extension.rs)
-        // grants EXTENSION_LIFECYCLE_CAPABILITY_IDS (4 ids) plus
-        // BUNDLED_EXTENSION_CAPABILITY_IDS. The 4 lifecycle ids are filtered
-        // out BY NAME (order-independent): their real production values are
-        // visibility-blocked (see `production_capability_surface()`'s doc) —
-        // checking them against a surface that (correctly) no longer contains
-        // them would fail for a reason unrelated to real drift. The remaining
-        // ~130 bundled-extension ids ARE checked, against the manifest-derived
-        // (not hand-transcribed) surface.
+        // grants EXTENSION_LIFECYCLE_CAPABILITY_IDS plus the real GitHub
+        // package ids and the other manifest-derived bundled extension ids.
+        // The lifecycle ids are filtered out BY NAME (order-independent):
+        // their real production values are visibility-blocked (see
+        // `production_capability_surface()`'s doc), so checking them against a
+        // surface that correctly omits them would report unrelated drift.
+        // Every remaining manifest-derived capability id is checked.
         ("extension", {
             let capability_ids =
                 profiles::extension::extension_lifecycle_tools_profile()?.capability_ids;


### PR DESCRIPTION
## Summary

- Close the final four capability waivers with executable evidence at their actual seams, bringing the shipped capability inventory to 123/123 hermetically tested.
- Add caller-path Reborn integration coverage for `github.handle_webhook` through the bundled GitHub WASM and `nearai.web_search` through the bundled hosted-MCP lifecycle, mediated credential, and hermetic network double.
- Reuse the existing whole-turn `web-access.search` and `web-access.get_content` tests rather than duplicating them in the Emulate runner.
- Generalize the inventory gate so non-Emulate evidence names an exact Cargo target, source file, and executable test; derive extension-lifecycle grants from the real bundled manifests instead of a stale copied list.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo build` (not run separately: workspace-wide clippy compiled every target and feature)
- [x] Relevant tests pass: capability inventory; full MCP, tool-call, web-access, extension-lifecycle, and QA-smoke suites
- [ ] `cargo test --features integration` if database-backed or integration behavior changed (not applicable: no database or production behavior changed)
- [x] Manual testing: confirmed the inventory gate failed on the missing named caller-path test before implementation, then passed with all four exact evidence references
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review (not run: the scoped diff was manually reviewed and passed the full required quality gates)

## Test Strategy

User behavior:
Developers and CI can mechanically prove that every shipped first-party capability has deterministic executable evidence without forcing local-only or hosted-MCP capabilities into the Emulate provider runner.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: the Python inventory gate now validates exact Cargo target/source/test references and rejects missing or non-test functions.
- Reborn integration: `github.handle_webhook` executes through the bundled WASM with normalized event assertions and zero network egress; `nearai.web_search` installs and activates the real bundled package, dispatches through hosted MCP with a mediated credential, validates exact request arguments, and observes the hermetic response.
- Recorded fixture: Not applicable: model tool choice and request shape did not change.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: full `reborn_integration_mcp`, `reborn_integration_tool_call`, `reborn_integration_web_access`, and `reborn_group_extensions` suites passed.
- Live canary: Not applicable: this PR adds deterministic local evidence; live drift coverage remains supplemental.

What the tests prove:
All 123 shipped capabilities now have executable hermetic evidence. The 119 provider operations remain standalone-Reborn + Emulate backed; the four non-Emulate operations are linked to real caller-path integration tests at their correct local-WASM or MCP seam. The gate fails if a named Cargo target, source, or executable test disappears.

Commands run:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --test reborn_integration_mcp` → 20 passed
- `cargo test --test reborn_integration_tool_call` → 29 passed
- `cargo test --test reborn_integration_wiring_parity` → 18 passed
- `cargo test --test reborn_integration_web_access` → 20 passed
- `cargo test --test reborn_group_extensions` → 14 passed
- `cargo test --test reborn_qa_smoke_scenarios_e2e` → 26 passed, 2 pre-existing ignored tests
- `tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_provider_capability_inventory.py -q` → 4 passed
- `uvx ruff check tests/e2e/provider_capability_inventory.py tests/e2e/scenarios/test_provider_capability_inventory.py`
- `scripts/pre-commit-safety.sh`

## Security Impact

None. Test-only changes exercise existing credential mediation and verify that the local GitHub webhook capability performs no network egress; production permissions, secrets, network policy, and runtime behavior are unchanged.

## Reborn Trust-Boundary Checklist

N/A: this PR tests existing WASM, hosted-MCP, credential, and egress boundaries but does not change production trust-bearing types or policies.

## Database Impact

None.

## Blast Radius

The Reborn integration harness capability grants, hosted-MCP fixture router, and provider capability inventory gate. A stale or incorrect manifest grant now fails the caller-path tests instead of silently leaving a shipped capability unexercised.

## Rollback Plan

Revert this PR to restore the 119/123 Emulate-only classification and four owned waivers. No product or persisted user state requires migration.

## Review Follow-Through

After capability breadth reaches 123/123, the next epic work should add reusable provider fault profiles and representative auth/scope/account-isolation matrices before expanding whole-path ingress and delivery journeys.

---

**Review track**: A (docs/tests/chore)
