### PR TITLE
chore: dummy PR to verify /benchmark canary

### DIFF
--- a/.github/workflows/zzz-repro-crossrepo-test.yml
+++ b/.github/workflows/zzz-repro-crossrepo-test.yml
@@ -1,0 +1,22 @@
+name: zzz-repro-crossrepo-test
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  t:
+    uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@main
+    with:
+      ironclaw-rev: main
+      pr-repo: nearai/ironclaw
+      pr-number: 6582
+      suite-name: ironclaw-smoke
+      dry-run: true
+    secrets:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -345,3 +345,5 @@ Licensed under either of:
 - MIT License ([LICENSE-MIT](LICENSE-MIT))
 
 at your option.
+
+<!-- dummy-canary-marker: verifying /benchmark micro-pinchbench-13 canary after nearai/benchmarks Actions access-policy fix (2026-07-23) -->


### PR DESCRIPTION
No functional change. Opened solely to trigger `/benchmark micro-pinchbench-13` and confirm the canary works after fixing nearai/benchmarks' Actions cross-repo access policy (was `access_level: none`, which silently broke every `/benchmark` invocation on this repo — the calling workflow's `uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@main` couldn't be resolved at all, producing a 0-job "workflow file issue" failure).

Will close this PR once the canary run is confirmed green.