### PR TITLE
fix(reborn): enable systemd user lingering

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -551,7 +551,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 | Config recovery on clobber | ✅ | ❌ | Restore last-known-good config on critical clobber signatures (missing metadata, missing `gateway.mode`, sharp size drops); foreground/service notices include rejected paths |
 | Modular `$include` files | ✅ | ❌ | Single-file top-level includes for isolated mutations; `plugins install`/`update` updates `plugins.json5` instead of flattening |
 | `config set --merge`/`--replace` | ✅ | ❌ | Additive vs intentional clobber for provider model maps |
-| Wrapper-based service install | ✅ | ✅ (Reborn) | `--wrapper`/`OPENCLAW_WRAPPER` validated executable LaunchAgent/systemd wrappers; Reborn's `ironclaw service install` covers launchd (macOS)/systemd (Linux) with a webui-token-file fallback and atomic install + rollback on failure |
+| Wrapper-based service install | ✅ | ✅ (Reborn) | `--wrapper`/`OPENCLAW_WRAPPER` validated executable LaunchAgent/systemd wrappers; Reborn's `ironclaw service install` covers launchd (macOS)/systemd (Linux) with a webui-token-file fallback, atomic installation, and rollback on service-install failures. On Linux, user lingering is enabled on a best-effort basis so the systemd user service starts at boot and survives logout; a denied or failed `enable-linger` attempt is non-fatal and does not roll back the installation. |
 
 ### Owner: _Unassigned_
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Choose an LLM provider, enter its API key in the hidden prompt, and accept the
 default model or enter another one. IronClaw provisions its local configuration,
 encrypted credential store, and WebUI login token. On macOS and Linux it also
 installs and starts the background service, then prints a link that opens the
-WebUI.
+WebUI. On Linux, setup enables systemd user lingering so the service starts
+on boot and survives logout. If local policy denies that step, run
+`sudo loginctl enable-linger "$USER"`.
 
 Use `ironclaw status` to check the service and print the login link again.
 Windows users can start the WebUI in the foreground with `ironclaw serve`.

--- a/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/service/systemd.rs
@@ -79,6 +79,26 @@ fn unit_content(invocation: &ServeInvocation, working_directory: &Path) -> Resul
     ))
 }
 
