### PR TITLE
fix(live-qa): operator extension-configuration values as a sequence

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1021,7 +1021,12 @@ async def _apply_extension_setup_api_after_start(
                 admin_url,
                 headers=headers,
                 json={
-                    "values": fields,
+                    # The operator surface takes a sequence of {handle, value}
+                    # entries, not a map (Vec<ExtensionAdminConfigurationValue>).
+                    "values": [
+                        {"handle": handle, "value": value}
+                        for handle, value in fields.items()
+                    ],
                     "expected_revision": revision,
                     "idempotency_key": f"live-qa-{uuid.uuid4()}",
                 },


### PR DESCRIPTION
Canary run [30055666215](https://github.com/nearai/ironclaw/actions/runs/30055666215) on merged main: all 8 Slack-dependent shards (QA 3/4/5/7/8A-8C/8D/9/10) failed identically at the Slack admin bootstrap — `Operator extension-configuration save failed: HTTP 422 ... values: invalid type: map, expected a sequence`.

The harness's #6520 reconciliation routed non-secret setup values to the operator surface but sent `values` as a JSON map; the wire type is `Vec<ExtensionAdminConfigurationValue>` (`{handle, value}` entries — `crates/ironclaw_webui/src/webui_v2/handlers.rs:2380`). One-hunk fix to the sequence shape the launcher and integration callers already use.

Google shards (QA 2A-2F) passed on the same run, confirming the rest of the reconciliation. QA 6D failed separately as a single live-LLM routine flake (sibling 6E green) — pre-existing long-case flake family, not addressed here.

After merge: re-dispatch Live Canary; expected result is the 8 Slack shards recovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF1EiatUVLjKKs3eYGMbKV