### PR TITLE
ci: count shell self-tests as tests in the regression gate

### DIFF
--- a/.github/workflows/regression-test-check.yml
+++ b/.github/workflows/regression-test-check.yml
@@ -198,6 +198,16 @@ jobs:
             exit 0
           fi
 
+          # Harness and CI-guard behaviour is tested by shell self-tests, not by
+          # cargo or pytest — scripts/test-*.sh and scripts/ci/test-*.sh are an
+          # established convention here (14 of them at time of writing). Without
+          # this, a fix to a guard script plus its new self-test reads to this
+          # check as "a bug fix with no tests", which is the opposite of true.
+          if grep -qE '^scripts/(ci/)?test-[^/]*\.sh$' <<< "$CHANGED_FILES"; then
+            echo "Shell self-test changes found under scripts/."
+            exit 0
+          fi
+
           # --- 5. No tests found ---
           if [ "$IS_FIX" = true ]; then
             echo "::warning::This PR looks like a bug fix but contains no test changes."


### PR DESCRIPTION
## Summary

The regression-test gate recognises Rust `#[cfg(test)]` edits, anything under `tests/`, Python `test_*.py`, and WebUI `*.test.ts`. It does not recognise shell self-tests.

So #6703 — a fix to a guard script that shipped **with** a new self-test case proving the guard fires — was reported as *"This PR looks like a bug fix but contains no test changes."* That is the opposite of true, and it is the only check that failed on it.

`scripts/test-*.sh` and `scripts/ci/test-*.sh` are an established convention here — **14 of them** at time of writing — and for the CI guard scripts they are the only executable coverage that exists. A gate that cannot see them will keep mislabelling exactly the PRs that add them.

## The change

Ten lines: one more recognised pattern, anchored to the `test-` prefix so helpers like `scripts/build-test-tools.sh` do not count as tests.

```bash
if grep -qE '^scripts/(ci/)?test-[^/]*\.sh$' <<< "$CHANGED_FILES"; then
  echo "Shell self-test changes found under scripts/."
  exit 0
fi
```

This widens what the gate accepts, which deserves saying plainly rather than burying: the justification is that these files are tests by every meaning the gate cares about — not that the gate was inconvenient at the time.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Validation

- [x] Pattern matches `scripts/test-mutation-audit.sh` and `scripts/ci/test-classify-test-scope.sh`
- [x] Pattern does **not** match `scripts/build-test-tools.sh` (verified both directions against the real `grep -qE` used by the workflow)
- [ ] `cargo` gates — not applicable, no Rust changed

## Test Strategy

**User behaviour:** none changed. CI workflow only.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

The change is a single recognised-path pattern in a gate; its own correctness is the two-direction match check above.

## Reviewer notes

- The prefix anchor is the load-bearing part. `test-*` is a claim that the file *is* a test; `*test*` would also swallow build helpers and fixtures.
- Context: #6703 merged with this check red. Worth deciding separately whether that gate should be blocking — this PR only makes its verdict correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
