### PR TITLE
fix(ci): switch /benchmark dispatcher to cross-repo workflow_dispatch

### DIFF
--- a/.github/workflows/nearai-bench-tests.yml
+++ b/.github/workflows/nearai-bench-tests.yml
@@ -54,11 +54,17 @@ jobs:
                                # forwarded cap needs explicit pre-run headroom on top of it
           HARD_CAP=360         # GitHub-hosted runner max job minutes
           MIN_REQUIRED=$((GUARD_MIN + SETUP_HEADROOM))
-          # Anchor to the 6-space with:-entry indentation so a future job-level
-          # (4-space) timeout-minutes on the parse job can't be misread here.
-          # First match then quit — no `| head`, which under pipefail can turn a
-          # multi-match sed into a SIGPIPE (141) hard-fail.
-          forwarded=$(sed -nE '/^      timeout-minutes:[[:space:]]*[0-9]+/{s@^      timeout-minutes:[[:space:]]*([0-9]+).*@\1@p; q}' \
+          # nearai/benchmarks is private and nearai/ironclaw is public, so the
+          # bench job can no longer `uses:` the reusable workflow (a private
+          # repo's cross-repo reusable-workflow access can only ever be
+          # granted to OTHER private repos — never to a public caller). It
+          # instead dispatches `bench-pr-reusable.yml` directly via
+          # `gh workflow run ... -f "timeout-minutes=N"` in a run: step, so
+          # anchor on that `-f "timeout-minutes=` flag instead of the old
+          # `with:`-block indentation. First match then quit — no `| head`,
+          # which under pipefail can turn a multi-match sed into a SIGPIPE
+          # (141) hard-fail.
+          forwarded=$(sed -nE '/-f "timeout-minutes=[0-9]+"/{s@.*-f "timeout-minutes=([0-9]+)".*@\1@p; q}' \
             .github/workflows/nearai-bench.yml)
           echo "forwarded timeout-minutes=${forwarded:-<none>} (guard=${GUARD_MIN}, setup headroom=${SETUP_HEADROOM}, cap=${HARD_CAP})"
           if [ -z "$forwarded" ]; then

--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -3,17 +3,33 @@
 # (optionally `--model <id>` and/or `--framework <ironclaw|ironclaw-reborn>`)
 # on a PR; this workflow validates auth,
 # parses the command, resolves the PR head SHA, reacts with 🚀, then
-# delegates to nearai/benchmarks's reusable workflow which builds the
-# harness against the PR's ironclaw SHA, runs the suite, compares against
-# a baseline, and posts a markdown comment back here.
+# triggers nearai/benchmarks's bench-pr-reusable.yml workflow (which builds
+# the harness against the PR's ironclaw SHA, runs the suite, compares
+# against a baseline, and posts a markdown comment back here).
 #
 # Setup / usage docs:
 # https://github.com/nearai/benchmarks/blob/main/docs/ci/README.md
 #
-# Requires `OPENROUTER_API_KEY` as an org-level (or repo-level) secret, plus
-# `NEARAI_API_KEY` for ironclaw-reborn runs (agent routes to NEAR AI cloud).
-# Only those secrets are forwarded — `secrets: inherit` is intentionally
-# NOT used (supply-chain hardening).
+# nearai/benchmarks is a PRIVATE repo (since 2026-07-22, PR #291). A
+# cross-repo reusable-workflow `uses:` call (the previous approach here) is
+# structurally incapable of working for a public caller -> private callee:
+# a private repo's Actions "Access" setting can only ever grant access to
+# OTHER PRIVATE repos in the org ("Access is allowed only from private
+# repositories" per GitHub's own docs) — nearai/ironclaw is public, so no
+# access-level setting on the benchmarks side can fix this while ironclaw
+# stays public. (Confirmed: every `/benchmark` run failed pre-flight with
+# 0 jobs / `referenced_workflows: []` from ~2026-07-21 onward.)
+#
+# Cross-repo `workflow_dispatch` triggering (this workflow's `bench` job)
+# is a different, unrestricted GitHub mechanism — the same as a human
+# clicking "Run workflow" on that repo — gated only on the calling token
+# having `actions: write` there. bench-pr-reusable.yml already declares a
+# matching `workflow_dispatch:` trigger (same inputs) for exactly this.
+# The triggered run posts its own result comment back to this PR directly
+# (via pr-repo/pr-number) using nearai/benchmarks' own secrets — nothing
+# needs forwarding from here, so `BENCHMARKS_DISPATCH_TOKEN` (a
+# fine-grained PAT, `actions: write` scoped to nearai/benchmarks only) is
+# the only new credential this side needs.
 
 name: nearai-bench
 
@@ -21,11 +37,10 @@ on:
   issue_comment:
     types: [created]
 
-# Minimum surface for what this workflow actually does. The called
-# reusable workflow (in nearai/benchmarks) declares its own ceiling
-# (pull-requests:write + issues:write); the effective permissions in the
-# called job are the intersection of these two, so a hostile change in
-# the benchmarks repo can't acquire writes we didn't grant here.
+# Minimum surface for the `parse` job's own steps (gh pr view/comment,
+# reactions). The `bench` job below overrides this down to `contents: read`
+# — it only dispatches a workflow_dispatch call with an explicit PAT, it
+# doesn't need any of this workflow's own GITHUB_TOKEN writes.
 #
 # `pull-requests: write` (not just `issues: write`) is required because
 # GitHub's reactions endpoint for PR-issue-comments rejects an
@@ -204,20 +219,16 @@ jobs:
   bench:
     needs: parse
     if: needs.parse.outputs.authorized == 'yes' && needs.parse.outputs.suite != ''
-    # Job-scoped writes so the called workflow can post the result
-    # comment + toggle the trigger-comment reaction. Called workflows
-    # can only DOWNGRADE the caller's GITHUB_TOKEN, so the workflow-level
-    # `pull-requests: read` (which the parse job uses for `gh pr view`)
-    # would otherwise leave the called workflow without write to publish
-    # results. The parse job stays on read; only this authorized,
-    # post-auth job grants writes.
+    runs-on: ubuntu-latest
+    # This job only *dispatches* the real run in nearai/benchmarks and
+    # returns — the benchmark itself (build/run/compare/PR comment) happens
+    # entirely inside that triggered run, on nearai/benchmarks' own compute
+    # and secrets. No id-token/pull-requests/issues writes needed here
+    # (those apply to the ambient GITHUB_TOKEN, which this step doesn't use
+    # for the privileged call — see BENCHMARKS_DISPATCH_TOKEN below).
+    timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
-      id-token: write       # the called workflow uses OIDC to assume an
-                            # AWS role for S3 persistence; without this it
-                            # fails to start.
     # Concurrency lives on the authorized job, not the workflow root —
     # otherwise an unauthorized commenter typing `/benchmark whatever`
     # would acquire the per-PR group and cancel an in-flight maintainer
@@ -225,40 +236,44 @@ jobs:
     concurrency:
       group: nearai-bench-${{ github.event.issue.number }}
       cancel-in-progress: true
-    # Tracks nearai/benchmarks main. Renderer / workflow changes there
-    # take effect on the next /benchmark without needing a deliberate
-    # SHA bump here. Both repos are under the same org with the same
-    # write-access set, so the supply-chain delta vs. a pinned SHA is
-    # small enough to trade for not stalling out every renderer change.
-    uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@main
-    with:
-      ironclaw-rev: ${{ needs.parse.outputs.head_sha }}
-      pr-repo: ${{ github.repository }}
-      pr-number: ${{ github.event.issue.number }}
-      suite-name: ${{ needs.parse.outputs.suite }}
-      model: ${{ needs.parse.outputs.model }}
-      # Empty when unspecified → the reusable workflow defaults to ironclaw.
-      framework: ${{ needs.parse.outputs.framework }}
-      # Bump from the reusable workflow's 240 default. The /benchmark path is
-      # used for the heavy container suites — claw-swe-bench-lite (80 tasks,
-      # ~3-4h at its TOML parallelism=3) and clawbench — where 240 is too low:
-      # the last full-suite run (run 29606955146) was cancelled by the 240-min
-      # job cap after only 7/350 tasks. 350 also sits above the run step's own
-      # internal `timeout --kill-after=120s 290m` guard, so an overrun is killed
-      # gracefully by that guard (which snapshots a partial run, uploads it, and
-      # posts the PR comment) instead of GitHub cancelling the job at the cap —
-      # under cancellation the compound-`if` upload/comment steps are skipped,
-      # which is why the cancelled run left no result comment. 350 < the 360-min
-      # hard cap on the ubuntu-16core runner. Lightweight suites (ironclaw-smoke,
-      # pinchbench) finish well before this — it is a ceiling, not a duration.
-      timeout-minutes: 350
-      trigger-comment-id: ${{ github.event.comment.id }}
-    # Scope inherited secrets to only what the reusable workflow needs.
-    # Replaces `secrets: inherit`, which gave the called workflow access
-    # to every secret available here.
-    secrets:
-      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      # ironclaw-reborn runs route the agent to NEAR AI cloud; the reusable
-      # workflow reads this for LLM_BACKEND=nearai. Optional there, so legacy
-      # ironclaw runs (OpenRouter) are unaffected if it's unset.
-      NEARAI_API_KEY: ${{ secrets.NEARAI_API_KEY }}
+    steps:
+      - name: Dispatch benchmark run in nearai/benchmarks
+        env:
+          # Fine-grained PAT, `actions: write` scoped to nearai/benchmarks
+          # only — needed because GITHUB_TOKEN here can't write to another
+          # repo's Actions API, and (per the header comment) a private
+          # repo's cross-repo *reusable-workflow* access can't be opened to
+          # a public caller at all, so `uses:` is not an option regardless.
+          GH_TOKEN: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
+          IRONCLAW_REV: ${{ needs.parse.outputs.head_sha }}
+          PR_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          SUITE: ${{ needs.parse.outputs.suite }}
+          MODEL: ${{ needs.parse.outputs.model }}
+          FRAMEWORK: ${{ needs.parse.outputs.framework }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          set -euo pipefail
+          # Bump from the reusable workflow's 240 default. The /benchmark
+          # path is used for the heavy container suites — claw-swe-bench-lite
+          # (80 tasks, ~3-4h at its TOML parallelism=3) and clawbench — where
+          # 240 is too low: the last full-suite run (run 29606955146) was
+          # cancelled by the 240-min job cap after only 7/350 tasks. 350 also
+          # sits above the run step's own internal
+          # `timeout --kill-after=120s 290m` guard, so an overrun is killed
+          # gracefully by that guard (which snapshots a partial run, uploads
+          # it, and posts the PR comment) instead of GitHub cancelling the
+          # job at the cap. 350 < the 360-min hard cap on the ubuntu-16core
+          # runner. Lightweight suites (ironclaw-smoke, pinchbench) finish
+          # well before this — it is a ceiling, not a duration.
+          gh workflow run bench-pr-reusable.yml \
+            --repo nearai/benchmarks --ref main \
+            -f "ironclaw-rev=${IRONCLAW_REV}" \
+            -f "pr-repo=${PR_REPO}" \
+            -f "pr-number=${PR_NUMBER}" \
+            -f "suite-name=${SUITE}" \
+            -f "model=${MODEL}" \
+            -f "framework=${FRAMEWORK}" \
+            -f "dry-run=false" \
+            -f "timeout-minutes=350" \
+            -f "trigger-comment-id=${COMMENT_ID}"


### PR DESCRIPTION
## Problem

Every `/benchmark` invocation on this repo's PRs has failed since nearai/benchmarks went private (~2026-07-21/22, nearai/benchmarks#291) — confirmed across 100+ consecutive runs, all failing pre-flight with 0 jobs and `referenced_workflows: []` (GitHub's generic "workflow file issue", no job ever starts).

Root cause: the `bench` job here calls nearai/benchmarks' `bench-pr-reusable.yml` via a cross-repo reusable-workflow `uses:` reference. GitHub's private-repo "Access" setting (Settings > Actions > General) governing this can **only** grant access to *other private repos in the same org* — "Access is allowed only from private repositories" per GitHub's own docs. This repo is public, so no access-level setting on the benchmarks side can unblock it while ironclaw stays public and benchmarks stays private (verified: flipping that setting to `organization` did not fix it).

## Fix

Switch the `bench` job from `uses:` to directly triggering `bench-pr-reusable.yml`'s existing `workflow_dispatch` trigger via `gh workflow run` — a different, unrestricted GitHub mechanism (same as a human clicking "Run workflow" on that repo), gated only on the calling token having `actions: write` there. `bench-pr-reusable.yml` already had a matching `workflow_dispatch` trigger with the same inputs (used for ad-hoc manual runs), so no changes were needed on that side beyond adding `trigger-comment-id` (nearai/benchmarks#305) so the reaction-toggle keeps working.

The triggered run posts its own result comment back to the PR directly (via `pr-repo`/`pr-number`) using nearai/benchmarks' own secrets — nothing needs forwarding from this side anymore, so this is strictly less privileged than before (the `bench` job here now only needs `contents: read` on its own `GITHUB_TOKEN`).

## Required before this works end-to-end

1. Merge nearai/benchmarks#305 (adds `trigger-comment-id` to `workflow_dispatch`).
2. Create a **fine-grained PAT** scoped to `nearai/benchmarks` only, permission `Actions: Read and write` (no other permissions needed), and add it as a repo secret named `BENCHMARKS_DISPATCH_TOKEN` on **nearai/ironclaw** (Settings > Secrets and variables > Actions). This can't be done via API — needs a human with access to both repos.
3. Merge this PR (issue_comment-triggered workflows always run the default-branch copy, so /benchmark won't pick this up until it's on `main`).

## Test plan

- [x] actionlint clean (pre-existing shellcheck style nit only, unrelated)
- [ ] After 1-3 above: `/benchmark micro-pinchbench-13` on a dummy PR completes a real run and posts a result comment