### PR TITLE
ci: pin TZ/locale for tests and reject orphan-history branches

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -26,6 +26,13 @@ env:
   # cfg!(test) covers unit tests; this covers integration/e2e that link the
   # non-cfg(test) library.
   IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+  # Pin wall-clock rendering inputs so a test cannot pass or fail on the
+  # runner's locale. Reborn renders model-visible time slices, and date/number
+  # formatting differs by locale, so an unpinned runner turns a formatting
+  # regression into an unreproducible flake. UTC also keeps recorded fixtures
+  # comparable with what a developer sees locally.
+  TZ: "UTC"
+  LANG: "C.UTF-8"
 
 jobs:
   changes:

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -27,10 +27,14 @@ jobs:
     name: Shares history with main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # pull_request defaults to GitHub's synthetic merge commit, which
+          # always has main as an ancestor and would make this check vacuous.
+          ref: ${{ github.event.pull_request.head.sha }}
           # Required: the default shallow clone has no ancestry to compare.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Require a common ancestor with main
         run: |

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -1,0 +1,53 @@
+name: "PR: History Check"
+
+# A branch with no common ancestor with `main` grafts a second root into the
+# repository when it merges. Everything it touches loses its history: `git
+# blame` and `git log --follow` stop at the graft, permanently, for every file
+# in the branch. It is not reversible after the fact without rewriting main.
+#
+# The usual cause is accidental rather than malicious — a fresh `git init` in
+# a working copy, a squashed export, or a clone that lost its remote — so the
+# branch looks entirely normal in a diff. This check is the only thing that
+# distinguishes it.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: history-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  common-ancestor:
+    name: Shares history with main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Required: the default shallow clone has no ancestry to compare.
+          fetch-depth: 0
+
+      - name: Require a common ancestor with main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin main
+
+          if base="$(git merge-base origin/main HEAD)" && [ -n "$base" ]; then
+            echo "common ancestor with main: $base"
+            exit 0
+          fi
+
+          echo "::error::This branch shares no commit history with main."
+          echo "Merging it would graft a second root into the repository and" >&2
+          echo "permanently break 'git blame' and 'git log --follow' for every" >&2
+          echo "file it touches." >&2
+          echo >&2
+          echo "Fix: rebase the work onto main rather than merging as-is." >&2
+          echo "  git fetch origin main" >&2
+          echo "  git rebase --onto origin/main --root   # or cherry-pick the commits" >&2
+          exit 1

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -50,6 +50,13 @@ env:
   # cfg!(test) covers unit tests; this covers integration/e2e that link the
   # non-cfg(test) library.
   IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+  # Pin wall-clock rendering inputs so a test cannot pass or fail on the
+  # runner's locale. Reborn renders model-visible time slices, and date/number
+  # formatting differs by locale, so an unpinned runner turns a formatting
+  # regression into an unreproducible flake. UTC also keeps recorded fixtures
+  # comparable with what a developer sees locally.
+  TZ: "UTC"
+  LANG: "C.UTF-8"
 
 jobs:
   changes:

--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -46,6 +46,13 @@ concurrency:
   group: reborn-e2e-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Pin wall-clock rendering inputs so a browser/API assertion cannot pass or
+  # fail on the runner's locale. This suite asserts rendered timestamps and
+  # schedule text, which are exactly the values that shift with TZ/locale.
+  TZ: "UTC"
+  LANG: "C.UTF-8"
+
 jobs:
   changes:
     name: Detect Reborn E2E scope

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -39,6 +39,13 @@ env:
   # cfg!(test) covers unit tests; this covers integration/e2e that link the
   # non-cfg(test) library.
   IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+  # Pin wall-clock rendering inputs so a test cannot pass or fail on the
