### PR TITLE
P2b: per-user hosted-MCP discovery, rebased onto main + per-thread hire-scoping (supersedes #6365)

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
@@ -100,6 +100,9 @@ const FROZEN_OTHER_MODE_TYPES: &[&str] = &[
     "HostedMcpDiscoveryEgress",
     "HostedMcpDiscoveryError",
     "HostedMcpEndpoint",
+    // P2b turn-start refresher that populates the per-user hosted-MCP discovery
+    // overlay — same Bucket-3 "hosted MCP" domain class, not a deployment tier.
+    "HostedMcpOverlayRefresher",
     // --- Local* (non-LocalDev): the `local_trigger_access` module has been
     //     folded to a config value — fire-time trigger access is now the
     //     `TriggerFireAccessPolicy` on `RebornRuntimeInput`, backed by config

--- a/crates/ironclaw_extension_host/src/active.rs
+++ b/crates/ironclaw_extension_host/src/active.rs
@@ -203,6 +203,34 @@ impl ActiveSnapshot {
         })
     }
 
+    /// Resolve a per-user DISCOVERED hosted-MCP tool id (P2b) whose exact id is
+    /// not in the static `capability_owner` map. A hosted-MCP extension's
+    /// capability adapter is per-extension and derives the wire tool name from
+    /// the request's capability id, so any `<provider>.<tool>` of an active
+    /// hosted-MCP provider dispatches through that provider's one adapter.
+    /// Authorization (per-user grants) still gates which discovered ids are
+    /// allowed, and the marketplace rejects tools the caller may not use, so
+    /// resolving broadly by provider is safe.
+    pub fn resolve_hosted_mcp_tool(
+        &self,
+        capability_id: &CapabilityId,
+    ) -> Option<ResolvedToolBinding> {
+        if self.capability_owner.contains_key(capability_id) {
+            return None;
+        }
+        let (provider, _tool) = capability_id.as_str().split_once('.')?;
+        let extension = self.extensions.get(provider)?;
+        if extension.resolved.runtime.kind() != ironclaw_host_api::RuntimeKind::Mcp {
+            return None;
+        }
+        let adapter = extension.extension.capability_adapter()?;
+        Some(ResolvedToolBinding {
+            adapter,
+            declaration: Arc::clone(&extension.resolved),
+            generation: self.generation,
+        })
+    }
+
     /// Resolve the active extension serving
     /// `/webhooks/extensions/{extension_id}/{route_suffix}` — the extension
     /// must be active, declare an inbound channel, and declare exactly this

