### PR TITLE
test(skills): establish routing Slice 0 baseline

### DIFF
--- a/crates/ironclaw_skills/tests/fixtures/routing_corpus.json
+++ b/crates/ironclaw_skills/tests/fixtures/routing_corpus.json
@@ -1,0 +1,169 @@
+{
+  "schema_version": 1,
+  "top_k": 5,
+  "cases": [
+    {
+      "id": "hacker-news-search-no-skill",
+      "class": "negative",
+      "prompt": "search Hacker News for any recent posts mentioning 'IronClaw' or 'NEAR AI'",
+      "relevant": [],
+      "forbidden": ["tech-debt-tracker"],
+      "expect_no_match": true,
+      "baseline_selected": ["tech-debt-tracker"],
+      "source_issue": 5417
+    },
+    {
+      "id": "generic-market-research-no-skill",
+      "class": "negative",
+      "prompt": "Research the latest market share numbers for database vendors and summarize the sources.",
+      "relevant": [],
+      "forbidden": ["portfolio", "product-prioritization"],
+      "expect_no_match": true,
+      "baseline_selected": ["coding", "llm-council"]
+    },
+    {
+      "id": "single-pr-code-review",
+      "class": "positive",
+      "prompt": "Review this pull request for bugs, missing tests, and undocumented assumptions.",
+      "relevant": ["code-review"],
+      "forbidden": ["parallel-pr-review"],
+      "expect_no_match": false,
+      "baseline_selected": ["code-review", "github", "coding", "review-checklist", "qa-review"]
+    },
+    {
+      "id": "batch-pr-review",
+      "class": "conflict",
+      "prompt": "Review the open PRs in this repository and synthesize the findings.",
+      "relevant": ["parallel-pr-review"],
+      "forbidden": ["review-readiness"],
+      "expect_no_match": false,
+      "baseline_selected": ["parallel-pr-review", "review-checklist", "qa-review", "review-readiness", "security-review"]
+    },
+    {
+      "id": "security-audit",
+      "class": "positive",
+      "prompt": "Audit these code changes for OWASP issues, injection, and secrets exposure.",
+      "relevant": ["security-review"],
+      "forbidden": ["review-readiness"],
+      "expect_no_match": false,
+      "baseline_selected": ["security-review", "coding"]
+    },
+    {
+      "id": "qa-test-plan",
+      "class": "positive",
+      "prompt": "Generate a QA test plan and identify the edge cases and missing regression coverage.",
+      "relevant": ["qa-review"],
+      "forbidden": ["review-readiness"],
+      "expect_no_match": false,
+      "baseline_selected": ["qa-review", "coding"]
+    },
+    {
+      "id": "merge-readiness",
+      "class": "conflict",
+      "prompt": "Is this PR ready to merge, and which checks or reviews are still missing?",
+      "relevant": ["review-readiness"],
+      "forbidden": ["parallel-pr-review"],
+      "expect_no_match": false,
+      "baseline_selected": ["review-checklist", "review-readiness", "qa-review", "security-review"]
+    },
+    {
+      "id": "create-autonomous-project",
+      "class": "conflict",
+      "prompt": "Create a new autonomous project for customer research.",
+      "relevant": ["new-project"],
+      "forbidden": ["project-setup"],
+      "expect_no_match": false,
+      "baseline_selected": ["new-project", "llm-council", "plan-mode"]
+    },
+    {
+      "id": "track-github-repository",
+      "class": "conflict",
+      "prompt": "Add nearai/ironclaw as a tracked repository project and set up its workflow.",
+      "relevant": ["project-setup"],
+      "forbidden": ["new-project"],
+      "expect_no_match": false,
+      "baseline_selected": ["coding", "new-project", "routine-advisor", "github-workflow", "github"]
+    },
+    {
+      "id": "commit-staged-changes",
+      "class": "positive",
+      "prompt": "Write a git commit message for my staged changes.",
+      "relevant": ["commit"],
+      "forbidden": ["coding"],
+      "expect_no_match": false,
+      "baseline_selected": ["commit", "coding", "github"]
+    },
+    {
+      "id": "record-architecture-decision",
+      "class": "positive",
+      "prompt": "Record this decision: use bounded CAS instead of a process-local mutex.",
+      "relevant": ["decision-capture"],
+      "forbidden": ["idea-parking"],
+      "expect_no_match": false,
+      "baseline_selected": ["decision-capture", "review-readiness"]
+    },
+    {
+      "id": "park-product-idea",
+      "class": "positive",
+      "prompt": "Park this idea for later: build a flaky-test quarantine dashboard.",
+      "relevant": ["idea-parking"],
+      "forbidden": ["decision-capture"],
+      "expect_no_match": false,
+      "baseline_selected": ["idea-parking", "coding"]
+    },
+    {
+      "id": "show-commitments",
+      "class": "positive",
+      "prompt": "Show my open commitments and what is overdue.",
+      "relevant": ["commitment-digest"],
+      "forbidden": ["commitment-setup"],
+      "expect_no_match": false,
+      "baseline_selected": ["commitment-digest", "commitment-triage", "commit", "ceo-setup", "decision-capture"]
+    },
+    {
+      "id": "setup-commitment-system",
+      "class": "conflict",
+      "prompt": "Set up the commitment tracking system for me.",
+      "relevant": ["commitment-setup"],
+      "forbidden": ["commitment-digest"],
+      "expect_no_match": false,
+      "baseline_selected": ["commitment-setup", "commitment-triage", "commitment-digest", "commit"]
+    },
+    {
+      "id": "recurring-monitor",
+      "class": "conflict",
+      "prompt": "Check this repository every morning and notify me when new issues appear.",
+      "relevant": ["routine-advisor"],
+      "forbidden": ["delegation"],
+      "expect_no_match": false,
+      "baseline_selected": ["routine-advisor"]
+    },
+    {
+      "id": "defi-portfolio",
+      "class": "positive",
+      "prompt": "Analyze my DeFi portfolio positions and suggest a rebalance.",
+      "relevant": ["portfolio"],
+      "forbidden": ["trader-setup"],
+      "expect_no_match": false,
+      "baseline_selected": ["portfolio"]
+    },
+    {
+      "id": "multi-model-opinions",
+      "class": "positive",
+      "prompt": "Ask multiple models for a second opinion and compare their answers.",
+      "relevant": ["llm-council"],
+      "forbidden": [],
+      "expect_no_match": false,
+      "baseline_selected": ["llm-council"]
+    },
+    {
+      "id": "local-web-ui-validation",
+      "class": "multi_skill",
+      "prompt": "Run the web UI locally in Docker and test the browser flow.",
+      "relevant": ["local-test", "web-ui-test"],
+      "forbidden": [],
+      "expect_no_match": false,
+      "baseline_selected": ["web-ui-test", "coding"]
+    }
+  ]
+}

