### PR TITLE
fix(mutation): refuse an audit that tested nothing

### DIFF
--- a/scripts/mutation-audit.sh
+++ b/scripts/mutation-audit.sh
@@ -87,9 +87,19 @@ if ! command -v cargo-mutants >/dev/null 2>&1; then
   exit 1
 fi
 
+# A path that no longer exists is the likeliest way to audit nothing: files get
+# moved between crates, an old command line keeps working, cargo-mutants filters
+# down to zero mutants, and the run reports success over a file it never read.
 args=(--package "$package" --timeout "$MUT_TIMEOUT" --jobs "$MUT_JOBS" --output "$MUT_OUT")
 for file in "${files[@]:-}"; do
-  [ -n "$file" ] && args+=(-f "$file")
+  [ -z "$file" ] && continue
+  if [ ! -f "$repo_root/$file" ] && [ ! -f "$file" ]; then
+    echo "error: no such file to audit: $file" >&2
+    echo "       it may have moved — an audit of a stale path finds zero" >&2
+    echo "       mutants and reports a clean run over code it never read." >&2
+    exit 1
+  fi
+  args+=(-f "$file")
 done
 [ "$MUT_ITERATE" = "1" ] && args+=(--iterate)
 
@@ -110,6 +120,23 @@ fi
 # $MUT_OUT itself finds nothing, which failed every audit at this final step —
 # see scripts/test-mutation-audit.sh section G.
 report_dir="$MUT_OUT/mutants.out"
+
+# Zero mutants is never a pass. cargo-mutants only WARNs ("No mutants found
+# under the active filters") and still exits 0, so without this the script
+# prints an empty triage queue and reads as "nothing to fix" — the same clean
+# bill of health the --package guard above exists to prevent. Caught here as
+# well as at the filter, because filters are not the only way to reach zero.
+total=0
+for outcome in caught missed unviable timeout; do
+  file="$report_dir/$outcome.txt"
+  [ -f "$file" ] && total=$((total + $(grep -c . "$file" || true)))
+done
+if [ "$total" -eq 0 ]; then
+  echo "error: the run produced zero mutants, so nothing was tested." >&2
+  echo "       an empty result is not a passing audit — check that the" >&2
+  echo "       package and file filters still match real code." >&2
+  exit 1
+fi
 
 python3 "$repo_root/scripts/ci/mutation_triage_queue.py" \
   --report-dir "$report_dir" \

--- a/scripts/test-mutation-audit.sh
+++ b/scripts/test-mutation-audit.sh
@@ -159,6 +159,46 @@ check "audit completes and writes the queue where cargo-mutants wrote results" \
 check "the generated queue carries the survivor, not an empty shell" \
   grep -q 'replace add with ()' "$audit_out/mutants.out/triage-queue.md"
 
+echo "▶ H. an audit that tests nothing is an error, not a pass"
+# Found in the field: crates/ironclaw_reborn_composition/src/extension_host/
+# channel_outbound_targets.rs moved to crates/ironclaw_extension_host/ in #6669.
+# The old command line still ran, cargo-mutants filtered to zero mutants, and
+# the audit exited 0 with an empty queue — a clean bill of health for a file it
+# never opened. cargo-mutants only WARNs in that case, so the script must judge.
+check "audit rejects a file path that does not exist" \
+  bash -c "! PATH='$stub_bin' MUT_OUT='$work/stale' '$audit' -p demo crates/gone/src/nope.rs 2>/dev/null"
+check "audit says the path may have moved" \
+  bash -c "PATH='$stub_bin' MUT_OUT='$work/stale' '$audit' -p demo crates/gone/src/nope.rs 2>&1 | grep -q 'may have moved'"
+
+empty_bin="$work/empty-bin"
+mkdir -p "$empty_bin"
+for tool in bash sed grep python3 mktemp rm dirname cat mkdir; do
+  src="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$src" ] && ln -sf "$src" "$empty_bin/$tool"
+done
+: >"$empty_bin/cargo-mutants"
+chmod +x "$empty_bin/cargo-mutants"
+cat >"$empty_bin/cargo" <<'STUB'
+#!/usr/bin/env bash
+# A run that generated no mutants at all: report files exist but are empty.
+out="."
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$out/mutants.out"
+: >"$out/mutants.out/missed.txt"
+: >"$out/mutants.out/caught.txt"
+STUB
+chmod +x "$empty_bin/cargo"
+
+check "audit rejects a run that produced zero mutants" \
+  bash -c "! PATH='$empty_bin' MUT_OUT='$work/zero' '$audit' -p demo 2>/dev/null"
+check "audit explains that an empty result is not a passing audit" \
+  bash -c "PATH='$empty_bin' MUT_OUT='$work/zero' '$audit' -p demo 2>&1 | grep -q 'not a passing audit'"
+
 echo
 if [ "$failures" -eq 0 ]; then
   echo "all mutation-harness self-tests passed"


