### PR TITLE
fix(auth): trust token response scopes over OAuth redirect echo

### DIFF
--- a/crates/ironclaw_reborn_composition/src/product_auth/serve/oauth.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth/serve/oauth.rs
@@ -464,33 +464,11 @@ async fn vendor_oauth_callback_attempt(
                 return Err(error);
             }
         };
-    // Vendor-echoed granted scopes: when the redirect carries a scope list it
-    // must include everything requested (else the user narrowed the consent —
-    // denied); when absent the requested scopes ride to the exchange, where
-    // the token-response scope extraction applies the recipe's rule.
-    let callback_scopes =
-        match resolve_callback_scopes(callback_state.requested_scopes(), query.scopes.as_deref()) {
-            Ok(CallbackScopeOutcome::Scopes(scopes)) => scopes,
-            Ok(CallbackScopeOutcome::ProviderDenied) => {
-                state
-                    .forget_pkce_verifier_everywhere(callback_scope, flow_id)
-                    .await;
-                let response = run_with_backend_timeout(state.product_auth.handle_oauth_callback(
-                    RebornOAuthCallbackRequest {
-                        scope: callback_scope.clone(),
-                        flow_id,
-                        opaque_state_hash: state_hash.clone(),
-                        outcome: RebornOAuthCallbackOutcome::ProviderDenied,
-                    },
-                ))
-                .await;
-                return oauth_callback_route_result_response(headers, response);
-            }
-            Err(error) => {
-                state.remove_pkce_verifier(flow_id);
-                return Err(error);
-            }
-        };
+    // The redirect's optional `scope` echo is non-authoritative: providers may
+    // omit, normalize, or return a cumulative grant there. The token response
+    // is the authoritative granted-scope source; the auth engine clamps it to
+    // the unified recipe ceiling before storing it.
+    let requested_scopes = callback_state.requested_scopes().to_vec();
     let authorization_code_hash = authorization_code_hash(code.expose_secret())?;
     let pkce_verifier_hash = pkce_verifier_hash(pkce_verifier.expose_secret())?;
 
@@ -508,7 +486,7 @@ async fn vendor_oauth_callback_attempt(
                 pkce_verifier: PkceVerifierSecret::new(pkce_verifier)
                     .map_err(ProductAuthRouteFailure::from)?,
                 pkce_verifier_hash,
-                scopes: callback_scopes,
+                scopes: requested_scopes,
             },
         },
     };
@@ -542,45 +520,6 @@ async fn vendor_oauth_callback_attempt(
     };
 
     Ok(oauth_callback_response(headers, response))
