### PR TITLE
fix(webui): render pairing prompts without text input

### DIFF
--- a/crates/ironclaw_product/src/auth_prompt.rs
+++ b/crates/ironclaw_product/src/auth_prompt.rs
@@ -57,7 +57,8 @@ impl AuthChallengeView {
                 channel: connection.channel.clone(),
                 strategy: Some(connection.strategy.as_str().to_string()),
                 instructions: Some(connection.instructions.clone()),
-                input_placeholder: Some(connection.input_placeholder),
+                input_placeholder: (!connection.input_placeholder.is_empty())
+                    .then_some(connection.input_placeholder),
                 submit_label: Some(connection.submit_label),
                 error_message: Some(connection.error_message),
             });

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream_auth.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream_auth.rs
@@ -1,5 +1,43 @@
 use super::*;
 
+struct FakePairingAuthChallengeProvider;
+
+#[async_trait]
+impl AuthChallengeProvider for FakePairingAuthChallengeProvider {
+    async fn challenge_for_gate(
+        &self,
+        _scope: &TurnScope,
+        _owner_user_id: &UserId,
+        _run_id: TurnRunId,
+        _gate_ref: &str,
+        _credential_requirements: &[RuntimeCredentialAuthRequirement],
+    ) -> Result<Option<AuthChallengeView>, ironclaw_auth::AuthProductError> {
+        Ok(Some(AuthChallengeView {
+            kind: AuthPromptChallengeKind::Pairing,
+            provider: AuthProviderId::new("telegram".to_string()).unwrap(),
+            account_label: None,
+            authorization_url: None,
+            expires_at: None,
+            pairing: Some(ironclaw_product::PairingAuthChallengeView {
+                issue: ironclaw_product::ChannelPairingIssue {
+                    code: ironclaw_product::ChannelPairingCode::new("ABCDEFGH").unwrap(),
+                    deep_link: Some("https://t.me/ironclaw_bot?start=ABCDEFGH".to_string()),
+                    expires_at: chrono::Utc::now() + chrono::Duration::minutes(15),
+                },
+                connection: ironclaw_product::ChannelConnectionRequirement {
+                    channel: "telegram".to_string(),
+                    display_name: "Telegram".to_string(),
+                    strategy: ironclaw_product::RebornChannelConnectStrategy::WebGeneratedCode,
+                    instructions: "Send the generated code to the Telegram bot.".to_string(),
+                    input_placeholder: String::new(),
+                    submit_label: "Open pairing".to_string(),
+                    error_message: "Telegram pairing failed.".to_string(),
+                },
+            }),
+        }))
+    }
+}
+
 #[tokio::test]
 async fn product_event_stream_enriches_auth_prompt_through_projection_stream() {
     let tenant_id = TenantId::new("webui-events-tenant").unwrap();
@@ -88,6 +126,132 @@ async fn product_event_stream_enriches_auth_prompt_through_projection_stream() {
                     && context.authorization_url.as_deref() == Some("https://github.com/login/oauth/authorize")
             ))
     )));
