### PR TITLE
chore(release): bump ironclaw to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-27
+
+First stable release of a rearchitected IronClaw. This is not an increment on
+the 0.29.x line — it is a ground-up rebuild of the agent runtime, storage,
+extension host, and web UI.
+
+**The `ironclaw` binary is the rearchitected CLI.** The v1 monolith builds as
+the `ironclaw-legacy` binary and is not published; 1.0.0 publishes the new
+`ironclaw` binary only.
+
+### This is not an in-place upgrade from 0.29.x
+
+There is no migration for v1 config, databases, settings, or secrets, and
+installing 1.0.0 does not touch your existing v1 data. Treat it as a fresh
+install: point `IRONCLAW_REBORN_HOME` at a new directory, run
+`ironclaw onboard`, and reconnect your providers and channels. Do not point it
+at a v1 data directory.
+
+### What ships
+
+- **Platforms.** Seven targets — macOS (Apple Silicon, Intel), Linux
+  (`x86_64`/`aarch64`, gnu and static musl), and Windows (`x86_64`), with shell,
+  PowerShell, and MSI installers.
+- **Guided setup.** `ironclaw onboard` provisions the config, the encrypted
+  credential store, an LLM provider (interactive key entry with a live probe),
+  a WebUI login token, and — on macOS and Linux — the background service. The
+  credential store's master key is provisioned in the OS keychain when one is
+  available, falling back to a locally cached key file otherwise.
+- **Model providers.** 26 providers in the built-in catalog, including NEAR AI,
+  OpenAI, Anthropic, Gemini, Bedrock, Ollama, OpenRouter, Groq, DeepSeek, and
+  any OpenAI-compatible endpoint. Manage routes with `ironclaw models`.
+- **Web UI.** `ironclaw serve` starts the WebChat v2 interface with the frontend
+  embedded in the binary — no separate asset deploy. Chat, extensions,
+  automations, settings, and admin surfaces are served from root-level routes.
+- **Extensions.** Twelve first-party extensions ship embedded and install
+  without a network fetch: GitHub, Gmail, Google Calendar, Docs, Drive, Sheets,
+  Slides, Notion, NEAR AI MCP, Slack, Telegram, and web access. Manage them with
+  `ironclaw extension` or the WebUI registry.
+- **Channels.** Slack and Telegram, both configured from the WebUI; Slack
+  connects per user through OAuth, Telegram through a per-user pairing code.
+- **Runtime.** Skills, scheduled and triggered automations, subagents, workspace
+  memory, and trace capture.
+- **Storage.** File-backed libSQL by default, so a stock install needs no
+  external database; PostgreSQL is opt-in via `[storage]`.
+- **Service management.** `ironclaw service install|start|stop|restart|status|uninstall`
+  runs the binary as a launchd user agent (macOS) or systemd user unit (Linux).
+
+### Known limitations
+
+- `ironclaw channels list`, `hooks list`, and `logs` appear in `--help` but
+  return an explicit "not implemented yet" error.
+- `mcp`, `memory`, `pairing`, `import`, and `login` subcommands from v1 have no
+  equivalent in this release; MCP servers and memory are reached through
+  extensions and the WebUI instead.
+- `onboard --import-history` parses but does nothing.
+- `skills` is list-only from the CLI.
+- `extension` and `skills` work out of the box: `ironclaw onboard` defaults to
+  the `local-dev` profile, where both are fully supported (as under
+  `local-dev-yolo`, `hosted-single-tenant`, and `hosted-single-tenant-volume`).
+  Only operators who explicitly choose `production` or `migration-dry-run`
+  hit a clear error instead.
+
+Please report problems at https://github.com/nearai/ironclaw/issues — include
+`ironclaw status --json` output.
+
+The itemized changes since 1.0.0-rc.1 follow; see the 1.0.0-rc.1 entry below for
+everything that landed between 0.29.1 and the release candidate.
+
+### Fixed
+
+- *(webui)* restore SSE streams across navigation, so chat keeps streaming when
+  the user moves between WebUI routes mid-turn ([#6425](https://github.com/nearai/ironclaw/pull/6425)).
+- *(webui)* stop the WebChat "Disconnected" lockout caused by rate-limit budget
+  exhaustion and navigation-race SSE thrash ([#6592](https://github.com/nearai/ironclaw/pull/6592)).
+
+### CI / Release
+
+- *(release)* update the Reborn Dockerfile and make the Reborn Docker image
+  buildable ([#6612](https://github.com/nearai/ironclaw/pull/6612)).
+- *(ci)* run the full Reborn test and E2E gates on `release-fix-*` pull-request
+  branches ([#6537](https://github.com/nearai/ironclaw/pull/6537)).
+
 ## [1.0.0-rc.1] - 2026-07-20
 
 First release candidate of a rearchitected IronClaw. This is not an increment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
Prepares the first stable release of the rearchitected IronClaw, cut from the `release-fix-1.0.0-rc.1` line at `a6f79acd`.

## Why a bump commit is required

cargo-dist derives the release version from the `ironclaw-v*` tag and requires a workspace package at that exact version. Tagging `a6f79acd` as `ironclaw-v1.0.0` while the package still reads `1.0.0-rc.1` fails in `dist plan` within ~40s — the same shape as `ironclaw-v1.0.0-rc.1`'s first release run.

## Changes

- `crates/ironclaw_reborn_cli/Cargo.toml`: `1.0.0-rc.1` → `1.0.0`.
- `Cargo.lock`: follow the member version so `--locked` builds resolve.
- `CHANGELOG.md`: add the `[1.0.0]` section. cargo-dist uses it verbatim as the GitHub Release body. It carries the rc.1 GA narrative forward (still accurate on this branch — the Tier-B monolith deletion is main-only, so the `ironclaw-legacy` note holds) and itemizes the four commits landed since the rc.1 tag: #6425, #6592, #6612, #6537.

## Verification

`dist plan --tag=ironclaw-v1.0.0` with cargo-dist 0.31.0 (matching the pinned `cargo-dist-version`) plans clean: all seven targets, shell and PowerShell installers, and the MSI — including the WiX up-to-date check that failed rc.1's first release run. Announcement metadata resolves to tag `ironclaw-v1.0.0`, title `1.0.0 - 2026-07-27`, `is_prerelease: false`.

`dist init` was deliberately not run: it would regenerate `ironclaw-release.yml` and drop the hardened job-permission boundary that `allow-dirty = ["ci"]` exists to protect.

## Not included

No `docker.yml` changes. That workflow only fires on `workflow_dispatch` or the hourly `schedule` (which pins `ref: main`), so nothing on this branch triggers an image publish. Note that `nearaidev/ironclaw:latest` therefore stays stale after this release — tracked by #6635.

## Release steps after merge

1. Squash merge. The released commit is the squash, not `a6f79acd`.
2. `git tag ironclaw-v1.0.0 <merge-commit> && git push origin ironclaw-v1.0.0`.
3. The Release workflow builds and publishes (~43m based on rc.1).