### PR TITLE
test(e2e): enforce typed journey coverage

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -211,6 +211,7 @@ jobs:
         run: >-
           pytest
           tests/e2e/scenarios/test_provider_capability_inventory.py
+          tests/e2e/scenarios/test_journey_coverage.py
           tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
           tests/e2e/scenarios/test_reborn_qa_trace_replay.py
           tests/e2e/scenarios/test_reborn_qa_trace_full_path.py

--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -476,3 +476,21 @@ Keep missing credentials, credential refresh, and account-scope behavior at
 their existing auth/runtime seams when a provider proxy cannot create the
 condition faithfully. Fault state must be reset independently from provider
 state after every case.
+
+## Whole-path journey inventory
+
+Use `tests/e2e/journey_types.py` and `tests/e2e/journey_cases.py` to register
+representative compositions across ingress, execution, provider state, and
+delivery. A `JourneyCase` is evidence metadata, not a workflow DSL: execution
+logic, provider setup, and readback remain in their owning test modules.
+
+Each case names its trace when it has one, isolated provider worlds, ingress,
+execution lane, delivery target, observable assertions, and an exact Pytest or
+Cargo test declaration. `test_journey_coverage.py` verifies that the evidence
+still exists and is executable. It also derives inbound and outbound channel
+surfaces from shipped first-party manifests, so adding a production channel
+without representative journey evidence fails CI.
+
+Prefer one representative whole-path case per supported ingress and delivery
+mechanism. Do not multiply every provider operation by every ingress or move
+provider-specific assertions into the generic registry.

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -114,6 +114,7 @@ full-path Emulate tests still start the legacy gateway binary.
 | `test_emulate_reborn_provider_contracts.py` | Reborn Emulate fixture contracts: Google account isolation and stateful reads/writes, Slack QA 9/10 provider shapes and strict-scope failures, and GitHub identity plus positive/negative state transitions |
 | `test_provider_fault_proxy.py` | Harness self-tests for reusable provider status, response, timeout, connection-reset, and lost-acknowledgement profiles plus safe request evidence and reset |
 | `test_provider_capability_inventory.py` | Fast completeness gate derived from shipped first-party manifests. Every static provider capability must be tested, live-only, unsupported, or covered by an owned waiver in `fixtures/provider_capability_coverage.toml`; non-Emulate evidence names its exact Cargo target, source, and executable test. |
+| `test_journey_coverage.py` | Fast whole-path completeness gate. Harvested provider traces are typed `JourneyCase` entries, while representative WebUI, Slack, Telegram, and scheduled-trigger journeys name exact executable Pytest or Cargo evidence. Production channel manifests cannot add an inbound or outbound surface without journey evidence. |
 | `test_reborn_qa_trace_full_path.py` | Harvested and typed provider operations through standalone Reborn and Emulate, including representative read/idempotent-write/non-idempotent-write fault cases with provider readback |
 | `test_reborn_emulate_full_path.py` | Install/auth a first-party extension, drive scripted Gmail/Calendar/Drive/GitHub tool calls, assert provider state and cleanup via Emulate |
 | `test_oauth_refresh.py` | Hosted Gmail OAuth refresh: expire token, real tool call, refresh via mock proxy without leaking `client_secret` |
@@ -202,6 +203,14 @@ success plus provider readback rather than recorded final-answer wording.
 baseline, and readback cases for operations not yet present in harvested
 journeys. These cases reuse the same Reborn process and reset only their mutable
 provider world.
+`JourneyCase` is the small composition layer above those operation contracts.
+It declares the trace (when recorded), provider worlds, ingress, execution
+lane, delivery target, observable assertions, and exact executable evidence.
+The harvested provider runner consumes these declarations directly; provider
+setup, normalization, and readback remain in provider-owned helpers rather
+than moving into a generic DSL. The journey coverage gate derives channel
+ingress and delivery requirements from shipped manifests and adds the built-in
+WebUI and scheduled-trigger surfaces.
 `ProviderFaultProfile` places a transparent proxy between that Reborn process
 and Emulate. Reusable profiles cover HTTP 400/401/403/404/409/429/5xx,
 timeout, connection reset, malformed/truncated/missing-field responses, and a

--- a/tests/e2e/journey_cases.py
+++ b/tests/e2e/journey_cases.py
@@ -1,0 +1,296 @@
+"""Typed inventory for harvested provider and representative product journeys."""
+
+import json
+import tomllib
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import TypeVar
+from urllib.parse import urlparse
+
+from journey_types import (
+    EvidenceRunner,
+    ExecutableEvidence,
+    JourneyCase,
+    JourneyDeliveryTarget,
+    JourneyExecution,
+    JourneyIngress,
+    ObservableAssertion,
+    ProviderWorld,
+)
+from provider_capability_inventory import EMULATE_SUPPORTED_TOOLS
+
+ROOT = Path(__file__).resolve().parents[2]
+TRACE_DIR = ROOT / "tests/fixtures/llm_traces/reborn_qa/live_canary"
+MANIFEST_PATH = TRACE_DIR / "case-manifest.json"
+ASSET_ROOT = ROOT / "crates/ironclaw_first_party_extensions/assets"
+
+_TOOL_WORLD_PREFIXES = {
+    "gmail__": ProviderWorld.GOOGLE,
+    "google-calendar__": ProviderWorld.GOOGLE,
+    "google-docs__": ProviderWorld.GOOGLE,
+    "google-drive__": ProviderWorld.GOOGLE,
+    "google-sheets__": ProviderWorld.GOOGLE,
+    "google-slides__": ProviderWorld.GOOGLE,
+    "github__": ProviderWorld.GITHUB,
+    "slack__": ProviderWorld.SLACK,
+}
+_HTTP_WORLD_HOSTS = {
+    "api.github.com": ProviderWorld.GITHUB,
+}
+_MUTATING_PROVIDER_TOOLS = {
+    "gmail__send_message": ProviderWorld.GOOGLE,
+    "google-docs__create_document": ProviderWorld.GOOGLE,
+    "google-sheets__create_spreadsheet": ProviderWorld.GOOGLE,
+    "google-sheets__append_values": ProviderWorld.GOOGLE,
+    "slack__send_message": ProviderWorld.SLACK,
+}
+_REPEAT_AFTER_RESET = {
+    "qa_5d_slack_strategy_doc_answer",
+    "qa_10f_slack_mention_encoding",
+}
+
+_PYTEST_PROVIDER_EVIDENCE = ExecutableEvidence(
+    runner=EvidenceRunner.PYTEST,
+    source="tests/e2e/scenarios/test_reborn_qa_trace_full_path.py",
+    test="test_qa_journey_provider_leg_replays_through_emulate",
+)
+
+
+def _tool_calls(trace: dict) -> list[dict]:
+    return [
+        call
+        for step in trace["steps"]
+        for call in step["response"].get("tool_calls", [])
+    ]
+
+
+def _provider_worlds(calls: Iterable[dict]) -> tuple[ProviderWorld, ...]:
+    worlds = set()
+    for call in calls:
+        worlds.update(
+            world
+            for prefix, world in _TOOL_WORLD_PREFIXES.items()
+            if call["name"].startswith(prefix)
+        )
+        if call["name"] == "builtin__http":
+            host = urlparse(call["arguments"].get("url", "")).hostname
+            if (world := _HTTP_WORLD_HOSTS.get(host)) is not None:
+                worlds.add(world)
+    return tuple(sorted(worlds, key=str)) or (ProviderWorld.NONE,)
+
+
+def _mutable_provider_worlds(calls: Iterable[dict]) -> tuple[ProviderWorld, ...]:
+    worlds = {
+        world
+        for call in calls
+        if (world := _MUTATING_PROVIDER_TOOLS.get(call["name"])) is not None
+    }
+    return tuple(sorted(worlds, key=str))
+
+
+def _provider_journey_cases() -> tuple[JourneyCase, ...]:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    excluded = set(manifest["no_model_cases"])
+    excluded.update(manifest.get("quarantined_model_cases", []))
+    cases = []
+    for case_id in manifest["selected_cases"]:
+        if case_id in excluded:
+            continue
+        trace_path = TRACE_DIR / f"{case_id}.json"
+        trace = json.loads(trace_path.read_text(encoding="utf-8"))
+        calls = _tool_calls(trace)
+        if not any(call["name"] in EMULATE_SUPPORTED_TOOLS for call in calls):
+            continue
+        cases.append(
+            JourneyCase(
+                case_id=case_id,
+                trace=str(trace_path.relative_to(ROOT)),
+                provider_worlds=_provider_worlds(calls),
+                mutable_provider_worlds=_mutable_provider_worlds(calls),
+                ingress=JourneyIngress.WEBUI,
+                execution=JourneyExecution.STANDALONE_REBORN,
+                delivery_target=JourneyDeliveryTarget.WEBUI,
+                assertions=(
+                    ObservableAssertion.TRACE_REPLAY_COMPLETE,
+                    ObservableAssertion.CAPABILITY_OUTCOMES,
+                    ObservableAssertion.PROVIDER_READBACK,
+                ),
+                evidence=_PYTEST_PROVIDER_EVIDENCE,
+                repeat_after_reset=case_id in _REPEAT_AFTER_RESET,
+            )
+        )
+    return tuple(cases)
+
+
+PROVIDER_JOURNEY_CASES = _provider_journey_cases()
+
+
+def _provider_journey_runs() -> tuple[
+    tuple[JourneyCase, ...],
+    tuple[str, ...],
+]:
+    runs = []
+    ids = []
+    for case in PROVIDER_JOURNEY_CASES:
+        runs.append(case)
+        ids.append(case.case_id)
+        if case.repeat_after_reset:
+            runs.append(case)
+            ids.append(f"{case.case_id}-isolated-repeat")
+    return tuple(runs), tuple(ids)
+
+
+PROVIDER_JOURNEY_RUNS, PROVIDER_JOURNEY_RUN_IDS = _provider_journey_runs()
+
+PRODUCT_JOURNEY_CASES = (
+    JourneyCase(
+        case_id="webui_text_turn_persists",
+        trace=None,
+        provider_worlds=(ProviderWorld.NONE,),
+        mutable_provider_worlds=(),
+        ingress=JourneyIngress.WEBUI,
+        execution=JourneyExecution.STANDALONE_REBORN,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        assertions=(ObservableAssertion.DURABLE_STATE,),
+        evidence=ExecutableEvidence(
+            runner=EvidenceRunner.PYTEST,
+            source="tests/e2e/scenarios/test_reborn_webui_v2_smoke.py",
+            test="test_reborn_v2_text_turn_persists",
+        ),
+    ),
+    JourneyCase(
+        case_id="slack_inbound_real_turn_reply",
+        trace=None,
+        provider_worlds=(ProviderWorld.SLACK,),
+        mutable_provider_worlds=(ProviderWorld.SLACK,),
+        ingress=JourneyIngress.SLACK,
+        execution=JourneyExecution.REBORN_INTEGRATION,
+        delivery_target=JourneyDeliveryTarget.SLACK,
+        assertions=(
+            ObservableAssertion.DURABLE_STATE,
+            ObservableAssertion.EXACT_DESTINATION,
+            ObservableAssertion.CREDENTIAL_INJECTION,
+        ),
+        evidence=ExecutableEvidence(
+            runner=EvidenceRunner.CARGO,
+            source="tests/integration/extension_delivery.rs",
+            test="slack_final_reply_flows_through_the_real_delivery_coordinator",
+            target="reborn_integration_extension_delivery",
+        ),
+    ),
+    JourneyCase(
+        case_id="telegram_inbound_real_turn_reply",
+        trace=None,
+        provider_worlds=(ProviderWorld.TELEGRAM,),
+        mutable_provider_worlds=(ProviderWorld.TELEGRAM,),
+        ingress=JourneyIngress.TELEGRAM,
+        execution=JourneyExecution.REBORN_INTEGRATION,
+        delivery_target=JourneyDeliveryTarget.TELEGRAM,
+        assertions=(
+            ObservableAssertion.DURABLE_STATE,
+            ObservableAssertion.EXACT_DESTINATION,
+            ObservableAssertion.CREDENTIAL_INJECTION,
+        ),
+        evidence=ExecutableEvidence(
+            runner=EvidenceRunner.CARGO,
+            source="tests/integration/extension_delivery.rs",
+            test="telegram_update_becomes_a_turn_and_a_coordinated_reply",
+            target="reborn_integration_extension_delivery",
+        ),
+    ),
+    JourneyCase(
+        case_id="scheduled_trigger_default_slack_delivery",
+        trace=None,
+        provider_worlds=(ProviderWorld.SLACK,),
+        mutable_provider_worlds=(ProviderWorld.SLACK,),
+        ingress=JourneyIngress.SCHEDULED_TRIGGER,
+        execution=JourneyExecution.REBORN_INTEGRATION,
+        delivery_target=JourneyDeliveryTarget.SLACK,
+        assertions=(
+            ObservableAssertion.DURABLE_STATE,
+            ObservableAssertion.EXACT_DESTINATION,
+            ObservableAssertion.EXACT_MUTATION_COUNT,
+            ObservableAssertion.CREDENTIAL_INJECTION,
+            ObservableAssertion.RESTART_IDEMPOTENCY,
+        ),
+        evidence=ExecutableEvidence(
+            runner=EvidenceRunner.CARGO,
+            source=("crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs"),
+            test=(
+                "scheduled_trigger_results_reach_exact_slack_targets_once_"
+                "across_restart"
+            ),
+            target="trigger_poller_e2e",
+            manifest="crates/ironclaw_reborn_composition/Cargo.toml",
+        ),
+    ),
+    JourneyCase(
+        case_id="scheduled_trigger_explicit_slack_delivery",
+        trace=None,
+        provider_worlds=(ProviderWorld.SLACK,),
+        mutable_provider_worlds=(ProviderWorld.SLACK,),
+        ingress=JourneyIngress.SCHEDULED_TRIGGER,
+        execution=JourneyExecution.REBORN_INTEGRATION,
+        delivery_target=JourneyDeliveryTarget.SLACK,
+        assertions=(
+            ObservableAssertion.DURABLE_STATE,
+            ObservableAssertion.EXACT_DESTINATION,
+            ObservableAssertion.EXACT_MUTATION_COUNT,
+            ObservableAssertion.CREDENTIAL_INJECTION,
+            ObservableAssertion.RESTART_IDEMPOTENCY,
+        ),
+        evidence=ExecutableEvidence(
+            runner=EvidenceRunner.CARGO,
+            source=("crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs"),
+            test=(
+                "scheduled_trigger_results_reach_exact_slack_targets_once_"
+                "across_restart"
+            ),
+            target="trigger_poller_e2e",
+            manifest="crates/ironclaw_reborn_composition/Cargo.toml",
+        ),
+    ),
+)
+
+ALL_JOURNEY_CASES = (*PROVIDER_JOURNEY_CASES, *PRODUCT_JOURNEY_CASES)
+
+
+def _production_channel_surfaces(direction: str) -> set[str]:
+    surfaces = set()
+    for manifest_path in sorted(ASSET_ROOT.glob("*/manifest.toml")):
+        with manifest_path.open("rb") as manifest_file:
+            manifest = tomllib.load(manifest_file)
+        channel = manifest.get("channel")
+        if channel is not None and channel.get(direction) is True:
+            surfaces.add(manifest["id"])
+    return surfaces
+
+
+def required_ingresses() -> set[str]:
+    """Built-in ingress plus every production channel declaring inbound."""
+    return {
+        JourneyIngress.WEBUI,
+        JourneyIngress.SCHEDULED_TRIGGER,
+        *_production_channel_surfaces("inbound"),
+    }
+
+
+def required_delivery_targets() -> set[str]:
+    """Built-in WebUI delivery plus every production outbound channel."""
+    return {
+        JourneyDeliveryTarget.WEBUI,
+        *_production_channel_surfaces("outbound"),
+    }
+
+
+T = TypeVar("T")
+
+
+def uncovered_surfaces(
+    required: Iterable[str],
+    cases: Iterable[JourneyCase],
+    selector: Callable[[JourneyCase], T],
+) -> set[str]:
+    """Return required surface IDs with no typed journey evidence."""
+    covered = {str(selector(case)) for case in cases}
+    return {str(surface) for surface in required} - covered

