### PR TITLE
fix(webui): preserve route state across SPA navigation

### DIFF
--- a/crates/ironclaw_webui/frontend/src/app/route-load-boundary.test.tsx
+++ b/crates/ironclaw_webui/frontend/src/app/route-load-boundary.test.tsx
@@ -5,10 +5,12 @@ import { test } from "vitest";
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter, useLocation, useNavigate } from "react-router";
 import "../i18n/en";
 import { I18nProvider } from "../lib/i18n";
 import {
   RouteErrorBoundary,
+  RouteLoadBoundary,
   RouteLoadError,
   RouteLoading,
 } from "./route-load-boundary";
@@ -68,6 +70,117 @@ test("route error boundary switches to its sanitized fallback", () => {
     assert.equal(reload.textContent, "Reload page");
     act(() => reload.click());
     assert.equal(reloads, 1);
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+    console.error = originalConsoleError;
+  }
+});
+
+test("healthy route navigation preserves state below the load boundary", () => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  let mounts = 0;
+  let unmounts = 0;
+
+  function StatefulRoute() {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const [count, setCount] = React.useState(0);
+
+    React.useEffect(() => {
+      mounts += 1;
+      return () => {
+        unmounts += 1;
+      };
+    }, []);
+
+    return (
+      <>
+        <span data-testid="route-state">{location.pathname}:{count}</span>
+        <button type="button" onClick={() => setCount((current) => current + 1)}>
+          Increment
+        </button>
+        <button type="button" onClick={() => navigate("/second")}>
+          Navigate
+        </button>
+      </>
+    );
+  }
+
+  try {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={["/first"]}>
+          <I18nProvider>
+            <RouteLoadBoundary>
+              <StatefulRoute />
+            </RouteLoadBoundary>
+          </I18nProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    const buttons = container.querySelectorAll("button");
+    act(() => buttons[0]?.click());
+    assert.equal(container.querySelector('[data-testid="route-state"]')?.textContent, "/first:1");
+
+    act(() => buttons[1]?.click());
+    assert.equal(container.querySelector('[data-testid="route-state"]')?.textContent, "/second:1");
+    assert.equal(mounts, 1);
+    assert.equal(unmounts, 0);
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+test("route navigation clears a prior load failure without remounting healthy routes", () => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const originalConsoleError = console.error;
+  console.error = () => {};
+
+  function RouteContent() {
+    const location = useLocation();
+    if (location.pathname === "/broken") {
+      throw new Error("private chunk failure details");
+    }
+    return <div data-testid="healthy-route">Healthy route</div>;
+  }
+
+  function Navigation() {
+    const navigate = useNavigate();
+    return (
+      <button type="button" onClick={() => navigate("/healthy")}>
+        Navigate
+      </button>
+    );
+  }
+
+  try {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={["/broken"]}>
+          <I18nProvider>
+            <Navigation />
+            <RouteLoadBoundary>
+              <RouteContent />
+            </RouteLoadBoundary>
+          </I18nProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    assert.ok(container.querySelector('[role="alert"]'));
+    act(() => container.querySelector("button")?.click());
+    assert.equal(
+      container.querySelector('[data-testid="healthy-route"]')?.textContent,
+      "Healthy route",
+    );
+    assert.equal(container.querySelector('[role="alert"]'), null);
   } finally {
     act(() => root.unmount());
     container.remove();

--- a/crates/ironclaw_webui/frontend/src/app/route-load-boundary.tsx
+++ b/crates/ironclaw_webui/frontend/src/app/route-load-boundary.tsx
@@ -47,19 +47,34 @@ export function RouteLoadError({ onRetry }: RouteLoadErrorProps) {
 interface RouteErrorBoundaryProps {
   children: React.ReactNode;
   fallback: React.ReactNode;
+  resetKey?: string;
 }
 
 interface RouteErrorBoundaryState {
   failed: boolean;
+  resetKey: string | undefined;
 }
 
 export class RouteErrorBoundary extends React.Component<
   RouteErrorBoundaryProps,
   RouteErrorBoundaryState
 > {
-  state: RouteErrorBoundaryState = { failed: false };
+  state: RouteErrorBoundaryState = {
+    failed: false,
+    resetKey: this.props.resetKey,
+  };
 
-  static getDerivedStateFromError(): RouteErrorBoundaryState {
+  static getDerivedStateFromProps(
+    props: RouteErrorBoundaryProps,
+    state: RouteErrorBoundaryState,
+  ): RouteErrorBoundaryState | null {
+    if (props.resetKey !== state.resetKey) {
+      return { failed: false, resetKey: props.resetKey };
+    }
+    return null;
+  }
+
+  static getDerivedStateFromError(): Pick<RouteErrorBoundaryState, "failed"> {
     return { failed: true };
   }
 
@@ -81,7 +96,9 @@ export function RouteLoadBoundary({ children }: RouteLoadBoundaryProps) {
 
   return (
     <RouteErrorBoundary
-      key={location.pathname}
+      // Reset only the failed state. A React key here would also remount healthy
+      // route descendants and discard layout, form, and preference state.
+      resetKey={location.pathname}
       fallback={<RouteLoadError onRetry={() => window.location.reload()} />}
     >
       <React.Suspense fallback={<RouteLoading />}>{children}</React.Suspense>

--- a/crates/ironclaw_webui/frontend/src/design-system/theme.test.tsx
+++ b/crates/ironclaw_webui/frontend/src/design-system/theme.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useInterfaceTheme } from "./theme";
+
+test("theme remounts from the live selection instead of the bootstrap snapshot", () => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const originalInitialTheme = window.__IRONCLAW_INITIAL_THEME__;
+
+  function ThemeHarness() {
+    const { theme, setTheme } = useInterfaceTheme();
+    return (
+      <button type="button" onClick={() => setTheme("dark")}>
+        {theme}
+      </button>
+    );
+  }
+
+  try {
+    window.__IRONCLAW_INITIAL_THEME__ = "light";
+    document.documentElement.dataset.theme = "light";
+    window.localStorage.setItem("ironclaw:v2-theme", "light");
+
+    const firstRoot = createRoot(container);
+    act(() => firstRoot.render(<ThemeHarness />));
+    act(() => container.querySelector("button")?.click());
+    assert.equal(container.textContent, "dark");
+    assert.equal(document.documentElement.dataset.theme, "dark");
+    assert.equal(window.localStorage.getItem("ironclaw:v2-theme"), "dark");
+    act(() => firstRoot.unmount());
+
+    const secondRoot = createRoot(container);
+    act(() => secondRoot.render(<ThemeHarness />));
+    assert.equal(container.textContent, "dark");
+    act(() => secondRoot.unmount());
+  } finally {
+    if (originalInitialTheme === undefined) {
+      delete window.__IRONCLAW_INITIAL_THEME__;
+    } else {
+      window.__IRONCLAW_INITIAL_THEME__ = originalInitialTheme;
+    }
+    delete document.documentElement.dataset.theme;
+    window.localStorage.removeItem("ironclaw:v2-theme");
+    container.remove();
+  }
+});

--- a/crates/ironclaw_webui/frontend/src/design-system/theme.ts
+++ b/crates/ironclaw_webui/frontend/src/design-system/theme.ts
@@ -6,13 +6,15 @@ export type InterfaceTheme = "light" | "dark";
 
 function getInitialTheme(): InterfaceTheme {
   try {
-    if (window.__IRONCLAW_INITIAL_THEME__ === "light" || window.__IRONCLAW_INITIAL_THEME__ === "dark") {
-      return window.__IRONCLAW_INITIAL_THEME__;
-    }
+    // The bootstrap snapshot prevents first-paint flicker, but it becomes stale
+    // after an in-app theme change. Prefer the live/persisted selection on remount.
     const current = document.documentElement.dataset.theme;
     if (current === "light" || current === "dark") return current;
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
     if (stored === "light" || stored === "dark") return stored;
+    if (window.__IRONCLAW_INITIAL_THEME__ === "light" || window.__IRONCLAW_INITIAL_THEME__ === "dark") {
+      return window.__IRONCLAW_INITIAL_THEME__;
+    }
     return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
   } catch (_) {
     return "light";

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -292,6 +292,7 @@ SEL_V2 = {
     "sign_out_button": "button[title='Sign out']",
     "nav_chat": "a[href='/chat']",
     "nav_settings_inference": "a[href='/settings/inference']",
+    "nav_settings_appearance": "a[href='/settings/appearance']",
     "settings_search_input": "input[type='search'][placeholder='Search settings...']",
     "appearance_theme_light": "[data-testid='appearance-theme-light']",
     "appearance_theme_dark": "[data-testid='appearance-theme-dark']",

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -532,7 +532,7 @@ async def test_reborn_v2_light_theme_semantic_colors_have_readable_contrast(
 
 
 async def test_reborn_v2_appearance_theme_selection_persists(reborn_v2_page):
-    """Appearance controls update the live theme and preserve it across reloads."""
+    """Appearance controls preserve the live theme across SPA navigation and reloads."""
     origin = await reborn_v2_page.evaluate("location.origin")
     await reborn_v2_page.goto(
         f"{origin}/v2/settings/appearance?token={REBORN_V2_AUTH_TOKEN}"
@@ -550,6 +550,28 @@ async def test_reborn_v2_appearance_theme_selection_persists(reborn_v2_page):
     )
     await reborn_v2_page.wait_for_function(
         'localStorage.getItem("ironclaw:v2-theme") === "dark"'
+    )
+
+    await reborn_v2_page.locator(SEL_V2["nav_chat"]).first.click()
+    await expect(
+        reborn_v2_page.locator(SEL_V2["chat_composer"])
+    ).to_be_visible(timeout=15000)
+    await expect(reborn_v2_page.locator("html")).to_have_attribute(
+        "data-theme", "dark"
+    )
+    await reborn_v2_page.wait_for_function(
+        'localStorage.getItem("ironclaw:v2-theme") === "dark"'
+    )
+
+    await reborn_v2_page.locator(SEL_V2["nav_settings_inference"]).first.click()
+    await expect(
+        reborn_v2_page.locator(SEL_V2["settings_search_input"])
+    ).to_be_visible(timeout=15000)
+    await reborn_v2_page.locator(SEL_V2["nav_settings_appearance"]).first.click()
+    dark_option = reborn_v2_page.locator(SEL_V2["appearance_theme_dark"])
+    await expect(dark_option).to_be_checked(timeout=15000)
+    await expect(reborn_v2_page.locator("html")).to_have_attribute(
+        "data-theme", "dark"
     )
 
     await reborn_v2_page.reload()

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -567,11 +567,17 @@ async def test_reborn_v2_appearance_theme_selection_persists(reborn_v2_page):
     await expect(
         reborn_v2_page.locator(SEL_V2["settings_search_input"])
     ).to_be_visible(timeout=15000)
+    await reborn_v2_page.wait_for_function(
+        'localStorage.getItem("ironclaw:v2-theme") === "dark"'
+    )
     await reborn_v2_page.locator(SEL_V2["nav_settings_appearance"]).first.click()
     dark_option = reborn_v2_page.locator(SEL_V2["appearance_theme_dark"])
     await expect(dark_option).to_be_checked(timeout=15000)
     await expect(reborn_v2_page.locator("html")).to_have_attribute(
         "data-theme", "dark"
+    )
+    await reborn_v2_page.wait_for_function(
+        'localStorage.getItem("ironclaw:v2-theme") === "dark"'
     )
 
     await reborn_v2_page.reload()


### PR DESCRIPTION
## Summary

- Preserves WebUI layout and route state across SPA navigation by resetting only the route error boundary's failed state instead of remounting healthy descendants with a pathname React key.
- Makes theme initialization prefer the current DOM and persisted localStorage selection over the stale application bootstrap snapshot.
- Adds unit coverage for route-state preservation, error recovery, and theme remounts, plus browser E2E coverage for theme persistence across SPA navigation and reloads.

<img width="956" height="808" alt="iShot_2026-07-27_21 12 55" src="https://github.com/user-attachments/assets/7bfae16e-5a45-4bf0-aa01-39163296320a" />


## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #6711

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust source changes
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust source changes
- [x] Relevant tests pass:
  - `TZ=UTC corepack pnpm test` — 885 passed
  - `corepack pnpm run lint:conventions`
  - `corepack pnpm run typecheck`
  - `corepack pnpm exec vite build`
  - `corepack pnpm run check:bundle`
  - `cargo test -p ironclaw_webui static_assets --lib` — 45 passed
  - `.venv/bin/python -m pytest scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_lazy_routes_preserve_direct_navigation scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_chunk_failure_can_reload_and_recover scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_appearance_theme_selection_persists -v --timeout=120` — 3 passed
- [ ] `cargo test --features integration` — Not applicable: no database or backend behavior changed
- [x] Manual/browser testing: verified theme persistence across Settings → Chat → Settings SPA navigation and full reload
- [x] Coding-agent self-review completed

## Test Strategy

User behavior:

A theme selected under Settings → Appearance remains active and persisted while navigating between pages and after a full reload. Healthy route and layout state is no longer discarded solely because the pathname changed.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: route boundary state preservation, route-error recovery, and live theme selection across remounts
- Reborn integration: Not applicable: no turn, runner, or product workflow behavior changed
- Recorded fixture: Not applicable: no model behavior changed
- Browser E2E: appearance theme persists across SPA navigation and reloads
- Backend or runtime: Not applicable: no backend or runtime behavior changed
- Live canary: Not applicable: deterministic browser coverage is sufficient

What the tests prove:

- Healthy descendants are not remounted when the pathname changes.
- A failed lazy route can still recover when navigation changes the reset key.
- A theme hook remount reads the live selection instead of the stale bootstrap snapshot.
- The selected theme and `ironclaw:v2-theme` localStorage value survive real sidebar navigation.
- Existing lazy chunk loading and reload recovery continue to work.

Commands run:

- `TZ=UTC corepack pnpm test`
- `corepack pnpm run lint:conventions`
- `corepack pnpm run typecheck`
- `corepack pnpm exec vite build`
- `corepack pnpm run check:bundle`
- `cargo test -p ironclaw_webui static_assets --lib`
- Targeted Playwright E2E command listed above
- `git diff --check origin/main...HEAD`

## Security Impact

None. This changes browser-local component and theme preference behavior only. It does not affect authentication, permissions, secrets, networking, file access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

N/A: browser-local presentation state only; no Reborn trust, authority, runtime, or persistence contracts changed.

## Database Impact

None. No schema, migration, PostgreSQL, or libSQL changes.

## Blast Radius

Limited to the WebUI route-loading boundary, browser-local theme initialization, and their tests.

The route-boundary change affects all lazy WebUI routes, but restores standard React Router state-preservation semantics while retaining route-error recovery. No backend or external API behavior changes.

Risk level: **low**.

## Rollback Plan

Revert this PR to restore the previous pathname-keyed remount behavior. No data or schema rollback is required.

## Review Follow-Through

The route-level code-splitting change from `f3f0b83e` was reviewed for related regressions. The shared pathname key was also capable of resetting layout, form, sidebar, and page-local state. This PR fixes that behavior at the shared boundary instead of adding a theme-only workaround.

No remaining blocking findings were identified.

---

**Review track**: B