### PR TITLE
fix(reborn): fall back to web-app delivery when a run's final-reply channel is removed mid-run

### DIFF
--- a/crates/ironclaw_outbound/src/lib.rs
+++ b/crates/ironclaw_outbound/src/lib.rs
@@ -61,8 +61,8 @@ pub use run_delivery_cleanup::{
 pub use run_final_reply_handoff::{MAX_RUN_FINAL_REPLY_HANDOFF_PAGE, RunFinalReplyHandoffRecord};
 pub use run_final_reply_target::{
     RouteCurrentRunFinalReply, RouteCurrentRunFinalReplyError, RouteCurrentRunFinalReplyRequest,
-    RunFinalReplyDestination, RunFinalReplyTargetRecord, RunFinalReplyTargetRequest,
-    WEB_APP_OUTBOUND_DELIVERY_TARGET_ID,
+    RunFinalReplyDestination, RunFinalReplyDowngrade, RunFinalReplyDowngradeReason,
+    RunFinalReplyTargetRecord, RunFinalReplyTargetRequest, WEB_APP_OUTBOUND_DELIVERY_TARGET_ID,
 };
 pub use service::{
     OutboundPolicyService, ReplyTargetBindingValidator, ThreadProjectionAccessPolicy,

--- a/crates/ironclaw_outbound/src/run_final_reply_target.rs
+++ b/crates/ironclaw_outbound/src/run_final_reply_target.rs
@@ -26,6 +26,25 @@ pub enum RunFinalReplyDestination {
     },
 }
 
+/// Why a sealed final-reply destination was replaced after the fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunFinalReplyDowngradeReason {
+    /// The destination's owning channel extension was removed after the run
+    /// sealed its route; the reply stays in the durable web transcript.
+    RetiredChannelRoute,
+}
+
+/// Typed, redacted downgrade evidence attached when a run's sealed external
+/// destination could no longer deliver and the host fell back to the WebApp
+/// transcript. Carries only the adapter/extension id — never conversation,
+/// credential, or vendor detail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunFinalReplyDowngrade {
+    pub reason: RunFinalReplyDowngradeReason,
+    pub retired_adapter: String,
+}
+
 /// Durable per-run final-reply routing decision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunFinalReplyTargetRecord {
@@ -33,6 +52,12 @@ pub struct RunFinalReplyTargetRecord {
     pub scope: TurnScope,
     pub actor: TurnActor,
     pub destination: RunFinalReplyDestination,
+    /// Present only when the host downgraded a sealed external destination
+    /// to the WebApp transcript (see [`RunFinalReplyDowngrade`]). Absent on
+    /// every normally-routed record; old persisted rows deserialize with
+    /// `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub downgrade: Option<RunFinalReplyDowngrade>,
 }
 
 /// Exact authority tuple required to read a per-run routing decision.
