### PR TITLE
fix(runner): a compaction outage is not a driver bug

### DIFF
--- a/crates/ironclaw_runner/src/text_loop_driver.rs
+++ b/crates/ironclaw_runner/src/text_loop_driver.rs
@@ -258,8 +258,15 @@ fn loop_failure_kind_name(kind: LoopFailureKind) -> &'static str {
         LoopFailureKind::InterruptedUnexpectedly => "interrupted_unexpectedly",
         LoopFailureKind::NoProgressDetected => "no_progress_detected",
         LoopFailureKind::PolicyDenied => "policy_denied",
-        // LoopFailureKind is `#[non_exhaustive]`; fail closed if a new variant
-        // lands in `ironclaw_turns` ahead of this matcher being updated.
+        LoopFailureKind::CompactionUnavailable => "compaction_unavailable",
+        // LoopFailureKind is `#[non_exhaustive]`; the wildcard is forced, not a
+        // choice. It must stay a fail-closed backstop for a variant that lands
+        // in `ironclaw_turns` before this matcher is updated — NOT a resting
+        // place for known variants. `every_loop_failure_kind_maps_to_its_own
+        // _category` below is what keeps it empty; `CompactionUnavailable` sat
+        // here undetected and reported a resource condition as `driver_bug`,
+        // which is non-auto-retriable and tells the user to contact support
+        // about an internal error that never happened.
         _ => "driver_bug",
     }
 }
@@ -267,6 +274,67 @@ fn loop_failure_kind_name(kind: LoopFailureKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every `LoopFailureKind` must map to its own category — never to the
+    /// `_ => "driver_bug"` backstop.
+    ///
+    /// `LoopFailureKind` is `#[non_exhaustive]`, so the wildcard is forced and
+    /// the compiler cannot catch a variant that falls through it. This test is
+    /// the substitute. It found `CompactionUnavailable` sitting in the
+    /// backstop: a resource condition was reported as `driver_bug`, which is
+    /// NOT auto-retriable (`retry_disposition::is_auto_retriable_category`)
+    /// while `compaction_unavailable` is — so an auto-recoverable run died and
+    /// told the user to contact support about an internal error that never
+    /// happened.
+    ///
+    /// The assertion compares against the kind's OWN `as_str()` rather than a
+    /// second literal list, so this cannot drift into the same duplication it
+    /// exists to police. A new variant in `ironclaw_turns` must be added to the
+    /// list below AND to `loop_failure_kind_name`; the compiler will not tell
+    /// you, this will.
+    #[test]
+    fn every_loop_failure_kind_maps_to_its_own_category() {
+        let kinds = [
+            LoopFailureKind::ModelError,
+            LoopFailureKind::ContextBuildFailed,
+            LoopFailureKind::CapabilityProtocolError,
+            LoopFailureKind::IterationLimit,
+            LoopFailureKind::InvalidModelOutput,
+            LoopFailureKind::CheckpointRejected,
+            LoopFailureKind::CheckpointUnavailable,
+            LoopFailureKind::TranscriptWriteFailed,
+            LoopFailureKind::DriverBug,
+            LoopFailureKind::InterruptedUnexpectedly,
+            LoopFailureKind::NoProgressDetected,
+            LoopFailureKind::PolicyDenied,
+            LoopFailureKind::CompactionUnavailable,
+        ];
+        for kind in kinds {
+            assert_eq!(
+                loop_failure_kind_name(kind),
+                kind.as_str(),
+                "{kind:?} does not map to its own category — it is falling \
+                 through the `_ => \"driver_bug\"` backstop, which reports a \
+                 real failure as an internal bug and changes its retry lane"
+            );
+        }
+    }
+
+    /// The backstop must remain reachable only by a genuinely unknown variant.
+    /// If this ever fails, a known kind has been removed from the matcher.
+    #[test]
+    fn only_driver_bug_itself_maps_to_the_driver_bug_category() {
+        assert_eq!(
+            loop_failure_kind_name(LoopFailureKind::DriverBug),
+            "driver_bug"
+        );
+        assert_eq!(
+            loop_failure_kind_name(LoopFailureKind::CompactionUnavailable),
+            "compaction_unavailable",
+            "a compaction outage is a retriable resource condition, not a bug \
+             in our driver"
+        );
+    }
     use crate::failure_categories::{
         MODEL_CREDENTIALS_UNAVAILABLE_CATEGORY, MODEL_CREDITS_EXHAUSTED_CATEGORY,
         MODEL_CREDITS_EXHAUSTED_REASON_KIND,


### PR DESCRIPTION
## What

`loop_failure_kind_name` mapped every `LoopFailureKind` to its run-failure category except one: **`CompactionUnavailable` fell through the `_ => "driver_bug"` backstop.**

The category `"compaction_unavailable"` already existed in `ALL_RUN_FAILURE_CATEGORIES` with its own user-facing summary. The only thing missing was the arm producing it.

## Why it matters

| | `compaction_unavailable` (correct) | `driver_bug` (what happened) |
|---|---|---|
| Auto-retriable? | **yes** | **no** |
| User sees | its own summary | *"The agent runtime reported an internal error. Retry the run, and contact support if it happens again."* |
| Metrics | resource outage | driver defect |

So a transient resource condition that should have re-driven itself from its checkpoint instead **killed the run** and told the user to report a bug in our code that had not occurred.

## Why the compiler could not catch it

`LoopFailureKind` is `#[non_exhaustive]`, so this downstream crate cannot match exhaustively — the wildcard is forced, not chosen. That is precisely why the variant sat there undetected.

`every_loop_failure_kind_maps_to_its_own_category` is the substitute for the missing compile-time check. It asserts against each kind's **own `as_str()`** rather than a second hand-written list of category literals, so the test cannot drift into the same duplication it polices — the driver's match is already a re-implementation of `as_str()`, and it is the copy that drifted.

Adding a variant in `ironclaw_turns` still requires updating both the matcher and the list in this test. The compiler will not say so; this test will.

## Validation

- Red-verified — removing the new arm fails with `left: "driver_bug"` / `right: "compaction_unavailable"`
- `cargo test -p ironclaw_runner --lib --no-fail-fast` — 356 passed, 0 failed
- `cargo clippy -p ironclaw_runner --all-targets --all-features -- -D warnings` — clean

## Correction to #6284 item 7

Found while auditing that item's catch-all cleanup. Its **other** claim does not hold, and I would rather say so than leave it as work someone picks up:

> **`failure_lane()` is vacuous** — ignores its `category` argument entirely

`failure_lane` is correct. The lane it returns is binary — re-drivable from a checkpoint, or terminal-with-an-explanation — and that genuinely depends only on checkpoint presence. The category *is* used, by `retry_disposition`, for the finer auto-vs-user-initiated decision. The unused parameter is a documented seam for a future mid-run safety-abort category mapping to `FailureLane::Security`.

Two implementations do compute the lane by separate paths (`failure_lane` and `RetryDisposition::failure_lane`), kept in agreement by `disposition_is_consistent_with_failure_lane`. That is worth collapsing eventually, but delegating would move the documented `Security` seam into `retry_disposition`, where it does not belong — so not in this PR.

Independent of #6684 and #6697 (different crate, different concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