+/// Enables lingering for the invoking user, so the user's systemd manager
+/// starts at boot and survives logout. This is deliberately a best-effort
+/// operation: a distribution's polkit policy may require an administrator,
+/// but the unit remains useful for an active login session.
+fn enable_linger(runner: &mut dyn ServiceCommandRunner) {
+    if runner
+        .run_checked(
+            "loginctl enable-linger",
+            Command::new("loginctl").args(["enable-linger"]),
+        )
+        .is_err()
+    {
+        eprintln!(
+            "warning: could not enable systemd lingering; the service will stop after logout \
+             and will not start at boot until lingering is enabled.\n  Run: sudo \
+             loginctl enable-linger \"$USER\""
+        );
+    }
+}
+
 fn restore_previous_unit(path: &Path, previous: Option<&[u8]>) -> Result<()> {
     match previous {
         Some(contents) => super::write_atomic(path, contents),
@@ -260,6 +280,7 @@ pub(super) fn install_with_runner(
         }
         return Err(combined_failure(error, rollback_errors));
     }
+    enable_linger(runner);
     println!("Installed systemd user service: {}", file.display());
     if let Some(note) = super::replaced_existing_service_file_note(replaced_existing) {
         println!("{note}");
@@ -616,6 +637,7 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingRunner {
+        programs: Vec<String>,
         labels: Vec<String>,
         args: Vec<Vec<String>>,
         fail_args: Option<Vec<&'static str>>,
@@ -627,6 +649,8 @@ mod tests {
 
     impl ServiceCommandRunner for RecordingRunner {
         fn run_checked(&mut self, label: &str, command: &mut Command) -> Result<()> {
+            self.programs
+                .push(command.get_program().to_string_lossy().into_owned());
             self.labels.push(label.to_string());
             self.args.push(
                 command
@@ -662,6 +686,8 @@ mod tests {
         }
 
         fn run_capture_checked(&mut self, label: &str, command: &mut Command) -> Result<String> {
+            self.programs
+                .push(command.get_program().to_string_lossy().into_owned());
             self.labels.push(label.to_string());
             self.args.push(
                 command
@@ -965,6 +991,53 @@ mod tests {
                 "systemctl daemon-reload",
                 "systemctl rollback daemon-reload"
             ]
+        );
+    }
+
+    #[test]
+    fn install_enables_lingering_after_enabling_the_user_unit() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = TempHomeGuard::set(tmp.path());
+        let mut runner = RecordingRunner::default();
+
+        install_with_runner(&sample_context(), &sample_invocation(), &mut runner)
+            .expect("install succeeds");
+
+        assert_eq!(
+            runner.labels,
+            [
+                "systemctl show unit state",
+                "systemctl daemon-reload",
+                "systemctl enable",
+                "loginctl enable-linger",
+            ]
+        );
+        assert_eq!(runner.programs[3], "loginctl");
+        assert_eq!(runner.args[3], ["enable-linger"]);
+    }
+
+    #[test]
+    fn install_continues_when_lingering_requires_administrator_authorization() {
+        let _lock = crate::runtime::test_env::lock_runtime_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = TempHomeGuard::set(tmp.path());
+        let mut runner = RecordingRunner {
+            fail_args: Some(vec!["enable-linger"]),
+            ..RecordingRunner::default()
+        };
+
+        install_with_runner(&sample_context(), &sample_invocation(), &mut runner)
+            .expect("a linger authorization failure must not roll back the installed unit");
+
+        assert_eq!(
+            runner.labels.last(),
+            Some(&"loginctl enable-linger".to_string())
+        );
+        assert_eq!(runner.programs.last().map(String::as_str), Some("loginctl"));
+        assert_eq!(
+            runner.args.last().expect("loginctl args must be recorded"),
+            &["enable-linger"]
         );
     }
 


### PR DESCRIPTION
## Summary

- Enable systemd user lingering during Linux service installation so Ironclaw survives logout and starts after reboot.
- Preserve a successful unit installation when local policy denies lingering; print the explicit `sudo loginctl enable-linger "$USER"` remediation.
- Add regression coverage and update onboarding/service documentation and feature parity notes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass:
  - `cargo +1.96.0 test -p ironclaw install_enables_lingering_after_enabling_the_user_unit`
  - `cargo +1.96.0 test -p ironclaw install_continues_when_lingering_requires_administrator_authorization`
- [x] `cargo test --features integration` if database-backed or integration behavior changed
  - Not applicable: no database or integration behavior changed.
- [x] Manual testing:
  - Verified the service-install command sequence through the injectable systemd runner: unit enable precedes `loginctl enable-linger`.
  - Verified an authorization failure does not roll back the installed user unit and provides manual remediation.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review
  - Not run: tool unavailable.

## Test Strategy

User behavior:

On Linux, after `ironclaw onboard` or `ironclaw service install`, the systemd user service should survive logout and start after reboot without requiring the user to discover and run `loginctl enable-linger` manually.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Added systemd install-path tests for successful lingering enablement and an authorization-denied linger attempt.
- Reborn integration: Not applicable: this is a local CLI/system-service operation with an existing injectable command-runner seam.
- Recorded fixture: Not applicable: no model behavior.
- Browser E2E: Not applicable: no browser behavior.
- Backend or runtime: Not applicable: no database, Docker, WASM, MCP, or external runtime behavior.
- Live canary: Not applicable: no provider/model behavior.

What the tests prove:

- Linux service installation invokes `loginctl enable-linger` only after the systemd user unit is enabled.
- A failed linger attempt leaves the unit installed and enabled, while surfacing a manual `sudo loginctl enable-linger "$USER"` fallback.

Commands run:

- `bash scripts/pre-commit-safety.sh`
- `cargo +1.96.0 fmt --all -- --check`
- `cargo +1.96.0 clippy --all --benches --tests --examples --all-features -- -D warnings`
- `cargo +1.96.0 build`
- `cargo +1.96.0 test -p ironclaw install_enables_lingering_after_enabling_the_user_unit`
- `cargo +1.96.0 test -p ironclaw install_continues_when_lingering_requires_administrator_authorization`
- `cargo +1.96.0 test`

`cargo +1.96.0 test` ran the CLI unit suite successfully, but 8 unrelated Docker-entrypoint smoke tests failed because their hermetic test `PATH` does not include `awk` (`entrypoint.sh: awk: command not found`).

## Security Impact

This invokes the local `loginctl enable-linger` command during Linux service installation. It does not elevate privileges or invoke `sudo`; if local policy denies the operation, Ironclaw reports the manual administrator command and retains the installed unit.

## Reborn Trust-Boundary Checklist

N/A: this change adds no public trust-bearing types, prompt content, serialization, queue/buffer, runtime-policy, or sandbox boundary changes. The only new side effect is a local OS service-management command through the existing injectable command-runner boundary.

## Database Impact

None.

## Blast Radius

Linux `ironclaw service install` and interactive onboarding, which uses that installation path. macOS, non-interactive onboarding, service start/stop/status/uninstall, persistence, and WebUI behavior are unchanged.

## Rollback Plan

Revert commit `1e9a50260` to restore the prior service-install behavior. Existing installations remain functional; users can disable lingering independently with `loginctl disable-linger "$USER"` if needed.

## Review Follow-Through

No known follow-up. Review should confirm best-effort behavior is appropriate for distributions whose local authorization policy requires administrator approval.

---

**Review track**: B
