### PR TITLE
Release fix 1.0.0 rc.1 dockerfile reborn

### DIFF
--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -62,7 +62,7 @@ WORKDIR /app
 RUN cargo chef cook \
     --profile dist \
     --package ironclaw \
-    --features libsql,postgres,inmemory-turn-state \
+    --features libsql,postgres \
     --recipe-path recipe.json
 RUN cargo chef cook \
     --profile dist \
@@ -92,7 +92,7 @@ WORKDIR /app
 RUN cargo build \
     --profile dist \
     --package ironclaw \
-    --features libsql,postgres,inmemory-turn-state \
+    --features libsql,postgres \
     --bin ironclaw
 
 RUN cargo build \

--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Multi-stage Dockerfile for the standalone Reborn CLI HTTP service.
 #
 # Build:
@@ -14,7 +16,9 @@
 
 FROM node:22.23.1-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS node_toolchain
 
-FROM rust:1.96-bookworm@sha256:5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc AS chef
+FROM rust:1.96-bookworm@sha256:5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc AS rust_toolchain
+
+FROM rust_toolchain AS chef
 
 COPY --from=node_toolchain /usr/local/bin/node /usr/local/bin/node
 COPY --from=node_toolchain /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
@@ -58,7 +62,7 @@ WORKDIR /app
 RUN cargo chef cook \
     --profile dist \
     --package ironclaw \
-    --features libsql,postgres \
+    --features libsql,postgres,inmemory-turn-state \
     --recipe-path recipe.json
 RUN cargo chef cook \
     --profile dist \
@@ -88,7 +92,7 @@ WORKDIR /app
 RUN cargo build \
     --profile dist \
     --package ironclaw \
-    --features libsql,postgres \
+    --features libsql,postgres,inmemory-turn-state \
     --bin ironclaw
 
 RUN cargo build \
@@ -98,36 +102,109 @@ RUN cargo build \
     --features libsql \
     --bin ironclaw-reborn-extension-ownership-migration
 
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim AS runtime-base
 
 RUN apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         ca-certificates \
+        gosu \
+        openssh-server \
         postgresql-client \
         sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/dist/ironclaw /usr/local/bin/ironclaw
-COPY --from=builder /app/target/dist/ironclaw-reborn-extension-ownership-migration /usr/local/bin/ironclaw-reborn-extension-ownership-migration
 COPY docker/reborn/config.toml /opt/ironclaw/reborn/config.toml
 COPY docker/reborn/config.hosted-single-tenant.toml /opt/ironclaw/reborn/config.hosted-single-tenant.toml
 COPY docker/reborn/config.hosted-single-tenant-volume.toml /opt/ironclaw/reborn/config.hosted-single-tenant-volume.toml
 COPY docker/reborn/config.production.toml /opt/ironclaw/reborn/config.production.toml
 COPY docker/reborn/entrypoint.sh /usr/local/bin/ironclaw-reborn-entrypoint
+COPY docker/reborn/start-sshd.sh /usr/local/bin/ironclaw-reborn-start-sshd
 
 ENV HOME=/home/ironclaw \
     IRONCLAW_REBORN_LOG=info \
     IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 
-RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
+RUN useradd -m -d /home/ironclaw -s /bin/bash -u 1000 ironclaw \
+    && useradd --non-unique --uid 1000 --gid ironclaw --home-dir /workspace --shell /bin/bash agent \
+    && passwd -d agent \
     && mkdir -p /data/ironclaw-reborn /workspace \
     && chown -R ironclaw:ironclaw /home/ironclaw /data/ironclaw-reborn /workspace \
-    && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint
+    && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint /usr/local/bin/ironclaw-reborn-start-sshd
 
 WORKDIR /workspace
 
-EXPOSE 3000
-
-USER ironclaw
+EXPOSE 3000 2222
 
 ENTRYPOINT ["ironclaw-reborn-entrypoint"]
