### PR TITLE
test(e2e): pin that a provider-world reset restores seed state

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -230,6 +230,7 @@ jobs:
           tests/e2e/scenarios/test_journey_coverage.py
           tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
           tests/e2e/scenarios/test_provider_fault_proxy.py
+          tests/e2e/scenarios/test_provider_world_isolation.py
           tests/e2e/scenarios/test_reborn_qa_trace_replay.py
           tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
           -m

--- a/tests/e2e/scenarios/test_provider_world_isolation.py
+++ b/tests/e2e/scenarios/test_provider_world_isolation.py
@@ -1,0 +1,104 @@
+"""Provider-world isolation between journeys (#6524 workstream 3).
+
+Every mutating journey depends on `ResettableEmulateProviderWorld.reset()` to
+hand the next journey a seed-state provider. That method is used by fixtures
+throughout the suite and asserted by nothing: if it stopped restoring state,
+the symptom would surface as an unrelated journey failing against data it
+never created, which is the hardest kind of failure to attribute.
+
+These tests exercise the world directly — no Reborn binary, no model replay —
+so they stay fast and fail for exactly one reason.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from conftest import ResettableEmulateProviderWorld
+from emulate_provider import github_json
+
+ISSUES_PATH = "/repos/nearai/ironclaw/issues"
+
+
+@pytest.fixture
+async def github_world():
+    world = ResettableEmulateProviderWorld()
+    await world.start({"github"})
+    try:
+        yield world
+    finally:
+        await world.close()
+
+
+async def _issue_titles(base_url: str) -> list[str]:
+    async with httpx.AsyncClient(timeout=15) as client:
+        issues = await github_json(client, base_url, "GET", ISSUES_PATH)
+    assert isinstance(issues, list), issues
+    return [issue["title"] for issue in issues]
+
+
+async def test_reset_restores_seed_state_after_a_journey_creates_data(github_world):
+    """A resource one journey creates must not exist for the next one."""
+    base_url = github_world.servers["github"]["url"]
+    seeded = await _issue_titles(base_url)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        await github_json(
+            client,
+            base_url,
+            "POST",
+            ISSUES_PATH,
+            payload={"title": "left-behind-by-a-previous-journey"},
+            expected_status=201,
+        )
+    assert "left-behind-by-a-previous-journey" in await _issue_titles(base_url)
+
+    await github_world.reset({"github"})
+
+    assert await _issue_titles(base_url) == seeded
+
+
+async def test_reset_keeps_the_url_stable_so_a_running_reborn_still_reaches_it(
+    github_world,
+):
+    """Reborn is started once with these URLs and outlives every reset.
+
+    Restarting the provider on a fresh port would leave the running process
+    pointing at a dead socket, and every journey after the first reset would
+    fail for a reason that has nothing to do with the journey.
+    """
+    before = github_world.servers["github"]["url"]
+    seeded = await _issue_titles(before)
+
+    await github_world.reset({"github"})
+
+    assert github_world.servers["github"]["url"] == before
+    # Still answering on the same socket after the restart.
+    assert await _issue_titles(before) == seeded
+
+
+async def test_reset_of_one_service_is_scoped_to_that_service(github_world):
+    """Resetting one provider must not disturb another's process.
+
+    The journey fixtures reset only the worlds a case actually mutated, so a
+    reset that reached further would silently discard state a concurrent or
+    later assertion still depends on.
+    """
+    base_url = github_world.servers["github"]["url"]
+    async with httpx.AsyncClient(timeout=15) as client:
+        await github_json(
+            client,
+            base_url,
+            "POST",
+            ISSUES_PATH,
+            payload={"title": "survives-an-unrelated-reset"},
+            expected_status=201,
+        )
+
+    # Nothing else is running in this world, so the observable contract is that
+    # resetting an empty selection leaves github's process untouched: same URL,
+    # still serving, and its data NOT discarded out from under a caller.
+    await github_world.reset(set())
+
+    assert github_world.servers["github"]["url"] == base_url
+    assert "survives-an-unrelated-reset" in await _issue_titles(base_url)

--- a/tests/e2e/scenarios/test_provider_world_isolation.py
+++ b/tests/e2e/scenarios/test_provider_world_isolation.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import httpx
 import pytest
 from conftest import ResettableEmulateProviderWorld
-from emulate_provider import github_json
+from emulate_provider import github_json, slack_post
 
 ISSUES_PATH = "/repos/nearai/ironclaw/issues"
 
@@ -28,6 +28,12 @@ async def github_world():
         yield world
     finally:
         await world.close()
+
+
+@pytest.fixture
+async def github_slack_world(github_world):
+    await github_world.start({"slack"})
+    return github_world
 
 
 async def _issue_titles(base_url: str) -> list[str]:
@@ -77,28 +83,55 @@ async def test_reset_keeps_the_url_stable_so_a_running_reborn_still_reaches_it(
     assert await _issue_titles(before) == seeded
 
 
-async def test_reset_of_one_service_is_scoped_to_that_service(github_world):
+async def test_reset_of_one_service_is_scoped_to_that_service(github_slack_world):
     """Resetting one provider must not disturb another's process.
 
     The journey fixtures reset only the worlds a case actually mutated, so a
     reset that reached further would silently discard state a concurrent or
     later assertion still depends on.
     """
-    base_url = github_world.servers["github"]["url"]
+    github_url = github_slack_world.servers["github"]["url"]
+    slack_url = github_slack_world.servers["slack"]["url"]
+    github_marker = "discarded-by-the-selected-reset"
+    slack_marker = "survives-an-unrelated-reset"
+
     async with httpx.AsyncClient(timeout=15) as client:
         await github_json(
             client,
-            base_url,
+            github_url,
             "POST",
             ISSUES_PATH,
-            payload={"title": "survives-an-unrelated-reset"},
+            payload={"title": github_marker},
             expected_status=201,
         )
 
-    # Nothing else is running in this world, so the observable contract is that
-    # resetting an empty selection leaves github's process untouched: same URL,
-    # still serving, and its data NOT discarded out from under a caller.
-    await github_world.reset(set())
+        channels = await slack_post(
+            client,
+            slack_url,
+            "conversations.list",
+            {"types": "public_channel"},
+        )
+        channel_id = next(
+            channel["id"]
+            for channel in channels["channels"]
+            if channel["name"] == "reborn-alerts"
+        )
+        await slack_post(
+            client,
+            slack_url,
+            "chat.postMessage",
+            {"channel": channel_id, "text": slack_marker},
+        )
 
-    assert github_world.servers["github"]["url"] == base_url
-    assert "survives-an-unrelated-reset" in await _issue_titles(base_url)
+        await github_slack_world.reset({"github"})
+
+        history = await slack_post(
+            client,
+            slack_url,
+            "conversations.history",
+            {"channel": channel_id},
+        )
+
+    assert github_marker not in await _issue_titles(github_url)
+    assert github_slack_world.servers["slack"]["url"] == slack_url
+    assert any(message["text"] == slack_marker for message in history["messages"])


### PR DESCRIPTION
## Summary

- Workstream 3 of #6524: directly verifies that `ResettableEmulateProviderWorld.reset()` restores seeded provider state on stable URLs.
- Adds the isolation scenario to the ordinary pinned-Emulate CI lane.
- Strengthens the scoped-reset case after review: GitHub is reset from a non-empty selection while a populated, unselected Slack world retains both its URL and message data.

If reset stopped restoring state, the symptom would land far from the cause: an unrelated journey would fail against data it never created.

## What's covered

The cases drive the provider world directly—no Reborn binary or model replay—so failures stay attributable to the fixture contract:

| Case | What breaks without it |
|---|---|
| Created resource is gone after reset | One journey's data becomes the next journey's surprise |
| URL survives the restart | The long-lived Reborn process keeps pointing at a reachable provider socket |
| Resetting one populated provider preserves another populated provider | An over-broad reset discards state owned by an unselected world |

**Sabotage-verified:** making `reset()` a no-op fails the seed-state case.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features`
- [ ] `cargo build` — Not applicable: the all-target, all-feature clippy gate compiled the workspace.
- [x] Relevant tests pass: `pytest scenarios/test_provider_world_isolation.py -v --timeout=120` — 3 passed against the documented `npx emulate@0.7.0` fallback.
- [ ] `cargo test --features integration` — Not applicable: no Rust, database, or Reborn integration behavior changed.
- [x] Manual testing: provider-issued GitHub and Slack read-backs are part of the executable test.
- [x] Review-address workflow run; the only actionable inline comment was verified and fixed.

Additional checks:

- `python -m py_compile scenarios/test_provider_world_isolation.py`
- `bash scripts/pre-commit-safety.sh`
- `git diff --check`
- `cargo test --workspace --lib` was not fully green locally: two unrelated existing Trace Commons tests in `ironclaw_host_runtime` reproducibly returned `NetworkDenied` (`dispatch_profile_token_without_enrollment_returns_onboard_guidance` and `dispatch_profile_set_without_enrollment_returns_onboard_guidance`). No Rust files changed; the PR's host-runtime CI bucket was green on the prior head.

## Test Strategy

User behavior: None changed. This PR strengthens test infrastructure that keeps provider-backed journeys isolated.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: `tests/e2e/scenarios/test_provider_world_isolation.py` directly exercises the resettable provider-world contract.
- Reborn integration: Not applicable: no Reborn product behavior changed.
- Recorded fixture: Not applicable: model choice and request shape are not involved.
- Browser E2E: Not applicable: the test talks directly to local provider emulators.
- Backend or runtime: GitHub and Slack Emulate processes are mutated and read back across a selective reset.
- Live canary: Not applicable: deterministic local provider emulators cover the contract.

What the tests prove: reset restores selected GitHub seed state on the stable endpoint, while an unselected Slack process keeps the same URL and retains a provider-issued message.

Commands run:

- `uv run --isolated --python 3.11 pytest scenarios/test_provider_world_isolation.py::test_reset_of_one_service_is_scoped_to_that_service -v --timeout=120`
- `uv run --isolated --python 3.11 pytest scenarios/test_provider_world_isolation.py -v --timeout=120`
- `cargo fmt --all -- --check`
- `cargo clippy --all --benches --tests --examples --all-features`
- `bash scripts/pre-commit-safety.sh`
- `cargo test --workspace --lib` (partial; unrelated failures documented above)

## Security Impact

None. No permissions, credentials, network policy, file access, tool execution, or sandbox behavior changed. Tests use existing loopback-only Emulate fixtures and existing test credentials.

## Reborn Trust-Boundary Checklist

N/A: test/CI-only change; no Reborn trust-bearing types, ingress, status variants, serialization, queues, errors, or sandbox/runtime names changed.

## Database Impact

None.

## Blast Radius

Limited to the resettable Emulate provider-world contract test and its selection in the Reborn E2E workflow. A failure can affect the provider-contract CI lane but cannot change shipping runtime behavior.

## Rollback Plan

Revert the PR commit(s) that add/select `test_provider_world_isolation.py`. No data or schema rollback is required.

## Review Follow-Through

CodeRabbit's scoped-reset comment is addressed by starting GitHub and Slack, mutating both providers, resetting the non-empty `{"github"}` selection, and proving Slack's URL and data survive. No other actionable review findings are known.

## Reviewer notes

- Assertions compare against actual provider state and provider-issued read-back rather than fixture internals.
- These tests need only Emulate—no built Ironclaw binary—so they remain suitable for the ordinary provider lane.
- Remaining WS3 leak surfaces (OAuth state, rate counters, membership) are outside this PR.

---

**Review track**: C (CI workflow and external-provider test lane)
