### PR TITLE
fix(webui): recover SSE across reloads and proxy EOFs

### DIFF
--- a/crates/ironclaw_webui/CLAUDE.md
+++ b/crates/ironclaw_webui/CLAUDE.md
@@ -124,14 +124,14 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
   (default 3 concurrent; override via `WebUiV2State::with_sse_concurrency_limit`)
   — a caller cannot bypass the cap by mixing SSE and WS. Exhaustion returns
   `429` with `retryable: true`.
-- The SPA also sends a bounded, random `connection_id` that is stable for one
-  loaded browser tab plus a monotonically increasing `connection_generation`
-  for each EventSource it creates. A same-caller, same-id stream supersedes its
-  prior generation without consuming another slot; a delayed older generation
+- The SPA also sends a bounded, random `connection_id` that is persisted in
+  per-tab `sessionStorage` together with a monotonically increasing
+  `connection_generation`. A same-caller, same-id stream supersedes its prior
+  generation without consuming another slot; a delayed older generation
   receives `204` and cannot cancel the current stream. This prevents
-  proxy-reordered closes/opens during thread navigation from stranding the
-  replacement stream behind the cap; distinct tabs still consume distinct
-  slots.
+  proxy-reordered closes/opens during thread navigation or full-page reload
+  from stranding the replacement stream behind the cap; distinct tabs still
+  consume distinct slots.
 - A successful facade subscription emits an application-level `keep_alive`
   frame immediately after admission. Browser connection state uses that frame
   as proof that the projection tail is ready instead of waiting for a model

--- a/crates/ironclaw_webui/CLAUDE.md
+++ b/crates/ironclaw_webui/CLAUDE.md
@@ -124,10 +124,12 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
   (default 3 concurrent; override via `WebUiV2State::with_sse_concurrency_limit`)
   — a caller cannot bypass the cap by mixing SSE and WS. Exhaustion returns
   `429` with `retryable: true`.
-- The SPA also sends a bounded, random `connection_id` that is persisted in
-  per-tab `sessionStorage` together with a monotonically increasing
-  `connection_generation`. A same-caller, same-id stream supersedes its prior
-  generation without consuming another slot; a delayed older generation
+- The SPA also sends a bounded, random `connection_id` together with a
+  monotonically increasing `connection_generation`. The pair is persisted in
+  `sessionStorage` but restored only for a Navigation Timing `reload`; fresh
+  top-level navigations ignore copied storage so duplicated/opener-created tabs
+  receive distinct identities. A same-caller, same-id stream supersedes its
+  prior generation without consuming another slot; a delayed older generation
   receives `204` and cannot cancel the current stream. This prevents
   proxy-reordered closes/opens during thread navigation or full-page reload
   from stranding the replacement stream behind the cap; distinct tabs still

--- a/crates/ironclaw_webui/CLAUDE.md
+++ b/crates/ironclaw_webui/CLAUDE.md
@@ -136,11 +136,17 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
   frame immediately after admission. Browser connection state uses that frame
   as proof that the projection tail is ready instead of waiting for a model
   delta or the periodic transport keep-alive.
+- The SPA owns transport recovery: a native EventSource error closes that
+  object and schedules one generation-ordered replacement through the bounded
+  backoff/watchdog path. Browser-native retries and app retries must not run
+  concurrently because native retries reuse their original connection
+  generation; visibility changes are lifecycle hints, not a recovery
+  requirement.
 - `after_cursor` is retained only within one mounted Chat route (including
-  native EventSource retries and visibility recovery). A route/thread remount
-  starts at the projection origin so the server returns durable state plus the
-  compacted current live state; it does not persist process-local live cursors
-  across SPA navigation.
+  controlled EventSource replacements and visibility recovery). A route/thread
+  remount starts at the projection origin so the server returns durable state
+  plus the compacted current live state; it does not persist process-local live
+  cursors across SPA navigation.
 - Every stream is closed after a max lifetime (5 min) and every `socket.send` /
   drain await is `timeout`-bounded, so a back-pressuring client or a stalled
   facade cannot pin a slot past the budget. Slots are RAII (`SseSlot`), released

--- a/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
@@ -24,6 +24,7 @@ import { NEW_DRAFT_KEY } from "./lib/draft-store";
 import { buildRuntimeContext } from "./lib/runtime-context";
 import { buildScopedLogsPath } from "../logs/lib/logs-data";
 import { useInterfacePreferences } from "../../lib/interface-preferences";
