### PR TITLE
test(e2e): pin that a case's fault state cannot reach the next one

### DIFF
--- a/tests/e2e/provider_fault_proxy.py
+++ b/tests/e2e/provider_fault_proxy.py
@@ -246,6 +246,10 @@ class ProviderFaultProxy:
         return {
             "rules": [dict(rule) for rule in self._rules],
             "requests": [dict(request) for request in self._requests],
+            # A delay profile parks a task that aborts its request later. One
+            # left running past a reset keeps firing during whatever case runs
+            # next, so the count is part of "is this proxy actually clean".
+            "pending_faults": len(self._delayed_requests),
         }
 
     def _take_rule(self, method: str, path: str) -> dict | None:

--- a/tests/e2e/scenarios/test_provider_fault_proxy.py
+++ b/tests/e2e/scenarios/test_provider_fault_proxy.py
@@ -12,6 +12,7 @@ from provider_fault_proxy import (
     PROVIDER_FAULT_PROFILES,
     ProviderFaultProfile,
     ProviderFaultProxy,
+    ProviderFaultProxyWorld,
 )
 
 _RESPONSE_PROFILE_NAMES = [
@@ -345,3 +346,106 @@ def test_every_published_profile_has_a_self_test():
         "untested": sorted(set(PROVIDER_FAULT_PROFILES) - covered),
         "stale": sorted(covered - set(PROVIDER_FAULT_PROFILES)),
     }
+
+
+# --- fault-state isolation between cases (#6524 workstream 3) -----------------
+#
+# `reset()` is the only thing standing between one case's fault rules and the
+# next case's requests, and it had no test. A leak here is nasty to diagnose
+# from the far end: the next journey fails against a fault it never armed, and
+# nothing in that journey's own code explains why.
+
+
+async def test_reset_disarms_rules_the_previous_case_left_behind(fault_proxy):
+    """An armed-but-unfired rule must not fire for whoever runs next."""
+    proxy, upstream_requests = fault_proxy
+    proxy.arm(PROVIDER_FAULT_PROFILES["http_500"], method="GET", path="/objects/1")
+
+    proxy.reset()
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{proxy.url}/objects/1")
+
+    assert response.status_code == 200
+    assert len(upstream_requests) == 1
+    assert proxy.state["rules"] == []
+
+
+async def test_reset_clears_recorded_evidence_from_the_previous_case(fault_proxy):
+    """Request evidence is per-case: counts and fingerprints must not carry."""
+    proxy, _ = fault_proxy
+    async with httpx.AsyncClient() as client:
+        await client.get(
+            f"{proxy.url}/objects/1",
+            headers={"Authorization": "Bearer previous-case-token"},
+        )
+    assert proxy.state["requests"]
+
+    proxy.reset()
+
+    assert proxy.state["requests"] == []
+    # An assertion like `assert_network_egress_count(1)` in the next case would
+    # silently pass on a leftover request, so the fingerprint must go too.
+    assert "previous-case-token" not in str(proxy.state)
+
+
+async def test_reset_leaves_no_delayed_fault_task_pending(fault_proxy):
+    """A parked delay must not outlive the case that armed it.
+
+    Not about the next request: the parked task holds its own request object,
+    so leaving it running cannot abort anyone else's call — I asserted that
+    first and sabotage proved the assertion blind. What it does leak is the
+    task itself, which stays asleep past the case, keeps the proxy alive in
+    the event loop, and fires its abort during whatever runs next.
+    """
+    proxy, _ = fault_proxy
+    proxy.arm(
+        ProviderFaultProfile(
+            name="slow_fault",
+            action="delay_before_disconnect",
+            delay_seconds=30.0,
+        ),
+        method="GET",
+        path="/objects/1",
+    )
+    async with httpx.AsyncClient(timeout=0.01) as client:
+        with pytest.raises(httpx.ReadTimeout):
+            await client.get(f"{proxy.url}/objects/1")
+    await asyncio.sleep(0)
+    assert proxy.state["pending_faults"] == 1, proxy.state
+
+    proxy.reset()
+    await asyncio.sleep(0)
+
+    assert proxy.state["pending_faults"] == 0, proxy.state
+
+
+async def test_world_reset_covers_every_provider_not_just_the_first():
+    """One un-reset provider is enough to leak, so the loop must cover all."""
+    upstreams = []
+    proxies = {}
+    try:
+        for service in ("google", "slack", "github"):
+            url, requests, runner = await _start_upstream()
+            upstreams.append(runner)
+            proxies[service] = url
+        world = ProviderFaultProxyWorld(proxies)
+        await world.start()
+        try:
+            for proxy in world.proxies.values():
+                proxy.arm(
+                    PROVIDER_FAULT_PROFILES["http_500"],
+                    method="GET",
+                    path="/objects/1",
+                )
+            world.reset()
+            assert [proxy.state["rules"] for proxy in world.proxies.values()] == [
+                [],
+                [],
+                [],
+            ]
+        finally:
+            await world.close()
+    finally:
+        for runner in upstreams:
+            await runner.cleanup()

--- a/tests/e2e/scenarios/test_provider_fault_proxy.py
+++ b/tests/e2e/scenarios/test_provider_fault_proxy.py
@@ -8,6 +8,7 @@ import gzip
 import httpx
 import pytest
 from aiohttp import web