@@ -81,7 +106,54 @@ pub trait RouteCurrentRunFinalReply: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::OutboundDeliveryTargetId;
+    use super::{
+        OutboundDeliveryTargetId, RunFinalReplyDestination, RunFinalReplyDowngrade,
+        RunFinalReplyDowngradeReason, RunFinalReplyTargetRecord,
+    };
+
+    /// The `downgrade` field is additive: rows persisted before it existed
+    /// (no key on the wire) must keep deserializing, and a `None` record must
+    /// serialize without the key so old readers see an unchanged shape.
+    #[test]
+    fn target_record_downgrade_field_is_wire_compatible() {
+        let historical = serde_json::json!({
+            "run_id": "0b8a2f6e-8c1d-4a4f-9d55-1f2e3c4b5a69",
+            "scope": {
+                "tenant_id": "tenant-wire",
+                "agent_id": null,
+                "project_id": null,
+                "thread_id": "thread-wire",
+                "thread_owner": {"mode": "explicit_user", "owner_user_id": "user-wire"}
+            },
+            "actor": {"user_id": "user-wire"},
+            "destination": {"kind": "web_app"}
+        });
+        let record: RunFinalReplyTargetRecord =
+            serde_json::from_value(historical).expect("pre-downgrade rows keep deserializing");
+        assert_eq!(record.downgrade, None);
+        let encoded = serde_json::to_value(&record).expect("serialize record");
+        assert!(
+            encoded.get("downgrade").is_none(),
+            "absent downgrade must not appear on the wire: {encoded}"
+        );
+
+        let downgraded = RunFinalReplyTargetRecord {
+            downgrade: Some(RunFinalReplyDowngrade {
+                reason: RunFinalReplyDowngradeReason::RetiredChannelRoute,
+                retired_adapter: "telegram".to_string(),
+            }),
+            destination: RunFinalReplyDestination::WebApp,
+            ..record
+        };
+        let encoded = serde_json::to_value(&downgraded).expect("serialize downgraded record");
+        assert_eq!(
+            encoded["downgrade"]["reason"], "retired_channel_route",
+            "the reason is a snake_case wire enum: {encoded}"
+        );
+        let round_tripped: RunFinalReplyTargetRecord =
+            serde_json::from_value(encoded).expect("downgraded record round-trips");
+        assert_eq!(round_tripped, downgraded);
+    }
 
     #[test]
     fn target_id_rejects_invisible_formatting_characters() {

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -2591,6 +2591,7 @@ async fn run_final_reply_target_is_durable_and_exactly_scoped() {
         destination: RunFinalReplyDestination::External {
             reply_target_binding_ref: reply_ref("reply:run-scoped-slack-dm"),
         },
+        downgrade: None,
     };
 
     first

--- a/crates/ironclaw_product/src/lib.rs
+++ b/crates/ironclaw_product/src/lib.rs
@@ -255,10 +255,10 @@ pub use policy::{
 };
 pub use run_delivery::{
     ApprovalPromptContextSource, BlockedAuthPromptSource, CurrentDeliveryTarget,
-    CurrentDeliveryTargetResolver, DeliveredChannelMessage, RunDeliveryError,
-    RunDeliveryEventHandler, RunDeliveryEventRouter, RunDeliveryObserver, RunDeliveryServices,
-    TriggeredRunDeliveryChannel, TriggeredRunDeliveryDriver, TriggeredRunDeliveryRequest,
-    TriggeredRunDeliveryRouter, TriggeredRunExternalDeliveryTarget,
+    CurrentDeliveryTargetResolver, DeliveredChannelMessage, RetiredChannelRouteAuthority,
+    RunDeliveryError, RunDeliveryEventHandler, RunDeliveryEventRouter, RunDeliveryObserver,
+    RunDeliveryServices, TriggeredRunDeliveryChannel, TriggeredRunDeliveryDriver,
+    TriggeredRunDeliveryRequest, TriggeredRunDeliveryRouter, TriggeredRunExternalDeliveryTarget,
 };
 pub use trigger_final_reply_target::{RunFinalReplyRoutingService, TriggerFinalReplyTargetService};
 // Adapter, projection, and event DTOs are re-exported from

--- a/crates/ironclaw_product/src/run_delivery.rs
+++ b/crates/ironclaw_product/src/run_delivery.rs
@@ -48,7 +48,9 @@ pub(crate) mod prompts;
 mod trigger_router;
 mod triggered;
 
-pub use lifecycle_events::{RunDeliveryEventHandler, RunDeliveryEventRouter};
+pub use lifecycle_events::{
+    RetiredChannelRouteAuthority, RunDeliveryEventHandler, RunDeliveryEventRouter,
+};
 pub use observer::RunDeliveryObserver;
 pub use trigger_router::{TriggeredRunDeliveryChannel, TriggeredRunDeliveryRouter};
 pub use triggered::{

--- a/crates/ironclaw_product/src/run_delivery/lifecycle_events.rs
+++ b/crates/ironclaw_product/src/run_delivery/lifecycle_events.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 
 use crate::{
     AuthPromptChallengeKind, OutboundPart, ProductInboundAck, ProductInboundEnvelope,
@@ -20,7 +20,8 @@ use ironclaw_outbound::{
     CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
     OutboundError, OutboundPolicyService, OutboundStateStore, PrepareCommunicationDeliveryRequest,
     ProjectionUpdateRef, RunDeliveryCleanupRecord, RunDeliveryCleanupRequest,
-    RunFinalReplyDestination, RunFinalReplyHandoffRecord, RunFinalReplyTargetRequest,
+    RunFinalReplyDestination, RunFinalReplyDowngrade, RunFinalReplyDowngradeReason,
+    RunFinalReplyHandoffRecord, RunFinalReplyTargetRecord, RunFinalReplyTargetRequest,
     RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin, SourceRouteContext,
 };
 use ironclaw_threads::{FinalizedAssistantMessageByRunRequest, ThreadScope};
@@ -85,9 +86,29 @@ struct DurableRunDeliveryReplay {
     /// leaks a permanent pending row that every later drain re-scans.
     run_state: Arc<dyn TurnStateStore>,
     outbound_state: Arc<dyn OutboundStateStore>,
+    /// Late-bound authority deciding whether an unowned handoff's route can
+    /// ever be owned again (its channel extension was removed). Without it, a
+    /// run that removes its own channel mid-run leaves a permanently pending
+    /// handoff and a reply nobody delivers; with it, the reply is downgraded
+    /// to the WebApp transcript with typed evidence. Composition fills the
+    /// slot once its installation authority exists.
+    route_authority: OnceLock<Arc<dyn RetiredChannelRouteAuthority>>,
     active: AtomicBool,
     dirty: AtomicBool,
     idle: Notify,
+}
+
+/// Host-side authority answering "can any handler for this adapter ever
+/// register again?" — true only when the owning channel extension is durably
+/// gone (removed), never merely unregistered during startup. Generic: the
+/// router names no concrete extension; composition implements this over the
+/// installation authority.
+#[async_trait]
+pub trait RetiredChannelRouteAuthority: Send + Sync {
+    async fn channel_route_is_retired(
+        &self,
+        adapter_id: &str,
+    ) -> Result<bool, ProductWorkflowError>;
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -167,6 +188,7 @@ impl RunDeliveryEventRouter {
             source,
             run_state,
             outbound_state,
+            route_authority: OnceLock::new(),
             active: AtomicBool::new(false),
             dirty: AtomicBool::new(false),
             idle: Notify::new(),
@@ -176,6 +198,25 @@ impl RunDeliveryEventRouter {
         // wakes the same drain so those rows remain recoverable.
         router.wake_durable_replay();
         router
+    }
+
+    /// Connect the retired-route authority once (composition, after its
+    /// installation authority exists). Returns `false` when the router has no
+    /// durable replay (ephemeral test routers) or the slot was already
+    /// connected. Wakes the durable drain so already-orphaned handoffs are
+    /// re-examined under the new authority.
+    pub fn set_retired_route_authority(
+        &self,
+        authority: Arc<dyn RetiredChannelRouteAuthority>,
+    ) -> bool {
+        let Some(replay) = self.inner.durable_replay.as_ref() else {
+            return false;
+        };
+        let connected = replay.route_authority.set(authority).is_ok();
+        if connected {
+            self.wake_durable_replay();
+        }
+        connected
     }
 
     /// Construct an in-memory enqueue-only router for tests that exercise
@@ -527,14 +568,20 @@ impl RunDeliveryEventRouter {
                         .complete_run_final_reply_handoff(&handoff)
                         .await?;
                 } else if !saw_deferred {
-                    // No registered handler proved ownership yet. This is
-                    // expected while channel graphs register during startup;
-                    // registration supplies the next wake.
-                    tracing::debug!(
-                        target = "ironclaw::reborn::run_delivery",
-                        run_id = %event.run_id,
-                        "completed-run delivery awaits its route handler"
-                    );
+                    // No registered handler proved ownership. Expected while
+                    // channel graphs register during startup (registration
+                    // supplies the next wake) — but if the route's owning
+                    // channel extension is durably retired (removed, possibly
+                    // by this very run), no registration is ever coming:
+                    // downgrade the reply to the WebApp transcript instead of
+                    // leaving a permanently pending handoff.
+                    if !self.settle_retired_route_handoff(replay, &handoff).await? {
+                        tracing::debug!(
+                            target = "ironclaw::reborn::run_delivery",
+                            run_id = %event.run_id,
+                            "completed-run delivery awaits its route handler"
+                        );
+                    }
                 }
                 after = Some(handoff);
             }
@@ -542,6 +589,87 @@ impl RunDeliveryEventRouter {
                 return Ok(());
             }
         }
+    }
+
+    /// Settle an unowned completed-run handoff whose channel route is durably
+    /// retired: downgrade the sealed destination to the WebApp transcript
+    /// (typed [`RunFinalReplyDowngrade`] evidence) and complete the handoff.
+    /// Returns `false` — leaving the handoff pending — for every uncertain
+    /// case: no connected authority, unreadable run state, a non-inbound
+    /// origin (WebUi cross-channel retirement keeps its policy-side story),
+    /// or an authority error. The reply itself already lives in the durable
+    /// web transcript; this writes the projectable evidence and stops the
+    /// permanent re-scan.
+    async fn settle_retired_route_handoff(
+        &self,
+        replay: &DurableRunDeliveryReplay,
+        handoff: &RunFinalReplyHandoffRecord,
+    ) -> Result<bool, DurableRunDeliveryReplayError> {
+        let Some(authority) = replay.route_authority.get() else {
+            return Ok(false);
+        };
+        let state = match replay
+            .run_state
+            .get_run_state(GetRunStateRequest {
+                scope: handoff.scope.clone(),
+                run_id: handoff.run_id,
+            })
+            .await
+        {
+            Ok(state) => state,
+            // Transient read failure: keep the handoff pending; the next
+            // drain retries with authoritative state.
+            Err(_) => return Ok(false),
+        };
+        let Some(actor) = state.actor.clone() else {
+            return Ok(false);
+        };
+        let Some(context) = state.product_context.as_ref() else {
+            return Ok(false);
+        };
+        if context.origin != TurnOriginKind::Inbound {
+            return Ok(false);
+        }
+        let Some(adapter) = context.adapter.as_ref() else {
+            return Ok(false);
+        };
+        match authority.channel_route_is_retired(adapter.as_str()).await {
+            Ok(true) => {}
+            Ok(false) => return Ok(false),
+            Err(error) => {
+                tracing::debug!(
+                    target = "ironclaw::reborn::run_delivery",
+                    run_id = %handoff.run_id,
+                    %error,
+                    "retired-route authority unavailable; handoff stays pending"
+                );
+                return Ok(false);
+            }
+        }
+        replay
+            .outbound_state
+            .put_run_final_reply_target(RunFinalReplyTargetRecord {
+                run_id: state.run_id,
+                scope: state.scope.clone(),
+                actor,
+                destination: RunFinalReplyDestination::WebApp,
+                downgrade: Some(RunFinalReplyDowngrade {
+                    reason: RunFinalReplyDowngradeReason::RetiredChannelRoute,
+                    retired_adapter: adapter.as_str().to_string(),
+                }),
+            })
+            .await?;
+        replay
+            .outbound_state
+            .complete_run_final_reply_handoff(handoff)
+            .await?;
+        tracing::warn!(
+            target = "ironclaw::reborn::run_delivery",
+            run_id = %handoff.run_id,
+            adapter = %adapter.as_str(),
+            "final reply downgraded to the web transcript: its channel route was removed mid-run"
+        );
+        Ok(true)
     }
 
     async fn load_handoff_event(

--- a/crates/ironclaw_product/src/trigger_final_reply_target.rs
+++ b/crates/ironclaw_product/src/trigger_final_reply_target.rs
@@ -245,6 +245,7 @@ impl RouteCurrentRunFinalReply for RunFinalReplyRoutingService {
                 ),
                 actor: TurnActor::new(scope.user_id),
                 destination,
+                downgrade: None,
             })
             .await
             .map_err(map_route_outbound_error)

--- a/crates/ironclaw_product/tests/run_delivery_contract.rs
+++ b/crates/ironclaw_product/tests/run_delivery_contract.rs
@@ -17,8 +17,9 @@ use ironclaw_outbound::{
     CommunicationModality, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
     DeliveredGateRouteStore, DeliveryDefaultScope, FilesystemOutboundStateStore,
     OutboundStateStore, RunDeliveryCleanupRequest, RunFinalReplyDestination,
-    RunFinalReplyTargetRecord, TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef,
-    TriggerSourceKind, TriggeredRunDeliveryOutcomeKind, TriggeredRunDeliveryStore,
+    RunFinalReplyDowngradeReason, RunFinalReplyTargetRecord, RunFinalReplyTargetRequest,
+    TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
+    TriggeredRunDeliveryOutcomeKind, TriggeredRunDeliveryStore,
 };
 use ironclaw_product::{
     AdapterInstallationId, AuthPromptChallengeKind, AuthPromptView, AuthRequirement,
@@ -36,10 +37,12 @@ use ironclaw_product::{
     DeliveryCoordinator, DeliveryReplyContextSource, DeliveryRetryPolicy,
     ProductConversationRouteKind, ProductWorkflowError, ResolveBindingRequest,
     ResolveStoredProductReplyTargetRequest, ResolvedChannelDelivery,
-    ResolvedStoredProductReplyTarget, RunDeliveryEventHandler, RunDeliveryEventRouter,
-    RunDeliveryObserver, RunDeliveryServices, TriggeredRunDeliveryDriver,
+    ResolvedStoredProductReplyTarget, RetiredChannelRouteAuthority, RunDeliveryEventHandler,
+    RunDeliveryEventRouter, RunDeliveryObserver, RunDeliveryServices, TriggeredRunDeliveryDriver,
     TriggeredRunDeliveryRequest, TriggeredRunExternalDeliveryTarget,
 };
+// Appended regression tests for the retired-channel-route downgrade live at
+// the end of this file (`unowned_handoff_*`).
 use ironclaw_threads::{
     AppendFinalizedAssistantMessageRequest, EnsureThreadRequest, InMemorySessionThreadService,
     MessageContent, SessionThreadService, ThreadScope,
@@ -2675,6 +2678,7 @@ async fn cross_channel_handoff_stays_pending_when_source_cleanup_fails_then_reop
             destination: RunFinalReplyDestination::External {
                 reply_target_binding_ref: target_ref,
             },
+            downgrade: None,
         })
         .await
         .expect("persist explicit destination");
@@ -3692,4 +3696,146 @@ async fn triggered_non_serviceable_typed_auth_cancels_with_exact_safe_notice() {
             "{challenge_kind:?} must not echo prompt or credential material"
         );
     }