+  # runner's locale. Reborn renders model-visible time slices, and date/number
+  # formatting differs by locale, so an unpinned runner turns a formatting
+  # regression into an unreproducible flake. UTC also keeps recorded fixtures
+  # comparable with what a developer sees locally.
+  TZ: "UTC"
+  LANG: "C.UTF-8"
   # PR #5086 measured mold linking the heaviest Reborn build in parallel with
   # no OOM, so keep Cargo's default parallelism. If runner OOMs recur, restore
   # the previous one-job Cargo build serialization as the one-line fallback.


### PR DESCRIPTION
## Summary

- Pin `TZ=UTC` and `LANG=C.UTF-8` in the four workflows that execute tests so model-visible timestamps, schedule text, and locale-sensitive formatting are deterministic.
- Add a pull-request history guard that rejects branches with no common ancestor with `main`.
- Check the actual pull-request head with an immutable checkout action and no persisted credentials, so GitHub's synthetic merge commit cannot make the guard pass vacuously.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust changed.
- [ ] `cargo build` — Not applicable: no product or build code changed.
- [x] Relevant tests pass: parsed all 26 workflow YAML files; verified the immutable checkout/ref/credential contract; `git diff --check` passed; pedantic `zizmor` scan reported no findings.
- [ ] `cargo test --features integration` — Not applicable: no database-backed or product integration behavior changed.
- [x] Manual testing: a scratch repository proved a normal/synthetic merge has `main` ancestry while an orphan PR head does not, reproducing why the explicit PR-head checkout is required.
- [x] If a coding agent was used and supports it, review follow-through was run before requesting review: every paginated PR comment surface and all four unresolved inline threads were audited.

## Test Strategy

User behavior: Product behavior is unchanged. CI test output is deterministic across runners, and pull requests without shared `main` history receive an actionable failing check.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable: this is declarative GitHub Actions configuration.
- Reborn integration: Not applicable: no Reborn behavior changed.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Not applicable: no backend or runtime behavior changed.
- Live canary: Not applicable: no provider behavior or model drift is involved.

What the tests prove: The workflow files remain valid YAML; the new checkout uses a full immutable action SHA, checks out `github.event.pull_request.head.sha`, retains full history, and does not persist credentials; an orphan head fails the exact `merge-base` predicate that a synthetic PR merge would incorrectly pass.

Commands run:
- `ruby -e 'require "yaml"; ... YAML.parse_file(...)'` over `.github/workflows/*.yml`
- Static `rg` assertions for the checkout SHA, PR-head ref, full history, and disabled credential persistence
- Scratch-repository normal/orphan/synthetic-merge ancestry probe
- `git diff --check`
- `uvx zizmor --persona pedantic .github/workflows/history-check.yml`

## Security Impact

The new workflow retains read-only repository permissions. The checkout action is pinned to the repository's existing v4.3.1 commit, checks out the event's immutable PR-head SHA, and sets `persist-credentials: false`. No product authentication, secrets, sandboxing, or network policy changes.

## Reborn Trust-Boundary Checklist

N/A: CI configuration only; no Reborn trust-bearing types, prompts, hashes, statuses, queues, errors, or runtime boundaries changed.

## Database Impact

None.

## Blast Radius

Four test workflows gain fixed timezone/locale environment variables. The new history workflow runs on pull requests targeting `main`; a malformed ref or checkout regression could make that informational check fail, but it does not alter product code or repository contents.

## Rollback Plan

Revert this PR to restore runner-provided timezone/locale behavior and remove the history check. If only the history guard causes unexpected failures, revert `.github/workflows/history-check.yml` independently.

## Review Follow-Through

The original four unresolved inline threads reduced to two valid duplicated findings: pin the checkout action and check out the actual PR head rather than GitHub's synthetic merge commit. Both are addressed in `24e8cc319`; credential persistence was also disabled because the read-only public fetch does not require it.

The post-fix IronLoop review separately asks to make this check a required Main-ruleset context and add merge-queue coverage. That is a valid enforcement-policy question but conflicts with this PR's stated advisory scope and would change repository-wide merge policy. It remains a maintainer decision; no ruleset mutation was made automatically.

---

**Review track**: C (CI)
