### PR TITLE
test(reborn): cover scheduled trigger delivery end to end

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_activation_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_activation_credentials.rs
@@ -121,10 +121,10 @@ impl ExtensionActivationCredentialGate for UnavailableExtensionActivationCredent
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) struct PrecheckedExtensionActivationCredentialGate;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 #[async_trait]
 impl ExtensionActivationCredentialGate for PrecheckedExtensionActivationCredentialGate {
     async fn ensure_credentials(

--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle.rs
@@ -1546,7 +1546,7 @@ impl ExtensionManagementPort {
         Ok(())
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) async fn activate_with_prechecked_credentials_for_test(
         &self,
         package_ref: LifecyclePackageRef,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -580,6 +580,8 @@ pub struct RebornRuntime {
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) outbound_state: Arc<dyn ironclaw_outbound::OutboundStateStorePort>,
     #[cfg(any(test, feature = "test-support"))]
+    pub(crate) triggered_run_delivery: Arc<dyn ironclaw_outbound::TriggeredRunDeliveryStore>,
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) delivered_gate_routes: Arc<dyn ironclaw_outbound::DeliveredGateRouteStore>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) delivery_coordinator: Option<Arc<ironclaw_product::DeliveryCoordinator>>,
@@ -1324,6 +1326,40 @@ impl RebornRuntime {
         Some(self.extension_management.installation_store_for_test())
     }
 
+    /// Test-only caller for the production lifecycle install path used by the
+    /// WebUI/product facade. This keeps whole-runtime channel tests on the real
+    /// catalog, installation store, and generic-host publication path.
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn install_extension_for_test(
+        &self,
+        package_ref: ironclaw_product::LifecyclePackageRef,
+    ) -> Result<ironclaw_product::LifecycleProductResponse, ironclaw_product::ProductWorkflowError>
+    {
+        self.extension_management
+            .install(package_ref, &self.actor_user_id)
+            .await
+    }
+
+    /// Test-only caller for the production static activation path with the
+    /// existing prechecked-credential gate. Whole-runtime channel tests use it
+    /// when the user-tool credential account is outside the scenario under
+    /// test; channel configuration and activation still run through their real
+    /// stores and generic-host publication.
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn activate_extension_for_test(
+        &self,
+        package_ref: ironclaw_product::LifecyclePackageRef,
+    ) -> Result<ironclaw_product::LifecycleProductResponse, ironclaw_product::ProductWorkflowError>
+    {
+        self.extension_management
+            .activate_with_prechecked_credentials_for_test(
+                package_ref,
+                crate::extension_host::extension_lifecycle::ExtensionActivationMode::Static,
+                &self.actor_user_id,
+            )
+            .await
+    }
+
     /// Test-support handles onto the approval/lease/gate stores the integration
     /// harness drives approve/deny flows through. All four stores are
     /// reconstructed fresh over the runtime's own composite root
@@ -1402,6 +1438,34 @@ impl RebornRuntime {
             Arc::clone(&self.delivered_gate_routes),
             Arc::clone(&self.outbound_preferences),
         ))