+from helpers import AUTH_TOKEN
 from provider_fault_proxy import (
     PROVIDER_FAULT_PROFILES,
     ProviderFaultProfile,
@@ -377,7 +378,7 @@ async def test_reset_clears_recorded_evidence_from_the_previous_case(fault_proxy
     async with httpx.AsyncClient() as client:
         await client.get(
             f"{proxy.url}/objects/1",
-            headers={"Authorization": "Bearer previous-case-token"},
+            headers={"Authorization": f"Bearer {AUTH_TOKEN}"},
         )
     assert proxy.state["requests"]
 
@@ -386,7 +387,7 @@ async def test_reset_clears_recorded_evidence_from_the_previous_case(fault_proxy
     assert proxy.state["requests"] == []
     # An assertion like `assert_network_egress_count(1)` in the next case would
     # silently pass on a leftover request, so the fingerprint must go too.
-    assert "previous-case-token" not in str(proxy.state)
+    assert AUTH_TOKEN not in str(proxy.state)
 
 
 async def test_reset_leaves_no_delayed_fault_task_pending(fault_proxy):
@@ -426,7 +427,7 @@ async def test_world_reset_covers_every_provider_not_just_the_first():
     proxies = {}
     try:
         for service in ("google", "slack", "github"):
-            url, requests, runner = await _start_upstream()
+            url, _requests, runner = await _start_upstream()
             upstreams.append(runner)
             proxies[service] = url
         world = ProviderFaultProxyWorld(proxies)


### PR DESCRIPTION
## Summary

Workstream 3 of #6524 owes *"fault state, OAuth state, rate counters, membership, messages, and created/deleted resources cannot leak between cases."* This closes the fault-state half.

`ProviderFaultProxy.reset()` is the only thing keeping one case's fault rules away from the next journey's requests — and **it had no test**. Every fault case in the suite depended on a method nothing checked.

A leak here is unpleasant from the far end: the next journey fails against a fault it never armed, and nothing in that journey's own code explains why.

## What's covered

One case per thing `reset()` does, plus the world-level loop:

| case | leak it prevents |
|---|---|
| armed rule disarmed | a rule that never fired hits the next case's request |
| recorded evidence cleared | `assert_network_egress_count(1)` passes on a leftover request; the credential fingerprint outlives its case |
| parked delay cancelled | a sleeping abort task fires during whatever runs next |
| world reset covers all proxies | one un-reset provider is enough to leak |

## The delay case was wrong the first time

Worth writing down, because the first version passed and proved nothing.

I asserted that a parked delay task would abort **the next case's request**. Sabotage showed the assertion was blind: removing the `task.cancel()` from `reset()` left all tests green. The premise was wrong — the parked task holds *its own* request object, so it cannot touch anyone else's call.

What it actually leaks is the task itself: still asleep past the case, keeping the proxy alive in the loop, firing its abort during whatever runs next. `state` now reports `pending_faults` so that is observable, and the rewritten assertion fails when `reset()` stops cancelling.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Dependencies

## Validation

- [x] `pytest tests/e2e/scenarios/test_provider_fault_proxy.py` — **28 passed**
- [x] `cd tests/e2e && uv run --project . --with ruff==0.15.21 ruff check scenarios/test_provider_fault_proxy.py` — **passed**
- [x] Sabotage-verified, one per case: dropping `self._rules.clear()` fails 2 cases, dropping `self._requests.clear()` fails 1, dropping the `task.cancel()` loop fails the delay case. All reverted.

## Test Strategy

User behavior: None changed. The E2E provider-fault harness now proves a reset leaves no fault rule, request evidence, credential fingerprint, or delayed task able to affect a later case.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider (the shared Emulate worlds these proxies front)
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: `tests/e2e/scenarios/test_provider_fault_proxy.py` adds four in-process proxy/world reset contract cases; 28 tests pass.
- Reborn integration: Not applicable: no Reborn product workflow or cross-crate runtime behavior changes.
- Recorded fixture: Not applicable: model tool selection and request shape do not change.
- Browser E2E: Not applicable: no browser-visible behavior changes.
- Backend or runtime: Not applicable: the in-process proxy contract does not require a database, Docker, WASM, MCP, or live provider.
- Live canary: Not applicable: deterministic harness behavior does not depend on a real model or provider.

What the tests prove: `reset()` clears every cross-case leak channel owned by `ProviderFaultProxy`, and `ProviderFaultProxyWorld.reset()` applies that contract to every configured provider proxy.

Commands run:
- `cd tests/e2e && uv run --project . pytest scenarios/test_provider_fault_proxy.py -q` — 28 passed.
- `cd tests/e2e && uv run --project . --with ruff==0.15.21 ruff check scenarios/test_provider_fault_proxy.py` — all checks passed.

## Reviewer notes

- `pending_faults` is added to `state` deliberately rather than reaching into `_delayed_requests` from the test: "is this proxy clean" is a property worth being able to ask, and a private-attribute assertion would have quietly rotted the first time the field was renamed.
- The remaining WS3 leak surfaces — OAuth state, rate counters, membership — are Emulate-side rather than proxy-side and are not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