--- a/crates/ironclaw_skills/tests/routing_corpus.rs
+++ b/crates/ironclaw_skills/tests/routing_corpus.rs
@@ -1,0 +1,299 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use ironclaw_skills::{
+    LoadedSkill, SkillSelectionOptions, SkillSource, SkillTrust, parse_skill_md,
+    prefilter_skills_with_options,
+};
+use serde::Deserialize;
+
+const TOP_K: usize = 5;
+const EVALUATION_TOKEN_BUDGET: usize = 100_000;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RoutingCorpus {
+    schema_version: u32,
+    top_k: usize,
+    cases: Vec<RoutingCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RoutingCase {
+    id: String,
+    class: RoutingCaseClass,
+    prompt: String,
+    relevant: Vec<String>,
+    forbidden: Vec<String>,
+    expect_no_match: bool,
+    baseline_selected: Vec<String>,
+    #[serde(default)]
+    source_issue: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum RoutingCaseClass {
+    Positive,
+    Negative,
+    Conflict,
+    MultiSkill,
+}
+
+#[derive(Debug, Default)]
+struct BaselineMetrics {
+    relevant_total: usize,
+    relevant_retrieved: usize,
+    positive_cases: usize,
+    relevant_top_one: usize,
+    forbidden_cases: usize,
+    forbidden_hits: usize,
+    no_match_cases: usize,
+    false_activations: usize,
+}
+
+#[test]
+fn real_skill_routing_corpus_matches_the_reviewed_legacy_baseline() {
+    let corpus: RoutingCorpus = serde_json::from_str(include_str!("fixtures/routing_corpus.json"))
+        .expect("routing corpus must parse");
+    assert_eq!(
+        corpus.schema_version, 1,
+        "unsupported routing corpus version"
+    );
+    assert_eq!(
+        corpus.top_k, TOP_K,
+        "the checked-in baseline and evaluator must use the same top-k"
+    );
+    assert!(
+        corpus.cases.len() >= 15,
+        "routing corpus must remain broad enough to cover conflicts and negatives"
+    );
+
+    let skills = load_bundled_skills();
+    let skills_by_name = skills
+        .iter()
+        .map(|skill| (skill.name().to_string(), skill))
+        .collect::<HashMap<_, _>>();
+    validate_corpus(&corpus, &skills_by_name);
+
+    let mut metrics = BaselineMetrics::default();
+    for case in &corpus.cases {
+        let selected = prefilter_skills_with_options(
+            &case.prompt,
+            &skills,
+            corpus.top_k,
+            EVALUATION_TOKEN_BUDGET,
+            &HashSet::new(),
+            SkillSelectionOptions::default(),
+        )
+        .selected
+        .into_iter()
+        .map(|skill| skill.name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            selected, case.baseline_selected,
+            "routing baseline changed for case {}; review whether this is an intentional quality change, then update the fixture",
+            case.id
+        );
+
+        metrics.relevant_total += case.relevant.len();
+        metrics.relevant_retrieved += case
+            .relevant
+            .iter()
+            .filter(|name| selected.contains(name))
+            .count();
+        if !case.relevant.is_empty() {
+            metrics.positive_cases += 1;
+            if selected
+                .first()
+                .is_some_and(|name| case.relevant.contains(name))
+            {
+                metrics.relevant_top_one += 1;
+            }
+        }
+        if !case.forbidden.is_empty() {
+            metrics.forbidden_cases += 1;
+            if case.forbidden.iter().any(|name| selected.contains(name)) {
+                metrics.forbidden_hits += 1;
+            }
+        }
+        if case.expect_no_match {
+            metrics.no_match_cases += 1;
+            if !selected.is_empty() {
+                metrics.false_activations += 1;
+            }
+        }
+
+        eprintln!(
+            "skill-routing-baseline case={} class={:?} selected={selected:?}",
+            case.id, case.class
+        );
+    }
+
+    // Slice 0 records these quality measurements without enforcing the epic's
+    // promotion thresholds. Slice 6 owns turning reviewed targets into gates.
+    eprintln!("skill-routing-baseline metrics={metrics:?}");
+}
+
+fn load_bundled_skills() -> Vec<LoadedSkill> {
+    let skills_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../skills");
+    let mut skill_paths = std::fs::read_dir(&skills_root)
+        .expect("bundled skills root must be readable")
+        .map(|entry| {
+            entry
+                .expect("skill directory entry must be readable")
+                .path()
+        })
+        .filter(|path| path.is_dir())
+        .map(|path| path.join("SKILL.md"))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    skill_paths.sort();
+
+    skill_paths
+        .into_iter()
+        .map(|path| load_bundled_skill(&path))
+        .collect()
+}
+
+fn load_bundled_skill(path: &Path) -> LoadedSkill {
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read bundled skill {}: {error}", path.display()));
+    let parsed = parse_skill_md(&raw)
+        .unwrap_or_else(|error| panic!("parse bundled skill {}: {error}", path.display()));
+    let directory_name = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "bundled skill path has no UTF-8 directory: {}",
+                path.display()
+            )
+        });
+    assert_eq!(
+        parsed.manifest.name,
+        directory_name,
+        "bundled skill name must match its directory for {}",
+        path.display()
+    );
+    let compiled_patterns = LoadedSkill::compile_patterns(&parsed.manifest.activation.patterns);
+    let lowercased_keywords = parsed
+        .manifest
+        .activation
+        .keywords
+        .iter()
+        .map(|keyword| keyword.to_lowercase())
+        .collect();
+    let lowercased_exclude_keywords = parsed
+        .manifest
+        .activation
+        .exclude_keywords
+        .iter()
+        .map(|keyword| keyword.to_lowercase())
+        .collect();
+    let lowercased_tags = parsed
+        .manifest
+        .activation
+        .tags
+        .iter()
+        .map(|tag| tag.to_lowercase())
+        .collect();
+
+    LoadedSkill {
+        manifest: parsed.manifest,
+        prompt_content: parsed.prompt_content,
+        trust: SkillTrust::Trusted,
+        source: SkillSource::Bundled(PathBuf::from(path)),
+        content_hash: String::new(),
+        compiled_patterns,
+        lowercased_keywords,
+        lowercased_exclude_keywords,
+        lowercased_tags,
+    }
+}
+
+fn validate_corpus(corpus: &RoutingCorpus, skills: &HashMap<String, &LoadedSkill>) {
+    let mut ids = HashSet::new();
+    let mut classes = HashSet::new();
+    let mut issue_5417_cases = 0;
+    for case in &corpus.cases {
+        assert!(
+            ids.insert(&case.id),
+            "duplicate routing case id: {}",
+            case.id
+        );
+        assert!(
+            !case.prompt.trim().is_empty(),
+            "routing case {} has an empty prompt",
+            case.id
+        );
+        classes.insert(format!("{:?}", case.class));
+        if case.class == RoutingCaseClass::Negative {
+            assert!(
+                case.relevant.is_empty(),
+                "negative routing case {} must not declare relevant skills",
+                case.id
+            );
+            assert!(
+                case.expect_no_match,
+                "negative routing case {} must expect no match",
+                case.id
+            );
+        } else {
+            assert!(
+                !case.relevant.is_empty(),
+                "non-negative routing case {} needs relevant skills",
+                case.id
+            );
+            assert!(
+                !case.expect_no_match,
+                "non-negative routing case {} cannot expect no match",
+                case.id
+            );
+        }
+        for name in case
+            .relevant
+            .iter()
+            .chain(&case.forbidden)
+            .chain(&case.baseline_selected)
+        {
+            assert!(
+                skills.contains_key(name),
+                "routing case {} references missing bundled skill {name}",
+                case.id
+            );
+        }
+        assert!(
+            case.relevant
+                .iter()
+                .all(|name| !case.forbidden.contains(name)),
+            "routing case {} marks the same skill relevant and forbidden",
+            case.id
+        );
+        if case.source_issue == Some(5417) {
+            issue_5417_cases += 1;
+            assert_eq!(
+                case.id, "hacker-news-search-no-skill",
+                "issue 5417 must identify the frozen Hacker News regression"
+            );
+            assert!(
+                case.forbidden
+                    .iter()
+                    .any(|name| name == "tech-debt-tracker"),
+                "issue 5417 must keep tech-debt-tracker as a forbidden activation"
+            );
+        }
+    }
+    assert_eq!(
+        issue_5417_cases, 1,
+        "the routing corpus must contain exactly one issue 5417 regression"
+    );
+    assert_eq!(
+        classes.len(),
+        4,
+        "routing corpus must cover positive, negative, conflict, and multi-skill cases"
+    );
+}

