### PR TITLE
Fix durable install CI stack overflow

### DIFF
--- a/tests/integration/durable.rs
+++ b/tests/integration/durable.rs
@@ -17,8 +17,15 @@ use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
 use serde_json::json;
 
-#[tokio::test]
-async fn extension_install_survives_independent_reopen() {
+#[test]
+fn extension_install_survives_independent_reopen() {
+    run_async_test_with_stack(
+        "extension_install_survives_independent_reopen",
+        extension_install_survives_independent_reopen_async,
+    );
+}
+
+async fn extension_install_survives_independent_reopen_async() {
     let group = RebornIntegrationGroup::extension_lifecycle()
         .await
         .expect("extension-lifecycle group builds");
@@ -52,4 +59,25 @@ async fn extension_install_survives_independent_reopen() {
         .assert_extension_install_persists_after_reopen("github")
         .await
         .expect("installed extension survives an independent reopen");
+}
+
+fn run_async_test_with_stack<F, Fut>(name: &'static str, test: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio test runtime")
+                .block_on(test());
+        })
+        .expect("spawn stack-sized test thread");
+    if let Err(panic) = handle.join() {
+        std::panic::resume_unwind(panic);
+    }
 }


### PR DESCRIPTION
## Summary

- Run the durable extension install/reopen integration test on a stack-sized test thread.
- Preserve the existing assertions while matching the established Reborn integration test runtime pattern.
- Fix the `Coverage (default)` stack overflow seen after #6615 merged.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6615

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_durable extension_install_survives_independent_reopen -- --nocapture`; `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_durable -- --nocapture`; `cargo llvm-cov -p ironclaw_reborn_integration_tests --test reborn_integration_durable --no-report -- extension_install_survives_independent_reopen --nocapture`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable: test-only runtime wrapper change.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior:
No product behavior changes. This only changes how one existing integration test is executed under the Rust test harness.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable: existing integration assertion is unchanged.
- Reborn integration: Updated `extension_install_survives_independent_reopen` to use a stack-sized current-thread runtime.
- Recorded fixture: Not applicable: no model fixture behavior changed.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: Not applicable: production runtime code is unchanged.
- Live canary: Not applicable: hermetic CI test harness fix.

What the tests prove:
The durable extension install/reopen scenario still installs GitHub through the real turn path, reports success, and reads the persisted installation through an independent reopened store without overflowing the default test thread stack.

Commands run:
`cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_durable extension_install_survives_independent_reopen -- --nocapture`
`cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_durable -- --nocapture`
`cargo fmt --all -- --check`
`git diff --check`
`cargo llvm-cov -p ironclaw_reborn_integration_tests --test reborn_integration_durable --no-report -- extension_install_survives_independent_reopen --nocapture`

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A: test harness execution wrapper only; no Reborn trust boundary, policy, runtime, serialization, or production code changed.

## Database Impact

None.

## Blast Radius

Limited to `tests/integration/durable.rs`. The only expected effect is preventing stack overflow in the durable extension install/reopen integration test under CI.

## Rollback Plan

Revert `45a881876` to restore the previous `#[tokio::test]` execution shape if this creates unexpected test-harness behavior.

## Review Follow-Through

PR #6615 is already merged. This follow-up addresses the post-merge CI failure; no additional ironloopai review request is needed.

---

**Review track**: A (docs/tests/chore)