### PR TITLE
test(playwright): reconcile suite to the merged #6520 lifecycle and setup contracts

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_extension_specificity.rs
+++ b/crates/ironclaw_architecture/tests/reborn_extension_specificity.rs
@@ -1040,6 +1040,14 @@ const ALLOWLIST: &[(&str, &str)] = &[
         "crates/ironclaw_host_runtime/src/first_party_tools/http.rs",
         "github",
     ),
+    // Presentation-only brand casing: the auth-gate card's display-name table
+    // must key on the wire vendor id to function (the prior `git_hub` key
+    // never matched and rendered "Github"). Same class as the table's
+    // carved-out `nearai` row; behavior stays manifest-generic.
+    (
+        "crates/ironclaw_webui/frontend/src/pages/chat/components/auth-oauth-card.tsx",
+        "github",
+    ),
     ("crates/ironclaw_product/src/adapter_registry.rs", "github"),
     ("crates/ironclaw_product/src/adapter_registry.rs", "slack"),
     (

--- a/crates/ironclaw_product/src/reborn_services/product_capability_handlers.rs
+++ b/crates/ironclaw_product/src/reborn_services/product_capability_handlers.rs
@@ -119,11 +119,18 @@ impl ProductCommandHandler {
                 let _: EmptyProductCommandInput = product_command_input(input)?;
                 command_output(services.trace_account_login_link(caller).await?)
             }
-            Self::TraceHoldAuthorize => command_output(
-                services
-                    .authorize_trace_hold(caller, product_command_input(input)?)
-                    .await?,
-            ),
+            Self::TraceHoldAuthorize => {
+                // The wire input is the command descriptor's request struct;
+                // deserializing it as the bare submission string rejected
+                // every well-formed request with a 400 (playwright live-serve
+                // regression).
+                let request: RebornTraceHoldAuthorizeProductRequest = product_command_input(input)?;
+                command_output(
+                    services
+                        .authorize_trace_hold(caller, request.submission_id)
+                        .await?,
+                )
+            }
             Self::OperatorConfigSetKey => {
                 let request: RebornOperatorConfigSetProductRequest = product_command_input(input)?;
                 command_output(

--- a/crates/ironclaw_product/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product/tests/reborn_services_contract.rs
@@ -15456,3 +15456,30 @@ async fn admin_last_admin_protection_survives_concurrent_demotion() {
         "the tenant must never be stranded without an admin"
     );
 }
+
+/// Playwright live-serve regression: `trace.hold_authorize` arrives on the
+/// wire as the command descriptor's request struct (`{"submission_id": ...}` —
+/// exactly what the webui handler serializes), but the command arm decoded it
+/// as a bare string and 400-rejected every well-formed authorize. Drives the
+/// real ProductSurface command door with that wire shape; an absent hold is
+/// the normal `{ authorized: false }` success, never an input error.
+#[tokio::test]
+async fn trace_hold_authorize_command_accepts_the_descriptor_wire_request() {
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(FakeTurnCoordinator::default()),
+    );
+    let response = ironclaw_host_api::ProductSurface::invoke(
+        &services,
+        caller_for_user("trace-hold-authorize-wire-user"),
+        ironclaw_host_api::ProductSurfaceInvokeRequest {
+            operation_id: CapabilityId::new(ironclaw_product::TRACE_HOLD_AUTHORIZE_COMMAND.id)
+                .expect("command id"),
+            input: json!({ "submission_id": uuid::Uuid::new_v4().to_string() }),
+            activity_id: ActivityId::new(),
+        },
+    )
+    .await
+    .expect("hold authorize command decodes its wire request");
+    assert_eq!(response.output, json!({ "authorized": false }));
+}

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/auth-oauth-card.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/auth-oauth-card.tsx
@@ -44,7 +44,7 @@ const CLOSED_NOTICE_GRACE_MS = 1500;
 // in this small allowlist.
 const PROVIDER_DISPLAY_NAMES = Object.freeze({
   nearai: "NEAR AI",
-  git_hub: ["Git", "Hub"].join(""),
+  github: ["Git", "Hub"].join(""),
 });
 
 function providerDisplayName(providerId) {

--- a/tests/e2e/scenarios/test_reborn_webui_v2_extensions_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_extensions_api.py
@@ -146,11 +146,6 @@ async def test_reborn_v2_extension_routes_require_auth_served(reborn_v2_server):
             ),
             (
                 "POST",
-                "/api/webchat/v2/extensions/web-access/activate",
-                {"client_action_id": client_action_id()},
-            ),
-            (
-                "POST",
                 "/api/webchat/v2/extensions/web-access/remove",
                 {"client_action_id": client_action_id()},
             ),
@@ -195,6 +190,7 @@ async def test_reborn_v2_extension_routes_reject_invalid_input_served(
 
         malformed_package_id = await client.post(
             f"{reborn_v2_server}/api/webchat/v2/extensions/bad%20id/remove",
+            json={"client_action_id": client_action_id()},
             timeout=15,
         )
         assert malformed_package_id.status_code == 400

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
@@ -545,16 +545,6 @@ async def _wait_for_request_count(
     )
 
 
-def _assert_install_requests(requests: list[dict], *package_ids: str):
-    assert [
-        request.get("package_ref") for request in requests
-    ] == [_package_ref(package_id) for package_id in package_ids]
-    for request in requests:
-        idempotency_key = request.get("idempotency_key")
-        assert isinstance(idempotency_key, str)
-        assert idempotency_key.strip()
-
-
 async def test_reborn_legacy_extensions_registry_search_and_install(
     reborn_v2_server, reborn_v2_browser
 ):
@@ -1237,7 +1227,6 @@ async def test_reborn_legacy_extensions_reinstall_after_remove_requires_setup_ag
                     "action": "submit",
                     "payload": {
                         "secrets": {"API_TOKEN": "fresh-token"},
-                        "fields": {},
                     },
                 },
             }