--- a/tests/integration/skill_activate.rs
+++ b/tests/integration/skill_activate.rs
@@ -58,6 +58,10 @@ async fn skill_activate_dispatches_and_injects_skill_context() {
         .assert_tool_result_contains("\"count\":1")
         .await
         .expect("skill_activate reported one skill activated");
+    harness
+        .assert_tool_result_contains("\"activated\":[\"greet\"]")
+        .await
+        .expect("skill_activate reported the explicitly requested skill");
 
     // Model-invoked skill discovery: before activation the skill advertises
     // itself as a one-line `- name: description` listing entry (the first
@@ -140,6 +144,160 @@ async fn skill_criteria_auto_activation_stays_off_on_coordinator_path() {
             .await
             .is_err(),
         "builtin.skill_activate must NOT have been invoked without an explicit call"
+    );
+}
+
+#[tokio::test]
+async fn coordinator_listing_uses_descriptor_order_without_criteria_input() {
+    let group = RebornIntegrationGroup::skill_activation_tools()
+        .await
+        .expect("skill-activation group builds");
+    let capability_harness = group
+        .capability_harness()
+        .expect("skill-activation group has a host-runtime capability harness");
+    let harness = group
+        .thread("conv-skill-listing-order")
+        .script([RebornScriptedReply::text("done")])
+        .build()
+        .await
+        .expect("thread builds");
+    capability_harness
+        .seed_user_skill_for_test(
+            &harness.binding.tenant_id,
+            &harness.binding.actor_user_id,
+            "alpha",
+            "alpha baseline skill",
+            "ALPHA_SKILL_SENTINEL",
+        )
+        .expect("alpha user skill seeds");
+    capability_harness
+        .seed_user_skill_for_test(
+            &harness.binding.tenant_id,
+            &harness.binding.actor_user_id,
+            "zulu",
+            "zulu baseline skill",
+            "ZULU_SKILL_SENTINEL",
+        )
+        .expect("zulu user skill seeds");
+
+    harness
+        .submit_turn("a request unrelated to the seeded activation keywords")
+        .await
+        .expect("turn completes");
+
+    harness
+        .assert_model_message_content_in_order(&[
+            "- greet: greets the user warmly",
+            "- alpha: alpha baseline skill",
+            "- zulu: zulu baseline skill",
+        ])
+        .await
+        .expect("coordinator listing must preserve source-then-name descriptor order");
+}
+
+#[tokio::test]
+async fn unknown_skill_activation_is_a_noop_and_the_run_continues() {
+    let group = RebornIntegrationGroup::skill_activation_tools()
+        .await
+        .expect("skill-activation group builds");
+    let harness = group
+        .thread("conv-skill-activate-unknown")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.skill_activate",
+                json!({"names": ["missing-helper"]}),
+            ),
+            RebornScriptedReply::text("the requested skill was unavailable"),
+        ])
+        .build()
+        .await
+        .expect("thread builds");
+
+    harness
+        .submit_turn("use the missing helper")
+        .await
+        .expect("turn completes despite the missing skill");
+
+    harness
+        .assert_tool_invoked("builtin.skill_activate")
+        .await
+        .expect("skill_activate dispatched through the real capability");
+    harness
+        .assert_tool_result_contains("\"count\":0")
+        .await
+        .expect("unknown skill currently produces an empty activation result");
+    harness
+        .assert_tool_result_contains("\"activated\":[]")
+        .await
+        .expect("unknown skill must not activate another candidate");
+    harness
+        .assert_reply_contains("requested skill was unavailable")
+        .await
+        .expect("model received another turn after the no-op activation");
+    let err = harness
+        .assert_model_request_contains("GREET_SKILL_PROMPT_SENTINEL")
+        .await
+        .expect_err("a missing request must not inject a different skill");
+    assert!(
+        err.to_string().starts_with("no model request contained"),
+        "expected the intended \"not found\" assertion failure, got a different harness error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn installed_skill_is_listed_but_not_model_activatable() {
+    let group = RebornIntegrationGroup::skill_activation_tools()
+        .await
+        .expect("skill-activation group builds");
+    let capability_harness = group
+        .capability_harness()
+        .expect("skill-activation group has a host-runtime capability harness");
+    let harness = group
+        .thread("conv-skill-activate-installed")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.skill_activate",
+                json!({"names": ["remote-helper"]}),
+            ),
+            RebornScriptedReply::text("the installed skill was unavailable"),
+        ])
+        .build()
+        .await
+        .expect("thread builds");
+    capability_harness
+        .seed_installed_user_skill_for_test(
+            &harness.binding.tenant_id,
+            &harness.binding.actor_user_id,
+            "remote-helper",
+            "a remotely installed helper",
+            "REMOTE_INSTALLED_SKILL_SENTINEL",
+        )
+        .expect("installed user skill seeds");
+
+    harness
+        .submit_turn("use the remote helper")
+        .await
+        .expect("turn completes despite installed skill trust");
+
+    harness
+        .assert_model_request_contains("- remote-helper: a remotely installed helper")
+        .await
+        .expect("installed skill remains safely discoverable");
+    harness
+        .assert_tool_result_contains("\"count\":0")
+        .await
+        .expect("installed skill is not admitted by model-selected activation");
+    harness
+        .assert_tool_result_contains("\"activated\":[]")
+        .await
+        .expect("installed skill must not activate another candidate");
+    let err = harness
+        .assert_model_request_contains("REMOTE_INSTALLED_SKILL_SENTINEL")
+        .await
+        .expect_err("installed skill prompt body must remain hidden");
+    assert!(
+        err.to_string().starts_with("no model request contained"),
+        "expected the intended \"not found\" assertion failure, got a different harness error: {err}"
     );
 }
 
