### PR TITLE
feat(sandbox): unwired Docker-connect retry, egress allowlist, shell limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -254,8 +254,16 @@ HEARTBEAT_NOTIFY_USER=default
 # Overrides Docker daemon discovery for the Reborn sandbox transport. Accepts a
 # unix socket path (optionally "unix://"-prefixed) or an http://host:port /
 # tcp://host:port address. Unset means "probe local defaults, then the
-# well-known unix sockets". Intended for CI runners and remote daemons.
+# well-known unix sockets".
+#
+# SECURITY: the http(s)/tcp form is plaintext and unauthenticated; the Docker
+# Engine API it reaches can create containers and mount host paths, so it is
+# restricted to a unix socket or a loopback address ("localhost"/127.0.0.1/::1)
+# by default. A non-loopback value (e.g. a remote daemon, or a DinD/CI sidecar
+# reachable at a container-network IP) additionally requires
+# IRONCLAW_REBORN_DOCKER_HOST_ALLOW_REMOTE=1 as an explicit second opt-in.
 # IRONCLAW_REBORN_DOCKER_HOST=unix:///var/run/docker.sock
+# IRONCLAW_REBORN_DOCKER_HOST_ALLOW_REMOTE=false  # required to use a non-loopback IRONCLAW_REBORN_DOCKER_HOST
 #
 # Extra domains appended to the sandboxed shell's default egress allowlist
 # (crates.io, npm, PyPI, the Go proxy, GitHub). Comma-separated hostnames;

--- a/.env.example
+++ b/.env.example
@@ -250,6 +250,19 @@ HEARTBEAT_NOTIFY_USER=default
 # SANDBOX_TIMEOUT_SECS=120
 # SANDBOX_MEMORY_LIMIT_MB=2048
 
+# Reborn sandbox container transport
+# Overrides Docker daemon discovery for the Reborn sandbox transport. Accepts a
+# unix socket path (optionally "unix://"-prefixed) or an http://host:port /
+# tcp://host:port address. Unset means "probe local defaults, then the
+# well-known unix sockets". Intended for CI runners and remote daemons.
+# IRONCLAW_REBORN_DOCKER_HOST=unix:///var/run/docker.sock
+#
+# Extra domains appended to the sandboxed shell's default egress allowlist
+# (crates.io, npm, PyPI, the Go proxy, GitHub). Comma-separated hostnames;
+# a leading "*." wildcard is allowed. These add to the defaults, never replace
+# them.
+# IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS=example.com,*.internal.example.com
+
 # ACP (Agent Client Protocol) agents
 # ACP_ENABLED=false                       # Enable ACP agent sandbox mode
 # ACP_MEMORY_LIMIT_MB=4096               # Memory limit for ACP containers

--- a/.env.example
+++ b/.env.example
@@ -259,9 +259,16 @@ HEARTBEAT_NOTIFY_USER=default
 #
 # Extra domains appended to the sandboxed shell's default egress allowlist
 # (crates.io, npm, PyPI, the Go proxy, GitHub). Comma-separated hostnames;
-# a leading "*." wildcard is allowed. These add to the defaults, never replace
-# them.
+# a leading "*." wildcard is allowed. A bare "*" is rejected (would allow
+# every host). These add to the defaults, never replace them.
 # IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS=example.com,*.internal.example.com
+#
+# Per-request egress volume cap (bytes) for the sandboxed shell's network
+# policy. Default 2147483648 (2 GiB) — generous enough for ordinary
+# cargo/npm/pip/git workflows while still bounding a single request well
+# short of a bulk-exfiltration attempt. Must be a positive integer; 0 or
+# non-numeric values fail to start.
+# IRONCLAW_SANDBOX_MAX_EGRESS_BYTES=2147483648
 
 # ACP (Agent Client Protocol) agents
 # ACP_ENABLED=false                       # Enable ACP agent sandbox mode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,6 +3894,7 @@ dependencies = [
  "ironclaw_approvals",
  "ironclaw_authorization",
  "ironclaw_capabilities",
+ "ironclaw_common",
  "ironclaw_event_projections",
  "ironclaw_events",
  "ironclaw_extensions",

--- a/crates/ironclaw_architecture/tests/reborn_extension_specificity.rs
+++ b/crates/ironclaw_architecture/tests/reborn_extension_specificity.rs
@@ -189,6 +189,19 @@ const PATH_TERM_COLLISIONS: &[(&str, &str, &str)] = &[
         "GitHub content API allowlist for skill installation",
     ),
     (
+        "crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs",
+        "github",
+        "default sandboxed-shell egress allowlist includes github.com/\
+         raw.githubusercontent.com/codeload.github.com for ordinary `git clone`/release-\
+         archive workflows — GitHub as a code host, not the github extension",
+    ),
+    (
+        "crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs",
+        "api.github.com",
+        "default sandboxed-shell egress allowlist includes GitHub's content API host for \
+         `gh`/archive-download workflows — GitHub as a code host, not the github extension",
+    ),
+    (
         "crates/ironclaw_host_runtime/src/first_party_tools/skill_management.rs",
         "github",
         "skill-install tool description names GitHub as a skill source",

--- a/crates/ironclaw_host_api/src/action.rs
+++ b/crates/ironclaw_host_api/src/action.rs
@@ -79,6 +79,22 @@ pub struct NetworkTargetPattern {
 }
 
 impl NetworkTargetPattern {
+    /// Deliberately more permissive than `ironclaw_network::parse_host_pattern`
+    /// (`crates/ironclaw_network/src/policy.rs`), which rejects a bare `*`.
+    /// That sibling is the chokepoint for untrusted operator-typed hostnames
+    /// (e.g. `IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS`) that were never
+    /// reviewed; this one validates already-reviewed declarations —
+    /// host-authored `NetworkPolicy` construction — where a bare `*`
+    /// legitimately means "every host", e.g.
+    /// `CapabilityNetworkProfile::DevWildcard`'s local-dev shell profile
+    /// (`ironclaw_reborn_composition::builtin_capability_policy::dev_wildcard_network_policy`).
+    /// The two validators diverge INTENTIONALLY on this point: do not
+    /// tighten this one to match `parse_host_pattern`'s wildcard rejection —
+    /// doing so breaks `DevWildcard`'s declared full-access grant. (Extension
+    /// manifest credential audiences are stricter still and already reject a
+    /// wildcard host at parse time — `ManifestV3Error::WildcardAudienceHost`
+    /// in `crates/ironclaw_extensions/src/v3.rs` — so they are not an example
+    /// of something this permissiveness exists for.)
     pub fn validate_declaration(&self) -> Result<(), crate::HostApiError> {
         validate_network_host_pattern(&self.host_pattern)?;
         Ok(())

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -23,6 +23,11 @@ hex = "0.4"
 ironclaw_approvals = { path = "../ironclaw_approvals" }
 ironclaw_authorization = { path = "../ironclaw_authorization" }
 ironclaw_capabilities = { path = "../ironclaw_capabilities" }
+# `sandbox_process::connect` reads the `IRONCLAW_REBORN_DOCKER_HOST` override
+# through `ironclaw_common::env_helpers::env_or_override`, so the retry path
+# honors the same runtime-override precedence the rest of Reborn uses instead
+# of a second, bare `std::env::var` lookup.
+ironclaw_common = { path = "../ironclaw_common" }
 ironclaw_process_sandbox = { path = "../ironclaw_process_sandbox" }
 ironclaw_events = { path = "../ironclaw_events" }
 ironclaw_extensions = { path = "../ironclaw_extensions" }

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -134,9 +134,12 @@ pub use process_port::{
 };
 pub use production::DefaultHostRuntime;
 pub use sandbox_process::{
-    RebornSandboxConfig, RebornSandboxContainerIdentity, RebornSandboxNetworkBroker,
-    RebornSandboxScopeKey, RebornSandboxSecretBroker, RebornSandboxUserKey,
-    RebornSandboxWorkspaceMode, RebornScopedSandboxCommandTransport, SandboxActivityRegistry,
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS, RebornSandboxConfig, RebornSandboxContainerIdentity,
+    RebornSandboxNetworkBroker, RebornSandboxScopeKey, RebornSandboxSecretBroker,
+    RebornSandboxUserKey, RebornSandboxWorkspaceMode, RebornScopedSandboxCommandTransport,
+    SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SandboxActivityRegistry, SandboxDockerReadiness,
+    connect_docker_with_retry, sandbox_allowed_domains, sandbox_docker_readiness,
+    sandbox_extra_allowed_domains, sandbox_network_policy,
 };
 /// Scoped cleanup guard consumed by the generic extension activation
 /// transaction's composition adapter. Raw obligation handoff stores remain

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -134,12 +134,13 @@ pub use process_port::{
 };
 pub use production::DefaultHostRuntime;
 pub use sandbox_process::{
-    DEFAULT_SANDBOX_ALLOWED_DOMAINS, RebornSandboxConfig, RebornSandboxContainerIdentity,
-    RebornSandboxNetworkBroker, RebornSandboxScopeKey, RebornSandboxSecretBroker,
-    RebornSandboxUserKey, RebornSandboxWorkspaceMode, RebornScopedSandboxCommandTransport,
-    SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SandboxActivityRegistry, SandboxDockerReadiness,
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS, DEFAULT_SANDBOX_MAX_EGRESS_BYTES, RebornSandboxConfig,
+    RebornSandboxContainerIdentity, RebornSandboxNetworkBroker, RebornSandboxScopeKey,
+    RebornSandboxSecretBroker, RebornSandboxUserKey, RebornSandboxWorkspaceMode,
+    RebornScopedSandboxCommandTransport, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
+    SANDBOX_MAX_EGRESS_BYTES_ENV, SandboxActivityRegistry, SandboxDockerReadiness,
     connect_docker_with_retry, sandbox_allowed_domains, sandbox_docker_readiness,
-    sandbox_extra_allowed_domains, sandbox_network_policy,
+    sandbox_extra_allowed_domains, sandbox_max_egress_bytes, sandbox_network_policy,
 };
 /// Scoped cleanup guard consumed by the generic extension activation
 /// transaction's composition adapter. Raw obligation handoff stores remain

--- a/crates/ironclaw_host_runtime/src/sandbox_process.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process.rs
@@ -58,8 +58,9 @@ pub use broker::{RebornSandboxNetworkBroker, RebornSandboxSecretBroker};
 pub use connect::{SandboxDockerReadiness, connect_docker_with_retry, sandbox_docker_readiness};
 pub use container_identity::{RebornSandboxContainerIdentity, RebornSandboxWorkspaceMode};
 pub use network_allowlist::{
-    DEFAULT_SANDBOX_ALLOWED_DOMAINS, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, sandbox_allowed_domains,
-    sandbox_extra_allowed_domains, sandbox_network_policy,
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS, DEFAULT_SANDBOX_MAX_EGRESS_BYTES,
+    SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SANDBOX_MAX_EGRESS_BYTES_ENV, sandbox_allowed_domains,
+    sandbox_extra_allowed_domains, sandbox_max_egress_bytes, sandbox_network_policy,
 };
 pub use registry::SandboxActivityRegistry;
 pub use scope_key::RebornSandboxScopeKey;

--- a/crates/ironclaw_host_runtime/src/sandbox_process.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process.rs
@@ -31,11 +31,14 @@ use crate::{
 
 mod broker;
 mod ca;
+mod connect;
 mod container_identity;
 mod credential_firewall;
 mod key_codec;
 mod mounts;
+mod network_allowlist;
 mod scope_key;
+pub(crate) mod shell_limits;
 
 // `attribution`, `registry`, and `user_key` are the persistent per-user
 // sandbox container model's identity/registry primitives: container naming,
@@ -52,16 +55,21 @@ mod user_key;
 use mounts::RebornSandboxMountSources;
 
 pub use broker::{RebornSandboxNetworkBroker, RebornSandboxSecretBroker};
+pub use connect::{SandboxDockerReadiness, connect_docker_with_retry, sandbox_docker_readiness};
 pub use container_identity::{RebornSandboxContainerIdentity, RebornSandboxWorkspaceMode};
+pub use network_allowlist::{
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS, SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, sandbox_allowed_domains,
+    sandbox_extra_allowed_domains, sandbox_network_policy,
+};
 pub use registry::SandboxActivityRegistry;
 pub use scope_key::RebornSandboxScopeKey;
 pub use user_key::RebornSandboxUserKey;
 
 const DEFAULT_IMAGE: &str = "ironclaw-worker:latest";
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(shell_limits::SHELL_TIMEOUT_DEFAULT_SECS);
 const DEFAULT_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const DEFAULT_CPU_SHARES: u32 = 1024;
-const DEFAULT_MAX_OUTPUT_BYTES: usize = 64 * 1024;
+const DEFAULT_MAX_OUTPUT_BYTES: usize = shell_limits::SHELL_OUTPUT_LIMIT_DEFAULT_BYTES as usize;
 const CONTAINER_WORKSPACE_ROOT: &str = "/workspace";
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -203,9 +203,19 @@ pub async fn connect_docker_with_retry() -> Result<Docker, RuntimeProcessError> 
 pub async fn sandbox_docker_readiness() -> SandboxDockerReadiness {
     match connect_once().await {
         Ok(_) => SandboxDockerReadiness::Ready,
-        Err(err) => SandboxDockerReadiness::Unreachable {
-            reason: err.to_string(),
-        },
+        Err(err) => {
+            // The underlying error embeds the configured socket path /
+            // remote address and Bollard's raw backend error (see
+            // `connect_override`). This probe is documented as a boot
+            // diagnostic surfaced on "a startup log line or health
+            // endpoint" — a surface that is not necessarily
+            // trusted-internal-only — so the public `reason` stays a fixed
+            // string and the detail goes to a debug log instead.
+            tracing::debug!(error = %err, "sandbox docker readiness probe failed");
+            SandboxDockerReadiness::Unreachable {
+                reason: "docker daemon unreachable".to_string(),
+            }
+        }
     }
 }
 
@@ -325,15 +335,19 @@ mod tests {
         );
     }
 
-    // Natural on this machine: no Docker daemon is running, so connect_once
-    // (and therefore the readiness probe) fails through local discovery.
-    // See the comment on `docker_host_env_override_is_consulted_first` for
-    // why this is a plain `#[test]` driving the async probe via `block_on`
-    // rather than `#[tokio::test]` holding the guard across an `.await`.
+    // Uses the env override (like the two tests above) so the daemon is
+    // deterministically unreachable and the underlying `RuntimeProcessError`
+    // is guaranteed to embed the configured endpoint (see
+    // `connect_override`'s format! strings) — that's the exact string the
+    // public `reason` must NOT leak. See the comment on
+    // `docker_host_env_override_is_consulted_first` for why this is a plain
+    // `#[test]` driving the async probe via `block_on` rather than
+    // `#[tokio::test]` holding the guard across an `.await`.
     #[test]
     fn readiness_surfaces_reason_on_unreachable_daemon() {
         let _guard = lock_env();
-        remove_runtime_env(DOCKER_HOST_ENV);
+        let unreachable_host = "/nonexistent/ironclaw-test-docker-readiness.sock";
+        set_runtime_env(DOCKER_HOST_ENV, unreachable_host);
 
         let readiness = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -341,14 +355,23 @@ mod tests {
             .expect("build current-thread runtime for test")
             .block_on(sandbox_docker_readiness());
 
+        remove_runtime_env(DOCKER_HOST_ENV);
+
         match readiness {
             SandboxDockerReadiness::Unreachable { reason } => {
                 assert!(!reason.is_empty(), "reason should be a non-empty string");
+                assert!(
+                    !reason.contains(unreachable_host),
+                    "readiness reason leaked the configured Docker endpoint \
+                     into a diagnostic surface that isn't necessarily \
+                     trusted-internal-only, got: {reason}"
+                );
             }
             SandboxDockerReadiness::Ready => {
-                // A real Docker daemon happens to be reachable on this
-                // machine/CI runner; readiness reporting Ready is also a
-                // valid, non-flaky outcome for this probe.
+                panic!(
+                    "expected Unreachable: {unreachable_host} is a nonexistent \
+                     socket path and can never be Ready"
+                );
             }
         }
     }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -48,6 +48,20 @@ use crate::RuntimeProcessError;
 /// not implement and must not be assumed to provide.
 const DOCKER_HOST_ENV: &str = "IRONCLAW_REBORN_DOCKER_HOST";
 
+/// Second, separately-named opt-in required before [`DOCKER_HOST_ENV`] may
+/// point at a non-loopback, plaintext HTTP(S)/TCP Docker daemon.
+///
+/// Mirrors the `SANDBOX_ALLOW_FULL_ACCESS` pattern (`.env.example`): a
+/// dangerous default (here, plaintext host-root-equivalent Docker API
+/// access reachable from off-box) needs its own explicit flag rather than
+/// being implied by setting the first, more innocuous-looking var. Bare
+/// "reject all non-loopback" was rejected by design review: it breaks the
+/// one legitimate case (a DinD/CI sidecar reachable at a container-network
+/// IP, not `127.0.0.1`) and operators who hit it would just disable the
+/// whole check. RFC1918-only was also rejected: a corporate `10.0.0.0/8`
+/// hosts plenty of attacker footholds and is not a trust boundary.
+const DOCKER_HOST_ALLOW_REMOTE_ENV: &str = "IRONCLAW_REBORN_DOCKER_HOST_ALLOW_REMOTE";
+
 /// Maximum connect attempts before giving up.
 const MAX_ATTEMPTS: u32 = 4;
 /// Base backoff between attempts; doubles each retry attempt.
@@ -133,6 +147,16 @@ async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
         return Ok(docker);
     }
 
+    if !is_loopback_docker_host(host) && !docker_host_allow_remote() {
+        return Err(RuntimeProcessError::ExecutionFailed(format!(
+            "{DOCKER_HOST_ENV}={host} is not a unix socket or loopback address; \
+             plaintext access to a remote Docker Engine API is host-root-equivalent \
+             (it can create containers and mount host paths). Set \
+             {DOCKER_HOST_ALLOW_REMOTE_ENV}=1 to explicitly allow a non-loopback \
+             Docker daemon (e.g. a DinD/CI sidecar reachable at a container-network IP)."
+        )));
+    }
+
     let docker = Docker::connect_with_http(
         host,
         CONNECT_ATTEMPT_TIMEOUT.as_secs(),
@@ -149,6 +173,46 @@ async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
         ))
     })?;
     Ok(docker)
