### PR TITLE
test(e2e): add credential-lifecycle fault profiles

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -213,6 +213,7 @@ jobs:
           tests/e2e/scenarios/test_provider_capability_inventory.py
           tests/e2e/scenarios/test_journey_coverage.py
           tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
+          tests/e2e/scenarios/test_provider_fault_proxy.py
           tests/e2e/scenarios/test_reborn_qa_trace_replay.py
           tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
           -v

--- a/tests/e2e/provider_fault_cases.py
+++ b/tests/e2e/provider_fault_cases.py
@@ -104,8 +104,8 @@ PROVIDER_FAULT_CASES = (
     # perform the write the scope existed to prevent.
     #
     # This is the only credential-lifecycle profile that belongs in this
-    # matrix. `missing_credential` and `expired_credential` return 401, which
-    # the GitHub extension classifies as `auth_required`
+    # matrix. `expired_credential` returns 401, which the GitHub extension
+    # classifies as `auth_required`
     # (assets/github/wasm-src/src/lib.rs), and the host turns that into a
     # re-auth gate and a blocked turn rather than a failed capability. They
     # need a gate-shaped journey, not this test's `status == "failed"` shape —

--- a/tests/e2e/provider_fault_cases.py
+++ b/tests/e2e/provider_fault_cases.py
@@ -99,6 +99,27 @@ PROVIDER_FAULT_CASES = (
         expected_preview_error="github_api_error_status_503",
         expected_outcome="unchanged",
     ),
+    # Authenticated but not authorised for this operation. The assertion that
+    # matters is `expected_outcome="unchanged"`: a scope rejection must not
+    # perform the write the scope existed to prevent.
+    #
+    # This is the only credential-lifecycle profile that belongs in this
+    # matrix. `missing_credential` and `expired_credential` return 401, which
+    # the GitHub extension classifies as `auth_required`
+    # (assets/github/wasm-src/src/lib.rs), and the host turns that into a
+    # re-auth gate and a blocked turn rather than a failed capability. They
+    # need a gate-shaped journey, not this test's `status == "failed"` shape —
+    # see the PR description.
+    ProviderFaultCase(
+        case_id="idempotent_write_wrong_scope",
+        operation=_operation("github_update_issue"),
+        profile="wrong_scope",
+        method="PATCH",
+        path="/repos/nearai/ironclaw/issues/1",
+        expected_tool_result="github_api_error_status_403",
+        expected_preview_error="github_api_error_status_403",
+        expected_outcome="unchanged",
+    ),
     ProviderFaultCase(
         case_id="non_idempotent_write_lost_acknowledgement",
         operation=_operation("github_create_issue"),

--- a/tests/e2e/provider_fault_proxy.py
+++ b/tests/e2e/provider_fault_proxy.py
@@ -107,19 +107,10 @@ PROVIDER_FAULT_PROFILES = {
         body=_json_error(503, "Service Unavailable"),
         headers={"Retry-After": "1"},
     ),
-    # Credential-lifecycle faults. A bare http_401 says only "rejected"; a real
-    # provider distinguishes *why* in the RFC 6750 challenge, and that is the
-    # only signal a client can use to tell "re-authenticate the user" from
-    # "refresh the token" from "this token will never be allowed to do this".
-    # Keeping them as named profiles means a journey asks for the condition it
-    # means rather than hand-rolling a status code per test.
-    "missing_credential": ProviderFaultProfile(
-        name="missing_credential",
-        action="respond",
-        status=401,
-        body=_json_error(401, "Requires authentication"),
-        headers={"WWW-Authenticate": 'Bearer realm="provider"'},
-    ),
+    # Provider-originated credential faults. A bare http_401 says only
+    # "rejected"; the RFC 6750 challenge distinguishes an expired token from
+    # one that lacks the required scope. Missing credentials are intentionally
+    # absent: host auth preflight blocks them before provider dispatch.
     "expired_credential": ProviderFaultProfile(
         name="expired_credential",
         action="respond",

--- a/tests/e2e/provider_fault_proxy.py
+++ b/tests/e2e/provider_fault_proxy.py
@@ -107,6 +107,47 @@ PROVIDER_FAULT_PROFILES = {
         body=_json_error(503, "Service Unavailable"),
         headers={"Retry-After": "1"},
     ),
+    # Credential-lifecycle faults. A bare http_401 says only "rejected"; a real
+    # provider distinguishes *why* in the RFC 6750 challenge, and that is the
+    # only signal a client can use to tell "re-authenticate the user" from
+    # "refresh the token" from "this token will never be allowed to do this".
+    # Keeping them as named profiles means a journey asks for the condition it
+    # means rather than hand-rolling a status code per test.
+    "missing_credential": ProviderFaultProfile(
+        name="missing_credential",
+        action="respond",
+        status=401,
+        body=_json_error(401, "Requires authentication"),
+        headers={"WWW-Authenticate": 'Bearer realm="provider"'},
+    ),
+    "expired_credential": ProviderFaultProfile(
+        name="expired_credential",
+        action="respond",
+        status=401,
+        body=_json_error(401, "Bad credentials"),
+        headers={
+            "WWW-Authenticate": (
+                'Bearer realm="provider", error="invalid_token", '
+                'error_description="The access token expired"'
+            )
+        },
+    ),
+    # Authenticated, but not for this operation. The scope headers mirror what
+    # GitHub returns, so a client can see both what it has and what it needed.
+    "wrong_scope": ProviderFaultProfile(
+        name="wrong_scope",
+        action="respond",
+        status=403,
+        body=_json_error(403, "Resource not accessible by integration"),
+        headers={
+            "WWW-Authenticate": (
+                'Bearer realm="provider", error="insufficient_scope", '
+                'scope="repo"'
+            ),
+            "X-Accepted-OAuth-Scopes": "repo",
+            "X-OAuth-Scopes": "read:user",
+        },
+    ),
     "timeout": ProviderFaultProfile(
         name="timeout",
         action="delay_before_disconnect",

--- a/tests/e2e/scenarios/test_provider_fault_proxy.py
+++ b/tests/e2e/scenarios/test_provider_fault_proxy.py
@@ -14,6 +14,12 @@ from provider_fault_proxy import (
     ProviderFaultProxy,
 )
 
+_RESPONSE_PROFILE_NAMES = [
+    name
+    for name, profile in PROVIDER_FAULT_PROFILES.items()
+    if profile.action == "respond"
+]
+
 
 async def _start_upstream() -> tuple[str, list[dict], web.AppRunner]:
     requests = []
@@ -116,21 +122,7 @@ async def test_provider_fault_proxy_preserves_compressed_responses(fault_proxy):
 
 @pytest.mark.parametrize(
     "profile_name",
-    (
-        "http_400",
-        "http_401",
-        "http_403",
-        "http_404",
-        "http_409",
-        "http_429",
-        "http_500",
-        "http_503",
-        "malformed_json",
-        "missing_field",
-        "missing_credential",
-        "expired_credential",
-        "wrong_scope",
-    ),
+    _RESPONSE_PROFILE_NAMES,
 )
 async def test_response_fault_profiles_do_not_reach_provider(
     fault_proxy,
@@ -149,47 +141,12 @@ async def test_response_fault_profiles_do_not_reach_provider(
     assert proxy.state["requests"][0]["forwarded"] is False
 
 
-"""Profiles whose behaviour is pinned by a dedicated test below.
-
-Response profiles are covered by the parametrized case above; these four are
-not response-shaped and each has its own test.
-"""
-_NON_RESPONSE_PROFILES_UNDER_TEST = frozenset(
-    {
-        "timeout",
-        "connection_reset",
-        "truncated_response",
-        "lost_acknowledgement",
-    }
-)
-
-
-def test_every_published_profile_has_a_self_test():
-    """A profile nobody exercises is a profile nobody can trust.
-
-    The catalogue is the reusable vocabulary journeys pick from, so a profile
-    added without coverage would ship as an available option whose behaviour
-    has never been observed. Fails the moment one is added here without a test.
-    """
-    covered = (
-        set(
-            test_response_fault_profiles_do_not_reach_provider.pytestmark[0].args[1]
-        )
-        | _NON_RESPONSE_PROFILES_UNDER_TEST
-    )
-    assert covered == set(PROVIDER_FAULT_PROFILES), {
-        "untested": sorted(set(PROVIDER_FAULT_PROFILES) - covered),
-        "stale": sorted(covered - set(PROVIDER_FAULT_PROFILES)),
-    }
-
-
 @pytest.mark.parametrize(
     ("profile_name", "status", "challenge_contains"),
-    (
-        ("missing_credential", 401, 'Bearer realm='),
+    [
         ("expired_credential", 401, 'error="invalid_token"'),
         ("wrong_scope", 403, 'error="insufficient_scope"'),
-    ),
+    ],
 )
 def test_credential_lifecycle_profiles_state_their_condition(
     profile_name,
@@ -199,12 +156,12 @@ def test_credential_lifecycle_profiles_state_their_condition(
     """Each credential-lifecycle fault names its condition in the challenge.
 
     The point of these profiles is that they are *not* interchangeable with a
-    bare `http_401`/`http_403`. A provider distinguishes "you sent nothing",
-    "your token expired", and "your token lacks the scope" in the RFC 6750
-    `WWW-Authenticate` challenge, and that is the only signal a client can key
+    bare `http_401`/`http_403`. A provider distinguishes "your token expired"
+    from "your token lacks the scope" in the RFC 6750 `WWW-Authenticate`
+    challenge, and that is the only signal a client can key
     credential-lifecycle handling on. A profile that dropped the challenge
-    would still be a 401 and would still look like a passing fault case, so
-    assert the discriminator itself.
+    would still have the same status and would still look like a passing fault
+    case, so assert the discriminator itself.
     """
     profile = PROVIDER_FAULT_PROFILES[profile_name]
     challenge = profile.headers.get("WWW-Authenticate", "")
@@ -220,18 +177,17 @@ def test_credential_lifecycle_profiles_are_not_aliases_of_generic_faults():
 
     challenges = {
         name: PROVIDER_FAULT_PROFILES[name].headers["WWW-Authenticate"]
-        for name in ("missing_credential", "expired_credential", "wrong_scope")
+        for name in ("expired_credential", "wrong_scope")
     }
-    assert len(set(challenges.values())) == 3, challenges
+    assert len(set(challenges.values())) == 2, challenges
 
 
 async def test_credential_lifecycle_faults_never_reach_the_provider(fault_proxy):
     """A rejected credential must not let the request through.
 
-    Weaker than it sounds and worth pinning: `wrong_scope` is the one of the
-    three that a proxy could plausibly forward — the caller *is* authenticated,
-    just not for this operation — and forwarding it would perform the very
-    side effect the scope was meant to prevent.
+    The caller is authenticated but not for this operation, so forwarding the
+    rejected request would perform the very side effect the scope was meant to
+    prevent.
     """
     proxy, upstream_requests = fault_proxy
     proxy.arm(
@@ -250,7 +206,9 @@ async def test_credential_lifecycle_faults_never_reach_the_provider(fault_proxy)
     assert response.status_code == 403
     assert 'error="insufficient_scope"' in response.headers["WWW-Authenticate"]
     assert upstream_requests == []
-    request = proxy.state["requests"][0]
+    requests = proxy.state["requests"]
+    assert len(requests) == 1
+    request = requests[0]
     assert request["fault"] == "wrong_scope"
     assert request["forwarded"] is False
     assert "scoped-too-narrowly" not in str(proxy.state)
@@ -361,3 +319,29 @@ async def test_counted_fifo_rules_fire_then_restore_transparency(fault_proxy):
     ]
     assert proxy.state["rules"] == []
     assert len(upstream_requests) == 1
+
+
+# Response profiles are exercised automatically by the parametrized test
+# above. Non-response profiles have distinct behavior and therefore point to
+# the dedicated tests pytest collects for each one.
+_NON_RESPONSE_PROFILE_TESTS = {
+    "timeout": test_timeout_profile_never_forwards_after_caller_times_out,
+    "connection_reset": test_connection_reset_before_forward_never_reaches_provider,
+    "truncated_response": test_truncated_response_aborts_before_declared_body_length,
+    "lost_acknowledgement": test_lost_acknowledgement_commits_once_then_disconnects,
+}
+
+
+def test_every_published_profile_has_a_self_test():
+    """Every published profile is exercised by a collected test."""
+    dedicated_tests = tuple(_NON_RESPONSE_PROFILE_TESTS.values())
+    assert all(
+        test.__module__ == __name__ and test.__name__.startswith("test_")
+        for test in dedicated_tests
+    ), dedicated_tests
+
+    covered = set(_RESPONSE_PROFILE_NAMES) | set(_NON_RESPONSE_PROFILE_TESTS)
+    assert covered == set(PROVIDER_FAULT_PROFILES), {
+        "untested": sorted(set(PROVIDER_FAULT_PROFILES) - covered),
+        "stale": sorted(covered - set(PROVIDER_FAULT_PROFILES)),
+    }

--- a/tests/e2e/scenarios/test_provider_fault_proxy.py
+++ b/tests/e2e/scenarios/test_provider_fault_proxy.py
@@ -127,6 +127,9 @@ async def test_provider_fault_proxy_preserves_compressed_responses(fault_proxy):
         "http_503",
         "malformed_json",
         "missing_field",
+        "missing_credential",
+        "expired_credential",
+        "wrong_scope",
     ),
 )
 async def test_response_fault_profiles_do_not_reach_provider(
@@ -144,6 +147,113 @@ async def test_response_fault_profiles_do_not_reach_provider(
     assert response.text == profile.body
     assert upstream_requests == []
     assert proxy.state["requests"][0]["forwarded"] is False
+
+
+"""Profiles whose behaviour is pinned by a dedicated test below.
+
+Response profiles are covered by the parametrized case above; these four are
+not response-shaped and each has its own test.
+"""
+_NON_RESPONSE_PROFILES_UNDER_TEST = frozenset(
+    {
+        "timeout",
+        "connection_reset",
+        "truncated_response",
+        "lost_acknowledgement",
+    }
+)
+
+
+def test_every_published_profile_has_a_self_test():
+    """A profile nobody exercises is a profile nobody can trust.
+
+    The catalogue is the reusable vocabulary journeys pick from, so a profile
+    added without coverage would ship as an available option whose behaviour
+    has never been observed. Fails the moment one is added here without a test.
+    """
+    covered = (
+        set(
+            test_response_fault_profiles_do_not_reach_provider.pytestmark[0].args[1]
+        )
+        | _NON_RESPONSE_PROFILES_UNDER_TEST
+    )
+    assert covered == set(PROVIDER_FAULT_PROFILES), {
+        "untested": sorted(set(PROVIDER_FAULT_PROFILES) - covered),
+        "stale": sorted(covered - set(PROVIDER_FAULT_PROFILES)),
+    }
+
+
+@pytest.mark.parametrize(
+    ("profile_name", "status", "challenge_contains"),
+    (
+        ("missing_credential", 401, 'Bearer realm='),
+        ("expired_credential", 401, 'error="invalid_token"'),
+        ("wrong_scope", 403, 'error="insufficient_scope"'),
+    ),
+)
+def test_credential_lifecycle_profiles_state_their_condition(
+    profile_name,
+    status,
+    challenge_contains,
+):
+    """Each credential-lifecycle fault names its condition in the challenge.
+
+    The point of these profiles is that they are *not* interchangeable with a
+    bare `http_401`/`http_403`. A provider distinguishes "you sent nothing",
+    "your token expired", and "your token lacks the scope" in the RFC 6750
+    `WWW-Authenticate` challenge, and that is the only signal a client can key
+    credential-lifecycle handling on. A profile that dropped the challenge
+    would still be a 401 and would still look like a passing fault case, so
+    assert the discriminator itself.
+    """
+    profile = PROVIDER_FAULT_PROFILES[profile_name]
+    challenge = profile.headers.get("WWW-Authenticate", "")
+
+    assert profile.status == status
+    assert challenge_contains in challenge, challenge
+
+
+def test_credential_lifecycle_profiles_are_not_aliases_of_generic_faults():
+    """The generic status profiles carry no challenge, so the pair differ."""
+    for generic_name in ("http_401", "http_403"):
+        assert "WWW-Authenticate" not in PROVIDER_FAULT_PROFILES[generic_name].headers
+
+    challenges = {
+        name: PROVIDER_FAULT_PROFILES[name].headers["WWW-Authenticate"]
+        for name in ("missing_credential", "expired_credential", "wrong_scope")
+    }
+    assert len(set(challenges.values())) == 3, challenges
+
+
+async def test_credential_lifecycle_faults_never_reach_the_provider(fault_proxy):
+    """A rejected credential must not let the request through.
+
+    Weaker than it sounds and worth pinning: `wrong_scope` is the one of the
+    three that a proxy could plausibly forward — the caller *is* authenticated,
+    just not for this operation — and forwarding it would perform the very
+    side effect the scope was meant to prevent.
+    """
+    proxy, upstream_requests = fault_proxy
+    proxy.arm(
+        PROVIDER_FAULT_PROFILES["wrong_scope"],
+        method="POST",
+        path="/objects",
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{proxy.url}/objects",
+            headers={"Authorization": "Bearer scoped-too-narrowly"},
+            json={"name": "never-created"},
+        )
+
+    assert response.status_code == 403
+    assert 'error="insufficient_scope"' in response.headers["WWW-Authenticate"]
+    assert upstream_requests == []
+    request = proxy.state["requests"][0]
+    assert request["fault"] == "wrong_scope"
+    assert request["forwarded"] is False
+    assert "scoped-too-narrowly" not in str(proxy.state)
 
 
 async def test_timeout_profile_never_forwards_after_caller_times_out(fault_proxy):


### PR DESCRIPTION
## Summary

- Add provider-originated `expired_credential` and `wrong_scope` fault profiles with actionable RFC 6750 challenges.
- Keep missing credentials at the existing host authentication preflight seam, where they are rejected before provider dispatch.
- Add the wrong-scope idempotent-write full-path case, data-driven profile self-tests, and explicit CI selection for the proxy self-test module.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust source changed; the targeted Rust binary build passed.
- [x] `cargo build` — `cargo build -p ironclaw --bin ironclaw`
- [x] Relevant tests pass:
  - `uv run --python 3.11 --project . pytest scenarios/test_provider_fault_proxy.py -q` — 24 passed
  - `uv run --python 3.11 --project . pytest 'scenarios/test_reborn_qa_trace_full_path.py::test_provider_fault_profile_preserves_safe_operation_outcomes[idempotent_write_wrong_scope]' -v --timeout=120` — 1 passed
  - `uvx --from ruff==0.15.21 ruff check --select PT007 scenarios/test_provider_fault_proxy.py` — passed
  - `uvx --from ruff==0.15.21 ruff check provider_fault_cases.py provider_fault_proxy.py scenarios/test_provider_fault_proxy.py` — passed
- [ ] `cargo test --features integration` — Not applicable: no database-backed behavior or production integration contract changed.
- [ ] Manual testing — Not applicable: this is hermetic provider-fault test infrastructure with no user-facing surface.
- [x] Multi-agent review and review-comment audit were run before requesting re-review.

The first full-path invocation reached the 120-second pytest timeout while its fixture was cold-building the binary. After `cargo build -p ironclaw --bin ironclaw`, the exact node passed in 24.17 seconds.

## Test Strategy

User behavior: When a provider rejects an expired or under-scoped credential, the test harness models the provider response accurately; an insufficient-scope response must not perform the protected write.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable: no production-owned local logic or public crate contract changed.
- Reborn integration: Not applicable: the existing authentication and capability execution paths are unchanged; this PR extends the existing full-path E2E matrix instead.
- Recorded fixture: Not applicable: model selection and tool arguments are unchanged.
- Browser E2E: Not applicable: no WebUI behavior changed.
- Backend or runtime: Updated `test_provider_fault_proxy.py` to exercise every published response profile automatically, map non-response profiles to collected dedicated tests, assert RFC 6750 discriminators, and prove wrong-scope requests never reach the provider. Added the proxy module to the Reborn E2E provider-contract CI invocation. The exact `idempotent_write_wrong_scope` full-path case passed.
- Live canary: Not applicable: the fault proxy is deliberately hermetic and does not depend on a live provider or model.

What the tests prove: Every published proxy profile has an executable self-test; credential faults remain distinguishable from generic 401/403 responses; an insufficient-scope rejection makes exactly one proxy attempt, never forwards upstream, and preserves the protected operation unchanged.

Commands run:

```text
uv run --python 3.11 --project . pytest scenarios/test_provider_fault_proxy.py -q
uvx --from ruff==0.15.21 ruff check --select PT007 scenarios/test_provider_fault_proxy.py
uvx --from ruff==0.15.21 ruff check provider_fault_cases.py provider_fault_proxy.py scenarios/test_provider_fault_proxy.py
uv run --python 3.11 --project . pytest 'scenarios/test_reborn_qa_trace_full_path.py::test_provider_fault_profile_preserves_safe_operation_outcomes[idempotent_write_wrong_scope]' -v --timeout=120
cargo fmt --all -- --check
cargo build -p ironclaw --bin ironclaw
bash scripts/pre-commit-safety.sh
git diff --check
```

The workflow YAML also parsed successfully with Ruby's YAML parser. `actionlint` was not available because Go is not installed in the local environment.

## Security Impact

No production security policy, permissions, network calls, secrets, file access, tool execution, or sandbox behavior changes. The test-only change strengthens coverage for expired and insufficient-scope provider responses. Missing credentials remain covered by the existing pre-dispatch host authentication boundary rather than an impossible provider-proxy profile.

## Reborn Trust-Boundary Checklist

N/A: test and CI selection changes only; no Reborn trust-bearing type, ingress, status, policy, runtime, serialization, queue, or sandbox contract changed.

## Database Impact

None.

## Blast Radius

Limited to the E2E provider-fault catalog, its self-tests/full-path case, and the Reborn E2E provider-contract CI job. A regression could make that CI job fail or add a small amount of test runtime; production binaries and runtime behavior are unchanged.

## Rollback Plan

Revert the PR commits. That removes the two credential fault profiles, wrong-scope full-path case, and CI self-test selection. There is no schema, persisted data, deployment, or compatibility rollback.

## Review Follow-Through

Addressed all seven accessible inline review threads: removed the unreachable missing-credential proxy profile, replaced the discarded string literal, made profile coverage data-driven without introspecting `pytestmark`, fixed PT007 parameter containers, guarded request indexing, added direct CI selection, and ran the requested exact full-path case plus applicable cargo gates. Threads are left unresolved for reviewer confirmation.

---

**Review track**: C (CI and security-focused test infrastructure)