+
+# Packages a checksum-verified cargo-dist release binary with common development
+# tools for coding and repository-automation workloads. The release workflow
+# stages the binary at this otherwise absent path. Keeping this as a separate
+# target leaves the default hosted runtime minimal.
+FROM runtime-base AS runtime-release-tools
+
+ARG BUN_VERSION=1.3.14
+ARG CLAUDE_CODE_VERSION=2.1.217
+ARG DOCKER_CLI_VERSION=29.6.1-1~debian.12~bookworm
+ARG DOCKER_CLI_SHA256=f8029852215e59f5e906ccbd397a7d916b3f2653d988adb9b2691041b29c70b4
+ARG GH_VERSION=2.96.0
+ARG GH_SHA256=11a731f4e0ca8c3db96ef6d2cc404dcab3d78247ce0e07c53e07117e7627d6a1
+
+RUN apt-get -o Acquire::Retries=3 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        jq \
+        libssl-dev \
+        openssh-client \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-venv \
+        ripgrep \
+        unzip \
+    && curl -fsSL "https://download.docker.com/linux/debian/dists/bookworm/pool/stable/amd64/docker-ce-cli_${DOCKER_CLI_VERSION}_amd64.deb" -o /tmp/docker-ce-cli.deb \
+    && echo "${DOCKER_CLI_SHA256}  /tmp/docker-ce-cli.deb" | sha256sum --check - \
+    && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb" -o /tmp/gh.deb \
+    && echo "${GH_SHA256}  /tmp/gh.deb" | sha256sum --check - \
+    && dpkg --install /tmp/docker-ce-cli.deb /tmp/gh.deb \
+    && rm -rf /var/lib/apt/lists/* /tmp/docker-ce-cli.deb /tmp/gh.deb
+
+COPY --from=node_toolchain /usr/local/bin/node /usr/local/bin/node
+COPY --from=node_toolchain /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
+COPY --from=rust_toolchain --chown=ironclaw:ironclaw /usr/local/cargo/ /usr/local/cargo/
+COPY --from=rust_toolchain --chown=ironclaw:ironclaw /usr/local/rustup/ /usr/local/rustup/
+
+ENV CARGO_HOME=/usr/local/cargo \
+    DISABLE_AUTOUPDATER=1 \
+    PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    RUSTUP_HOME=/usr/local/rustup
+
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -sf /usr/local/cargo/bin/cargo /usr/local/bin/cargo \
+    && ln -sf /usr/local/cargo/bin/rustc /usr/local/bin/rustc \
+    && ln -sf /usr/local/cargo/bin/rustup /usr/local/bin/rustup \
+    && npm install --global \
+        "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+        "bun@${BUN_VERSION}" \
+    && npm cache clean --force \
+    && bun --version \
+    && claude --version \
+    && docker --version \
+    && gh --version \
+    && cargo --version \
+    && rustc --version
+
+COPY --chmod=0755 docker/reborn/release/ironclaw /usr/local/bin/ironclaw
+
+USER root
+
+# Default source-built hosted runtime.
+FROM runtime-base AS runtime
+
+COPY --from=builder /app/target/dist/ironclaw /usr/local/bin/ironclaw
+COPY --from=builder /app/target/dist/ironclaw-reborn-extension-ownership-migration /usr/local/bin/ironclaw-reborn-extension-ownership-migration
+
+USER root

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -33,6 +33,23 @@ else
   IRONCLAW_REBORN_HOME="/data/ironclaw-reborn"
 fi
 export IRONCLAW_REBORN_HOME
+
+ssh_public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "$IRONCLAW_REBORN_HOME" /workspace
+  chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace
+  if [ -n "$ssh_public_key" ]; then
+    ironclaw-reborn-start-sshd
+    IRONCLAW_REBORN_SSH_STARTED=1
+    export IRONCLAW_REBORN_SSH_STARTED
+  fi
+  exec gosu ironclaw "$0" "$@"
+fi
+if [ -n "$ssh_public_key" ] && [ "${IRONCLAW_REBORN_SSH_STARTED:-}" != "1" ]; then
+  echo "direct SSH requires the container entrypoint to start as root" >&2
+  exit 1
+fi
+
 if [ -n "${IRONCLAW_REBORN_DEFAULT_CONFIG:-}" ]; then
   default_config="$IRONCLAW_REBORN_DEFAULT_CONFIG"
 else

--- a/docker/reborn/start-sshd.sh
+++ b/docker/reborn/start-sshd.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
+if [ -z "$public_key" ]; then
+  exit 0
+fi
+
+ssh_dir="$IRONCLAW_REBORN_HOME/ssh"
+host_key="$ssh_dir/ssh_host_ed25519_key"
+authorized_keys="$ssh_dir/authorized_keys"
+config="$ssh_dir/sshd_config"
+
+mkdir -p "$ssh_dir" /run/sshd
+chmod 755 "$ssh_dir"
+
+if [ ! -s "$host_key" ]; then
+  ssh-keygen -q -t ed25519 -N '' -f "$host_key"
+fi
+chmod 600 "$host_key"
+
+authorized_keys_tmp="$authorized_keys.tmp.$$"
+config_tmp="$config.tmp.$$"
+trap 'rm -f "$authorized_keys_tmp" "$config_tmp"' EXIT HUP INT TERM
+
+printf '%s\n' "$public_key" > "$authorized_keys_tmp"
+if ! ssh-keygen -l -f "$authorized_keys_tmp" >/dev/null 2>&1; then
+  echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY is not a valid OpenSSH public key" >&2
+  exit 1
+fi
+chmod 644 "$authorized_keys_tmp"
+mv "$authorized_keys_tmp" "$authorized_keys"
+
+{
+  printf '%s\n' \
+    'Port 2222' \
+    'ListenAddress 0.0.0.0' \
+    "HostKey \"$host_key\"" \
+    "PidFile \"$ssh_dir/sshd.pid\"" \
+    "AuthorizedKeysFile \"$authorized_keys\"" \
+    'AllowUsers agent' \
+    'AuthenticationMethods publickey' \
+    'PubkeyAuthentication yes' \
+    'PasswordAuthentication no' \
+    'KbdInteractiveAuthentication no' \
+    'PermitEmptyPasswords no' \
+    'PermitRootLogin no' \
+    'StrictModes yes' \
+    'UsePAM no' \
+    'X11Forwarding no' \
+    'PrintMotd no' \
+    "SetEnv IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME CARGO_HOME=/usr/local/cargo RUSTUP_HOME=/usr/local/rustup" \
+    'Subsystem sftp internal-sftp'
+} > "$config_tmp"
+chmod 600 "$config_tmp"
+mv "$config_tmp" "$config"
+
+/usr/sbin/sshd -t -f "$config"
+/usr/sbin/sshd -f "$config"
+
+trap - EXIT HUP INT TERM


### PR DESCRIPTION
Crabshack-compatible Dockerfile with support for direct SSH into the agent container, plus some tools for the agent to use via shell access.