+    }
+
+    /// Test-only accessor for the same durable triggered-delivery outcome store
+    /// the composition-owned post-submit hook records into. Whole-path tests use
+    /// it to await detached delivery completion without observing task timing.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn triggered_run_delivery_store_for_test(
+        &self,
+    ) -> Option<Arc<dyn ironclaw_outbound::TriggeredRunDeliveryStore>> {
+        Some(Arc::clone(&self.triggered_run_delivery))
+    }
+
+    /// Test-only readiness projection for the production generic channel-host
+    /// assembly. Activation publishes snapshots asynchronously; whole-runtime
+    /// delivery tests wait until the owning preference codec is routable before
+    /// firing a trigger.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn active_channel_preference_codec_ids_for_test(&self) -> Vec<String> {
+        self.channel_host_assembly
+            .as_ref()
+            .map(|assembly| {
+                assembly
+                    .active_preference_codecs()
+                    .into_iter()
+                    .map(|(extension_id, _)| extension_id)
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -4494,6 +4558,8 @@ pub async fn build_runtime(input: RebornRuntimeInput) -> Result<RebornRuntime, R
         outbound_preferences: services.outbound_preferences.clone(),
         #[cfg(any(test, feature = "test-support"))]
         outbound_state: services.outbound_state.clone(),
+        #[cfg(any(test, feature = "test-support"))]
+        triggered_run_delivery: services.triggered_run_delivery.clone(),
         #[cfg(any(test, feature = "test-support"))]
         delivered_gate_routes: services.delivered_gate_routes.clone(),
         #[cfg(any(test, feature = "test-support"))]

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -8,16 +8,19 @@
 #![cfg(feature = "test-support")]
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
 use ironclaw_conversations::{AdapterInstallationId, AdapterKind, ExternalActorRef};
 use ironclaw_host_api::{
-    AgentId, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
-    ExecutionContext, ExtensionId, GrantConstraints, MountView, NetworkPolicy, Principal,
-    ProviderToolName, ResourceEstimate, RunId, RuntimeKind, TenantId, TrustClass, UserId,
+    AdapterInstallationId as ProductAdapterInstallationId, AgentId, CapabilityGrant,
+    CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind, ExecutionContext, ExtensionId,
+    GrantConstraints, MountView, NetworkPolicy, Principal, ProviderToolName, ResourceEstimate,
+    RunId, RuntimeKind, TenantId, TrustClass, UserId,
 };
 use ironclaw_host_runtime::{
     RuntimeCapabilityOutcome, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_PAUSE_CAPABILITY_ID,
@@ -27,20 +30,30 @@ use ironclaw_loop_host::{
     HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
     HostManagedModelResponse,
 };
+use ironclaw_network::{
+    NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
+};
+use ironclaw_outbound::{
+    CommunicationPreferenceRecord, DeliveryDefaultScope, TriggeredRunDeliveryOutcomeKind,
+    TriggeredRunDeliveryStore,
+};
+use ironclaw_product::{LifecyclePackageKind, LifecyclePackageRef, RebornOutboundDeliveryTargetId};
 use ironclaw_reborn_composition::{
-    RebornCompositionProfile, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
-    RebornRuntimeProfileOptions, TriggerPollerSettings, build_reborn_runtime,
+    ChannelExtensionBinding, RebornCompositionProfile, RebornRuntime, RebornRuntimeIdentity,
+    RebornRuntimeInput, RebornRuntimeProfileOptions, TriggerPollerSettings, build_reborn_runtime,
     local_runtime_build_input_with_options,
 };
 use ironclaw_runner::runtime::ToolDisclosureMode;
 use ironclaw_triggers::{
     TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
-    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerId, TriggerPollerWorkerConfig, TriggerRecord,
-    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerDeliveryTargetId, TriggerId,
+    TriggerPollerWorkerConfig, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
+    TriggerSourceKind, TriggerState,
 };
 use ironclaw_turns::run_profile::{
     LoopCapabilityPort, ProviderToolCall, RegisterProviderToolCallRequest,
 };
+use ironclaw_turns::{ReplyTargetBindingRef, TurnRunId};
 use serde_json::{Value, json};
 use tokio::sync::Mutex as TokioMutex;
 
@@ -48,6 +61,18 @@ const TENANT: &str = "trigger-e2e-tenant";
 const USER: &str = "trigger-e2e-owner";
 const AGENT: &str = "trigger-e2e-agent";
 const TRIGGER_PROMPT: &str = "trigger-e2e-prompt-marker-do-not-rephrase";
+const QA_9B_PROMPT: &str = "QA_9B scheduled health digest";
+const QA_9B_RESULT: &str = "QA_9B scheduled health digest complete";
+const QA_9D_PROMPT: &str = "QA_9D scheduled release digest";
+const QA_9D_RESULT: &str = "QA_9D scheduled release digest complete";
+const SLACK_TEAM: &str = "T-TRIGGER-E2E";
+const SLACK_USER: &str = "U-TRIGGER-E2E";
+const SLACK_DEFAULT_DM: &str = "D-TRIGGER-DEFAULT";
+const SLACK_PER_TRIGGER_CHANNEL: &str = "C-TRIGGER-OVERRIDE";
+const QA_9B_TARGET_ID: &str = "slack:personal-dm:T-TRIGGER-E2E:trigger-e2e-owner";
+const QA_9D_TARGET_ID: &str = "slack:shared-channel:T-TRIGGER-E2E:C-TRIGGER-OVERRIDE";
+const TEST_SECRET_MASTER_KEY: &str =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 /// Name of the trigger the fired run's capability call attempts to create.
 /// Issue #5505's fix strips `builtin.trigger_create` from the model-visible
 /// surface for a `scheduled_trigger` fire, so this name must NEVER appear in
@@ -110,6 +135,130 @@ impl HostManagedModelGateway for RecordingGateway {
         Ok(HostManagedModelResponse::assistant_reply(
             "trigger e2e ok".to_string(),
         ))
+    }
+}
+
+#[derive(Debug, Default)]
+struct DeliveryJourneyGateway {
+    requests: TokioMutex<Vec<HostManagedModelRequest>>,
+}
+
+impl DeliveryJourneyGateway {
+    async fn request_count_containing(&self, needle: &str) -> usize {
+        self.requests
+            .lock()
+            .await
+            .iter()
+            .filter(|request| {
+                request
+                    .messages
+                    .iter()
+                    .any(|message| message.content.contains(needle))
+            })
+            .count()
+    }
+}
+
+#[async_trait]
+impl HostManagedModelGateway for DeliveryJourneyGateway {
+    async fn stream_model(
+        &self,
+        request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        let reply = if request
+            .messages
+            .iter()
+            .any(|message| message.content.contains(QA_9B_PROMPT))
+        {
+            QA_9B_RESULT
+        } else if request
+            .messages
+            .iter()
+            .any(|message| message.content.contains(QA_9D_PROMPT))
+        {
+            QA_9D_RESULT
+        } else {
+            "unexpected scheduled-trigger prompt"
+        };
+        self.requests.lock().await.push(request);
+        Ok(HostManagedModelResponse::assistant_reply(reply.to_string()))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SlackWireMessage {
+    url: String,
+    authorization: Option<String>,
+    body: Value,
+}
+
+#[derive(Debug, Default)]
+struct FakeSlackProvider {
+    wire_messages: StdMutex<Vec<SlackWireMessage>>,
+    provider_messages: StdMutex<Vec<Value>>,
+    next_message_id: AtomicUsize,
+}
+
+impl FakeSlackProvider {
+    fn wire_messages(&self) -> Vec<SlackWireMessage> {
+        self.wire_messages
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn provider_messages(&self) -> Vec<Value> {
+        self.provider_messages
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+#[async_trait]
+impl NetworkHttpEgress for FakeSlackProvider {
+    async fn execute(
+        &self,
+        request: NetworkHttpRequest,
+    ) -> Result<NetworkHttpResponse, NetworkHttpError> {
+        let authorization = request
+            .headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+            .map(|(_, value)| value.clone());
+        let body = serde_json::from_slice::<Value>(&request.body).unwrap_or(Value::Null);
+        if request.url.ends_with("/api/chat.postMessage") {
+            self.wire_messages
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(SlackWireMessage {
+                    url: request.url.clone(),
+                    authorization,
+                    body: body.clone(),
+                });
+            self.provider_messages
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(body.clone());
+        }
+        let message_id = self.next_message_id.fetch_add(1, Ordering::SeqCst);
+        let response_body = serde_json::json!({
+            "ok": true,
+            "channel": body["channel"],
+            "ts": format!("1710000001.{message_id:06}"),
+        })
+        .to_string()
+        .into_bytes();
+        Ok(NetworkHttpResponse {
+            status: 200,
+            headers: vec![("content-type".to_string(), "application/json".to_string())],
+            usage: NetworkUsage {
+                request_bytes: request.body.len() as u64,
+                response_bytes: response_body.len() as u64,
+                resolved_ip: None,
+            },
+            body: response_body,
+        })
     }
 }
 
@@ -390,6 +539,7 @@ async fn build_runtime_with<G: HostManagedModelGateway + 'static>(
     model_gateway: Arc<G>,
     trigger_poller: TriggerPollerSettings,
 ) -> RebornRuntime {
+    seed_test_secret_master_key(root.path());
     let host_home_root = root.path().join("host-home");
     std::fs::create_dir_all(&host_home_root).expect("host home root");
     let input = local_runtime_build_input_with_options(
@@ -416,6 +566,269 @@ async fn build_runtime_with<G: HostManagedModelGateway + 'static>(
     build_reborn_runtime(input).await.expect("runtime builds")
 }
 
+async fn build_runtime_with_slack_delivery(
+    root: &tempfile::TempDir,
+    model_gateway: Arc<DeliveryJourneyGateway>,
+    slack_provider: Arc<FakeSlackProvider>,
+) -> RebornRuntime {
+    seed_test_secret_master_key(root.path());
+    let host_home_root = root.path().join("host-home");
+    std::fs::create_dir_all(&host_home_root).expect("host home root");
+    let input = local_runtime_build_input_with_options(
+        RebornCompositionProfile::LocalDevYolo,
+        USER,
+        root.path().join("local-dev"),
+        RebornRuntimeProfileOptions {
+            confirm_host_access: true,
+        },
+    )
+    .expect("local-yolo runtime input")
+    .with_local_dev_confirmed_host_home_root(host_home_root)
+    .with_bundled_first_party_for_test()
+    .with_network_http_egress_for_test(slack_provider)
+    .with_channel_extension_bindings(vec![ChannelExtensionBinding {
+        extension_id: "slack".to_string(),
+        adapter: Arc::new(ironclaw_slack_extension::SlackChannelAdapter),
+        preference_target_codec: Some(Arc::new(
+            ironclaw_slack_extension::SlackPreferenceTargetCodec,
+        )),
+    }]);
+    let input = RebornRuntimeInput::from_build_input(input)
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: TENANT.to_string(),
+            agent_id: AGENT.to_string(),
+            source_binding_id: "trigger-delivery-e2e-source".to_string(),
+            reply_target_binding_id: "trigger-delivery-e2e-reply".to_string(),
+        })
+        .with_trigger_poller_settings(
+            TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test()
+                .with_worker_config(
+                    TriggerPollerWorkerConfig::default()
+                        .set_poll_interval(Duration::from_millis(20)),
+                ),
+        )
+        .with_model_gateway_override(model_gateway);
+
+    build_reborn_runtime(input).await.expect("runtime builds")
+}
+
+async fn configure_and_activate_slack_for_delivery(runtime: &RebornRuntime) {
+    let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "slack")
+        .expect("valid Slack package ref");
+    runtime
+        .install_extension_for_test(package_ref.clone())
+        .await
+        .expect("install Slack through the production lifecycle port");
+    runtime
+        .configure_admin_group_for_test(
+            "extension.slack",
+            vec![
+                (
+                    "slack_bot_token".to_string(),
+                    "xoxb-trigger-e2e".to_string(),
+                ),
+                (
+                    "slack_signing_secret".to_string(),
+                    "signing-trigger-e2e".to_string(),
+                ),
+                ("slack_team_id".to_string(), SLACK_TEAM.to_string()),
+                ("slack_api_app_id".to_string(), "A-TRIGGER-E2E".to_string()),
+                (
+                    "slack_installation_id".to_string(),
+                    "I-TRIGGER-E2E".to_string(),
+                ),
+                (
+                    "slack_bot_user_id".to_string(),
+                    "U-BOT-TRIGGER-E2E".to_string(),
+                ),
+                (
+                    "slack_oauth_client_id".to_string(),
+                    "trigger-e2e-client".to_string(),
+                ),
+                (
+                    "slack_oauth_client_secret".to_string(),
+                    "trigger-e2e-client-secret".to_string(),
+                ),
+            ],
+        )
+        .await
+        .expect("configure Slack through the production admin-configuration resolver");
+    runtime
+        .activate_extension_for_test(package_ref)
+        .await
+        .expect("activate Slack through the production lifecycle port");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !runtime
+        .active_channel_preference_codec_ids_for_test()
+        .iter()
+        .any(|extension_id| extension_id == "slack")
+    {
+        assert!(
+            Instant::now() < deadline,
+            "Slack activation never became routable through the generic channel host"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn slack_reply_target(channel: &str, actor: Option<&str>) -> ReplyTargetBindingRef {
+    let installation =
+        ProductAdapterInstallationId::new("slack").expect("valid deployment installation id");
+    let agent = AgentId::new(AGENT).expect("valid agent id");
+    match actor {
+        Some(actor) => ironclaw_slack_extension::slack_personal_dm_reply_target_binding_ref(
+            &installation,
+            &agent,
+            None,
+            SLACK_TEAM,
+            channel,
+            actor,
+        )
+        .expect("valid Slack DM target"),
+        None => ironclaw_slack_extension::slack_shared_channel_reply_target_binding_ref(
+            &installation,
+            &agent,
+            None,
+            SLACK_TEAM,
+            channel,
+        )
+        .expect("valid Slack shared-channel target"),
+    }
+}
+
+async fn configure_delivery_targets(runtime: &RebornRuntime) {
+    let tenant_id = TenantId::new(TENANT).expect("valid tenant id");
+    let user_id = UserId::new(USER).expect("valid user id");
+    register_delivery_targets(runtime);
+    runtime
+        .local_dev_outbound_preferences_for_test()
+        .expect("local runtime exposes outbound preferences")
+        .put_communication_preference(CommunicationPreferenceRecord {
+            scope: DeliveryDefaultScope::personal(tenant_id, user_id.clone()),
+            final_reply_target: Some(slack_reply_target(SLACK_DEFAULT_DM, Some(SLACK_USER))),
+            progress_target: None,
+            approval_prompt_target: None,
+            auth_prompt_target: None,
+            default_modality: None,
+            updated_at: Utc::now(),
+            updated_by: user_id,
+        })
+        .await
+        .expect("seed the creator's default Slack DM");
+}
+
+fn register_delivery_targets(runtime: &RebornRuntime) {
+    runtime
+        .register_static_outbound_delivery_target_for_test(
+            "qa-9b-static",
+            RebornOutboundDeliveryTargetId::new(QA_9B_TARGET_ID).expect("valid default target id"),
+            "slack",
+            "QA 9B default DM",
+            Some("scheduled-trigger default target"),
+            slack_reply_target(SLACK_DEFAULT_DM, Some(SLACK_USER)),
+        )
+        .expect("register the default Slack DM target");
+    runtime
+        .register_static_outbound_delivery_target_for_test(
+            "qa-9d-static",
+            RebornOutboundDeliveryTargetId::new(QA_9D_TARGET_ID)
+                .expect("valid per-trigger target id"),
+            "slack",
+            "QA 9D override",
+            Some("scheduled-trigger target override"),
+            slack_reply_target(SLACK_PER_TRIGGER_CHANNEL, None),
+        )
+        .expect("register the per-trigger Slack target");
+}
+
+async fn pair_trigger_creator(runtime: &RebornRuntime) {
+    runtime
+        .trigger_conversation_pairing()
+        .expect("trigger poller exposes its conversation pairing service")
+        .pair_external_actor(
+            TenantId::new(TENANT).expect("valid tenant id"),
+            AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("valid adapter kind"),
+            AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                .expect("valid trigger installation id"),
+            ExternalActorRef::new(TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, USER)
+                .expect("valid trigger actor ref"),
+            UserId::new(USER).expect("valid user id"),
+        )
+        .await
+        .expect("pair trigger creator");
+}
+
+async fn seed_due_delivery_trigger(
+    repository: &Arc<dyn TriggerRepository>,
+    prompt: &str,
+    delivery_target: Option<&str>,
+) -> TriggerId {
+    let trigger_id = TriggerId::new();
+    let fire_at = Utc::now() - chrono::Duration::seconds(120);
+    repository
+        .upsert_trigger(TriggerRecord {
+            trigger_id,
+            tenant_id: TenantId::new(TENANT).expect("valid tenant id"),
+            creator_user_id: UserId::new(USER).expect("valid user id"),
+            agent_id: Some(AgentId::new(AGENT).expect("valid agent id")),
+            project_id: None,
+            name: format!("{prompt} trigger"),
+            source: TriggerSourceKind::Schedule,
+            schedule: TriggerSchedule::once(fire_at, "UTC").expect("valid once schedule"),
+            prompt: prompt.to_string(),
+            delivery_target: delivery_target.map(|target| {
+                TriggerDeliveryTargetId::new(target).expect("valid trigger delivery target")
+            }),
+            state: TriggerState::Scheduled,
+            next_run_at: fire_at,
+            last_run_at: None,
+            last_fired_slot: None,
+            last_status: None,
+            active_fire_slot: None,
+            active_run_ref: None,
+            created_at: Utc::now(),
+        })
+        .await
+        .expect("seed due delivery trigger");
+    trigger_id
+}
+
+async fn wait_for_delivered_run(
+    repository: &Arc<dyn TriggerRepository>,
+    delivery_store: &Arc<dyn TriggeredRunDeliveryStore>,
+    trigger_id: TriggerId,
+) -> TurnRunId {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let history = repository
+            .list_trigger_run_history(
+                TenantId::new(TENANT).expect("valid tenant id"),
+                trigger_id,
+                1,
+            )
+            .await
+            .expect("read trigger run history");
+        if let Some(run_id) = history.first().and_then(|run| run.run_id)
+            && let Some(record) = delivery_store
+                .load_triggered_run_delivery(run_id)
+                .await
+                .expect("read triggered delivery outcome")
+        {
+            assert_eq!(
+                record.outcome,
+                TriggeredRunDeliveryOutcomeKind::Delivered,
+                "triggered run must reach the provider successfully"
+            );
+            return run_id;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "trigger {trigger_id} did not record a delivery outcome within 15s"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
 /// Same as [`build_runtime_with`], but with an explicit
 /// [`ToolDisclosureMode`] instead of the implicit `Off` default. Kept
 /// separate (rather than adding a parameter to `build_runtime_with`) because
@@ -428,6 +841,7 @@ async fn build_runtime_with_tool_disclosure<G: HostManagedModelGateway + 'static
     trigger_poller: TriggerPollerSettings,
     tool_disclosure: ToolDisclosureMode,
 ) -> RebornRuntime {
+    seed_test_secret_master_key(root.path());
     let host_home_root = root.path().join("host-home");
     std::fs::create_dir_all(&host_home_root).expect("host home root");
     let input = local_runtime_build_input_with_options(
@@ -453,6 +867,19 @@ async fn build_runtime_with_tool_disclosure<G: HostManagedModelGateway + 'static
         .with_tool_disclosure(tool_disclosure);
 
     build_reborn_runtime(input).await.expect("runtime builds")
+}
+
+/// Keep parallel runtime tests off the ambient OS keychain. The production
+/// resolver deliberately prefers this cached dotfile, so this still exercises
+/// the real local-dev secret-store construction without process-global env
+/// mutation or platform keychain serialization.
+fn seed_test_secret_master_key(root: &Path) {
+    let local_dev_root = root.join("local-dev");
+    std::fs::create_dir_all(&local_dev_root).expect("local-dev root");
+    let key_path = local_dev_root.join(".reborn-local-dev-secrets-master-key");
+    if !key_path.exists() {
+        std::fs::write(key_path, TEST_SECRET_MASTER_KEY).expect("seed test secret master key");
+    }
 }
 
 async fn invoke_trigger_create(runtime: &RebornRuntime, input: Value) -> Value {
@@ -692,6 +1119,145 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
         final_record.state,
         TriggerState::Completed,
         "once schedule: state must be Completed after clear_active_fire — record: {final_record:?}",
+    );
+}
+
+/// QA-9B + QA-9D whole-path regression:
+///
+/// due trigger -> trusted ingress -> real Reborn run -> persisted final reply
+/// -> generic triggered-delivery hook -> real Slack adapter -> host-mediated
+/// credential injection -> fake Slack HTTP boundary.
+///
+/// The two arms prove that the creator's default DM is used when the trigger
+/// has no target and that an explicit per-trigger target overrides that
+/// default. Re-polling and rebuilding the runtime over the same durable store
+/// must not repeat either provider mutation.
+#[tokio::test]
+async fn scheduled_trigger_results_reach_exact_slack_targets_once_across_restart() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let model_gateway = Arc::new(DeliveryJourneyGateway::default());
+    let slack_provider = Arc::new(FakeSlackProvider::default());
+    let runtime = build_runtime_with_slack_delivery(
+        &root,
+        Arc::clone(&model_gateway),
+        Arc::clone(&slack_provider),
+    )
+    .await;
+
+    configure_and_activate_slack_for_delivery(&runtime).await;
+    configure_delivery_targets(&runtime).await;
+    pair_trigger_creator(&runtime).await;
+
+    let repository = runtime.trigger_repository();
+    let delivery_store = runtime
+        .triggered_run_delivery_store_for_test()
+        .expect("local runtime exposes the production triggered-delivery store");
+    let default_target_trigger = seed_due_delivery_trigger(&repository, QA_9B_PROMPT, None).await;
+    let explicit_target_trigger =
+        seed_due_delivery_trigger(&repository, QA_9D_PROMPT, Some(QA_9D_TARGET_ID)).await;
+
+    wait_for_delivered_run(&repository, &delivery_store, default_target_trigger).await;
+    wait_for_delivered_run(&repository, &delivery_store, explicit_target_trigger).await;
+
+    let provider_messages = slack_provider.provider_messages();
+    assert_eq!(
+        provider_messages.len(),
+        2,
+        "one provider-side message per scheduled trigger: {provider_messages:?}"
+    );
+    assert_slack_message(
+        &provider_messages,
+        QA_9B_RESULT,
+        SLACK_DEFAULT_DM,
+        "QA-9B default delivery",
+    );
+    assert_slack_message(
+        &provider_messages,
+        QA_9D_RESULT,
+        SLACK_PER_TRIGGER_CHANNEL,
+        "QA-9D per-trigger override",
+    );
+
+    let wire_messages = slack_provider.wire_messages();
+    assert_eq!(
+        wire_messages.len(),
+        2,
+        "exactly two Slack wire mutations: {wire_messages:?}"
+    );
+    assert!(
+        wire_messages.iter().all(|message| {
+            message.url == "https://slack.com/api/chat.postMessage"
+                && message.authorization.as_deref() == Some("Bearer xoxb-trigger-e2e")
+                && provider_messages.contains(&message.body)
+        }),
+        "each provider mutation must cross the real Slack adapter and host credential boundary: \
+         {wire_messages:?}"
+    );
+    assert_eq!(
+        model_gateway.request_count_containing(QA_9B_PROMPT).await,
+        1,
+        "QA-9B must execute exactly one model run"
+    );
+    assert_eq!(
+        model_gateway.request_count_containing(QA_9D_PROMPT).await,
+        1,
+        "QA-9D must execute exactly one model run"
+    );
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert_eq!(
+        slack_provider.provider_messages().len(),
+        2,
+        "re-polling completed one-shot triggers must not duplicate delivery"
+    );
+    runtime.shutdown().await.expect("first runtime shutdown");
+
+    let restarted = build_runtime_with_slack_delivery(
+        &root,
+        Arc::clone(&model_gateway),
+        Arc::clone(&slack_provider),
+    )
+    .await;
+    register_delivery_targets(&restarted);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    restarted
+        .shutdown()
+        .await
+        .expect("restarted runtime shutdown");
+
+    assert_eq!(
+        slack_provider.provider_messages().len(),
+        2,
+        "restart over the same durable trigger state must not duplicate provider effects"
+    );
+    assert_eq!(
+        model_gateway.request_count_containing(QA_9B_PROMPT).await,
+        1,
+        "restart must not rerun QA-9B"
+    );
+    assert_eq!(
+        model_gateway.request_count_containing(QA_9D_PROMPT).await,
+        1,
+        "restart must not rerun QA-9D"
+    );
+}
+
+fn assert_slack_message(
+    messages: &[Value],
+    expected_text: &str,
+    expected_channel: &str,
+    scenario: &str,
+) {
+    let matching = messages.iter().filter(|message| {
+        message["channel"] == expected_channel
+            && message["text"]
+                .as_str()
+                .is_some_and(|text| text.contains(expected_text))
+    });
+    assert_eq!(
+        matching.count(),
+        1,
+        "{scenario} must create exactly one message in {expected_channel}: {messages:?}"
     );
 }
 

--- a/tests/integration/channel_connection_projection.rs
+++ b/tests/integration/channel_connection_projection.rs
@@ -1,9 +1,9 @@
-//! RED journey: a channel's descriptor-declared connection contract must be
-//! the one the model sees through `builtin.extension_search`.
+//! Caller-level regression: channel connection render guidance must not leak
+//! into the model-visible `builtin.extension_search` result.
 //!
-//! This is intentionally a caller-level test. Both the catalog projection and
-//! the account-setup registry are compiled from the resolved manifest; checking
-//! either in isolation would not catch drift in the model-visible projection.
+//! The descriptor still identifies the package as a channel so the model can
+//! reason about its surface, while WebUI-only setup copy stays on the display
+//! preview path.
 
 #[allow(dead_code)]
 #[path = "support/mod.rs"]
@@ -17,7 +17,7 @@ use reborn_support::reply::RebornScriptedReply;
 use serde_json::json;
 
 #[tokio::test]
-async fn extension_search_projects_descriptor_declared_web_generated_code_guidance() {
+async fn extension_search_omits_ui_only_connection_copy_from_model_output() {
     let group = RebornIntegrationGroup::extension_delivery()
         .await
         .expect("extension-delivery group builds with the Telegram manifest");
@@ -49,26 +49,14 @@ async fn extension_search_projects_descriptor_declared_web_generated_code_guidan
         .iter()
         .find(|entry| entry["package_ref"]["id"] == "telegram")
         .unwrap_or_else(|| panic!("Telegram catalog result in {output}"));
-    let connection = &telegram["channel_connection"];
-    assert_eq!(
-        connection["strategy"], "web_generated_code",
-        "extension_search must preserve the descriptor's WebGeneratedCode strategy: {connection}"
+    assert!(
+        telegram["surface_kinds"]
+            .as_array()
+            .is_some_and(|kinds| kinds.iter().any(|kind| kind == "channel")),
+        "model-visible search must still identify Telegram as a channel: {telegram}"
     );
     assert!(
-        connection["instructions"]
-            .as_str()
-            .is_some_and(|instructions| instructions.contains("IronClaw pairing panel")),
-        "manifest-authored connection guidance must survive catalog projection: {connection}"
-    );
-
-    let rendered = connection.to_string().to_ascii_lowercase();
-    assert!(
-        !rendered.contains("/pair"),
-        "the generic connection contract must never invent an unsupported /pair command: {connection}"
-    );
-    assert!(
-        !rendered.contains("get the pairing code from")
-            && !rendered.contains("get the pairing code"),
-        "WebGeneratedCode means IronClaw mints the code/deep link; the bot does not issue it: {connection}"
+        telegram.get("channel_connection").is_none(),
+        "model-visible search must omit UI-only connection guidance: {telegram}"
     );
 }

--- a/tests/integration/group_triggers/main.rs
+++ b/tests/integration/group_triggers/main.rs
@@ -73,14 +73,15 @@ async fn triggers_group_e2e() {
     //   - gate raise/approve/deny/resume: `triggered_gate_group` below
     //   - one-shot fire -> Completed: `trigger_poller_e2e.rs` + `repository_contract.rs`
     //   - reply persists in trigger's own thread: `reborn_integration_triggered_submit.rs`
-    //   - push leg (trigger -> channel outbound delivery): the generic
-    //     channel-host e2e suite (`channel_host/e2e_tests.rs`, triggered
-    //     scenarios incl. the generic post-submit hook)
+    //   - push leg (trigger -> channel outbound delivery):
+    //     `trigger_poller_e2e.rs::scheduled_trigger_results_reach_exact_slack_targets_once_across_restart`
+    //     joins the production poller/run graph to the generic post-submit
+    //     hook and real Slack adapter; `channel_host/e2e_tests.rs` retains
+    //     the focused channel-host contracts.
     //
-    // Still BLOCKED at int tier: the PUSH half. `deliver_triggered_run` is a
-    // private fn reachable only via a detached `tokio::spawn` hook, not wired
-    // into any harness turn lifecycle — covered instead by the composition
-    // channel-host e2e triggered scenarios + `outbound_delivery_contract.rs`.
+    // This grouped int-tier harness still does not expose the detached
+    // post-submit hook directly; the composition whole-runtime test above
+    // covers that asynchronous boundary through its durable outcome store.
 
     // C-DENYEDGE row 4: a scheduled-trigger fire must not be able to create
     // its own follow-up trigger. Uses THIS group's `triggers()` capability

--- a/tests/integration/triggered_submit.rs
+++ b/tests/integration/triggered_submit.rs
@@ -1,8 +1,8 @@
 //! E-TRIGGERED-SUBMIT: proves the trusted-trigger submission seam end-to-end —
 //! `TrustedTriggerFireSubmitter` propagates `TurnOriginKind::ScheduledTrigger`
 //! into persisted run state at `TurnCoordinator::get_run_state`. Contrast arm:
-//! C-TRIGGERED-ORIGIN. Delivery/push routing stays with the Slack
-//! services-shell spike (C-TRIGGERED-DELIVERY defer).
+//! C-TRIGGERED-ORIGIN. Scheduled delivery/push routing is covered by
+//! `trigger_poller_e2e.rs::scheduled_trigger_results_reach_exact_slack_targets_once_across_restart`.
 
 #[allow(dead_code)]
 #[path = "support/mod.rs"]
@@ -81,7 +81,8 @@ async fn interactive_submit_carries_inbound_origin_not_scheduled_trigger() {
 
 /// Int-tier delivery contract: a completed triggered run persists its reply in
 /// the trigger's own thread. No `OutboundDeliverySink` push happens at this
-/// tier — that's the Slack services-shell (C-TRIGGERED-DELIVERY defer).
+/// tier — the composition whole-runtime test named above covers the detached
+/// delivery hook and real Slack adapter.
 #[tokio::test]
 async fn triggered_run_completes_and_persists_reply_in_trigger_thread() {
     let harness = RebornIntegrationHarness::test_default()


### PR DESCRIPTION
## Summary

- Add one hermetic whole-runtime journey that connects a due scheduled trigger to trusted ingress, a real Reborn run, the detached post-submit delivery hook, and the real Slack adapter.
- Cover both creator-default DM routing (QA-9B) and explicit per-trigger channel routing (QA-9D), with provider-side state and raw HTTP wire assertions.
- Prove model execution and Slack delivery stay exactly once across repeated polls and a runtime restart over the same durable state.
- Add test-support-only lifecycle/readiness/outcome accessors and remove ambient macOS Keychain dependence from the parallel trigger-poller test harness.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Part of #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (covered by the stronger workspace `--all-targets --all-features` lane)
- [ ] `cargo build` (not run separately; clippy compiled all workspace targets)
- [x] Relevant tests pass: `trigger_poller_e2e` 10/10; architecture suite; Reborn Rust E2E gate
- [ ] `cargo test --features integration` if database-backed or integration behavior changed (not applicable: no product or schema behavior changed)
- [ ] Manual testing (not applicable: hermetic automated test-only change)
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior:

A due scheduled automation delivers its final response exactly once to the intended Slack destination. With no trigger target it uses the creator's default DM; with a trigger target it overrides that default with the selected channel.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable: no deterministic product logic changed.
- Reborn integration: `scheduled_trigger_results_reach_exact_slack_targets_once_across_restart` in `trigger_poller_e2e.rs`; integration coverage-map comments now point to this whole path.
- Recorded fixture: Not applicable: the model boundary is scripted deterministically and no model-choice/request-shape behavior changed.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: Real local-dev composition, trigger repository, trusted submission, durable delivery outcome store, extension lifecycle, generic channel host, Slack adapter, and restart over the same local storage.
- Live canary: Not applicable for the PR gate: this hermetic regression replaces waiting on a live model/provider for QA-9B/QA-9D; live canaries remain supplemental drift detection.

What the tests prove:

- QA-9B routes to the creator's default Slack DM and QA-9D routes to its explicit per-trigger channel.
- Both results pass through the real Slack adapter to `chat.postMessage` with host-side bearer-token injection.
- Provider state matches the captured raw HTTP request bodies.
- Each prompt reaches the model once and each provider mutation happens once, including after extra poll ticks and runtime restart.
- Parallel tests use a cached temporary test master key rather than ambient OS Keychain state.

Commands run:

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_composition --test trigger_poller_e2e --features test-support`
- `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture`
- `bash scripts/reborn-e2e-rust.sh`
- `scripts/pre-commit-safety.sh`

A broad `cargo test -p ironclaw_reborn_composition --features test-support --no-fail-fast` audit was also attempted. The changed 10-test binary passes independently; the broad lane exposed unrelated ambient-environment assertions for the configured Codex model/trace state and was not reported as a clean pass.

## Security Impact

No production behavior changes. The PR extends existing activation helpers and adds read-only store/readiness accessors only under `cfg(test)` or the `test-support` feature. The new test verifies that the Slack credential is injected at the host/provider boundary, not supplied by the model.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no production public trust-bearing type added.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: unchanged; trigger submission uses the production trusted-ingress materializer.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: N/A; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: N/A; none added.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: N/A; no serialization/schema change.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: test doubles are scoped to two expected calls and do not ship in production.
- [x] Driver/operator-visible errors have stable class semantics: N/A; no production error behavior changed.
- [x] Sandbox/native/host names accurately describe trust boundary: the fake is named for the Slack provider HTTP boundary; the real adapter and host credential path remain in use.

## Database Impact

None. No migrations or schema changes; the test uses temporary local-dev durable storage and recreates the runtime over the same root.

## Blast Radius

Test-support surface in Reborn composition and the trigger-poller integration test. Production builds without `test-support` are unchanged.

## Rollback Plan

Revert this PR. It adds no production state or migrations.

## Review Follow-Through

No known product follow-up is required. Reviewer attention is most useful on whether the chosen test-support accessors remain the narrowest deterministic seams for detached delivery completion and channel-host readiness.

---

**Review track**: A (docs/tests/chore)

## Main compatibility reconciliation

- Rebasing exposed a stale caller-level assertion from #6613: model-visible extension search now intentionally omits UI-only channel connection guidance.
- Updated that integration contract without changing product behavior.
- Verified with the full 14-test channel-connection projection binary and its clippy target.