@@ -272,6 +430,16 @@ fn skill_activate_ambiguous_name_surfaces_recoverable_failed() {
                 .assert_reply_contains("that name is ambiguous")
                 .await
                 .expect("run recovered and finalized");
+            harness
+                .assert_model_message_content_in_order(&[
+                    "- duplicate: a system-scoped skill",
+                    "- greet: greets the user warmly",
+                    "- duplicate: a user-scoped skill",
+                ])
+                .await
+                .expect(
+                    "the baseline listing exposes ambiguous bare names without qualified recovery identifiers",
+                );
             // Neither candidate's instructions may leak into a later model request —
             // an ambiguous selection activates nothing.
             for sentinel in [

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -274,6 +274,33 @@ impl RebornIntegrationHarness {
         .into())
     }
 
+    /// Assert that one model-visible message contains every `needle` in the
+    /// supplied order. Other content may appear between needles.
+    pub async fn assert_model_message_content_in_order(
+        &self,
+        needles: &[&str],
+    ) -> HarnessResult<()> {
+        if needles.is_empty() {
+            return Err("ordered model-message assertion needs at least one needle".into());
+        }
+        let requests = self.scripted_llm.captured_requests();
+        'message: for message in requests.iter().flatten() {
+            let mut remaining = message.content.as_str();
+            for needle in needles {
+                let Some(position) = remaining.find(needle) else {
+                    continue 'message;
+                };
+                remaining = &remaining[position + needle.len()..];
+            }
+            return Ok(());
+        }
+        Err(format!(
+            "no model message content contained {needles:?} in order; captured {} request(s)",
+            requests.len()
+        )
+        .into())
+    }
+
     /// Assert the exact number of interactive, tool-capable calls observed by
     /// the recoverable-failure provider wrapper. Text-only system-inference
     /// calls used for compaction are intentionally excluded.

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -1506,6 +1506,36 @@ impl HostRuntimeCapabilityHarness {
         Ok(())
     }
 
