### PR TITLE
ops: add admin-config-preserving extension reset

### DIFF
--- a/scripts/reset-extension-state.sh
+++ b/scripts/reset-extension-state.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Reset IronClaw extension and user channel state while preserving administrator
+configuration, managed secrets, and automations.
+
+IronClaw must be stopped before applying the reset.
+
+Local/libSQL:
+  scripts/reset-extension-state.sh --local-root PATH
+  scripts/reset-extension-state.sh --local-root PATH --apply --server-stopped
+
+PostgreSQL:
+  scripts/reset-extension-state.sh --database-url URL
+  scripts/reset-extension-state.sh --database-url URL --apply --server-stopped
+
+Without --apply, the script only reports what would be removed.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+local_root=""
+database_url=""
+apply=false
+server_stopped=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --local-root)
+      [ "$#" -ge 2 ] || die "--local-root requires a path"
+      local_root="$2"
+      shift 2
+      ;;
+    --database-url)
+      [ "$#" -ge 2 ] || die "--database-url requires a URL"
+      database_url="$2"
+      shift 2
+      ;;
+    --apply)
+      apply=true
+      shift
+      ;;
+    --server-stopped)
+      server_stopped=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ -n "$local_root" ] && [ -n "$database_url" ]; then
+  die "choose either --local-root or --database-url, not both"
+fi
+if [ -z "$local_root" ] && [ -z "$database_url" ]; then
+  usage >&2
+  exit 1
+fi
+if [ "$apply" = true ] && [ "$server_stopped" != true ]; then
+  die "--apply requires --server-stopped"
+fi
+
+path_predicate=$(cat <<'SQL'
+(
+  path = '/system/extensions'
+  OR path LIKE '/system/extensions/%'
+  OR path LIKE '/tenants/%/shared/channel-identities'
+  OR path LIKE '/tenants/%/shared/channel-identities/%'
+  OR path LIKE '/tenants/%/shared/channel-dm-targets'
+  OR path LIKE '/tenants/%/shared/channel-dm-targets/%'
+  OR path LIKE '/tenants/%/shared/reply-contexts'
+  OR path LIKE '/tenants/%/shared/reply-contexts/%'
+  OR path LIKE '/tenants/%/shared/channel-pairing'
+  OR path LIKE '/tenants/%/shared/channel-pairing/%'
+)
+SQL
+)
+
+extension_count_sql=$(cat <<SQL
+SELECT
+  (SELECT COUNT(*) FROM root_filesystem_entries WHERE $path_predicate)
+  + (SELECT COUNT(*) FROM root_filesystem_events WHERE $path_predicate)
+  + (SELECT COUNT(*) FROM root_filesystem_sequences WHERE $path_predicate);
+SQL
+)
+
+delete_sql=$(cat <<SQL
+DELETE FROM root_filesystem_events WHERE $path_predicate;
+DELETE FROM root_filesystem_sequences WHERE $path_predicate;
+DELETE FROM root_filesystem_entries WHERE $path_predicate;
+SQL
+)
+
+if [ -n "$local_root" ]; then
+  command -v sqlite3 >/dev/null 2>&1 || die "sqlite3 is required for --local-root"
+  [ -d "$local_root" ] || die "local storage root does not exist: $local_root"
+
+  local_root="$(cd "$local_root" && pwd -P)"
+  [ "$local_root" != "/" ] || die "refusing to use / as the local storage root"
+
+  database="$local_root/reborn-local-dev.db"
+  package_root="$local_root/system/extensions"
+  [ -f "$database" ] || die "local IronClaw database not found: $database"
+
+  sqlite_query() {
+    sqlite3 -bail -noheader "$database" "$1"
+  }
+
+  extension_rows_before="$(sqlite_query "$extension_count_sql")"
+  automations_before="$(sqlite_query "SELECT COUNT(*) FROM trigger_records;")"
+  automation_runs_before="$(sqlite_query "SELECT COUNT(*) FROM trigger_run_history;")"
+  package_files_before=0
+  if [ -d "$package_root" ]; then
+    package_files_before="$(find "$package_root" -type f | wc -l | tr -d ' ')"
+  fi
+
+  printf 'Backend: local/libSQL\n'
+  printf 'Extension database rows to remove: %s\n' "$extension_rows_before"
+  printf 'Extension package files to remove: %s\n' "$package_files_before"
+  printf 'Automation definitions to preserve: %s\n' "$automations_before"
+  printf 'Automation history rows to preserve: %s\n' "$automation_runs_before"
+
+  if [ "$apply" != true ]; then
+    printf 'Dry run only; nothing changed. Add --apply --server-stopped to reset.\n'
+    exit 0
+  fi
+
+  sqlite3 -bail "$database" <<SQL
+BEGIN IMMEDIATE;
+$delete_sql
+COMMIT;
+SQL
+
+  if [ -d "$package_root" ]; then
+    find "$package_root" -mindepth 1 -depth -delete
+  else
+    mkdir -p "$package_root"
+  fi
+
+  extension_rows_after="$(sqlite_query "$extension_count_sql")"
+  automations_after="$(sqlite_query "SELECT COUNT(*) FROM trigger_records;")"
+  automation_runs_after="$(sqlite_query "SELECT COUNT(*) FROM trigger_run_history;")"
+
+elif [ -n "$database_url" ]; then
+  command -v psql >/dev/null 2>&1 || die "psql is required for --database-url"
+
+  psql_query() {
+    psql "$database_url" -X -v ON_ERROR_STOP=1 -qAt -c "$1"
+  }
+
+  extension_rows_before="$(psql_query "$extension_count_sql")"
+  automations_before="$(psql_query "SELECT COUNT(*) FROM trigger_records;")"
+  automation_runs_before="$(psql_query "SELECT COUNT(*) FROM trigger_run_history;")"
+
+  printf 'Backend: PostgreSQL\n'
+  printf 'Extension database rows to remove: %s\n' "$extension_rows_before"
+  printf 'Automation definitions to preserve: %s\n' "$automations_before"
+  printf 'Automation history rows to preserve: %s\n' "$automation_runs_before"
+
+  if [ "$apply" != true ]; then
+    printf 'Dry run only; nothing changed. Add --apply --server-stopped to reset.\n'
+    exit 0
+  fi
+
+  psql "$database_url" -X -v ON_ERROR_STOP=1 -q <<SQL
+BEGIN;
+$delete_sql
+COMMIT;
+SQL
+
+  extension_rows_after="$(psql_query "$extension_count_sql")"
+  automations_after="$(psql_query "SELECT COUNT(*) FROM trigger_records;")"
+  automation_runs_after="$(psql_query "SELECT COUNT(*) FROM trigger_run_history;")"
+fi
+
+[ "$extension_rows_after" = "0" ] ||
+  die "extension reset incomplete: $extension_rows_after database rows remain"
+[ "$automations_after" = "$automations_before" ] ||
+  die "automation count changed from $automations_before to $automations_after"
+[ "$automation_runs_after" = "$automation_runs_before" ] ||
+  die "automation history count changed from $automation_runs_before to $automation_runs_after"
+
+printf 'Reset complete. Extension package/install and user channel state are empty.\n'
+printf 'Administrator configuration, managed secrets, and automations were preserved.\n'
+printf 'Start the new IronClaw version and reinstall the extensions it needs.\n'