@@ -1447,14 +1436,7 @@ async def test_reborn_legacy_configure_modal_saves_manual_secret_and_fields(
                         "auto_generate": False,
                     },
                 ],
-                "fields": [
-                    {
-                        "name": "workspace",
-                        "prompt": "Workspace",
-                        "placeholder": "team-slug",
-                        "optional": False,
-                    }
-                ],
+                "fields": [],
                 "onboarding": {
                     "credential_instructions": "Paste credentials from the provider.",
                     "credential_next_step": "Save to continue.",
@@ -1475,7 +1457,6 @@ async def test_reborn_legacy_configure_modal_saves_manual_secret_and_fields(
         await expect(page.get_by_text("Paste credentials from the provider.")).to_be_visible()
         await page.locator('input[type="password"]').nth(0).fill("secret-token")
         await page.locator('input[type="password"]').nth(1).fill("rotated-secret")
-        await page.locator('input[type="text"][placeholder="team-slug"]').fill("team-a")
         await page.get_by_role("button", name="Save").click()
 
         await expect(page.get_by_role("heading", name="Configure Config Tool")).to_have_count(0)
@@ -1489,7 +1470,6 @@ async def test_reborn_legacy_configure_modal_saves_manual_secret_and_fields(
                             "API_TOKEN": "secret-token",
                             "OPTIONAL_SECRET": "rotated-secret",
                         },
-                        "fields": {"workspace": "team-a"},
                     },
                 },
             }
@@ -1540,14 +1520,7 @@ async def test_reborn_legacy_configure_modal_renders_field_variants(
                         "auto_generate": True,
                     },
                 ],
-                "fields": [
-                    {
-                        "name": "workspace",
-                        "prompt": "Workspace",
-                        "placeholder": "team-slug",
-                        "optional": True,
-                    }
-                ],
+                "fields": [],
                 "onboarding": None,
             }
         },
@@ -1565,14 +1538,12 @@ async def test_reborn_legacy_configure_modal_renders_field_variants(
         await expect(modal).to_contain_text("Existing token")
         await expect(modal).to_contain_text("Optional secret")
         await expect(modal).to_contain_text("Generated secret")
-        await expect(modal).to_contain_text("Workspace")
         await expect(modal.get_by_text("configured", exact=True)).to_be_visible()
-        await expect(modal.get_by_text("optional", exact=True)).to_have_count(2)
+        await expect(modal.get_by_text("optional", exact=True)).to_have_count(1)
         await expect(modal.get_by_text("Auto-generated if left blank")).to_be_visible()
         await expect(
             modal.locator('input[type="password"][placeholder*="leave blank to keep"]')
         ).to_have_count(1)
-        await expect(modal.locator('input[type="text"][placeholder="team-slug"]')).to_be_visible()
 
         await modal.get_by_role("button", name="Cancel").click()
         assert harness["setup_submit_requests"] == []
@@ -1693,7 +1664,6 @@ async def test_reborn_legacy_configure_handles_selector_sensitive_package_ids(
                     "action": "submit",
                     "payload": {
                         "secrets": {"API_TOKEN": "quoted-secret"},
-                        "fields": {},
                     },
                 },
             }
@@ -1759,7 +1729,6 @@ async def test_reborn_legacy_configure_modal_blank_existing_secret_is_not_submit
                     "action": "submit",
                     "payload": {
                         "secrets": {},
-                        "fields": {},
                     },
                 },
             }
@@ -1978,7 +1947,6 @@ async def test_reborn_legacy_configure_modal_enter_key_submits(
                     "action": "submit",
                     "payload": {
                         "secrets": {"API_TOKEN": "enter-token"},
-                        "fields": {},
                     },
                 },
             }
@@ -2525,8 +2493,10 @@ async def test_reborn_legacy_configure_oauth_localizes_https_authorization_error
         )
         opened = await page.evaluate("() => window.__openedUrls")
         assert opened == ["about:blank"]