+}
+
+/// Answers retired only for one adapter id — the double for "the extension
+/// was removed and can never re-register a handler".
+struct StaticRetiredRouteAuthority {
+    retired_adapter: &'static str,
+}
+
+#[async_trait]
+impl RetiredChannelRouteAuthority for StaticRetiredRouteAuthority {
+    async fn channel_route_is_retired(
+        &self,
+        adapter_id: &str,
+    ) -> Result<bool, ProductWorkflowError> {
+        Ok(adapter_id == self.retired_adapter)
+    }
+}
+
+/// Self-removal regression (live incident: "uninstall telegram" asked in
+/// telegram): a completed channel-origin run whose owning extension was
+/// removed mid-run has an unowned handoff no handler will ever claim. Without
+/// the retired-route authority it pends forever (the pre-fix drop). With it,
+/// the router downgrades the sealed destination to the WebApp transcript with
+/// typed evidence and completes the handoff.
+#[tokio::test]
+async fn unowned_handoff_of_retired_channel_route_downgrades_to_web_app() {
+    let run_id = TurnRunId::new();
+    let mut state = event_run_state(run_id, ProductConversationRouteKind::Direct);
+    state.status = TurnStatus::Completed;
+    state.event_cursor = EventCursor(1);
+    let completed_event =
+        TurnLifecycleEvent::from_run_state(&state, TurnEventKind::Completed, None);
+    let scope = state.scope.clone();
+    let actor = state.actor.clone().expect("fixture run has an actor");
+    let turns = Arc::new(RunMapTurnCoordinator {
+        states: HashMap::from([(run_id, state)]),
+    });
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let event_log = Arc::new(StaticDurableTurnEventLog::new(vec![completed_event]));
+    let router = RunDeliveryEventRouter::new(
+        event_log as Arc<dyn TurnEventProjectionSource>,
+        run_state_store(Arc::clone(&turns) as Arc<dyn TurnCoordinator>),
+        Arc::clone(&store) as Arc<dyn OutboundStateStore>,
+    );
+    router.wait_until_durable_replay_idle().await;
+    let pending = store
+        .list_pending_run_final_reply_handoffs_after(None, 8)
+        .await
+        .expect("pending handoffs list");
+    assert_eq!(
+        pending.len(),
+        1,
+        "an unowned handoff without a retired-route authority must stay pending, not vanish"
+    );
+
+    assert!(
+        router.set_retired_route_authority(Arc::new(StaticRetiredRouteAuthority {
+            retired_adapter: EXTENSION_ID,
+        })),
+        "the durable router accepts one retired-route authority"
+    );
+    router.wait_until_durable_replay_idle().await;
+
+    let pending = store
+        .list_pending_run_final_reply_handoffs_after(None, 8)
+        .await
+        .expect("pending handoffs list");
+    assert!(
+        pending.is_empty(),
+        "the retired route's handoff must settle instead of pending forever: {pending:?}"
+    );
+    let record = store
+        .load_run_final_reply_target(RunFinalReplyTargetRequest {
+            run_id,
+            scope,
+            actor,
+        })
+        .await
+        .expect("downgraded record reads")
+        .expect("the downgrade writes a durable run target record");
+    assert_eq!(record.destination, RunFinalReplyDestination::WebApp);
+    let downgrade = record
+        .downgrade
+        .expect("the downgraded record carries typed evidence");
+    assert_eq!(
+        downgrade.reason,
+        RunFinalReplyDowngradeReason::RetiredChannelRoute
+    );
+    assert_eq!(downgrade.retired_adapter, EXTENSION_ID);
+}
+
+/// The discriminator half: an adapter that is merely unregistered (startup
+/// window) is NOT retired — the handoff must keep waiting for its handler and
+/// no downgrade may be written.
+#[tokio::test]
+async fn unowned_handoff_of_live_channel_route_stays_pending() {
+    let run_id = TurnRunId::new();
+    let mut state = event_run_state(run_id, ProductConversationRouteKind::Direct);
+    state.status = TurnStatus::Completed;
+    state.event_cursor = EventCursor(1);
+    let completed_event =
+        TurnLifecycleEvent::from_run_state(&state, TurnEventKind::Completed, None);
+    let scope = state.scope.clone();
+    let actor = state.actor.clone().expect("fixture run has an actor");
+    let turns = Arc::new(RunMapTurnCoordinator {
+        states: HashMap::from([(run_id, state)]),
+    });
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let event_log = Arc::new(StaticDurableTurnEventLog::new(vec![completed_event]));
+    let router = RunDeliveryEventRouter::new(
+        event_log as Arc<dyn TurnEventProjectionSource>,
+        run_state_store(Arc::clone(&turns) as Arc<dyn TurnCoordinator>),
+        Arc::clone(&store) as Arc<dyn OutboundStateStore>,
+    );
+    assert!(
+        router.set_retired_route_authority(Arc::new(StaticRetiredRouteAuthority {
+            retired_adapter: "some-other-extension",
+        }))
+    );
+    router.wait_until_durable_replay_idle().await;
+
+    let pending = store
+        .list_pending_run_final_reply_handoffs_after(None, 8)
+        .await
+        .expect("pending handoffs list");
+    assert_eq!(
+        pending.len(),
+        1,
+        "a live (merely unregistered) route must keep its handoff pending"
+    );
+    assert!(
+        store
+            .load_run_final_reply_target(RunFinalReplyTargetRequest {
+                run_id,
+                scope,
+                actor,
+            })
+            .await
+            .expect("run target record reads")
+            .is_none(),
+        "no downgrade may be written for a live route"
+    );
 }