+import { CONNECTION_STATUS } from "./lib/connection-status";
 
 /* Grace window before an active thread's sidebar state is cleared to idle.
  * Long enough for SSE to rehydrate a gate/run after a thread switch (so a
@@ -143,6 +144,8 @@ export function Chat({
   const activeThreadHasOnboarding =
     Boolean(activeThreadId) && Boolean(pendingOnboarding);
   const activeThreadIsProcessing = Boolean(activeThreadId) && isProcessing;
+  const isRecoveringConnection =
+    sseStatus === CONNECTION_STATUS.RECONNECTING;
   const activeRunId = activeRun?.runId || null;
   const streamingAssistantTextVisible = hasVisibleStreamingAssistantText(
     messages,
@@ -174,6 +177,7 @@ export function Chat({
     activeThreadHasGate ||
     activeThreadHasOnboarding ||
     (activeThreadIsProcessing &&
+      !isRecoveringConnection &&
       !activeThreadHasGate &&
       !activeThreadHasOnboarding) ||
     cooldownSeconds > 0;
@@ -209,6 +213,7 @@ export function Chat({
       activeRun?.runId &&
       activeRun.threadId === activeThreadId &&
       activeThreadIsProcessing &&
+      !isRecoveringConnection &&
       !activeThreadHasGate &&
       !activeThreadHasOnboarding
   );

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
@@ -452,7 +452,7 @@ export function useChat(threadId) {
 
   React.useEffect(() => {
     connectionStatusRef.current = sseStatus;
-    if (sseStatus !== CONNECTION_STATUS.DISCONNECTED) return;
+    if (!isConnectionLostStatus(sseStatus)) return;
     const wasProcessing = isProcessingRef.current;
     if (!wasProcessing) return;
     const runId = activeRunRef.current?.runId || null;

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
@@ -541,11 +541,13 @@ export function useChat(threadId) {
       const localRunBlocksSend =
         Boolean(sendTargetThreadId) &&
         localRunAdmissionRef.current?.threadId === sendTargetThreadId;
+      const recoveryProbeSend =
+        connectionStatusRef.current === CONNECTION_STATUS.RECONNECTING &&
+        (processingBlocksSend || activeRunBlocksSend || localRunBlocksSend);
       if (
         submitBusyRef.current ||
-        processingBlocksSend ||
-        activeRunBlocksSend ||
-        localRunBlocksSend
+        (!recoveryProbeSend &&
+          (processingBlocksSend || activeRunBlocksSend || localRunBlocksSend))
       ) {
         return null;
       }
@@ -608,7 +610,7 @@ export function useChat(threadId) {
       // Only the rendered thread has an SSE settle path in this hook. Background
       // target sends are left to the server's rejected_busy response instead.
       const shouldTrackLocalRun = shouldRenderInCurrentThread;
-      if (shouldTrackLocalRun) {
+      if (shouldTrackLocalRun && !recoveryProbeSend) {
         streamErrorClosedAdmissionThreadIdsRef.current.delete(sendThreadId);
         localRunAdmissionRef.current = {
           threadId: sendThreadId,
@@ -714,7 +716,7 @@ export function useChat(threadId) {
         // server's notice (if present) as a system message so the user
         // knows to resend.
         if (response?.outcome === "rejected_busy") {
-          if (shouldTrackLocalRun) {
+          if (shouldTrackLocalRun && !recoveryProbeSend) {
             localRunAdmissionRef.current = null;
           }
           const markRejected = (prev) =>
@@ -759,7 +761,9 @@ export function useChat(threadId) {
               appendSystemNotice(false);
             }
           }
-          updateCurrentRunState(() => setIsProcessing(false));
+          if (!recoveryProbeSend) {
+            updateCurrentRunState(() => setIsProcessing(false));
+          }
           submitBusyRef.current = false;
         } else if (!response?.run_id) {
           if (shouldTrackLocalRun) {
@@ -769,7 +773,7 @@ export function useChat(threadId) {
         }
         return response;
       } catch (err) {
-        if (shouldTrackLocalRun) {
+        if (shouldTrackLocalRun && !recoveryProbeSend) {
           streamErrorClosedAdmissionThreadIdsRef.current.delete(sendThreadId);
           localRunAdmissionRef.current = null;
         }
@@ -799,7 +803,9 @@ export function useChat(threadId) {
         ];
         updateCurrentThread(appendFailure);
         updateSeededTarget(appendFailure);
-        updateCurrentRunState(() => setIsProcessing(false));
+        if (!recoveryProbeSend) {
+          updateCurrentRunState(() => setIsProcessing(false));
+        }
         submitBusyRef.current = false;
         throw err;
       } finally {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -33,21 +33,52 @@ const V2_EVENT_NAMES = [
 const EVENT_SOURCE_OPEN = 1;
 const SSE_CONNECTION_STORAGE_KEY = "ironclaw:v2-sse-connection";
 
-function newConnectionState() {
+type SseConnectionState = {
+  connectionId: string;
+  generation: number;
+};
+
+function newConnectionState(): SseConnectionState {
   return { connectionId: clientActionId(), generation: 0 };
 }
 
-function loadConnectionState() {
+function isDocumentReload(): boolean {
+  try {
+    const navigation =
+      globalThis.performance?.getEntriesByType?.("navigation")[0];
+    return Boolean(
+      navigation &&
+        "type" in navigation &&
+        navigation.type === "reload",
+    );
+  } catch (_) {
+    return false;
+  }
+}
+
+function loadConnectionState(): SseConnectionState {
+  // sessionStorage can be copied into a newly opened or duplicated tab. Only
+  // an actual reload may reuse the predecessor document's stream identity;
+  // every fresh top-level navigation must get an independent server slot.
+  if (!isDocumentReload()) return newConnectionState();
   try {
     const raw = globalThis.sessionStorage?.getItem(SSE_CONNECTION_STORAGE_KEY);
     if (!raw) return newConnectionState();
-    const parsed = JSON.parse(raw);
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return newConnectionState();
+    const candidate = parsed as Record<string, unknown>;
+    const connectionId = candidate.connectionId;
+    const generation = candidate.generation;
     const validConnectionId =
-      typeof parsed?.connectionId === "string" &&
-      /^[A-Za-z0-9_-]{1,64}$/.test(parsed.connectionId);
+      typeof connectionId === "string" &&
+      /^[A-Za-z0-9_-]{1,64}$/.test(connectionId);
     const validGeneration =
-      Number.isSafeInteger(parsed?.generation) && parsed.generation >= 0;
-    if (validConnectionId && validGeneration) return parsed;
+      typeof generation === "number" &&
+      Number.isSafeInteger(generation) &&
+      generation >= 0;
+    if (validConnectionId && validGeneration) {
+      return { connectionId, generation };
+    }
   } catch (_) {
     // Storage may be unavailable or contain stale data. A fresh identity still
     // gives this document a usable stream; the server's max lifetime bounds
@@ -56,16 +87,17 @@ function loadConnectionState() {
   return newConnectionState();
 }
 
-// sessionStorage survives a reload but is scoped to the browser tab. Persisting
-// both values lets a reloaded document supersede the proxy-held stream from its
-// predecessor without allowing an older generation to cancel the replacement.
+// Persisting both values lets a reloaded document supersede the proxy-held
+// stream from its predecessor without allowing an older generation to cancel
+// the replacement. Fresh documents intentionally ignore copied storage above.
 const sseConnectionState = loadConnectionState();
 
-function connectionGeneration() {
-  sseConnectionState.generation = Math.min(
-    Number.MAX_SAFE_INTEGER,
-    sseConnectionState.generation + 1,
-  );
+function nextConnectionState(): SseConnectionState {
+  if (sseConnectionState.generation >= Number.MAX_SAFE_INTEGER) {
+    sseConnectionState.connectionId = clientActionId();
+    sseConnectionState.generation = 0;
+  }
+  sseConnectionState.generation += 1;
   try {
     globalThis.sessionStorage?.setItem(
       SSE_CONNECTION_STORAGE_KEY,
@@ -74,7 +106,7 @@ function connectionGeneration() {
   } catch (_) {
     // Best effort. The in-memory identity still covers SPA route switches.
   }
-  return sseConnectionState.generation;
+  return { ...sseConnectionState };
 }
 
 function eventSourceReadyStateConstant(staticValue: unknown, fallback: number) {
@@ -176,11 +208,12 @@ export function useSSE({ threadId, onEvent, enabled }) {
           : CONNECTION_STATUS.CONNECTING,
       );
 
+      const connectionState = nextConnectionState();
       es = openEventStream({
         threadId,
         afterCursor: lastEventId || undefined,
-        connectionId: sseConnectionState.connectionId,
-        connectionGeneration: connectionGeneration(),
+        connectionId: connectionState.connectionId,
+        connectionGeneration: connectionState.generation,
       });
       const source = es;
 
@@ -209,10 +242,10 @@ export function useSSE({ threadId, onEvent, enabled }) {
         }
         const rawType = frame.type || fallbackType;
         const type = rawType === "stream_error" ? "error" : rawType;
-        // Some browsers resume an interrupted EventSource by delivering the
-        // next frame without a second `open` callback. A normal frame proves
-        // the transport recovered and must clear a stale reconnecting badge.
-        // Classified stream errors keep their own terminal/retry state below.
+        // Any valid non-error application frame proves the active replacement
+        // transport is live and must clear a stale reconnecting badge, even if
+        // its `open` callback was delayed. Classified stream errors keep their
+        // own terminal/retry state below.
         if (type !== "error") markConnected(source);
         onEventRef.current?.({
           // The frame's own `type` field is the canonical source;

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -32,18 +32,50 @@ const V2_EVENT_NAMES = [
 
 const EVENT_SOURCE_CLOSED = 2;
 const EVENT_SOURCE_OPEN = 1;
-// Stable for this browser tab's loaded SPA. Reusing it across Chat route
-// mounts lets the server supersede a proxy-held stream from the prior thread
-// instead of rejecting the replacement against the per-user connection cap.
-const SSE_CONNECTION_ID = clientActionId();
-let nextConnectionGeneration = 0;
+const SSE_CONNECTION_STORAGE_KEY = "ironclaw:v2-sse-connection";
+
+function newConnectionState() {
+  return { connectionId: clientActionId(), generation: 0 };
+}
+
+function loadConnectionState() {
+  try {
+    const raw = globalThis.sessionStorage?.getItem(SSE_CONNECTION_STORAGE_KEY);
+    if (!raw) return newConnectionState();
+    const parsed = JSON.parse(raw);
+    const validConnectionId =
+      typeof parsed?.connectionId === "string" &&
+      /^[A-Za-z0-9_-]{1,64}$/.test(parsed.connectionId);
+    const validGeneration =
+      Number.isSafeInteger(parsed?.generation) && parsed.generation >= 0;
+    if (validConnectionId && validGeneration) return parsed;
+  } catch (_) {
+    // Storage may be unavailable or contain stale data. A fresh identity still
+    // gives this document a usable stream; the server's max lifetime bounds
+    // any proxy-held stream that cannot be superseded.
+  }
+  return newConnectionState();
+}
+
+// sessionStorage survives a reload but is scoped to the browser tab. Persisting
+// both values lets a reloaded document supersede the proxy-held stream from its
+// predecessor without allowing an older generation to cancel the replacement.
+const sseConnectionState = loadConnectionState();
 
 function connectionGeneration() {
-  nextConnectionGeneration =
-    nextConnectionGeneration >= Number.MAX_SAFE_INTEGER
-      ? 1
-      : nextConnectionGeneration + 1;
-  return nextConnectionGeneration;
+  sseConnectionState.generation = Math.min(
+    Number.MAX_SAFE_INTEGER,
+    sseConnectionState.generation + 1,
+  );
+  try {
+    globalThis.sessionStorage?.setItem(
+      SSE_CONNECTION_STORAGE_KEY,
+      JSON.stringify(sseConnectionState),
+    );
+  } catch (_) {
+    // Best effort. The in-memory identity still covers SPA route switches.
+  }
+  return sseConnectionState.generation;
 }
 
 function eventSourceReadyStateConstant(staticValue: unknown, fallback: number) {
@@ -156,7 +188,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
       es = openEventStream({
         threadId,
         afterCursor: lastEventId || undefined,
-        connectionId: SSE_CONNECTION_ID,
+        connectionId: sseConnectionState.connectionId,
         connectionGeneration: connectionGeneration(),
       });
       const source = es;

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -30,7 +30,6 @@ const V2_EVENT_NAMES = [
   "stream_error",
 ];
 
-const EVENT_SOURCE_CLOSED = 2;
 const EVENT_SOURCE_OPEN = 1;
 const SSE_CONNECTION_STORAGE_KEY = "ironclaw:v2-sse-connection";
 
@@ -82,13 +81,6 @@ function eventSourceReadyStateConstant(staticValue: unknown, fallback: number) {
   return typeof staticValue === "number" ? staticValue : fallback;
 }
 
-function isEventSourceClosed(source) {
-  const closedState = typeof EventSource === "function"
-    ? eventSourceReadyStateConstant(EventSource.CLOSED, EVENT_SOURCE_CLOSED)
-    : EVENT_SOURCE_CLOSED;
-  return source?.readyState === closedState;
-}
-
 function isEventSourceOpen(source) {
   const openState = typeof EventSource === "function"
     ? eventSourceReadyStateConstant(EventSource.OPEN, EVENT_SOURCE_OPEN)
@@ -119,9 +111,8 @@ export function useSSE({ threadId, onEvent, enabled }) {
     let terminalErrorReceived = false;
     // This cursor belongs to this mounted route only. A route remount must
     // hydrate current state from the projection origin because the composite
-    // cursor contains a process-local live rail. Native EventSource retries
-    // still carry Last-Event-ID automatically, and explicit retries within
-    // this effect may resume from the latest frame observed here.
+    // cursor contains a process-local live rail. Controlled retries within this
+    // effect resume from the latest frame observed here.
     let lastEventId = null;
     const maxReconnectDelay = 30_000;
     const reconnectOpenDeadline = 10_000;
@@ -195,9 +186,9 @@ export function useSSE({ threadId, onEvent, enabled }) {
 
       // A replacement EventSource can remain in CONNECTING forever without
       // firing either callback when a proxy accepts the HTTP request but does
-      // not establish the event stream. Bound reconnect attempts explicitly;
-      // the initial connection remains browser-managed, while every recovery
-      // attempt must prove it opened within this deadline.
+      // not establish the event stream. Bound every recovery attempt
+      // explicitly; the initial attempt still reports its native failure
+      // through `onerror`.
       if (reconnectAttempts > 0) scheduleOpenWatchdog(source);
 
       source.onopen = () => {
@@ -275,17 +266,13 @@ export function useSSE({ threadId, onEvent, enabled }) {
           dispatchFrame(event, "error");
           return;
         }
-        // Preserve EventSource's native retry for transient failures. Closing
-        // it immediately creates a fresh HTTP stream for every error, which can
-        // race server-side slot release behind a proxy and strand the client in
-        // a reconnect loop. The watchdog below remains the bounded fallback if
-        // native recovery never opens or delivers another frame.
-        if (!isEventSourceClosed(source)) {
-          setStatus(CONNECTION_STATUS.RECONNECTING);
-          scheduleOpenWatchdog(source);
-          return;
-        }
-        reconnectWithTimer();
+        // Native EventSource retries reuse the original URL and therefore the
+        // same connection generation. A proxy can deliver one of those retries
+        // late, allowing equal-generation requests to supersede each other and
+        // repeatedly end as short 200 responses. Close the native retry state
+        // machine and schedule exactly one app-owned replacement; `connect()`
+        // gives it a newer generation that stale requests cannot cancel.
+        reconnectWithTimer(CONNECTION_STATUS.RECONNECTING);
       };
 
       // Cover anything emitted without an `event:` field — defensive

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -141,6 +141,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
     let reconnectAttempts = 0;
     let disposed = false;
     let terminalErrorReceived = false;
+    let readySource = null;
     // This cursor belongs to this mounted route only. A route remount must
     // hydrate current state from the projection origin because the composite
     // cursor contains a process-local live rail. Controlled retries within this
@@ -159,6 +160,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
     function markConnected(source) {
       if (disposed || terminalErrorReceived || es !== source) return;
       clearOpenWatchdog();
+      readySource = source;
       reconnectAttempts = 0;
       setStatus(CONNECTION_STATUS.CONNECTED);
     }
@@ -168,10 +170,6 @@ export function useSSE({ threadId, onEvent, enabled }) {
       openWatchdog = setTimeout(() => {
         openWatchdog = null;
         if (disposed || terminalErrorReceived || es !== source) return;
-        if (isEventSourceOpen(source)) {
-          markConnected(source);
-          return;
-        }
         reconnectWithTimer(CONNECTION_STATUS.RECONNECTING);
       }, reconnectOpenDeadline);
     }
@@ -181,6 +179,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
     ) {
       if (disposed || terminalErrorReceived) return;
       if (es) {
+        readySource = null;
         es.close();
         es = null;
       }
@@ -225,7 +224,11 @@ export function useSSE({ threadId, onEvent, enabled }) {
       if (reconnectAttempts > 0) scheduleOpenWatchdog(source);
 
       source.onopen = () => {
-        markConnected(source);
+        // HTTP headers alone do not prove the server-side subscription is
+        // usable. A proxy can open the response and immediately EOF before the
+        // server's ready frame. Keep the watchdog and retry streak until a
+        // valid application frame reaches dispatchFrame().
+        scheduleOpenWatchdog(source);
       };
 
       const dispatchFrame = (event, fallbackType) => {
@@ -268,6 +271,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
             clearTimeout(reconnectTimer);
             reconnectTimer = null;
           }
+          readySource = null;
           es = null;
           source.close();
           setStatus(CONNECTION_STATUS.DISCONNECTED);
@@ -327,6 +331,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
       }
       clearOpenWatchdog();
       if (es) {
+        readySource = null;
         es.close();
         es = null;
       }
@@ -349,8 +354,8 @@ export function useSSE({ threadId, onEvent, enabled }) {
 
     function handleNetworkOnline() {
       if (disposed || terminalErrorReceived) return;
-      if (es && isEventSourceOpen(es)) {
-        markConnected(es);
+      if (es && readySource === es && isEventSourceOpen(es)) {
+        setStatus(CONNECTION_STATUS.CONNECTED);
         return;
       }
       setStatus(CONNECTION_STATUS.RECONNECTING);
@@ -378,6 +383,7 @@ export function useSSE({ threadId, onEvent, enabled }) {
       if (reconnectTimer) clearTimeout(reconnectTimer);
       clearOpenWatchdog();
       const source = es;
+      readySource = null;
       es = null;
       source?.close();
     };

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
@@ -5,6 +5,7 @@ import { test } from "vitest";
 import vm from "node:vm";
 
 import { channelConnectionDisplayName } from "../../../lib/channel-connection-events";
+import { CONNECTION_STATUS } from "./connection-status";
 
 function chatSourceForTest() {
   const source = readFileSync(new URL("../chat.tsx", import.meta.url), "utf8");
@@ -127,6 +128,7 @@ function renderChat({
       ],
     },
     NEW_DRAFT_KEY: "new",
+    CONNECTION_STATUS,
     THREAD_STATE: { NEEDS_ATTENTION: "needs_attention", RUNNING: "running" },
     buildRuntimeContext: () => ({}),
     buildScopedLogsPath: ({ threadId }) => `/logs?thread_id=${threadId}`,
@@ -220,6 +222,42 @@ test("Chat leaves the composer editable while a run is processing", () => {
   const props = componentProps(chatInput, components.ChatInput);
   assert.equal(props.disabled, false);
   assert.equal(props.sendDisabled, true);
+});
+
+test("Chat allows a server-validated send while the active run stream reconnects", async () => {
+  let sentContent = null;
+  const { tree, components } = renderChat({
+    hookState: {
+      messages: [{ id: "message-1" }],
+      isProcessing: true,
+      pendingGate: null,
+      suggestions: [],
+      sseStatus: CONNECTION_STATUS.RECONNECTING,
+      historyLoading: false,
+      hasMore: false,
+      cooldownSeconds: 0,
+      recoveryNotice: null,
+      activeRun: { runId: "run-1", threadId: "thread-1", status: "running" },
+      send: async (content) => {
+        sentContent = content;
+        return { outcome: "rejected_busy" };
+      },
+      cancelRun: async () => {},
+      retryMessage: () => {},
+      approve: () => {},
+      recoverHistory: () => {},
+      loadMore: () => {},
+      setSuggestions: () => {},
+      submitAuthToken: async () => {},
+    },
+  });
+
+  const chatInput = findComponent(tree, components.ChatInput);
+  const props = componentProps(chatInput, components.ChatInput);
+  assert.equal(props.sendDisabled, false);
+  assert.equal(props.canCancel, false);
+  await props.onSend("check whether the prior run finished");
+  assert.equal(sentContent, "check whether the prior run finished");
 });
 
 test("Chat shows typing indicator before assistant text streams", () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/connection-status.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/connection-status.ts
@@ -12,7 +12,6 @@ export type ConnectionStatus =
 
 const CONNECTION_LOST_STATUSES: ReadonlySet<string> = new Set([
   CONNECTION_STATUS.DISCONNECTED,
-  CONNECTION_STATUS.RECONNECTING,
 ]);
 
 function normalizeConnectionStatus(status: unknown): string {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -199,7 +199,7 @@ function createReactStub({
   return react;
 }
 
-test("useChat: disconnected SSE rewrites an active driver_unavailable error", () => {
+test("useChat: reconnecting SSE rewrites an active driver_unavailable error", () => {
   const threadId = "thread-1";
   const setCalls = [];
   let renderedMessages = [
@@ -261,13 +261,13 @@ test("useChat: disconnected SSE rewrites an active driver_unavailable error", ()
           typeof updater === "function" ? updater(renderedMessages) : updater;
       },
     }),
-    useSSE: () => ({ status: CONNECTION_STATUS.DISCONNECTED }),
+    useSSE: () => ({ status: CONNECTION_STATUS.RECONNECTING }),
   };
 
   runUseChatSource(context);
   const chat = context.globalThis.__testExports.useChat(threadId);
 
-  assert.equal(chat.sseStatus, CONNECTION_STATUS.DISCONNECTED);
+  assert.equal(chat.sseStatus, CONNECTION_STATUS.RECONNECTING);
   assert.equal(renderedMessages.length, 1);
   assert.equal(renderedMessages[0].content, CONNECTION_LOST_RUN_FAILURE_MESSAGE);
   assert.equal(
@@ -520,7 +520,10 @@ test("useChat.send: accepted ref reconciles pending message on timeline reload",
   );
 });
 
-function createSendCaptureContext() {
+function createSendCaptureContext({
+  ReactStub = createReactStub(),
+  sseStatus = CONNECTION_STATUS.IDLE,
+} = {}) {
   let sentBody = null;
   let renderedMessages = [];
   const context = {
@@ -529,7 +532,7 @@ function createSendCaptureContext() {
     Error,
     Map,
     Math,
-    React: createReactStub(),
+    React: ReactStub,
     addPending,
     toRenderAttachment,
     toWireAttachment,
@@ -576,7 +579,7 @@ function createSendCaptureContext() {
           typeof updater === "function" ? updater(renderedMessages) : updater;
       },
     }),
-    useSSE: () => ({ status: CONNECTION_STATUS.IDLE }),
+    useSSE: () => ({ status: sseStatus }),
   };
   return {
     context,
@@ -584,6 +587,34 @@ function createSendCaptureContext() {
     renderedMessages: () => renderedMessages,
   };
 }
+
+test("useChat.send: reconnecting stream releases stale run admission before sending", async () => {
+  const threadId = "thread-1";
+  const ReactStub = createReactStub({
+    initialByIndex: new Map([
+      [STATE_SLOT.activeRun, { runId: "stale-run", threadId, status: "running" }],
+      [STATE_SLOT.isProcessing, true],
+    ]),
+    runEffects: true,
+  });
+  const { context, sentBody } = createSendCaptureContext({
+    ReactStub,
+    sseStatus: CONNECTION_STATUS.RECONNECTING,
+  });
+
+  runUseChatSource(context);
+  const renderChat = () => {
+    ReactStub.__beginRender();
+    return context.globalThis.__testExports.useChat(threadId);
+  };
+
+  renderChat();
+  const chatAfterConnectionLoss = renderChat();
+  await chatAfterConnectionLoss.send("send despite stale stream state");
+
+  assert.equal(sentBody()?.content, "send despite stale stream state");
+  assert.equal(sentBody()?.threadId, threadId);
+});
 
 test("useChat.send: forwards staged attachments to sendMessage in wire shape", async () => {
   const threadId = "thread-1";

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -199,7 +199,7 @@ function createReactStub({
   return react;
 }
 
-test("useChat: reconnecting SSE rewrites an active driver_unavailable error", () => {
+test("useChat: reconnecting SSE preserves an active run without adding an error", () => {
   const threadId = "thread-1";
   const setCalls = [];
   let renderedMessages = [
@@ -269,15 +269,9 @@ test("useChat: reconnecting SSE rewrites an active driver_unavailable error", ()
 
   assert.equal(chat.sseStatus, CONNECTION_STATUS.RECONNECTING);
   assert.equal(renderedMessages.length, 1);
-  assert.equal(renderedMessages[0].content, CONNECTION_LOST_RUN_FAILURE_MESSAGE);
-  assert.equal(
-    stateUpdatesFor(setCalls, STATE_SLOT.isProcessing).at(-1)?.value,
-    false,
-  );
-  assert.equal(
-    stateUpdatesFor(setCalls, STATE_SLOT.activeRun).at(-1)?.value,
-    null,
-  );
+  assert.notEqual(renderedMessages[0].content, CONNECTION_LOST_RUN_FAILURE_MESSAGE);
+  assert.equal(stateUpdatesFor(setCalls, STATE_SLOT.isProcessing).length, 0);
+  assert.equal(stateUpdatesFor(setCalls, STATE_SLOT.activeRun).length, 0);
 });
 
 test("useChat: disconnected SSE surfaces connection error before run id is known", () => {
@@ -523,6 +517,8 @@ test("useChat.send: accepted ref reconciles pending message on timeline reload",
 function createSendCaptureContext({
   ReactStub = createReactStub(),
   sseStatus = CONNECTION_STATUS.IDLE,
+  sendResponse = null,
+  sendError = null,
 } = {}) {
   let sentBody = null;
   let renderedMessages = [];
@@ -557,6 +553,8 @@ function createSendCaptureContext({
     resolveGateRequest: async () => {},
     sendMessage: async (body) => {
       sentBody = body;
+      if (sendError) throw sendError;
+      if (sendResponse) return sendResponse;
       return {
         accepted_message_ref: "msg:message-1",
         run_id: "run-1",
@@ -614,6 +612,81 @@ test("useChat.send: reconnecting stream releases stale run admission before send
 
   assert.equal(sentBody()?.content, "send despite stale stream state");
   assert.equal(sentBody()?.threadId, threadId);
+});
+
+test("useChat.send: reconnecting busy rejection preserves the active run", async () => {
+  const threadId = "thread-1";
+  const stateSlots = new Map();
+  const setCalls = [];
+  const ReactStub = createReactStub({
+    initialByIndex: new Map([
+      [STATE_SLOT.activeRun, { runId: "active-run", threadId, status: "running" }],
+      [STATE_SLOT.isProcessing, true],
+    ]),
+    stateSlots,
+    setCalls,
+    runEffects: true,
+  });
+  const { context, sentBody, renderedMessages } = createSendCaptureContext({
+    ReactStub,
+    sseStatus: CONNECTION_STATUS.RECONNECTING,
+    sendResponse: {
+      outcome: "rejected_busy",
+      notice: "Thread is still running.",
+    },
+  });
+
+  runUseChatSource(context);
+  const renderChat = () => {
+    ReactStub.__beginRender();
+    return context.globalThis.__testExports.useChat(threadId);
+  };
+
+  renderChat();
+  await renderChat().send("check whether the prior run finished");
+
+  assert.equal(sentBody()?.content, "check whether the prior run finished");
+  assert.equal(stateSlots.get(STATE_SLOT.isProcessing)?.value, true);
+  assert.equal(stateSlots.get(STATE_SLOT.activeRun)?.value.runId, "active-run");
+  assert.equal(
+    renderedMessages().some(
+      (message) => message.content === CONNECTION_LOST_RUN_FAILURE_MESSAGE,
+    ),
+    false,
+  );
+});
+
+test("useChat.send: reconnecting request failure preserves the active run", async () => {
+  const threadId = "thread-1";
+  const stateSlots = new Map();
+  const ReactStub = createReactStub({
+    initialByIndex: new Map([
+      [STATE_SLOT.activeRun, { runId: "active-run", threadId, status: "running" }],
+      [STATE_SLOT.isProcessing, true],
+    ]),
+    stateSlots,
+    runEffects: true,
+  });
+  const { context } = createSendCaptureContext({
+    ReactStub,
+    sseStatus: CONNECTION_STATUS.RECONNECTING,
+    sendError: new Error("network unavailable"),
+  });
+
+  runUseChatSource(context);
+  const renderChat = () => {
+    ReactStub.__beginRender();
+    return context.globalThis.__testExports.useChat(threadId);
+  };
+
+  renderChat();
+  await assert.rejects(
+    renderChat().send("check whether the prior run finished"),
+    /network unavailable/,
+  );
+
+  assert.equal(stateSlots.get(STATE_SLOT.isProcessing)?.value, true);
+  assert.equal(stateSlots.get(STATE_SLOT.activeRun)?.value.runId, "active-run");
 });
 
 test("useChat.send: forwards staged attachments to sendMessage in wire shape", async () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -200,16 +200,19 @@ test("useSSE resumes delivery after returning to a hidden tab", () => {
   resumed.readyState = context.EventSource.CONNECTING;
   resumed.onerror({});
 
-  assert.equal(resumed.closeCalls, 0);
-  assert.equal(timers.filter((timer) => timer.delay === 10_000).length, 1);
+  assert.equal(resumed.closeCalls, 1);
+  const reconnectTimer = timers.find((timer) => timer.delay === 2000);
+  assert.ok(reconnectTimer);
+  reconnectTimer.handler();
 
-  resumed.readyState = context.EventSource.OPEN;
-  resumed.listener("projection_update")({
+  const replacement = streams[2];
+  replacement.readyState = context.EventSource.OPEN;
+  replacement.listener("projection_update")({
     data: JSON.stringify({ type: "projection_update", state: { items: [] } }),
     lastEventId: "after-tab-resume",
   });
 
-  assert.equal(streams.length, 2);
+  assert.equal(streams.length, 3);
   assert.equal(events.length, 1);
   assert.deepEqual(statuses, [
     "connecting",
@@ -217,35 +220,55 @@ test("useSSE resumes delivery after returning to a hidden tab", () => {
     "paused",
     "connecting",
     "reconnecting",
+    "reconnecting",
     "connected",
   ]);
 });
 
-test("useSSE lets EventSource recover transient failures natively", () => {
+test("useSSE replaces a short successful stream with a newer generation", () => {
   const { context, statuses, streams, timers } = createHarness();
 
   assert.deepEqual(statuses, ["connecting"]);
   const stream = streams[0];
+  stream.readyState = context.EventSource.OPEN;
+  stream.onopen();
   stream.readyState = context.EventSource.CONNECTING;
   stream.onerror({});
 
-  assert.deepEqual(statuses, ["connecting", "reconnecting"]);
-  assert.equal(stream.closeCalls, 0);
+  assert.deepEqual(statuses, [
+    "connecting",
+    "connected",
+    "reconnecting",
+  ]);
+  assert.equal(stream.closeCalls, 1);
   assert.equal(timers.length, 1);
-  assert.equal(timers[0].delay, 10_000);
+  assert.equal(timers[0].delay, 2000);
 
-  stream.readyState = context.EventSource.OPEN;
-  stream.listener("keep_alive")({
+  timers[0].handler();
+  const replacement = streams[1];
+  assert.equal(replacement.args.connectionGeneration, 2);
+
+  replacement.readyState = context.EventSource.OPEN;
+  replacement.listener("keep_alive")({
     data: JSON.stringify({ type: "keep_alive" }),
     lastEventId: "resume-cursor",
   });
 
-  assert.equal(timers[0].cleared, true);
-  assert.equal(streams.length, 1);
-  assert.deepEqual(statuses, ["connecting", "reconnecting", "connected"]);
+  assert.equal(
+    timers.find((timer) => timer.delay === 10_000)?.cleared,
+    true,
+  );
+  assert.equal(streams.length, 2);
+  assert.deepEqual(statuses, [
+    "connecting",
+    "connected",
+    "reconnecting",
+    "reconnecting",
+    "connected",
+  ]);
 });
 
-test("useSSE keeps one watchdog across repeated native errors", () => {
+test("useSSE schedules one replacement across duplicate transport errors", () => {
   const { context, statuses, streams, timers } = createHarness();
 
   const stream = streams[0];
@@ -254,19 +277,19 @@ test("useSSE keeps one watchdog across repeated native errors", () => {
   stream.onerror({});
 
   assert.equal(timers.length, 1);
-  assert.equal(timers[0].delay, 10_000);
-  assert.equal(stream.closeCalls, 0);
-  assert.deepEqual(statuses, ["connecting", "reconnecting", "reconnecting"]);
+  assert.equal(timers[0].delay, 2000);
+  assert.equal(stream.closeCalls, 1);
+  assert.deepEqual(statuses, ["connecting", "reconnecting"]);
 });
 
-test("useSSE falls back to app reconnect timer for closed streams", () => {
+test("useSSE uses the controlled reconnect path for closed streams", () => {
   const { context, statuses, streams, timers } = createHarness();
 
   const stream = streams[0];
   stream.readyState = context.EventSource.CLOSED;
   stream.onerror({});
 
-  assert.deepEqual(statuses, ["connecting", "disconnected"]);
+  assert.deepEqual(statuses, ["connecting", "reconnecting"]);
   assert.equal(stream.closeCalls, 1);
   assert.equal(timers.length, 1);
   assert.equal(timers[0].delay, 2000);
@@ -274,7 +297,7 @@ test("useSSE falls back to app reconnect timer for closed streams", () => {
   timers[0].handler();
 
   assert.equal(streams.length, 2);
-  assert.deepEqual(statuses, ["connecting", "disconnected", "reconnecting"]);
+  assert.deepEqual(statuses, ["connecting", "reconnecting", "reconnecting"]);
 });
 
 test("useSSE replaces a reconnect attempt that never finishes opening", () => {
@@ -283,10 +306,6 @@ test("useSSE replaces a reconnect attempt that never finishes opening", () => {
   const first = streams[0];
   first.readyState = context.EventSource.CONNECTING;
   first.onerror({});
-
-  const nativeWatchdog = timers.find((timer) => timer.delay === 10_000);
-  assert.ok(nativeWatchdog);
-  nativeWatchdog.handler();
 
   const reconnectTimer = timers.find((timer) => timer.delay === 2000);
   assert.ok(reconnectTimer);
@@ -308,7 +327,6 @@ test("useSSE replaces a reconnect attempt that never finishes opening", () => {
   );
   assert.deepEqual(statuses, [
     "connecting",
-    "reconnecting",
     "reconnecting",
     "reconnecting",
     "reconnecting",

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -28,6 +28,8 @@ function createHarness({
   online = true,
   visibilityState = "visible",
   onEvent = () => {},
+  sessionStorage = createSessionStorage(),
+  connectionId = "browser-tab-connection",
 } = {}) {
   const statuses = [];
   const streams = [];
@@ -46,12 +48,13 @@ function createHarness({
   const context = {
     CONNECTION_STATUS,
     authScope: () => "tenant:user",
-    clientActionId: () => "browser-tab-connection",
+    clientActionId: () => connectionId,
     EventSource,
     JSON,
     Math,
     globalThis: {
-      crypto: { randomUUID: () => "browser-tab-connection" },
+      crypto: { randomUUID: () => connectionId },
+      sessionStorage,
     },
     openEventStream: (args) => {
       const listeners = new Map();
@@ -137,6 +140,15 @@ function createHarness({
     streams,
     timers,
     windowListeners,
+  };
+}
+
+function createSessionStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
   };
 }
 
@@ -396,6 +408,35 @@ test("useSSE discards a volatile live cursor when the chat page remounts", () =>
   assert.equal(streams[1].args.connectionGeneration, 2);
 
   cleanup();
+});
+
+test("useSSE preserves connection identity and generation across a document reload", () => {
+  const sessionStorage = createSessionStorage();
+  const firstDocument = createHarness({
+    sessionStorage,
+    connectionId: "first-document-id",
+  });
+
+  assert.equal(firstDocument.streams[0].args.connectionId, "first-document-id");
+  assert.equal(firstDocument.streams[0].args.connectionGeneration, 1);
+  firstDocument.cleanup();
+
+  const reloadedDocument = createHarness({
+    sessionStorage,
+    connectionId: "new-id-must-not-be-used",
+  });
+
+  assert.equal(
+    reloadedDocument.streams[0].args.connectionId,
+    "first-document-id",
+    "a reload must address the same server slot as the proxy-held predecessor",
+  );
+  assert.equal(
+    reloadedDocument.streams[0].args.connectionGeneration,
+    2,
+    "a reload must supersede rather than be rejected as a stale generation",
+  );
+  reloadedDocument.cleanup();
 });
 
 test("useSSE ignores callbacks from a stream disposed by a thread switch", () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -30,6 +30,7 @@ function createHarness({
   onEvent = () => {},
   sessionStorage = createSessionStorage(),
   connectionId = "browser-tab-connection",
+  navigationType = "navigate",
 } = {}) {
   const statuses = [];
   const streams = [];
@@ -54,6 +55,10 @@ function createHarness({
     Math,
     globalThis: {
       crypto: { randomUUID: () => connectionId },
+      performance: {
+        getEntriesByType: (type) =>
+          type === "navigation" ? [{ type: navigationType }] : [],
+      },
       sessionStorage,
     },
     openEventStream: (args) => {
@@ -442,6 +447,7 @@ test("useSSE preserves connection identity and generation across a document relo
   const reloadedDocument = createHarness({
     sessionStorage,
     connectionId: "new-id-must-not-be-used",
+    navigationType: "reload",
   });
 
   assert.equal(
@@ -455,6 +461,134 @@ test("useSSE preserves connection identity and generation across a document relo
     "a reload must supersede rather than be rejected as a stale generation",
   );
   reloadedDocument.cleanup();
+});
+
+test("useSSE gives a duplicated tab a fresh connection identity", () => {
+  const copiedSessionStorage = createSessionStorage({
+    "ironclaw:v2-sse-connection": JSON.stringify({
+      connectionId: "original-tab-id",
+      generation: 7,
+    }),
+  });
+
+  const duplicatedTab = createHarness({
+    sessionStorage: copiedSessionStorage,
+    connectionId: "duplicated-tab-id",
+    navigationType: "navigate",
+  });
+
+  assert.equal(duplicatedTab.streams[0].args.connectionId, "duplicated-tab-id");
+  assert.equal(duplicatedTab.streams[0].args.connectionGeneration, 1);
+  duplicatedTab.cleanup();
+});
+
+test("useSSE rejects malformed or unavailable persisted connection state", () => {
+  const invalidValues = [
+    "{not-json",
+    JSON.stringify({ connectionId: "x".repeat(65), generation: 3 }),
+    JSON.stringify({ connectionId: "invalid/id", generation: 3 }),
+    JSON.stringify({ connectionId: "stored-id", generation: -1 }),
+    JSON.stringify({
+      connectionId: "stored-id",
+      generation: Number.MAX_SAFE_INTEGER + 1,
+    }),
+  ];
+
+  invalidValues.forEach((value, index) => {
+    const sessionStorage = createSessionStorage({
+      "ironclaw:v2-sse-connection": value,
+    });
+    const harness = createHarness({
+      sessionStorage,
+      connectionId: `fallback-id-${index}`,
+      navigationType: "reload",
+    });
+    assert.equal(harness.streams[0].args.connectionId, `fallback-id-${index}`);
+    assert.equal(harness.streams[0].args.connectionGeneration, 1);
+    harness.cleanup();
+  });
+
+  const unavailableStorage = {
+    getItem() {
+      throw new Error("storage unavailable");
+    },
+    setItem() {},
+  };
+  const harness = createHarness({
+    sessionStorage: unavailableStorage,
+    connectionId: "fallback-after-read-error",
+    navigationType: "reload",
+  });
+  assert.equal(
+    harness.streams[0].args.connectionId,
+    "fallback-after-read-error",
+  );
+  assert.equal(harness.streams[0].args.connectionGeneration, 1);
+  harness.cleanup();
+});
+
+test("useSSE normalizes valid persisted connection state", () => {
+  const sessionStorage = createSessionStorage({
+    "ironclaw:v2-sse-connection": JSON.stringify({
+      connectionId: "stored-id",
+      generation: 4,
+      ignored: "copied external data",
+    }),
+  });
+  const harness = createHarness({
+    sessionStorage,
+    connectionId: "unused-id",
+    navigationType: "reload",
+  });
+
+  assert.deepEqual(
+    JSON.parse(sessionStorage.getItem("ironclaw:v2-sse-connection")),
+    { connectionId: "stored-id", generation: 5 },
+  );
+  harness.cleanup();
+});
+
+test("useSSE keeps reconnect generations in memory when storage writes fail", () => {
+  const sessionStorage = {
+    getItem: () =>
+      JSON.stringify({ connectionId: "stored-id", generation: 4 }),
+    setItem() {
+      throw new Error("storage unavailable");
+    },
+  };
+  const harness = createHarness({
+    sessionStorage,
+    connectionId: "unused-id",
+    navigationType: "reload",
+  });
+
+  assert.equal(harness.streams[0].args.connectionId, "stored-id");
+  assert.equal(harness.streams[0].args.connectionGeneration, 5);
+  harness.render("thread-2");
+  assert.equal(harness.streams[1].args.connectionId, "stored-id");
+  assert.equal(harness.streams[1].args.connectionGeneration, 6);
+  harness.cleanup();
+});
+
+test("useSSE rotates identity before the generation counter would saturate", () => {
+  const sessionStorage = createSessionStorage({
+    "ironclaw:v2-sse-connection": JSON.stringify({
+      connectionId: "saturated-id",
+      generation: Number.MAX_SAFE_INTEGER,
+    }),
+  });
+  const harness = createHarness({
+    sessionStorage,
+    connectionId: "rotated-id",
+    navigationType: "reload",
+  });
+
+  assert.equal(harness.streams[0].args.connectionId, "rotated-id");
+  assert.equal(harness.streams[0].args.connectionGeneration, 1);
+  harness.render("thread-2");
+  assert.equal(harness.streams[1].args.connectionId, "rotated-id");
+  assert.equal(harness.streams[1].args.connectionGeneration, 2);
+  harness.cleanup();
 });
 
 test("useSSE ignores callbacks from a stream disposed by a thread switch", () => {

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -163,6 +163,10 @@ test("useSSE reflects browser offline and online events", () => {
   const stream = streams[0];
   stream.readyState = context.EventSource.OPEN;
   stream.onopen();
+  stream.listener("keep_alive")({
+    data: JSON.stringify({ type: "keep_alive" }),
+    lastEventId: "initial-ready",
+  });
   windowListeners.get("offline")();
   assert.deepEqual(statuses, ["connecting", "connected", "reconnecting"]);
 
@@ -194,6 +198,10 @@ test("useSSE resumes delivery after returning to a hidden tab", () => {
   const initial = streams[0];
   initial.readyState = context.EventSource.OPEN;
   initial.onopen();
+  initial.listener("keep_alive")({
+    data: JSON.stringify({ type: "keep_alive" }),
+    lastEventId: "initial-ready",
+  });
 
   context.document.visibilityState = "hidden";
   documentListeners.get("visibilitychange")();
@@ -218,7 +226,8 @@ test("useSSE resumes delivery after returning to a hidden tab", () => {
   });
 
   assert.equal(streams.length, 3);
-  assert.equal(events.length, 1);
+  assert.equal(events.length, 2);
+  assert.equal(events.at(-1).type, "projection_update");
   assert.deepEqual(statuses, [
     "connecting",
     "connected",
@@ -242,14 +251,13 @@ test("useSSE replaces a short successful stream with a newer generation", () => 
 
   assert.deepEqual(statuses, [
     "connecting",
-    "connected",
     "reconnecting",
   ]);
   assert.equal(stream.closeCalls, 1);
-  assert.equal(timers.length, 1);
-  assert.equal(timers[0].delay, 2000);
+  const firstRetry = timers.find((timer) => timer.delay === 2000);
+  assert.ok(firstRetry);
 
-  timers[0].handler();
+  firstRetry.handler();
   const replacement = streams[1];
   assert.equal(replacement.args.connectionGeneration, 2);
 
@@ -266,10 +274,51 @@ test("useSSE replaces a short successful stream with a newer generation", () => 
   assert.equal(streams.length, 2);
   assert.deepEqual(statuses, [
     "connecting",
-    "connected",
     "reconnecting",
     "reconnecting",
     "connected",
+  ]);
+});
+
+test("useSSE backs off streams that open then EOF before a ready frame", () => {
+  const { context, statuses, streams, timers } = createHarness();
+
+  const first = streams[0];
+  first.readyState = context.EventSource.OPEN;
+  first.onopen();
+  first.onerror({});
+
+  const firstRetry = timers.at(-1);
+  assert.equal(firstRetry.delay, 2000);
+  firstRetry.handler();
+
+  const second = streams[1];
+  second.readyState = context.EventSource.OPEN;
+  second.onopen();
+  second.onerror({});
+
+  const secondRetry = timers.at(-1);
+  assert.equal(secondRetry.delay, 4000);
+  secondRetry.handler();
+
+  const ready = streams[2];
+  ready.readyState = context.EventSource.OPEN;
+  ready.onopen();
+  ready.listener("keep_alive")({
+    data: JSON.stringify({ type: "keep_alive" }),
+    lastEventId: "ready-after-backoff",
+  });
+  ready.onerror({});
+
+  assert.equal(timers.at(-1).delay, 2000);
+  assert.deepEqual(statuses, [
+    "connecting",
+    "reconnecting",
+    "reconnecting",
+    "reconnecting",
+    "reconnecting",
+    "connected",
+    "reconnecting",
   ]);
 });
 

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -136,6 +136,7 @@ async def _install_fake_v2_event_source(page) -> None:
         """
         (() => {
           let activeStream = null;
+          window.__v2SseUrls = [];
           const currentStream = () => {
             if (!activeStream || activeStream.readyState === 2) {
               throw new Error("no EventSource stream is open");
@@ -146,6 +147,7 @@ async def _install_fake_v2_event_source(page) -> None:
             constructor(url) {
               super();
               this.url = url;
+              window.__v2SseUrls.push(String(url));
               this.readyState = 0;
               if (activeStream && activeStream.readyState !== 2) {
                 activeStream.close();
@@ -884,11 +886,12 @@ async def test_reborn_v2_composer_accepts_draft_while_run_is_processing(reborn_v
     await expect(reborn_v2_page.locator(SEL_V2["msg_user"])).to_have_count(1, timeout=1000)
 
 
-async def test_reborn_v2_disconnected_run_shows_status_and_stops_typing(
+async def test_reborn_v2_transient_reconnect_preserves_run_and_allows_send(
     reborn_v2_server, reborn_v2_browser
 ) -> None:
-    """A disconnected active run shows transport status and stops spinning."""
+    """A recoverable transport error preserves the run and defers send admission."""
     thread_id = "thread-disconnected-run"
+    send_requests: list[dict] = []
     context = await reborn_v2_browser.new_context(viewport={"width": 1280, "height": 720})
     page = await context.new_page()
     await _install_fake_v2_event_source(page)
@@ -937,14 +940,24 @@ async def test_reborn_v2_disconnected_run_shows_status_and_stops_typing(
         await fulfill_json(route, {"messages": [], "next_cursor": None})
 
     async def handle_send(route) -> None:
+        send_requests.append(route.request.post_data_json)
+        if len(send_requests) == 1:
+            await fulfill_json(
+                route,
+                {
+                    "thread_id": thread_id,
+                    "run_id": "run-disconnected",
+                    "status": "running",
+                },
+                status=202,
+            )
+            return
         await fulfill_json(
             route,
             {
-                "thread_id": thread_id,
-                "run_id": "run-disconnected",
-                "status": "running",
+                "outcome": "rejected_busy",
+                "notice": "Thread is still running.",
             },
-            status=202,
         )
 
     await page.route("**/api/webchat/v2/session", handle_session)