-        assert harness["oauth_start_requests"][0]["body"]["provider"] == "google"
-        assert harness["oauth_start_requests"][0]["body"]["scopes"] == ["email"]
+        start_body = harness["oauth_start_requests"][0]["body"]
+        assert start_body["requirement"] == "GOOGLE_AUTH"
+        assert start_body["invocation_id"] == "inv-1"
+        assert start_body["expires_at"]
     finally:
         await harness["context"].close()
 
@@ -2605,7 +2575,9 @@ async def test_reborn_legacy_configure_oauth_start_failure_stays_visible(
         await expect(
             page.get_by_role("heading", name="Configure OAuth Tool")
         ).to_be_visible()
-        assert harness["oauth_start_requests"][0]["body"]["provider"] == "google"
+        start_body = harness["oauth_start_requests"][0]["body"]
+        assert start_body["requirement"] == "GOOGLE_AUTH"
+        assert start_body["invocation_id"] == "inv-1"
         assert await page.evaluate("() => window.__openedPopups[0].closed") is True
     finally:
         await harness["context"].close()


### PR DESCRIPTION
Reconciles the three Playwright shards that went red on the post-merge main dispatch ([run 30056093903](https://github.com/nearai/ironclaw/actions/runs/30056093903)) to the merged #6520 wire contracts — and fixes the two product-side defects the shards exposed. Never-weaken discipline: every reconciled expectation is pinned to the current contract with its intent preserved; two failures turned out to be product bugs and are fixed product-side with red-before/green-after regression tests.

## Product fixes

- **`trace.hold_authorize` rejected every well-formed request** (`served-api-routes` → `test_reborn_v2_trace_credits_and_hold_authorize_served`): the command arm in `product_capability_handlers.rs` decoded its input as a bare `String` while the descriptor and the webui handler carry `{"submission_id": …}` — a #6583 command-unification regression. Fixed to decode `RebornTraceHoldAuthorizeProductRequest`; regression test drives the real `ProductSurface` command door with the exact wire shape (verified red pre-fix, green post-fix).
- **"Waiting for Github"** (`legacy-auth-inputs` → `test_reborn_legacy_oauth_prompt_opens_https_authorization_only`): the auth-gate card's brand-casing table keyed `git_hub`, which never matches the wire vendor id `github`, so the generic title-caser produced "Github". Keyed on the wire id; specificity-gate allowlisted with a justification comment (presentation-only casing, same class as the table's `nearai` row).

## Per-shard test reconciliations

**legacy-settings-extensions** (13 failures, one file):
- Deleted a stale duplicate `_assert_install_requests` helper that shadowed the correct one and asserted the retired `idempotency_key`; the SPA sends a per-gesture `client_action_id` (fixes the 5 `assert False` install-flavored tests incl. the setup/delivery matrix).
- Setup-submit expectations drop the retired `payload.fields` — non-secret deployment values live on the operator extension-configuration surface (`PUT /operator/extension-configuration/extension.{id}`) and the setup route rejects a fields payload; the SPA submits `{action: "submit", payload: {secrets}}` only (fixes the 3 body-mismatch tests + the two configure-modal fixture tests, whose field-input expectations are dropped accordingly).
- OAuth-start asserts pin the current wire `{requirement, expires_at, invocation_id}` (manifest credential handle; provider + scopes resolve server-side) — fixes the two `KeyError: 'provider'` tests with equal-strength replacements.

**served-api-routes**:
- The deleted `/activate` route leaves the authenticated-surface auth matrix; its absence stays pinned by the dedicated `test_reborn_v2_public_activation_route_is_absent_served` (404) test.
- The malformed-package-id remove probe now sends the required JSON body so handler path-validation (400) is exercised instead of the Json extractor's 415.

## Verified

`cargo test -p ironclaw_product --test reborn_services_contract` 254/254 (new regression red-before verified) · `cargo test -p ironclaw_architecture` green incl. specificity gate · frontend `pnpm test` 856/856 + `pnpm lint` (tsc) clean · touched python compiles. Not run locally: the Playwright shards themselves (need the built serve binary + browsers) — the reconciled expectations are cross-checked against the current handlers and SPA source; the dispatch on this branch's CI is the executable proof.

## Explicit follow-ups (out of scope here)

- Mocked setup-view fixtures still carry `"fields": []` keys the server no longer emits; harmless to the SPA and left to keep the diff reviewable.
- The provider display-name table belongs in the manifest (`[auth.<vendor>] display_name`) projected through the gate payload, removing the frontend allowlist entirely — worth a small design pass.
- One `Workspace (team) ID` admin-configuration string in the same suite references the operator-config sequence shape; if #6602's `values`-as-sequence change lands first, a trivial rebase-time recheck applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF1EiatUVLjKKs3eYGMbKV