--- a/tests/e2e/journey_cases.py
+++ b/tests/e2e/journey_cases.py
@@ -1,21 +1,23 @@
 """Typed inventory for harvested provider and representative product journeys."""
 
 import json
-import tomllib
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import TypeVar
 from urllib.parse import urlparse
 
+import tomllib
 from journey_types import (
-    EvidenceRunner,
-    ExecutableEvidence,
+    CargoEvidence,
     JourneyCase,
     JourneyDeliveryTarget,
     JourneyExecution,
     JourneyIngress,
     ObservableAssertion,
+    ProductJourneyCase,
+    ProviderJourneyCase,
     ProviderWorld,
+    PytestEvidence,
 )
 from provider_capability_inventory import EMULATE_SUPPORTED_TOOLS
 
@@ -49,8 +51,7 @@ _REPEAT_AFTER_RESET = {
     "qa_10f_slack_mention_encoding",
 }
 
-_PYTEST_PROVIDER_EVIDENCE = ExecutableEvidence(
-    runner=EvidenceRunner.PYTEST,
+_PYTEST_PROVIDER_EVIDENCE = PytestEvidence(
     source="tests/e2e/scenarios/test_reborn_qa_trace_full_path.py",
     test="test_qa_journey_provider_leg_replays_through_emulate",
 )
@@ -88,7 +89,7 @@ def _mutable_provider_worlds(calls: Iterable[dict]) -> tuple[ProviderWorld, ...]
     return tuple(sorted(worlds, key=str))
 
 
-def _provider_journey_cases() -> tuple[JourneyCase, ...]:
+def _provider_journey_cases() -> tuple[ProviderJourneyCase, ...]:
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     excluded = set(manifest["no_model_cases"])
     excluded.update(manifest.get("quarantined_model_cases", []))
@@ -102,7 +103,7 @@ def _provider_journey_cases() -> tuple[JourneyCase, ...]:
         if not any(call["name"] in EMULATE_SUPPORTED_TOOLS for call in calls):
             continue
         cases.append(
-            JourneyCase(
+            ProviderJourneyCase(
                 case_id=case_id,
                 trace=str(trace_path.relative_to(ROOT)),
                 provider_worlds=_provider_worlds(calls),
@@ -126,7 +127,7 @@ PROVIDER_JOURNEY_CASES = _provider_journey_cases()
 
 
 def _provider_journey_runs() -> tuple[
-    tuple[JourneyCase, ...],
+    tuple[ProviderJourneyCase, ...],
     tuple[str, ...],
 ]:
     runs = []
@@ -143,24 +144,21 @@ def _provider_journey_runs() -> tuple[
 PROVIDER_JOURNEY_RUNS, PROVIDER_JOURNEY_RUN_IDS = _provider_journey_runs()
 
 PRODUCT_JOURNEY_CASES = (
-    JourneyCase(
+    ProductJourneyCase(
         case_id="webui_text_turn_persists",
-        trace=None,
         provider_worlds=(ProviderWorld.NONE,),
         mutable_provider_worlds=(),
         ingress=JourneyIngress.WEBUI,
         execution=JourneyExecution.STANDALONE_REBORN,
         delivery_target=JourneyDeliveryTarget.WEBUI,
         assertions=(ObservableAssertion.DURABLE_STATE,),
-        evidence=ExecutableEvidence(
-            runner=EvidenceRunner.PYTEST,
+        evidence=PytestEvidence(
             source="tests/e2e/scenarios/test_reborn_webui_v2_smoke.py",
             test="test_reborn_v2_text_turn_persists",
         ),
     ),
-    JourneyCase(
+    ProductJourneyCase(
         case_id="slack_inbound_real_turn_reply",
-        trace=None,
         provider_worlds=(ProviderWorld.SLACK,),
         mutable_provider_worlds=(ProviderWorld.SLACK,),
         ingress=JourneyIngress.SLACK,
@@ -171,16 +169,14 @@ PRODUCT_JOURNEY_CASES = (
             ObservableAssertion.EXACT_DESTINATION,
             ObservableAssertion.CREDENTIAL_INJECTION,
         ),
-        evidence=ExecutableEvidence(
-            runner=EvidenceRunner.CARGO,
+        evidence=CargoEvidence(
             source="tests/integration/extension_delivery.rs",
             test="slack_final_reply_flows_through_the_real_delivery_coordinator",
             target="reborn_integration_extension_delivery",
         ),
     ),
-    JourneyCase(
+    ProductJourneyCase(
         case_id="telegram_inbound_real_turn_reply",
-        trace=None,
         provider_worlds=(ProviderWorld.TELEGRAM,),
         mutable_provider_worlds=(ProviderWorld.TELEGRAM,),
         ingress=JourneyIngress.TELEGRAM,
@@ -191,16 +187,14 @@ PRODUCT_JOURNEY_CASES = (
             ObservableAssertion.EXACT_DESTINATION,
             ObservableAssertion.CREDENTIAL_INJECTION,
         ),
-        evidence=ExecutableEvidence(
-            runner=EvidenceRunner.CARGO,
+        evidence=CargoEvidence(
             source="tests/integration/extension_delivery.rs",
             test="telegram_update_becomes_a_turn_and_a_coordinated_reply",
             target="reborn_integration_extension_delivery",
         ),
     ),
-    JourneyCase(
-        case_id="scheduled_trigger_default_slack_delivery",
-        trace=None,
+    ProductJourneyCase(
+        case_id="scheduled_trigger_slack_delivery_default_and_explicit",
         provider_worlds=(ProviderWorld.SLACK,),
         mutable_provider_worlds=(ProviderWorld.SLACK,),
         ingress=JourneyIngress.SCHEDULED_TRIGGER,
@@ -213,34 +207,7 @@ PRODUCT_JOURNEY_CASES = (
             ObservableAssertion.CREDENTIAL_INJECTION,
             ObservableAssertion.RESTART_IDEMPOTENCY,
         ),
-        evidence=ExecutableEvidence(
-            runner=EvidenceRunner.CARGO,
-            source=("crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs"),
-            test=(
-                "scheduled_trigger_results_reach_exact_slack_targets_once_"
-                "across_restart"
-            ),
-            target="trigger_poller_e2e",
-            manifest="crates/ironclaw_reborn_composition/Cargo.toml",
-        ),
-    ),
-    JourneyCase(
-        case_id="scheduled_trigger_explicit_slack_delivery",
-        trace=None,
-        provider_worlds=(ProviderWorld.SLACK,),
-        mutable_provider_worlds=(ProviderWorld.SLACK,),
-        ingress=JourneyIngress.SCHEDULED_TRIGGER,
-        execution=JourneyExecution.REBORN_INTEGRATION,
-        delivery_target=JourneyDeliveryTarget.SLACK,
-        assertions=(
-            ObservableAssertion.DURABLE_STATE,
-            ObservableAssertion.EXACT_DESTINATION,
-            ObservableAssertion.EXACT_MUTATION_COUNT,
-            ObservableAssertion.CREDENTIAL_INJECTION,
-            ObservableAssertion.RESTART_IDEMPOTENCY,
-        ),
-        evidence=ExecutableEvidence(
-            runner=EvidenceRunner.CARGO,
+        evidence=CargoEvidence(
             source=("crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs"),
             test=(
                 "scheduled_trigger_results_reach_exact_slack_targets_once_"

--- a/tests/e2e/journey_types.py
+++ b/tests/e2e/journey_types.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import TypeAlias
 
 
 class ProviderWorld(StrEnum):
@@ -41,33 +42,49 @@ class ObservableAssertion(StrEnum):
     RESTART_IDEMPOTENCY = "restart_idempotency"
 
 
-class EvidenceRunner(StrEnum):
-    PYTEST = "pytest"
-    CARGO = "cargo"
+@dataclass(frozen=True)
+class PytestEvidence:
+    """One exact Pytest declaration that CI can execute."""
+
+    source: str
+    test: str
 
 
 @dataclass(frozen=True)
-class ExecutableEvidence:
-    """One exact test declaration that CI can execute."""
+class CargoEvidence:
+    """One exact Cargo test declaration that CI can execute."""
 
-    runner: EvidenceRunner
     source: str
     test: str
-    target: str | None = None
+    target: str
     manifest: str | None = None
 
 
 @dataclass(frozen=True)
-class JourneyCase:
-    """One declarative whole-path proof; runners retain execution logic."""
+class JourneyCaseBase:
+    """Shared metadata for one declarative whole-path proof."""
 
     case_id: str
-    trace: str | None
     provider_worlds: tuple[ProviderWorld, ...]
     mutable_provider_worlds: tuple[ProviderWorld, ...]
     ingress: JourneyIngress
     execution: JourneyExecution
     delivery_target: JourneyDeliveryTarget
     assertions: tuple[ObservableAssertion, ...]
-    evidence: ExecutableEvidence
+    evidence: PytestEvidence | CargoEvidence
+
+
+@dataclass(frozen=True)
+class ProviderJourneyCase(JourneyCaseBase):
+    """A harvested provider journey whose full-path runner requires a trace."""
+
+    trace: str
     repeat_after_reset: bool = False
+
+
+@dataclass(frozen=True)
+class ProductJourneyCase(JourneyCaseBase):
+    """A trace-less product journey proved by its owning executable test."""
+
+
+JourneyCase: TypeAlias = ProviderJourneyCase | ProductJourneyCase

--- a/tests/e2e/journey_types.py
+++ b/tests/e2e/journey_types.py
@@ -1,0 +1,73 @@
+"""Typed vocabulary shared by whole-path journey registries and runners."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ProviderWorld(StrEnum):
+    NONE = "none"
+    GOOGLE = "google"
+    GITHUB = "github"
+    SLACK = "slack"
+    TELEGRAM = "telegram"
+
+
+class JourneyIngress(StrEnum):
+    WEBUI = "webui"
+    SLACK = "slack"
+    TELEGRAM = "telegram"
+    SCHEDULED_TRIGGER = "scheduled_trigger"
+
+
+class JourneyExecution(StrEnum):
+    STANDALONE_REBORN = "standalone_reborn"
+    REBORN_INTEGRATION = "reborn_integration"
+
+
+class JourneyDeliveryTarget(StrEnum):
+    WEBUI = "webui"
+    SLACK = "slack"
+    TELEGRAM = "telegram"
+
+
+class ObservableAssertion(StrEnum):
+    TRACE_REPLAY_COMPLETE = "trace_replay_complete"
+    CAPABILITY_OUTCOMES = "capability_outcomes"
+    PROVIDER_READBACK = "provider_readback"
+    DURABLE_STATE = "durable_state"
+    EXACT_DESTINATION = "exact_destination"
+    EXACT_MUTATION_COUNT = "exact_mutation_count"
+    CREDENTIAL_INJECTION = "credential_injection"
+    RESTART_IDEMPOTENCY = "restart_idempotency"
+
+
+class EvidenceRunner(StrEnum):
+    PYTEST = "pytest"
+    CARGO = "cargo"
+
+
+@dataclass(frozen=True)
+class ExecutableEvidence:
+    """One exact test declaration that CI can execute."""
+
+    runner: EvidenceRunner
+    source: str
+    test: str
+    target: str | None = None
+    manifest: str | None = None
+
+
+@dataclass(frozen=True)
+class JourneyCase:
+    """One declarative whole-path proof; runners retain execution logic."""
+
+    case_id: str
+    trace: str | None
+    provider_worlds: tuple[ProviderWorld, ...]
+    mutable_provider_worlds: tuple[ProviderWorld, ...]
+    ingress: JourneyIngress
+    execution: JourneyExecution
+    delivery_target: JourneyDeliveryTarget
+    assertions: tuple[ObservableAssertion, ...]
+    evidence: ExecutableEvidence
+    repeat_after_reset: bool = False

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -1,0 +1,167 @@
+"""Completeness gate for typed whole-path journey evidence."""
+
+import ast
+import json
+import re
+import tomllib
+from pathlib import Path
+
+from journey_cases import (
+    ALL_JOURNEY_CASES,
+    PROVIDER_JOURNEY_CASES,
+    required_delivery_targets,
+    required_ingresses,
+    uncovered_surfaces,
+)
+from journey_types import EvidenceRunner, JourneyCase, ProviderWorld
+from provider_capability_inventory import EMULATE_SUPPORTED_TOOLS
+
+ROOT = Path(__file__).resolve().parents[3]
+TRACE_DIR = ROOT / "tests/fixtures/llm_traces/reborn_qa/live_canary"
+MANIFEST_PATH = TRACE_DIR / "case-manifest.json"
+
+
+def _manifest_provider_journeys() -> set[str]:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    excluded = set(manifest["no_model_cases"])
+    excluded.update(manifest.get("quarantined_model_cases", []))
+    cases = set()
+    for case_id in manifest["selected_cases"]:
+        if case_id in excluded:
+            continue
+        trace = json.loads((TRACE_DIR / f"{case_id}.json").read_text(encoding="utf-8"))
+        if any(
+            call["name"] in EMULATE_SUPPORTED_TOOLS
+            for step in trace["steps"]
+            for call in step["response"].get("tool_calls", [])
+        ):
+            cases.add(case_id)
+    return cases
+
+
+def _cargo_targets(manifest_path: Path) -> dict[str, str]:
+    with manifest_path.open("rb") as manifest_file:
+        manifest = tomllib.load(manifest_file)
+    return {
+        target["name"]: target["path"]
+        for target in manifest.get("test", [])
+        if "path" in target
+    }
+
+
+def _assert_python_evidence(case: JourneyCase) -> None:
+    evidence = case.evidence
+    source_path = ROOT / evidence.source
+    assert source_path.is_file(), f"{case.case_id}: missing {evidence.source}"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    tests = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+    assert evidence.test in tests, (
+        f"{case.case_id}: pytest evidence {evidence.test!r} is missing from "
+        f"{evidence.source}"
+    )
+
+
+def _assert_rust_evidence(case: JourneyCase) -> None:
+    evidence = case.evidence
+    source_path = ROOT / evidence.source
+    assert source_path.is_file(), f"{case.case_id}: missing {evidence.source}"
+    source = source_path.read_text(encoding="utf-8")
+    declaration = re.compile(
+        rf"(?P<attributes>(?:^[ \t]*#\s*\[[^\n]+\][ \t]*\n)+)"
+        rf"^[ \t]*(?:pub\s+)?(?:async\s+)?fn\s+{re.escape(evidence.test)}\s*\(",
+        re.MULTILINE,
+    ).search(source)
+    assert declaration, (
+        f"{case.case_id}: Rust evidence {evidence.test!r} is missing from "
+        f"{evidence.source}"
+    )
+    attributes = set(
+        re.findall(
+            r"#\s*\[\s*([A-Za-z_][A-Za-z0-9_:]*)",
+            declaration.group("attributes"),
+        )
+    )
+    assert attributes & {"test", "tokio::test"}, (
+        f"{case.case_id}: Rust evidence {evidence.test!r} is not executable"
+    )
+    assert not attributes & {"cfg", "cfg_attr", "ignore"}, (
+        f"{case.case_id}: Rust evidence {evidence.test!r} is disabled"
+    )
+
+    manifest_path = (
+        ROOT / evidence.manifest
+        if evidence.manifest is not None
+        else ROOT / "Cargo.toml"
+    )
+    targets = _cargo_targets(manifest_path)
+    if evidence.target in targets:
+        expected_source = (manifest_path.parent / targets[evidence.target]).resolve()
+        assert expected_source == source_path.resolve(), (
+            f"{case.case_id}: Cargo target {evidence.target!r} points to "
+            f"{expected_source}, not {source_path}"
+        )
+        return
+
+    auto_target = manifest_path.parent / "tests" / f"{evidence.target}.rs"
+    assert auto_target.resolve() == source_path.resolve(), (
+        f"{case.case_id}: unknown Cargo target {evidence.target!r} in {manifest_path}"
+    )
+
+
+def test_provider_journey_registry_matches_every_harvested_emulate_journey():
+    """Manifest additions cannot bypass the typed whole-path runner."""
+    registered = {case.case_id for case in PROVIDER_JOURNEY_CASES}
+    assert registered == _manifest_provider_journeys()
+
+
+def test_every_journey_has_complete_typed_executable_evidence():
+    """A coverage claim must name a real trace/world/path/assertion and test."""
+    case_ids = [case.case_id for case in ALL_JOURNEY_CASES]
+    duplicates = sorted(
+        case_id for case_id in set(case_ids) if case_ids.count(case_id) > 1
+    )
+    assert not duplicates, f"duplicate journey ids: {duplicates}"
+
+    for case in ALL_JOURNEY_CASES:
+        assert case.provider_worlds, f"{case.case_id}: provider_worlds is empty"
+        assert case.assertions, f"{case.case_id}: assertions is empty"
+        if case.trace is not None:
+            trace_path = ROOT / case.trace
+            assert trace_path.is_file(), f"{case.case_id}: missing trace {case.trace}"
+            assert ProviderWorld.NONE not in case.provider_worlds, (
+                f"{case.case_id}: provider trace has no classified provider world"
+            )
+        if case.evidence.runner is EvidenceRunner.PYTEST:
+            _assert_python_evidence(case)
+        else:
+            _assert_rust_evidence(case)
+
+
+def test_every_supported_ingress_and_delivery_target_has_journey_evidence():
+    """Production channel manifests and built-in surfaces stay a closed set."""
+    missing_ingress = uncovered_surfaces(
+        required_ingresses(), ALL_JOURNEY_CASES, lambda case: case.ingress
+    )
+    missing_delivery = uncovered_surfaces(
+        required_delivery_targets(),
+        ALL_JOURNEY_CASES,
+        lambda case: case.delivery_target,
+    )
+    assert not missing_ingress, f"ingresses lack journey evidence: {missing_ingress}"
+    assert not missing_delivery, (
+        f"delivery targets lack journey evidence: {missing_delivery}"
+    )
+
+
+def test_surface_gate_reports_a_new_uncovered_surface():
+    """The completeness gate must fail loudly when production gains a surface."""
+    assert uncovered_surfaces(
+        {"webui", "future-ingress"},
+        ALL_JOURNEY_CASES,
+        lambda case: case.ingress,
+    ) == {"future-ingress"}

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -52,11 +52,7 @@ def _manifest_provider_journeys() -> set[str]:
 def _cargo_targets(manifest_path: Path) -> dict[str, dict]:
     with manifest_path.open("rb") as manifest_file:
         manifest = tomllib.load(manifest_file)
-    return {
-        target["name"]: target
-        for target in manifest.get("test", [])
-        if "path" in target
-    }
+    return {target["name"]: target for target in manifest.get("test", [])}
 
 
 def _disabling_pytest_marks(
@@ -103,7 +99,7 @@ def _pytest_mark_aliases(tree: ast.Module) -> dict[str, set[str]]:
             isinstance(statement, ast.Expr)
             and isinstance(statement.value, ast.Call)
             and isinstance(statement.value.func, ast.Attribute)
-            and statement.value.func.attr in {"append", "extend"}
+            and statement.value.func.attr in {"append", "extend", "insert"}
             and isinstance(statement.value.func.value, ast.Name)
         ):
             collection = aliases.setdefault(statement.value.func.value.id, set())
@@ -260,7 +256,8 @@ def _assert_cargo_target(
             f"{case_id}: Cargo target {evidence.target!r} requires features "
             f"{required_features} that journey evidence does not enable"
         )
-        expected_source = (manifest_path.parent / target["path"]).resolve()
+        target_path = target.get("path", f"tests/{evidence.target}.rs")
+        expected_source = (manifest_path.parent / target_path).resolve()
         assert expected_source == source_path.resolve(), (
             f"{case_id}: Cargo target {evidence.target!r} points to "
             f"{expected_source}, not {source_path}"
@@ -454,14 +451,22 @@ def test_cargo_evidence_rejects_a_misdirected_target(tmp_path: Path):
         )
 
 
-def test_cargo_evidence_rejects_a_feature_gated_target(tmp_path: Path):
+@pytest.mark.parametrize(
+    "path_entry",
+    ['path = "tests/journey.rs"\n', ""],
+    ids=["explicit-path", "implicit-path"],
+)
+def test_cargo_evidence_rejects_a_feature_gated_target(
+    tmp_path: Path,
+    path_entry: str,
+):
     """A target that CI cannot run cannot satisfy executable evidence."""
     (tmp_path / "tests").mkdir()
     manifest_path = tmp_path / "Cargo.toml"
     manifest_path.write_text(
         "[[test]]\n"
         'name = "journey"\n'
-        'path = "tests/journey.rs"\n'
+        f"{path_entry}"
         'required-features = ["test-support"]\n',
         encoding="utf-8",
     )

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -53,7 +53,16 @@ def _cargo_test_config(manifest_path: Path) -> tuple[dict[str, dict], bool]:
     with manifest_path.open("rb") as manifest_file:
         manifest = tomllib.load(manifest_file)
     targets = {target["name"]: target for target in manifest.get("test", [])}
-    autotests_enabled = manifest.get("package", {}).get("autotests", True)
+    package = manifest.get("package", {})
+    if "autotests" in package:
+        autotests_enabled = package["autotests"]
+    else:
+        edition = package.get("edition", "2015")
+        has_manual_target = any(
+            manifest.get(target_kind)
+            for target_kind in ("lib", "bin", "test", "bench", "example")
+        )
+        autotests_enabled = edition != "2015" or not has_manual_target
     return targets, autotests_enabled
 
 
@@ -524,6 +533,34 @@ def test_cargo_evidence_rejects_disabled_implicit_discovery(tmp_path: Path):
         '[package]\nname = "synthetic"\nversion = "0.1.0"\nautotests = false\n',
         encoding="utf-8",
     )
+    source_path = tmp_path / "tests/journey.rs"
+    source_path.touch()
+    evidence = CargoEvidence(
+        source="tests/journey.rs",
+        test="required_journey",
+        target="journey",
+    )
+    with pytest.raises(AssertionError, match="automatic test discovery"):
+        _assert_cargo_target(
+            "synthetic",
+            evidence,
+            source_path,
+            root=tmp_path,
+        )
+
+
+def test_cargo_evidence_rejects_legacy_manual_target_implicit_discovery(
+    tmp_path: Path,
+):
+    """Edition 2015 disables default discovery when a target is configured."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "synthetic"\nversion = "0.1.0"\n'
+        '[[bin]]\nname = "tool"\npath = "src/main.rs"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "src/main.rs").touch()
     source_path = tmp_path / "tests/journey.rs"
     source_path.touch()
     evidence = CargoEvidence(

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -49,10 +49,12 @@ def _manifest_provider_journeys() -> set[str]:
     return cases
 
 
-def _cargo_targets(manifest_path: Path) -> dict[str, dict]:
+def _cargo_test_config(manifest_path: Path) -> tuple[dict[str, dict], bool]:
     with manifest_path.open("rb") as manifest_file:
         manifest = tomllib.load(manifest_file)
-    return {target["name"]: target for target in manifest.get("test", [])}
+    targets = {target["name"]: target for target in manifest.get("test", [])}
+    autotests_enabled = manifest.get("package", {}).get("autotests", True)
+    return targets, autotests_enabled
 
 
 def _disabling_pytest_marks(
@@ -248,9 +250,12 @@ def _assert_cargo_target(
         if evidence.manifest is not None
         else root / "Cargo.toml"
     )
-    targets = _cargo_targets(manifest_path)
+    targets, autotests_enabled = _cargo_test_config(manifest_path)
     if evidence.target in targets:
         target = targets[evidence.target]
+        assert target.get("harness", True) is not False, (
+            f"{case_id}: Cargo target {evidence.target!r} disables the test harness"
+        )
         required_features = target.get("required-features", [])
         assert not required_features, (
             f"{case_id}: Cargo target {evidence.target!r} requires features "
@@ -264,6 +269,9 @@ def _assert_cargo_target(
         )
         return
 
+    assert autotests_enabled, (
+        f"{case_id}: Cargo manifest disables automatic test discovery"
+    )
     auto_target = manifest_path.parent / "tests" / f"{evidence.target}.rs"
     assert auto_target.resolve() == source_path.resolve(), (
         f"{case_id}: unknown Cargo target {evidence.target!r} in {manifest_path}"
@@ -478,6 +486,52 @@ def test_cargo_evidence_rejects_a_feature_gated_target(
         target="journey",
     )
     with pytest.raises(AssertionError, match="requires features"):
+        _assert_cargo_target(
+            "synthetic",
+            evidence,
+            source_path,
+            root=tmp_path,
+        )
+
+
+def test_cargo_evidence_rejects_a_harnessless_target(tmp_path: Path):
+    """A binary without Cargo's test harness cannot prove a named test runs."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "Cargo.toml").write_text(
+        '[[test]]\nname = "journey"\npath = "tests/journey.rs"\nharness = false\n',
+        encoding="utf-8",
+    )
+    source_path = tmp_path / "tests/journey.rs"
+    source_path.touch()
+    evidence = CargoEvidence(
+        source="tests/journey.rs",
+        test="required_journey",
+        target="journey",
+    )
+    with pytest.raises(AssertionError, match="disables the test harness"):
+        _assert_cargo_target(
+            "synthetic",
+            evidence,
+            source_path,
+            root=tmp_path,
+        )
+
+
+def test_cargo_evidence_rejects_disabled_implicit_discovery(tmp_path: Path):
+    """An inferred tests-directory target requires Cargo autotests."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "synthetic"\nversion = "0.1.0"\nautotests = false\n',
+        encoding="utf-8",
+    )
+    source_path = tmp_path / "tests/journey.rs"
+    source_path.touch()
+    evidence = CargoEvidence(
+        source="tests/journey.rs",
+        test="required_journey",
+        target="journey",
+    )
+    with pytest.raises(AssertionError, match="automatic test discovery"):
         _assert_cargo_target(
             "synthetic",
             evidence,

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -3,19 +3,26 @@
 import ast
 import json
 import re
-import tomllib
 from pathlib import Path
 
 import pytest
-
+import tomllib
 from journey_cases import (
     ALL_JOURNEY_CASES,
     PROVIDER_JOURNEY_CASES,
+    PROVIDER_JOURNEY_RUN_IDS,
+    PROVIDER_JOURNEY_RUNS,
     required_delivery_targets,
     required_ingresses,
     uncovered_surfaces,
 )
-from journey_types import EvidenceRunner, JourneyCase, ProviderWorld
+from journey_types import (
+    CargoEvidence,
+    JourneyCase,
+    ProviderJourneyCase,
+    ProviderWorld,
+    PytestEvidence,
+)
 from provider_capability_inventory import EMULATE_SUPPORTED_TOOLS
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -52,13 +59,48 @@ def _cargo_targets(manifest_path: Path) -> dict[str, str]:
     }
 
 
-def _disabling_pytest_marks(node: ast.AST) -> set[str]:
-    return {
+def _disabling_pytest_marks(
+    node: ast.AST,
+    aliases: dict[str, set[str]],
+) -> set[str]:
+    marks = {
         candidate.attr
         for candidate in ast.walk(node)
         if isinstance(candidate, ast.Attribute)
         and candidate.attr in _DISABLING_PYTEST_MARKS
     }
+    for candidate in ast.walk(node):
+        if isinstance(candidate, ast.Name):
+            marks.update(aliases.get(candidate.id, set()))
+    return marks
+
+
+def _pytest_mark_aliases(tree: ast.Module) -> dict[str, set[str]]:
+    aliases: dict[str, set[str]] = {}
+    changed = True
+    while changed:
+        changed = False
+        for statement in tree.body:
+            if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = (
+                statement.targets
+                if isinstance(statement, ast.Assign)
+                else [statement.target]
+            )
+            if statement.value is None:
+                continue
+            marks = _disabling_pytest_marks(statement.value, aliases)
+            for target in targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id != "pytestmark"
+                    and marks
+                    and aliases.get(target.id) != marks
+                ):
+                    aliases[target.id] = marks
+                    changed = True
+    return aliases
 
 
 def _assert_python_test_declaration(
@@ -67,6 +109,7 @@ def _assert_python_test_declaration(
     source_label: str,
 ) -> None:
     tree = ast.parse(source)
+    aliases = _pytest_mark_aliases(tree)
     module_disabling_marks = set()
     for statement in tree.body:
         if isinstance(statement, (ast.Assign, ast.AnnAssign)):
@@ -79,7 +122,17 @@ def _assert_python_test_declaration(
                 isinstance(target, ast.Name) and target.id == "pytestmark"
                 for target in targets
             ):
-                module_disabling_marks.update(_disabling_pytest_marks(statement.value))
+                module_disabling_marks.update(
+                    _disabling_pytest_marks(statement.value, aliases)
+                )
+        elif (
+            isinstance(statement, ast.AugAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == "pytestmark"
+        ):
+            module_disabling_marks.update(
+                _disabling_pytest_marks(statement.value, aliases)
+            )
     assert not module_disabling_marks, (
         f"pytest evidence {test_name!r} is disabled by module-level marks "
         f"{sorted(module_disabling_marks)} in {source_label}"
@@ -97,7 +150,7 @@ def _assert_python_test_declaration(
     disabling_marks = {
         mark
         for decorator in tests[test_name].decorator_list
-        for mark in _disabling_pytest_marks(decorator)
+        for mark in _disabling_pytest_marks(decorator, aliases)
     }
     assert not disabling_marks, (
         f"pytest evidence {test_name!r} is disabled by test-level marks "
@@ -105,8 +158,7 @@ def _assert_python_test_declaration(
     )
 
 
-def _assert_python_evidence(case: JourneyCase) -> None:
-    evidence = case.evidence
+def _assert_python_evidence(case: JourneyCase, evidence: PytestEvidence) -> None:
     source_path = ROOT / evidence.source
     assert source_path.is_file(), f"{case.case_id}: missing {evidence.source}"
     _assert_python_test_declaration(
@@ -116,20 +168,78 @@ def _assert_python_evidence(case: JourneyCase) -> None:
     )
 
 
-def _assert_rust_evidence(case: JourneyCase) -> None:
-    evidence = case.evidence
-    source_path = ROOT / evidence.source
-    assert source_path.is_file(), f"{case.case_id}: missing {evidence.source}"
-    source = source_path.read_text(encoding="utf-8")
+def _rust_code_without_comments_or_strings(source: str) -> str:
+    """Mask Rust comments and strings while preserving line positions."""
+    result = list(source)
+    index = 0
+    block_depth = 0
+    while index < len(source):
+        if block_depth:
+            if source.startswith("/*", index):
+                result[index : index + 2] = "  "
+                block_depth += 1
+                index += 2
+            elif source.startswith("*/", index):
+                result[index : index + 2] = "  "
+                block_depth -= 1
+                index += 2
+            else:
+                if source[index] != "\n":
+                    result[index] = " "
+                index += 1
+            continue
+        if source.startswith("//", index):
+            end = source.find("\n", index)
+            end = len(source) if end == -1 else end
+            result[index:end] = " " * (end - index)
+            index = end
+            continue
+        if source.startswith("/*", index):
+            result[index : index + 2] = "  "
+            block_depth = 1
+            index += 2
+            continue
+        raw_match = re.match(r'(?:b)?r(#{0,255})"', source[index:])
+        if raw_match:
+            hashes = raw_match.group(1)
+            delimiter = f'"{hashes}'
+            end = source.find(delimiter, index + raw_match.end())
+            end = len(source) if end == -1 else end + len(delimiter)
+            for position in range(index, end):
+                if source[position] != "\n":
+                    result[position] = " "
+            index = end
+            continue
+        if source[index] == '"':
+            end = index + 1
+            while end < len(source):
+                if source[end] == "\\":
+                    end += 2
+                    continue
+                end += 1
+                if source[end - 1] == '"':
+                    break
+            for position in range(index, min(end, len(source))):
+                if source[position] != "\n":
+                    result[position] = " "
+            index = end
+            continue
+        index += 1
+    return "".join(result)
+
+
+def _assert_rust_test_declaration(
+    source: str,
+    test_name: str,
+    source_label: str,
+) -> None:
+    source = _rust_code_without_comments_or_strings(source)
     declaration = re.compile(
         rf"(?P<attributes>(?:^[ \t]*#\s*\[[^\n]+\][ \t]*\n)+)"
-        rf"^[ \t]*(?:pub\s+)?(?:async\s+)?fn\s+{re.escape(evidence.test)}\s*\(",
+        rf"^[ \t]*(?:pub\s+)?(?:async\s+)?fn\s+{re.escape(test_name)}\s*\(",
         re.MULTILINE,
     ).search(source)
-    assert declaration, (
-        f"{case.case_id}: Rust evidence {evidence.test!r} is missing from "
-        f"{evidence.source}"
-    )
+    assert declaration, f"Rust evidence {test_name!r} is missing from {source_label}"
     attributes = set(
         re.findall(
             r"#\s*\[\s*([A-Za-z_][A-Za-z0-9_:]*)",
@@ -137,36 +247,76 @@ def _assert_rust_evidence(case: JourneyCase) -> None:
         )
     )
     assert attributes & {"test", "tokio::test"}, (
-        f"{case.case_id}: Rust evidence {evidence.test!r} is not executable"
+        f"Rust evidence {test_name!r} is not executable"
     )
     assert not attributes & {"cfg", "cfg_attr", "ignore"}, (
-        f"{case.case_id}: Rust evidence {evidence.test!r} is disabled"
+        f"Rust evidence {test_name!r} is disabled"
     )
 
+
+def _assert_cargo_target(
+    case_id: str,
+    evidence: CargoEvidence,
+    source_path: Path,
+    root: Path = ROOT,
+) -> None:
     manifest_path = (
-        ROOT / evidence.manifest
+        root / evidence.manifest
         if evidence.manifest is not None
-        else ROOT / "Cargo.toml"
+        else root / "Cargo.toml"
     )
     targets = _cargo_targets(manifest_path)
     if evidence.target in targets:
         expected_source = (manifest_path.parent / targets[evidence.target]).resolve()
         assert expected_source == source_path.resolve(), (
-            f"{case.case_id}: Cargo target {evidence.target!r} points to "
+            f"{case_id}: Cargo target {evidence.target!r} points to "
             f"{expected_source}, not {source_path}"
         )
         return
 
     auto_target = manifest_path.parent / "tests" / f"{evidence.target}.rs"
     assert auto_target.resolve() == source_path.resolve(), (
-        f"{case.case_id}: unknown Cargo target {evidence.target!r} in {manifest_path}"
+        f"{case_id}: unknown Cargo target {evidence.target!r} in {manifest_path}"
     )
+
+
+def _assert_rust_evidence(case: JourneyCase, evidence: CargoEvidence) -> None:
+    source_path = ROOT / evidence.source
+    assert source_path.is_file(), f"{case.case_id}: missing {evidence.source}"
+    _assert_rust_test_declaration(
+        source_path.read_text(encoding="utf-8"),
+        evidence.test,
+        evidence.source,
+    )
+    _assert_cargo_target(case.case_id, evidence, source_path)
 
 
 def test_provider_journey_registry_matches_every_harvested_emulate_journey():
     """Manifest additions cannot bypass the typed whole-path runner."""
     registered = {case.case_id for case in PROVIDER_JOURNEY_CASES}
     assert registered == _manifest_provider_journeys()
+
+
+def test_provider_journey_runs_preserve_isolated_repeat_cases():
+    """The two isolation probes remain doubled while ordinary cases run once."""
+    expected_repeat_cases = {
+        "qa_5d_slack_strategy_doc_answer",
+        "qa_10f_slack_mention_encoding",
+    }
+    actual_repeat_cases = {
+        case.case_id for case in PROVIDER_JOURNEY_CASES if case.repeat_after_reset
+    }
+    assert actual_repeat_cases == expected_repeat_cases
+
+    expected_ids = []
+    for case in PROVIDER_JOURNEY_CASES:
+        expected_ids.append(case.case_id)
+        if case.case_id in expected_repeat_cases:
+            expected_ids.append(f"{case.case_id}-isolated-repeat")
+    assert list(PROVIDER_JOURNEY_RUN_IDS) == expected_ids
+    assert [case.case_id for case in PROVIDER_JOURNEY_RUNS] == [
+        case_id.removesuffix("-isolated-repeat") for case_id in expected_ids
+    ]
 
 
 def test_every_journey_has_complete_typed_executable_evidence():
@@ -180,16 +330,16 @@ def test_every_journey_has_complete_typed_executable_evidence():
     for case in ALL_JOURNEY_CASES:
         assert case.provider_worlds, f"{case.case_id}: provider_worlds is empty"
         assert case.assertions, f"{case.case_id}: assertions is empty"
-        if case.trace is not None:
+        if isinstance(case, ProviderJourneyCase):
             trace_path = ROOT / case.trace
             assert trace_path.is_file(), f"{case.case_id}: missing trace {case.trace}"
             assert ProviderWorld.NONE not in case.provider_worlds, (
                 f"{case.case_id}: provider trace has no classified provider world"
             )
-        if case.evidence.runner is EvidenceRunner.PYTEST:
-            _assert_python_evidence(case)
+        if isinstance(case.evidence, PytestEvidence):
+            _assert_python_evidence(case, case.evidence)
         else:
-            _assert_rust_evidence(case)
+            _assert_rust_evidence(case, case.evidence)
 
 
 def test_every_supported_ingress_and_delivery_target_has_journey_evidence():
@@ -235,13 +385,64 @@ def test_surface_gate_reports_a_new_uncovered_surface():
             "def test_required_journey():\n"
             "    pass\n"
         ),
+        (
+            "skip = pytest.mark.skip\n"
+            "@skip(reason='disabled')\n"
+            "def test_required_journey():\n"
+            "    pass\n"
+        ),
+        (
+            "pytestmark = []\n"
+            "pytestmark += [pytest.mark.skip]\n"
+            "def test_required_journey():\n"
+            "    pass\n"
+        ),
     ],
 )
 def test_python_evidence_rejects_disabled_tests(source: str):
     """A named Python test cannot satisfy the gate while disabled."""
-    with pytest.raises(AssertionError, match="disabled by .* marks"):
+    with pytest.raises(AssertionError, match=r"disabled by .* marks"):
         _assert_python_test_declaration(
             source,
             "test_required_journey",
             "synthetic.py",
+        )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        '#[cfg(feature = "disabled")]\n#[test]\nfn required_journey() {}\n',
+        "#[cfg_attr(test, ignore)]\n#[test]\nfn required_journey() {}\n",
+        "#[ignore]\n#[test]\nfn required_journey() {}\n",
+        "/*\n#[tokio::test]\nasync fn required_journey() {}\n*/\n",
+    ],
+)
+def test_rust_evidence_rejects_disabled_or_commented_tests(source: str):
+    """Disabled or commented Rust declarations cannot satisfy the gate."""
+    with pytest.raises(AssertionError, match=r"(disabled|missing)"):
+        _assert_rust_test_declaration(source, "required_journey", "synthetic.rs")
+
+
+def test_cargo_evidence_rejects_a_misdirected_target(tmp_path: Path):
+    """A Cargo target must resolve to the source named by the evidence."""
+    (tmp_path / "tests").mkdir()
+    manifest_path = tmp_path / "Cargo.toml"
+    manifest_path.write_text(
+        '[[test]]\nname = "journey"\npath = "tests/actual.rs"\n',
+        encoding="utf-8",
+    )
+    expected_source = tmp_path / "tests/expected.rs"
+    expected_source.touch()
+    evidence = CargoEvidence(
+        source="tests/expected.rs",
+        test="required_journey",
+        target="journey",
+    )
+    with pytest.raises(AssertionError, match="points to"):
+        _assert_cargo_target(
+            "synthetic",
+            evidence,
+            expected_source,
+            root=tmp_path,
         )

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -59,7 +59,7 @@ def _cargo_test_config(manifest_path: Path) -> tuple[dict[str, dict], bool]:
     else:
         edition = package.get("edition", "2015")
         has_manual_target = any(
-            manifest.get(target_kind)
+            target_kind in manifest
             for target_kind in ("lib", "bin", "test", "bench", "example")
         )
         autotests_enabled = edition != "2015" or not has_manual_target
@@ -262,6 +262,9 @@ def _assert_cargo_target(
     targets, autotests_enabled = _cargo_test_config(manifest_path)
     if evidence.target in targets:
         target = targets[evidence.target]
+        assert target.get("test", True) is not False, (
+            f"{case_id}: Cargo target {evidence.target!r} disables test execution"
+        )
         assert target.get("harness", True) is not False, (
             f"{case_id}: Cargo target {evidence.target!r} disables the test harness"
         )
@@ -526,6 +529,29 @@ def test_cargo_evidence_rejects_a_harnessless_target(tmp_path: Path):
         )
 
 
+def test_cargo_evidence_rejects_a_target_with_test_disabled(tmp_path: Path):
+    """A target excluded from cargo test cannot satisfy executable evidence."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "Cargo.toml").write_text(
+        '[[test]]\nname = "journey"\npath = "tests/journey.rs"\ntest = false\n',
+        encoding="utf-8",
+    )
+    source_path = tmp_path / "tests/journey.rs"
+    source_path.touch()
+    evidence = CargoEvidence(
+        source="tests/journey.rs",
+        test="required_journey",
+        target="journey",
+    )
+    with pytest.raises(AssertionError, match="disables test execution"):
+        _assert_cargo_target(
+            "synthetic",
+            evidence,
+            source_path,
+            root=tmp_path,
+        )
+
+
 def test_cargo_evidence_rejects_disabled_implicit_discovery(tmp_path: Path):
     """An inferred tests-directory target requires Cargo autotests."""
     (tmp_path / "tests").mkdir()
@@ -561,6 +587,33 @@ def test_cargo_evidence_rejects_legacy_manual_target_implicit_discovery(
         encoding="utf-8",
     )
     (tmp_path / "src/main.rs").touch()
+    source_path = tmp_path / "tests/journey.rs"
+    source_path.touch()
+    evidence = CargoEvidence(
+        source="tests/journey.rs",
+        test="required_journey",
+        target="journey",
+    )
+    with pytest.raises(AssertionError, match="automatic test discovery"):
+        _assert_cargo_target(
+            "synthetic",
+            evidence,
+            source_path,
+            root=tmp_path,
+        )
+
+
+def test_cargo_evidence_counts_an_empty_lib_table_as_a_manual_target(
+    tmp_path: Path,
+):
+    """Even an empty target table disables edition-2015 auto-discovery."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "synthetic"\nversion = "0.1.0"\n[lib]\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "src/lib.rs").touch()
     source_path = tmp_path / "tests/journey.rs"
     source_path.touch()
     evidence = CargoEvidence(

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -230,7 +230,8 @@ def _assert_rust_test_declaration(
     source = _rust_code_without_comments_or_strings(source)
     declaration = re.compile(
         rf"(?P<attributes>(?:^[ \t]*#\s*\[[^\n]+\][ \t]*\n)+)"
-        rf"^[ \t]*(?:pub\s+)?(?:async\s+)?fn\s+{re.escape(test_name)}\s*\(",
+        rf"^[ \t]*(?:pub\s+)?(?P<async>async\s+)?"
+        rf"fn\s+{re.escape(test_name)}\s*\(",
         re.MULTILINE,
     ).search(source)
     assert declaration, f"Rust evidence {test_name!r} is missing from {source_label}"
@@ -240,9 +241,12 @@ def _assert_rust_test_declaration(
             declaration.group("attributes"),
         )
     )
-    assert attributes & {"test", "tokio::test"}, (
-        f"Rust evidence {test_name!r} is not executable"
-    )
+    if declaration.group("async"):
+        assert "tokio::test" in attributes, (
+            f"Rust evidence {test_name!r} lacks an async-compatible test attribute"
+        )
+    else:
+        assert "test" in attributes, f"Rust evidence {test_name!r} is not executable"
     assert not attributes & {"cfg", "cfg_attr", "ignore"}, (
         f"Rust evidence {test_name!r} is disabled"
     )
@@ -444,6 +448,13 @@ def test_python_evidence_rejects_disabled_tests(source: str):
 def test_rust_evidence_rejects_disabled_or_commented_tests(source: str):
     """Disabled or commented Rust declarations cannot satisfy the gate."""
     with pytest.raises(AssertionError, match=r"(disabled|missing)"):
+        _assert_rust_test_declaration(source, "required_journey", "synthetic.rs")
+
+
+def test_rust_evidence_rejects_plain_test_attribute_on_async_function():
+    """Cargo's plain test harness cannot execute an async test function."""
+    source = "#[test]\nasync fn required_journey() {}\n"
+    with pytest.raises(AssertionError, match="async-compatible"):
         _assert_rust_test_declaration(source, "required_journey", "synthetic.rs")
 
 

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -49,11 +49,11 @@ def _manifest_provider_journeys() -> set[str]:
     return cases
 
 
-def _cargo_targets(manifest_path: Path) -> dict[str, str]:
+def _cargo_targets(manifest_path: Path) -> dict[str, dict]:
     with manifest_path.open("rb") as manifest_file:
         manifest = tomllib.load(manifest_file)
     return {
-        target["name"]: target["path"]
+        target["name"]: target
         for target in manifest.get("test", [])
         if "path" in target
     }
@@ -77,12 +77,8 @@ def _disabling_pytest_marks(
 
 def _pytest_mark_aliases(tree: ast.Module) -> dict[str, set[str]]:
     aliases: dict[str, set[str]] = {}
-    changed = True
-    while changed:
-        changed = False
-        for statement in tree.body:
-            if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
-                continue
+    for statement in tree.body:
+        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
             targets = (
                 statement.targets
                 if isinstance(statement, ast.Assign)
@@ -90,16 +86,29 @@ def _pytest_mark_aliases(tree: ast.Module) -> dict[str, set[str]]:
             )
             if statement.value is None:
                 continue
-            marks = _disabling_pytest_marks(statement.value, aliases)
+            if isinstance(statement.value, ast.Name):
+                marks = aliases.setdefault(statement.value.id, set())
+            else:
+                marks = _disabling_pytest_marks(statement.value, aliases)
             for target in targets:
-                if (
-                    isinstance(target, ast.Name)
-                    and target.id != "pytestmark"
-                    and marks
-                    and aliases.get(target.id) != marks
-                ):
+                if isinstance(target, ast.Name):
                     aliases[target.id] = marks
-                    changed = True
+        elif isinstance(statement, ast.AugAssign) and isinstance(
+            statement.target, ast.Name
+        ):
+            aliases.setdefault(statement.target.id, set()).update(
+                _disabling_pytest_marks(statement.value, aliases)
+            )
+        elif (
+            isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Attribute)
+            and statement.value.func.attr in {"append", "extend"}
+            and isinstance(statement.value.func.value, ast.Name)
+        ):
+            collection = aliases.setdefault(statement.value.func.value.id, set())
+            for argument in statement.value.args:
+                collection.update(_disabling_pytest_marks(argument, aliases))
     return aliases
 
 
@@ -110,29 +119,7 @@ def _assert_python_test_declaration(
 ) -> None:
     tree = ast.parse(source)
     aliases = _pytest_mark_aliases(tree)
-    module_disabling_marks = set()
-    for statement in tree.body:
-        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
-            targets = (
-                statement.targets
-                if isinstance(statement, ast.Assign)
-                else [statement.target]
-            )
-            if statement.value is not None and any(
-                isinstance(target, ast.Name) and target.id == "pytestmark"
-                for target in targets
-            ):
-                module_disabling_marks.update(
-                    _disabling_pytest_marks(statement.value, aliases)
-                )
-        elif (
-            isinstance(statement, ast.AugAssign)
-            and isinstance(statement.target, ast.Name)
-            and statement.target.id == "pytestmark"
-        ):
-            module_disabling_marks.update(
-                _disabling_pytest_marks(statement.value, aliases)
-            )
+    module_disabling_marks = aliases.get("pytestmark", set())
     assert not module_disabling_marks, (
         f"pytest evidence {test_name!r} is disabled by module-level marks "
         f"{sorted(module_disabling_marks)} in {source_label}"
@@ -267,7 +254,13 @@ def _assert_cargo_target(
     )
     targets = _cargo_targets(manifest_path)
     if evidence.target in targets:
-        expected_source = (manifest_path.parent / targets[evidence.target]).resolve()
+        target = targets[evidence.target]
+        required_features = target.get("required-features", [])
+        assert not required_features, (
+            f"{case_id}: Cargo target {evidence.target!r} requires features "
+            f"{required_features} that journey evidence does not enable"
+        )
+        expected_source = (manifest_path.parent / target["path"]).resolve()
         assert expected_source == source_path.resolve(), (
             f"{case_id}: Cargo target {evidence.target!r} points to "
             f"{expected_source}, not {source_path}"
@@ -397,6 +390,19 @@ def test_surface_gate_reports_a_new_uncovered_surface():
             "def test_required_journey():\n"
             "    pass\n"
         ),
+        (
+            "pytestmark = []\n"
+            "pytestmark.append(pytest.mark.skip)\n"
+            "def test_required_journey():\n"
+            "    pass\n"
+        ),
+        (
+            "marks = []\n"
+            "marks += [pytest.mark.skip]\n"
+            "pytestmark = marks\n"
+            "def test_required_journey():\n"
+            "    pass\n"
+        ),
     ],
 )
 def test_python_evidence_rejects_disabled_tests(source: str):
@@ -444,5 +450,32 @@ def test_cargo_evidence_rejects_a_misdirected_target(tmp_path: Path):
             "synthetic",
             evidence,
             expected_source,
+            root=tmp_path,
+        )
+
+
+def test_cargo_evidence_rejects_a_feature_gated_target(tmp_path: Path):
+    """A target that CI cannot run cannot satisfy executable evidence."""
+    (tmp_path / "tests").mkdir()
+    manifest_path = tmp_path / "Cargo.toml"
+    manifest_path.write_text(
+        "[[test]]\n"
+        'name = "journey"\n'
+        'path = "tests/journey.rs"\n'
+        'required-features = ["test-support"]\n',
+        encoding="utf-8",
+    )
+    source_path = tmp_path / "tests/journey.rs"
+    source_path.touch()
+    evidence = CargoEvidence(
+        source="tests/journey.rs",
+        test="required_journey",
+        target="journey",
+    )
+    with pytest.raises(AssertionError, match="requires features"):
+        _assert_cargo_target(
+            "synthetic",
+            evidence,
+            source_path,
             root=tmp_path,
         )

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -6,6 +6,8 @@ import re
 import tomllib
 from pathlib import Path
 
+import pytest
+
 from journey_cases import (
     ALL_JOURNEY_CASES,
     PROVIDER_JOURNEY_CASES,
@@ -19,6 +21,7 @@ from provider_capability_inventory import EMULATE_SUPPORTED_TOOLS
 ROOT = Path(__file__).resolve().parents[3]
 TRACE_DIR = ROOT / "tests/fixtures/llm_traces/reborn_qa/live_canary"
 MANIFEST_PATH = TRACE_DIR / "case-manifest.json"
+_DISABLING_PYTEST_MARKS = {"skip", "skipif", "xfail"}
 
 
 def _manifest_provider_journeys() -> set[str]:
@@ -49,20 +52,67 @@ def _cargo_targets(manifest_path: Path) -> dict[str, str]:
     }
 
 
+def _disabling_pytest_marks(node: ast.AST) -> set[str]:
+    return {
+        candidate.attr
+        for candidate in ast.walk(node)
+        if isinstance(candidate, ast.Attribute)
+        and candidate.attr in _DISABLING_PYTEST_MARKS
+    }
+
+
+def _assert_python_test_declaration(
+    source: str,
+    test_name: str,
+    source_label: str,
+) -> None:
+    tree = ast.parse(source)
+    module_disabling_marks = set()
+    for statement in tree.body:
+        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            targets = (
+                statement.targets
+                if isinstance(statement, ast.Assign)
+                else [statement.target]
+            )
+            if statement.value is not None and any(
+                isinstance(target, ast.Name) and target.id == "pytestmark"
+                for target in targets
+            ):
+                module_disabling_marks.update(_disabling_pytest_marks(statement.value))
+    assert not module_disabling_marks, (
+        f"pytest evidence {test_name!r} is disabled by module-level marks "
+        f"{sorted(module_disabling_marks)} in {source_label}"
+    )
+
+    tests = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+    assert test_name in tests, (
+        f"pytest evidence {test_name!r} is missing from {source_label}"
+    )
+    disabling_marks = {
+        mark
+        for decorator in tests[test_name].decorator_list
+        for mark in _disabling_pytest_marks(decorator)
+    }
+    assert not disabling_marks, (
+        f"pytest evidence {test_name!r} is disabled by test-level marks "
+        f"{sorted(disabling_marks)} in {source_label}"
+    )
+
+
 def _assert_python_evidence(case: JourneyCase) -> None:
     evidence = case.evidence
     source_path = ROOT / evidence.source
     assert source_path.is_file(), f"{case.case_id}: missing {evidence.source}"
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    tests = {
-        node.name
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name.startswith("test_")
-    }
-    assert evidence.test in tests, (
-        f"{case.case_id}: pytest evidence {evidence.test!r} is missing from "
-        f"{evidence.source}"
+    _assert_python_test_declaration(
+        source_path.read_text(encoding="utf-8"),
+        evidence.test,
+        evidence.source,
     )
 
 
@@ -165,3 +215,33 @@ def test_surface_gate_reports_a_new_uncovered_surface():
         ALL_JOURNEY_CASES,
         lambda case: case.ingress,
     ) == {"future-ingress"}
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "@pytest.mark.skip(reason='disabled')\n"
+            "def test_required_journey():\n"
+            "    pass\n"
+        ),
+        (
+            "pytestmark = pytest.mark.skip(reason='disabled')\n"
+            "def test_required_journey():\n"
+            "    pass\n"
+        ),
+        (
+            "@pytest.mark.xfail(run=False, reason='disabled')\n"
+            "def test_required_journey():\n"
+            "    pass\n"
+        ),
+    ],
+)
+def test_python_evidence_rejects_disabled_tests(source: str):
+    """A named Python test cannot satisfy the gate while disabled."""
+    with pytest.raises(AssertionError, match="disabled by .* marks"):
+        _assert_python_test_declaration(
+            source,
+            "test_required_journey",
+            "synthetic.py",
+        )

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -16,6 +16,7 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
+
 from emulate_provider import (
     github_headers,
     github_json,
@@ -24,6 +25,7 @@ from emulate_provider import (
     slack_post,
 )
 from helpers import EMULATE_GITHUB_BEARER, EMULATE_SLACK_BEARER
+from journey_cases import PROVIDER_JOURNEY_RUN_IDS, PROVIDER_JOURNEY_RUNS
 from provider_capability_inventory import (
     EMULATE_SUPPORTED_TOOLS,
     capability_id_to_wire_name,
@@ -110,65 +112,6 @@ GOOGLE_TOOL_PREFIXES = (
 PROVIDER_TOOL_NAMES = EMULATE_SUPPORTED_TOOLS
 ALL_EXTENSIONS = (*GOOGLE_EXTENSIONS, "github", "slack")
 TRACE_BOOTSTRAP_TOOLS = {"builtin__extension_search"}
-MUTATING_PROVIDER_TOOLS = {
-    "gmail__send_message": "google",
-    "google-docs__create_document": "google",
-    "google-sheets__create_spreadsheet": "google",
-    "google-sheets__append_values": "google",
-    "slack__send_message": "slack",
-}
-
-
-def _provider_journey_cases() -> tuple[str, ...]:
-    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-    no_model = set(manifest["no_model_cases"])
-    # Quarantined traces encode the retired activation flow; their fixtures
-    # live under quarantined_retired_activation/ and are not replayable here.
-    quarantined = set(manifest.get("quarantined_model_cases", []))
-    cases = []
-    for case in manifest["selected_cases"]:
-        if case in no_model or case in quarantined:
-            continue
-        trace = json.loads((TRACE_DIR / f"{case}.json").read_text(encoding="utf-8"))
-        if any(
-            call["name"] in PROVIDER_TOOL_NAMES
-            for step in trace["steps"]
-            for call in step["response"].get("tool_calls", [])
-        ):
-            cases.append(case)
-    return tuple(cases)
-
-
-def _mutating_provider_services(case: str) -> set[str]:
-    trace = json.loads((TRACE_DIR / f"{case}.json").read_text(encoding="utf-8"))
-    return {
-        service
-        for step in trace["steps"]
-        for call in step["response"].get("tool_calls", [])
-        if (service := MUTATING_PROVIDER_TOOLS.get(call["name"])) is not None
-    }
-
-
-PROVIDER_JOURNEY_CASES = _provider_journey_cases()
-ISOLATION_REPEAT_CASES = (
-    "qa_5d_slack_strategy_doc_answer",
-    "qa_10f_slack_mention_encoding",
-)
-
-
-def _provider_journey_runs() -> tuple[tuple[str, ...], tuple[str, ...]]:
-    runs = []
-    ids = []
-    for case in PROVIDER_JOURNEY_CASES:
-        runs.append(case)
-        ids.append(case)
-        if case in ISOLATION_REPEAT_CASES:
-            runs.append(case)
-            ids.append(f"{case}-isolated-repeat")
-    return tuple(runs), tuple(ids)
-
-
-PROVIDER_JOURNEY_RUNS, PROVIDER_JOURNEY_RUN_IDS = _provider_journey_runs()
 
 
 @pytest.fixture(scope="module")
@@ -266,10 +209,10 @@ async def reborn_qa_emulate_runtime(
 async def reborn_qa_emulate_provider_server(
     reborn_qa_emulate_runtime,
     resettable_emulate_provider_world,
-    case,
+    journey_case,
 ):
     """Reset mutated providers while reusing the built binary and Reborn."""
-    services = _mutating_provider_services(case)
+    services = {str(world) for world in journey_case.mutable_provider_worlds}
     reset_services = services - {"slack"}
     try:
         yield reborn_qa_emulate_runtime
@@ -278,7 +221,7 @@ async def reborn_qa_emulate_provider_server(
             await _cleanup_slack_provider_mutations(
                 reborn_qa_emulate_runtime["emulate_slack_url"],
                 reborn_qa_emulate_runtime["slack_state"],
-                case,
+                journey_case.case_id,
             )
         if reset_services:
             await resettable_emulate_provider_world.reset(reset_services)
@@ -1333,16 +1276,17 @@ async def test_slack_mutation_cleanup_covers_thread_replies(
 
 
 @pytest.mark.parametrize(
-    "case", PROVIDER_JOURNEY_RUNS, ids=PROVIDER_JOURNEY_RUN_IDS
+    "journey_case", PROVIDER_JOURNEY_RUNS, ids=PROVIDER_JOURNEY_RUN_IDS
 )
 async def test_qa_journey_provider_leg_replays_through_emulate(
     reborn_qa_emulate_provider_server,
     mock_llm_server,
-    case,
+    journey_case,
 ):
     """Every harvested provider journey executes through standalone Reborn."""
+    case = journey_case.case_id
     server = reborn_qa_emulate_provider_server["base_url"]
-    trace_path = TRACE_DIR / f"{case}.json"
+    trace_path = ROOT / journey_case.trace
     if _raw_trace_uses_tool_prefix(
         trace_path, "google-sheets__"
     ):


### PR DESCRIPTION
## Summary

- Add a minimal typed `JourneyCase` inventory for harvested provider journeys and representative WebUI, Slack, Telegram, and scheduled-trigger paths.
- Migrate the existing harvested-provider runner to consume the typed cases without changing its one-build/one-Reborn execution model or losing any collected cases.
- Add a blocking completeness gate that derives shipped channel ingress/outbound surfaces from first-party manifests and verifies each journey's exact Pytest or Cargo evidence remains present and enabled.
- Document the composition boundary: the registry is evidence metadata, while setup, execution, and provider-specific readback stay in their owning tests.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust code changed.
- [ ] `cargo build` — Not run separately; the representative full-path Pytest built/started the required Reborn binary.
- [x] Relevant tests pass: journey/capability completeness gates; full-path collection; one real GitHub-to-Gmail Reborn + Emulate journey.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: no database or product integration behavior changed.
- [x] Manual testing: inspected the derived surface set (`webui`, scheduled trigger, Slack, Telegram) and all typed provider-world assignments.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; the scoped test-only diff passed its focused checks and repository safety script.

## Test Strategy

User behavior:

Developers get a deterministic CI failure when a harvested Emulate-backed journey bypasses the typed runner, when a shipped ingress/delivery mechanism lacks representative whole-path evidence, or when referenced evidence stops being an executable test.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `test_journey_coverage.py` validates exact registry/catalog equality, typed case completeness, enabled Pytest/Cargo declarations and targets, shipped ingress/delivery coverage, and negative self-tests for newly uncovered surfaces and disabled Python evidence.
- Reborn integration: Existing Slack, Telegram, and scheduled-trigger Cargo evidence is registered and mechanically checked; no Rust integration behavior changed.
- Recorded fixture: Every harvested trace containing an Emulate-supported tool is derived independently and required to appear in the typed provider runner.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: The existing full-path runner consumes `JourneyCase` directly; a representative GitHub release lookup plus Gmail delivery passed through standalone Reborn and Emulate with provider verification.
- Live canary: Not applicable: this PR consumes already-sanitized recorded traces and adds deterministic local/CI enforcement; live drift remains supplemental.

What the tests prove:

- All 18 currently harvested Emulate-backed provider journeys remain in the full-path runner, including both repeat-after-reset cases.
- The full provider test module still collects all 125 provider-journey, operation, and fault-profile tests.
- WebUI, scheduled-trigger, Slack, and Telegram ingress plus WebUI, Slack, and Telegram delivery all name exact executable evidence.
- Adding a shipped first-party inbound/outbound channel or an unregistered harvested provider trace fails the blocking provider lane with an actionable missing surface/case.
- A Python evidence test disabled by module/test-level `skip`, `skipif`, or `xfail` marks is rejected rather than counted as coverage.
- The change does not assert exact final model prose or create a broad workflow DSL.

Commands run:

- `uvx ruff check journey_types.py journey_cases.py scenarios/test_journey_coverage.py scenarios/test_reborn_qa_trace_full_path.py`
- `uvx ruff format journey_types.py journey_cases.py scenarios/test_journey_coverage.py`
- `tests/e2e/.venv/bin/python -m pytest scenarios/test_journey_coverage.py scenarios/test_provider_capability_inventory.py -q` → 29 passed
- `tests/e2e/.venv/bin/python -m pytest scenarios/test_reborn_qa_trace_full_path.py --collect-only -q` → 125 collected
- `tests/e2e/.venv/bin/python -m pytest 'scenarios/test_reborn_qa_trace_full_path.py::test_qa_journey_provider_leg_replays_through_emulate[qa_4e_github_release_email_delivery]' -q` → 1 passed
- `cargo fmt --all -- --check`
- `scripts/pre-commit-safety.sh`
- `git diff --check`

## Security Impact

None. Test-only Python metadata, validation, documentation, and CI selection changed. Production permissions, credentials, network mediation, and runtime behavior are unchanged.

## Reborn Trust-Boundary Checklist

N/A: the PR references existing caller-path evidence but changes no production trust-bearing types, ingress handling, credential flow, runtime policy, serialization, or sandbox boundary.

## Database Impact

None.

## Blast Radius

The existing combined Reborn provider E2E lane gains one fast completeness module, and its harvested-journey parametrization now receives typed cases. A stale evidence name, unclassified new channel surface, or newly harvested provider trace can fail the lane before expensive execution.

## Rollback Plan

Revert this commit to restore string-based provider-journey discovery and remove the new completeness gate. No product state or schema rollback is needed.

## Review Follow-Through

Post-review hardening now rejects aliased or mutated disabled Pytest marks, commented/disabled/misdirected Cargo evidence, and loss of the two isolation-repeat runs. Evidence and journey variants now make missing Cargo targets and provider traces unrepresentable, and the duplicate scheduled-trigger inventory row is one combined proof.
Follow-up hardening also tracks shared-list `pytestmark` mutations and rejects Cargo evidence targets whose required features are not enabled by the coverage runner.
Cargo target validation retains implicit-path entries so their required features cannot bypass the executable-evidence gate.
Cargo evidence also rejects harness-disabled configured targets and autotests-disabled implicit discovery.
Implicit Cargo discovery also follows the edition-2015 manual-target default, including empty manual target tables. Explicit Cargo targets with `test = false` are rejected as non-executable evidence.
Async Rust evidence now requires an async-compatible test attribute; invalid `#[test] async fn` declarations are rejected.

Reviewer attention is most useful on whether the typed vocabulary stays minimal and whether the manifest-derived ingress/delivery denominator is the right closed production surface. Provider-specific setup/readback intentionally remains outside the generic registry.

---

**Review track**: A (docs/tests/chore)