@@ -996,14 +1009,62 @@ async def test_reborn_v2_disconnected_run_shows_status_and_stops_typing(
 
         await page.evaluate("() => window.__failLatestV2Sse(0)")
         await expect(connection_status).to_have_text("Reconnecting...", timeout=5000)
+        await expect(page.locator(SEL_V2["typing_indicator"])).to_be_visible()
+        await expect(page.locator(SEL_V2["msg_error"])).to_have_count(0)
 
-        await page.evaluate("() => window.__failLatestV2Sse(2)")
-        await expect(connection_status).to_have_text("Disconnected", timeout=5000)
+        await composer.fill("check whether the prior run finished")
+        await composer.press("Enter")
+        await expect(page.locator(SEL_V2["msg_user"])).to_have_count(2, timeout=5000)
+        assert [request["content"] for request in send_requests] == [
+            "summarize 3 X/Twitter posts",
+            "check whether the prior run finished",
+        ]
+        await expect(page.get_by_text("Thread is still running.")).to_be_visible()
+        await expect(page.locator(SEL_V2["typing_indicator"])).to_be_visible()
+        await expect(page.locator(SEL_V2["msg_error"])).to_have_count(0)
 
-        await expect(page.locator(SEL_V2["typing_indicator"])).to_have_count(0, timeout=5000)
-        await expect(page.locator(SEL_V2["msg_error"]).last).to_contain_text(
-            "Connection to the server was lost. Please reconnect and try again.",
+        # The app-owned replacement opens after bounded backoff and clears the
+        # badge without requiring a tab switch.
+        await expect(connection_status).to_have_count(0, timeout=5000)
+        await page.evaluate(
+            """
+            () => window.__emitV2Sse("projection_update", {
+              state: {
+                items: [
+                  {
+                    run_status: {
+                      run_id: "run-disconnected",
+                      status: "completed"
+                    }
+                  }
+                ]
+              }
+            }, "cursor-terminal")
+            """
+        )
+        await expect(page.locator(SEL_V2["typing_indicator"])).to_have_count(
+            0,
             timeout=5000,
+        )
+
+        # A real document reload reuses the tab identity with a newer
+        # generation so it supersedes a proxy-held predecessor.
+        before_reload_url = await page.evaluate(
+            "() => window.__v2SseUrls.at(-1)"
+        )
+        await page.reload()
+        await expect(page.locator(SEL_V2["chat_composer"])).to_be_visible(
+            timeout=15000
+        )
+        await page.wait_for_function("window.__v2SseUrls.length > 0")
+        after_reload_url = await page.evaluate(
+            "() => window.__v2SseUrls.at(-1)"
+        )
+        before_query = parse_qs(urlparse(before_reload_url).query)
+        after_query = parse_qs(urlparse(after_reload_url).query)
+        assert after_query["connection_id"] == before_query["connection_id"]
+        assert int(after_query["connection_generation"][0]) > int(
+            before_query["connection_generation"][0]
         )
     finally:
         await context.close()

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -157,6 +157,10 @@ async def _install_fake_v2_event_source(page) -> None:
                 if (activeStream !== this || this.readyState === 2) return;
                 this.readyState = 1;
                 if (typeof this.onopen === "function") this.onopen(new Event("open"));
+                this.dispatchEvent(new MessageEvent("keep_alive", {
+                  data: JSON.stringify({ type: "keep_alive" }),
+                  lastEventId: crypto.randomUUID(),
+                }));
               }, 0);
             }
             close() {


### PR DESCRIPTION
## Summary

- Persist the WebChat SSE `connection_id` and monotonically increasing generation across actual document reloads, allowing a reloaded page to supersede a proxy-retained predecessor stream.
- Ignore copied `sessionStorage` on fresh top-level navigation so duplicated/opener-created tabs receive independent connection identities and cannot cancel one another.
- Make the SPA own EventSource recovery: close a failed native EventSource and open exactly one backoff-controlled replacement with a newer generation. Treat HTTP open as provisional and reset retry backoff only after a valid application frame proves the subscription is usable.
- Keep active run state provisional while SSE reconnects. The composer may ask the server for authoritative admission; `rejected_busy` or request failure preserves the existing run instead of creating a false connection-loss error.
- Add unit and browser regressions for reload continuity, duplicated tabs, malformed/unavailable storage, generation rollover, replacement ordering, recovery sends, and transient reconnect completion.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Test Card

- **Pure frontend behavior:** `pnpm test` — 102 files, 839 tests passed.
- **Frontend static checks:** `pnpm lint` passed source conventions and TypeScript typecheck.
- **Production bundle:** `pnpm build` passed; Vite reported only the existing large-chunk advisory.
- **Browser caller path:** `pytest tests/e2e/scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_transient_reconnect_preserves_run_and_allows_send -q` — passed in Chromium. This covers transient recovery, server-validated follow-up send, no false failure bubble, automatic badge recovery, and reload URL continuity.
- **Caller/crate path:** `cargo test -p ironclaw_webui --all-features` passed completely.
- **Zero-warning crate check:** `cargo clippy -p ironclaw_webui --all-targets --all-features -- -D warnings` passed.
- **Formatting and safety:** `cargo fmt --all -- --check` and `scripts/pre-commit-safety.sh` passed.
- **Integration/DB tier:** omitted because this changes browser transport lifecycle only and does not touch persistence, runtime execution, or external-service behavior.
- **Test guide note:** `docs/internal/testing-playbook.md` is absent from this release branch; test selection followed `crates/ironclaw_webui/AGENTS.md`, `CLAUDE.md`, and the Reborn testing guidance instead.

## Expected QA Result

A healthy `/events` request remains pending. If the proxy/server ends it early, the UI briefly shows `Reconnecting`, then opens one request with the same `connection_id` and a strictly larger `connection_generation`. The badge clears without a page switch, active output can resume, and no false connection-loss message is added. A follow-up send reaches the server; if the prior run is still active, `rejected_busy` leaves that run visible. A duplicated tab uses a different `connection_id`.

## Security Impact

None. The persisted value is a random, bounded connection identifier and generation counter, not an authentication credential. Existing authentication, query validation, per-caller capacity enforcement, and event redaction are unchanged.

## Reborn Trust-Boundary Checklist

N/A: this changes browser-side SSE lifecycle and local admission state only. It does not change trust-bearing types, authorization, prompt ingress, persistence, runtime dispatch, or server error vocabulary. The server continues to validate and bound the untrusted query parameters.

## Database Impact

None.

## Blast Radius

WebChat v2 EventSource lifecycle and composer admission during transport recovery. Invalid storage falls back to a fresh random identity; storage write failure retains in-memory ordering; generation saturation rotates the identity before reuse. Backoff remains bounded at 30 seconds and the existing 10-second open watchdog still replaces stalled attempts.

## Rollback Plan

Revert commits `298bc816b`, `565af67e4`, `d0eaf8bf6`, and `9e72b6fa4`. This restores browser-native retry behavior, per-document in-memory connection identity, and disconnected-only run cleanup. No migration or durable server state is involved.

## Review Follow-Through

Hosted QA should verify rapid thread switching, hard refresh, duplicated tabs, short `200` responses, automatic badge recovery, follow-up admission during reconnecting, and resumed final/model delta events without a tab switch.

---

**Review track**: B