--- a/scripts/test-reset-extension-state.sh
+++ b/scripts/test-reset-extension-state.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$repo_root/scripts/reset-extension-state.sh"
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/ironclaw-extension-reset.XXXXXX")"
+storage_root="$fixture_root/storage"
+database="$storage_root/reborn-local-dev.db"
+
+cleanup() {
+  find "$fixture_root" -depth -delete
+}
+trap cleanup EXIT
+
+mkdir -p "$storage_root/system/extensions/slack"
+printf 'fixture\n' >"$storage_root/system/extensions/slack/manifest.toml"
+
+sqlite3 "$database" <<'SQL'
+CREATE TABLE root_filesystem_entries (path TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE root_filesystem_events (id INTEGER PRIMARY KEY, path TEXT);
+CREATE TABLE root_filesystem_sequences (path TEXT PRIMARY KEY, value INTEGER);
+CREATE TABLE trigger_records (id TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE trigger_run_history (id TEXT PRIMARY KEY, value TEXT);
+
+INSERT INTO root_filesystem_entries(path, value) VALUES
+  ('/system/extensions', 'extension-root'),
+  ('/system/extensions/.installations/slack', 'installed'),
+  ('/system/extensions/slack/package.wasm', 'package'),
+  ('/system/extensions-backup/keep', 'not-an-extension'),
+  ('/tenants/default/shared/extension-admin-configuration/groups/extension.slack.json', 'admin'),
+  ('/tenants/default/shared/extension-admin-configuration/groups/extension.slack/revisions/1.json', 'admin-revision'),
+  ('/tenants/default/users/__ironclaw_tenant_shared_admin__/secrets/secrets/admin-slack-token.json', 'encrypted-admin-secret'),
+  ('/tenants/default/shared/channel-identities/slack/U123', 'identity'),
+  ('/tenants/default/shared/channel-dm-targets/slack/U123', 'dm-target'),
+  ('/tenants/default/shared/reply-contexts/slack/C123', 'reply-context'),
+  ('/tenants/default/shared/channel-pairing/slack/U123', 'pairing'),
+  ('/tenants/default/shared/conversations/thread-1', 'conversation');
+
+INSERT INTO root_filesystem_events(path) VALUES
+  ('/system/extensions/.installations/slack'),
+  ('/tenants/default/shared/extension-admin-configuration/groups/extension.slack.json'),
+  ('/tenants/default/shared/channel-identities/slack/U123'),
+  ('/tenants/default/shared/conversations/thread-1');
+
+INSERT INTO root_filesystem_sequences(path, value) VALUES
+  ('/system/extensions/.installations/slack', 1),
+  ('/tenants/default/shared/extension-admin-configuration/groups/extension.slack.json', 1),
+  ('/tenants/default/shared/channel-pairing/slack/U123', 1),
+  ('/tenants/default/shared/conversations/thread-1', 1);
+
+INSERT INTO trigger_records(id, value) VALUES
+  ('automation-1', 'keep this automation');
+INSERT INTO trigger_run_history(id, value) VALUES
+  ('run-1', 'keep this run');
+SQL
+
+resettable_extension_entry_count() {
+  sqlite3 "$database" "
+    SELECT COUNT(*) FROM root_filesystem_entries
+    WHERE path = '/system/extensions'
+       OR path LIKE '/system/extensions/%'
+       OR path LIKE '/tenants/%/shared/channel-identities'
+       OR path LIKE '/tenants/%/shared/channel-identities/%'
+       OR path LIKE '/tenants/%/shared/channel-dm-targets'
+       OR path LIKE '/tenants/%/shared/channel-dm-targets/%'
+       OR path LIKE '/tenants/%/shared/reply-contexts'
+       OR path LIKE '/tenants/%/shared/reply-contexts/%'
+       OR path LIKE '/tenants/%/shared/channel-pairing'
+       OR path LIKE '/tenants/%/shared/channel-pairing/%';
+  "
+}
+
+assert_equals() {
+  expected="$1"
+  actual="$2"
+  message="$3"
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s (expected %s, got %s)\n' "$message" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+"$script" --local-root "$storage_root" >"$fixture_root/dry-run.txt"
+assert_equals 7 "$(resettable_extension_entry_count)" "dry-run must not change extension rows"
+assert_equals 1 "$(find "$storage_root/system/extensions" -type f | wc -l | tr -d ' ')" \
+  "dry-run must not remove package files"
+
+if "$script" --local-root "$storage_root" --apply >"$fixture_root/missing-confirmation.txt" 2>&1; then
+  printf 'FAIL: --apply must require confirmation that IronClaw is stopped\n' >&2
+  exit 1
+fi
+
+"$script" --local-root "$storage_root" --apply --server-stopped \
+  >"$fixture_root/apply.txt"
+
+assert_equals 0 "$(resettable_extension_entry_count)" "extension package/install entries must be removed"
+assert_equals 0 "$(sqlite3 "$database" "
+  SELECT COUNT(*) FROM root_filesystem_events
+  WHERE path = '/system/extensions'
+     OR path LIKE '/system/extensions/%'
+     OR path LIKE '/tenants/%/shared/channel-identities'
+     OR path LIKE '/tenants/%/shared/channel-identities/%';
+")" "extension events must be removed"
+assert_equals 0 "$(sqlite3 "$database" "
+  SELECT COUNT(*) FROM root_filesystem_sequences
+  WHERE path = '/system/extensions'
+     OR path LIKE '/system/extensions/%'
+     OR path LIKE '/tenants/%/shared/channel-pairing'
+     OR path LIKE '/tenants/%/shared/channel-pairing/%';
+")" "extension sequences must be removed"
+assert_equals 0 "$(sqlite3 "$database" "
+  SELECT COUNT(*) FROM root_filesystem_entries
+  WHERE path IN (
+    '/tenants/default/shared/channel-identities/slack/U123',
+    '/tenants/default/shared/channel-dm-targets/slack/U123',
+    '/tenants/default/shared/reply-contexts/slack/C123',
+    '/tenants/default/shared/channel-pairing/slack/U123'
+  );
+")" "channel connection state must be removed"
+assert_equals 5 "$(sqlite3 "$database" "
+  SELECT COUNT(*) FROM root_filesystem_entries
+  WHERE path IN (
+    '/tenants/default/shared/extension-admin-configuration/groups/extension.slack.json',
+    '/tenants/default/shared/extension-admin-configuration/groups/extension.slack/revisions/1.json',
+    '/tenants/default/users/__ironclaw_tenant_shared_admin__/secrets/secrets/admin-slack-token.json'
+  )
+  UNION ALL
+  SELECT COUNT(*) FROM root_filesystem_events
+  WHERE path = '/tenants/default/shared/extension-admin-configuration/groups/extension.slack.json'
+  UNION ALL
+  SELECT COUNT(*) FROM root_filesystem_sequences
+  WHERE path = '/tenants/default/shared/extension-admin-configuration/groups/extension.slack.json';
+" | awk '{ total += $1 } END { print total }')" \
+  "admin configuration records and managed secrets must remain"
+assert_equals 4 "$(sqlite3 "$database" "
+  SELECT COUNT(*) FROM root_filesystem_entries
+  WHERE path IN (
+    '/system/extensions-backup/keep',
+    '/tenants/default/shared/conversations/thread-1'
+  )
+  UNION ALL
+  SELECT COUNT(*) FROM root_filesystem_events
+  WHERE path = '/tenants/default/shared/conversations/thread-1'
+  UNION ALL
+  SELECT COUNT(*) FROM root_filesystem_sequences
+  WHERE path = '/tenants/default/shared/conversations/thread-1';
+" | awk '{ total += $1 } END { print total }')" "unrelated filesystem state must remain"
+assert_equals "automation-1|keep this automation" \
+  "$(sqlite3 "$database" "SELECT id || '|' || value FROM trigger_records;")" \
+  "automation definitions must remain unchanged"
+assert_equals "run-1|keep this run" \
+  "$(sqlite3 "$database" "SELECT id || '|' || value FROM trigger_run_history;")" \
+  "automation history must remain unchanged"
+assert_equals 0 "$(find "$storage_root/system/extensions" -mindepth 1 | wc -l | tr -d ' ')" \
+  "extension package files must be removed"
+
+"$script" --local-root "$storage_root" --apply --server-stopped \
+  >"$fixture_root/second-apply.txt"
+assert_equals 1 "$(sqlite3 "$database" "SELECT COUNT(*) FROM trigger_records;")" \
+  "rerunning the reset must preserve automations"
+
+printf 'PASS: extension reset preserves only admin configuration, automations, and unrelated state\n'


### PR DESCRIPTION
## Summary

- Add one self-contained operator script for the post-#6520 reset: `scripts/reset-extension-state.sh`.
- Remove extension packages/installations plus user channel identities, DM targets, reply contexts, and pairings while preserving tenant administrator configuration, managed admin secrets, automations, run history, conversations, and unrelated state.
- Support local/libSQL and PostgreSQL deployments, default to a dry run, require explicit `--apply --server-stopped`, and verify the targeted rows are gone while automation counts are unchanged.
- Add a disposable SQLite fixture covering dry-run behavior, confirmation, exact deletion boundaries, protected admin-secret paths, unrelated state, and idempotent reruns.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6520

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust files changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust files changed.
- [ ] `cargo build` — Not applicable: the change is two Bash scripts.
- [x] Relevant tests pass: `scripts/test-reset-extension-state.sh`
- [ ] `cargo test --features integration` — Not applicable: no application runtime or schema code changed.
- [x] Manual testing: disposable libSQL/SQLite fixture exercises dry run, rejected unconfirmed apply, confirmed apply, and a second idempotent apply.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; PR is draft pending QA dry-run evidence.

## Test Strategy

User behavior:

An operator stops IronClaw, runs the script once without `--apply` to inspect counts, snapshots the deployment, then reruns with `--apply --server-stopped`. The upgraded binary starts without incompatible extension installation rows. Administrators do not re-enter configuration or managed secrets; users reinstall/re-pair extensions as needed.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `scripts/test-reset-extension-state.sh` creates a disposable database and package tree and asserts exact deletion/preservation boundaries.
- Reborn integration: Not applicable: this is an offline operator script and does not alter the Reborn runtime path.
- Recorded fixture: Not applicable: no model/provider behavior.
- Browser E2E: Not applicable: no browser surface.
- Backend or runtime: libSQL/SQLite destructive path is exercised locally. PostgreSQL uses the same SQL predicates and transaction shape; a Railway QA dry run is pending before apply.
- Live canary: Pending: snapshot and dry-run one Railway QA instance, apply there, restart, reinstall/re-pair, and verify Slack/Telegram admin configuration resolution before touching additional QA instances.

What the tests prove:

The script deletes `/system/extensions` and the four user channel-state subtrees across RootFilesystem entries/events/sequences, deletes local package files, leaves administrator configuration records/revisions and tenant-managed encrypted secret rows untouched, leaves automations/history and unrelated state unchanged, requires stopped-server acknowledgement, and is idempotent.

Commands run:

- `bash -n scripts/reset-extension-state.sh scripts/test-reset-extension-state.sh`
- `shellcheck scripts/reset-extension-state.sh scripts/test-reset-extension-state.sh`
- `scripts/test-reset-extension-state.sh`
- `git diff origin/main...HEAD --check`

## Security Impact

The script is destructive only within explicit extension/package and user channel-state prefixes. It does not read, decrypt, print, update, or delete administrator secret material. The tenant administrator configuration subtree and tenant-shared managed-secret owner are outside the delete predicate. Apply requires explicit confirmation that IronClaw is stopped. Database deletion is transactional; the local package directory is removed afterward and the operation is safe to rerun.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no Rust/API types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A; no prompt path.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: N/A; no hashes or authentication logic.
- [x] New/changed status, exit, policy, runtime, or error variants: N/A; no variants changed. Command: `git diff origin/main...HEAD --name-only` shows only the two scripts.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: N/A; no Serde types changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: N/A; no queues or counters added.
- [x] Driver/operator-visible errors have stable class semantics: N/A; no runtime error enums changed. The script exits nonzero with a concise operator error.
- [x] Sandbox/native/host names accurately describe trust boundary: N/A; no runtime boundary names changed.

## Database Impact

No schema change and no SQL migration registration. The script deletes matching rows from `root_filesystem_entries`, `root_filesystem_events`, and `root_filesystem_sequences` in one transaction for libSQL or PostgreSQL. It never targets `trigger_records`, `trigger_run_history`, `/tenants/*/shared/extension-admin-configuration`, or `/tenants/*/users/__ironclaw_tenant_shared_admin__/secrets`. Local deployments also clear physical files under `<local-root>/system/extensions`.

## Blast Radius

Extension packages/installations and user channel identities, DM targets, reply contexts, and pairings are reset. Users must reinstall and re-pair. Locally installed third-party extension packages must be restored/reinstalled. Automations remain stored but extension-backed delivery may not work until reinstall/pairing finishes. Administrator configuration, managed admin secrets, conversations, LLM/provider configuration, and unrelated state are preserved. Legacy per-installation channel config under `/system/extensions` is intentionally deleted.

## Rollback Plan

Before apply, stop IronClaw and snapshot both the database and local storage volume. If verification fails, stop the new binary and restore the matching pre-reset snapshot together with the prior application version. The script does not create its own backup. Run the default dry-run first and canary one QA instance before broader rollout.

## Review Follow-Through

Reviewer focus: exact path predicates, the admin-config/managed-secret exclusion, PostgreSQL/libSQL parity, and the local database-then-package deletion order. Before marking ready, append Railway QA dry-run/apply/restart evidence and run the repository review workflow if available.

---

**Review track**: C