--- a/crates/ironclaw_product/tests/trigger_final_reply_target_contract.rs
+++ b/crates/ironclaw_product/tests/trigger_final_reply_target_contract.rs
@@ -241,6 +241,7 @@ async fn trigger_targets_validate_current_authority_and_inherit_the_exact_source
             destination: RunFinalReplyDestination::External {
                 reply_target_binding_ref: external_binding.clone(),
             },
+            downgrade: None,
         })
         .await
         .expect("external destination seals");
@@ -252,6 +253,7 @@ async fn trigger_targets_validate_current_authority_and_inherit_the_exact_source
             destination: RunFinalReplyDestination::External {
                 reply_target_binding_ref: removed_binding,
             },
+            downgrade: None,
         })
         .await
         .expect("removed destination seals");
@@ -261,6 +263,7 @@ async fn trigger_targets_validate_current_authority_and_inherit_the_exact_source
             scope: turn_scope,
             actor,
             destination: RunFinalReplyDestination::WebApp,
+            downgrade: None,
         })
         .await
         .expect("web app destination seals");

--- a/crates/ironclaw_reborn_composition/src/extension_host/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/mod.rs
@@ -49,6 +49,7 @@ pub(crate) mod mcp_discovery;
 pub(crate) mod operator_config_capability;
 pub(crate) mod provider_instance_readiness;
 pub(crate) mod reply_contexts;