+}
+
+#[tokio::test]
+async fn product_event_stream_projects_pairing_prompt_without_text_input_placeholder() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-telegram-pairing-thread").unwrap();
+    let turn_run = TurnRunId::new();
+    let gate_ref = "gate:telegram-pairing";
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let credential_requirements = vec![RuntimeCredentialAuthRequirement {
+        provider: VendorId::new("telegram").unwrap(),
+        setup: RuntimeCredentialAccountSetup::Pairing,
+        requester_extension: ExtensionId::new("telegram").unwrap(),
+        provider_scopes: Vec::new(),
+    }];
+    let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    )
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
+                run_id: turn_run,
+                status: TurnStatus::BlockedAuth,
+                kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: GateRef::new(gate_ref).unwrap(),
+                    gate_kind: TurnBlockedGateKind::Auth,
+                    activity_id: None,
+                    credential_requirements: credential_requirements.clone(),
+                }),
+                sanitized_reason: Some("Telegram pairing required".to_string()),
+                detail: None,
+                retryable: None,
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: TurnRunState {
+                gate_ref: Some(GateRef::new(gate_ref).unwrap()),
+                credential_requirements,
+                ..turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1))
+            },
+        }),
+    )
+    .with_auth_challenges(Arc::new(FakePairingAuthChallengeProvider));
+
+    let events = services
+        .product_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    let prompt = events
+        .iter()
+        .find_map(|event| match event.payload() {
+            ProductOutboundPayload::AuthPrompt(prompt) => Some(prompt),
+            _ => None,
+        })
+        .expect("pairing auth prompt");
+    assert_eq!(prompt.turn_run_id, turn_run);
+    assert_eq!(
+        prompt.challenge_kind,
+        Some(AuthPromptChallengeKind::Pairing)
+    );
+    assert_eq!(prompt.provider.as_deref(), Some("telegram"));
+    assert_eq!(
+        prompt
+            .connection
+            .as_ref()
+            .expect("connection context")
+            .input_placeholder,
+        None
+    );
+    assert_eq!(
+        prompt.pairing.as_ref().expect("pairing context").code,
+        "ABCDEFGH"
+    );
+
+    let auth_context = events
+        .iter()
+        .find_map(|event| match event.payload() {
+            ProductOutboundPayload::ProjectionUpdate { state } => {
+                state.items.iter().find_map(|item| match item {
+                    ProductProjectionItem::Gate {
+                        gate_kind,
+                        auth_context,
+                        ..
+                    } if *gate_kind == ProductGateKind::Auth => auth_context.as_deref(),
+                    _ => None,
+                })
+            }
+            _ => None,
+        })
+        .expect("projected pairing auth context");
+    assert_eq!(
+        auth_context
+            .connection
+            .as_ref()
+            .expect("projected connection context")
+            .input_placeholder,
+        None
+    );
+    assert_eq!(
+        auth_context
+            .pairing
+            .as_ref()
+            .expect("projected pairing context")
+            .code,
+        "ABCDEFGH"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Normalize an empty channel-pairing `input_placeholder` to an absent optional WebUI projection field.
- Prevent Telegram's `BlockedAuth` pairing prompt from being rejected as a `400 InvalidRequest / Validation` stream error.
- Add a caller-level projection regression test covering the auth prompt and projected gate context.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run locally; CI requested as the validation lane.
- [ ] `cargo build` — not run locally; CI requested as the validation lane.
- [ ] Relevant tests pass: not run locally; the new regression test is `product_event_stream_projects_pairing_prompt_without_text_input_placeholder` and will run in CI.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — not applicable; no database or backend behavior changed.
- [ ] Manual testing — the pre-fix failure was reproduced in QA deployment logs; the fix has not been deployed yet.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run.

## Test Strategy

User behavior: Given a Telegram install that blocks for web-generated-code pairing, WebChat renders the pairing prompt instead of terminating the chat event stream with a validation error.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added a projection contract test that drives a real `BlockedAuth` lifecycle event through `product_event_stream().drain(...)` using a Telegram-shaped pairing challenge with an empty manifest placeholder.
- Reborn integration: Not applicable; the existing composition projection test seam directly reaches the production code that returned the QA validation error, without adding unrelated runner/model setup.
- Recorded fixture: Not applicable; model choice and request shape are unchanged.
- Browser E2E: Not applicable; frontend behavior is unchanged and the server-side projection contract reproduces the exact failure before SSE framing.
- Backend or runtime: Not applicable; no database, runtime lane, or provider call changed.
- Live canary: Not run; QA logs supplied the pre-fix evidence and deployment verification should happen after CI.

What the tests prove: An empty manifest placeholder becomes `None`, while the pairing challenge, deep link, code, auth prompt, and projected gate context remain renderable.

Commands run:

```text
cargo fmt --all
cargo fmt --all -- --check
git diff --check
```

No compile, clippy, or test command was run locally by request; CI is the execution evidence.

## Security Impact

None. No permissions, credentials, secret handling, network calls, file access, tool execution, or sandbox policy changed. Pairing codes and deep links remain inside the existing product-safe projection DTO.

## Reborn Trust-Boundary Checklist

N/A: this changes only normalization of an optional presentation field and adds regression coverage. It does not change constructors for authority-bearing types, trust classification, status variants, persistence defaults, queues, error taxonomy, or runtime boundaries.

## Database Impact

None. No schema, migration, PostgreSQL, or libSQL behavior changed.

## Blast Radius

Limited to WebUI projection rendering for channel-pairing auth challenges. Non-empty placeholders retain their existing wire value; empty placeholders are omitted instead of being rejected by product projection validation. Approval, resource, OAuth, and manual-token gates are unchanged.

## Rollback Plan

Revert this commit. That restores the previous strict `Some("")` behavior, including the known Telegram pairing stream failure.

## Review Follow-Through

CI must compile and execute the new projection regression test before merge. After deployment, repeat Telegram connect in QA and verify the pairing panel appears without `facade rejected SSE drain` validation logs.

---

**Review track**: B (user-visible Reborn bug fix)