+    /// C-SKILL baseline: seed the same user-scoped bundle shape as
+    /// [`Self::seed_user_skill_for_test`], then add the URL-install provenance
+    /// sidecar that makes the production filesystem source downgrade its trust
+    /// to `Installed`. This drives the caller-level "listed but not
+    /// model-activatable" behavior without bypassing descriptor discovery.
+    pub(crate) fn seed_installed_user_skill_for_test(
+        &self,
+        tenant: &TenantId,
+        user: &UserId,
+        name: &str,
+        description: &str,
+        prompt: &str,
+    ) -> HarnessResult<()> {
+        self.seed_user_skill_for_test(tenant, user, name, description, prompt)?;
+        let metadata_path = self
+            .storage_root_for_test()
+            .join("tenants")
+            .join(tenant.as_str())
+            .join("users")
+            .join(user.as_str())
+            .join("skills")
+            .join(name)
+            .join(".ironclaw-install.json");
+        std::fs::write(
+            metadata_path,
+            br#"{"source":"installed_url","source_url":"https://skills.example.test/SKILL.md"}"#,
+        )?;
+        Ok(())
+    }
+
     /// C-ATTACH: the attachment read port + inbound lander over this harness's
     /// local-dev workspace filesystem, for wiring `DefaultPlannedRuntimeParts.attachment_read_port`
     /// and `DefaultInboundTurnService::with_inbound_attachments` — mirrors


