### PR TITLE
fix(automations): inherit implicit source channel target

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_host.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_host.rs
@@ -47,7 +47,8 @@ use ironclaw_product::{
     DefaultProductSurface, DeliveryCoordinator, PreferenceTargetCodec,
     ProductActorUserResolutionRequest, ProductActorUserResolver,
     ProductConversationSubjectRouteResolver, ProductInstallationKey, ProductInstallationScope,
-    ProductWorkflowError, ResolvedProductActorUser, RunDeliveryObserver, RunDeliveryServices,
+    ProductWorkflowError, ResolveStoredProductReplyTargetRequest, ResolvedProductActorUser,
+    ResolvedStoredProductReplyTarget, RunDeliveryObserver, RunDeliveryServices,
     StaticProductInstallationResolver, TriggeredRunDeliveryChannel,
 };
 use ironclaw_threads::SessionThreadService;
@@ -160,7 +161,6 @@ enum ReconciledChannel {
     /// Assembly-built generic graph for exactly this channel source.
     Generic {
         source: HostedChannelSource,
-        #[cfg(feature = "test-support")]
         conversation_binding: Arc<dyn ConversationBindingService>,
         /// The post-admission observer registered with the sink (test seam:
         /// gate-resolution acks arriving from non-channel surfaces are
@@ -215,7 +215,6 @@ impl HostedChannelSource {
 
 struct BuiltGenericChannelGraph {
     registration: ChannelIngressRegistration,
-    #[cfg(feature = "test-support")]
     conversation_binding: Arc<dyn ConversationBindingService>,
     #[cfg(feature = "test-support")]
     observer: Option<Arc<dyn PostAdmissionObserver>>,
@@ -329,6 +328,40 @@ impl GenericChannelHostAssembly {
                     .map(|codec| (extension_id, codec))
             })
             .collect()
+    }
+
+    /// Resolve an opaque run-state reply binding through the active channel
+    /// conversation stores. Each channel owns a separate durable binding
+    /// root, so misses are expected until the owning channel is reached.
+    pub(crate) async fn resolve_stored_reply_target(
+        &self,
+        request: ResolveStoredProductReplyTargetRequest,
+    ) -> Result<Option<ResolvedStoredProductReplyTarget>, ProductWorkflowError> {
+        let bindings = {
+            let reconciled = self.reconciled.lock().await;
+            reconciled
+                .values()
+                .filter_map(|channel| match channel {
+                    ReconciledChannel::Generic {
+                        conversation_binding,
+                        ..
+                    } => Some(Arc::clone(conversation_binding)),
+                    ReconciledChannel::Untouched { .. } => None,
+                })
+                .collect::<Vec<_>>()
+        };
+        for binding in bindings {
+            match binding.resolve_stored_reply_target(request.clone()).await {
+                Ok(target) => return Ok(Some(target)),
+                // The product binding deliberately maps both an absent opaque
+                // ref and denied access to this fail-closed result. Continue
+                // across extension-scoped stores; no denied binding is ever
+                // returned or used as routing authority.
+                Err(ProductWorkflowError::BindingAccessDenied) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(None)
     }
 
     /// Currently assembled channel lanes for product-owned triggered-run
@@ -466,7 +499,6 @@ impl GenericChannelHostAssembly {
                                 extension_id.clone(),
                                 ReconciledChannel::Generic {
                                     source,
-                                    #[cfg(feature = "test-support")]
                                     conversation_binding: graph.conversation_binding,
                                     #[cfg(feature = "test-support")]
                                     observer: graph.observer,
@@ -598,7 +630,6 @@ impl GenericChannelHostAssembly {
         };
         Ok(Some(BuiltGenericChannelGraph {
             registration,
-            #[cfg(feature = "test-support")]
             conversation_binding: binding,
             #[cfg(feature = "test-support")]
             observer: observer.map(|observer| observer as Arc<dyn PostAdmissionObserver>),

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_host/tests/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_host/tests/e2e_tests.rs
@@ -54,7 +54,7 @@ use ironclaw_product::{
     AdapterInstallationId, AuthRequirement, AuthResolutionPayload, AuthResolutionResult,
     ExternalActorRef, ExternalConversationRef, ExternalEventId, ParsedProductInbound,
     ProductAdapterId, ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload,
-    ProtocolAuthEvidence, TrustedInboundContext,
+    ProductTriggerReason, ProtocolAuthEvidence, TrustedInboundContext, UserMessagePayload,
 };
 use ironclaw_product::{
     ApprovalInteractionActionView, ApprovalInteractionDecision, ApprovalInteractionScope,
@@ -494,10 +494,16 @@ async fn build_harness_with_options(options: HarnessOptions) -> Harness {
         },
     ));
 
-    let identity_lookup = Arc::new(RecordingUserIdentityLookup::new([(
-        format!("{INSTALLATION}:{SLACK_USER}"),
-        UserId::new(USER).expect("user"), // safety: static test user id is valid.
-    )]));
+    let identity_lookup = Arc::new(RecordingUserIdentityLookup::new([
+        (
+            format!("{INSTALLATION}:{SLACK_USER}"),
+            UserId::new(USER).expect("user"), // safety: static test user id is valid.
+        ),
+        (
+            format!("{TELEGRAM_INSTALLATION}:{TELEGRAM_USER}"),
+            UserId::new(USER).expect("user"), // safety: static test user id is valid.
+        ),
+    ]));
     let outbound_delivery_targets =
         Arc::new(crate::outbound::MutableOutboundDeliveryTargetRegistry::default());
     let current_delivery_targets = Arc::new(
@@ -5351,6 +5357,75 @@ async fn telegram_target_is_enumerated_resolved_and_delivered_through_generic_wi
             provider as Arc<dyn OutboundDeliveryTargetProvider>,
         )
         .expect("register target provider");
+    let current_targets = current_target_resolver(&harness.assembly, Arc::clone(&registry));
+
+    let binding_service = harness
+        .assembly
+        .binding_service_for_extension_for_test("telegram")
+        .expect("Telegram binding service");
+    let adapter_id = ProductAdapterId::new("telegram").expect("adapter id");
+    let installation_id =
+        AdapterInstallationId::new(TELEGRAM_INSTALLATION).expect("installation id");
+    let evidence = ProtocolAuthEvidence::test_verified(
+        AuthRequirement::SharedSecretHeader {
+            header_name: "X-Telegram-Bot-Api-Secret-Token".to_string(),
+        },
+        installation_id.as_str(),
+    );
+    let context = TrustedInboundContext::from_verified_evidence(
+        adapter_id,
+        installation_id,
+        chrono::Utc::now(),
+        &evidence,
+    )
+    .expect("trusted Telegram context");
+    let parsed = ParsedProductInbound::new(
+        ExternalEventId::new("telegram:event:implicit-trigger-target").expect("event id"),
+        ExternalActorRef::new("telegram_user", TELEGRAM_USER, None::<String>)
+            .expect("Telegram actor"),
+        ExternalConversationRef::new(None, TELEGRAM_USER, None, None)
+            .expect("Telegram conversation"),
+        ProductInboundPayload::UserMessage(
+            UserMessagePayload::new(
+                "send me a random number every minute",
+                Vec::new(),
+                ProductTriggerReason::DirectChat,
+            )
+            .expect("Telegram message"),
+        ),
+    )
+    .expect("parsed Telegram inbound");
+    let envelope =
+        ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("Telegram envelope");
+    let source_binding = binding_service
+        .resolve_binding(ResolveBindingRequest::from_envelope(&envelope))
+        .await
+        .expect("Telegram conversation binds");
+    assert!(
+        source_binding
+            .reply_target_binding_ref
+            .as_str()
+            .starts_with("reply:"),
+        "source runs carry the conversation store's opaque binding"
+    );
+    let source_scope = ResourceScope {
+        tenant_id: TenantId::new(TENANT).expect("tenant"),
+        user_id: user.clone(),
+        agent_id: Some(AgentId::new(AGENT).expect("agent")),
+        project_id: Some(ProjectId::new(PROJECT).expect("project")),
+        mission_id: None,
+        thread_id: Some(source_binding.thread_id),
+        invocation_id: InvocationId::new(),
+    };
+    let inherited_target = current_targets
+        .resolve_current_target_id(&source_scope, &source_binding.reply_target_binding_ref)
+        .await
+        .expect("implicit source target lookup")
+        .expect("opaque Telegram source binding resolves to a current target");
+    assert_eq!(
+        inherited_target, telegram.summary.target_id,
+        "implicit trigger delivery inherits the source Telegram DM"
+    );
 
     let scope = foreign_run_scope();
     harness.ensure_scope_thread(&scope).await;
@@ -5372,7 +5447,7 @@ async fn telegram_target_is_enumerated_resolved_and_delivered_through_generic_wi
         Arc::clone(&harness.assembly),
         Arc::clone(&delivery_store) as Arc<dyn TriggeredRunDeliveryStore>,
         harness.outbound.clone() as Arc<dyn CommunicationPreferenceRepository>,
-        current_target_resolver(&harness.assembly, registry),
+        current_targets,
         Arc::clone(&harness.event_router),
     );
     let fire = TriggerFire {

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_host/tests/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_host/tests/e2e_tests.rs
@@ -5357,6 +5357,33 @@ async fn telegram_target_is_enumerated_resolved_and_delivered_through_generic_wi
             provider as Arc<dyn OutboundDeliveryTargetProvider>,
         )
         .expect("register target provider");
+    registry
+        .register_provider(
+            "telegram-topicless-parent",
+            Arc::new(
+                ironclaw_outbound::HostOwnedOutboundDeliveryTargetProvider::new(
+                    ironclaw_outbound::OutboundDeliveryTargetSummary::new(
+                        ironclaw_outbound::OutboundDeliveryTargetId::new(
+                            "telegram:shared-channel:-100123",
+                        )
+                        .expect("target id"),
+                        "telegram",
+                        "Telegram parent chat",
+                        None,
+                    )
+                    .expect("target summary"),
+                    ironclaw_outbound::DeliveryTargetCapabilities {
+                        final_replies: true,
+                        ..Default::default()
+                    },
+                    ironclaw_outbound::RunFinalReplyDestination::External {
+                        reply_target_binding_ref: ReplyTargetBindingRef::new("tg:-100123:_:_")
+                            .expect("topicless Telegram parent target"),
+                    },
+                ),
+            ),
+        )
+        .expect("register topicless Telegram parent target");
     let current_targets = current_target_resolver(&harness.assembly, Arc::clone(&registry));
 
     let binding_service = harness
@@ -5372,6 +5399,53 @@ async fn telegram_target_is_enumerated_resolved_and_delivered_through_generic_wi
         },
         installation_id.as_str(),
     );
+    let topic_context = TrustedInboundContext::from_verified_evidence(
+        adapter_id.clone(),
+        installation_id.clone(),
+        chrono::Utc::now(),
+        &evidence,
+    )
+    .expect("trusted Telegram topic context");
+    let topic_parsed = ParsedProductInbound::new(
+        ExternalEventId::new("telegram:event:implicit-topic-target").expect("event id"),
+        ExternalActorRef::new("telegram_user", TELEGRAM_USER, None::<String>)
+            .expect("Telegram actor"),
+        ExternalConversationRef::new(None, "-100123", Some("77"), None)
+            .expect("Telegram topic conversation"),
+        ProductInboundPayload::UserMessage(
+            UserMessagePayload::new(
+                "send me a random number every minute",
+                Vec::new(),
+                ProductTriggerReason::BotMention,
+            )
+            .expect("Telegram topic message"),
+        ),
+    )
+    .expect("parsed Telegram topic inbound");
+    let topic_envelope = ProductInboundEnvelope::from_trusted_parse(topic_context, topic_parsed)
+        .expect("Telegram topic envelope");
+    let topic_binding = binding_service
+        .resolve_binding(ResolveBindingRequest::from_envelope(&topic_envelope))
+        .await
+        .expect("Telegram topic binds");
+    let topic_scope = ResourceScope {
+        tenant_id: TenantId::new(TENANT).expect("tenant"),
+        user_id: user.clone(),
+        agent_id: Some(AgentId::new(AGENT).expect("agent")),
+        project_id: Some(ProjectId::new(PROJECT).expect("project")),
+        mission_id: None,
+        thread_id: Some(topic_binding.thread_id),
+        invocation_id: InvocationId::new(),
+    };
+    assert!(
+        current_targets
+            .resolve_current_target_id(&topic_scope, &topic_binding.reply_target_binding_ref)
+            .await
+            .expect("implicit topic target lookup")
+            .is_none(),
+        "a topic-scoped source must not downgrade to the topicless parent chat"
+    );
+
     let context = TrustedInboundContext::from_verified_evidence(
         adapter_id,
         installation_id,

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_outbound_targets.rs
@@ -30,6 +30,8 @@ use ironclaw_host_api::{AgentId, ExtensionId, ProjectId, ResourceScope, TenantId
 use ironclaw_outbound::{OutboundDeliveryTargetProvider, OutboundError, RunFinalReplyDestination};
 use ironclaw_product::{
     AdapterInstallationId, ExternalConversationRef, PreferenceTargetEncodeRequest,
+    ProductConversationRouteKind, ResolveStoredProductReplyTargetRequest,
+    StoredProductReplyTargetAccess,
 };
 use ironclaw_product::{
     CurrentDeliveryTarget, CurrentDeliveryTargetResolver, PreferenceTargetCodec,
@@ -165,12 +167,73 @@ impl CurrentDeliveryTargetResolver for ComposedCurrentDeliveryTargetResolver {
         target: &ReplyTargetBindingRef,
     ) -> Result<Option<OutboundDeliveryTargetId>, ProductWorkflowError> {
         let caller = Self::outbound_scope(scope.tenant_id.clone(), scope.user_id.clone());
-        self.targets
+        let resolved = self
+            .targets
             .resolve_reply_target_binding(&caller, target)
             .await
-            .map(|entry| entry.map(|entry| entry.summary.target_id))
-            .map_err(map_current_target_error)
+            .map_err(map_current_target_error)?;
+        if let Some(entry) = resolved {
+            return Ok(Some(entry.summary.target_id));
+        }
+
+        let Some(thread_id) = scope.thread_id.clone() else {
+            return Ok(None);
+        };
+        let Some(assembly) = self.assembly()? else {
+            return Ok(None);
+        };
+        let stored = assembly
+            .resolve_stored_reply_target(ResolveStoredProductReplyTargetRequest {
+                scope: TurnScope::new_with_owner(
+                    scope.tenant_id.clone(),
+                    scope.agent_id.clone(),
+                    scope.project_id.clone(),
+                    thread_id,
+                    Some(scope.user_id.clone()),
+                ),
+                actor: TurnActor::new(scope.user_id.clone()),
+                reply_target_binding_ref: target.clone(),
+                access: StoredProductReplyTargetAccess::OrdinaryReply,
+            })
+            .await?;
+        let Some(stored) = stored else {
+            return Ok(None);
+        };
+        let Some(codec) = assembly.preference_target_codec(stored.adapter_id.as_str()) else {
+            return Ok(None);
+        };
+        let expects_direct_message = stored.route_kind == ProductConversationRouteKind::Direct;
+        let entries = self
+            .targets
+            .list_outbound_delivery_targets(&caller)
+            .await
+            .map_err(map_current_target_error)?;
+        Ok(entries.into_iter().find_map(|entry| {
+            if entry.summary.channel.as_str() != stored.adapter_id.as_str() {
+                return None;
+            }
+            let RunFinalReplyDestination::External {
+                reply_target_binding_ref,
+            } = &entry.destination
+            else {
+                return None;
+            };
+            if codec.is_personal_direct_message(reply_target_binding_ref) != expects_direct_message
+            {
+                return None;
+            }
+            let conversation = codec.conversation_for_target(reply_target_binding_ref)?;
+            same_channel_destination(&conversation, &stored.external_conversation_ref)
+                .then(|| entry.summary.target_id)
+        }))
     }
+}
+
+fn same_channel_destination(
+    left: &ExternalConversationRef,
+    right: &ExternalConversationRef,
+) -> bool {
+    left.space_id() == right.space_id() && left.conversation_id() == right.conversation_id()
 }
 
 fn map_current_target_error(error: OutboundError) -> ProductWorkflowError {

--- a/crates/ironclaw_reborn_composition/src/extension_host/channel_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/channel_outbound_targets.rs
@@ -224,7 +224,7 @@ impl CurrentDeliveryTargetResolver for ComposedCurrentDeliveryTargetResolver {
             }
             let conversation = codec.conversation_for_target(reply_target_binding_ref)?;
             same_channel_destination(&conversation, &stored.external_conversation_ref)
-                .then(|| entry.summary.target_id)
+                .then_some(entry.summary.target_id)
         }))
     }
 }
@@ -233,7 +233,7 @@ fn same_channel_destination(
     left: &ExternalConversationRef,
     right: &ExternalConversationRef,
 ) -> bool {
-    left.space_id() == right.space_id() && left.conversation_id() == right.conversation_id()
+    left == right
 }
 
 fn map_current_target_error(error: OutboundError) -> ProductWorkflowError {


### PR DESCRIPTION
## Summary

- Resolve opaque conversation bindings (`reply:<uuid>`) through the active channel binding services before matching the caller's current outbound target.
- Preserve current authority checks by matching only caller-scoped registry targets and the channel's registered codec.
- Compare the complete conversation identity, including Telegram forum `topic_id`, so a topic-scoped automation cannot downgrade to its parent chat.
- Extend the existing production-wiring Telegram test to cover both the implicit DM route that failed in QA and topic-isolation behavior.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6520

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`: CI pending on `875f365af`
- [ ] `cargo build`: CI pending on `875f365af`
- [ ] Relevant tests pass: CI pending on `875f365af`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed: Not applicable; no database schema/backend behavior changed
- [x] Manual testing: QA reproduction confirmed that an implicit Telegram automation persisted `delivery_target_id = null`, while explicit Telegram/Slack targets worked.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

`cargo fmt --all -- --check` and `git diff --check` completed locally. The original DM regression test was run before the first fix and failed at the new opaque-binding assertion as expected. Per requester direction, post-fix Rust compilation and tests are delegated to CI rather than a local build.

## Test Strategy

User behavior:

Creating an automation from Telegram with “send me …” should inherit that Telegram DM without requiring “in Telegram” in the prompt. If the source is a Telegram forum topic, inheritance must not silently route the result to the topicless parent chat.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Extended the existing generic channel-host production-wiring test for Telegram.
- Reborn integration: The existing composition E2E creates a real opaque Telegram DM binding and resolves it through the production current-target resolver. It also creates an opaque Telegram forum-topic binding, supplies a topicless parent-chat candidate through the real target registry, and asserts that resolution fails closed rather than downgrading the destination.
- Recorded fixture: Not applicable: no model-choice or request-shape behavior changed.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: Covered by the composition channel-host E2E; CI pending.
- Live canary: Original behavior reproduced in Railway QA before this fix; post-deploy canary pending merge/deploy.

What the tests prove:

The production Telegram binding service emits an opaque `reply:<uuid>` source binding, and the generic resolver maps a direct-chat binding back to the currently authorized Telegram personal-DM target rather than returning `None`. A forum-topic binding does not match a target for the same parent chat when `topic_id` differs. Existing assertions continue to cover final delivery through the same resolver.

Commands run:

- `cargo test -p ironclaw_reborn_composition --lib telegram_target_is_enumerated_resolved_and_delivered_through_generic_wiring -- --nocapture` — failed before the original fix at the opaque Telegram DM assertion, proving the original regression.
- `cargo fmt --all -- --check` — passed after the review fix.
- `git diff --check` — passed after the review fix.
- Post-fix cargo compilation/test run omitted per requester; CI pending.

## Security Impact

No new authority is granted. Stored conversation bindings are resolved with the authenticated user, tenant, and thread scope. The result is matched only against targets returned by the caller-scoped outbound registry and the active channel codec. Destination matching uses `ExternalConversationRef` identity, which includes space, conversation, and topic while excluding reply-message metadata. Missing, denied, inactive, unpaired, or topic-mismatched targets remain unresolved.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no public types or constructors changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. N/A; no prompt construction changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. N/A; no hashing changed.
- [x] New/changed status, exit, policy, runtime, or error variants: N/A; no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. N/A; no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. No new queue or counter; lookup scans the active reconciled channel set.
- [x] Driver/operator-visible errors have stable class semantics. Existing `ProductWorkflowError` classes are preserved.
- [x] Sandbox/native/host names accurately describe trust boundary. N/A; no runtime lane or sandbox change.

## Database Impact

None. No schema, migration, or backend-specific persistence behavior changes.

## Blast Radius

Generic implicit source-channel target resolution for automations. Telegram is the regression case; Slack and other active generic channel extensions use the same path. Explicit target selection and final delivery behavior are unchanged. Topic/thread identity is now preserved during inherited-target matching.

## Rollback Plan

Revert this PR (commits `3918cf61f` and `875f365af`). This restores the previous behavior where opaque source bindings do not inherit a channel target; explicit targets continue to work.

## Review Follow-Through

CI and automated re-review are pending on `875f365af`. After they pass, deploy to QA and repeat the implicit Telegram automation canary before production rollout.

---

**Review track**: C