--- a/crates/ironclaw_extension_host/src/mcp.rs
+++ b/crates/ironclaw_extension_host/src/mcp.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use ironclaw_extensions::{
-    ExtensionPackage, ExtensionRuntime, ManifestSource, SharedExtensionRegistry,
+    ExtensionPackage, ExtensionRuntime, ManifestSource, OverlayScope, ScopedPackageOverlay,
+    SharedExtensionRegistry,
 };
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, NetworkPolicy, NetworkScheme, NetworkTargetPattern,
-    RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeHttpEgress,
+    CapabilityDescriptor, CapabilityId, ExtensionId, NetworkPolicy, NetworkScheme,
+    NetworkTargetPattern, ResourceScope, RuntimeCredentialInjection, RuntimeCredentialSource,
+    RuntimeHttpEgress,
 };
 use ironclaw_mcp::{
     McpHostHttpClient, McpHostHttpEgressPlan, McpHostHttpEgressPlanRequest,
@@ -19,35 +21,76 @@ const MCP_TIMEOUT_MS: u32 = 60_000;
 pub fn hosted_http_mcp_runtime(
     registry: Arc<SharedExtensionRegistry>,
     runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 ) -> McpRuntime<
     McpHostHttpClient<McpRuntimeHttpAdapter<Arc<dyn RuntimeHttpEgress>>, RegistryMcpEgressPlanner>,
 > {
-    let client = McpHostHttpClient::new(
-        McpRuntimeHttpAdapter::new(runtime_http_egress),
-        RegistryMcpEgressPlanner::new(registry),
-    );
+    let mut planner = RegistryMcpEgressPlanner::new(registry);
+    if let Some(overlay) = scoped_overlay {
+        planner = planner.with_scoped_overlay(overlay);
+    }
+    let client = McpHostHttpClient::new(McpRuntimeHttpAdapter::new(runtime_http_egress), planner);
     McpRuntime::new(McpRuntimeConfig::default(), client)
 }
 
 #[derive(Debug, Clone)]
 pub struct RegistryMcpEgressPlanner {
     registry: Arc<SharedExtensionRegistry>,
+    /// Per-user discovered-package overlay (P2b). Credential injection for a
+    /// DISCOVERED hosted-MCP tool must resolve its descriptor from the caller's
+    /// overlay — the discovered capability id is not in the global registry, so
+    /// resolving against `registry` alone injects no credential and the call
+    /// egresses unauthenticated. `None` for callers with no overlay (discovery,
+    /// static-only providers).
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 }
 
 impl RegistryMcpEgressPlanner {
     pub fn new(registry: Arc<SharedExtensionRegistry>) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            scoped_overlay: None,
+        }
+    }
+
+    pub fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
+    }
+
+    /// Resolve `capability_id`'s descriptor for `scope`, consulting the caller's
+    /// per-user overlay so a DISCOVERED capability (absent from the global
+    /// registry) still resolves. Falls back to the global snapshot when there is
+    /// no overlay.
+    fn scoped_capability(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Option<CapabilityDescriptor> {
+        match &self.scoped_overlay {
+            Some(overlay) => {
+                let owner = OverlayScope::new(
+                    scope.tenant_id.clone(),
+                    scope.user_id.clone(),
+                    scope.thread_id.clone(),
+                );
+                overlay
+                    .view_for(&owner, self.registry.snapshot())
+                    .get_capability(capability_id)
+                    .cloned()
+            }
+            None => self.registry.snapshot().get_capability(capability_id).cloned(),
+        }
     }
 
     fn credential_injections(
         &self,
+        scope: &ResourceScope,
         provider: &ExtensionId,
         capability_id: &CapabilityId,
         endpoint: &HostedMcpEndpoint,
     ) -> Vec<RuntimeCredentialInjection> {
-        self.registry
-            .snapshot()
-            .get_capability(capability_id)
+        self.scoped_capability(scope, capability_id)
             .filter(|descriptor| &descriptor.provider == provider)
             .map(|descriptor| {
                 descriptor
@@ -83,8 +126,12 @@ impl McpHostHttpEgressPlanner for RegistryMcpEgressPlanner {
         if !hosted_mcp_url_allowed(request.url, &endpoint) {
             return McpHostHttpEgressPlan::default();
         }
-        let credential_injections =
-            self.credential_injections(request.provider, request.capability_id, &endpoint);
+        let credential_injections = self.credential_injections(
+            request.scope,
+            request.provider,
+            request.capability_id,
+            &endpoint,
+        );
         McpHostHttpEgressPlan {
             // Credential-free hosted MCP providers are valid: the manifest may
             // expose a public/unauthenticated server, and host network policy
@@ -215,7 +262,8 @@ mod tests {
         let capability_id = CapabilityId::new("notion.notion-search").unwrap();
         let endpoint = HostedMcpEndpoint::parse(NOTION_MCP_URL).unwrap();
 
-        let injections = planner.credential_injections(&provider, &capability_id, &endpoint);
+        let injections =
+            planner.credential_injections(&sample_scope(), &provider, &capability_id, &endpoint);
 
         assert_eq!(injections.len(), 1);
         assert_eq!(

--- a/crates/ironclaw_extension_host/src/mcp.rs
+++ b/crates/ironclaw_extension_host/src/mcp.rs
@@ -139,7 +139,10 @@ impl HostedMcpEndpoint {
 }
 
 pub fn hosted_http_mcp_endpoint(package: &ExtensionPackage) -> Option<HostedMcpEndpoint> {
-    if package.manifest.source != ManifestSource::HostBundled {
+    if !matches!(
+        package.manifest.source,
+        ManifestSource::HostBundled | ManifestSource::InstalledLocal
+    ) {
         return None;
     }
     let ExtensionRuntime::Mcp {

--- a/crates/ironclaw_extension_host/src/resolver.rs
+++ b/crates/ironclaw_extension_host/src/resolver.rs
@@ -47,7 +47,9 @@ impl SnapshotToolResolver {
 impl ToolResolver for SnapshotToolResolver {
     fn resolve(&self, capability_id: &CapabilityId) -> Option<ResolvedCapability> {
         let snapshot = self.watch.current();
-        let binding = snapshot.resolve_tool(capability_id)?;
+        let binding = snapshot
+            .resolve_tool(capability_id)
+            .or_else(|| snapshot.resolve_hosted_mcp_tool(capability_id))?;
         let provider = ExtensionId::new(binding.declaration.id.as_str()).ok()?;
         let runtime = binding.declaration.runtime.kind();
         Some(ResolvedCapability {

--- a/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
+++ b/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
@@ -79,7 +79,13 @@ pub fn package_with_discovered_hosted_mcp_tools(
 }
 
 fn hosted_http_mcp_url(package: &ExtensionPackage) -> Option<&str> {
-    if package.manifest.source != ManifestSource::HostBundled {
+    // InstalledLocal (operator-installed volume) providers are discovery-eligible
+    // alongside compiled-in HostBundled ones (P2b). Discovery still runs under
+    // the caller's scope and leases the caller's credential.
+    if !matches!(
+        package.manifest.source,
+        ManifestSource::HostBundled | ManifestSource::InstalledLocal
+    ) {
         return None;
     }
     let ExtensionRuntime::Mcp {

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -279,7 +279,10 @@ impl ExtensionPackage {
         manifest_digest: Option<String>,
         capabilities: Vec<CapabilityDescriptor>,
     ) -> Result<Self, ExtensionError> {
-        if manifest.source != ManifestSource::HostBundled {
+        if !matches!(
+            manifest.source,
+            ManifestSource::HostBundled | ManifestSource::InstalledLocal
+        ) {
             return Err(ExtensionError::InvalidManifest {
                 reason:
                     "inline dynamic descriptor schemas are only supported for host-bundled packages"
@@ -322,8 +325,10 @@ impl ExtensionPackage {
         let consistent = match self.descriptor_schema_mode {
             CapabilityDescriptorSchemaMode::ManifestRefs => self.capabilities == expected,
             CapabilityDescriptorSchemaMode::InlineDynamic => {
-                self.manifest.source == ManifestSource::HostBundled
-                    && descriptors_match_except_schema(&self.capabilities, &expected)
+                matches!(
+                    self.manifest.source,
+                    ManifestSource::HostBundled | ManifestSource::InstalledLocal
+                ) && descriptors_match_except_schema(&self.capabilities, &expected)
             }
         };
         if !consistent {

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -449,7 +449,7 @@ pub use lifecycle::{
     ExtensionLifecycleEvent, ExtensionLifecycleEventSink, ExtensionLifecycleService,
 };
 pub use scoped_overlay::{
-    DEFAULT_SCOPED_OVERLAY_TTL, OverlaidRegistryView, OverlayFreshness, OverlayOwner,
+    DEFAULT_SCOPED_OVERLAY_TTL, OverlaidRegistryView, OverlayFreshness, OverlayScope,
     ScopedPackageOverlay,
 };
 pub use registry::{ExtensionRegistry, SharedExtensionRegistry};

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -398,6 +398,7 @@ mod hosted_mcp_discovery;
 mod installations;
 mod lifecycle;
 mod registry;
+mod scoped_overlay;
 pub mod resolved;
 pub mod v2;
 pub mod v3;
@@ -441,6 +442,10 @@ pub use installations::{
 };
 pub use lifecycle::{
     ExtensionLifecycleEvent, ExtensionLifecycleEventSink, ExtensionLifecycleService,
+};
+pub use scoped_overlay::{
+    DEFAULT_SCOPED_OVERLAY_TTL, OverlaidRegistryView, OverlayFreshness, OverlayOwner,
+    ScopedPackageOverlay,
 };
 pub use registry::{ExtensionRegistry, SharedExtensionRegistry};
 

--- a/crates/ironclaw_extensions/src/scoped_overlay.rs
+++ b/crates/ironclaw_extensions/src/scoped_overlay.rs
@@ -93,6 +93,24 @@ impl OverlayScope {
 /// and the turn-start refresher still re-discovers once an idle entry expires.
 pub const DEFAULT_SCOPED_OVERLAY_TTL: Duration = Duration::from_secs(1800);
 
+/// How long past its TTL a discovered entry is retained (still served as
+/// last-good) before eviction.
+///
+/// Bounds the growth the thread cache axis would otherwise cause: a one-off
+/// job's thread never recurs, so freshness (which only gates *re-discovery* of
+/// the same scope) never expires it and it would be served-stale forever.
+/// Serving stays available within `[expiry, expiry + retention]` so a
+/// concurrent turn that skips the in-flight refresh keeps the surface, but a
+/// finished thread's entry is swept once it has been stale this long.
+/// Comfortably exceeds any bounded run plus the refresh gap.
+pub const OVERLAY_STALE_RETENTION: Duration = Duration::from_secs(1800);
+
+/// Hard cap on total live entries — a backstop against pathological growth
+/// (e.g. a burst of concurrent one-off jobs faster than the retention sweep).
+/// When exceeded, the entries closest to (or furthest past) expiry are evicted
+/// first.
+const MAX_OVERLAY_ENTRIES: usize = 4096;
+
 #[derive(Debug, Clone)]
 struct OverlayEntry {
     package: Arc<ExtensionPackage>,
@@ -119,24 +137,70 @@ pub enum OverlayFreshness {
 /// tenant + user + thread) and extension. Composition owns one instance and shares it
 /// (via `Arc`) with every registry consumer that resolves capabilities for a
 /// scoped request.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ScopedPackageOverlay {
     entries: RwLock<HashMap<(OverlayScope, ExtensionId), OverlayEntry>>,
+    /// How long past its TTL an entry is kept (still served last-good) before
+    /// eviction. A composition knob: production uses [`OVERLAY_STALE_RETENTION`];
+    /// a shorter value tightens the bound where discovered surfaces churn fast.
+    stale_retention: Duration,
+}
+
+impl Default for ScopedPackageOverlay {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ScopedPackageOverlay {
     pub fn new() -> Self {
-        Self::default()
+        Self::with_stale_retention(OVERLAY_STALE_RETENTION)
+    }
+
+    /// Construct with an explicit stale-retention window (see the field).
+    pub fn with_stale_retention(stale_retention: Duration) -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            stale_retention,
+        }
     }
 
     /// Store (or refresh) `owner`'s discovered surface for `package.id`.
+    ///
+    /// Opportunistically evicts entries stale beyond the retention window (and
+    /// enforces [`MAX_OVERLAY_ENTRIES`]) on the same lock, so the per-thread key
+    /// axis cannot grow the cache without bound — inserts run at every turn-start
+    /// discovery, so the sweep keeps pace with new threads.
     pub fn insert(&self, owner: OverlayScope, package: ExtensionPackage, ttl: Duration) {
         let key = (owner, package.id.clone());
         let entry = OverlayEntry {
             package: Arc::new(package),
             expires_at: Instant::now() + ttl,
         };
-        self.entries.write().insert(key, entry);
+        let mut entries = self.entries.write();
+        entries.insert(key, entry);
+        self.evict_locked(&mut entries, Instant::now());
+    }
+
+    /// Evict entries stale beyond the retention window, then enforce the hard
+    /// cap (most-expired first). Called under the write lock from `insert`.
+    fn evict_locked(
+        &self,
+        entries: &mut HashMap<(OverlayScope, ExtensionId), OverlayEntry>,
+        now: Instant,
+    ) {
+        entries.retain(|_, entry| entry.expires_at + self.stale_retention > now);
+        if entries.len() > MAX_OVERLAY_ENTRIES {
+            let mut by_expiry: Vec<((OverlayScope, ExtensionId), Instant)> = entries
+                .iter()
+                .map(|(key, entry)| (key.clone(), entry.expires_at))
+                .collect();
+            by_expiry.sort_by_key(|(_, expires_at)| *expires_at);
+            let excess = entries.len() - MAX_OVERLAY_ENTRIES;
+            for (key, _) in by_expiry.into_iter().take(excess) {
+                entries.remove(&key);
+            }
+        }
     }
 
     /// Drop `owner`'s entry for `extension_id` (e.g. missing credential).
@@ -442,6 +506,63 @@ runtime_credentials = [
 
     fn capability(id: &str) -> CapabilityId {
         CapabilityId::new(id).expect("capability id")
+    }
+
+    #[test]
+    fn stale_entries_beyond_retention_are_evicted_so_one_off_threads_dont_leak() {
+        // The thread cache axis means a one-off job's thread never recurs, so
+        // freshness alone never expires its entry — retention-based eviction
+        // bounds the growth. With a zero retention window, a stale (TTL-0) entry
+        // is swept by the next insert's opportunistic eviction.
+        let overlay = ScopedPackageOverlay::with_stale_retention(Duration::ZERO);
+        let one_off = owner_thread("worker-agent", "thread-a");
+        overlay.insert(
+            one_off.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::ZERO,
+        );
+        // A later job's insert triggers the sweep.
+        let live = owner_thread("worker-agent", "thread-b");
+        overlay.insert(
+            live.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        assert!(
+            overlay.packages_for(&one_off).is_empty(),
+            "one-off thread's stale-beyond-retention entry must be evicted"
+        );
+        assert_eq!(
+            overlay.packages_for(&live).len(),
+            1,
+            "a fresh entry must survive the sweep"
+        );
+    }
+
+    #[test]
+    fn stale_within_retention_is_still_served_last_good() {
+        // Default (non-zero) retention keeps a just-expired entry served, so a
+        // concurrent turn that skips the in-flight refresh keeps the surface.
+        let overlay = ScopedPackageOverlay::new();
+        let job = owner_thread("worker-agent", "thread-a");
+        overlay.insert(
+            job.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::ZERO,
+        );
+        // Trigger a sweep with another insert; the just-expired entry is within
+        // the retention window, so it is retained.
+        overlay.insert(
+            owner_thread("worker-agent", "thread-b"),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+        assert_eq!(
+            overlay.packages_for(&job).len(),
+            1,
+            "stale-but-within-retention entry must still be served last-good"
+        );
     }
 
     #[test]

--- a/crates/ironclaw_extensions/src/scoped_overlay.rs
+++ b/crates/ironclaw_extensions/src/scoped_overlay.rs
@@ -5,7 +5,8 @@
 //! hirer-granted connector tools for a worker-agent bearer). The global
 //! [`crate::SharedExtensionRegistry`] holds exactly one surface per extension
 //! id, so per-principal discovered surfaces live here instead: an in-memory,
-//! TTL-bounded cache keyed by ([`OverlayOwner`] = tenant + user, `ExtensionId`).
+//! TTL-bounded cache keyed by ([`OverlayScope`] = tenant + user + thread,
+//! `ExtensionId`).
 //!
 //! This is a **derived cache**, not lifecycle state: nothing here is
 //! persisted, installation records are never touched, and a restart simply
@@ -14,11 +15,13 @@
 //! snapshot — the same view feeds the model surface, authorization, dispatch
 //! and egress planning so no parallel resolution pipeline exists.
 //!
-//! Security invariant: entries are keyed by the full tenant+user owner whose
-//! credential produced the discovery result — never by a bare `UserId`, which
-//! is unique only within a tenant — and a view only ever merges entries for
-//! the single owner it was built for. Cross-user AND cross-tenant leakage are
-//! regression-tested failure modes.
+//! Security invariant: entries are keyed by the full tenant + user + thread
+//! scope whose credential produced the discovery result — never by a bare
+//! `UserId` (unique only within a tenant), and never by owner alone (a managed
+//! agent serves many hires under one identity, distinguished only by thread) —
+//! and a view only ever merges entries for the single scope it was built for.
+//! Cross-user, cross-tenant AND cross-thread leakage are regression-tested
+//! failure modes.
 
 use std::{
     collections::HashMap,
@@ -26,29 +29,42 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ironclaw_host_api::{CapabilityDescriptor, CapabilityId, ExtensionId, TenantId, UserId};
+use ironclaw_host_api::{CapabilityDescriptor, CapabilityId, ExtensionId, TenantId, ThreadId, UserId};
 use parking_lot::RwLock;
 
 use crate::{CapabilityVisibility, ExtensionPackage, ExtensionRegistry};
 
-/// The owner axis a discovered surface is keyed by: `tenant_id` **and**
-/// `user_id`. A bare `UserId` is not a safe key — `UserId` is unique only
-/// within a tenant, so keying by user alone lets one tenant's discovered
-/// tool surface (and the refresher's negative-cache / single-flight verdicts)
-/// bleed into another tenant that reuses the same user id. Every overlay and
-/// refresher operation takes this owner so the tenant axis can never be
-/// dropped at a call site.
+/// The scope axes a discovered surface is keyed by: `tenant_id`, `user_id`,
+/// **and** `thread_id`.
+///
+/// The tenant axis is non-negotiable — a bare `UserId` is unique only within a
+/// tenant, so keying by user alone lets one tenant's discovered tool surface
+/// (and the refresher's negative-cache / single-flight verdicts) bleed into
+/// another tenant that reuses the same user id.
+///
+/// The thread axis is load-bearing for **isolation**, not merely cache
+/// efficiency. A managed worker agent serves several hires under ONE IronClaw
+/// identity (its own tenant + user); the only thing distinguishing hire A's
+/// discovered surface (e.g. a buyer's `timeless__*` connector) from hire B's
+/// (`firefly__*`) is the thread each job runs on. Keyed by owner alone, hire
+/// A's cached tools would serve hire B — a cross-buyer personal-data leak.
+/// `thread_id` is `None` only for non-threaded runtimes (one execution context,
+/// so the owner axis is sufficient); consumers treat `None` as its own bucket,
+/// never a wildcard. Every overlay and refresher operation takes this scope so
+/// no axis can be dropped at a call site.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct OverlayOwner {
+pub struct OverlayScope {
     tenant_id: TenantId,
     user_id: UserId,
+    thread_id: Option<ThreadId>,
 }
 
-impl OverlayOwner {
-    pub fn new(tenant_id: TenantId, user_id: UserId) -> Self {
+impl OverlayScope {
+    pub fn new(tenant_id: TenantId, user_id: UserId, thread_id: Option<ThreadId>) -> Self {
         Self {
             tenant_id,
             user_id,
+            thread_id,
         }
     }
 
@@ -58,6 +74,10 @@ impl OverlayOwner {
 
     pub fn user_id(&self) -> &UserId {
         &self.user_id
+    }
+
+    pub fn thread_id(&self) -> Option<&ThreadId> {
+        self.thread_id.as_ref()
     }
 }
 
@@ -95,13 +115,13 @@ pub enum OverlayFreshness {
     Stale,
 }
 
-/// In-memory discovered-package cache keyed by owner ([`OverlayOwner`]:
-/// tenant + user) and extension. Composition owns one instance and shares it
+/// In-memory discovered-package cache keyed by scope ([`OverlayScope`]:
+/// tenant + user + thread) and extension. Composition owns one instance and shares it
 /// (via `Arc`) with every registry consumer that resolves capabilities for a
 /// scoped request.
 #[derive(Debug, Default)]
 pub struct ScopedPackageOverlay {
-    entries: RwLock<HashMap<(OverlayOwner, ExtensionId), OverlayEntry>>,
+    entries: RwLock<HashMap<(OverlayScope, ExtensionId), OverlayEntry>>,
 }
 
 impl ScopedPackageOverlay {
@@ -110,7 +130,7 @@ impl ScopedPackageOverlay {
     }
 
     /// Store (or refresh) `owner`'s discovered surface for `package.id`.
-    pub fn insert(&self, owner: OverlayOwner, package: ExtensionPackage, ttl: Duration) {
+    pub fn insert(&self, owner: OverlayScope, package: ExtensionPackage, ttl: Duration) {
         let key = (owner, package.id.clone());
         let entry = OverlayEntry {
             package: Arc::new(package),
@@ -120,7 +140,7 @@ impl ScopedPackageOverlay {
     }
 
     /// Drop `owner`'s entry for `extension_id` (e.g. missing credential).
-    pub fn remove(&self, owner: &OverlayOwner, extension_id: &ExtensionId) {
+    pub fn remove(&self, owner: &OverlayScope, extension_id: &ExtensionId) {
         self.entries
             .write()
             .remove(&(owner.clone(), extension_id.clone()));
@@ -140,7 +160,7 @@ impl ScopedPackageOverlay {
     /// paths below.
     pub fn get(
         &self,
-        owner: &OverlayOwner,
+        owner: &OverlayScope,
         extension_id: &ExtensionId,
     ) -> Option<(Arc<ExtensionPackage>, OverlayFreshness)> {
         let entries = self.entries.read();
@@ -156,7 +176,7 @@ impl ScopedPackageOverlay {
     /// Re-arm the TTL on an existing entry (a transient discovery failure kept
     /// the last-good surface; avoid re-running discovery every turn while the
     /// provider is down).
-    pub fn touch(&self, owner: &OverlayOwner, extension_id: &ExtensionId, ttl: Duration) {
+    pub fn touch(&self, owner: &OverlayScope, extension_id: &ExtensionId, ttl: Duration) {
         if let Some(entry) = self
             .entries
             .write()
@@ -169,7 +189,7 @@ impl ScopedPackageOverlay {
     /// The owner's last-good overlay packages (for grant/provider-trust minting
     /// at surface-request time). Serves stale entries too — see
     /// [`OverlayFreshness`]: freshness gates re-discovery, not serving.
-    pub fn packages_for(&self, owner: &OverlayOwner) -> Vec<Arc<ExtensionPackage>> {
+    pub fn packages_for(&self, owner: &OverlayScope) -> Vec<Arc<ExtensionPackage>> {
         self.entries
             .read()
             .iter()
@@ -187,7 +207,7 @@ impl ScopedPackageOverlay {
     /// to its `&ExtensionRegistry` API.
     pub fn merged_snapshot(
         &self,
-        owner: &OverlayOwner,
+        owner: &OverlayScope,
         global: Arc<ExtensionRegistry>,
     ) -> Arc<ExtensionRegistry> {
         let packages = self.packages_for(owner);
@@ -211,7 +231,7 @@ impl ScopedPackageOverlay {
     /// discovered packages (fresh or stale — serving is not freshness-gated).
     pub fn view_for(
         &self,
-        owner: &OverlayOwner,
+        owner: &OverlayScope,
         global: Arc<ExtensionRegistry>,
     ) -> OverlaidRegistryView {
         let overlays = self.packages_for(owner);
@@ -404,12 +424,20 @@ runtime_credentials = [
         UserId::new(id).expect("user id")
     }
 
-    fn owner(id: &str) -> OverlayOwner {
-        OverlayOwner::new(TenantId::new("tenant-a").expect("tenant"), user(id))
+    fn owner(id: &str) -> OverlayScope {
+        OverlayScope::new(TenantId::new("tenant-a").expect("tenant"), user(id), None)
     }
 
-    fn owner_in(tenant: &str, id: &str) -> OverlayOwner {
-        OverlayOwner::new(TenantId::new(tenant).expect("tenant"), user(id))
+    fn owner_in(tenant: &str, id: &str) -> OverlayScope {
+        OverlayScope::new(TenantId::new(tenant).expect("tenant"), user(id), None)
+    }
+
+    fn owner_thread(id: &str, thread: &str) -> OverlayScope {
+        OverlayScope::new(
+            TenantId::new("tenant-a").expect("tenant"),
+            user(id),
+            Some(ThreadId::new(thread).expect("thread id")),
+        )
     }
 
     fn capability(id: &str) -> CapabilityId {
@@ -545,6 +573,62 @@ runtime_credentials = [
                 .is_none()
         );
         assert!(overlay.get(&tenant_b, &static_package().id).is_none());
+    }
+
+    #[test]
+    fn overlay_entries_never_leak_across_threads_for_the_same_owner() {
+        // The managed-agent isolation case: buyer A hires the agent and grants
+        // `timeless`, buyer B hires the SAME agent and grants `firefly`. Both
+        // jobs run under the agent's single IronClaw identity (same tenant +
+        // user), distinguished only by the thread each dispatch runs on. Keyed
+        // by owner alone, job B would see job A's `timeless` — a cross-buyer
+        // personal-data leak. Keyed by thread, each job sees only its own.
+        let overlay = ScopedPackageOverlay::new();
+        let job_a = owner_thread("worker-agent", "thread-a");
+        let job_b = owner_thread("worker-agent", "thread-b");
+        overlay.insert(
+            job_a.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+        overlay.insert(
+            job_b.clone(),
+            discovered_package("firefly__list_documents"),
+            Duration::from_secs(60),
+        );
+
+        let a_view = overlay.view_for(&job_a, global_registry());
+        assert!(
+            a_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "job A sees its own connector"
+        );
+        assert!(
+            a_view
+                .get_capability(&capability("agent-market.firefly__list_documents"))
+                .is_none(),
+            "job A must NOT see buyer B's connector"
+        );
+
+        let b_view = overlay.view_for(&job_b, global_registry());
+        assert!(
+            b_view
+                .get_capability(&capability("agent-market.firefly__list_documents"))
+                .is_some(),
+            "job B sees its own connector"
+        );
+        assert!(
+            b_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none(),
+            "job B must NOT see buyer A's connector"
+        );
+
+        // And a thread-less scope for the same owner is its own bucket — it sees
+        // neither job's surface.
+        let threadless = owner("worker-agent");
+        assert!(!overlay.view_for(&threadless, global_registry()).has_overlays());
     }
 
     #[test]

--- a/crates/ironclaw_extensions/src/scoped_overlay.rs
+++ b/crates/ironclaw_extensions/src/scoped_overlay.rs
@@ -1,0 +1,627 @@
+//! Per-user discovered-package overlay over the global extension registry.
+//!
+//! Hosted-MCP providers can serve a **per-principal** `tools/list` (e.g. the
+//! agent marketplace returns concierge tools for a concierge bearer and the
+//! hirer-granted connector tools for a worker-agent bearer). The global
+//! [`crate::SharedExtensionRegistry`] holds exactly one surface per extension
+//! id, so per-principal discovered surfaces live here instead: an in-memory,
+//! TTL-bounded cache keyed by ([`OverlayOwner`] = tenant + user, `ExtensionId`).
+//!
+//! This is a **derived cache**, not lifecycle state: nothing here is
+//! persisted, installation records are never touched, and a restart simply
+//! re-discovers lazily. Consumers read through [`OverlaidRegistryView`], which
+//! prefers the caller's overlay entries and falls back to the global
+//! snapshot — the same view feeds the model surface, authorization, dispatch
+//! and egress planning so no parallel resolution pipeline exists.
+//!
+//! Security invariant: entries are keyed by the full tenant+user owner whose
+//! credential produced the discovery result — never by a bare `UserId`, which
+//! is unique only within a tenant — and a view only ever merges entries for
+//! the single owner it was built for. Cross-user AND cross-tenant leakage are
+//! regression-tested failure modes.
+
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use ironclaw_host_api::{CapabilityDescriptor, CapabilityId, ExtensionId, TenantId, UserId};
+use parking_lot::RwLock;
+
+use crate::{CapabilityVisibility, ExtensionPackage, ExtensionRegistry};
+
+/// The owner axis a discovered surface is keyed by: `tenant_id` **and**
+/// `user_id`. A bare `UserId` is not a safe key — `UserId` is unique only
+/// within a tenant, so keying by user alone lets one tenant's discovered
+/// tool surface (and the refresher's negative-cache / single-flight verdicts)
+/// bleed into another tenant that reuses the same user id. Every overlay and
+/// refresher operation takes this owner so the tenant axis can never be
+/// dropped at a call site.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OverlayOwner {
+    tenant_id: TenantId,
+    user_id: UserId,
+}
+
+impl OverlayOwner {
+    pub fn new(tenant_id: TenantId, user_id: UserId) -> Self {
+        Self {
+            tenant_id,
+            user_id,
+        }
+    }
+
+    pub fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+
+    pub fn user_id(&self) -> &UserId {
+        &self.user_id
+    }
+}
+
+/// Default lifetime of a discovered per-user surface. It MUST comfortably
+/// exceed the longest single run: discovery runs at turn start and the
+/// discovered tools are then read live on every capability dispatch, so a TTL
+/// shorter than the run makes late tool calls (e.g. a worker agent's final
+/// `marketplace__submit_deliverable` after minutes of work — worse under an
+/// LLM-provider 5xx storm that stretches the run) vanish from the surface
+/// mid-run with `unknown_capability`. 30 min covers any realistic bounded run;
+/// a stable per-agent tool set (all of the agent's active connector grants)
+/// means the long window does not stale a worker's surface across dispatches,
+/// and the turn-start refresher still re-discovers once an idle entry expires.
+pub const DEFAULT_SCOPED_OVERLAY_TTL: Duration = Duration::from_secs(1800);
+
+#[derive(Debug, Clone)]
+struct OverlayEntry {
+    package: Arc<ExtensionPackage>,
+    expires_at: Instant,
+}
+
+/// Freshness of a cached discovered surface. Freshness gates whether the
+/// turn-start refresher **re-discovers**; it does NOT gate whether readers
+/// **serve** the entry. Readers always serve the last-good package (fresh or
+/// stale) so a concurrent turn that skips the in-flight refresh — or any turn
+/// hitting an entry right at TTL expiry — keeps the discovered surface instead
+/// of flapping back to the static manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverlayFreshness {
+    /// Within TTL — no re-discovery needed.
+    Fresh,
+    /// Past TTL — the turn-start refresher should re-discover. The entry stays
+    /// served as last-good until discovery replaces it or an auth failure
+    /// removes it.
+    Stale,
+}
+
+/// In-memory discovered-package cache keyed by owner ([`OverlayOwner`]:
+/// tenant + user) and extension. Composition owns one instance and shares it
+/// (via `Arc`) with every registry consumer that resolves capabilities for a
+/// scoped request.
+#[derive(Debug, Default)]
+pub struct ScopedPackageOverlay {
+    entries: RwLock<HashMap<(OverlayOwner, ExtensionId), OverlayEntry>>,
+}
+
+impl ScopedPackageOverlay {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store (or refresh) `owner`'s discovered surface for `package.id`.
+    pub fn insert(&self, owner: OverlayOwner, package: ExtensionPackage, ttl: Duration) {
+        let key = (owner, package.id.clone());
+        let entry = OverlayEntry {
+            package: Arc::new(package),
+            expires_at: Instant::now() + ttl,
+        };
+        self.entries.write().insert(key, entry);
+    }
+
+    /// Drop `owner`'s entry for `extension_id` (e.g. missing credential).
+    pub fn remove(&self, owner: &OverlayOwner, extension_id: &ExtensionId) {
+        self.entries
+            .write()
+            .remove(&(owner.clone(), extension_id.clone()));
+    }
+
+    /// Drop every owner's entry for `extension_id` (extension deactivated or
+    /// replaced tenant-wide).
+    pub fn remove_extension(&self, extension_id: &ExtensionId) {
+        self.entries
+            .write()
+            .retain(|(_, entry_extension), _| entry_extension != extension_id);
+    }
+
+    /// The cached package for `(owner, extension_id)` with its freshness, if
+    /// any. The turn-start refresher uses the freshness to decide whether to
+    /// re-discover; the stale entry is still served as last-good by the reader
+    /// paths below.
+    pub fn get(
+        &self,
+        owner: &OverlayOwner,
+        extension_id: &ExtensionId,
+    ) -> Option<(Arc<ExtensionPackage>, OverlayFreshness)> {
+        let entries = self.entries.read();
+        let entry = entries.get(&(owner.clone(), extension_id.clone()))?;
+        let freshness = if entry.expires_at > Instant::now() {
+            OverlayFreshness::Fresh
+        } else {
+            OverlayFreshness::Stale
+        };
+        Some((Arc::clone(&entry.package), freshness))
+    }
+
+    /// Re-arm the TTL on an existing entry (a transient discovery failure kept
+    /// the last-good surface; avoid re-running discovery every turn while the
+    /// provider is down).
+    pub fn touch(&self, owner: &OverlayOwner, extension_id: &ExtensionId, ttl: Duration) {
+        if let Some(entry) = self
+            .entries
+            .write()
+            .get_mut(&(owner.clone(), extension_id.clone()))
+        {
+            entry.expires_at = Instant::now() + ttl;
+        }
+    }
+
+    /// The owner's last-good overlay packages (for grant/provider-trust minting
+    /// at surface-request time). Serves stale entries too — see
+    /// [`OverlayFreshness`]: freshness gates re-discovery, not serving.
+    pub fn packages_for(&self, owner: &OverlayOwner) -> Vec<Arc<ExtensionPackage>> {
+        self.entries
+            .read()
+            .iter()
+            .filter(|((entry_owner, _), _)| entry_owner == owner)
+            .map(|(_, entry)| Arc::clone(&entry.package))
+            .collect()
+    }
+
+    /// A concrete `ExtensionRegistry` snapshot with the owner's last-good
+    /// discovered packages merged in (each overlaid extension's static package
+    /// replaced by its discovered one). Returns the `global` Arc unchanged when
+    /// the owner has no overlay entries — zero cost for the common case, so
+    /// every existing `self.registry.snapshot()` consumer can resolve an
+    /// owner's discovered capabilities by reading this instead, with no change
+    /// to its `&ExtensionRegistry` API.
+    pub fn merged_snapshot(
+        &self,
+        owner: &OverlayOwner,
+        global: Arc<ExtensionRegistry>,
+    ) -> Arc<ExtensionRegistry> {
+        let packages = self.packages_for(owner);
+        if packages.is_empty() {
+            return global;
+        }
+        let mut merged = global.as_ref().clone();
+        for package in packages {
+            // Replace the static package with the discovered one. The
+            // discovered package was already validated at discovery time, so use
+            // the trusted (non-revalidating) insert to keep this off the
+            // per-invocation hot path; the preceding `remove` clears the static
+            // capability ids so there is no id collision to check.
+            merged.remove(&package.id);
+            merged.insert_validated(package.as_ref().clone());
+        }
+        Arc::new(merged)
+    }
+
+    /// Build the owner's merged view over `global` from the last-good
+    /// discovered packages (fresh or stale — serving is not freshness-gated).
+    pub fn view_for(
+        &self,
+        owner: &OverlayOwner,
+        global: Arc<ExtensionRegistry>,
+    ) -> OverlaidRegistryView {
+        let overlays = self.packages_for(owner);
+        OverlaidRegistryView { global, overlays }
+    }
+}
+
+/// A single user's capability-resolution view: the global registry snapshot
+/// with that user's discovered packages layered on top. For an overlaid
+/// extension the overlay package **replaces** the global one — its discovered
+/// capability set is the extension's surface for this user.
+#[derive(Debug, Clone)]
+pub struct OverlaidRegistryView {
+    global: Arc<ExtensionRegistry>,
+    overlays: Vec<Arc<ExtensionPackage>>,
+}
+
+impl OverlaidRegistryView {
+    /// A view with no overlay entries (scope-less callers).
+    pub fn global_only(global: Arc<ExtensionRegistry>) -> Self {
+        Self {
+            global,
+            overlays: Vec::new(),
+        }
+    }
+
+    pub fn has_overlays(&self) -> bool {
+        !self.overlays.is_empty()
+    }
+
+    fn overlaid_extension(&self, id: &ExtensionId) -> Option<&ExtensionPackage> {
+        self.overlays
+            .iter()
+            .find(|package| &package.id == id)
+            .map(Arc::as_ref)
+    }
+
+    pub fn get_extension(&self, id: &ExtensionId) -> Option<&ExtensionPackage> {
+        self.overlaid_extension(id)
+            .or_else(|| self.global.get_extension(id))
+    }
+
+    pub fn get_capability(&self, id: &CapabilityId) -> Option<&CapabilityDescriptor> {
+        for package in &self.overlays {
+            if let Some(descriptor) = package
+                .capabilities
+                .iter()
+                .find(|descriptor| &descriptor.id == id)
+            {
+                return Some(descriptor);
+            }
+            // The overlay replaces this extension's whole surface: a global
+            // capability belonging to an overlaid extension is masked even
+            // when the discovered set no longer contains it.
+            if self
+                .global
+                .get_capability(id)
+                .is_some_and(|descriptor| descriptor.provider == package.id)
+            {
+                return None;
+            }
+        }
+        self.global.get_capability(id)
+    }
+
+    pub fn capability_visibility(&self, id: &CapabilityId) -> Option<CapabilityVisibility> {
+        for package in &self.overlays {
+            if let Some(capability) = package
+                .manifest
+                .capabilities
+                .iter()
+                .find(|capability| &capability.id == id)
+            {
+                return Some(capability.visibility);
+            }
+            if self
+                .global
+                .get_capability(id)
+                .is_some_and(|descriptor| descriptor.provider == package.id)
+            {
+                return None;
+            }
+        }
+        self.global.capability_visibility(id)
+    }
+
+    /// All capabilities visible in this view: global capabilities of
+    /// non-overlaid extensions plus every overlay capability.
+    pub fn capabilities(&self) -> impl Iterator<Item = &CapabilityDescriptor> {
+        let overlaid_ids: Vec<&ExtensionId> =
+            self.overlays.iter().map(|package| &package.id).collect();
+        self.global
+            .capabilities()
+            .filter(move |descriptor| !overlaid_ids.contains(&&descriptor.provider))
+            .chain(
+                self.overlays
+                    .iter()
+                    .flat_map(|package| package.capabilities.iter()),
+            )
+    }
+
+    /// The overlay packages themselves (for grant/provider-trust minting).
+    pub fn overlay_packages(&self) -> impl Iterator<Item = &ExtensionPackage> {
+        self.overlays.iter().map(Arc::as_ref)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ExtensionManifest, HostPortCatalog, ManifestSource};
+    use ironclaw_host_api::VirtualPath;
+
+    const STATIC_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "agent-market"
+name = "Agent Market"
+version = "0.1.0"
+description = "Marketplace tools"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "https://market.example.com/mcp"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "agent-market.search_agents"
+description = "Search the marketplace"
+effects = ["dispatch_capability", "network", "use_secret"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/search.input.json"
+output_schema_ref = "schemas/search.output.json"
+runtime_credentials = [
+  { handle = "agent-market-token", audience = { scheme = "https", host_pattern = "market.example.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " }, required = true }
+]
+"#;
+
+    fn capability_provider_contracts() -> crate::HostApiContractRegistry {
+        let mut contracts = crate::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                crate::host_api::capability_provider::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
+
+    fn static_package() -> ExtensionPackage {
+        let manifest = ExtensionManifest::parse(
+            STATIC_MANIFEST,
+            ManifestSource::HostBundled,
+            &HostPortCatalog::default(),
+            &capability_provider_contracts(),
+        )
+        .expect("valid manifest");
+        ExtensionPackage::from_manifest(
+            manifest,
+            VirtualPath::new("/system/extensions/agent-market").expect("root"),
+        )
+        .expect("valid package")
+    }
+
+    fn discovered_package(tool: &str) -> ExtensionPackage {
+        let tools = vec![crate::HostedMcpDiscoveredTool {
+            name: tool.to_string(),
+            description: format!("discovered {tool}"),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: Default::default(),
+        }];
+        crate::package_with_discovered_hosted_mcp_tools(&static_package(), &tools)
+            .expect("discoverable package")
+    }
+
+    fn global_registry() -> Arc<ExtensionRegistry> {
+        let mut registry = ExtensionRegistry::new();
+        registry.insert(static_package()).expect("insert static");
+        Arc::new(registry)
+    }
+
+    fn user(id: &str) -> UserId {
+        UserId::new(id).expect("user id")
+    }
+
+    fn owner(id: &str) -> OverlayOwner {
+        OverlayOwner::new(TenantId::new("tenant-a").expect("tenant"), user(id))
+    }
+
+    fn owner_in(tenant: &str, id: &str) -> OverlayOwner {
+        OverlayOwner::new(TenantId::new(tenant).expect("tenant"), user(id))
+    }
+
+    fn capability(id: &str) -> CapabilityId {
+        CapabilityId::new(id).expect("capability id")
+    }
+
+    #[test]
+    fn view_prefers_overlay_and_masks_replaced_static_capabilities() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let view = overlay.view_for(&worker, global_registry());
+        assert!(view.has_overlays());
+        assert!(
+            view.get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "discovered capability must resolve"
+        );
+        assert!(
+            view.get_capability(&capability("agent-market.search_agents"))
+                .is_none(),
+            "static capability of an overlaid extension must be masked"
+        );
+        let ids: Vec<&str> = view
+            .capabilities()
+            .map(|descriptor| descriptor.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["agent-market.timeless__list_meetings"]);
+    }
+
+    #[test]
+    fn merged_snapshot_replaces_static_package_for_owner_and_is_untouched_for_others() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let worker_reg = overlay.merged_snapshot(&worker, global_registry());
+        assert!(
+            worker_reg
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "merged snapshot resolves the discovered capability by plain get_capability"
+        );
+        assert!(
+            worker_reg
+                .get_capability(&capability("agent-market.search_agents"))
+                .is_none(),
+            "the static capability is replaced in the owner's merged snapshot"
+        );
+
+        let other_reg = overlay.merged_snapshot(&owner("other"), global_registry());
+        assert!(
+            other_reg
+                .get_capability(&capability("agent-market.search_agents"))
+                .is_some(),
+            "another user's merged snapshot keeps the static surface"
+        );
+        assert!(
+            other_reg
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn merged_snapshot_returns_global_arc_unchanged_without_overlay() {
+        let overlay = ScopedPackageOverlay::new();
+        let global = global_registry();
+        let merged = overlay.merged_snapshot(&owner("nobody"), Arc::clone(&global));
+        assert!(Arc::ptr_eq(&global, &merged), "zero-cost passthrough");
+    }
+
+    #[test]
+    fn overlay_entries_never_leak_across_users() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        let other = owner("concierge-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let other_view = overlay.view_for(&other, global_registry());
+        assert!(!other_view.has_overlays());
+        assert!(
+            other_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none(),
+            "another user's discovered capability must not resolve"
+        );
+        assert!(
+            other_view
+                .get_capability(&capability("agent-market.search_agents"))
+                .is_some(),
+            "the static surface must remain intact for other users"
+        );
+    }
+
+    #[test]
+    fn overlay_entries_never_leak_across_tenants_for_the_same_user_id() {
+        // The exact isolation Ilya flagged: same UserId, different tenant must
+        // not share a discovered surface or negative-cache verdict.
+        let overlay = ScopedPackageOverlay::new();
+        let tenant_a = owner_in("tenant-a", "shared-user");
+        let tenant_b = owner_in("tenant-b", "shared-user");
+        overlay.insert(
+            tenant_a.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let a_view = overlay.view_for(&tenant_a, global_registry());
+        assert!(a_view.has_overlays(), "owning tenant sees its surface");
+
+        let b_view = overlay.view_for(&tenant_b, global_registry());
+        assert!(
+            !b_view.has_overlays(),
+            "a different tenant with the same user id must not see it"
+        );
+        assert!(
+            b_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none()
+        );
+        assert!(overlay.get(&tenant_b, &static_package().id).is_none());
+    }
+
+    #[test]
+    fn readers_serve_stale_last_good_so_concurrent_skipped_turns_keep_the_surface() {
+        // Point 2: an entry past TTL is still served (last-good). A concurrent
+        // turn that skips the in-flight refresh must not flap to the static
+        // manifest.
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(0), // already expired
+        );
+
+        assert_eq!(
+            overlay.get(&worker, &static_package().id).map(|(_, f)| f),
+            Some(OverlayFreshness::Stale),
+            "the entry is stale (refresher would re-discover)"
+        );
+        let view = overlay.view_for(&worker, global_registry());
+        assert!(
+            view.get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "but readers still serve the stale last-good surface"
+        );
+        assert!(
+            overlay
+                .merged_snapshot(&worker, global_registry())
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "merged_snapshot serves last-good too"
+        );
+    }
+
+    #[test]
+    fn get_reports_stale_after_ttl_and_touch_re_arms_to_fresh() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(0),
+        );
+
+        let (package, freshness) = overlay
+            .get(&worker, &static_package().id)
+            .expect("stale entry retained");
+        assert_eq!(
+            freshness,
+            OverlayFreshness::Stale,
+            "get() reports Stale so the refresher re-discovers"
+        );
+        assert_eq!(package.id.as_str(), "agent-market");
+
+        overlay.touch(&worker, &static_package().id, Duration::from_secs(60));
+        let (_, freshness) = overlay
+            .get(&worker, &static_package().id)
+            .expect("touched entry");
+        assert_eq!(freshness, OverlayFreshness::Fresh);
+    }
+
+    #[test]
+    fn remove_extension_clears_every_user() {
+        let overlay = ScopedPackageOverlay::new();
+        overlay.insert(
+            owner("a"),
+            discovered_package("t1"),
+            Duration::from_secs(60),
+        );
+        overlay.insert(
+            owner("b"),
+            discovered_package("t2"),
+            Duration::from_secs(60),
+        );
+        overlay.remove_extension(&static_package().id);
+        assert!(overlay.get(&owner("a"), &static_package().id).is_none());
+        assert!(overlay.get(&owner("b"), &static_package().id).is_none());
+    }
+}

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -25,7 +25,7 @@ use ironclaw_capabilities::{
     CapabilityHost, CapabilityInvocationError, CapabilityInvocationResult,
     CapabilityObligationHandler, CapabilitySpawnRequest, CapabilitySpawnResult,
 };
-use ironclaw_extensions::{ExtensionRegistry, SharedExtensionRegistry};
+use ironclaw_extensions::{ExtensionRegistry, OverlayOwner, ScopedPackageOverlay, SharedExtensionRegistry};
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     ApprovalRequestId, CapabilityDispatcher, CapabilityId, DenyReason, DispatchFailureKind,
@@ -109,6 +109,7 @@ use crate::{
 /// Default production wiring for [`HostRuntime`].
 pub struct DefaultHostRuntime {
     registry: Arc<SharedExtensionRegistry>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
     dispatcher: Arc<dyn CapabilityDispatcher>,
     authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
     trust_policy: Arc<dyn TrustPolicy>,
@@ -186,6 +187,28 @@ impl DefaultHostRuntime {
         )
     }
 
+    /// Attach the per-user discovered-package overlay (P2b): per-invocation
+    /// capability resolution then merges the request user's discovered
+    /// hosted-MCP surface over the global registry.
+    pub fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
+    }
+
+    fn scoped_snapshot(
+        &self,
+        tenant_id: &ironclaw_host_api::TenantId,
+        user_id: &ironclaw_host_api::UserId,
+    ) -> Arc<ExtensionRegistry> {
+        match &self.scoped_overlay {
+            Some(overlay) => overlay.merged_snapshot(
+                &OverlayOwner::new(tenant_id.clone(), user_id.clone()),
+                self.registry.snapshot(),
+            ),
+            None => self.registry.snapshot(),
+        }
+    }
+
     pub fn from_shared_registry(
         registry: Arc<SharedExtensionRegistry>,
         dispatcher: Arc<dyn CapabilityDispatcher>,
@@ -195,6 +218,7 @@ impl DefaultHostRuntime {
     ) -> Self {
         Self {
             registry,
+            scoped_overlay: None,
             dispatcher,
             authorizer,
             trust_policy: Arc::new(HostTrustPolicy::fail_closed()),
@@ -432,7 +456,7 @@ impl HostRuntime for DefaultHostRuntime {
         let invocation_id = context.invocation_id;
         let total_started_at = live_latency_started_at();
 
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
 
         // Validate the execution context before the kernel's credential pre-flight
         // queries the secret store. Without this guard a malformed
@@ -536,7 +560,7 @@ impl HostRuntime for DefaultHostRuntime {
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
 
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
 
         // Validate the execution context before the kernel's credential pre-flight
         // queries the secret store. Without this guard a malformed
@@ -594,7 +618,7 @@ impl HostRuntime for DefaultHostRuntime {
         // Trust classification runs inside the kernel's `authorize_resumed` fold,
         // which fails the blocked run on a trust rejection (replacing the former
         // host_runtime pre-authorization + `context.trust` stamp).
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
         let host = self.capability_host(&registry);
         match host
             .resume_json(
@@ -657,7 +681,7 @@ impl HostRuntime for DefaultHostRuntime {
         // credential gate, and a trust rejection fails the blocked run there —
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
         let host = self.capability_host(&registry);
         match host
             .auth_resume_json(
@@ -751,7 +775,7 @@ impl HostRuntime for DefaultHostRuntime {
         // `resume_spawn_json` fold, which fails the blocked run on rejection —
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
         let host = self.capability_host(&registry);
         match host
             .resume_spawn_json(
@@ -798,7 +822,10 @@ impl HostRuntime for DefaultHostRuntime {
         &self,
         request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, HostRuntimeError> {
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(
+            &request.context.tenant_id,
+            &request.context.user_id,
+        );
         let catalog = CapabilityCatalog::new(
             &registry,
             self.authorizer.as_ref(),

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -25,7 +25,7 @@ use ironclaw_capabilities::{
     CapabilityHost, CapabilityInvocationError, CapabilityInvocationResult,
     CapabilityObligationHandler, CapabilitySpawnRequest, CapabilitySpawnResult,
 };
-use ironclaw_extensions::{ExtensionRegistry, OverlayOwner, ScopedPackageOverlay, SharedExtensionRegistry};
+use ironclaw_extensions::{ExtensionRegistry, OverlayScope, ScopedPackageOverlay, SharedExtensionRegistry};
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     ApprovalRequestId, CapabilityDispatcher, CapabilityId, DenyReason, DispatchFailureKind,
@@ -199,10 +199,11 @@ impl DefaultHostRuntime {
         &self,
         tenant_id: &ironclaw_host_api::TenantId,
         user_id: &ironclaw_host_api::UserId,
+        thread_id: Option<&ironclaw_host_api::ThreadId>,
     ) -> Arc<ExtensionRegistry> {
         match &self.scoped_overlay {
             Some(overlay) => overlay.merged_snapshot(
-                &OverlayOwner::new(tenant_id.clone(), user_id.clone()),
+                &OverlayScope::new(tenant_id.clone(), user_id.clone(), thread_id.cloned()),
                 self.registry.snapshot(),
             ),
             None => self.registry.snapshot(),
@@ -456,7 +457,11 @@ impl HostRuntime for DefaultHostRuntime {
         let invocation_id = context.invocation_id;
         let total_started_at = live_latency_started_at();
 
-        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
 
         // Validate the execution context before the kernel's credential pre-flight
         // queries the secret store. Without this guard a malformed
@@ -560,7 +565,11 @@ impl HostRuntime for DefaultHostRuntime {
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
 
-        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
 
         // Validate the execution context before the kernel's credential pre-flight
         // queries the secret store. Without this guard a malformed
@@ -618,7 +627,11 @@ impl HostRuntime for DefaultHostRuntime {
         // Trust classification runs inside the kernel's `authorize_resumed` fold,
         // which fails the blocked run on a trust rejection (replacing the former
         // host_runtime pre-authorization + `context.trust` stamp).
-        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
         let host = self.capability_host(&registry);
         match host
             .resume_json(
@@ -681,7 +694,11 @@ impl HostRuntime for DefaultHostRuntime {
         // credential gate, and a trust rejection fails the blocked run there —
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
-        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
         let host = self.capability_host(&registry);
         match host
             .auth_resume_json(
@@ -775,7 +792,11 @@ impl HostRuntime for DefaultHostRuntime {
         // `resume_spawn_json` fold, which fails the blocked run on rejection —
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
-        let registry = self.scoped_snapshot(&context.resource_scope.tenant_id, &context.resource_scope.user_id);
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
         let host = self.capability_host(&registry);
         match host
             .resume_spawn_json(
@@ -825,6 +846,7 @@ impl HostRuntime for DefaultHostRuntime {
         let registry = self.scoped_snapshot(
             &request.context.tenant_id,
             &request.context.user_id,
+            request.context.thread_id.as_ref(),
         );
         let catalog = CapabilityCatalog::new(
             &registry,

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -812,6 +812,7 @@ where
             self.surface_version.clone(),
             runtime_policy,
         )
+        .with_scoped_overlay(Arc::clone(&self.scoped_overlay))
         .with_surface_filesystem(surface_filesystem)
         .with_trust_policy_dyn(Arc::clone(&self.trust_policy))
         .with_process_manager(process_manager)

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -21,7 +21,9 @@ use ironclaw_events::{
     InMemoryAuditSink, InMemoryDurableAuditLog, InMemoryDurableEventLog, InMemoryEventSink,
     SecurityAuditSink,
 };
-use ironclaw_extensions::{ExtensionRegistry, ExtensionRuntime, SharedExtensionRegistry};
+use ironclaw_extensions::{
+    ExtensionRegistry, ExtensionRuntime, ScopedPackageOverlay, SharedExtensionRegistry,
+};
 use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{DiskFilesystem, RootFilesystem, ScopedFilesystem};
@@ -129,6 +131,7 @@ where
     R: ProcessResultStorePort + 'static,
 {
     registry: Arc<SharedExtensionRegistry>,
+    scoped_overlay: Arc<ScopedPackageOverlay>,
     trust_policy: Arc<dyn TrustPolicy>,
     trust_policy_configured: bool,
     filesystem: Arc<F>,
@@ -296,6 +299,49 @@ impl ProductAuthProviderRuntimePorts {
             .await
     }
 
+    /// Resolve the owning scope for `handle` (caller's own secret first, then
+    /// the tenant-shared admin-managed secret — the same rule the dispatch-time
+    /// obligation preflight uses) and stage it. `AuthRequired` when no owner
+    /// scope holds the handle. Used by turn-start hosted-MCP discovery (P2b),
+    /// whose run scope is not the canonical scope user secrets are stored under.
+    pub async fn stage_owner_resolved_secret_once(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) -> Result<(), ProductAuthCredentialStageError> {
+        let owner = crate::obligations::secret_owner_scope(self.secret_store.as_ref(), scope, handle)
+            .await
+            .map_err(stage_secret_error)?;
+        let Some(source_scope) = owner else {
+            return Err(ProductAuthCredentialStageError::AuthRequired);
+        };
+        self.stage_secret_from_scope_once(&source_scope, scope, capability_id, handle)
+            .await
+    }
+
+    /// Discard staged discovery state (network policy + secret material) for
+    /// (scope, capability) after a host-driven egress call completes (P2b
+    /// turn-start discovery).
+    pub fn discard_staged_discovery_state(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) {
+        self.network_policy_store
+            .discard_for_capability(scope, capability_id);
+        if let Err(error) = self
+            .secret_injection_store
+            .discard_for_capability(scope, capability_id)
+        {
+            tracing::debug!(
+                error = ?error,
+                capability_id = %capability_id,
+                "failed to discard staged discovery secret material"
+            );
+        }
+    }
+
     /// Stage one declared credential requirement for a host-driven call that
     /// bypasses the dispatch obligation pipeline (hosted-MCP discovery runs
     /// at activation, not through a capability invocation, so nothing else
@@ -434,6 +480,7 @@ where
         let credential_session_store: Arc<dyn CredentialSessionStore> = credential_broker;
         Self {
             registry: Arc::new(SharedExtensionRegistry::new((*registry).clone())),
+            scoped_overlay: Arc::new(ScopedPackageOverlay::new()),
             trust_policy: Arc::new(HostTrustPolicy::fail_closed()),
             trust_policy_configured: false,
             filesystem,
@@ -645,6 +692,12 @@ where
     /// Builds the upper service without production validation.
     pub fn shared_extension_registry(&self) -> Arc<SharedExtensionRegistry> {
         Arc::clone(&self.registry)
+    }
+
+    /// The per-user discovered-package overlay shared by every scoped
+    /// capability-resolution path (P2b).
+    pub fn scoped_package_overlay(&self) -> Arc<ScopedPackageOverlay> {
+        Arc::clone(&self.scoped_overlay)
     }
 
     /// Returns the canonical host-runtime HTTP egress port when configured.

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -670,7 +670,10 @@ where
         });
         let mcp = self.mcp_runtime.as_ref().map(|runtime| {
             ServiceResolvedRuntimeAdapter::new(
-                Arc::new(McpRuntimeAdapter::from_executor(Arc::clone(runtime))),
+                Arc::new(
+                    McpRuntimeAdapter::from_executor(Arc::clone(runtime))
+                        .with_scoped_overlay(Arc::clone(&self.scoped_overlay)),
+                ),
                 Arc::clone(&invocation_services),
             )
         });

--- a/crates/ironclaw_host_runtime/src/services/builder.rs
+++ b/crates/ironclaw_host_runtime/src/services/builder.rs
@@ -41,6 +41,7 @@ where
     {
         let Self {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem: _,
@@ -87,6 +88,7 @@ where
         component_types.filesystem = ProductionComponentType::of::<T>();
         HostRuntimeServices {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem,
@@ -152,6 +154,7 @@ where
     {
         let Self {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem,
@@ -208,6 +211,7 @@ where
         component_types.resource_governor = ProductionComponentType::of::<T>();
         HostRuntimeServices {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem,

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -8,7 +8,7 @@ use std::{
 use async_trait::async_trait;
 use futures_util::FutureExt;
 
-use ironclaw_extensions::ExtensionPackage;
+use ironclaw_extensions::{ExtensionPackage, OverlayScope, ScopedPackageOverlay};
 use ironclaw_host_api::{
     CapabilityDescriptor, InvocationOrigin, MountView, ResourceEstimate, ResourceReservation,
     UserId, runtime_policy::EffectiveRuntimePolicy,
@@ -407,11 +407,51 @@ where
 #[derive(Clone)]
 pub(super) struct McpRuntimeAdapter {
     executor: Arc<dyn McpExecutor>,
+    /// Per-user discovered-package overlay (P2b). The scope-free resolver binds
+    /// the STATIC package, so a DISCOVERED hosted-MCP tool would fail
+    /// `CapabilityNotDeclared` (its id is not in the static package). At
+    /// dispatch the scope is known, so we swap in the caller's discovered
+    /// package when it declares the requested capability. `None` when no overlay
+    /// is wired (static-only deployments).
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 }
 
 impl McpRuntimeAdapter {
     pub(super) fn from_executor(executor: Arc<dyn McpExecutor>) -> Self {
-        Self { executor }
+        Self {
+            executor,
+            scoped_overlay: None,
+        }
+    }
+
+    pub(super) fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
+    }
+
+    /// The caller's discovered package for `capability_id`'s provider, when the
+    /// overlay holds one that actually declares this capability. Returned as an
+    /// owned `Arc` so the borrow used as `McpExecutionRequest.package` lives for
+    /// the dispatch call.
+    fn discovered_package(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Option<Arc<ExtensionPackage>> {
+        let overlay = self.scoped_overlay.as_ref()?;
+        let (provider, _tool) = capability_id.as_str().split_once('.')?;
+        let extension_id = ironclaw_host_api::ExtensionId::new(provider).ok()?;
+        let owner = OverlayScope::new(
+            scope.tenant_id.clone(),
+            scope.user_id.clone(),
+            scope.thread_id.clone(),
+        );
+        let (package, _freshness) = overlay.get(&owner, &extension_id)?;
+        package
+            .capabilities
+            .iter()
+            .any(|descriptor| &descriptor.id == capability_id)
+            .then_some(package)
     }
 }
 
@@ -425,12 +465,19 @@ where
         &self,
         request: RuntimeLaneRequest<'_, F, G>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
+        // The scope-free resolver bound the STATIC package; swap in the caller's
+        // discovered package (P2b) when it declares this capability, so a
+        // per-user hosted-MCP tool is not rejected as `CapabilityNotDeclared`
+        // and its descriptor's credential requirements resolve. Held as an owned
+        // `Arc` so the `&ExtensionPackage` borrow lives for the executor call.
+        let discovered = self.discovered_package(&request.scope, request.capability_id);
+        let package = discovered.as_deref().unwrap_or(request.package);
         let execution = self
             .executor
             .execute_extension_json(
                 request.governor,
                 McpExecutionRequest {
-                    package: request.package,
+                    package,
                     capability_id: request.capability_id,
                     scope: request.scope,
                     estimate: request.estimate,

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -474,6 +474,16 @@ where
         let url = request.url.as_deref().ok_or_else(|| {
             McpClientError::client(request_denied(McpRequestDeniedCause::MissingUrl))
         })?;
+        // Stamp the SEP-414 `_meta` attribution on the tool-facing methods only.
+        // `initialize` carries no per-turn attribution and must keep its exact
+        // handshake params. Threading it through the shared planner (rather than
+        // each call site) guarantees `tools/list` and `tools/call` agree.
+        let params = match method {
+            McpJsonRpcMethod::ToolsList | McpJsonRpcMethod::ToolsCall => {
+                Some(params_with_sep414_meta(params, &request.scope))
+            }
+            _ => params,
+        };
         let body =
             encode_json_rpc_request(id, method.as_str(), params).map_err(McpClientError::client)?;
         let policy_headers = vec![
@@ -961,6 +971,54 @@ fn protocol_version_from_initialize_response(
         ));
     }
     Ok(protocol_version.to_string())
+}
+
+/// Builds the SEP-414 `_meta` attribution block the host stamps on every
+/// outbound MCP `tools/list` / `tools/call`.
+///
+/// It is derived from the trusted turn [`ResourceScope`] and merged into
+/// `params` *after* argument serialization, so extension and model code can
+/// neither read nor forge it. Hosted providers (the marketplace connector
+/// endpoint) resolve the caller's dispatch/hire from `io.ironclaw/threadId` —
+/// never from tool arguments — which is what lets one stable per-user token
+/// serve concurrent jobs without cross-job data bleed. Absent a thread scope
+/// (non-threaded runtime) the key is omitted rather than sent empty.
+fn sep414_meta(scope: &ResourceScope) -> Value {
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "io.ironclaw/userId".to_string(),
+        Value::String(scope.user_id.as_str().to_string()),
+    );
+    meta.insert(
+        "io.ironclaw/invocationId".to_string(),
+        Value::String(scope.invocation_id.to_string()),
+    );
+    if let Some(thread_id) = scope.thread_id.as_ref() {
+        meta.insert(
+            "io.ironclaw/threadId".to_string(),
+            Value::String(thread_id.as_str().to_string()),
+        );
+    }
+    Value::Object(meta)
+}
+
+/// Merge [`sep414_meta`] into an outbound `params` object, creating the object
+/// when the method carries no other params (e.g. `tools/list`, whose params are
+/// `None`). Both call sites (`call_tool`, `discover_tools`) pass either an
+/// object or `None`; a non-object value is preserved under `"params"` so a
+/// future caller cannot silently drop it.
+fn params_with_sep414_meta(params: Option<Value>, scope: &ResourceScope) -> Value {
+    let mut object = match params {
+        Some(Value::Object(map)) => map,
+        None => serde_json::Map::new(),
+        Some(other) => {
+            let mut map = serde_json::Map::new();
+            map.insert("params".to_string(), other);
+            map
+        }
+    };
+    object.insert("_meta".to_string(), sep414_meta(scope));
+    Value::Object(object)
 }
 
 fn encode_json_rpc_request(
@@ -1854,7 +1912,137 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_host_api::{
+        AgentId, InvocationId, MissionId, ProjectId, TenantId, ThreadId, UserId,
+    };
     use serde_json::json;
+
+    /// Never invoked: `plan_json_rpc` builds the outbound body without touching
+    /// the transport. Present only to satisfy `McpHostHttpClient`'s `H: McpHostHttp`.
+    struct UnusedHttp;
+
+    #[async_trait]
+    impl McpHostHttp for UnusedHttp {
+        async fn request(
+            &self,
+            _request: CapabilityHostHttpRequest,
+        ) -> Result<McpHostHttpResponse, McpHostHttpError> {
+            unreachable!("plan_json_rpc must not touch the transport")
+        }
+    }
+
+    fn planning_client() -> McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner> {
+        McpHostHttpClient::new(
+            UnusedHttp,
+            StaticMcpHostHttpEgressPlanner::new(McpHostHttpEgressPlan::default()),
+        )
+    }
+
+    fn scope_with_thread(thread_id: Option<&str>) -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant-a").unwrap(),
+            user_id: UserId::new("user-a").unwrap(),
+            agent_id: Some(AgentId::new("agent-a").unwrap()),
+            project_id: Some(ProjectId::new("project-a").unwrap()),
+            mission_id: Some(MissionId::new("mission-a").unwrap()),
+            thread_id: thread_id.map(|id| ThreadId::new(id).unwrap()),
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    fn meta_probe_request(scope: ResourceScope, input: Value) -> McpClientRequest {
+        McpClientRequest {
+            provider: ExtensionId::new("agent-market").unwrap(),
+            capability_id: CapabilityId::new("agent-market.timeless__list_meetings").unwrap(),
+            scope,
+            transport: "http".to_string(),
+            command: None,
+            args: Vec::new(),
+            url: Some("https://mcp.example.test/rpc".to_string()),
+            input,
+            max_output_bytes: 1_000_000,
+        }
+    }
+
+    /// The outbound `params` object that `plan_json_rpc` actually encodes.
+    fn planned_params(client: &McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner>, request: &McpClientRequest, method: McpJsonRpcMethod, params: Option<Value>) -> Value {
+        let planned = client
+            .plan_json_rpc(request, Some(1), method, params)
+            .expect("planning succeeds");
+        let decoded: Value = serde_json::from_slice(&planned.body).expect("body is JSON");
+        decoded
+            .get("params")
+            .cloned()
+            .unwrap_or(Value::Null)
+    }
+
+    #[test]
+    fn tools_call_stamps_sep414_thread_attribution_on_the_wire() {
+        let client = planning_client();
+        let request =
+            meta_probe_request(scope_with_thread(Some("thread-a")), json!({"limit": 10}));
+
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::ToolsCall,
+            Some(json!({ "name": "timeless__list_meetings", "arguments": { "limit": 10 } })),
+        );
+
+        // Attribution is carried in `_meta`, never derived from arguments — this
+        // is what lets one stable per-user token serve concurrent jobs without a
+        // buyer seeing another buyer's connector.
+        assert_eq!(params["_meta"]["io.ironclaw/threadId"], json!("thread-a"));
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+        assert!(params["_meta"]["io.ironclaw/invocationId"].is_string());
+        // Original tool arguments survive the merge untouched.
+        assert_eq!(params["name"], json!("timeless__list_meetings"));
+        assert_eq!(params["arguments"], json!({ "limit": 10 }));
+    }
+
+    #[test]
+    fn tools_list_stamps_sep414_thread_attribution_even_without_other_params() {
+        let client = planning_client();
+        let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
+
+        // `tools/list` carries no other params (`None`) — the block must still
+        // materialize so per-turn discovery is attributed to its thread.
+        let params = planned_params(&client, &request, McpJsonRpcMethod::ToolsList, None);
+
+        assert_eq!(params["_meta"]["io.ironclaw/threadId"], json!("thread-a"));
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+    }
+
+    #[test]
+    fn initialize_handshake_is_not_stamped_with_attribution() {
+        let client = planning_client();
+        let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
+
+        // The handshake predates any turn attribution; stamping it would corrupt
+        // the exact `initialize` params contract.
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::Initialize,
+            Some(json!({ "protocolVersion": "2025-06-18" })),
+        );
+
+        assert!(params.get("_meta").is_none());
+        assert_eq!(params["protocolVersion"], json!("2025-06-18"));
+    }
+
+    #[test]
+    fn thread_less_scope_omits_thread_id_but_keeps_user_attribution() {
+        let client = planning_client();
+        let request = meta_probe_request(scope_with_thread(None), Value::Null);
+
+        let params = planned_params(&client, &request, McpJsonRpcMethod::ToolsList, None);
+
+        // A non-threaded runtime sends no thread key (absent, not empty) but is
+        // still user-attributed.
+        assert!(params["_meta"].get("io.ironclaw/threadId").is_none());
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+    }
 
     #[test]
     fn mcp_auth_context_preserves_product_auth_oauth_setup() {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1078,6 +1078,13 @@ pub(crate) struct RebornRuntimeStores {
     pub(crate) in_memory_budget_event_sink: Arc<ironclaw_resources::InMemoryBudgetEventSink>,
     pub(crate) extension_registry: Arc<ExtensionRegistry>,
     pub(crate) shared_extension_registry: Arc<SharedExtensionRegistry>,
+    /// Per-user discovered hosted-MCP overlay (P2b), shared with the host
+    /// runtime's scoped capability-resolution paths.
+    pub(crate) scoped_overlay: Arc<ironclaw_extensions::ScopedPackageOverlay>,
+    /// Product-auth runtime ports (egress + one-shot secret/policy staging) for
+    /// turn-start hosted-MCP discovery (P2b). None when host egress is absent.
+    pub(crate) product_auth_runtime_ports:
+        Option<ironclaw_host_runtime::ProductAuthProviderRuntimePorts>,
     pub(crate) scoped_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     pub(crate) turn_state: Arc<TurnStateRowStore<CompositeRootFilesystem>>,
     pub(crate) checkpoint_state_store: Arc<dyn CheckpointStateStorePort>,
@@ -5531,6 +5538,8 @@ async fn build_backend_production(
         }
     };
     let shared_extension_registry = services.shared_extension_registry();
+    let scoped_overlay = services.scoped_package_overlay();
+    let product_auth_runtime_ports = services.product_auth_provider_runtime_ports();
 
     #[cfg(test)]
     let local_dev_wasm_runtime_credential_provider_captured =
@@ -5543,6 +5552,8 @@ async fn build_backend_production(
 
     Ok(RebornRuntimeStores {
         host_runtime,
+        scoped_overlay,
+        product_auth_runtime_ports,
         #[cfg(test)]
         turn_coordinator,
         readiness: readiness_for(profile, true, true, product_auth_ready),

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -961,10 +961,15 @@ where
     };
     let runtime_http_egress = runtime_ports.runtime_http_egress();
     let registry = services.shared_extension_registry();
+    // Per-user discovered-package overlay (P2b): the egress planner needs it to
+    // resolve credentials for DISCOVERED hosted-MCP tools (absent from the
+    // global registry), else those calls egress unauthenticated.
+    let scoped_overlay = services.scoped_package_overlay();
 
     Ok(services.with_mcp_runtime(Arc::new(hosted_http_mcp_runtime(
         registry,
         runtime_http_egress,
+        Some(scoped_overlay),
     ))))
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -80,7 +80,13 @@ impl PolicyApprovalLeaseTermsProvider {
         // (#5459 P1): their own private capability resolves, anyone else's
         // yields no grant and the lease stays unavailable.
         let Some(grant) = surface
-            .grants(extension_id, &gate.resource_scope().user_id)
+            .grants(
+                extension_id,
+                &ironclaw_extensions::OverlayOwner::new(
+                    gate.resource_scope().tenant_id.clone(),
+                    gate.resource_scope().user_id.clone(),
+                ),
+            )
             .into_iter()
             .find(|grant| grant.capability == *capability)
         else {

--- a/crates/ironclaw_reborn_composition/src/runtime/approval.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/approval.rs
@@ -82,9 +82,10 @@ impl PolicyApprovalLeaseTermsProvider {
         let Some(grant) = surface
             .grants(
                 extension_id,
-                &ironclaw_extensions::OverlayOwner::new(
+                &ironclaw_extensions::OverlayScope::new(
                     gate.resource_scope().tenant_id.clone(),
                     gate.resource_scope().user_id.clone(),
+                    gate.resource_scope().thread_id.clone(),
                 ),
             )
             .into_iter()

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -49,6 +49,7 @@ use crate::runtime::ComposedSelectableSkillContextSource;
 use ironclaw_product::projection::{CapabilityDisplayPreviewResult, CapabilityDisplayPreviewStore};
 
 pub(crate) mod extension_surface;
+mod hosted_mcp_overlay;
 mod external_tool_capability;
 mod outbound_delivery;
 mod project_create;

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -127,7 +127,17 @@ pub(super) fn capability_wiring(
         &[EffectKind::ExternalWrite],
     );
     let extension_surface_source =
-        ExtensionCapabilitySurfaceSource::new(Some(services.extension_management.clone()));
+        ExtensionCapabilitySurfaceSource::new(Some(services.extension_management.clone()))
+            .with_scoped_overlay(services.scoped_overlay.clone());
+    // Turn-start per-user hosted-MCP discovery (P2b): only when the product-auth
+    // runtime ports are present (host egress + secret staging).
+    let hosted_mcp_overlay_refresher = services.product_auth_runtime_ports.clone().map(|ports| {
+        Arc::new(hosted_mcp_overlay::HostedMcpOverlayRefresher::new(
+            services.scoped_overlay.clone(),
+            services.shared_extension_registry.clone(),
+            ports,
+        ))
+    });
     // First-class project creation reuses the same access-controlled
     // `ProjectService` service the WebUI v2 surface wires (composition owns the
     // service, never the raw repository), so an agent-created project is a real
@@ -173,6 +183,7 @@ pub(super) fn capability_wiring(
             memory_mounts,
             system_extensions_lifecycle_mounts,
             extension_surface_source,
+            hosted_mcp_overlay_refresher,
             input_resolver: Arc::clone(&capability_input_resolver),
             result_writer: Arc::clone(&capability_result_writer),
             milestone_sink,
@@ -207,6 +218,7 @@ struct RefreshingLoopCapabilityPortFactory {
     memory_mounts: MountView,
     system_extensions_lifecycle_mounts: MountView,
     extension_surface_source: ExtensionCapabilitySurfaceSource,
+    hosted_mcp_overlay_refresher: Option<Arc<hosted_mcp_overlay::HostedMcpOverlayRefresher>>,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
@@ -237,11 +249,15 @@ impl LoopCapabilityPortFactory for RefreshingLoopCapabilityPortFactory {
         &self,
         run_context: &LoopRunContext,
     ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
-        let skill_mounts = scoped_skill_management_mount_view(&local_dev_resource_scope_for_run(
-            run_context,
-            &self.fallback_user_id,
-        ))
-        .map_err(host_api_agent_loop_error)?;
+        let run_scope = local_dev_resource_scope_for_run(run_context, &self.fallback_user_id);
+        // Per-user hosted-MCP discovery BEFORE the surface/resolver snapshot so
+        // this turn's grants, surface, and dispatch see the caller's discovered
+        // tools. Failures degrade to last-good/static and never fail the turn.
+        if let Some(refresher) = &self.hosted_mcp_overlay_refresher {
+            refresher.refresh_for_scope(&run_scope).await;
+        }
+        let skill_mounts =
+            scoped_skill_management_mount_view(&run_scope).map_err(host_api_agent_loop_error)?;
         create_refreshing_capability_port(RefreshingCapabilityPortConfig {
             runtime: Arc::clone(&self.runtime),
             run_context: run_context.clone(),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -1126,6 +1126,10 @@ fn visible_capability_request(
         .cloned()
         .or_else(|| run_context.actor().map(|actor| actor.user_id.clone()))
         .unwrap_or_else(|| fallback_user_id.clone());
+    let overlay_owner = ironclaw_extensions::OverlayOwner::new(
+        run_context.scope.tenant_id.clone(),
+        user_id.clone(),
+    );
     let mut grants = inputs.policy.builtin_grants(
         &extension_id,
         inputs.workspace_mounts,
@@ -1135,7 +1139,7 @@ fn visible_capability_request(
     );
     grants
         .grants
-        .extend(inputs.extension_surface.grants(&extension_id, &user_id));
+        .extend(inputs.extension_surface.grants(&extension_id, &overlay_owner));
     let mut context = ExecutionContext::local_default(
         user_id,
         extension_id,
@@ -1190,7 +1194,7 @@ fn visible_capability_request(
             evaluated_at: Utc::now(),
         },
     );
-    provider_trust.extend(inputs.extension_surface.provider_trust(&context.user_id));
+    provider_trust.extend(inputs.extension_surface.provider_trust(&overlay_owner));
 
     Ok(HostVisibleCapabilityRequest::new(
         context,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -1143,9 +1143,10 @@ fn visible_capability_request(
         .cloned()
         .or_else(|| run_context.actor().map(|actor| actor.user_id.clone()))
         .unwrap_or_else(|| fallback_user_id.clone());
-    let overlay_owner = ironclaw_extensions::OverlayOwner::new(
+    let overlay_owner = ironclaw_extensions::OverlayScope::new(
         run_context.scope.tenant_id.clone(),
         user_id.clone(),
+        Some(run_context.scope.thread_id.clone()),
     );
     let mut grants = inputs.policy.builtin_grants(
         &extension_id,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -9,7 +9,7 @@ use ironclaw_host_api::{
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 use crate::extension_host::extension_lifecycle::RebornLocalExtensionManagementPort;
-use ironclaw_extensions::{InstallationOwner, OverlayOwner, ScopedPackageOverlay};
+use ironclaw_extensions::{InstallationOwner, OverlayScope, ScopedPackageOverlay};
 use ironclaw_product::ProductSurfaceFailure;
 
 #[derive(Clone, Default)]
@@ -101,7 +101,7 @@ impl ExtensionCapabilitySurface {
     /// for replaced by its discovered (per-principal) capability set. The
     /// overlay applies only to extensions with a caller-visible active
     /// installation (fail closed).
-    fn caller_capabilities(&self, caller: &OverlayOwner) -> Vec<ActiveExtensionCapability> {
+    fn caller_capabilities(&self, caller: &OverlayScope) -> Vec<ActiveExtensionCapability> {
         let user = caller.user_id();
         let overlay_capabilities = self.overlay_capabilities(caller);
         let overlaid_providers: Vec<&ExtensionId> = overlay_capabilities
@@ -119,7 +119,7 @@ impl ExtensionCapabilitySurface {
         merged
     }
 
-    fn overlay_capabilities(&self, caller: &OverlayOwner) -> Vec<ActiveExtensionCapability> {
+    fn overlay_capabilities(&self, caller: &OverlayScope) -> Vec<ActiveExtensionCapability> {
         let Some(overlay) = &self.scoped_overlay else {
             return Vec::new();
         };
@@ -157,7 +157,7 @@ impl ExtensionCapabilitySurface {
     pub(in crate::runtime) fn grants(
         &self,
         grantee: &ExtensionId,
-        caller: &OverlayOwner,
+        caller: &OverlayScope,
     ) -> Vec<CapabilityGrant> {
         self.caller_capabilities(caller)
             .iter()
@@ -185,7 +185,7 @@ impl ExtensionCapabilitySurface {
     /// advertised to other users' surfaces.
     pub(super) fn provider_trust(
         &self,
-        caller: &OverlayOwner,
+        caller: &OverlayScope,
     ) -> BTreeMap<ExtensionId, TrustDecision> {
         let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
         for capability in &self.caller_capabilities(caller) {
@@ -284,8 +284,8 @@ mod tests {
     use super::*;
     use ironclaw_host_api::TenantId;
 
-    fn test_owner(user: &ironclaw_host_api::UserId) -> OverlayOwner {
-        OverlayOwner::new(TenantId::new("tenant-a").unwrap(), user.clone())
+    fn test_owner(user: &ironclaw_host_api::UserId) -> OverlayScope {
+        OverlayScope::new(TenantId::new("tenant-a").unwrap(), user.clone(), None)
     }
     use ironclaw_host_api::{
         CapabilityId, NetworkScheme, NetworkTargetPattern, PermissionMode, UserId,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -9,11 +9,13 @@ use ironclaw_host_api::{
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 use crate::extension_host::extension_lifecycle::RebornLocalExtensionManagementPort;
+use ironclaw_extensions::{InstallationOwner, OverlayOwner, ScopedPackageOverlay};
 use ironclaw_product::ProductSurfaceFailure;
 
 #[derive(Clone, Default)]
 pub(in crate::runtime) struct ExtensionCapabilitySurfaceSource {
     extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
     #[cfg(test)]
     static_surface: Option<ExtensionCapabilitySurface>,
 }
@@ -24,15 +26,27 @@ impl ExtensionCapabilitySurfaceSource {
     ) -> Self {
         Self {
             extension_management,
+            scoped_overlay: None,
             #[cfg(test)]
             static_surface: None,
         }
+    }
+
+    /// Attach the per-user discovered-package overlay so grants and provider
+    /// trust cover the caller's discovered hosted-MCP surface (P2b).
+    pub(in crate::runtime) fn with_scoped_overlay(
+        mut self,
+        overlay: Arc<ScopedPackageOverlay>,
+    ) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
     }
 
     #[cfg(test)]
     pub(in crate::runtime) fn from_surface(surface: ExtensionCapabilitySurface) -> Self {
         Self {
             extension_management: None,
+            scoped_overlay: None,
             static_surface: Some(surface),
         }
     }
@@ -47,13 +61,17 @@ impl ExtensionCapabilitySurfaceSource {
         let Some(extension_management) = self.extension_management.as_deref() else {
             return Ok(ExtensionCapabilitySurface::default());
         };
-        ExtensionCapabilitySurface::from_extension_management(extension_management).await
+        let mut surface =
+            ExtensionCapabilitySurface::from_extension_management(extension_management).await?;
+        surface.scoped_overlay = self.scoped_overlay.clone();
+        Ok(surface)
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub(in crate::runtime) struct ExtensionCapabilitySurface {
     active_capabilities: Vec<ActiveExtensionCapability>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 }
 
 impl ExtensionCapabilitySurface {
@@ -63,6 +81,7 @@ impl ExtensionCapabilitySurface {
     ) -> Self {
         Self {
             active_capabilities,
+            scoped_overlay: None,
         }
     }
 
@@ -73,7 +92,60 @@ impl ExtensionCapabilitySurface {
             active_capabilities: extension_management
                 .active_model_visible_capabilities()
                 .await?,
+            scoped_overlay: None,
         })
+    }
+
+    /// The caller's effective capability set: active capabilities visible to
+    /// the caller, with any extension the caller holds a discovered overlay
+    /// for replaced by its discovered (per-principal) capability set. The
+    /// overlay applies only to extensions with a caller-visible active
+    /// installation (fail closed).
+    fn caller_capabilities(&self, caller: &OverlayOwner) -> Vec<ActiveExtensionCapability> {
+        let user = caller.user_id();
+        let overlay_capabilities = self.overlay_capabilities(caller);
+        let overlaid_providers: Vec<&ExtensionId> = overlay_capabilities
+            .iter()
+            .map(|capability| &capability.provider)
+            .collect();
+        let mut merged: Vec<ActiveExtensionCapability> = self
+            .active_capabilities
+            .iter()
+            .filter(|capability| capability.owner.visible_to(user))
+            .filter(|capability| !overlaid_providers.contains(&&capability.provider))
+            .cloned()
+            .collect();
+        merged.extend(overlay_capabilities);
+        merged
+    }
+
+    fn overlay_capabilities(&self, caller: &OverlayOwner) -> Vec<ActiveExtensionCapability> {
+        let Some(overlay) = &self.scoped_overlay else {
+            return Vec::new();
+        };
+        let user = caller.user_id();
+        let mut capabilities = Vec::new();
+        for package in overlay.packages_for(caller) {
+            let caller_sees_provider = self.active_capabilities.iter().any(|capability| {
+                capability.provider == package.id && capability.owner.visible_to(user)
+            });
+            if !caller_sees_provider {
+                continue;
+            }
+            for descriptor in &package.capabilities {
+                capabilities.push(ActiveExtensionCapability {
+                    id: descriptor.id.clone(),
+                    provider: descriptor.provider.clone(),
+                    effects: descriptor.effects.clone(),
+                    default_permission: descriptor.default_permission,
+                    runtime_credentials: descriptor.runtime_credentials.clone(),
+                    network_targets: descriptor.network_targets.clone(),
+                    max_egress_bytes: None,
+                    owner: InstallationOwner::user(user.clone()),
+                });
+            }
+        }
+        capabilities
     }
 
     /// Mint capability grants for one request (#5459 P1: filtered to the
@@ -85,11 +157,10 @@ impl ExtensionCapabilitySurface {
     pub(in crate::runtime) fn grants(
         &self,
         grantee: &ExtensionId,
-        caller: &ironclaw_host_api::UserId,
+        caller: &OverlayOwner,
     ) -> Vec<CapabilityGrant> {
-        self.active_capabilities
+        self.caller_capabilities(caller)
             .iter()
-            .filter(|capability| capability.owner.visible_to(caller))
             .map(|capability| CapabilityGrant {
                 id: CapabilityGrantId::new(),
                 capability: capability.id.clone(),
@@ -114,13 +185,10 @@ impl ExtensionCapabilitySurface {
     /// advertised to other users' surfaces.
     pub(super) fn provider_trust(
         &self,
-        caller: &ironclaw_host_api::UserId,
+        caller: &OverlayOwner,
     ) -> BTreeMap<ExtensionId, TrustDecision> {
         let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
-        for capability in &self.active_capabilities {
-            if !capability.owner.visible_to(caller) {
-                continue;
-            }
+        for capability in &self.caller_capabilities(caller) {
             let effects = effects_by_provider
                 .entry(capability.provider.clone())
                 .or_default();
@@ -214,6 +282,11 @@ pub(crate) fn extension_network_policy(capability: &ActiveExtensionCapability) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_host_api::TenantId;
+
+    fn test_owner(user: &ironclaw_host_api::UserId) -> OverlayOwner {
+        OverlayOwner::new(TenantId::new("tenant-a").unwrap(), user.clone())
+    }
     use ironclaw_host_api::{
         CapabilityId, NetworkScheme, NetworkTargetPattern, PermissionMode, UserId,
     };
@@ -294,7 +367,7 @@ mod tests {
 
         for member in [&alice, &bob] {
             let member_capabilities: Vec<_> = surface
-                .grants(&grantee, member)
+                .grants(&grantee, &test_owner(member))
                 .into_iter()
                 .map(|grant| grant.capability.as_str().to_string())
                 .collect();
@@ -306,7 +379,7 @@ mod tests {
         }
 
         let carol_capabilities: Vec<_> = surface
-            .grants(&grantee, &carol)
+            .grants(&grantee, &test_owner(&carol))
             .into_iter()
             .map(|grant| grant.capability.as_str().to_string())
             .collect();
@@ -317,10 +390,10 @@ mod tests {
         assert!(carol_capabilities.contains(&"hacker-news.top_stories".to_string()));
 
         for member in [&alice, &bob] {
-            let member_trust = surface.provider_trust(member);
+            let member_trust = surface.provider_trust(&test_owner(member));
             assert!(member_trust.contains_key(&ExtensionId::new("market-data").unwrap()));
         }
-        let carol_trust = surface.provider_trust(&carol);
+        let carol_trust = surface.provider_trust(&test_owner(&carol));
         assert!(
             !carol_trust.contains_key(&ExtensionId::new("market-data").unwrap()),
             "a member-held provider must not be advertised to a non-member"

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/hosted_mcp_overlay.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/hosted_mcp_overlay.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 use ironclaw_extensions::{
-    DEFAULT_SCOPED_OVERLAY_TTL, ExtensionPackage, OverlayFreshness, OverlayOwner,
+    DEFAULT_SCOPED_OVERLAY_TTL, ExtensionPackage, OverlayFreshness, OverlayScope,
     ScopedPackageOverlay, SharedExtensionRegistry, is_hosted_http_mcp_package,
 };
 use ironclaw_host_api::{
@@ -62,8 +62,8 @@ pub(super) struct HostedMcpOverlayRefresher {
     runtime_ports: ProductAuthProviderRuntimePorts,
     /// Single-flight: an (owner, extension) pair being discovered by one turn
     /// is skipped by concurrent turns, which serve the last-good overlay.
-    in_flight: Mutex<HashSet<(OverlayOwner, ExtensionId)>>,
-    negative_until: Mutex<HashMap<(OverlayOwner, ExtensionId), Instant>>,
+    in_flight: Mutex<HashSet<(OverlayScope, ExtensionId)>>,
+    negative_until: Mutex<HashMap<(OverlayScope, ExtensionId), Instant>>,
 }
 
 impl HostedMcpOverlayRefresher {
@@ -93,7 +93,11 @@ impl HostedMcpOverlayRefresher {
                     .map(|(capability_id, handle)| (package.clone(), capability_id, handle))
             })
             .collect();
-        let owner = OverlayOwner::new(scope.tenant_id.clone(), scope.user_id.clone());
+        let owner = OverlayScope::new(
+            scope.tenant_id.clone(),
+            scope.user_id.clone(),
+            scope.thread_id.clone(),
+        );
         for (package, capability_id, handle) in eligible {
             let key = (owner.clone(), package.id.clone());
             if matches!(
@@ -117,7 +121,7 @@ impl HostedMcpOverlayRefresher {
     async fn refresh_one(
         &self,
         scope: &ResourceScope,
-        owner: &OverlayOwner,
+        owner: &OverlayScope,
         package: &ExtensionPackage,
         capability_id: &CapabilityId,
         handle: &SecretHandle,
@@ -219,7 +223,7 @@ impl HostedMcpOverlayRefresher {
 
     /// Re-arm a stale last-good entry so a transient provider failure does not
     /// drop the user's discovered surface (and does not re-probe every turn).
-    fn keep_last_good(&self, owner: &OverlayOwner, package: &ExtensionPackage) {
+    fn keep_last_good(&self, owner: &OverlayScope, package: &ExtensionPackage) {
         if self.overlay.get(owner, &package.id).is_some() {
             self.overlay
                 .touch(owner, &package.id, DEFAULT_SCOPED_OVERLAY_TTL);
@@ -228,7 +232,7 @@ impl HostedMcpOverlayRefresher {
         }
     }
 
-    fn negative_cache_active(&self, key: &(OverlayOwner, ExtensionId)) -> bool {
+    fn negative_cache_active(&self, key: &(OverlayScope, ExtensionId)) -> bool {
         let Ok(mut negative) = self.negative_until.lock() else {
             return false; // silent-ok: poisoned negative cache only re-probes
         };
@@ -242,7 +246,7 @@ impl HostedMcpOverlayRefresher {
         }
     }
 
-    fn negative_insert(&self, owner: &OverlayOwner, package: &ExtensionPackage) {
+    fn negative_insert(&self, owner: &OverlayScope, package: &ExtensionPackage) {
         if let Ok(mut negative) = self.negative_until.lock() {
             negative.insert(
                 (owner.clone(), package.id.clone()),
@@ -251,14 +255,14 @@ impl HostedMcpOverlayRefresher {
         }
     }
 
-    fn begin(&self, key: &(OverlayOwner, ExtensionId)) -> bool {
+    fn begin(&self, key: &(OverlayScope, ExtensionId)) -> bool {
         self.in_flight
             .lock()
             .map(|mut in_flight| in_flight.insert(key.clone()))
             .unwrap_or(false) // silent-ok: poisoned single-flight skips refresh this turn
     }
 
-    fn finish(&self, key: &(OverlayOwner, ExtensionId)) {
+    fn finish(&self, key: &(OverlayScope, ExtensionId)) {
         if let Ok(mut in_flight) = self.in_flight.lock() {
             in_flight.remove(key);
         }

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/hosted_mcp_overlay.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/hosted_mcp_overlay.rs
@@ -1,0 +1,314 @@
+//! Turn-start per-user hosted-MCP discovery (P2b).
+//!
+//! Hosted-MCP providers with a per-user secret credential (e.g. the agent
+//! marketplace) serve a **per-principal** `tools/list`. This refresher runs
+//! before a turn's capability port is built: for every active hosted-MCP
+//! extension whose discovery template binds a [`SecretHandle`]-sourced
+//! runtime credential, it stages the TURN USER's secret and re-runs
+//! `tools/list` discovery under that user's scope, caching the discovered
+//! package in the [`ScopedPackageOverlay`] the surface/dispatch/egress paths
+//! all read.
+//!
+//! Failure semantics (user-visible contract):
+//! - **Missing credential** (`CredentialStageError::AuthRequired`): the user
+//!   has no secret for the extension — discovery is skipped and
+//!   negative-cached, the static manifest surface stays, and a dispatch of a
+//!   static tool produces the model-visible auth gate naming the missing
+//!   handle (`required_secrets`). No silent success, no wasted egress.
+//! - **Transient failure** (provider down, timeout): the last-good discovered
+//!   surface is kept serving (its TTL is re-armed) so a provider blip does not
+//!   flap the user's tool surface; with no last-good entry the static
+//!   manifest fallback applies.
+//! - **Permanent failure** (malformed discovery result): negative-cached so a
+//!   broken provider is not re-probed every turn.
+//!
+//! Discovery here never mutates installation state — the overlay is a derived
+//! cache (see `ironclaw_extensions::scoped_overlay`).
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use ironclaw_extensions::{
+    DEFAULT_SCOPED_OVERLAY_TTL, ExtensionPackage, OverlayFreshness, OverlayOwner,
+    ScopedPackageOverlay, SharedExtensionRegistry, is_hosted_http_mcp_package,
+};
+use ironclaw_host_api::{
+    CapabilityId, CredentialStageError, ExtensionId, ResourceScope,
+    RuntimeCredentialRequirementSource, SecretHandle,
+};
+use ironclaw_host_runtime::ProductAuthProviderRuntimePorts;
+use std::sync::Mutex;
+
+use ironclaw_extension_host::{HostedMcpDiscoveryError, discover_hosted_mcp_package};
+
+/// Per-turn discovery is on the turn-start path: bound it well below the MCP
+/// lane's 60 s transport timeout so a hung provider costs one bounded wait,
+/// not a wedged turn.
+const TURN_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// How long a missing-credential / permanent-failure verdict suppresses
+/// re-probing. Long enough to keep failed discovery off every turn, short
+/// enough that a freshly provisioned token is picked up within ~2 minutes.
+const NEGATIVE_TTL: Duration = Duration::from_secs(120);
+
+/// Turn-start per-user hosted-MCP discovery driver. One instance per composed
+/// runtime, shared by every capability-port factory invocation.
+pub(super) struct HostedMcpOverlayRefresher {
+    overlay: Arc<ScopedPackageOverlay>,
+    registry: Arc<SharedExtensionRegistry>,
+    runtime_ports: ProductAuthProviderRuntimePorts,
+    /// Single-flight: an (owner, extension) pair being discovered by one turn
+    /// is skipped by concurrent turns, which serve the last-good overlay.
+    in_flight: Mutex<HashSet<(OverlayOwner, ExtensionId)>>,
+    negative_until: Mutex<HashMap<(OverlayOwner, ExtensionId), Instant>>,
+}
+
+impl HostedMcpOverlayRefresher {
+    pub(super) fn new(
+        overlay: Arc<ScopedPackageOverlay>,
+        registry: Arc<SharedExtensionRegistry>,
+        runtime_ports: ProductAuthProviderRuntimePorts,
+    ) -> Self {
+        Self {
+            overlay,
+            registry,
+            runtime_ports,
+            in_flight: Mutex::new(HashSet::new()),
+            negative_until: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Refresh the scope user's discovered surfaces for every eligible
+    /// hosted-MCP extension. Never fails the turn: every failure mode
+    /// degrades to the previous surface (last-good or static manifest).
+    pub(super) async fn refresh_for_scope(&self, scope: &ResourceScope) {
+        let snapshot = self.registry.snapshot();
+        let eligible: Vec<(ExtensionPackage, CapabilityId, SecretHandle)> = snapshot
+            .extensions()
+            .filter_map(|package| {
+                per_user_secret_discovery_template(package)
+                    .map(|(capability_id, handle)| (package.clone(), capability_id, handle))
+            })
+            .collect();
+        let owner = OverlayOwner::new(scope.tenant_id.clone(), scope.user_id.clone());
+        for (package, capability_id, handle) in eligible {
+            let key = (owner.clone(), package.id.clone());
+            if matches!(
+                self.overlay.get(&owner, &package.id),
+                Some((_, OverlayFreshness::Fresh))
+            ) {
+                continue;
+            }
+            if self.negative_cache_active(&key) {
+                continue;
+            }
+            if !self.begin(&key) {
+                continue;
+            }
+            self.refresh_one(scope, &owner, &package, &capability_id, &handle)
+                .await;
+            self.finish(&key);
+        }
+    }
+
+    async fn refresh_one(
+        &self,
+        scope: &ResourceScope,
+        owner: &OverlayOwner,
+        package: &ExtensionPackage,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) {
+        // Stage the turn user's secret for the discovery egress (the MCP lane
+        // consumes staged one-shot credentials only). AuthRequired here IS the
+        // "user has no token" verdict.
+        match self
+            .runtime_ports
+            .stage_owner_resolved_secret_once(scope, capability_id, handle)
+            .await
+        {
+            Ok(()) => {}
+            Err(CredentialStageError::AuthRequired) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    secret_handle = %handle,
+                    "hosted MCP per-user discovery skipped: credential not provisioned"
+                );
+                // The user has no credential: any previously discovered
+                // surface no longer authenticates — drop it so dispatch
+                // failures surface the missing credential instead of calling
+                // out with tools the provider will reject.
+                self.overlay.remove(owner, &package.id);
+                self.negative_insert(owner, package);
+                return;
+            }
+            Err(CredentialStageError::Backend) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    "hosted MCP per-user discovery skipped: credential staging backend failure"
+                );
+                self.keep_last_good(owner, package);
+                return;
+            }
+        }
+
+        // The egress pipeline requires a STAGED network policy for
+        // (scope, capability) — the dispatch path stages it via the
+        // ApplyNetworkPolicy obligation; stage the equivalent hosted-MCP
+        // policy for this discovery call.
+        self.runtime_ports.stage_network_policy_once(
+            scope,
+            capability_id,
+            hosted_mcp_discovery_network_policy(package),
+        );
+        let discovery = tokio::time::timeout(
+            TURN_DISCOVERY_TIMEOUT,
+            discover_hosted_mcp_package(
+                package,
+                scope.clone(),
+                self.runtime_ports.runtime_http_egress(),
+            ),
+        )
+        .await;
+        self.runtime_ports
+            .discard_staged_discovery_state(scope, capability_id);
+        match discovery {
+            Ok(Ok(discovered)) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    capability_count = discovered.capabilities.len(),
+                    "hosted MCP per-user discovery refreshed the user's tool surface"
+                );
+                self.overlay
+                    .insert(owner.clone(), discovered, DEFAULT_SCOPED_OVERLAY_TTL);
+            }
+            Ok(Err(HostedMcpDiscoveryError::Transient(reason))) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    reason,
+                    "hosted MCP per-user discovery failed transiently; keeping last-good surface"
+                );
+                self.keep_last_good(owner, package);
+            }
+            Ok(Err(HostedMcpDiscoveryError::Permanent(reason))) => {
+                tracing::warn!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    reason,
+                    "hosted MCP per-user discovery failed permanently; suppressing re-probe"
+                );
+                self.negative_insert(owner, package);
+            }
+            Err(_elapsed) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    "hosted MCP per-user discovery timed out; keeping last-good surface"
+                );
+                self.keep_last_good(owner, package);
+            }
+        }
+    }
+
+    /// Re-arm a stale last-good entry so a transient provider failure does not
+    /// drop the user's discovered surface (and does not re-probe every turn).
+    fn keep_last_good(&self, owner: &OverlayOwner, package: &ExtensionPackage) {
+        if self.overlay.get(owner, &package.id).is_some() {
+            self.overlay
+                .touch(owner, &package.id, DEFAULT_SCOPED_OVERLAY_TTL);
+        } else {
+            self.negative_insert(owner, package);
+        }
+    }
+
+    fn negative_cache_active(&self, key: &(OverlayOwner, ExtensionId)) -> bool {
+        let Ok(mut negative) = self.negative_until.lock() else {
+            return false; // silent-ok: poisoned negative cache only re-probes
+        };
+        match negative.get(key) {
+            Some(until) if *until > Instant::now() => true,
+            Some(_) => {
+                negative.remove(key);
+                false
+            }
+            None => false,
+        }
+    }
+
+    fn negative_insert(&self, owner: &OverlayOwner, package: &ExtensionPackage) {
+        if let Ok(mut negative) = self.negative_until.lock() {
+            negative.insert(
+                (owner.clone(), package.id.clone()),
+                Instant::now() + NEGATIVE_TTL,
+            );
+        }
+    }
+
+    fn begin(&self, key: &(OverlayOwner, ExtensionId)) -> bool {
+        self.in_flight
+            .lock()
+            .map(|mut in_flight| in_flight.insert(key.clone()))
+            .unwrap_or(false) // silent-ok: poisoned single-flight skips refresh this turn
+    }
+
+    fn finish(&self, key: &(OverlayOwner, ExtensionId)) {
+        if let Ok(mut in_flight) = self.in_flight.lock() {
+            in_flight.remove(key);
+        }
+    }
+}
+
+/// The discovery template for per-user hosted-MCP refresh: the package must be
+/// a hosted HTTP MCP provider whose FIRST capability (the discovery planning
+/// template) binds at least one [`SecretHandle`]-sourced runtime credential.
+/// Product-auth-account providers (e.g. NEAR AI) keep their activation-time
+/// discovery semantics and are not refreshed per user here.
+/// The discovery egress network policy: allow exactly the provider's audience
+/// host(s) over https, mirroring the grant-constraint policy the dispatch path
+/// stages for the same extension.
+fn hosted_mcp_discovery_network_policy(
+    package: &ExtensionPackage,
+) -> ironclaw_host_api::NetworkPolicy {
+    let mut allowed_targets = Vec::new();
+    for capability in &package.manifest.capabilities {
+        for credential in &capability.runtime_credentials {
+            if !allowed_targets.contains(&credential.audience) {
+                allowed_targets.push(credential.audience.clone());
+            }
+        }
+        for target in &capability.network_targets {
+            if !allowed_targets.contains(target) {
+                allowed_targets.push(target.clone());
+            }
+        }
+    }
+    ironclaw_host_api::NetworkPolicy {
+        allowed_targets,
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(2 * 1024 * 1024),
+    }
+}
+
+fn per_user_secret_discovery_template(
+    package: &ExtensionPackage,
+) -> Option<(CapabilityId, SecretHandle)> {
+    if !is_hosted_http_mcp_package(package) {
+        return None;
+    }
+    let template = package.manifest.capabilities.first()?;
+    let handle = template.runtime_credentials.iter().find_map(|credential| {
+        matches!(
+            credential.source,
+            RuntimeCredentialRequirementSource::SecretHandle
+        )
+        .then(|| credential.handle.clone())
+    })?;
+    Some((template.id.clone(), handle))
+}

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -97,6 +97,7 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
             .system_extensions_lifecycle_mounts_for_test()
             .clone(),
         extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+        hosted_mcp_overlay_refresher: None,
         input_resolver,
         result_writer,
         milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -1565,6 +1565,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -1875,6 +1876,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -2393,6 +2395,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -2643,6 +2646,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -2727,6 +2731,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -2929,6 +2934,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -3266,6 +3272,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -3696,6 +3703,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -3853,6 +3861,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -4709,6 +4718,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -4825,6 +4835,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -5075,6 +5086,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -5194,6 +5206,7 @@ mod tests {
                 .system_extensions_lifecycle_mounts_for_test()
                 .clone(),
             extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+            hosted_mcp_overlay_refresher: None,
             input_resolver,
             result_writer,
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),


### PR DESCRIPTION
Supersedes #6365. That reference PR carried the P2b work on our downstream deploy branch; per @ilblackdragon's review this reimplements it **cleanly on top of post-#6116 `main`** (the capability path moved from the dispatcher to a scope-free `ToolResolver`, and `extension_host` was extracted into its own crate), and adds the per-thread hire-scoping the marketplace needs.

## What P2b does

Hosted-MCP providers can serve a **per-principal** `tools/list` (e.g. the agent marketplace returns a hired worker agent's per-hire connector tools). The global `ExtensionRegistry` holds one surface per extension id, so per-principal discovered surfaces live in a derived, TTL-bounded in-memory overlay (`ScopedPackageOverlay`) that a turn-start refresher populates and every capability-resolution path reads through — model surface, authorization, dispatch, and egress planning, so no parallel resolution pipeline exists.

## Review points from #6365, addressed

- **(1) Tenant-scope the overlay key.** The cache and the refresher's single-flight / negative-cache verdicts are keyed by the full `OverlayScope` (tenant **+** user), never a bare `UserId` (unique only within a tenant). Cross-user **and** cross-tenant leakage are regression-tested.
- **(2) Serve last-good (stale) instead of flapping to the static manifest.** Freshness gates *re-discovery*, not *serving*: readers always serve the last-good discovered package (fresh or stale) so a concurrent turn that skips the in-flight refresh, or one hitting an entry at TTL expiry, keeps the discovered surface.
- **(3) A single scoped resolver.** On post-#6116 `main` capabilities are pre-bound at activation and resolved scope-free; the MCP adapter derives the wire tool name dynamically from `capability_id`, so one per-extension adapter serves any discovered `<provider>.<tool>`. `SnapshotToolResolver::resolve` falls back to `resolve_hosted_mcp_tool` (provider-prefix) for discovered ids — no second pipeline.

## New since #6365

- **Per-thread cache axis.** `OverlayScope` gains a `thread_id`. This is load-bearing for **isolation**, not just cache efficiency: a managed worker agent serves several hires under one IronClaw identity, and the only thing distinguishing hire A's surface from hire B's is the thread each job runs on. Keyed by owner alone, hire A's cached tools would serve hire B — a cross-buyer personal-data leak. Threaded through the refresher (writer), the surface grants/provider-trust, and the six pre-dispatch `scoped_snapshot` gates (readers); `LoopRunContext::new` pins `thread_id = scope.thread_id`, so writer and readers agree and the cache still hits within a job. New `overlay_entries_never_leak_across_threads_for_the_same_owner` test.
- **SEP-414 `_meta` thread attribution** stamped on outbound `tools/list` **and** `tools/call` (`io.ironclaw/{threadId,userId,invocationId}`), from the trusted turn scope, after argument serialization. This lets a hosted provider resolve the caller's dispatch/hire from the thread and hire-scope its catalog, so one stable per-user token serves concurrent jobs without cross-job connector bleed. Gated to the two tool-facing methods; `initialize` keeps its exact handshake params.

The marketplace side (resolve `thread -> dispatch -> assignment -> authorizing hire`, and hire-scope `tools/list` / `tools/call`) is a companion change in the agents-market repo; this PR is the IronClaw half.

## Verification

- `cargo test` green: composition, extensions, extension_host, host_runtime, mcp suites; new cross-thread / cross-tenant / cross-user overlay isolation tests and the `plan_json_rpc` `_meta` wire-shape tests.
- `cargo clippy --all-targets --all-features -D warnings` clean on the changed crates.
- Exercised end-to-end on staging: a managed worker agent (stable token, no broker session) called `timeless__*` connector tools that resolved to exactly its dispatch's authorizing hire and succeeded.

@ilblackdragon — re-review please; this is the rebased-onto-`main` version you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EReVXAns5QZCngMfQpSN9L
