### PR TITLE
test(integration): cover the expired-credential resume arm

### DIFF
--- a/tests/integration/group_journeys/main.rs
+++ b/tests/integration/group_journeys/main.rs
@@ -51,6 +51,7 @@ mod support;
 mod scenario_auth_deny_then_retry_journey;
 mod scenario_auth_gate_grant_resume;
 mod scenario_auth_then_approval_journey;
+mod scenario_expired_credential_resume;
 mod scenario_interactive_approval_journey;
 mod scenario_multi_actor_gate_isolation;
 
@@ -107,6 +108,17 @@ async fn journeys_group_auth_convergence_e2e() {
     report.record(
         "auth_gate_grant_resume",
         scenario_auth_gate_grant_resume::run(&g_grant).await,
+    );
+
+    // The EXPIRED arm: a stored credential the provider rejects, reconnected
+    // mid-run. Fresh group for the same reason as `g_grant` — a shared group's
+    // already-seeded credential would resolve immediately and never park.
+    let g_expired = RebornIntegrationGroup::live_auth_and_approval()
+        .await
+        .expect("expired-credential resume group builds");
+    report.record(
+        "expired_credential_resume",
+        scenario_expired_credential_resume::run(&g_expired).await,
     );
     report.assert_all_passed();
 }

--- a/tests/integration/group_journeys/scenario_expired_credential_resume.rs
+++ b/tests/integration/group_journeys/scenario_expired_credential_resume.rs
@@ -1,0 +1,99 @@
+//! C-JOURNEY — the EXPIRED-credential arm of the auth gate: a credential the
+//! user connected earlier is still stored and still injected, the provider
+//! rejects it (401), the run parks on a re-auth gate, the user reconnects, and
+//! the parked `github.get_repo` re-dispatches **with the new credential** and
+//! completes.
+//!
+//! Distinct from `scenario_auth_gate_grant_resume`, which starts from NO
+//! credential: there the gate is raised before any provider call, so there is
+//! nothing stored that could be wrongly reused. Here a rejected credential
+//! exists for the whole flow, and reusing it on resume is the actual failure
+//! mode — the run would 401 again or loop. `auth/auth_gate.rs`'s
+//! `runtime_401_after_injection_populates_provider_credential_requirement`
+//! covers the same 401 park but drains it with `deny`, so the resume half of
+//! the expired path was owned by neither.
+//!
+//! The two credentials must carry DIFFERENT material or this scenario cannot
+//! fail: with one shared token string, a stale-credential reuse bug still
+//! produces a request whose header matches, and the assertion passes on the
+//! bug it exists to catch. Hence `seed_capability_credential_account_with_token`.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use ironclaw_turns::TurnStatus;
+use serde_json::json;
+
+/// The credential the provider rejects. Must differ from the material
+/// `resolve_auth_gate` mints (`itest-github-token`) — see the module doc.
+const STALE_TOKEN: &str = "itest-github-expired-token";
+
+/// What the user's reconnect mints, via the production manual-token flow.
+const RECONNECTED_TOKEN: &str = "itest-github-token";
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    let h = g
+        .thread("conv-expired-credential-resume")
+        .script([
+            // Gated tool-call turn = the call plus the one post-resume reply.
+            RebornScriptedReply::tool_call(
+                "github.get_repo",
+                json!({"owner": "octocat", "repo": "hello-world"}),
+            ),
+            RebornScriptedReply::text(
+                "EXPIREDRESUME repo info retrieved after reconnecting github",
+            ),
+        ])
+        .build()
+        .await?;
+
+    // Auto-approve so `github.get_repo`'s Ask approval never fires — the auth
+    // gate must be the only block in the path.
+    h.enable_auto_approve().await?;
+
+    // The user connected GitHub at some earlier point: a real Configured
+    // account with real material, which dispatch will find and inject.
+    h.seed_capability_credential_account_with_token("github", "stale github", &[], STALE_TOKEN)
+        .await?;
+
+    // First dispatch is rejected; the post-reconnect dispatch is accepted.
+    // FIFO, one status consumed per call — so this also pins that exactly one
+    // call happens before the park (a hot retry would eat the 200 and the
+    // resume would fail).
+    let capability = g
+        .capability_harness()
+        .ok_or("expired-credential resume needs the host-runtime capability")?;
+    capability.install_network_status_script(401)?;
+    capability.install_network_status_script(200)?;
+
+    let (run, auth_gate) = h
+        .submit_turn_until_auth_blocked("EXPIREDRESUME look up the repo")
+        .await?;
+
+    // The park is genuinely the expired path: the stored credential really was
+    // injected and really was what the provider rejected. Without this the
+    // scenario could be silently exercising the credential-MISSING path that
+    // `scenario_auth_gate_grant_resume` already owns.
+    h.assert_network_egress_header_contains("api.github.com", "authorization", STALE_TOKEN)
+        .await?;
+
+    // "User reconnects": the grant is stored through the production
+    // manual-token flow, then the parked capability re-dispatches.
+    h.resolve_auth_gate(run, &auth_gate).await?;
+    h.wait_for_status(run, TurnStatus::Completed).await?;
+
+    // The assertion this scenario exists for: the resumed dispatch carried the
+    // RECONNECTED credential. A resume that reused the rejected one would still
+    // reach `Completed` here — the scripted 200 does not care which token it
+    // sees — so status alone cannot discriminate, and only the header can.
+    h.assert_network_egress_header_contains("api.github.com", "authorization", RECONNECTED_TOKEN)
+        .await?;
+
+    // ...and the re-dispatch actually executed the tool rather than merely
+    // unblocking: only the provider body surfacing back proves that.
+    h.assert_tool_result_contains("octocat/hello-world").await?;
+
+    // Exactly two provider calls: the rejected one and the resumed one. Pins
+    // that the 401 was not hot-retried against the provider (#5878 shape).
+    h.assert_network_egress_count(2).await?;
+    Ok(())
+}

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -1815,6 +1815,26 @@ impl RebornIntegrationHarness {
         label: &str,
         provider_scopes: &[&str],
     ) -> HarnessResult<()> {
+        self.seed_capability_credential_account_with_token(
+            provider,
+            label,
+            provider_scopes,
+            &format!("itest-{provider}-token"),
+        )
+        .await
+    }
+
+    /// [`Self::seed_capability_credential_account`] with caller-chosen token
+    /// material, so a later credential can be told apart from this one on the
+    /// wire. See `seed_credential_account_with_token` for why identical
+    /// material would make a re-auth assertion unable to fail.
+    pub async fn seed_capability_credential_account_with_token(
+        &self,
+        provider: &str,
+        label: &str,
+        provider_scopes: &[&str],
+        token: &str,
+    ) -> HarnessResult<()> {
         let harness = match &self._shared.capability {
             GroupCapability::HostRuntime(arc) => arc,
             GroupCapability::Recording | GroupCapability::RecordingNoProgress => {
@@ -1832,7 +1852,7 @@ impl RebornIntegrationHarness {
             .unwrap_or_else(|| self.binding.actor_user_id.clone());
         let scope = self.run_resource_scope_for_user(dispatch_user);
         harness
-            .seed_credential_account_with_material(&scope, provider, label, provider_scopes)
+            .seed_credential_account_with_token(&scope, provider, label, provider_scopes, token)
             .await
     }
 

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -427,6 +427,34 @@ impl HostRuntimeCapabilityHarness {
         label: &str,
         provider_scopes: &[&str],
     ) -> HarnessResult<()> {
+        self.seed_credential_account_with_token(
+            scope,
+            provider,
+            label,
+            provider_scopes,
+            &format!("itest-{provider}-token"),
+        )
+        .await
+    }
+
+    /// [`Self::seed_credential_account_with_material`] with the token material
+    /// chosen by the caller.
+    ///
+    /// Needed to tell one credential from another **on the wire**. A test that
+    /// seeds a credential, has the provider reject it, and then re-authenticates
+    /// cannot prove the resumed dispatch used the NEW credential if both seeds
+    /// mint the same string — the assertion would pass just as happily on a
+    /// stale-credential reuse bug, which is the whole failure it exists to
+    /// catch. Distinct material makes `assert_network_egress_header_contains`
+    /// discriminate.
+    pub(crate) async fn seed_credential_account_with_token(
+        &self,
+        scope: &ResourceScope,
+        provider: &str,
+        label: &str,
+        provider_scopes: &[&str],
+        token: &str,
+    ) -> HarnessResult<()> {
         let product_auth = self
             .product_auth
             .as_ref()
@@ -447,7 +475,7 @@ impl HostRuntimeCapabilityHarness {
             .submit_manual_token(ironclaw_auth::RebornManualTokenSubmitRequest::new(
                 scope.clone(),
                 challenge.interaction_id,
-                secrecy::SecretString::from(format!("itest-{provider}-token")),
+                secrecy::SecretString::from(token.to_string()),
             ))
             .await
             .map_err(|error| format!("manual token submit failed: {error:?}"))?;

--- a/tests/integration/support/harness/profiles/github.rs
+++ b/tests/integration/support/harness/profiles/github.rs
@@ -7,7 +7,6 @@ use ironclaw_host_api::{
     CapabilityId, CredentialStageError, MountPermissions, RuntimeKind, SecretHandle, UserId,
 };
 use ironclaw_host_runtime::{READ_FILE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID};
-use ironclaw_network::NetworkHttpEgress;
 
 use super::super::super::github as github_support;
 use super::super::options::{HostRuntimeHarnessOptions, ToolsProfile};
@@ -54,9 +53,13 @@ pub(crate) fn file_and_github_auth_tools_profile() -> HarnessResult<ToolsProfile
     // post-resume dispatch would attempt a live network call.
     let github_fixture_response =
         br#"{"id":1,"full_name":"octocat/hello-world","private":false}"#.to_vec();
-    let network_egress: Arc<dyn NetworkHttpEgress> = Arc::new(
-        RecordingNetworkHttpEgress::with_body(github_fixture_response),
-    );
+    // Recording (not just dyn) so the handle is retained: scenarios need to
+    // script statuses onto this lane and read back the captured requests, and
+    // `with_network_http_egress_for_test` alone wires the transport without
+    // keeping anything to observe it through.
+    let network_egress = Arc::new(RecordingNetworkHttpEgress::with_body(
+        github_fixture_response,
+    ));
     Ok(ToolsProfile {
         capability_ids: vec![
             CapabilityId::new(WRITE_FILE_CAPABILITY_ID)?,
@@ -68,7 +71,7 @@ pub(crate) fn file_and_github_auth_tools_profile() -> HarnessResult<ToolsProfile
             workspace_mounts(MountPermissions::read_write_list_delete())?,
             None,
         )
-        .with_network_http_egress_for_test(network_egress)
+        .with_recording_network_egress(network_egress)
         .with_activated_bundled_extension(github_support::extension_package()?),
         network_policy_override: Some(wildcard_test_policy()),
         provider_trust_override: Some(bundled_extension_provider_trust()?),


### PR DESCRIPTION
## Summary

#6710 added reusable credential-lifecycle fault profiles. This pins the product behaviour behind the 401 half of them — **token expires mid-task, user reconnects, the parked work continues** — which no tier owned.

Two neighbouring tests each cover part of it:

| existing test | starts from | drains via |
|---|---|---|
| `auth/auth_gate.rs::runtime_401_after_injection_...` | credential injected, provider 401 | **deny** |
| `scenario_auth_gate_grant_resume` | **no credential** (gate before any provider call) | grant + resume |

The expired case is the combination neither reaches: a stored credential that *is* injected, *is* rejected, and must be **replaced** on resume. Reusing the rejected one is the failure mode — the run 401s again or loops — and it is invisible to both tests above.

## The assertion, and why the harness had to change

The scenario seeds a credential, scripts the provider to reject then accept, parks on the gate, reconnects through the production manual-token flow, and asserts the resumed dispatch carried the **new** credential.

That last part is the whole test, and it did not work at first. Both seeding paths minted the same `itest-{provider}-token` string, so:

- a stale-credential reuse bug still produces a request whose `authorization` header matches → assertion passes on the bug it exists to catch;
- `wait_for_status(Completed)` cannot discriminate either, because the scripted `200` does not care which token it sees.

So seeding now takes caller-chosen material (`seed_credential_account_with_token`) and the two credentials differ on the wire. Without that, this scenario would be decorative — green, and blind to the only bug it targets.

**Verified by sabotage.** Making the reconnect mint the already-rejected token fails it with:

```
expired_credential_resume: no network egress request matching url "api.github.com"
has header "authorization" with the expected value
```

Reverted; 16/16 pass.

## One profile fix

`file_and_github_auth_tools_profile` installed its recording network egress via `with_network_http_egress_for_test`, which wires the dyn transport but retains **no typed handle** — so `install_network_status_script` and `captured_network_requests` were unavailable on that group. It now uses `with_recording_network_egress`, which does both. This surfaced as a real failure on the first run (`host runtime harness has no recording network egress to script`), not as a guess.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Validation

- [x] `cargo test -p ironclaw_reborn_integration_tests --features integration --test reborn_group_journeys` — **16 passed, 0 failed**
- [x] Sabotage-verified: the discriminating assertion fails when the resume reuses the rejected credential
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p ironclaw_reborn_integration_tests --features integration --tests -- -D warnings` — clean
- [x] Full binary re-run after the profile change, to confirm the three neighbouring scenarios still pass

## Test Strategy

**User behaviour:** none changed. Test-tier only; no production code is touched.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions (a rejected credential must not be reused after re-auth)
- [x] External provider
- [x] Cross-component behavior (gate → resume → capability re-dispatch → egress)

Tests added or updated:
- `group_journeys/scenario_expired_credential_resume.rs` — new scenario, registered on its own `live_auth_and_approval` group (a shared group's already-seeded credential would resolve immediately and never park — the same reason `g_grant` is separate).
- `support/harness/mod.rs`, `support/builder.rs` — seeding accepts caller-chosen token material; the existing callers keep their behaviour through a delegating default.

**What the tests prove.** Not that a re-auth unblocks the run — that `Completed` would happen anyway. That the resumed dispatch used the credential the user just supplied.

## Reviewer notes

- The scenario also asserts `assert_network_egress_count(2)`, pinning that the 401 was not hot-retried against the provider (the #5878 shape) — one rejected call, one resumed call.
- It asserts the **stale** token on the first request too, so the scenario cannot silently drift into exercising the credential-missing path that `scenario_auth_gate_grant_resume` already owns.
- `STALE_TOKEN` / `RECONNECTED_TOKEN` are synthetic fixtures, never real credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