-}
-
-enum CallbackScopeOutcome {
-    Scopes(Vec<ProviderScope>),
-    ProviderDenied,
-}
-
-/// Generic scope-echo rule: a vendor that echoes granted scopes on the
-/// redirect must have granted everything requested; a vendor that echoes
-/// nothing leaves scope resolution to the token response (recipe-driven).
-fn resolve_callback_scopes(
-    requested_scopes: &[ProviderScope],
-    query_scopes: Option<&str>,
-) -> Result<CallbackScopeOutcome, ProductAuthRouteFailure> {
-    let Some(raw) = query_scopes else {
-        return Ok(CallbackScopeOutcome::Scopes(requested_scopes.to_vec()));
-    };
-    if raw.trim() != raw {
-        return Err(ProductAuthRouteFailure::malformed_callback());
-    }
-    if raw.is_empty() {
-        return Ok(CallbackScopeOutcome::ProviderDenied);
-    }
-    let echoed = raw
-        .split([' ', ','])
-        .filter(|scope| !scope.is_empty())
-        .map(|scope| {
-            ProviderScope::new(scope.to_string())
-                .map_err(|_| ProductAuthRouteFailure::malformed_callback())
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    if requested_scopes
-        .iter()
-        .all(|requested| echoed.iter().any(|scope| scope == requested))
-    {
-        Ok(CallbackScopeOutcome::Scopes(requested_scopes.to_vec()))
-    } else {
-        Ok(CallbackScopeOutcome::ProviderDenied)
-    }
 }
 
 // Formats the success shape only; `Err` propagates so the handler wrapper

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
@@ -2023,6 +2023,37 @@ async fn product_auth_google_oauth_callback_accepts_provider_extra_scopes_withou
 }
 
 #[tokio::test]
+async fn product_auth_google_oauth_callback_ignores_incomplete_redirect_scope() {
+    let provider_client = Arc::new(RecordingProviderClient::default());
+    let (app, dispatcher) = build_app_with_google_oauth_provider(provider_client.clone());
+    let (start_json, state) = start_google_oauth_flow(&app).await;
+
+    let callback_response = app
+        .oneshot(callback_request(format!(
+            "/api/reborn/product-auth/oauth/google/callback?state={state}&code=google-auth-code&scope={GOOGLE_GMAIL_READONLY_SCOPE}"
+        )))
+        .await
+        .expect("oneshot");
+
+    assert_eq!(callback_response.status(), StatusCode::OK);
+    let callback_body = read_body_string(callback_response).await;
+    let callback_json: serde_json::Value =
+        serde_json::from_str(&callback_body).expect("callback json");
+    assert_eq!(callback_json["flow_id"], start_json["flow_id"]);
+    assert_eq!(callback_json["status"], "completed");
+    assert_eq!(dispatcher.events().len(), 1);
+    assert_eq!(
+        provider_client.exchanged_scopes(),
+        vec![vec![
+            GOOGLE_GMAIL_READONLY_SCOPE.to_string(),
+            GOOGLE_CALENDAR_READONLY_SCOPE.to_string()
+        ]],
+        "the provider exchange must receive the server-owned request scopes, \
+         not the redirect's non-authoritative scope echo"
+    );
+}
+
+#[tokio::test]
 async fn product_auth_google_oauth_browser_callback_notifies_chat_without_secrets() {
     let (app, dispatcher) = build_app_with_google_oauth();
     let (start_json, state) = start_google_oauth_flow(&app).await;
@@ -2058,9 +2089,10 @@ async fn product_auth_google_oauth_browser_callback_notifies_chat_without_secret
 }
 
 #[tokio::test]
-async fn product_auth_google_oauth_callback_rejects_disallowed_scopes() {
-    let (app, dispatcher) = build_app_with_google_oauth();
-    let (_, state) = start_google_oauth_flow(&app).await;
+async fn product_auth_google_oauth_callback_does_not_trust_redirect_scopes_outside_recipe() {
+    let provider_client = Arc::new(RecordingProviderClient::default());
+    let (app, dispatcher) = build_app_with_google_oauth_provider(provider_client.clone());
+    let (start_json, state) = start_google_oauth_flow(&app).await;
 
     let response = app
         .clone()
@@ -2070,13 +2102,23 @@ async fn product_auth_google_oauth_callback_rejects_disallowed_scopes() {
         .await
         .expect("oneshot");
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
     let body = read_body_string(response).await;
-    assert!(body.contains("\"code\":\"provider_denied\""));
+    let callback_json: serde_json::Value = serde_json::from_str(&body).expect("callback json");
+    assert_eq!(callback_json["flow_id"], start_json["flow_id"]);
+    assert_eq!(callback_json["status"], "completed");
     assert!(!body.contains(&state));
     assert!(!body.contains("google-auth-code"));
     assert!(!body.contains(DISALLOWED_GOOGLE_SCOPE));
-    assert!(dispatcher.events().is_empty());
+    assert_eq!(dispatcher.events().len(), 1);
+    assert_eq!(
+        provider_client.exchanged_scopes(),
+        vec![vec![
+            GOOGLE_GMAIL_READONLY_SCOPE.to_string(),
+            GOOGLE_CALENDAR_READONLY_SCOPE.to_string()
+        ]],
+        "a redirect scope outside the recipe must not become exchange authority"
+    );
 
     let replay_response = app
         .oneshot(callback_request(format!(
@@ -2094,7 +2136,8 @@ async fn product_auth_google_oauth_callback_rejects_disallowed_scopes() {
 
 #[tokio::test]
 async fn product_auth_google_oauth_callback_provider_denial_is_sanitized() {
-    let (app, dispatcher) = build_app_with_google_oauth();
+    let provider_client = Arc::new(RecordingProviderClient::default());
+    let (app, dispatcher) = build_app_with_google_oauth_provider(provider_client.clone());
     let (_, state) = start_google_oauth_flow(&app).await;
 
     let response = app
@@ -2110,6 +2153,10 @@ async fn product_auth_google_oauth_callback_provider_denial_is_sanitized() {
     assert!(!body.contains(&state));
     assert!(!body.contains("access_denied"));
     assert!(dispatcher.events().is_empty());
+    assert!(
+        provider_client.exchanged_scopes().is_empty(),
+        "an explicit provider denial must not reach token exchange"
+    );
 }
 
 #[tokio::test]
@@ -2133,9 +2180,9 @@ async fn product_auth_google_oauth_callback_unknown_state_is_sanitized() {
 }
 
 #[tokio::test]
-async fn product_auth_google_oauth_callback_rejects_empty_parsed_scopes() {
+async fn product_auth_google_oauth_callback_accepts_empty_redirect_scope() {
     let (app, dispatcher) = build_app_with_google_oauth();
-    let (_, state) = start_google_oauth_flow(&app).await;
+    let (start_json, state) = start_google_oauth_flow(&app).await;
 
     let response = app
         .clone()
@@ -2145,12 +2192,14 @@ async fn product_auth_google_oauth_callback_rejects_empty_parsed_scopes() {
         .await
         .expect("oneshot");
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
     let body = read_body_string(response).await;
-    assert!(body.contains("\"code\":\"provider_denied\""));
+    let callback_json: serde_json::Value = serde_json::from_str(&body).expect("callback json");
+    assert_eq!(callback_json["flow_id"], start_json["flow_id"]);
+    assert_eq!(callback_json["status"], "completed");
     assert!(!body.contains(&state));
     assert!(!body.contains("google-auth-code"));
-    assert!(dispatcher.events().is_empty());
+    assert_eq!(dispatcher.events().len(), 1);
 
     let replay_response = app
         .oneshot(callback_request(format!(

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
@@ -2054,6 +2054,43 @@ async fn product_auth_google_oauth_callback_ignores_incomplete_redirect_scope() 
 }
 
 #[tokio::test]
+async fn product_auth_google_oauth_callback_missing_code_is_rejected_without_exchange() {
+    let provider_client = Arc::new(RecordingProviderClient::default());
+    let (app, dispatcher) = build_app_with_google_oauth_provider(provider_client.clone());
+    let (start_json, state) = start_google_oauth_flow(&app).await;
+
+    let response = app
+        .clone()
+        .oneshot(callback_request(format!(
+            "/api/reborn/product-auth/oauth/google/callback?state={state}"
+        )))
+        .await
+        .expect("oneshot");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"malformed_callback\""));
+    assert!(!body.contains(&state));
+    assert!(dispatcher.events().is_empty());
+    assert!(
+        provider_client.exchanged_scopes().is_empty(),
+        "a callback without an authorization code must not reach token exchange"
+    );
+
+    let flow_id = start_json["flow_id"].as_str().expect("flow id");
+    let invocation_id = start_json["callback_scope"]["invocation_id"]
+        .as_str()
+        .expect("invocation id");
+    let status_response =
+        get_oauth_flow_status(&app, flow_id, &format!("?invocation_id={invocation_id}")).await;
+    assert_eq!(status_response.status(), StatusCode::OK);
+    let status_body = read_body_string(status_response).await;
+    let status_json: serde_json::Value = serde_json::from_str(&status_body).expect("status json");
+    assert_eq!(status_json["status"], "pending");
+    assert!(!status_body.contains(&state));
+}
+
+#[tokio::test]
 async fn product_auth_google_oauth_browser_callback_notifies_chat_without_secrets() {
     let (app, dispatcher) = build_app_with_google_oauth();
     let (start_json, state) = start_google_oauth_flow(&app).await;

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -273,10 +273,11 @@ Rules:
   scopes there. The token response is the authoritative granted-scope source;
   the auth engine applies the recipe's missing-scope policy and clamps an
   echoed grant to the unified recipe ceiling before storing it.
-- Once a callback is tied to a known scoped flow, missing authorization code,
-  missing one-shot PKCE material, or malformed/oversized callback input must
-  durably mark that flow `failed` before discarding callback material. Provider
-  denial is terminal through the same scoped flow boundary.
+- Once a callback is tied to a known scoped flow, missing authorization code or
+  malformed/oversized callback input must be rejected before token exchange or
+  product effects. A missing authorization code leaves the flow pending for a
+  valid retry. Missing one-shot PKCE material and provider denial are terminal
+  and durably mark the flow `failed` before discarding callback material.
 - Callback completion emits typed continuations; callback routes must not
   directly activate extensions, resume turns, replay messages, or dispatch work.
 - Terminal flows cannot be completed or canceled again.
@@ -519,7 +520,7 @@ tenant/user fields.
 | --- | --- | --- |
 | `POST` | `/api/reborn/product-auth/oauth/start` | Open an OAuth setup flow; returns redacted authorization URL + invocation scope. |
 | `POST` | `/api/webchat/v2/extensions/{package_id}/setup/oauth/start` | Open an installed extension's manifest-declared OAuth requirement by opaque requirement name; provider, label, scopes, and lifecycle continuation are server-owned. |
-| `GET`  | `/api/reborn/product-auth/oauth/callback/{flow_id}` | Public OAuth callback; validates the scoped flow and state hash before any product effect. |
+| `GET`  | `/api/reborn/product-auth/oauth/callback/{provider}` | Public OAuth callback; validates the scoped flow and state hash before any product effect. |
 | `GET` | `/api/reborn/product-auth/oauth/flow/{flow_id}/status` | Observational caller-scoped durable status read. It performs no continuation dispatch, activation, compensation, provider cleanup, or other writes. |
 | `POST` | `/api/reborn/product-auth/oauth/flow/{flow_id}/reconcile` | Explicit bounded recovery command that retries only a completed flow's unfenced internal continuation. It never repeats provider exchange, revokes a valid credential, or performs uninstall cleanup. |
 | `POST` | `/api/reborn/product-auth/oauth/google/start` | Open a Google product-auth setup flow from configured Reborn Google OAuth client metadata; returns a Google authorization URL with PKCE/offline consent and invocation scope. |
@@ -604,9 +605,6 @@ Rules:
 
 - OAuth start, provider exchange, callback success, callback replay, stale,
   canceled, malformed, denied, and cross-scope callback behavior;
-- caller-level callback coverage pins that an incomplete provider redirect
-  `scope` echo still reaches exchange with the server-owned requested scopes
-  (`webui_v2_product_auth::product_auth_google_oauth_callback_ignores_incomplete_redirect_scope`);
 - secure manual-token submit, bound account update, cross-scope denial, empty
   input, expiry, and debug redaction;
 - composition-facade manual-token request/submit, stale/duplicate/malformed
@@ -624,6 +622,15 @@ Rules:
   cleanup quarantine reporting;
 - serde validation for newtypes and snake_case wire enums;
 - serialization checks proving raw code/verifier/token material is absent.
+
+`ironclaw_reborn_composition` caller-level tests additionally cover:
+
+- an incomplete provider redirect `scope` echo still reaching exchange with the
+  server-owned requested scopes
+  (`webui_v2_product_auth::product_auth_google_oauth_callback_ignores_incomplete_redirect_scope`);
+- a callback without an authorization code being rejected before exchange while
+  the valid flow remains pending for retry
+  (`webui_v2_product_auth::product_auth_google_oauth_callback_missing_code_is_rejected_without_exchange`).
 
 ---
 

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -268,10 +268,15 @@ Rules:
 - Public callbacks must validate and claim the scoped flow/state/provider/PKCE
   hash before exchanging raw code/verifier through non-serializable one-shot
   provider inputs and completing the flow.
+- A provider redirect's optional `scope` echo is bounded as untrusted input but
+  is not grant authority: providers may omit, normalize, or return cumulative
+  scopes there. The token response is the authoritative granted-scope source;
+  the auth engine applies the recipe's missing-scope policy and clamps an
+  echoed grant to the unified recipe ceiling before storing it.
 - Once a callback is tied to a known scoped flow, missing authorization code,
-  missing one-shot PKCE material, or malformed/invalid scope input must durably
-  mark that flow `failed` before discarding callback material. Provider denial
-  is terminal through the same scoped flow boundary.
+  missing one-shot PKCE material, or malformed/oversized callback input must
+  durably mark that flow `failed` before discarding callback material. Provider
+  denial is terminal through the same scoped flow boundary.
 - Callback completion emits typed continuations; callback routes must not
   directly activate extensions, resume turns, replay messages, or dispatch work.
 - Terminal flows cannot be completed or canceled again.
@@ -514,7 +519,7 @@ tenant/user fields.
 | --- | --- | --- |
 | `POST` | `/api/reborn/product-auth/oauth/start` | Open an OAuth setup flow; returns redacted authorization URL + invocation scope. |
 | `POST` | `/api/webchat/v2/extensions/{package_id}/setup/oauth/start` | Open an installed extension's manifest-declared OAuth requirement by opaque requirement name; provider, label, scopes, and lifecycle continuation are server-owned. |
-| `GET`  | `/api/reborn/product-auth/oauth/callback/{flow_id}` | Public OAuth callback; validates scope/state hash before any product effect. |
+| `GET`  | `/api/reborn/product-auth/oauth/callback/{flow_id}` | Public OAuth callback; validates the scoped flow and state hash before any product effect. |
 | `GET` | `/api/reborn/product-auth/oauth/flow/{flow_id}/status` | Observational caller-scoped durable status read. It performs no continuation dispatch, activation, compensation, provider cleanup, or other writes. |
 | `POST` | `/api/reborn/product-auth/oauth/flow/{flow_id}/reconcile` | Explicit bounded recovery command that retries only a completed flow's unfenced internal continuation. It never repeats provider exchange, revokes a valid credential, or performs uninstall cleanup. |
 | `POST` | `/api/reborn/product-auth/oauth/google/start` | Open a Google product-auth setup flow from configured Reborn Google OAuth client metadata; returns a Google authorization URL with PKCE/offline consent and invocation scope. |
@@ -599,6 +604,9 @@ Rules:
 
 - OAuth start, provider exchange, callback success, callback replay, stale,
   canceled, malformed, denied, and cross-scope callback behavior;
+- caller-level callback coverage pins that an incomplete provider redirect
+  `scope` echo still reaches exchange with the server-owned requested scopes
+  (`webui_v2_product_auth::product_auth_google_oauth_callback_ignores_incomplete_redirect_scope`);
 - secure manual-token submit, bound account update, cross-scope denial, empty
   input, expiry, and debug redaction;
 - composition-facade manual-token request/submit, stale/duplicate/malformed


### PR DESCRIPTION
## Summary

- Stop treating the provider redirect's optional `scope` echo as authorization truth.
- Exchange a valid authorization code with the server-owned requested scopes, then rely on the token response and existing unified recipe-ceiling clamp for the actual grant.
- Preserve explicit provider denial, callback input bounds, scoped flow/state/provider validation, PKCE handling, and sanitized errors.
- Add caller-level regressions for incomplete, empty, and out-of-recipe redirect scope echoes, plus proof that `access_denied` never reaches token exchange.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — delegated to CI; another checkout currently holds the shared Cargo target lock.
- [ ] `cargo build` — not run separately; the focused route test binary compiled successfully.
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth` (45 passed)
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — not applicable; no database behavior changed.
- [ ] Manual testing — pending QA deployment with a real Gmail then Google Calendar connection.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run; PR remains draft.

## Test Strategy

User behavior: A user who already connected Gmail can connect Google Calendar without IronClaw rejecting Google's authorization callback merely because the redirect's optional scope echo is incomplete, empty, normalized, or cumulative.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Updated the caller-level `webui_v2_product_auth` route suite. The new regression failed before the fix with HTTP 400 instead of 200, then passed after the fix. The suite also proves out-of-recipe redirect scopes do not become exchange authority and explicit `access_denied` performs no token exchange.
- Reborn integration: Not applicable: the existing composed Axum route test is the highest deterministic seam for a third-party browser callback and drives the real callback handler plus product-auth service boundary.
- Recorded fixture: Not applicable: no model decision or request-shape behavior changed.
- Browser E2E: Not applicable: no frontend behavior changed, and a real Google consent redirect is not hermetic browser coverage.
- Backend or runtime: Not applicable: no database, filesystem, runtime lane, or schema behavior changed.
- Live canary: Pending after QA deployment: connect Gmail, then Google Calendar, and confirm both remain configured.

What the tests prove: The callback keeps server-owned requested scopes through provider exchange regardless of the untrusted redirect scope echo; explicit provider denial remains terminal before exchange; callback secrets remain absent from responses; replay remains terminal; and all neighboring product-auth route tests remain green.

Commands run:

- `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth product_auth_google_oauth_callback_ignores_incomplete_redirect_scope -- --exact` (red before fix: 400 vs 200; green after fix)
- `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth product_auth_google_oauth_callback_`
- `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth` (45 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`

## Security Impact

The callback now exchanges a valid authorization code even when the provider's optional redirect `scope` echo differs from the request. The redirect echo remains bounded as untrusted input but is not grant authority. Existing state hash, tenant scope, flow provider, single-use PKCE, replay, and explicit provider-denial checks are unchanged. The token response remains authoritative and is clamped to the unified vendor recipe ceiling before storage, preventing over-claim.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new types or constructors.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: not applicable; callback fields never enter prompts.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: existing state/code/PKCE hash behavior is unchanged.
- [x] New/changed status, exit, policy, runtime, or error variants: none.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: the non-authoritative redirect scope field retains its 4 KiB input bound.
- [x] Driver/operator-visible errors have stable class semantics: no error variants changed; explicit provider denial remains `provider_denied`.
- [x] Sandbox/native/host names accurately describe trust boundary: not applicable; no runtime or sandbox surface changed.

## Database Impact

None. No schema, migration, or persistence representation changed.

## Blast Radius

Recipe-driven OAuth callback handling for all vendors. A provider that returns a valid code but a misleading redirect scope now reaches token exchange; actual grant enforcement remains at the token-response boundary. Explicit provider errors and malformed callback protections are unchanged.

## Rollback Plan

Revert commit `d54df8098`. This restores the pre-exchange redirect-scope comparison without any data migration or cleanup.

## Review Follow-Through

CI and the real Google QA sequence remain outstanding. Before merge, verify the focused auth/composition lanes are green; after QA deploy, connect Gmail followed by Google Calendar and confirm the shared Google account retains both grants.

---

**Review track**: C (OAuth trust-boundary behavior)