### PR TITLE
fix(webui): preserve workspace tree state across root navigation

### DIFF
--- a/crates/ironclaw_webui/frontend/src/app/app.tsx
+++ b/crates/ironclaw_webui/frontend/src/app/app.tsx
@@ -221,7 +221,6 @@ export function App() {
           <Route path="welcome" element={(<LazyRoute><OnboardingPage /></LazyRoute>)} />
           <Route path="chat" element={(<LazyRoute><ChatPage /></LazyRoute>)} />
           <Route path="chat/:threadId" element={(<LazyRoute><ChatPage /></LazyRoute>)} />
-          <Route path="workspace" element={(<LazyRoute><WorkspacePage /></LazyRoute>)} />
           <Route path="workspace/*" element={(<LazyRoute><WorkspacePage /></LazyRoute>)} />
           <Route path="projects" element={(<LazyRoute><ProjectsPage /></LazyRoute>)} />
           <Route path="projects/:projectId" element={(<LazyRoute><ProjectsPage /></LazyRoute>)} />

--- a/tests/e2e/scenarios/test_reborn_v2_file_download.py
+++ b/tests/e2e/scenarios/test_reborn_v2_file_download.py
@@ -303,6 +303,7 @@ async def test_workspace_tree_keyboard_navigation_and_accessibility(
     # to the newly selected, visible item.
     breadcrumb = page.get_by_role("navigation", name="workspace")
     await breadcrumb.get_by_role("button", name="Home", exact=True).click()
+    await expect(guide).to_be_visible()
     report = tree.get_by_role("treeitem", name="report.pdf", exact=True)
     await expect(report).to_be_visible()
     report_row = page.locator(


### PR DESCRIPTION
## Summary
- use one workspace route for both the root and deep-linked paths
- preserve expanded tree state when breadcrumb navigation returns to the root

## Test Strategy
- [x] Frontend unit tests: `vitest run src/pages/workspace/components/workspace-presentation.test.tsx src/pages/workspace/lib/workspace-presenters.test.ts` (14 passed)
- [x] TypeScript: `tsc --noEmit`
- [ ] Backend tests: Not applicable: frontend route configuration only
- [ ] E2E/browser: Covered by the existing failing regression scenario in CI
- [ ] Live canary: Not applicable: no provider or runtime behavior changed