### PR TITLE
fix(live-qa): map setup values onto declared admin-group handles

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -963,6 +963,46 @@ def _extension_setup_secret_readiness(status: object) -> dict[str, object]:
     }
 
 
+def _map_admin_configuration_values(
+    fields: dict[str, object],
+    declared_handles: set[str],
+) -> tuple[dict[str, object], list[str]]:
+    """Map bare setup-source names onto the admin group's declared handles.
+
+    Same exact-or-``_{name}``-suffix rule the secrets matcher uses. Returns
+    the mapped values plus the sorted unmapped source names. A source that
+    would overwrite an already-mapped handle (e.g. declared ``foo_bar`` fed
+    by both ``foo_bar`` and ``bar``) is ambiguous and raises: the submitted
+    value must never depend on dict order.
+    """
+    declared: dict[str, object] = {}
+    mapped_sources: dict[str, str] = {}
+    unmapped: list[str] = []
+    for source_name, value in fields.items():
+        if source_name in declared_handles:
+            target = source_name
+        else:
+            matches = [
+                handle
+                for handle in declared_handles
+                if handle.endswith(f"_{source_name}")
+            ]
+            if len(matches) != 1:
+                unmapped.append(source_name)
+                continue
+            target = matches[0]
+        if target in declared:
+            raise LiveQaError(
+                "Ambiguous admin-configuration mapping: sources "
+                f"{mapped_sources[target]!r} and {source_name!r} both resolve to "
+                f"declared handle {target!r}"
+            )
+        declared[target] = value
+        mapped_sources[target] = source_name
+    return declared, sorted(unmapped)
+
+
+
 async def _apply_extension_setup_api_after_start(
     *,
     base_url: str,
@@ -1012,38 +1052,41 @@ async def _apply_extension_setup_api_after_start(
                 headers=headers,
             )
             catalog_response.raise_for_status()
-            revision = 0
+            # Fail closed on catalog drift: an absent group would otherwise
+            # degrade to revision=0 + an empty payload and resurface later as
+            # an opaque conflict or missing-field error.
+            group = next(
+                (
+                    entry
+                    for entry in catalog_response.json().get("groups", [])
+                    if isinstance(entry, dict)
+                    and entry.get("group_id") == f"extension.{package_id}"
+                ),
+                None,
+            )
+            if group is None or group.get("revision") is None:
+                raise LiveQaError(
+                    f"Operator catalog does not declare group extension.{package_id} "
+                    "with a revision; cannot route non-secret setup values"
+                )
+            revision = int(group.get("revision") or 0)
             declared_handles: set[str] = set()
-            for group in catalog_response.json().get("groups", []):
-                if isinstance(group, dict) and group.get("group_id") == f"extension.{package_id}":
-                    revision = int(group.get("revision") or 0)
-                    for descriptor in group.get("fields") or []:
-                        handle = descriptor.get("handle") if isinstance(descriptor, dict) else None
-                        if isinstance(handle, str) and handle:
-                            declared_handles.add(handle)
-                    break
+            for descriptor in group.get("fields") or []:
+                handle = descriptor.get("handle") if isinstance(descriptor, dict) else None
+                if isinstance(handle, str) and handle:
+                    declared_handles.add(handle)
+            if not declared_handles:
+                raise LiveQaError(
+                    f"Operator group extension.{package_id} declares no field handles; "
+                    "cannot route non-secret setup values"
+                )
             # The capability rejects handles the group does not declare. The
             # setup payload uses bare source names (team_id, bot_user_id, ...);
-            # map each onto the group's declared handle with the same
-            # exact-or-`_{name}`-suffix rule the secrets matcher uses, send
-            # only mapped ones, and surface leftovers loudly so a real gap
-            # fails later at the group-complete/setup assertions with context.
-            declared: dict[str, object] = {}
-            undeclared: list[str] = []
-            for source_name, value in fields.items():
-                if source_name in declared_handles:
-                    declared[source_name] = value
-                    continue
-                matches = [
-                    handle
-                    for handle in declared_handles
-                    if handle.endswith(f"_{source_name}")
-                ]
-                if len(matches) == 1:
-                    declared[matches[0]] = value
-                else:
-                    undeclared.append(source_name)
-            undeclared = sorted(undeclared)
+            # map each onto the group's declared handle (see
+            # _map_admin_configuration_values), send only mapped ones, and
+            # surface leftovers loudly so a real gap fails later at the
+            # group-complete/setup assertions with context.
+            declared, undeclared = _map_admin_configuration_values(fields, declared_handles)
             if undeclared:
                 print(
                     "[reborn-webui-v2-live-qa] WARNING: skipping values undeclared by "

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -1013,10 +1013,42 @@ async def _apply_extension_setup_api_after_start(
             )
             catalog_response.raise_for_status()
             revision = 0
+            declared_handles: set[str] = set()
             for group in catalog_response.json().get("groups", []):
                 if isinstance(group, dict) and group.get("group_id") == f"extension.{package_id}":
                     revision = int(group.get("revision") or 0)
+                    for descriptor in group.get("fields") or []:
+                        handle = descriptor.get("handle") if isinstance(descriptor, dict) else None
+                        if isinstance(handle, str) and handle:
+                            declared_handles.add(handle)
                     break
+            # The capability rejects handles the group does not declare. The
+            # setup payload uses bare source names (team_id, bot_user_id, ...);
+            # map each onto the group's declared handle with the same
+            # exact-or-`_{name}`-suffix rule the secrets matcher uses, send
+            # only mapped ones, and surface leftovers loudly so a real gap
+            # fails later at the group-complete/setup assertions with context.
+            declared: dict[str, object] = {}
+            undeclared: list[str] = []
+            for source_name, value in fields.items():
+                if source_name in declared_handles:
+                    declared[source_name] = value
+                    continue
+                matches = [
+                    handle
+                    for handle in declared_handles
+                    if handle.endswith(f"_{source_name}")
+                ]
+                if len(matches) == 1:
+                    declared[matches[0]] = value
+                else:
+                    undeclared.append(source_name)
+            undeclared = sorted(undeclared)
+            if undeclared:
+                print(
+                    "[reborn-webui-v2-live-qa] WARNING: skipping values undeclared by "
+                    f"extension.{package_id} admin group: {undeclared}"
+                )
             admin_response = await client.put(
                 admin_url,
                 headers=headers,
@@ -1025,7 +1057,7 @@ async def _apply_extension_setup_api_after_start(
                     # entries, not a map (Vec<ExtensionAdminConfigurationValue>).
                     "values": [
                         {"handle": handle, "value": value}
-                        for handle, value in fields.items()
+                        for handle, value in declared.items()
                     ],
                     "expected_revision": revision,
                     "idempotency_key": f"live-qa-{uuid.uuid4()}",
@@ -1034,7 +1066,8 @@ async def _apply_extension_setup_api_after_start(
             if admin_response.status_code != 200:
                 raise LiveQaError(
                     "Operator extension-configuration save failed: "
-                    f"HTTP {admin_response.status_code}: {admin_response.text[:300]}"
+                    f"HTTP {admin_response.status_code}: {admin_response.text[:300]}; "
+                    f"sent_handles={sorted(declared)} undeclared_skipped={undeclared}"
                 )
         response = await client.post(
             setup_url,

--- a/scripts/reborn_webui_v2_live_qa/test_admin_handle_mapping.py
+++ b/scripts/reborn_webui_v2_live_qa/test_admin_handle_mapping.py
@@ -1,0 +1,85 @@
+"""Deterministic coverage for the admin-configuration handle mapping.
+
+The live-canary Slack bootstrap routes non-secret setup values to the
+operator extension-configuration surface; these tests pin the pure mapping
+(bare source names -> declared ``slack_*`` handles) without a live server.
+"""
+
+import unittest
+
+from run_live_qa import LiveQaError, _map_admin_configuration_values
+
+SLACK_DECLARED = {
+    "slack_bot_token",
+    "slack_signing_secret",
+    "slack_team_id",
+    "slack_api_app_id",
+    "slack_installation_id",
+    "slack_bot_user_id",
+    "slack_shared_subject_user_id",
+    "slack_oauth_client_id",
+    "slack_oauth_client_secret",
+}
+
+
+class AdminHandleMappingTests(unittest.TestCase):
+    def test_bare_slack_sources_map_onto_declared_handles(self):
+        declared, unmapped = _map_admin_configuration_values(
+            {
+                "team_id": "T123",
+                "api_app_id": "A456",
+                "installation_id": "I789",
+                "bot_user_id": "U000",
+                "shared_subject_user_id": "U111",
+                "oauth_client_id": "C222",
+            },
+            SLACK_DECLARED,
+        )
+        self.assertEqual(
+            declared,
+            {
+                "slack_team_id": "T123",
+                "slack_api_app_id": "A456",
+                "slack_installation_id": "I789",
+                "slack_bot_user_id": "U000",
+                "slack_shared_subject_user_id": "U111",
+                "slack_oauth_client_id": "C222",
+            },
+        )
+        self.assertEqual(unmapped, [])
+
+    def test_exact_handle_names_pass_through(self):
+        declared, unmapped = _map_admin_configuration_values(
+            {"slack_team_id": "T123"}, SLACK_DECLARED
+        )
+        self.assertEqual(declared, {"slack_team_id": "T123"})
+        self.assertEqual(unmapped, [])
+
+    def test_unmapped_sources_are_reported_not_submitted(self):
+        declared, unmapped = _map_admin_configuration_values(
+            {"team_id": "T123", "bot_username": "qa_bot", "auth_user_id": "U9"},
+            SLACK_DECLARED,
+        )
+        self.assertEqual(declared, {"slack_team_id": "T123"})
+        self.assertEqual(unmapped, ["auth_user_id", "bot_username"])
+
+    def test_suffix_ambiguity_across_declared_handles_is_unmapped(self):
+        # `user_id` suffix-matches both bot_user_id and shared_subject_user_id
+        # declared handles -> ambiguous, never guessed.
+        declared, unmapped = _map_admin_configuration_values(
+            {"user_id": "U1"},
+            {"slack_bot_user_id", "slack_shared_subject_user_id"},
+        )
+        self.assertEqual(declared, {})
+        self.assertEqual(unmapped, ["user_id"])
+
+    def test_duplicate_target_mapping_raises(self):
+        with self.assertRaises(LiveQaError):
+            _map_admin_configuration_values(
+                {"foo_bar": "explicit", "bar": "suffixed"},
+                {"foo_bar"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Layer two behind #6602 (which was validated pre-merge via `use_target_harness` on run [30058129072](https://github.com/nearai/ironclaw/actions/runs/30058129072)): with the 422 shape fixed, all Slack shards advanced to `HTTP 400 invalid_value` — the harness forwarded bare setup-source names (`team_id`, `bot_user_id`, `oauth_client_id`, …) where the `extension.slack` operator group declares prefixed handles (`slack_team_id`, …). Google lanes (QA 2/6) passed fully on the same run, isolating the failure to this mapping.

Fix mirrors the harness's own secrets matcher: exact-or-`_{name}`-suffix mapping onto the group's declared handles (read from the catalog GET already performed), warn-and-skip unmapped values, and include the sent handle set in the failure message so any further layer names itself.

Validation plan: dispatch Live Canary with `target_ref` = this branch head + `use_target_harness: true`; expected outcome is the 8 Slack shards passing their bootstrap and running their cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF1EiatUVLjKKs3eYGMbKV