### PR TITLE
perf(webui): defer Markdown and syntax highlighting during chat streaming

### DIFF
--- a/crates/ironclaw_webui/frontend/scripts/check-bundle-budgets.ts
+++ b/crates/ironclaw_webui/frontend/scripts/check-bundle-budgets.ts
@@ -15,7 +15,7 @@ const distDir = resolve(here, "..", "dist");
 const manifestPath = resolve(distDir, ".vite", "manifest.json");
 
 const LOGIN_GZIP_BUDGET = 180_000;
-const CHAT_GZIP_BUDGET = 280_000;
+const CHAT_GZIP_BUDGET = 210_000;
 const CHUNK_RAW_BUDGET = 500_000;
 
 export function resolveBundleAsset(distRoot: string, file: string): string {

--- a/crates/ironclaw_webui/frontend/src/lib/markdown.test.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/markdown.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { afterEach, test, vi } from "vitest";
 
-// `renderMarkdown` is memo-cached by the renderer (markdown-renderer.tsx), so
-// the security-relevant invariant — every parsed payload passes through
-// DOMPurify.sanitize — must be pinned so a future change to the memo deps or to
-// this function cannot silently drop sanitization.
+// `renderMarkdown` is loaded only after a response stabilizes, so the
+// security-relevant invariant — every parsed payload passes through
+// DOMPurify.sanitize — must be pinned so deferred loading cannot silently drop
+// sanitization.
 //
 // Stub the npm imports per test so each case is isolated and the real browser
 // DOMPurify implementation is never needed under Vitest's node environment.

--- a/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.test.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.test.ts
@@ -2,9 +2,12 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 
-import { highlightCodeBlocks } from "./syntax-highlighting";
+import {
+  highlightCodeBlocks,
+  SUPPORTED_LANGUAGES,
+} from "./syntax-highlighting";
 
-const SUPPORTED_LANGUAGES = [
+const EXPECTED_SUPPORTED_LANGUAGES = [
   "bash",
   "c",
   "cpp",
@@ -26,9 +29,17 @@ const SUPPORTED_LANGUAGES = [
   "yaml",
 ];
 
-test("highlights every explicitly supported language", () => {
+test("highlight registry matches the supported language allowlist", () => {
+  assert.deepEqual(
+    Object.keys(SUPPORTED_LANGUAGES).sort(),
+    [...EXPECTED_SUPPORTED_LANGUAGES].sort(),
+  );
+});
+
+test("highlights every language in the implementation registry", () => {
   const root = document.createElement("div");
-  const codeBlocks = SUPPORTED_LANGUAGES.map((language) => {
+  const languageNames = Object.keys(SUPPORTED_LANGUAGES);
+  const codeBlocks = languageNames.map((language) => {
     const pre = document.createElement("pre");
     const code = document.createElement("code");
     code.className = `language-${language}`;
@@ -44,7 +55,7 @@ test("highlights every explicitly supported language", () => {
     assert.equal(
       code.dataset.highlighted,
       "yes",
-      `expected ${SUPPORTED_LANGUAGES[index]} to be highlighted`,
+      `expected ${languageNames[index]} to be highlighted`,
     );
   }
 });

--- a/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.test.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { highlightCodeBlocks } from "./syntax-highlighting";
+
+const SUPPORTED_LANGUAGES = [
+  "bash",
+  "c",
+  "cpp",
+  "csharp",
+  "css",
+  "diff",
+  "go",
+  "java",
+  "javascript",
+  "json",
+  "kotlin",
+  "markdown",
+  "python",
+  "ruby",
+  "rust",
+  "sql",
+  "typescript",
+  "xml",
+  "yaml",
+];
+
+test("highlights every explicitly supported language", () => {
+  const root = document.createElement("div");
+  const codeBlocks = SUPPORTED_LANGUAGES.map((language) => {
+    const pre = document.createElement("pre");
+    const code = document.createElement("code");
+    code.className = `language-${language}`;
+    code.textContent = "example";
+    pre.append(code);
+    root.append(pre);
+    return code;
+  });
+
+  highlightCodeBlocks(root);
+
+  for (const [index, code] of codeBlocks.entries()) {
+    assert.equal(
+      code.dataset.highlighted,
+      "yes",
+      `expected ${SUPPORTED_LANGUAGES[index]} to be highlighted`,
+    );
+  }
+});

--- a/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.ts
@@ -22,7 +22,7 @@ import yaml from "highlight.js/lib/languages/yaml";
 // Keep this set focused on the languages most commonly emitted in assistant
 // responses. Highlight.js aliases cover variants such as js/jsx, ts/tsx,
 // sh/shell, html, and cs; unsupported fences remain readable plain code.
-const SUPPORTED_LANGUAGES = {
+export const SUPPORTED_LANGUAGES = {
   bash,
   c,
   cpp,

--- a/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.ts
+++ b/crates/ironclaw_webui/frontend/src/lib/syntax-highlighting.ts
@@ -1,0 +1,60 @@
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import c from "highlight.js/lib/languages/c";
+import cpp from "highlight.js/lib/languages/cpp";
+import csharp from "highlight.js/lib/languages/csharp";
+import css from "highlight.js/lib/languages/css";
+import diff from "highlight.js/lib/languages/diff";
+import go from "highlight.js/lib/languages/go";
+import java from "highlight.js/lib/languages/java";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import markdown from "highlight.js/lib/languages/markdown";
+import python from "highlight.js/lib/languages/python";
+import ruby from "highlight.js/lib/languages/ruby";
+import rust from "highlight.js/lib/languages/rust";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+// Keep this set focused on the languages most commonly emitted in assistant
+// responses. Highlight.js aliases cover variants such as js/jsx, ts/tsx,
+// sh/shell, html, and cs; unsupported fences remain readable plain code.
+const SUPPORTED_LANGUAGES = {
+  bash,
+  c,
+  cpp,
+  csharp,
+  css,
+  diff,
+  go,
+  java,
+  javascript,
+  json,
+  kotlin,
+  markdown,
+  python,
+  ruby,
+  rust,
+  sql,
+  typescript,
+  xml,
+  yaml,
+};
+
+for (const [name, language] of Object.entries(SUPPORTED_LANGUAGES)) {
+  hljs.registerLanguage(name, language);
+}
+
+export function highlightCodeBlocks(root: ParentNode): void {
+  root.querySelectorAll<HTMLElement>("pre code").forEach((codeElement) => {
+    if (codeElement.dataset.highlighted === "yes") return;
+    try {
+      hljs.highlightElement(codeElement);
+    } catch {
+      // Unknown languages and malformed code stay readable as plain text.
+    }
+  });
+}

--- a/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
@@ -23,6 +23,7 @@ import { useChat } from "./hooks/useChat";
 import { channelConnectionDisplayName } from "../../lib/channel-connection-events";
 import { channelConnectionFromGate } from "./lib/gates";
 import { NEW_DRAFT_KEY } from "./lib/draft-store";
+import { messageBelongsToActiveRun } from "./lib/message-types";
 import { buildRuntimeContext } from "./lib/runtime-context";
 import { buildScopedLogsPath } from "../logs/lib/logs-data";
 import { useInterfacePreferences } from "../../lib/interface-preferences";
@@ -52,7 +53,7 @@ function hasVisibleStreamingAssistantText(messages, activeRunId) {
     message.isFinalReply === false &&
     typeof message.content === "string" &&
     message.content.length > 0 &&
-    (!activeRunId || message.turnRunId === activeRunId)
+    messageBelongsToActiveRun(message, activeRunId)
   );
 }
 

--- a/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
@@ -358,6 +358,7 @@ export function Chat({
             onLoadMore={loadMore}
             onRetryMessage={retryMessage}
             threadId={activeThreadId}
+            activeRunId={activeRunId}
             logsPath={logsPath}
             pending={activeThreadIsProcessing}
           >

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
@@ -2,7 +2,10 @@ import { Icon } from "../../../design-system/icons";
 import React from "react";
 import { useT } from "../../../lib/i18n";
 import { summarizeActivity } from "../lib/activity-summary";
-import type { ChatMessage } from "../lib/message-types";
+import {
+  messageBelongsToActiveRun,
+  type ChatMessage,
+} from "../lib/message-types";
 import { MarkdownRenderer } from "./markdown-renderer";
 import { ToolActivity } from "./tool-activity";
 
@@ -72,8 +75,7 @@ export function ActivityRun({ activity, activeRunId = null }: ActivityRunProps) 
 function ActivityItem({ item, activeRunId }: ActivityItemProps) {
   if (item.role === "thinking") {
     const isStreaming =
-      typeof activeRunId === "string" &&
-      item.turnRunId === activeRunId;
+      messageBelongsToActiveRun(item, activeRunId);
     return (
       <ReasoningItem
         content={item.content}

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
@@ -2,10 +2,26 @@ import { Icon } from "../../../design-system/icons";
 import React from "react";
 import { useT } from "../../../lib/i18n";
 import { summarizeActivity } from "../lib/activity-summary";
+import type { ChatMessage } from "../lib/message-types";
 import { MarkdownRenderer } from "./markdown-renderer";
 import { ToolActivity } from "./tool-activity";
 
-export function ActivityRun({ activity, activeRunId = null }) {
+type ActivityRunProps = {
+  activity: ChatMessage[];
+  activeRunId?: string | null;
+};
+
+type ActivityItemProps = {
+  item: ChatMessage;
+  activeRunId: string | null;
+};
+
+type ReasoningItemProps = {
+  content?: string;
+  streaming?: boolean;
+};
+
+export function ActivityRun({ activity, activeRunId = null }: ActivityRunProps) {
   const t = useT();
   const summary = React.useMemo(() => summarizeActivity(activity, t), [activity, t]);
   const shouldAutoExpand = shouldExpandActivityRun(activity);
@@ -53,7 +69,7 @@ export function ActivityRun({ activity, activeRunId = null }) {
   );
 }
 
-function ActivityItem({ item, activeRunId }) {
+function ActivityItem({ item, activeRunId }: ActivityItemProps) {
   if (item.role === "thinking") {
     const isStreaming =
       typeof activeRunId === "string" &&
@@ -76,7 +92,7 @@ function ActivityItem({ item, activeRunId }) {
   return null;
 }
 
-function ReasoningItem({ content, streaming = false }) {
+function ReasoningItem({ content, streaming = false }: ReasoningItemProps) {
   if (!content) return null;
   return (
     <div className="flex min-w-0 gap-3">

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
@@ -5,7 +5,7 @@ import { summarizeActivity } from "../lib/activity-summary";
 import { MarkdownRenderer } from "./markdown-renderer";
 import { ToolActivity } from "./tool-activity";
 
-export function ActivityRun({ activity, activeRunId }) {
+export function ActivityRun({ activity, activeRunId = null }) {
   const t = useT();
   const summary = React.useMemo(() => summarizeActivity(activity, t), [activity, t]);
   const shouldAutoExpand = shouldExpandActivityRun(activity);
@@ -55,10 +55,13 @@ export function ActivityRun({ activity, activeRunId }) {
 
 function ActivityItem({ item, activeRunId }) {
   if (item.role === "thinking") {
+    const isStreaming =
+      typeof activeRunId === "string" &&
+      item.turnRunId === activeRunId;
     return (
       <ReasoningItem
         content={item.content}
-        streaming={item.turnRunId === activeRunId}
+        streaming={isStreaming}
       />
     );
   }

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
@@ -5,7 +5,7 @@ import { summarizeActivity } from "../lib/activity-summary";
 import { MarkdownRenderer } from "./markdown-renderer";
 import { ToolActivity } from "./tool-activity";
 
-export function ActivityRun({ activity }) {
+export function ActivityRun({ activity, activeRunId }) {
   const t = useT();
   const summary = React.useMemo(() => summarizeActivity(activity, t), [activity, t]);
   const shouldAutoExpand = shouldExpandActivityRun(activity);
@@ -44,6 +44,7 @@ export function ActivityRun({ activity }) {
             <ActivityItem
               key={item.id || `${item.role || "activity"}-${index}`}
               item={item}
+              activeRunId={activeRunId}
             />
           ))}
         </div>
@@ -52,9 +53,14 @@ export function ActivityRun({ activity }) {
   );
 }
 
-function ActivityItem({ item }) {
+function ActivityItem({ item, activeRunId }) {
   if (item.role === "thinking") {
-    return (<ReasoningItem content={item.content} />);
+    return (
+      <ReasoningItem
+        content={item.content}
+        streaming={item.turnRunId === activeRunId}
+      />
+    );
   }
 
   if (item.role === "tool_activity" || hasToolCalls(item)) {
@@ -67,7 +73,7 @@ function ActivityItem({ item }) {
   return null;
 }
 
-function ReasoningItem({ content }) {
+function ReasoningItem({ content, streaming = false }) {
   if (!content) return null;
   return (
     <div className="flex min-w-0 gap-3">
@@ -77,7 +83,11 @@ function ReasoningItem({ content }) {
         <Icon name="spark" className="h-4 w-4" />
       </div>
       <div className="min-w-0 flex-1 border-l-2 border-white/10 pl-3 text-iron-300 v2-chat-readable-width">
-        <MarkdownRenderer content={content} className="text-[13px]" />
+        <MarkdownRenderer
+          content={content}
+          className="text-[13px]"
+          streaming={streaming}
+        />
       </div>
     </div>
   );

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.streaming.test.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.streaming.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+// @ts-nocheck
+import assert from "node:assert/strict";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { test, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const { renderMarkdownMock } = vi.hoisted(() => ({
+  renderMarkdownMock: vi.fn((content) => `<p>${content}</p>`),
+}));
+
+vi.mock("../../../lib/i18n", () => ({ useT: () => (key) => key }));
+vi.mock("../../../lib/markdown", () => ({ renderMarkdown: renderMarkdownMock }));
+
+test("streaming Markdown throttles snapshots and stops after a load failure", async () => {
+  vi.useFakeTimers();
+  renderMarkdownMock.mockReset();
+  renderMarkdownMock.mockImplementation((content) => `<p>${content}</p>`);
+  const { MarkdownRenderer } = await import("./markdown-renderer");
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+
+  try {
+    act(() => {
+      root.render(React.createElement(MarkdownRenderer, {
+        content: "**first**",
+        streaming: true,
+      }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    assert.equal(renderMarkdownMock.mock.calls.length, 1);
+
+    act(() => {
+      root.render(React.createElement(MarkdownRenderer, {
+        content: "**second**",
+        streaming: true,
+      }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(149);
+    });
+    assert.equal(renderMarkdownMock.mock.calls.length, 1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    assert.equal(renderMarkdownMock.mock.calls.length, 2);
+
+    renderMarkdownMock.mockImplementation(() => {
+      throw new Error("markdown chunk failed");
+    });
+    act(() => {
+      root.render(React.createElement(MarkdownRenderer, {
+        content: "**failure**",
+        streaming: true,
+      }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    assert.equal(renderMarkdownMock.mock.calls.length, 3);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    assert.equal(renderMarkdownMock.mock.calls.length, 3);
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  }
+});

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
@@ -188,11 +188,6 @@ test("markdown and syntax highlighting stay out of the synchronous chat chunk", 
     /highlight\.js\/lib\/core/,
     "the lazy highlighter should start from highlight.js core",
   );
-  assert.match(
-    highlighterSource,
-    /const SUPPORTED_LANGUAGES = \{/,
-    "the lazy highlighter should declare its explicit language set",
-  );
 });
 
 test("streaming markdown renders sanitized snapshots at a bounded cadence", () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
@@ -12,6 +12,10 @@ const appCssSource = readFileSync(
   new URL("../../../styles/app.css", import.meta.url),
   "utf8",
 );
+const highlighterSource = readFileSync(
+  new URL("../../../lib/syntax-highlighting.ts", import.meta.url),
+  "utf8",
+);
 
 function rendererEnhancerSourceForTest() {
   const lines = [];
@@ -158,15 +162,50 @@ function translator(prefix) {
     })[key] || key;
 }
 
-test("markdown code blocks are passed through highlight.js when available", () => {
-  assert.ok(
-    rendererSource.includes('import hljs from "highlight.js/lib/common"'),
-    "highlight.js should be bundled through npm rather than loaded from a window global",
+test("markdown and syntax highlighting stay out of the synchronous chat chunk", () => {
+  assert.doesNotMatch(
+    rendererSource,
+    /^import .*["'](?:highlight\.js|\.\.\/\.\.\/\.\.\/lib\/markdown)["'];?$/m,
+    "expensive markdown dependencies should not be statically imported by the chat renderer",
   );
   assert.match(
     rendererSource,
-    /hljs\.highlightElement\(codeEl\)/,
-    "markdown code blocks should be enhanced by highlight.js after rendering",
+    /import\("\.\.\/\.\.\/\.\.\/lib\/markdown"\)/,
+    "the sanitized markdown pipeline should load only for stable non-empty content",
+  );
+  assert.match(
+    rendererSource,
+    /root\?\.querySelector\("pre code"\)[\s\S]*import\("\.\.\/\.\.\/\.\.\/lib\/syntax-highlighting"\)/,
+    "syntax highlighting should load only after rendered code is present",
+  );
+  assert.doesNotMatch(
+    highlighterSource,
+    /highlight\.js\/lib\/common/,
+    "the broad highlight.js common bundle must not return",
+  );
+  assert.match(
+    highlighterSource,
+    /highlight\.js\/lib\/core/,
+    "the lazy highlighter should start from highlight.js core",
+  );
+  for (const language of ["bash", "javascript", "json", "python", "rust", "typescript"]) {
+    assert.ok(
+      highlighterSource.includes(`highlight.js/lib/languages/${language}`),
+      `expected the explicit highlighter language set to include ${language}`,
+    );
+  }
+});
+
+test("streaming markdown stays on the escaped text path until completion", () => {
+  assert.match(
+    rendererSource,
+    /if \(streaming \|\| !normalizedContent\) \{[\s\S]*setRendered\(null\)/,
+    "streaming updates should not invoke marked or DOMPurify",
+  );
+  assert.match(
+    rendererSource,
+    /if \(renderedHtml === null\) \{[\s\S]*\{normalizedContent\}[\s\S]*dangerouslySetInnerHTML=\{\{ __html: renderedHtml \}\}/,
+    "only the completed sanitized result may be passed to innerHTML",
   );
 });
 

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
@@ -196,11 +196,26 @@ test("markdown and syntax highlighting stay out of the synchronous chat chunk", 
   }
 });
 
-test("streaming markdown stays on the escaped text path until completion", () => {
+test("streaming markdown renders sanitized snapshots at a bounded cadence", () => {
   assert.match(
     rendererSource,
-    /if \(streaming \|\| !normalizedContent\) \{[\s\S]*setRendered\(null\)/,
-    "streaming updates should not invoke marked or DOMPurify",
+    /const STREAMING_RENDER_INTERVAL_MS = 150/,
+    "streaming rendering should have an explicit cadence budget",
+  );
+  assert.match(
+    rendererSource,
+    /const delay = Math\.max\(0, STREAMING_RENDER_INTERVAL_MS[\s\S]*setTimeout/,
+    "streaming updates should batch rendering instead of parsing every projection",
+  );
+  assert.match(
+    rendererSource,
+    /html: renderMarkdown\(currentContent\)/,
+    "every streamed snapshot must still pass through the markdown sanitizer",
+  );
+  assert.match(
+    rendererSource,
+    /if \(streaming \|\| renderedHtml === null\) return undefined/,
+    "syntax highlighting and code controls should wait for the completed reply",
   );
   assert.match(
     rendererSource,

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
@@ -188,12 +188,11 @@ test("markdown and syntax highlighting stay out of the synchronous chat chunk", 
     /highlight\.js\/lib\/core/,
     "the lazy highlighter should start from highlight.js core",
   );
-  for (const language of ["bash", "javascript", "json", "python", "rust", "typescript"]) {
-    assert.ok(
-      highlighterSource.includes(`highlight.js/lib/languages/${language}`),
-      `expected the explicit highlighter language set to include ${language}`,
-    );
-  }
+  assert.match(
+    highlighterSource,
+    /const SUPPORTED_LANGUAGES = \{/,
+    "the lazy highlighter should declare its explicit language set",
+  );
 });
 
 test("streaming markdown renders sanitized snapshots at a bounded cadence", () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.test.ts
@@ -222,6 +222,16 @@ test("streaming markdown renders sanitized snapshots at a bounded cadence", () =
     /if \(renderedHtml === null\) \{[\s\S]*\{normalizedContent\}[\s\S]*dangerouslySetInnerHTML=\{\{ __html: renderedHtml \}\}/,
     "only the completed sanitized result may be passed to innerHTML",
   );
+  assert.match(
+    rendererSource,
+    /React\.useEffect\(\(\) => \{\s*latestContentRef\.current = normalizedContent;\s*latestStreamingRef\.current = streaming;/,
+    "async rendering should only observe committed stream snapshots",
+  );
+  assert.match(
+    rendererSource,
+    /markdownLoadFailedRef\.current = true[\s\S]*markdownLoadFailedRef\.current/,
+    "a failed Markdown chunk should stop repeated stream retries",
+  );
 });
 
 test("markdown code block controls use resynced labels after language changes", async () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.tsx
@@ -4,6 +4,7 @@ import { toast } from "../../../lib/toast";
 import { useT } from "../../../lib/i18n";
 
 const COLLAPSE_PX = 360;
+const STREAMING_RENDER_INTERVAL_MS = 150;
 
 /* Enhance rendered <pre> code blocks in place: syntax highlight, a hover
    toolbar (copy + soft-wrap toggle), and collapse for very tall blocks.
@@ -140,44 +141,92 @@ function MarkdownRendererImpl({ content, className = "", streaming = false }) {
   const ref = React.useRef(null);
   const normalizedContent = typeof content === "string" ? content : "";
   const [rendered, setRendered] = React.useState(null);
+  const latestContentRef = React.useRef(normalizedContent);
+  const latestStreamingRef = React.useRef(streaming);
+  const mountedRef = React.useRef(true);
+  const renderInFlightRef = React.useRef(false);
+  const lastRenderAtRef = React.useRef(0);
+  const renderTimerRef = React.useRef(null);
+  const requestRenderRef = React.useRef(() => false);
+  const scheduleStreamingRenderRef = React.useRef(() => {});
+
+  latestContentRef.current = normalizedContent;
+  latestStreamingRef.current = streaming;
   const renderedHtml =
-    !streaming && rendered?.source === normalizedContent
+    normalizedContent && rendered &&
+    (streaming || rendered.source === normalizedContent)
       ? rendered.html
       : null;
 
-  // Streaming projections update for every chunk. Keep that hot path as
-  // escaped React text and defer the full marked + DOMPurify pipeline until
-  // the reply stabilizes. The loading fallback is also text, so markdown can
-  // never reach innerHTML before sanitization completes.
-  React.useEffect(() => {
-    let active = true;
-    if (streaming || !normalizedContent) {
-      setRendered(null);
-      return () => {
-        active = false;
-      };
-    }
-
-    setRendered(null);
+  requestRenderRef.current = () => {
+    if (!latestContentRef.current || renderInFlightRef.current) return false;
+    renderInFlightRef.current = true;
     import("../../../lib/markdown")
       .then(({ renderMarkdown }) => {
-        if (active) {
-          setRendered({
-            source: normalizedContent,
-            html: renderMarkdown(normalizedContent),
-          });
-        }
+        const currentContent = latestContentRef.current;
+        if (!mountedRef.current || !currentContent) return;
+        lastRenderAtRef.current = Date.now();
+        setRendered({
+          source: currentContent,
+          html: renderMarkdown(currentContent),
+        });
       })
       .catch(() => {
-        if (active) setRendered(null);
+        if (mountedRef.current) setRendered(null);
+      })
+      .finally(() => {
+        renderInFlightRef.current = false;
+        if (mountedRef.current && latestStreamingRef.current) {
+          scheduleStreamingRenderRef.current();
+        }
       });
-    return () => {
-      active = false;
-    };
+    return true;
+  };
+
+  scheduleStreamingRenderRef.current = () => {
+    if (
+      renderTimerRef.current !== null ||
+      renderInFlightRef.current ||
+      !latestContentRef.current
+    ) {
+      return;
+    }
+    const elapsed = Date.now() - lastRenderAtRef.current;
+    const delay = Math.max(0, STREAMING_RENDER_INTERVAL_MS - elapsed);
+    renderTimerRef.current = setTimeout(() => {
+      renderTimerRef.current = null;
+      requestRenderRef.current();
+    }, delay);
+  };
+
+  // Streaming projections update for every chunk. Render a sanitized snapshot
+  // at a bounded cadence so Markdown remains legible while avoiding the full
+  // marked + DOMPurify pipeline for every projection. The first snapshot
+  // safely falls back to escaped React text while the lazy module loads.
+  React.useEffect(() => {
+    if (!normalizedContent) {
+      if (renderTimerRef.current !== null) {
+        clearTimeout(renderTimerRef.current);
+        renderTimerRef.current = null;
+      }
+      setRendered(null);
+      return;
+    }
+
+    if (streaming) {
+      scheduleStreamingRenderRef.current();
+      return;
+    }
+
+    if (renderTimerRef.current !== null) {
+      clearTimeout(renderTimerRef.current);
+      renderTimerRef.current = null;
+    }
+    requestRenderRef.current();
   }, [normalizedContent, streaming]);
 
   React.useEffect(() => {
-    if (renderedHtml === null) return undefined;
+    if (streaming || renderedHtml === null) return undefined;
     enhanceCodeBlocks(ref.current, t);
     const root = ref.current;
     if (!root?.querySelector("pre code")) return undefined;
@@ -193,7 +242,15 @@ function MarkdownRendererImpl({ content, className = "", streaming = false }) {
     return () => {
       active = false;
     };
-  }, [renderedHtml, t]);
+  }, [renderedHtml, streaming, t]);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (renderTimerRef.current !== null) clearTimeout(renderTimerRef.current);
+    };
+  }, []);
 
   if (renderedHtml === null) {
     return (

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.tsx
@@ -145,13 +145,13 @@ function MarkdownRendererImpl({ content, className = "", streaming = false }) {
   const latestStreamingRef = React.useRef(streaming);
   const mountedRef = React.useRef(true);
   const renderInFlightRef = React.useRef(false);
+  const markdownLoadFailedRef = React.useRef(false);
   const lastRenderAtRef = React.useRef(0);
+  const lastRenderedSourceRef = React.useRef(null);
   const renderTimerRef = React.useRef(null);
   const requestRenderRef = React.useRef(() => false);
   const scheduleStreamingRenderRef = React.useRef(() => {});
 
-  latestContentRef.current = normalizedContent;
-  latestStreamingRef.current = streaming;
   const renderedHtml =
     normalizedContent && rendered &&
     (streaming || rendered.source === normalizedContent)
@@ -159,19 +159,27 @@ function MarkdownRendererImpl({ content, className = "", streaming = false }) {
       : null;
 
   requestRenderRef.current = () => {
-    if (!latestContentRef.current || renderInFlightRef.current) return false;
+    if (
+      !latestContentRef.current ||
+      renderInFlightRef.current ||
+      markdownLoadFailedRef.current
+    ) {
+      return false;
+    }
     renderInFlightRef.current = true;
     import("../../../lib/markdown")
       .then(({ renderMarkdown }) => {
         const currentContent = latestContentRef.current;
         if (!mountedRef.current || !currentContent) return;
         lastRenderAtRef.current = Date.now();
+        lastRenderedSourceRef.current = currentContent;
         setRendered({
           source: currentContent,
           html: renderMarkdown(currentContent),
         });
       })
       .catch(() => {
+        markdownLoadFailedRef.current = true;
         if (mountedRef.current) setRendered(null);
       })
       .finally(() => {
@@ -187,6 +195,8 @@ function MarkdownRendererImpl({ content, className = "", streaming = false }) {
     if (
       renderTimerRef.current !== null ||
       renderInFlightRef.current ||
+      markdownLoadFailedRef.current ||
+      latestContentRef.current === lastRenderedSourceRef.current ||
       !latestContentRef.current
     ) {
       return;
@@ -203,12 +213,20 @@ function MarkdownRendererImpl({ content, className = "", streaming = false }) {
   // at a bounded cadence so Markdown remains legible while avoiding the full
   // marked + DOMPurify pipeline for every projection. The first snapshot
   // safely falls back to escaped React text while the lazy module loads.
+  // Keep the latest snapshot commit-scoped so a discarded concurrent render
+  // cannot leak its content into an async Markdown render.
+  React.useEffect(() => {
+    latestContentRef.current = normalizedContent;
+    latestStreamingRef.current = streaming;
+  }, [normalizedContent, streaming]);
+
   React.useEffect(() => {
     if (!normalizedContent) {
       if (renderTimerRef.current !== null) {
         clearTimeout(renderTimerRef.current);
         renderTimerRef.current = null;
       }
+      lastRenderedSourceRef.current = null;
       setRendered(null);
       return;
     }

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/markdown-renderer.tsx
@@ -1,7 +1,5 @@
 // @ts-nocheck
-import hljs from "highlight.js/lib/common";
 import React from "react";
-import { renderMarkdown } from "../../../lib/markdown";
 import { toast } from "../../../lib/toast";
 import { useT } from "../../../lib/i18n";
 
@@ -34,13 +32,6 @@ function enhanceCodeBlocks(root, t) {
     pre.dataset.wrapped = "0";
 
     const codeEl = pre.querySelector("code");
-    if (codeEl) {
-      try {
-        hljs.highlightElement(codeEl);
-      } catch {
-        // highlight failure is non-fatal
-      }
-    }
 
     const wrap = document.createElement("div");
     wrap.className = "markdown-code-frame";
@@ -144,29 +135,87 @@ function syncCodeBlockLabels(pre, labels) {
   }
 }
 
-function MarkdownRendererImpl({ content, className = "" }) {
+function MarkdownRendererImpl({ content, className = "", streaming = false }) {
   const t = useT();
   const ref = React.useRef(null);
+  const normalizedContent = typeof content === "string" ? content : "";
+  const [rendered, setRendered] = React.useState(null);
+  const renderedHtml =
+    !streaming && rendered?.source === normalizedContent
+      ? rendered.html
+      : null;
 
-  // marked.parse + DOMPurify.sanitize are expensive; only re-run when
-  // the source content actually changes, not on every parent render
-  // (during streaming the message list re-renders on every token).
-  const rendered = React.useMemo(() => renderMarkdown(content), [content]);
+  // Streaming projections update for every chunk. Keep that hot path as
+  // escaped React text and defer the full marked + DOMPurify pipeline until
+  // the reply stabilizes. The loading fallback is also text, so markdown can
+  // never reach innerHTML before sanitization completes.
+  React.useEffect(() => {
+    let active = true;
+    if (streaming || !normalizedContent) {
+      setRendered(null);
+      return () => {
+        active = false;
+      };
+    }
+
+    setRendered(null);
+    import("../../../lib/markdown")
+      .then(({ renderMarkdown }) => {
+        if (active) {
+          setRendered({
+            source: normalizedContent,
+            html: renderMarkdown(normalizedContent),
+          });
+        }
+      })
+      .catch(() => {
+        if (active) setRendered(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [normalizedContent, streaming]);
 
   React.useEffect(() => {
+    if (renderedHtml === null) return undefined;
     enhanceCodeBlocks(ref.current, t);
-  }, [rendered, t]);
+    const root = ref.current;
+    if (!root?.querySelector("pre code")) return undefined;
+
+    let active = true;
+    import("../../../lib/syntax-highlighting")
+      .then(({ highlightCodeBlocks }) => {
+        if (active && ref.current === root) highlightCodeBlocks(root);
+      })
+      .catch(() => {
+        // Syntax highlighting is an optional enhancement.
+      });
+    return () => {
+      active = false;
+    };
+  }, [renderedHtml, t]);
+
+  if (renderedHtml === null) {
+    return (
+      <div
+        ref={ref}
+        className={["markdown-body", "whitespace-pre-wrap", className].join(" ")}
+      >
+        {normalizedContent}
+      </div>
+    );
+  }
 
   return (
     <div
       ref={ref}
       className={["markdown-body", className].join(" ")}
-      dangerouslySetInnerHTML={{ __html: rendered }}
+      dangerouslySetInnerHTML={{ __html: renderedHtml }}
     />
   );
 }
 
-// Memoized so a bubble whose `content`/`className` are unchanged skips
+// Memoized so a bubble whose `content`/`className`/`streaming` are unchanged skips
 // re-rendering when sibling messages update (e.g. a new streaming chunk
 // elsewhere in the list).
 export const MarkdownRenderer = React.memo(MarkdownRendererImpl);

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -103,20 +103,27 @@ test("assistant bubbles expose final reply state for live QA", () => {
 
 test("assistant bubbles keep streaming projections off the full markdown path", async () => {
   const { MessageBubble } = await import("./message-bubble");
-  const render = (isFinalReply: boolean) =>
+  const render = (isFinalReply: boolean, activeRunId: string | null) =>
     renderToStaticMarkup(
       React.createElement(MessageBubble, {
         message: {
           id: "assistant-stream",
           role: CHAT_MESSAGE_ROLES.ASSISTANT,
           content: '<img src=x onerror="alert(1)">',
+          turnRunId: "run-1",
           isFinalReply,
         },
+        activeRunId,
       }),
     );
 
-  assert.match(render(false), /data-streaming="true"/);
-  assert.match(render(true), /data-streaming="false"/);
+  assert.match(render(false, "run-1"), /data-streaming="true"/);
+  assert.match(render(true, "run-1"), /data-streaming="false"/);
+  assert.match(
+    render(false, null),
+    /data-streaming="false"/,
+    "historical assistant drafts must render through the completed Markdown path",
+  );
 });
 
 test("thinking bubbles defer Markdown only for the active run", async () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -159,6 +159,23 @@ test("active reasoning in an activity run defers Markdown", async () => {
   assert.match(render(null), /data-streaming="false"/);
 });
 
+test("untagged reasoning in an activity run renders Markdown", async () => {
+  const { ActivityRun } = await import("./activity-run");
+  const markup = renderToStaticMarkup(
+    React.createElement(ActivityRun, {
+      activity: [
+        {
+          id: "thinking-history",
+          role: CHAT_MESSAGE_ROLES.THINKING,
+          content: "Completed **reasoning**.",
+        },
+      ],
+    }),
+  );
+
+  assert.match(markup, /data-streaming="false"/);
+});
+
 test("only final assistant replies expose the run artifact download", async () => {
   const { MessageBubble } = await import("./message-bubble");
   const render = (isFinalReply: boolean) =>

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -119,6 +119,46 @@ test("assistant bubbles keep streaming projections off the full markdown path", 
   assert.match(render(true), /data-streaming="false"/);
 });
 
+test("thinking bubbles defer Markdown only for the active run", async () => {
+  const { MessageBubble } = await import("./message-bubble");
+  const render = (activeRunId: string | null) =>
+    renderToStaticMarkup(
+      React.createElement(MessageBubble, {
+        message: {
+          id: "thinking-run-1",
+          role: CHAT_MESSAGE_ROLES.THINKING,
+          content: "Working on **this**.",
+          turnRunId: "run-1",
+        },
+        activeRunId,
+      }),
+    );
+
+  assert.match(render("run-1"), /data-streaming="true"/);
+  assert.match(render(null), /data-streaming="false"/);
+});
+
+test("active reasoning in an activity run defers Markdown", async () => {
+  const { ActivityRun } = await import("./activity-run");
+  const render = (activeRunId: string | null) =>
+    renderToStaticMarkup(
+      React.createElement(ActivityRun, {
+        activeRunId,
+        activity: [
+          {
+            id: "thinking-run-1",
+            role: CHAT_MESSAGE_ROLES.THINKING,
+            content: "Working on **this**.",
+            turnRunId: "run-1",
+          },
+        ],
+      }),
+    );
+
+  assert.match(render("run-1"), /data-streaming="true"/);
+  assert.match(render(null), /data-streaming="false"/);
+});
+
 test("only final assistant replies expose the run artifact download", async () => {
   const { MessageBubble } = await import("./message-bubble");
   const render = (isFinalReply: boolean) =>

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -12,8 +12,16 @@ import {
 vi.mock("./markdown-renderer", async () => {
   const { createElement } = await import("react");
   return {
-    MarkdownRenderer: ({ content, className }) =>
-      createElement("div", { className, "data-testid": "markdown" }, content),
+    MarkdownRenderer: ({ content, className, streaming }) =>
+      createElement(
+        "div",
+        {
+          className,
+          "data-testid": "markdown",
+          "data-streaming": String(Boolean(streaming)),
+        },
+        content,
+      ),
   };
 });
 
@@ -91,6 +99,24 @@ test("assistant bubbles expose final reply state for live QA", () => {
     /data-final-reply=\{finalReplyState\}/,
     "live QA should be able to distinguish streaming text from the final answer",
   );
+});
+
+test("assistant bubbles keep streaming projections off the full markdown path", async () => {
+  const { MessageBubble } = await import("./message-bubble");
+  const render = (isFinalReply: boolean) =>
+    renderToStaticMarkup(
+      React.createElement(MessageBubble, {
+        message: {
+          id: "assistant-stream",
+          role: CHAT_MESSAGE_ROLES.ASSISTANT,
+          content: '<img src=x onerror="alert(1)">',
+          isFinalReply,
+        },
+      }),
+    );
+
+  assert.match(render(false), /data-streaming="true"/);
+  assert.match(render(true), /data-streaming="false"/);
 });
 
 test("only final assistant replies expose the run artifact download", async () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
@@ -11,6 +11,7 @@ import { fetchRunArtifact } from "../../../lib/api";
 import { saveBlob } from "../../../lib/download";
 import {
   CHAT_MESSAGE_ROLES,
+  messageBelongsToActiveRun,
   type ChatAttachment,
   type ChatMessage,
 } from "../lib/message-types";
@@ -104,11 +105,11 @@ function MessageBubbleImpl({
       : undefined;
   const isStreamingAssistantReply =
     role === CHAT_MESSAGE_ROLES.ASSISTANT &&
-    message.isFinalReply === false;
+    message.isFinalReply === false &&
+    messageBelongsToActiveRun(message, activeRunId);
   const isStreamingThinking =
     role === CHAT_MESSAGE_ROLES.THINKING &&
-    typeof activeRunId === "string" &&
-    message.turnRunId === activeRunId;
+    messageBelongsToActiveRun(message, activeRunId);
   const failureCategory =
     role === CHAT_MESSAGE_ROLES.ERROR &&
     typeof message.failureCategory === "string"

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
@@ -83,6 +83,9 @@ function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
     typeof message.isFinalReply === "boolean"
       ? String(message.isFinalReply)
       : undefined;
+  const isStreamingAssistantReply =
+    role === CHAT_MESSAGE_ROLES.ASSISTANT &&
+    message.isFinalReply === false;
   const failureCategory =
     role === CHAT_MESSAGE_ROLES.ERROR &&
     typeof message.failureCategory === "string"
@@ -225,7 +228,7 @@ function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
           {role === CHAT_MESSAGE_ROLES.ASSISTANT ||
           role === CHAT_MESSAGE_ROLES.SYSTEM ||
           role === CHAT_MESSAGE_ROLES.ERROR
-            ? (<div className={contentOpacityClass}><MarkdownRenderer content={content} /></div>)
+            ? (<div className={contentOpacityClass}><MarkdownRenderer content={content} streaming={isStreamingAssistantReply} /></div>)
             : (<div className="v2-wrap-anywhere whitespace-pre-wrap break-words"><span className={contentOpacityClass}>{content}</span></div>)}
 
           {status === "error" && (

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
@@ -33,6 +33,7 @@ type MessageBubbleProps = {
   message: ChatMessage;
   onRetry?: (message: ChatMessage) => void;
   threadId?: string | null;
+  activeRunId?: string | null;
 };
 
 function formatTimestamp(value?: string) {
@@ -45,12 +46,21 @@ function formatTimestamp(value?: string) {
 /* Collapsible provider-reasoning summary. Collapsed by default so the
    thread stays clean; expands to the full reasoning markdown. Data comes
    from the `thinking` projection item (PR #4230). */
-function ThinkingDisclosure({ content }: { content?: string }) {
+function ThinkingDisclosure({
+  content,
+  streaming = false,
+}: {
+  content?: string;
+  streaming?: boolean;
+}) {
   const t = useT();
   const [open, setOpen] = React.useState(false);
   if (!content) return null;
   return (
-    <div className="flex flex-col items-start">
+    <div
+      className="flex flex-col items-start"
+      data-streaming={String(streaming)}
+    >
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
@@ -67,14 +77,23 @@ function ThinkingDisclosure({ content }: { content?: string }) {
       {open &&
       (
         <div className="mt-1 border-l-2 border-white/10 pl-3 text-iron-300">
-          <MarkdownRenderer content={content} className="text-[13px]" />
+          <MarkdownRenderer
+            content={content}
+            className="text-[13px]"
+            streaming={streaming}
+          />
         </div>
       )}
     </div>
   );
 }
 
-function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
+function MessageBubbleImpl({
+  message,
+  onRetry,
+  threadId,
+  activeRunId,
+}: MessageBubbleProps) {
   const t = useT();
   const { role, content, images, attachments, generatedImages, isOptimistic, status, error, toolCalls, timestamp } = message;
   const isUser = role === CHAT_MESSAGE_ROLES.USER;
@@ -86,6 +105,10 @@ function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
   const isStreamingAssistantReply =
     role === CHAT_MESSAGE_ROLES.ASSISTANT &&
     message.isFinalReply === false;
+  const isStreamingThinking =
+    role === CHAT_MESSAGE_ROLES.THINKING &&
+    typeof activeRunId === "string" &&
+    message.turnRunId === activeRunId;
   const failureCategory =
     role === CHAT_MESSAGE_ROLES.ERROR &&
     typeof message.failureCategory === "string"
@@ -157,7 +180,12 @@ function MessageBubbleImpl({ message, onRetry, threadId }: MessageBubbleProps) {
   }
 
   if (role === CHAT_MESSAGE_ROLES.THINKING) {
-    return (<ThinkingDisclosure content={content} />);
+    return (
+      <ThinkingDisclosure
+        content={content}
+        streaming={isStreamingThinking}
+      />
+    );
   }
 
   if (role === CHAT_MESSAGE_ROLES.IMAGE) {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
@@ -126,6 +126,7 @@ export function MessageList({
   onLoadMore,
   onRetryMessage,
   threadId,
+  activeRunId,
   logsPath,
   pending = false,
   children,
@@ -386,12 +387,19 @@ export function MessageList({
         )}
         {grouped.map((item) =>
           item.type === "activity-run"
-            ? (<ActivityRun key={item.id} activity={item.activity} />)
+            ? (
+                <ActivityRun
+                  key={item.id}
+                  activity={item.activity}
+                  activeRunId={activeRunId}
+                />
+              )
             : (<MessageBubble
                 key={item.id}
                 message={item.message}
                 onRetry={onRetryMessage}
                 threadId={threadId}
+                activeRunId={activeRunId}
               />)
         )}
         {children}

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
@@ -6,6 +6,7 @@ import vm from "node:vm";
 
 import { channelConnectionDisplayName } from "../../../lib/channel-connection-events";
 import { channelConnectionFromGate } from "./gates";
+import { messageBelongsToActiveRun } from "./message-types";
 
 function chatSourceForTest() {
   const source = readFileSync(new URL("../chat.tsx", import.meta.url), "utf8");
@@ -128,6 +129,7 @@ function renderChat({
     html: (strings, ...values) => ({ strings: Array.from(strings), values }),
     channelConnectionDisplayName,
     channelConnectionFromGate,
+    messageBelongsToActiveRun,
     setThreadState: (threadId, state) =>
       threadStateUpdates.push({ threadId, state }),
     toast: (message, options) => toastCalls.push({ message, options }),
@@ -410,6 +412,42 @@ test("Chat keeps typing indicator when streamed text belongs to another run", ()
       cooldownSeconds: 0,
       recoveryNotice: null,
       activeRun: { runId: "run-1", threadId: "thread-1", status: "running" },
+      send: async () => ({}),
+      cancelRun: async () => {},
+      retryMessage: () => {},
+      approve: () => {},
+      recoverHistory: () => {},
+      loadMore: () => {},
+      setSuggestions: () => {},
+      submitAuthToken: async () => {},
+    },
+  });
+
+  assert.ok(findComponent(tree, components.TypingIndicator));
+});
+
+test("Chat keeps typing indicator for a historical assistant draft without an active run", () => {
+  const { tree, components } = renderChat({
+    hookState: {
+      messages: [
+        { id: "message-1", role: "user", content: "hello" },
+        {
+          id: "msg-draft",
+          role: "assistant",
+          content: "historical draft",
+          isFinalReply: false,
+          turnRunId: "run-old",
+        },
+      ],
+      isProcessing: true,
+      pendingGate: null,
+      suggestions: [],
+      sseStatus: "open",
+      historyLoading: false,
+      hasMore: false,
+      cooldownSeconds: 0,
+      recoveryNotice: null,
+      activeRun: null,
       send: async () => ({}),
       cancelRun: async () => {},
       retryMessage: () => {},

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
@@ -42,6 +42,18 @@ export type ChatMessage = {
   [key: string]: unknown;
 };
 
+export function messageBelongsToActiveRun(
+  message: ChatMessage | null | undefined,
+  activeRunId: string | null | undefined,
+): boolean {
+  return (
+    typeof activeRunId === "string" &&
+    activeRunId.length > 0 &&
+    typeof message?.turnRunId === "string" &&
+    message.turnRunId === activeRunId
+  );
+}
+
 export type ErrorChatMessage = {
   id: string;
   role: typeof CHAT_MESSAGE_ROLES.ERROR;


### PR DESCRIPTION
## Summary

- Replaces `highlight.js/lib/common` with the core highlighter and an explicit language set.
- Renders active streaming assistant responses as escaped React text, avoiding repeated Markdown parsing, sanitization, and syntax highlighting for every projection update.
- Dynamically loads `marked` and DOMPurify after a response stabilizes, and loads syntax highlighting only when the sanitized result contains code blocks.
- Preserves DOMPurify sanitization, external-link hardening, code copy/wrap/expand controls, and readable fallback rendering for unsupported languages.
- Tightens the initial `/chat` JavaScript budget from 280 KB to 210 KB gzip.

## Linked Issue

Closes #6631

## Validation

- `TZ=UTC pnpm --dir crates/ironclaw_webui/frontend test` — 884 tests passed
- `pnpm --dir crates/ironclaw_webui/frontend lint`
- `pnpm --dir crates/ironclaw_webui/frontend build`
  - Initial `/chat`: 202.3 KB gzip, down from 272.9 KB
  - Lazy Markdown chunk: 61.2 KB raw
  - Lazy syntax-highlighting chunk: 91.7 KB raw
- `cargo clippy -p ironclaw_webui --all-features --all-targets -- -D warnings`
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`
- `cargo test -p ironclaw_webui --all-features`
  - 178 tests passed
  - 24 HTTP-provider tests could not bind loopback ports inside the local sandbox
- Existing rendering Playwright E2E was not run because its mock LLM also requires loopback bind permission.

## Test Strategy

- Unit/component: added caller coverage proving streaming assistant messages select the lightweight rendering path.
- Security contract: retained tests proving every completed Markdown render passes through DOMPurify.
- Bundle contract: tightened the production `/chat` gzip budget to prevent synchronous Markdown/highlighter regressions.
- Browser E2E: no new scenario; existing browser coverage already verifies sanitized final assistant HTML, while bundle-loading behavior is covered more deterministically by the production build gate.

## Security Impact

Yes. Streaming content is rendered as React text and is therefore escaped. Completed Markdown continues through DOMPurify before reaching `dangerouslySetInnerHTML`. Dynamic-load failures fail closed to plain text.

## Database Impact

No schema, migration, or persistence changes.

## Blast Radius

Limited to the shared WebUI Markdown renderer and frontend bundle composition. Backend APIs, streaming transport, and durable projection behavior are unchanged.

## Rollback Plan

Revert commit `f3dbf5cc9` to restore synchronous Markdown parsing and the previous Highlight.js common bundle.

## Risk

Medium. The shared renderer now completes asynchronously and unsupported syntax languages fall back to readable plain code, but sanitization and code-block controls remain intact.