### PR TITLE
feat(sandbox): persistent per-user sandbox container (V1 Phase A)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,10 @@ on:
 
 env:
   IMAGE_NAME: nearaidev/ironclaw
+  # Sandbox worker image (Dockerfile.process-sandbox): the image the
+  # `ironclaw-dind` bake step pulls for scoped process-sandbox launches.
+  # Published from this same run so it always matches `ironclaw`'s tag/sha.
+  IMAGE_NAME_WORKER: nearaidev/ironclaw-worker
 
 jobs:
   build:
@@ -42,6 +46,9 @@ jobs:
       contents: read
       packages: read
       actions: write
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+      worker_sha_tag: ${{ steps.tags.outputs.sha_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -79,6 +86,7 @@ jobs:
           IS_RELEASE_BUILD: ${{ inputs.release && 'true' || 'false' }}
           INPUT_TAG: ${{ inputs.tag }}
           SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
+          IMAGE_NAME_WORKER: ${{ env.IMAGE_NAME_WORKER }}
         run: |
           if [[ -n "${INPUT_TAG}" && ! "${INPUT_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
             echo "::error::Input tag '${INPUT_TAG}' does not match Docker tag grammar"
@@ -107,6 +115,11 @@ jobs:
             TAGS="${TAGS},${IMAGE_NAME}:${INPUT_TAG}"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+          # ironclaw-worker mirrors ironclaw's tag scheme exactly — derive it
+          # by swapping the image name so the two never drift apart.
+          WORKER_TAGS="${TAGS//${IMAGE_NAME}/${IMAGE_NAME_WORKER}}"
+          echo "worker_tags=${WORKER_TAGS}" >> "$GITHUB_OUTPUT"
 
           # The Reborn Dockerfile has a single `runtime` stage — WASM
           # extensions are compiled into the binary via
@@ -161,6 +174,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push (ironclaw-worker)
+        if: steps.check.outputs.skip != 'true'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile.process-sandbox
+          push: true
+          tags: ${{ steps.tags.outputs.worker_tags }}
+          labels: |
+            ironclaw.git.sha=${{ steps.source_sha.outputs.sha }}
+          platforms: linux/amd64
+          # Separate cache scope: process-sandbox has a completely different
+          # layer graph (debian:bookworm-slim + apt packages) than the
+          # ironclaw runtime image — a shared scope would evict useful layers
+          # from both builds on every run.
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
+
       - name: Create releases-manager app token
         id: app-token
         if: steps.check.outputs.skip != 'true'
@@ -197,6 +228,7 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         env:
           TAGS: ${{ steps.tags.outputs.tags }}
+          WORKER_TAGS: ${{ steps.tags.outputs.worker_tags }}
           VERSION: ${{ steps.version.outputs.version }}
           SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
         run: |
@@ -206,6 +238,11 @@ jobs:
             echo "**ironclaw:**"
             echo '```'
             echo "${TAGS}" | tr ',' '\n'
+            echo '```'
+            echo ""
+            echo "**ironclaw-worker:**"
+            echo '```'
+            echo "${WORKER_TAGS}" | tr ',' '\n'
             echo '```'
             echo ""
             echo "- version: \`${VERSION}\`"
@@ -220,6 +257,35 @@ jobs:
           {
             echo "## Docker Images — skipped"
             echo ""
-            echo "Current commit already built for \`${IMAGE_NAME}:staging\`."
+            echo "Current commit already built for \`${IMAGE_NAME}:staging\` / \`${IMAGE_NAME_WORKER}:staging\`."
             echo "- sha: \`${SOURCE_SHA}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  smoke-worker-image:
+    name: Smoke test (ironclaw-worker)
+    needs: build
+    if: needs.build.outputs.skip != 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    env:
+      IMAGE_NAME_WORKER: nearaidev/ironclaw-worker
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ vars.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Pull and run ironclaw-worker
+        env:
+          WORKER_SHA_TAG: ${{ needs.build.outputs.worker_sha_tag }}
+        run: |
+          IMAGE="${IMAGE_NAME_WORKER}:${WORKER_SHA_TAG}"
+          echo "Smoke testing ${IMAGE}"
+          docker pull "${IMAGE}"
+          # Proves the tini -> process-sandbox-entrypoint -> capsh chain
+          # actually execs the given command instead of falling through to
+          # the image's "missing command" default CMD.
+          docker run --rm "${IMAGE}" sh -c "echo ok"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "ironclaw_approvals",
  "ironclaw_authorization",
  "ironclaw_capabilities",
+ "ironclaw_common",
  "ironclaw_dispatcher",
  "ironclaw_event_projections",
  "ironclaw_events",

--- a/Dockerfile.process-sandbox
+++ b/Dockerfile.process-sandbox
@@ -25,14 +25,38 @@ RUN apt-get update \
        iptables \
        libcap2-bin \
        tini \
+       tmux \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (gh)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY docker/process-sandbox-entrypoint.sh /usr/local/bin/process-sandbox-entrypoint
 RUN chmod +x /usr/local/bin/process-sandbox-entrypoint \
     && useradd -m -u 1000 -s /bin/bash sandbox \
-    && mkdir -p /workspace /ironclaw/state/tools /ironclaw/state/cache /ironclaw/broker \
+    && mkdir -p /workspace/.home /ironclaw/state/tools /ironclaw/state/cache /ironclaw/broker \
     && chown -R sandbox:sandbox /workspace /ironclaw
+
+# Rust toolchain, installed as the sandbox user under the workspace-relative
+# HOME so it survives container-rm/recreate only via the bind-mounted
+# workspace (matches the design's "HOME=/workspace/.home so caches/dotfiles
+# persist" decision) — installed at build time into a location Cargo can
+# still find once HOME is redirected to /workspace/.home at runtime via
+# CARGO_HOME/RUSTUP_HOME pointed at a workspace-relative path is NOT done at
+# build time (the workspace doesn't exist yet); instead rustup installs to
+# the image's default /home/sandbox/.cargo, and the container launch env
+# additionally sets CARGO_HOME=/workspace/.home/.cargo, RUSTUP_HOME=/workspace/.home/.rustup
+# with a first-run copy step in the entrypoint script — see entrypoint change below.
+USER sandbox
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/home/sandbox/.cargo/bin:${PATH}"
+USER root
 
 WORKDIR /workspace
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/process-sandbox-entrypoint"]

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -28,8 +28,8 @@ use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, Decision, DenyReason,
     EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, MissionId, NetworkPolicy,
     Obligation, Obligations, Principal, ProjectId, ResourceCeiling, ResourceEstimate,
-    ResourceScope, RuntimeCredentialRequirementSource, RuntimeKind, SandboxQuota, ScopedPath,
-    TenantId, ThreadId, UserId,
+    ResourceReservationId, ResourceScope, RuntimeCredentialRequirementSource, RuntimeKind,
+    SandboxQuota, ScopedPath, TenantId, ThreadId, UserId,
 };
 use ironclaw_trust::{AuthorityCeiling, TrustDecision};
 use serde::{Deserialize, Serialize};
@@ -1071,6 +1071,22 @@ fn obligations_for_grant(
     {
         obligations.push(Obligation::ApplyNetworkPolicy {
             policy: grant.constraints.network.clone(),
+        });
+    }
+
+    // Process-spawning capabilities must reserve resources before dispatch so a
+    // configured governor can enforce a ceiling on concurrent/aggregate spawns.
+    // NOTE: this is currently a no-op behaviorally — `reserve_resource_obligation`
+    // (ironclaw_host_runtime::obligations::BuiltinObligationHandler) only fails
+    // closed when no resource governor is configured, and production always
+    // constructs a governor with an unlimited default ceiling. Emitting the
+    // obligation here just wires the dispatch-time hook; an actual limit is set
+    // by a later slice. This applies to both TenantSandboxProcessPort and the
+    // unsandboxed local-dev HostProcessPort, since both share
+    // `EffectKind::SpawnProcess`.
+    if descriptor.effects.contains(&EffectKind::SpawnProcess) {
+        obligations.push(Obligation::ReserveResources {
+            reservation_id: ResourceReservationId::new(),
         });
     }
 

--- a/crates/ironclaw_authorization/tests/capability_access_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_access_contract.rs
@@ -128,6 +128,69 @@ async fn capability_access_returns_grant_constraints_as_runtime_obligations() {
 }
 
 #[tokio::test]
+async fn obligations_include_reserve_resources_for_spawn_process_capability() {
+    let descriptor = CapabilityDescriptor {
+        effects: vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+        ..wasm_descriptor()
+    };
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+    );
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate::default(),
+        )
+        .await;
+
+    let Decision::Allow { obligations } = decision else {
+        panic!("expected allow decision with obligations, got {decision:?}");
+    };
+    assert!(
+        obligations
+            .as_slice()
+            .iter()
+            .any(|obligation| matches!(obligation, Obligation::ReserveResources { .. }))
+    );
+}
+
+#[tokio::test]
+async fn obligations_omit_reserve_resources_for_non_spawn_process_capability() {
+    let descriptor = wasm_descriptor();
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate::default(),
+        )
+        .await;
+
+    let Decision::Allow { obligations } = decision else {
+        panic!("expected allow decision with obligations, got {decision:?}");
+    };
+    assert!(
+        !obligations
+            .as_slice()
+            .iter()
+            .any(|obligation| matches!(obligation, Obligation::ReserveResources { .. }))
+    );
+}
+
+#[tokio::test]
 async fn capability_access_allows_first_party_dynamic_secret_consumers_without_static_secret_grant()
 {
     let descriptor = CapabilityDescriptor {

--- a/crates/ironclaw_host_api/src/path.rs
+++ b/crates/ironclaw_host_api/src/path.rs
@@ -68,6 +68,11 @@ const VIRTUAL_ROOTS: &[&str] = &[
     "/system/skills",
     "/users",
     "/projects",
+    // Sandboxed-profile boot-owner workspace mount (Task A8): the abstract-FS
+    // backend root the `HostedSingleTenantVolumeSandboxed` profile registers
+    // via `mount_sandbox_user_workspace_root`, redirecting the `/workspace`
+    // capability grant directly onto it instead of `/projects/workspace`.
+    "/workspace",
     "/memory",
     "/artifacts",
     "/tmp",

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -23,6 +23,7 @@ hex = "0.4"
 ironclaw_approvals = { path = "../ironclaw_approvals" }
 ironclaw_authorization = { path = "../ironclaw_authorization" }
 ironclaw_capabilities = { path = "../ironclaw_capabilities" }
+ironclaw_common = { path = "../ironclaw_common" }
 ironclaw_process_sandbox = { path = "../ironclaw_process_sandbox" }
 ironclaw_dispatcher = { path = "../ironclaw_dispatcher" }
 ironclaw_events = { path = "../ironclaw_events" }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -154,7 +154,8 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
                 "command": { "type": "string", "description": "Shell command to execute. Prefer ONE command that does the whole job: combine steps with '&&' or pipes, or write and run a single script (awk/python) — do NOT issue one command per metric/day/line, and don't re-read files you already have." },
                 "workdir": { "type": "string", "description": "Optional scoped working directory" },
                 "timeout": { "type": "integer", "minimum": 1, "description": "Timeout in seconds. Default 120, maximum 600 (values above are clamped)." },
-                "output_limit": { "type": "integer", "minimum": 1024, "description": "Maximum captured output (stdout+stderr) in bytes. Default 65536, maximum 1048576 (values above are clamped)." }
+                "output_limit": { "type": "integer", "minimum": 1024, "description": "Maximum captured output (stdout+stderr) in bytes. Default 65536, maximum 1048576 (values above are clamped)." },
+                "background": { "type": "boolean", "description": "Run detached and return immediately with a pid and log path instead of waiting for completion. Default false. Use for long-running processes such as dev servers; the container survives after this call returns, and subsequent shell calls report still-live background processes in a footer." }
             },
             "required": ["command"],
             "additionalProperties": false
@@ -855,6 +856,18 @@ fn response_body_limit_schema(require_save_to: bool) -> Value {
 #[cfg(test)]
 mod tests {
     use super::resolve_builtin_input_schema_ref;
+
+    #[test]
+    fn shell_schema_documents_background_flag_default_and_capability() {
+        let schema = resolve_builtin_input_schema_ref("schemas/builtin/shell.input.v1.json")
+            .expect("shell schema is registered");
+        let description = schema["properties"]["background"]["description"]
+            .as_str()
+            .expect("background description is a string");
+        assert!(description.contains("false"));
+        assert!(description.contains("dev server") || description.contains("returns immediately"));
+        assert_eq!(schema["properties"]["background"]["type"], "boolean");
+    }
 
     #[test]
     fn trigger_create_prompt_description_warns_against_self_referential_creation_prompts() {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -153,7 +153,8 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
             "properties": {
                 "command": { "type": "string", "description": "Shell command to execute. Prefer ONE command that does the whole job: combine steps with '&&' or pipes, or write and run a single script (awk/python) — do NOT issue one command per metric/day/line, and don't re-read files you already have." },
                 "workdir": { "type": "string", "description": "Optional scoped working directory" },
-                "timeout": { "type": "integer", "minimum": 1, "description": "Timeout in seconds" }
+                "timeout": { "type": "integer", "minimum": 1, "description": "Timeout in seconds. Default 120, maximum 600 (values above are clamped)." },
+                "output_limit": { "type": "integer", "minimum": 1024, "description": "Maximum captured output (stdout+stderr) in bytes. Default 65536, maximum 1048576 (values above are clamped)." }
             },
             "required": ["command"],
             "additionalProperties": false
@@ -934,5 +935,37 @@ mod tests {
                 "{reference} should be registered"
             );
         }
+    }
+
+    #[test]
+    fn shell_schema_timeout_and_output_limit_descriptions_state_default_and_max() {
+        // The schema is the model's contract: it must see the same
+        // default/ceiling numbers the process ports actually clamp to
+        // (`sandbox_process::shell_limits`), so a call that overshoots isn't
+        // a surprise.
+        let schema = resolve_builtin_input_schema_ref("schemas/builtin/shell.input.v1.json")
+            .expect("shell schema is registered");
+
+        let timeout_description = schema["properties"]["timeout"]["description"]
+            .as_str()
+            .expect("timeout description is a string");
+        assert!(
+            timeout_description.contains("120") && timeout_description.contains("600"),
+            "timeout description must state its default (120) and max (600): {timeout_description}"
+        );
+
+        let output_limit_description = schema["properties"]["output_limit"]["description"]
+            .as_str()
+            .expect("output_limit description is a string");
+        assert!(
+            output_limit_description.contains("65536")
+                && output_limit_description.contains("1048576"),
+            "output_limit description must state its default (65536) and max (1048576): {output_limit_description}"
+        );
+        assert_eq!(
+            schema["properties"]["output_limit"]["minimum"].as_u64(),
+            Some(1024),
+            "output_limit schema floor must match SHELL_OUTPUT_LIMIT_MIN_BYTES"
+        );
     }
 }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -60,7 +60,9 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                 max_input_tokens: None,
                 max_output_tokens: None,
                 max_wall_clock_ms: Some(MAX_SHELL_WALL_CLOCK_MS),
-                max_output_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES.max(SHELL_OUTPUT_LIMIT_MAX_BYTES)),
+                max_output_bytes: Some(
+                    FIRST_PARTY_MAX_OUTPUT_BYTES.max(SHELL_OUTPUT_LIMIT_MAX_BYTES),
+                ),
                 sandbox: Some(SandboxQuota {
                     process_count: Some(1),
                     ..SandboxQuota::default()

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -12,6 +12,10 @@ use crate::{
     CommandExecutionRequest, FirstPartyCapabilityError, FirstPartyCapabilityRequest,
     RuntimeProcessError, SavedCommandOutput, SavedCommandOutputSanitization,
     process_output::saved_output_filename,
+    sandbox_process::shell_limits::{
+        SHELL_OUTPUT_LIMIT_DEFAULT_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES, SHELL_TIMEOUT_DEFAULT_SECS,
+        SHELL_TIMEOUT_MAX_SECS,
+    },
 };
 
 use super::{FIRST_PARTY_MAX_OUTPUT_BYTES, first_party_capability_manifest};
@@ -21,16 +25,22 @@ mod shell_core;
 
 pub const SHELL_CAPABILITY_ID: &str = "builtin.shell";
 
-const DEFAULT_SHELL_WALL_CLOCK_MS: u64 = 120_000;
-const MAX_SHELL_WALL_CLOCK_MS: u64 = 120_000;
-const MAX_SHELL_TIMEOUT_SECS: u64 = MAX_SHELL_WALL_CLOCK_MS / 1000;
-const DEFAULT_SHELL_OUTPUT_BYTES: u64 = crate::process_output::COMMAND_MAX_OUTPUT_SIZE as u64;
+const DEFAULT_SHELL_WALL_CLOCK_MS: u64 = SHELL_TIMEOUT_DEFAULT_SECS * 1_000;
+// The manifest's hard ceiling mirrors the model-adjustable `timeout`/
+// `output_limit` ceilings enforced by the process ports (HostProcessPort,
+// TenantSandboxProcessPort) — see `sandbox_process::shell_limits`. A
+// caller-requested value above these is clamped there, never rejected here.
+const MAX_SHELL_WALL_CLOCK_MS: u64 = SHELL_TIMEOUT_MAX_SECS * 1_000;
+const DEFAULT_SHELL_OUTPUT_BYTES: u64 = SHELL_OUTPUT_LIMIT_DEFAULT_BYTES;
 const SAVED_OUTPUT_SCOPED_DIR: &str = "command-outputs";
 
 pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
     first_party_capability_manifest(
         SHELL_CAPABILITY_ID,
-        "Execute shell commands with copied v1 validation and saved-file references for large local output",
+        "Execute shell commands with copied v1 validation and saved-file references for large local output. \
+         `timeout` (seconds) and `output_limit` (bytes) are model-adjustable per call: timeout defaults to \
+         120s and is clamped to a 600s ceiling, output_limit defaults to 64 KiB and is clamped to a 1 MiB \
+         ceiling — values outside these ranges are clamped, not rejected.",
         vec![
             EffectKind::DispatchCapability,
             EffectKind::SpawnProcess,
@@ -50,7 +60,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                 max_input_tokens: None,
                 max_output_tokens: None,
                 max_wall_clock_ms: Some(MAX_SHELL_WALL_CLOCK_MS),
-                max_output_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES),
+                max_output_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES.max(SHELL_OUTPUT_LIMIT_MAX_BYTES)),
                 sandbox: Some(SandboxQuota {
                     process_count: Some(1),
                     ..SandboxQuota::default()
@@ -65,15 +75,12 @@ pub(super) async fn dispatch(
 ) -> Result<(Value, Duration), FirstPartyCapabilityError> {
     let parsed = shell_core::parse_shell_request(&request.input).map_err(shell_error)?;
     reject_unbacked_scoped_workdir(request, parsed.workdir.as_deref())?;
-    if parsed
-        .timeout_secs
-        .is_some_and(|timeout_secs| timeout_secs > MAX_SHELL_TIMEOUT_SECS)
-    {
-        return Err(FirstPartyCapabilityError::new(
-            RuntimeDispatchErrorKind::Resource,
-        ));
-    }
     shell_core::validate_command(&parsed.command, false).map_err(shell_error)?;
+    // `timeout_secs`/`output_limit_bytes` are forwarded as the model
+    // requested them; the process port (HostProcessPort or
+    // TenantSandboxProcessPort) clamps each to its operator ceiling — see
+    // `sandbox_process::shell_limits`. Values above the ceiling are clamped
+    // there, never rejected here.
     let output = request
         .services
         .process
@@ -83,6 +90,7 @@ pub(super) async fn dispatch(
             command: parsed.command,
             workdir: parsed.workdir,
             timeout_secs: parsed.timeout_secs,
+            output_limit_bytes: parsed.output_limit_bytes,
             extra_env: parsed.extra_env,
         })
         .await

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -94,6 +94,7 @@ pub(super) async fn dispatch(
             timeout_secs: parsed.timeout_secs,
             output_limit_bytes: parsed.output_limit_bytes,
             extra_env: parsed.extra_env,
+            background: parsed.background,
         })
         .await
         .map_err(process_error)?;

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell_core.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell_core.rs
@@ -69,6 +69,7 @@ pub(super) struct ShellExecutionRequest {
     pub timeout_secs: Option<u64>,
     pub output_limit_bytes: Option<u64>,
     pub extra_env: HashMap<String, String>,
+    pub background: bool,
 }
 
 impl ShellExecutionRequest {
@@ -79,6 +80,7 @@ impl ShellExecutionRequest {
             timeout_secs: None,
             output_limit_bytes: None,
             extra_env: HashMap::new(),
+            background: false,
         }
     }
 }
@@ -96,7 +98,18 @@ pub(super) fn parse_shell_request(
     request.workdir = parse_workdir(params)?;
     request.timeout_secs = parse_timeout(params)?;
     request.output_limit_bytes = parse_output_limit(params)?;
+    request.background = parse_background(params)?;
     Ok(request)
+}
+
+fn parse_background(params: &Value) -> Result<bool, ShellExecutionError> {
+    match params.get("background") {
+        None | Some(Value::Null) => Ok(false),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(ShellExecutionError::InvalidParameters(
+            "background must be a boolean".to_string(),
+        )),
+    }
 }
 
 fn parse_workdir(params: &Value) -> Result<Option<String>, ShellExecutionError> {
@@ -581,6 +594,15 @@ mod tests {
                 "expected invalid parameters for {input:?}"
             );
         }
+    }
+
+    #[test]
+    fn parse_shell_request_reads_background_flag_default_false() {
+        let parsed = parse_shell_request(&json!({"command": "echo hi"})).unwrap();
+        assert!(!parsed.background);
+        let parsed =
+            parse_shell_request(&json!({"command": "npm run dev", "background": true})).unwrap();
+        assert!(parsed.background);
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/first_party_tools/shell_core.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/shell_core.rs
@@ -67,6 +67,7 @@ pub(super) struct ShellExecutionRequest {
     pub command: String,
     pub workdir: Option<String>,
     pub timeout_secs: Option<u64>,
+    pub output_limit_bytes: Option<u64>,
     pub extra_env: HashMap<String, String>,
 }
 
@@ -76,6 +77,7 @@ impl ShellExecutionRequest {
             command: command.into(),
             workdir: None,
             timeout_secs: None,
+            output_limit_bytes: None,
             extra_env: HashMap::new(),
         }
     }
@@ -93,6 +95,7 @@ pub(super) fn parse_shell_request(
     let mut request = ShellExecutionRequest::new(command.to_string());
     request.workdir = parse_workdir(params)?;
     request.timeout_secs = parse_timeout(params)?;
+    request.output_limit_bytes = parse_output_limit(params)?;
     Ok(request)
 }
 
@@ -125,6 +128,29 @@ fn parse_timeout(params: &Value) -> Result<Option<u64>, ShellExecutionError> {
             if value == 0 {
                 return Err(ShellExecutionError::InvalidParameters(
                     "timeout must be greater than 0".to_string(),
+                ));
+            }
+            Ok(Some(value))
+        }
+    }
+}
+
+/// Parse the optional `output_limit` (bytes). Range clamping to the operator
+/// floor/ceiling happens downstream in `sandbox_process::shell_limits`
+/// (over-cap and under-floor values are clamped, never rejected here) — this
+/// only rejects a malformed value.
+fn parse_output_limit(params: &Value) -> Result<Option<u64>, ShellExecutionError> {
+    match params.get("output_limit") {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let value = value.as_u64().ok_or_else(|| {
+                ShellExecutionError::InvalidParameters(
+                    "output_limit must be a positive integer number of bytes".to_string(),
+                )
+            })?;
+            if value == 0 {
+                return Err(ShellExecutionError::InvalidParameters(
+                    "output_limit must be greater than 0".to_string(),
                 ));
             }
             Ok(Some(value))
@@ -528,13 +554,15 @@ mod tests {
         let parsed = parse_shell_request(&json!({
             "command": "echo hi",
             "workdir": "  /workspace  ",
-            "timeout": 7
+            "timeout": 7,
+            "output_limit": 4096
         }))
         .expect("valid shell request");
 
         assert_eq!(parsed.command, "echo hi");
         assert_eq!(parsed.workdir.as_deref(), Some("/workspace"));
         assert_eq!(parsed.timeout_secs, Some(7));
+        assert_eq!(parsed.output_limit_bytes, Some(4096));
 
         for input in [
             json!({}),
@@ -542,6 +570,8 @@ mod tests {
             json!({"command": "echo hi", "workdir": 123}),
             json!({"command": "echo hi", "timeout": 0}),
             json!({"command": "echo hi", "timeout": "1"}),
+            json!({"command": "echo hi", "output_limit": 0}),
+            json!({"command": "echo hi", "output_limit": "1"}),
         ] {
             assert!(
                 matches!(
@@ -551,6 +581,28 @@ mod tests {
                 "expected invalid parameters for {input:?}"
             );
         }
+    }
+
+    #[test]
+    fn parse_shell_request_leaves_output_limit_unset_when_omitted() {
+        let parsed = parse_shell_request(&json!({"command": "echo hi"}))
+            .expect("valid shell request without output_limit");
+
+        assert_eq!(parsed.output_limit_bytes, None);
+    }
+
+    #[test]
+    fn parse_shell_request_accepts_output_limit_above_the_operator_cap() {
+        // parse_shell_request only rejects malformed values; clamping an
+        // over-cap request to SHELL_OUTPUT_LIMIT_MAX_BYTES is the sandbox
+        // transport's job (see sandbox_process::shell_limits).
+        let parsed = parse_shell_request(&json!({
+            "command": "echo hi",
+            "output_limit": 10 * 1024 * 1024
+        }))
+        .expect("valid shell request");
+
+        assert_eq!(parsed.output_limit_bytes, Some(10 * 1024 * 1024));
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -368,7 +368,14 @@ impl LocalInvocationServicesResolver {
             {
                 Ok(Arc::clone(&self.filesystem))
             }
-            FilesystemBackendKind::ScopedVirtual => {
+            // `TenantWorkspace` (hosted, per-tenant sandboxed process
+            // backends) uses the identical mount-scoped-view mechanism as
+            // `ScopedVirtual`: both hand the invocation a filesystem view
+            // narrowed to the resolved mount set, never the raw root. The
+            // backends differ in which process backend they pair with
+            // (`None` vs `TenantSandbox`), not in how the filesystem is
+            // scoped.
+            FilesystemBackendKind::ScopedVirtual | FilesystemBackendKind::TenantWorkspace => {
                 let mounts =
                     mounts.ok_or(InvocationServicesError::UnsupportedFilesystemBackend {
                         backend: plan.filesystem_backend,

--- a/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -159,6 +159,7 @@ async fn local_resolver_routes_post_edit_check_to_the_deployment_isolated_proces
                 workdir: None,
                 timeout_secs: Some(30),
                 extra_env: std::collections::HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .expect("named test port runs");
@@ -266,6 +267,7 @@ async fn local_resolver_uses_configured_sandbox_process_backend() {
             workdir: None,
             timeout_secs: None,
             extra_env: Default::default(),
+            output_limit_bytes: None,
         })
         .await
         .unwrap();
@@ -433,6 +435,39 @@ fn local_resolver_accepts_hosted_scoped_virtual_filesystem_with_mounts() {
             mounts: Some(&mounts),
         })
         .expect("hosted scoped virtual filesystem should resolve with explicit mounts");
+
+    assert!(services.runtime_http_egress.is_none());
+}
+
+/// `TenantWorkspace` (the sandboxed-shell profile's filesystem backend) must
+/// resolve through the identical mount-scoped-view mechanism as
+/// `ScopedVirtual` once mounts are supplied — merged arm in
+/// `filesystem_for_plan`. Red on base: `TenantWorkspace` fell into the
+/// catch-all `_ => Err(UnsupportedFilesystemBackend)` arm even with mounts
+/// present.
+#[test]
+fn local_resolver_accepts_hosted_tenant_workspace_filesystem_with_mounts() {
+    let resolver = resolver_without_http();
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::HostedSafe;
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::TenantWorkspace;
+    let mounts = scoped_mount_view();
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: Some(&mounts),
+        })
+        .expect("hosted tenant workspace filesystem should resolve with explicit mounts");
 
     assert!(services.runtime_http_egress.is_none());
 }

--- a/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -160,6 +160,7 @@ async fn local_resolver_routes_post_edit_check_to_the_deployment_isolated_proces
                 timeout_secs: Some(30),
                 extra_env: std::collections::HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .expect("named test port runs");
@@ -268,6 +269,7 @@ async fn local_resolver_uses_configured_sandbox_process_backend() {
             timeout_secs: None,
             extra_env: Default::default(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .unwrap();

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -125,9 +125,10 @@ pub use sandbox_process::{
     DEFAULT_SANDBOX_ALLOWED_DOMAINS, ReapSummary, RebornSandboxConfig,
     RebornSandboxContainerIdentity, RebornSandboxNetworkBroker, RebornSandboxScopeKey,
     RebornSandboxSecretBroker, RebornSandboxUserKey, RebornSandboxWorkspaceMode,
-    RebornScopedSandboxCommandTransport, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SandboxDockerReadiness,
-    SandboxReaper, SandboxReaperConfig, connect_docker_with_retry, sandbox_allowed_domains,
-    sandbox_docker_readiness, sandbox_extra_allowed_domains, sandbox_network_policy,
+    RebornScopedSandboxCommandTransport, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
+    SandboxActivityRegistry, SandboxDockerReadiness, SandboxReaper, SandboxReaperConfig,
+    connect_docker_with_retry, sandbox_allowed_domains, sandbox_docker_readiness,
+    sandbox_extra_allowed_domains, sandbox_network_policy,
 };
 pub use services::{
     ExtensionLaneToolBinder, ExtensionToolBindError, HostRuntimeServices,

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -124,10 +124,10 @@ pub use production::DefaultHostRuntime;
 pub use sandbox_process::{
     DEFAULT_SANDBOX_ALLOWED_DOMAINS, ReapSummary, RebornSandboxConfig,
     RebornSandboxContainerIdentity, RebornSandboxNetworkBroker, RebornSandboxScopeKey,
-    RebornSandboxSecretBroker, RebornSandboxWorkspaceMode, RebornScopedSandboxCommandTransport,
-    SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SandboxDockerReadiness, SandboxReaper, SandboxReaperConfig,
-    connect_docker_with_retry, sandbox_allowed_domains, sandbox_docker_readiness,
-    sandbox_extra_allowed_domains, sandbox_network_policy,
+    RebornSandboxSecretBroker, RebornSandboxUserKey, RebornSandboxWorkspaceMode,
+    RebornScopedSandboxCommandTransport, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SandboxDockerReadiness,
+    SandboxReaper, SandboxReaperConfig, connect_docker_with_retry, sandbox_allowed_domains,
+    sandbox_docker_readiness, sandbox_extra_allowed_domains, sandbox_network_policy,
 };
 pub use services::{
     ExtensionLaneToolBinder, ExtensionToolBindError, HostRuntimeServices,

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -122,9 +122,12 @@ pub use process_port::{
 };
 pub use production::DefaultHostRuntime;
 pub use sandbox_process::{
-    RebornSandboxConfig, RebornSandboxContainerIdentity, RebornSandboxNetworkBroker,
-    RebornSandboxScopeKey, RebornSandboxSecretBroker, RebornSandboxWorkspaceMode,
-    RebornScopedSandboxCommandTransport,
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS, ReapSummary, RebornSandboxConfig,
+    RebornSandboxContainerIdentity, RebornSandboxNetworkBroker, RebornSandboxScopeKey,
+    RebornSandboxSecretBroker, RebornSandboxWorkspaceMode, RebornScopedSandboxCommandTransport,
+    SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SandboxDockerReadiness, SandboxReaper, SandboxReaperConfig,
+    connect_docker_with_retry, sandbox_allowed_domains, sandbox_docker_readiness,
+    sandbox_extra_allowed_domains, sandbox_network_policy,
 };
 pub use services::{
     ExtensionLaneToolBinder, ExtensionToolBindError, HostRuntimeServices,

--- a/crates/ironclaw_host_runtime/src/post_edit_check.rs
+++ b/crates/ironclaw_host_runtime/src/post_edit_check.rs
@@ -357,6 +357,7 @@ pub(crate) async fn run_post_edit_check(
             timeout_secs: Some(config.timeout().as_secs()),
             extra_env: HashMap::new(),
             output_limit_bytes: None,
+            background: false,
         })
         .await;
     match outcome {

--- a/crates/ironclaw_host_runtime/src/post_edit_check.rs
+++ b/crates/ironclaw_host_runtime/src/post_edit_check.rs
@@ -356,6 +356,7 @@ pub(crate) async fn run_post_edit_check(
             workdir,
             timeout_secs: Some(config.timeout().as_secs()),
             extra_env: HashMap::new(),
+            output_limit_bytes: None,
         })
         .await;
     match outcome {

--- a/crates/ironclaw_host_runtime/src/process_output.rs
+++ b/crates/ironclaw_host_runtime/src/process_output.rs
@@ -565,16 +565,25 @@ fn expires_at_unix_secs() -> u64 {
 }
 
 pub(crate) fn truncate_output(s: &str) -> String {
-    if s.len() <= COMMAND_MAX_OUTPUT_SIZE {
+    truncate_output_to(s, COMMAND_MAX_OUTPUT_SIZE)
+}
+
+/// Truncate `s` to at most `limit` bytes, keeping a head/tail window (like
+/// [`truncate_output`]) rather than a fixed [`COMMAND_MAX_OUTPUT_SIZE`]. Used
+/// where the caller supplies a model-adjustable output cap (e.g. the
+/// sandboxed shell's `output_limit`, clamped by
+/// `sandbox_process::shell_limits`).
+pub(crate) fn truncate_output_to(s: &str, limit: usize) -> String {
+    if s.len() <= limit {
         s.to_string()
     } else {
-        let half = COMMAND_MAX_OUTPUT_SIZE / 2;
+        let half = limit / 2;
         let head_end = floor_char_boundary(s, half);
         let tail_start = floor_char_boundary(s, s.len() - half);
         format!(
             "{}\n\n... [truncated {} bytes] ...\n\n{}",
             &s[..head_end],
-            s.len() - COMMAND_MAX_OUTPUT_SIZE,
+            s.len() - limit,
             &s[tail_start..]
         )
     }
@@ -619,6 +628,20 @@ mod tests {
         let output = "x".repeat(COMMAND_MAX_OUTPUT_SIZE);
 
         assert_eq!(truncate_output(&output), output);
+    }
+
+    #[test]
+    fn truncate_output_to_honors_a_caller_supplied_limit_distinct_from_the_default() {
+        let limit = 4096;
+        let output = "x".repeat(limit + 10);
+
+        let truncated = truncate_output_to(&output, limit);
+
+        assert!(truncated.len() < output.len());
+        assert!(truncated.contains(&format!("truncated {} bytes", output.len() - limit)));
+
+        let within_limit = "y".repeat(limit);
+        assert_eq!(truncate_output_to(&within_limit, limit), within_limit);
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -78,6 +78,12 @@ pub struct CommandExecutionRequest {
     /// `sandbox_process::shell_limits` for the sandbox transport's clamp.
     pub output_limit_bytes: Option<u64>,
     pub extra_env: HashMap<String, String>,
+    /// Run the command detached and return immediately instead of waiting
+    /// for completion. Only the sandboxed transport
+    /// ([`TenantSandboxProcessPort`]) supports this; [`HostProcessPort`]
+    /// rejects it since the unsandboxed host path has no container to
+    /// outlive the request.
+    pub background: bool,
 }
 
 /// Process-port command result normalized for capability handlers.
@@ -228,6 +234,11 @@ impl RuntimeProcessPort for HostProcessPort {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        if request.background {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "background execution is not supported outside the sandboxed profile".to_string(),
+            ));
+        }
         let cwd = resolve_local_host_workdir(request.workdir.as_deref(), &self.workdir_aliases)
             .map_err(|e| {
                 RuntimeProcessError::ExecutionFailed(format!(
@@ -461,6 +472,7 @@ mod tests {
                 timeout_secs: None,
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .unwrap();
@@ -482,6 +494,7 @@ mod tests {
             timeout_secs: None,
             extra_env: HashMap::new(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .unwrap();
@@ -506,6 +519,7 @@ mod tests {
             timeout_secs: Some(6_000),
             extra_env: HashMap::new(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .unwrap();
@@ -530,6 +544,7 @@ mod tests {
             timeout_secs: Some(45),
             extra_env: HashMap::new(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .unwrap();
@@ -550,6 +565,7 @@ mod tests {
             timeout_secs: None,
             extra_env: HashMap::new(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .unwrap();
@@ -573,6 +589,7 @@ mod tests {
             timeout_secs: None,
             extra_env: HashMap::new(),
             output_limit_bytes: Some(10 * 1024 * 1024),
+            background: false,
         })
         .await
         .unwrap();
@@ -596,6 +613,7 @@ mod tests {
             timeout_secs: None,
             extra_env: HashMap::new(),
             output_limit_bytes: Some(10),
+            background: false,
         })
         .await
         .unwrap();
@@ -619,6 +637,7 @@ mod tests {
                 timeout_secs: None,
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .unwrap_err();
@@ -642,6 +661,7 @@ mod tests {
                 timeout_secs: Some(1),
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .unwrap_err();
@@ -666,11 +686,34 @@ mod tests {
                 timeout_secs: None,
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .unwrap();
 
         assert!(output.output.contains("... [truncated 1 bytes] ..."));
+    }
+
+    #[tokio::test]
+    async fn host_process_port_rejects_background_true() {
+        let port = HostProcessPort::new();
+        let error = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope::system(),
+                mounts: None,
+                command: "sleep 1".to_string(),
+                workdir: None,
+                timeout_secs: Some(1),
+                extra_env: HashMap::new(),
+                output_limit_bytes: None,
+                background: true,
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, RuntimeProcessError::ExecutionFailed(ref reason) if reason.contains("background")),
+            "expected background rejection reason, got: {error:?}"
+        );
     }
 
     #[cfg(unix)]
@@ -775,6 +818,7 @@ mod tests {
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .expect("command succeeds");
@@ -806,6 +850,7 @@ mod tests {
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .expect("command succeeds");
@@ -830,6 +875,7 @@ mod tests {
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .expect("command succeeds");

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -23,7 +23,9 @@ use crate::process_output::{
     CapturedCommandOutput, SavedCommandOutput, StreamCapture, capture_command_output,
     read_stream_capped, truncate_output_to,
 };
-use crate::sandbox_process::shell_limits::{clamp_shell_output_limit_bytes, clamp_shell_timeout_secs};
+use crate::sandbox_process::shell_limits::{
+    clamp_shell_output_limit_bytes, clamp_shell_timeout_secs,
+};
 
 /// Environment variables safe to forward to local child processes.
 const SAFE_ENV_VARS: &[&str] = &[
@@ -509,7 +511,10 @@ mod tests {
         .unwrap();
 
         // An over-cap timeout is clamped, not rejected.
-        assert_eq!(transport.requests.lock().unwrap()[0].timeout_secs, Some(600));
+        assert_eq!(
+            transport.requests.lock().unwrap()[0].timeout_secs,
+            Some(600)
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -21,10 +21,9 @@ use crate::process_aliases::{
 };
 use crate::process_output::{
     CapturedCommandOutput, SavedCommandOutput, StreamCapture, capture_command_output,
-    read_stream_capped, truncate_output,
+    read_stream_capped, truncate_output_to,
 };
-
-const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
+use crate::sandbox_process::shell_limits::{clamp_shell_output_limit_bytes, clamp_shell_timeout_secs};
 
 /// Environment variables safe to forward to local child processes.
 const SAFE_ENV_VARS: &[&str] = &[
@@ -72,6 +71,10 @@ pub struct CommandExecutionRequest {
     pub command: String,
     pub workdir: Option<String>,
     pub timeout_secs: Option<u64>,
+    /// Optional model-requested cap on captured output (stdout+stderr)
+    /// bytes. Ports clamp this to their own floor/ceiling — see
+    /// `sandbox_process::shell_limits` for the sandbox transport's clamp.
+    pub output_limit_bytes: Option<u64>,
     pub extra_env: HashMap<String, String>,
 }
 
@@ -147,14 +150,16 @@ impl RuntimeProcessPort for TenantSandboxProcessPort {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-        let timeout = request
-            .timeout_secs
-            .map(Duration::from_secs)
-            .unwrap_or(DEFAULT_COMMAND_TIMEOUT);
+        // Clamp the model-adjustable `timeout`/`output_limit` to the
+        // operator ceilings before the transport (e.g. the Docker sandbox
+        // transport) ever sees them — see `sandbox_process::shell_limits`.
+        let timeout = clamp_shell_timeout_secs(request.timeout_secs);
+        let output_limit = clamp_shell_output_limit_bytes(request.output_limit_bytes);
         let mut request = request;
         request.timeout_secs = Some(timeout.as_secs());
+        request.output_limit_bytes = Some(output_limit as u64);
         let mut output = self.transport.run_command(request).await?;
-        output.output = truncate_output(&output.output);
+        output.output = truncate_output_to(&output.output, output_limit);
         output.sandboxed = true;
         Ok(output)
     }
@@ -227,10 +232,13 @@ impl RuntimeProcessPort for HostProcessPort {
                     "cannot determine working directory: {e}"
                 ))
             })?;
-        let timeout = request
-            .timeout_secs
-            .map(Duration::from_secs)
-            .unwrap_or(DEFAULT_COMMAND_TIMEOUT);
+        // Same operator ceiling as the sandboxed transport (see
+        // `sandbox_process::shell_limits`), applied here so the unsandboxed
+        // host path can't be used to bypass the model-adjustable `timeout`
+        // clamp. `output_limit` is not honored on this path: it captures via
+        // a fixed preview/save-to-file split (`process_output`) independent
+        // of the sandbox's inline-capture cap.
+        let timeout = clamp_shell_timeout_secs(request.timeout_secs);
         if self.env_mode == HostProcessEnvMode::Inherited {
             tracing::warn!(
                 host_access = "full-local",
@@ -450,6 +458,7 @@ mod tests {
                 workdir: None,
                 timeout_secs: None,
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .unwrap();
@@ -470,6 +479,7 @@ mod tests {
             workdir: None,
             timeout_secs: None,
             extra_env: HashMap::new(),
+            output_limit_bytes: None,
         })
         .await
         .unwrap();
@@ -477,7 +487,117 @@ mod tests {
         let requests = transport.requests.lock().unwrap();
         assert_eq!(
             requests[0].timeout_secs,
-            Some(DEFAULT_COMMAND_TIMEOUT.as_secs())
+            Some(clamp_shell_timeout_secs(None).as_secs())
+        );
+    }
+
+    #[tokio::test]
+    async fn tenant_sandbox_process_port_clamps_timeout_over_cap_to_600() {
+        let transport = std::sync::Arc::new(RecordingSandboxTransport::default());
+        let port = TenantSandboxProcessPort::new(transport.clone());
+
+        port.run_command(CommandExecutionRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            command: "echo sandbox".to_string(),
+            workdir: None,
+            timeout_secs: Some(6_000),
+            extra_env: HashMap::new(),
+            output_limit_bytes: None,
+        })
+        .await
+        .unwrap();
+
+        // An over-cap timeout is clamped, not rejected.
+        assert_eq!(transport.requests.lock().unwrap()[0].timeout_secs, Some(600));
+    }
+
+    #[tokio::test]
+    async fn tenant_sandbox_process_port_honors_timeout_within_range() {
+        let transport = std::sync::Arc::new(RecordingSandboxTransport::default());
+        let port = TenantSandboxProcessPort::new(transport.clone());
+
+        port.run_command(CommandExecutionRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            command: "echo sandbox".to_string(),
+            workdir: None,
+            timeout_secs: Some(45),
+            extra_env: HashMap::new(),
+            output_limit_bytes: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(transport.requests.lock().unwrap()[0].timeout_secs, Some(45));
+    }
+
+    #[tokio::test]
+    async fn tenant_sandbox_process_port_output_limit_unset_defaults_to_64kib() {
+        let transport = std::sync::Arc::new(RecordingSandboxTransport::default());
+        let port = TenantSandboxProcessPort::new(transport.clone());
+
+        port.run_command(CommandExecutionRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            command: "echo sandbox".to_string(),
+            workdir: None,
+            timeout_secs: None,
+            extra_env: HashMap::new(),
+            output_limit_bytes: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            transport.requests.lock().unwrap()[0].output_limit_bytes,
+            Some(65_536)
+        );
+    }
+
+    #[tokio::test]
+    async fn tenant_sandbox_process_port_output_limit_over_cap_is_clamped_to_1mib() {
+        let transport = std::sync::Arc::new(RecordingSandboxTransport::default());
+        let port = TenantSandboxProcessPort::new(transport.clone());
+
+        port.run_command(CommandExecutionRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            command: "echo sandbox".to_string(),
+            workdir: None,
+            timeout_secs: None,
+            extra_env: HashMap::new(),
+            output_limit_bytes: Some(10 * 1024 * 1024),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            transport.requests.lock().unwrap()[0].output_limit_bytes,
+            Some(1_048_576)
+        );
+    }
+
+    #[tokio::test]
+    async fn tenant_sandbox_process_port_output_limit_below_floor_is_clamped_up() {
+        let transport = std::sync::Arc::new(RecordingSandboxTransport::default());
+        let port = TenantSandboxProcessPort::new(transport.clone());
+
+        port.run_command(CommandExecutionRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            command: "echo sandbox".to_string(),
+            workdir: None,
+            timeout_secs: None,
+            extra_env: HashMap::new(),
+            output_limit_bytes: Some(10),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            transport.requests.lock().unwrap()[0].output_limit_bytes,
+            Some(1024)
         );
     }
 
@@ -493,6 +613,7 @@ mod tests {
                 workdir: None,
                 timeout_secs: None,
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .unwrap_err();
@@ -515,6 +636,7 @@ mod tests {
                 workdir: None,
                 timeout_secs: Some(1),
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .unwrap_err();
@@ -538,6 +660,7 @@ mod tests {
                 workdir: None,
                 timeout_secs: None,
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .unwrap();
@@ -646,6 +769,7 @@ mod tests {
                 workdir: Some("/workspace/qa-coding-smoke".to_string()),
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .expect("command succeeds");
@@ -676,6 +800,7 @@ mod tests {
                 workdir: None,
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .expect("command succeeds");
@@ -699,6 +824,7 @@ mod tests {
                 workdir: None,
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .expect("command succeeds");

--- a/crates/ironclaw_host_runtime/src/sandbox_process.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process.rs
@@ -37,6 +37,7 @@ mod network_allowlist;
 mod reaper;
 mod scope_key;
 pub mod shell_limits;
+mod user_key;
 
 use mounts::RebornSandboxMountSources;
 
@@ -44,15 +45,16 @@ pub use broker::{RebornSandboxNetworkBroker, RebornSandboxSecretBroker};
 pub use connect::{SandboxDockerReadiness, connect_docker_with_retry, sandbox_docker_readiness};
 pub use container_identity::{RebornSandboxContainerIdentity, RebornSandboxWorkspaceMode};
 pub use network_allowlist::{
-    DEFAULT_SANDBOX_ALLOWED_DOMAINS, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
-    sandbox_allowed_domains, sandbox_extra_allowed_domains, sandbox_network_policy,
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, sandbox_allowed_domains,
+    sandbox_extra_allowed_domains, sandbox_network_policy,
 };
 pub use reaper::{ReapSummary, SandboxReaper, SandboxReaperConfig};
+pub use scope_key::RebornSandboxScopeKey;
 pub use shell_limits::{
     SHELL_OUTPUT_LIMIT_DEFAULT_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES, SHELL_TIMEOUT_DEFAULT_SECS,
     SHELL_TIMEOUT_MAX_SECS, clamp_shell_output_limit_bytes, clamp_shell_timeout_secs,
 };
-pub use scope_key::RebornSandboxScopeKey;
+pub use user_key::RebornSandboxUserKey;
 
 /// Docker label prefix for container metadata attached by
 /// [`RebornScopedSandboxCommandTransport`] — shared with [`reaper`] so the

--- a/crates/ironclaw_host_runtime/src/sandbox_process.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process.rs
@@ -35,6 +35,7 @@ mod container_identity;
 mod mounts;
 mod network_allowlist;
 mod reaper;
+mod registry;
 mod scope_key;
 pub mod shell_limits;
 mod user_key;
@@ -49,6 +50,7 @@ pub use network_allowlist::{
     sandbox_extra_allowed_domains, sandbox_network_policy,
 };
 pub use reaper::{ReapSummary, SandboxReaper, SandboxReaperConfig};
+pub use registry::SandboxActivityRegistry;
 pub use scope_key::RebornSandboxScopeKey;
 pub use shell_limits::{
     SHELL_OUTPUT_LIMIT_DEFAULT_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES, SHELL_TIMEOUT_DEFAULT_SECS,

--- a/crates/ironclaw_host_runtime/src/sandbox_process.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process.rs
@@ -43,6 +43,7 @@ pub use network_allowlist::{
     sandbox_extra_allowed_domains, sandbox_network_policy,
 };
 pub use reaper::{ReapSummary, SandboxReaper, SandboxReaperConfig};
+use registry::BackgroundJobRegistry;
 pub use registry::SandboxActivityRegistry;
 pub use scope_key::RebornSandboxScopeKey;
 pub use shell_limits::{
@@ -243,6 +244,7 @@ pub struct RebornScopedSandboxCommandTransport {
     docker: Docker,
     config: RebornSandboxConfig,
     activity: Arc<SandboxActivityRegistry>,
+    background_jobs: Arc<BackgroundJobRegistry>,
 }
 
 impl std::fmt::Debug for RebornScopedSandboxCommandTransport {
@@ -270,6 +272,7 @@ impl RebornScopedSandboxCommandTransport {
             docker,
             config,
             activity: Arc::new(SandboxActivityRegistry::new()),
+            background_jobs: Arc::new(BackgroundJobRegistry::new()),
         }
     }
 
@@ -417,7 +420,33 @@ impl SandboxCommandTransport for RebornScopedSandboxCommandTransport {
             &workspace,
         )
         .await?;
-        let output = exec_transport::exec_in_container(
+
+        if request.background {
+            let command_preview = request.command.clone();
+            let launch = exec_transport::exec_background_in_container(
+                &self.docker,
+                &container_id,
+                workdir,
+                env,
+                request.command,
+            )
+            .await?;
+            self.background_jobs
+                .record(&key, launch.pid, command_preview);
+            self.activity.touch(&key);
+            return Ok(CommandExecutionOutput {
+                output: format!(
+                    "Started in background: pid {}, log {}",
+                    launch.pid, launch.log_path
+                ),
+                saved_output: None,
+                exit_code: 0,
+                sandboxed: true,
+                duration: Duration::from_secs(0),
+            });
+        }
+
+        let mut output = exec_transport::exec_in_container(
             &self.docker,
             &container_id,
             workdir,
@@ -428,7 +457,44 @@ impl SandboxCommandTransport for RebornScopedSandboxCommandTransport {
         )
         .await?;
         self.activity.touch(&key);
+        self.reconcile_background_jobs(&container_id, &key).await;
+        output
+            .output
+            .push_str(&exec_transport::render_background_footer(
+                &self.background_jobs.jobs_for(&key),
+            ));
         Ok(output)
+    }
+}
+
+impl RebornScopedSandboxCommandTransport {
+    /// Cheap `ps -o pid=` sweep against the tracked background pids so a
+    /// process that has since exited drops off the footer instead of being
+    /// reported as still live forever.
+    async fn reconcile_background_jobs(&self, container_id: &str, key: &RebornSandboxUserKey) {
+        let tracked = self.background_jobs.jobs_for(key);
+        if tracked.is_empty() {
+            return;
+        }
+        let alive = exec_transport::exec_in_container(
+            &self.docker,
+            container_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "ps -o pid= --no-headers".to_string(),
+            Duration::from_secs(5),
+            4096,
+        )
+        .await;
+        let Ok(alive) = alive else {
+            return;
+        };
+        let alive_pids: Vec<u32> = alive
+            .output
+            .split_whitespace()
+            .filter_map(|token| token.trim().parse::<u32>().ok())
+            .collect();
+        self.background_jobs.drop_dead(key, &alive_pids);
     }
 }
 
@@ -840,6 +906,7 @@ mod tests {
                 timeout_secs: Some(1),
                 extra_env: HashMap::new(),
                 output_limit_bytes: None,
+                background: false,
             })
             .await
             .unwrap_err();

--- a/crates/ironclaw_host_runtime/src/sandbox_process.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process.rs
@@ -9,20 +9,12 @@ use std::{
     collections::HashMap,
     path::{Component, Path, PathBuf},
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use async_trait::async_trait;
-use bollard::{
-    Docker,
-    container::{
-        Config, CreateContainerOptions, LogOutput, LogsOptions, RemoveContainerOptions,
-        StartContainerOptions, WaitContainerOptions,
-    },
-    models::HostConfig,
-};
-use futures_util::StreamExt;
-use ironclaw_host_api::ResourceScope;
+use bollard::Docker;
+use ironclaw_host_api::{MountView, ResourceScope};
 
 use crate::{
     CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandTransport,
@@ -32,6 +24,7 @@ use crate::{
 mod broker;
 mod connect;
 mod container_identity;
+mod exec_transport;
 mod mounts;
 mod network_allowlist;
 mod reaper;
@@ -249,6 +242,7 @@ impl RebornSandboxConfig {
 pub struct RebornScopedSandboxCommandTransport {
     docker: Docker,
     config: RebornSandboxConfig,
+    activity: Arc<SandboxActivityRegistry>,
 }
 
 impl std::fmt::Debug for RebornScopedSandboxCommandTransport {
@@ -272,18 +266,38 @@ impl RebornScopedSandboxCommandTransport {
     }
 
     pub fn new(docker: Docker, config: RebornSandboxConfig) -> Self {
-        Self { docker, config }
+        Self {
+            docker,
+            config,
+            activity: Arc::new(SandboxActivityRegistry::new()),
+        }
+    }
+
+    /// Overrides the default activity registry with one shared elsewhere
+    /// (e.g. with a [`SandboxReaper`] instance), so both observe the same
+    /// per-user last-activity timestamps. Composition wiring is the
+    /// expected caller.
+    pub fn with_activity_registry(mut self, activity: Arc<SandboxActivityRegistry>) -> Self {
+        self.activity = activity;
+        self
     }
 
     pub fn into_process_port(self) -> TenantSandboxProcessPort {
         TenantSandboxProcessPort::new(Arc::new(self))
     }
 
+    /// Initializes (and returns) the per-user host workspace directory that
+    /// backs the persistent container's flat `/workspace` bind — every
+    /// thread/project/agent for the same `{tenant, user}` pair shares this
+    /// one directory, matching the container reuse in `exec_transport`. Also
+    /// seeds `.home` (owner-only) so `HOME=/workspace/.home` (set in
+    /// `exec_transport::user_container_launch_config`) always resolves to a
+    /// real, private directory.
     async fn prepare_workspace(
         &self,
         scope: &ResourceScope,
     ) -> Result<PathBuf, RuntimeProcessError> {
-        let key = RebornSandboxScopeKey::from_scope(scope);
+        let key = RebornSandboxUserKey::from_scope(scope);
         let workspace = key.workspace_path(&self.config.workspace_root);
         tokio::fs::create_dir_all(&workspace)
             .await
@@ -305,6 +319,23 @@ impl RebornScopedSandboxCommandTransport {
                     "sandbox workspace permissions could not be set: {error}"
                 ))
             })?;
+        }
+        let home = workspace.join(".home");
+        tokio::fs::create_dir_all(&home).await.map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox workspace HOME could not be initialized: {error}"
+            ))
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o700))
+                .await
+                .map_err(|error| {
+                    RuntimeProcessError::ExecutionFailed(format!(
+                        "sandbox workspace HOME permissions could not be set: {error}"
+                    ))
+                })?;
         }
         tokio::fs::canonicalize(&workspace).await.map_err(|error| {
             RuntimeProcessError::ExecutionFailed(format!(
@@ -339,140 +370,6 @@ impl RebornScopedSandboxCommandTransport {
             Ok(ContainerWorkdir::from_relative(requested))
         }
     }
-
-    async fn execute_in_container(
-        &self,
-        request: CommandExecutionRequest,
-        workspace: &Path,
-        workdir: ContainerWorkdir,
-        timeout: Duration,
-    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-        let scope_key = RebornSandboxScopeKey::from_scope(&request.scope);
-        let container_name = format!(
-            "{}-{}",
-            scope_key.container_name_prefix(),
-            uuid::Uuid::new_v4()
-        );
-        // Clamp to `[SHELL_OUTPUT_LIMIT_MIN_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES]`
-        // before the request is consumed by `container_launch_config`; falls
-        // back to the configured default (itself `SHELL_OUTPUT_LIMIT_DEFAULT_BYTES`
-        // unless overridden) when the model omits `output_limit`.
-        let output_limit_bytes = clamp_shell_output_limit_bytes(Some(
-            request
-                .output_limit_bytes
-                .unwrap_or(self.config.max_output_bytes as u64),
-        ));
-        let launch = self
-            .container_launch_config(request, workspace, workdir)
-            .await?;
-
-        let created = self
-            .docker
-            .create_container(
-                Some(CreateContainerOptions {
-                    name: container_name.clone(),
-                    platform: None,
-                }),
-                launch,
-            )
-            .await
-            .map_err(|error| {
-                RuntimeProcessError::ExecutionFailed(format!(
-                    "sandbox container create failed: {error}"
-                ))
-            })?;
-        let container_id = created.id;
-        let started_at = Instant::now();
-
-        let result = async {
-            self.docker
-                .start_container(&container_id, None::<StartContainerOptions<String>>)
-                .await
-                .map_err(|error| {
-                    RuntimeProcessError::ExecutionFailed(format!(
-                        "sandbox container start failed: {error}"
-                    ))
-                })?;
-            let exit_code = wait_for_container(&self.docker, &container_id).await?;
-            let output = collect_logs(&self.docker, &container_id, output_limit_bytes).await?;
-            Ok(CommandExecutionOutput {
-                output,
-                // Sandbox logs are pre-capped by `collect_logs`; saved-output
-                // refs are currently local-process only.
-                saved_output: None,
-                exit_code,
-                sandboxed: true,
-                duration: started_at.elapsed(),
-            })
-        };
-
-        let result = match tokio::time::timeout(timeout, result).await {
-            Ok(result) => result,
-            Err(_) => Err(RuntimeProcessError::Timeout(timeout)),
-        };
-        if let Err(error) = self
-            .docker
-            .remove_container(
-                &container_id,
-                Some(RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
-            )
-            .await
-        {
-            tracing::debug!(?error, "best-effort removal of sandbox container failed");
-        }
-        result
-    }
-
-    async fn container_launch_config(
-        &self,
-        request: CommandExecutionRequest,
-        workspace: &Path,
-        workdir: ContainerWorkdir,
-    ) -> Result<Config<String>, RuntimeProcessError> {
-        let labels = reaper::build_container_labels(&request.scope)?;
-        let env = self.config.command_env(request.extra_env)?;
-        let container_user = self.config.container_identity.container_user()?;
-        let mut binds = self
-            .config
-            .mount_sources
-            .prepare_container_binds(workspace, request.mounts.as_ref())
-            .await?
-            .into_iter()
-            .map(|bind| bind.into_docker_bind())
-            .collect::<Vec<_>>();
-        self.config.append_broker_binds(&mut binds)?;
-        let host_config = HostConfig {
-            binds: Some(binds),
-            memory: Some(self.config.memory_bytes as i64),
-            cpu_shares: Some(self.config.cpu_shares as i64),
-            auto_remove: Some(false),
-            network_mode: self.config.container_network_mode(),
-            cap_drop: Some(vec!["ALL".to_string()]),
-            security_opt: Some(vec!["no-new-privileges:true".to_string()]),
-            readonly_rootfs: Some(true),
-            tmpfs: Some(
-                [("/tmp".to_string(), "size=512M".to_string())]
-                    .into_iter()
-                    .collect(),
-            ),
-            ..Default::default()
-        };
-        Ok(Config {
-            image: Some(self.config.image.clone()),
-            cmd: Some(vec!["sh".to_string(), "-c".to_string(), request.command]),
-            working_dir: Some(workdir.into_string()),
-            env: Some(env),
-            labels: Some(labels),
-            host_config: Some(host_config),
-            user: container_user,
-            attach_stdout: Some(false),
-            attach_stderr: Some(false),
-            ..Default::default()
-        })
-    }
 }
 
 #[async_trait]
@@ -482,7 +379,16 @@ impl SandboxCommandTransport for RebornScopedSandboxCommandTransport {
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
         reject_nul("sandbox command", &request.command)?;
+        // Phase A scope narrowing: a persistent container's binds are fixed
+        // at creation time from the flat per-user `/workspace` bind only
+        // (`exec_transport::user_container_launch_config` always resolves
+        // binds with `mounts: None`) — a later request naming a scoped
+        // `MountView` grant can never be retrofitted onto an already-running
+        // container, so it is rejected up front rather than silently
+        // ignored.
+        reject_non_workspace_mount_grants(request.mounts.as_ref())?;
 
+        let key = RebornSandboxUserKey::from_scope(&request.scope);
         let workspace = self.prepare_workspace(&request.scope).await?;
         let workdir = Self::resolve_container_workdir(request.workdir.as_deref())?;
         // Clamp to `[SHELL_TIMEOUT_MIN_SECS, SHELL_TIMEOUT_MAX_SECS]` — the
@@ -492,75 +398,63 @@ impl SandboxCommandTransport for RebornScopedSandboxCommandTransport {
             .timeout_secs
             .unwrap_or_else(|| self.config.default_timeout.as_secs());
         let timeout = clamp_shell_timeout_secs(Some(requested_secs));
-        self.execute_in_container(request, &workspace, workdir, timeout)
-            .await
+        // Clamp to `[SHELL_OUTPUT_LIMIT_MIN_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES]`,
+        // falling back to the configured default when the model omits
+        // `output_limit`.
+        let output_limit = clamp_shell_output_limit_bytes(Some(
+            request
+                .output_limit_bytes
+                .unwrap_or(self.config.max_output_bytes as u64),
+        ));
+        let env = self.config.command_env(request.extra_env)?;
+
+        let container_id = exec_transport::ensure_container(
+            &self.docker,
+            &self.config,
+            &key,
+            &request.scope.tenant_id,
+            &request.scope.user_id,
+            &workspace,
+        )
+        .await?;
+        let output = exec_transport::exec_in_container(
+            &self.docker,
+            &container_id,
+            workdir,
+            env,
+            request.command,
+            timeout,
+            output_limit,
+        )
+        .await?;
+        self.activity.touch(&key);
+        Ok(output)
     }
 }
 
-async fn wait_for_container(
-    docker: &Docker,
-    container_id: &str,
-) -> Result<i64, RuntimeProcessError> {
-    let mut stream = docker.wait_container(
-        container_id,
-        Some(WaitContainerOptions {
-            condition: "not-running",
-        }),
-    );
-    match stream.next().await {
-        Some(Ok(result)) => Ok(result.status_code),
-        Some(Err(error)) => Err(RuntimeProcessError::ExecutionFailed(format!(
-            "sandbox container wait failed: {error}"
-        ))),
-        None => Err(RuntimeProcessError::ExecutionFailed(
-            "sandbox container wait stream ended unexpectedly".to_string(),
-        )),
+/// Phase A scope-narrowing guard: persistent per-user containers only
+/// support the default `/workspace` bind (see `run_command` above), so any
+/// caller-supplied `MountView` grant — scoped or not — is rejected before
+/// the container is ever touched, with a clear error, rather than being
+/// silently dropped by `exec_transport::user_container_launch_config`'s
+/// hardcoded `mounts: None`.
+fn reject_non_workspace_mount_grants(
+    mounts: Option<&MountView>,
+) -> Result<(), RuntimeProcessError> {
+    let Some(mounts) = mounts else {
+        return Ok(());
+    };
+    if mounts.mounts.is_empty() {
+        return Ok(());
     }
+    Err(RuntimeProcessError::ExecutionFailed(
+        "sandbox command rejected: persistent per-user sandbox containers only support the \
+         default /workspace bind in Phase A; scoped mount grants are not supported"
+            .to_string(),
+    ))
 }
 
-async fn collect_logs(
-    docker: &Docker,
-    container_id: &str,
-    limit: usize,
-) -> Result<String, RuntimeProcessError> {
-    let mut stream = docker.logs(
-        container_id,
-        Some(LogsOptions::<String> {
-            stdout: true,
-            stderr: true,
-            follow: false,
-            ..Default::default()
-        }),
-    );
-    let mut stdout = String::new();
-    let mut stderr = String::new();
-    let half_limit = limit / 2;
-    while let Some(result) = stream.next().await {
-        match result {
-            Ok(LogOutput::StdOut { message }) => {
-                append_with_limit(&mut stdout, &String::from_utf8_lossy(&message), half_limit);
-            }
-            Ok(LogOutput::StdErr { message }) => {
-                append_with_limit(&mut stderr, &String::from_utf8_lossy(&message), half_limit);
-            }
-            Ok(_) => {}
-            Err(error) => {
-                return Err(RuntimeProcessError::ExecutionFailed(format!(
-                    "sandbox log collection failed: {error}"
-                )));
-            }
-        }
-    }
-    if stderr.is_empty() {
-        Ok(stdout)
-    } else if stdout.is_empty() {
-        Ok(stderr)
-    } else {
-        Ok(format!("{stdout}\n\n--- stderr ---\n{stderr}"))
-    }
-}
-
-fn append_with_limit(buffer: &mut String, text: &str, limit: usize) {
+pub(super) fn append_with_limit(buffer: &mut String, text: &str, limit: usize) {
     if buffer.len() >= limit {
         return;
     }
@@ -621,6 +515,25 @@ fn validate_relative_workdir(path: &Path) -> Result<(), RuntimeProcessError> {
         }
     }
     Ok(())
+}
+
+/// Wraps `value` in single quotes, escaping any embedded single quote so the
+/// result is safe to interpolate into a `sh -c '...'` argument. The one
+/// shell-quoting implementation in this crate — `exec_transport`'s
+/// pgid-isolation wrapper calls this instead of hand-rolling its own.
+pub(crate) fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod shell_quote_tests {
+    use super::*;
+
+    #[test]
+    fn shell_single_quote_escapes_embedded_single_quotes() {
+        assert_eq!(shell_single_quote("echo hi"), "'echo hi'");
+        assert_eq!(shell_single_quote("it's"), "'it'\\''s'");
+    }
 }
 
 #[cfg(test)]
@@ -816,7 +729,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn container_launch_config_applies_unix_socket_broker_env_binds_and_none_network() {
+    async fn user_container_launch_config_applies_unix_socket_broker_env_binds_and_none_network() {
         let temp = tempfile::tempdir().unwrap();
         let workspace = temp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
@@ -827,26 +740,13 @@ mod tests {
             .unwrap()
             .with_secret_broker_unix_socket(&secret_socket)
             .unwrap();
-        let transport = RebornScopedSandboxCommandTransport::new(
-            Docker::connect_with_local_defaults().unwrap(),
-            config,
-        );
-        let launch = transport
-            .container_launch_config(
-                CommandExecutionRequest {
-                    scope: ResourceScope::system(),
-                    mounts: None,
-                    command: "true".to_string(),
-                    workdir: None,
-                    timeout_secs: Some(1),
-                    extra_env: HashMap::new(),
-                    output_limit_bytes: None,
-                },
-                &workspace,
-                ContainerWorkdir::workspace_root(),
-            )
-            .await
-            .unwrap();
+        let tenant = ironclaw_host_api::TenantId::new("tenant-a").unwrap();
+        let user = ironclaw_host_api::UserId::new("user-a").unwrap();
+
+        let launch =
+            exec_transport::user_container_launch_config(&config, &tenant, &user, &workspace)
+                .await
+                .unwrap();
         let host_config = launch.host_config.unwrap();
         let binds = host_config.binds.unwrap();
         let env = launch.env.unwrap();
@@ -870,33 +770,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn container_launch_config_applies_http_proxy_broker_env_and_drops_none_network() {
+    async fn user_container_launch_config_applies_http_proxy_broker_env_and_drops_none_network() {
         let temp = tempfile::tempdir().unwrap();
         let workspace = temp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
         let config = RebornSandboxConfig::new(temp.path().join("workspaces"))
             .with_network_broker_proxy_url("http://broker.internal:8181")
             .unwrap();
-        let transport = RebornScopedSandboxCommandTransport::new(
-            Docker::connect_with_local_defaults().unwrap(),
-            config,
-        );
-        let launch = transport
-            .container_launch_config(
-                CommandExecutionRequest {
-                    scope: ResourceScope::system(),
-                    mounts: None,
-                    command: "true".to_string(),
-                    workdir: None,
-                    timeout_secs: Some(1),
-                    extra_env: HashMap::new(),
-                    output_limit_bytes: None,
-                },
-                &workspace,
-                ContainerWorkdir::workspace_root(),
-            )
-            .await
-            .unwrap();
+        let tenant = ironclaw_host_api::TenantId::new("tenant-a").unwrap();
+        let user = ironclaw_host_api::UserId::new("user-a").unwrap();
+
+        let launch =
+            exec_transport::user_container_launch_config(&config, &tenant, &user, &workspace)
+                .await
+                .unwrap();
         let host_config = launch.host_config.unwrap();
         let binds = host_config.binds.unwrap();
         let env = launch.env.unwrap();
@@ -913,8 +800,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn reject_non_workspace_mount_grants_allows_none_and_empty_but_rejects_any_grant() {
+        assert!(reject_non_workspace_mount_grants(None).is_ok());
+        assert!(reject_non_workspace_mount_grants(Some(&MountView::default())).is_ok());
+
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/app").unwrap(),
+            process_read_only_permissions(),
+        )])
+        .unwrap();
+        let error = reject_non_workspace_mount_grants(Some(&mounts)).unwrap_err();
+
+        assert!(format!("{error}").contains("scoped mount grants are not supported"));
+    }
+
     #[tokio::test]
-    async fn run_command_rejects_unconfigured_scoped_mount_before_container_create() {
+    async fn run_command_rejects_any_scoped_mount_grant_before_container_touch() {
         let temp = tempfile::tempdir().unwrap();
         let docker = Docker::connect_with_local_defaults().unwrap();
         let transport = RebornScopedSandboxCommandTransport::new(
@@ -941,7 +844,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(format!("{error}").contains("no trusted sandbox mount source"));
+        assert!(format!("{error}").contains("scoped mount grants are not supported"));
     }
 
     fn process_read_only_permissions() -> MountPermissions {

--- a/crates/ironclaw_host_runtime/src/sandbox_process.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process.rs
@@ -30,21 +30,45 @@ use crate::{
 };
 
 mod broker;
+mod connect;
 mod container_identity;
 mod mounts;
+mod network_allowlist;
+mod reaper;
 mod scope_key;
+pub mod shell_limits;
 
 use mounts::RebornSandboxMountSources;
 
 pub use broker::{RebornSandboxNetworkBroker, RebornSandboxSecretBroker};
+pub use connect::{SandboxDockerReadiness, connect_docker_with_retry, sandbox_docker_readiness};
 pub use container_identity::{RebornSandboxContainerIdentity, RebornSandboxWorkspaceMode};
+pub use network_allowlist::{
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
+    sandbox_allowed_domains, sandbox_extra_allowed_domains, sandbox_network_policy,
+};
+pub use reaper::{ReapSummary, SandboxReaper, SandboxReaperConfig};
+pub use shell_limits::{
+    SHELL_OUTPUT_LIMIT_DEFAULT_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES, SHELL_TIMEOUT_DEFAULT_SECS,
+    SHELL_TIMEOUT_MAX_SECS, clamp_shell_output_limit_bytes, clamp_shell_timeout_secs,
+};
 pub use scope_key::RebornSandboxScopeKey;
 
+/// Docker label prefix for container metadata attached by
+/// [`RebornScopedSandboxCommandTransport`] — shared with [`reaper`] so the
+/// reaper's container-listing filter and this transport's container-creation
+/// labels never drift apart.
+const LABEL_PREFIX: &str = "ironclaw";
+
 const DEFAULT_IMAGE: &str = "ironclaw-worker:latest";
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+// Sourced from `shell_limits` so the config-level default and the per-call
+// clamp default (used when the model omits `timeout`/`output_limit`) can
+// never drift apart. The per-call ceilings (`SHELL_TIMEOUT_MAX_SECS`,
+// `SHELL_OUTPUT_LIMIT_MAX_BYTES`) are applied in `execute_in_container`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(shell_limits::SHELL_TIMEOUT_DEFAULT_SECS);
 const DEFAULT_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const DEFAULT_CPU_SHARES: u32 = 1024;
-const DEFAULT_MAX_OUTPUT_BYTES: usize = 64 * 1024;
+const DEFAULT_MAX_OUTPUT_BYTES: usize = shell_limits::SHELL_OUTPUT_LIMIT_DEFAULT_BYTES as usize;
 const CONTAINER_WORKSPACE_ROOT: &str = "/workspace";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -239,7 +263,7 @@ impl std::fmt::Debug for RebornScopedSandboxCommandTransport {
 
 impl RebornScopedSandboxCommandTransport {
     pub async fn connect(config: RebornSandboxConfig) -> Result<Self, RuntimeProcessError> {
-        let docker = connect_docker().await?;
+        let docker = connect_docker_with_retry().await?;
         Ok(Self::new(docker, config))
     }
 
@@ -325,6 +349,15 @@ impl RebornScopedSandboxCommandTransport {
             scope_key.container_name_prefix(),
             uuid::Uuid::new_v4()
         );
+        // Clamp to `[SHELL_OUTPUT_LIMIT_MIN_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES]`
+        // before the request is consumed by `container_launch_config`; falls
+        // back to the configured default (itself `SHELL_OUTPUT_LIMIT_DEFAULT_BYTES`
+        // unless overridden) when the model omits `output_limit`.
+        let output_limit_bytes = clamp_shell_output_limit_bytes(Some(
+            request
+                .output_limit_bytes
+                .unwrap_or(self.config.max_output_bytes as u64),
+        ));
         let launch = self
             .container_launch_config(request, workspace, workdir)
             .await?;
@@ -357,8 +390,7 @@ impl RebornScopedSandboxCommandTransport {
                     ))
                 })?;
             let exit_code = wait_for_container(&self.docker, &container_id).await?;
-            let output =
-                collect_logs(&self.docker, &container_id, self.config.max_output_bytes).await?;
+            let output = collect_logs(&self.docker, &container_id, output_limit_bytes).await?;
             Ok(CommandExecutionOutput {
                 output,
                 // Sandbox logs are pre-capped by `collect_logs`; saved-output
@@ -396,6 +428,7 @@ impl RebornScopedSandboxCommandTransport {
         workspace: &Path,
         workdir: ContainerWorkdir,
     ) -> Result<Config<String>, RuntimeProcessError> {
+        let labels = reaper::build_container_labels(&request.scope)?;
         let env = self.config.command_env(request.extra_env)?;
         let container_user = self.config.container_identity.container_user()?;
         let mut binds = self
@@ -428,6 +461,7 @@ impl RebornScopedSandboxCommandTransport {
             cmd: Some(vec!["sh".to_string(), "-c".to_string(), request.command]),
             working_dir: Some(workdir.into_string()),
             env: Some(env),
+            labels: Some(labels),
             host_config: Some(host_config),
             user: container_user,
             attach_stdout: Some(false),
@@ -447,52 +481,16 @@ impl SandboxCommandTransport for RebornScopedSandboxCommandTransport {
 
         let workspace = self.prepare_workspace(&request.scope).await?;
         let workdir = Self::resolve_container_workdir(request.workdir.as_deref())?;
-        let timeout = request
+        // Clamp to `[SHELL_TIMEOUT_MIN_SECS, SHELL_TIMEOUT_MAX_SECS]` — the
+        // model-adjustable `timeout` field is bounded by the operator
+        // ceiling here rather than rejected when it overshoots.
+        let requested_secs = request
             .timeout_secs
-            .map(Duration::from_secs)
-            .unwrap_or(self.config.default_timeout);
+            .unwrap_or_else(|| self.config.default_timeout.as_secs());
+        let timeout = clamp_shell_timeout_secs(Some(requested_secs));
         self.execute_in_container(request, &workspace, workdir, timeout)
             .await
     }
-}
-
-async fn connect_docker() -> Result<Docker, RuntimeProcessError> {
-    if let Ok(docker) = Docker::connect_with_local_defaults()
-        && docker.ping().await.is_ok()
-    {
-        return Ok(docker);
-    }
-    #[cfg(unix)]
-    {
-        for socket in unix_socket_candidates() {
-            if socket.exists() {
-                let socket = socket.to_string_lossy();
-                if let Ok(docker) =
-                    Docker::connect_with_socket(&socket, 120, bollard::API_DEFAULT_VERSION)
-                    && docker.ping().await.is_ok()
-                {
-                    return Ok(docker);
-                }
-            }
-        }
-    }
-    Err(RuntimeProcessError::ExecutionFailed(
-        "could not connect to Docker daemon for Reborn sandbox".to_string(),
-    ))
-}
-
-#[cfg(unix)]
-fn unix_socket_candidates() -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
-        candidates.push(home.join(".docker/run/docker.sock"));
-        candidates.push(home.join(".colima/default/docker.sock"));
-        candidates.push(home.join(".rd/docker.sock"));
-    }
-    if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from) {
-        candidates.push(runtime_dir.join("docker.sock"));
-    }
-    candidates
 }
 
 async fn wait_for_container(
@@ -838,6 +836,7 @@ mod tests {
                     workdir: None,
                     timeout_secs: Some(1),
                     extra_env: HashMap::new(),
+                    output_limit_bytes: None,
                 },
                 &workspace,
                 ContainerWorkdir::workspace_root(),
@@ -887,6 +886,7 @@ mod tests {
                     workdir: None,
                     timeout_secs: Some(1),
                     extra_env: HashMap::new(),
+                    output_limit_bytes: None,
                 },
                 &workspace,
                 ContainerWorkdir::workspace_root(),
@@ -932,6 +932,7 @@ mod tests {
                 workdir: None,
                 timeout_secs: Some(1),
                 extra_env: HashMap::new(),
+                output_limit_bytes: None,
             })
             .await
             .unwrap_err();

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -1,0 +1,292 @@
+//! Docker daemon connectivity hardening for the Reborn sandbox process
+//! transport.
+//!
+//! Docker socket discovery is inherently flaky in dev environments (Docker
+//! Desktop restarts, Colima cold start, transient daemon busy states, etc).
+//! This module wraps the existing single-attempt connect logic
+//! ([`connect_once`]) in a bounded retry loop, adds an
+//! `IRONCLAW_REBORN_DOCKER_HOST` env override for environments where local
+//! socket discovery doesn't apply (CI runners, remote daemons), and exposes
+//! a cheap readiness probe for boot diagnostics.
+//!
+//! CRITICAL: retry exhaustion here always propagates as a hard
+//! [`RuntimeProcessError`]. Callers MUST NOT catch that error and fall back
+//! to running the command unsandboxed on the host — there is no
+//! host-execution fallback path for sandboxed command execution. See
+//! `docs/safety-and-sandbox.md`.
+
+#[cfg(unix)]
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bollard::Docker;
+use ironclaw_common::env_helpers::env_or_override;
+
+use crate::RuntimeProcessError;
+
+/// Env var that, when set, short-circuits Docker daemon discovery to a
+/// direct connect against the given endpoint instead of probing local
+/// socket candidates. Accepts a unix socket path (optionally `unix://`
+/// prefixed) or an `http://host:port` / `tcp://host:port` address.
+const DOCKER_HOST_ENV: &str = "IRONCLAW_REBORN_DOCKER_HOST";
+
+/// Maximum connect attempts before giving up.
+const MAX_ATTEMPTS: u32 = 4;
+/// Base backoff between attempts; doubles each retry attempt.
+const BASE_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Outcome of a Docker daemon readiness probe, surfaced as a boot
+/// diagnostic.
+///
+/// This is a diagnostic signal only (e.g. for a startup log line or health
+/// endpoint) — it must never be used to gate a fallback to unsandboxed
+/// execution. See module docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxDockerReadiness {
+    Ready,
+    Unreachable { reason: String },
+}
+
+/// Single connection attempt: env override first, then local-default
+/// discovery, then well-known unix socket candidates. No retry here — see
+/// [`connect_docker_with_retry`] for the retrying entrypoint.
+async fn connect_once() -> Result<Docker, RuntimeProcessError> {
+    if let Some(override_host) = env_or_override(DOCKER_HOST_ENV) {
+        return connect_override(&override_host).await;
+    }
+
+    if let Ok(docker) = Docker::connect_with_local_defaults()
+        && docker.ping().await.is_ok()
+    {
+        return Ok(docker);
+    }
+
+    #[cfg(unix)]
+    {
+        for socket in unix_socket_candidates() {
+            if socket.exists() {
+                let socket = socket.to_string_lossy();
+                if let Ok(docker) =
+                    Docker::connect_with_socket(&socket, 120, bollard::API_DEFAULT_VERSION)
+                    && docker.ping().await.is_ok()
+                {
+                    return Ok(docker);
+                }
+            }
+        }
+    }
+
+    Err(RuntimeProcessError::ExecutionFailed(
+        "could not connect to Docker daemon for Reborn sandbox".to_string(),
+    ))
+}
+
+/// Connect to the daemon at an explicit `IRONCLAW_REBORN_DOCKER_HOST`
+/// override: tried as a unix socket path first (when it looks like one),
+/// otherwise as an HTTP(S) address.
+async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
+    if host.starts_with("unix://") || host.starts_with('/') {
+        let docker =
+            Docker::connect_with_socket(host, 120, bollard::API_DEFAULT_VERSION).map_err(|e| {
+                RuntimeProcessError::ExecutionFailed(format!(
+                    "{DOCKER_HOST_ENV} unix socket connect failed for {host}: {e}"
+                ))
+            })?;
+        docker.ping().await.map_err(|e| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "{DOCKER_HOST_ENV} unix socket ping failed for {host}: {e}"
+            ))
+        })?;
+        return Ok(docker);
+    }
+
+    let docker =
+        Docker::connect_with_http(host, 120, bollard::API_DEFAULT_VERSION).map_err(|e| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "{DOCKER_HOST_ENV} http connect failed for {host}: {e}"
+            ))
+        })?;
+    docker.ping().await.map_err(|e| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "{DOCKER_HOST_ENV} http ping failed for {host}: {e}"
+        ))
+    })?;
+    Ok(docker)
+}
+
+#[cfg(unix)]
+fn unix_socket_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        candidates.push(home.join(".docker/run/docker.sock"));
+        candidates.push(home.join(".colima/default/docker.sock"));
+        candidates.push(home.join(".rd/docker.sock"));
+    }
+    if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from) {
+        candidates.push(runtime_dir.join("docker.sock"));
+    }
+    candidates
+}
+
+/// Retry `f` up to `attempts` times with doubling backoff starting at
+/// `base_backoff`, sleeping between attempts (not after the last one).
+///
+/// Kept private and local to this module: there is exactly one production
+/// caller ([`connect_docker_with_retry`]); this is not a general-purpose
+/// retry utility for the crate.
+async fn run_with_retry<F, Fut, T>(
+    attempts: u32,
+    base_backoff: Duration,
+    mut f: F,
+) -> Result<T, RuntimeProcessError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, RuntimeProcessError>>,
+{
+    let mut last_err = None;
+    let mut backoff = base_backoff;
+
+    for attempt in 0..attempts {
+        match f().await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                last_err = Some(err);
+                if attempt + 1 < attempts {
+                    tokio::time::sleep(backoff).await;
+                    backoff *= 2;
+                }
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| {
+        RuntimeProcessError::ExecutionFailed(
+            "could not connect to Docker daemon for Reborn sandbox".to_string(),
+        )
+    }))
+}
+
+/// Connect to the Docker daemon with a bounded retry loop (exponential
+/// backoff, capped total wait of a few seconds).
+///
+/// CRITICAL: on retry exhaustion this returns `Err`, which callers MUST
+/// propagate as a hard failure. There is no fallback to running the sandbox
+/// command unsandboxed on the host — see module docs and
+/// `docs/safety-and-sandbox.md`.
+pub async fn connect_docker_with_retry() -> Result<Docker, RuntimeProcessError> {
+    run_with_retry(MAX_ATTEMPTS, BASE_BACKOFF, connect_once).await
+}
+
+/// Boot-time Docker daemon readiness probe.
+///
+/// Thin wrapper around a single connect attempt (not the retry loop — this
+/// is meant to be a fast, one-shot diagnostic reported at startup, not a
+/// gate that blocks boot waiting for the daemon to come up).
+pub async fn sandbox_docker_readiness() -> SandboxDockerReadiness {
+    match connect_once().await {
+        Ok(_) => SandboxDockerReadiness::Ready,
+        Err(err) => SandboxDockerReadiness::Unreachable {
+            reason: err.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use ironclaw_common::env_helpers::{lock_env, remove_runtime_env, set_runtime_env};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn retry_loop_succeeds_after_transient_failures() {
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<u32, RuntimeProcessError> =
+            run_with_retry(5, Duration::from_millis(1), || {
+                let call = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if call < 3 {
+                        Err(RuntimeProcessError::ExecutionFailed(format!(
+                            "transient failure {call}"
+                        )))
+                    } else {
+                        Ok(42)
+                    }
+                }
+            })
+            .await;
+
+        assert_eq!(result, Ok(42));
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_loop_exhausts_and_returns_last_error() {
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<u32, RuntimeProcessError> =
+            run_with_retry(4, Duration::from_millis(1), || {
+                let call = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    Err::<u32, _>(RuntimeProcessError::ExecutionFailed(format!(
+                        "permanent failure {call}"
+                    )))
+                }
+            })
+            .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        match result {
+            Err(RuntimeProcessError::ExecutionFailed(msg)) => {
+                assert_eq!(msg, "permanent failure 4");
+            }
+            other => panic!("expected exhausted ExecutionFailed, got {other:?}"),
+        }
+    }
+
+    // Live daemon behavior for the override branch (actually dialing the
+    // configured endpoint) is proven in the Docker-gated integration tier —
+    // this machine has no Docker daemon. This test only proves the env
+    // override is read and selected before local-default discovery: an
+    // unreachable override path must fail with an error naming the override
+    // env var, not the generic local-discovery failure message.
+    #[tokio::test]
+    async fn docker_host_env_override_is_consulted_first() {
+        let _guard = lock_env();
+        set_runtime_env(DOCKER_HOST_ENV, "/nonexistent/ironclaw-test-docker.sock");
+
+        let result = connect_once().await;
+
+        remove_runtime_env(DOCKER_HOST_ENV);
+
+        let err = result.expect_err("no daemon reachable at nonexistent override path");
+        let message = err.to_string();
+        assert!(
+            message.contains(DOCKER_HOST_ENV),
+            "expected override branch error to name {DOCKER_HOST_ENV}, got: {message}"
+        );
+    }
+
+    // Natural on this machine: no Docker daemon is running, so connect_once
+    // (and therefore the readiness probe) fails through local discovery.
+    #[tokio::test]
+    async fn readiness_surfaces_reason_on_unreachable_daemon() {
+        let _guard = lock_env();
+        remove_runtime_env(DOCKER_HOST_ENV);
+
+        let readiness = sandbox_docker_readiness().await;
+
+        match readiness {
+            SandboxDockerReadiness::Unreachable { reason } => {
+                assert!(!reason.is_empty(), "reason should be a non-empty string");
+            }
+            SandboxDockerReadiness::Ready => {
+                // A real Docker daemon happens to be reachable on this
+                // machine/CI runner; readiness reporting Ready is also a
+                // valid, non-flaky outcome for this probe.
+            }
+        }
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/exec_transport.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/exec_transport.rs
@@ -1,0 +1,728 @@
+//! Exec-based lifecycle for the persistent per-user sandbox container.
+//!
+//! Replaces the ephemeral per-command create/run/remove model entirely —
+//! there is no fallback path, per the design's "Relation to ephemeral
+//! model: Replace" decision. [`ensure_container`] reuses (or transparently
+//! restarts) the one container that already exists for a `{tenant, user}`
+//! pair, keyed by the Docker labels [`super::registry`] attaches; every
+//! individual shell command then runs as a fresh `docker exec` via
+//! [`exec_in_container`] rather than a fresh container.
+
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use bollard::{
+    Docker,
+    container::{
+        Config, CreateContainerOptions, InspectContainerOptions, ListContainersOptions, LogOutput,
+        StartContainerOptions,
+    },
+    exec::{CreateExecOptions, StartExecOptions, StartExecResults},
+    models::HostConfig,
+};
+use futures_util::StreamExt;
+use ironclaw_host_api::{TenantId, UserId};
+
+use crate::{CommandExecutionOutput, RuntimeProcessError};
+
+use super::{
+    ContainerWorkdir, LABEL_PREFIX, RebornSandboxConfig, RebornSandboxUserKey,
+    registry::{build_user_container_labels, user_container_label_filter},
+    shell_single_quote,
+};
+
+/// Finds the one container already labeled for `{tenant_id, user_id}` and
+/// makes sure it is running (creating or restarting it as needed), or
+/// creates a fresh one if none exists yet. Returns the container ID a
+/// subsequent [`exec_in_container`] call can target.
+pub(super) async fn ensure_container(
+    docker: &Docker,
+    config: &RebornSandboxConfig,
+    key: &RebornSandboxUserKey,
+    tenant_id: &TenantId,
+    user_id: &UserId,
+    workspace: &Path,
+) -> Result<String, RuntimeProcessError> {
+    let filters = user_container_label_filter(LABEL_PREFIX, tenant_id, user_id);
+    let found = docker
+        .list_containers(Some(ListContainersOptions {
+            all: true,
+            filters,
+            ..Default::default()
+        }))
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox container lookup failed: {error}"
+            ))
+        })?;
+
+    match found.as_slice() {
+        [] => {
+            create_and_start_user_container(docker, config, key, tenant_id, user_id, workspace)
+                .await
+        }
+        [existing] => {
+            let container_id = existing.id.clone().ok_or_else(|| {
+                RuntimeProcessError::ExecutionFailed(
+                    "sandbox container lookup returned an unnamed container".to_string(),
+                )
+            })?;
+            ensure_running(docker, &container_id).await?;
+            Ok(container_id)
+        }
+        multiple => Err(RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox container registry has {} containers for one user; expected at most one",
+            multiple.len()
+        ))),
+    }
+}
+
+async fn ensure_running(docker: &Docker, container_id: &str) -> Result<(), RuntimeProcessError> {
+    let inspected = docker
+        .inspect_container(container_id, None::<InspectContainerOptions>)
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox container inspect failed: {error}"
+            ))
+        })?;
+    let running = inspected
+        .state
+        .as_ref()
+        .and_then(|state| state.running)
+        .unwrap_or(false);
+    if !running {
+        docker
+            .start_container(container_id, None::<StartContainerOptions<String>>)
+            .await
+            .map_err(|error| {
+                RuntimeProcessError::ExecutionFailed(format!(
+                    "sandbox container restart failed: {error}"
+                ))
+            })?;
+    }
+    Ok(())
+}
+
+async fn create_and_start_user_container(
+    docker: &Docker,
+    config: &RebornSandboxConfig,
+    key: &RebornSandboxUserKey,
+    tenant_id: &TenantId,
+    user_id: &UserId,
+    workspace: &Path,
+) -> Result<String, RuntimeProcessError> {
+    let launch = user_container_launch_config(config, tenant_id, user_id, workspace).await?;
+    let created = docker
+        .create_container(
+            Some(CreateContainerOptions {
+                name: key.container_name(),
+                platform: None,
+            }),
+            launch,
+        )
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox container create failed: {error}"
+            ))
+        })?;
+    docker
+        .start_container(&created.id, None::<StartContainerOptions<String>>)
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!("sandbox container start failed: {error}"))
+        })?;
+    Ok(created.id)
+}
+
+/// The persistent container's own launch `cmd` is a no-op long-lived
+/// process (`sleep infinity`) — the container never runs the model's
+/// command directly; every command arrives later via `docker exec`.
+pub(super) async fn user_container_launch_config(
+    config: &RebornSandboxConfig,
+    tenant_id: &TenantId,
+    user_id: &UserId,
+    workspace: &Path,
+) -> Result<Config<String>, RuntimeProcessError> {
+    let labels = build_user_container_labels(LABEL_PREFIX, tenant_id, user_id);
+    let mut env = config.command_env(std::collections::HashMap::new())?;
+    env.push("HOME=/workspace/.home".to_string());
+    let container_user = config.container_identity.container_user()?;
+    let mut binds = config
+        .mount_sources
+        .prepare_container_binds(workspace, None)
+        .await?
+        .into_iter()
+        .map(|bind| bind.into_docker_bind())
+        .collect::<Vec<_>>();
+    config.append_broker_binds(&mut binds)?;
+    let host_config = HostConfig {
+        binds: Some(binds),
+        memory: Some(config.memory_bytes as i64),
+        cpu_shares: Some(config.cpu_shares as i64),
+        auto_remove: Some(false),
+        network_mode: config.container_network_mode(),
+        cap_drop: Some(vec!["ALL".to_string()]),
+        security_opt: Some(vec!["no-new-privileges:true".to_string()]),
+        readonly_rootfs: Some(true),
+        tmpfs: Some(
+            [("/tmp".to_string(), "size=512M".to_string())]
+                .into_iter()
+                .collect(),
+        ),
+        ..Default::default()
+    };
+    Ok(Config {
+        image: Some(config.image.clone()),
+        cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),
+        env: Some(env),
+        labels: Some(labels),
+        host_config: Some(host_config),
+        user: container_user,
+        attach_stdout: Some(false),
+        attach_stderr: Some(false),
+        ..Default::default()
+    })
+}
+
+/// `setsid` creates a new session AND process group whose pgid equals its
+/// own pid. `exec` replaces the current process image in place, so the pid
+/// docker reports via `inspect_exec` stays the same value and now doubles
+/// as the whole job's pgid — `kill -KILL -<pid>` on timeout reaches every
+/// descendant without touching the container's own PID 1.
+fn wrap_command_for_pgid_isolation(command: &str) -> String {
+    format!("exec setsid sh -c {}", shell_single_quote(command))
+}
+
+pub(super) async fn exec_in_container(
+    docker: &Docker,
+    container_id: &str,
+    workdir: ContainerWorkdir,
+    env: Vec<String>,
+    command: String,
+    timeout: Duration,
+    output_limit: usize,
+) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+    let wrapped = wrap_command_for_pgid_isolation(&command);
+    let exec = docker
+        .create_exec(
+            container_id,
+            CreateExecOptions {
+                cmd: Some(vec!["sh".to_string(), "-c".to_string(), wrapped]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                working_dir: Some(workdir.into_string()),
+                env: Some(env),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!("sandbox exec create failed: {error}"))
+        })?;
+    let started_at = Instant::now();
+
+    let run = async {
+        match docker
+            .start_exec(
+                &exec.id,
+                Some(StartExecOptions {
+                    detach: false,
+                    tty: false,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .map_err(|error| {
+                RuntimeProcessError::ExecutionFailed(format!("sandbox exec start failed: {error}"))
+            })? {
+            StartExecResults::Attached { output, .. } => {
+                collect_exec_output(output, output_limit).await
+            }
+            StartExecResults::Detached => Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox exec unexpectedly detached".to_string(),
+            )),
+        }
+    };
+
+    let output = match tokio::time::timeout(timeout, run).await {
+        Ok(result) => result?,
+        Err(_) => {
+            kill_exec_process_group(docker, container_id, &exec.id).await;
+            return Err(RuntimeProcessError::Timeout(timeout));
+        }
+    };
+
+    let exit_code = docker
+        .inspect_exec(&exec.id)
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!("sandbox exec inspect failed: {error}"))
+        })?
+        .exit_code
+        .unwrap_or(-1);
+
+    Ok(CommandExecutionOutput {
+        output,
+        saved_output: None,
+        exit_code,
+        sandboxed: true,
+        duration: started_at.elapsed(),
+    })
+}
+
+/// Best-effort: kills the whole process group the timed-out exec started
+/// (see [`wrap_command_for_pgid_isolation`]), but never fails the caller
+/// over it — the caller already treats the command as having timed out
+/// regardless of whether this cleanup exec itself succeeds.
+async fn kill_exec_process_group(docker: &Docker, container_id: &str, exec_id: &str) {
+    let Ok(inspected) = docker.inspect_exec(exec_id).await else {
+        return;
+    };
+    let Some(pid) = inspected.pid else { return };
+    let kill_cmd = format!("kill -KILL -{pid} 2>/dev/null || true");
+    if let Ok(kill_exec) = docker
+        .create_exec(
+            container_id,
+            CreateExecOptions {
+                cmd: Some(vec!["sh".to_string(), "-c".to_string(), kill_cmd]),
+                attach_stdout: Some(false),
+                attach_stderr: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        && let Err(error) = docker
+            .start_exec(
+                &kill_exec.id,
+                Some(StartExecOptions {
+                    detach: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+    {
+        tracing::debug!(?error, "best-effort sandbox exec timeout kill failed");
+    }
+}
+
+async fn collect_exec_output(
+    mut stream: std::pin::Pin<
+        Box<dyn futures_util::Stream<Item = Result<LogOutput, bollard::errors::Error>> + Send>,
+    >,
+    limit: usize,
+) -> Result<String, RuntimeProcessError> {
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let half_limit = limit / 2;
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(LogOutput::StdOut { message }) => {
+                super::append_with_limit(
+                    &mut stdout,
+                    &String::from_utf8_lossy(&message),
+                    half_limit,
+                );
+            }
+            Ok(LogOutput::StdErr { message }) => {
+                super::append_with_limit(
+                    &mut stderr,
+                    &String::from_utf8_lossy(&message),
+                    half_limit,
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                return Err(RuntimeProcessError::ExecutionFailed(format!(
+                    "sandbox exec output collection failed: {error}"
+                )));
+            }
+        }
+    }
+    if stderr.is_empty() {
+        Ok(stdout)
+    } else if stdout.is_empty() {
+        Ok(stderr)
+    } else {
+        Ok(format!("{stdout}\n\n--- stderr ---\n{stderr}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrapped_command_runs_under_setsid_for_process_group_isolation() {
+        let wrapped = wrap_command_for_pgid_isolation("echo hi && sleep 1");
+        assert_eq!(wrapped, "exec setsid sh -c 'echo hi && sleep 1'");
+    }
+
+    #[tokio::test]
+    async fn user_container_launch_config_uses_persistent_cmd_and_user_labels() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let config = RebornSandboxConfig::new(temp.path().join("workspaces"));
+        let tenant = ironclaw_host_api::TenantId::new("tenant-a").unwrap();
+        let user = ironclaw_host_api::UserId::new("user-a").unwrap();
+
+        let launch = user_container_launch_config(&config, &tenant, &user, &workspace)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            launch.cmd,
+            Some(vec!["sleep".to_string(), "infinity".to_string()])
+        );
+        let labels = launch.labels.unwrap();
+        assert_eq!(labels.get("ironclaw.tenant").unwrap(), "tenant-a");
+        assert_eq!(labels.get("ironclaw.user").unwrap(), "user-a");
+        let env = launch.env.unwrap();
+        assert!(env.iter().any(|e| e == "HOME=/workspace/.home"));
+        let host_config = launch.host_config.unwrap();
+        assert_eq!(host_config.auto_remove, Some(false));
+    }
+}
+
+// `#[path]` resolution for a module declared inline inside another inline
+// module is relative to a *fictitious* per-module directory chain (here
+// `src/sandbox_process/exec_transport/docker_tests/`, which does not exist
+// on disk) — verified empirically, since none of those intermediate
+// directories are real. Declaring `docker_gate` at THIS file's top level
+// instead resolves relative to `exec_transport.rs`'s own real directory
+// (`src/sandbox_process/`, two levels above the crate root), matching the
+// convention `sandbox_reaper_docker.rs` uses one level up (that file sits
+// directly in `tests/`, so it only needs `"support/docker_gate.rs"`).
+#[cfg(test)]
+#[path = "../../tests/support/docker_gate.rs"]
+mod docker_gate;
+
+/// Real-Docker tests for the exec-based persistent container lifecycle.
+/// Gated the way `sandbox_reaper_docker.rs` already gates its tests: a
+/// visible `SKIP: ...` line, never a silent `#[ignore]` vanish.
+#[cfg(test)]
+mod docker_tests {
+    use super::*;
+    use bollard::container::RemoveContainerOptions;
+
+    fn docker_tests_config(workspaces_root: &Path) -> RebornSandboxConfig {
+        RebornSandboxConfig::new(workspaces_root.to_path_buf())
+            .with_image(docker_gate::configured_sandbox_image())
+    }
+
+    async fn best_effort_remove(docker: &Docker, container_id: &str) {
+        let _ = docker
+            .remove_container(
+                container_id,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+    }
+
+    #[tokio::test]
+    async fn exec_reuses_container_across_commands_file_persists_env_does_not() {
+        if !docker_gate::docker_available() {
+            eprintln!(
+                "SKIP: no docker daemon reachable — exec_reuses_container_across_commands_file_persists_env_does_not requires a real Docker daemon (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+        let image = docker_gate::configured_sandbox_image();
+        if !docker_gate::docker_image_available(&image) {
+            eprintln!(
+                "SKIP: sandbox worker image {image:?} is not built locally — requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+
+        let docker = Docker::connect_with_local_defaults().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let config = docker_tests_config(temp.path());
+        let tenant = ironclaw_host_api::TenantId::new("exec-reuse-tenant").unwrap();
+        let user = ironclaw_host_api::UserId::new("exec-reuse-user").unwrap();
+        let key = RebornSandboxUserKey::from_tenant_user(&tenant, &user);
+        let workspace = key.workspace_path(temp.path());
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let container_id = ensure_container(&docker, &config, &key, &tenant, &user, &workspace)
+            .await
+            .expect("first ensure_container creates the container");
+
+        exec_in_container(
+            &docker,
+            &container_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "echo persisted > /workspace/marker.txt".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .expect("write exec succeeds");
+
+        let read = exec_in_container(
+            &docker,
+            &container_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "cat /workspace/marker.txt".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .expect("read exec succeeds against the SAME container");
+        assert!(
+            read.output.contains("persisted"),
+            "file written in one exec must be visible to the next: {read:?}"
+        );
+
+        let with_env = exec_in_container(
+            &docker,
+            &container_id,
+            ContainerWorkdir::workspace_root(),
+            vec!["PROBE_VAR=set".to_string()],
+            "echo $PROBE_VAR".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .expect("env-setting exec succeeds");
+        assert!(with_env.output.contains("set"));
+
+        let without_env = exec_in_container(
+            &docker,
+            &container_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "echo [$PROBE_VAR]".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .expect("later exec succeeds");
+        assert!(
+            without_env.output.contains("[]"),
+            "env set in one exec must NOT bleed into the next (stateless exec): {without_env:?}"
+        );
+
+        best_effort_remove(&docker, &container_id).await;
+    }
+
+    #[tokio::test]
+    async fn stopped_container_restarts_transparently_on_next_exec() {
+        if !docker_gate::docker_available() {
+            eprintln!(
+                "SKIP: no docker daemon reachable — stopped_container_restarts_transparently_on_next_exec requires a real Docker daemon (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+        let image = docker_gate::configured_sandbox_image();
+        if !docker_gate::docker_image_available(&image) {
+            eprintln!(
+                "SKIP: sandbox worker image {image:?} is not built locally — requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+
+        let docker = Docker::connect_with_local_defaults().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let config = docker_tests_config(temp.path());
+        let tenant = ironclaw_host_api::TenantId::new("restart-tenant").unwrap();
+        let user = ironclaw_host_api::UserId::new("restart-user").unwrap();
+        let key = RebornSandboxUserKey::from_tenant_user(&tenant, &user);
+        let workspace = key.workspace_path(temp.path());
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let container_id = ensure_container(&docker, &config, &key, &tenant, &user, &workspace)
+            .await
+            .expect("first ensure_container creates the container");
+        docker
+            .stop_container(&container_id, None)
+            .await
+            .expect("stop out of band");
+
+        let reused_id = ensure_container(&docker, &config, &key, &tenant, &user, &workspace)
+            .await
+            .expect("ensure_container transparently restarts a stopped container");
+        assert_eq!(
+            reused_id, container_id,
+            "restart must reuse the same container, not recreate one"
+        );
+
+        let output = exec_in_container(
+            &docker,
+            &reused_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "echo alive".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .expect("exec against the restarted container succeeds");
+        assert!(output.output.contains("alive"));
+
+        best_effort_remove(&docker, &container_id).await;
+    }
+
+    #[tokio::test]
+    async fn timeout_kills_process_group_but_container_survives() {
+        if !docker_gate::docker_available() {
+            eprintln!(
+                "SKIP: no docker daemon reachable — timeout_kills_process_group_but_container_survives requires a real Docker daemon (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+        let image = docker_gate::configured_sandbox_image();
+        if !docker_gate::docker_image_available(&image) {
+            eprintln!(
+                "SKIP: sandbox worker image {image:?} is not built locally — requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+
+        let docker = Docker::connect_with_local_defaults().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let config = docker_tests_config(temp.path());
+        let tenant = ironclaw_host_api::TenantId::new("timeout-tenant").unwrap();
+        let user = ironclaw_host_api::UserId::new("timeout-user").unwrap();
+        let key = RebornSandboxUserKey::from_tenant_user(&tenant, &user);
+        let workspace = key.workspace_path(temp.path());
+        std::fs::create_dir_all(&workspace).unwrap();
+        let container_id = ensure_container(&docker, &config, &key, &tenant, &user, &workspace)
+            .await
+            .expect("ensure_container succeeds");
+
+        let timed_out = exec_in_container(
+            &docker,
+            &container_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "sleep 100".to_string(),
+            Duration::from_secs(1),
+            4096,
+        )
+        .await;
+        assert!(
+            matches!(timed_out, Err(RuntimeProcessError::Timeout(_))),
+            "long-running exec must time out: {timed_out:?}"
+        );
+
+        let still_alive = exec_in_container(
+            &docker,
+            &container_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "echo alive".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .expect("the container itself must survive a timeout kill of the exec'd process group");
+        assert!(still_alive.output.contains("alive"));
+
+        best_effort_remove(&docker, &container_id).await;
+    }
+
+    #[tokio::test]
+    async fn cross_user_containers_and_workspaces_are_isolated() {
+        if !docker_gate::docker_available() {
+            eprintln!(
+                "SKIP: no docker daemon reachable — cross_user_containers_and_workspaces_are_isolated requires a real Docker daemon (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+        let image = docker_gate::configured_sandbox_image();
+        if !docker_gate::docker_image_available(&image) {
+            eprintln!(
+                "SKIP: sandbox worker image {image:?} is not built locally — requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+
+        let docker = Docker::connect_with_local_defaults().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let config = docker_tests_config(temp.path());
+
+        let tenant = ironclaw_host_api::TenantId::new("isolation-tenant").unwrap();
+        let user_a = ironclaw_host_api::UserId::new("isolation-user-a").unwrap();
+        let user_b = ironclaw_host_api::UserId::new("isolation-user-b").unwrap();
+        let key_a = RebornSandboxUserKey::from_tenant_user(&tenant, &user_a);
+        let key_b = RebornSandboxUserKey::from_tenant_user(&tenant, &user_b);
+        let workspace_a = key_a.workspace_path(temp.path());
+        let workspace_b = key_b.workspace_path(temp.path());
+        std::fs::create_dir_all(&workspace_a).unwrap();
+        std::fs::create_dir_all(&workspace_b).unwrap();
+
+        let container_a =
+            ensure_container(&docker, &config, &key_a, &tenant, &user_a, &workspace_a)
+                .await
+                .unwrap();
+        let container_b =
+            ensure_container(&docker, &config, &key_b, &tenant, &user_b, &workspace_b)
+                .await
+                .unwrap();
+        assert_ne!(
+            container_a, container_b,
+            "distinct users must get distinct containers"
+        );
+
+        exec_in_container(
+            &docker,
+            &container_a,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "echo user-a-secret > /workspace/user-a-only.txt".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .unwrap();
+
+        let leak_check = exec_in_container(
+            &docker,
+            &container_b,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "cat /workspace/user-a-only.txt 2>&1 || echo NOT_FOUND".to_string(),
+            Duration::from_secs(10),
+            4096,
+        )
+        .await
+        .unwrap();
+        assert!(
+            leak_check.output.contains("NOT_FOUND"),
+            "user B's container must not see user A's workspace file: {leak_check:?}"
+        );
+
+        // The design's hard invariant: user B's workspace host path must
+        // not appear ANYWHERE in user A's container mount table, and vice
+        // versa — a bind-mount-source leak would be a full sandbox escape.
+        let inspected_a = docker.inspect_container(&container_a, None).await.unwrap();
+        let binds_a = inspected_a.host_config.unwrap().binds.unwrap_or_default();
+        let workspace_b_str = workspace_b.to_string_lossy().to_string();
+        assert!(
+            binds_a.iter().all(|bind| !bind.contains(&workspace_b_str)),
+            "user B's workspace path must not appear in user A's mount table: {binds_a:?}"
+        );
+
+        let inspected_b = docker.inspect_container(&container_b, None).await.unwrap();
+        let binds_b = inspected_b.host_config.unwrap().binds.unwrap_or_default();
+        let workspace_a_str = workspace_a.to_string_lossy().to_string();
+        assert!(
+            binds_b.iter().all(|bind| !bind.contains(&workspace_a_str)),
+            "user A's workspace path must not appear in user B's mount table: {binds_b:?}"
+        );
+
+        best_effort_remove(&docker, &container_a).await;
+        best_effort_remove(&docker, &container_b).await;
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/exec_transport.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/exec_transport.rs
@@ -843,4 +843,66 @@ mod docker_tests {
         best_effort_remove(&docker, &container_a).await;
         best_effort_remove(&docker, &container_b).await;
     }
+
+    #[tokio::test]
+    async fn fat_image_provides_git_node_python_rust_gh_tmux_under_non_root_home() {
+        if !docker_gate::docker_available() {
+            eprintln!(
+                "SKIP: no docker daemon reachable — fat_image_provides_git_node_python_rust_gh_tmux_under_non_root_home requires a real Docker daemon (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+        let image = docker_gate::configured_sandbox_image();
+        if !docker_gate::docker_image_available(&image) {
+            eprintln!(
+                "SKIP: sandbox worker image {image:?} is not built locally with the Task A7 Dockerfile changes — requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+            );
+            return;
+        }
+
+        let docker = Docker::connect_with_local_defaults().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let config = docker_tests_config(temp.path());
+        let tenant = ironclaw_host_api::TenantId::new("fat-image-tenant").unwrap();
+        let user = ironclaw_host_api::UserId::new("fat-image-user").unwrap();
+        let key = RebornSandboxUserKey::from_tenant_user(&tenant, &user);
+        let workspace = key.workspace_path(temp.path());
+        std::fs::create_dir_all(&workspace).unwrap();
+        let container_id = ensure_container(&docker, &config, &key, &tenant, &user, &workspace)
+            .await
+            .unwrap();
+
+        let probe = exec_in_container(
+            &docker,
+            &container_id,
+            ContainerWorkdir::workspace_root(),
+            Vec::new(),
+            "command -v git node python3 cargo gh tmux && whoami && echo $HOME".to_string(),
+            Duration::from_secs(20),
+            4096,
+        )
+        .await
+        .expect("probe exec succeeds");
+
+        for binary in ["/git", "/node", "/python3", "/cargo", "/gh", "/tmux"] {
+            assert!(
+                probe.output.contains(binary),
+                "expected {binary} on PATH: {probe:?}"
+            );
+        }
+        assert!(
+            probe.output.contains("sandbox"),
+            "must run as the non-root sandbox user: {probe:?}"
+        );
+        assert!(
+            !probe.output.contains("\nroot\n"),
+            "must not run as root: {probe:?}"
+        );
+        assert!(
+            probe.output.contains("/workspace/.home"),
+            "HOME must be workspace-relative: {probe:?}"
+        );
+
+        best_effort_remove(&docker, &container_id).await;
+    }
 }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/exec_transport.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/exec_transport.rs
@@ -29,7 +29,7 @@ use crate::{CommandExecutionOutput, RuntimeProcessError};
 
 use super::{
     ContainerWorkdir, LABEL_PREFIX, RebornSandboxConfig, RebornSandboxUserKey,
-    registry::{build_user_container_labels, user_container_label_filter},
+    registry::{self, build_user_container_labels, user_container_label_filter},
     shell_single_quote,
 };
 
@@ -273,6 +273,124 @@ pub(super) async fn exec_in_container(
         sandboxed: true,
         duration: started_at.elapsed(),
     })
+}
+
+/// Result of launching a detached (`background: true`) command inside the
+/// container: the pid the launch script reported (which is also its
+/// `setsid`-created pgid, per [`wrap_command_for_pgid_isolation`]) and the
+/// container-local log path its stdout/stderr were redirected to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct BackgroundLaunch {
+    pub(super) pid: u32,
+    pub(super) log_path: String,
+}
+
+/// Launches `command` detached inside the container (`setsid ... &`),
+/// redirecting its output to a per-pid log under `/workspace/.ironclaw/`,
+/// and returns immediately with the launched pid instead of waiting for
+/// completion.
+pub(super) async fn exec_background_in_container(
+    docker: &Docker,
+    container_id: &str,
+    workdir: ContainerWorkdir,
+    env: Vec<String>,
+    command: String,
+) -> Result<BackgroundLaunch, RuntimeProcessError> {
+    let launch_script = format!(
+        "mkdir -p /workspace/.ironclaw && {} >>/workspace/.ironclaw/bg-$$.log 2>&1 & echo $!",
+        wrap_command_for_pgid_isolation(&command),
+    );
+    let exec = docker
+        .create_exec(
+            container_id,
+            CreateExecOptions {
+                cmd: Some(vec!["sh".to_string(), "-c".to_string(), launch_script]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                working_dir: Some(workdir.into_string()),
+                env: Some(env),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox background launch failed: {error}"
+            ))
+        })?;
+    let launch_timeout = Duration::from_secs(10);
+    let pid_output = tokio::time::timeout(launch_timeout, async {
+        match docker
+            .start_exec(
+                &exec.id,
+                Some(StartExecOptions {
+                    detach: false,
+                    tty: false,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .map_err(|error| {
+                RuntimeProcessError::ExecutionFailed(format!(
+                    "sandbox background launch start failed: {error}"
+                ))
+            })? {
+            StartExecResults::Attached { output, .. } => collect_exec_output(output, 256).await,
+            StartExecResults::Detached => Ok(String::new()),
+        }
+    })
+    .await
+    .map_err(|_| RuntimeProcessError::Timeout(launch_timeout))??;
+    let pid: u32 = pid_output.trim().parse().map_err(|_| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox background launch did not report a pid: {pid_output:?}"
+        ))
+    })?;
+    Ok(BackgroundLaunch {
+        pid,
+        log_path: format!("/workspace/.ironclaw/bg-{pid}.log"),
+    })
+}
+
+/// Renders the "still-live background processes" footer appended to every
+/// foreground shell result. Empty when there are no tracked survivors.
+pub(super) fn render_background_footer(jobs: &[registry::BackgroundJob]) -> String {
+    if jobs.is_empty() {
+        return String::new();
+    }
+    let mut footer = String::from("\n\nLive background processes:");
+    for job in jobs {
+        footer.push_str(&format!("\n  pid {} ({})", job.pid, job.command_preview));
+    }
+    footer
+}
+
+#[cfg(test)]
+mod footer_tests {
+    use super::*;
+
+    #[test]
+    fn empty_job_list_renders_no_footer() {
+        assert_eq!(render_background_footer(&[]), "");
+    }
+
+    #[test]
+    fn footer_lists_every_survivor_with_pid_and_command_preview() {
+        let jobs = vec![
+            registry::BackgroundJob {
+                pid: 101,
+                command_preview: "npm run dev".to_string(),
+            },
+            registry::BackgroundJob {
+                pid: 202,
+                command_preview: "python -m http.server".to_string(),
+            },
+        ];
+        assert_eq!(
+            render_background_footer(&jobs),
+            "\n\nLive background processes:\n  pid 101 (npm run dev)\n  pid 202 (python -m http.server)",
+        );
+    }
 }
 
 /// Best-effort: kills the whole process group the timed-out exec started

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -1,0 +1,153 @@
+//! Default egress allowlist for the sandboxed (`TenantSandbox`) shell
+//! profile.
+//!
+//! IronClaw's sandboxed shell needs outbound network access for ordinary
+//! package-manager workflows (`pip install`, `npm install`, `git clone`,
+//! `curl` against a registry) without granting the container unrestricted
+//! internet access. The model mirrors legacy IronClaw's sandbox: soft
+//! enforcement through an HTTP(S) forward proxy that only permits requests
+//! to an allowlist of known package-registry and source-hosting domains,
+//! plus any extra domains an operator configures.
+//!
+//! This module owns the *domain list* — the set of hosts the sandboxed
+//! profile's `builtin.shell` grant should carry in its
+//! [`NetworkPolicy`](ironclaw_host_api::NetworkPolicy) `allowed_targets`, and
+//! that a host-side allowlist proxy would enforce for real. It does not
+//! itself enforce anything — enforcement is the transport/proxy wiring
+//! (`RebornSandboxConfig::with_network_broker_proxy_url`, wired at
+//! `crates/ironclaw_reborn_composition/src/sandbox_boot.rs`) plus, still
+//! outstanding (see the `TODO(follow-up, not built here)` there), the
+//! actual proxy server.
+use ironclaw_host_api::{NetworkPolicy, NetworkTargetPattern};
+
+/// Environment variable operators can set to add domains to the sandboxed
+/// shell's egress allowlist, on top of [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`].
+/// Comma-separated hostnames (e.g. `example.com,*.internal.example.com`).
+pub const SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV: &str = "IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS";
+
+/// Default egress allowlist for the sandboxed shell profile — the package
+/// registries and source hosts ordinary `pip`/`npm`/`git`/`curl` workflows
+/// need, mirroring legacy IronClaw's sandbox allowlist.
+pub const DEFAULT_SANDBOX_ALLOWED_DOMAINS: &[&str] = &[
+    // Rust
+    "crates.io",
+    "static.crates.io",
+    "index.crates.io",
+    // Node/npm
+    "registry.npmjs.org",
+    "nodejs.org",
+    // Python
+    "pypi.org",
+    "files.pythonhosted.org",
+    // Go
+    "proxy.golang.org",
+    // GitHub (source + release archives)
+    "github.com",
+    "raw.githubusercontent.com",
+    "api.github.com",
+    "codeload.github.com",
+];
+
+/// Reads [`SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV`] and returns the operator's
+/// configured extra domains, trimmed and with empty entries dropped. Returns
+/// an empty `Vec` (never an error) when the variable is unset or empty — the
+/// extra-domains hook is optional.
+pub fn sandbox_extra_allowed_domains() -> Vec<String> {
+    std::env::var(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV)
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|domain| !domain.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The full sandboxed-shell egress allowlist: [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`]
+/// plus any operator-configured extras from
+/// [`sandbox_extra_allowed_domains`].
+pub fn sandbox_allowed_domains() -> Vec<String> {
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS
+        .iter()
+        .map(|domain| (*domain).to_string())
+        .chain(sandbox_extra_allowed_domains())
+        .collect()
+}
+
+/// [`sandbox_allowed_domains`], expressed as [`NetworkPolicy`] `allowed_targets`
+/// — ready to carry on the sandboxed profile's `builtin.shell` grant so
+/// `validate_network_policy_metadata` (which rejects an empty allowlist)
+/// passes, and so the policy documents what the container is actually meant
+/// to reach.
+pub fn sandbox_network_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: sandbox_allowed_domains()
+            .into_iter()
+            .map(|host_pattern| NetworkTargetPattern {
+                scheme: None,
+                host_pattern,
+                port: None,
+            })
+            .collect(),
+        deny_private_ip_ranges: true,
+        max_egress_bytes: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_allowlist_covers_the_major_package_registries_and_github() {
+        for expected in [
+            "crates.io",
+            "registry.npmjs.org",
+            "pypi.org",
+            "files.pythonhosted.org",
+            "proxy.golang.org",
+            "github.com",
+            "raw.githubusercontent.com",
+        ] {
+            assert!(
+                DEFAULT_SANDBOX_ALLOWED_DOMAINS.contains(&expected),
+                "expected {expected} in the default sandbox allowlist"
+            );
+        }
+    }
+
+    #[test]
+    fn sandbox_network_policy_is_non_empty_and_denies_private_ips() {
+        let policy = sandbox_network_policy();
+        assert!(
+            !policy.allowed_targets.is_empty(),
+            "sandboxed shell network policy must not be the empty (deny-all) default"
+        );
+        assert!(policy.deny_private_ip_ranges);
+        assert!(
+            policy
+                .allowed_targets
+                .iter()
+                .any(|target| target.host_pattern == "github.com")
+        );
+    }
+
+    #[test]
+    fn extra_domains_env_is_parsed_and_merged() {
+        // SAFETY: test-local env var, no concurrent readers of this key in
+        // this crate's test binary.
+        unsafe {
+            std::env::set_var(
+                SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
+                " example.internal , , *.corp.example.com",
+            );
+        }
+        let extras = sandbox_extra_allowed_domains();
+        unsafe {
+            std::env::remove_var(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+        }
+        assert_eq!(extras, vec!["example.internal", "*.corp.example.com"]);
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/reaper.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/reaper.rs
@@ -1,26 +1,36 @@
-//! Orphaned sandbox container reaper.
+//! Persistent per-user sandbox container reaper.
 //!
-//! Sandbox containers are launched per command invocation
-//! (`RebornScopedSandboxCommandTransport::execute_in_container`) and normally
-//! removed inline once the command finishes. A container can survive that
-//! best-effort removal — host crash mid-command, killed process, a lost
-//! connection to the daemon — and become an orphan: a running container whose
-//! owning invocation is gone. [`SandboxReaper`] periodically lists containers
-//! this transport created (via the `ironclaw.*` labels set in
-//! `container_launch_config`) and removes the ones that are definitively
-//! orphaned.
+//! The sandboxed profile now runs one long-lived container per `{tenant,
+//! user}` pair (see `super::exec_transport`), reused across every shell
+//! invocation rather than recreated per command. A container therefore
+//! belongs to a *user*, not an invocation, and its lifecycle is a two-stage
+//! idle/retention policy instead of invocation-liveness:
 //!
-//! **Deliberate fix over the legacy `src/orchestrator/reaper.rs`:** that
-//! implementation treated "the run-state lookup failed" the same as "the run
-//! is gone" and reaped in both cases. A transient backend/filesystem error is
-//! not evidence of anything — reaping on it can kill a container whose
-//! invocation is still very much alive. [`liveness_for`] treats a query error
-//! as [`Liveness::Alive`]: the scan skips the container this tick and
-//! re-evaluates it next tick, so only a *definitive* not-found or terminal
-//! run status is ever grounds for removal.
+//! 1. **Idle-stop**: a *running* container with no recorded activity for
+//!    `idle_stop_after` is stopped (not removed) — the user's workspace and
+//!    container state are preserved for the next command.
+//! 2. **Retention-remove**: a *stopped* container whose `finished_at` is
+//!    older than `remove_stopped_after` is removed outright.
 //!
-//! This module is NOT wired into composition yet — spawning [`SandboxReaper::run`]
-//! as an owned background task is a later slice (composition/factory.rs).
+//! A **forced recycle** age (`forced_recycle_after`, measured from the
+//! container's `created_at` label) overrides both stages as a janitor
+//! backstop: past that age a running container is stopped and a stopped one
+//! is removed immediately, regardless of idle/retention windows.
+//!
+//! [`decide_reap_action`] is the pure decision function driving all of this
+//! — deliberately free of I/O so it can be exhaustively unit tested on a
+//! fake clock. **Never reap on uncertainty**: an unknown idle duration (no
+//! activity record — e.g. after a process restart lost the in-memory map)
+//! or an unknown `finished_at` (can't attribute a stop time) always yields
+//! [`ReapAction::None`]. Containers whose `ironclaw.tenant`/`ironclaw.user`
+//! labels are missing or fail to parse are skipped entirely by
+//! [`SandboxReaper::scan_and_reap`] — never reaped — since they cannot be
+//! attributed to a user record at all.
+//!
+//! "Orphan sweep" (a user has no live record at all) is deliberately not
+//! this module's job: in the fixed-owner single-tenant profile users never
+//! disappear, so that sweep has no trigger yet — it is a named follow-up
+//! for a future multi-user profile.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -30,134 +40,61 @@ use bollard::{
     models::ContainerSummary,
 };
 use chrono::{DateTime, Utc};
-use ironclaw_host_api::{InvocationId, ResourceScope};
-use ironclaw_run_state::{RunStateStore, RunStatus};
+use ironclaw_host_api::{TenantId, UserId};
 
 use crate::RuntimeProcessError;
 
 use super::LABEL_PREFIX;
+use super::registry::{self, SandboxActivityRegistry, UserContainerCandidate};
+use super::user_key::RebornSandboxUserKey;
 
-/// Docker label carrying the invocation ID that created the container.
-pub(crate) fn label_invocation_id(prefix: &str) -> String {
-    format!("{prefix}.invocation_id")
+/// Overrides [`SandboxReaperConfig::idle_stop_after`]. Unset, empty,
+/// non-numeric, or zero falls back to the default.
+const IDLE_STOP_AFTER_ENV: &str = "IRONCLAW_SANDBOX_IDLE_STOP_SECS";
+/// Overrides [`SandboxReaperConfig::remove_stopped_after`].
+const REMOVE_STOPPED_AFTER_ENV: &str = "IRONCLAW_SANDBOX_REMOVE_STOPPED_SECS";
+/// Overrides [`SandboxReaperConfig::forced_recycle_after`].
+const FORCED_RECYCLE_AFTER_ENV: &str = "IRONCLAW_SANDBOX_FORCED_RECYCLE_SECS";
+
+const DEFAULT_IDLE_STOP_AFTER_SECS: u64 = 15 * 60;
+const DEFAULT_REMOVE_STOPPED_AFTER_SECS: u64 = 7 * 24 * 3600;
+const DEFAULT_FORCED_RECYCLE_AFTER_SECS: u64 = 7 * 24 * 3600;
+
+/// Pure resolution of a duration-in-seconds config knob from an
+/// already-read raw env value, falling back to `default_secs` when the
+/// value is absent, empty, non-numeric, or zero. Kept separate from the env
+/// read itself (mirrors `sandbox_quota::resolve_sandbox_max_concurrent_from_raw`)
+/// so tests can drive every branch with an explicit `Some`/`None` input
+/// instead of mutating process-global env — this crate is used from a
+/// `#![forbid(unsafe_code)]` composition crate that bans `std::env::set_var`,
+/// and raw env mutation is flaky under parallel test execution regardless.
+pub(crate) fn resolve_duration_secs_from_raw(raw: Option<String>, default_secs: u64) -> Duration {
+    let secs = raw
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default_secs);
+    Duration::from_secs(secs)
 }
 
-/// Docker label carrying the JSON-serialized [`ResourceScope`] the container
-/// was launched under.
-pub(crate) fn label_resource_scope(prefix: &str) -> String {
-    format!("{prefix}.resource_scope")
+fn idle_stop_after_from_env() -> Duration {
+    resolve_duration_secs_from_raw(
+        std::env::var(IDLE_STOP_AFTER_ENV).ok(),
+        DEFAULT_IDLE_STOP_AFTER_SECS,
+    )
 }
 
-/// Docker label carrying the container's RFC3339 creation timestamp, as
-/// recorded by the transport (not Docker's own `Created` field), so orphan
-/// age is always attributable to our own labeling scheme.
-pub(crate) fn label_created_at(prefix: &str) -> String {
-    format!("{prefix}.created_at")
+fn remove_stopped_after_from_env() -> Duration {
+    resolve_duration_secs_from_raw(
+        std::env::var(REMOVE_STOPPED_AFTER_ENV).ok(),
+        DEFAULT_REMOVE_STOPPED_AFTER_SECS,
+    )
 }
 
-/// Builds the `ironclaw.*` Docker labels for a container launched under
-/// `scope`. Used by `container_launch_config` in the parent module.
-///
-/// The `resource_scope` label is the scope's existing `Serialize` impl
-/// (`ResourceScope` derives `Serialize`/`Deserialize`) — never reconstructed
-/// from ad-hoc string fields, so the reaper's parse side always matches
-/// whatever shape `ResourceScope` actually has.
-pub(crate) fn build_container_labels(
-    scope: &ResourceScope,
-) -> Result<HashMap<String, String>, RuntimeProcessError> {
-    let resource_scope_json = serde_json::to_string(scope).map_err(|error| {
-        RuntimeProcessError::ExecutionFailed(format!(
-            "sandbox container labels could not serialize resource scope: {error}"
-        ))
-    })?;
-    let mut labels = HashMap::with_capacity(3);
-    labels.insert(
-        label_invocation_id(LABEL_PREFIX),
-        scope.invocation_id.to_string(),
-    );
-    labels.insert(label_resource_scope(LABEL_PREFIX), resource_scope_json);
-    labels.insert(label_created_at(LABEL_PREFIX), Utc::now().to_rfc3339());
-    Ok(labels)
-}
-
-/// A parsed, attributable sandbox container: the pieces of the `ironclaw.*`
-/// labels the reaper needs to decide liveness and age.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ReapCandidate {
-    container_id: String,
-    invocation_id: InvocationId,
-    scope: ResourceScope,
-    created_at: DateTime<Utc>,
-}
-
-impl ReapCandidate {
-    /// Parses a [`ContainerSummary`] into a candidate. Returns `None` when
-    /// the container has no ID or its labels are missing/unparseable — such
-    /// a container cannot be attributed to an invocation, so the reaper must
-    /// leave it alone rather than guess.
-    fn from_summary(container: &ContainerSummary, label_prefix: &str) -> Option<Self> {
-        let container_id = container.id.clone()?;
-        let labels = container.labels.as_ref()?;
-
-        let invocation_id = labels
-            .get(&label_invocation_id(label_prefix))
-            .and_then(|value| InvocationId::parse(value).ok())?;
-        let scope = labels
-            .get(&label_resource_scope(label_prefix))
-            .and_then(|value| serde_json::from_str::<ResourceScope>(value).ok())?;
-        let created_at = labels
-            .get(&label_created_at(label_prefix))
-            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
-            .map(|value| value.with_timezone(&Utc))?;
-
-        Some(Self {
-            container_id,
-            invocation_id,
-            scope,
-            created_at,
-        })
-    }
-
-    fn age(&self, now: DateTime<Utc>) -> Duration {
-        (now - self.created_at).to_std().unwrap_or(Duration::ZERO)
-    }
-}
-
-/// Whether a sandbox container's owning invocation is still alive, as far as
-/// the reaper can tell.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Liveness {
-    /// The run is still running/blocked, OR the liveness query itself failed
-    /// (backend/filesystem error) — never conflate "I don't know" with
-    /// "it's gone".
-    Alive,
-    /// The run-state store definitively has no record for this invocation,
-    /// or the record is in a terminal status (`Completed`/`Failed`).
-    Orphaned,
-}
-
-/// Determines liveness for one invocation by querying `run_state`.
-///
-/// This is a free function (not a `SandboxReaper` method) so it can be unit
-/// tested against a fake [`RunStateStore`] without a Docker connection.
-pub(crate) async fn liveness_for(
-    run_state: &dyn RunStateStore,
-    scope: &ResourceScope,
-    invocation_id: InvocationId,
-) -> Liveness {
-    match run_state.get(scope, invocation_id).await {
-        Ok(Some(record)) => match record.status {
-            RunStatus::Running | RunStatus::BlockedApproval | RunStatus::BlockedAuth => {
-                Liveness::Alive
-            }
-            RunStatus::Completed | RunStatus::Failed => Liveness::Orphaned,
-        },
-        // Definitively no record for this invocation: orphan.
-        Ok(None) => Liveness::Orphaned,
-        // Transient query error: never reap on uncertainty. Skip this scan;
-        // the next tick re-evaluates from scratch.
-        Err(_) => Liveness::Alive,
-    }
+fn forced_recycle_after_from_env() -> Duration {
+    resolve_duration_secs_from_raw(
+        std::env::var(FORCED_RECYCLE_AFTER_ENV).ok(),
+        DEFAULT_FORCED_RECYCLE_AFTER_SECS,
+    )
 }
 
 /// Configuration for [`SandboxReaper`].
@@ -165,10 +102,18 @@ pub(crate) async fn liveness_for(
 pub struct SandboxReaperConfig {
     /// How often the reaper lists containers and evaluates them.
     pub scan_interval: Duration,
-    /// Minimum container age (by the `ironclaw.created_at` label) before it
-    /// is eligible for reaping, even if definitively orphaned. Guards
-    /// against racing a container that is mid-create.
-    pub orphan_threshold: Duration,
+    /// How long a *running* container may go with no recorded activity
+    /// before it is stopped (not removed). Default 15 minutes, overridable
+    /// via [`IDLE_STOP_AFTER_ENV`].
+    pub idle_stop_after: Duration,
+    /// How long a *stopped* container is retained before it is removed.
+    /// Default 7 days, overridable via [`REMOVE_STOPPED_AFTER_ENV`].
+    pub remove_stopped_after: Duration,
+    /// Forced-recycle age (from the container's `created_at` label) past
+    /// which a running container is stopped and a stopped one is removed
+    /// immediately, regardless of the idle/retention windows above.
+    /// Default 7 days, overridable via [`FORCED_RECYCLE_AFTER_ENV`].
+    pub forced_recycle_after: Duration,
     /// Prefix for the `ironclaw.*` Docker labels this reaper looks for.
     pub label_prefix: String,
 }
@@ -177,9 +122,76 @@ impl Default for SandboxReaperConfig {
     fn default() -> Self {
         Self {
             scan_interval: Duration::from_secs(300),
-            orphan_threshold: Duration::from_secs(600),
+            idle_stop_after: idle_stop_after_from_env(),
+            remove_stopped_after: remove_stopped_after_from_env(),
+            forced_recycle_after: forced_recycle_after_from_env(),
             label_prefix: LABEL_PREFIX.to_string(),
         }
+    }
+}
+
+/// What [`decide_reap_action`] concluded a container should have done to
+/// it. Pure decision output — [`SandboxReaper::scan_and_reap`] is the only
+/// caller that turns this into a Docker call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReapAction {
+    None,
+    Stop,
+    Remove,
+}
+
+/// Pure two-stage idle/retention decision, with a forced-recycle backstop.
+/// No I/O — every input is a value the caller already read from Docker/the
+/// activity registry, so this is exhaustively unit-testable on a fake
+/// clock (see `decision_tests` below).
+///
+/// **Never reap on uncertainty**: `idle: None` (no activity record for a
+/// running container) and `finished_at: None` (no attributable stop time
+/// for a stopped container) both yield [`ReapAction::None`] rather than
+/// treating "unknown" as "eligible" — this holds even when the container's
+/// age has crossed `forced_recycle_after`: a stopped container with an
+/// unparseable/absent `finished_at` is left alone, not force-removed,
+/// because "unknown" must never be reinterpreted as "eligible" just because
+/// another signal (age) happens to be known.
+pub(crate) fn decide_reap_action(
+    now: DateTime<Utc>,
+    created_at: DateTime<Utc>,
+    running: bool,
+    finished_at: Option<DateTime<Utc>>,
+    idle: Option<Duration>,
+    config: &SandboxReaperConfig,
+) -> ReapAction {
+    let age = (now - created_at).to_std().unwrap_or(Duration::ZERO);
+    let past_forced_recycle_age = age >= config.forced_recycle_after;
+
+    if running {
+        // Forced recycle overrides the idle window outright: a running
+        // container's age is always known (it is the container's own
+        // `created_at` label), so there is no uncertainty to defer to here.
+        if past_forced_recycle_age {
+            return ReapAction::Stop;
+        }
+        return match idle {
+            Some(idle) if idle >= config.idle_stop_after => ReapAction::Stop,
+            _ => ReapAction::None, // no activity record: never reap on uncertainty
+        };
+    }
+
+    match finished_at {
+        Some(finished_at) => {
+            if past_forced_recycle_age {
+                return ReapAction::Remove;
+            }
+            let stopped_for = (now - finished_at).to_std().unwrap_or(Duration::ZERO);
+            if stopped_for >= config.remove_stopped_after {
+                ReapAction::Remove
+            } else {
+                ReapAction::None
+            }
+        }
+        // Can't attribute a stop time: never reap on uncertainty, even if
+        // the container's age alone would otherwise justify forced recycle.
+        None => ReapAction::None,
     }
 }
 
@@ -190,25 +202,23 @@ pub struct ReapSummary {
     pub reaped: usize,
 }
 
-/// Periodically removes orphaned sandbox containers.
-///
-/// Not wired into composition yet: constructing and spawning `run()` as an
-/// owned background task is a later slice.
+/// Periodically stops idle and removes retention-expired persistent
+/// per-user sandbox containers.
 pub struct SandboxReaper {
     docker: Docker,
-    run_state: Arc<dyn RunStateStore>,
+    activity: Arc<SandboxActivityRegistry>,
     config: SandboxReaperConfig,
 }
 
 impl SandboxReaper {
     pub fn new(
         docker: Docker,
-        run_state: Arc<dyn RunStateStore>,
+        activity: Arc<SandboxActivityRegistry>,
         config: SandboxReaperConfig,
     ) -> Self {
         Self {
             docker,
-            run_state,
+            activity,
             config,
         }
     }
@@ -235,39 +245,64 @@ impl SandboxReaper {
         }
     }
 
-    /// Lists `ironclaw`-labeled containers, evaluates each against
-    /// `orphan_threshold` and [`liveness_for`], and reaps the definitively
-    /// orphaned ones. Errors listing containers are propagated (a Docker
-    /// connectivity failure means the scan learned nothing, not that
-    /// everything is fine); errors reaping an individual container are
-    /// best-effort and logged.
+    /// Lists every persistent sandbox container (any container carrying the
+    /// `ironclaw.created_at` label), evaluates each against
+    /// [`decide_reap_action`], and acts on the result. Errors listing
+    /// containers are propagated (a Docker connectivity failure means the
+    /// scan learned nothing, not that everything is fine); errors reaping
+    /// an individual container are best-effort and logged.
     pub async fn scan_and_reap(&self) -> Result<ReapSummary, RuntimeProcessError> {
-        let containers = self.list_ironclaw_containers().await?;
+        let containers = self.list_persistent_containers().await?;
         let now = Utc::now();
         let mut summary = ReapSummary::default();
 
         for container in &containers {
-            let Some(candidate) = ReapCandidate::from_summary(container, &self.config.label_prefix)
+            let Some(candidate) =
+                UserContainerCandidate::from_summary(container, &self.config.label_prefix)
             else {
-                // Unattributable container (missing/unparseable labels): not
-                // ours to manage, leave it alone.
+                // Unattributable container (missing/unparseable created_at
+                // label): not ours to manage, leave it alone.
+                continue;
+            };
+            let Some((tenant_id, user_id)) =
+                parse_tenant_user_labels(container, &self.config.label_prefix)
+            else {
+                // Missing/unparseable tenant or user label: never reap on
+                // uncertainty — this is the "unparseable/foreign labels"
+                // half of dropping orphan-sweep duty.
                 continue;
             };
             summary.considered += 1;
 
-            if candidate.age(now) < self.config.orphan_threshold {
-                continue;
-            }
+            let key = RebornSandboxUserKey::from_tenant_user(&tenant_id, &user_id);
+            let running = container.state.as_deref() == Some("running");
+            let idle = self.activity.idle_for(&key, std::time::Instant::now());
+            let finished_at = if running {
+                None
+            } else {
+                self.finished_at(&candidate.container_id).await
+            };
 
-            let liveness = liveness_for(
-                self.run_state.as_ref(),
-                &candidate.scope,
-                candidate.invocation_id,
-            )
-            .await;
-            if liveness == Liveness::Orphaned {
-                self.reap_container(&candidate.container_id).await;
-                summary.reaped += 1;
+            let action = decide_reap_action(
+                now,
+                candidate.created_at,
+                running,
+                finished_at,
+                idle,
+                &self.config,
+            );
+
+            match action {
+                ReapAction::None => {}
+                ReapAction::Stop => {
+                    self.stop_container(&candidate.container_id).await;
+                    summary.reaped += 1;
+                }
+                ReapAction::Remove => {
+                    self.remove_container(&candidate.container_id).await;
+                    self.activity.forget(&key);
+                    summary.reaped += 1;
+                }
             }
         }
 
@@ -279,11 +314,13 @@ impl SandboxReaper {
         Ok(summary)
     }
 
-    async fn list_ironclaw_containers(&self) -> Result<Vec<ContainerSummary>, RuntimeProcessError> {
+    async fn list_persistent_containers(
+        &self,
+    ) -> Result<Vec<ContainerSummary>, RuntimeProcessError> {
         let mut filters: HashMap<String, Vec<String>> = HashMap::new();
         filters.insert(
             "label".to_string(),
-            vec![label_invocation_id(&self.config.label_prefix)],
+            vec![registry::label_created_at(&self.config.label_prefix)],
         );
         self.docker
             .list_containers(Some(ListContainersOptions {
@@ -299,11 +336,33 @@ impl SandboxReaper {
             })
     }
 
-    /// Best-effort stop-then-remove, mirroring the removal style already
-    /// used inline in `execute_in_container`: never fail the scan over a
-    /// single container's teardown error, just log at `debug!` (never
-    /// `info!` — background tasks must not write to the REPL surface).
-    async fn reap_container(&self, container_id: &str) {
+    /// Inspects `container_id` for its `State.FinishedAt` timestamp.
+    /// Returns `None` on any inspect failure or unparseable/absent value —
+    /// callers treat that the same as "can't attribute a stop time", which
+    /// [`decide_reap_action`] already leaves alone rather than reaping.
+    async fn finished_at(&self, container_id: &str) -> Option<DateTime<Utc>> {
+        let inspected = self
+            .docker
+            .inspect_container(
+                container_id,
+                None::<bollard::container::InspectContainerOptions>,
+            )
+            .await
+            .ok()?;
+        let raw = inspected.state?.finished_at?;
+        // Docker reports the zero value ("0001-01-01T00:00:00Z") for a
+        // container that has never exited; that is not a real stop time.
+        let parsed = DateTime::parse_from_rfc3339(&raw).ok()?;
+        if parsed.timestamp() <= 0 {
+            return None;
+        }
+        Some(parsed.with_timezone(&Utc))
+    }
+
+    /// Best-effort stop: never fail the scan over a single container's
+    /// teardown error, just log at `debug!` (never `info!` — background
+    /// tasks must not write to the REPL surface).
+    async fn stop_container(&self, container_id: &str) {
         if let Err(error) = self
             .docker
             .stop_container(container_id, Some(StopContainerOptions { t: 0 }))
@@ -315,6 +374,11 @@ impl SandboxReaper {
                 "sandbox reaper best-effort stop failed"
             );
         }
+    }
+
+    /// Best-effort forced removal, mirroring [`Self::stop_container`]'s
+    /// error handling.
+    async fn remove_container(&self, container_id: &str) {
         if let Err(error) = self
             .docker
             .remove_container(
@@ -335,213 +399,194 @@ impl SandboxReaper {
     }
 }
 
+/// Parses the `ironclaw.tenant`/`ironclaw.user` labels off a
+/// [`ContainerSummary`] into a `{TenantId, UserId}` pair. `None` when
+/// either label is missing or fails to parse into a valid id — the
+/// container cannot be attributed to a user record, so the caller must
+/// leave it alone rather than guess.
+fn parse_tenant_user_labels(
+    container: &ContainerSummary,
+    label_prefix: &str,
+) -> Option<(TenantId, UserId)> {
+    let labels = container.labels.as_ref()?;
+    let tenant_id = labels
+        .get(&registry::label_tenant(label_prefix))
+        .and_then(|value| TenantId::new(value).ok())?;
+    let user_id = labels
+        .get(&registry::label_user(label_prefix))
+        .and_then(|value| UserId::new(value).ok())?;
+    Some((tenant_id, user_id))
+}
+
+#[cfg(test)]
+mod decision_tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+
+    fn config() -> SandboxReaperConfig {
+        SandboxReaperConfig {
+            scan_interval: Duration::from_secs(300),
+            idle_stop_after: Duration::from_secs(900),
+            remove_stopped_after: Duration::from_secs(7 * 24 * 3600),
+            forced_recycle_after: Duration::from_secs(7 * 24 * 3600),
+            label_prefix: LABEL_PREFIX.to_string(),
+        }
+    }
+
+    #[test]
+    fn running_container_under_idle_threshold_is_left_alone() {
+        let now = Utc::now();
+        let action = decide_reap_action(
+            now,
+            now,
+            true,
+            None,
+            Some(Duration::from_secs(60)),
+            &config(),
+        );
+        assert_eq!(action, ReapAction::None);
+    }
+
+    #[test]
+    fn running_container_past_idle_threshold_is_stopped() {
+        let now = Utc::now();
+        let action = decide_reap_action(
+            now,
+            now,
+            true,
+            None,
+            Some(Duration::from_secs(1_000)),
+            &config(),
+        );
+        assert_eq!(action, ReapAction::Stop);
+    }
+
+    #[test]
+    fn running_container_with_no_activity_record_is_left_alone_not_stopped() {
+        // A process restart loses the in-memory activity map; treating
+        // "unknown" as "reap" would mass-stop every warm container on
+        // every composition restart. Mirrors the old reaper's "never
+        // reap on uncertainty" rule.
+        let now = Utc::now();
+        let action = decide_reap_action(now, now, true, None, None, &config());
+        assert_eq!(action, ReapAction::None);
+    }
+
+    #[test]
+    fn stopped_container_under_retention_is_left_alone() {
+        let now = Utc::now();
+        let finished_at = now - ChronoDuration::hours(1);
+        let action = decide_reap_action(
+            now,
+            now - ChronoDuration::days(1),
+            false,
+            Some(finished_at),
+            None,
+            &config(),
+        );
+        assert_eq!(action, ReapAction::None);
+    }
+
+    #[test]
+    fn stopped_container_past_retention_is_removed() {
+        let now = Utc::now();
+        let finished_at = now - ChronoDuration::days(8);
+        let action = decide_reap_action(
+            now,
+            now - ChronoDuration::days(8),
+            false,
+            Some(finished_at),
+            None,
+            &config(),
+        );
+        assert_eq!(action, ReapAction::Remove);
+    }
+
+    #[test]
+    fn stopped_container_with_unknown_finished_at_is_left_alone() {
+        let now = Utc::now();
+        let action = decide_reap_action(
+            now,
+            now - ChronoDuration::days(8),
+            false,
+            None,
+            None,
+            &config(),
+        );
+        assert_eq!(action, ReapAction::None);
+    }
+
+    #[test]
+    fn running_container_past_forced_recycle_age_is_stopped_first() {
+        let now = Utc::now();
+        let action = decide_reap_action(
+            now,
+            now - ChronoDuration::days(8),
+            true,
+            None,
+            Some(Duration::ZERO),
+            &config(),
+        );
+        assert_eq!(action, ReapAction::Stop);
+    }
+
+    #[test]
+    fn already_stopped_container_past_forced_recycle_age_is_removed_even_within_retention() {
+        let now = Utc::now();
+        let finished_at = now - ChronoDuration::minutes(5);
+        let action = decide_reap_action(
+            now,
+            now - ChronoDuration::days(8),
+            false,
+            Some(finished_at),
+            None,
+            &config(),
+        );
+        assert_eq!(action, ReapAction::Remove);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
-    use ironclaw_host_api::{CapabilityId, InvocationId, UserId};
-    use ironclaw_run_state::{RunRecord, RunStart, RunStateError};
-
-    /// A fake [`RunStateStore`] whose `get` returns one of three canned
-    /// answers, so `liveness_for` can be tested without a real filesystem or
-    /// Docker daemon. Every other trait method is unreachable from these
-    /// tests — the reaper only ever calls `get`.
-    enum FixedResponse {
-        Found(RunStatus),
-        NotFound,
-        Error,
-    }
-
-    struct FixedRunStateStore(FixedResponse);
-
-    #[async_trait]
-    impl RunStateStore for FixedRunStateStore {
-        async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
-            unreachable!("reaper liveness tests never call start()")
-        }
-
-        async fn block_approval(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _approval: ironclaw_host_api::ApprovalRequest,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("reaper liveness tests never call block_approval()")
-        }
-
-        async fn block_auth(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _error_kind: String,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("reaper liveness tests never call block_auth()")
-        }
-
-        async fn complete(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("reaper liveness tests never call complete()")
-        }
-
-        async fn fail(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _error_kind: String,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("reaper liveness tests never call fail()")
-        }
-
-        async fn get(
-            &self,
-            scope: &ResourceScope,
-            invocation_id: InvocationId,
-        ) -> Result<Option<RunRecord>, RunStateError> {
-            match &self.0 {
-                FixedResponse::Found(status) => Ok(Some(RunRecord {
-                    invocation_id,
-                    capability_id: CapabilityId::new("builtin.shell").unwrap(),
-                    scope: scope.clone(),
-                    authenticated_actor_user_id: None,
-                    status: *status,
-                    approval_request_id: None,
-                    error_kind: None,
-                })),
-                FixedResponse::NotFound => Ok(None),
-                FixedResponse::Error => Err(RunStateError::Backend(
-                    "transient backend failure".to_string(),
-                )),
-            }
-        }
-
-        async fn records_for_scope(
-            &self,
-            _scope: &ResourceScope,
-        ) -> Result<Vec<RunRecord>, RunStateError> {
-            unreachable!("reaper liveness tests never call records_for_scope()")
-        }
-    }
-
-    fn test_scope() -> ResourceScope {
-        ResourceScope::local_default(
-            UserId::new("reaper-test-user").unwrap(),
-            InvocationId::new(),
-        )
-        .unwrap()
-    }
-
-    #[tokio::test]
-    async fn is_container_live_treats_transient_query_error_as_alive() {
-        // HEADLINE regression: a backend/filesystem error from the run-state
-        // store must never be treated as "the run is gone". Reaping here
-        // would kill a container whose invocation is still alive but whose
-        // liveness query merely failed this tick.
-        let store = FixedRunStateStore(FixedResponse::Error);
-        let scope = test_scope();
-
-        let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
-
-        assert_eq!(liveness, Liveness::Alive);
-    }
-
-    #[tokio::test]
-    async fn is_container_live_reaps_when_run_definitively_absent() {
-        let store = FixedRunStateStore(FixedResponse::NotFound);
-        let scope = test_scope();
-
-        let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
-
-        assert_eq!(liveness, Liveness::Orphaned);
-    }
-
-    #[tokio::test]
-    async fn is_container_live_reaps_when_run_is_terminal() {
-        for status in [RunStatus::Completed, RunStatus::Failed] {
-            let store = FixedRunStateStore(FixedResponse::Found(status));
-            let scope = test_scope();
-
-            let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
-
-            assert_eq!(liveness, Liveness::Orphaned, "status: {status:?}");
-        }
-    }
-
-    #[tokio::test]
-    async fn is_container_live_stays_alive_while_running_or_blocked() {
-        for status in [
-            RunStatus::Running,
-            RunStatus::BlockedApproval,
-            RunStatus::BlockedAuth,
-        ] {
-            let store = FixedRunStateStore(FixedResponse::Found(status));
-            let scope = test_scope();
-
-            let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
-
-            assert_eq!(liveness, Liveness::Alive, "status: {status:?}");
-        }
-    }
-
-    #[test]
-    fn list_ironclaw_containers_parses_scope_and_invocation_labels() {
-        let scope = test_scope();
-        let labels = build_container_labels(&scope).unwrap();
-        let container = ContainerSummary {
-            id: Some("abc123".to_string()),
-            labels: Some(labels),
-            ..Default::default()
-        };
-
-        let candidate = ReapCandidate::from_summary(&container, LABEL_PREFIX)
-            .expect("round-tripped labels must parse back into a candidate");
-
-        assert_eq!(candidate.container_id, "abc123");
-        assert_eq!(candidate.invocation_id, scope.invocation_id);
-        assert_eq!(candidate.scope, scope);
-    }
-
-    #[test]
-    fn missing_labels_do_not_parse_into_a_candidate() {
-        let container = ContainerSummary {
-            id: Some("no-labels".to_string()),
-            labels: None,
-            ..Default::default()
-        };
-
-        assert!(ReapCandidate::from_summary(&container, LABEL_PREFIX).is_none());
-    }
-
-    #[test]
-    fn unparseable_resource_scope_label_does_not_parse_into_a_candidate() {
-        let scope = test_scope();
-        let container = ContainerSummary {
-            id: Some("bad-scope".to_string()),
-            labels: Some(HashMap::from([
-                (
-                    label_invocation_id(LABEL_PREFIX),
-                    scope.invocation_id.to_string(),
-                ),
-                (
-                    label_resource_scope(LABEL_PREFIX),
-                    "not valid json".to_string(),
-                ),
-                (label_created_at(LABEL_PREFIX), Utc::now().to_rfc3339()),
-            ])),
-            ..Default::default()
-        };
-
-        assert!(ReapCandidate::from_summary(&container, LABEL_PREFIX).is_none());
-    }
 
     #[test]
     fn default_config_matches_plan_thresholds() {
         let config = SandboxReaperConfig::default();
 
         assert_eq!(config.scan_interval, Duration::from_secs(300));
-        assert_eq!(config.orphan_threshold, Duration::from_secs(600));
+        assert_eq!(config.idle_stop_after, Duration::from_secs(900));
+        assert_eq!(
+            config.remove_stopped_after,
+            Duration::from_secs(7 * 24 * 3600)
+        );
+        assert_eq!(
+            config.forced_recycle_after,
+            Duration::from_secs(7 * 24 * 3600)
+        );
         assert_eq!(config.label_prefix, "ironclaw");
+    }
+
+    #[test]
+    fn env_override_resolution_falls_back_on_absent_empty_or_invalid_values() {
+        for raw in [
+            None,
+            Some(String::new()),
+            Some("not-a-number".to_string()),
+            Some("0".to_string()),
+        ] {
+            assert_eq!(
+                resolve_duration_secs_from_raw(raw, 42),
+                Duration::from_secs(42)
+            );
+        }
+    }
+
+    #[test]
+    fn env_override_resolution_uses_a_valid_positive_value() {
+        assert_eq!(
+            resolve_duration_secs_from_raw(Some("120".to_string()), 42),
+            Duration::from_secs(120)
+        );
     }
 }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/reaper.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/reaper.rs
@@ -1,0 +1,547 @@
+//! Orphaned sandbox container reaper.
+//!
+//! Sandbox containers are launched per command invocation
+//! (`RebornScopedSandboxCommandTransport::execute_in_container`) and normally
+//! removed inline once the command finishes. A container can survive that
+//! best-effort removal — host crash mid-command, killed process, a lost
+//! connection to the daemon — and become an orphan: a running container whose
+//! owning invocation is gone. [`SandboxReaper`] periodically lists containers
+//! this transport created (via the `ironclaw.*` labels set in
+//! `container_launch_config`) and removes the ones that are definitively
+//! orphaned.
+//!
+//! **Deliberate fix over the legacy `src/orchestrator/reaper.rs`:** that
+//! implementation treated "the run-state lookup failed" the same as "the run
+//! is gone" and reaped in both cases. A transient backend/filesystem error is
+//! not evidence of anything — reaping on it can kill a container whose
+//! invocation is still very much alive. [`liveness_for`] treats a query error
+//! as [`Liveness::Alive`]: the scan skips the container this tick and
+//! re-evaluates it next tick, so only a *definitive* not-found or terminal
+//! run status is ever grounds for removal.
+//!
+//! This module is NOT wired into composition yet — spawning [`SandboxReaper::run`]
+//! as an owned background task is a later slice (composition/factory.rs).
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use bollard::{
+    Docker,
+    container::{ListContainersOptions, RemoveContainerOptions, StopContainerOptions},
+    models::ContainerSummary,
+};
+use chrono::{DateTime, Utc};
+use ironclaw_host_api::{InvocationId, ResourceScope};
+use ironclaw_run_state::{RunStateStore, RunStatus};
+
+use crate::RuntimeProcessError;
+
+use super::LABEL_PREFIX;
+
+/// Docker label carrying the invocation ID that created the container.
+pub(crate) fn label_invocation_id(prefix: &str) -> String {
+    format!("{prefix}.invocation_id")
+}
+
+/// Docker label carrying the JSON-serialized [`ResourceScope`] the container
+/// was launched under.
+pub(crate) fn label_resource_scope(prefix: &str) -> String {
+    format!("{prefix}.resource_scope")
+}
+
+/// Docker label carrying the container's RFC3339 creation timestamp, as
+/// recorded by the transport (not Docker's own `Created` field), so orphan
+/// age is always attributable to our own labeling scheme.
+pub(crate) fn label_created_at(prefix: &str) -> String {
+    format!("{prefix}.created_at")
+}
+
+/// Builds the `ironclaw.*` Docker labels for a container launched under
+/// `scope`. Used by `container_launch_config` in the parent module.
+///
+/// The `resource_scope` label is the scope's existing `Serialize` impl
+/// (`ResourceScope` derives `Serialize`/`Deserialize`) — never reconstructed
+/// from ad-hoc string fields, so the reaper's parse side always matches
+/// whatever shape `ResourceScope` actually has.
+pub(crate) fn build_container_labels(
+    scope: &ResourceScope,
+) -> Result<HashMap<String, String>, RuntimeProcessError> {
+    let resource_scope_json = serde_json::to_string(scope).map_err(|error| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox container labels could not serialize resource scope: {error}"
+        ))
+    })?;
+    let mut labels = HashMap::with_capacity(3);
+    labels.insert(
+        label_invocation_id(LABEL_PREFIX),
+        scope.invocation_id.to_string(),
+    );
+    labels.insert(label_resource_scope(LABEL_PREFIX), resource_scope_json);
+    labels.insert(label_created_at(LABEL_PREFIX), Utc::now().to_rfc3339());
+    Ok(labels)
+}
+
+/// A parsed, attributable sandbox container: the pieces of the `ironclaw.*`
+/// labels the reaper needs to decide liveness and age.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReapCandidate {
+    container_id: String,
+    invocation_id: InvocationId,
+    scope: ResourceScope,
+    created_at: DateTime<Utc>,
+}
+
+impl ReapCandidate {
+    /// Parses a [`ContainerSummary`] into a candidate. Returns `None` when
+    /// the container has no ID or its labels are missing/unparseable — such
+    /// a container cannot be attributed to an invocation, so the reaper must
+    /// leave it alone rather than guess.
+    fn from_summary(container: &ContainerSummary, label_prefix: &str) -> Option<Self> {
+        let container_id = container.id.clone()?;
+        let labels = container.labels.as_ref()?;
+
+        let invocation_id = labels
+            .get(&label_invocation_id(label_prefix))
+            .and_then(|value| InvocationId::parse(value).ok())?;
+        let scope = labels
+            .get(&label_resource_scope(label_prefix))
+            .and_then(|value| serde_json::from_str::<ResourceScope>(value).ok())?;
+        let created_at = labels
+            .get(&label_created_at(label_prefix))
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.with_timezone(&Utc))?;
+
+        Some(Self {
+            container_id,
+            invocation_id,
+            scope,
+            created_at,
+        })
+    }
+
+    fn age(&self, now: DateTime<Utc>) -> Duration {
+        (now - self.created_at).to_std().unwrap_or(Duration::ZERO)
+    }
+}
+
+/// Whether a sandbox container's owning invocation is still alive, as far as
+/// the reaper can tell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Liveness {
+    /// The run is still running/blocked, OR the liveness query itself failed
+    /// (backend/filesystem error) — never conflate "I don't know" with
+    /// "it's gone".
+    Alive,
+    /// The run-state store definitively has no record for this invocation,
+    /// or the record is in a terminal status (`Completed`/`Failed`).
+    Orphaned,
+}
+
+/// Determines liveness for one invocation by querying `run_state`.
+///
+/// This is a free function (not a `SandboxReaper` method) so it can be unit
+/// tested against a fake [`RunStateStore`] without a Docker connection.
+pub(crate) async fn liveness_for(
+    run_state: &dyn RunStateStore,
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+) -> Liveness {
+    match run_state.get(scope, invocation_id).await {
+        Ok(Some(record)) => match record.status {
+            RunStatus::Running | RunStatus::BlockedApproval | RunStatus::BlockedAuth => {
+                Liveness::Alive
+            }
+            RunStatus::Completed | RunStatus::Failed => Liveness::Orphaned,
+        },
+        // Definitively no record for this invocation: orphan.
+        Ok(None) => Liveness::Orphaned,
+        // Transient query error: never reap on uncertainty. Skip this scan;
+        // the next tick re-evaluates from scratch.
+        Err(_) => Liveness::Alive,
+    }
+}
+
+/// Configuration for [`SandboxReaper`].
+#[derive(Debug, Clone)]
+pub struct SandboxReaperConfig {
+    /// How often the reaper lists containers and evaluates them.
+    pub scan_interval: Duration,
+    /// Minimum container age (by the `ironclaw.created_at` label) before it
+    /// is eligible for reaping, even if definitively orphaned. Guards
+    /// against racing a container that is mid-create.
+    pub orphan_threshold: Duration,
+    /// Prefix for the `ironclaw.*` Docker labels this reaper looks for.
+    pub label_prefix: String,
+}
+
+impl Default for SandboxReaperConfig {
+    fn default() -> Self {
+        Self {
+            scan_interval: Duration::from_secs(300),
+            orphan_threshold: Duration::from_secs(600),
+            label_prefix: LABEL_PREFIX.to_string(),
+        }
+    }
+}
+
+/// Summary of one `scan_and_reap` pass, for logging/tests.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReapSummary {
+    pub considered: usize,
+    pub reaped: usize,
+}
+
+/// Periodically removes orphaned sandbox containers.
+///
+/// Not wired into composition yet: constructing and spawning `run()` as an
+/// owned background task is a later slice.
+pub struct SandboxReaper {
+    docker: Docker,
+    run_state: Arc<dyn RunStateStore>,
+    config: SandboxReaperConfig,
+}
+
+impl SandboxReaper {
+    pub fn new(
+        docker: Docker,
+        run_state: Arc<dyn RunStateStore>,
+        config: SandboxReaperConfig,
+    ) -> Self {
+        Self {
+            docker,
+            run_state,
+            config,
+        }
+    }
+
+    /// Runs the scan loop until `shutdown` reports `true`. Composition owns
+    /// spawning this as a task and driving `shutdown` — this method itself
+    /// has no opinion on how it is scheduled.
+    pub async fn run(&self, mut shutdown: tokio::sync::watch::Receiver<bool>) {
+        let mut interval = tokio::time::interval(self.config.scan_interval);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    if let Err(error) = self.scan_and_reap().await {
+                        tracing::debug!(?error, "sandbox reaper scan failed");
+                    }
+                }
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Lists `ironclaw`-labeled containers, evaluates each against
+    /// `orphan_threshold` and [`liveness_for`], and reaps the definitively
+    /// orphaned ones. Errors listing containers are propagated (a Docker
+    /// connectivity failure means the scan learned nothing, not that
+    /// everything is fine); errors reaping an individual container are
+    /// best-effort and logged.
+    pub async fn scan_and_reap(&self) -> Result<ReapSummary, RuntimeProcessError> {
+        let containers = self.list_ironclaw_containers().await?;
+        let now = Utc::now();
+        let mut summary = ReapSummary::default();
+
+        for container in &containers {
+            let Some(candidate) = ReapCandidate::from_summary(container, &self.config.label_prefix)
+            else {
+                // Unattributable container (missing/unparseable labels): not
+                // ours to manage, leave it alone.
+                continue;
+            };
+            summary.considered += 1;
+
+            if candidate.age(now) < self.config.orphan_threshold {
+                continue;
+            }
+
+            let liveness = liveness_for(
+                self.run_state.as_ref(),
+                &candidate.scope,
+                candidate.invocation_id,
+            )
+            .await;
+            if liveness == Liveness::Orphaned {
+                self.reap_container(&candidate.container_id).await;
+                summary.reaped += 1;
+            }
+        }
+
+        tracing::debug!(
+            considered = summary.considered,
+            reaped = summary.reaped,
+            "sandbox reaper scan complete"
+        );
+        Ok(summary)
+    }
+
+    async fn list_ironclaw_containers(&self) -> Result<Vec<ContainerSummary>, RuntimeProcessError> {
+        let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+        filters.insert(
+            "label".to_string(),
+            vec![label_invocation_id(&self.config.label_prefix)],
+        );
+        self.docker
+            .list_containers(Some(ListContainersOptions {
+                all: true,
+                filters,
+                ..Default::default()
+            }))
+            .await
+            .map_err(|error| {
+                RuntimeProcessError::ExecutionFailed(format!(
+                    "sandbox reaper container list failed: {error}"
+                ))
+            })
+    }
+
+    /// Best-effort stop-then-remove, mirroring the removal style already
+    /// used inline in `execute_in_container`: never fail the scan over a
+    /// single container's teardown error, just log at `debug!` (never
+    /// `info!` — background tasks must not write to the REPL surface).
+    async fn reap_container(&self, container_id: &str) {
+        if let Err(error) = self
+            .docker
+            .stop_container(container_id, Some(StopContainerOptions { t: 0 }))
+            .await
+        {
+            tracing::debug!(
+                ?error,
+                container_id,
+                "sandbox reaper best-effort stop failed"
+            );
+        }
+        if let Err(error) = self
+            .docker
+            .remove_container(
+                container_id,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+        {
+            tracing::debug!(
+                ?error,
+                container_id,
+                "sandbox reaper best-effort removal failed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use ironclaw_host_api::{CapabilityId, InvocationId, UserId};
+    use ironclaw_run_state::{RunRecord, RunStart, RunStateError};
+
+    /// A fake [`RunStateStore`] whose `get` returns one of three canned
+    /// answers, so `liveness_for` can be tested without a real filesystem or
+    /// Docker daemon. Every other trait method is unreachable from these
+    /// tests — the reaper only ever calls `get`.
+    enum FixedResponse {
+        Found(RunStatus),
+        NotFound,
+        Error,
+    }
+
+    struct FixedRunStateStore(FixedResponse);
+
+    #[async_trait]
+    impl RunStateStore for FixedRunStateStore {
+        async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
+            unreachable!("reaper liveness tests never call start()")
+        }
+
+        async fn block_approval(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _approval: ironclaw_host_api::ApprovalRequest,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("reaper liveness tests never call block_approval()")
+        }
+
+        async fn block_auth(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _error_kind: String,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("reaper liveness tests never call block_auth()")
+        }
+
+        async fn complete(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("reaper liveness tests never call complete()")
+        }
+
+        async fn fail(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _error_kind: String,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("reaper liveness tests never call fail()")
+        }
+
+        async fn get(
+            &self,
+            scope: &ResourceScope,
+            invocation_id: InvocationId,
+        ) -> Result<Option<RunRecord>, RunStateError> {
+            match &self.0 {
+                FixedResponse::Found(status) => Ok(Some(RunRecord {
+                    invocation_id,
+                    capability_id: CapabilityId::new("builtin.shell").unwrap(),
+                    scope: scope.clone(),
+                    authenticated_actor_user_id: None,
+                    status: *status,
+                    approval_request_id: None,
+                    error_kind: None,
+                })),
+                FixedResponse::NotFound => Ok(None),
+                FixedResponse::Error => Err(RunStateError::Backend(
+                    "transient backend failure".to_string(),
+                )),
+            }
+        }
+
+        async fn records_for_scope(
+            &self,
+            _scope: &ResourceScope,
+        ) -> Result<Vec<RunRecord>, RunStateError> {
+            unreachable!("reaper liveness tests never call records_for_scope()")
+        }
+    }
+
+    fn test_scope() -> ResourceScope {
+        ResourceScope::local_default(
+            UserId::new("reaper-test-user").unwrap(),
+            InvocationId::new(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn is_container_live_treats_transient_query_error_as_alive() {
+        // HEADLINE regression: a backend/filesystem error from the run-state
+        // store must never be treated as "the run is gone". Reaping here
+        // would kill a container whose invocation is still alive but whose
+        // liveness query merely failed this tick.
+        let store = FixedRunStateStore(FixedResponse::Error);
+        let scope = test_scope();
+
+        let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
+
+        assert_eq!(liveness, Liveness::Alive);
+    }
+
+    #[tokio::test]
+    async fn is_container_live_reaps_when_run_definitively_absent() {
+        let store = FixedRunStateStore(FixedResponse::NotFound);
+        let scope = test_scope();
+
+        let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
+
+        assert_eq!(liveness, Liveness::Orphaned);
+    }
+
+    #[tokio::test]
+    async fn is_container_live_reaps_when_run_is_terminal() {
+        for status in [RunStatus::Completed, RunStatus::Failed] {
+            let store = FixedRunStateStore(FixedResponse::Found(status));
+            let scope = test_scope();
+
+            let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
+
+            assert_eq!(liveness, Liveness::Orphaned, "status: {status:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn is_container_live_stays_alive_while_running_or_blocked() {
+        for status in [
+            RunStatus::Running,
+            RunStatus::BlockedApproval,
+            RunStatus::BlockedAuth,
+        ] {
+            let store = FixedRunStateStore(FixedResponse::Found(status));
+            let scope = test_scope();
+
+            let liveness = liveness_for(&store, &scope, scope.invocation_id).await;
+
+            assert_eq!(liveness, Liveness::Alive, "status: {status:?}");
+        }
+    }
+
+    #[test]
+    fn list_ironclaw_containers_parses_scope_and_invocation_labels() {
+        let scope = test_scope();
+        let labels = build_container_labels(&scope).unwrap();
+        let container = ContainerSummary {
+            id: Some("abc123".to_string()),
+            labels: Some(labels),
+            ..Default::default()
+        };
+
+        let candidate = ReapCandidate::from_summary(&container, LABEL_PREFIX)
+            .expect("round-tripped labels must parse back into a candidate");
+
+        assert_eq!(candidate.container_id, "abc123");
+        assert_eq!(candidate.invocation_id, scope.invocation_id);
+        assert_eq!(candidate.scope, scope);
+    }
+
+    #[test]
+    fn missing_labels_do_not_parse_into_a_candidate() {
+        let container = ContainerSummary {
+            id: Some("no-labels".to_string()),
+            labels: None,
+            ..Default::default()
+        };
+
+        assert!(ReapCandidate::from_summary(&container, LABEL_PREFIX).is_none());
+    }
+
+    #[test]
+    fn unparseable_resource_scope_label_does_not_parse_into_a_candidate() {
+        let scope = test_scope();
+        let container = ContainerSummary {
+            id: Some("bad-scope".to_string()),
+            labels: Some(HashMap::from([
+                (
+                    label_invocation_id(LABEL_PREFIX),
+                    scope.invocation_id.to_string(),
+                ),
+                (
+                    label_resource_scope(LABEL_PREFIX),
+                    "not valid json".to_string(),
+                ),
+                (label_created_at(LABEL_PREFIX), Utc::now().to_rfc3339()),
+            ])),
+            ..Default::default()
+        };
+
+        assert!(ReapCandidate::from_summary(&container, LABEL_PREFIX).is_none());
+    }
+
+    #[test]
+    fn default_config_matches_plan_thresholds() {
+        let config = SandboxReaperConfig::default();
+
+        assert_eq!(config.scan_interval, Duration::from_secs(300));
+        assert_eq!(config.orphan_threshold, Duration::from_secs(600));
+        assert_eq!(config.label_prefix, "ironclaw");
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/registry.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/registry.rs
@@ -125,6 +125,58 @@ impl SandboxActivityRegistry {
     }
 }
 
+/// A single tracked background (`background: true`) shell launch, kept
+/// per-user so the foreground command path can render a "still-live
+/// background processes" footer. A named struct rather than a `(u32,
+/// String)` tuple — `jobs_for` return values flow into formatting code
+/// where a bare tuple's field order is not self-documenting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BackgroundJob {
+    pub(crate) pid: u32,
+    pub(crate) command_preview: String,
+}
+
+/// Push-based in-memory map of per-user background job launches, keyed on
+/// [`RebornSandboxUserKey`] the same way [`SandboxActivityRegistry`] is.
+/// Kept as a sibling registry (single responsibility) rather than folded
+/// into the activity map.
+#[derive(Debug, Default)]
+pub(crate) struct BackgroundJobRegistry {
+    jobs: Mutex<HashMap<RebornSandboxUserKey, Vec<BackgroundJob>>>,
+}
+
+impl BackgroundJobRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<RebornSandboxUserKey, Vec<BackgroundJob>>> {
+        self.jobs
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    pub(crate) fn record(&self, key: &RebornSandboxUserKey, pid: u32, command_preview: String) {
+        self.lock()
+            .entry(key.clone())
+            .or_default()
+            .push(BackgroundJob {
+                pid,
+                command_preview,
+            });
+    }
+
+    pub(crate) fn jobs_for(&self, key: &RebornSandboxUserKey) -> Vec<BackgroundJob> {
+        self.lock().get(key).cloned().unwrap_or_default()
+    }
+
+    pub(crate) fn drop_dead(&self, key: &RebornSandboxUserKey, alive_pids: &[u32]) {
+        if let Some(jobs) = self.lock().get_mut(key) {
+            jobs.retain(|job| alive_pids.contains(&job.pid));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ironclaw_host_runtime/src/sandbox_process/registry.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/registry.rs
@@ -1,0 +1,214 @@
+//! Labels-as-identity container registry for the persistent per-user
+//! sandbox model. Two responsibilities:
+//!
+//! 1. Docker label construction/parsing for `{tenant, user, created_at}`
+//!    identity — crash-safe (survives daemon restart), no DB.
+//! 2. A push-based in-memory last-activity map. The exec transport calls
+//!    [`SandboxActivityRegistry::touch`] after every successful command;
+//!    the reaper only ever reads via `idle_for`/`last_activity` — it
+//!    never inspects container stats to infer activity. Labels are
+//!    immutable post-create and NEVER carry this mutable state.
+
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+use bollard::models::ContainerSummary;
+use chrono::{DateTime, Utc};
+use ironclaw_host_api::{TenantId, UserId};
+
+use super::user_key::RebornSandboxUserKey;
+
+pub(crate) fn label_tenant(prefix: &str) -> String {
+    format!("{prefix}.tenant")
+}
+pub(crate) fn label_user(prefix: &str) -> String {
+    format!("{prefix}.user")
+}
+pub(crate) fn label_created_at(prefix: &str) -> String {
+    format!("{prefix}.created_at")
+}
+
+pub(crate) fn build_user_container_labels(
+    prefix: &str,
+    tenant_id: &TenantId,
+    user_id: &UserId,
+) -> HashMap<String, String> {
+    HashMap::from([
+        (label_tenant(prefix), tenant_id.as_str().to_string()),
+        (label_user(prefix), user_id.as_str().to_string()),
+        (label_created_at(prefix), Utc::now().to_rfc3339()),
+    ])
+}
+
+pub(crate) fn user_container_label_filter(
+    prefix: &str,
+    tenant_id: &TenantId,
+    user_id: &UserId,
+) -> HashMap<String, Vec<String>> {
+    HashMap::from([(
+        "label".to_string(),
+        vec![
+            format!("{}={}", label_tenant(prefix), tenant_id.as_str()),
+            format!("{}={}", label_user(prefix), user_id.as_str()),
+        ],
+    )])
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UserContainerCandidate {
+    pub(crate) container_id: String,
+    pub(crate) created_at: DateTime<Utc>,
+}
+
+impl UserContainerCandidate {
+    pub(crate) fn from_summary(container: &ContainerSummary, label_prefix: &str) -> Option<Self> {
+        let container_id = container.id.clone()?;
+        let labels = container.labels.as_ref()?;
+        let created_at = labels
+            .get(&label_created_at(label_prefix))
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.with_timezone(&Utc))?;
+        Some(Self {
+            container_id,
+            created_at,
+        })
+    }
+
+    pub(crate) fn age(&self, now: DateTime<Utc>) -> Duration {
+        (now - self.created_at).to_std().unwrap_or(Duration::ZERO)
+    }
+}
+
+/// Push-based in-memory map of per-user last-activity timestamps, keyed on
+/// [`RebornSandboxUserKey`]. Cross-crate consumers (e.g. the reborn runtime
+/// composition wiring that owns the reaper loop) need to construct and pass
+/// this registry, so it is `pub` and re-exported at the crate root — unlike
+/// the label helpers and candidate type above, which stay internal to this
+/// crate.
+#[derive(Debug, Default)]
+pub struct SandboxActivityRegistry {
+    last_activity: Mutex<HashMap<RebornSandboxUserKey, Instant>>,
+}
+
+impl SandboxActivityRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<RebornSandboxUserKey, Instant>> {
+        // Recover from poisoning rather than panic: a background reaper
+        // must never crash the whole process over a prior panic elsewhere
+        // that poisoned this unrelated mutex.
+        self.last_activity
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    pub(crate) fn touch(&self, key: &RebornSandboxUserKey) {
+        self.lock().insert(key.clone(), Instant::now());
+    }
+
+    pub(crate) fn last_activity(&self, key: &RebornSandboxUserKey) -> Option<Instant> {
+        self.lock().get(key).copied()
+    }
+
+    pub(crate) fn forget(&self, key: &RebornSandboxUserKey) {
+        self.lock().remove(key);
+    }
+
+    pub(crate) fn idle_for(&self, key: &RebornSandboxUserKey, now: Instant) -> Option<Duration> {
+        self.last_activity(key)
+            .map(|activity| now.saturating_duration_since(activity))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{TenantId, UserId};
+
+    #[test]
+    fn label_filter_targets_tenant_and_user_labels_only() {
+        let tenant = TenantId::new("tenant-a").unwrap();
+        let user = UserId::new("user-a").unwrap();
+
+        let filter = user_container_label_filter("ironclaw", &tenant, &user);
+
+        assert_eq!(
+            filter.get("label").unwrap(),
+            &vec![
+                "ironclaw.tenant=tenant-a".to_string(),
+                "ironclaw.user=user-a".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn candidate_parses_created_at_and_ignores_missing_labels() {
+        let tenant = TenantId::new("tenant-a").unwrap();
+        let user = UserId::new("user-a").unwrap();
+        let labels = build_user_container_labels("ironclaw", &tenant, &user);
+        let container = ContainerSummary {
+            id: Some("abc123".to_string()),
+            labels: Some(labels),
+            ..Default::default()
+        };
+
+        let candidate = UserContainerCandidate::from_summary(&container, "ironclaw")
+            .expect("round-tripped labels must parse");
+
+        assert_eq!(candidate.container_id, "abc123");
+
+        let missing = ContainerSummary {
+            id: Some("no-labels".to_string()),
+            labels: None,
+            ..Default::default()
+        };
+        assert!(UserContainerCandidate::from_summary(&missing, "ironclaw").is_none());
+    }
+
+    #[test]
+    fn activity_registry_touch_then_idle_for_reports_elapsed_duration() {
+        let registry = SandboxActivityRegistry::new();
+        let tenant = TenantId::new("t").unwrap();
+        let user = UserId::new("u").unwrap();
+        let scope = ironclaw_host_api::ResourceScope {
+            tenant_id: tenant,
+            user_id: user,
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: ironclaw_host_api::InvocationId::new(),
+        };
+        let key = RebornSandboxUserKey::from_scope(&scope);
+
+        assert!(registry.last_activity(&key).is_none());
+        registry.touch(&key);
+        let idle = registry.idle_for(&key, Instant::now() + Duration::from_secs(5));
+        assert!(idle.unwrap() >= Duration::from_secs(5));
+    }
+
+    #[test]
+    fn activity_registry_forget_clears_the_entry() {
+        let registry = SandboxActivityRegistry::new();
+        let scope = ironclaw_host_api::ResourceScope {
+            tenant_id: TenantId::new("t").unwrap(),
+            user_id: UserId::new("u").unwrap(),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: ironclaw_host_api::InvocationId::new(),
+        };
+        let key = RebornSandboxUserKey::from_scope(&scope);
+        registry.touch(&key);
+
+        registry.forget(&key);
+
+        assert!(registry.last_activity(&key).is_none());
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/shell_limits.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/shell_limits.rs
@@ -71,7 +71,10 @@ mod tests {
             clamp_shell_timeout_secs(Some(6_000)),
             Duration::from_secs(SHELL_TIMEOUT_MAX_SECS)
         );
-        assert_eq!(clamp_shell_timeout_secs(Some(601)), Duration::from_secs(600));
+        assert_eq!(
+            clamp_shell_timeout_secs(Some(601)),
+            Duration::from_secs(600)
+        );
     }
 
     #[test]
@@ -99,10 +102,7 @@ mod tests {
             clamp_shell_output_limit_bytes(Some(10 * 1024 * 1024)),
             SHELL_OUTPUT_LIMIT_MAX_BYTES as usize
         );
-        assert_eq!(
-            clamp_shell_output_limit_bytes(Some(1_048_577)),
-            1_048_576
-        );
+        assert_eq!(clamp_shell_output_limit_bytes(Some(1_048_577)), 1_048_576);
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/sandbox_process/shell_limits.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/shell_limits.rs
@@ -1,0 +1,120 @@
+//! Model-adjustable clamp bounds for `builtin.shell` timeout and captured
+//! output size.
+//!
+//! The model may request a `timeout` and `output_limit` per call (see
+//! `first_party_tools::schemas` and `first_party_tools::shell_core`); this
+//! module owns the operator ceilings both values are clamped to before they
+//! reach the sandbox transport, plus the defaults used when unset.
+
+use std::time::Duration;
+
+/// Default shell command timeout when the model omits `timeout`.
+pub const SHELL_TIMEOUT_DEFAULT_SECS: u64 = 120;
+/// Operator ceiling for `timeout`. Requests above this are clamped down,
+/// never rejected.
+pub const SHELL_TIMEOUT_MAX_SECS: u64 = 600;
+/// Floor for `timeout`; zero-second timeouts are rejected upstream by
+/// `shell_core::parse_timeout`, but the clamp still enforces the floor for
+/// any other caller of `clamp_shell_timeout_secs`.
+pub const SHELL_TIMEOUT_MIN_SECS: u64 = 1;
+
+/// Default captured-output cap (stdout+stderr) when the model omits
+/// `output_limit`.
+pub const SHELL_OUTPUT_LIMIT_DEFAULT_BYTES: u64 = 64 * 1024;
+/// Operator ceiling for `output_limit`. Requests above this are clamped
+/// down, never rejected.
+pub const SHELL_OUTPUT_LIMIT_MAX_BYTES: u64 = 1024 * 1024;
+/// Floor for `output_limit`; requests below this are clamped up.
+pub const SHELL_OUTPUT_LIMIT_MIN_BYTES: u64 = 1024;
+
+/// Clamp a model-requested shell timeout (seconds) to
+/// `[SHELL_TIMEOUT_MIN_SECS, SHELL_TIMEOUT_MAX_SECS]`, defaulting to
+/// `SHELL_TIMEOUT_DEFAULT_SECS` when unset.
+pub fn clamp_shell_timeout_secs(requested: Option<u64>) -> Duration {
+    let secs = requested
+        .unwrap_or(SHELL_TIMEOUT_DEFAULT_SECS)
+        .clamp(SHELL_TIMEOUT_MIN_SECS, SHELL_TIMEOUT_MAX_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Clamp a model-requested output cap (bytes) to
+/// `[SHELL_OUTPUT_LIMIT_MIN_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES]`,
+/// defaulting to `SHELL_OUTPUT_LIMIT_DEFAULT_BYTES` when unset.
+pub fn clamp_shell_output_limit_bytes(requested: Option<u64>) -> usize {
+    let bytes = requested
+        .unwrap_or(SHELL_OUTPUT_LIMIT_DEFAULT_BYTES)
+        .clamp(SHELL_OUTPUT_LIMIT_MIN_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES);
+    bytes as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_unset_defaults_to_120() {
+        assert_eq!(
+            clamp_shell_timeout_secs(None),
+            Duration::from_secs(SHELL_TIMEOUT_DEFAULT_SECS)
+        );
+        assert_eq!(clamp_shell_timeout_secs(None), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn timeout_within_range_is_honored() {
+        assert_eq!(clamp_shell_timeout_secs(Some(45)), Duration::from_secs(45));
+    }
+
+    #[test]
+    fn timeout_over_cap_is_clamped_to_600() {
+        assert_eq!(
+            clamp_shell_timeout_secs(Some(6_000)),
+            Duration::from_secs(SHELL_TIMEOUT_MAX_SECS)
+        );
+        assert_eq!(clamp_shell_timeout_secs(Some(601)), Duration::from_secs(600));
+    }
+
+    #[test]
+    fn timeout_below_floor_is_clamped_up() {
+        // parse_timeout rejects 0 before this is reached in production, but
+        // the clamp itself must still hold the floor for any other caller.
+        assert_eq!(
+            clamp_shell_timeout_secs(Some(0)),
+            Duration::from_secs(SHELL_TIMEOUT_MIN_SECS)
+        );
+    }
+
+    #[test]
+    fn output_limit_unset_defaults_to_64kib() {
+        assert_eq!(
+            clamp_shell_output_limit_bytes(None),
+            SHELL_OUTPUT_LIMIT_DEFAULT_BYTES as usize
+        );
+        assert_eq!(clamp_shell_output_limit_bytes(None), 65536);
+    }
+
+    #[test]
+    fn output_limit_over_cap_is_clamped_to_1mib() {
+        assert_eq!(
+            clamp_shell_output_limit_bytes(Some(10 * 1024 * 1024)),
+            SHELL_OUTPUT_LIMIT_MAX_BYTES as usize
+        );
+        assert_eq!(
+            clamp_shell_output_limit_bytes(Some(1_048_577)),
+            1_048_576
+        );
+    }
+
+    #[test]
+    fn output_limit_below_floor_is_clamped_up() {
+        assert_eq!(
+            clamp_shell_output_limit_bytes(Some(10)),
+            SHELL_OUTPUT_LIMIT_MIN_BYTES as usize
+        );
+    }
+
+    #[test]
+    fn output_limit_within_range_is_honored() {
+        assert_eq!(clamp_shell_output_limit_bytes(Some(200_000)), 200_000);
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/user_key.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/user_key.rs
@@ -1,0 +1,137 @@
+//! Coarse `{tenant, user}` container identity key for the persistent
+//! per-user sandbox container model (Phase A). Unlike
+//! [`super::scope_key::RebornSandboxScopeKey`] (fine-grained; includes
+//! agent/project/thread/invocation and is used for nothing
+//! container-related after this phase), this key derives container name
+//! and workspace root from `{tenant_id, user_id}` ONLY — every
+//! thread/project/agent for the same user shares one container.
+
+use std::path::{Path, PathBuf};
+
+use ironclaw_host_api::{ResourceScope, TenantId, UserId};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RebornSandboxUserKey {
+    digest: String,
+}
+
+impl RebornSandboxUserKey {
+    pub fn from_scope(scope: &ResourceScope) -> Self {
+        Self::from_tenant_user(&scope.tenant_id, &scope.user_id)
+    }
+
+    /// Scope-free constructor: builds the same digest `from_scope` would,
+    /// from just the `{tenant_id, user_id}` pair. This is what Task A5's
+    /// reaper needs — a `ContainerSummary`'s `ironclaw.tenant`/
+    /// `ironclaw.user` labels are exactly a `{TenantId, UserId}` pair, not
+    /// a reconstructable `ResourceScope` (no agent/project/thread/
+    /// invocation survive on a label). One formula, two entry points.
+    pub fn from_tenant_user(tenant_id: &TenantId, user_id: &UserId) -> Self {
+        let raw = format!(
+            "tenant:{}:{}|user:{}:{}",
+            tenant_id.as_str().len(),
+            tenant_id.as_str(),
+            user_id.as_str().len(),
+            user_id.as_str(),
+        );
+        Self {
+            digest: hex::encode(Sha256::digest(raw.as_bytes())),
+        }
+    }
+
+    pub fn workspace_path(&self, root: &Path) -> PathBuf {
+        root.join("users").join(&self.digest)
+    }
+
+    pub fn container_name(&self) -> String {
+        format!("ironclaw-reborn-sandbox-user-{}", &self.digest[..24])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ThreadId};
+
+    fn scope(
+        tenant: &str,
+        user: &str,
+        project: Option<&str>,
+        thread: Option<&str>,
+    ) -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new(tenant).unwrap(),
+            user_id: UserId::new(user).unwrap(),
+            agent_id: Some(AgentId::new("agent").unwrap()),
+            project_id: project.map(|v| ProjectId::new(v).unwrap()),
+            mission_id: None,
+            thread_id: thread.map(|v| ThreadId::new(v).unwrap()),
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    #[test]
+    fn one_container_key_per_user_regardless_of_project_or_thread() {
+        let root = Path::new("/tmp/reborn-sandbox");
+        let a = RebornSandboxUserKey::from_scope(&scope("t", "u", Some("proj-a"), None));
+        let b =
+            RebornSandboxUserKey::from_scope(&scope("t", "u", Some("proj-b"), Some("thread-x")));
+
+        assert_eq!(a.workspace_path(root), b.workspace_path(root));
+        assert_eq!(a.container_name(), b.container_name());
+    }
+
+    #[test]
+    fn key_isolates_tenants_with_same_user() {
+        let root = Path::new("/tmp/reborn-sandbox");
+        let left = RebornSandboxUserKey::from_scope(&scope("tenant-a", "same-user", None, None));
+        let right = RebornSandboxUserKey::from_scope(&scope("tenant-b", "same-user", None, None));
+
+        assert_ne!(left.workspace_path(root), right.workspace_path(root));
+        assert_ne!(left.container_name(), right.container_name());
+    }
+
+    #[test]
+    fn key_isolates_users_within_same_tenant() {
+        let root = Path::new("/tmp/reborn-sandbox");
+        let left = RebornSandboxUserKey::from_scope(&scope("tenant", "user-a", None, None));
+        let right = RebornSandboxUserKey::from_scope(&scope("tenant", "user-b", None, None));
+
+        assert_ne!(left.workspace_path(root), right.workspace_path(root));
+    }
+
+    #[test]
+    fn length_prefixing_prevents_boundary_collision() {
+        // Without a length-prefixed encoding, tenant="a", user="b:c" and
+        // tenant="a:b", user="c" would hash identically after naive
+        // concatenation. Regression for that class of collision.
+        let root = Path::new("/tmp/reborn-sandbox");
+        let left = RebornSandboxUserKey::from_scope(&scope("a", "b:c", None, None));
+        let right = RebornSandboxUserKey::from_scope(&scope("a:b", "c", None, None));
+
+        assert_ne!(left.workspace_path(root), right.workspace_path(root));
+    }
+
+    #[test]
+    fn from_tenant_user_matches_from_scope_for_the_same_pair() {
+        // Task A5's reaper only ever has `{tenant, user}` label strings to
+        // work with (no agent/project/thread/invocation survive on a
+        // Docker label) — this constructor must produce the exact same
+        // digest `from_scope` would, or the reaper's key would never match
+        // the activity registry's key for a container it just listed.
+        let root = Path::new("/tmp/reborn-sandbox");
+        let via_scope =
+            RebornSandboxUserKey::from_scope(&scope("t", "u", Some("proj-a"), Some("thread-x")));
+        let via_pair = RebornSandboxUserKey::from_tenant_user(
+            &TenantId::new("t").unwrap(),
+            &UserId::new("u").unwrap(),
+        );
+
+        assert_eq!(
+            via_scope.workspace_path(root),
+            via_pair.workspace_path(root)
+        );
+        assert_eq!(via_scope.container_name(), via_pair.container_name());
+    }
+}

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -544,6 +544,7 @@ async fn inherited_env_runtime_policy_selects_inherited_local_process_port() {
             workdir: Some(workdir.path().display().to_string()),
             timeout_secs: Some(5),
             extra_env: Default::default(),
+            output_limit_bytes: None,
         })
         .await
         .expect("command succeeds");
@@ -579,6 +580,7 @@ async fn scrubbed_runtime_policy_resets_managed_local_process_port_after_inherit
             workdir: Some(workdir.path().display().to_string()),
             timeout_secs: Some(5),
             extra_env: Default::default(),
+            output_limit_bytes: None,
         })
         .await
         .expect("command succeeds");

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -545,6 +545,7 @@ async fn inherited_env_runtime_policy_selects_inherited_local_process_port() {
             timeout_secs: Some(5),
             extra_env: Default::default(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .expect("command succeeds");
@@ -581,6 +582,7 @@ async fn scrubbed_runtime_policy_resets_managed_local_process_port_after_inherit
             timeout_secs: Some(5),
             extra_env: Default::default(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .expect("command succeeds");

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -3559,6 +3559,16 @@ async fn builtin_shell_tenant_sandbox_process_uses_callers_scope_for_two_user_is
 
 #[tokio::test]
 async fn builtin_shell_rejects_hosted_process_plan_before_handler_runs() {
+    // `hosted_dev_policy()` resolves `process_backend: TenantSandbox`, but this
+    // runtime is only wired with a local `RecordingProcessPort` (no
+    // `with_tenant_sandbox_process_port`). `TenantWorkspace` filesystem access
+    // itself now resolves fine (it's a mount-scoped view, same mechanism as
+    // `ScopedVirtual`), so the rejection no longer happens as an authorization
+    // denial — it happens one step later, at process-backend resolution in
+    // `LocalInvocationServicesResolver::resolve`: there is no tenant-sandbox
+    // process port configured to satisfy the `TenantSandbox` plan, so
+    // `InvocationServicesError::UnsupportedProcessBackend` fires and maps to
+    // `RuntimeFailureKind::Backend`. The handler still never runs.
     let process_port = Arc::new(RecordingProcessPort::default());
     let runtime =
         runtime_with_process_port_and_policy(Arc::clone(&process_port), hosted_dev_policy());
@@ -3572,7 +3582,7 @@ async fn builtin_shell_rejects_hosted_process_plan_before_handler_runs() {
     .await
     .unwrap_err();
 
-    assert_eq!(error, RuntimeFailureKind::Authorization);
+    assert_eq!(error, RuntimeFailureKind::Backend);
     assert!(
         process_port.requests.lock().unwrap().is_empty(),
         "hosted shell must fail at invocation-service resolution before the handler can run"
@@ -3600,6 +3610,8 @@ async fn builtin_shell_rejects_invalid_inputs_before_spawn() {
         json!({"command": "echo hi", "workdir": 123}),
         json!({"command": "echo hi", "timeout": 0}),
         json!({"command": "echo hi", "timeout": "1"}),
+        json!({"command": "echo hi", "output_limit": 0}),
+        json!({"command": "echo hi", "output_limit": "1"}),
     ] {
         let err = invoke_shell(input).await.unwrap_err();
 
@@ -3632,12 +3644,27 @@ async fn builtin_shell_invalid_input_failure_carries_the_reason_through_the_runt
 }
 
 #[tokio::test]
-async fn builtin_shell_rejects_timeout_above_manifest_ceiling() {
-    let err = invoke_shell(json!({"command": "echo hi", "timeout": 121}))
+async fn builtin_shell_honors_timeout_above_the_old_120s_default() {
+    // `timeout` is model-adjustable up to a 600s operator ceiling
+    // (`sandbox_process::shell_limits::SHELL_TIMEOUT_MAX_SECS`); a value
+    // above the 120s default is honored, not rejected.
+    let output = invoke_shell(json!({"command": "echo hi", "timeout": 121}))
         .await
-        .unwrap_err();
+        .unwrap();
 
-    assert_eq!(err, RuntimeFailureKind::Resource);
+    assert_eq!(output["exit_code"], json!(0));
+}
+
+#[tokio::test]
+async fn builtin_shell_clamps_rather_than_rejects_timeout_above_the_600s_ceiling() {
+    // A command that completes immediately still succeeds when `timeout`
+    // overshoots the ceiling: the value is clamped to 600s downstream in the
+    // process port, never rejected at dispatch.
+    let output = invoke_shell(json!({"command": "echo hi", "timeout": 6_000}))
+        .await
+        .unwrap();
+
+    assert_eq!(output["exit_code"], json!(0));
 }
 
 #[tokio::test]
@@ -6772,17 +6799,39 @@ async fn builtin_read_file_reads_scoped_virtual_filesystem_through_mount_service
 }
 
 #[tokio::test]
-async fn builtin_read_file_rejects_tenant_workspace_before_filesystem_access() {
+async fn builtin_read_file_under_tenant_workspace_is_mount_gated() {
+    // `TenantWorkspace` now resolves to the same mount-scoped filesystem view
+    // as `ScopedVirtual` (see `LocalInvocationServicesResolver::filesystem_for_plan`),
+    // so it is no longer an unsupported backend that hosted read_file always
+    // fails against. The real security invariant is that access is gated by
+    // the resolved `MountView`: a grant that covers the path allows the read,
+    // and the absence of a covering grant still denies it before the file is
+    // touched.
     let temp = tempfile::tempdir().unwrap();
-    std::fs::write(temp.path().join("README.md"), "must not be read\n").unwrap();
+    std::fs::write(temp.path().join("README.md"), "tenant workspace read\n").unwrap();
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
     let runtime = runtime_with_filesystem_and_policy(filesystem, hosted_dev_policy());
 
-    let error = invoke_with_context(
+    // (a) With a read-only /workspace mount granting access, the read succeeds.
+    let output = invoke_with_context(
         &runtime,
         READ_FILE_CAPABILITY_ID,
         json!({"path": "/workspace/README.md"}),
         execution_context_with_mounts([READ_FILE_CAPABILITY_ID], mounts),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(output["content"], json!("     1│ tenant workspace read"));
+    assert_eq!(output["path"], json!("/workspace/README.md"));
+
+    // (b) Without any mount covering the path, the same tenant-workspace
+    // resolution still denies the read before touching the filesystem.
+    let error = invoke_with_context(
+        &runtime,
+        READ_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/README.md"}),
+        execution_context_with_mounts([READ_FILE_CAPABILITY_ID], MountView::default()),
     )
     .await
     .unwrap_err();

--- a/crates/ironclaw_host_runtime/tests/sandbox_cross_tenant_escape.rs
+++ b/crates/ironclaw_host_runtime/tests/sandbox_cross_tenant_escape.rs
@@ -1,0 +1,185 @@
+//! Real-Docker cross-tenant escape test for the Reborn sandbox process
+//! transport.
+//!
+//! Mandated by `.claude/rules/safety-and-sandbox.md` ("Process and shell
+//! execution: real OS isolation, per tenant") for any change touching
+//! process ports / profile->backend mapping: "user B runs a shell command
+//! and the test asserts it cannot read user A's files." This proves the
+//! **host bind-mount boundary** specifically — not the container-workdir
+//! string validation `sandbox_process.rs`'s existing unit tests
+//! (`relative_workdir_rejects_escape`, `container_workdir_rejects_host_absolute_paths`)
+//! already cover. Those tests prove `resolve_container_workdir` rejects a
+//! malformed *string*; this test proves that even a well-formed in-container
+//! path can never resolve to another tenant's data, because each tenant's
+//! container only ever has ITS OWN scope-keyed host directory bind-mounted
+//! at `/workspace` (`container_launch_config` in `sandbox_process.rs`).
+//!
+//! Requires a reachable Docker daemon AND a locally-built `ironclaw-worker`
+//! image. Neither is available on a typical dev machine (this worktree has
+//! no Docker) — the test is authored to run for real in CI/hosted lanes that
+//! have both, and skips cleanly (a visible `SKIP: ...` line, never a silent
+//! pass) everywhere else.
+
+#[path = "support/docker_gate.rs"]
+mod docker_gate;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
+use ironclaw_host_runtime::{
+    CommandExecutionRequest, RebornSandboxConfig, RebornSandboxScopeKey,
+    RebornScopedSandboxCommandTransport, SandboxCommandTransport,
+};
+
+fn tenant_scope(tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: Some(AgentId::new("agent").unwrap()),
+        project_id: Some(ProjectId::new("project").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+#[tokio::test]
+async fn sandbox_containers_cannot_read_across_tenant_host_bind_mounts() {
+    if !docker_gate::docker_available() {
+        eprintln!(
+            "SKIP: no docker daemon reachable — sandbox_containers_cannot_read_across_tenant_host_bind_mounts requires a real Docker daemon (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+    let image = docker_gate::configured_sandbox_image();
+    if !docker_gate::docker_image_available(&image) {
+        eprintln!(
+            "SKIP: sandbox worker image {image:?} is not built locally — sandbox_containers_cannot_read_across_tenant_host_bind_mounts requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+
+    let workspace_root = tempfile::tempdir().expect("tempdir for sandbox workspace root");
+    let config = RebornSandboxConfig::new(workspace_root.path());
+
+    // One shared transport instance, exactly as composition wires it in
+    // production (a single `Arc<TenantSandboxProcessPort>` binding serves
+    // every tenant) — the test must prove per-request scope isolation holds
+    // from a single shared connection, not merely across separately
+    // connected transports.
+    let transport = RebornScopedSandboxCommandTransport::connect(config)
+        .await
+        .expect("real docker connect should succeed when the daemon is reachable");
+
+    let scope_a = tenant_scope("tenant-a", "user-a");
+    let scope_b = tenant_scope("tenant-b", "user-b");
+
+    // Host-side leaf directory `ironclaw-worker`'s container for tenant A
+    // gets bind-mounted at (`<root>/scopes/<digest-a>`). Only its basename is
+    // used inside the escape attempt below — the test never needs A's
+    // container to disclose it, it derives it independently host-side,
+    // exactly like an attacker who already knows (or guesses) the scope
+    // digest scheme would.
+    let key_a = RebornSandboxScopeKey::from_scope(&scope_a);
+    let a_dir_name = key_a
+        .workspace_path(workspace_root.path())
+        .file_name()
+        .expect("scope workspace path has a leaf directory name")
+        .to_string_lossy()
+        .to_string();
+
+    // --- User A writes a marker file under its own /workspace. ---
+    let marker_secret = "IRONCLAW-TENANT-A-SECRET-MARKER";
+    let write_output = transport
+        .run_command(CommandExecutionRequest {
+            scope: scope_a.clone(),
+            mounts: None,
+            command: format!("printf '{marker_secret}' > /workspace/marker.txt"),
+            workdir: None,
+            timeout_secs: Some(30),
+            extra_env: HashMap::new(),
+            output_limit_bytes: None,
+        })
+        .await
+        .expect("tenant A marker write should succeed");
+    assert_eq!(
+        write_output.exit_code, 0,
+        "tenant A marker write failed: {}",
+        write_output.output
+    );
+
+    // --- User B attempts to read A's marker two ways. ---
+    // 1. Workspace-relative path: if request-scope isolation were broken and
+    //    every tenant shared one workspace root, this alone would already
+    //    leak A's file.
+    // 2. `/workspace/../<A-scope-digest>/marker.txt`: a well-formed,
+    //    in-container relative-looking path that only resolves to A's host
+    //    directory if B's container has A's *parent* directory bind-mounted
+    //    (not just B's own scope-keyed leaf dir). Docker bind mounts do not
+    //    expose the host parent of a bind-mounted directory inside the
+    //    container, so `/workspace/..` resolves to the container's own root
+    //    filesystem, never the host `scopes/` directory — this is the real
+    //    host-level containment boundary, independent of any string
+    //    validation `resolve_container_workdir` performs before launch.
+    let read_output = transport
+        .run_command(CommandExecutionRequest {
+            scope: scope_b.clone(),
+            mounts: None,
+            command: format!(
+                "{{ echo --relative--; cat marker.txt; echo --escape--; cat /workspace/../{a_dir_name}/marker.txt; }} 2>&1; true"
+            ),
+            workdir: None,
+            timeout_secs: Some(30),
+            extra_env: HashMap::new(),
+            output_limit_bytes: None,
+        })
+        .await
+        .expect("tenant B read attempt should complete (denial is expected inside the output, not a transport error)");
+
+    assert_eq!(
+        read_output.exit_code, 0,
+        "the wrapper command always exits 0 regardless of the inner `cat` failures; a nonzero \
+         exit means the harness itself broke, not that isolation held: {}",
+        read_output.output
+    );
+    assert!(
+        !read_output.output.contains(marker_secret),
+        "tenant B must never be able to read tenant A's marker content via either path; got: {}",
+        read_output.output
+    );
+    assert!(
+        !read_output
+            .output
+            .contains(&workspace_root.path().display().to_string()),
+        "tenant B's output must never disclose the host sandbox workspace path; got: {}",
+        read_output.output
+    );
+
+    // Independent host-side confirmation: A's marker really did land under
+    // A's own scope-keyed host directory (proves the write above was a real
+    // assertion, not a false negative from a broken write path).
+    let host_marker_path = key_a
+        .workspace_path(workspace_root.path())
+        .join("marker.txt");
+    let host_marker_contents = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::fs::read_to_string(&host_marker_path),
+    )
+    .await
+    .expect("host marker read should not time out")
+    .expect("tenant A's marker file should exist under A's own host-scoped directory");
+    assert_eq!(host_marker_contents, marker_secret);
+
+    // And B's own scope directory must never have received A's file either
+    // (rules out a bug where the write silently fanned out to every scope
+    // dir under the shared root).
+    let key_b = RebornSandboxScopeKey::from_scope(&scope_b);
+    let b_marker_path = key_b
+        .workspace_path(workspace_root.path())
+        .join("marker.txt");
+    assert!(
+        !b_marker_path.exists(),
+        "tenant B's host-scoped directory must not contain tenant A's marker file"
+    );
+}

--- a/crates/ironclaw_host_runtime/tests/sandbox_cross_tenant_escape.rs
+++ b/crates/ironclaw_host_runtime/tests/sandbox_cross_tenant_escape.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 
 use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
 use ironclaw_host_runtime::{
-    CommandExecutionRequest, RebornSandboxConfig, RebornSandboxScopeKey,
+    CommandExecutionRequest, RebornSandboxConfig, RebornSandboxUserKey,
     RebornScopedSandboxCommandTransport, SandboxCommandTransport,
 };
 
@@ -81,7 +81,7 @@ async fn sandbox_containers_cannot_read_across_tenant_host_bind_mounts() {
     // container to disclose it, it derives it independently host-side,
     // exactly like an attacker who already knows (or guesses) the scope
     // digest scheme would.
-    let key_a = RebornSandboxScopeKey::from_scope(&scope_a);
+    let key_a = RebornSandboxUserKey::from_scope(&scope_a);
     let a_dir_name = key_a
         .workspace_path(workspace_root.path())
         .file_name()
@@ -174,7 +174,7 @@ async fn sandbox_containers_cannot_read_across_tenant_host_bind_mounts() {
     // And B's own scope directory must never have received A's file either
     // (rules out a bug where the write silently fanned out to every scope
     // dir under the shared root).
-    let key_b = RebornSandboxScopeKey::from_scope(&scope_b);
+    let key_b = RebornSandboxUserKey::from_scope(&scope_b);
     let b_marker_path = key_b
         .workspace_path(workspace_root.path())
         .join("marker.txt");

--- a/crates/ironclaw_host_runtime/tests/sandbox_cross_tenant_escape.rs
+++ b/crates/ironclaw_host_runtime/tests/sandbox_cross_tenant_escape.rs
@@ -100,6 +100,7 @@ async fn sandbox_containers_cannot_read_across_tenant_host_bind_mounts() {
             timeout_secs: Some(30),
             extra_env: HashMap::new(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .expect("tenant A marker write should succeed");
@@ -133,6 +134,7 @@ async fn sandbox_containers_cannot_read_across_tenant_host_bind_mounts() {
             timeout_secs: Some(30),
             extra_env: HashMap::new(),
             output_limit_bytes: None,
+            background: false,
         })
         .await
         .expect("tenant B read attempt should complete (denial is expected inside the output, not a transport error)");

--- a/crates/ironclaw_host_runtime/tests/sandbox_reaper_docker.rs
+++ b/crates/ironclaw_host_runtime/tests/sandbox_reaper_docker.rs
@@ -1,11 +1,21 @@
-//! Real-Docker tests for [`ironclaw_host_runtime::SandboxReaper`].
+//! Real-Docker tests for [`ironclaw_host_runtime::SandboxReaper`]'s two-stage
+//! per-user lifecycle.
 //!
-//! `sandbox_process.rs`'s no-Docker unit tests (in `sandbox_process/reaper.rs`)
-//! already pin the liveness-decision logic (headline: a transient run-state
-//! query error is never treated as "the run is gone"). These tests prove the
-//! Docker-facing half: that a reaper pointed at a real daemon actually removes
-//! a container it has decided is orphaned, and actually leaves alone a
-//! container it has decided is alive (or uncertain).
+//! `sandbox_process/reaper.rs`'s no-Docker unit tests already pin the pure
+//! stage-decision logic (`decide_reap_action` on a fake clock: idle→stop,
+//! retention→remove, forced-recycle by age, and "never reap on uncertainty").
+//! These tests prove the Docker-facing half: that a reaper pointed at a real
+//! daemon actually stops a container it decides to stop, actually removes one
+//! it decides to remove, and actually leaves alone one it decides to keep.
+//!
+//! The in-memory [`SandboxActivityRegistry`]'s `touch` is crate-private, so an
+//! integration test can only hand the reaper an *empty* registry (every
+//! container reads back `idle == None`). The three cases below therefore drive
+//! the reaper through all three [`ReapAction`]s using the wall-clock
+//! `ironclaw.created_at` label — a container whose label places its age past
+//! `forced_recycle_after` is stopped (if running) or removed (if stopped),
+//! while a young running container survives. The idle-stop-by-activity path is
+//! covered by the crate's fake-clock unit tests, which can touch the registry.
 //!
 //! Requires a reachable Docker daemon AND a locally-built `ironclaw-worker`
 //! image, same gate as `sandbox_cross_tenant_escape.rs`. Neither is available
@@ -20,62 +30,95 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use bollard::{
     Docker,
-    container::{Config, CreateContainerOptions, RemoveContainerOptions, StartContainerOptions},
+    container::{
+        Config, CreateContainerOptions, InspectContainerOptions, RemoveContainerOptions,
+        StartContainerOptions,
+    },
     models::HostConfig,
 };
 use chrono::Utc;
-use ironclaw_host_api::{
-    AgentId, ApprovalRequest, InvocationId, ProjectId, ResourceScope, TenantId, UserId,
-};
-use ironclaw_host_runtime::{SandboxReaper, SandboxReaperConfig};
-use ironclaw_run_state::{RunRecord, RunStart, RunStateError, RunStateStore};
+use ironclaw_host_api::{TenantId, UserId};
+use ironclaw_host_runtime::{SandboxActivityRegistry, SandboxReaper, SandboxReaperConfig};
 
-const LABEL_INVOCATION_ID: &str = "ironclaw.invocation_id";
-const LABEL_RESOURCE_SCOPE: &str = "ironclaw.resource_scope";
+// The persistent-container identity labels the production launch config
+// attaches (see `sandbox_process/registry.rs`). Written as literals here
+// because those helper fns are `pub(crate)` and unreachable from an
+// integration test — the reaper's real listing filter keys on
+// `ironclaw.created_at`, and it rebuilds the per-user key from
+// `ironclaw.tenant`/`ironclaw.user`.
+const LABEL_TENANT: &str = "ironclaw.tenant";
+const LABEL_USER: &str = "ironclaw.user";
 const LABEL_CREATED_AT: &str = "ironclaw.created_at";
 
-fn test_scope() -> ResourceScope {
-    ResourceScope {
-        tenant_id: TenantId::new("reaper-docker-tenant").unwrap(),
-        user_id: UserId::new("reaper-docker-user").unwrap(),
-        agent_id: Some(AgentId::new("agent").unwrap()),
-        project_id: Some(ProjectId::new("project").unwrap()),
-        mission_id: None,
-        thread_id: None,
-        invocation_id: InvocationId::new(),
-    }
-}
-
-/// Builds the same `ironclaw.*` labels `container_launch_config` attaches in
-/// production, so these tests exercise the reaper's real listing filter
-/// (`ironclaw.invocation_id`) and label parsing, not a test-only shortcut.
-/// `created_at` is caller-supplied so tests can place a container on either
-/// side of `orphan_threshold` without sleeping.
-fn ironclaw_labels(
-    scope: &ResourceScope,
-    created_at: chrono::DateTime<Utc>,
-) -> HashMap<String, String> {
+fn user_labels(created_at: chrono::DateTime<Utc>) -> HashMap<String, String> {
+    let tenant = TenantId::new("reaper-docker-tenant").unwrap();
+    let user = UserId::new("reaper-docker-user").unwrap();
     HashMap::from([
-        (
-            LABEL_INVOCATION_ID.to_string(),
-            scope.invocation_id.to_string(),
-        ),
-        (
-            LABEL_RESOURCE_SCOPE.to_string(),
-            serde_json::to_string(scope).unwrap(),
-        ),
+        (LABEL_TENANT.to_string(), tenant.as_str().to_string()),
+        (LABEL_USER.to_string(), user.as_str().to_string()),
         (LABEL_CREATED_AT.to_string(), created_at.to_rfc3339()),
     ])
 }
 
-/// Starts a long-running, labeled container directly (bypassing
-/// `SandboxCommandTransport::run_command`, which blocks until the command
-/// exits — these tests need a container that is still *running* when the
-/// reaper scans it, simulating a host crash mid-command).
-async fn start_labeled_container(
+/// A test config whose `forced_recycle_after` is short enough that a
+/// container carrying a `created_at` label a couple of minutes in the past is
+/// past the recycle age, without any real waiting. `idle_stop_after` and
+/// `remove_stopped_after` are left large so the *only* trigger these tests
+/// exercise is age-based forced recycle (the one axis an integration test can
+/// drive without touching the crate-private activity registry).
+fn forced_recycle_config() -> SandboxReaperConfig {
+    SandboxReaperConfig {
+        scan_interval: Duration::from_secs(300),
+        idle_stop_after: Duration::from_secs(900),
+        remove_stopped_after: Duration::from_secs(7 * 24 * 3600),
+        forced_recycle_after: Duration::from_secs(60),
+        label_prefix: "ironclaw".to_string(),
+    }
+}
+
+/// Starts a long-running labeled container (bypassing the command transport,
+/// which blocks until its command exits — these tests need a container that is
+/// still *running* when the reaper scans it).
+async fn start_running_container(
     docker: &Docker,
     image: &str,
     labels: HashMap<String, String>,
+) -> String {
+    let container_id = create_labeled_container(docker, image, labels, "sleep 300").await;
+    docker
+        .start_container(&container_id, None::<StartContainerOptions<String>>)
+        .await
+        .expect("container start should succeed against a reachable daemon");
+    container_id
+}
+
+/// Creates, starts, and waits for a labeled container to exit, leaving it in
+/// the `exited` state with a real `finished_at` — the shape the reaper's
+/// remove branch requires (a stopped container with a known stop time).
+async fn start_then_exit_container(
+    docker: &Docker,
+    image: &str,
+    labels: HashMap<String, String>,
+) -> String {
+    let container_id = create_labeled_container(docker, image, labels, "exit 0").await;
+    docker
+        .start_container(&container_id, None::<StartContainerOptions<String>>)
+        .await
+        .expect("container start should succeed against a reachable daemon");
+    for _ in 0..50 {
+        if !container_running(docker, &container_id).await {
+            return container_id;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("container did not reach the exited state within the poll window");
+}
+
+async fn create_labeled_container(
+    docker: &Docker,
+    image: &str,
+    labels: HashMap<String, String>,
+    command: &str,
 ) -> String {
     let name = format!("ironclaw-reaper-docker-test-{}", uuid::Uuid::new_v4());
     let config = Config {
@@ -83,7 +126,7 @@ async fn start_labeled_container(
         cmd: Some(vec![
             "sh".to_string(),
             "-c".to_string(),
-            "sleep 300".to_string(),
+            command.to_string(),
         ]),
         labels: Some(labels),
         host_config: Some(HostConfig {
@@ -93,25 +136,27 @@ async fn start_labeled_container(
         }),
         ..Default::default()
     };
-    let created = docker
-        .create_container(
-            Some(CreateContainerOptions {
-                name,
-                platform: None,
-            }),
-            config,
-        )
-        .await
-        .expect("container create should succeed against a reachable daemon");
     docker
-        .start_container(&created.id, None::<StartContainerOptions<String>>)
+        .create_container(Some(CreateContainerOptions { name, platform: None }), config)
         .await
-        .expect("container start should succeed against a reachable daemon");
-    created.id
+        .expect("container create should succeed against a reachable daemon")
+        .id
 }
 
 async fn container_exists(docker: &Docker, container_id: &str) -> bool {
-    docker.inspect_container(container_id, None).await.is_ok()
+    docker
+        .inspect_container(container_id, None::<InspectContainerOptions>)
+        .await
+        .is_ok()
+}
+
+async fn container_running(docker: &Docker, container_id: &str) -> bool {
+    docker
+        .inspect_container(container_id, None::<InspectContainerOptions>)
+        .await
+        .ok()
+        .and_then(|c| c.state.and_then(|s| s.running))
+        .unwrap_or(false)
 }
 
 async fn best_effort_remove(docker: &Docker, container_id: &str) {
@@ -124,168 +169,6 @@ async fn best_effort_remove(docker: &Docker, container_id: &str) {
             }),
         )
         .await;
-}
-
-/// Always reports "no record" — mirrors an invocation whose run-state has
-/// genuinely aged out or was never recorded (definitive orphan).
-struct AlwaysAbsentRunStateStore;
-
-/// Always reports a transient backend failure — mirrors a run-state store
-/// that is momentarily unreachable, not evidence the invocation is gone.
-struct AlwaysErrorRunStateStore;
-
-// The reaper only ever calls `get`; the writer methods must exist to satisfy
-// the trait but are never invoked. They're written inline (not via a
-// declarative macro) because `#[async_trait]` sees a macro *invocation*, not
-// the expanded `async fn`s, and cannot rewrite them — which produces E0195.
-#[async_trait::async_trait]
-impl RunStateStore for AlwaysAbsentRunStateStore {
-    async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysAbsentRunStateStore never calls start()")
-    }
-    async fn block_approval(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-        _approval: ApprovalRequest,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysAbsentRunStateStore never calls block_approval()")
-    }
-    async fn block_auth(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-        _error_kind: String,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysAbsentRunStateStore never calls block_auth()")
-    }
-    async fn complete(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysAbsentRunStateStore never calls complete()")
-    }
-    async fn fail(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-        _error_kind: String,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysAbsentRunStateStore never calls fail()")
-    }
-    async fn records_for_scope(
-        &self,
-        _scope: &ResourceScope,
-    ) -> Result<Vec<RunRecord>, RunStateError> {
-        unreachable!("AlwaysAbsentRunStateStore never calls records_for_scope()")
-    }
-    async fn get(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-    ) -> Result<Option<RunRecord>, RunStateError> {
-        Ok(None)
-    }
-}
-
-#[async_trait::async_trait]
-impl RunStateStore for AlwaysErrorRunStateStore {
-    async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysErrorRunStateStore never calls start()")
-    }
-    async fn block_approval(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-        _approval: ApprovalRequest,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysErrorRunStateStore never calls block_approval()")
-    }
-    async fn block_auth(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-        _error_kind: String,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysErrorRunStateStore never calls block_auth()")
-    }
-    async fn complete(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysErrorRunStateStore never calls complete()")
-    }
-    async fn fail(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-        _error_kind: String,
-    ) -> Result<RunRecord, RunStateError> {
-        unreachable!("AlwaysErrorRunStateStore never calls fail()")
-    }
-    async fn records_for_scope(
-        &self,
-        _scope: &ResourceScope,
-    ) -> Result<Vec<RunRecord>, RunStateError> {
-        unreachable!("AlwaysErrorRunStateStore never calls records_for_scope()")
-    }
-    async fn get(
-        &self,
-        _scope: &ResourceScope,
-        _invocation_id: InvocationId,
-    ) -> Result<Option<RunRecord>, RunStateError> {
-        Err(RunStateError::Backend(
-            "simulated transient run-state backend failure".to_string(),
-        ))
-    }
-}
-
-#[tokio::test]
-async fn kill_mid_command_orphan_past_threshold_is_reaped() {
-    if !docker_gate::docker_available() {
-        eprintln!(
-            "SKIP: no docker daemon reachable — kill_mid_command_orphan_past_threshold_is_reaped requires a real Docker daemon (CI/hosted Docker lane only)"
-        );
-        return;
-    }
-    let image = docker_gate::configured_sandbox_image();
-    if !docker_gate::docker_image_available(&image) {
-        eprintln!(
-            "SKIP: sandbox worker image {image:?} is not built locally — kill_mid_command_orphan_past_threshold_is_reaped requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
-        );
-        return;
-    }
-
-    let docker = Docker::connect_with_local_defaults().unwrap();
-    let scope = test_scope();
-    // Simulates "host crashed mid-command": container is still running, its
-    // created_at label is already older than orphan_threshold, and no
-    // run-state record exists for its invocation (definitive orphan).
-    let created_at = Utc::now() - chrono::Duration::seconds(120);
-    let labels = ironclaw_labels(&scope, created_at);
-    let container_id = start_labeled_container(&docker, &image, labels).await;
-
-    let reaper = SandboxReaper::new(
-        docker.clone(),
-        Arc::new(AlwaysAbsentRunStateStore),
-        SandboxReaperConfig {
-            scan_interval: Duration::from_secs(300),
-            orphan_threshold: Duration::from_secs(60),
-            label_prefix: "ironclaw".to_string(),
-        },
-    );
-
-    reaper
-        .scan_and_reap()
-        .await
-        .expect("scan against a reachable daemon should succeed");
-
-    assert!(
-        !container_exists(&docker, &container_id).await,
-        "orphaned container past the threshold must be reaped"
-    );
 }
 
 #[tokio::test]
@@ -305,22 +188,16 @@ async fn young_running_container_survives_scan() {
     }
 
     let docker = Docker::connect_with_local_defaults().unwrap();
-    let scope = test_scope();
-    // Freshly created: even though no run-state record exists either, the
-    // container has not yet crossed orphan_threshold and must survive.
-    let labels = ironclaw_labels(&scope, Utc::now());
-    let container_id = start_labeled_container(&docker, &image, labels).await;
+    // Freshly created: not past forced-recycle age, and the empty activity
+    // registry reports `idle == None` — "never reap on uncertainty" keeps it.
+    let labels = user_labels(Utc::now());
+    let container_id = start_running_container(&docker, &image, labels).await;
 
     let reaper = SandboxReaper::new(
         docker.clone(),
-        Arc::new(AlwaysAbsentRunStateStore),
-        SandboxReaperConfig {
-            scan_interval: Duration::from_secs(300),
-            orphan_threshold: Duration::from_secs(600),
-            label_prefix: "ironclaw".to_string(),
-        },
+        Arc::new(SandboxActivityRegistry::new()),
+        forced_recycle_config(),
     );
-
     reaper
         .scan_and_reap()
         .await
@@ -328,53 +205,96 @@ async fn young_running_container_survives_scan() {
 
     let survived = container_exists(&docker, &container_id).await;
     best_effort_remove(&docker, &container_id).await;
-    assert!(survived, "young container under the threshold must survive");
+    assert!(
+        survived,
+        "a young running container with no idle record must survive the scan"
+    );
 }
 
 #[tokio::test]
-async fn transient_liveness_error_container_survives_scan() {
+async fn running_container_past_forced_recycle_age_is_stopped_not_removed() {
     if !docker_gate::docker_available() {
         eprintln!(
-            "SKIP: no docker daemon reachable — transient_liveness_error_container_survives_scan requires a real Docker daemon (CI/hosted Docker lane only)"
+            "SKIP: no docker daemon reachable — running_container_past_forced_recycle_age_is_stopped_not_removed requires a real Docker daemon (CI/hosted Docker lane only)"
         );
         return;
     }
     let image = docker_gate::configured_sandbox_image();
     if !docker_gate::docker_image_available(&image) {
         eprintln!(
-            "SKIP: sandbox worker image {image:?} is not built locally — transient_liveness_error_container_survives_scan requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+            "SKIP: sandbox worker image {image:?} is not built locally — running_container_past_forced_recycle_age_is_stopped_not_removed requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
         );
         return;
     }
 
     let docker = Docker::connect_with_local_defaults().unwrap();
-    let scope = test_scope();
-    // Old enough to be reap-eligible by age alone, but the run-state store
-    // fails the liveness query — the headline behavior (never reap on
-    // uncertainty) must keep this container alive.
-    let created_at = Utc::now() - chrono::Duration::seconds(120);
-    let labels = ironclaw_labels(&scope, created_at);
-    let container_id = start_labeled_container(&docker, &image, labels).await;
+    // Age (via the created_at label) is past forced_recycle_after while the
+    // container is still running: forced recycle stops it first (stop, not
+    // remove — the user's workspace bind mount is preserved for restart).
+    let labels = user_labels(Utc::now() - chrono::Duration::seconds(120));
+    let container_id = start_running_container(&docker, &image, labels).await;
 
     let reaper = SandboxReaper::new(
         docker.clone(),
-        Arc::new(AlwaysErrorRunStateStore),
-        SandboxReaperConfig {
-            scan_interval: Duration::from_secs(300),
-            orphan_threshold: Duration::from_secs(60),
-            label_prefix: "ironclaw".to_string(),
-        },
+        Arc::new(SandboxActivityRegistry::new()),
+        forced_recycle_config(),
     );
-
     reaper
         .scan_and_reap()
         .await
-        .expect("scan against a reachable daemon should succeed even when run-state queries fail");
+        .expect("scan against a reachable daemon should succeed");
 
-    let survived = container_exists(&docker, &container_id).await;
+    let still_exists = container_exists(&docker, &container_id).await;
+    let still_running = container_running(&docker, &container_id).await;
     best_effort_remove(&docker, &container_id).await;
     assert!(
-        survived,
-        "a transient run-state query error must never cause a reap"
+        still_exists,
+        "a running container past forced-recycle age must be stopped, not removed"
+    );
+    assert!(
+        !still_running,
+        "a running container past forced-recycle age must be stopped"
+    );
+}
+
+#[tokio::test]
+async fn stopped_container_past_forced_recycle_age_is_removed() {
+    if !docker_gate::docker_available() {
+        eprintln!(
+            "SKIP: no docker daemon reachable — stopped_container_past_forced_recycle_age_is_removed requires a real Docker daemon (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+    let image = docker_gate::configured_sandbox_image();
+    if !docker_gate::docker_image_available(&image) {
+        eprintln!(
+            "SKIP: sandbox worker image {image:?} is not built locally — stopped_container_past_forced_recycle_age_is_removed requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+
+    let docker = Docker::connect_with_local_defaults().unwrap();
+    // Already stopped (known finished_at) and past forced-recycle age: removed
+    // outright even though it is still within the normal retention window.
+    let labels = user_labels(Utc::now() - chrono::Duration::seconds(120));
+    let container_id = start_then_exit_container(&docker, &image, labels).await;
+
+    let reaper = SandboxReaper::new(
+        docker.clone(),
+        Arc::new(SandboxActivityRegistry::new()),
+        forced_recycle_config(),
+    );
+    reaper
+        .scan_and_reap()
+        .await
+        .expect("scan against a reachable daemon should succeed");
+
+    let survived = container_exists(&docker, &container_id).await;
+    if survived {
+        best_effort_remove(&docker, &container_id).await;
+    }
+    assert!(
+        !survived,
+        "a stopped container past forced-recycle age must be removed"
     );
 }

--- a/crates/ironclaw_host_runtime/tests/sandbox_reaper_docker.rs
+++ b/crates/ironclaw_host_runtime/tests/sandbox_reaper_docker.rs
@@ -1,0 +1,380 @@
+//! Real-Docker tests for [`ironclaw_host_runtime::SandboxReaper`].
+//!
+//! `sandbox_process.rs`'s no-Docker unit tests (in `sandbox_process/reaper.rs`)
+//! already pin the liveness-decision logic (headline: a transient run-state
+//! query error is never treated as "the run is gone"). These tests prove the
+//! Docker-facing half: that a reaper pointed at a real daemon actually removes
+//! a container it has decided is orphaned, and actually leaves alone a
+//! container it has decided is alive (or uncertain).
+//!
+//! Requires a reachable Docker daemon AND a locally-built `ironclaw-worker`
+//! image, same gate as `sandbox_cross_tenant_escape.rs`. Neither is available
+//! on this development machine — the tests are authored to run for real in
+//! CI/hosted Docker lanes and skip cleanly (a visible `SKIP: ...` line, never
+//! a silent pass) everywhere else.
+
+#[path = "support/docker_gate.rs"]
+mod docker_gate;
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use bollard::{
+    Docker,
+    container::{Config, CreateContainerOptions, RemoveContainerOptions, StartContainerOptions},
+    models::HostConfig,
+};
+use chrono::Utc;
+use ironclaw_host_api::{
+    AgentId, ApprovalRequest, InvocationId, ProjectId, ResourceScope, TenantId, UserId,
+};
+use ironclaw_host_runtime::{SandboxReaper, SandboxReaperConfig};
+use ironclaw_run_state::{RunRecord, RunStart, RunStateError, RunStateStore};
+
+const LABEL_INVOCATION_ID: &str = "ironclaw.invocation_id";
+const LABEL_RESOURCE_SCOPE: &str = "ironclaw.resource_scope";
+const LABEL_CREATED_AT: &str = "ironclaw.created_at";
+
+fn test_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("reaper-docker-tenant").unwrap(),
+        user_id: UserId::new("reaper-docker-user").unwrap(),
+        agent_id: Some(AgentId::new("agent").unwrap()),
+        project_id: Some(ProjectId::new("project").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+/// Builds the same `ironclaw.*` labels `container_launch_config` attaches in
+/// production, so these tests exercise the reaper's real listing filter
+/// (`ironclaw.invocation_id`) and label parsing, not a test-only shortcut.
+/// `created_at` is caller-supplied so tests can place a container on either
+/// side of `orphan_threshold` without sleeping.
+fn ironclaw_labels(
+    scope: &ResourceScope,
+    created_at: chrono::DateTime<Utc>,
+) -> HashMap<String, String> {
+    HashMap::from([
+        (
+            LABEL_INVOCATION_ID.to_string(),
+            scope.invocation_id.to_string(),
+        ),
+        (
+            LABEL_RESOURCE_SCOPE.to_string(),
+            serde_json::to_string(scope).unwrap(),
+        ),
+        (LABEL_CREATED_AT.to_string(), created_at.to_rfc3339()),
+    ])
+}
+
+/// Starts a long-running, labeled container directly (bypassing
+/// `SandboxCommandTransport::run_command`, which blocks until the command
+/// exits — these tests need a container that is still *running* when the
+/// reaper scans it, simulating a host crash mid-command).
+async fn start_labeled_container(
+    docker: &Docker,
+    image: &str,
+    labels: HashMap<String, String>,
+) -> String {
+    let name = format!("ironclaw-reaper-docker-test-{}", uuid::Uuid::new_v4());
+    let config = Config {
+        image: Some(image.to_string()),
+        cmd: Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "sleep 300".to_string(),
+        ]),
+        labels: Some(labels),
+        host_config: Some(HostConfig {
+            auto_remove: Some(false),
+            network_mode: Some("none".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let created = docker
+        .create_container(
+            Some(CreateContainerOptions {
+                name,
+                platform: None,
+            }),
+            config,
+        )
+        .await
+        .expect("container create should succeed against a reachable daemon");
+    docker
+        .start_container(&created.id, None::<StartContainerOptions<String>>)
+        .await
+        .expect("container start should succeed against a reachable daemon");
+    created.id
+}
+
+async fn container_exists(docker: &Docker, container_id: &str) -> bool {
+    docker.inspect_container(container_id, None).await.is_ok()
+}
+
+async fn best_effort_remove(docker: &Docker, container_id: &str) {
+    let _ = docker
+        .remove_container(
+            container_id,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+}
+
+/// Always reports "no record" — mirrors an invocation whose run-state has
+/// genuinely aged out or was never recorded (definitive orphan).
+struct AlwaysAbsentRunStateStore;
+
+/// Always reports a transient backend failure — mirrors a run-state store
+/// that is momentarily unreachable, not evidence the invocation is gone.
+struct AlwaysErrorRunStateStore;
+
+// The reaper only ever calls `get`; the writer methods must exist to satisfy
+// the trait but are never invoked. They're written inline (not via a
+// declarative macro) because `#[async_trait]` sees a macro *invocation*, not
+// the expanded `async fn`s, and cannot rewrite them — which produces E0195.
+#[async_trait::async_trait]
+impl RunStateStore for AlwaysAbsentRunStateStore {
+    async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysAbsentRunStateStore never calls start()")
+    }
+    async fn block_approval(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+        _approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysAbsentRunStateStore never calls block_approval()")
+    }
+    async fn block_auth(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+        _error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysAbsentRunStateStore never calls block_auth()")
+    }
+    async fn complete(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysAbsentRunStateStore never calls complete()")
+    }
+    async fn fail(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+        _error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysAbsentRunStateStore never calls fail()")
+    }
+    async fn records_for_scope(
+        &self,
+        _scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        unreachable!("AlwaysAbsentRunStateStore never calls records_for_scope()")
+    }
+    async fn get(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        Ok(None)
+    }
+}
+
+#[async_trait::async_trait]
+impl RunStateStore for AlwaysErrorRunStateStore {
+    async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysErrorRunStateStore never calls start()")
+    }
+    async fn block_approval(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+        _approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysErrorRunStateStore never calls block_approval()")
+    }
+    async fn block_auth(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+        _error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysErrorRunStateStore never calls block_auth()")
+    }
+    async fn complete(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysErrorRunStateStore never calls complete()")
+    }
+    async fn fail(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+        _error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        unreachable!("AlwaysErrorRunStateStore never calls fail()")
+    }
+    async fn records_for_scope(
+        &self,
+        _scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        unreachable!("AlwaysErrorRunStateStore never calls records_for_scope()")
+    }
+    async fn get(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        Err(RunStateError::Backend(
+            "simulated transient run-state backend failure".to_string(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn kill_mid_command_orphan_past_threshold_is_reaped() {
+    if !docker_gate::docker_available() {
+        eprintln!(
+            "SKIP: no docker daemon reachable — kill_mid_command_orphan_past_threshold_is_reaped requires a real Docker daemon (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+    let image = docker_gate::configured_sandbox_image();
+    if !docker_gate::docker_image_available(&image) {
+        eprintln!(
+            "SKIP: sandbox worker image {image:?} is not built locally — kill_mid_command_orphan_past_threshold_is_reaped requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+
+    let docker = Docker::connect_with_local_defaults().unwrap();
+    let scope = test_scope();
+    // Simulates "host crashed mid-command": container is still running, its
+    // created_at label is already older than orphan_threshold, and no
+    // run-state record exists for its invocation (definitive orphan).
+    let created_at = Utc::now() - chrono::Duration::seconds(120);
+    let labels = ironclaw_labels(&scope, created_at);
+    let container_id = start_labeled_container(&docker, &image, labels).await;
+
+    let reaper = SandboxReaper::new(
+        docker.clone(),
+        Arc::new(AlwaysAbsentRunStateStore),
+        SandboxReaperConfig {
+            scan_interval: Duration::from_secs(300),
+            orphan_threshold: Duration::from_secs(60),
+            label_prefix: "ironclaw".to_string(),
+        },
+    );
+
+    reaper
+        .scan_and_reap()
+        .await
+        .expect("scan against a reachable daemon should succeed");
+
+    assert!(
+        !container_exists(&docker, &container_id).await,
+        "orphaned container past the threshold must be reaped"
+    );
+}
+
+#[tokio::test]
+async fn young_running_container_survives_scan() {
+    if !docker_gate::docker_available() {
+        eprintln!(
+            "SKIP: no docker daemon reachable — young_running_container_survives_scan requires a real Docker daemon (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+    let image = docker_gate::configured_sandbox_image();
+    if !docker_gate::docker_image_available(&image) {
+        eprintln!(
+            "SKIP: sandbox worker image {image:?} is not built locally — young_running_container_survives_scan requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+
+    let docker = Docker::connect_with_local_defaults().unwrap();
+    let scope = test_scope();
+    // Freshly created: even though no run-state record exists either, the
+    // container has not yet crossed orphan_threshold and must survive.
+    let labels = ironclaw_labels(&scope, Utc::now());
+    let container_id = start_labeled_container(&docker, &image, labels).await;
+
+    let reaper = SandboxReaper::new(
+        docker.clone(),
+        Arc::new(AlwaysAbsentRunStateStore),
+        SandboxReaperConfig {
+            scan_interval: Duration::from_secs(300),
+            orphan_threshold: Duration::from_secs(600),
+            label_prefix: "ironclaw".to_string(),
+        },
+    );
+
+    reaper
+        .scan_and_reap()
+        .await
+        .expect("scan against a reachable daemon should succeed");
+
+    let survived = container_exists(&docker, &container_id).await;
+    best_effort_remove(&docker, &container_id).await;
+    assert!(survived, "young container under the threshold must survive");
+}
+
+#[tokio::test]
+async fn transient_liveness_error_container_survives_scan() {
+    if !docker_gate::docker_available() {
+        eprintln!(
+            "SKIP: no docker daemon reachable — transient_liveness_error_container_survives_scan requires a real Docker daemon (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+    let image = docker_gate::configured_sandbox_image();
+    if !docker_gate::docker_image_available(&image) {
+        eprintln!(
+            "SKIP: sandbox worker image {image:?} is not built locally — transient_liveness_error_container_survives_scan requires a locally-built ironclaw-worker image (CI/hosted Docker lane only)"
+        );
+        return;
+    }
+
+    let docker = Docker::connect_with_local_defaults().unwrap();
+    let scope = test_scope();
+    // Old enough to be reap-eligible by age alone, but the run-state store
+    // fails the liveness query — the headline behavior (never reap on
+    // uncertainty) must keep this container alive.
+    let created_at = Utc::now() - chrono::Duration::seconds(120);
+    let labels = ironclaw_labels(&scope, created_at);
+    let container_id = start_labeled_container(&docker, &image, labels).await;
+
+    let reaper = SandboxReaper::new(
+        docker.clone(),
+        Arc::new(AlwaysErrorRunStateStore),
+        SandboxReaperConfig {
+            scan_interval: Duration::from_secs(300),
+            orphan_threshold: Duration::from_secs(60),
+            label_prefix: "ironclaw".to_string(),
+        },
+    );
+
+    reaper
+        .scan_and_reap()
+        .await
+        .expect("scan against a reachable daemon should succeed even when run-state queries fail");
+
+    let survived = container_exists(&docker, &container_id).await;
+    best_effort_remove(&docker, &container_id).await;
+    assert!(
+        survived,
+        "a transient run-state query error must never cause a reap"
+    );
+}

--- a/crates/ironclaw_host_runtime/tests/sandbox_workspace_fs_parity_docker.rs
+++ b/crates/ironclaw_host_runtime/tests/sandbox_workspace_fs_parity_docker.rs
@@ -1,0 +1,111 @@
+//! Real-Docker test proving the persistent sandbox container's shell writes
+//! and the composition `/workspace` abstract-FS mount (Task A8) resolve the
+//! identical host directory, in both directions.
+//!
+//! Requires a reachable Docker daemon AND a locally-built `ironclaw-worker`
+//! image, same gate as `sandbox_reaper_docker.rs`/`sandbox_cross_tenant_escape.rs`.
+//! Neither is available on this development machine — this test is authored
+//! to run for real in CI/hosted Docker lanes and skip cleanly (a visible
+//! `SKIP: ...` line, never a silent pass) everywhere else.
+
+#[path = "support/docker_gate.rs"]
+mod docker_gate;
+#[path = "support/sandbox_transport.rs"]
+mod sandbox_transport;
+
+use std::collections::HashMap;
+
+use ironclaw_host_api::{AgentId, InvocationId, ResourceScope, TenantId, UserId, VirtualPath};
+use ironclaw_host_runtime::{CommandExecutionRequest, RebornSandboxUserKey, RuntimeProcessPort};
+
+fn owner_scope(tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).expect("tenant id"),
+        user_id: UserId::new(user).expect("user id"),
+        agent_id: Some(AgentId::new("reborn-cli").expect("agent id")),
+        project_id: None,
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+/// Shell writes to /workspace inside the persistent sandbox container; the
+/// abstract-FS /workspace mount (this task) must read the identical bytes
+/// back from the same host directory, and vice versa.
+#[tokio::test]
+async fn shell_write_and_abstract_fs_read_share_the_same_workspace_bytes() {
+    if !docker_gate::docker_available() {
+        eprintln!("SKIP: no reachable Docker daemon");
+        return;
+    }
+    let image = docker_gate::configured_sandbox_image();
+    if !docker_gate::docker_image_available(&image) {
+        eprintln!("SKIP: sandbox image {image} not built locally");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonical root");
+    let scope = owner_scope("docker-parity-tenant", "docker-parity-user");
+    let workspace_dir = RebornSandboxUserKey::from_scope(&scope).workspace_path(&root);
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+
+    // Composition-equivalent abstract-FS mount, built the same way
+    // mount_sandbox_user_workspace_root does in ironclaw_reborn_composition.
+    let mut disk = ironclaw_filesystem::DiskFilesystem::new();
+    disk.mount_local(
+        VirtualPath::new("/workspace").expect("virtual path"),
+        ironclaw_host_api::HostPath::from_path_buf(workspace_dir.clone()),
+    )
+    .expect("mount /workspace");
+
+    // Persistent sandbox transport (Task A3), workspace bind == workspace_dir.
+    let port = sandbox_transport::connect_for_test(&workspace_dir, &image)
+        .await
+        .expect("sandbox transport connects");
+
+    port.run_command(CommandExecutionRequest {
+        scope: scope.clone(),
+        mounts: None,
+        command: "echo hi > /workspace/f.txt".to_string(),
+        workdir: None,
+        timeout_secs: Some(30),
+        output_limit_bytes: None,
+        extra_env: HashMap::new(),
+        background: false,
+    })
+    .await
+    .expect("shell write succeeds");
+
+    let bytes = ironclaw_filesystem::RootFilesystem::read_file(
+        &disk,
+        &VirtualPath::new("/workspace/f.txt").expect("virtual path"),
+    )
+    .await
+    .expect("abstract FS read succeeds");
+    assert_eq!(bytes, b"hi\n");
+
+    ironclaw_filesystem::RootFilesystem::write_file(
+        &disk,
+        &VirtualPath::new("/workspace/g.txt").expect("virtual path"),
+        b"from-write-file",
+    )
+    .await
+    .expect("abstract FS write succeeds");
+
+    let cat = port
+        .run_command(CommandExecutionRequest {
+            scope,
+            mounts: None,
+            command: "cat /workspace/g.txt".to_string(),
+            workdir: None,
+            timeout_secs: Some(30),
+            output_limit_bytes: None,
+            extra_env: HashMap::new(),
+            background: false,
+        })
+        .await
+        .expect("shell read succeeds");
+    assert_eq!(cat.output.trim(), "from-write-file");
+}

--- a/crates/ironclaw_host_runtime/tests/support/docker_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/support/docker_gate.rs
@@ -1,0 +1,43 @@
+//! Docker daemon / sandbox-image availability gate for real-Docker crate-tier
+//! tests in this crate.
+//!
+//! Real-Docker tests run only where a daemon (and the locally-built
+//! `ironclaw-worker` image) is reachable — CI/hosted Docker runners, not this
+//! development machine. Callers MUST skip with a visible "SKIP: ..." line on
+//! `eprintln!` when either check fails, never a silent pass — a quietly
+//! vanishing assertion is indistinguishable from a real green run.
+
+use std::process::Command;
+
+/// True iff the `docker` CLI can reach a live daemon (`docker version`
+/// succeeds only against a running daemon). Mirrors the gate
+/// `ironclaw_process_sandbox/tests/docker_security.rs` already uses.
+pub fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// True iff `image` is present in the local Docker image store (i.e. it was
+/// built, not just referenced). The Reborn sandbox worker image
+/// (`ironclaw-worker:latest` by default, `IRONCLAW_REBORN_SANDBOX_IMAGE` /
+/// `IRONCLAW_SANDBOX_IMAGE` override) is never pulled automatically — a
+/// daemon can be reachable with the image still missing.
+pub fn docker_image_available(image: &str) -> bool {
+    Command::new("docker")
+        .args(["image", "inspect", image])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Resolve the sandbox worker image name the same way
+/// `RebornSandboxConfig::new` does, so the gate checks the image the test
+/// will actually launch.
+pub fn configured_sandbox_image() -> String {
+    std::env::var("IRONCLAW_REBORN_SANDBOX_IMAGE")
+        .or_else(|_| std::env::var("IRONCLAW_SANDBOX_IMAGE"))
+        .unwrap_or_else(|_| "ironclaw-worker:latest".to_string())
+}

--- a/crates/ironclaw_host_runtime/tests/support/sandbox_transport.rs
+++ b/crates/ironclaw_host_runtime/tests/support/sandbox_transport.rs
@@ -1,0 +1,20 @@
+use std::path::Path;
+
+use ironclaw_host_runtime::{
+    RebornSandboxConfig, RebornScopedSandboxCommandTransport, RuntimeProcessError,
+    TenantSandboxProcessPort,
+};
+
+/// Connects a real, no-broker sandbox transport for Docker-real tests, with
+/// `workspace_root` bound to the per-user directory the abstract-FS
+/// `/workspace` mount also points at (parity is proven by both sides
+/// resolving the same host directory, not by any code sharing).
+pub async fn connect_for_test(
+    workspace_dir: &Path,
+    image: &str,
+) -> Result<TenantSandboxProcessPort, RuntimeProcessError> {
+    let config =
+        RebornSandboxConfig::new(workspace_dir.to_path_buf()).with_image(image.to_string());
+    let transport = RebornScopedSandboxCommandTransport::connect(config).await?;
+    Ok(transport.into_process_port())
+}

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -642,6 +642,9 @@ pub(crate) fn build_services_input_with_options(
         | RebornProfile::HostedSingleTenantVolume => {
             build_standalone_local_runtime_services_input(profile, owner_id, config, options)?
         }
+        RebornProfile::HostedSingleTenantVolumeSandboxed => {
+            build_sandboxed_local_runtime_services_input(profile, owner_id, config, options)?
+        }
         RebornProfile::HostedSingleTenant => build_hosted_single_tenant_services_input(
             profile,
             owner_id,
@@ -701,6 +704,67 @@ fn build_standalone_local_runtime_services_input(
         nearai_mcp_bootstrap_config_from_env().context("NEAR AI MCP bootstrap config")?,
     );
     Ok(services_input)
+}
+
+/// Subdirectory (under the profile's local-runtime storage root, the same
+/// root `ironclaw_reborn_composition::local_dev_db_path` resolves the libsql
+/// db file against) where the sandbox transport bind-mounts per-scope tenant
+/// workspaces.
+const SANDBOX_WORKSPACES_SUBDIR: &str = "sandbox-workspaces";
+
+/// Boot-time failure for the `hosted-single-tenant-volume-sandboxed`
+/// profile's tenant-sandbox process backend. Deliberately fail-closed: a
+/// profile that requests `TenantSandbox` never silently falls back to
+/// `RebornRuntimeProcessBinding::None` (which would mean running shell
+/// commands unsandboxed on the host) — see `docs/safety-and-sandbox.md`.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SandboxProcessBootError {
+    #[error(
+        "profile={profile} requires a reachable Docker daemon for its tenant-sandbox process \
+         backend; refusing to boot with an unsandboxed fallback: {reason}"
+    )]
+    DockerUnreachable {
+        profile: RebornProfile,
+        reason: String,
+    },
+}
+
+/// Build the `hosted-single-tenant-volume-sandboxed` profile's services
+/// input: the same local-runtime storage assembly every standalone profile
+/// uses, plus a real `TenantSandbox` process-port binding backed by a live
+/// Docker connection.
+///
+/// The Docker connect and sandbox-transport construction themselves live in
+/// [`ironclaw_reborn_composition::tenant_sandbox_process_binding`], not
+/// here: this crate's workspace dependencies are pinned to the
+/// composition/config/traces/webui facade set
+/// (`reborn_cli_binary_crate_stays_separate_from_v1_root` in
+/// `ironclaw_architecture`), so `runtime/` must never depend on
+/// `ironclaw_host_runtime` directly. Bridges that async composition call
+/// through [`block_on_cli`] rather than threading `async fn` through
+/// `build_services_input_with_options`/`build_runtime_input_with_options` —
+/// those are called from dozens of synchronous unit tests via the
+/// `#[cfg(test)]` `build_runtime_input` wrapper, and `block_on_cli` is this
+/// crate's existing bridge for exactly this shape of problem (see its other
+/// call sites in `commands/`).
+fn build_sandboxed_local_runtime_services_input(
+    profile: RebornProfile,
+    owner_id: &str,
+    config: &RebornBootConfig,
+    options: RuntimeInputOptions,
+) -> anyhow::Result<RebornBuildInput> {
+    let sandbox_workspaces_root =
+        local_runtime_storage_root(config, profile).join(SANDBOX_WORKSPACES_SUBDIR);
+    let connect = ironclaw_reborn_composition::tenant_sandbox_process_binding(
+        sandbox_workspaces_root,
+    );
+    let binding = block_on_cli(connect).map_err(|error| SandboxProcessBootError::DockerUnreachable {
+        profile,
+        reason: error.to_string(),
+    })?;
+    let services_input =
+        build_standalone_local_runtime_services_input(profile, owner_id, config, options)?;
+    Ok(services_input.with_runtime_process_binding(binding))
 }
 
 fn build_hosted_single_tenant_services_input(
@@ -1088,6 +1152,9 @@ fn composition_profile(profile: RebornProfile) -> RebornCompositionProfile {
         RebornProfile::HostedSingleTenant => RebornCompositionProfile::HostedSingleTenant,
         RebornProfile::HostedSingleTenantVolume => {
             RebornCompositionProfile::HostedSingleTenantVolume
+        }
+        RebornProfile::HostedSingleTenantVolumeSandboxed => {
+            RebornCompositionProfile::HostedSingleTenantVolumeSandboxed
         }
         RebornProfile::Production => RebornCompositionProfile::Production,
         RebornProfile::MigrationDryRun => RebornCompositionProfile::MigrationDryRun,
@@ -2198,6 +2265,65 @@ regex_activation_enabled = false
                 ironclaw_reborn_config::RebornProfile::HostedSingleTenantVolume,
             ),
             reborn_home.join("hosted-single-tenant-volume")
+        );
+    }
+
+    /// Crate-tier fast local regression for A2's boot-fail-closed matrix row
+    /// (the `(deployment, backend)` row named in
+    /// `docs/plans/2026-07-20-reborn-sandbox-plan.md` Workstream A2):
+    /// building the runtime input for the sandboxed profile now performs a
+    /// real Docker connect attempt and must fail closed — never silently
+    /// fall back to `RebornRuntimeProcessBinding::None` (unsandboxed host
+    /// execution) — when the daemon is unreachable. Forces unreachability
+    /// deterministically via `IRONCLAW_REBORN_DOCKER_HOST` rather than
+    /// relying on this machine happening to have no Docker daemon. This is
+    /// the fast in-process complement to the CLI-subprocess-level
+    /// `build_runtime_input_hosted_single_tenant_volume_sandboxed_fails_closed_without_docker`
+    /// smoke test in `tests/smoke.rs` — not a duplicate: this one proves the
+    /// `build_runtime_input` seam directly, the smoke test proves the real
+    /// `ironclaw run` binary surfaces the same failure.
+    #[test]
+    fn build_runtime_input_rejects_hosted_single_tenant_volume_sandboxed_profile_without_docker() {
+        let _lock = lock_runtime_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _docker_host = EnvGuard::set(
+            "IRONCLAW_REBORN_DOCKER_HOST",
+            "/nonexistent/ironclaw-a2-crate-test-docker.sock",
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.clone().into_os_string()),
+            None,
+            None,
+            Some("hosted-single-tenant-volume-sandboxed".into()),
+        )
+        .expect("boot config");
+
+        // The storage root computation itself needs no Docker — pin it
+        // independently of the (expected-failing) full build below.
+        assert_eq!(
+            local_runtime_storage_root(
+                &config,
+                ironclaw_reborn_config::RebornProfile::HostedSingleTenantVolumeSandboxed,
+            ),
+            reborn_home.join("hosted-single-tenant-volume-sandboxed")
+        );
+
+        let error = match build_runtime_input(&config, RuntimeInputCaller::Run) {
+            Ok(_) => panic!("sandboxed profile must fail closed without a reachable Docker daemon"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("hosted-single-tenant-volume-sandboxed"),
+            "error should name the profile: {message}"
+        );
+        assert!(
+            message.contains("Docker"),
+            "error should name Docker unreachability, not a silent host fallback: {message}"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -755,16 +755,18 @@ fn build_sandboxed_local_runtime_services_input(
 ) -> anyhow::Result<RebornBuildInput> {
     let sandbox_workspaces_root =
         local_runtime_storage_root(config, profile).join(SANDBOX_WORKSPACES_SUBDIR);
-    let connect = ironclaw_reborn_composition::tenant_sandbox_process_binding(
-        sandbox_workspaces_root,
-    );
-    let binding = block_on_cli(connect).map_err(|error| SandboxProcessBootError::DockerUnreachable {
-        profile,
-        reason: error.to_string(),
-    })?;
+    let connect =
+        ironclaw_reborn_composition::tenant_sandbox_process_binding(sandbox_workspaces_root);
+    let tenant_sandbox =
+        block_on_cli(connect).map_err(|error| SandboxProcessBootError::DockerUnreachable {
+            profile,
+            reason: error.to_string(),
+        })?;
     let services_input =
         build_standalone_local_runtime_services_input(profile, owner_id, config, options)?;
-    Ok(services_input.with_runtime_process_binding(binding))
+    Ok(services_input
+        .with_runtime_process_binding(tenant_sandbox.binding)
+        .with_sandbox_activity_registry(tenant_sandbox.activity))
 }
 
 fn build_hosted_single_tenant_services_input(

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1139,6 +1139,10 @@ fn profile_list_shows_supported_profiles_without_reborn_home() {
         stdout.contains("hosted-single-tenant-volume"),
         "stdout: {stdout}"
     );
+    assert!(
+        stdout.contains("hosted-single-tenant-volume-sandboxed"),
+        "stdout: {stdout}"
+    );
     assert!(stdout.contains("production"), "stdout: {stdout}");
     assert!(stdout.contains("migration-dry-run"), "stdout: {stdout}");
     assert!(
@@ -1165,7 +1169,7 @@ fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
     let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     assert_eq!(json["selector"], "IRONCLAW_REBORN_PROFILE");
     let profiles = json["profiles"].as_array().expect("profiles array");
-    assert_eq!(profiles.len(), 6);
+    assert_eq!(profiles.len(), 7);
     assert!(
         profiles
             .iter()
@@ -1188,6 +1192,9 @@ fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
             .any(|profile| profile["name"] == "hosted-single-tenant-volume"
                 && profile["default"] == false)
     );
+    assert!(profiles.iter().any(|profile| profile["name"]
+        == "hosted-single-tenant-volume-sandboxed"
+        && profile["default"] == false));
     assert!(
         profiles
             .iter()
@@ -3674,6 +3681,55 @@ fn run_rejects_invalid_profile() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains(INVALID_PROFILE_MESSAGE), "stderr: {stderr}");
+}
+
+/// Boot-path fail-closed test for the A2 `(deployment, backend)` matrix row
+/// (`docs/plans/2026-07-20-reborn-sandbox-plan.md` Workstream A2): the
+/// `hosted-single-tenant-volume-sandboxed` profile's `TenantSandbox` process
+/// backend now performs a real Docker connect during `ironclaw run` boot.
+/// Forces the daemon unreachable deterministically via
+/// `IRONCLAW_REBORN_DOCKER_HOST` (rather than relying on this machine simply
+/// having no Docker installed) and asserts the real binary exits non-zero
+/// naming both the profile and Docker — never a silent fall back to an
+/// unsandboxed host process backend. This is the real-binary complement to
+/// the crate-tier
+/// `build_runtime_input_rejects_hosted_single_tenant_volume_sandboxed_profile_without_docker`
+/// unit test in `src/runtime/mod.rs`, which proves the same failure at the
+/// `build_runtime_input` seam without paying subprocess spawn cost.
+#[test]
+fn build_runtime_input_hosted_single_tenant_volume_sandboxed_fails_closed_without_docker() {
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    let output = Command::new(reborn_bin())
+        .args(["run", "-m", "ping"])
+        .env("IRONCLAW_REBORN_HOME", temp.path().join("reborn-home"))
+        .env(
+            "IRONCLAW_REBORN_PROFILE",
+            "hosted-single-tenant-volume-sandboxed",
+        )
+        .env(
+            "IRONCLAW_REBORN_DOCKER_HOST",
+            "/nonexistent/ironclaw-smoke-test-docker.sock",
+        )
+        .output()
+        .expect("ironclaw-reborn run should run");
+
+    assert!(
+        !output.status.success(),
+        "sandboxed profile should fail closed without a reachable Docker daemon; stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hosted-single-tenant-volume-sandboxed"),
+        "stderr should name the profile: {stderr}"
+    );
+    assert!(
+        stderr.contains("Docker"),
+        "stderr should name Docker unreachability rather than silently falling back to an \
+         unsandboxed process backend: {stderr}"
+    );
 }
 
 #[test]

--- a/crates/ironclaw_reborn_composition/src/deployment.rs
+++ b/crates/ironclaw_reborn_composition/src/deployment.rs
@@ -27,6 +27,7 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use crate::RebornBuildError;
 use crate::RebornCompositionProfile;
 use crate::input::RebornBuildInput;
 use crate::readiness::{RebornReadinessDiagnostic, RebornReadinessState};
@@ -291,6 +292,43 @@ impl DeploymentConfig {
         }
     }
 
+    /// Single-tenant hosted preview identical to
+    /// [`DeploymentConfig::hosted_single_tenant_volume`] except process
+    /// execution routes to a per-tenant Docker sandbox instead of staying
+    /// disabled: requests the existing `(HostedMultiTenant, HostedSafe)`
+    /// resolver row (`ironclaw_runtime_policy::resolver` — filesystem
+    /// `TenantWorkspace`, process `TenantSandbox`) rather than adding a new
+    /// resolver row or `RuntimeProfile` variant. Boots fail-closed
+    /// (`RebornRuntimeProcessBinding::validate_for_production_policy` rejects
+    /// `TenantSandbox` paired with no bound process port) until the sandbox
+    /// transport is wired into a production call site (a later slice) — the
+    /// same "existing guard, new caller" shape as the filesystem side.
+    pub fn hosted_single_tenant_volume_sandboxed() -> Self {
+        Self {
+            profile: RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
+            policy_request: Some(RuntimePolicyRequest {
+                deployment: DeploymentMode::HostedMultiTenant,
+                requested_profile: RuntimeProfile::HostedSafe,
+                yolo_disclosure_acknowledged: false,
+                org_policy: OrgPolicyConstraints::default(),
+            }),
+            traffic: TrafficPolicy::Serve {
+                required_readiness:
+                    RebornReadinessState::HostedSingleTenantVolumeSandboxedValidated,
+                veto_on_production_blocking_diagnostic: false,
+            },
+            readiness: ReadinessContract {
+                state: RebornReadinessState::HostedSingleTenantVolumeSandboxedValidated,
+                diagnostics: vec![
+                    RebornReadinessDiagnostic::hosted_single_tenant_volume_sandboxed(),
+                ],
+            },
+            hosted_extension_installation_state: true,
+            storage_shape: StorageShape::LocalDevRoot,
+            ..Self::hosted_single_tenant()
+        }
+    }
+
     /// Production: the production-shaped substrate, serving live traffic only
     /// once readiness validates.
     pub fn production() -> Self {
@@ -340,6 +378,9 @@ impl DeploymentConfig {
             RebornCompositionProfile::HostedSingleTenant => Self::hosted_single_tenant(),
             RebornCompositionProfile::HostedSingleTenantVolume => {
                 Self::hosted_single_tenant_volume()
+            }
+            RebornCompositionProfile::HostedSingleTenantVolumeSandboxed => {
+                Self::hosted_single_tenant_volume_sandboxed()
             }
             RebornCompositionProfile::Production => Self::production(),
             RebornCompositionProfile::MigrationDryRun => Self::migration_dry_run(),
@@ -429,6 +470,22 @@ pub enum RebornRuntimeProfileError {
     Policy(#[from] ResolveError),
     #[error("profile={profile} carries no runtime-policy request to resolve")]
     MissingPolicyRequest { profile: RebornCompositionProfile },
+    /// The libsql-volume-shaped hosted profiles
+    /// (`hosted-single-tenant-volume`, `-sandboxed`) serve real tenant data
+    /// off the operator's own machine, so — unlike `local-dev`/`local-dev-yolo`
+    /// — they must never fall back to the single-user dotfile/keychain
+    /// secrets-master-key chain. Boot fails closed instead of silently
+    /// generating/reading `.reborn-local-dev-secrets-master-key`.
+    #[error(
+        "profile requires a hosted-shaped secrets master key: {env_name} must be set (it must \
+         never fall back to the single-user local-dev dotfile/keychain chain)"
+    )]
+    MissingSecretMasterKeyEnv { env_name: String },
+    /// `{env_name}` was set but the value is unusable (empty, or fails
+    /// `validate_resolved_master_key`'s format check) — named-source error
+    /// from the shared validator, not an opaque `SecretsCrypto` failure.
+    #[error("hosted secrets master key is invalid: {0}")]
+    InvalidSecretMasterKey(RebornBuildError),
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -480,6 +537,9 @@ pub fn local_runtime_build_input_with_options(
     if profile == RebornCompositionProfile::HostedSingleTenantVolume {
         return hosted_single_tenant_volume_build_input(owner_id, root);
     }
+    if profile == RebornCompositionProfile::HostedSingleTenantVolumeSandboxed {
+        return hosted_single_tenant_volume_sandboxed_build_input(owner_id, root);
+    }
 
     // Build the deployment once, here, where the operator's host-access
     // confirmation is known, and carry it on the input rather than letting
@@ -494,6 +554,58 @@ pub fn local_runtime_build_input_with_options(
     )
 }
 
+/// Resolve and validate the externally-supplied secrets master key required
+/// to boot a libsql-volume-shaped hosted profile
+/// (`hosted-single-tenant-volume`/`-sandboxed`). These profiles serve real
+/// tenant data outside the operator's own machine, so — unlike
+/// `local-dev`/`local-dev-yolo` — they must never fall back to the
+/// single-user local-dev key sources (dotfile, OS keychain); an unset env
+/// var fails closed instead of silently generating/persisting
+/// `.reborn-local-dev-secrets-master-key`. Reuses
+/// `validate_resolved_master_key` so a malformed key gets the same
+/// fail-loud, source-named error as the local-dev resolver, rather than
+/// surfacing as an opaque `SecretsCrypto` error later.
+///
+/// Takes the raw env value as a parameter instead of reading
+/// `std::env::var` inline so tests can drive both branches without
+/// mutating process-global env: this crate is `#![forbid(unsafe_code)]`,
+/// which blocks `std::env::set_var` in-process. Mirrors the established
+/// `resolve_local_dev_secret_master_key_with_env` pattern in `factory.rs`.
+fn hosted_volume_secret_master_key_from_raw(
+    env_name: &'static str,
+    raw_env_value: Option<String>,
+) -> Result<ironclaw_secrets::SecretMaterial, RebornRuntimeProfileError> {
+    let Some(raw) = raw_env_value else {
+        return Err(RebornRuntimeProfileError::MissingSecretMasterKeyEnv {
+            env_name: env_name.to_string(),
+        });
+    };
+    if raw.is_empty() {
+        return Err(RebornRuntimeProfileError::InvalidSecretMasterKey(
+            RebornBuildError::InvalidConfig {
+                reason: format!("{env_name} must not be empty"),
+            },
+        ));
+    }
+    crate::factory::validate_resolved_master_key(
+        &raw,
+        &crate::factory::MasterKeySource::EnvNamed(env_name),
+    )
+    .map_err(RebornRuntimeProfileError::InvalidSecretMasterKey)?;
+    Ok(ironclaw_secrets::SecretMaterial::from(raw))
+}
+
+/// Production entry point: resolves [`hosted_volume_secret_master_key_from_raw`]
+/// against the real `IRONCLAW_REBORN_SECRET_MASTER_KEY` env var — the same
+/// name/constant the Postgres production path defaults to
+/// (`input::DEFAULT_REBORN_SECRET_MASTER_KEY_ENV`), though unlike that path
+/// this profile has no `config.toml` override for the env var name.
+fn hosted_volume_secret_master_key()
+-> Result<ironclaw_secrets::SecretMaterial, RebornRuntimeProfileError> {
+    let env_name = crate::input::DEFAULT_REBORN_SECRET_MASTER_KEY_ENV;
+    hosted_volume_secret_master_key_from_raw(env_name, std::env::var(env_name).ok())
+}
+
 /// Build the hosted single-tenant volume substrate input with the matching
 /// secure hosted runtime policy.
 pub(crate) fn hosted_single_tenant_volume_build_input(
@@ -502,12 +614,60 @@ pub(crate) fn hosted_single_tenant_volume_build_input(
 ) -> Result<RebornBuildInput, RebornRuntimeProfileError> {
     let policy =
         hosted_single_tenant_volume_runtime_policy().map_err(RebornRuntimeProfileError::Policy)?;
+    let secret_master_key = hosted_volume_secret_master_key()?;
     Ok(RebornBuildInput::local_dev_with_profile(
         RebornCompositionProfile::HostedSingleTenantVolume,
         owner_id,
         root,
     )
-    .with_runtime_policy(policy))
+    .with_runtime_policy(policy)
+    .with_local_dev_secret_master_key(secret_master_key))
+}
+
+/// Build the hosted single-tenant volume-sandboxed substrate input with the
+/// matching `(HostedMultiTenant, HostedSafe)` runtime policy. Mirrors
+/// [`hosted_single_tenant_volume_build_input`] exactly (this profile is
+/// meaningless without durable persistent-volume storage): same local-dev
+/// storage-input shape, same hardened secrets-master-key requirement. The
+/// only difference is the resolved policy's process backend (`TenantSandbox`
+/// instead of `None`), which is why it boots fail-closed until a production
+/// call site binds a tenant sandbox process port (later slice).
+pub(crate) fn hosted_single_tenant_volume_sandboxed_build_input(
+    owner_id: impl Into<String>,
+    root: PathBuf,
+) -> Result<RebornBuildInput, RebornRuntimeProfileError> {
+    let policy = hosted_single_tenant_volume_sandboxed_runtime_policy()
+        .map_err(RebornRuntimeProfileError::Policy)?;
+    let secret_master_key = hosted_volume_secret_master_key()?;
+    Ok(RebornBuildInput::local_dev_with_profile(
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
+        owner_id,
+        root,
+    )
+    .with_runtime_policy(policy)
+    .with_local_dev_secret_master_key(secret_master_key))
+}
+
+/// Resolved policy for the hosted single-tenant volume-sandboxed profile.
+///
+/// Requests the **existing** `(HostedMultiTenant, HostedSafe)` resolver row
+/// (`ironclaw_runtime_policy::resolver` — filesystem `TenantWorkspace`,
+/// process `TenantSandbox`, network `Brokered`, secrets `TenantBroker`,
+/// approvals `AskWrites`) rather than adding a new resolver row or
+/// `RuntimeProfile` variant.
+pub fn hosted_single_tenant_volume_sandboxed_runtime_policy()
+-> Result<EffectiveRuntimePolicy, ResolveError> {
+    // Always carries a policy request, so `None` is unreachable in practice;
+    // it maps to the resolver's own fail-closed shape rather than being
+    // unwrapped (mirrors `hosted_single_tenant_volume_runtime_policy`).
+    DeploymentConfig::hosted_single_tenant_volume_sandboxed()
+        .resolve()
+        .and_then(|policy| {
+            policy.ok_or(ResolveError::IncompatibleDeployment {
+                deployment: ironclaw_host_api::runtime_policy::DeploymentMode::HostedMultiTenant,
+                profile: ironclaw_host_api::runtime_policy::RuntimeProfile::HostedSafe,
+            })
+        })
 }
 
 /// Resolved policy for the standalone local development runtime profile.
@@ -558,6 +718,10 @@ pub fn local_dev_yolo_runtime_policy(
         RebornRuntimeProfileError::MissingPolicyRequest { .. } => {
             unreachable!("local-dev-yolo carries a runtime-policy request")
         }
+        RebornRuntimeProfileError::MissingSecretMasterKeyEnv { .. }
+        | RebornRuntimeProfileError::InvalidSecretMasterKey(_) => {
+            unreachable!("local-dev-yolo does not resolve a hosted secrets master key")
+        }
     })
 }
 
@@ -584,6 +748,12 @@ fn local_runtime_policy_for_local_dev_shape(
         }
         RebornRuntimeProfileError::MissingPolicyRequest { .. } => {
             unreachable!("{profile_name} carries a runtime-policy request")
+        }
+        RebornRuntimeProfileError::MissingSecretMasterKeyEnv { .. }
+        | RebornRuntimeProfileError::InvalidSecretMasterKey(_) => {
+            unreachable!(
+                "{profile_name} does not resolve a hosted secrets master key in policy resolution"
+            )
         }
     })
 }
@@ -612,6 +782,7 @@ mod tests {
             RebornCompositionProfile::LocalDevYolo,
             RebornCompositionProfile::HostedSingleTenant,
             RebornCompositionProfile::HostedSingleTenantVolume,
+            RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
             RebornCompositionProfile::Production,
             RebornCompositionProfile::MigrationDryRun,
         ] {
@@ -652,6 +823,11 @@ mod tests {
             ),
             (
                 RebornCompositionProfile::HostedSingleTenantVolume,
+                RuntimeSubstrate::Local,
+                true,
+            ),
+            (
+                RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
                 RuntimeSubstrate::Local,
                 true,
             ),
@@ -709,6 +885,7 @@ mod tests {
             RebornCompositionProfile::LocalDevYolo,
             RebornCompositionProfile::HostedSingleTenant,
             RebornCompositionProfile::HostedSingleTenantVolume,
+            RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
             RebornCompositionProfile::Production,
         ] {
             let config = DeploymentConfig::for_profile(profile, true);
@@ -741,6 +918,7 @@ mod tests {
             RebornCompositionProfile::LocalDevYolo,
             RebornCompositionProfile::HostedSingleTenant,
             RebornCompositionProfile::HostedSingleTenantVolume,
+            RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
         ] {
             let config = DeploymentConfig::for_profile(profile, true);
             assert!(
@@ -834,6 +1012,19 @@ mod tests {
         assert_eq!(policy.resolved_profile, RuntimeProfile::SecureDefault);
         assert_eq!(policy.process_backend, ProcessBackendKind::None);
         assert_eq!(policy.approval_policy, ApprovalPolicy::AskAlways);
+    }
+
+    #[test]
+    fn hosted_single_tenant_volume_sandboxed_requests_the_existing_hosted_safe_row() {
+        let policy = resolved(DeploymentConfig::hosted_single_tenant_volume_sandboxed());
+        assert_eq!(policy.deployment, DeploymentMode::HostedMultiTenant);
+        assert_eq!(policy.resolved_profile, RuntimeProfile::HostedSafe);
+        assert_eq!(policy.process_backend, ProcessBackendKind::TenantSandbox);
+        assert_eq!(
+            policy.filesystem_backend,
+            ironclaw_host_api::runtime_policy::FilesystemBackendKind::TenantWorkspace
+        );
+        assert_eq!(policy.approval_policy, ApprovalPolicy::AskWrites);
     }
 
     #[test]
@@ -933,5 +1124,209 @@ mod local_runtime_profile_tests {
                 RebornRuntimeProfileError::UnsupportedProfile { .. }
             ));
         }
+    }
+}
+
+/// Regression coverage for the C1 slice: the libsql-volume-shaped hosted
+/// profiles (`hosted-single-tenant-volume`, `-sandboxed`) must require an
+/// externally-supplied `IRONCLAW_REBORN_SECRET_MASTER_KEY` and fail closed
+/// instead of falling back to the single-user local-dev dotfile/keychain
+/// chain. Plain `local-dev`/`local-dev-yolo` are untouched — see
+/// `local_runtime_profile_tests::unconfirmed_yolo_fails_closed_before_an_input_is_built`
+/// for that shape's (correct) fallback behaviour.
+///
+/// The resolution/validation logic (`hosted_volume_secret_master_key_from_raw`)
+/// is exercised with an injected raw value rather than a mutated
+/// `std::env::var`: this crate is `#![forbid(unsafe_code)]`, which blocks
+/// `std::env::set_var` in-process (see `factory.rs`'s
+/// `resolve_local_dev_secret_master_key_with_env` for the same established
+/// pattern). The "env-unset" cases below instead rely on the ambient test
+/// process never setting `IRONCLAW_REBORN_SECRET_MASTER_KEY`, which is real
+/// production behaviour, not a simulation.
+#[cfg(test)]
+mod hosted_volume_secret_master_key_tests {
+    use super::*;
+
+    fn valid_master_key() -> String {
+        ironclaw_secrets::keychain::generate_master_key_hex()
+    }
+
+    /// Case 1 (headline regression): with a valid key resolved and carried on
+    /// the build input — the exact shape `hosted_single_tenant_volume_build_input`
+    /// produces once `IRONCLAW_REBORN_SECRET_MASTER_KEY` is set — a full
+    /// `build_reborn_services` build succeeds AND never writes the plaintext
+    /// dotfile that sits next to the encrypted secrets in the data root. This
+    /// locks the actual gap: before this slice, `secret_master_key` was
+    /// hardcoded to `None` for every `LocalDev`-shaped input, so this profile
+    /// always fell through to `resolve_local_dev_secret_master_key`, which
+    /// generates and persists that dotfile.
+    #[tokio::test]
+    async fn env_set_valid_key_builds_and_never_writes_the_local_dev_dotfile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("data-root");
+        let key = valid_master_key();
+
+        let policy = hosted_single_tenant_volume_runtime_policy().expect("policy resolves");
+        let input = RebornBuildInput::local_dev_with_profile(
+            RebornCompositionProfile::HostedSingleTenantVolume,
+            "volume-owner",
+            root.clone(),
+        )
+        .with_runtime_policy(policy)
+        .with_local_dev_secret_master_key(ironclaw_secrets::SecretMaterial::from(key));
+
+        crate::factory::build_reborn_services(input)
+            .await
+            .expect("hosted-single-tenant-volume build succeeds with an explicit master key");
+
+        let dotfile = root.join(crate::factory::LOCAL_DEV_SECRETS_MASTER_KEY_PATH);
+        assert!(
+            !dotfile.exists(),
+            "an explicit master key must never be persisted to the local-dev dotfile at {}",
+            dotfile.display()
+        );
+    }
+
+    /// Case 2: an explicit-but-malformed key must fail with
+    /// `validate_resolved_master_key`'s named, source-attributed error — not
+    /// an opaque `SecretsCrypto` rejection several layers deeper.
+    #[test]
+    fn env_set_malformed_key_fails_with_validate_resolved_master_key_named_error() {
+        // 64 zero chars: passes the length floor but has a single distinct
+        // byte, so the entropy check rejects it (mirrors
+        // `resolve_local_dev_secret_master_key_rejects_malformed_env_without_persisting`).
+        let error = hosted_volume_secret_master_key_from_raw(
+            "IRONCLAW_REBORN_SECRET_MASTER_KEY",
+            Some("0".repeat(64)),
+        )
+        .expect_err("malformed master key must be rejected");
+
+        let reason = match error {
+            RebornRuntimeProfileError::InvalidSecretMasterKey(
+                RebornBuildError::InvalidConfig { reason },
+            ) => reason,
+            other => panic!("expected InvalidSecretMasterKey(InvalidConfig), got {other:?}"),
+        };
+        assert!(
+            reason.contains("IRONCLAW_REBORN_SECRET_MASTER_KEY"),
+            "error must name the env var, got: {reason}"
+        );
+        assert!(
+            reason.contains("master key"),
+            "error must mention the master key (validate_resolved_master_key's message), got: {reason}"
+        );
+    }
+
+    /// Case 3 (headline regression): with the env var unset, the profile
+    /// boots fail-closed instead of silently generating a key. No dotfile is
+    /// ever generated because the failure happens before `build_local_runtime`
+    /// (and therefore `build_secret_store`) is ever reached.
+    #[test]
+    fn env_unset_fails_closed_and_never_generates_a_dotfile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("data-root");
+        assert!(!root.exists(), "precondition: data root not yet created");
+
+        let error = match hosted_single_tenant_volume_build_input("volume-owner", root.clone()) {
+            Ok(_) => panic!("an unset master-key env must fail closed"),
+            Err(error) => error,
+        };
+
+        assert!(
+            matches!(
+                &error,
+                RebornRuntimeProfileError::MissingSecretMasterKeyEnv { env_name }
+                    if env_name == "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+            ),
+            "expected MissingSecretMasterKeyEnv, got {error:?}"
+        );
+        assert!(
+            !root
+                .join(crate::factory::LOCAL_DEV_SECRETS_MASTER_KEY_PATH)
+                .exists(),
+            "a fail-closed boot must never generate/persist a local-dev dotfile"
+        );
+    }
+
+    /// Case 4: a pre-seeded (valid) dotfile must NOT rescue an unset env var.
+    /// Unlike plain `local-dev`, this profile never consults the dotfile at
+    /// all — proven here because the failure occurs in the build-input layer,
+    /// before any code that would open the data root ever runs.
+    #[test]
+    fn dotfile_preseeded_env_unset_still_fails_closed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("data-root");
+        std::fs::create_dir_all(&root).expect("create data root");
+        let dotfile = root.join(crate::factory::LOCAL_DEV_SECRETS_MASTER_KEY_PATH);
+        std::fs::write(&dotfile, valid_master_key()).expect("seed a valid cached dotfile");
+        assert!(dotfile.exists(), "precondition: dotfile is seeded");
+
+        let error = match hosted_single_tenant_volume_build_input("volume-owner", root.clone()) {
+            Ok(_) => panic!("a pre-seeded dotfile must not rescue an unset env var"),
+            Err(error) => error,
+        };
+
+        assert!(
+            matches!(
+                &error,
+                RebornRuntimeProfileError::MissingSecretMasterKeyEnv { .. }
+            ),
+            "expected MissingSecretMasterKeyEnv (dotfile ignored), got {error:?}"
+        );
+    }
+
+    /// Case 5: this resolution path never calls into the OS keychain — it
+    /// only ever reads `IRONCLAW_REBORN_SECRET_MASTER_KEY` and validates the
+    /// result. That is a structural guarantee (`hosted_volume_secret_master_key_from_raw`'s
+    /// body has no keychain touchpoint), not one that depends on
+    /// `IRONCLAW_DISABLE_OS_KEYCHAIN` being set — so resolution behaves
+    /// identically regardless of that flag. This documents that the
+    /// local-dev keychain-ambiguity (see project memory on reborn test
+    /// keychain suppression) is out of scope for this profile by being
+    /// inapplicable: there is no keychain fallback branch to suppress.
+    #[test]
+    fn keychain_is_never_consulted_regardless_of_disable_keychain_env() {
+        let key = valid_master_key();
+        let resolved = hosted_volume_secret_master_key_from_raw(
+            "IRONCLAW_REBORN_SECRET_MASTER_KEY",
+            Some(key.clone()),
+        )
+        .expect("valid explicit key resolves without touching the keychain");
+        assert_eq!(
+            secrecy::ExposeSecret::expose_secret(&resolved),
+            key.as_str(),
+            "the resolved key must be exactly the supplied env value, never a keychain-sourced one"
+        );
+    }
+
+    /// The "+1" build-through-the-caller test: drives the *outermost*
+    /// production entry point (`local_runtime_build_input_with_options`, the
+    /// function `serve`/the CLI actually call) rather than the
+    /// profile-specific inner helper, proving the fail-closed dispatch is
+    /// wired all the way through — not just reachable when a test calls the
+    /// inner function directly.
+    #[test]
+    fn local_runtime_build_input_with_options_fails_closed_for_volume_profile_when_env_unset() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("data-root");
+
+        let error = match local_runtime_build_input_with_options(
+            RebornCompositionProfile::HostedSingleTenantVolume,
+            "volume-owner",
+            root,
+            RebornRuntimeProfileOptions::default(),
+        ) {
+            Ok(_) => panic!("the outermost production entry point must also fail closed"),
+            Err(error) => error,
+        };
+
+        assert!(
+            matches!(
+                &error,
+                RebornRuntimeProfileError::MissingSecretMasterKeyEnv { env_name }
+                    if env_name == "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+            ),
+            "expected MissingSecretMasterKeyEnv, got {error:?}"
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1751,6 +1751,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         storage,
         runtime_policy,
         runtime_process_binding,
+        sandbox_activity,
         product_auth_ports,
         oauth_provider_configs,
         oauth_dcr_callback,
@@ -1984,8 +1985,16 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             local_runtime_identity: local_runtime_identity_for_nearai_mcp.as_ref(),
             resource_governor: Arc::clone(&store_graph.resource_governor)
                 as Arc<dyn ironclaw_resources::ResourceGovernor>,
-            run_state: Arc::clone(&store_graph.run_state)
-                as Arc<dyn ironclaw_run_state::RunStateStore>,
+            // Reuse the SAME registry `tenant_sandbox_process_binding`
+            // injected into the exec transport (threaded here via
+            // `RebornBuildInput::sandbox_activity`), so the reaper's idle
+            // reads observe the transport's writes. Non-sandboxed profiles
+            // (and any caller that never wired one) fall back to a fresh,
+            // never-touched registry — `is_sandboxed_profile` gates whether
+            // `build` does anything with it at all.
+            activity: sandbox_activity
+                .clone()
+                .unwrap_or_else(|| Arc::new(ironclaw_host_runtime::SandboxActivityRegistry::new())),
         },
     )
     .await?;
@@ -4657,6 +4666,7 @@ async fn build_production_shaped(
         // generic ingress lane lands.
         account_setup_descriptors: _,
         runtime_process_binding,
+        sandbox_activity: _,
         required_runtime_backends,
         require_runtime_http_egress,
         require_wasm_credentials,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -473,6 +473,13 @@ pub struct RebornServices {
     #[cfg(feature = "test-support")]
     pub(crate) channel_egress_credential_bridges:
         Option<Arc<crate::extension_host::channel_egress::BridgedChannelEgressCredentials>>,
+    /// D4-1 orphan-sandbox-container reaper, already spawned (guarded on a
+    /// successful, independent Docker connect) for the tenant-sandboxed
+    /// profile only. `build_reborn_runtime` moves this onto `RebornRuntime`
+    /// so `RebornRuntime::shutdown` can cancel it alongside every other owned
+    /// background worker. `None` on every non-sandboxed profile and when the
+    /// reaper's own Docker connect could not be established.
+    pub(crate) sandbox_reaper_handle: Option<crate::sandbox_reaper_task::SandboxReaperRuntimeHandle>,
 }
 
 struct ChannelHostWiring {
@@ -1605,6 +1612,7 @@ impl RebornServices {
             channel_delivery_resolver: None,
             #[cfg(feature = "test-support")]
             channel_egress_credential_bridges: None,
+            sandbox_reaper_handle: None,
         }
     }
 }
@@ -1755,6 +1763,15 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         account_setup_descriptors,
         ..
     } = input;
+    // D3-2/D4-1: whether this build is the tenant-sandboxed shell profile
+    // (`hosted-single-tenant-volume-sandboxed`) — gates the tenant
+    // concurrency ceiling and the orphan-container reaper spawn below.
+    // Checked by reference so `runtime_process_binding` stays available for
+    // `apply_runtime_process_binding` further down.
+    let is_sandboxed_profile = matches!(
+        &runtime_process_binding,
+        RebornRuntimeProcessBinding::TenantSandbox { .. }
+    );
     // Label for logging/errors; behaviour reads `deployment`'s axes.
     let profile = deployment.profile();
     // Computed before `oauth_provider_configs` is consumed by
@@ -1793,12 +1810,13 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             root,
             workspace_root,
             host_home_root,
+            secret_master_key,
         } => (
             root,
             workspace_root,
             host_home_root,
             StorageBackendInput::LocalDefault,
-            None::<ironclaw_secrets::SecretMaterial>,
+            secret_master_key,
             None::<bool>,
         ),
         RebornStorageInput::HostedSingleTenantPostgres { .. }
@@ -1955,6 +1973,35 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         identity_substrate_db,
     })
     .await?;
+
+    // D3-2: bound this tenant's concurrent SpawnProcess reservations for the
+    // sandboxed profile only — every other profile leaves the tenant account
+    // unlimited. Turns the D3-1 `ReserveResources` obligation from a no-op
+    // into an actual gate.
+    let sandbox_reaper_handle = if is_sandboxed_profile {
+        let sandbox_tenant_id = crate::sandbox_quota::resolve_local_runtime_tenant_id(
+            local_runtime_identity_for_nearai_mcp.as_ref(),
+        )?;
+        let governor: Arc<dyn ironclaw_resources::ResourceGovernor> =
+            Arc::clone(&store_graph.resource_governor) as Arc<dyn ironclaw_resources::ResourceGovernor>;
+        crate::sandbox_quota::apply_sandbox_tenant_ceiling(
+            &governor,
+            sandbox_tenant_id,
+            crate::sandbox_quota::sandbox_max_concurrent_from_env(),
+        )
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("sandbox tenant concurrency ceiling could not be set: {error}"),
+        })?;
+
+        // D4-1: spawn the orphan-container reaper. Guarded internally —
+        // returns `None` rather than failing this build if Docker is not
+        // reachable at this (independent, best-effort) connect attempt.
+        crate::sandbox_reaper_task::maybe_spawn_sandbox_reaper(Arc::clone(&store_graph.run_state)
+            as Arc<dyn ironclaw_run_state::RunStateStore>)
+        .await
+    } else {
+        None
+    };
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> = Arc::new(
         DefaultTurnCoordinator::new(Arc::clone(&store_graph.turn_state)),
@@ -2725,6 +2772,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         channel_delivery_resolver: channel_host_wiring.channel_delivery_resolver,
         #[cfg(feature = "test-support")]
         channel_egress_credential_bridges: channel_host_wiring.channel_egress_credential_bridges,
+        sandbox_reaper_handle,
     })
 }
 
@@ -3760,9 +3808,13 @@ pub async fn open_local_dev_secret_store(
 
 /// Where a resolved local-dev master key came from, used to name the source in
 /// fail-loud error messages.
-enum MasterKeySource {
+pub(crate) enum MasterKeySource {
     File(PathBuf),
     Env,
+    /// A named env var other than the local-dev `SECRETS_MASTER_KEY` — e.g. the
+    /// hosted-volume profiles read `IRONCLAW_REBORN_SECRET_MASTER_KEY`, and a
+    /// malformed-key error must name the var the operator actually set.
+    EnvNamed(&'static str),
     Keychain,
 }
 
@@ -3775,7 +3827,7 @@ enum MasterKeySource {
 /// layers deep in `SecretsCrypto::new`, with no pointer to the file the
 /// operator must fix. See `.claude/rules/error-handling.md` (fail loud, name
 /// the operation).
-fn validate_resolved_master_key(
+pub(crate) fn validate_resolved_master_key(
     key: &str,
     source: &MasterKeySource,
 ) -> Result<(), RebornBuildError> {
@@ -3786,6 +3838,7 @@ fn validate_resolved_master_key(
                 "env var {}",
                 ironclaw_secrets::keychain::SECRETS_MASTER_KEY_ENV
             ),
+            MasterKeySource::EnvNamed(env_name) => format!("env var {env_name}"),
             MasterKeySource::Keychain => "the OS keychain".to_string(),
         };
         RebornBuildError::InvalidConfig {
@@ -5607,6 +5660,10 @@ where
         channel_delivery_resolver: None,
         #[cfg(feature = "test-support")]
         channel_egress_credential_bridges: None,
+        // D4-1's reaper is wired only on the tenant-sandboxed local-runtime
+        // build path (`build_local_runtime`); this production/postgres path
+        // never sets `runtime_process_binding` to `TenantSandbox` today.
+        sandbox_reaper_handle: None,
     })
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -479,7 +479,7 @@ pub struct RebornServices {
     /// so `RebornRuntime::shutdown` can cancel it alongside every other owned
     /// background worker. `None` on every non-sandboxed profile and when the
     /// reaper's own Docker connect could not be established.
-    pub(crate) sandbox_reaper_handle: Option<crate::sandbox_reaper_task::SandboxReaperRuntimeHandle>,
+    pub(crate) sandbox_runtime_bindings: crate::sandbox_composition::SandboxRuntimeBindings,
 }
 
 struct ChannelHostWiring {
@@ -1612,7 +1612,7 @@ impl RebornServices {
             channel_delivery_resolver: None,
             #[cfg(feature = "test-support")]
             channel_egress_credential_bridges: None,
-            sandbox_reaper_handle: None,
+            sandbox_runtime_bindings: crate::sandbox_composition::SandboxRuntimeBindings::none(),
         }
     }
 }
@@ -1978,30 +1978,17 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
     // sandboxed profile only — every other profile leaves the tenant account
     // unlimited. Turns the D3-1 `ReserveResources` obligation from a no-op
     // into an actual gate.
-    let sandbox_reaper_handle = if is_sandboxed_profile {
-        let sandbox_tenant_id = crate::sandbox_quota::resolve_local_runtime_tenant_id(
-            local_runtime_identity_for_nearai_mcp.as_ref(),
-        )?;
-        let governor: Arc<dyn ironclaw_resources::ResourceGovernor> =
-            Arc::clone(&store_graph.resource_governor) as Arc<dyn ironclaw_resources::ResourceGovernor>;
-        crate::sandbox_quota::apply_sandbox_tenant_ceiling(
-            &governor,
-            sandbox_tenant_id,
-            crate::sandbox_quota::sandbox_max_concurrent_from_env(),
-        )
-        .map_err(|error| RebornBuildError::InvalidConfig {
-            reason: format!("sandbox tenant concurrency ceiling could not be set: {error}"),
-        })?;
-
-        // D4-1: spawn the orphan-container reaper. Guarded internally —
-        // returns `None` rather than failing this build if Docker is not
-        // reachable at this (independent, best-effort) connect attempt.
-        crate::sandbox_reaper_task::maybe_spawn_sandbox_reaper(Arc::clone(&store_graph.run_state)
-            as Arc<dyn ironclaw_run_state::RunStateStore>)
-        .await
-    } else {
-        None
-    };
+    let sandbox_runtime_bindings = crate::sandbox_composition::SandboxRuntimeBindings::build(
+        crate::sandbox_composition::SandboxProfileBindingInputs {
+            is_sandboxed_profile,
+            local_runtime_identity: local_runtime_identity_for_nearai_mcp.as_ref(),
+            resource_governor: Arc::clone(&store_graph.resource_governor)
+                as Arc<dyn ironclaw_resources::ResourceGovernor>,
+            run_state: Arc::clone(&store_graph.run_state)
+                as Arc<dyn ironclaw_run_state::RunStateStore>,
+        },
+    )
+    .await?;
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> = Arc::new(
         DefaultTurnCoordinator::new(Arc::clone(&store_graph.turn_state)),
@@ -2772,7 +2759,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         channel_delivery_resolver: channel_host_wiring.channel_delivery_resolver,
         #[cfg(feature = "test-support")]
         channel_egress_credential_bridges: channel_host_wiring.channel_egress_credential_bridges,
-        sandbox_reaper_handle,
+        sandbox_runtime_bindings,
     })
 }
 
@@ -5663,7 +5650,7 @@ where
         // D4-1's reaper is wired only on the tenant-sandboxed local-runtime
         // build path (`build_local_runtime`); this production/postgres path
         // never sets `runtime_process_binding` to `TenantSandbox` today.
-        sandbox_reaper_handle: None,
+        sandbox_runtime_bindings: crate::sandbox_composition::SandboxRuntimeBindings::none(),
     })
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -46,8 +46,9 @@ use crate::extension_host::{
 use crate::input::{RebornLocalRuntimeIdentity, RebornRuntimeProcessBinding, RebornStorageInput};
 use crate::local_dev_authorization::{StoreApprovalSettingsProvider, local_dev_authorizer};
 use crate::local_dev_mounts::{
-    ambient_workspace_mount_view, memory_mount_view, scoped_skill_context_mount_view,
-    skill_management_mount_view, system_extensions_lifecycle_mount_view, workspace_mount_view,
+    ambient_workspace_mount_view, memory_mount_view, sandbox_user_workspace_mount_view,
+    scoped_skill_context_mount_view, skill_management_mount_view,
+    system_extensions_lifecycle_mount_view, workspace_mount_view,
 };
 use crate::outbound::outbound_preferences_capability::{
     extend_builtin_first_party_package as extend_builtin_outbound_preferences_package,
@@ -186,6 +187,22 @@ type WorkspaceFilesystems = (
     Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     MountView,
 );
+
+/// Which host directory the runtime `MountView`'s `/workspace` grant (and,
+/// for the sandboxed variant, the abstract-FS `/workspace` catalog mount)
+/// resolve against. Computed once per build; both filesystem-assembly
+/// functions below take it by reference instead of an `Option<&Path>` +
+/// `bool` pair so "sandboxed but no path" and "ambient but a path was
+/// supplied" are unrepresentable.
+enum WorkspaceRootMode {
+    /// Non-sandboxed profiles: the existing `/projects/workspace` +
+    /// optional host-home ambient view (local-dev, local-dev-yolo,
+    /// hosted-single-tenant).
+    Ambient,
+    /// `HostedSingleTenantVolumeSandboxed`: the boot owner's per-user
+    /// sandbox workspace directory, mounted directly at `/workspace`.
+    SandboxUser(PathBuf),
+}
 
 const LOCAL_DEV_DEFAULT_SYSTEM_PROMPT_PATH: &str = "system/prompts/default-system.md";
 const LOCAL_DEV_LEGACY_SKILLS_BACKFILL_MARKER: &str = ".legacy-skills-backfilled";
@@ -1906,11 +1923,37 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
         }
     })?;
     crate::extension_host::bundled_skills::ensure_bundled_reborn_skills_installed(&root).await?;
+    // Which host directory the runtime `/workspace` grant resolves against.
+    // Sandboxed-profile builds redirect it onto the boot owner's per-user
+    // sandbox workspace directory (Task A1's `RebornSandboxUserKey`) instead
+    // of the ambient `/projects/workspace` mount, so `read_file`/`write_file`
+    // and the sandbox container's own `/workspace` bind (Task A3) resolve the
+    // same host directory. Computed once, before `owner_user_id` and
+    // `local_runtime_identity` move into `RebornStoreGraphInput` below.
+    let workspace_root_mode = if is_sandboxed_profile {
+        let owner_scope = match &local_runtime_identity {
+            Some(identity) => configured_runtime_owner_scope(owner_user_id.clone(), identity),
+            None => default_runtime_owner_scope(owner_user_id.clone()).map_err(|error| {
+                RebornBuildError::InvalidConfig {
+                    reason: error.to_string(),
+                }
+            })?,
+        };
+        let path = ironclaw_host_runtime::RebornSandboxUserKey::from_scope(&owner_scope)
+            .workspace_path(&root);
+        std::fs::create_dir_all(&path).map_err(|_| RebornBuildError::InvalidConfig {
+            reason: "sandbox user workspace root could not be initialized".to_string(),
+        })?;
+        WorkspaceRootMode::SandboxUser(path)
+    } else {
+        WorkspaceRootMode::Ambient
+    };
     let filesystem_bundle = build_local_runtime_root_filesystem(
         &root,
         &workspace_root,
         host_home_root.as_ref(),
         storage_backend_input,
+        &workspace_root_mode,
     )
     .await?;
     let extension_installation_state_path =
@@ -1945,6 +1988,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             Arc::clone(&filesystem),
             &workspace_root,
             host_home_root.as_ref(),
+            &workspace_root_mode,
         )?;
     let http_body_filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
         Arc::clone(&filesystem),
@@ -3360,6 +3404,7 @@ async fn build_local_runtime_root_filesystem(
     workspace_root: &Path,
     host_home_root: Option<&HostHomeRoot>,
     storage_backend_input: StorageBackendInput,
+    workspace_root_mode: &WorkspaceRootMode,
 ) -> Result<RootFilesystemBundle, RebornBuildError> {
     let local = Arc::new(local_dev_project_filesystem(
         root,
@@ -3379,6 +3424,9 @@ async fn build_local_runtime_root_filesystem(
         }
     };
     mount_local_dev_project_roots(&mut composite, local)?;
+    if let WorkspaceRootMode::SandboxUser(sandbox_workspace_root) = workspace_root_mode {
+        mount_sandbox_user_workspace_root(&mut composite, sandbox_workspace_root)?;
+    }
     Ok(RootFilesystemBundle {
         filesystem: Arc::new(composite),
         durable_backend,
@@ -3495,6 +3543,7 @@ pub(crate) async fn open_local_dev_root_filesystem_for_test(
         &workspace_root,
         None,
         StorageBackendInput::LocalDefault,
+        &WorkspaceRootMode::Ambient,
     )
     .await?;
     Ok(bundle.filesystem)
@@ -3522,6 +3571,7 @@ pub(crate) async fn open_local_dev_extension_installation_store_for_test(
         &workspace_root,
         None,
         StorageBackendInput::LocalDefault,
+        &WorkspaceRootMode::Ambient,
     )
     .await?;
     let filesystem: Arc<dyn RootFilesystem> = bundle.filesystem;
@@ -3746,6 +3796,35 @@ fn mount_local_dev_project_roots(
             BackendCapabilities::bytes_only(),
         )?,
         local,
+    )?;
+    Ok(())
+}
+
+/// Registers the per-user sandbox workspace directory as an abstract-FS mount
+/// at virtual root `/workspace`, so `read_file`/`write_file` (via the
+/// `Workspace`-profile `MountView`) and the sandbox container's `/workspace`
+/// bind (Task A3, `RebornSandboxMountSources::add_local_source`) resolve to
+/// the identical host directory. Sandboxed-profile builds only.
+fn mount_sandbox_user_workspace_root(
+    root: &mut CompositeRootFilesystem,
+    workspace_root: &Path,
+) -> Result<(), RebornBuildError> {
+    let mut disk = DiskFilesystem::new();
+    disk.mount_local(
+        VirtualPath::new("/workspace")?,
+        HostPath::from_path_buf(workspace_root.to_path_buf()),
+    )?;
+    root.mount(
+        local_dev_mount_descriptor(
+            "/workspace",
+            "sandbox-user-workspace",
+            BackendKind::DiskFilesystem,
+            StorageClass::FileContent,
+            ContentKind::ProjectFile,
+            IndexPolicy::NotIndexed,
+            BackendCapabilities::bytes_only(),
+        )?,
+        Arc::new(disk),
     )?;
     Ok(())
 }
@@ -4238,27 +4317,39 @@ fn build_workspace_filesystems(
     filesystem: Arc<CompositeRootFilesystem>,
     workspace_root: &Path,
     host_home_root: Option<&HostHomeRoot>,
+    workspace_root_mode: &WorkspaceRootMode,
 ) -> Result<WorkspaceFilesystems, RebornBuildError> {
     let read_only_workspace_mounts = workspace_mount_view(MountPermissions::read_only(), &[])
         .map_err(|error| RebornBuildError::InvalidConfig {
             reason: error.to_string(),
         })?;
-    let host_home_aliases = host_home_root
-        .map(|root| root.aliases())
-        .unwrap_or_default();
-    let workspace_aliases = if host_home_root.is_some() {
-        vec![workspace_root]
-    } else {
-        Vec::new()
+    let runtime_workspace_mounts = match workspace_root_mode {
+        WorkspaceRootMode::SandboxUser(_) => {
+            sandbox_user_workspace_mount_view(MountPermissions::read_write()).map_err(|error| {
+                RebornBuildError::InvalidConfig {
+                    reason: error.to_string(),
+                }
+            })?
+        }
+        WorkspaceRootMode::Ambient => {
+            let host_home_aliases = host_home_root
+                .map(|root| root.aliases())
+                .unwrap_or_default();
+            let workspace_aliases = if host_home_root.is_some() {
+                vec![workspace_root]
+            } else {
+                Vec::new()
+            };
+            ambient_workspace_mount_view(
+                MountPermissions::read_write(),
+                &workspace_aliases,
+                &host_home_aliases,
+            )
+            .map_err(|error| RebornBuildError::InvalidConfig {
+                reason: error.to_string(),
+            })?
+        }
     };
-    let runtime_workspace_mounts = ambient_workspace_mount_view(
-        MountPermissions::read_write(),
-        &workspace_aliases,
-        &host_home_aliases,
-    )
-    .map_err(|error| RebornBuildError::InvalidConfig {
-        reason: error.to_string(),
-    })?;
     let skill_filesystem = Arc::new(ScopedFilesystem::new(
         Arc::clone(&filesystem),
         scoped_skill_context_mount_view,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1957,6 +1957,10 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
     // Same local-dev deployment identity anchors channel egress credentials
     // ([channel.config] secret handles) and their vendor calls.
     let channel_egress_scope = nearai_mcp_owner_scope.clone();
+    // Task A6: the sandbox concurrency ceiling call site (below) needs
+    // `owner_user_id` too, but `owner_user_id` is moved into
+    // `RebornStoreGraphInput` next — clone it first.
+    let sandbox_owner_user_id_for_ceiling = owner_user_id.clone();
     let mut store_graph = build_local_runtime_store_graph(RebornStoreGraphInput {
         filesystem: Arc::clone(&filesystem),
         owner_user_id,
@@ -1995,6 +1999,7 @@ async fn build_local_runtime(input: RebornBuildInput) -> Result<RebornServices, 
             activity: sandbox_activity
                 .clone()
                 .unwrap_or_else(|| Arc::new(ironclaw_host_runtime::SandboxActivityRegistry::new())),
+            owner_user_id: sandbox_owner_user_id_for_ceiling,
         },
     )
     .await?;

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
@@ -231,3 +231,143 @@ fn filesystem_root() -> std::path::PathBuf {
     }
     path
 }
+
+/// Stub `SandboxCommandTransport` so `is_sandboxed_profile` (gated on
+/// `runtime_process_binding` being `TenantSandbox`, not on the deployment
+/// profile alone) actually flips true for these tests — mirrors
+/// `approval_gates::RecordingSandboxTransport`, never invoked here since
+/// these tests exercise the filesystem mount, not shell execution.
+#[derive(Debug, Default)]
+struct NoopSandboxTransport;
+
+#[async_trait::async_trait]
+impl ironclaw_host_runtime::SandboxCommandTransport for NoopSandboxTransport {
+    async fn run_command(
+        &self,
+        _request: ironclaw_host_runtime::CommandExecutionRequest,
+    ) -> Result<
+        ironclaw_host_runtime::CommandExecutionOutput,
+        ironclaw_host_runtime::RuntimeProcessError,
+    > {
+        unimplemented!("workspace-mount tests never execute shell commands")
+    }
+}
+
+fn tenant_sandbox_process_binding_for_test() -> RebornRuntimeProcessBinding {
+    let process_port = Arc::new(ironclaw_host_runtime::TenantSandboxProcessPort::new(
+        Arc::new(NoopSandboxTransport),
+    ));
+    RebornRuntimeProcessBinding::tenant_sandbox(process_port)
+}
+
+#[tokio::test]
+async fn sandboxed_profile_workspace_mount_is_per_user_and_shares_bytes_with_host_dir() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage_root = dir.path().join("hosted-sandboxed");
+
+    let services = build_reborn_services(
+        RebornBuildInput::local_dev_with_profile(
+            RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
+            "sandbox-owner",
+            storage_root.clone(),
+        )
+        .with_runtime_policy(
+            crate::hosted_single_tenant_volume_sandboxed_runtime_policy()
+                .expect("sandboxed policy resolves"),
+        )
+        .with_runtime_process_binding(tenant_sandbox_process_binding_for_test()),
+    )
+    .await
+    .expect("hosted-single-tenant-volume-sandboxed services build");
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local-dev runtime substrate");
+
+    let workspace_grant = local_runtime
+        .workspace_mounts
+        .mounts
+        .iter()
+        .find(|mount| mount.alias.as_str() == "/workspace")
+        .expect("/workspace grant exists for the sandboxed profile");
+    assert_eq!(workspace_grant.target.as_str(), "/workspace");
+    assert_eq!(workspace_grant.permissions, MountPermissions::read_write());
+
+    // write_file (abstract FS) -> assert on the real per-user host dir.
+    let path = ironclaw_host_api::VirtualPath::new("/workspace/f.txt").expect("virtual path");
+    local_runtime
+        .extension_filesystem
+        .write_file(&path, b"from-fs-tools")
+        .await
+        .expect("write through composite /workspace mount");
+
+    let owner_scope = default_runtime_owner_scope(
+        ironclaw_host_api::UserId::new("sandbox-owner").expect("owner id"),
+    )
+    .expect("owner scope resolves");
+    let canonical_root = storage_root.canonicalize().expect("canonical storage root");
+    let host_workspace_dir = ironclaw_host_runtime::RebornSandboxUserKey::from_scope(&owner_scope)
+        .workspace_path(&canonical_root);
+    assert_eq!(
+        std::fs::read(host_workspace_dir.join("f.txt")).expect("host file exists"),
+        b"from-fs-tools"
+    );
+
+    // reverse: write directly on the host dir (what a shell `echo` inside the
+    // container does), read back through the abstract FS /workspace mount.
+    std::fs::write(host_workspace_dir.join("g.txt"), b"from-shell").expect("host write");
+    let bytes = local_runtime
+        .extension_filesystem
+        .read_file(&ironclaw_host_api::VirtualPath::new("/workspace/g.txt").expect("virtual path"))
+        .await
+        .expect("read through composite /workspace mount");
+    assert_eq!(bytes, b"from-shell");
+}
+
+#[tokio::test]
+async fn sandbox_user_workspace_directories_do_not_overlap_across_owners() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    std::fs::create_dir_all(&root).expect("root");
+    let canonical_root = root.canonicalize().expect("canonical root");
+
+    let scope_a =
+        default_runtime_owner_scope(ironclaw_host_api::UserId::new("user-a").expect("user id"))
+            .expect("owner scope resolves");
+    let scope_b =
+        default_runtime_owner_scope(ironclaw_host_api::UserId::new("user-b").expect("user id"))
+            .expect("owner scope resolves");
+
+    let path_a = ironclaw_host_runtime::RebornSandboxUserKey::from_scope(&scope_a)
+        .workspace_path(&canonical_root);
+    let path_b = ironclaw_host_runtime::RebornSandboxUserKey::from_scope(&scope_b)
+        .workspace_path(&canonical_root);
+
+    assert_ne!(
+        path_a, path_b,
+        "different owners must not share a workspace directory"
+    );
+    assert!(
+        !path_a.starts_with(&path_b) && !path_b.starts_with(&path_a),
+        "one user's workspace directory must not nest inside another's: {path_a:?} vs {path_b:?}"
+    );
+
+    // The mount registration itself must fail closed if it were ever pointed
+    // at a shared parent instead of the digest leaf: assert mounting user A's
+    // path denies access to a file only present under user B's path.
+    std::fs::create_dir_all(&path_a).expect("user a dir");
+    std::fs::create_dir_all(&path_b).expect("user b dir");
+    std::fs::write(path_b.join("secret.txt"), b"user-b-only").expect("user b file");
+
+    let mut composite = CompositeRootFilesystem::new();
+    mount_sandbox_user_workspace_root(&mut composite, &path_a).expect("mount user a workspace");
+    let escape = composite
+        .read_file(
+            &ironclaw_host_api::VirtualPath::new("/workspace/secret.txt").expect("virtual path"),
+        )
+        .await;
+    assert!(
+        escape.is_err(),
+        "user A's /workspace mount must not see user B's file"
+    );
+}

--- a/crates/ironclaw_reborn_composition/src/factory/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/tests.rs
@@ -733,6 +733,7 @@ async fn local_dev_default_product_auth_preserves_manual_token_across_rebuilds()
         &local_dev_root.join("workspace"),
         None,
         StorageBackendInput::LocalDefault,
+        &WorkspaceRootMode::Ambient,
     )
     .await
     .expect("local-dev filesystem rebuild")

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -9,7 +9,7 @@ use ironclaw_host_api::runtime_policy::{
     EffectiveRuntimePolicy, FilesystemBackendKind, NetworkMode, SecretMode,
 };
 use ironclaw_host_api::{AgentId, TenantId};
-use ironclaw_host_runtime::TenantSandboxProcessPort;
+use ironclaw_host_runtime::{SandboxActivityRegistry, TenantSandboxProcessPort};
 #[cfg(any(test, feature = "test-support"))]
 use ironclaw_network::NetworkHttpEgress;
 use ironclaw_trust::HostTrustPolicy;
@@ -183,6 +183,14 @@ pub struct RebornBuildInput {
     pub(crate) runtime_policy: Option<EffectiveRuntimePolicy>,
     pub(crate) turn_run_wake_notifier: Option<Arc<dyn TurnRunWakeNotifier>>,
     pub(crate) runtime_process_binding: RebornRuntimeProcessBinding,
+    /// The `SandboxActivityRegistry` `tenant_sandbox_process_binding`
+    /// constructed and injected into the exec transport, when
+    /// `runtime_process_binding` is a `TenantSandbox` binding. `factory.rs`
+    /// forwards this same instance into `SandboxRuntimeBindings::build` so
+    /// the reaper reads the exact registry the transport writes into,
+    /// rather than a second independently constructed one. `None` for every
+    /// non-sandboxed profile.
+    pub(crate) sandbox_activity: Option<Arc<SandboxActivityRegistry>>,
     pub(crate) required_runtime_backends: Vec<ironclaw_host_api::RuntimeKind>,
     pub(crate) require_runtime_http_egress: bool,
     pub(crate) require_wasm_credentials: bool,
@@ -711,6 +719,20 @@ impl RebornBuildInput {
         self
     }
 
+    /// Supply the `SandboxActivityRegistry` a `tenant_sandbox_process_binding`
+    /// caller received alongside its `TenantSandboxBinding.binding` (see
+    /// `sandbox_boot::TenantSandboxBinding`), so `build_local_runtime` can
+    /// forward the SAME instance into `SandboxRuntimeBindings::build` rather
+    /// than the reaper reading a second, empty registry the transport never
+    /// writes into.
+    pub fn with_sandbox_activity_registry(
+        mut self,
+        activity: Arc<SandboxActivityRegistry>,
+    ) -> Self {
+        self.sandbox_activity = Some(activity);
+        self
+    }
+
     pub fn require_runtime_http_egress(mut self) -> Self {
         self.require_runtime_http_egress = true;
         self
@@ -863,6 +885,7 @@ impl RebornBuildInput {
             runtime_policy: None,
             turn_run_wake_notifier: None,
             runtime_process_binding: RebornRuntimeProcessBinding::default(),
+            sandbox_activity: None,
             required_runtime_backends: Vec::new(),
             require_runtime_http_egress: false,
             require_wasm_credentials: false,

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -24,7 +24,12 @@ use crate::deployment::DeploymentConfig;
 use crate::{RebornCompositionProfile, RebornProductAuthServicePorts};
 
 const DEFAULT_REBORN_POSTGRES_URL_ENV: &str = "IRONCLAW_REBORN_POSTGRES_URL";
-const DEFAULT_REBORN_SECRET_MASTER_KEY_ENV: &str = "IRONCLAW_REBORN_SECRET_MASTER_KEY";
+/// Backend-agnostic: the env var naming convention for an operator-supplied
+/// secrets master key is shared by the Postgres production path
+/// (`resolve_postgres_storage_from_config_and_env`) and the volume-shaped
+/// hosted profiles (`deployment::hosted_single_tenant_volume*_build_input`),
+/// so this stays `pub(crate)` rather than private to this module.
+pub(crate) const DEFAULT_REBORN_SECRET_MASTER_KEY_ENV: &str = "IRONCLAW_REBORN_SECRET_MASTER_KEY";
 const REBORN_POSTGRES_POOL_MAX_SIZE_ENV: &str = "IRONCLAW_REBORN_POSTGRES_POOL_MAX_SIZE";
 const REBORN_POSTGRES_RESOURCE_GOVERNOR_SINGLETON_ENV: &str =
     "IRONCLAW_REBORN_POSTGRES_RESOURCE_GOVERNOR_SINGLETON";
@@ -252,6 +257,14 @@ pub(crate) enum RebornStorageInput {
         root: PathBuf,
         workspace_root: Option<PathBuf>,
         host_home_root: Option<PathBuf>,
+        /// Externally-supplied secrets master key. `None` for plain
+        /// `local-dev`/`local-dev-yolo` (correct: single-user local dev keeps
+        /// the dotfile/keychain fallback chain). `Some` for the
+        /// libsql-volume-shaped hosted profiles
+        /// (`hosted-single-tenant-volume`, `-sandboxed`), which must never
+        /// fall back to that single-user chain — see
+        /// `deployment::hosted_single_tenant_volume_build_input`.
+        secret_master_key: Option<ironclaw_secrets::SecretMaterial>,
     },
     HostedSingleTenantPostgres {
         root: PathBuf,
@@ -376,6 +389,7 @@ impl RebornBuildInput {
                 root,
                 workspace_root: None,
                 host_home_root: None,
+                secret_master_key: None,
             },
         )
     }
@@ -497,6 +511,32 @@ impl RebornBuildInput {
 
     pub fn with_local_dev_confirmed_host_home_root(self, host_home_root: PathBuf) -> Self {
         self.with_local_runtime_confirmed_host_home_root(host_home_root)
+    }
+
+    /// Carry an externally-resolved secrets master key on a `LocalDev`-shaped
+    /// storage input so `build_local_runtime` never falls back to the
+    /// single-user dotfile/keychain chain (`resolve_local_dev_secret_master_key`)
+    /// for it. No-op on non-`LocalDev` storage shapes, mirroring
+    /// `with_local_runtime_workspace_root`'s match-and-ignore shape.
+    ///
+    /// Used only by the libsql-volume-shaped hosted profiles
+    /// (`hosted-single-tenant-volume`, `-sandboxed`); plain
+    /// `local-dev`/`local-dev-yolo` never call this, so they keep the
+    /// dotfile/keychain fallback the single-user local-dev shape correctly
+    /// relies on.
+    ///
+    pub(crate) fn with_local_dev_secret_master_key(
+        mut self,
+        secret_master_key: ironclaw_secrets::SecretMaterial,
+    ) -> Self {
+        if let RebornStorageInput::LocalDev {
+            secret_master_key: key,
+            ..
+        } = &mut self.storage
+        {
+            *key = Some(secret_master_key);
+        }
+        self
     }
 
     pub fn requires_local_runtime_confirmed_host_home_root(&self) -> bool {

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -133,7 +133,7 @@ pub use ironclaw_product_workflow::{
 };
 pub use ironclaw_runner::failure_lane::{ALL_RUN_FAILURE_CATEGORIES, FailureLane, failure_lane};
 pub use ironclaw_runner::runtime::DEFAULT_TURN_RUNNER_WORKER_COUNT;
-pub use sandbox_boot::tenant_sandbox_process_binding;
+pub use sandbox_boot::{TenantSandboxBinding, tenant_sandbox_process_binding};
 // Re-exported for `ironclaw_reborn_cli` (`runtime/mod.rs` turn-failure display):
 // the CLI consumes composition as its facade and must not grow a direct
 // `ironclaw_runner` edge for one summary helper. All other run-failure

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -44,14 +44,15 @@ mod production_runtime_policy;
 mod profile_approval_authorization;
 mod projection;
 mod provider_identity;
-mod sandbox_boot;
-mod sandbox_quota;
-mod sandbox_reaper_task;
 mod readiness;
 mod root;
 mod runtime;
 mod runtime_input;
 mod runtime_profile_approval_policy;
+mod sandbox_boot;
+mod sandbox_composition;
+mod sandbox_quota;
+mod sandbox_reaper_task;
 mod support;
 #[cfg(feature = "test-support")]
 pub mod test_support;

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -44,6 +44,9 @@ mod production_runtime_policy;
 mod profile_approval_authorization;
 mod projection;
 mod provider_identity;
+mod sandbox_boot;
+mod sandbox_quota;
+mod sandbox_reaper_task;
 mod readiness;
 mod root;
 mod runtime;
@@ -113,6 +116,12 @@ pub use ironclaw_host_api::{
 /// binary's [`ChannelExtensionBinding`] construction.
 pub use ironclaw_product_adapters::{ChannelAdapter, NormalizedInboundMessage};
 pub use ironclaw_product_workflow::PreferenceTargetCodec;
+// Re-exported so `ironclaw_reborn_cli` (`runtime/mod.rs`'s
+// `hosted-single-tenant-volume-sandboxed` boot-input assembly) can obtain a
+// real `TenantSandbox` process binding without depending on
+// `ironclaw_host_runtime` directly — the CLI boundary test
+// (`reborn_cli_binary_crate_stays_separate_from_v1_root`) pins its workspace
+// dependencies to exactly the composition-facade set.
 pub use ironclaw_product_workflow::{
     ChannelConnectionNoticePolicy, ChannelConnectionRequirement, ExtensionAccountSetupDescriptor,
     RebornChannelConnectStrategy,
@@ -123,6 +132,7 @@ pub use ironclaw_product_workflow::{
 };
 pub use ironclaw_runner::failure_lane::{ALL_RUN_FAILURE_CATEGORIES, FailureLane, failure_lane};
 pub use ironclaw_runner::runtime::DEFAULT_TURN_RUNNER_WORKER_COUNT;
+pub use sandbox_boot::tenant_sandbox_process_binding;
 // Re-exported for `ironclaw_reborn_cli` (`runtime/mod.rs` turn-failure display):
 // the CLI consumes composition as its facade and must not grow a direct
 // `ironclaw_runner` edge for one summary helper. All other run-failure
@@ -156,7 +166,8 @@ pub use llm_admin::openai_compat_serve::build_openai_compat_route_mount;
 // it reaches this helper through composition's facade.
 pub use deployment::{
     RebornRuntimeProfileError, RebornRuntimeProfileOptions, hosted_single_tenant_runtime_policy,
-    hosted_single_tenant_volume_runtime_policy, local_dev_runtime_policy,
+    hosted_single_tenant_volume_runtime_policy,
+    hosted_single_tenant_volume_sandboxed_runtime_policy, local_dev_runtime_policy,
     local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,
 };

--- a/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_mounts.rs
@@ -54,6 +54,29 @@ pub(crate) fn ambient_workspace_mount_view(
     MountView::new(mounts)
 }
 
+/// Virtual target for the `HostedSingleTenantVolumeSandboxed` profile's
+/// `/workspace` grant. Alias and target coincide at `/workspace` because the
+/// abstract-FS mount registered by `mount_sandbox_user_workspace_root` in
+/// `factory.rs` IS the per-user sandbox workspace directory — unlike
+/// `ambient_workspace_mount_view`, there is no intermediate
+/// `/projects/workspace` indirection here, by design.
+const SANDBOX_WORKSPACE_TARGET: &str = "/workspace";
+
+/// Workspace `MountView` for the `HostedSingleTenantVolumeSandboxed` profile:
+/// redirects the runtime `/workspace` grant onto the per-user sandbox
+/// workspace mount instead of `/projects/workspace`, so `read_file`/
+/// `write_file` resolve the same host directory the sandbox container's own
+/// `/workspace` bind (Task A3) uses.
+pub(crate) fn sandbox_user_workspace_mount_view(
+    permissions: MountPermissions,
+) -> Result<MountView, HostApiError> {
+    MountView::new(vec![grant(
+        WORKSPACE_ALIAS,
+        SANDBOX_WORKSPACE_TARGET,
+        permissions,
+    )?])
+}
+
 pub(crate) fn scoped_skill_context_mount_view(
     scope: &ResourceScope,
 ) -> Result<MountView, HostApiError> {

--- a/crates/ironclaw_reborn_composition/src/readiness.rs
+++ b/crates/ironclaw_reborn_composition/src/readiness.rs
@@ -14,6 +14,7 @@ pub enum RebornReadinessState {
     DevOnly,
     HostedSingleTenantValidated,
     HostedSingleTenantVolumePreviewValidated,
+    HostedSingleTenantVolumeSandboxedValidated,
     ProductionValidated,
     MigrationDryRunValidated,
 }
@@ -79,6 +80,7 @@ pub enum RebornReadinessDiagnosticReason {
     Disabled,
     DevOnlyProfile,
     HostedSingleTenantVolumePreview,
+    HostedSingleTenantVolumeSandboxedPreview,
     Missing,
     LocalOnly,
     Unverified,
@@ -92,6 +94,9 @@ impl RebornReadinessDiagnosticReason {
             Self::Disabled => "disabled",
             Self::DevOnlyProfile => "dev-only-profile",
             Self::HostedSingleTenantVolumePreview => "hosted-single-tenant-volume-preview",
+            Self::HostedSingleTenantVolumeSandboxedPreview => {
+                "hosted-single-tenant-volume-sandboxed-preview"
+            }
             Self::Missing => "missing",
             Self::LocalOnly => "local-only",
             Self::Unverified => "unverified",
@@ -120,6 +125,9 @@ impl<'de> Deserialize<'de> for RebornReadinessDiagnosticReason {
             "disabled" => Self::Disabled,
             "dev-only-profile" => Self::DevOnlyProfile,
             "hosted-single-tenant-volume-preview" => Self::HostedSingleTenantVolumePreview,
+            "hosted-single-tenant-volume-sandboxed-preview" => {
+                Self::HostedSingleTenantVolumeSandboxedPreview
+            }
             "missing" => Self::Missing,
             "local-only" => Self::LocalOnly,
             "unverified" => Self::Unverified,
@@ -300,6 +308,21 @@ impl RebornReadinessDiagnostic {
             profile: RebornCompositionProfile::HostedSingleTenantVolume,
             component: RebornReadinessDiagnosticComponent::CompositionProfile,
             reason: RebornReadinessDiagnosticReason::HostedSingleTenantVolumePreview,
+            status: RebornReadinessDiagnosticStatus::Warning,
+            blocks_production: true,
+        }
+    }
+
+    /// The sandboxed-shell variant of the hosted volume preview: process
+    /// execution routes to a per-tenant Docker sandbox (`TenantSandbox`)
+    /// instead of staying disabled, so it carries its own preview reason
+    /// rather than reusing [`RebornReadinessDiagnostic::hosted_single_tenant_volume`].
+    /// Boots fail-closed until the sandbox transport is wired (A2).
+    pub fn hosted_single_tenant_volume_sandboxed() -> Self {
+        Self {
+            profile: RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
+            component: RebornReadinessDiagnosticComponent::CompositionProfile,
+            reason: RebornReadinessDiagnosticReason::HostedSingleTenantVolumeSandboxedPreview,
             status: RebornReadinessDiagnosticStatus::Warning,
             blocks_production: true,
         }

--- a/crates/ironclaw_reborn_composition/src/root/profile.rs
+++ b/crates/ironclaw_reborn_composition/src/root/profile.rs
@@ -12,6 +12,7 @@ pub enum RebornCompositionProfile {
     LocalDevYolo,
     HostedSingleTenant,
     HostedSingleTenantVolume,
+    HostedSingleTenantVolumeSandboxed,
     Production,
     MigrationDryRun,
 }
@@ -24,6 +25,7 @@ impl RebornCompositionProfile {
             Self::LocalDevYolo => "local-dev-yolo",
             Self::HostedSingleTenant => "hosted-single-tenant",
             Self::HostedSingleTenantVolume => "hosted-single-tenant-volume",
+            Self::HostedSingleTenantVolumeSandboxed => "hosted-single-tenant-volume-sandboxed",
             Self::Production => "production",
             Self::MigrationDryRun => "migration-dry-run",
         }
@@ -80,6 +82,7 @@ impl FromStr for RebornCompositionProfile {
             "local-dev-yolo" => Ok(Self::LocalDevYolo),
             "hosted-single-tenant" => Ok(Self::HostedSingleTenant),
             "hosted-single-tenant-volume" => Ok(Self::HostedSingleTenantVolume),
+            "hosted-single-tenant-volume-sandboxed" => Ok(Self::HostedSingleTenantVolumeSandboxed),
             "production" => Ok(Self::Production),
             "migration-dry-run" => Ok(Self::MigrationDryRun),
             _ => Err(RebornCompositionProfileParseError { value: normalized }),

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2441,6 +2441,14 @@ impl RebornRuntime {
                 .shutdown(ironclaw_auth::KEEPALIVE_SWEEP_SHUTDOWN_TIMEOUT)
                 .await;
         }
+        // D4-1: cancel the sandboxed profile's orphan-container reaper, if
+        // one was spawned (tenant-sandboxed profile with Docker reachable at
+        // boot). `None` on every other profile.
+        if let Some(sandbox_reaper) = self.services.sandbox_reaper_handle {
+            sandbox_reaper
+                .shutdown(crate::sandbox_reaper_task::SANDBOX_REAPER_SHUTDOWN_TIMEOUT)
+                .await;
+        }
         self.trace_flush_worker.shutdown().await;
         if let Some(skill_learning_extraction_tasks) = self.skill_learning_extraction_tasks {
             skill_learning_extraction_tasks.shutdown().await;

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2441,14 +2441,15 @@ impl RebornRuntime {
                 .shutdown(ironclaw_auth::KEEPALIVE_SWEEP_SHUTDOWN_TIMEOUT)
                 .await;
         }
-        // D4-1: cancel the sandboxed profile's orphan-container reaper, if
-        // one was spawned (tenant-sandboxed profile with Docker reachable at
-        // boot). `None` on every other profile.
-        if let Some(sandbox_reaper) = self.services.sandbox_reaper_handle {
-            sandbox_reaper
-                .shutdown(crate::sandbox_reaper_task::SANDBOX_REAPER_SHUTDOWN_TIMEOUT)
-                .await;
-        }
+        // D4-1/A0: one shutdown call for every sandboxed-profile background
+        // task (reaper today; Phase C's egress-proxy/secret-lease daemons join
+        // the same call once they exist). A no-op for every non-sandboxed
+        // profile — `shutdown_all` on an all-`None` `SandboxRuntimeBindings`
+        // returns immediately.
+        self.services
+            .sandbox_runtime_bindings
+            .shutdown_all(crate::sandbox_reaper_task::SANDBOX_REAPER_SHUTDOWN_TIMEOUT)
+            .await;
         self.trace_flush_worker.shutdown().await;
         if let Some(skill_learning_extraction_tasks) = self.skill_learning_extraction_tasks {
             skill_learning_extraction_tasks.shutdown().await;

--- a/crates/ironclaw_reborn_composition/src/sandbox_boot.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_boot.rs
@@ -1,0 +1,189 @@
+//! Boot-time construction of the `TenantSandbox` process-port binding for
+//! composition profiles that request it (today: only
+//! `hosted-single-tenant-volume-sandboxed`).
+//!
+//! This is the one place composition reaches into
+//! `ironclaw_host_runtime`'s sandbox transport to produce a
+//! [`RebornRuntimeProcessBinding`]. Callers above composition — notably the
+//! `ironclaw` CLI binary crate — enter Reborn only through this crate's
+//! public surface and must never depend on `ironclaw_host_runtime` directly
+//! (enforced by
+//! `ironclaw_architecture::reborn_cli_binary_crate_stays_separate_from_v1_root`),
+//! so the Docker connect + transport construction lives here rather than at
+//! the CLI boot-input assembly call site.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ironclaw_host_runtime::{RebornSandboxConfig, RebornScopedSandboxCommandTransport};
+
+use crate::RebornBuildError;
+use crate::input::RebornRuntimeProcessBinding;
+
+/// Full proxy URL (e.g. `http://allowlist-proxy.internal:3128`) the
+/// sandboxed shell container's `http_proxy`/`https_proxy` env should point
+/// at. Takes priority over [`SANDBOX_HTTP_PROXY_PORT_ENV`] when both are set.
+///
+/// Soft-enforcement model (mirrors legacy IronClaw's sandbox): the container
+/// keeps normal bridge networking and is steered through this proxy, which
+/// is expected to enforce the egress allowlist
+/// (`ironclaw_host_runtime::sandbox_allowed_domains`) — see the follow-up
+/// note below.
+const SANDBOX_HTTP_PROXY_URL_ENV: &str = "IRONCLAW_SANDBOX_HTTP_PROXY";
+
+/// Port of an allowlist proxy reachable via the Docker host-gateway address
+/// (`172.17.0.1` on Linux, `host.docker.internal` elsewhere — see
+/// `RebornSandboxConfig::with_network_broker_port`). Used only when
+/// [`SANDBOX_HTTP_PROXY_URL_ENV`] is unset; lets an operator run the proxy on
+/// the host without hardcoding its address.
+const SANDBOX_HTTP_PROXY_PORT_ENV: &str = "IRONCLAW_SANDBOX_HTTP_PROXY_PORT";
+
+/// Connect to the Docker daemon and build a `TenantSandbox` process-port
+/// binding rooted at `sandbox_workspaces_root`. Fails closed: any Docker
+/// connect failure returns `Err`, never a silent
+/// `RebornRuntimeProcessBinding::none()` fallback (which would mean running
+/// sandbox-profile shell commands unsandboxed on the host) — see
+/// `docs/safety-and-sandbox.md`.
+///
+/// Network egress: if [`SANDBOX_HTTP_PROXY_URL_ENV`] or
+/// [`SANDBOX_HTTP_PROXY_PORT_ENV`] names a reachable proxy, the container
+/// gets normal (bridge) networking plus `http_proxy`/`https_proxy` env
+/// pointing at it, so pip/npm/git/curl workflows can reach the allowlisted
+/// registries (`ironclaw_host_runtime::sandbox_allowed_domains`). Without
+/// either env var the sandbox falls back to the prior `--network none`
+/// posture — no egress at all, but still a safe default rather than a
+/// build failure — until a proxy address is configured.
+///
+/// TODO(follow-up, not built here): this only points the container at a
+/// proxy address; it does not stand one up. The actual host-side allowlist
+/// **proxy server** — a forward proxy that enforces
+/// `ironclaw_host_runtime::sandbox_allowed_domains` and is reachable from
+/// the sandbox container at the configured address — still needs to be
+/// built and deployed. Until it lands, setting either env var here routes
+/// the container's traffic at *something*, but that something must already
+/// exist and enforce the allowlist, or the container effectively gets open
+/// egress.
+pub async fn tenant_sandbox_process_binding(
+    sandbox_workspaces_root: PathBuf,
+) -> Result<RebornRuntimeProcessBinding, RebornBuildError> {
+    let config = with_sandbox_network_broker(RebornSandboxConfig::new(sandbox_workspaces_root))?;
+    let transport = RebornScopedSandboxCommandTransport::connect(config)
+        .await
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!(
+                "tenant-sandbox process backend requires a reachable Docker daemon: {error}"
+            ),
+        })?;
+    let process_port = Arc::new(transport.into_process_port());
+    Ok(RebornRuntimeProcessBinding::tenant_sandbox(process_port))
+}
+
+/// Applies the configured proxy broker (if any) to `config`. Missing or
+/// invalid configuration is handled gracefully: an absent env var leaves the
+/// sandbox at its safe `--network none` default rather than failing the
+/// build; an invalid `SANDBOX_HTTP_PROXY_URL_ENV` value fails closed with a
+/// descriptive error rather than silently falling back to no proxy (which
+/// would look configured but silently grant no egress instead of the
+/// intended allowlisted egress).
+fn with_sandbox_network_broker(
+    config: RebornSandboxConfig,
+) -> Result<RebornSandboxConfig, RebornBuildError> {
+    with_sandbox_network_broker_from_values(
+        config,
+        std::env::var(SANDBOX_HTTP_PROXY_URL_ENV).ok(),
+        std::env::var(SANDBOX_HTTP_PROXY_PORT_ENV).ok(),
+    )
+}
+
+/// Inner resolver taking the raw proxy env values as parameters so tests can
+/// drive every branch without mutating process-global env — this crate is
+/// `#![forbid(unsafe_code)]`, which bans `std::env::set_var`. Mirrors the
+/// `hosted_volume_secret_master_key_from_raw` pattern in `deployment.rs`.
+fn with_sandbox_network_broker_from_values(
+    config: RebornSandboxConfig,
+    proxy_url: Option<String>,
+    proxy_port: Option<String>,
+) -> Result<RebornSandboxConfig, RebornBuildError> {
+    if let Some(proxy_url) = proxy_url {
+        return config
+            .with_network_broker_proxy_url(proxy_url)
+            .map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!(
+                    "{SANDBOX_HTTP_PROXY_URL_ENV} is not a usable proxy URL: {error}"
+                ),
+            });
+    }
+    if let Some(raw_port) = proxy_port {
+        let port = raw_port
+            .trim()
+            .parse::<u16>()
+            .map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!(
+                    "{SANDBOX_HTTP_PROXY_PORT_ENV} must be a valid port number: {error}"
+                ),
+            })?;
+        return Ok(config.with_network_broker_port(port));
+    }
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These drive `with_sandbox_network_broker_from_values` directly with
+    // explicit env values so no process-global env mutation is needed — this
+    // crate is `#![forbid(unsafe_code)]`, which bans `std::env::set_var`.
+
+    #[test]
+    fn missing_proxy_env_leaves_sandbox_at_safe_default() {
+        let config = with_sandbox_network_broker_from_values(
+            RebornSandboxConfig::new("/tmp/reborn-sandbox"),
+            None,
+            None,
+        )
+        .expect("no proxy env configured is not an error");
+
+        // No broker configured: the config's Debug output still shows the
+        // safe `network_broker: None` default.
+        assert!(format!("{config:?}").contains("network_broker: None"));
+    }
+
+    #[test]
+    fn proxy_url_env_wires_a_network_broker() {
+        let config = with_sandbox_network_broker_from_values(
+            RebornSandboxConfig::new("/tmp/reborn-sandbox"),
+            Some("http://proxy.internal:3128".to_string()),
+            None,
+        )
+        .expect("valid proxy URL wires successfully");
+
+        assert!(!format!("{config:?}").contains("network_broker: None"));
+    }
+
+    #[test]
+    fn invalid_proxy_url_env_fails_closed() {
+        let result = with_sandbox_network_broker_from_values(
+            RebornSandboxConfig::new("/tmp/reborn-sandbox"),
+            Some("not a url".to_string()),
+            None,
+        );
+
+        assert!(
+            result.is_err(),
+            "an unusable proxy URL must fail closed, not silently drop the broker"
+        );
+    }
+
+    #[test]
+    fn proxy_port_env_wires_a_network_broker_via_host_gateway() {
+        let config = with_sandbox_network_broker_from_values(
+            RebornSandboxConfig::new("/tmp/reborn-sandbox"),
+            None,
+            Some("8181".to_string()),
+        )
+        .expect("valid proxy port wires successfully");
+
+        assert!(!format!("{config:?}").contains("network_broker: None"));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/sandbox_boot.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_boot.rs
@@ -108,20 +108,19 @@ fn with_sandbox_network_broker_from_values(
         return config
             .with_network_broker_proxy_url(proxy_url)
             .map_err(|error| RebornBuildError::InvalidConfig {
-                reason: format!(
-                    "{SANDBOX_HTTP_PROXY_URL_ENV} is not a usable proxy URL: {error}"
-                ),
+                reason: format!("{SANDBOX_HTTP_PROXY_URL_ENV} is not a usable proxy URL: {error}"),
             });
     }
     if let Some(raw_port) = proxy_port {
-        let port = raw_port
-            .trim()
-            .parse::<u16>()
-            .map_err(|error| RebornBuildError::InvalidConfig {
-                reason: format!(
-                    "{SANDBOX_HTTP_PROXY_PORT_ENV} must be a valid port number: {error}"
-                ),
-            })?;
+        let port =
+            raw_port
+                .trim()
+                .parse::<u16>()
+                .map_err(|error| RebornBuildError::InvalidConfig {
+                    reason: format!(
+                        "{SANDBOX_HTTP_PROXY_PORT_ENV} must be a valid port number: {error}"
+                    ),
+                })?;
         return Ok(config.with_network_broker_port(port));
     }
     Ok(config)

--- a/crates/ironclaw_reborn_composition/src/sandbox_boot.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_boot.rs
@@ -15,7 +15,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use ironclaw_host_runtime::{RebornSandboxConfig, RebornScopedSandboxCommandTransport};
+use ironclaw_host_runtime::{
+    RebornSandboxConfig, RebornScopedSandboxCommandTransport, SandboxActivityRegistry,
+};
 
 use crate::RebornBuildError;
 use crate::input::RebornRuntimeProcessBinding;
@@ -65,17 +67,33 @@ const SANDBOX_HTTP_PROXY_PORT_ENV: &str = "IRONCLAW_SANDBOX_HTTP_PROXY_PORT";
 /// egress.
 pub async fn tenant_sandbox_process_binding(
     sandbox_workspaces_root: PathBuf,
-) -> Result<RebornRuntimeProcessBinding, RebornBuildError> {
+) -> Result<TenantSandboxBinding, RebornBuildError> {
     let config = with_sandbox_network_broker(RebornSandboxConfig::new(sandbox_workspaces_root))?;
+    let activity = Arc::new(SandboxActivityRegistry::new());
     let transport = RebornScopedSandboxCommandTransport::connect(config)
         .await
         .map_err(|error| RebornBuildError::InvalidConfig {
             reason: format!(
                 "tenant-sandbox process backend requires a reachable Docker daemon: {error}"
             ),
-        })?;
+        })?
+        .with_activity_registry(Arc::clone(&activity));
     let process_port = Arc::new(transport.into_process_port());
-    Ok(RebornRuntimeProcessBinding::tenant_sandbox(process_port))
+    Ok(TenantSandboxBinding {
+        binding: RebornRuntimeProcessBinding::tenant_sandbox(process_port),
+        activity,
+    })
+}
+
+/// Return value of [`tenant_sandbox_process_binding`]: the process-port
+/// binding plus the SAME [`SandboxActivityRegistry`] instance the exec
+/// transport now writes activity into, so a caller that also spawns
+/// `SandboxReaper` (via `sandbox_composition`/`factory.rs`) reads the exact
+/// timestamps the transport is recording — never a second, independently
+/// constructed registry.
+pub struct TenantSandboxBinding {
+    pub binding: RebornRuntimeProcessBinding,
+    pub activity: Arc<SandboxActivityRegistry>,
 }
 
 /// Applies the configured proxy broker (if any) to `config`. Missing or

--- a/crates/ironclaw_reborn_composition/src/sandbox_composition.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_composition.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 
 use ironclaw_host_runtime::SandboxActivityRegistry;
 use ironclaw_resources::ResourceGovernor;
-use ironclaw_run_state::RunStateStore;
 
 use crate::RebornBuildError;
 use crate::input::RebornLocalRuntimeIdentity;
@@ -53,7 +52,12 @@ pub(crate) struct SandboxProfileBindingInputs<'a> {
     pub(crate) is_sandboxed_profile: bool,
     pub(crate) local_runtime_identity: Option<&'a RebornLocalRuntimeIdentity>,
     pub(crate) resource_governor: Arc<dyn ResourceGovernor>,
-    pub(crate) run_state: Arc<dyn RunStateStore>,
+    /// The activity registry the transport (`sandbox_boot::tenant_sandbox_process_binding`)
+    /// already constructed and injected into the exec transport — the reaper
+    /// must observe the SAME instance, never a second independently
+    /// constructed registry, or its idle/activity reads would never match
+    /// what the transport records.
+    pub(crate) activity: Arc<SandboxActivityRegistry>,
 }
 
 pub(crate) struct SandboxRuntimeBindings {
@@ -105,12 +109,14 @@ impl SandboxRuntimeBindings {
         // D4-1: spawn the orphan-container reaper. Guarded internally —
         // returns `None` rather than failing this build if Docker is not
         // reachable at this (independent, best-effort) connect attempt.
+        // Shares `inputs.activity` with the exec transport (Task A5) so
+        // both observe the same per-user last-activity timestamps.
         let reaper =
-            crate::sandbox_reaper_task::maybe_spawn_sandbox_reaper(Arc::clone(&inputs.run_state))
+            crate::sandbox_reaper_task::maybe_spawn_sandbox_reaper(Arc::clone(&inputs.activity))
                 .await;
 
         Ok(Self {
-            activity: Arc::new(SandboxActivityRegistry::new()),
+            activity: inputs.activity,
             reaper,
             egress_proxy: None,
             secret_lease: None,
@@ -134,67 +140,8 @@ impl SandboxRuntimeBindings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironclaw_host_api::{
-        ApprovalRequest, InvocationId, ResourceEstimate, ResourceScope, UserId,
-    };
+    use ironclaw_host_api::{InvocationId, ResourceEstimate, ResourceScope, UserId};
     use ironclaw_resources::InMemoryResourceGovernor;
-    use ironclaw_run_state::{RunRecord, RunStart, RunStateError, RunStateStore};
-
-    /// Mirrors `sandbox_reaper_task::tests::AlwaysAbsentRunStateStore`:
-    /// these tests never exercise real run-state persistence, they only
-    /// need some `Arc<dyn RunStateStore>` to construct `build`'s argument.
-    struct AlwaysAbsentRunStateStore;
-
-    #[async_trait::async_trait]
-    impl RunStateStore for AlwaysAbsentRunStateStore {
-        async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls start()")
-        }
-        async fn block_approval(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _approval: ApprovalRequest,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls block_approval()")
-        }
-        async fn block_auth(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _error_kind: String,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls block_auth()")
-        }
-        async fn complete(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls complete()")
-        }
-        async fn fail(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _error_kind: String,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls fail()")
-        }
-        async fn records_for_scope(
-            &self,
-            _scope: &ResourceScope,
-        ) -> Result<Vec<RunRecord>, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls records_for_scope()")
-        }
-        async fn get(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-        ) -> Result<Option<RunRecord>, RunStateError> {
-            Ok(None)
-        }
-    }
 
     fn governor() -> Arc<dyn ironclaw_resources::ResourceGovernor> {
         Arc::new(InMemoryResourceGovernor::new())
@@ -206,7 +153,7 @@ mod tests {
             is_sandboxed_profile: false,
             local_runtime_identity: None,
             resource_governor: governor(),
-            run_state: Arc::new(AlwaysAbsentRunStateStore),
+            activity: Arc::new(SandboxActivityRegistry::new()),
         })
         .await
         .expect("non-sandboxed profile never fails to build inert bindings");
@@ -224,7 +171,7 @@ mod tests {
             is_sandboxed_profile: true,
             local_runtime_identity: None,
             resource_governor: Arc::clone(&governor),
-            run_state: Arc::new(AlwaysAbsentRunStateStore),
+            activity: Arc::new(SandboxActivityRegistry::new()),
         })
         .await
         .expect("sandboxed profile build succeeds even with no reachable Docker daemon");

--- a/crates/ironclaw_reborn_composition/src/sandbox_composition.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_composition.rs
@@ -12,6 +12,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use ironclaw_host_api::UserId;
 use ironclaw_host_runtime::SandboxActivityRegistry;
 use ironclaw_resources::ResourceGovernor;
 
@@ -58,6 +59,10 @@ pub(crate) struct SandboxProfileBindingInputs<'a> {
     /// constructed registry, or its idle/activity reads would never match
     /// what the transport records.
     pub(crate) activity: Arc<SandboxActivityRegistry>,
+    /// Task A6: the sandbox concurrency ceiling is scoped per-user (not
+    /// per-tenant), so one user cannot starve every other user in the
+    /// tenant.
+    pub(crate) owner_user_id: UserId,
 }
 
 pub(crate) struct SandboxRuntimeBindings {
@@ -82,7 +87,7 @@ impl SandboxRuntimeBindings {
     }
 
     /// Builds the sandboxed profile's runtime bindings: applies the
-    /// tenant concurrency ceiling and spawns the orphan-container reaper.
+    /// per-user concurrency ceiling and spawns the orphan-container reaper.
     /// Moved verbatim out of `build_local_runtime`'s inline
     /// `if is_sandboxed_profile` block (D3-2/D4-1) — behavior-preserving,
     /// this task only relocates the wiring behind one seam. Non-sandboxed
@@ -97,13 +102,14 @@ impl SandboxRuntimeBindings {
 
         let sandbox_tenant_id =
             crate::sandbox_quota::resolve_local_runtime_tenant_id(inputs.local_runtime_identity)?;
-        crate::sandbox_quota::apply_sandbox_tenant_ceiling(
+        crate::sandbox_quota::apply_sandbox_user_ceiling(
             &inputs.resource_governor,
             sandbox_tenant_id,
+            inputs.owner_user_id,
             crate::sandbox_quota::sandbox_max_concurrent_from_env(),
         )
         .map_err(|error| RebornBuildError::InvalidConfig {
-            reason: format!("sandbox tenant concurrency ceiling could not be set: {error}"),
+            reason: format!("sandbox user concurrency ceiling could not be set: {error}"),
         })?;
 
         // D4-1: spawn the orphan-container reaper. Guarded internally —
@@ -154,6 +160,7 @@ mod tests {
             local_runtime_identity: None,
             resource_governor: governor(),
             activity: Arc::new(SandboxActivityRegistry::new()),
+            owner_user_id: UserId::new("probe-user").unwrap(),
         })
         .await
         .expect("non-sandboxed profile never fails to build inert bindings");
@@ -165,13 +172,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sandboxed_profile_applies_the_tenant_ceiling() {
+    async fn sandboxed_profile_applies_the_user_ceiling() {
         let governor = governor();
+        let owner_user_id = UserId::new("probe-user").unwrap();
         let bindings = SandboxRuntimeBindings::build(SandboxProfileBindingInputs {
             is_sandboxed_profile: true,
             local_runtime_identity: None,
             resource_governor: Arc::clone(&governor),
             activity: Arc::new(SandboxActivityRegistry::new()),
+            owner_user_id: owner_user_id.clone(),
         })
         .await
         .expect("sandboxed profile build succeeds even with no reachable Docker daemon");
@@ -182,7 +191,7 @@ mod tests {
         let tenant_id = crate::sandbox_quota::resolve_local_runtime_tenant_id(None).unwrap();
         let scope = ResourceScope {
             tenant_id,
-            user_id: UserId::new("probe-user").unwrap(),
+            user_id: owner_user_id,
             agent_id: None,
             project_id: None,
             mission_id: None,

--- a/crates/ironclaw_reborn_composition/src/sandbox_composition.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_composition.rs
@@ -1,0 +1,260 @@
+//! Single composition seam for every sandboxed-profile runtime background
+//! task and shared handle. `factory.rs` gets exactly one construction call
+//! site (`SandboxRuntimeBindings::build`, inside `build_local_runtime`) and
+//! `runtime.rs` gets exactly one shutdown call
+//! (`SandboxRuntimeBindings::shutdown_all`) for the whole family — the
+//! per-user activity registry (Task A2), the reaper handle (already built;
+//! Task A5 flips its wiring to use the activity registry), and Phase C's
+//! egress-proxy/secret-lease daemon handles all live behind this one
+//! struct instead of `factory.rs` growing a new field and a new shutdown
+//! block per sandbox subsystem.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ironclaw_host_runtime::SandboxActivityRegistry;
+use ironclaw_resources::ResourceGovernor;
+use ironclaw_run_state::RunStateStore;
+
+use crate::RebornBuildError;
+use crate::input::RebornLocalRuntimeIdentity;
+
+/// Reserved for Phase C (secret-broker + egress-allowlist proxy daemons).
+/// Declared now so `SandboxRuntimeBindings`'s shape does not change again
+/// when Phase C lands. Both handle structs are declared canonically here
+/// with their real fields (shutdown_tx/handle + local_addr/socket_path,
+/// mirroring `SandboxReaperRuntimeHandle`); Phase A only ever sets them to
+/// `None`. Phase C imports these types from `sandbox_composition` and
+/// constructs `Some(..)` — it does NOT redeclare same-named structs.
+// Constructed by Phase C (egress proxy / secret-lease daemon); reserved here so
+// SandboxRuntimeBindings's shape is stable.
+#[allow(dead_code)]
+pub(crate) struct SandboxEgressProxyRuntimeHandle {
+    shutdown_tx: tokio::sync::watch::Sender<bool>,
+    handle: tokio::task::JoinHandle<()>,
+    pub(crate) local_addr: std::net::SocketAddr,
+}
+
+// Constructed by Phase C (egress proxy / secret-lease daemon); reserved here so
+// SandboxRuntimeBindings's shape is stable.
+#[allow(dead_code)]
+pub(crate) struct SandboxSecretLeaseDaemonHandle {
+    shutdown_tx: tokio::sync::watch::Sender<bool>,
+    handle: tokio::task::JoinHandle<()>,
+    pub(crate) socket_path: std::path::PathBuf,
+}
+
+/// Inputs `build` needs out of `build_local_runtime`'s local scope. A
+/// struct (not four positional params) so Task A6 can add
+/// `owner_user_id` and Task A5 can source `activity` from
+/// `sandbox_boot`'s returned binding without another signature churn at
+/// every call site.
+pub(crate) struct SandboxProfileBindingInputs<'a> {
+    pub(crate) is_sandboxed_profile: bool,
+    pub(crate) local_runtime_identity: Option<&'a RebornLocalRuntimeIdentity>,
+    pub(crate) resource_governor: Arc<dyn ResourceGovernor>,
+    pub(crate) run_state: Arc<dyn RunStateStore>,
+}
+
+pub(crate) struct SandboxRuntimeBindings {
+    pub(crate) activity: Arc<SandboxActivityRegistry>,
+    pub(crate) reaper: Option<crate::sandbox_reaper_task::SandboxReaperRuntimeHandle>,
+    pub(crate) egress_proxy: Option<SandboxEgressProxyRuntimeHandle>,
+    pub(crate) secret_lease: Option<SandboxSecretLeaseDaemonHandle>,
+}
+
+impl SandboxRuntimeBindings {
+    /// The non-sandboxed-profile / production-build-context case: no
+    /// background tasks. The activity registry is still real (not
+    /// `Option`) so the field never needs unwrapping at call sites — it
+    /// is simply never touched by anything for these profiles.
+    pub(crate) fn none() -> Self {
+        Self {
+            activity: Arc::new(SandboxActivityRegistry::new()),
+            reaper: None,
+            egress_proxy: None,
+            secret_lease: None,
+        }
+    }
+
+    /// Builds the sandboxed profile's runtime bindings: applies the
+    /// tenant concurrency ceiling and spawns the orphan-container reaper.
+    /// Moved verbatim out of `build_local_runtime`'s inline
+    /// `if is_sandboxed_profile` block (D3-2/D4-1) — behavior-preserving,
+    /// this task only relocates the wiring behind one seam. Non-sandboxed
+    /// profiles get `Self::none()` immediately, without touching the
+    /// governor or spawning anything.
+    pub(crate) async fn build(
+        inputs: SandboxProfileBindingInputs<'_>,
+    ) -> Result<Self, RebornBuildError> {
+        if !inputs.is_sandboxed_profile {
+            return Ok(Self::none());
+        }
+
+        let sandbox_tenant_id =
+            crate::sandbox_quota::resolve_local_runtime_tenant_id(inputs.local_runtime_identity)?;
+        crate::sandbox_quota::apply_sandbox_tenant_ceiling(
+            &inputs.resource_governor,
+            sandbox_tenant_id,
+            crate::sandbox_quota::sandbox_max_concurrent_from_env(),
+        )
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("sandbox tenant concurrency ceiling could not be set: {error}"),
+        })?;
+
+        // D4-1: spawn the orphan-container reaper. Guarded internally —
+        // returns `None` rather than failing this build if Docker is not
+        // reachable at this (independent, best-effort) connect attempt.
+        let reaper =
+            crate::sandbox_reaper_task::maybe_spawn_sandbox_reaper(Arc::clone(&inputs.run_state))
+                .await;
+
+        Ok(Self {
+            activity: Arc::new(SandboxActivityRegistry::new()),
+            reaper,
+            egress_proxy: None,
+            secret_lease: None,
+        })
+    }
+
+    /// The one shutdown call site for every sandbox background task.
+    /// `RebornRuntime::shutdown` calls this unconditionally (the struct
+    /// is always present on `RebornServices`, never `Option` at that
+    /// level — `none()` just means every field inside is empty, so this
+    /// is a cheap no-op for non-sandboxed profiles).
+    pub(crate) async fn shutdown_all(self, timeout: Duration) {
+        if let Some(reaper) = self.reaper {
+            reaper.shutdown(timeout).await;
+        }
+        // Phase C: egress_proxy/secret_lease daemon shutdown joins here
+        // too, once those variants are ever `Some`.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{
+        ApprovalRequest, InvocationId, ResourceEstimate, ResourceScope, UserId,
+    };
+    use ironclaw_resources::InMemoryResourceGovernor;
+    use ironclaw_run_state::{RunRecord, RunStart, RunStateError, RunStateStore};
+
+    /// Mirrors `sandbox_reaper_task::tests::AlwaysAbsentRunStateStore`:
+    /// these tests never exercise real run-state persistence, they only
+    /// need some `Arc<dyn RunStateStore>` to construct `build`'s argument.
+    struct AlwaysAbsentRunStateStore;
+
+    #[async_trait::async_trait]
+    impl RunStateStore for AlwaysAbsentRunStateStore {
+        async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls start()")
+        }
+        async fn block_approval(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _approval: ApprovalRequest,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls block_approval()")
+        }
+        async fn block_auth(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _error_kind: String,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls block_auth()")
+        }
+        async fn complete(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls complete()")
+        }
+        async fn fail(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _error_kind: String,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls fail()")
+        }
+        async fn records_for_scope(
+            &self,
+            _scope: &ResourceScope,
+        ) -> Result<Vec<RunRecord>, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls records_for_scope()")
+        }
+        async fn get(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+        ) -> Result<Option<RunRecord>, RunStateError> {
+            Ok(None)
+        }
+    }
+
+    fn governor() -> Arc<dyn ironclaw_resources::ResourceGovernor> {
+        Arc::new(InMemoryResourceGovernor::new())
+    }
+
+    #[tokio::test]
+    async fn non_sandboxed_profile_yields_inert_bindings_with_no_reaper() {
+        let bindings = SandboxRuntimeBindings::build(SandboxProfileBindingInputs {
+            is_sandboxed_profile: false,
+            local_runtime_identity: None,
+            resource_governor: governor(),
+            run_state: Arc::new(AlwaysAbsentRunStateStore),
+        })
+        .await
+        .expect("non-sandboxed profile never fails to build inert bindings");
+
+        assert!(bindings.reaper.is_none());
+        assert!(bindings.egress_proxy.is_none());
+        assert!(bindings.secret_lease.is_none());
+        bindings.shutdown_all(Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test]
+    async fn sandboxed_profile_applies_the_tenant_ceiling() {
+        let governor = governor();
+        let bindings = SandboxRuntimeBindings::build(SandboxProfileBindingInputs {
+            is_sandboxed_profile: true,
+            local_runtime_identity: None,
+            resource_governor: Arc::clone(&governor),
+            run_state: Arc::new(AlwaysAbsentRunStateStore),
+        })
+        .await
+        .expect("sandboxed profile build succeeds even with no reachable Docker daemon");
+
+        // The ceiling is live regardless of whether the reaper spawn found
+        // a Docker daemon (best-effort, mirrors
+        // `sandbox_reaper_task::tests::no_docker_daemon_yields_no_handle`).
+        let tenant_id = crate::sandbox_quota::resolve_local_runtime_tenant_id(None).unwrap();
+        let scope = ResourceScope {
+            tenant_id,
+            user_id: UserId::new("probe-user").unwrap(),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        };
+        let first = governor
+            .reserve(scope, ResourceEstimate::default().set_concurrency_slots(1))
+            .expect("first reservation is within the default ceiling");
+        drop(first);
+
+        bindings.shutdown_all(Duration::from_secs(1)).await;
+    }
+
+    #[test]
+    fn none_constructor_produces_no_handles() {
+        let bindings = SandboxRuntimeBindings::none();
+        assert!(bindings.reaper.is_none());
+        assert!(bindings.egress_proxy.is_none());
+        assert!(bindings.secret_lease.is_none());
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/sandbox_quota.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_quota.rs
@@ -1,0 +1,184 @@
+//! Tenant-level concurrency ceiling for the `hosted-single-tenant-volume-sandboxed`
+//! profile (D3-2).
+//!
+//! `ironclaw_authorization::obligations_for_grant` already emits a
+//! `ReserveResources` obligation for every `EffectKind::SpawnProcess`
+//! capability grant (D3-1), and `ironclaw_host_runtime::obligations::
+//! reserve_resource_obligation` already reserves against whatever
+//! `ResourceGovernor` composition wires in. Both are no-ops today because no
+//! deployment ever calls `set_limit` for a `SpawnProcess`-relevant account —
+//! this module is the one caller that does, for the sandboxed profile only.
+//!
+//! Kept as its own module (not inlined into `factory.rs`, which is already
+//! thousands of lines) so the boot call site stays a single line.
+
+use std::sync::Arc;
+
+use ironclaw_host_api::TenantId;
+use ironclaw_resources::{ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits};
+
+/// Overrides the sandboxed profile's per-tenant concurrent `SpawnProcess`
+/// ceiling. Unset, or set to a non-positive/unparseable value, falls back to
+/// [`DEFAULT_SANDBOX_MAX_CONCURRENT`].
+pub(crate) const SANDBOX_MAX_CONCURRENT_ENV: &str = "IRONCLAW_SANDBOX_MAX_CONCURRENT";
+
+/// Default per-tenant concurrent sandbox-process ceiling when
+/// [`SANDBOX_MAX_CONCURRENT_ENV`] is not set. Deliberately small: the
+/// sandboxed profile runs one Docker container per shell invocation, and an
+/// unbounded ceiling defeats the point of D3-2 (bounding a single tenant's
+/// concurrent container fan-out).
+pub(crate) const DEFAULT_SANDBOX_MAX_CONCURRENT: u32 = 4;
+
+/// Resolves the configured ceiling from [`SANDBOX_MAX_CONCURRENT_ENV`],
+/// falling back to [`DEFAULT_SANDBOX_MAX_CONCURRENT`] when the env var is
+/// absent, empty, non-numeric, or zero (zero would mean "no sandboxed shell
+/// calls ever succeed", which is never an intentional deployment choice —
+/// operators who want that should not enable the sandboxed profile).
+pub(crate) fn sandbox_max_concurrent_from_env() -> u32 {
+    resolve_sandbox_max_concurrent_from_raw(std::env::var(SANDBOX_MAX_CONCURRENT_ENV).ok())
+}
+
+/// Pure resolution of the sandbox max-concurrency ceiling from an already-read
+/// raw env value. Kept separate from [`sandbox_max_concurrent_from_env`] so
+/// tests can exercise the parse/validate/default logic directly with an
+/// explicit `Some`/`None` input instead of mutating process env — a raw
+/// `std::env::var` read does not observe
+/// `ironclaw_common::env_helpers::set_runtime_env`'s thread-local override,
+/// so round-tripping through real env vars in tests is both unnecessary and
+/// unreliable under parallel test execution.
+pub(crate) fn resolve_sandbox_max_concurrent_from_raw(raw: Option<String>) -> u32 {
+    raw.and_then(|raw| raw.trim().parse::<u32>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_SANDBOX_MAX_CONCURRENT)
+}
+
+/// Sets the tenant-scoped `max_concurrency_slots` ceiling on `governor` for
+/// `tenant_id`. Composition calls this once at boot, only for the
+/// `hosted-single-tenant-volume-sandboxed` profile — every other profile
+/// leaves the tenant account unlimited, matching D3-1's "no-op until D3-2"
+/// note.
+///
+/// This is what turns the D3-1 `ReserveResources` obligation from a no-op
+/// into an actual gate: `FilesystemResourceGovernor`/
+/// `InMemoryResourceGovernor::reserve_with_outcome` check `max_concurrency_slots`
+/// against the account's current outstanding reservations, so the
+/// `N+1`th concurrent `SpawnProcess` reservation for this tenant is denied as
+/// a model-visible outcome (never a host error) once this ceiling is set.
+pub(crate) fn apply_sandbox_tenant_ceiling(
+    governor: &Arc<dyn ResourceGovernor>,
+    tenant_id: TenantId,
+    max_concurrent: u32,
+) -> Result<(), ResourceError> {
+    governor.set_limit(
+        ResourceAccount::tenant(tenant_id),
+        ResourceLimits::default().set_max_concurrency_slots(max_concurrent),
+    )
+}
+
+/// Resolves the tenant id the sandboxed-profile boot ceiling applies to:
+/// the local-runtime identity's tenant when one was supplied, else the same
+/// `reborn_cli()` default identity every other local-runtime call site falls
+/// back to (mirrors `local_dev_extension_lifecycle_surface_context` in
+/// `factory.rs`).
+pub(crate) fn resolve_local_runtime_tenant_id(
+    local_runtime_identity: Option<&crate::input::RebornLocalRuntimeIdentity>,
+) -> Result<TenantId, crate::RebornBuildError> {
+    if let Some(identity) = local_runtime_identity {
+        return Ok(identity.tenant_id.clone());
+    }
+    let default_identity = crate::runtime_input::RebornRuntimeIdentity::reborn_cli();
+    TenantId::new(default_identity.tenant_id).map_err(|error| crate::RebornBuildError::InvalidConfig {
+        reason: error.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{InvocationId, ResourceEstimate, ResourceScope, UserId};
+    use ironclaw_resources::InMemoryResourceGovernor;
+
+    use super::*;
+
+    fn tenant(id: &str) -> TenantId {
+        TenantId::new(id.to_string()).expect("valid tenant id")
+    }
+
+    fn scope(tenant_id: &TenantId) -> ResourceScope {
+        ResourceScope {
+            tenant_id: tenant_id.clone(),
+            user_id: UserId::new("sandbox-quota-test-user").expect("valid user id"),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    #[test]
+    fn env_override_is_read_and_validated() {
+        assert_eq!(
+            resolve_sandbox_max_concurrent_from_raw(None),
+            DEFAULT_SANDBOX_MAX_CONCURRENT,
+            "unset falls back to the default"
+        );
+
+        assert_eq!(
+            resolve_sandbox_max_concurrent_from_raw(Some("7".to_string())),
+            7,
+            "a valid number is used"
+        );
+
+        assert_eq!(
+            resolve_sandbox_max_concurrent_from_raw(Some("0".to_string())),
+            DEFAULT_SANDBOX_MAX_CONCURRENT,
+            "zero must not disable the sandboxed profile entirely"
+        );
+
+        assert_eq!(
+            resolve_sandbox_max_concurrent_from_raw(Some("not-a-number".to_string())),
+            DEFAULT_SANDBOX_MAX_CONCURRENT,
+            "unparseable falls back to the default"
+        );
+    }
+
+    /// D3-2's headline behavior: once the tenant ceiling is applied, the
+    /// `N+1`th concurrent reservation for that tenant is *denied* — a
+    /// model-visible outcome from `ResourceGovernor::reserve`, never a host
+    /// panic/error — while a distinct tenant is unaffected.
+    #[test]
+    fn ceiling_denies_the_second_concurrent_reservation_for_the_same_tenant() {
+        let governor: Arc<dyn ResourceGovernor> = Arc::new(InMemoryResourceGovernor::new());
+        let tenant_id = tenant("sandboxed-tenant");
+
+        apply_sandbox_tenant_ceiling(&governor, tenant_id.clone(), 1)
+            .expect("setting a finite ceiling on an empty account succeeds");
+
+        let first_scope = scope(&tenant_id);
+        let first = governor
+            .reserve(first_scope, ResourceEstimate::default().set_concurrency_slots(1))
+            .expect("first reservation is within the ceiling");
+
+        let second_scope = scope(&tenant_id);
+        let second = governor.reserve(
+            second_scope,
+            ResourceEstimate::default().set_concurrency_slots(1),
+        );
+        assert!(
+            second.is_err(),
+            "second concurrent reservation for a tenant capped at 1 must be denied, not succeed"
+        );
+
+        // A different tenant is never affected by this tenant's ceiling.
+        let other_tenant = tenant("other-tenant");
+        let other_scope = scope(&other_tenant);
+        governor
+            .reserve(
+                other_scope,
+                ResourceEstimate::default().set_concurrency_slots(1),
+            )
+            .expect("an unrelated tenant's account is unaffected by this ceiling");
+
+        drop(first);
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/sandbox_quota.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_quota.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use ironclaw_host_api::TenantId;
+use ironclaw_host_api::{TenantId, UserId};
 use ironclaw_resources::{ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits};
 
 /// Overrides the sandboxed profile's per-tenant concurrent `SpawnProcess`
@@ -52,25 +52,27 @@ pub(crate) fn resolve_sandbox_max_concurrent_from_raw(raw: Option<String>) -> u3
         .unwrap_or(DEFAULT_SANDBOX_MAX_CONCURRENT)
 }
 
-/// Sets the tenant-scoped `max_concurrency_slots` ceiling on `governor` for
-/// `tenant_id`. Composition calls this once at boot, only for the
-/// `hosted-single-tenant-volume-sandboxed` profile — every other profile
-/// leaves the tenant account unlimited, matching D3-1's "no-op until D3-2"
-/// note.
+/// Sets the per-user `max_concurrency_slots` ceiling on `governor` for
+/// `user_id` within `tenant_id`. Composition calls this once at boot, only
+/// for the `hosted-single-tenant-volume-sandboxed` profile — every other
+/// profile leaves the account unlimited, matching D3-1's "no-op until D3-2"
+/// note. Scoped per-user (not per-tenant) so one user cannot starve every
+/// other user in the tenant by exhausting the shared ceiling.
 ///
 /// This is what turns the D3-1 `ReserveResources` obligation from a no-op
 /// into an actual gate: `FilesystemResourceGovernor`/
 /// `InMemoryResourceGovernor::reserve_with_outcome` check `max_concurrency_slots`
 /// against the account's current outstanding reservations, so the
-/// `N+1`th concurrent `SpawnProcess` reservation for this tenant is denied as
+/// `N+1`th concurrent `SpawnProcess` reservation for this user is denied as
 /// a model-visible outcome (never a host error) once this ceiling is set.
-pub(crate) fn apply_sandbox_tenant_ceiling(
+pub(crate) fn apply_sandbox_user_ceiling(
     governor: &Arc<dyn ResourceGovernor>,
     tenant_id: TenantId,
+    user_id: UserId,
     max_concurrent: u32,
 ) -> Result<(), ResourceError> {
     governor.set_limit(
-        ResourceAccount::tenant(tenant_id),
+        ResourceAccount::user(tenant_id, user_id),
         ResourceLimits::default().set_max_concurrency_slots(max_concurrent),
     )
 }
@@ -105,10 +107,10 @@ mod tests {
         TenantId::new(id.to_string()).expect("valid tenant id")
     }
 
-    fn scope(tenant_id: &TenantId) -> ResourceScope {
+    fn scope_for(tenant_id: &TenantId, user_id: &UserId) -> ResourceScope {
         ResourceScope {
             tenant_id: tenant_id.clone(),
-            user_id: UserId::new("sandbox-quota-test-user").expect("valid user id"),
+            user_id: user_id.clone(),
             agent_id: None,
             project_id: None,
             mission_id: None,
@@ -144,45 +146,47 @@ mod tests {
         );
     }
 
-    /// D3-2's headline behavior: once the tenant ceiling is applied, the
-    /// `N+1`th concurrent reservation for that tenant is *denied* — a
-    /// model-visible outcome from `ResourceGovernor::reserve`, never a host
-    /// panic/error — while a distinct tenant is unaffected.
+    /// D3-2's headline behavior, now scoped per-user (not per-tenant): once
+    /// a user's ceiling is applied, the `N+1`th concurrent reservation for
+    /// that same user is *denied* — a model-visible outcome from
+    /// `ResourceGovernor::reserve`, never a host panic/error — while a
+    /// sibling user in the same tenant is unaffected. This strictly
+    /// supersedes the old per-tenant test: the old behavior let one user
+    /// starve every other user in the tenant, which this change fixes.
     #[test]
-    fn ceiling_denies_the_second_concurrent_reservation_for_the_same_tenant() {
+    fn ceiling_denies_the_second_concurrent_reservation_for_the_same_user_but_not_a_sibling_user() {
         let governor: Arc<dyn ResourceGovernor> = Arc::new(InMemoryResourceGovernor::new());
         let tenant_id = tenant("sandboxed-tenant");
+        let user_id = UserId::new("user-a").expect("valid user id");
 
-        apply_sandbox_tenant_ceiling(&governor, tenant_id.clone(), 1)
+        apply_sandbox_user_ceiling(&governor, tenant_id.clone(), user_id.clone(), 1)
             .expect("setting a finite ceiling on an empty account succeeds");
 
-        let first_scope = scope(&tenant_id);
         let first = governor
             .reserve(
-                first_scope,
+                scope_for(&tenant_id, &user_id),
                 ResourceEstimate::default().set_concurrency_slots(1),
             )
             .expect("first reservation is within the ceiling");
-
-        let second_scope = scope(&tenant_id);
         let second = governor.reserve(
-            second_scope,
+            scope_for(&tenant_id, &user_id),
             ResourceEstimate::default().set_concurrency_slots(1),
         );
         assert!(
             second.is_err(),
-            "second concurrent reservation for a tenant capped at 1 must be denied, not succeed"
+            "second concurrent reservation for a capped user must be denied"
         );
 
-        // A different tenant is never affected by this tenant's ceiling.
-        let other_tenant = tenant("other-tenant");
-        let other_scope = scope(&other_tenant);
+        // A sibling user in the SAME tenant is unaffected — this is the
+        // headline behavior change from the old per-tenant ceiling, where one
+        // user could starve every other user in the tenant.
+        let sibling_user = UserId::new("user-b").expect("valid user id");
         governor
             .reserve(
-                other_scope,
+                scope_for(&tenant_id, &sibling_user),
                 ResourceEstimate::default().set_concurrency_slots(1),
             )
-            .expect("an unrelated tenant's account is unaffected by this ceiling");
+            .expect("a sibling user in the same tenant is unaffected by user-a's ceiling");
 
         drop(first);
     }

--- a/crates/ironclaw_reborn_composition/src/sandbox_quota.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_quota.rs
@@ -87,8 +87,10 @@ pub(crate) fn resolve_local_runtime_tenant_id(
         return Ok(identity.tenant_id.clone());
     }
     let default_identity = crate::runtime_input::RebornRuntimeIdentity::reborn_cli();
-    TenantId::new(default_identity.tenant_id).map_err(|error| crate::RebornBuildError::InvalidConfig {
-        reason: error.to_string(),
+    TenantId::new(default_identity.tenant_id).map_err(|error| {
+        crate::RebornBuildError::InvalidConfig {
+            reason: error.to_string(),
+        }
     })
 }
 
@@ -156,7 +158,10 @@ mod tests {
 
         let first_scope = scope(&tenant_id);
         let first = governor
-            .reserve(first_scope, ResourceEstimate::default().set_concurrency_slots(1))
+            .reserve(
+                first_scope,
+                ResourceEstimate::default().set_concurrency_slots(1),
+            )
             .expect("first reservation is within the ceiling");
 
         let second_scope = scope(&tenant_id);

--- a/crates/ironclaw_reborn_composition/src/sandbox_reaper_task.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_reaper_task.rs
@@ -18,8 +18,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use ironclaw_host_runtime::{SandboxReaper, SandboxReaperConfig};
-use ironclaw_run_state::RunStateStore;
+use ironclaw_host_runtime::{SandboxActivityRegistry, SandboxReaper, SandboxReaperConfig};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
@@ -73,7 +72,7 @@ impl SandboxReaperRuntimeHandle {
 /// unavailability at its own (earlier) connect, so a reaper-spawn failure
 /// here must not additionally fail boot.
 pub(crate) async fn maybe_spawn_sandbox_reaper(
-    run_state: Arc<dyn RunStateStore>,
+    activity: Arc<SandboxActivityRegistry>,
 ) -> Option<SandboxReaperRuntimeHandle> {
     let docker = match ironclaw_host_runtime::connect_docker_with_retry().await {
         Ok(docker) => docker,
@@ -88,7 +87,7 @@ pub(crate) async fn maybe_spawn_sandbox_reaper(
 
     let reaper = Arc::new(SandboxReaper::new(
         docker,
-        run_state,
+        activity,
         SandboxReaperConfig::default(),
     ));
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -105,73 +104,6 @@ pub(crate) async fn maybe_spawn_sandbox_reaper(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironclaw_host_api::{ApprovalRequest, InvocationId, ResourceScope};
-    use ironclaw_run_state::{RunRecord, RunStart, RunStateError};
-
-    /// Minimal stand-in for a `RunStateStore` backend: the reaper-task tests
-    /// here never exercise real run-state persistence (that is
-    /// `ironclaw_run_state`'s own coverage), they only need *some*
-    /// `Arc<dyn RunStateStore>` to construct `maybe_spawn_sandbox_reaper`'s
-    /// argument. `ironclaw_run_state::test_support` is private to that crate,
-    /// so this local fake mirrors
-    /// `sandbox_reaper_docker.rs`'s `AlwaysAbsentRunStateStore`: `get`
-    /// reports "no record", and the writer methods are never called by
-    /// either test, so they're `unreachable!()`. Written inline (not via a
-    /// declarative macro) because `#[async_trait]` sees a macro
-    /// *invocation*, not the expanded `async fn`s, and cannot rewrite them —
-    /// which produces E0195.
-    struct AlwaysAbsentRunStateStore;
-
-    #[async_trait::async_trait]
-    impl RunStateStore for AlwaysAbsentRunStateStore {
-        async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls start()")
-        }
-        async fn block_approval(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _approval: ApprovalRequest,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls block_approval()")
-        }
-        async fn block_auth(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _error_kind: String,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls block_auth()")
-        }
-        async fn complete(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls complete()")
-        }
-        async fn fail(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-            _error_kind: String,
-        ) -> Result<RunRecord, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls fail()")
-        }
-        async fn records_for_scope(
-            &self,
-            _scope: &ResourceScope,
-        ) -> Result<Vec<RunRecord>, RunStateError> {
-            unreachable!("AlwaysAbsentRunStateStore never calls records_for_scope()")
-        }
-        async fn get(
-            &self,
-            _scope: &ResourceScope,
-            _invocation_id: InvocationId,
-        ) -> Result<Option<RunRecord>, RunStateError> {
-            Ok(None)
-        }
-    }
 
     /// The guard the module doc promises: no Docker daemon means `None`, not
     /// a panic/error. This machine's dev/CI default has no Docker daemon, so
@@ -182,9 +114,9 @@ mod tests {
     /// it up rather than asserting the environment.
     #[tokio::test]
     async fn no_docker_daemon_yields_no_handle() {
-        let run_state: Arc<dyn RunStateStore> = Arc::new(AlwaysAbsentRunStateStore);
+        let activity = Arc::new(SandboxActivityRegistry::new());
 
-        match maybe_spawn_sandbox_reaper(run_state).await {
+        match maybe_spawn_sandbox_reaper(activity).await {
             None => {}
             Some(handle) => {
                 // A real Docker daemon happens to be reachable on this

--- a/crates/ironclaw_reborn_composition/src/sandbox_reaper_task.rs
+++ b/crates/ironclaw_reborn_composition/src/sandbox_reaper_task.rs
@@ -1,0 +1,222 @@
+//! Composition-owned spawn of `ironclaw_host_runtime::SandboxReaper` (D4-1).
+//!
+//! The reaper core (`ironclaw_host_runtime::sandbox_process::reaper`) is
+//! deliberately unopinionated about scheduling — composition is the one
+//! place that connects to Docker, constructs the reaper, spawns it as a
+//! background task, and owns its cancellation. This module is that one
+//! place; `factory.rs` calls [`maybe_spawn_sandbox_reaper`] with a single
+//! line rather than growing its own Docker-connect-and-spawn logic.
+//!
+//! Guarded, not required: the sandboxed profile's boot path
+//! (`sandbox_boot::tenant_sandbox_process_binding`) already fails the whole
+//! boot closed if Docker is unreachable, so by the time this is called the
+//! daemon was reachable a moment ago. This function still tolerates a
+//! transient failure of its own (independent) connect attempt by returning
+//! `None` — the reaper is a best-effort orphan sweep, not a boot
+//! precondition, so its absence must never fail composition.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ironclaw_host_runtime::{SandboxReaper, SandboxReaperConfig};
+use ironclaw_run_state::RunStateStore;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+/// How long [`SandboxReaperRuntimeHandle::shutdown`] waits for the reaper's
+/// in-flight scan to observe the shutdown signal and return before it aborts
+/// the task outright. Mirrors `CREDENTIAL_REFRESH_WORKER_SHUTDOWN_TIMEOUT`'s
+/// role for the credential-refresh worker.
+pub(crate) const SANDBOX_REAPER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Owned handle to a spawned [`SandboxReaper::run`] task. Composition holds
+/// exactly one of these (on `RebornRuntime`) for the sandboxed profile and
+/// drives shutdown from `RebornRuntime::shutdown` alongside every other
+/// owned background worker.
+pub(crate) struct SandboxReaperRuntimeHandle {
+    shutdown_tx: watch::Sender<bool>,
+    handle: JoinHandle<()>,
+}
+
+impl SandboxReaperRuntimeHandle {
+    /// Signals the reaper's scan loop to stop and awaits the task, aborting
+    /// it if it has not stopped within `timeout`.
+    pub(crate) async fn shutdown(self, timeout: Duration) {
+        // A closed receiver (task already gone) is not an error here.
+        let _ = self.shutdown_tx.send(true);
+        let mut handle = self.handle;
+        match tokio::time::timeout(timeout, &mut handle).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                tracing::debug!(?error, "sandbox reaper task join failed");
+            }
+            Err(_) => {
+                tracing::debug!(
+                    ?timeout,
+                    "sandbox reaper did not stop before shutdown timeout; aborting"
+                );
+                handle.abort();
+                if let Err(error) = handle.await
+                    && error.is_panic()
+                {
+                    tracing::debug!(?error, "aborted sandbox reaper task panicked");
+                }
+            }
+        }
+    }
+}
+
+/// Connects to Docker and spawns [`SandboxReaper::run`] as an owned
+/// background task, returning `None` (never an error) when Docker is not
+/// reachable — this machine's dev/CI environment commonly has no Docker
+/// daemon, and the sandboxed profile itself already fails closed on Docker
+/// unavailability at its own (earlier) connect, so a reaper-spawn failure
+/// here must not additionally fail boot.
+pub(crate) async fn maybe_spawn_sandbox_reaper(
+    run_state: Arc<dyn RunStateStore>,
+) -> Option<SandboxReaperRuntimeHandle> {
+    let docker = match ironclaw_host_runtime::connect_docker_with_retry().await {
+        Ok(docker) => docker,
+        Err(error) => {
+            tracing::debug!(
+                ?error,
+                "sandbox reaper: Docker daemon unreachable, skipping reaper spawn"
+            );
+            return None;
+        }
+    };
+
+    let reaper = Arc::new(SandboxReaper::new(
+        docker,
+        run_state,
+        SandboxReaperConfig::default(),
+    ));
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = tokio::spawn(async move {
+        reaper.run(shutdown_rx).await;
+    });
+
+    Some(SandboxReaperRuntimeHandle {
+        shutdown_tx,
+        handle,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{ApprovalRequest, InvocationId, ResourceScope};
+    use ironclaw_run_state::{RunRecord, RunStart, RunStateError};
+
+    /// Minimal stand-in for a `RunStateStore` backend: the reaper-task tests
+    /// here never exercise real run-state persistence (that is
+    /// `ironclaw_run_state`'s own coverage), they only need *some*
+    /// `Arc<dyn RunStateStore>` to construct `maybe_spawn_sandbox_reaper`'s
+    /// argument. `ironclaw_run_state::test_support` is private to that crate,
+    /// so this local fake mirrors
+    /// `sandbox_reaper_docker.rs`'s `AlwaysAbsentRunStateStore`: `get`
+    /// reports "no record", and the writer methods are never called by
+    /// either test, so they're `unreachable!()`. Written inline (not via a
+    /// declarative macro) because `#[async_trait]` sees a macro
+    /// *invocation*, not the expanded `async fn`s, and cannot rewrite them —
+    /// which produces E0195.
+    struct AlwaysAbsentRunStateStore;
+
+    #[async_trait::async_trait]
+    impl RunStateStore for AlwaysAbsentRunStateStore {
+        async fn start(&self, _start: RunStart) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls start()")
+        }
+        async fn block_approval(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _approval: ApprovalRequest,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls block_approval()")
+        }
+        async fn block_auth(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _error_kind: String,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls block_auth()")
+        }
+        async fn complete(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls complete()")
+        }
+        async fn fail(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+            _error_kind: String,
+        ) -> Result<RunRecord, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls fail()")
+        }
+        async fn records_for_scope(
+            &self,
+            _scope: &ResourceScope,
+        ) -> Result<Vec<RunRecord>, RunStateError> {
+            unreachable!("AlwaysAbsentRunStateStore never calls records_for_scope()")
+        }
+        async fn get(
+            &self,
+            _scope: &ResourceScope,
+            _invocation_id: InvocationId,
+        ) -> Result<Option<RunRecord>, RunStateError> {
+            Ok(None)
+        }
+    }
+
+    /// The guard the module doc promises: no Docker daemon means `None`, not
+    /// a panic/error. This machine's dev/CI default has no Docker daemon, so
+    /// that is the expected branch here; mirrors
+    /// `connect::tests::readiness_surfaces_reason_on_unreachable_daemon`'s
+    /// tolerance for a CI runner that happens to have Docker reachable —
+    /// `Some` is also a valid, non-flaky outcome there, and this test cleans
+    /// it up rather than asserting the environment.
+    #[tokio::test]
+    async fn no_docker_daemon_yields_no_handle() {
+        let run_state: Arc<dyn RunStateStore> = Arc::new(AlwaysAbsentRunStateStore);
+
+        match maybe_spawn_sandbox_reaper(run_state).await {
+            None => {}
+            Some(handle) => {
+                // A real Docker daemon happens to be reachable on this
+                // machine/CI runner: the spawn succeeding is not itself the
+                // property under test here (that is Docker-gated coverage
+                // elsewhere) — just prove the handle is a real, cancellable
+                // task and clean it up.
+                handle.shutdown(SANDBOX_REAPER_SHUTDOWN_TIMEOUT).await;
+            }
+        }
+    }
+
+    /// The handle's cancellation path (shutdown signal -> task observes it
+    /// and returns -> join succeeds) is exercised directly against a
+    /// `SandboxReaper::run` future without going through Docker, proving the
+    /// handle is a real owned/cancellable task rather than a fire-and-forget
+    /// spawn. Mirrors the shape `maybe_spawn_sandbox_reaper` produces, just
+    /// without the Docker connect this machine cannot perform.
+    #[tokio::test]
+    async fn shutdown_stops_a_running_task_before_the_timeout() {
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let handle = tokio::spawn(async move {
+            // Stand-in for `SandboxReaper::run`'s own shutdown-aware loop.
+            let _ = shutdown_rx.changed().await;
+        });
+        let handle = SandboxReaperRuntimeHandle {
+            shutdown_tx,
+            handle,
+        };
+
+        handle.shutdown(SANDBOX_REAPER_SHUTDOWN_TIMEOUT).await;
+        // Reaching here without hanging proves the shutdown signal reached
+        // the task and the join completed inside the timeout.
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/webui/facade.rs
+++ b/crates/ironclaw_reborn_composition/src/webui/facade.rs
@@ -762,6 +762,11 @@ fn status_response_from_readiness(readiness: &RebornReadiness) -> RebornOperator
             RebornOperatorStatusSeverity::Warning,
             Some("mounted-volume hosted preview is ready for single-tenant validation but is not production storage".to_string()),
         ),
+        crate::RebornReadinessState::HostedSingleTenantVolumeSandboxedValidated => (
+            RebornOperatorStatusState::Degraded,
+            RebornOperatorStatusSeverity::Warning,
+            Some("sandboxed-shell hosted preview is ready for single-tenant validation but process execution is not yet wired to the sandbox transport".to_string()),
+        ),
         crate::RebornReadinessState::ProductionValidated => (
             RebornOperatorStatusState::Ready,
             RebornOperatorStatusSeverity::Info,

--- a/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
+++ b/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
@@ -1,12 +1,18 @@
+use std::sync::Arc;
+
 use ironclaw_reborn_composition::{
-    RebornBuildInput, RebornCompositionProfile, RebornFacadeReadiness, RebornReadiness,
-    RebornReadinessDiagnostic, RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
+    RebornBuildInput, RebornCompositionError, RebornCompositionProfile, RebornFacadeReadiness,
+    RebornProductionRuntimePolicy, RebornReadiness, RebornReadinessDiagnostic,
+    RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
     RebornReadinessDiagnosticStatus, RebornReadinessState, RebornRuntimeProfileOptions,
     RebornWorkerReadiness, build_reborn_services, hosted_single_tenant_volume_runtime_policy,
-    local_dev_yolo_runtime_policy, local_runtime_build_input_with_options,
+    hosted_single_tenant_volume_sandboxed_runtime_policy, local_dev_yolo_runtime_policy,
+    local_runtime_build_input_with_options,
 };
 
-use ironclaw_host_api::runtime_policy::{FilesystemBackendKind, RuntimeProfile, SecretMode};
+use ironclaw_host_api::runtime_policy::{
+    FilesystemBackendKind, ProcessBackendKind, RuntimeProfile, SecretMode,
+};
 use ironclaw_host_runtime::{
     ProductionWiringComponent, ProductionWiringIssue, ProductionWiringIssueKind,
     ProductionWiringReport,
@@ -61,6 +67,18 @@ fn profile_parse_accepts_kebab_and_snake_case() {
         RebornCompositionProfile::HostedSingleTenantVolume
     );
     assert_eq!(
+        "hosted_single_tenant_volume_sandboxed"
+            .parse::<RebornCompositionProfile>()
+            .unwrap(),
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed
+    );
+    assert_eq!(
+        "hosted-single-tenant-volume-sandboxed"
+            .parse::<RebornCompositionProfile>()
+            .unwrap(),
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed
+    );
+    assert_eq!(
         "migration-dry-run"
             .parse::<RebornCompositionProfile>()
             .unwrap(),
@@ -75,6 +93,9 @@ fn full_graph_profiles_match_production_strictness() {
     assert!(!RebornCompositionProfile::LocalDevYolo.requires_production_shape());
     assert!(!RebornCompositionProfile::HostedSingleTenant.requires_production_shape());
     assert!(!RebornCompositionProfile::HostedSingleTenantVolume.requires_production_shape());
+    assert!(
+        !RebornCompositionProfile::HostedSingleTenantVolumeSandboxed.requires_production_shape()
+    );
     assert!(RebornCompositionProfile::Production.requires_production_shape());
     assert!(RebornCompositionProfile::MigrationDryRun.requires_production_shape());
 }
@@ -86,6 +107,9 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
     assert!(RebornCompositionProfile::LocalDevYolo.uses_local_runtime_substrate());
     assert!(RebornCompositionProfile::HostedSingleTenant.uses_local_runtime_substrate());
     assert!(RebornCompositionProfile::HostedSingleTenantVolume.uses_local_runtime_substrate());
+    assert!(
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed.uses_local_runtime_substrate()
+    );
     assert!(!RebornCompositionProfile::Production.uses_local_runtime_substrate());
     assert!(!RebornCompositionProfile::MigrationDryRun.uses_local_runtime_substrate());
 
@@ -94,6 +118,9 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
     assert!(RebornCompositionProfile::LocalDevYolo.uses_local_dev_storage_input());
     assert!(!RebornCompositionProfile::HostedSingleTenant.uses_local_dev_storage_input());
     assert!(RebornCompositionProfile::HostedSingleTenantVolume.uses_local_dev_storage_input());
+    assert!(
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed.uses_local_dev_storage_input()
+    );
     assert!(!RebornCompositionProfile::Production.uses_local_dev_storage_input());
     assert!(!RebornCompositionProfile::MigrationDryRun.uses_local_dev_storage_input());
 
@@ -107,6 +134,10 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
         RebornCompositionProfile::HostedSingleTenantVolume
             .uses_hosted_extension_installation_state()
     );
+    assert!(
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed
+            .uses_hosted_extension_installation_state()
+    );
     assert!(!RebornCompositionProfile::Production.uses_hosted_extension_installation_state());
     assert!(!RebornCompositionProfile::MigrationDryRun.uses_hosted_extension_installation_state());
 
@@ -115,6 +146,7 @@ fn profile_predicates_capture_hosted_volume_substrate_contract() {
     assert!(RebornCompositionProfile::LocalDevYolo.starts_live_runtime());
     assert!(RebornCompositionProfile::HostedSingleTenant.starts_live_runtime());
     assert!(RebornCompositionProfile::HostedSingleTenantVolume.starts_live_runtime());
+    assert!(RebornCompositionProfile::HostedSingleTenantVolumeSandboxed.starts_live_runtime());
     assert!(RebornCompositionProfile::Production.starts_live_runtime());
     assert!(!RebornCompositionProfile::MigrationDryRun.starts_live_runtime());
 }
@@ -153,6 +185,88 @@ fn hosted_single_tenant_volume_runtime_policy_is_processless_secure_default() {
     assert_eq!(policy.filesystem_backend.as_str(), "scoped_virtual");
     assert_eq!(policy.secret_mode.as_str(), "brokered_handles");
     assert_eq!(policy.network_mode.as_str(), "brokered");
+}
+
+#[test]
+fn hosted_single_tenant_volume_sandboxed_runtime_policy_is_hosted_safe() {
+    let policy = hosted_single_tenant_volume_sandboxed_runtime_policy()
+        .expect("sandboxed hosted volume policy resolves");
+
+    // Requests the EXISTING `(HostedMultiTenant, HostedSafe)` resolver row
+    // (resolver.rs:325-340) rather than a new resolver row or `RuntimeProfile`
+    // variant.
+    assert_eq!(policy.requested_profile, RuntimeProfile::HostedSafe);
+    assert_eq!(policy.resolved_profile, RuntimeProfile::HostedSafe);
+    assert_eq!(policy.process_backend, ProcessBackendKind::TenantSandbox);
+    assert_eq!(
+        policy.filesystem_backend,
+        FilesystemBackendKind::TenantWorkspace
+    );
+}
+
+// Fail-closed pin: the profile's resolved policy pairs `TenantSandbox` process
+// backend with no bound process port until a production call site wires a
+// tenant sandbox process (a later slice, tracked separately from this
+// profile/routing slice). Uses the existing, already-fail-closed
+// `RebornRuntimeProcessBinding::validate_for_production_policy` guard through
+// its public entry point rather than adding a new one.
+#[test]
+fn hosted_single_tenant_volume_sandboxed_rejects_missing_tenant_sandbox_process_port() {
+    let policy = hosted_single_tenant_volume_sandboxed_runtime_policy()
+        .expect("sandboxed hosted volume policy resolves");
+
+    let error = RebornProductionRuntimePolicy::without_process_port(policy)
+        .expect_err("TenantSandbox process backend requires a bound process port");
+
+    assert!(matches!(
+        error,
+        RebornCompositionError::MissingTenantSandboxProcessPort
+    ));
+}
+
+/// Counterpart to `..._rejects_missing_tenant_sandbox_process_port` above:
+/// proves the profile's policy accepts a `TenantSandbox` binding once one is
+/// wired — the same production validation gate
+/// (`RebornRuntimeProcessBinding::validate_for_production_policy`, reached
+/// through the same public entry point) that A2's
+/// `ironclaw_reborn_composition::tenant_sandbox_process_binding` boot path
+/// (`crates/ironclaw_reborn_composition/src/sandbox_boot.rs`) must satisfy.
+/// Uses a fake `SandboxCommandTransport` instead of a live Docker daemon —
+/// this is a policy-validation proof, not a real-container proof (the A3/
+/// capstone slices cover that).
+#[test]
+fn hosted_single_tenant_volume_sandboxed_accepts_wired_tenant_sandbox_process_port() {
+    let policy = hosted_single_tenant_volume_sandboxed_runtime_policy()
+        .expect("sandboxed hosted volume policy resolves");
+
+    let process_port = Arc::new(ironclaw_host_runtime::TenantSandboxProcessPort::new(
+        Arc::new(FakeSandboxCommandTransport),
+    ));
+
+    RebornProductionRuntimePolicy::with_tenant_sandbox_process_port(policy, process_port)
+        .expect("TenantSandbox process backend accepts a wired tenant sandbox process port");
+}
+
+#[derive(Debug)]
+struct FakeSandboxCommandTransport;
+
+#[async_trait::async_trait]
+impl ironclaw_host_runtime::SandboxCommandTransport for FakeSandboxCommandTransport {
+    async fn run_command(
+        &self,
+        _request: ironclaw_host_runtime::CommandExecutionRequest,
+    ) -> Result<
+        ironclaw_host_runtime::CommandExecutionOutput,
+        ironclaw_host_runtime::RuntimeProcessError,
+    > {
+        Ok(ironclaw_host_runtime::CommandExecutionOutput {
+            output: String::new(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: std::time::Duration::ZERO,
+        })
+    }
 }
 
 #[test]
@@ -379,6 +493,7 @@ fn production_blocker_rejects_non_production_shaped_profiles() {
         RebornCompositionProfile::LocalDevYolo,
         RebornCompositionProfile::HostedSingleTenant,
         RebornCompositionProfile::HostedSingleTenantVolume,
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
     ] {
         let diagnostic = RebornReadinessDiagnostic::production_blocker(
             profile,
@@ -434,6 +549,52 @@ fn hosted_single_tenant_volume_is_visible_as_preview_readiness() {
     );
     assert_eq!(diagnostic.status, RebornReadinessDiagnosticStatus::Warning);
     assert!(diagnostic.blocks_production);
+}
+
+#[test]
+fn hosted_single_tenant_volume_sandboxed_is_visible_as_preview_readiness() {
+    let diagnostic = RebornReadinessDiagnostic::hosted_single_tenant_volume_sandboxed();
+
+    assert_eq!(
+        diagnostic.profile,
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed
+    );
+    assert_eq!(
+        diagnostic.component,
+        RebornReadinessDiagnosticComponent::CompositionProfile
+    );
+    assert_eq!(
+        diagnostic.reason,
+        RebornReadinessDiagnosticReason::HostedSingleTenantVolumeSandboxedPreview
+    );
+    assert_eq!(diagnostic.status, RebornReadinessDiagnosticStatus::Warning);
+    assert!(diagnostic.blocks_production);
+}
+
+#[tokio::test]
+async fn hosted_single_tenant_volume_sandboxed_factory_readiness_includes_preview_diagnostic() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = local_runtime_build_input_with_options(
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
+        "readiness-contract-owner",
+        dir.path().to_path_buf(),
+        Default::default(),
+    )
+    .unwrap();
+    let services = build_reborn_services(input).await.unwrap();
+
+    assert_eq!(
+        services.readiness.profile,
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed
+    );
+    assert_eq!(
+        services.readiness.state,
+        RebornReadinessState::HostedSingleTenantVolumeSandboxedValidated
+    );
+    assert_eq!(
+        services.readiness.diagnostics,
+        vec![RebornReadinessDiagnostic::hosted_single_tenant_volume_sandboxed()]
+    );
 }
 
 #[tokio::test]
@@ -630,6 +791,7 @@ fn production_wiring_report_skipped_for_non_production_profiles() {
         RebornCompositionProfile::LocalDevYolo,
         RebornCompositionProfile::HostedSingleTenant,
         RebornCompositionProfile::HostedSingleTenantVolume,
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
     ] {
         assert!(
             RebornReadinessDiagnostic::from_production_wiring_report(profile, &report).is_empty()

--- a/crates/ironclaw_reborn_composition/tests/sandbox_two_user_composition.rs
+++ b/crates/ironclaw_reborn_composition/tests/sandbox_two_user_composition.rs
@@ -1,0 +1,229 @@
+//! Composition-tier proof that the `hosted-single-tenant-volume-sandboxed`
+//! profile resolves a per-user tenant-sandbox scope identity, not a shared
+//! singleton — the wiring half of the cross-tenant isolation invariant in
+//! `.claude/rules/safety-and-sandbox.md` ("Process and shell execution: real
+//! OS isolation, per tenant"). The companion real-Docker crate-tier test
+//! (`ironclaw_host_runtime/tests/sandbox_cross_tenant_escape.rs`) proves the
+//! actual host bind-mount containment; this test runs everywhere (no
+//! Docker) and proves composition forwards each caller's own scope through
+//! to the sandbox transport instead of collapsing it onto one shared owner
+//! scope.
+//!
+//! Uses a recording fake `SandboxCommandTransport` (same pattern as
+//! `ProductionReadySandboxTransport` in `facade_factory.rs`) wired through
+//! `RebornRuntimeProcessBinding::tenant_sandbox`, so no container is ever
+//! launched.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind, ExecutionContext,
+    ExtensionId, GrantConstraints, MountView, Principal, ResourceEstimate, ResourceScope,
+    RuntimeKind, TrustClass, UserId, runtime_policy::ApprovalPolicy,
+};
+use ironclaw_host_runtime::{
+    CommandExecutionOutput, CommandExecutionRequest, RebornSandboxScopeKey,
+    RuntimeCapabilityRequest, RuntimeProcessError, SHELL_CAPABILITY_ID, SandboxCommandTransport,
+    TenantSandboxProcessPort, sandbox_network_policy,
+};
+use ironclaw_reborn_composition::{
+    RebornCompositionProfile, RebornRuntimeProcessBinding, build_reborn_services,
+    hosted_single_tenant_volume_sandboxed_runtime_policy, local_runtime_build_input_with_options,
+};
+
+/// `hosted-single-tenant-volume-sandboxed` requires an externally-supplied
+/// secrets master key (fail-closed by design — see
+/// `deployment.rs::hosted_volume_secret_master_key`); this crate's tests
+/// serialize mutation of that one env var behind a lock, mirroring the
+/// `EnvVarGuard`/`SECRETS_MASTER_KEY_ENV_LOCK` pattern already used in
+/// `facade_factory.rs`.
+static SECRET_MASTER_KEY_ENV_LOCK: Mutex<()> = Mutex::new(());
+const SECRET_MASTER_KEY_ENV: &str = "IRONCLAW_REBORN_SECRET_MASTER_KEY";
+
+struct EnvVarGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(value: &str) -> Self {
+        let lock = SECRET_MASTER_KEY_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let previous = std::env::var_os(SECRET_MASTER_KEY_ENV);
+        // SAFETY: mutation is serialized by `SECRET_MASTER_KEY_ENV_LOCK`
+        // above, and the prior value is restored on drop before the lock is
+        // released.
+        unsafe {
+            std::env::set_var(SECRET_MASTER_KEY_ENV, value);
+        }
+        Self {
+            _lock: lock,
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `set` above — still holding the serializing lock.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(SECRET_MASTER_KEY_ENV, value),
+                None => std::env::remove_var(SECRET_MASTER_KEY_ENV),
+            }
+        }
+    }
+}
+
+/// Records every `CommandExecutionRequest.scope` it is handed instead of
+/// touching Docker — lets this test observe exactly which scope composition
+/// forwarded per invocation.
+#[derive(Debug, Default)]
+struct RecordingSandboxTransport {
+    scopes: Mutex<Vec<ResourceScope>>,
+}
+
+#[async_trait]
+impl SandboxCommandTransport for RecordingSandboxTransport {
+    async fn run_command(
+        &self,
+        request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        self.scopes
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .push(request.scope);
+        Ok(CommandExecutionOutput {
+            output: "ok".to_string(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: std::time::Duration::ZERO,
+        })
+    }
+}
+
+fn shell_execution_context(user: &str) -> ExecutionContext {
+    let grants = CapabilitySet {
+        grants: vec![CapabilityGrant {
+            id: CapabilityGrantId::new(),
+            capability: CapabilityId::new(SHELL_CAPABILITY_ID).unwrap(),
+            grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
+            issued_by: Principal::HostRuntime,
+            constraints: GrantConstraints {
+                allowed_effects: vec![
+                    EffectKind::DispatchCapability,
+                    EffectKind::SpawnProcess,
+                    EffectKind::ExecuteCode,
+                    EffectKind::ReadFilesystem,
+                    EffectKind::WriteFilesystem,
+                    EffectKind::Network,
+                ],
+                mounts: MountView::default(),
+                // The sandboxed profile carries a real, non-empty egress
+                // allowlist (proxy-enforced, see `sandbox_boot.rs` and
+                // `ironclaw_host_runtime::sandbox_process::network_allowlist`)
+                // rather than `NetworkPolicy::default()`'s empty deny-all —
+                // an empty allowlist fails
+                // `validate_network_policy_metadata` and blocks every
+                // `builtin.shell` invocation in this profile.
+                network: sandbox_network_policy(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: None,
+            },
+        }],
+    };
+    ExecutionContext::local_default(
+        UserId::new(user).unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::FirstParty,
+        TrustClass::UserTrusted,
+        grants,
+        MountView::default(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn hosted_single_tenant_volume_sandboxed_forwards_distinct_scope_per_user() {
+    let _env_guard = EnvVarGuard::set("01234567890123456789012345678901");
+    let dir = tempfile::tempdir().unwrap();
+
+    let transport = Arc::new(RecordingSandboxTransport::default());
+    let process_port = Arc::new(TenantSandboxProcessPort::new(transport.clone()));
+    // Bypass the approval gate the sandboxed profile's real policy carries
+    // (`AskWrites`) so the shell invocation reaches the process port
+    // directly — the thing under test is scope forwarding through
+    // composition's `TenantSandbox` binding, not the approval pipeline,
+    // which is covered elsewhere. `process_backend` stays `TenantSandbox`,
+    // the real value under test.
+    let mut policy = hosted_single_tenant_volume_sandboxed_runtime_policy()
+        .expect("sandboxed profile policy resolves");
+    assert_eq!(
+        policy.process_backend.as_str(),
+        "tenant_sandbox",
+        "sanity: the profile under test must resolve TenantSandbox process backend"
+    );
+    policy.approval_policy = ApprovalPolicy::Minimal;
+
+    let input = local_runtime_build_input_with_options(
+        RebornCompositionProfile::HostedSingleTenantVolumeSandboxed,
+        "sandboxed-two-user-owner",
+        dir.path().to_path_buf(),
+        Default::default(),
+    )
+    .expect("sandboxed profile build input resolves with the master key env set")
+    .with_runtime_policy(policy)
+    .with_runtime_process_binding(RebornRuntimeProcessBinding::tenant_sandbox(process_port));
+
+    let services = build_reborn_services(input)
+        .await
+        .expect("sandboxed profile services build with a wired TenantSandbox binding");
+    let runtime = services
+        .host_runtime
+        .as_deref()
+        .expect("sandboxed profile composes a host runtime");
+
+    for user in ["user-a", "user-b"] {
+        let outcome = runtime
+            .invoke_capability(RuntimeCapabilityRequest::new(
+                shell_execution_context(user),
+                CapabilityId::new(SHELL_CAPABILITY_ID).unwrap(),
+                ResourceEstimate::default(),
+                serde_json::json!({"command": "true"}),
+            ))
+            .await
+            .expect("shell invocation returns an outcome");
+        assert!(
+            matches!(
+                outcome,
+                ironclaw_host_runtime::RuntimeCapabilityOutcome::Completed(_)
+            ),
+            "expected user {user} shell invocation to complete via the recording sandbox \
+             transport, got {outcome:?}"
+        );
+    }
+
+    let scopes = transport
+        .scopes
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    assert_eq!(
+        scopes.len(),
+        2,
+        "expected exactly one recorded request per user, got {scopes:?}"
+    );
+    let key_a = RebornSandboxScopeKey::from_scope(&scopes[0]);
+    let key_b = RebornSandboxScopeKey::from_scope(&scopes[1]);
+    assert_ne!(scopes[0].user_id, scopes[1].user_id);
+    assert_ne!(
+        key_a, key_b,
+        "composition must forward each user's own scope through the shared TenantSandbox \
+         binding, not collapse both users onto one shared sandbox scope identity: {:?} vs {:?}",
+        scopes[0], scopes[1]
+    );
+}

--- a/crates/ironclaw_reborn_config/src/profile.rs
+++ b/crates/ironclaw_reborn_config/src/profile.rs
@@ -22,6 +22,11 @@ pub enum RebornProfile {
     /// persistent volume. Intended for SSO-only Railway-style deployments while
     /// the full PostgreSQL production composition continues to mature.
     HostedSingleTenantVolume,
+    /// Single-tenant hosted preview identical to `HostedSingleTenantVolume`
+    /// except process execution routes to a per-tenant Docker sandbox instead
+    /// of staying disabled. Boots fail-closed until the sandbox transport is
+    /// wired into a production call site (a later slice).
+    HostedSingleTenantVolumeSandboxed,
     /// Production startup. Future runtime composition must fail closed here if
     /// required durable services are absent.
     Production,
@@ -31,11 +36,12 @@ pub enum RebornProfile {
 }
 
 impl RebornProfile {
-    const ALL: [Self; 6] = [
+    const ALL: [Self; 7] = [
         Self::LocalDev,
         Self::LocalDevYolo,
         Self::HostedSingleTenant,
         Self::HostedSingleTenantVolume,
+        Self::HostedSingleTenantVolumeSandboxed,
         Self::Production,
         Self::MigrationDryRun,
     ];
@@ -58,6 +64,7 @@ impl RebornProfile {
             Self::LocalDevYolo => "local-dev-yolo",
             Self::HostedSingleTenant => "hosted-single-tenant",
             Self::HostedSingleTenantVolume => "hosted-single-tenant-volume",
+            Self::HostedSingleTenantVolumeSandboxed => "hosted-single-tenant-volume-sandboxed",
             Self::Production => "production",
             Self::MigrationDryRun => "migration-dry-run",
         }
@@ -66,14 +73,19 @@ impl RebornProfile {
     pub fn starts_hosted_single_tenant_listener(self) -> bool {
         matches!(
             self,
-            Self::HostedSingleTenant | Self::HostedSingleTenantVolume
+            Self::HostedSingleTenant
+                | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantVolumeSandboxed
         )
     }
 
     pub fn uses_standalone_local_runtime_volume(self) -> bool {
         matches!(
             self,
-            Self::LocalDev | Self::LocalDevYolo | Self::HostedSingleTenantVolume
+            Self::LocalDev
+                | Self::LocalDevYolo
+                | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantVolumeSandboxed
         )
     }
 
@@ -81,6 +93,7 @@ impl RebornProfile {
         match self {
             Self::HostedSingleTenant => "hosted-single-tenant",
             Self::HostedSingleTenantVolume => "hosted-single-tenant-volume",
+            Self::HostedSingleTenantVolumeSandboxed => "hosted-single-tenant-volume-sandboxed",
             Self::LocalDev | Self::LocalDevYolo | Self::Production | Self::MigrationDryRun => {
                 "local-dev"
             }
@@ -94,6 +107,7 @@ impl RebornProfile {
                 | Self::LocalDevYolo
                 | Self::HostedSingleTenant
                 | Self::HostedSingleTenantVolume
+                | Self::HostedSingleTenantVolumeSandboxed
         )
     }
 }
@@ -107,6 +121,7 @@ impl FromStr for RebornProfile {
             "local-dev-yolo" => Ok(Self::LocalDevYolo),
             "hosted-single-tenant" => Ok(Self::HostedSingleTenant),
             "hosted-single-tenant-volume" => Ok(Self::HostedSingleTenantVolume),
+            "hosted-single-tenant-volume-sandboxed" => Ok(Self::HostedSingleTenantVolumeSandboxed),
             "production" => Ok(Self::Production),
             "migration-dry-run" => Ok(Self::MigrationDryRun),
             other => Err(RebornConfigError::InvalidProfile {

--- a/crates/ironclaw_reborn_config/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_config/tests/profile_contract.rs
@@ -16,6 +16,10 @@ fn profile_wire_values_are_stable() {
         RebornProfile::HostedSingleTenantVolume.as_str(),
         "hosted-single-tenant-volume"
     );
+    assert_eq!(
+        RebornProfile::HostedSingleTenantVolumeSandboxed.as_str(),
+        "hosted-single-tenant-volume-sandboxed"
+    );
     assert_eq!(RebornProfile::Production.as_str(), "production");
     assert_eq!(RebornProfile::MigrationDryRun.as_str(), "migration-dry-run");
 }
@@ -29,6 +33,7 @@ fn all_profiles_are_exposed_in_display_order() {
             RebornProfile::LocalDevYolo,
             RebornProfile::HostedSingleTenant,
             RebornProfile::HostedSingleTenantVolume,
+            RebornProfile::HostedSingleTenantVolumeSandboxed,
             RebornProfile::Production,
             RebornProfile::MigrationDryRun,
         ]
@@ -54,6 +59,10 @@ fn profile_parsing_accepts_expected_values() {
         Ok(RebornProfile::HostedSingleTenantVolume)
     );
     assert_eq!(
+        RebornProfile::from_str("hosted-single-tenant-volume-sandboxed"),
+        Ok(RebornProfile::HostedSingleTenantVolumeSandboxed)
+    );
+    assert_eq!(
         RebornProfile::from_str("production"),
         Ok(RebornProfile::Production)
     );
@@ -69,6 +78,9 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
     assert!(!RebornProfile::LocalDevYolo.starts_hosted_single_tenant_listener());
     assert!(RebornProfile::HostedSingleTenant.starts_hosted_single_tenant_listener());
     assert!(RebornProfile::HostedSingleTenantVolume.starts_hosted_single_tenant_listener());
+    assert!(
+        RebornProfile::HostedSingleTenantVolumeSandboxed.starts_hosted_single_tenant_listener()
+    );
     assert!(!RebornProfile::Production.starts_hosted_single_tenant_listener());
     assert!(!RebornProfile::MigrationDryRun.starts_hosted_single_tenant_listener());
 
@@ -76,6 +88,9 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
     assert!(RebornProfile::LocalDevYolo.uses_standalone_local_runtime_volume());
     assert!(!RebornProfile::HostedSingleTenant.uses_standalone_local_runtime_volume());
     assert!(RebornProfile::HostedSingleTenantVolume.uses_standalone_local_runtime_volume());
+    assert!(
+        RebornProfile::HostedSingleTenantVolumeSandboxed.uses_standalone_local_runtime_volume()
+    );
     assert!(!RebornProfile::Production.uses_standalone_local_runtime_volume());
     assert!(!RebornProfile::MigrationDryRun.uses_standalone_local_runtime_volume());
 
@@ -96,6 +111,10 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
         "hosted-single-tenant-volume"
     );
     assert_eq!(
+        RebornProfile::HostedSingleTenantVolumeSandboxed.local_runtime_storage_subdir(),
+        "hosted-single-tenant-volume-sandboxed"
+    );
+    assert_eq!(
         RebornProfile::Production.local_runtime_storage_subdir(),
         "local-dev"
     );
@@ -108,6 +127,9 @@ fn profile_predicates_capture_hosted_volume_local_runtime_contract() {
     assert!(RebornProfile::LocalDevYolo.supports_local_runtime_skill_management());
     assert!(RebornProfile::HostedSingleTenant.supports_local_runtime_skill_management());
     assert!(RebornProfile::HostedSingleTenantVolume.supports_local_runtime_skill_management());
+    assert!(
+        RebornProfile::HostedSingleTenantVolumeSandboxed.supports_local_runtime_skill_management()
+    );
     assert!(!RebornProfile::Production.supports_local_runtime_skill_management());
     assert!(!RebornProfile::MigrationDryRun.supports_local_runtime_skill_management());
 }

--- a/docker/process-sandbox-entrypoint.sh
+++ b/docker/process-sandbox-entrypoint.sh
@@ -49,4 +49,8 @@ if [ "${IRONCLAW_EGRESS_LOCKDOWN:-}" = "broker-only" ]; then
   iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 fi
 
+mkdir -p "$HOME" 2>/dev/null || true
+[ -d /home/sandbox/.cargo ] && [ ! -d /workspace/.home/.cargo ] && cp -a /home/sandbox/.cargo /workspace/.home/.cargo 2>/dev/null || true
+[ -d /home/sandbox/.rustup ] && [ ! -d /workspace/.home/.rustup ] && cp -a /home/sandbox/.rustup /workspace/.home/.rustup 2>/dev/null || true
+
 exec capsh --drop=all --user=sandbox -- -c 'exec "$@"' process-sandbox "$@"

--- a/docs/plans/composition-pubuse.snapshot
+++ b/docs/plans/composition-pubuse.snapshot
@@ -53,7 +53,7 @@ pub use ironclaw_product_workflow::{
 };
 pub use ironclaw_runner::failure_lane::{ALL_RUN_FAILURE_CATEGORIES, FailureLane, failure_lane};
 pub use ironclaw_runner::runtime::DEFAULT_TURN_RUNNER_WORKER_COUNT;
-pub use sandbox_boot::tenant_sandbox_process_binding;
+pub use sandbox_boot::{TenantSandboxBinding, tenant_sandbox_process_binding};
 pub use ironclaw_runner::failure_summary::reborn_failure_summary_for_category;
 pub use ironclaw_runtime_policy::{
     ResolveRequest as RuntimePolicyResolveRequest, resolve as resolve_runtime_policy,

--- a/docs/plans/composition-pubuse.snapshot
+++ b/docs/plans/composition-pubuse.snapshot
@@ -53,6 +53,7 @@ pub use ironclaw_product_workflow::{
 };
 pub use ironclaw_runner::failure_lane::{ALL_RUN_FAILURE_CATEGORIES, FailureLane, failure_lane};
 pub use ironclaw_runner::runtime::DEFAULT_TURN_RUNNER_WORKER_COUNT;
+pub use sandbox_boot::tenant_sandbox_process_binding;
 pub use ironclaw_runner::failure_summary::reborn_failure_summary_for_category;
 pub use ironclaw_runtime_policy::{
     ResolveRequest as RuntimePolicyResolveRequest, resolve as resolve_runtime_policy,

--- a/docs/plans/composition-pubuse.snapshot
+++ b/docs/plans/composition-pubuse.snapshot
@@ -76,7 +76,8 @@ pub use llm_admin::nearai_mcp::{
 pub use llm_admin::openai_compat_serve::build_openai_compat_route_mount;
 pub use deployment::{
     RebornRuntimeProfileError, RebornRuntimeProfileOptions, hosted_single_tenant_runtime_policy,
-    hosted_single_tenant_volume_runtime_policy, local_dev_runtime_policy,
+    hosted_single_tenant_volume_runtime_policy,
+    hosted_single_tenant_volume_sandboxed_runtime_policy, local_dev_runtime_policy,
     local_dev_yolo_runtime_policy, local_runtime_build_input,
     local_runtime_build_input_with_options,
 };


### PR DESCRIPTION
**Stack 1/3** — Phase A of the persistent sandbox program. Next: `sandbox/v1-cli-session`, then `sandbox/v1-egress`.

Replaces ephemeral per-command containers with a **persistent container keyed by `{tenant, user}`**, so live processes (dev servers now, CLIs later) survive across commands.

- `RebornSandboxUserKey` identity + labels-as-identity registry with a push-based activity map
- Persistent docker-exec transport (replaces ephemeral run-per-command)
- `background: true` detached execution with a live-process footer
- Two-stage reaper: idle/retention lifecycle, spares live background jobs at idle-stop, debounced removal
- Per-user concurrency ceiling (`ResourceAccount::user`, was tenant)
- Fat image: git/node/python/rust/gh/tmux, workspace-persistent HOME, npm prefix/PATH into `/workspace`
- `/workspace` mounted at the abstract-FS root with byte-parity coverage

Docker-gated tests self-skip without a daemon (`SKIP:` line, never `#[ignore]`) — CI is the arbiter for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)