### PR TITLE
fix(test-infra): repair the #6520 audit fallout — coverage-lane crash, blind auth suites, weakened guards

### DIFF
--- a/scripts/auth_live_canary/config.example.env
+++ b/scripts/auth_live_canary/config.example.env
@@ -12,9 +12,9 @@ GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 AUTH_LIVE_GOOGLE_ACCESS_TOKEN=
 AUTH_LIVE_GOOGLE_REFRESH_TOKEN=
-AUTH_LIVE_GOOGLE_SCOPES=gmail.modify gmail.compose calendar.events
-# Set to 0 to skip forced refresh on first probe.
-AUTH_LIVE_FORCE_GOOGLE_REFRESH=1
+# Space-separated full scope URLs; defaults to GOOGLE_SCOPE_DEFAULT in
+# run_live_canary.py when unset.
+AUTH_LIVE_GOOGLE_SCOPES=https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events
 
 # GitHub
 AUTH_LIVE_GITHUB_TOKEN=

--- a/scripts/ci/reborn-coverage-int-tier-tests.sh
+++ b/scripts/ci/reborn-coverage-int-tier-tests.sh
@@ -6,54 +6,57 @@
 # Integration-tier (task T0-COV) is the set of in-process suites under
 # tests/integration/ (post-restructure home of the roadmap integration suite;
 # see docs/superpowers/specs/2026-06-26-reborn-integration-test-framework-design.md):
-#   - tests/integration/<name>.rs   (flat [[test]] binaries; Cargo `name` is
-#                                    reborn_integration_<name>)
-#   - tests/integration/group_<x>/  ([[test]] binaries; Cargo `name` is
-#                                    reborn_group_<x>)
+#   - tests/integration/<name>.rs        (flat bins; `name = reborn_integration_<name>`)
+#   - tests/integration/group_<x>/       (group bins; `name = reborn_group_<x>`)
+#   - tests/integration/<domain>/<n>.rs  (domain-folder bins, e.g. auth/;
+#                                         `name = reborn_integration_<n>`)
 #
-# Discovery is dynamic so coverage automatically picks up new int-tier suites
-# as they land (mirrors scripts/ci/run-reborn-group-tests.sh's dir->name
-# rewrite and scripts/ci/run-reborn-root-partition.sh's overall shape).
+# Discovery is registration-driven: the workspace Cargo.toml's `[[test]]`
+# entries are the single source of truth, and every entry whose `path` sits
+# under tests/integration/ is selected. Deriving candidates from a filesystem
+# walk instead has already burned us once: the previous `find -maxdepth 1`
+# walk could not see domain-folder bins, so the six tests/integration/auth/
+# suites (oauth_connect, oauth_popup_journeys, oauth_refresh, auth_gate,
+# auth_failure, reopen_resume_through_gate) ran in NO PR or merge-queue lane
+# — their only executor was the push-to-main coverage workflow. Selecting
+# from the registration makes a new suite impossible to register without
+# also being selected, whatever directory shape it uses, and a registered
+# entry whose file was deleted fails the lane loudly ("couldn't read the
+# file") instead of being silently skipped.
 #
-# Candidate names are filtered against Cargo.toml's `[[test]] name = "..."`
-# entries: not every flat tests/integration/<name>.rs file is its own binary
-# — a file can be a #[path]-mounted shared-fixture sibling included by two or
-# more real suites instead (see slack_pairing_fixtures.rs, mounted by
-# slack_pairing_redeem.rs / slack_pairing_actor_resolution.rs), and such
-# siblings have no `[[test]]` entry of their own. Without this filter, a bare
-# directory scan derives a nonexistent `--test reborn_integration_<sibling>`
-# arg and `cargo llvm-cov ... test` fails outright with "no test target
-# named" before running anything in the lane.
+# `#[path]`-mounted shared-fixture siblings (auth/common.rs,
+# slack_pairing_fixtures.rs, support/) have no `[[test]]` entry and are
+# therefore never selected — same reason the old walk filtered its
+# candidates against the registration.
 
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo_root}"
 