### PR DESCRIPTION
## Summary

- add a checked-in 18-case routing corpus over the real bundled skill catalog
- freeze the current top-5 selector output while separately labeling relevant, forbidden, conflict, multi-skill, and no-match expectations
- reproduce #5417's Hacker News false activation as a reviewed baseline
- pin coordinator listing order, explicit activation, missing-skill, ambiguous-name, and installed-trust behavior through the Reborn caller path

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6565
Related #5417

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (covered by the stronger workspace-wide all-targets command below)
- [ ] `cargo build` — not run separately; workspace clippy compiled all targets
- [x] Relevant tests pass: `cargo test -p ironclaw_skills`, `cargo test --test reborn_integration_skill_activate`, and `cargo test -p ironclaw_architecture`
- [ ] `cargo test --features integration` — not applicable; no database-backed behavior changed
- [ ] Manual testing — not applicable; this PR adds deterministic automated baselines
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — draft PR; review closeout has not been requested yet

## Test Strategy

User behavior:

No production behavior changes. Maintainers gain a frozen, reviewable baseline for skill-routing quality and caller-path regressions before later slices change routing or activation behavior.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: added an 18-case real-catalog routing corpus covering positive, negative, conflict, and multi-skill requests. The evaluator validates every referenced skill, parses every bundled `SKILL.md`, checks directory/name consistency, freezes exact selector output, and reports baseline quality metrics.
- Reborn integration: pinned model-visible descriptor ordering, exact explicit activation, missing-skill no-op behavior, ambiguous unqualified names, and installed-but-untrusted listing without prompt-body disclosure.
- Recorded fixture: Not applicable: no real-model tool choice is introduced or changed; Slice 0 records deterministic selector and scripted caller behavior.
- Browser E2E: Not applicable: no WebUI behavior changes.
- Backend or runtime: Not applicable: no backend or runtime implementation changes; the existing local filesystem and runner harness exercises the relevant production-shaped path.
- Live canary: Not applicable: Slice 0 establishes deterministic baselines; live model drift measurement is deferred to the evaluation rollout slice.

