### PR TITLE
test(trace): bind replay results by exact tool call

### DIFF
--- a/crates/ironclaw_llm/CLAUDE.md
+++ b/crates/ironclaw_llm/CLAUDE.md
@@ -286,3 +286,6 @@ Providers in this crate import it as `use ironclaw_common::llm_costs as costs;`
 ## Trace Recording
 
 Set `IRONCLAW_RECORD_TRACE=1` to enable live trace recording via `RecordingLlm`. Traces are JSON files containing: memory snapshot, HTTP exchanges from tools, and LLM steps (user inputs, text responses, tool call responses). Replay these in E2E tests via `TraceLlm`. Configure output path with `IRONCLAW_TRACE_OUTPUT` (default: `trace_{timestamp}.json`).
+
+Arguments derived from an earlier tool result use an exact `$trace_result`
+marker with the original `tool_call_id` and an RFC 6901 JSON Pointer.

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -42,6 +42,7 @@ pub mod runtime;
 pub mod session;
 pub mod smart_routing;
 mod token_refreshing;
+pub mod trace_binding;
 // arch-exempt: scaffolding, Phase A helpers awaiting first per-provider caller, plan #4522
 // Remove the allow once any production call site references these items.
 #[allow(dead_code)]

--- a/crates/ironclaw_llm/src/recording.rs
+++ b/crates/ironclaw_llm/src/recording.rs
@@ -27,6 +27,7 @@ use crate::provider::{
     ChatMessage, CompletionRequest, CompletionResponse, CompletionStreamSink, LlmProvider,
     ModelMetadata, Role, ToolCompletionRequest, ToolCompletionResponse,
 };
+use crate::trace_binding::{ObservedToolResult, canonical_tool_result_payload};
 
 // ── Trace format types ─────────────────────────────────────────────
 
@@ -570,32 +571,28 @@ fn safe_truncate(content: &str, max_bytes: usize) -> String {
 // the literal ID into the fixture, replay-time mission_create will produce
 // a fresh ID and the recorded mission_fire will fail with "not found".
 //
-// Solution: at recording time, scan the prior conversation's tool result
-// messages, build a `{call_id: {field: value}}` lookup, and rewrite any
-// matching literal value in the new tool call's arguments as a template
-// `{{call_id.field}}`. The replay engine's `substitute_templates` already
-// resolves those templates against the *current* tool result values.
+// Solution: rewrite matching values as exact `$trace_result` references to the
+// original tool-call ID and an RFC 6901 JSON Pointer. Replay resolves those
+// references against the current run's result.
 
-/// Build a `{key: {field: stringified_value}}` lookup of every prior tool
-/// result in the conversation, used to parameterize subsequent tool-call
-/// arguments at recording time.
+#[derive(Default)]
+struct PriorToolLookup {
+    exact: Vec<ObservedToolResult>,
+    /// Legacy fallback for sanitized user messages that have lost call IDs.
+    legacy: HashMap<String, HashMap<String, String>>,
+}
+
+/// Build a lookup of every prior tool result in the conversation.
 ///
 /// The recorder must handle two shapes of "prior tool result":
 ///
 /// 1. **Native `Role::Tool` messages** — keyed by their `tool_call_id`.
 ///    Used by providers that pass tool results through unmodified.
-/// 2. **Sanitized user messages** — `sanitize_tool_messages` rewrites
-///    orphaned tool results as `Role::User` content of the form
-///    `[Tool \`name\` returned: <json>]`. These have no call_id, so we key
-///    them by `tool:<name>` instead. The replay engine resolves both forms
-///    via the same `{{key.field}}` template syntax.
-///
-/// In both cases, only top-level scalar fields of the JSON content are
-/// indexed (string, number, bool). Nested objects and arrays are skipped —
-/// they're rarely useful as parameterization keys and would inflate the
-/// lookup with noise.
-fn build_prior_tool_lookup(messages: &[ChatMessage]) -> HashMap<String, HashMap<String, String>> {
-    let mut lookup: HashMap<String, HashMap<String, String>> = HashMap::new();
+/// 2. **Sanitized user messages** have no call ID. Those retain the legacy
+///    top-level `{{tool:name.field}}` fallback until the sanitizer preserves
+///    the original ID.
+fn build_prior_tool_lookup(messages: &[ChatMessage]) -> PriorToolLookup {
+    let mut lookup = PriorToolLookup::default();
     for msg in messages {
         // ── Shape 1: native Role::Tool with structured content. ──
         if msg.role == Role::Tool {
@@ -603,7 +600,12 @@ fn build_prior_tool_lookup(messages: &[ChatMessage]) -> HashMap<String, HashMap<
                 continue;
             };
             let content = unwrap_tool_output(&msg.content);
-            index_json_into(&mut lookup, call_id, &content);
+            if let Some(parsed) = parse_tool_result_content(&content) {
+                lookup.exact.push(ObservedToolResult {
+                    tool_call_id: call_id.to_string(),
+                    content: parsed,
+                });
+            }
             continue;
         }
         // ── Shape 2: Role::User rewrite of orphaned tool results. ──
@@ -613,10 +615,16 @@ fn build_prior_tool_lookup(messages: &[ChatMessage]) -> HashMap<String, HashMap<
             // Key as `tool:<name>` so it doesn't collide with call_ids
             // and stays unique across multiple tool invocations.
             let key = format!("tool:{tool_name}");
-            index_json_into(&mut lookup, &key, payload);
+            index_json_into(&mut lookup.legacy, &key, payload);
         }
     }
     lookup
+}
+
+fn parse_tool_result_content(content: &str) -> Option<serde_json::Value> {
+    serde_json::from_str(content).ok().or_else(|| {
+        coerce_python_repr_to_json(content).and_then(|json| serde_json::from_str(&json).ok())
+    })
 }
 
 /// Parse a JSON object literal out of `content` and merge its top-level
@@ -798,22 +806,40 @@ fn json_value_as_scalar_string(v: &serde_json::Value) -> Option<String> {
     }
 }
 
-/// Walk a JSON value and replace any string that exactly matches a value in
-/// the lookup with a `{{call_id.field}}` template. Operates in place.
+/// Replace a string that uniquely matches a prior result with an exact
+/// tool-call-ID/JSON-Pointer binding.
 ///