-mapfile -t names < <(
-  {
-    find tests/integration -maxdepth 1 -type f -name '*.rs' \
-      | sed -E 's#^tests/integration/#reborn_integration_#; s#\.rs$##'
-    find tests/integration -mindepth 1 -maxdepth 1 -type d -name 'group_*' \
-      -exec sh -c 'test -f "$1/main.rs"' _ {} ';' -print \
-      | sed -E 's#^tests/integration/group_#reborn_group_#'
-  } | LC_ALL=C sort -u | while IFS= read -r candidate; do
-    if awk -v name="${candidate}" '
-      /^\[\[test\]\]/ { in_test=1; next }
-      /^\[/ { in_test=0 }
-      in_test && $0 == "name = \"" name "\"" { found=1; exit }
-      END { exit !found }
-    ' Cargo.toml; then
-      printf '%s\n' "${candidate}"
-    fi
-  done
-)
+# Plain string + while-read (no `mapfile`): macOS dev machines ship bash 3.2,
+# and the guardrail must be runnable where it is written, not only on CI.
+names="$(
+  awk '
+    /^\[\[test\]\]/ { in_test = 1; name = ""; next }
+    /^\[/           { in_test = 0 }
+    in_test && /^name = "/ {
+      name = $0
+      sub(/^name = "/, "", name)
+      sub(/"$/, "", name)
+    }
+    in_test && /^path = "tests\/integration\// && name != "" {
+      print name
+      name = ""
+    }
+  ' Cargo.toml | LC_ALL=C sort -u
+)"
 
-if [ "${#names[@]}" -eq 0 ]; then
+if [ -z "${names}" ]; then
   echo "No Reborn integration-tier test binaries discovered" >&2
   exit 1
 fi
 
-for name in "${names[@]}"; do
+printf '%s\n' "${names}" | while IFS= read -r name; do
   printf -- '--test\n%s\n' "${name}"
 done

--- a/scripts/ci/reborn-coverage-int-tier-tests.sh
+++ b/scripts/ci/reborn-coverage-int-tier-tests.sh
@@ -37,30 +37,30 @@ cd "${repo_root}"
 # Plain string + while-read (no `mapfile`): macOS dev machines ship bash 3.2,
 # and the guardrail must be runnable where it is written, not only on CI.
 #
-# The awk buffers each [[test]] stanza's `name`/`path` and emits at the
-# stanza boundary (next table header or EOF) — Cargo treats TOML key order
-# as irrelevant, so `path` before `name` must select exactly like the
-# conventional order (pinned by harness case D6's reversed-order stanza).
+# The manifest is parsed with Python's stdlib `tomllib` (python3 is already a
+# hard dependency of this lane's sibling scripts, e.g.
+# scripts/ci/lib/reborn_coverage_lcov.py) so the selector accepts exactly what
+# Cargo accepts — key order, spacing, and trailing comments can never drop a
+# registration the way a line-regex parser could (pinned by harness case D6's
+# reversed-order and compact stanzas).
 names="$(
-  awk '
-    function flush_stanza() {
-      if (in_test && name != "" && path_matches) {
-        print name
-      }
-      in_test = 0
-      name = ""
-      path_matches = 0
-    }
-    /^\[\[test\]\]/ { flush_stanza(); in_test = 1; next }
-    /^\[/           { flush_stanza() }
-    in_test && /^name = "/ {
-      name = $0
-      sub(/^name = "/, "", name)
-      sub(/"$/, "", name)
-    }
-    in_test && /^path = "tests\/integration\// { path_matches = 1 }
-    END { flush_stanza() }
-  ' Cargo.toml | LC_ALL=C sort -u
+  python3 - <<'PY'
+import tomllib
+
+with open("Cargo.toml", "rb") as manifest:
+    data = tomllib.load(manifest)
+
+names = {
+    entry["name"]
+    for entry in data.get("test", [])
+    if isinstance(entry, dict)
+    and isinstance(entry.get("name"), str)
+    and isinstance(entry.get("path"), str)
+    and entry["path"].startswith("tests/integration/")
+}
+for name in sorted(names):
+    print(name)
+PY
 )"
 
 if [ -z "${names}" ]; then

--- a/scripts/ci/reborn-coverage-int-tier-tests.sh
+++ b/scripts/ci/reborn-coverage-int-tier-tests.sh
@@ -36,19 +36,30 @@ cd "${repo_root}"
 
 # Plain string + while-read (no `mapfile`): macOS dev machines ship bash 3.2,
 # and the guardrail must be runnable where it is written, not only on CI.
+#
+# The awk buffers each [[test]] stanza's `name`/`path` and emits at the
+# stanza boundary (next table header or EOF) — Cargo treats TOML key order
+# as irrelevant, so `path` before `name` must select exactly like the
+# conventional order (pinned by harness case D6's reversed-order stanza).
 names="$(
   awk '
-    /^\[\[test\]\]/ { in_test = 1; name = ""; next }
-    /^\[/           { in_test = 0 }
+    function flush_stanza() {
+      if (in_test && name != "" && path_matches) {
+        print name
+      }
+      in_test = 0
+      name = ""
+      path_matches = 0
+    }
+    /^\[\[test\]\]/ { flush_stanza(); in_test = 1; next }
+    /^\[/           { flush_stanza() }
     in_test && /^name = "/ {
       name = $0
       sub(/^name = "/, "", name)
       sub(/"$/, "", name)
     }
-    in_test && /^path = "tests\/integration\// && name != "" {
-      print name
-      name = ""
-    }
+    in_test && /^path = "tests\/integration\// { path_matches = 1 }
+    END { flush_stanza() }
   ' Cargo.toml | LC_ALL=C sort -u
 )"
 

--- a/scripts/ci/reborn-coverage-lane-run.sh
+++ b/scripts/ci/reborn-coverage-lane-run.sh
@@ -3,17 +3,18 @@
 # Run one instrumented Reborn integration-tier coverage lane and produce that
 # lane's lcov tracefile.
 #
-# The 34 tests/integration/ suites (see reborn-coverage-int-tier-tests.sh for
-# the canonical enumeration) are split across 5 lanes in
+# The tests/integration/ suites (see reborn-coverage-int-tier-tests.sh for
+# the canonical, registration-driven enumeration — flat, domain-folder, and
+# group bins alike) are split across 5 lanes in
 # .github/workflows/reborn-tests.yml's `reborn-integration-coverage` matrix
-# job: 4 modulo-partitions of the 27 flat `reborn_integration_*` suites, plus
-# one dedicated lane for all 7 `reborn_group_*` suites.
+# job: 4 modulo-partitions of the `reborn_integration_*` suites, plus one
+# dedicated lane for the `reborn_group_*` suites.
 #
-# This script is the SINGLE execution of the 34 int-tier suites for pass/fail
+# This script is the SINGLE execution of the int-tier suites for pass/fail
 # purposes too: `cargo llvm-cov ... test` has the same pass/fail semantics as
-# `cargo test`, so there is no separate uninstrumented run of the 27 flat
-# suites. (The 7 group suites also still have their own uninstrumented
-# `reborn-group-tests` job via run-reborn-group-tests.sh, which stays as the
+# `cargo test`, so there is no separate uninstrumented run of the
+# `reborn_integration_*` suites. (The group suites also still have their own
+# uninstrumented `reborn-group-tests` job via run-reborn-group-tests.sh, which stays as the
 # fast low-contention pass/fail signal for that suite; this lane additionally
 # runs them once more, instrumented, for coverage.)
 #
@@ -36,12 +37,12 @@
 # reborn_group_* rewrite rules), so this script never re-derives that mapping.
 #
 # Modes (REBORN_COV_LANE_MODE):
-#   flat-partition  Modulo-partitions the 27 reborn_integration_* suites
+#   flat-partition  Modulo-partitions the reborn_integration_* suites
 #                   across REBORN_COV_LANE_PARTITIONS lanes; REBORN_COV_LANE_INDEX
 #                   (0-based) selects this lane's slice — mirrors
 #                   scripts/ci/run-reborn-root-partition.sh's partitioning.
-#   group           Runs all reborn_group_* suites (7 total) — the one
-#                   dedicated group coverage lane.
+#   group           Runs all reborn_group_* suites — the one dedicated
+#                   group coverage lane.
 #
 # Usage: REBORN_COV_LANE_MODE=... [other env] reborn-coverage-lane-run.sh <output-lcov-path>
 

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -924,9 +924,11 @@ assert_eq "D5: support/ dir is not discovered as a suite" \
 # with no [[test]] entry (auth/common.rs) is not. Pins the #6520-audit blind
 # spot: the retired `find -maxdepth 1` walk could not see domain-folder bins,
 # so the six tests/integration/auth/ suites ran in no PR coverage lane.
-# The third stanza writes `path` BEFORE `name`: Cargo treats TOML key order
-# as irrelevant, so the selector must too — an order-dependent parser would
-# silently skip the stanza and recreate the blind spot this case pins.
+# The third stanza writes `path` BEFORE `name` and the fourth uses compact
+# `key="value"` spacing with a trailing comment: Cargo accepts all of these,
+# so the selector must too — a line-regex parser keyed to one formatting
+# style would silently skip such stanzas and recreate the blind spot this
+# case pins.
 d6="${tmp_root}/d6"
 setup_int_tier_case "${d6}" reborn_integration_flat
 : > "${d6}/tests/integration/flat.rs"
@@ -934,6 +936,7 @@ mkdir -p "${d6}/tests/integration/auth"
 : > "${d6}/tests/integration/auth/oauth_connect.rs"
 : > "${d6}/tests/integration/auth/common.rs"
 : > "${d6}/tests/integration/auth/pathfirst_probe.rs"
+: > "${d6}/tests/integration/auth/compact_probe.rs"
 cat >>"${d6}/Cargo.toml" <<'EOF'
 [[test]]
 name = "reborn_integration_oauth_connect"
@@ -942,11 +945,15 @@ path = "tests/integration/auth/oauth_connect.rs"
 [[test]]
 path = "tests/integration/auth/pathfirst_probe.rs"
 name = "reborn_integration_pathfirst_probe"
+
+[[test]]
+name="reborn_integration_compact_probe" # compact TOML: no spaces, trailing comment
+path="tests/integration/auth/compact_probe.rs"
 EOF
 capture "${d6}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D6: domain-folder bin exits 0" 0 "${CAP_RC}"
-assert_eq "D6: registered domain-folder bins (either key order) are selected; unregistered sibling is not" \
-  "$(printf -- '--test\nreborn_integration_flat\n--test\nreborn_integration_oauth_connect\n--test\nreborn_integration_pathfirst_probe')" \
+assert_eq "D6: registered domain-folder bins (any key order or spacing) are selected; unregistered sibling is not" \
+  "$(printf -- '--test\nreborn_integration_compact_probe\n--test\nreborn_integration_flat\n--test\nreborn_integration_oauth_connect\n--test\nreborn_integration_pathfirst_probe')" \
   "${CAP_OUT}"
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -828,11 +828,13 @@ fi
 #
 # The script derives its repo root from its own path and `cd`s there, so
 # each case copies it into a fresh temp tree's scripts/ci/ and builds a
-# tests/integration/ subtree alongside it, then invokes the copy. It also
-# filters candidates against a `[[test]] name = "..."` entry in Cargo.toml
-# (see that script's header comment), so every case seeds a fake Cargo.toml
-# with one `[[test]]` block per fixture suite the case constructs — mirrors
-# the real repo root always having a `[[test]]` entry per suite.
+# tests/integration/ subtree alongside it, then invokes the copy. Discovery
+# is registration-driven (see that script's header comment): every `[[test]]`
+# entry in Cargo.toml whose `path` sits under tests/integration/ is selected,
+# so each case seeds a fake Cargo.toml with one `[[test]]` block per fixture
+# suite it constructs — mirrors the real repo root always having a `[[test]]`
+# entry per suite. The on-disk fixture files are kept for tree realism; an
+# unregistered file must never be selected (D6).
 
 setup_int_tier_case() {
   local case_dir="$1"
@@ -916,6 +918,28 @@ capture "${d5}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D5: support/ dir alongside flat suites exits 0" 0 "${CAP_RC}"
 assert_eq "D5: support/ dir is not discovered as a suite" \
   "$(printf -- '--test\nreborn_integration_only')" "${CAP_OUT}"
+
+# D6: domain-folder bins (tests/integration/auth/oauth_connect.rs) are
+# selected via their [[test]] registration, while a #[path]-mounted sibling
+# with no [[test]] entry (auth/common.rs) is not. Pins the #6520-audit blind
+# spot: the retired `find -maxdepth 1` walk could not see domain-folder bins,
+# so the six tests/integration/auth/ suites ran in no PR coverage lane.
+d6="${tmp_root}/d6"
+setup_int_tier_case "${d6}" reborn_integration_flat
+: > "${d6}/tests/integration/flat.rs"
+mkdir -p "${d6}/tests/integration/auth"
+: > "${d6}/tests/integration/auth/oauth_connect.rs"
+: > "${d6}/tests/integration/auth/common.rs"
+cat >>"${d6}/Cargo.toml" <<'EOF'
+[[test]]
+name = "reborn_integration_oauth_connect"
+path = "tests/integration/auth/oauth_connect.rs"
+EOF
+capture "${d6}/scripts/ci/reborn-coverage-int-tier-tests.sh"
+assert_exit_code "D6: domain-folder bin exits 0" 0 "${CAP_RC}"
+assert_eq "D6: registered domain-folder bin is selected; unregistered sibling is not" \
+  "$(printf -- '--test\nreborn_integration_flat\n--test\nreborn_integration_oauth_connect')" \
+  "${CAP_OUT}"
 
 # ---------------------------------------------------------------------------
 # R. reborn-coverage-ratchet.sh (coverage-floor ratchet gate)

--- a/scripts/ci/test-reborn-coverage.sh
+++ b/scripts/ci/test-reborn-coverage.sh
@@ -924,21 +924,29 @@ assert_eq "D5: support/ dir is not discovered as a suite" \
 # with no [[test]] entry (auth/common.rs) is not. Pins the #6520-audit blind
 # spot: the retired `find -maxdepth 1` walk could not see domain-folder bins,
 # so the six tests/integration/auth/ suites ran in no PR coverage lane.
+# The third stanza writes `path` BEFORE `name`: Cargo treats TOML key order
+# as irrelevant, so the selector must too — an order-dependent parser would
+# silently skip the stanza and recreate the blind spot this case pins.
 d6="${tmp_root}/d6"
 setup_int_tier_case "${d6}" reborn_integration_flat
 : > "${d6}/tests/integration/flat.rs"
 mkdir -p "${d6}/tests/integration/auth"
 : > "${d6}/tests/integration/auth/oauth_connect.rs"
 : > "${d6}/tests/integration/auth/common.rs"
+: > "${d6}/tests/integration/auth/pathfirst_probe.rs"
 cat >>"${d6}/Cargo.toml" <<'EOF'
 [[test]]
 name = "reborn_integration_oauth_connect"
 path = "tests/integration/auth/oauth_connect.rs"
+
+[[test]]
+path = "tests/integration/auth/pathfirst_probe.rs"
+name = "reborn_integration_pathfirst_probe"
 EOF
 capture "${d6}/scripts/ci/reborn-coverage-int-tier-tests.sh"
 assert_exit_code "D6: domain-folder bin exits 0" 0 "${CAP_RC}"
-assert_eq "D6: registered domain-folder bin is selected; unregistered sibling is not" \
-  "$(printf -- '--test\nreborn_integration_flat\n--test\nreborn_integration_oauth_connect')" \
+assert_eq "D6: registered domain-folder bins (either key order) are selected; unregistered sibling is not" \
+  "$(printf -- '--test\nreborn_integration_flat\n--test\nreborn_integration_oauth_connect\n--test\nreborn_integration_pathfirst_probe')" \
   "${CAP_OUT}"
 
 # ---------------------------------------------------------------------------

--- a/scripts/live-canary/ACCOUNTS.md
+++ b/scripts/live-canary/ACCOUNTS.md
@@ -197,13 +197,16 @@ Required when enabling Gmail or Calendar probes:
 - `AUTH_LIVE_GOOGLE_ACCESS_TOKEN`
 - `AUTH_LIVE_GOOGLE_REFRESH_TOKEN`
 - `AUTH_LIVE_GOOGLE_SCOPES`
-- `AUTH_LIVE_FORCE_GOOGLE_REFRESH`
 
 Notes:
 
 - `AUTH_LIVE_GOOGLE_ACCESS_TOKEN` is required if a refresh token is provided.
-- The runner seeds the token, then can deliberately expire the access token so
-  refresh is exercised on first use.
+- The runner refreshes the access token harness-side before the gateway
+  starts (`_preflight_refresh_google_token`) so a stale CI-stored token is
+  fresh when seeded; the canary never reaches into persistence to expire
+  tokens. (The former `AUTH_LIVE_FORCE_GOOGLE_REFRESH` deliberate-expiry
+  flow was removed with `expire_secret_in_db`; a product-side
+  refresh-under-expiry proof is a tracked follow-up.)
 - Gmail and Calendar share `google_oauth_token`.
 
 Recommended scopes:

--- a/tests/e2e/scenarios/test_reborn_private_tool_installs.py
+++ b/tests/e2e/scenarios/test_reborn_private_tool_installs.py
@@ -25,6 +25,7 @@ import uuid
 import httpx
 
 from reborn_webui_harness import (
+    client_action_id,
     create_thread,
     enable_reborn_global_auto_approve,
     reborn_bearer_headers,
@@ -62,7 +63,12 @@ async def _import_tool(client: httpx.AsyncClient, base_url: str, zip_path) -> No
 async def _install(client: httpx.AsyncClient, base_url: str, tool_id: str) -> None:
     install = await client.post(
         f"{base_url}{EXTENSIONS_BASE}/install",
-        json={"package_ref": _package_ref(tool_id)},
+        json={
+            "package_ref": _package_ref(tool_id),
+            # #6520 install contract: one distinct install gesture = one
+            # stable client action id (reborn_webui_harness.client_action_id).
+            "client_action_id": client_action_id(),
+        },
         timeout=15,
     )
     assert install.status_code == 200, install.text

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -1669,6 +1669,18 @@ async fn telegram_update_becomes_a_turn_and_a_coordinated_reply_impl(storage: St
 async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_to_the_paired_user(
     #[case] storage: StorageMode,
 ) {
+    // Boxed like `telegram_update_becomes_a_turn_and_a_coordinated_reply`
+    // above: inline, this journey's future overflows the 2 MiB test-thread
+    // stack under llvm-cov instrumentation (main's Coverage lanes).
+    Box::pin(
+        unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_to_the_paired_user_impl(storage),
+    )
+    .await;
+}
+
+async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_to_the_paired_user_impl(
+    storage: StorageMode,
+) {
     let group = RebornIntegrationGroup::builder()
         .storage(storage)
         .extension_delivery()

--- a/tests/integration/group_extensions/main.rs
+++ b/tests/integration/group_extensions/main.rs
@@ -20,6 +20,7 @@ mod support;
 // Modules are alphabetical (rustfmt reorders `mod` decls); execution order is
 // set by the `report.record(...)` sequence below, not declaration order.
 mod scenario_credential_extension_lifecycle_state_machine;
+mod scenario_existing_member_reinstall_reconciles_to_active;
 mod scenario_extension_install_github_normal_gate;
 mod scenario_extension_install_instance_not_configured;
 mod scenario_extension_install_reauth_gate;
@@ -193,6 +194,16 @@ async fn extensions_group_e2e_inner() {
     report.record(
         "google_family_install_gate_and_shared_account",
         scenario_google_family_install_gate_and_shared_account::run(&g).await,
+    );
+
+    // Scenario 11: the retired Activate action's structural successor — an
+    // EXISTING member's idempotent install retry reconciles setup_needed →
+    // active on the shared store (distinct actor via `with_actor_id`, so no
+    // scenario-order coupling; no remove in between; positively pins the
+    // intermediate setup_needed phase cross-thread).
+    report.record(
+        "existing_member_reinstall_reconciles_to_active",
+        scenario_existing_member_reinstall_reconciles_to_active::run(&g).await,
     );
 
     report.assert_all_passed();

--- a/tests/integration/group_extensions/scenario_existing_member_reinstall_reconciles_to_active.rs
+++ b/tests/integration/group_extensions/scenario_existing_member_reinstall_reconciles_to_active.rs
@@ -1,0 +1,121 @@
+//! The public Activate action is gone (#6520): `setup_needed -> active` is
+//! reconciled by an EXISTING member re-entering the idempotent install action
+//! after their personal setup completes (`extension_lifecycle.rs`'s
+//! `Some(existing)` same-caller arm). This scenario drives that successor
+//! path on the shared store — install, observe `setup_needed` cross-thread,
+//! complete setup, re-install the SAME membership with no remove in between,
+//! observe `active` cross-thread. It is also the only scenario that
+//! positively observes the intermediate `setup_needed` phase at this tier;
+//! both arms were retired alongside the Activate vocabulary.
+//!
+//! Runs as a DISTINCT actor (`with_actor_id`, E-MULTIUSER seam) so github is
+//! uninstalled and un-credentialed for THIS caller regardless of Scenario 1's
+//! default-actor github install on the same shared store — membership and
+//! credentials are per-user (#5459 P1). That kills scenario-order coupling
+//! both ways: earlier scenarios cannot pre-credential this caller, and this
+//! caller's private membership stays invisible to the default actor.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+const ACTOR: &str = "reconcile-member-actor";
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    // ── Phase 1: first install for THIS caller — parks the normal
+    // per-account credential gate; denial leaves the joined membership
+    // resting at setup_needed (removal is the sole reset action). ───────────
+    let installer = g
+        .thread("ext-reconcile-phase-install")
+        .with_actor_id(ACTOR)
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                json!({"extension_id": "github"}),
+            ),
+            RebornScriptedReply::text("github needs a credential"),
+        ])
+        .build()
+        .await?;
+    let (run_id, gate_ref) = installer
+        .submit_turn_until_auth_blocked("install github")
+        .await?;
+    installer.deny_auth_gate(run_id, &gate_ref).await?;
+    installer
+        .wait_for_status(run_id, ironclaw_turns::TurnStatus::Completed)
+        .await?;
+
+    // ── Phase 2: cross-thread view — the membership positively reads
+    // setup_needed. Only this caller's github entry can carry a phase (their
+    // sole installation), so the value assert is entry-precise. ─────────────
+    let pending_viewer = g
+        .thread("ext-reconcile-phase-pending-viewer")
+        .with_actor_id(ACTOR)
+        .script([
+            RebornScriptedReply::tool_call("builtin.extension_search", json!({"query": "github"})),
+            RebornScriptedReply::text("searched"),
+        ])
+        .build()
+        .await?;
+    pending_viewer
+        .submit_turn("search github before setup")
+        .await?;
+    pending_viewer
+        .assert_tool_invoked("builtin.extension_search")
+        .await?;
+    pending_viewer
+        .assert_tool_result_contains(r#""installation_phase":"setup_needed""#)
+        .await?;
+
+    // ── Phase 3: personal setup completes out-of-band for this caller. ─────
+    installer
+        .seed_capability_credential_account("github", "itest github reconcile", &[])
+        .await?;
+
+    // ── Phase 4: the SAME member re-enters the idempotent install — the
+    // existing-caller retry arm reconciles the completed setup to active
+    // without any remove. ───────────────────────────────────────────────────
+    let retrier = g
+        .thread("ext-reconcile-phase-retry")
+        .with_actor_id(ACTOR)
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                json!({"extension_id": "github"}),
+            ),
+            RebornScriptedReply::text("github reconciled"),
+        ])
+        .build()
+        .await?;
+    retrier.submit_turn("install github again").await?;
+    retrier
+        .assert_tool_invoked("builtin.extension_install")
+        .await?;
+    retrier
+        .assert_tool_result_contains("\"installed\":true")
+        .await?;
+    retrier
+        .assert_tool_result_contains("\"phase\":\"active\"")
+        .await?;
+
+    // ── Phase 5: cross-thread view — the reconciliation propagated. ────────
+    let active_viewer = g
+        .thread("ext-reconcile-phase-active-viewer")
+        .with_actor_id(ACTOR)
+        .script([
+            RebornScriptedReply::tool_call("builtin.extension_search", json!({"query": "github"})),
+            RebornScriptedReply::text("searched"),
+        ])
+        .build()
+        .await?;
+    active_viewer
+        .submit_turn("search github after setup")
+        .await?;
+    active_viewer
+        .assert_tool_invoked("builtin.extension_search")
+        .await?;
+    active_viewer
+        .assert_tool_result_contains(r#""installation_phase":"active""#)
+        .await?;
+    Ok(())
+}

--- a/tests/integration/group_extensions/scenario_remove_then_absent_cross_thread.rs
+++ b/tests/integration/group_extensions/scenario_remove_then_absent_cross_thread.rs
@@ -102,13 +102,22 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
 
     // `assert_tool_result_contains` returns `Ok` when present, `Err` when
     // absent — invert to assert absence.
+    //
+    // The wire contract omits the `installation_phase` key entirely for a
+    // catalog entry the caller has no visible installation of
+    // (`LifecycleSearchExtensionSummary.installation_phase` is
+    // `skip_serializing_if = "Option::is_none"`), so after a propagated
+    // remove the key must not appear in this query's result at all. Guarding
+    // one stale value is not discriminating: phase 1 installs WITH a seeded
+    // credential, so a stale projection would read `active` (not
+    // `setup_needed`) and slip past a single-value probe.
     if viewer
-        .assert_tool_result_contains(r#""installation_phase":"setup_needed""#)
+        .assert_tool_result_contains(r#""installation_phase""#)
         .await
         .is_ok()
     {
         return Err(
-            "removed extension still shows installation_phase:setup_needed in cross-thread search; \
+            "removed extension still carries an installation_phase in cross-thread search; \
              builtin.extension_remove did not propagate through the shared store"
                 .into(),
         );


### PR DESCRIPTION
## Summary

- Repairs the testing-infrastructure fallout identified by the deep post-merge audit of #6520 (the parts not already fixed by #6602/#6603):
- **Coverage-lane crash (live on main):** `reborn_integration_extension_delivery` SIGABRTs with a stack overflow under llvm-cov instrumentation since the #6520 merge commit, killing `Coverage (default)` and `Coverage (all-features)` on every main push. The 400-line pairing-attribution journey's future overflows the 2 MiB test-thread stack when instrumentation inflates its frames — boxed via the same `Box::pin` + `_impl` pattern its sibling `telegram_update_becomes_a_turn_and_a_coordinated_reply` already uses.
- **E2E Coverage red (live on main):** `test_private_tool_installs_full_path` fails with `{"field":"client_action_id","validation_code":"missing_field"}` — the #6520 install contract requires the client gesture id and this scenario was never reconciled. Now sends `client_action_id` per the SPA contract (`extensions-api.ts`), same as the #6603-reconciled specs.
- **Six integration suites ran in no PR lane:** `scripts/ci/reborn-coverage-int-tier-tests.sh` discovered suites with `find -maxdepth 1`, which cannot see domain-folder bins — so all six `tests/integration/auth/` suites (`oauth_connect`, `oauth_popup_journeys`, `oauth_refresh`, `auth_gate`, `auth_failure`, `reopen_resume_through_gate`) ran only in the push-to-main coverage workflow (itself crashed by the bug above; four of the six ran nowhere at all post-merge). Discovery is now registration-driven — every workspace `[[test]]` whose `path` sits under `tests/integration/` is selected — so a suite cannot be registered without also being selected, in any directory shape. Also made the selector bash-3.2-portable (`mapfile` → plain string), so the guardrail runs on macOS dev machines; that fixes 12 previously-failing section-D harness assertions locally.
- **Weakened lifecycle guards re-armed:** `scenario_remove_then_absent_cross_thread`'s phase-4 guard checked absence of `"installation_phase":"setup_needed"` while #6520's edit made the pre-remove state `active` — a stale search projection would read `active` and pass. The guard now asserts the wire contract directly: the `installation_phase` key is omitted entirely for a caller with no visible installation. And the retired Activate action's structural successor — an existing member's idempotent install retry reconciling `setup_needed → active` — had zero integration-tier coverage (`setup_needed` was never positively observed at that tier); a new scenario drives it on the shared store as a distinct actor.
- Dead auth-canary config cleanup: `AUTH_LIVE_FORCE_GOOGLE_REFRESH` and the deliberate-expiry note documented a flow #6520 deleted (`expire_secret_in_db`); the scopes example drifted from `GOOGLE_SCOPE_DEFAULT`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related: post-merge audit of #6520; follow-ups #6602/#6603 fixed the canary wire shape and the Playwright shards, this PR covers the remaining regressions. No pre-existing issue tracks them.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_reborn_integration_tests --tests -- -D warnings` (default) and `--all-features` — the only crate with Rust changes; both lanes clean
- [x] `cargo build -p ironclaw`
- [x] Relevant tests pass: see per-fix evidence below
- [ ] `cargo test --features integration` — not applicable: no database-backed behavior changed (test/CI/docs-only diff)
- [x] Manual testing: local red→green reproductions for both live main breakages (below)
- [ ] `review-pr` / `pr-shepherd --fix` — not run (agent session; full command evidence inline)

## Test Strategy

User behavior: none changed — this PR touches tests, CI selection, and docs only. The production crates are untouched.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior (CI lane selection; integration-suite coverage)

Tests added or updated:
- Unit or contract: `test-reborn-coverage.sh` section D — new case D6 pins domain-folder-bin selection and unregistered-sibling exclusion; D1–D5 pass unchanged against the rewritten selector.
- Reborn integration: `scenario_existing_member_reinstall_reconciles_to_active` (new, group_extensions, distinct actor via `with_actor_id`; positively pins cross-thread `setup_needed`, then the same-member idempotent-install reconciliation to `active` with no remove); `scenario_remove_then_absent_cross_thread` guard re-armed to the key-absence wire contract; `extension_delivery.rs` overflowing journey boxed (`_impl` extraction, in-file precedent).
- Recorded fixture: none.
- Browser E2E: `test_reborn_private_tool_installs.py` reconciled to the #6520 install gesture contract.
- Backend or runtime: none (no production code changed).
- Live canary: none (docs-only canary changes; the product-side refresh-under-expiry proof remains a tracked follow-up, noted in ACCOUNTS.md).

What the tests prove:

- The coverage lanes can run `reborn_integration_extension_delivery` under llvm-cov again (the exact previously-crashing invocation passes locally).
- The private-tool-installs journey passes against the merged install contract through the real serve binary.
- Any registered integration suite is selected by the coverage lanes regardless of directory shape, and the six auth suites are green before being wired in.
- A remove that fails to propagate to the search projection can no longer pass the cross-thread guard (any surviving `installation_phase` fails it).
- The Activate-successor reconciliation path (existing member, credential completed out-of-band, idempotent re-install → `active`) is pinned at the integration tier, cross-thread, on the shared store.

Commands run (local, all exit 0 unless noted):

- `cargo llvm-cov --no-report -p ironclaw_reborn_integration_tests --test reborn_integration_extension_delivery` — **red first** (reproduced main's crash: `thread 'unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_to_the_paired_user::case_1_libsql' has overflowed its stack`, SIGABRT), then green after the fix (`-- --skip case_2_postgres` locally: no Postgres service; CI provides one — 18 passed / 0 failed).
- `cargo test --test reborn_integration_extension_delivery -- --skip case_2_postgres` — green uninstrumented.
- `cargo test --test reborn_group_extensions` — 15 passed / 0 failed, including the new scenario and the re-armed guard.
- `cargo test --test reborn_integration_oauth_connect --test reborn_integration_oauth_popup_journeys --test reborn_integration_oauth_refresh --test reborn_integration_auth_gate --test reborn_integration_auth_failure --test reborn_integration_reopen_resume_through_gate` — 71 passed / 0 failed (proven green before wiring into CI lanes).
- `tests/e2e: pytest scenarios/test_reborn_private_tool_installs.py` — red on main (the standing E2E Coverage failure), green with the fix through the real `ironclaw serve` binary.
- `bash scripts/ci/test-reborn-coverage.sh` — all 14 section-D assertions pass (D1–D6); the 12 remaining failures are the pre-existing section-C fake-`gh` cases, identical on the pristine tree (which additionally fails all 12 D assertions there, because the old `mapfile` selector cannot run under macOS bash 3.2 at all).
- `bash scripts/ci/reborn-coverage-int-tier-tests.sh` — emits 56 suites (was 50), including the six auth suites; every emitted name cross-checked against `Cargo.toml`.
- `shellcheck` on both edited scripts — clean (the two remaining findings in the harness are pre-existing and identical at base).
- `bash scripts/pre-commit-safety.sh` — pass.

## Security Impact

None. No production code changed. The auth suites newly running in PR CI only *increase* enforcement of existing OAuth/gate behavior.

## Reborn Trust-Boundary Checklist

N/A — no Reborn production/runtime/DB code changed (tests, CI scripts, and docs only).

## Database Impact

None.

## Blast Radius

CI coverage-lane selection (`reborn-coverage-int-tier-tests.sh` consumers: `reborn-coverage-lane-run.sh`, its 5-lane matrix in `reborn-tests.yml`), the `Coverage (default)`/`Coverage (all-features)`/`E2E Coverage` jobs on main, the `reborn_group_extensions` and `reborn_integration_extension_delivery` suites, and the auth-canary docs. Lane-shape note: the six auth suites join the four flat modulo-partitions (~1.5 suites/lane more); they run 0.01–4.2 s each uninstrumented locally, so lane duration impact is small.

## Rollback Plan

Revert the PR; every change is test/CI/docs-scoped and independently revertible per commit. Reverting the selector commit alone returns the auth suites to their pre-PR blind spot (and re-breaks local D-section harness runs on macOS); reverting the extension_delivery commit re-crashes the main coverage lanes.

## Review Follow-Through

Known follow-ups deliberately NOT in this PR (from the same audit): a restoration-tracking issue for the 15 quarantined live-canary replay fixtures; a product-side Google refresh-under-expiry canary proof (the harness-side deletion is now documented in ACCOUNTS.md); the `ironclaw_product` readiness-derivation duplication cluster; a PR/merge-queue trigger for the nightly-only Playwright suite; and a CI lane for the live-QA/canary Python unit suites plus a Python lint pass (`ruff` F811 would have caught #6520's duplicate Playwright helper). The live-QA harness unit-suite repair (`test_run_live_qa.py`, red on main) is in flight separately with the operator's local changes and is intentionally untouched here.

---

**Review track**: C (CI/Infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGtnyQSPh8ouwypXioXWTc
