### PR TITLE
fix(webui): normalize shared control typography

### DIFF
--- a/crates/ironclaw_webui/frontend/src/design-system/button.tsx
+++ b/crates/ironclaw_webui/frontend/src/design-system/button.tsx
@@ -40,9 +40,9 @@ const BASE =
 /* ── Size classes ──────────────────────────────────────────────────── */
 
 const SIZES = {
-  sm:      "h-9 rounded-[10px] px-3 text-xs",
-  md:      "min-h-[44px] rounded-[14px] px-3.5 text-[13px] md:min-h-[50px] md:rounded-[16px] md:px-4 md:text-sm",
-  lg:      "min-h-[54px] rounded-[18px] px-6 text-base",
+  sm:      "h-9 rounded-[10px] px-3 text-ui-sm",
+  md:      "min-h-[44px] rounded-[14px] px-3.5 text-ui md:min-h-[50px] md:rounded-[16px] md:px-4",
+  lg:      "min-h-[54px] rounded-[18px] px-6 text-ui-lg",
   icon:    "h-[44px] w-[44px] rounded-[14px] md:h-[50px] md:w-[50px] md:rounded-[16px]",
   "icon-sm": "h-9 w-9 rounded-[10px]",
 };

--- a/crates/ironclaw_webui/frontend/src/design-system/input.tsx
+++ b/crates/ironclaw_webui/frontend/src/design-system/input.tsx
@@ -3,8 +3,8 @@
  *
  * All styling via Tailwind + CSS variables — no app.css classes.
  * Sizes and focus ring match the reference AppInput exactly:
- *   mobile  h-[44px] rounded-[14px] px-3.5 text-[13px]
- *   desktop h-[50px] rounded-[16px] px-4   text-sm
+ *   mobile  h-[44px] rounded-[14px] px-3.5 text-ui
+ *   desktop h-[50px] rounded-[16px] px-4   text-ui
  *
  * Exports
  *   Input       — <input> wrapper
@@ -28,9 +28,9 @@ const INPUT_BASE =
 
 /* Sizes mirroring reference AppInput */
 const INPUT_SIZES = {
-  sm: "h-9 rounded-[10px] px-3 text-[12px]",
-  md: "h-[44px] rounded-[14px] px-3.5 text-[13px] md:h-[50px] md:rounded-[16px] md:px-4 md:text-sm",
-  lg: "h-[54px] rounded-[18px] px-4 text-base",
+  sm: "h-9 rounded-[10px] px-3 text-ui-sm",
+  md: "h-[44px] rounded-[14px] px-3.5 text-ui md:h-[50px] md:rounded-[16px] md:px-4",
+  lg: "h-[54px] rounded-[18px] px-4 text-ui-lg",
 };
 
 /* ─── Input ───────────────────────────────────────────────────────── */