+}
+
+/// Extracts the bare host (no scheme, no port, no path) from an
+/// `IRONCLAW_REBORN_DOCKER_HOST` HTTP(S)/TCP address such as
+/// `http://127.0.0.1:2375`, `tcp://docker-sidecar:2375`, or
+/// `[::1]:2375`.
+fn docker_host_component(addr: &str) -> &str {
+    let without_scheme = addr.split_once("://").map_or(addr, |(_, rest)| rest);
+    let without_path = without_scheme
+        .split_once('/')
+        .map_or(without_scheme, |(host, _)| host);
+    if let Some(after_bracket) = without_path.strip_prefix('[') {
+        // IPv6 literal: "[::1]:2375" -> "::1"
+        return after_bracket.split(']').next().unwrap_or(after_bracket);
+    }
+    without_path
+        .rsplit_once(':')
+        .map_or(without_path, |(host, _)| host)
+}
+
+/// Whether an `IRONCLAW_REBORN_DOCKER_HOST` HTTP(S)/TCP address resolves (by
+/// literal, not DNS) to loopback — the documented safe default for this
+/// override. `localhost` and IPv4/IPv6 loopback literals count; a hostname
+/// that merely *might* resolve to loopback at connect time does not, since
+/// that would make the guard dependent on DNS state.
+fn is_loopback_docker_host(addr: &str) -> bool {
+    let host = docker_host_component(addr);
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Whether the operator has set the separate [`DOCKER_HOST_ALLOW_REMOTE_ENV`]
+/// opt-in permitting a non-loopback [`DOCKER_HOST_ENV`] target.
+fn docker_host_allow_remote() -> bool {
+    env_or_override(DOCKER_HOST_ALLOW_REMOTE_ENV).is_some_and(|value| {
+        let value = value.trim().to_ascii_lowercase();
+        value == "1" || value == "true"
+    })
 }
 
 #[cfg(unix)]
@@ -370,6 +434,87 @@ mod tests {
         assert!(
             message.contains(DOCKER_HOST_ENV),
             "expected http override branch error to name {DOCKER_HOST_ENV}, got: {message}"
+        );
+    }
+
+    // Plaintext, unauthenticated access to a remote Docker Engine API is
+    // host-root-equivalent (see the module doc comment on DOCKER_HOST_ENV).
+    // A non-loopback host must be refused by default, before any socket is
+    // even opened, unless the operator has separately opted in via
+    // DOCKER_HOST_ALLOW_REMOTE_ENV. This reaches the guard directly (not
+    // through connect_once/connect_docker_with_retry) so it doesn't need a
+    // reachable daemon: the trust-boundary check must fire before any I/O.
+    #[test]
+    fn connect_override_rejects_non_loopback_host_without_opt_in() {
+        let _guard = lock_env();
+        remove_runtime_env(DOCKER_HOST_ALLOW_REMOTE_ENV);
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(connect_override("http://203.0.113.5:2375"));
+
+        let err = result.expect_err("non-loopback host must be rejected without the opt-in");
+        let message = err.to_string();
+        assert!(
+            message.contains(DOCKER_HOST_ALLOW_REMOTE_ENV),
+            "error must name the opt-in env var so an operator doesn't have \
+             to read Rust source to proceed, got: {message}"
+        );
+        assert!(
+            message.contains("203.0.113.5"),
+            "error must name the disallowed host, got: {message}"
+        );
+    }
+
+    // With the opt-in set, the trust-boundary check must get out of the way
+    // — the call should reach real Docker connect/ping logic (which then
+    // fails because nothing is listening at that address, not because of
+    // the trust boundary). This machine has no Docker daemon, so this only
+    // proves the guard was passed, not that a real remote daemon connects;
+    // see the module doc comment for why a Docker-client mock was rejected.
+    #[test]
+    fn connect_override_proceeds_past_trust_boundary_with_opt_in() {
+        let _guard = lock_env();
+        set_runtime_env(DOCKER_HOST_ALLOW_REMOTE_ENV, "1");
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(connect_override("http://203.0.113.5:2375"));
+
+        remove_runtime_env(DOCKER_HOST_ALLOW_REMOTE_ENV);
+
+        let err = result.expect_err("203.0.113.5:2375 has nothing listening");
+        let message = err.to_string();
+        assert!(
+            !message.contains(DOCKER_HOST_ALLOW_REMOTE_ENV),
+            "with the opt-in set, the failure must come from the real \
+             connect/ping attempt, not the trust-boundary guard, got: {message}"
+        );
+    }
+
+    // Loopback addresses must be unaffected by the new guard — this is the
+    // documented safe default and must keep working with no opt-in set.
+    #[test]
+    fn connect_override_loopback_host_is_unaffected_by_the_remote_guard() {
+        let _guard = lock_env();
+        remove_runtime_env(DOCKER_HOST_ALLOW_REMOTE_ENV);
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(connect_override("http://127.0.0.1:1"));
+
+        let err = result.expect_err("nothing is listening on 127.0.0.1:1");
+        let message = err.to_string();
+        assert!(
+            !message.contains(DOCKER_HOST_ALLOW_REMOTE_ENV),
+            "loopback host must not be routed through the remote-host guard, \
+             got: {message}"
         );
     }
 

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -148,6 +148,31 @@ async fn connect_once_attempt() -> Result<Docker, RuntimeProcessError> {
 /// Connect to the daemon at an explicit `IRONCLAW_REBORN_DOCKER_HOST`
 /// override: tried as a unix socket path first (when it looks like one),
 /// otherwise as an HTTP(S) address.
+///
+/// SANITIZATION: every error constructed in this function is fixed text
+/// naming only the env var, the endpoint KIND (unix socket / http
+/// endpoint), and a safe failure CATEGORY (connect / ping / rejected). It
+/// never embeds `host` or a backend (Bollard) error's `Display`. This is
+/// deliberate and applies at every branch, not just the ones that reach
+/// Bollard: this crate's `AGENTS.md` bans "raw host paths, backend error
+/// details ... in errors, events, snapshots, logs, or docs" outright, with
+/// no carve-out for `debug!`-level logging. A previous fix here sanitized
+/// only `SandboxDockerReadiness.reason`, which papered over the symptom —
+/// the underlying `RuntimeProcessError` still carried the full endpoint and
+/// raw Bollard error text into debug logs and every retry consumer, and an
+/// `IRONCLAW_REBORN_DOCKER_HOST` containing `user:pass@host` user-info would
+/// have leaked that credential into both.
+///
+/// This does cost operator debuggability: today nothing in this crate
+/// records which literal endpoint or backend error caused a connect
+/// failure, not even at debug level. That's an intentional trade rather
+/// than an oversight — the operator already knows the value they put in
+/// `IRONCLAW_REBORN_DOCKER_HOST`, so the software doesn't need to echo it
+/// back to them, and the fixed kind+category (e.g. "unix socket ping
+/// failed") is enough to tell them whether the daemon is unreachable
+/// (connect) or unhealthy (ping) without re-introducing a host/credential
+/// leak into a surface (debug logs, boot diagnostics) that isn't
+/// necessarily trusted-internal-only.
 async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
     if host.starts_with("unix://") || host.starts_with('/') {
         let docker = Docker::connect_with_socket(
@@ -155,14 +180,14 @@ async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
             CONNECT_ATTEMPT_TIMEOUT.as_secs(),
             bollard::API_DEFAULT_VERSION,
         )
-        .map_err(|e| {
+        .map_err(|_e| {
             RuntimeProcessError::ExecutionFailed(format!(
-                "{DOCKER_HOST_ENV} unix socket connect failed for {host}: {e}"
+                "{DOCKER_HOST_ENV} unix socket connect failed"
             ))
         })?;
-        docker.ping().await.map_err(|e| {
+        docker.ping().await.map_err(|_e| {
             RuntimeProcessError::ExecutionFailed(format!(
-                "{DOCKER_HOST_ENV} unix socket ping failed for {host}: {e}"
+                "{DOCKER_HOST_ENV} unix socket ping failed"
             ))
         })?;
         return Ok(docker);
@@ -170,7 +195,7 @@ async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
 
     if !is_loopback_docker_host(host) && !docker_host_allow_remote() {
         return Err(RuntimeProcessError::ExecutionFailed(format!(
-            "{DOCKER_HOST_ENV}={host} is not a unix socket or loopback address; \
+            "{DOCKER_HOST_ENV} target is not a unix socket or loopback address; \
              plaintext access to a remote Docker Engine API is host-root-equivalent \
              (it can create containers and mount host paths). Set \
              {DOCKER_HOST_ALLOW_REMOTE_ENV}=1 to explicitly allow a non-loopback \
@@ -183,15 +208,13 @@ async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
         CONNECT_ATTEMPT_TIMEOUT.as_secs(),
         bollard::API_DEFAULT_VERSION,
     )
-    .map_err(|e| {
+    .map_err(|_e| {
         RuntimeProcessError::ExecutionFailed(format!(
-            "{DOCKER_HOST_ENV} http connect failed for {host}: {e}"
+            "{DOCKER_HOST_ENV} http endpoint connect failed"
         ))
     })?;
-    docker.ping().await.map_err(|e| {
-        RuntimeProcessError::ExecutionFailed(format!(
-            "{DOCKER_HOST_ENV} http ping failed for {host}: {e}"
-        ))
+    docker.ping().await.map_err(|_e| {
+        RuntimeProcessError::ExecutionFailed(format!("{DOCKER_HOST_ENV} http endpoint ping failed"))
     })?;
     Ok(docker)
 }
@@ -320,13 +343,16 @@ pub async fn sandbox_docker_readiness() -> SandboxDockerReadiness {
     match connect_once().await {
         Ok(_) => SandboxDockerReadiness::Ready,
         Err(err) => {
-            // The underlying error embeds the configured socket path /
-            // remote address and Bollard's raw backend error (see
-            // `connect_override`). This probe is documented as a boot
-            // diagnostic surfaced on "a startup log line or health
-            // endpoint" — a surface that is not necessarily
-            // trusted-internal-only — so the public `reason` stays a fixed
-            // string and the detail goes to a debug log instead.
+            // `err` is already sanitized at construction time
+            // (`connect_once`/`connect_override`): fixed endpoint-kind +
+            // failure-category text only, never the configured socket path,
+            // remote address, or Bollard's raw backend error. That holds
+            // for this `debug!` field too, not just the public `reason`
+            // below — this probe is documented as a boot diagnostic
+            // surfaced on "a startup log line or health endpoint", a
+            // surface that is not necessarily trusted-internal-only, and
+            // this crate's `AGENTS.md` bans raw host paths/backend error
+            // details in logs outright (no debug-level carve-out).
             tracing::debug!(error = %err, "sandbox docker readiness probe failed");
             SandboxDockerReadiness::Unreachable {
                 reason: "docker daemon unreachable".to_string(),
@@ -476,9 +502,16 @@ mod tests {
             "error must name the opt-in env var so an operator doesn't have \
              to read Rust source to proceed, got: {message}"
         );
+        // ironloop review finding (PR #6746): this rejection is constructed
+        // from the operator-supplied host without ever touching Bollard, so
+        // it's easy to assume echoing it back is harmless — but the same
+        // host string can carry `user:pass@` credentials, and this crate's
+        // `AGENTS.md` bans raw host paths in errors outright. The host must
+        // NOT appear in the message.
         assert!(
-            message.contains("203.0.113.5"),
-            "error must name the disallowed host, got: {message}"
+            !message.contains("203.0.113.5"),
+            "error must not echo the disallowed host back (raw host paths \
+             are banned from errors — see AGENTS.md), got: {message}"
         );
     }
 
@@ -713,6 +746,106 @@ mod tests {
                 reason: "docker daemon unreachable".to_string(),
             },
             "expected the stalled daemon to be reported Unreachable, not Ready"
+        );
+    }
+
+    // ironloop review finding (PR #6746): the earlier fix in this file
+    // (`readiness_surfaces_reason_on_unreachable_daemon`) only sanitized
+    // `SandboxDockerReadiness.reason`. The underlying `RuntimeProcessError`
+    // built by `connect_override` still embedded the full configured
+    // endpoint and Bollard's raw error text, so every *other* consumer of
+    // that error (debug logs, the retry loop's exhausted error) still saw
+    // it — and if `IRONCLAW_REBORN_DOCKER_HOST` carried `user:pass@host`
+    // user-info, that credential leaked into both. This pins the fix at
+    // its source (`connect_override`'s error constructors), covering the
+    // http connect/ping branch where the credential-bearing case actually
+    // lives.
+    //
+    // `readiness`'s `debug!(error = %err, ...)` field logs `err`'s exact
+    // `Display` output — the same string asserted on below — so proving
+    // this string is clean also proves the log field is clean; there is no
+    // separate log-formatting path to test independently.
+    //
+    // RED evidence: reverting the `_e` param names in `connect_override`
+    // back to `e` and re-inserting `for {host}: {e}` into the four
+    // Bollard-facing format! calls (the pre-fix shape) makes this test fail
+    // with the host and "hunter2" both present in the message — see the
+    // task report for the captured failure output.
+    #[test]
+    fn connect_override_http_errors_never_leak_host_or_userinfo_credential() {
+        let _guard = lock_env();
+
+        // `docker_host_component` parses the host out by splitting on the
+        // last `:`, so a `user:pass@host` URL's parsed "host" is
+        // `user:pass@host` — never equal to `localhost` nor a valid
+        // `IpAddr` — and `is_loopback_docker_host` (correctly, fail-closed)
+        // treats any user-info-bearing URL as non-loopback regardless of
+        // the real host. Set the remote opt-in so this test reaches the
+        // connect/ping error branches under test rather than the separate
+        // rejection branch (covered by
+        // `connect_override_rejects_non_loopback_host_without_opt_in`).
+        set_runtime_env(DOCKER_HOST_ALLOW_REMOTE_ENV, "1");
+        let host = "http://user:hunter2@127.0.0.1:1";
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(connect_override(host));
+
+        remove_runtime_env(DOCKER_HOST_ALLOW_REMOTE_ENV);
+
+        let err = result.expect_err("nothing is listening on 127.0.0.1:1");
+        let message = err.to_string();
+
+        assert!(
+            !message.contains("hunter2"),
+            "error must never leak a credential supplied via user-info in \
+             {DOCKER_HOST_ENV}, got: {message}"
+        );
+        assert!(
+            !message.contains("user:hunter2"),
+            "error must never leak the user-info component of {DOCKER_HOST_ENV}, \
+             got: {message}"
+        );
+        assert!(
+            !message.contains("127.0.0.1"),
+            "error must not embed the configured host at all (fixed kind + \
+             category only), got: {message}"
+        );
+        assert!(
+            message.contains(DOCKER_HOST_ENV) && message.contains("http endpoint"),
+            "error should still name the env var and endpoint kind so an \
+             operator gets a safe category, got: {message}"
+        );
+    }
+
+    // Companion to the http-branch test above, covering the unix socket
+    // connect/ping error branch with a path that looks like it could carry
+    // sensitive topology (a nonstandard, identifying socket path).
+    #[test]
+    fn connect_override_unix_socket_errors_never_leak_the_configured_path() {
+        let _guard = lock_env();
+
+        let host = "/nonexistent/ironclaw-test-docker-leak-check.sock";
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(connect_override(host));
+
+        let err = result.expect_err("no daemon reachable at nonexistent override path");
+        let message = err.to_string();
+
+        assert!(
+            !message.contains(host),
+            "error must not embed the configured unix socket path, got: {message}"
+        );
+        assert!(
+            message.contains(DOCKER_HOST_ENV) && message.contains("unix socket"),
+            "error should still name the env var and endpoint kind so an \
+             operator gets a safe category, got: {message}"
         );
     }
 }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -38,6 +38,14 @@ use crate::RuntimeProcessError;
 /// direct connect against the given endpoint instead of probing local
 /// socket candidates. Accepts a unix socket path (optionally `unix://`
 /// prefixed) or an `http://host:port` / `tcp://host:port` address.
+///
+/// SECURITY: the non-socket form connects in **plaintext, unauthenticated**
+/// — there is no `connect_with_ssl` branch here. The Docker Engine API this
+/// reaches can create containers and mount host paths, so a non-loopback
+/// value hands that authority to anyone on the network path. Set it only to a
+/// unix socket or a loopback address (the CI/DinD case it exists for). A
+/// genuinely remote daemon needs a TLS/mTLS transport, which this module does
+/// not implement and must not be assumed to provide.
 const DOCKER_HOST_ENV: &str = "IRONCLAW_REBORN_DOCKER_HOST";
 
 /// Maximum connect attempts before giving up.
@@ -288,6 +296,32 @@ mod tests {
         assert!(
             message.contains(DOCKER_HOST_ENV),
             "expected override branch error to name {DOCKER_HOST_ENV}, got: {message}"
+        );
+    }
+
+    // The override has two branches; the test above only reaches the unix
+    // socket one. This reaches the http/tcp one, which is the branch CI
+    // runners and DinD actually take, and pins that its failure is still
+    // attributed to the env var rather than falling through to the generic
+    // local-discovery message. Port 1 on loopback has nothing listening.
+    #[test]
+    fn docker_host_env_override_http_branch_reports_the_env_var() {
+        let _guard = lock_env();
+        set_runtime_env(DOCKER_HOST_ENV, "http://127.0.0.1:1");
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(connect_once());
+
+        remove_runtime_env(DOCKER_HOST_ENV);
+
+        let err = result.expect_err("nothing is listening on 127.0.0.1:1");
+        let message = err.to_string();
+        assert!(
+            message.contains(DOCKER_HOST_ENV),
+            "expected http override branch error to name {DOCKER_HOST_ENV}, got: {message}"
         );
     }
 

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -91,7 +91,28 @@ pub enum SandboxDockerReadiness {
 /// Single connection attempt: env override first, then local-default
 /// discovery, then well-known unix socket candidates. No retry here — see
 /// [`connect_docker_with_retry`] for the retrying entrypoint.
+///
+/// The whole attempt (all three sub-branches, sequentially) is bounded by
+/// [`CONNECT_ATTEMPT_TIMEOUT`] here, in one place, so every caller — the
+/// retry loop *and* the one-shot [`sandbox_docker_readiness`] probe —
+/// inherits the same bound automatically. This matters most for the
+/// local-default branch: `Docker::connect_with_local_defaults()` uses
+/// Bollard's own internal client timeout, which this module does not
+/// parameterize, so without an outer timeout here a stalled (connects but
+/// never answers `ping()`) local daemon would block past what either caller
+/// promises.
 async fn connect_once() -> Result<Docker, RuntimeProcessError> {
+    match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, connect_once_attempt()).await {
+        Ok(result) => result,
+        Err(_elapsed) => Err(RuntimeProcessError::ExecutionFailed(format!(
+            "docker connect attempt timed out after {CONNECT_ATTEMPT_TIMEOUT:?}"
+        ))),
+    }
+}
+
+/// The actual connect logic for a single attempt, unbounded — wrapped by
+/// [`connect_once`], which is the only caller.
+async fn connect_once_attempt() -> Result<Docker, RuntimeProcessError> {
     if let Some(override_host) = env_or_override(DOCKER_HOST_ENV) {
         return connect_override(&override_host).await;
     }
@@ -273,35 +294,28 @@ where
 /// Worst-case wall-clock bound: `MAX_ATTEMPTS` (4) attempts, each capped at
 /// `CONNECT_ATTEMPT_TIMEOUT` (5s), plus cumulative doubling backoff between
 /// attempts (250ms + 500ms + 1000ms = 1.75s, none after the last attempt) —
-/// about 21.75s, comfortably under 30s. `connect_once` tries local-default
-/// discovery first, which uses Bollard's own internal client timeout rather
-/// than a parameter this module controls; each attempt is wrapped in
-/// [`tokio::time::timeout`] so that path is bounded too, regardless of what
-/// Bollard does internally. `retry_worst_case_wall_clock_is_bounded` (below)
-/// pins this arithmetic so a future change to the constants can't silently
-/// blow the bound back out.
+/// about 21.75s, comfortably under 30s. The per-attempt bound is enforced
+/// inside [`connect_once`] itself (see its doc comment), including the
+/// local-default discovery branch, which otherwise uses Bollard's own
+/// internal client timeout rather than a parameter this module controls.
+/// `retry_worst_case_wall_clock_is_bounded` (below) pins this arithmetic so a
+/// future change to the constants can't silently blow the bound back out.
 ///
 /// CRITICAL: on retry exhaustion this returns `Err`, which callers MUST
 /// propagate as a hard failure. There is no fallback to running the sandbox
 /// command unsandboxed on the host — see module docs and
 /// `docs/safety-and-sandbox.md`.
 pub async fn connect_docker_with_retry() -> Result<Docker, RuntimeProcessError> {
-    run_with_retry(MAX_ATTEMPTS, BASE_BACKOFF, || async {
-        match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, connect_once()).await {
-            Ok(result) => result,
-            Err(_elapsed) => Err(RuntimeProcessError::ExecutionFailed(format!(
-                "docker connect attempt timed out after {CONNECT_ATTEMPT_TIMEOUT:?}"
-            ))),
-        }
-    })
-    .await
+    run_with_retry(MAX_ATTEMPTS, BASE_BACKOFF, connect_once).await
 }
 
 /// Boot-time Docker daemon readiness probe.
 ///
 /// Thin wrapper around a single connect attempt (not the retry loop — this
 /// is meant to be a fast, one-shot diagnostic reported at startup, not a
-/// gate that blocks boot waiting for the daemon to come up).
+/// gate that blocks boot waiting for the daemon to come up). Bounded by
+/// [`CONNECT_ATTEMPT_TIMEOUT`] via [`connect_once`] — a daemon that accepts
+/// the connection but never answers cannot stall this past that bound.
 pub async fn sandbox_docker_readiness() -> SandboxDockerReadiness {
     match connect_once().await {
         Ok(_) => SandboxDockerReadiness::Ready,
@@ -592,6 +606,113 @@ mod tests {
             "connect_docker_with_retry's worst-case wall clock ({worst_case:?}) \
              no longer matches its documented \"about 21.75s, comfortably \
              under 30s\" bound",
+        );
+    }
+
+    // ironloop review finding (PR #6746): sandbox_docker_readiness() called
+    // connect_once() directly with nothing wrapping the local-default
+    // discovery branch, which uses Bollard's own internal 120s client
+    // timeout rather than CONNECT_ATTEMPT_TIMEOUT. A daemon that accepts the
+    // connection but never answers `ping()` (the dangerous case — a closed
+    // port fails fast and proves nothing) could stall the "cheap one-shot
+    // probe" documented on `SandboxDockerReadiness` for up to two minutes.
+    //
+    // This reproduces that exact daemon shape: a real unix-socket listener
+    // that accepts the connection and then never writes a response. Real
+    // `DOCKER_HOST` (Bollard's own env var, not this module's
+    // `IRONCLAW_REBORN_DOCKER_HOST` override) is pointed at it so
+    // `connect_once` takes the `Docker::connect_with_local_defaults()`
+    // branch — the one with no parameterized timeout — rather than the
+    // override branch, which already threaded `CONNECT_ATTEMPT_TIMEOUT`
+    // through to Bollard before this fix.
+    //
+    // Plain `#[test]` (not `#[tokio::test]`), same reasoning as
+    // `docker_host_env_override_is_consulted_first` above: `lock_env()`'s
+    // guard must not be held across an `.await` in an outer async fn
+    // (clippy `await_holding_lock`), so a current-thread runtime's
+    // `block_on` drives the probe to completion synchronously inside the
+    // guarded section instead. `block_on` also drives the
+    // `tokio::time::timeout` wrapper, so the ceiling assertion still holds.
+    #[cfg(unix)]
+    #[test]
+    fn sandbox_docker_readiness_bounded_when_daemon_accepts_but_never_answers() {
+        let _guard = lock_env();
+        remove_runtime_env(DOCKER_HOST_ENV);
+
+        // Unix socket paths are capped at `SUN_LEN` (~104 bytes on macOS),
+        // which `std::env::temp_dir()` can blow through on some CI/dev
+        // layouts — use `/tmp` directly, kept short.
+        let dir = std::path::PathBuf::from("/tmp").join(format!(
+            "ic-dsock-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+                % 1_000_000
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir for stalled docker socket");
+        let socket_path = dir.join("d.sock");
+
+        let listener = std::os::unix::net::UnixListener::bind(&socket_path)
+            .expect("bind stalled docker socket");
+        // Detached on purpose: the process exits when the test binary's main
+        // thread returns, which tears this down regardless of whether the
+        // 300s sleep below ever completes.
+        let _accept_thread = std::thread::spawn(move || {
+            if let Ok((stream, _addr)) = listener.accept() {
+                std::thread::sleep(Duration::from_secs(300));
+                drop(stream);
+            }
+        });
+
+        let original_docker_host = std::env::var_os("DOCKER_HOST");
+        // SAFETY: guarded by `lock_env()`, same pattern as
+        // `runtime_mask_hides_real_env` above — no other test mutates
+        // `DOCKER_HOST` concurrently.
+        unsafe {
+            std::env::set_var("DOCKER_HOST", format!("unix://{}", socket_path.display()));
+        }
+
+        // Generous ceiling, not a tight window: comfortably more than
+        // 2x CONNECT_ATTEMPT_TIMEOUT so ordinary CI scheduling jitter can't
+        // flake it, but far short of Bollard's 120s internal default —
+        // enough to prove the bound without a slow test.
+        let ceiling = CONNECT_ATTEMPT_TIMEOUT * 2 + Duration::from_secs(2);
+        let started = std::time::Instant::now();
+        let outcome = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(async { tokio::time::timeout(ceiling, sandbox_docker_readiness()).await });
+        let elapsed = started.elapsed();
+
+        // SAFETY: still under the same `lock_env()` guard as the set above.
+        unsafe {
+            match original_docker_host {
+                Some(value) => std::env::set_var("DOCKER_HOST", value),
+                None => std::env::remove_var("DOCKER_HOST"),
+            }
+        }
+        remove_runtime_env(DOCKER_HOST_ENV);
+        std::fs::remove_dir_all(&dir).ok();
+
+        let readiness = outcome.unwrap_or_else(|_| {
+            panic!(
+                "sandbox_docker_readiness() did not return within {ceiling:?} \
+                 (2x CONNECT_ATTEMPT_TIMEOUT + slack) even though it is \
+                 documented as a cheap, bounded one-shot probe; a daemon \
+                 that accepts the connection and never answers must not be \
+                 able to stall it past that bound (elapsed={elapsed:?})"
+            )
+        });
+
+        assert_eq!(
+            readiness,
+            SandboxDockerReadiness::Unreachable {
+                reason: "docker daemon unreachable".to_string(),
+            },
+            "expected the stalled daemon to be reported Unreachable, not Ready"
         );
     }
 }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -1,0 +1,321 @@
+//! Docker daemon connectivity hardening for the Reborn sandbox process
+//! transport.
+//!
+//! Docker socket discovery is inherently flaky in dev environments (Docker
+//! Desktop restarts, Colima cold start, transient daemon busy states, etc).
+//! This module wraps the existing single-attempt connect logic
+//! ([`connect_once`]) in a bounded retry loop, adds an
+//! `IRONCLAW_REBORN_DOCKER_HOST` env override for environments where local
+//! socket discovery doesn't apply (CI runners, remote daemons), and exposes
+//! a cheap readiness probe for boot diagnostics.
+//!
+//! CRITICAL: retry exhaustion here always propagates as a hard
+//! [`RuntimeProcessError`]. Callers MUST NOT catch that error and fall back
+//! to running the command unsandboxed on the host — there is no
+//! host-execution fallback path for sandboxed command execution. See
+//! `docs/safety-and-sandbox.md`.
+//!
+//! Ships unwired. `sandbox_process`'s own `connect_docker` is still the
+//! single-attempt path the live transport uses; this module is re-exported at
+//! the crate root for its two real future consumers in
+//! `ironclaw_reborn_composition`: `sandbox_reaper_task`, which calls
+//! [`connect_docker_with_retry`] before entering the reaper loop, and
+//! `sandbox_composition`'s boot diagnostic, which calls
+//! [`sandbox_docker_readiness`]. Repointing `connect_docker` at the retrying
+//! path changes the live transport's failure timing, so it ships in the PR
+//! that carries a test for it rather than riding in on this module's arrival.
+
+#[cfg(unix)]
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bollard::Docker;
+use ironclaw_common::env_helpers::env_or_override;
+
+use crate::RuntimeProcessError;
+
+/// Env var that, when set, short-circuits Docker daemon discovery to a
+/// direct connect against the given endpoint instead of probing local
+/// socket candidates. Accepts a unix socket path (optionally `unix://`
+/// prefixed) or an `http://host:port` / `tcp://host:port` address.
+const DOCKER_HOST_ENV: &str = "IRONCLAW_REBORN_DOCKER_HOST";
+
+/// Maximum connect attempts before giving up.
+const MAX_ATTEMPTS: u32 = 4;
+/// Base backoff between attempts; doubles each retry attempt.
+const BASE_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Outcome of a Docker daemon readiness probe, surfaced as a boot
+/// diagnostic.
+///
+/// This is a diagnostic signal only (e.g. for a startup log line or health
+/// endpoint) — it must never be used to gate a fallback to unsandboxed
+/// execution. See module docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxDockerReadiness {
+    Ready,
+    Unreachable { reason: String },
+}
+
+/// Single connection attempt: env override first, then local-default
+/// discovery, then well-known unix socket candidates. No retry here — see
+/// [`connect_docker_with_retry`] for the retrying entrypoint.
+async fn connect_once() -> Result<Docker, RuntimeProcessError> {
+    if let Some(override_host) = env_or_override(DOCKER_HOST_ENV) {
+        return connect_override(&override_host).await;
+    }
+
+    if let Ok(docker) = Docker::connect_with_local_defaults()
+        && docker.ping().await.is_ok()
+    {
+        return Ok(docker);
+    }
+
+    #[cfg(unix)]
+    {
+        for socket in unix_socket_candidates() {
+            if socket.exists() {
+                let socket = socket.to_string_lossy();
+                if let Ok(docker) =
+                    Docker::connect_with_socket(&socket, 120, bollard::API_DEFAULT_VERSION)
+                    && docker.ping().await.is_ok()
+                {
+                    return Ok(docker);
+                }
+            }
+        }
+    }
+
+    Err(RuntimeProcessError::ExecutionFailed(
+        "could not connect to Docker daemon for Reborn sandbox".to_string(),
+    ))
+}
+
+/// Connect to the daemon at an explicit `IRONCLAW_REBORN_DOCKER_HOST`
+/// override: tried as a unix socket path first (when it looks like one),
+/// otherwise as an HTTP(S) address.
+async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
+    if host.starts_with("unix://") || host.starts_with('/') {
+        let docker =
+            Docker::connect_with_socket(host, 120, bollard::API_DEFAULT_VERSION).map_err(|e| {
+                RuntimeProcessError::ExecutionFailed(format!(
+                    "{DOCKER_HOST_ENV} unix socket connect failed for {host}: {e}"
+                ))
+            })?;
+        docker.ping().await.map_err(|e| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "{DOCKER_HOST_ENV} unix socket ping failed for {host}: {e}"
+            ))
+        })?;
+        return Ok(docker);
+    }
+
+    let docker =
+        Docker::connect_with_http(host, 120, bollard::API_DEFAULT_VERSION).map_err(|e| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "{DOCKER_HOST_ENV} http connect failed for {host}: {e}"
+            ))
+        })?;
+    docker.ping().await.map_err(|e| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "{DOCKER_HOST_ENV} http ping failed for {host}: {e}"
+        ))
+    })?;
+    Ok(docker)
+}
+
+#[cfg(unix)]
+fn unix_socket_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        candidates.push(home.join(".docker/run/docker.sock"));
+        candidates.push(home.join(".colima/default/docker.sock"));
+        candidates.push(home.join(".rd/docker.sock"));
+    }
+    if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from) {
+        candidates.push(runtime_dir.join("docker.sock"));
+    }
+    candidates
+}
+
+/// Retry `f` up to `attempts` times with doubling backoff starting at
+/// `base_backoff`, sleeping between attempts (not after the last one).
+///
+/// Kept private and local to this module: there is exactly one production
+/// caller ([`connect_docker_with_retry`]); this is not a general-purpose
+/// retry utility for the crate.
+async fn run_with_retry<F, Fut, T>(
+    attempts: u32,
+    base_backoff: Duration,
+    mut f: F,
+) -> Result<T, RuntimeProcessError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, RuntimeProcessError>>,
+{
+    let mut last_err = None;
+    let mut backoff = base_backoff;
+
+    for attempt in 0..attempts {
+        match f().await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                last_err = Some(err);
+                if attempt + 1 < attempts {
+                    tokio::time::sleep(backoff).await;
+                    backoff *= 2;
+                }
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| {
+        RuntimeProcessError::ExecutionFailed(
+            "could not connect to Docker daemon for Reborn sandbox".to_string(),
+        )
+    }))
+}
+
+/// Connect to the Docker daemon with a bounded retry loop (exponential
+/// backoff, capped total wait of a few seconds).
+///
+/// CRITICAL: on retry exhaustion this returns `Err`, which callers MUST
+/// propagate as a hard failure. There is no fallback to running the sandbox
+/// command unsandboxed on the host — see module docs and
+/// `docs/safety-and-sandbox.md`.
+pub async fn connect_docker_with_retry() -> Result<Docker, RuntimeProcessError> {
+    run_with_retry(MAX_ATTEMPTS, BASE_BACKOFF, connect_once).await
+}
+
+/// Boot-time Docker daemon readiness probe.
+///
+/// Thin wrapper around a single connect attempt (not the retry loop — this
+/// is meant to be a fast, one-shot diagnostic reported at startup, not a
+/// gate that blocks boot waiting for the daemon to come up).
+pub async fn sandbox_docker_readiness() -> SandboxDockerReadiness {
+    match connect_once().await {
+        Ok(_) => SandboxDockerReadiness::Ready,
+        Err(err) => SandboxDockerReadiness::Unreachable {
+            reason: err.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use ironclaw_common::env_helpers::{lock_env, remove_runtime_env, set_runtime_env};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn retry_loop_succeeds_after_transient_failures() {
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<u32, RuntimeProcessError> =
+            run_with_retry(5, Duration::from_millis(1), || {
+                let call = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if call < 3 {
+                        Err(RuntimeProcessError::ExecutionFailed(format!(
+                            "transient failure {call}"
+                        )))
+                    } else {
+                        Ok(42)
+                    }
+                }
+            })
+            .await;
+
+        assert_eq!(result, Ok(42));
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_loop_exhausts_and_returns_last_error() {
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<u32, RuntimeProcessError> =
+            run_with_retry(4, Duration::from_millis(1), || {
+                let call = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    Err::<u32, _>(RuntimeProcessError::ExecutionFailed(format!(
+                        "permanent failure {call}"
+                    )))
+                }
+            })
+            .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        match result {
+            Err(RuntimeProcessError::ExecutionFailed(msg)) => {
+                assert_eq!(msg, "permanent failure 4");
+            }
+            other => panic!("expected exhausted ExecutionFailed, got {other:?}"),
+        }
+    }
+
+    // Live daemon behavior for the override branch (actually dialing the
+    // configured endpoint) is proven in the Docker-gated integration tier —
+    // this machine has no Docker daemon. This test only proves the env
+    // override is read and selected before local-default discovery: an
+    // unreachable override path must fail with an error naming the override
+    // env var, not the generic local-discovery failure message.
+    //
+    // Plain `#[test]` (not `#[tokio::test]`) so the `lock_env()` guard —
+    // which must stay held for the whole set-env/connect/read-error window
+    // to keep this test's env mutation from interleaving with any other
+    // test touching the same runtime-env overlay — is never held across a
+    // `.await` in an outer async fn. `block_on` drives `connect_once` to
+    // completion synchronously inside the guarded section instead, so
+    // there's no clippy-visible suspension point while the guard is live.
+    #[test]
+    fn docker_host_env_override_is_consulted_first() {
+        let _guard = lock_env();
+        set_runtime_env(DOCKER_HOST_ENV, "/nonexistent/ironclaw-test-docker.sock");
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(connect_once());
+
+        remove_runtime_env(DOCKER_HOST_ENV);
+
+        let err = result.expect_err("no daemon reachable at nonexistent override path");
+        let message = err.to_string();
+        assert!(
+            message.contains(DOCKER_HOST_ENV),
+            "expected override branch error to name {DOCKER_HOST_ENV}, got: {message}"
+        );
+    }
+
+    // Natural on this machine: no Docker daemon is running, so connect_once
+    // (and therefore the readiness probe) fails through local discovery.
+    // See the comment on `docker_host_env_override_is_consulted_first` for
+    // why this is a plain `#[test]` driving the async probe via `block_on`
+    // rather than `#[tokio::test]` holding the guard across an `.await`.
+    #[test]
+    fn readiness_surfaces_reason_on_unreachable_daemon() {
+        let _guard = lock_env();
+        remove_runtime_env(DOCKER_HOST_ENV);
+
+        let readiness = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime for test")
+            .block_on(sandbox_docker_readiness());
+
+        match readiness {
+            SandboxDockerReadiness::Unreachable { reason } => {
+                assert!(!reason.is_empty(), "reason should be a non-empty string");
+            }
+            SandboxDockerReadiness::Ready => {
+                // A real Docker daemon happens to be reachable on this
+                // machine/CI runner; readiness reporting Ready is also a
+                // valid, non-flaky outcome for this probe.
+            }
+        }
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/connect.rs
@@ -53,6 +53,15 @@ const MAX_ATTEMPTS: u32 = 4;
 /// Base backoff between attempts; doubles each retry attempt.
 const BASE_BACKOFF: Duration = Duration::from_millis(250);
 
+/// Per-attempt bound on a single connect (dial + `ping()`).
+///
+/// A Docker daemon that has accepted a TCP/unix-socket connection but hasn't
+/// answered `ping()` within a few seconds is not healthy — waiting longer
+/// than this just delays the inevitable retry (or failure). This is also the
+/// client-side request timeout handed to `bollard::Docker::connect_with_*`,
+/// so the two mechanisms agree on the same bound.
+const CONNECT_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Outcome of a Docker daemon readiness probe, surfaced as a boot
 /// diagnostic.
 ///
@@ -84,9 +93,11 @@ async fn connect_once() -> Result<Docker, RuntimeProcessError> {
         for socket in unix_socket_candidates() {
             if socket.exists() {
                 let socket = socket.to_string_lossy();
-                if let Ok(docker) =
-                    Docker::connect_with_socket(&socket, 120, bollard::API_DEFAULT_VERSION)
-                    && docker.ping().await.is_ok()
+                if let Ok(docker) = Docker::connect_with_socket(
+                    &socket,
+                    CONNECT_ATTEMPT_TIMEOUT.as_secs(),
+                    bollard::API_DEFAULT_VERSION,
+                ) && docker.ping().await.is_ok()
                 {
                     return Ok(docker);
                 }
@@ -104,12 +115,16 @@ async fn connect_once() -> Result<Docker, RuntimeProcessError> {
 /// otherwise as an HTTP(S) address.
 async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
     if host.starts_with("unix://") || host.starts_with('/') {
-        let docker =
-            Docker::connect_with_socket(host, 120, bollard::API_DEFAULT_VERSION).map_err(|e| {
-                RuntimeProcessError::ExecutionFailed(format!(
-                    "{DOCKER_HOST_ENV} unix socket connect failed for {host}: {e}"
-                ))
-            })?;
+        let docker = Docker::connect_with_socket(
+            host,
+            CONNECT_ATTEMPT_TIMEOUT.as_secs(),
+            bollard::API_DEFAULT_VERSION,
+        )
+        .map_err(|e| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "{DOCKER_HOST_ENV} unix socket connect failed for {host}: {e}"
+            ))
+        })?;
         docker.ping().await.map_err(|e| {
             RuntimeProcessError::ExecutionFailed(format!(
                 "{DOCKER_HOST_ENV} unix socket ping failed for {host}: {e}"
@@ -118,12 +133,16 @@ async fn connect_override(host: &str) -> Result<Docker, RuntimeProcessError> {
         return Ok(docker);
     }
 
-    let docker =
-        Docker::connect_with_http(host, 120, bollard::API_DEFAULT_VERSION).map_err(|e| {
-            RuntimeProcessError::ExecutionFailed(format!(
-                "{DOCKER_HOST_ENV} http connect failed for {host}: {e}"
-            ))
-        })?;
+    let docker = Docker::connect_with_http(
+        host,
+        CONNECT_ATTEMPT_TIMEOUT.as_secs(),
+        bollard::API_DEFAULT_VERSION,
+    )
+    .map_err(|e| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "{DOCKER_HOST_ENV} http connect failed for {host}: {e}"
+        ))
+    })?;
     docker.ping().await.map_err(|e| {
         RuntimeProcessError::ExecutionFailed(format!(
             "{DOCKER_HOST_ENV} http ping failed for {host}: {e}"
@@ -185,14 +204,33 @@ where
 }
 
 /// Connect to the Docker daemon with a bounded retry loop (exponential
-/// backoff, capped total wait of a few seconds).
+/// backoff between attempts).
+///
+/// Worst-case wall-clock bound: `MAX_ATTEMPTS` (4) attempts, each capped at
+/// `CONNECT_ATTEMPT_TIMEOUT` (5s), plus cumulative doubling backoff between
+/// attempts (250ms + 500ms + 1000ms = 1.75s, none after the last attempt) —
+/// about 21.75s, comfortably under 30s. `connect_once` tries local-default
+/// discovery first, which uses Bollard's own internal client timeout rather
+/// than a parameter this module controls; each attempt is wrapped in
+/// [`tokio::time::timeout`] so that path is bounded too, regardless of what
+/// Bollard does internally. `retry_worst_case_wall_clock_is_bounded` (below)
+/// pins this arithmetic so a future change to the constants can't silently
+/// blow the bound back out.
 ///
 /// CRITICAL: on retry exhaustion this returns `Err`, which callers MUST
 /// propagate as a hard failure. There is no fallback to running the sandbox
 /// command unsandboxed on the host — see module docs and
 /// `docs/safety-and-sandbox.md`.
 pub async fn connect_docker_with_retry() -> Result<Docker, RuntimeProcessError> {
-    run_with_retry(MAX_ATTEMPTS, BASE_BACKOFF, connect_once).await
+    run_with_retry(MAX_ATTEMPTS, BASE_BACKOFF, || async {
+        match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, connect_once()).await {
+            Ok(result) => result,
+            Err(_elapsed) => Err(RuntimeProcessError::ExecutionFailed(format!(
+                "docker connect attempt timed out after {CONNECT_ATTEMPT_TIMEOUT:?}"
+            ))),
+        }
+    })
+    .await
 }
 
 /// Boot-time Docker daemon readiness probe.
@@ -374,5 +412,41 @@ mod tests {
                 );
             }
         }
+    }
+
+    // Pins the worst-case wall-clock bound documented on
+    // `connect_docker_with_retry`. A real end-to-end timing test would need
+    // a Docker daemon that accepts the connection but never answers
+    // `ping()` (not reproducible without a mock Docker client, which was
+    // rejected by design review for this module) and would be flaky under
+    // CI scheduling jitter regardless. Pinning the constants' arithmetic
+    // instead makes any future change to MAX_ATTEMPTS, CONNECT_ATTEMPT_TIMEOUT,
+    // or BASE_BACKOFF that blows the documented bound back out fail loudly
+    // and deterministically.
+    #[test]
+    fn retry_worst_case_wall_clock_is_bounded() {
+        let mut worst_case = Duration::ZERO;
+        let mut backoff = BASE_BACKOFF;
+        for attempt in 0..MAX_ATTEMPTS {
+            worst_case += CONNECT_ATTEMPT_TIMEOUT;
+            if attempt + 1 < MAX_ATTEMPTS {
+                worst_case += backoff;
+                backoff *= 2;
+            }
+        }
+
+        assert_eq!(
+            worst_case,
+            Duration::from_millis(21_750),
+            "connect_docker_with_retry's worst-case wall clock changed; if \
+             intentional, update this pin AND the doc comment on \
+             connect_docker_with_retry",
+        );
+        assert!(
+            worst_case <= Duration::from_secs(30),
+            "connect_docker_with_retry's worst-case wall clock ({worst_case:?}) \
+             no longer matches its documented \"about 21.75s, comfortably \
+             under 30s\" bound",
+        );
     }
 }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -111,7 +111,9 @@ pub fn sandbox_extra_allowed_domains() -> Result<Vec<String>, NetworkPolicyError
     raw.split(',')
         .map(str::trim)
         .filter(|domain| !domain.is_empty())
-        .map(|domain| ironclaw_network::parse_host_pattern(domain).map(|pattern| pattern.host_pattern))
+        .map(|domain| {
+            ironclaw_network::parse_host_pattern(domain).map(|pattern| pattern.host_pattern)
+        })
         .collect()
 }
 
@@ -230,7 +232,10 @@ mod tests {
 
         let policy = sandbox_network_policy().unwrap();
 
-        assert_eq!(policy.max_egress_bytes, Some(DEFAULT_SANDBOX_MAX_EGRESS_BYTES));
+        assert_eq!(
+            policy.max_egress_bytes,
+            Some(DEFAULT_SANDBOX_MAX_EGRESS_BYTES)
+        );
     }
 
     #[test]
@@ -263,7 +268,10 @@ mod tests {
         let _guard = lock_env();
         remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
 
-        assert_eq!(sandbox_extra_allowed_domains().unwrap(), Vec::<String>::new());
+        assert_eq!(
+            sandbox_extra_allowed_domains().unwrap(),
+            Vec::<String>::new()
+        );
     }
 
     // A bare `*` turns `host_matches_pattern` (ironclaw_network::policy) into

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -26,7 +26,7 @@
 //! take it as an input, and because a list of hostnames is reviewable on its
 //! own in a way it will not be once it is buried in a proxy PR.
 use ironclaw_common::env_helpers::env_or_override;
-use ironclaw_host_api::NetworkPolicy;
+use ironclaw_host_api::{NetworkPolicy, NetworkTargetPattern};
 use ironclaw_network::NetworkPolicyError;
 
 /// Environment variable operators can set to add domains to the sandboxed
@@ -128,27 +128,37 @@ pub const DEFAULT_SANDBOX_ALLOWED_DOMAINS: &[&str] = &[
 /// key honors the same runtime-override precedence as the sibling
 /// `connect::DOCKER_HOST_ENV` — one env-reading convention across
 /// `sandbox_process`, not two.
-pub fn sandbox_extra_allowed_domains() -> Result<Vec<String>, NetworkPolicyError> {
+pub fn sandbox_extra_allowed_domains() -> Result<Vec<NetworkTargetPattern>, NetworkPolicyError> {
     let Some(raw) = env_or_override(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV) else {
         return Ok(Vec::new());
     };
     raw.split(',')
         .map(str::trim)
         .filter(|domain| !domain.is_empty())
-        .map(|domain| {
-            ironclaw_network::parse_host_pattern(domain).map(|pattern| pattern.host_pattern)
-        })
+        .map(ironclaw_network::parse_host_pattern)
         .collect()
 }
 
-/// The full sandboxed-shell egress allowlist: [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`]
-/// plus any operator-configured extras from
-/// [`sandbox_extra_allowed_domains`]. `Err` when an extra domain fails
-/// hostname-shape validation — see [`sandbox_extra_allowed_domains`].
-pub fn sandbox_allowed_domains() -> Result<Vec<String>, NetworkPolicyError> {
+/// The full sandboxed-shell egress allowlist, as validated
+/// [`NetworkTargetPattern`]s: [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`] plus any
+/// operator-configured extras from [`sandbox_extra_allowed_domains`]. `Err`
+/// when an extra domain fails hostname-shape validation — see
+/// [`sandbox_extra_allowed_domains`].
+///
+/// Carries the [`NetworkTargetPattern`] [`sandbox_extra_allowed_domains`]
+/// already validated straight through rather than downgrading it to a
+/// `String` and reconstructing the pattern by hand later — the validated
+/// value is the proof that it passed [`ironclaw_network::parse_host_pattern`];
+/// discarding it and rebuilding the struct from a bare string would let the
+/// two drift apart.
+pub fn sandbox_allowed_domains() -> Result<Vec<NetworkTargetPattern>, NetworkPolicyError> {
     Ok(DEFAULT_SANDBOX_ALLOWED_DOMAINS
         .iter()
-        .map(|domain| (*domain).to_string())
+        .map(|domain| NetworkTargetPattern {
+            scheme: None,
+            host_pattern: (*domain).to_string(),
+            port: None,
+        })
         .chain(sandbox_extra_allowed_domains()?)
         .collect())
 }
@@ -180,14 +190,7 @@ pub fn sandbox_max_egress_bytes() -> Result<u64, NetworkPolicyError> {
 /// until someone audits traffic; a boot failure is loud and immediate.
 pub fn sandbox_network_policy() -> Result<NetworkPolicy, NetworkPolicyError> {
     Ok(NetworkPolicy {
-        allowed_targets: sandbox_allowed_domains()?
-            .into_iter()
-            .map(|host_pattern| ironclaw_host_api::NetworkTargetPattern {
-                scheme: None,
-                host_pattern,
-                port: None,
-            })
-            .collect(),
+        allowed_targets: sandbox_allowed_domains()?,
         deny_private_ip_ranges: true,
         max_egress_bytes: Some(sandbox_max_egress_bytes()?),
     })
@@ -294,7 +297,7 @@ mod tests {
 
         assert_eq!(
             sandbox_extra_allowed_domains().unwrap(),
-            Vec::<String>::new()
+            Vec::<NetworkTargetPattern>::new()
         );
     }
 
@@ -366,12 +369,17 @@ mod tests {
 
         remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
 
-        assert_eq!(extras, vec!["example.internal", "*.corp.example.com"]);
+        let extra_hosts: Vec<&str> = extras
+            .iter()
+            .map(|pattern| pattern.host_pattern.as_str())
+            .collect();
+        assert_eq!(extra_hosts, vec!["example.internal", "*.corp.example.com"]);
+        let all_hosts: Vec<&str> = all.iter().map(|p| p.host_pattern.as_str()).collect();
         assert!(
-            all.contains(&"crates.io".to_string()),
-            "operator extras must not displace the defaults: {all:?}"
+            all_hosts.contains(&"crates.io"),
+            "operator extras must not displace the defaults: {all_hosts:?}"
         );
-        assert!(all.contains(&"example.internal".to_string()));
-        assert!(all.contains(&"*.corp.example.com".to_string()));
+        assert!(all_hosts.contains(&"example.internal"));
+        assert!(all_hosts.contains(&"*.corp.example.com"));
     }
 }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -152,15 +152,23 @@ pub fn sandbox_extra_allowed_domains() -> Result<Vec<NetworkTargetPattern>, Netw
 /// discarding it and rebuilding the struct from a bare string would let the
 /// two drift apart.
 pub fn sandbox_allowed_domains() -> Result<Vec<NetworkTargetPattern>, NetworkPolicyError> {
-    Ok(DEFAULT_SANDBOX_ALLOWED_DOMAINS
-        .iter()
-        .map(|domain| NetworkTargetPattern {
-            scheme: None,
-            host_pattern: (*domain).to_string(),
-            port: None,
-        })
+    Ok(parse_host_patterns(DEFAULT_SANDBOX_ALLOWED_DOMAINS)?
+        .into_iter()
         .chain(sandbox_extra_allowed_domains()?)
         .collect())
+}
+
+/// Applies [`ironclaw_network::parse_host_pattern`] to each `domain`, so
+/// [`sandbox_allowed_domains`]'s hardcoded defaults validate through the
+/// identical chokepoint operator-supplied extras already go through in
+/// [`sandbox_extra_allowed_domains`] — see that function's doc comment for
+/// why hand-building [`NetworkTargetPattern`] here instead would let the two
+/// drift apart.
+fn parse_host_patterns(domains: &[&str]) -> Result<Vec<NetworkTargetPattern>, NetworkPolicyError> {
+    domains
+        .iter()
+        .map(|domain| ironclaw_network::parse_host_pattern(domain))
+        .collect()
 }
 
 /// Reads [`SANDBOX_MAX_EGRESS_BYTES_ENV`] and returns the operator's
@@ -288,6 +296,26 @@ mod tests {
         assert!(sandbox_max_egress_bytes().is_err());
 
         remove_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV);
+    }
+
+    // Defaults must fail the same way operator-supplied extras do when an
+    // entry doesn't pass `parse_host_pattern` — pins that `sandbox_allowed_
+    // domains` routes `DEFAULT_SANDBOX_ALLOWED_DOMAINS` through the same
+    // validator instead of hand-building `NetworkTargetPattern` for them
+    // (coderabbitai review on PR #6746: the round-trip through `String` and
+    // back left a second construction site where `scheme`/`port` could
+    // drift from the validator's contract, and defaults could ship
+    // unvalidated where extras could not).
+    #[test]
+    fn parse_host_patterns_rejects_a_malformed_entry_like_extras_do() {
+        assert!(parse_host_patterns(&["github.com", "not a host!"]).is_err());
+    }
+
+    #[test]
+    fn parse_host_patterns_matches_the_real_default_list() {
+        let parsed = parse_host_patterns(DEFAULT_SANDBOX_ALLOWED_DOMAINS).unwrap();
+        let hosts: Vec<&str> = parsed.iter().map(|p| p.host_pattern.as_str()).collect();
+        assert_eq!(hosts, DEFAULT_SANDBOX_ALLOWED_DOMAINS);
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -57,9 +57,25 @@ pub const SANDBOX_MAX_EGRESS_BYTES_ENV: &str = "IRONCLAW_SANDBOX_MAX_EGRESS_BYTE
 /// against one request's `estimated_bytes` by `ironclaw_network`'s policy
 /// enforcer), not a cumulative session budget, so it does not by itself
 /// bound how much data a long-running sandboxed session moves in total
-/// across many requests; that is future work for the CONNECT proxy this
-/// list feeds. [`SANDBOX_MAX_EGRESS_BYTES_ENV`] lets an operator tighten (or
-/// loosen) this for their own risk tolerance and workload shape.
+/// across many requests.
+///
+/// That per-request model holds today only because the sole consumer of
+/// this constant is `PolicyNetworkHttpEgress`, a host-mediated HTTP client
+/// that sees plaintext method/URL/headers/body and computes
+/// `estimated_bytes` for a request before sending it
+/// (`estimate_http_request_bytes`,
+/// `crates/ironclaw_network/src/egress.rs`). It is **not established** that
+/// the same model transfers to the CONNECT/forward proxy this list feeds
+/// (see the module doc above): a CONNECT proxy tunnels opaque TLS bytes
+/// after the handshake and never sees plaintext, so it cannot compute "one
+/// request's size" the way `estimate_http_request_bytes` does — streamed
+/// per-connection byte metering is the natural fit for that transport, not
+/// discrete pre-flight request sizing. Whether `max_egress_bytes` should
+/// mean "per request" or "cumulative per connection" once the proxy exists
+/// is an open design question for that proxy-wiring PR to resolve, not
+/// something this constant already answers. [`SANDBOX_MAX_EGRESS_BYTES_ENV`]
+/// lets an operator tighten (or loosen) this for their own risk tolerance
+/// and workload shape in the meantime.
 ///
 /// Mirrors `MCP_NETWORK_EGRESS_LIMIT`'s shape
 /// (`crates/ironclaw_extension_host/src/mcp.rs`, `activation_transaction.rs`)
@@ -67,6 +83,14 @@ pub const SANDBOX_MAX_EGRESS_BYTES_ENV: &str = "IRONCLAW_SANDBOX_MAX_EGRESS_BYTE
 /// its value: that one is sized for MCP tool-call JSON responses (2 MiB) and
 /// is not a template here; the sandboxed shell's legitimate payloads are
 /// orders of magnitude larger.
+// TODO(security): this value is sized and validated against
+// `PolicyNetworkHttpEgress`'s per-request `estimated_bytes` check
+// (`crates/ironclaw_network/src/egress.rs`). The CONNECT-proxy wiring PR
+// (see module doc above) must explicitly decide streaming vs. cumulative
+// byte metering for that transport before assuming `max_egress_bytes`
+// carries the same "per request" meaning there — a proxy that reuses this
+// constant without that decision is not enforcing what this doc comment
+// describes.
 pub const DEFAULT_SANDBOX_MAX_EGRESS_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
 /// Default egress allowlist for the sandboxed shell profile — the package

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -25,6 +25,7 @@
 //! reads this list in production today. It arrives first because both of them
 //! take it as an input, and because a list of hostnames is reviewable on its
 //! own in a way it will not be once it is buried in a proxy PR.
+use ironclaw_common::env_helpers::env_or_override;
 use ironclaw_host_api::{NetworkPolicy, NetworkTargetPattern};
 
 /// Environment variable operators can set to add domains to the sandboxed
@@ -59,9 +60,13 @@ pub const DEFAULT_SANDBOX_ALLOWED_DOMAINS: &[&str] = &[
 /// configured extra domains, trimmed and with empty entries dropped. Returns
 /// an empty `Vec` (never an error) when the variable is unset or empty — the
 /// extra-domains hook is optional.
+///
+/// Read through `env_or_override` rather than a bare `std::env::var`, so this
+/// key honors the same runtime-override precedence as the sibling
+/// `connect::DOCKER_HOST_ENV` — one env-reading convention across
+/// `sandbox_process`, not two.
 pub fn sandbox_extra_allowed_domains() -> Vec<String> {
-    std::env::var(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV)
-        .ok()
+    env_or_override(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV)
         .map(|raw| {
             raw.split(',')
                 .map(str::trim)
@@ -105,6 +110,8 @@ pub fn sandbox_network_policy() -> NetworkPolicy {
 
 #[cfg(test)]
 mod tests {
+    use ironclaw_common::env_helpers::{lock_env, remove_runtime_env, set_runtime_env};
+
     use super::*;
 
     #[test]
@@ -142,19 +149,38 @@ mod tests {
     }
 
     #[test]
-    fn extra_domains_env_is_parsed_and_merged() {
-        // SAFETY: test-local env var, no concurrent readers of this key in
-        // this crate's test binary.
-        unsafe {
-            std::env::set_var(
-                SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
-                " example.internal , , *.corp.example.com",
-            );
-        }
+    fn extra_domains_env_absent_yields_no_extras() {
+        let _guard = lock_env();
+        remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+
+        assert!(sandbox_extra_allowed_domains().is_empty());
+    }
+
+    #[test]
+    fn extra_domains_env_is_parsed_and_merged_into_the_full_allowlist() {
+        // The guard is held across the whole set/read/clear window: this
+        // process's env is global, and the sibling `connect` tests mutate it
+        // too. Raw `std::env::set_var` here would race them.
+        let _guard = lock_env();
+        set_runtime_env(
+            SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
+            " example.internal , , *.corp.example.com",
+        );
+
         let extras = sandbox_extra_allowed_domains();
-        unsafe {
-            std::env::remove_var(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
-        }
+        // Asserted while the override is still set: `sandbox_allowed_domains`
+        // must *append* to the defaults, not replace them. Clearing first
+        // would make a replace-instead-of-chain regression invisible.
+        let all = sandbox_allowed_domains();
+
+        remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+
         assert_eq!(extras, vec!["example.internal", "*.corp.example.com"]);
+        assert!(
+            all.contains(&"crates.io".to_string()),
+            "operator extras must not displace the defaults: {all:?}"
+        );
+        assert!(all.contains(&"example.internal".to_string()));
+        assert!(all.contains(&"*.corp.example.com".to_string()));
     }
 }

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -34,6 +34,41 @@ use ironclaw_network::NetworkPolicyError;
 /// Comma-separated hostnames (e.g. `example.com,*.internal.example.com`).
 pub const SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV: &str = "IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS";
 
+/// Environment variable operators can set to override
+/// [`DEFAULT_SANDBOX_MAX_EGRESS_BYTES`] — the per-request egress volume cap
+/// carried on the sandboxed shell's [`NetworkPolicy`]. Same
+/// `env_or_override` precedence as [`SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV`] and
+/// `connect::DOCKER_HOST_ENV`.
+pub const SANDBOX_MAX_EGRESS_BYTES_ENV: &str = "IRONCLAW_SANDBOX_MAX_EGRESS_BYTES";
+
+/// Default per-request egress volume cap for the sandboxed shell profile, in
+/// bytes: **2 GiB** (`2 * 1024 * 1024 * 1024`).
+///
+/// This is a product tradeoff between two failure modes: too low, and a
+/// legitimate `cargo fetch`/`npm install`/`docker pull`-style dependency
+/// resolve (which can pull single artifacts in the hundreds-of-MB range —
+/// large ML/CUDA wheels, `node_modules` tarballs, monorepo shallow clones)
+/// gets blocked and reported as if it were malicious; too high, and the cap
+/// stops meaning anything. 2 GiB is generous enough to pass those ordinary
+/// package-manager workloads (which sit one to two orders of magnitude
+/// below it) while still bounding a single request far short of what a
+/// deliberate bulk-exfiltration attempt would need to move — this is a
+/// **per-request** ceiling (`NetworkPolicy::max_egress_bytes` is checked
+/// against one request's `estimated_bytes` by `ironclaw_network`'s policy
+/// enforcer), not a cumulative session budget, so it does not by itself
+/// bound how much data a long-running sandboxed session moves in total
+/// across many requests; that is future work for the CONNECT proxy this
+/// list feeds. [`SANDBOX_MAX_EGRESS_BYTES_ENV`] lets an operator tighten (or
+/// loosen) this for their own risk tolerance and workload shape.
+///
+/// Mirrors `MCP_NETWORK_EGRESS_LIMIT`'s shape
+/// (`crates/ironclaw_extension_host/src/mcp.rs`, `activation_transaction.rs`)
+/// — a named constant feeding `NetworkPolicy::max_egress_bytes` — but not
+/// its value: that one is sized for MCP tool-call JSON responses (2 MiB) and
+/// is not a template here; the sandboxed shell's legitimate payloads are
+/// orders of magnitude larger.
+pub const DEFAULT_SANDBOX_MAX_EGRESS_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
 /// Default egress allowlist for the sandboxed shell profile — the package
 /// registries and source hosts ordinary `pip`/`npm`/`git`/`curl` workflows
 /// need, mirroring legacy IronClaw's sandbox allowlist.
@@ -92,6 +127,19 @@ pub fn sandbox_allowed_domains() -> Result<Vec<String>, NetworkPolicyError> {
         .collect())
 }
 
+/// Reads [`SANDBOX_MAX_EGRESS_BYTES_ENV`] and returns the operator's
+/// configured per-request egress cap, or [`DEFAULT_SANDBOX_MAX_EGRESS_BYTES`]
+/// when unset. `Err` when the override is set but not a positive `u64` —
+/// same fail-loud posture as [`sandbox_extra_allowed_domains`]: a malformed
+/// override must refuse to start, not silently fall back to the default
+/// while the operator believes their tighter value took effect.
+pub fn sandbox_max_egress_bytes() -> Result<u64, NetworkPolicyError> {
+    let Some(raw) = env_or_override(SANDBOX_MAX_EGRESS_BYTES_ENV) else {
+        return Ok(DEFAULT_SANDBOX_MAX_EGRESS_BYTES);
+    };
+    ironclaw_network::parse_egress_limit(&raw)
+}
+
 /// [`sandbox_allowed_domains`], expressed as [`NetworkPolicy`] `allowed_targets`
 /// — ready to carry on the sandboxed profile's `builtin.shell` grant so
 /// `validate_network_policy_metadata` (which rejects an empty allowlist)
@@ -115,7 +163,7 @@ pub fn sandbox_network_policy() -> Result<NetworkPolicy, NetworkPolicyError> {
             })
             .collect(),
         deny_private_ip_ranges: true,
-        max_egress_bytes: None,
+        max_egress_bytes: Some(sandbox_max_egress_bytes()?),
     })
 }
 
@@ -145,6 +193,16 @@ mod tests {
 
     #[test]
     fn sandbox_network_policy_is_non_empty_and_denies_private_ips() {
+        // Guarded and reset like the env-mutating tests below: `sandbox_
+        // network_policy` now reads the shared runtime-env overlay through
+        // `sandbox_extra_allowed_domains`/`sandbox_max_egress_bytes`, so this
+        // test must not race a sibling test's mid-flight override of either
+        // env var (e.g. the deliberately-invalid `*` set by
+        // `sandbox_network_policy_propagates_the_wildcard_rejection`).
+        let _guard = lock_env();
+        remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+        remove_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV);
+
         let policy = sandbox_network_policy().unwrap();
         assert!(
             !policy.allowed_targets.is_empty(),
@@ -157,6 +215,47 @@ mod tests {
                 .iter()
                 .any(|target| target.host_pattern == "github.com")
         );
+    }
+
+    // The sandboxed shell is the one profile whose entire purpose is running
+    // untrusted code; an absent egress cap there means a single request can
+    // exfiltrate an unbounded amount of data through the (otherwise
+    // allowlisted) proxy. `max_egress_bytes: None` is the repo-wide default
+    // everywhere else, but not here.
+    #[test]
+    fn sandbox_network_policy_sets_a_concrete_egress_ceiling() {
+        let _guard = lock_env();
+        remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+        remove_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV);
+
+        let policy = sandbox_network_policy().unwrap();
+
+        assert_eq!(policy.max_egress_bytes, Some(DEFAULT_SANDBOX_MAX_EGRESS_BYTES));
+    }
+
+    #[test]
+    fn sandbox_max_egress_bytes_env_override_is_honored() {
+        let _guard = lock_env();
+        set_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV, "1048576");
+
+        let result = sandbox_max_egress_bytes();
+
+        remove_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV);
+
+        assert_eq!(result.unwrap(), 1_048_576);
+    }
+
+    #[test]
+    fn sandbox_max_egress_bytes_env_rejects_zero_and_non_numeric() {
+        let _guard = lock_env();
+
+        set_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV, "0");
+        assert!(sandbox_max_egress_bytes().is_err());
+
+        set_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV, "not-a-number");
+        assert!(sandbox_max_egress_bytes().is_err());
+
+        remove_runtime_env(SANDBOX_MAX_EGRESS_BYTES_ENV);
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -26,7 +26,8 @@
 //! take it as an input, and because a list of hostnames is reviewable on its
 //! own in a way it will not be once it is buried in a proxy PR.
 use ironclaw_common::env_helpers::env_or_override;
-use ironclaw_host_api::{NetworkPolicy, NetworkTargetPattern};
+use ironclaw_host_api::NetworkPolicy;
+use ironclaw_network::NetworkPolicyError;
 
 /// Environment variable operators can set to add domains to the sandboxed
 /// shell's egress allowlist, on top of [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`].
@@ -59,33 +60,36 @@ pub const DEFAULT_SANDBOX_ALLOWED_DOMAINS: &[&str] = &[
 /// Reads [`SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV`] and returns the operator's
 /// configured extra domains, trimmed and with empty entries dropped. Returns
 /// an empty `Vec` (never an error) when the variable is unset or empty — the
-/// extra-domains hook is optional.
+/// extra-domains hook itself is optional. Returns `Err` when a configured
+/// entry fails [`ironclaw_network::parse_host_pattern`]'s hostname-shape
+/// check (empty, bare `*`, or not a valid hostname / `*.`-wildcard) — see
+/// that function's doc comment for why a typo here is not survivable.
 ///
 /// Read through `env_or_override` rather than a bare `std::env::var`, so this
 /// key honors the same runtime-override precedence as the sibling
 /// `connect::DOCKER_HOST_ENV` — one env-reading convention across
 /// `sandbox_process`, not two.
-pub fn sandbox_extra_allowed_domains() -> Vec<String> {
-    env_or_override(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV)
-        .map(|raw| {
-            raw.split(',')
-                .map(str::trim)
-                .filter(|domain| !domain.is_empty())
-                .map(str::to_string)
-                .collect()
-        })
-        .unwrap_or_default()
+pub fn sandbox_extra_allowed_domains() -> Result<Vec<String>, NetworkPolicyError> {
+    let Some(raw) = env_or_override(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV) else {
+        return Ok(Vec::new());
+    };
+    raw.split(',')
+        .map(str::trim)
+        .filter(|domain| !domain.is_empty())
+        .map(|domain| ironclaw_network::parse_host_pattern(domain).map(|pattern| pattern.host_pattern))
+        .collect()
 }
 
 /// The full sandboxed-shell egress allowlist: [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`]
 /// plus any operator-configured extras from
-/// [`sandbox_extra_allowed_domains`].
-pub fn sandbox_allowed_domains() -> Vec<String> {
-    DEFAULT_SANDBOX_ALLOWED_DOMAINS
+/// [`sandbox_extra_allowed_domains`]. `Err` when an extra domain fails
+/// hostname-shape validation — see [`sandbox_extra_allowed_domains`].
+pub fn sandbox_allowed_domains() -> Result<Vec<String>, NetworkPolicyError> {
+    Ok(DEFAULT_SANDBOX_ALLOWED_DOMAINS
         .iter()
         .map(|domain| (*domain).to_string())
-        .chain(sandbox_extra_allowed_domains())
-        .collect()
+        .chain(sandbox_extra_allowed_domains()?)
+        .collect())
 }
 
 /// [`sandbox_allowed_domains`], expressed as [`NetworkPolicy`] `allowed_targets`
@@ -93,11 +97,18 @@ pub fn sandbox_allowed_domains() -> Vec<String> {
 /// `validate_network_policy_metadata` (which rejects an empty allowlist)
 /// passes, and so the policy documents what the container is actually meant
 /// to reach.
-pub fn sandbox_network_policy() -> NetworkPolicy {
-    NetworkPolicy {
-        allowed_targets: sandbox_allowed_domains()
+///
+/// `Err` propagates a hostname-shape validation failure from
+/// [`sandbox_allowed_domains`] rather than silently dropping the bad entry or
+/// falling back to a narrowed allowlist — callers MUST treat this as a hard
+/// boot-time failure (refuse to start), never as "log and continue with
+/// whatever validated". A silently narrowed sandbox allowlist is invisible
+/// until someone audits traffic; a boot failure is loud and immediate.
+pub fn sandbox_network_policy() -> Result<NetworkPolicy, NetworkPolicyError> {
+    Ok(NetworkPolicy {
+        allowed_targets: sandbox_allowed_domains()?
             .into_iter()
-            .map(|host_pattern| NetworkTargetPattern {
+            .map(|host_pattern| ironclaw_host_api::NetworkTargetPattern {
                 scheme: None,
                 host_pattern,
                 port: None,
@@ -105,7 +116,7 @@ pub fn sandbox_network_policy() -> NetworkPolicy {
             .collect(),
         deny_private_ip_ranges: true,
         max_egress_bytes: None,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -134,7 +145,7 @@ mod tests {
 
     #[test]
     fn sandbox_network_policy_is_non_empty_and_denies_private_ips() {
-        let policy = sandbox_network_policy();
+        let policy = sandbox_network_policy().unwrap();
         assert!(
             !policy.allowed_targets.is_empty(),
             "sandboxed shell network policy must not be the empty (deny-all) default"
@@ -153,7 +164,56 @@ mod tests {
         let _guard = lock_env();
         remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
 
-        assert!(sandbox_extra_allowed_domains().is_empty());
+        assert_eq!(sandbox_extra_allowed_domains().unwrap(), Vec::<String>::new());
+    }
+
+    // A bare `*` turns `host_matches_pattern` (ironclaw_network::policy) into
+    // "match every host" — one operator typo would silently convert the
+    // package-registry allowlist into allow-all egress for the one profile
+    // whose entire purpose is holding untrusted code. This must hard-fail,
+    // not silently drop the bad entry: a boot failure is loud, a silently
+    // narrowed allowlist is invisible until someone audits traffic.
+    #[test]
+    fn extra_domains_env_rejects_bare_wildcard() {
+        let _guard = lock_env();
+        set_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, "example.com,*");
+
+        let result = sandbox_extra_allowed_domains();
+
+        remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+
+        assert!(
+            result.is_err(),
+            "bare `*` in the extra-domains env must be rejected, not silently allowed"
+        );
+    }
+
+    #[test]
+    fn extra_domains_env_rejects_malformed_hostname() {
+        let _guard = lock_env();
+        set_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, "not a host!");
+
+        let result = sandbox_extra_allowed_domains();
+
+        remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sandbox_network_policy_propagates_the_wildcard_rejection() {
+        let _guard = lock_env();
+        set_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, "*");
+
+        let result = sandbox_network_policy();
+
+        remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+
+        assert!(
+            result.is_err(),
+            "sandbox_network_policy must hard-fail (not fall back to a \
+             narrowed policy) when the operator-supplied allowlist is invalid"
+        );
     }
 
     #[test]
@@ -167,11 +227,11 @@ mod tests {
             " example.internal , , *.corp.example.com",
         );
 
-        let extras = sandbox_extra_allowed_domains();
+        let extras = sandbox_extra_allowed_domains().unwrap();
         // Asserted while the override is still set: `sandbox_allowed_domains`
         // must *append* to the defaults, not replace them. Clearing first
         // would make a replace-instead-of-chain regression invisible.
-        let all = sandbox_allowed_domains();
+        let all = sandbox_allowed_domains().unwrap();
 
         remove_runtime_env(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
 

--- a/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/network_allowlist.rs
@@ -1,0 +1,160 @@
+//! Default egress allowlist for the sandboxed (`TenantSandbox`) shell
+//! profile.
+//!
+//! IronClaw's sandboxed shell needs outbound network access for ordinary
+//! package-manager workflows (`pip install`, `npm install`, `git clone`,
+//! `curl` against a registry) without granting the container unrestricted
+//! internet access. The model mirrors legacy IronClaw's sandbox: soft
+//! enforcement through an HTTP(S) forward proxy that only permits requests
+//! to an allowlist of known package-registry and source-hosting domains,
+//! plus any extra domains an operator configures.
+//!
+//! This module owns the *domain list* — the set of hosts the sandboxed
+//! profile's `builtin.shell` grant should carry in its
+//! [`NetworkPolicy`](ironclaw_host_api::NetworkPolicy) `allowed_targets`. It
+//! does not itself enforce anything; it is the policy input consumed by two
+//! things that do: the CONNECT/forward proxy
+//! (`ironclaw_host_runtime::sandbox_process::egress_proxy`), spawned and
+//! bound via `crates/ironclaw_reborn_composition/src/sandbox_egress_proxy_task.rs`
+//! and `sandbox_boot.rs`'s `with_sandbox_network_broker`, and the topological
+//! guardrail that the container's Docker network is pinned `internal: true`
+//! with no default route off the host, so the proxy is the container's only
+//! path to the outside world.
+//!
+//! Ships unwired: neither of those two enforcers is on `main` yet, so nothing
+//! reads this list in production today. It arrives first because both of them
+//! take it as an input, and because a list of hostnames is reviewable on its
+//! own in a way it will not be once it is buried in a proxy PR.
+use ironclaw_host_api::{NetworkPolicy, NetworkTargetPattern};
+
+/// Environment variable operators can set to add domains to the sandboxed
+/// shell's egress allowlist, on top of [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`].
+/// Comma-separated hostnames (e.g. `example.com,*.internal.example.com`).
+pub const SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV: &str = "IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS";
+
+/// Default egress allowlist for the sandboxed shell profile — the package
+/// registries and source hosts ordinary `pip`/`npm`/`git`/`curl` workflows
+/// need, mirroring legacy IronClaw's sandbox allowlist.
+pub const DEFAULT_SANDBOX_ALLOWED_DOMAINS: &[&str] = &[
+    // Rust
+    "crates.io",
+    "static.crates.io",
+    "index.crates.io",
+    // Node/npm
+    "registry.npmjs.org",
+    "nodejs.org",
+    // Python
+    "pypi.org",
+    "files.pythonhosted.org",
+    // Go
+    "proxy.golang.org",
+    // GitHub (source + release archives)
+    "github.com",
+    "raw.githubusercontent.com",
+    "api.github.com",
+    "codeload.github.com",
+];
+
+/// Reads [`SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV`] and returns the operator's
+/// configured extra domains, trimmed and with empty entries dropped. Returns
+/// an empty `Vec` (never an error) when the variable is unset or empty — the
+/// extra-domains hook is optional.
+pub fn sandbox_extra_allowed_domains() -> Vec<String> {
+    std::env::var(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV)
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|domain| !domain.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The full sandboxed-shell egress allowlist: [`DEFAULT_SANDBOX_ALLOWED_DOMAINS`]
+/// plus any operator-configured extras from
+/// [`sandbox_extra_allowed_domains`].
+pub fn sandbox_allowed_domains() -> Vec<String> {
+    DEFAULT_SANDBOX_ALLOWED_DOMAINS
+        .iter()
+        .map(|domain| (*domain).to_string())
+        .chain(sandbox_extra_allowed_domains())
+        .collect()
+}
+
+/// [`sandbox_allowed_domains`], expressed as [`NetworkPolicy`] `allowed_targets`
+/// — ready to carry on the sandboxed profile's `builtin.shell` grant so
+/// `validate_network_policy_metadata` (which rejects an empty allowlist)
+/// passes, and so the policy documents what the container is actually meant
+/// to reach.
+pub fn sandbox_network_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: sandbox_allowed_domains()
+            .into_iter()
+            .map(|host_pattern| NetworkTargetPattern {
+                scheme: None,
+                host_pattern,
+                port: None,
+            })
+            .collect(),
+        deny_private_ip_ranges: true,
+        max_egress_bytes: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_allowlist_covers_the_major_package_registries_and_github() {
+        for expected in [
+            "crates.io",
+            "registry.npmjs.org",
+            "pypi.org",
+            "files.pythonhosted.org",
+            "proxy.golang.org",
+            "github.com",
+            "raw.githubusercontent.com",
+        ] {
+            assert!(
+                DEFAULT_SANDBOX_ALLOWED_DOMAINS.contains(&expected),
+                "expected {expected} in the default sandbox allowlist"
+            );
+        }
+    }
+
+    #[test]
+    fn sandbox_network_policy_is_non_empty_and_denies_private_ips() {
+        let policy = sandbox_network_policy();
+        assert!(
+            !policy.allowed_targets.is_empty(),
+            "sandboxed shell network policy must not be the empty (deny-all) default"
+        );
+        assert!(policy.deny_private_ip_ranges);
+        assert!(
+            policy
+                .allowed_targets
+                .iter()
+                .any(|target| target.host_pattern == "github.com")
+        );
+    }
+
+    #[test]
+    fn extra_domains_env_is_parsed_and_merged() {
+        // SAFETY: test-local env var, no concurrent readers of this key in
+        // this crate's test binary.
+        unsafe {
+            std::env::set_var(
+                SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV,
+                " example.internal , , *.corp.example.com",
+            );
+        }
+        let extras = sandbox_extra_allowed_domains();
+        unsafe {
+            std::env::remove_var(SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV);
+        }
+        assert_eq!(extras, vec!["example.internal", "*.corp.example.com"]);
+    }
+}

--- a/crates/ironclaw_host_runtime/src/sandbox_process/shell_limits.rs
+++ b/crates/ironclaw_host_runtime/src/sandbox_process/shell_limits.rs
@@ -1,0 +1,139 @@
+//! Model-adjustable clamp bounds for `builtin.shell` timeout and captured
+//! output size.
+//!
+//! The model may request a `timeout` and `output_limit` per call (see
+//! `first_party_tools::schemas` and `first_party_tools::shell_core`); this
+//! module owns the operator ceilings both values are clamped to before they
+//! reach the sandbox transport, plus the defaults used when unset.
+//!
+//! Only the two `*_DEFAULT_*` constants have a caller today — `sandbox_process`'s
+//! `DEFAULT_TIMEOUT`/`DEFAULT_MAX_OUTPUT_BYTES`, which previously carried the
+//! same numbers as bare literals. The ceilings, floors, and the two clamp
+//! functions are `#[allow(dead_code)]` until the per-call limits are wired,
+//! which happens in three named places at once: `process_port`'s
+//! `RuntimeProcessPort` request path, `sandbox_process`'s
+//! `execute_in_container`, and `first_party_tools::shell` /
+//! `first_party_tools::shell_core` (the `timeout` / `output_limit` schema
+//! fields). Wiring them is a behavior change — today the transport applies a
+//! model-supplied `timeout_secs` with no ceiling at all — so it ships with its
+//! own test, in its own PR, rather than being smuggled in behind this module's
+//! arrival.
+
+use std::time::Duration;
+
+/// Default shell command timeout when the model omits `timeout`.
+pub(crate) const SHELL_TIMEOUT_DEFAULT_SECS: u64 = 120;
+/// Operator ceiling for `timeout`. Requests above this are clamped down,
+/// never rejected.
+#[allow(dead_code)] // consumer: process_port / execute_in_container / first_party_tools::shell — see module doc
+pub(crate) const SHELL_TIMEOUT_MAX_SECS: u64 = 600;
+/// Floor for `timeout`; zero-second timeouts are rejected upstream by
+/// `shell_core::parse_timeout`, but the clamp still enforces the floor for
+/// any other caller of `clamp_shell_timeout_secs`.
+#[allow(dead_code)] // consumer: process_port / execute_in_container / first_party_tools::shell — see module doc
+pub(crate) const SHELL_TIMEOUT_MIN_SECS: u64 = 1;
+
+/// Default captured-output cap (stdout+stderr) when the model omits
+/// `output_limit`.
+pub(crate) const SHELL_OUTPUT_LIMIT_DEFAULT_BYTES: u64 = 64 * 1024;
+/// Operator ceiling for `output_limit`. Requests above this are clamped
+/// down, never rejected.
+#[allow(dead_code)] // consumer: process_port / execute_in_container / first_party_tools::shell — see module doc
+pub(crate) const SHELL_OUTPUT_LIMIT_MAX_BYTES: u64 = 1024 * 1024;
+/// Floor for `output_limit`; requests below this are clamped up.
+#[allow(dead_code)] // consumer: process_port / execute_in_container / first_party_tools::shell — see module doc
+pub(crate) const SHELL_OUTPUT_LIMIT_MIN_BYTES: u64 = 1024;
+
+/// Clamp a model-requested shell timeout (seconds) to
+/// `[SHELL_TIMEOUT_MIN_SECS, SHELL_TIMEOUT_MAX_SECS]`, defaulting to
+/// `SHELL_TIMEOUT_DEFAULT_SECS` when unset.
+#[allow(dead_code)] // consumer: process_port / execute_in_container / first_party_tools::shell — see module doc
+pub(crate) fn clamp_shell_timeout_secs(requested: Option<u64>) -> Duration {
+    let secs = requested
+        .unwrap_or(SHELL_TIMEOUT_DEFAULT_SECS)
+        .clamp(SHELL_TIMEOUT_MIN_SECS, SHELL_TIMEOUT_MAX_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Clamp a model-requested output cap (bytes) to
+/// `[SHELL_OUTPUT_LIMIT_MIN_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES]`,
+/// defaulting to `SHELL_OUTPUT_LIMIT_DEFAULT_BYTES` when unset.
+#[allow(dead_code)] // consumer: process_port / execute_in_container / first_party_tools::shell — see module doc
+pub(crate) fn clamp_shell_output_limit_bytes(requested: Option<u64>) -> usize {
+    let bytes = requested
+        .unwrap_or(SHELL_OUTPUT_LIMIT_DEFAULT_BYTES)
+        .clamp(SHELL_OUTPUT_LIMIT_MIN_BYTES, SHELL_OUTPUT_LIMIT_MAX_BYTES);
+    bytes as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_unset_defaults_to_120() {
+        assert_eq!(
+            clamp_shell_timeout_secs(None),
+            Duration::from_secs(SHELL_TIMEOUT_DEFAULT_SECS)
+        );
+        assert_eq!(clamp_shell_timeout_secs(None), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn timeout_within_range_is_honored() {
+        assert_eq!(clamp_shell_timeout_secs(Some(45)), Duration::from_secs(45));
+    }
+
+    #[test]
+    fn timeout_over_cap_is_clamped_to_600() {
+        assert_eq!(
+            clamp_shell_timeout_secs(Some(6_000)),
+            Duration::from_secs(SHELL_TIMEOUT_MAX_SECS)
+        );
+        assert_eq!(
+            clamp_shell_timeout_secs(Some(601)),
+            Duration::from_secs(600)
+        );
+    }
+
+    #[test]
+    fn timeout_below_floor_is_clamped_up() {
+        // parse_timeout rejects 0 before this is reached in production, but
+        // the clamp itself must still hold the floor for any other caller.
+        assert_eq!(
+            clamp_shell_timeout_secs(Some(0)),
+            Duration::from_secs(SHELL_TIMEOUT_MIN_SECS)
+        );
+    }
+
+    #[test]
+    fn output_limit_unset_defaults_to_64kib() {
+        assert_eq!(
+            clamp_shell_output_limit_bytes(None),
+            SHELL_OUTPUT_LIMIT_DEFAULT_BYTES as usize
+        );
+        assert_eq!(clamp_shell_output_limit_bytes(None), 65536);
+    }
+
+    #[test]
+    fn output_limit_over_cap_is_clamped_to_1mib() {
+        assert_eq!(
+            clamp_shell_output_limit_bytes(Some(10 * 1024 * 1024)),
+            SHELL_OUTPUT_LIMIT_MAX_BYTES as usize
+        );
+        assert_eq!(clamp_shell_output_limit_bytes(Some(1_048_577)), 1_048_576);
+    }
+
+    #[test]
+    fn output_limit_below_floor_is_clamped_up() {
+        assert_eq!(
+            clamp_shell_output_limit_bytes(Some(10)),
+            SHELL_OUTPUT_LIMIT_MIN_BYTES as usize
+        );
+    }
+
+    #[test]
+    fn output_limit_within_range_is_honored() {
+        assert_eq!(clamp_shell_output_limit_bytes(Some(200_000)), 200_000);
+    }
+}

--- a/crates/ironclaw_network/src/lib.rs
+++ b/crates/ironclaw_network/src/lib.rs
@@ -19,7 +19,8 @@ mod url_target;
 pub use egress::{NetworkHttpEgress, NetworkHttpTransport, PolicyNetworkHttpEgress};
 pub use error::NetworkHttpError;
 pub use policy::{
-    NetworkPolicyError, StaticNetworkPolicyEnforcer, parse_host_pattern, target_matches_pattern,
+    NetworkPolicyError, StaticNetworkPolicyEnforcer, parse_egress_limit, parse_host_pattern,
+    target_matches_pattern,
 };
 pub use resolver::NetworkResolver;
 pub use test_rewrite::{

--- a/crates/ironclaw_network/src/lib.rs
+++ b/crates/ironclaw_network/src/lib.rs
@@ -18,7 +18,9 @@ mod url_target;
 
 pub use egress::{NetworkHttpEgress, NetworkHttpTransport, PolicyNetworkHttpEgress};
 pub use error::NetworkHttpError;
-pub use policy::{StaticNetworkPolicyEnforcer, target_matches_pattern};
+pub use policy::{
+    NetworkPolicyError, StaticNetworkPolicyEnforcer, parse_host_pattern, target_matches_pattern,
+};
 pub use resolver::NetworkResolver;
 pub use test_rewrite::{
     HostRewriteMap, HostRewriteMapError, RewriteNetworkTransport, TEST_HTTP_REWRITE_MAP_ENV,

--- a/crates/ironclaw_network/src/policy.rs
+++ b/crates/ironclaw_network/src/policy.rs
@@ -31,6 +31,8 @@ pub enum NetworkPolicyError {
         estimated: u64,
         limit: u64,
     },
+    #[error("invalid network host pattern {pattern:?}: {reason}")]
+    InvalidHostPattern { pattern: String, reason: String },
 }
 
 impl NetworkPolicyError {
@@ -48,6 +50,70 @@ impl NetworkPolicyError {
 
     pub fn is_egress_estimate_required(&self) -> bool {
         matches!(self, Self::EgressEstimateRequired { .. })
+    }
+
+    pub fn is_invalid_host_pattern(&self) -> bool {
+        matches!(self, Self::InvalidHostPattern { .. })
+    }
+}
+
+/// Parses one operator- or config-supplied hostname string into a validated
+/// [`NetworkTargetPattern`] with `scheme: None, port: None`.
+///
+/// This is the chokepoint for turning untrusted "extra allowed domain"
+/// strings into policy the enforcer will actually honor. It is stricter than
+/// [`NetworkTargetPattern::validate_declaration`]: that method accepts a bare
+/// `*` because some manifest-declared grants (e.g. `CapabilityNetworkProfile::
+/// DevWildcard`, MCP full-network credential audiences) legitimately mean
+/// "every host" and are reviewed as such at declaration time. A hostname
+/// typed into an env var was never reviewed — `host_matches_pattern` (this
+/// module) treats `*` as "match every host", so a typo here silently turns a
+/// package-registry allowlist into allow-all egress for the one profile whose
+/// entire purpose is holding untrusted code. Reject it instead of trusting it.
+///
+/// Accepts: a bare hostname (`example.com`) or a single `*.`-prefixed
+/// wildcard label (`*.example.com`). Rejects: empty/whitespace-only input,
+/// the bare wildcard `*`, and anything containing characters outside
+/// `[A-Za-z0-9.-]` or with an empty/malformed label.
+pub fn parse_host_pattern(raw: &str) -> Result<NetworkTargetPattern, NetworkPolicyError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(invalid_host_pattern(raw, "must not be empty"));
+    }
+    if trimmed == "*" {
+        return Err(invalid_host_pattern(
+            raw,
+            "bare `*` would match every host; use a specific hostname or a \
+             `*.`-prefixed wildcard label",
+        ));
+    }
+
+    let label_source = trimmed.strip_prefix("*.").unwrap_or(trimmed);
+    let shape_ok = !label_source.is_empty()
+        && !label_source.starts_with('.')
+        && !label_source.ends_with('.')
+        && !label_source.contains("..")
+        && label_source
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'));
+    if !shape_ok {
+        return Err(invalid_host_pattern(
+            raw,
+            "must be a valid hostname or a `*.`-prefixed wildcard label",
+        ));
+    }
+
+    Ok(NetworkTargetPattern {
+        scheme: None,
+        host_pattern: trimmed.to_string(),
+        port: None,
+    })
+}
+
+fn invalid_host_pattern(raw: &str, reason: &str) -> NetworkPolicyError {
+    NetworkPolicyError::InvalidHostPattern {
+        pattern: raw.to_string(),
+        reason: reason.to_string(),
     }
 }
 

--- a/crates/ironclaw_network/src/policy.rs
+++ b/crates/ironclaw_network/src/policy.rs
@@ -33,6 +33,8 @@ pub enum NetworkPolicyError {
     },
     #[error("invalid network host pattern {pattern:?}: {reason}")]
     InvalidHostPattern { pattern: String, reason: String },
+    #[error("invalid network egress limit {raw:?}: {reason}")]
+    InvalidEgressLimit { raw: String, reason: String },
 }
 
 impl NetworkPolicyError {
@@ -55,6 +57,31 @@ impl NetworkPolicyError {
     pub fn is_invalid_host_pattern(&self) -> bool {
         matches!(self, Self::InvalidHostPattern { .. })
     }
+
+    pub fn is_invalid_egress_limit(&self) -> bool {
+        matches!(self, Self::InvalidEgressLimit { .. })
+    }
+}
+
+/// Parses one operator-supplied egress byte-limit string (e.g. from an env
+/// var override) into a positive `u64`. Rejects non-numeric input and zero —
+/// `max_egress_bytes: Some(0)` would deny every request with an egress
+/// estimate and is never what an operator setting a volume cap means; if
+/// they want to disable the cap, unsetting the override (falling back to the
+/// caller's own default) is the way to do that, not `0`.
+pub fn parse_egress_limit(raw: &str) -> Result<u64, NetworkPolicyError> {
+    let trimmed = raw.trim();
+    let parsed: u64 = trimmed.parse().map_err(|_| NetworkPolicyError::InvalidEgressLimit {
+        raw: raw.to_string(),
+        reason: "must be a positive integer number of bytes".to_string(),
+    })?;
+    if parsed == 0 {
+        return Err(NetworkPolicyError::InvalidEgressLimit {
+            raw: raw.to_string(),
+            reason: "must not be zero".to_string(),
+        });
+    }
+    Ok(parsed)
 }
 
 /// Parses one operator- or config-supplied hostname string into a validated

--- a/crates/ironclaw_network/src/policy.rs
+++ b/crates/ironclaw_network/src/policy.rs
@@ -91,14 +91,23 @@ pub fn parse_egress_limit(raw: &str) -> Result<u64, NetworkPolicyError> {
 ///
 /// This is the chokepoint for turning untrusted "extra allowed domain"
 /// strings into policy the enforcer will actually honor. It is stricter than
-/// [`NetworkTargetPattern::validate_declaration`]: that method accepts a bare
-/// `*` because some manifest-declared grants (e.g. `CapabilityNetworkProfile::
-/// DevWildcard`, MCP full-network credential audiences) legitimately mean
-/// "every host" and are reviewed as such at declaration time. A hostname
-/// typed into an env var was never reviewed — `host_matches_pattern` (this
-/// module) treats `*` as "match every host", so a typo here silently turns a
-/// package-registry allowlist into allow-all egress for the one profile whose
-/// entire purpose is holding untrusted code. Reject it instead of trusting it.
+/// [`NetworkTargetPattern::validate_declaration`] (`crates/ironclaw_host_api/
+/// src/action.rs`): that method accepts a bare `*` because some
+/// host-authored grants — e.g. `CapabilityNetworkProfile::DevWildcard`'s
+/// local-dev shell profile — legitimately mean "every host" and are reviewed
+/// as such at declaration time. A hostname typed into an env var was never
+/// reviewed — `host_matches_pattern` (this module) treats `*` as "match
+/// every host", so a typo here silently turns a package-registry allowlist
+/// into allow-all egress for the one profile whose entire purpose is holding
+/// untrusted code. Reject it instead of trusting it.
+///
+/// The two validators diverge INTENTIONALLY and this direction must not be
+/// collapsed either: `validate_declaration` must not be tightened to match
+/// this function's wildcard rejection, since that would break
+/// `DevWildcard`'s declared full-access grant. (Extension manifest
+/// credential audiences are already stricter than either of these — they
+/// reject a wildcard host outright via `ManifestV3Error::WildcardAudienceHost`
+/// — so they are not an example of a legitimate bare-`*` consumer either.)
 ///
 /// Accepts: a bare hostname (`example.com`) or a single `*.`-prefixed
 /// wildcard label (`*.example.com`). Rejects: empty/whitespace-only input,

--- a/crates/ironclaw_network/src/policy.rs
+++ b/crates/ironclaw_network/src/policy.rs
@@ -118,6 +118,12 @@ pub fn parse_host_pattern(raw: &str) -> Result<NetworkTargetPattern, NetworkPoli
     if trimmed.is_empty() {
         return Err(invalid_host_pattern(raw, "must not be empty"));
     }
+    // Mirror `validate_declaration`'s 253-byte cap (the DNS name length
+    // limit) so this validator is never laxer than the sibling it claims to
+    // be stricter than — see the doc comment above.
+    if trimmed.len() > 253 {
+        return Err(invalid_host_pattern(raw, "must be at most 253 bytes"));
+    }
     if trimmed == "*" {
         return Err(invalid_host_pattern(
             raw,

--- a/crates/ironclaw_network/src/policy.rs
+++ b/crates/ironclaw_network/src/policy.rs
@@ -71,10 +71,12 @@ impl NetworkPolicyError {
 /// caller's own default) is the way to do that, not `0`.
 pub fn parse_egress_limit(raw: &str) -> Result<u64, NetworkPolicyError> {
     let trimmed = raw.trim();
-    let parsed: u64 = trimmed.parse().map_err(|_| NetworkPolicyError::InvalidEgressLimit {
-        raw: raw.to_string(),
-        reason: "must be a positive integer number of bytes".to_string(),
-    })?;
+    let parsed: u64 = trimmed
+        .parse()
+        .map_err(|_| NetworkPolicyError::InvalidEgressLimit {
+            raw: raw.to_string(),
+            reason: "must be a positive integer number of bytes".to_string(),
+        })?;
     if parsed == 0 {
         return Err(NetworkPolicyError::InvalidEgressLimit {
             raw: raw.to_string(),

--- a/crates/ironclaw_network/tests/network_policy_contract.rs
+++ b/crates/ironclaw_network/tests/network_policy_contract.rs
@@ -376,6 +376,37 @@ fn parse_host_pattern_rejects_empty_and_bare_wildcard() {
     );
 }
 
+// `parse_host_pattern` is documented as the *stricter* chokepoint relative
+// to `NetworkTargetPattern::validate_declaration`
+// (`crates/ironclaw_host_api/src/action.rs`), which caps host patterns at
+// 253 bytes (the DNS name length limit). A validator billed as strictly
+// stricter must not be laxer on any axis, including length — an unbounded
+// `parse_host_pattern` would let an operator-supplied env var push an
+// arbitrarily large string into `NetworkPolicy::allowed_targets` that
+// `validate_declaration` would have rejected.
+#[test]
+fn parse_host_pattern_rejects_patterns_over_253_bytes() {
+    let too_long = format!("{}.example.com", "a".repeat(250));
+    assert!(too_long.len() > 253);
+    assert!(
+        parse_host_pattern(&too_long)
+            .unwrap_err()
+            .is_invalid_host_pattern(),
+        "parse_host_pattern must reject patterns over 253 bytes, matching \
+         validate_declaration's length cap"
+    );
+}
+
+#[test]
+fn parse_host_pattern_accepts_pattern_at_exactly_253_bytes() {
+    // 253 bytes is the DNS name length limit and validate_declaration's
+    // exact cap; parse_host_pattern must not be stricter than that either.
+    let label = "a".repeat(249);
+    let at_limit = format!("{label}.com");
+    assert_eq!(at_limit.len(), 253);
+    assert!(parse_host_pattern(&at_limit).is_ok());
+}
+
 #[test]
 fn parse_host_pattern_rejects_malformed_hostnames() {
     for bad in [

--- a/crates/ironclaw_network/tests/network_policy_contract.rs
+++ b/crates/ironclaw_network/tests/network_policy_contract.rs
@@ -3,7 +3,8 @@ use ironclaw_host_api::{
     ProjectId, ResourceScope, TenantId, ThreadId, UserId,
 };
 use ironclaw_network::{
-    NetworkRequest, StaticNetworkPolicyEnforcer, network_target_for_url, target_matches_pattern,
+    NetworkRequest, StaticNetworkPolicyEnforcer, network_target_for_url, parse_host_pattern,
+    target_matches_pattern,
 };
 
 #[tokio::test]
@@ -329,6 +330,62 @@ fn pattern(
         scheme,
         host_pattern: host_pattern.to_string(),
         port,
+    }
+}
+
+// `parse_host_pattern` is the chokepoint an untrusted operator-supplied
+// hostname string (e.g. the sandbox's `IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS`)
+// must go through before becoming policy. Unlike `NetworkTargetPattern::
+// validate_declaration` (shape-only, permits a reviewed `*` for legitimate
+// full-access grants), this rejects the bare wildcard outright: a typo in an
+// env var was never reviewed, and `host_matches_pattern` treats `*` as
+// "match every host".
+#[test]
+fn parse_host_pattern_accepts_plain_and_wildcard_hostnames() {
+    let plain = parse_host_pattern("crates.io").unwrap();
+    assert_eq!(plain.host_pattern, "crates.io");
+    assert_eq!(plain.scheme, None);
+    assert_eq!(plain.port, None);
+
+    let wildcard = parse_host_pattern("*.corp.example.com").unwrap();
+    assert_eq!(wildcard.host_pattern, "*.corp.example.com");
+}
+
+#[test]
+fn parse_host_pattern_trims_surrounding_whitespace() {
+    let pattern = parse_host_pattern("  crates.io  ").unwrap();
+    assert_eq!(pattern.host_pattern, "crates.io");
+}
+
+#[test]
+fn parse_host_pattern_rejects_empty_and_bare_wildcard() {
+    assert!(parse_host_pattern("").unwrap_err().is_invalid_host_pattern());
+    assert!(
+        parse_host_pattern("   ")
+            .unwrap_err()
+            .is_invalid_host_pattern()
+    );
+    assert!(
+        parse_host_pattern("*")
+            .unwrap_err()
+            .is_invalid_host_pattern()
+    );
+}
+
+#[test]
+fn parse_host_pattern_rejects_malformed_hostnames() {
+    for bad in [
+        "not a host!",
+        "..leading-dot.com",
+        "trailing-dot.com.",
+        "double..dot.com",
+        "has space.com",
+        "embedded\0nul.com",
+    ] {
+        assert!(
+            parse_host_pattern(bad).unwrap_err().is_invalid_host_pattern(),
+            "expected {bad:?} to be rejected"
+        );
     }
 }
 

--- a/crates/ironclaw_network/tests/network_policy_contract.rs
+++ b/crates/ironclaw_network/tests/network_policy_contract.rs
@@ -359,7 +359,11 @@ fn parse_host_pattern_trims_surrounding_whitespace() {
 
 #[test]
 fn parse_host_pattern_rejects_empty_and_bare_wildcard() {
-    assert!(parse_host_pattern("").unwrap_err().is_invalid_host_pattern());
+    assert!(
+        parse_host_pattern("")
+            .unwrap_err()
+            .is_invalid_host_pattern()
+    );
     assert!(
         parse_host_pattern("   ")
             .unwrap_err()
@@ -383,7 +387,9 @@ fn parse_host_pattern_rejects_malformed_hostnames() {
         "embedded\0nul.com",
     ] {
         assert!(
-            parse_host_pattern(bad).unwrap_err().is_invalid_host_pattern(),
+            parse_host_pattern(bad)
+                .unwrap_err()
+                .is_invalid_host_pattern(),
             "expected {bad:?} to be rejected"
         );
     }


### PR DESCRIPTION
## Why

The sandbox container transport has never been sliced to `main`. Six modules (~5,455 lines) live only on `sandbox/shell-integration`, and they block the `sandbox-docker-tests` CI job, the W6 credential swap, and three finished branches queued behind them.

This is **slice 1 of 4** — the three leaf modules that depend on nothing else unlanded. Chosen and ordered by actual `cargo build` probes off `origin/main`, not by reading imports: this project has already been burned once by picking a slice whose *files* looked separable and whose *symbols* were not.

## What's here

| Module | Lines | Depends on |
|---|---|---|
| `sandbox_process/connect.rs` | 311 | `bollard`, new `ironclaw_common` dep |
| `sandbox_process/network_allowlist.rs` | 155 | `ironclaw_host_api` only |
| `sandbox_process/shell_limits.rs` | 120 | `std` only |

- **`connect`** — bounded-retry Docker connect (4 attempts, 250 ms doubling backoff), an `IRONCLAW_REBORN_DOCKER_HOST` override for CI/remote daemons, and a cheap readiness probe. Retry exhaustion propagates as a hard `RuntimeProcessError`; there is deliberately no unsandboxed-host fallback, and the module doc says so.
- **`network_allowlist`** — the default sandboxed-shell egress allowlist (crates.io / npm / PyPI / Go proxy / GitHub) expressed as a `NetworkPolicy`, plus the `IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS` operator hook.
- **`shell_limits`** — `builtin.shell`'s timeout and captured-output defaults, floors, and ceilings.

## Unwired by design

All three land with no production caller, following the convention already merged in `ca.rs` and `credential_firewall.rs`: each module doc names its **real** future consumer, and no fake caller is invented to silence a lint.

- `connect` → `ironclaw_reborn_composition`'s `sandbox_reaper_task` and `sandbox_composition`'s boot diagnostic.
- `network_allowlist` → the egress proxy (slice 2) and `sandbox_egress_proxy_task`.
- `shell_limits`' clamps → `process_port`, `execute_in_container`, and `first_party_tools::shell`.

The only behavior-adjacent change is `sandbox_process`'s `DEFAULT_TIMEOUT` / `DEFAULT_MAX_OUTPUT_BYTES` now reading `shell_limits`' constants instead of repeating the same two literals — identical values.

Worth being explicit about one thing this PR does **not** do: `shell_limits` defines a 600 s timeout ceiling, but the live transport still applies a model-supplied `timeout_secs` with no ceiling at all. Wiring the clamp is a real behavior change and ships with its own test, in its own PR. It is not smuggled in behind this module's arrival.

## Architecture ratchet

`reborn_extension_specificity`'s `PATH_TERM_COLLISIONS` gains two entries for `network_allowlist.rs`. The allowlist names `github.com` and `api.github.com` as **code hosts** for ordinary `git clone` / release-archive workflows, not as the `github` extension — which is exactly the distinction that table exists to record. No ratchet count was weakened.

## Test tier

Crate-tier only, which the testing rule endorses while these are unwired — there is no production path to drive. Integration-tier coverage is owed by the PR that gives each module a caller, and is noted per-module in the decomposition plan.

## Gates

Baseline established on clean `origin/main` first, so pre-existing failures are distinguishable from new ones.

| Gate | Result |
|---|---|
| `cargo build -p ironclaw_host_runtime` | clean |
| `cargo test -p ironclaw_host_runtime --lib` | **502 passed, 5 failed** — baseline on clean main was **487 passed, 5 failed**. Same 5 by name: 2 known-failing `first_party_tools::trace_commons` onboard-guidance tests, 3 environmental `SocketNotFoundError` (no local Docker daemon). +15 new tests, 0 new failures. |
| `cargo test -p ironclaw_architecture` | all suites pass |
| `cargo fmt --all --check` | clean |
| `cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings` | clean |
| `cargo deny check` | `advisories ok, bans ok, licenses ok, sources ok` |
| `python3 scripts/check_no_panics.py --base origin/main --head HEAD` | `OK: No panic-inducing calls in changed production code.` |

`ironclaw_common` is promoted from transitive to direct here (`connect` reads its env-override helper). `deny.toml` sets `unmaintained = "workspace"`, so that promotion was specifically checked against advisories — it is a workspace path dependency, and `cargo deny` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)