-/// We only do *full-string* replacement (not substring) to avoid corrupting
-/// strings that incidentally contain a UUID; the replay's
-/// `substitute_templates` is symmetric and resolves the template back to the
-/// current value.
-fn parameterize_value(
-    value: &mut serde_json::Value,
-    lookup: &HashMap<String, HashMap<String, String>>,
-) {
+/// Full-string replacement avoids corrupting incidental substrings. Ambiguous
+/// matches remain literal rather than guessing which tool call produced them.
+fn parameterize_value(value: &mut serde_json::Value, lookup: &PriorToolLookup) {
     match value {
         serde_json::Value::String(s) => {
-            // Look for a (call_id, field) pair whose value exactly matches `s`.
-            // Use the first match — duplicates are pathological and rare.
-            for (call_id, fields) in lookup {
+            let mut exact_matches = Vec::new();
+            for result in &lookup.exact {
+                let Some(payload) = canonical_tool_result_payload(&result.content) else {
+                    continue;
+                };
+                find_string_pointers(
+                    payload.as_ref(),
+                    s,
+                    String::new(),
+                    &mut exact_matches,
+                    &result.tool_call_id,
+                );
+                if exact_matches.len() > 1 {
+                    break;
+                }
+            }
+            if let [(tool_call_id, pointer)] = exact_matches.as_slice() {
+                *value = serde_json::json!({
+                    "$trace_result": {
+                        "tool_call_id": tool_call_id,
+                        "pointer": pointer,
+                    }
+                });
+                return;
+            }
+            for (call_id, fields) in &lookup.legacy {
                 for (field, recorded) in fields {
                     if recorded == s {
                         *s = format!("{{{{{call_id}.{field}}}}}");
@@ -834,6 +860,50 @@ fn parameterize_value(
         }
         _ => {}
     }
+}
+
+fn find_string_pointers(
+    value: &serde_json::Value,
+    target: &str,
+    pointer: String,
+    matches: &mut Vec<(String, String)>,
+    tool_call_id: &str,
+) {
+    if matches.len() > 1 {
+        return;
+    }
+    match value {
+        serde_json::Value::String(candidate) if candidate == target => {
+            matches.push((tool_call_id.to_string(), pointer));
+        }
+        serde_json::Value::Object(map) => {
+            for (key, child) in map {
+                find_string_pointers(
+                    child,
+                    target,
+                    format!("{pointer}/{}", escape_json_pointer_token(key)),
+                    matches,
+                    tool_call_id,
+                );
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                find_string_pointers(
+                    child,
+                    target,
+                    format!("{pointer}/{index}"),
+                    matches,
+                    tool_call_id,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn escape_json_pointer_token(token: &str) -> String {
+    token.replace('~', "~0").replace('/', "~1")
 }
 
 // ── RecordingLlm ───────────────────────────────────────────────────
@@ -1081,7 +1151,7 @@ impl RecordingLlm {
         &self,
         hint: Option<RequestHint>,
         tool_results: Vec<ExpectedToolResult>,
-        prior_tool_lookup: &HashMap<String, HashMap<String, String>>,
+        prior_tool_lookup: &PriorToolLookup,
         response: &ToolCompletionResponse,
     ) {
         let step = if response.tool_calls.is_empty() {
@@ -1168,12 +1238,9 @@ impl LlmProvider for RecordingLlm {
     ) -> Result<ToolCompletionResponse, LlmError> {
         let (hint, tool_results) = self.capture_new_messages(&request.messages).await;
         // Parameterize tool call arguments BEFORE the request is consumed.
-        // We need access to the prior conversation's tool results (Role::Tool
-        // messages) so we can rewrite literal IDs/values that came from a
-        // previous tool's output as `{{call_id.field}}` templates. The replay
-        // engine resolves these templates at lookup time using the *current*
-        // tool result values, so non-deterministic IDs (mission UUIDs, etc.)
-        // don't bake the recording-time values into the fixture.
+        // Literal IDs from native Role::Tool results become exact call-ID /
+        // JSON-Pointer references. Sanitized user messages that lost their
+        // call ID retain the legacy template fallback.
         let prior_tool_lookup = build_prior_tool_lookup(&request.messages);
         let response = self.inner.complete_with_tools(request).await?;
         self.record_tool_completion_response(hint, tool_results, &prior_tool_lookup, &response)
@@ -1249,6 +1316,55 @@ mod tests {
     }
 
     struct StreamingStub;
+    struct ToolCallStub;
+
+    #[async_trait]
+    impl LlmProvider for ToolCallStub {
+        fn model_name(&self) -> &str {
+            "tool-call-stub"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            Err(LlmError::RequestFailed {
+                provider: "tool-call-stub".to_string(),
+                reason: "text completion is not used by this test".to_string(),
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _request: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            Ok(ToolCompletionResponse {
+                content: None,
+                tool_calls: vec![crate::provider::ToolCall {
+                    id: "call_read".to_string(),
+                    name: "google-docs__read_content".to_string(),
+                    arguments: serde_json::json!({
+                        "document_id": "fresh-document",
+                        "label": "root-value",
+                    }),
+                    reasoning: None,
+                    signature: None,
+                    arguments_parse_error: None,
+                }],
+                input_tokens: 1,
+                output_tokens: 1,
+                finish_reason: crate::provider::FinishReason::ToolUse,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+                reasoning: None,
+                reasoning_details: None,
+            })
+        }
+    }
 
     #[async_trait]
     impl LlmProvider for StreamingStub {
@@ -1466,6 +1582,60 @@ mod tests {
             &trace.steps.last().expect("recorded response").response,
             TraceResponse::Text { content, .. } if content == "tool-aware answer"
         ));
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_records_exact_result_bindings() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("exact_binding_trace.json");
+        let recorder = RecordingLlm::new(
+            Arc::new(ToolCallStub),
+            path.clone(),
+            "tool-call-test".to_string(),
+        );
+
+        recorder
+            .complete_with_tools(ToolCompletionRequest::new(
+                vec![
+                    ChatMessage::user("create and read"),
+                    ChatMessage::tool_result(
+                        "call_create",
+                        "google-docs__create_document",
+                        r#"{"document":{"id":"fresh-document"}}"#,
+                    ),
+                    ChatMessage::tool_result("call_label", "builtin__label", r#""root-value""#),
+                ],
+                Vec::new(),
+            ))
+            .await
+            .expect("stubbed tool completion succeeds");
+
+        let trace: TraceFile = serde_json::from_str(
+            &std::fs::read_to_string(path).expect("tool trace is flushed incrementally"),
+        )
+        .expect("tool trace parses");
+        let TraceResponse::ToolCalls { tool_calls, .. } =
+            &trace.steps.last().expect("recorded response").response
+        else {
+            panic!("expected recorded tool calls");
+        };
+        assert_eq!(
+            tool_calls[0].arguments,
+            serde_json::json!({
+                "document_id": {
+                    "$trace_result": {
+                        "tool_call_id": "call_create",
+                        "pointer": "/document/id",
+                    }
+                },
+                "label": {
+                    "$trace_result": {
+                        "tool_call_id": "call_label",
+                        "pointer": "",
+                    }
+                }
+            })
+        );
     }
 
     #[tokio::test]
@@ -2068,6 +2238,53 @@ mod tests {
         assert!(trace.memory_snapshot.is_empty());
         assert!(trace.http_exchanges.is_empty());
         assert!(trace.steps[0].expected_tool_results.is_empty());
+    }
+
+    #[test]
+    fn parameterizes_nested_tool_result_with_exact_binding() {
+        let messages = vec![ChatMessage::tool_result(
+            "call_upload",
+            "google-drive__upload_file",
+            r#"{"file":{"id":"fresh-file-id"}}"#,
+        )];
+        let lookup = build_prior_tool_lookup(&messages);
+        let mut arguments = serde_json::json!({"file_id": "fresh-file-id"});
+
+        parameterize_value(&mut arguments, &lookup);
+
+        assert_eq!(
+            arguments,
+            serde_json::json!({
+                "file_id": {
+                    "$trace_result": {
+                        "tool_call_id": "call_upload",
+                        "pointer": "/file/id"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn leaves_ambiguous_tool_result_value_literal() {
+        let messages = vec![
+            ChatMessage::tool_result(
+                "call_first",
+                "google-drive__upload_file",
+                r#"{"file":{"id":"same-id"}}"#,
+            ),
+            ChatMessage::tool_result(
+                "call_second",
+                "google-drive__upload_file",
+                r#"{"file":{"id":"same-id"}}"#,
+            ),
+        ];
+        let lookup = build_prior_tool_lookup(&messages);
+        let mut arguments = serde_json::json!({"file_id": "same-id"});
+
+        parameterize_value(&mut arguments, &lookup);
+
+        assert_eq!(arguments, serde_json::json!({"file_id": "same-id"}));
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/trace_binding.rs
+++ b/crates/ironclaw_llm/src/trace_binding.rs
@@ -1,0 +1,268 @@
+//! Exact references from recorded tool arguments to earlier tool results.
+
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TraceResultBinding {
+    tool_call_id: String,
+    pointer: String,
+}
+
+/// A tool result visible to a trace recorder or replay provider.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObservedToolResult {
+    pub tool_call_id: String,
+    pub content: serde_json::Value,
+}
+
+/// Failure while resolving an exact result binding.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TraceBindingError {
+    #[error("invalid $trace_result: {0}")]
+    InvalidMarker(String),
+    #[error("trace result has no tool call with id {0:?}")]
+    MissingToolCall(String),
+    #[error("trace result has multiple tool results with id {0:?}")]
+    DuplicateToolCall(String),
+    #[error("trace result for tool call {tool_call_id:?} has no JSON Pointer {pointer:?}")]
+    MissingPointer {
+        tool_call_id: String,
+        pointer: String,
+    },
+}
+
+/// Resolve every exact `$trace_result` marker in a recorded argument.
+///
+/// Markers use an assistant tool-call ID plus an RFC 6901 JSON Pointer:
+/// `{"$trace_result":{"tool_call_id":"call_1","pointer":"/file/id"}}`.
+pub fn resolve_trace_result_bindings(
+    value: &mut serde_json::Value,
+    observed: &[ObservedToolResult],
+) -> Result<(), TraceBindingError> {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                resolve_trace_result_bindings(item, observed)?;
+            }
+        }
+        serde_json::Value::Object(map) if map.contains_key("$trace_result") => {
+            if map.len() != 1 {
+                return Err(TraceBindingError::InvalidMarker(
+                    "marker object must contain only $trace_result".to_string(),
+                ));
+            }
+            let marker = map.get("$trace_result").cloned().ok_or_else(|| {
+                TraceBindingError::InvalidMarker("missing marker payload".to_string())
+            })?;
+            let binding: TraceResultBinding = serde_json::from_value(marker).map_err(|error| {
+                TraceBindingError::InvalidMarker(format!(
+                    "expected non-empty tool_call_id and JSON Pointer: {error}"
+                ))
+            })?;
+            if binding.tool_call_id.is_empty() {
+                return Err(TraceBindingError::InvalidMarker(
+                    "tool_call_id must be non-empty".to_string(),
+                ));
+            }
+            if !binding.pointer.is_empty() && !binding.pointer.starts_with('/') {
+                return Err(TraceBindingError::InvalidMarker(
+                    "pointer must be empty or start with '/'".to_string(),
+                ));
+            }
+            let mut matching_results = observed
+                .iter()
+                .filter(|result| result.tool_call_id == binding.tool_call_id);
+            let result = matching_results
+                .next()
+                .ok_or_else(|| TraceBindingError::MissingToolCall(binding.tool_call_id.clone()))?;
+            if matching_results.next().is_some() {
+                return Err(TraceBindingError::DuplicateToolCall(binding.tool_call_id));
+            }
+            let payload = canonical_tool_result_payload(&result.content).ok_or_else(|| {
+                TraceBindingError::MissingPointer {
+                    tool_call_id: binding.tool_call_id.clone(),
+                    pointer: binding.pointer.clone(),
+                }
+            })?;
+            *value = payload.pointer(&binding.pointer).cloned().ok_or(
+                TraceBindingError::MissingPointer {
+                    tool_call_id: binding.tool_call_id,
+                    pointer: binding.pointer,
+                },
+            )?;
+        }
+        serde_json::Value::Object(map) => {
+            for item in map.values_mut() {
+                resolve_trace_result_bindings(item, observed)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Return the provider JSON inside a complete host evidence envelope.
+pub(crate) fn canonical_tool_result_payload(
+    content: &serde_json::Value,
+) -> Option<Cow<'_, serde_json::Value>> {
+    let Some(object) = content.as_object() else {
+        return Some(Cow::Borrowed(content));
+    };
+    if !["schema_version", "status", "trust"]
+        .iter()
+        .all(|key| object.contains_key(*key))
+    {
+        return Some(Cow::Borrowed(content));
+    }
+    let detail = object.get("detail").and_then(serde_json::Value::as_object);
+    let preview = detail
+        .filter(|detail| {
+            detail
+                .get("next_offset")
+                .is_none_or(serde_json::Value::is_null)
+                && matches!(
+                    (
+                        detail.get("byte_len").and_then(serde_json::Value::as_u64),
+                        detail
+                            .get("total_bytes")
+                            .and_then(serde_json::Value::as_u64),
+                    ),
+                    (Some(byte_len), Some(total_bytes)) if byte_len == total_bytes
+                )
+        })
+        .and_then(|detail| detail.get("preview"))
+        .and_then(serde_json::Value::as_str);
+    preview
+        .and_then(|preview| serde_json::from_str(preview).ok())
+        .map(Cow::Owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_exact_call_id_and_json_pointer() {
+        let mut arguments = serde_json::json!({
+            "file_id": {
+                "$trace_result": {
+                    "tool_call_id": "call_upload",
+                    "pointer": "/files/0/a~1b~0c"
+                }
+            }
+        });
+        let observed = vec![
+            ObservedToolResult {
+                tool_call_id: "call_upload".to_string(),
+                content: serde_json::json!({"files": [{"a/b~c": "fresh"}]}),
+            },
+            ObservedToolResult {
+                tool_call_id: "call_similar".to_string(),
+                content: serde_json::json!({"files": [{"a/b~c": "wrong"}]}),
+            },
+        ];
+
+        resolve_trace_result_bindings(&mut arguments, &observed).expect("binding should resolve");
+
+        assert_eq!(arguments, serde_json::json!({"file_id": "fresh"}));
+    }
+
+    #[test]
+    fn missing_call_id_does_not_guess() {
+        let mut arguments = serde_json::json!({
+            "$trace_result": {
+                "tool_call_id": "missing",
+                "pointer": "/file/id"
+            }
+        });
+        let observed = vec![ObservedToolResult {
+            tool_call_id: "call_upload".to_string(),
+            content: serde_json::json!({"file": {"id": "must-not-be-used"}}),
+        }];
+
+        assert_eq!(
+            resolve_trace_result_bindings(&mut arguments, &observed),
+            Err(TraceBindingError::MissingToolCall("missing".to_string()))
+        );
+    }
+
+    #[test]
+    fn duplicate_call_id_does_not_guess() {
+        let mut arguments = serde_json::json!({
+            "$trace_result": {
+                "tool_call_id": "call_upload",
+                "pointer": "/file/id"
+            }
+        });
+        let observed = vec![
+            ObservedToolResult {
+                tool_call_id: "call_upload".to_string(),
+                content: serde_json::json!({"file": {"id": "first"}}),
+            },
+            ObservedToolResult {
+                tool_call_id: "call_upload".to_string(),
+                content: serde_json::json!({"file": {"id": "second"}}),
+            },
+        ];
+
+        assert_eq!(
+            resolve_trace_result_bindings(&mut arguments, &observed),
+            Err(TraceBindingError::DuplicateToolCall(
+                "call_upload".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn unwraps_only_complete_host_evidence_previews() {
+        let mut complete = serde_json::json!({
+            "$trace_result": {
+                "tool_call_id": "call_upload",
+                "pointer": "/file/id"
+            }
+        });
+        let complete_result = ObservedToolResult {
+            tool_call_id: "call_upload".to_string(),
+            content: serde_json::json!({
+                "schema_version": 1,
+                "status": "success",
+                "trust": "provider",
+                "detail": {
+                    "byte_len": 24,
+                    "total_bytes": 24,
+                    "preview": "{\"file\":{\"id\":\"fresh\"}}"
+                }
+            }),
+        };
+
+        resolve_trace_result_bindings(&mut complete, std::slice::from_ref(&complete_result))
+            .expect("complete preview should resolve");
+        assert_eq!(complete, serde_json::json!("fresh"));
+
+        let mut truncated_result = complete_result.clone();
+        truncated_result.content["detail"]["byte_len"] = serde_json::json!(12);
+        let mut truncated = serde_json::json!({
+            "$trace_result": {
+                "tool_call_id": "call_upload",
+                "pointer": "/file/id"
+            }
+        });
+        assert!(matches!(
+            resolve_trace_result_bindings(&mut truncated, &[truncated_result]),
+            Err(TraceBindingError::MissingPointer { .. })
+        ));
+
+        let mut paged = truncated;
+        paged["$trace_result"]["pointer"] = serde_json::json!("/detail/preview");
+        let mut paged_result = complete_result;
+        paged_result.content["detail"]["next_offset"] = serde_json::json!(24);
+        assert!(matches!(
+            resolve_trace_result_bindings(&mut paged, &[paged_result]),
+            Err(TraceBindingError::MissingPointer { .. })
+        ));
+    }
+}

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -124,6 +124,8 @@ def _new_llm_trace_state() -> dict:
         "next_response": 0,
         "expected_user_inputs": {},
         "request_hints": [],
+        "pending_tool_calls": [],
+        "tool_call_id_aliases": {},
         "error": None,
     }
 
@@ -149,6 +151,7 @@ def _parse_llm_trace(trace: object, source: str | None = None) -> dict:
     expected_user_inputs = {0: first_response["content"]}
     request_hints = []
     pending_user_input = True
+    seen_tool_call_ids: set[str] = set()
     for index, step in enumerate(steps[1:], start=1):
         if not isinstance(step, dict) or not isinstance(step.get("response"), dict):
             raise ValueError(f"trace.steps[{index}].response must be an object")
@@ -178,12 +181,21 @@ def _parse_llm_trace(trace: object, source: str | None = None) -> dict:
             for tool_index, tool_call in enumerate(tool_calls):
                 if (
                     not isinstance(tool_call, dict)
+                    or not isinstance(tool_call.get("id"), str)
+                    or not tool_call["id"]
                     or not isinstance(tool_call.get("name"), str)
                     or not isinstance(tool_call.get("arguments"), dict)
                 ):
                     raise ValueError(
                         f"trace.steps[{index}].tool_calls[{tool_index}] is invalid"
                     )
+                tool_call_id = tool_call["id"]
+                if tool_call_id in seen_tool_call_ids:
+                    raise ValueError(
+                        f"trace.steps[{index}].tool_calls[{tool_index}] "
+                        f"reuses tool call id {tool_call_id!r}"
+                    )
+                seen_tool_call_ids.add(tool_call_id)
         else:
             raise ValueError(
                 f"trace.steps[{index}] has unsupported response type {response_type!r}"
@@ -233,6 +245,8 @@ def _parse_llm_trace(trace: object, source: str | None = None) -> dict:
         "next_response": 0,
         "expected_user_inputs": expected_user_inputs,
         "request_hints": request_hints,
+        "pending_tool_calls": [],
+        "tool_call_id_aliases": {},
         "error": None,
     }
 
@@ -252,6 +266,12 @@ def _next_llm_trace_response(
             "recorded LLM trace is exhausted but the agent requested another response"
         )
         raise web.HTTPConflict(text=state["error"])
+
+    try:
+        _capture_trace_tool_call_id_aliases(state, messages)
+    except ValueError as error:
+        state["error"] = str(error)
+        raise web.HTTPConflict(text=state["error"]) from error
 
     request_hint = state["request_hints"][next_index]
     min_message_count = request_hint.get("min_message_count")
@@ -331,73 +351,250 @@ def _next_llm_trace_response(
             raise web.HTTPConflict(text=state["error"])
         try:
             response["tool_calls"] = _resolve_trace_result_bindings(
-                response["tool_calls"], messages
+                response["tool_calls"],
+                _trace_tool_results_with_recorded_ids(state, messages),
             )
         except ValueError as error:
             state["error"] = str(error)
             raise web.HTTPConflict(text=state["error"]) from error
+        state["pending_tool_calls"] = deepcopy(response["tool_calls"])
 
     state["next_response"] += 1
     return response
 
 
-def _resolve_trace_result_bindings(value: object, messages: list[dict]) -> object:
-    """Resolve test-only arguments from earlier real capability results.
-
-    Harvested traces necessarily contain the provider IDs returned during the
-    live run. Full-path replay creates fresh Docs and Sheets resources, so a
-    later recorded call must consume the ID returned by the local provider,
-    not the stale live ID. Tests opt into that behavior with an argument value
-    shaped like::
-
-        {"$trace_result": {"tool": "google-docs__create_document",
-                            "fields": ["documentId", "document_id", "id"]}}
-
-    The marker is accepted only inside the mock server; committed trace files
-    remain unchanged and production code never sees it.
-    """
+def _resolve_trace_result_bindings(
+    value: object,
+    tool_results: list[dict],
+) -> object:
+    """Resolve exact tool-call-ID/JSON-Pointer markers recursively."""
     if isinstance(value, list):
-        return [_resolve_trace_result_bindings(item, messages) for item in value]
+        return [
+            _resolve_trace_result_bindings(item, tool_results) for item in value
+        ]
     if not isinstance(value, dict):
         return value
-
-    if set(value) == {"$trace_result"}:
-        binding = value["$trace_result"]
-        if not isinstance(binding, dict):
-            raise ValueError("$trace_result binding must be an object")
-        tool = binding.get("tool")
-        fields = binding.get("fields")
-        if not isinstance(tool, str) or not tool:
-            raise ValueError("$trace_result.tool must be a non-empty string")
-        if (
-            not isinstance(fields, list)
-            or not fields
-            or not all(isinstance(field, str) and field for field in fields)
-        ):
-            raise ValueError("$trace_result.fields must be non-empty strings")
-
-        named_results = _find_named_tool_results(messages, tool)
-        for result in reversed(named_results):
-            payload = _parse_trace_result_content(result.get("content"))
-            found = _find_trace_result_field(payload, fields)
-            if found is not None:
-                return found
-        observed = [
-            {
-                "name": result.get("name"),
-                "content": str(result.get("content", ""))[:500],
-            }
-            for result in _find_tool_results(messages)
-        ]
+    if "$trace_result" not in value:
+        return {
+            key: _resolve_trace_result_bindings(item, tool_results)
+            for key, item in value.items()
+        }
+    if set(value) != {"$trace_result"}:
         raise ValueError(
-            f"recorded LLM trace could not bind a result from {tool} "
-            f"using fields {fields}; observed tool results: {observed}"
+            "$trace_result marker object must contain only $trace_result"
         )
 
-    return {
-        key: _resolve_trace_result_bindings(item, messages)
-        for key, item in value.items()
+    binding = value["$trace_result"]
+    if not isinstance(binding, dict) or set(binding) != {
+        "tool_call_id",
+        "pointer",
+    }:
+        raise ValueError(
+            "$trace_result must contain exactly tool_call_id and pointer"
+        )
+    tool_call_id = binding["tool_call_id"]
+    pointer = binding["pointer"]
+    if not isinstance(tool_call_id, str) or not tool_call_id:
+        raise ValueError("$trace_result.tool_call_id must be a non-empty string")
+    if not isinstance(pointer, str) or (
+        pointer and not pointer.startswith("/")
+    ):
+        raise ValueError(
+            "$trace_result.pointer must be empty or start with '/'"
+        )
+
+    matching_results = [
+        candidate
+        for candidate in tool_results
+        if candidate.get("tool_call_id") == tool_call_id
+    ]
+    if not matching_results:
+        observed_ids = [
+            candidate.get("tool_call_id") for candidate in tool_results
+        ]
+        raise ValueError(
+            f"trace result has no tool call with id {tool_call_id!r}; "
+            f"observed tool call IDs: {observed_ids}"
+        )
+    if len(matching_results) > 1:
+        raise ValueError(
+            f"trace result has multiple tool results with id {tool_call_id!r}"
+        )
+    result = matching_results[0]
+    parsed_content = _parse_trace_result_content(result.get("content"))
+    content = _canonical_trace_result_payload(parsed_content)
+    if content is parsed_content and _is_trace_result_evidence(parsed_content):
+        raise ValueError(
+            f"trace result for tool call {tool_call_id!r} "
+            f"has no JSON Pointer {pointer!r}"
+        )
+    try:
+        return _resolve_trace_json_pointer(content, pointer)
+    except (KeyError, IndexError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"trace result for tool call {tool_call_id!r} "
+            f"has no JSON Pointer {pointer!r}"
+        ) from error
+
+
+def _resolve_trace_json_pointer(document: object, pointer: str) -> object:
+    current = document
+    if not pointer:
+        return current
+    for raw_token in pointer[1:].split("/"):
+        token = _decode_trace_pointer_token(raw_token)
+        if isinstance(current, dict):
+            current = current[token]
+        elif isinstance(current, list):
+            if not token.isascii() or not token.isdecimal():
+                raise ValueError("array pointer token must be a decimal index")
+            current = current[int(token)]
+        else:
+            raise TypeError("pointer traversed a scalar")
+    return current
+
+
+def _decode_trace_pointer_token(token: str) -> str:
+    decoded = []
+    index = 0
+    while index < len(token):
+        if token[index] != "~":
+            decoded.append(token[index])
+            index += 1
+            continue
+        if index + 1 >= len(token) or token[index + 1] not in {"0", "1"}:
+            raise ValueError("invalid JSON Pointer escape")
+        decoded.append("~" if token[index + 1] == "0" else "/")
+        index += 2
+    return "".join(decoded)
+
+
+def _canonical_trace_result_payload(content: object) -> object:
+    if not isinstance(content, dict):
+        return content
+    if not _is_trace_result_evidence(content):
+        return content
+    detail = content.get("detail")
+    if not isinstance(detail, dict) or not isinstance(detail.get("preview"), str):
+        return content
+    byte_len = detail.get("byte_len")
+    total_bytes = detail.get("total_bytes")
+    if (
+        isinstance(byte_len, bool)
+        or not isinstance(byte_len, int)
+        or isinstance(total_bytes, bool)
+        or not isinstance(total_bytes, int)
+        or byte_len != total_bytes
+        or detail.get("next_offset") is not None
+    ):
+        return content
+    try:
+        return json.loads(detail["preview"])
+    except json.JSONDecodeError:
+        return content
+
+
+def _is_trace_result_evidence(content: object) -> bool:
+    return isinstance(content, dict) and {
+        "schema_version",
+        "status",
+        "trust",
+    } <= set(content)
+
+
+def _capture_trace_tool_call_id_aliases(state: dict, messages: list[dict]) -> None:
+    """Map stable fixture call IDs to IDs normalized by the provider stack."""
+    pending = state.get("pending_tool_calls") or []
+    if not pending:
+        return
+    actual_calls = next(
+        (
+            message.get("tool_calls") or []
+            for message in reversed(messages)
+            if message.get("role") == "assistant" and message.get("tool_calls")
+        ),
+        [],
+    )
+    if len(actual_calls) != len(pending):
+        state["pending_tool_calls"] = []
+        raise ValueError(
+            "trace tool-call alias count mismatch: "
+            f"recorded {len(pending)}, observed {len(actual_calls)}"
+        )
+
+    recorded_calls_by_identity: dict[tuple[str, str], list[dict]] = {}
+    for recorded in pending:
+        identity = _trace_tool_call_identity(recorded)
+        if identity is not None:
+            recorded_calls_by_identity.setdefault(identity, []).append(recorded)
+
+    actual_calls_by_identity: dict[tuple[str, str], list[dict]] = {}
+    for actual in actual_calls:
+        identity = _trace_tool_call_identity(actual)
+        if identity is not None:
+            actual_calls_by_identity.setdefault(identity, []).append(actual)
+
+    aliases = state["tool_call_id_aliases"]
+    for identity, recorded_calls in recorded_calls_by_identity.items():
+        actual_candidates = actual_calls_by_identity.get(identity, [])
+        if len(recorded_calls) > 1 or len(actual_candidates) > 1:
+            raise ValueError(
+                "ambiguous trace tool-call aliases for normalized tool name "
+                f"{identity[0]!r}; repeated calls must have distinct arguments"
+            )
+        if len(recorded_calls) != 1 or len(actual_candidates) != 1:
+            continue
+        recorded = recorded_calls[0]
+        actual = actual_candidates[0]
+        recorded_id = recorded.get("id")
+        actual_id = actual.get("id")
+        if (
+            isinstance(recorded_id, str)
+            and recorded_id
+            and isinstance(actual_id, str)
+            and actual_id
+        ):
+            aliases[recorded_id] = actual_id
+    state["pending_tool_calls"] = []
+
+
+def _trace_tool_call_identity(call: dict) -> tuple[str, str] | None:
+    function = call.get("function")
+    if isinstance(function, dict):
+        name = function.get("name") or call.get("name")
+        arguments = function.get("arguments", call.get("arguments"))
+    else:
+        name = call.get("name")
+        arguments = call.get("arguments")
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(name, str) or not isinstance(arguments, dict):
+        return None
+    return (
+        name.replace("-", "_"),
+        json.dumps(arguments, sort_keys=True, separators=(",", ":")),
+    )
+
+
+def _trace_tool_results_with_recorded_ids(
+    state: dict,
+    messages: list[dict],
+) -> list[dict]:
+    """Present runtime results under their stable fixture IDs."""
+    runtime_to_recorded = {
+        runtime_id: recorded_id
+        for recorded_id, runtime_id in state["tool_call_id_aliases"].items()
     }
+    results = []
+    for observed in _find_tool_results(messages, after_latest_user=False):
+        rewritten = dict(observed)
+        runtime_id = rewritten.get("tool_call_id")
+        rewritten["tool_call_id"] = runtime_to_recorded.get(runtime_id, runtime_id)
+        results.append(rewritten)
+    return results
 
 
 def _parse_trace_result_content(content: object) -> object:
@@ -1964,8 +2161,12 @@ def _extract_tool_name(msg: dict) -> str:
     return "unknown"
 
 
-def _find_tool_results(messages: list[dict]) -> list[dict]:
-    """Collect every fresh tool result that follows the most recent user turn.
+def _find_tool_results(
+    messages: list[dict],
+    *,
+    after_latest_user: bool = True,
+) -> list[dict]:
+    """Collect tool results, optionally limited to the most recent user turn.
 
     A single assistant turn can dispatch *several* tool calls (the v2 engine
     fans them out in parallel and CodeAct can call multiple Python helpers
@@ -1974,10 +2175,11 @@ def _find_tool_results(messages: list[dict]) -> list[dict]:
     acknowledge each result instead of dropping all but the first.
     """
     last_user_idx = -1
-    for i in range(len(messages) - 1, -1, -1):
-        if messages[i].get("role") == "user":
-            last_user_idx = i
-            break
+    if after_latest_user:
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
 
     tool_call_names: dict[str, str] = {}
     results: list[dict] = []
@@ -2000,6 +2202,7 @@ def _find_tool_results(messages: list[dict]) -> list[dict]:
                 name = tool_call_names.get(message.get("tool_call_id", ""), name)
             results.append({
                 "name": name,
+                "tool_call_id": message.get("tool_call_id"),
                 "content": message.get("content", ""),
             })
     return results
@@ -2884,6 +3087,7 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
         if trace_response["type"] == "tool_calls":
             calls = [
                 {
+                    "id": tool_call.get("id"),
                     "tool_name": tool_call["name"],
                     "arguments": tool_call["arguments"],
                 }
@@ -3106,7 +3310,7 @@ def _tool_call_response(cid: str, calls: list[dict] | dict) -> web.Response:
         calls = [calls]
     tool_calls = [
         {
-            "id": f"call_{uuid.uuid4().hex[:8]}",
+            "id": tc.get("id") or f"call_{uuid.uuid4().hex[:8]}",
             "type": "function",
             "function": {
                 "name": tc["tool_name"],
@@ -3186,7 +3390,7 @@ async def _stream_tool_call(
     await resp.prepare(request)
     base = _make_base(cid)
     for idx, tc in enumerate(calls):
-        call_id = f"call_{uuid.uuid4().hex[:8]}"
+        call_id = tc.get("id") or f"call_{uuid.uuid4().hex[:8]}"
         # Header chunk: declare a new tool call slot at this index. Only
         # the very first chunk in the stream needs the assistant role.
         delta: dict = {

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -575,8 +575,13 @@ def _provider_leg(trace: dict, provider_tools: frozenset[str]) -> dict:
     }
 
 
-def _result_binding(tool: str, *fields: str) -> dict:
-    return {"$trace_result": {"tool": tool, "fields": list(fields)}}
+def _result_binding(tool_call_id: str, pointer: str) -> dict:
+    return {
+        "$trace_result": {
+            "tool_call_id": tool_call_id,
+            "pointer": pointer,
+        }
+    }
 
 
 def _inject_deferred_tool_disclosure(trace: dict) -> None:
@@ -604,14 +609,47 @@ def _inject_deferred_tool_disclosure(trace: dict) -> None:
                 "type": "tool_calls",
                 "tool_calls": [
                     {
+                        "id": f"call_disclose_{index}",
                         "name": "capability_info",
                         "arguments": {"name": name.replace("__", ".")},
                     }
-                    for name in provider_names
+                    for index, name in enumerate(provider_names)
                 ],
             }
         },
     )
+
+
+def test_injected_deferred_tool_disclosures_have_stable_ids():
+    trace = {
+        "steps": [
+            {"response": {"type": "user_input", "content": "inspect Slack"}},
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "id": "call_whoami",
+                            "name": "slack__whoami",
+                            "arguments": {},
+                        }
+                    ],
+                }
+            },
+            {"response": {"type": "text", "content": "done"}},
+        ]
+    }
+
+    _inject_deferred_tool_disclosure(trace)
+
+    disclosure_calls = trace["steps"][1]["response"]["tool_calls"]
+    assert disclosure_calls == [
+        {
+            "id": "call_disclose_0",
+            "name": "capability_info",
+            "arguments": {"name": "slack.whoami"},
+        }
+    ]
 
 
 def _coalesce_independent_provider_reads(trace: dict, batch_size: int = 25) -> None:
@@ -648,8 +686,8 @@ def _coalesce_independent_provider_reads(trace: dict, batch_size: int = 25) -> N
 
 
 def _normalize_google_arguments(trace: dict, case: str) -> None:
-    created_document = False
-    created_spreadsheet = False
+    created_document_call_id = None
+    created_spreadsheet_call_id = None
     document_upload_contents = []
     for step in trace["steps"]:
         for call in step["response"].get("tool_calls", []):
@@ -664,6 +702,7 @@ def _normalize_google_arguments(trace: dict, case: str) -> None:
     seeded_spreadsheet = (
         "sheet_reborn_bug_tracker" if case.startswith("qa_7") else "sheet_reborn_abc"
     )
+    seeded_sheet_id = 0
 
     for step in trace["steps"]:
         if "tool_calls" not in step["response"]:
@@ -675,7 +714,7 @@ def _normalize_google_arguments(trace: dict, case: str) -> None:
             _replace_value(arguments, "EMAIL_REDACTED", "e2e.google@example.com")
 
             if name == "google-docs__create_document":
-                created_document = True
+                created_document_call_id = call.get("id")
                 call["name"] = "google-drive__upload_file"
                 content = (
                     document_upload_contents[document_upload_index]
@@ -694,29 +733,31 @@ def _normalize_google_arguments(trace: dict, case: str) -> None:
                 call["name"] = "google-drive__download_file"
                 call["arguments"] = {
                     "file_id": (
-                        _result_binding("google-drive__upload_file", "id", "file_id")
-                        if created_document
+                        _result_binding(created_document_call_id, "/file/id")
+                        if created_document_call_id
                         else "drv_near_ai_strategy"
                     )
                 }
 
             if name == "google-sheets__create_spreadsheet":
-                created_spreadsheet = True
+                created_spreadsheet_call_id = call.get("id")
             elif name.startswith("google-sheets__"):
                 if "spreadsheet_id" in arguments:
                     arguments["spreadsheet_id"] = (
                         _result_binding(
-                            "google-sheets__create_spreadsheet",
-                            "spreadsheetId",
-                            "spreadsheet_id",
-                            "id",
+                            created_spreadsheet_call_id, "/spreadsheet_id"
                         )
-                        if created_spreadsheet
+                        if created_spreadsheet_call_id
                         else seeded_spreadsheet
                     )
-                if created_spreadsheet and "sheet_id" in arguments:
-                    arguments["sheet_id"] = _result_binding(
-                        "google-sheets__create_spreadsheet", "sheetId", "sheet_id"
+                if "sheet_id" in arguments:
+                    arguments["sheet_id"] = (
+                        _result_binding(
+                            created_spreadsheet_call_id,
+                            "/sheets/0/sheet_id",
+                        )
+                        if created_spreadsheet_call_id
+                        else seeded_sheet_id
                     )
 
             if name == "gmail__get_message":
@@ -731,6 +772,35 @@ def _normalize_google_arguments(trace: dict, case: str) -> None:
         if step["response"].get("type") != "tool_calls"
         or step["response"].get("tool_calls")
     ]
+
+
+def test_google_normalization_seeds_consistent_spreadsheet_and_sheet_ids():
+    trace = {
+        "steps": [
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "id": "call_format",
+                            "name": "google-sheets__format_cells",
+                            "arguments": {
+                                "spreadsheet_id": "harvested-spreadsheet",
+                                "sheet_id": 123,
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    _normalize_google_arguments(trace, "qa_7c_slack_bug_logger_routine")
+
+    assert trace["steps"][0]["response"]["tool_calls"][0]["arguments"] == {
+        "spreadsheet_id": "sheet_reborn_bug_tracker",
+        "sheet_id": 0,
+    }
 
 
 def _normalize_slack_arguments(

--- a/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_replay.py
@@ -18,6 +18,11 @@ from provider_capability_inventory import (
     PROVIDER_WIRE_PREFIXES,
     capability_id_to_wire_name,
 )
+from mock_llm import (
+    _capture_trace_tool_call_id_aliases,
+    _resolve_trace_result_bindings,
+    _trace_tool_results_with_recorded_ids,
+)
 
 pytest_plugins = ["reborn_webui_harness"]
 
@@ -39,6 +44,345 @@ def _model_cases() -> list[str]:
 
 
 MODEL_CASES = _model_cases()
+
+
+def test_exact_trace_result_binding_uses_only_the_requested_call():
+    arguments = {
+        "document_id": {
+            "$trace_result": {
+                "tool_call_id": "call_create",
+                "pointer": "/document/documentId",
+            }
+        }
+    }
+    observed = [
+        {
+            "tool_call_id": "call_create",
+            "content": {"document": {"documentId": "fresh-document"}},
+        },
+        {
+            "tool_call_id": "call_similar",
+            "content": {"document": {"documentId": "wrong-document"}},
+        },
+    ]
+
+    assert _resolve_trace_result_bindings(arguments, observed) == {
+        "document_id": "fresh-document"
+    }
+
+
+def test_exact_trace_result_binding_does_not_guess_missing_calls():
+    marker = {
+        "$trace_result": {
+            "tool_call_id": "call_missing",
+            "pointer": "/document/documentId",
+        }
+    }
+    observed = [
+        {
+            "tool_call_id": "call_similar",
+            "content": {"document": {"documentId": "wrong-document"}},
+        }
+    ]
+
+    with pytest.raises(ValueError, match="no tool call with id"):
+        _resolve_trace_result_bindings(marker, observed)
+
+
+def test_exact_trace_result_binding_rejects_duplicate_observed_ids():
+    marker = {
+        "$trace_result": {
+            "tool_call_id": "call_create",
+            "pointer": "/document/documentId",
+        }
+    }
+    observed = [
+        {
+            "tool_call_id": "call_create",
+            "content": {"document": {"documentId": "first-document"}},
+        },
+        {
+            "tool_call_id": "call_create",
+            "content": {"document": {"documentId": "second-document"}},
+        },
+    ]
+
+    with pytest.raises(ValueError, match="multiple tool results with id"):
+        _resolve_trace_result_bindings(marker, observed)
+
+
+def test_exact_trace_result_binding_uses_results_from_prior_user_turns():
+    marker = {
+        "$trace_result": {
+            "tool_call_id": "call_create",
+            "pointer": "/document/documentId",
+        }
+    }
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "runtime_create",
+                    "function": {
+                        "name": "google_docs__create_document",
+                        "arguments": json.dumps({"title": "first turn"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "runtime_create",
+            "content": json.dumps(
+                {"document": {"documentId": "fresh-document"}}
+            ),
+        },
+        {"role": "user", "content": "Now read that document"},
+    ]
+    state = {
+        "tool_call_id_aliases": {"call_create": "runtime_create"},
+    }
+
+    observed = _trace_tool_results_with_recorded_ids(state, messages)
+
+    assert _resolve_trace_result_bindings(marker, observed) == "fresh-document"
+
+
+def test_exact_trace_result_binding_rejects_paged_evidence_preview():
+    marker = {
+        "$trace_result": {
+            "tool_call_id": "call_create",
+            "pointer": "/detail/preview",
+        }
+    }
+    observed = [
+        {
+            "tool_call_id": "call_create",
+            "content": {
+                "schema_version": 1,
+                "status": "success",
+                "trust": "provider",
+                "detail": {
+                    "byte_len": 48,
+                    "total_bytes": 48,
+                    "next_offset": 48,
+                    "preview": json.dumps(
+                        {"document": {"documentId": "partial-document"}}
+                    ),
+                },
+            },
+        }
+    ]
+
+    with pytest.raises(ValueError, match="has no JSON Pointer"):
+        _resolve_trace_result_bindings(marker, observed)
+
+
+def test_exact_trace_result_binding_unwraps_complete_preview_and_pointer_escapes():
+    preview = json.dumps({"files": [{"a/b~c": "escaped-hit"}]})
+    marker = {
+        "$trace_result": {
+            "tool_call_id": "call_list",
+            "pointer": "/files/0/a~1b~0c",
+        }
+    }
+    observed = [
+        {
+            "tool_call_id": "call_list",
+            "content": {
+                "schema_version": 1,
+                "status": "success",
+                "trust": "provider",
+                "detail": {
+                    "byte_len": len(preview),
+                    "total_bytes": len(preview),
+                    "preview": preview,
+                },
+            },
+        }
+    ]
+
+    assert _resolve_trace_result_bindings(marker, observed) == "escaped-hit"
+
+
+def test_trace_aliasing_rejects_indistinguishable_parallel_calls():
+    state = {
+        "pending_tool_calls": [
+            {
+                "id": "call_first",
+                "name": "google-docs__create_document",
+                "arguments": {"title": "same"},
+            },
+            {
+                "id": "call_second",
+                "name": "google-docs__create_document",
+                "arguments": {"title": "same"},
+            },
+        ],
+        "tool_call_id_aliases": {},
+    }
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "runtime_second",
+                    "function": {
+                        "name": "google_docs__create_document",
+                        "arguments": json.dumps({"title": "same"}),
+                    },
+                },
+                {
+                    "id": "runtime_first",
+                    "function": {
+                        "name": "google_docs__create_document",
+                        "arguments": json.dumps({"title": "same"}),
+                    },
+                },
+            ],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="ambiguous trace tool-call aliases"):
+        _capture_trace_tool_call_id_aliases(state, messages)
+
+
+def test_trace_aliasing_matches_reordered_calls_by_arguments():
+    state = {
+        "pending_tool_calls": [
+            {
+                "id": "call_wanted",
+                "name": "google-docs__create_document",
+                "arguments": {"title": "wanted"},
+            },
+            {
+                "id": "call_other",
+                "name": "google-docs__create_document",
+                "arguments": {"title": "other"},
+            },
+        ],
+        "tool_call_id_aliases": {},
+    }
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "runtime_other",
+                    "function": {
+                        "name": "google_docs__create_document",
+                        "arguments": json.dumps({"title": "other"}),
+                    },
+                },
+                {
+                    "id": "runtime_wanted",
+                    "function": {
+                        "name": "google_docs__create_document",
+                        "arguments": json.dumps({"title": "wanted"}),
+                    },
+                },
+            ],
+        }
+    ]
+
+    _capture_trace_tool_call_id_aliases(state, messages)
+
+    assert state["tool_call_id_aliases"] == {
+        "call_wanted": "runtime_wanted",
+        "call_other": "runtime_other",
+    }
+
+
+def test_trace_aliasing_discards_mismatched_pending_batch():
+    state = {
+        "pending_tool_calls": [
+            {
+                "id": "call_pending",
+                "name": "google-docs__create_document",
+                "arguments": {},
+            }
+        ],
+        "tool_call_id_aliases": {},
+    }
+
+    with pytest.raises(ValueError, match="alias count mismatch"):
+        _capture_trace_tool_call_id_aliases(state, [])
+
+    assert state["pending_tool_calls"] == []
+
+
+async def test_trace_install_rejects_missing_tool_call_id(mock_llm_server):
+    trace = {
+        "steps": [
+            {"response": {"type": "user_input", "content": "create"}},
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "name": "google-docs__create_document",
+                            "arguments": {},
+                        }
+                    ],
+                }
+            },
+        ]
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{mock_llm_server}/__mock/llm_trace",
+            json={"source": "missing-id.json", "trace": trace},
+            timeout=15,
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == (
+        "trace.steps[1].tool_calls[0] is invalid"
+    )
+
+
+async def test_trace_install_rejects_duplicate_tool_call_id(mock_llm_server):
+    trace = {
+        "steps": [
+            {"response": {"type": "user_input", "content": "create twice"}},
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "id": "call_duplicate",
+                            "name": "google-docs__create_document",
+                            "arguments": {"title": "first"},
+                        }
+                    ],
+                }
+            },
+            {
+                "response": {
+                    "type": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "id": "call_duplicate",
+                            "name": "google-docs__create_document",
+                            "arguments": {"title": "second"},
+                        }
+                    ],
+                }
+            },
+        ]
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{mock_llm_server}/__mock/llm_trace",
+            json={"source": "duplicate-id.json", "trace": trace},
+            timeout=15,
+        )
+
+    assert response.status_code == 400
+    assert "reuses tool call id 'call_duplicate'" in response.json()["error"]
 
 
 def _load_case(case: str) -> dict:
@@ -282,7 +626,16 @@ async def test_trace_replay_binds_fresh_provider_ids_into_follow_up_calls(
                 "response": {
                     "type": "tool_calls",
                     "tool_calls": [
-                        {"name": "google-docs__create_document", "arguments": {}}
+                        {
+                            "id": "call_create_document",
+                            "name": "google-docs__create_document",
+                            "arguments": {"title": "wanted"},
+                        },
+                        {
+                            "id": "call_create_other_document",
+                            "name": "google-docs__create_document",
+                            "arguments": {"title": "other"},
+                        }
                     ],
                 }
             },
@@ -291,12 +644,13 @@ async def test_trace_replay_binds_fresh_provider_ids_into_follow_up_calls(
                     "type": "tool_calls",
                     "tool_calls": [
                         {
+                            "id": "call_read_document",
                             "name": "google-docs__read_content",
                             "arguments": {
                                 "document_id": {
                                     "$trace_result": {
-                                        "tool": "google-docs__create_document",
-                                        "fields": ["documentId", "document_id", "id"],
+                                        "tool_call_id": "call_create_document",
+                                        "pointer": "/document/documentId",
                                     }
                                 }
                             },
@@ -319,14 +673,30 @@ async def test_trace_replay_binds_fresh_provider_ids_into_follow_up_calls(
         )
         created.raise_for_status()
         created_message = created.json()["choices"][0]["message"]
+        created_message["tool_calls"][0]["id"] = "runtime_normalized_call_id"
+        created_message["tool_calls"][0]["function"]["name"] = (
+            "google_docs__create_document"
+        )
+        created_message["tool_calls"][1]["id"] = "runtime_other_call_id"
+        created_message["tool_calls"][1]["function"]["name"] = (
+            "google_docs__create_document"
+        )
+        created_message["tool_calls"].reverse()
         messages.extend(
             [
                 created_message,
                 {
                     "role": "tool",
-                    "tool_call_id": created_message["tool_calls"][0]["id"],
+                    "tool_call_id": "runtime_normalized_call_id",
                     "content": json.dumps(
                         {"document": {"documentId": "doc-created-locally"}}
+                    ),
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "runtime_other_call_id",
+                    "content": json.dumps(
+                        {"document": {"documentId": "wrong-document"}}
                     ),
                 },
             ]
@@ -357,7 +727,13 @@ async def test_trace_replay_accepts_direct_calls_from_deferred_tool_catalog(
             {
                 "response": {
                     "type": "tool_calls",
-                    "tool_calls": [{"name": "slack__whoami", "arguments": {}}],
+                    "tool_calls": [
+                        {
+                            "id": "call_whoami",
+                            "name": "slack__whoami",
+                            "arguments": {},
+                        }
+                    ],
                 }
             },
         ]
@@ -396,7 +772,13 @@ async def test_trace_replay_stops_after_failed_capability_result(mock_llm_server
             {
                 "response": {
                     "type": "tool_calls",
-                    "tool_calls": [{"name": "slack__whoami", "arguments": {}}],
+                    "tool_calls": [
+                        {
+                            "id": "call_whoami",
+                            "name": "slack__whoami",
+                            "arguments": {},
+                        }
+                    ],
                 }
             },
             {"response": {"type": "text", "content": "done"}},
@@ -442,7 +824,13 @@ async def test_trace_replay_accepts_exact_expected_capability_failure(mock_llm_s
             {
                 "response": {
                     "type": "tool_calls",
-                    "tool_calls": [{"name": "slack__whoami", "arguments": {}}],
+                    "tool_calls": [
+                        {
+                            "id": "call_whoami",
+                            "name": "slack__whoami",
+                            "arguments": {},
+                        }
+                    ],
                 }
             },
             {

--- a/tests/fixtures/llm_traces/README.md
+++ b/tests/fixtures/llm_traces/README.md
@@ -226,6 +226,26 @@ Returns a `ToolCompletionResponse` with `FinishReason::ToolUse`. The agent loop 
 | `name` | string | Must match a registered tool name (e.g. `echo`, `write_file`, `read_file`, `memory_write`, `shell`). |
 | `arguments` | object | Tool parameters as JSON. Must conform to the tool's `parameters_schema()`. |
 
+#### Binding a later call to an earlier tool result
+
+When a provider creates a fresh resource, later calls must use the ID returned
+by the current replay—not the stale ID captured during recording. Reference
+the exact tool call and an RFC 6901 JSON Pointer into its result:
+
+```json
+{
+  "file_id": {
+    "$trace_result": {
+      "tool_call_id": "call_upload_1",
+      "pointer": "/file/id"
+    }
+  }
+}
+```
+
+Missing call IDs or pointers fail loudly. Replay never searches by tool name
+or guesses among similarly named fields.
+
 #### `user_input` -- user message marker (recording only)
 
 ```json

--- a/tests/fixtures/llm_traces/live/routine_btc_create_test_and_refire.json
+++ b/tests/fixtures/llm_traces/live/routine_btc_create_test_and_refire.json
@@ -379,7 +379,7 @@
             "id": "call_b4d5b1ea6b4b4d3184b1d227",
             "name": "routine_fire",
             "arguments": {
-              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+              "name": {"$trace_result":{"tool_call_id":"call_657a9167a2d74cdd88556b34","pointer":"/name"}}
             }
           }
         ],
@@ -406,7 +406,7 @@
             "id": "call_7febebee51a647b38f1187a2",
             "name": "routine_history",
             "arguments": {
-              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+              "name": {"$trace_result":{"tool_call_id":"call_657a9167a2d74cdd88556b34","pointer":"/name"}}
             }
           }
         ],
@@ -433,7 +433,7 @@
             "id": "call_23968adef6b64abb9ccd2090",
             "name": "job_status",
             "arguments": {
-              "job_id": "{{call_b4d5b1ea6b4b4d3184b1d227.thread_id}}"
+              "job_id": {"$trace_result":{"tool_call_id":"call_b4d5b1ea6b4b4d3184b1d227","pointer":"/thread_id"}}
             }
           }
         ],
@@ -509,7 +509,7 @@
             "id": "call_4e9e7350c1f84d73b3b2baee",
             "name": "routine_history",
             "arguments": {
-              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+              "name": {"$trace_result":{"tool_call_id":"call_657a9167a2d74cdd88556b34","pointer":"/name"}}
             }
           }
         ],
@@ -650,7 +650,7 @@
             "id": "call_a3f00734525c4707a0edbfdc",
             "name": "routine_update",
             "arguments": {
-              "name": "{{call_4e9e7350c1f84d73b3b2baee.name}}",
+              "name": {"$trace_result":{"tool_call_id":"call_4e9e7350c1f84d73b3b2baee","pointer":"/name"}},
               "prompt": "Fetch the current Bitcoin price using the http tool. Call: http(method=\"GET\", url=\"https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd\"). Parse the response to extract the bitcoin.usd price and report it clearly in a formatted message like \"Bitcoin Price: $XXX,XXX USD\"."
             }
           }
@@ -678,7 +678,7 @@
             "id": "call_05c529ff62ea4620aeca7165",
             "name": "routine_fire",
             "arguments": {
-              "name": "{{call_4e9e7350c1f84d73b3b2baee.name}}"
+              "name": {"$trace_result":{"tool_call_id":"call_4e9e7350c1f84d73b3b2baee","pointer":"/name"}}
             }
           }
         ],
@@ -705,7 +705,7 @@
             "id": "call_17e42824f0994356914beb8f",
             "name": "routine_history",
             "arguments": {
-              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+              "name": {"$trace_result":{"tool_call_id":"call_657a9167a2d74cdd88556b34","pointer":"/name"}}
             }
           }
         ],
@@ -753,7 +753,7 @@
             "id": "call_ac9051b4a2ed4d6ba6e0c5eb",
             "name": "job_status",
             "arguments": {
-              "job_id": "{{call_05c529ff62ea4620aeca7165.thread_id}}"
+              "job_id": {"$trace_result":{"tool_call_id":"call_05c529ff62ea4620aeca7165","pointer":"/thread_id"}}
             }
           }
         ],
@@ -845,7 +845,7 @@
             "id": "call_e023cfbd1ff94b33968678ef",
             "name": "routine_history",
             "arguments": {
-              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+              "name": {"$trace_result":{"tool_call_id":"call_657a9167a2d74cdd88556b34","pointer":"/name"}}
             }
           }
         ],

--- a/tests/support/trace_llm.rs
+++ b/tests/support/trace_llm.rs
@@ -13,6 +13,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 use ironclaw_llm::LlmError;
+use ironclaw_llm::trace_binding::{ObservedToolResult, resolve_trace_result_bindings};
 use ironclaw_llm::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, Role, ToolCall,
     ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
@@ -505,29 +506,31 @@ impl TraceLlm {
             .find(|m| matches!(m.role, Role::User))
             .map(|m| m.content.clone());
 
-        let mut step = {
-            let mut steps = self.steps.lock().unwrap();
-            if steps.is_empty() {
-                return Err(LlmError::RequestFailed {
-                    provider: self.model_name.clone(),
-                    reason: format!(
-                        "TraceLlm exhausted: served {} call(s), no steps left",
-                        self.calls_served.load(Ordering::Relaxed)
-                    ),
-                });
-            }
+        let mut steps = self.steps.lock().unwrap();
+        if steps.is_empty() {
+            return Err(LlmError::RequestFailed {
+                provider: self.model_name.clone(),
+                reason: format!(
+                    "TraceLlm exhausted: served {} call(s), no steps left",
+                    self.calls_served.load(Ordering::Relaxed)
+                ),
+            });
+        }
 
+        // Select and clone a step, but leave it queued until every binding
+        // resolves so a corrected retry can replay the same response.
+        let selected_index = {
             // (1) Head fast path: head matches (or has no hint at all).
             let head_matches = step_matches(&steps[0], last_user_content.as_deref());
             if head_matches {
-                steps.pop_front().expect("checked non-empty above")
+                0
             } else {
                 // (2) Hint scan: look for the first step whose hint substring
                 //     is present in the current last user message.
                 let scan_pos = (1..steps.len())
                     .find(|&i| step_matches(&steps[i], last_user_content.as_deref()));
                 if let Some(idx) = scan_pos {
-                    steps.remove(idx).expect("scan position is valid")
+                    idx
                 } else {
                     // (3) Legacy fallback: nothing matches. Return the head
                     //     and warn — preserves the "warn but continue" contract
@@ -541,10 +544,14 @@ impl TraceLlm {
                             last_user_content.as_deref(),
                         );
                     }
-                    steps.pop_front().expect("checked non-empty above")
+                    0
                 }
             }
         };
+        let mut step = steps
+            .get(selected_index)
+            .cloned()
+            .expect("selected trace step remains queued");
 
         // Soft-validate min_message_count on the chosen step.
         if let Some(ref hint) = step.request_hint
@@ -564,16 +571,48 @@ impl TraceLlm {
             ref mut tool_calls, ..
         } = step.response
         {
+            let observed = Self::extract_observed_tool_results(messages);
             let vars = Self::extract_tool_result_vars(messages);
-            if !vars.is_empty() {
-                for tc in tool_calls.iter_mut() {
+            for tc in tool_calls.iter_mut() {
+                resolve_trace_result_bindings(&mut tc.arguments, &observed).map_err(|error| {
+                    LlmError::RequestFailed {
+                        provider: "trace".to_string(),
+                        reason: error.to_string(),
+                    }
+                })?;
+                if !vars.is_empty() {
                     Self::substitute_templates(&mut tc.arguments, &vars);
                 }
             }
         }
 
+        steps
+            .remove(selected_index)
+            .expect("selected trace step remains queued");
+        drop(steps);
         self.calls_served.fetch_add(1, Ordering::Relaxed);
         Ok(step)
+    }
+
+    fn extract_observed_tool_results(messages: &[ChatMessage]) -> Vec<ObservedToolResult> {
+        messages
+            .iter()
+            .filter_map(|message| {
+                if message.role != Role::Tool {
+                    return None;
+                }
+                let tool_call_id = message.tool_call_id.clone()?;
+                let content = Self::unwrap_tool_output(&message.content);
+                let parsed = serde_json::from_str(content.as_ref()).ok().or_else(|| {
+                    coerce_python_repr_to_json(content.as_ref())
+                        .and_then(|json| serde_json::from_str(&json).ok())
+                })?;
+                Some(ObservedToolResult {
+                    tool_call_id,
+                    content: parsed,
+                })
+            })
+            .collect()
     }
 
     /// Build a map of `"key.field" -> resolved_value` from tool result

--- a/tests/trace_llm_tests.rs
+++ b/tests/trace_llm_tests.rs
@@ -1,2 +1,73 @@
 mod support;
-// Tests are defined inside support/trace_llm.rs
+
+use crate::support::trace_llm::{LlmTrace, TraceLlm, TraceResponse, TraceStep, TraceToolCall};
+use ironclaw_llm::{ChatMessage, LlmProvider, ToolCompletionRequest};
+
+#[tokio::test]
+async fn trace_llm_resolves_exact_result_binding_through_provider_call() {
+    let trace = LlmTrace::single_turn(
+        "trace-test",
+        "create and read",
+        vec![TraceStep {
+            request_hint: None,
+            response: TraceResponse::ToolCalls {
+                tool_calls: vec![TraceToolCall {
+                    id: "call_read".to_string(),
+                    name: "google-docs__read_content".to_string(),
+                    arguments: serde_json::json!({
+                        "document_id": {
+                            "$trace_result": {
+                                "tool_call_id": "call_create",
+                                "pointer": "/document/id"
+                            }
+                        }
+                    }),
+                }],
+                input_tokens: 1,
+                output_tokens: 1,
+            },
+            expected_tool_results: Vec::new(),
+        }],
+    );
+    let provider = TraceLlm::from_trace(trace);
+    let error = provider
+        .complete_with_tools(ToolCompletionRequest::new(
+            vec![ChatMessage::user("create and read")],
+            Vec::new(),
+        ))
+        .await
+        .expect_err("missing tool evidence should reject the replay step");
+    assert!(error.to_string().contains("call_create"));
+    assert_eq!(
+        provider.calls(),
+        0,
+        "failed binding must not consume the step"
+    );
+
+    let request = ToolCompletionRequest::new(
+        vec![
+            ChatMessage::user("create and read"),
+            ChatMessage::tool_result(
+                "call_create",
+                "google-docs__create_document",
+                r#"{"document":{"id":"fresh-document"}}"#,
+            ),
+            ChatMessage::tool_result(
+                "call_similar",
+                "google-docs__create_document",
+                r#"{"document":{"id":"wrong-document"}}"#,
+            ),
+        ],
+        Vec::new(),
+    );
+
+    let response = provider
+        .complete_with_tools(request)
+        .await
+        .expect("trace response should resolve");
+
+    assert_eq!(
+        response.tool_calls[0].arguments,
+        serde_json::json!({"document_id": "fresh-document"})
+    );
+}


### PR DESCRIPTION
## Summary

- Replace heuristic dynamic-result lookup with one exact fixture marker: the original `tool_call_id` plus an RFC 6901 JSON Pointer.
- Teach the opt-in recorder, Rust `TraceLlm`, and existing Python mock LLM to produce/resolve that marker, including provider-normalized call IDs and complete host-evidence previews.
- Migrate the one committed fixture that used the old dynamic templates and exercise the real Docs journey through Reborn and Emulate.

This deliberately does **not** introduce trace format versioning, migrate the fixture catalog, change importer behavior, move trace types, or add a cross-language conformance framework.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build` (built by the standalone Reborn/Emulate E2E setup)
- [x] Relevant tests pass (listed below)
- [ ] `cargo test --features integration` — Not applicable: no database-backed behavior changed.
- [x] Manual testing: QA 5D replayed through standalone Reborn, first-party capabilities, mediated HTTP, and Emulate using the fresh provider-issued document ID.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review.

## Test Strategy

User behavior:

Recorded-model tests can replay a later capability call using the fresh resource ID returned by the current hermetic provider run. They no longer guess by tool name or a list of possible field names.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:

- Unit or contract: exact call-ID/pointer success, missing-call failure, complete-vs-truncated evidence, recorder nested binding, and recorder ambiguity behavior.
- Reborn integration: `TraceLlm` caller test proves exact binding through the provider call; the existing trace-format suite remains green.
- Recorded fixture: one legacy dynamic-template fixture migrated; the 61-file Reborn QA scrub validator and all 45 Python replay tests pass.
- Browser E2E: Not applicable: no browser behavior changes.
- Backend or runtime: the complete pinned-Emulate smoke lane passed: inventory, journey coverage, provider contracts, fixture replay, and all full-path Reborn journeys (215 tests). The previously flaky QA 6C/6E sequence also passed five consecutive stress runs.
- Live canary: Not applicable: no live-model/provider behavior changes.

What the tests prove:

A binding consumes only the named prior tool call and exact result path; missing IDs, missing pointers, ambiguous recorder matches, and truncated evidence fail rather than selecting a plausible value. The caller-level Docs run proves a fixture call ID still resolves when the provider stack normalizes the runtime call ID.

Commands run:

```text
cargo test -p ironclaw_llm --no-fail-fast                     # 942 passed
cargo test --test trace_llm_tests
cargo test --test trace_format                                # 8 passed
cargo test -p ironclaw_architecture
cargo clippy -p ironclaw_llm --all-targets --all-features -- -D warnings
cargo clippy --workspace --all-targets --all-features -- -D warnings
uv run --project tests/e2e --no-sync pytest -q tests/e2e/scenarios/test_reborn_qa_trace_replay.py  # 45 passed
IRONCLAW_EMULATE_CLI=<pinned fork CLI> uv run --project tests/e2e --no-sync pytest -q <five Reborn/Emulate smoke files> --timeout=120  # 215 passed
IRONCLAW_EMULATE_CLI=<pinned fork CLI> uv run --project tests/e2e --no-sync pytest -q tests/e2e/scenarios/test_reborn_qa_trace_full_path.py -k "qa_6c or qa_6e" --timeout=120  # 5 consecutive runs passed
scripts/ci/check-reborn-qa-fixtures.sh                         # 61 files passed
jq empty tests/fixtures/llm_traces/live/routine_btc_create_test_and_refire.json
```

`scripts/pre-commit-safety.sh` was also run. Its composition budget passed, then it stopped on an existing `ARCH-SPRAWL` warning in `crates/ironclaw_auth/src/product_auth/api/auth.rs`; this PR has no diff in that file.

## Security Impact

None. This changes test replay infrastructure and the opt-in trace recorder. Binding failures report IDs and paths, not provider result values.

## Reborn Trust-Boundary Checklist

N/A: no Reborn trust, policy, ingress, persistence, authorization, or production runtime boundary changes.

## Database Impact

None.

## Blast Radius

Eleven files: the trace binding helper, recorder, Rust replay support, existing Python mock LLM, focused tests/docs, and one fixture. Existing trace shape and legacy `{{call.field}}` replay remain compatible.

## Rollback Plan

Revert this PR. No database, fixture-catalog, or product migration is involved.

## Review Follow-Through

Reviewer judgment is most useful around exact call-ID aliasing and the rule that host-evidence previews are usable only when complete.

---

**Review track**: A (docs/tests/chore)