@@ -67,7 +67,7 @@ export function Textarea({
       rows={rows}
       className={cn(
         INPUT_BASE,
-        "rounded-[14px] px-3.5 py-3 text-[13px] md:rounded-[16px] md:px-4 md:text-sm",
+        "rounded-[14px] px-3.5 py-3 text-ui md:rounded-[16px] md:px-4",
         "resize-y min-h-[80px]",
         error && "border-[var(--v2-danger-text)] focus:ring-[color-mix(in_srgb,var(--v2-danger-text)_28%,transparent)]",
         className
@@ -120,7 +120,7 @@ export function Label({ children, className = "", required = false, ...rest }) {
   return (
     <label
       className={cn(
-        "block text-[13px] font-medium text-[var(--v2-text-strong)] md:text-sm",
+        "block text-ui font-medium text-[var(--v2-text-strong)]",
         className
       )}
       {...rest}

--- a/crates/ironclaw_webui/frontend/src/design-system/select-menu.tsx
+++ b/crates/ironclaw_webui/frontend/src/design-system/select-menu.tsx
@@ -288,7 +288,10 @@ export function SelectMenu({
   return (
     <div
       ref={rootRef}
-      className={cn("relative inline-block min-w-[9.5rem] text-left", className)}
+      className={cn(
+        "relative inline-block min-w-[9.5rem] text-left font-sans text-ui",
+        className
+      )}
       {...rootPassthroughProps}
     >
       <button
@@ -311,7 +314,7 @@ export function SelectMenu({
         className={cn(
           "inline-flex h-8 w-full items-center justify-between gap-2 rounded-[8px] border",
           "border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-2.5",
-          "font-mono text-xs text-[var(--v2-text-strong)] shadow-none transition-colors",
+          "text-[var(--v2-text-strong)] shadow-none transition-colors",
           "hover:bg-[var(--v2-surface-muted)]",
           "focus-visible:outline-none focus-visible:ring-2",
           "focus-visible:ring-[color-mix(in_srgb,var(--v2-accent)_32%,transparent)]",
@@ -362,7 +365,7 @@ export function SelectMenu({
                 onClick={() => chooseOption(option)}
                 className={cn(
                   "flex w-full items-center justify-between gap-3 rounded-[7px] px-2.5 py-2",
-                  "text-left font-mono text-xs text-[var(--v2-text)] transition-colors",
+                  "text-left text-[var(--v2-text)] transition-colors",
                   "focus-visible:outline-none",
                   "focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--v2-accent)_30%,transparent)]",
                   "disabled:cursor-not-allowed disabled:opacity-50",

--- a/crates/ironclaw_webui/frontend/src/design-system/typography.test.tsx
+++ b/crates/ironclaw_webui/frontend/src/design-system/typography.test.tsx
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { isValidElement, type ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
+
+import { Button } from "./button";
+import { Input, Label, Select, Textarea } from "./input";
+import { SelectMenu } from "./select-menu";
+
+type StyledElementProps = {
+  className?: string;
+  children?: unknown;
+};
+
+function classNameOf(element: unknown): string {
+  assert.ok(isValidElement<StyledElementProps>(element));
+  return element.props.className ?? "";
+}
+
+test("the root and semantic control type scale stay stable across viewports (#6702)", () => {
+  const appCss = readFileSync(new URL("../styles/app.css", import.meta.url), "utf8");
+
+  assert.match(appCss, /--text-ui-sm:\s*0\.75rem;/);
+  assert.match(appCss, /--text-ui:\s*0\.8125rem;/);
+  assert.match(appCss, /--text-ui-lg:\s*1rem;/);
+  assert.match(appCss, /html\s*\{[^}]*font-size:\s*16px;/s);
+  assert.match(
+    appCss,
+    /@layer base\s*\{[^{}]*button, input, select, textarea\s*\{[^}]*font:\s*inherit;/s
+  );
+  assert.doesNotMatch(
+    appCss,
+    /@media\s*\(min-width:\s*1024px\)\s*\{[^}]*html\s*\{[^}]*font-size:/s
+  );
+});
+
+test("medium shared controls use one viewport-independent semantic size (#6702)", () => {
+  const button = Button({ children: "Save" }) as ReactElement<StyledElementProps>;
+  const input = Input({});
+  const textarea = Textarea({});
+  const selectWrapper = Select({ children: null });
+  const label = Label({ children: "Name" });
+
+  const select = (selectWrapper.props.children as ReactElement<StyledElementProps>[])[0];
+  const classes = [
+    classNameOf(button),
+    classNameOf(input),
+    classNameOf(textarea),
+    classNameOf(select),
+    classNameOf(label),
+  ];
+
+  for (const className of classes) {
+    assert.match(className, /(?:^|\s)text-ui(?:\s|$)/);
+    assert.doesNotMatch(className, /md:text-sm|text-\[13px\]/);
+  }
+
+  const selectMenu = renderToStaticMarkup(
+    <SelectMenu
+      value="default"
+      options={[{ value: "default", label: "Default" }]}
+      aria-label="Provider"
+    />
+  );
+  assert.match(selectMenu, /class="[^"]*\bfont-sans\b[^"]*\btext-ui\b[^"]*"/);
+  assert.doesNotMatch(selectMenu, /\bfont-mono\b|\bmd:text-sm\b|text-\[13px\]/);
+});
+
+test("SelectMenu allows monospace only through an explicit override (#6702)", () => {
+  const selectMenu = renderToStaticMarkup(
+    <SelectMenu
+      value="default"
+      options={[{ value: "default", label: "Default" }]}
+      aria-label="Provider"
+      buttonClassName="font-mono"
+    />
+  );
+
+  assert.match(selectMenu, /<button[^>]*class="[^"]*\bfont-mono\b[^"]*"/);
+});

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-dialog.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-dialog.tsx
@@ -80,7 +80,7 @@ export function ProviderDialog({
               onChange={(value) => formState.update("adapter", value)}
               ariaLabel={t("llm.adapter")}
               className="w-full"
-              buttonClassName="h-[44px] rounded-[14px] border-[var(--v2-panel-border)] bg-[var(--v2-input-bg)] px-3.5 font-sans text-[13px] text-[var(--v2-text-strong)] md:h-[50px] md:rounded-[16px] md:px-4 md:text-sm"
+              buttonClassName="h-[44px] rounded-[14px] border-[var(--v2-panel-border)] bg-[var(--v2-input-bg)] px-3.5 text-[var(--v2-text-strong)] md:h-[50px] md:rounded-[16px] md:px-4"
             />
           </div>
           </>
@@ -121,7 +121,7 @@ export function ProviderDialog({
             onChange={(value) => formState.update("model", value)}
             ariaLabel={t("llm.defaultModel")}
             className="w-full"
-            buttonClassName="h-[44px] rounded-[14px] border-[var(--v2-panel-border)] bg-[var(--v2-input-bg)] px-3.5 font-sans text-[13px] text-[var(--v2-text-strong)] md:h-[50px] md:rounded-[16px] md:px-4 md:text-sm"
+            buttonClassName="h-[44px] rounded-[14px] border-[var(--v2-panel-border)] bg-[var(--v2-input-bg)] px-3.5 text-[var(--v2-text-strong)] md:h-[50px] md:rounded-[16px] md:px-4"
             menuClassName="!top-auto bottom-[calc(100%+0.35rem)] max-h-64 overflow-y-auto"
           />
         )}

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-dialog.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-dialog.tsx
@@ -10,6 +10,9 @@ import {
 } from "../lib/llm-providers";
 import { useProviderDialogForm } from "../hooks/useProviderDialogForm";
 
+const PROVIDER_SELECT_BUTTON_CLASS_NAME =
+  "h-[44px] rounded-[14px] border-[var(--v2-panel-border)] bg-[var(--v2-input-bg)] px-3.5 text-[var(--v2-text-strong)] md:h-[50px] md:rounded-[16px] md:px-4";
+
 export function ProviderDialog({
   provider,
   allProviderIds,
@@ -80,7 +83,7 @@ export function ProviderDialog({
               onChange={(value) => formState.update("adapter", value)}
               ariaLabel={t("llm.adapter")}
               className="w-full"
-              buttonClassName="h-[44px] rounded-[14px] border-[var(--v2-panel-border)] bg-[var(--v2-input-bg)] px-3.5 text-[var(--v2-text-strong)] md:h-[50px] md:rounded-[16px] md:px-4"
+              buttonClassName={PROVIDER_SELECT_BUTTON_CLASS_NAME}
             />
           </div>
           </>
@@ -121,7 +124,7 @@ export function ProviderDialog({
             onChange={(value) => formState.update("model", value)}
             ariaLabel={t("llm.defaultModel")}
             className="w-full"
-            buttonClassName="h-[44px] rounded-[14px] border-[var(--v2-panel-border)] bg-[var(--v2-input-bg)] px-3.5 text-[var(--v2-text-strong)] md:h-[50px] md:rounded-[16px] md:px-4"
+            buttonClassName={PROVIDER_SELECT_BUTTON_CLASS_NAME}
             menuClassName="!top-auto bottom-[calc(100%+0.35rem)] max-h-64 overflow-y-auto"
           />
         )}

--- a/crates/ironclaw_webui/frontend/src/styles/app.css
+++ b/crates/ironclaw_webui/frontend/src/styles/app.css
@@ -7,6 +7,10 @@
   --font-serif: "Newsreader", "Lyon Text", "Instrument Serif", georgia, serif;
   --font-mono: "Geist Mono", "SF Mono", "JetBrains Mono", ui-monospace,
     monospace;
+  /* Semantic type scale for shared controls. Keep these viewport-independent. */
+  --text-ui-sm: 0.75rem;
+  --text-ui: 0.8125rem;
+  --text-ui-lg: 1rem;
   --color-iron-950: var(--v2-canvas-strong);
   --color-iron-900: var(--v2-surface);
   --color-iron-800: var(--v2-surface-soft);
@@ -135,12 +139,8 @@
 
 html {
   background: var(--v2-canvas);
+  font-size: 16px;
   scroll-behavior: auto;
-}
-
-/* Slightly tighter type scale on large screens */
-@media (min-width: 1024px) {
-  html { font-size: 15px; }
 }
 
 body {
@@ -152,8 +152,10 @@ body {
 }
 
 /* Font inheritance for form elements */
-button, input, select, textarea {
-  font: inherit;
+@layer base {
+  button, input, select, textarea {
+    font: inherit;
+  }
 }
 
 button {

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -105,23 +105,53 @@ async def _assert_readable(locator, label: str) -> dict[str, list[float]]:
     return colors
 
 
-async def _typography_metrics(locator) -> dict:
-    return await locator.evaluate(
-        """element => {
-          const style = getComputedStyle(element);
-          const rect = element.getBoundingClientRect();
+async def _typography_metrics(page, selectors: dict[str, str]) -> dict:
+    return await page.evaluate(
+        """selectors => {
+          const semanticSize = getComputedStyle(document.documentElement)
+            .getPropertyValue("--text-ui").trim();
+          if (!semanticSize) {
+            throw new Error("Semantic typography token --text-ui is not defined");
+          }
+          const probe = document.createElement("span");
+          probe.style.cssText =
+            "position:absolute;visibility:hidden;font-size:var(--text-ui)";
+          document.body.append(probe);
+          const expectedFontSize = getComputedStyle(probe).fontSize;
+          probe.remove();
+
+          const controls = Object.fromEntries(
+            Object.entries(selectors).map(([name, selector]) => {
+              const element = document.querySelector(selector);
+              if (!element) {
+                throw new Error(`Typography target not found: ${name} (${selector})`);
+              }
+              const style = getComputedStyle(element);
+              const rect = element.getBoundingClientRect();
+              return [name, {
+                className: element.className,
+                clientHeight: element.clientHeight,
+                clientWidth: element.clientWidth,
+                expectedFontSize,
+                fontFamily: style.fontFamily,
+                fontSize: style.fontSize,
+                height: rect.height,
+                semanticSize,
+                scrollHeight: element.scrollHeight,
+                scrollWidth: element.scrollWidth,
+              }];
+            })
+          );
           return {
-            className: element.className,
-            clientHeight: element.clientHeight,
-            clientWidth: element.clientWidth,
-            fontFamily: style.fontFamily,
-            fontSize: style.fontSize,
-            height: rect.height,
-            scrollHeight: element.scrollHeight,
-            scrollWidth: element.scrollWidth,
-            semanticSize: style.getPropertyValue("--text-ui"),
+            controls,
+            rootFontSize: getComputedStyle(document.documentElement).fontSize,
+            viewport: {
+              documentWidth: document.documentElement.scrollWidth,
+              viewportWidth: window.innerWidth,
+            },
           };
-        }"""
+        }""",
+        selectors,
     )
 
 
@@ -131,8 +161,9 @@ def _assert_control_typography(
     *,
     expected_height: float | None = None,
 ) -> None:
-    assert metrics["fontSize"] == "13px", (
-        f"{label} font size was {metrics['fontSize']}: {metrics}"
+    assert metrics["fontSize"] == metrics["expectedFontSize"], (
+        f"{label} font size was {metrics['fontSize']}, "
+        f"expected semantic --text-ui size {metrics['expectedFontSize']}: {metrics}"
     )
     assert metrics["scrollWidth"] <= metrics["clientWidth"] + 1, (
         f"{label} clipped horizontally: {metrics}"
@@ -306,7 +337,6 @@ async def test_reborn_v2_shared_control_typography_is_stable(
             ),
         )
 
-    await page.route("**/api/webchat/v2/settings/tools", handle_tools)
     try:
         await page.goto(f"{reborn_v2_server}/")
         token_input = page.locator(SEL_V2["login_token"])
@@ -319,33 +349,59 @@ async def test_reborn_v2_shared_control_typography_is_stable(
         )
 
         expected_height = 44 if width < 768 else 50
+        login_page_metrics = await _typography_metrics(
+            page,
+            {
+                "tokenInput": SEL_V2["login_token"],
+                "connectButton": "form button[type='submit']",
+                "tokenLabel": "label[for='v2-token']",
+            },
+        )
+        login_metrics = login_page_metrics["controls"]
         _assert_control_typography(
-            await _typography_metrics(token_input),
+            login_metrics["tokenInput"],
             f"{locale} token input at {width}px",
             expected_height=expected_height,
         )
         _assert_control_typography(
-            await _typography_metrics(connect_button),
+            login_metrics["connectButton"],
             f"{locale} connect button at {width}px",
             expected_height=expected_height,
         )
         _assert_control_typography(
-            await _typography_metrics(token_label),
+            login_metrics["tokenLabel"],
             f"{locale} token label at {width}px",
         )
-        assert await page.locator("html").evaluate(
-            "element => getComputedStyle(element).fontSize"
-        ) == "16px"
+        assert login_page_metrics["rootFontSize"] == "16px"
 
-        await page.goto(
-            f"{reborn_v2_server}/settings/tools"
-            f"?token={REBORN_V2_AUTH_TOKEN}"
-        )
-        permission = page.locator(
-            SEL_V2["settings_tool_row_for"].format(name="typography_check")
-        ).locator(SEL_V2["settings_tool_permission"])
-        await expect(permission).to_be_visible(timeout=15000)
-        permission_metrics = await _typography_metrics(permission)
+        tools_route = "**/api/webchat/v2/settings/tools"
+        await page.route(tools_route, handle_tools)
+        try:
+            await page.goto(
+                f"{reborn_v2_server}/settings/tools"
+                f"?token={REBORN_V2_AUTH_TOKEN}"
+            )
+            tool_row_selector = SEL_V2["settings_tool_row_for"].format(
+                name="typography_check"
+            )
+            permission = page.locator(tool_row_selector).locator(
+                SEL_V2["settings_tool_permission"]
+            )
+            await expect(permission).to_be_visible(timeout=15000)
+            permission_metrics = (
+                await _typography_metrics(
+                    page,
+                    {
+                        "permission": (
+                            f"{tool_row_selector} "
+                            f"{SEL_V2['settings_tool_permission']}"
+                        )
+                    },
+                )
+            )["controls"]["permission"]
+        finally:
+            await page.unroute(tools_route, handle_tools)
+
         _assert_control_typography(
             permission_metrics,
             f"{locale} SelectMenu at {width}px",
@@ -360,17 +416,16 @@ async def test_reborn_v2_shared_control_typography_is_stable(
         )
         skill_content = page.locator("textarea").first
         await expect(skill_content).to_be_visible(timeout=15000)
+        skills_metrics = await _typography_metrics(
+            page,
+            {"skillContent": "textarea"},
+        )
         _assert_control_typography(
-            await _typography_metrics(skill_content),
+            skills_metrics["controls"]["skillContent"],
             f"{locale} textarea at {width}px",
         )
 
-        viewport_metrics = await page.evaluate(
-            """() => ({
-              documentWidth: document.documentElement.scrollWidth,
-              viewportWidth: window.innerWidth,
-            })"""
-        )
+        viewport_metrics = skills_metrics["viewport"]
         assert viewport_metrics["documentWidth"] <= viewport_metrics["viewportWidth"], (
             f"{locale} layout overflowed at {width}px: {viewport_metrics}"
         )

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -32,6 +32,7 @@ from urllib.parse import parse_qs, urlparse
 
 import aiohttp
 import httpx
+import pytest
 from playwright.async_api import expect
 from helpers import REBORN_V2_AUTH_TOKEN, SEL_V2
 from reborn_webui_harness import (
@@ -102,6 +103,47 @@ async def _assert_readable(locator, label: str) -> dict[str, list[float]]:
     ratio = _contrast_ratio(colors["foreground"], colors["background"])
     assert ratio >= 4.5, f"{label} contrast was {ratio:.2f}:1 with colors {colors}"
     return colors
+
+
+async def _typography_metrics(locator) -> dict:
+    return await locator.evaluate(
+        """element => {
+          const style = getComputedStyle(element);
+          const rect = element.getBoundingClientRect();
+          return {
+            className: element.className,
+            clientHeight: element.clientHeight,
+            clientWidth: element.clientWidth,
+            fontFamily: style.fontFamily,
+            fontSize: style.fontSize,
+            height: rect.height,
+            scrollHeight: element.scrollHeight,
+            scrollWidth: element.scrollWidth,
+            semanticSize: style.getPropertyValue("--text-ui"),
+          };
+        }"""
+    )
+
+
+def _assert_control_typography(
+    metrics: dict,
+    label: str,
+    *,
+    expected_height: float | None = None,
+) -> None:
+    assert metrics["fontSize"] == "13px", (
+        f"{label} font size was {metrics['fontSize']}: {metrics}"
+    )
+    assert metrics["scrollWidth"] <= metrics["clientWidth"] + 1, (
+        f"{label} clipped horizontally: {metrics}"
+    )
+    assert metrics["scrollHeight"] <= metrics["clientHeight"] + 1, (
+        f"{label} clipped vertically: {metrics}"
+    )
+    if expected_height is not None:
+        assert abs(metrics["height"] - expected_height) <= 1, (
+            f"{label} height was {metrics['height']}px, expected {expected_height}px"
+        )
 
 
 async def _wait_for_automation_named(
@@ -208,6 +250,132 @@ async def test_reborn_v2_serves_shell_and_gates_auth(reborn_v2_server, reborn_v2
         assert urlparse(anon_page.url).path == "/login"
     finally:
         await anon_ctx.close()
+
+
+@pytest.mark.parametrize(
+    ("locale", "expected_lang", "connect_label"),
+    [
+        pytest.param("en-US", "en", "Connect", id="english"),
+        pytest.param("zh-CN", "zh-CN", "连接", id="simplified-chinese"),
+    ],
+)
+@pytest.mark.parametrize("width", [375, 768, 1024, 1440])
+async def test_reborn_v2_shared_control_typography_is_stable(
+    reborn_v2_server,
+    reborn_v2_browser,
+    locale,
+    expected_lang,
+    connect_label,
+    width,
+):
+    """Shared controls keep one size without viewport or locale clipping."""
+    context = await reborn_v2_browser.new_context(
+        locale=locale,
+        viewport={"width": width, "height": 900},
+    )
+    page = await context.new_page()
+
+    async def handle_tools(route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "entries": [
+                        {
+                            "key": "agent.auto_approve_tools",
+                            "value": False,
+                            "mutable": True,
+                            "source": "default",
+                        },
+                        {
+                            "key": "tool.typography_check",
+                            "value": {
+                                "name": "typography_check",
+                                "description": "Shared control typography.",
+                                "state": "ask_each_time",
+                                "default_state": "ask_each_time",
+                                "locked": False,
+                                "effective_source": "default",
+                            },
+                            "mutable": True,
+                            "source": "default",
+                        },
+                    ]
+                }
+            ),
+        )
+
+    await page.route("**/api/webchat/v2/settings/tools", handle_tools)
+    try:
+        await page.goto(f"{reborn_v2_server}/")
+        token_input = page.locator(SEL_V2["login_token"])
+        connect_button = page.locator("form button[type='submit']")
+        token_label = page.locator("label[for='v2-token']")
+        await expect(token_input).to_be_visible(timeout=15000)
+        await expect(connect_button).to_have_text(connect_label, timeout=15000)
+        await expect(page.locator("html")).to_have_attribute(
+            "lang", expected_lang
+        )
+
+        expected_height = 44 if width < 768 else 50
+        _assert_control_typography(
+            await _typography_metrics(token_input),
+            f"{locale} token input at {width}px",
+            expected_height=expected_height,
+        )
+        _assert_control_typography(
+            await _typography_metrics(connect_button),
+            f"{locale} connect button at {width}px",
+            expected_height=expected_height,
+        )
+        _assert_control_typography(
+            await _typography_metrics(token_label),
+            f"{locale} token label at {width}px",
+        )
+        assert await page.locator("html").evaluate(
+            "element => getComputedStyle(element).fontSize"
+        ) == "16px"
+
+        await page.goto(
+            f"{reborn_v2_server}/settings/tools"
+            f"?token={REBORN_V2_AUTH_TOKEN}"
+        )
+        permission = page.locator(
+            SEL_V2["settings_tool_row_for"].format(name="typography_check")
+        ).locator(SEL_V2["settings_tool_permission"])
+        await expect(permission).to_be_visible(timeout=15000)
+        permission_metrics = await _typography_metrics(permission)
+        _assert_control_typography(
+            permission_metrics,
+            f"{locale} SelectMenu at {width}px",
+        )
+        assert "Mono" not in permission_metrics["fontFamily"], (
+            f"SelectMenu defaulted to monospace: {permission_metrics['fontFamily']}"
+        )
+
+        await page.goto(
+            f"{reborn_v2_server}/settings/skills"
+            f"?token={REBORN_V2_AUTH_TOKEN}"
+        )
+        skill_content = page.locator("textarea").first
+        await expect(skill_content).to_be_visible(timeout=15000)
+        _assert_control_typography(
+            await _typography_metrics(skill_content),
+            f"{locale} textarea at {width}px",
+        )
+
+        viewport_metrics = await page.evaluate(
+            """() => ({
+              documentWidth: document.documentElement.scrollWidth,
+              viewportWidth: window.innerWidth,
+            })"""
+        )
+        assert viewport_metrics["documentWidth"] <= viewport_metrics["viewportWidth"], (
+            f"{locale} layout overflowed at {width}px: {viewport_metrics}"
+        )
+    finally:
+        await context.close()
 
 
 async def test_reborn_v2_lazy_routes_preserve_direct_navigation(


### PR DESCRIPTION
## Summary

- Establishes a stable 16px WebUI root font size and adds a semantic `text-ui-*` scale for shared controls.
- Normalizes medium Button, Input, Textarea, Select, Label, and SelectMenu text to 13px without responsive size jumps.
- Makes SelectMenu use the UI sans-serif font by default while retaining explicit monospace overrides.
- Moves form font inheritance into Tailwind's base layer so semantic typography utilities apply correctly without changing control dimensions or Chat message typography.
- Adds unit coverage and browser E2E coverage across 375px, 768px, 1024px, and 1440px in English and Simplified Chinese.

<img width="839" height="390" alt="image" src="https://github.com/user-attachments/assets/6b4a58e5-7c14-468b-ad30-4906deaddd28" />
<img width="1391" height="487" alt="image" src="https://github.com/user-attachments/assets/cfaabc41-132e-4c78-af80-e16cfffbbba3" />


## Linked Issue

Closes #6702

## Validation

- `TZ=UTC corepack pnpm test`
- `corepack pnpm lint:conventions`
- `corepack pnpm typecheck`
- `corepack pnpm exec vite build`
- `corepack pnpm check:bundle`
- `cargo test -p ironclaw_webui --all-features`
- `cargo clippy -p ironclaw_webui --all-targets --all-features -- -D warnings`
- Playwright typography matrix: 8 passed
- `scripts/pre-commit-safety.sh`

## Security Impact

None.

## Database Impact

None.

## Blast Radius

Limited to WebUI root typography and shared design-system controls.

## Rollback Plan

Revert this PR to restore the previous responsive root and control typography rules.

---

**Review track**: B