### PR TITLE
fix(reborn): hide static connection failures from model search

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_host/extension_lifecycle_capabilities.rs
@@ -292,18 +292,23 @@ fn channel_connection_display_preview(
     })
 }
 
-/// The structured connect requirement carries render chrome for the in-chat
-/// connection panel and rides the display-preview side channel only. Strip it
-/// from the model-visible tool output so the model sees just activation prose.
+/// Structured channel connection requirements carry render chrome for WebUI.
+/// Strip them from model-visible lifecycle output so static fallback copy is
+/// never mistaken for live connection state.
 fn without_model_visible_connection_chrome(
     mut response: LifecycleProductResponse,
 ) -> LifecycleProductResponse {
-    if let Some(LifecycleProductPayload::ExtensionInstall {
-        connection_required,
-        ..
-    }) = response.payload.as_mut()
-    {
-        *connection_required = None;
+    match response.payload.as_mut() {
+        Some(LifecycleProductPayload::ExtensionInstall {
+            connection_required,
+            ..
+        }) => *connection_required = None,
+        Some(LifecycleProductPayload::ExtensionSearch { extensions, .. }) => {
+            for extension in extensions {
+                extension.summary.channel_connection = None;
+            }
+        }
+        _ => {}
     }
     response
 }
@@ -672,6 +677,48 @@ mod tests {
         assert!(
             install.effects.contains(&EffectKind::Network),
             "install readiness reconciliation needs runtime HTTP egress for hosted MCP discovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_visible_extension_search_omits_channel_connection_failure_copy() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let services = build_runtime_substrate(crate::deployment::local_dev_build_input(
+            "extension-search-model-output-owner",
+            dir.path().join("local-dev"),
+        ))
+        .await
+        .expect("local-dev services build");
+
+        let search = invoke_json(
+            &services,
+            EXTENSION_SEARCH_CAPABILITY_ID,
+            serde_json::json!({"query": "slack"}),
+        )
+        .await
+        .expect("Slack search succeeds");
+        let slack = search["payload"]["extensions"]
+            .as_array()
+            .expect("extensions array")
+            .iter()
+            .find(|extension| extension["package_ref"]["id"] == "slack")
+            .expect("Slack search result");
+
+        assert!(
+            slack["surface_kinds"]
+                .as_array()
+                .is_some_and(|kinds| kinds.iter().any(|kind| kind == "channel")),
+            "model-visible search must still identify Slack as a channel: {slack}"
+        );
+        assert!(
+            slack.get("channel_connection").is_none(),
+            "model-visible search must not expose UI-only connection failure copy: {slack}"
+        );
+        assert!(
+            !serde_json::to_string(&search)
+                .expect("search response serializes")
+                .contains("Slack OAuth connection failed"),
+            "static OAuth failure copy must not be presented as live model-visible state"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
@@ -2086,7 +2086,7 @@ async fn product_auth_google_oauth_callback_missing_code_is_rejected_without_exc
     assert_eq!(status_response.status(), StatusCode::OK);
     let status_body = read_body_string(status_response).await;
     let status_json: serde_json::Value = serde_json::from_str(&status_body).expect("status json");
-    assert_eq!(status_json["status"], "pending");
+    assert_eq!(status_json["status"], "awaiting_user");
     assert!(!status_body.contains(&state));
 }
 


### PR DESCRIPTION
## Summary

- Strip UI-only channel connection descriptors from model-visible extension search results so static OAuth fallback copy cannot be mistaken for live failure state.
- Add a caller-level Slack regression test covering the exact production message.
- Correct the broken #6610 missing-code callback expectation from the nonexistent `pending` state to the actual retryable `awaiting_user` state, restoring main Tests (Reborn).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (workspace all-target clippy was started cleanly, then interrupted at user request to publish immediately)
- [ ] `cargo build`
- [x] Relevant tests pass:
  - `cargo test -p ironclaw_reborn_composition --lib model_visible_extension_search_omits_channel_connection_failure_copy -- --nocapture`
  - `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth product_auth_google_oauth_callback_missing_code_is_rejected_without_exchange -- --exact --nocapture`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; deterministic regressions cover both paths.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: Asking to connect Slack no longer exposes static OAuth failure copy to the model as if an authorization attempt failed; malformed Google OAuth callbacks remain retryable without exchange.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: caller-level lifecycle capability test drives a real Slack `extension_search` and asserts channel identity remains while connection failure chrome is absent. Existing product-auth route test now asserts the durable state actually produced by a missing-code callback.
- Reborn integration: Not applicable; both regressions are covered at the real composition capability/HTTP caller seams without a model loop.
- Recorded fixture: Not applicable; this fixes deterministic model-visible input, not provider tool choice.
- Browser E2E: Not applicable; no browser rendering behavior changes.
- Backend or runtime: Not applicable; no backend or runtime-lane behavior changes.
- Live canary: Not applicable; deterministic tests reproduce both failures.

What the tests prove: Slack remains discoverable as a channel without leaking static failure copy to the model, and a missing authorization code returns a sanitized 400 without token exchange while preserving `awaiting_user`.

Commands run:
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_composition --lib model_visible_extension_search_omits_channel_connection_failure_copy -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth product_auth_google_oauth_callback_missing_code_is_rejected_without_exchange -- --exact --nocapture`

## Security Impact

None. No permission, network, secret, filesystem, or tool-execution authority changes.

## Reborn Trust-Boundary Checklist

N/A: this narrows model-visible presentation data and corrects a test expectation; no trust-bearing types, ingress, authority, persistence, or error variants change.

## Database Impact

None.

## Blast Radius

Model-visible `builtin.extension_search` output for channel extensions no longer includes the WebUI connection descriptor. WebUI catalog and display-preview representations are unchanged. The OAuth change is test-only.

## Rollback Plan

Revert this commit. That would restore the static connection-copy leak and the known-red #6610 test expectation.

## Review Follow-Through

The full workspace clippy command was interrupted only because the user requested immediate PR publication; CI should complete the remaining lint matrix.

---

**Review track**: B