What the tests prove:

- the current real catalog produces a stable, reviewable top-5 result per case
- #5417 remains visibly reproduced as `tech-debt-tracker` selected for the Hacker News no-match prompt
- explicit activation loads only the requested trusted skill body
- missing and installed-but-untrusted requests activate nothing and disclose no prompt body
- duplicate bare names fail recoverably while both ambiguous unqualified entries remain model-visible
- coordinator listing order remains deterministic by source and name while criteria ranking is absent from that path

Commands run:

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_skills` (229 unit tests + 1 corpus contract)
- `cargo test --test reborn_integration_skill_activate` (20 tests)
- `cargo test -p ironclaw_architecture`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `scripts/pre-commit-safety.sh`
- `git diff --check`

## Security Impact

None to production behavior. The PR adds regression coverage proving that installed-but-untrusted skill instructions remain hidden and cannot be model-activated.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: Not applicable: no production types or constructors changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable: no prompt assembly changed; tests exercise the existing boundary.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable: no hashing behavior changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: Not applicable: no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Not applicable: the test-only corpus schema does not affect persisted production data.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable: no production collections or counters changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Not applicable: no error semantics changed.
- [x] Sandbox/native/host names accurately describe trust boundary. The installed-skill fixture uses the production install sidecar shape and verifies discoverable-only behavior.

## Database Impact

None. No schema, migration, PostgreSQL, or libSQL behavior changes.

## Blast Radius

Test-only changes in `ironclaw_skills` and the existing Reborn skill-activation integration harness. Catalog or selector changes will intentionally require reviewing and updating the frozen baseline. No runtime configuration or production code changes.

## Rollback Plan

Revert commit `d2672cad2`. There is no runtime state, migration, or compatibility impact.

## Review Follow-Through

Slice 0 intentionally records current deficiencies rather than fixing them: the Hacker News false activation, zero-result missing/installed activation response, unqualified ambiguity, and non-task-ranked coordinator listing. Later slices should change these behaviors and update the baseline with explicit quality evidence. Quality thresholds remain measurement-only until the evaluation-gate slice.

---

**Review track**: A (tests/chore)