### PR DESCRIPTION
## Summary

`scripts/mutation-audit.sh` reports success after auditing nothing.

Point it at a path that no longer exists and cargo-mutants filters down to zero mutants, emits a `WARN`, and exits 0. The script then writes an empty triage queue and exits 0 too — which reads exactly like *"we checked this file and found no problems."* It had checked nothing.

Not hypothetical. This is how the first run of the follow-up audit to #6681 went: #6669 moved `channel_outbound_targets.rs` out of `ironclaw_reborn_composition` into the new `ironclaw_extension_host` crate, the previous command line still ran, and the audit came back clean over a file it never opened.

## The fix

Two guards, because a stale path is not the only route to zero — a wrong package filter, or a crate with nothing mutable, arrives there too.

**Before the run**, reject a `-f` path that does not resolve:

```
error: no such file to audit: crates/gone/src/nope.rs
       it may have moved — an audit of a stale path finds zero
       mutants and reports a clean run over code it never read.
```

**After the run**, reject a report containing no mutants at all:

```
error: the run produced zero mutants, so nothing was tested.
       an empty result is not a passing audit — check that the
       package and file filters still match real code.
```

Catching it at both ends means the script cannot report success over work it did not do.

## Why this is worth its own PR

This is the **third** instance of one failure class in this tool, and the pattern is the point:

1. #6681 — results were read from `$MUT_OUT` while cargo-mutants wrote them to `$MUT_OUT/mutants.out`, so the triage queue was never produced on any path.
2. #6681 — the self-tests drove `mutation_triage_queue.py` directly with hand-built fixtures and never the script that wires it, so they stayed green while every real audit failed.
3. This PR — a stale path reports "found 0 problems."

Same shape every time: **machinery that quietly does nothing is indistinguishable from machinery that checked and found nothing wrong.** That is the exact failure this whole tool exists to detect, and it keeps recurring inside the tool itself — which is the strongest argument available for mechanical guards over careful reading.

The audit is on `main` now and others may start running it. This is the guard that stops someone concluding a module is clean when it was never read.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Validation

- [x] `./scripts/test-mutation-audit.sh` — 21/21
- [x] Section H verified red against `main`'s script: checked out the pre-fix `mutation-audit.sh`, re-ran, both new cases fail (the old script writes a triage queue for `crates/gone/src/nope.rs`)
- [x] Confirmed against a real audit: the corrected path (`-p ironclaw_extension_host`) runs 52 mutants where the stale path reported zero
- [ ] `cargo fmt` / `clippy` / `cargo test` — not applicable, no Rust changed

## Test Strategy

**User behaviour:** none changed. Shell and self-test only; no production code is touched.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- `scripts/test-mutation-audit.sh` section H — drives `mutation-audit.sh` end to end behind a stub `cargo` that produces an empty report, and asserts both guards fire with their explanatory messages.

**What the tests prove.** Not that the guards exist — that the script *fails* when an audit tests nothing. A guard that silently does nothing is worse than no guard, which is the same trap sections A and G already pin.

## Reviewer notes

- The path check accepts either a repo-root-relative or cwd-relative path, since the script `cd`s to the repo root but users type paths from wherever they are.
- The zero-mutant check sums the four cargo-mutants outcome files rather than parsing its stdout, so it is unaffected by output-format changes.
- Related: #6674 (the harness), #6681 (the first two instances), #6524 workstream 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