+pub(crate) mod retired_route_authority;
 pub(crate) mod run_delivery_ports;
 pub(crate) mod skill_auto_activate_capability;
 pub(crate) mod skill_learning;

--- a/crates/ironclaw_reborn_composition/src/extension_host/retired_route_authority.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/retired_route_authority.rs
@@ -1,0 +1,47 @@
+//! Installation-backed [`RetiredChannelRouteAuthority`]: the durable answer to
+//! "can the run-delivery router ever see a handler for this adapter again?".
+//!
+//! A channel adapter id doubles as its extension/installation id (one channel
+//! surface per extension), so a missing installation row is the fail-closed
+//! proof that the route is retired — a merely-unregistered handler during
+//! startup still has its installation row and stays pending. See
+//! `ironclaw_product::RunDeliveryEventRouter::set_retired_route_authority`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_extensions::{ExtensionInstallationId, ExtensionInstallationStore};
+use ironclaw_product::{ProductWorkflowError, RetiredChannelRouteAuthority};
+
+pub(crate) struct InstallationBackedRetiredRouteAuthority {
+    installations: Arc<dyn ExtensionInstallationStore>,
+}
+
+impl InstallationBackedRetiredRouteAuthority {
+    pub(crate) fn new(installations: Arc<dyn ExtensionInstallationStore>) -> Self {
+        Self { installations }
+    }
+}
+
+#[async_trait]
+impl RetiredChannelRouteAuthority for InstallationBackedRetiredRouteAuthority {
+    async fn channel_route_is_retired(
+        &self,
+        adapter_id: &str,
+    ) -> Result<bool, ProductWorkflowError> {
+        let installation_id =
+            ExtensionInstallationId::new(adapter_id.to_string()).map_err(|error| {
+                ProductWorkflowError::Transient {
+                    reason: format!("retired-route adapter id is invalid: {error}"),
+                }
+            })?;
+        let installation = self
+            .installations
+            .get_installation(&installation_id)
+            .await
+            .map_err(|error| ProductWorkflowError::Transient {
+                reason: format!("retired-route installation read failed: {error}"),
+            })?;
+        Ok(installation.is_none())
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3797,6 +3797,18 @@ pub async fn build_runtime(input: RebornRuntimeInput) -> Result<RebornRuntime, R
         Arc::clone(&turn_state_store) as Arc<dyn ironclaw_turns::TurnStateStore>,
         Arc::clone(&services.outbound_state),
     ));
+    // A run that removes its own channel extension mid-run completes with a
+    // sealed route no handler will ever own again. The installation-backed
+    // authority lets the router prove that retirement and downgrade the final
+    // reply to the WebApp transcript instead of leaving a permanently pending
+    // handoff (and a user staring at a never-finalized channel status).
+    if let Some(local_runtime) = local_runtime {
+        channel_run_delivery_events.set_retired_route_authority(Arc::new(
+            crate::extension_host::retired_route_authority::InstallationBackedRetiredRouteAuthority::new(
+                local_runtime.extension_management.installation_store_handle(),
+            ),
+        ));
+    }
     // Skill learning shares the turn-end seam with trace capture (composed
     // additively, so the trace-capture path is unchanged). It is active only
     // when a learning model is configured (a stronger model than the run's, via

--- a/tests/integration/delivery_user_journeys.rs
+++ b/tests/integration/delivery_user_journeys.rs
@@ -285,6 +285,7 @@ impl MatrixOutboundFacade {
                 destination: RunFinalReplyDestination::External {
                     reply_target_binding_ref: self.reply_target_binding_ref.clone(),
                 },
+                downgrade: None,
             })
             .await
             .map_err(|_| {
@@ -1510,6 +1511,7 @@ async fn web_app_source_can_seal_the_current_run_to_web_app_without_external_egr
             scope: harness.turn_scope.clone(),
             actor: caller.actor(),
             destination: RunFinalReplyDestination::WebApp,
+            downgrade: None,
         })
         .await
         .expect("the host-owned WebUI destination is sealed onto this run");

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -2071,3 +2071,380 @@ async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_t
     ingress.drain().await;
     assert_delivered_attempt(services, &repaired_scope).await;
 }
