### PR TITLE
test: isolate Trace Commons coverage from local state

### DIFF
--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -81,18 +81,18 @@ const SKILL_NAME: &str = "reborn-skill-e2e";
 const TRACE_COMMONS_TEST_CHILD: &str = "IRONCLAW_TRACE_COMMONS_TEST_CHILD";
 
 fn isolated_trace_commons_base_dir(test_name: &str) -> Option<std::path::PathBuf> {
-    if std::env::var_os(TRACE_COMMONS_TEST_CHILD).is_some() {
-        return Some(
-            std::env::var_os("IRONCLAW_BASE_DIR")
-                .expect("child IRONCLAW_BASE_DIR")
-                .into(),
-        );
+    if let (Some(marker), Some(base_dir)) = (
+        std::env::var_os(TRACE_COMMONS_TEST_CHILD),
+        std::env::var_os("IRONCLAW_BASE_DIR"),
+    ) && marker == base_dir
+    {
+        return Some(base_dir.into());
     }
 
     let dir = tempfile::tempdir().expect("tempdir for IRONCLAW_BASE_DIR");
     let status = std::process::Command::new(std::env::current_exe().expect("current test binary"))
         .args(["--exact", test_name, "--nocapture"])
-        .env(TRACE_COMMONS_TEST_CHILD, "1")
+        .env(TRACE_COMMONS_TEST_CHILD, dir.path())
         .env("IRONCLAW_BASE_DIR", dir.path())
         .status()
         .expect("run isolated Trace Commons test process");

--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -90,13 +90,18 @@ fn isolated_trace_commons_base_dir(test_name: &str) -> Option<std::path::PathBuf
     }
 
     let dir = tempfile::tempdir().expect("tempdir for IRONCLAW_BASE_DIR");
-    let status = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+    let output = std::process::Command::new(std::env::current_exe().expect("current test binary"))
         .args(["--exact", test_name, "--nocapture"])
         .env(TRACE_COMMONS_TEST_CHILD, dir.path())
         .env("IRONCLAW_BASE_DIR", dir.path())
-        .status()
+        .output()
         .expect("run isolated Trace Commons test process");
-    assert!(status.success(), "isolated Trace Commons test failed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success() && stdout.contains("test result: ok. 1 passed; 0 failed;"),
+        "isolated Trace Commons test did not run exactly one test\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     // ponytail: a child process isolates the existing env-based API; inject a
     // base path into the capability harness if production gains that seam.
     None

--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -78,21 +78,28 @@ const REBORN_FIRST_PARTY_E2E_COVERED_CAPABILITIES: &[&str] = &[
 
 const SKILL_NAME: &str = "reborn-skill-e2e";
 
-static TRACE_COMMONS_BASE_DIR: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+const TRACE_COMMONS_TEST_CHILD: &str = "IRONCLAW_TRACE_COMMONS_TEST_CHILD";
 
-fn setup_trace_commons_base_dir() -> &'static tempfile::TempDir {
-    TRACE_COMMONS_BASE_DIR.get_or_init(|| {
-        let dir = tempfile::tempdir().expect("tempdir for IRONCLAW_BASE_DIR");
-        let _env_guard = ironclaw_common::env_helpers::lock_env();
-        // SAFETY: OnceLock serializes this one write before either Trace Commons test
-        // reads the process-wide base directory.
-        unsafe {
-            std::env::set_var("IRONCLAW_BASE_DIR", dir.path());
-        }
-        // ponytail: process isolation is enough while only these tests read this state;
-        // inject an explicit path into the harness if that boundary grows.
-        dir
-    })
+fn isolated_trace_commons_base_dir(test_name: &str) -> Option<std::path::PathBuf> {
+    if std::env::var_os(TRACE_COMMONS_TEST_CHILD).is_some() {
+        return Some(
+            std::env::var_os("IRONCLAW_BASE_DIR")
+                .expect("child IRONCLAW_BASE_DIR")
+                .into(),
+        );
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir for IRONCLAW_BASE_DIR");
+    let status = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+        .args(["--exact", test_name, "--nocapture"])
+        .env(TRACE_COMMONS_TEST_CHILD, "1")
+        .env("IRONCLAW_BASE_DIR", dir.path())
+        .status()
+        .expect("run isolated Trace Commons test process");
+    assert!(status.success(), "isolated Trace Commons test failed");
+    // ponytail: a child process isolates the existing env-based API; inject a
+    // base path into the capability harness if production gains that seam.
+    None
 }
 
 fn host_runtime_tool_wait() -> HarnessWaitConfig {
@@ -560,10 +567,14 @@ async fn reborn_trace_trigger_management_first_party_tools_parity() {
 
 #[tokio::test]
 async fn reborn_trace_trace_commons_first_party_tools_parity() {
-    let base_dir = setup_trace_commons_base_dir();
+    let Some(base_dir) =
+        isolated_trace_commons_base_dir("reborn_trace_trace_commons_first_party_tools_parity")
+    else {
+        return;
+    };
     assert_eq!(
         ironclaw_common::paths::ironclaw_base_dir(),
-        base_dir.path(),
+        base_dir,
         "Trace Commons coverage must not read developer state"
     );
     let onboard = CapabilityId::new(TRACE_COMMONS_ONBOARD_CAPABILITY_ID).expect("capability id");
@@ -739,7 +750,11 @@ async fn reborn_trace_trace_commons_first_party_tools_parity() {
 
 #[tokio::test]
 async fn reborn_trace_trace_commons_pilot_tools_are_model_visible() {
-    let _base_dir = setup_trace_commons_base_dir();
+    if isolated_trace_commons_base_dir("reborn_trace_trace_commons_pilot_tools_are_model_visible")
+        .is_none()
+    {
+        return;
+    }
     let onboard = CapabilityId::new(TRACE_COMMONS_ONBOARD_CAPABILITY_ID).expect("capability id");
     let status = CapabilityId::new(TRACE_COMMONS_STATUS_CAPABILITY_ID).expect("capability id");
     let credits = CapabilityId::new(TRACE_COMMONS_CREDITS_CAPABILITY_ID).expect("capability id");

--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -78,6 +78,23 @@ const REBORN_FIRST_PARTY_E2E_COVERED_CAPABILITIES: &[&str] = &[
 
 const SKILL_NAME: &str = "reborn-skill-e2e";
 
+static TRACE_COMMONS_BASE_DIR: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+
+fn setup_trace_commons_base_dir() -> &'static tempfile::TempDir {
+    TRACE_COMMONS_BASE_DIR.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("tempdir for IRONCLAW_BASE_DIR");
+        let _env_guard = ironclaw_common::env_helpers::lock_env();
+        // SAFETY: OnceLock serializes this one write before either Trace Commons test
+        // reads the process-wide base directory.
+        unsafe {
+            std::env::set_var("IRONCLAW_BASE_DIR", dir.path());
+        }
+        // ponytail: process isolation is enough while only these tests read this state;
+        // inject an explicit path into the harness if that boundary grows.
+        dir
+    })
+}
+
 fn host_runtime_tool_wait() -> HarnessWaitConfig {
     HarnessWaitConfig {
         timeout: Duration::from_secs(10),
@@ -543,6 +560,12 @@ async fn reborn_trace_trigger_management_first_party_tools_parity() {
 
 #[tokio::test]
 async fn reborn_trace_trace_commons_first_party_tools_parity() {
+    let base_dir = setup_trace_commons_base_dir();
+    assert_eq!(
+        ironclaw_common::paths::ironclaw_base_dir(),
+        base_dir.path(),
+        "Trace Commons coverage must not read developer state"
+    );
     let onboard = CapabilityId::new(TRACE_COMMONS_ONBOARD_CAPABILITY_ID).expect("capability id");
     let status = CapabilityId::new(TRACE_COMMONS_STATUS_CAPABILITY_ID).expect("capability id");
     let credits = CapabilityId::new(TRACE_COMMONS_CREDITS_CAPABILITY_ID).expect("capability id");
@@ -716,6 +739,7 @@ async fn reborn_trace_trace_commons_first_party_tools_parity() {
 
 #[tokio::test]
 async fn reborn_trace_trace_commons_pilot_tools_are_model_visible() {
+    let _base_dir = setup_trace_commons_base_dir();
     let onboard = CapabilityId::new(TRACE_COMMONS_ONBOARD_CAPABILITY_ID).expect("capability id");
     let status = CapabilityId::new(TRACE_COMMONS_STATUS_CAPABILITY_ID).expect("capability id");
     let credits = CapabilityId::new(TRACE_COMMONS_CREDITS_CAPABILITY_ID).expect("capability id");


### PR DESCRIPTION
## Summary

- isolate the Trace Commons parity tests from developer enrollment state
- re-run each affected test in a child process with a temporary `IRONCLAW_BASE_DIR` configured before process startup
- assert the child resolves that isolated directory before exercising the tools

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #6359.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: the full `reborn_trace_first_party_tool_coverage` binary passed 26 tests with 2 intentional ignores
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — not applicable; this isolates a test harness path and changes no database behavior
- [x] Manual testing: reproduced RED with an enabled `policy.json` under a controlled `IRONCLAW_BASE_DIR`, then reran the same exact test GREEN; after review, both focused tests also pass with a deliberately hostile parent value because the child overrides it before startup
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not available in this environment; `scripts/pre-commit-safety.sh` passed

Additional required checks:

- `cargo test` — 607 passed across the default suites
- `scripts/pre-commit-safety.sh` — passed

## Test Strategy

User behavior: developers with prior Trace Commons enrollment can run the root Trace Commons parity coverage without their local policy changing the result.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: not applicable; the affected behavior is in the existing root harness test.
- Reborn integration: updated `tests/reborn_trace_first_party_tool_coverage.rs`.
- Recorded fixture: not applicable; model choice is unchanged.
- Browser E2E: not applicable; no browser surface changed.
- Backend or runtime: not applicable; no backend or runtime implementation changed.
- Live canary: not applicable; the regression is local filesystem isolation.

What the tests prove: an enrolled policy outside the test cannot make the Trace Commons status result report `enrolled: true`, and neither scenario mutates process-global environment while its test binary is running.

Commands run:

```console
IRONCLAW_BASE_DIR=<controlled-enrolled-state> cargo +1.96.0 test -p ironclaw_reborn_integration_tests --test reborn_trace_first_party_tool_coverage reborn_trace_trace_commons_first_party_tools_parity -- --exact --nocapture
cargo +1.96.0 test -p ironclaw_reborn_integration_tests --test reborn_trace_first_party_tool_coverage
cargo +1.96.0 fmt --all -- --check
cargo +1.96.0 clippy --all --benches --tests --examples --all-features -- -D warnings
cargo +1.96.0 build
cargo +1.96.0 test
scripts/pre-commit-safety.sh
```

## Security Impact

None. The change only redirects test state to temporary child-process directories and does not alter production file access.

## Reborn Trust-Boundary Checklist

N/A: test-harness isolation only; no production trust-bearing types, ingress, policy, runtime, status, or serialization behavior changed.

## Database Impact

None.

## Blast Radius

Only the two Trace Commons cases in `reborn_trace_first_party_tool_coverage`; each child process owns one temporary directory.

## Rollback Plan

Revert these test-only commits.

## Review Follow-Through

Child-process isolation uses the existing env-based API without adding a production seam. If the capability harness gains explicit path injection later, these tests can adopt it and drop the re-exec helper.

---

**Review track**: A (tests)