+
+const SELF_REMOVAL_REPLY: &str = "Telegram is uninstalled; this is the goodbye reply.";
+
+/// First model call: dispatch `builtin.extension_remove` for the channel the
+/// conversation rides on. Second call: the goodbye reply the delivery stack
+/// must not drop.
+#[derive(Debug, Default)]
+struct SelfRemovalGateway {
+    calls: Mutex<usize>,
+}
+
+#[async_trait::async_trait]
+impl HostManagedModelGateway for SelfRemovalGateway {
+    async fn stream_model(
+        &self,
+        _request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        Err(HostManagedModelError::safe(
+            ironclaw_loop_host::HostManagedModelErrorKind::InvalidRequest,
+            "self-removal gateway expects the capability-aware model path",
+        ))
+    }
+
+    async fn stream_model_with_capabilities(
+        &self,
+        _request: HostManagedModelRequest,
+        capabilities: std::sync::Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        let call_index = {
+            let mut calls = self.calls.lock().expect("self-removal gateway lock");
+            let index = *calls;
+            *calls += 1;
+            index
+        };
+        if call_index > 0 {
+            return Ok(HostManagedModelResponse::assistant_reply(
+                SELF_REMOVAL_REPLY,
+            ));
+        }
+        let candidate = capabilities
+            .register_provider_tool_call(
+                ironclaw_turns::run_profile::RegisterProviderToolCallRequest::new(
+                    ironclaw_turns::run_profile::ProviderToolCall {
+                        provider_id: "test-provider".to_string(),
+                        provider_model_id: "test-model".to_string(),
+                        turn_id: Some("provider-turn-self-removal".to_string()),
+                        id: "call-self-removal".to_string(),
+                        name: ironclaw_host_api::ProviderToolName::new("builtin__extension_remove")
+                            .expect("provider tool name"),
+                        arguments: json!({ "extension_id": "telegram" }),
+                        response_reasoning: None,
+                        reasoning: None,
+                        signature: None,
+                    },
+                ),
+            )
+            .await
+            .map_err(|error| {
+                HostManagedModelError::safe(
+                    ironclaw_loop_host::HostManagedModelErrorKind::InvalidRequest,
+                    format!("self-removal tool call registration failed: {error}"),
+                )
+            })?;
+        Ok(HostManagedModelResponse::capability_calls(
+            vec![candidate],
+            "",
+        ))
+    }
+}
+
+/// Installation-backed retired-route authority mirroring the production
+/// composition wiring (`InstallationBackedRetiredRouteAuthority`): a missing
+/// installation row is the durable proof the route can never be re-owned.
+struct InstallationRetiredRouteAuthority {
+    installations: Arc<dyn ironclaw_extensions::ExtensionInstallationStore>,
+}
+
+#[async_trait::async_trait]
+impl ironclaw_product::RetiredChannelRouteAuthority for InstallationRetiredRouteAuthority {
+    async fn channel_route_is_retired(
+        &self,
+        adapter_id: &str,
+    ) -> Result<bool, ironclaw_product::ProductWorkflowError> {
+        let installation_id = ironclaw_extensions::ExtensionInstallationId::new(
+            adapter_id.to_string(),
+        )
+        .map_err(|error| ironclaw_product::ProductWorkflowError::Transient {
+            reason: format!("retired-route adapter id invalid: {error}"),
+        })?;
+        self.installations
+            .get_installation(&installation_id)
+            .await
+            .map(|installation| installation.is_none())
+            .map_err(|error| ironclaw_product::ProductWorkflowError::Transient {
+                reason: format!("retired-route installation read failed: {error}"),
+            })
+    }
+}
+
+/// Live-incident regression (run 5916438c…: "can you uninstall telegram"
+/// asked IN telegram): the run really removes the channel — then its final
+/// reply's sealed route belongs to an extension that no longer exists. The
+/// pre-fix contract dropped the reply and left the durable handoff pending
+/// forever. Post-fix, the durable run-delivery replay proves the route is
+/// retired against the REAL installation store (the same rows the REAL
+/// `builtin.extension_remove` deleted mid-run) and downgrades the reply to
+/// the WebApp transcript with typed evidence, never re-sending on the wire.
+#[tokio::test]
+async fn self_removed_channel_final_reply_downgrades_to_web_app() {
+    let group = RebornIntegrationGroup::builder()
+        .storage(StorageMode::LibSql)
+        .extension_delivery()
+        .await
+        .expect("delivery group builds on this backend");
+    let services = reborn_services(&group);
+
+    let inbound = group
+        .thread("conv-telegram-self-removal-inbound")
+        .script([RebornScriptedReply::text("unused")])
+        .build()
+        .await
+        .expect("inbound thread builds");
+    let event_router = group
+        .run_delivery_events()
+        .expect("delivery group wires the canonical run-delivery event router");
+    let assembly = services
+        .start_channel_host_assembly_for_test(ChannelHostAssemblyTestWiring {
+            thread_service: inbound
+                .thread_service_for_test()
+                .expect("group thread service"),
+            turn_coordinator: inbound.turn_coordinator_for_test(),
+            run_delivery_events: Arc::clone(&event_router),
+            identity: ChannelHostIdentity {
+                tenant_id: inbound.binding.tenant_id.clone(),
+                agent_id: inbound.binding.agent_id.clone().expect("binding agent id"),
+                project_id: inbound.binding.project_id.clone(),
+                operator_user_id: inbound
+                    .binding
+                    .subject_user_id
+                    .clone()
+                    .expect("binding subject user id"),
+            },
+        })
+        .expect("the production channel host assembly starts over the composed runtime");
+
+    let lifecycle = group
+        .thread("conv-telegram-self-removal-lifecycle")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                json!({"extension_id": "telegram"}),
+            ),
+            RebornScriptedReply::text("installed and ready"),
+        ])
+        .build()
+        .await
+        .expect("telegram lifecycle thread builds");
+    configure_admin_group(
+        &group,
+        "extension.telegram",
+        0,
+        json!([
+            {"handle": "telegram_webhook_url", "value": "https://hooks.example.test/webhooks/extensions/telegram/updates"},
+            {"handle": "telegram_bot_token", "value": TELEGRAM_BOT_TOKEN},
+            {"handle": "telegram_webhook_secret", "value": TELEGRAM_WEBHOOK_SECRET},
+            {"handle": "bot_username", "value": "itest_self_removal_bot"}
+        ]),
+    )
+    .await;
+    let (install_run_id, _gate_ref) = lifecycle
+        .submit_turn_until_auth_blocked("install telegram")
+        .await
+        .expect("unpaired Telegram install parks on its pairing requirement");
+    let paired_user = inbound
+        .binding
+        .subject_user_id
+        .clone()
+        .expect("binding subject user id");
+    let bootstrap_code = services
+        .pairing_mint_for_test("telegram", &paired_user)
+        .await
+        .expect("setup-needed Telegram exposes pairing before readiness");
+    assert_eq!(
+        services
+            .pairing_consume_for_test(
+                "telegram",
+                TELEGRAM_INSTALLATION,
+                &bootstrap_code,
+                ("user", "7331", None, "5550001"),
+                (
+                    lifecycle.turn_coordinator_for_test(),
+                    lifecycle.turn_state_store_for_test(),
+                    inbound.binding.tenant_id.clone(),
+                ),
+            )
+            .await
+            .expect("bootstrap pairing completes")
+            .as_ref(),
+        Some(&paired_user)
+    );
+    lifecycle
+        .wait_for_status(install_run_id, ironclaw_turns::TurnStatus::Completed)
+        .await
+        .expect("pairing continuation resumes the exact blocked install");
+
+    let telegram_binding_service =
+        wait_for_production_registration(&assembly, services, "telegram").await;
+    let ingress = VendorIngress::production(
+        services
+            .extension_ingress_parts()
+            .expect("composition built the generic ingress"),
+    );
+    let evidence = ironclaw_product::auth::mark_shared_secret_header_verified(
+        "X-Telegram-Bot-Api-Secret-Token".to_string(),
+        TELEGRAM_INSTALLATION,
+    );
+    let chat_body = json!({
+        "update_id": 901,
+        "message": {
+            "message_id": 12,
+            "date": 1710000000,
+            "text": "please uninstall telegram",
+            "from": {"id": 7331, "is_bot": false, "first_name": "Sam"},
+            "chat": {"id": 5550001, "type": "private"}
+        }
+    })
+    .to_string();
+    let vendor_scope = preresolve_vendor_turn_scope(
+        &telegram_binding_service,
+        &ironclaw_telegram_extension::TelegramChannelAdapter::default(),
+        "telegram",
+        TELEGRAM_INSTALLATION,
+        &evidence,
+        &chat_body,
+    )
+    .await;
+    assert_eq!(vendor_scope.explicit_owner_user_id(), Some(&paired_user));
+    inbound.register_scope_gateway_for_test(
+        vendor_scope.clone(),
+        Arc::new(SelfRemovalGateway::default()),
+    );
+
+    let status = ingress
+        .post(
+            TELEGRAM_ROUTE,
+            &chat_body,
+            vec![(
+                "X-Telegram-Bot-Api-Secret-Token",
+                TELEGRAM_WEBHOOK_SECRET.to_string(),
+            )],
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    ingress.drain().await;
+
+    // The removal is REAL: the run's `builtin.extension_remove` deletes the
+    // durable installation row the retired-route authority reads.
+    let installation_store = services
+        .extension_installation_store_for_test()
+        .expect("extension delivery profile carries the lifecycle store");
+    let installation_id = ironclaw_extensions::ExtensionInstallationId::new(TELEGRAM_INSTALLATION)
+        .expect("Telegram installation id");
+    let removal_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if installation_store
+            .get_installation(&installation_id)
+            .await
+            .expect("installation state reads")
+            .is_none()
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < removal_deadline,
+            "the scripted run must actually remove the telegram installation"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // The durable replay path (the production router shape) over the group's
+    // REAL turn-event log and outbound store: the completed run materializes a
+    // handoff no live handler owns, the installation-backed authority proves
+    // the route retired, and the reply downgrades to the WebApp transcript.
+    let (outbound_store, _route_store, _preferences) = services
+        .outbound_delivery_stores_for_test()
+        .expect("delivery group exposes the composed outbound stores");
+    let turn_store = lifecycle.turn_state_store_for_test();
+    let authority = Arc::new(InstallationRetiredRouteAuthority {
+        installations: Arc::clone(&installation_store),
+    });
+    let downgrade_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let downgraded = loop {
+        let replay_router = ironclaw_product::RunDeliveryEventRouter::new(
+            Arc::clone(&turn_store) as Arc<dyn ironclaw_turns::TurnEventProjectionSource>,
+            Arc::clone(&turn_store) as Arc<dyn ironclaw_turns::TurnStateStore>,
+            Arc::clone(&outbound_store) as Arc<dyn ironclaw_outbound::OutboundStateStore>,
+        );
+        assert!(replay_router.set_retired_route_authority(Arc::clone(&authority) as _));
+        replay_router.wait_until_durable_replay_idle().await;
+        let pending = outbound_store
+            .list_pending_run_final_reply_handoffs_after(None, 64)
+            .await
+            .expect("pending handoffs list");
+        if let Some(handoff) = pending.iter().find(|handoff| handoff.scope == vendor_scope) {
+            // Materialized but not yet settled: the run may still be
+            // completing its removal teardown — keep polling.
+            assert!(
+                tokio::time::Instant::now() < downgrade_deadline,
+                "the retired route's handoff must settle, got pending {handoff:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            continue;
+        }
+        // Either not yet materialized or already settled: the downgraded
+        // record is the durable proof of settlement. The record is keyed by
+        // run id; discover it from the durable event log by scanning for the
+        // vendor-scope Completed run.
+        let page = ironclaw_turns::TurnEventProjectionSource::read_turn_event_log_after(
+            turn_store.as_ref(),
+            None,
+            256,
+        )
+        .await
+        .expect("turn event log reads");
+        let completed_run = page
+            .entries
+            .iter()
+            .filter(|event| {
+                event.scope == vendor_scope
+                    && event.kind == ironclaw_turns::TurnEventKind::Completed
+            })
+            .map(|event| event.run_id)
+            .next_back();
+        if let Some(run_id) = completed_run {
+            let record = outbound_store
+                .load_run_final_reply_target(ironclaw_outbound::RunFinalReplyTargetRequest {
+                    run_id,
+                    scope: vendor_scope.clone(),
+                    actor: ironclaw_turns::TurnActor::new(paired_user.clone()),
+                })
+                .await
+                .expect("run final-reply target reads");
+            if let Some(record) = record
+                && record.downgrade.is_some()
+            {
+                break record;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < downgrade_deadline,
+            "the self-removal run's reply must downgrade to the WebApp transcript"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    assert_eq!(
+        downgraded.destination,
+        ironclaw_outbound::RunFinalReplyDestination::WebApp
+    );
+    let downgrade = downgraded.downgrade.expect("typed downgrade evidence");
+    assert_eq!(
+        downgrade.reason,
+        ironclaw_outbound::RunFinalReplyDowngradeReason::RetiredChannelRoute
+    );
+    assert_eq!(downgrade.retired_adapter, TELEGRAM_INSTALLATION);
+
+    // The goodbye reply must never reach the removed channel's wire.
+    assert!(
+        !inbound
+            .captured_network_requests_for_test()
+            .iter()
+            .any(|request| {
+                request.url.ends_with("/sendMessage")
+                    && String::from_utf8_lossy(&request.body).contains(SELF_REMOVAL_REPLY)
+            }),
+        "a removed channel must not receive the final reply on the wire"
+    );
+}


### PR DESCRIPTION
## The live incident

Asked in telegram: *"can you uninstall telegram"*. The run genuinely removed the extension (post-#6520 removal works), completed server-side (run `5916438c-ea04-467e-8271-b312f23a33ba`, status `Completed`), and then tried to deliver its goodbye reply — to the channel it had just destroyed. The reply was silently dropped, the telegram status message stayed "Ironclaw is thinking…" forever, and the durable final-reply handoff row stayed pending permanently (re-scanned by every later drain).

## Root cause

The durable run-delivery replay (`RunDeliveryEventRouter::drain_completed_handoffs`) treats an unowned completed-run handoff as "awaiting its route handler" — correct during startup registration, but a route whose owning channel extension was **removed** can never be owned again. There was no way to distinguish the two, so self-removal produced a permanently pending handoff and a dropped reply.

## The fix: fallback delivery, not denial

The router accepts a late-bound `RetiredChannelRouteAuthority`. When an unowned handoff's owning adapter (from the run's `ProductTurnContext`) is **provably retired** — its installation row is durably gone — the replay:

1. downgrades the run's sealed destination to the WebApp transcript (where the completed reply already durably lives),
2. writes typed, redacted evidence on the run's final-reply target record — `RunFinalReplyDowngrade { reason: retired_channel_route, retired_adapter }` — so projections can render "delivered to web app — the channel was removed" instead of nothing,
3. completes the handoff.

Composition implements the authority over the extension installation store (`InstallationBackedRetiredRouteAuthority`) and connects it in `build_reborn_runtime`. A merely-unregistered route (startup window) still has its installation row and keeps waiting — pinned by a dedicated test.

### Rejected alternatives

- **Deny removal while a run is active** — self-removal from a conversation is a legitimate ask; the lifecycle rule requires removal not to race execution *silently*, not to be impossible.
- **Deliver-then-teardown sequencing** — would couple the removal capability to delivery timing across an async seam (the reply doesn't exist until the model's final turn, which happens after the tool call returns), and still leaves the crash-between window.

The `downgrade` field is wire-compatible: `serde(default)`, absent on every normally-routed record, with a historical-row round-trip pin.

## Tests (each verified red before the fix)

- `run_delivery_contract::unowned_handoff_of_retired_channel_route_downgrades_to_web_app` — router-seam regression: pending-forever pre-fix, settled + typed evidence post-fix.
- `run_delivery_contract::unowned_handoff_of_live_channel_route_stays_pending` — the discriminator: startup-window routes are never downgraded.
- `extension_delivery::self_removed_channel_final_reply_downgrades_to_web_app` — full journey: telegram install + admin config + pairing, a real verified ingress update whose scripted model dispatches `builtin.extension_remove`, the real installation row deleted mid-run, the durable replay over the real turn-event log + outbound store settles with downgrade evidence, and the goodbye reply never hits the removed channel's wire. (Red on the pre-fix code with the live incident's exact signature: `the retired route's handoff must settle, got pending RunFinalReplyHandoffRecord {…}`.)
- `run_final_reply_target::tests::target_record_downgrade_field_is_wire_compatible` — wire stability.

Verification: extension_delivery 21/21 (libsql + postgres), run_delivery_contract 44/44, delivery_user_journeys 29/29, outbound suites green, `cargo test -p ironclaw_architecture` green, fmt + clippy (`--all-targets --all-features -D warnings`) clean on touched crates.

## Known limitations (deliberate scope)

- The WebUi-origin cross-channel case (a web-originated run explicitly routed to an external channel that is then removed mid-run) keeps its existing policy-side story; the retired-route settlement currently engages for channel-origin (`Inbound`) runs — the live-incident shape.
- Finalizing the removed channel's *status message* is skipped: the adapter is already gone, so there is nothing safe to send through; the WebApp fallback is the contract.
- No UI rendering of the downgrade evidence yet — the typed record is projection-ready for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF1EiatUVLjKKs3eYGMbKV
