### PR TITLE
feat(mcp): SEP-414 _meta attribution on outbound hosted-MCP tools/list + tools/call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **SEP-414 `_meta` attribution on outbound hosted-MCP calls:** `tools/list`
-  and `tools/call` now carry a host-derived `_meta` block
-  (`io.ironclaw/userId`, `io.ironclaw/invocationId`, optional
-  `io.ironclaw/threadId`) so hosted providers can dedupe retried
-  side-effecting calls and scope state to the calling conversation.
-  `initialize` is untouched; servers that ignore `_meta` see no change.
+- **Opt-in SEP-414 `_meta` attribution on outbound hosted-MCP calls:** a
+  provider whose manifest declares `[mcp] attribution = "sep414"` receives a
+  host-derived `_meta` block (`io.ironclaw/userId`,
+  `io.ironclaw/invocationId`, optional `io.ironclaw/threadId`) on
+  `tools/list` + `tools/call`, so it can dedupe retried side-effecting calls
+  and scope state to the calling conversation. Strictly opt-in: providers
+  that don't declare it — all existing ones — keep today's wire shape and
+  receive no caller identifiers. `initialize` is never stamped.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SEP-414 `_meta` attribution on outbound hosted-MCP calls:** `tools/list`
+  and `tools/call` now carry a host-derived `_meta` block
+  (`io.ironclaw/userId`, `io.ironclaw/invocationId`, optional
+  `io.ironclaw/threadId`) so hosted providers can dedupe retried
+  side-effecting calls and scope state to the calling conversation.
+  `initialize` is untouched; servers that ignore `_meta` see no change.
+
 ### Fixed
 
 - **Agent-loop termination recovery:** tell the model when no-progress or the

--- a/crates/ironclaw_extension_host/src/mcp.rs
+++ b/crates/ironclaw_extension_host/src/mcp.rs
@@ -85,6 +85,17 @@ impl McpHostHttpEgressPlanner for RegistryMcpEgressPlanner {
         }
         let credential_injections =
             self.credential_injections(request.provider, request.capability_id, &endpoint);
+        // Caller attribution is strictly opt-in: only a provider whose
+        // manifest declares `[mcp] attribution = "sep414"` gets the SEP-414
+        // `_meta` block stamped on its tool calls.
+        let sep414_attribution = self
+            .registry
+            .snapshot()
+            .get_extension(request.provider)
+            .is_some_and(|package| {
+                package.manifest.mcp_attribution
+                    == Some(ironclaw_extensions::McpAttribution::Sep414)
+            });
         McpHostHttpEgressPlan {
             // Credential-free hosted MCP providers are valid: the manifest may
             // expose a public/unauthenticated server, and host network policy
@@ -98,6 +109,7 @@ impl McpHostHttpEgressPlanner for RegistryMcpEgressPlanner {
             credential_injections,
             response_body_limit: Some(MCP_RESPONSE_BODY_LIMIT),
             timeout_ms: Some(MCP_TIMEOUT_MS),
+            sep414_attribution,
         }
     }
 }
@@ -500,6 +512,7 @@ mod tests {
                         host_apis: Vec::new(),
                         host_api_surfaces: Vec::new(),
                         hooks: Vec::new(),
+                        mcp_attribution: None,
                         capabilities: vec![ironclaw_extensions::CapabilityManifest {
                             id: CapabilityId::new(capability_id).unwrap(),
                             description: "Search".to_string(),

--- a/crates/ironclaw_extension_host/src/recipes.rs
+++ b/crates/ironclaw_extension_host/src/recipes.rs
@@ -189,6 +189,7 @@ mod tests {
             host_apis: Vec::new(),
             section_surfaces: Vec::new(),
             hooks: Vec::new(),
+            mcp_attribution: None,
         }
     }
 

--- a/crates/ironclaw_extension_host/src/recipes.rs
+++ b/crates/ironclaw_extension_host/src/recipes.rs
@@ -189,7 +189,6 @@ mod tests {
             host_apis: Vec::new(),
             section_surfaces: Vec::new(),
             hooks: Vec::new(),
-            mcp_attribution: None,
         }
     }
 

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -164,6 +164,9 @@ pub struct ExtensionManifest {
     /// capability declarations on demand — see
     /// [`Self::capability_surfaces`].
     pub host_api_surfaces: Vec<CapabilitySurfaceDeclV2>,
+    /// Hosted-MCP caller attribution the provider opted into (v3 `[mcp]
+    /// attribution`); `None` = the host stamps nothing.
+    pub mcp_attribution: Option<McpAttribution>,
     /// Declarative hook entries the extension declared. Structurally
     /// validated by the v2 parser; projected into typed hook entries by the
     /// composition loader. Empty for the common no-hooks case.
@@ -210,6 +213,7 @@ impl TryFrom<ExtensionManifestV2> for ExtensionManifest {
             capabilities: manifest.capabilities,
             host_api_surfaces: manifest.host_api_surfaces,
             hooks: manifest.hooks,
+            mcp_attribution: manifest.mcp_attribution,
         })
     }
 }
@@ -418,6 +422,7 @@ pub use resolved::{
     ResolvedSectionSurface,
 };
 pub use v2::{
+    McpAttribution,
     CapabilityDeclV2, CapabilitySurfaceDeclV2, CapabilityVisibility, ExtensionManifestV2,
     ExtensionRuntimeV2, HookSectionEntryV2, HostApiContractRegistry, HostApiId,
     HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,

--- a/crates/ironclaw_extensions/src/resolved.rs
+++ b/crates/ironclaw_extensions/src/resolved.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ExtensionAdminConfigurationDescriptor;
 
-use crate::v2::{
+use crate::v2::{McpAttribution, 
     CapabilityDeclV2, CapabilitySurfaceDeclV2, ExtensionManifestV2, ExtensionRuntimeV2,
     HookSectionEntryV2, HostApiId, HostApiRefV2, ManifestSectionPath, ManifestSource,
     ManifestV2Error, requested_trust_to_descriptor_trust,
@@ -87,6 +87,11 @@ pub struct ResolvedMcpDeclaration {
     /// The server-connection credential handles (injected on every server
     /// call; discovered tools cannot declare their own).
     pub credential_handles: Vec<SecretHandle>,
+    /// Caller-attribution contract the provider opted into (`[mcp]
+    /// attribution`); `None` = the host stamps nothing. `serde(default)`
+    /// keeps installation records persisted before this field readable.
+    #[serde(default)]
+    pub attribution: Option<McpAttribution>,
 }
 
 /// One vendor the extension authenticates against: the account setup this
@@ -243,6 +248,7 @@ impl ResolvedExtensionManifest {
             capabilities: self.tools.clone(),
             host_api_surfaces,
             hooks: self.hooks.clone(),
+            mcp_attribution: self.mcp.as_ref().and_then(|m| m.attribution),
         })
     }
 }

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -587,6 +587,17 @@ impl ExtensionRuntimeV2 {
     }
 }
 
+/// Attribution contract a hosted-MCP provider opted into (v3 `[mcp]
+/// attribution`). Absent for every provider that did not explicitly request
+/// caller attribution — the host stamps nothing for them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum McpAttribution {
+    /// SEP-414 `_meta` block (`io.ironclaw/userId` / `invocationId` /
+    /// optional `threadId`) on outbound `tools/list` + `tools/call`.
+    #[serde(rename = "sep414")]
+    Sep414,
+}
+
 /// Validated v2 manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExtensionManifestV2 {
@@ -638,6 +649,9 @@ pub struct ExtensionManifestV2 {
     /// declare no hooks (the common case). See [`HookSectionEntryV2`] for
     /// the clean-boundary rationale.
     pub hooks: Vec<HookSectionEntryV2>,
+    /// Hosted-MCP caller attribution the provider opted into (v3 `[mcp]
+    /// attribution`); `None` = never stamp.
+    pub mcp_attribution: Option<McpAttribution>,
 }
 
 /// v2 manifest parser/validator errors.
@@ -985,6 +999,8 @@ impl ExtensionManifestV2 {
             capabilities: Vec::new(),
             host_api_surfaces: Vec::new(),
             hooks,
+            // v2 manifests predate hosted-MCP attribution — never stamped.
+            mcp_attribution: None,
         })
     }
 }

--- a/crates/ironclaw_extensions/src/v3.rs
+++ b/crates/ironclaw_extensions/src/v3.rs
@@ -32,6 +32,7 @@ use thiserror::Error;
 use crate::ExtensionAdminConfigurationDescriptor;
 use crate::resolved::{ResolvedAuthSurface, ResolvedExtensionManifest, ResolvedMcpDeclaration};
 use crate::v2::{
+    McpAttribution,
     CapabilityDeclV2, CapabilitySurfaceDeclV2, ExtensionManifestV2, ExtensionRuntimeV2,
     MAX_MANIFEST_BYTES, ManifestSource, RESERVED_HOST_BUNDLED_ID_PREFIX, RawCapabilityV2,
     RawRuntimeCredentialV2, requested_trust_to_descriptor_trust,
@@ -200,10 +201,21 @@ struct RawMcpV3 {
     effects: Vec<EffectKind>,
     #[serde(default)]
     credentials: Vec<RawMcpCredentialV3>,
+    /// Opt-in caller attribution on outbound tools/list + tools/call. Absent
+    /// (the default) means the host stamps nothing for this provider.
+    #[serde(default)]
+    attribution: Option<RawMcpAttributionV3>,
 }
 
 fn default_mcp_permission() -> PermissionMode {
     PermissionMode::Ask
+}
+
+/// Raw `[mcp] attribution` value.
+#[derive(Debug, Clone, Copy, Deserialize)]
+enum RawMcpAttributionV3 {
+    #[serde(rename = "sep414")]
+    Sep414,
 }
 
 #[derive(Debug, Deserialize)]
@@ -553,6 +565,9 @@ pub(crate) fn parse_v3(
         capabilities,
         host_api_surfaces,
         hooks: Vec::new(),
+        mcp_attribution: mcp.as_ref().and_then(|m| m.attribution).map(|a| match a {
+            RawMcpAttributionV3::Sep414 => McpAttribution::Sep414,
+        }),
     };
 
     let auth = recipes
@@ -596,6 +611,7 @@ pub(crate) fn parse_v3(
                         .collect()
                 })
                 .unwrap_or_default(),
+            attribution: manifest.mcp_attribution,
         }),
         tools: manifest.capabilities.clone(),
         channel: raw.channel,

--- a/crates/ironclaw_extensions/tests/manifest_v3_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v3_contract.rs
@@ -935,3 +935,37 @@ fn memory_surface_without_document_store_fails_closed() {
         "{error}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// [mcp] attribution opt-in (SEP-414)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mcp_attribution_defaults_to_none() {
+    // A manifest that says nothing about attribution must never be stamped —
+    // the privacy default for every existing provider.
+    let record = parse_v3(&mcp_manifest()).expect("mcp manifest parses");
+    assert_eq!(record.manifest().mcp_attribution, None);
+}
+
+#[test]
+fn mcp_attribution_sep414_parses() {
+    let manifest = mcp_manifest().replace(
+        "[mcp]\n",
+        "[mcp]\nattribution = \"sep414\"\n",
+    );
+    let record = parse_v3(&manifest).expect("attributed mcp manifest parses");
+    assert_eq!(
+        record.manifest().mcp_attribution,
+        Some(ironclaw_extensions::McpAttribution::Sep414)
+    );
+}
+
+#[test]
+fn mcp_attribution_unknown_value_is_rejected() {
+    let manifest = mcp_manifest().replace(
+        "[mcp]\n",
+        "[mcp]\nattribution = \"telemetry-v9\"\n",
+    );
+    parse_v3(&manifest).expect_err("unknown attribution value must not parse");
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -232,6 +232,7 @@ pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError>
             // first-party builtin hooks are installed by the composition
             // loader directly, not via this manifest surface.
             hooks: Vec::new(),
+            mcp_attribution: None,
         },
         VirtualPath::new("/system/extensions/builtin")?,
     )

--- a/crates/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
@@ -48,6 +48,7 @@ fn first_party_test_package(service: &str, capability_id: &str) -> ExtensionPack
                 origin_gate_matrix: None,
             }],
             hooks: Vec::new(),
+            mcp_attribution: None,
         },
         VirtualPath::new(format!("/system/extensions/{service}")).unwrap(),
     )

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -292,6 +292,10 @@ pub struct McpHostHttpEgressPlan {
     pub credential_injections: Vec<RuntimeCredentialInjection>,
     pub response_body_limit: Option<u64>,
     pub timeout_ms: Option<u32>,
+    /// `true` only when the provider's manifest opted into SEP-414 caller
+    /// attribution (`[mcp] attribution = "sep414"`); the default plan stamps
+    /// nothing.
+    pub sep414_attribution: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -474,19 +478,9 @@ where
         let url = request.url.as_deref().ok_or_else(|| {
             McpClientError::client(request_denied(McpRequestDeniedCause::MissingUrl))
         })?;
-        // Stamp the SEP-414 `_meta` attribution on the tool-facing methods only.
-        // `initialize` must keep its exact handshake params, and neither it nor
-        // the post-handshake `notifications/initialized` carries per-turn
-        // attribution. Threading it through the shared planner (rather than
-        // each call site) guarantees `tools/list` and `tools/call` agree.
-        let params = match method {
-            McpJsonRpcMethod::ToolsList | McpJsonRpcMethod::ToolsCall => {
-                Some(params_with_sep414_meta(params, &request.scope))
-            }
-            _ => params,
-        };
         let body =
-            encode_json_rpc_request(id, method.as_str(), params).map_err(McpClientError::client)?;
+            encode_json_rpc_request(id, method.as_str(), params.clone())
+                .map_err(McpClientError::client)?;
         let policy_headers = vec![
             ("Content-Type".to_string(), "application/json".to_string()),
             (
@@ -505,6 +499,27 @@ where
             headers: &policy_headers,
             body: &body,
         });
+
+        // Stamp the SEP-414 `_meta` attribution on the tool-facing methods,
+        // and ONLY for providers whose manifest opted in ([mcp] attribution =
+        // "sep414" → the planner sets the flag). Every other provider keeps
+        // today's wire shape — no host identity or conversation identifiers
+        // are disclosed to servers that never asked for them. `initialize`
+        // keeps its exact handshake params, and neither it nor the
+        // post-handshake `notifications/initialized` carries per-turn
+        // attribution. Threading this through the shared planner (rather than
+        // each call site) guarantees `tools/list` and `tools/call` agree.
+        let body = if plan.sep414_attribution
+            && matches!(
+                method,
+                McpJsonRpcMethod::ToolsList | McpJsonRpcMethod::ToolsCall
+            ) {
+            let params = Some(params_with_sep414_meta(params, &request.scope));
+            encode_json_rpc_request(id, method.as_str(), params)
+                .map_err(McpClientError::client)?
+        } else {
+            body
+        };
         Ok(PlannedMcpJsonRpc {
             id,
             method,
@@ -974,8 +989,11 @@ fn protocol_version_from_initialize_response(
     Ok(protocol_version.to_string())
 }
 
-/// Builds the SEP-414 `_meta` attribution block the host stamps on every
-/// outbound MCP `tools/list` / `tools/call`.
+/// Builds the SEP-414 `_meta` attribution block the host stamps on outbound
+/// MCP `tools/list` / `tools/call` — ONLY for providers whose manifest opted
+/// in via `[mcp] attribution = "sep414"` (the egress planner sets
+/// [`McpHostHttpEgressPlan::sep414_attribution`]); every other provider's
+/// wire shape is unchanged.
 ///
 /// "SEP-414" refers to the Model Context Protocol spec-enhancement proposal
 /// for propagating caller context through the reserved `_meta` request field
@@ -1945,6 +1963,19 @@ mod tests {
         )
     }
 
+    /// A planner whose provider opted into SEP-414 attribution
+    /// (`[mcp] attribution = "sep414"`).
+    fn attributed_planning_client() -> McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner>
+    {
+        McpHostHttpClient::new(
+            UnusedHttp,
+            StaticMcpHostHttpEgressPlanner::new(McpHostHttpEgressPlan {
+                sep414_attribution: true,
+                ..McpHostHttpEgressPlan::default()
+            }),
+        )
+    }
+
     fn scope_with_thread(thread_id: Option<&str>) -> ResourceScope {
         ResourceScope {
             tenant_id: TenantId::new("tenant-a").unwrap(),
@@ -1987,7 +2018,7 @@ mod tests {
 
     #[test]
     fn tools_call_stamps_sep414_thread_attribution_on_the_wire() {
-        let client = planning_client();
+        let client = attributed_planning_client();
         let scope = scope_with_thread(Some("thread-a"));
         let expected_invocation = scope.invocation_id.to_string();
         let request = meta_probe_request(scope, json!({"limit": 10}));
@@ -2017,7 +2048,7 @@ mod tests {
 
     #[test]
     fn tools_list_stamps_sep414_thread_attribution_even_without_other_params() {
-        let client = planning_client();
+        let client = attributed_planning_client();
         let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
 
         // `tools/list` carries no other params (`None`) — the block must still
@@ -2030,7 +2061,7 @@ mod tests {
 
     #[test]
     fn initialize_handshake_is_not_stamped_with_attribution() {
-        let client = planning_client();
+        let client = attributed_planning_client();
         let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
 
         // The handshake predates any turn attribution; stamping it would corrupt
@@ -2046,9 +2077,29 @@ mod tests {
         assert_eq!(params["protocolVersion"], json!("2025-06-18"));
     }
 
+    /// The privacy contract: a provider that did NOT opt in receives no
+    /// attribution at all — its wire shape is byte-identical to today's.
+    #[test]
+    fn non_opted_provider_gets_no_attribution() {
+        let client = planning_client();
+        let request =
+            meta_probe_request(scope_with_thread(Some("thread-a")), json!({"limit": 10}));
+
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::ToolsCall,
+            Some(json!({ "name": "search_agents", "arguments": { "limit": 10 } })),
+        );
+
+        assert!(params.get("_meta").is_none(), "no opt-in ⇒ no _meta block");
+        assert_eq!(params["name"], json!("search_agents"));
+        assert_eq!(params["arguments"], json!({ "limit": 10 }));
+    }
+
     #[test]
     fn thread_less_scope_omits_thread_id_but_keeps_user_attribution() {
-        let client = planning_client();
+        let client = attributed_planning_client();
         let request = meta_probe_request(scope_with_thread(None), Value::Null);
 
         let params = planned_params(&client, &request, McpJsonRpcMethod::ToolsList, None);

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -1988,8 +1988,9 @@ mod tests {
     #[test]
     fn tools_call_stamps_sep414_thread_attribution_on_the_wire() {
         let client = planning_client();
-        let request =
-            meta_probe_request(scope_with_thread(Some("thread-a")), json!({"limit": 10}));
+        let scope = scope_with_thread(Some("thread-a"));
+        let expected_invocation = scope.invocation_id.to_string();
+        let request = meta_probe_request(scope, json!({"limit": 10}));
 
         let params = planned_params(
             &client,
@@ -2003,7 +2004,12 @@ mod tests {
         // buyer seeing another buyer's connector.
         assert_eq!(params["_meta"]["io.ironclaw/threadId"], json!("thread-a"));
         assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
-        assert!(params["_meta"]["io.ironclaw/invocationId"].is_string());
+        // The invocation id must be THE turn's id, not merely some string —
+        // it is the provider-side replay-dedup key.
+        assert_eq!(
+            params["_meta"]["io.ironclaw/invocationId"],
+            json!(expected_invocation)
+        );
         // Original tool arguments survive the merge untouched.
         assert_eq!(params["name"], json!("search_agents"));
         assert_eq!(params["arguments"], json!({ "limit": 10 }));

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -474,6 +474,17 @@ where
         let url = request.url.as_deref().ok_or_else(|| {
             McpClientError::client(request_denied(McpRequestDeniedCause::MissingUrl))
         })?;
+        // Stamp the SEP-414 `_meta` attribution on the tool-facing methods only.
+        // `initialize` must keep its exact handshake params, and neither it nor
+        // the post-handshake `notifications/initialized` carries per-turn
+        // attribution. Threading it through the shared planner (rather than
+        // each call site) guarantees `tools/list` and `tools/call` agree.
+        let params = match method {
+            McpJsonRpcMethod::ToolsList | McpJsonRpcMethod::ToolsCall => {
+                Some(params_with_sep414_meta(params, &request.scope))
+            }
+            _ => params,
+        };
         let body =
             encode_json_rpc_request(id, method.as_str(), params).map_err(McpClientError::client)?;
         let policy_headers = vec![
@@ -961,6 +972,60 @@ fn protocol_version_from_initialize_response(
         ));
     }
     Ok(protocol_version.to_string())
+}
+
+/// Builds the SEP-414 `_meta` attribution block the host stamps on every
+/// outbound MCP `tools/list` / `tools/call`.
+///
+/// "SEP-414" refers to the Model Context Protocol spec-enhancement proposal
+/// for propagating caller context through the reserved `_meta` request field
+/// (modelcontextprotocol/modelcontextprotocol#414); the `io.ironclaw/*` keys
+/// follow `_meta`'s reverse-DNS naming rule, so servers that don't know them
+/// ignore the block entirely.
+///
+/// It is derived from the trusted turn [`ResourceScope`] and merged into
+/// `params` *after* argument serialization, so extension and model code can
+/// neither read nor forge it. Hosted providers (the marketplace connector
+/// endpoint) resolve the caller's dispatch/hire from `io.ironclaw/threadId` —
+/// never from tool arguments — which is what lets one stable per-user token
+/// serve concurrent jobs without cross-job data bleed. Absent a thread scope
+/// (non-threaded runtime) the key is omitted rather than sent empty.
+fn sep414_meta(scope: &ResourceScope) -> Value {
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "io.ironclaw/userId".to_string(),
+        Value::String(scope.user_id.as_str().to_string()),
+    );
+    meta.insert(
+        "io.ironclaw/invocationId".to_string(),
+        Value::String(scope.invocation_id.to_string()),
+    );
+    if let Some(thread_id) = scope.thread_id.as_ref() {
+        meta.insert(
+            "io.ironclaw/threadId".to_string(),
+            Value::String(thread_id.as_str().to_string()),
+        );
+    }
+    Value::Object(meta)
+}
+
+/// Merge [`sep414_meta`] into an outbound `params` object, creating the object
+/// when the method carries no other params (e.g. `tools/list`, whose params are
+/// `None`). Both call sites (`call_tool`, `discover_tools`) pass either an
+/// object or `None`; a non-object value is preserved under `"params"` so a
+/// future caller cannot silently drop it.
+fn params_with_sep414_meta(params: Option<Value>, scope: &ResourceScope) -> Value {
+    let mut object = match params {
+        Some(Value::Object(map)) => map,
+        None => serde_json::Map::new(),
+        Some(other) => {
+            let mut map = serde_json::Map::new();
+            map.insert("params".to_string(), other);
+            map
+        }
+    };
+    object.insert("_meta".to_string(), sep414_meta(scope));
+    Value::Object(object)
 }
 
 fn encode_json_rpc_request(
@@ -1854,7 +1919,139 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_host_api::{
+        AgentId, InvocationId, MissionId, ProjectId, TenantId, ThreadId, UserId,
+    };
     use serde_json::json;
+
+    /// Never invoked: `plan_json_rpc` builds the outbound body without touching
+    /// the transport. Present only to satisfy `McpHostHttpClient`'s `H: McpHostHttp`.
+    struct UnusedHttp;
+
+    #[async_trait]
+    impl McpHostHttp for UnusedHttp {
+        async fn request(
+            &self,
+            _request: CapabilityHostHttpRequest,
+        ) -> Result<McpHostHttpResponse, McpHostHttpError> {
+            unreachable!("plan_json_rpc must not touch the transport")
+        }
+    }
+
+    fn planning_client() -> McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner> {
+        McpHostHttpClient::new(
+            UnusedHttp,
+            StaticMcpHostHttpEgressPlanner::new(McpHostHttpEgressPlan::default()),
+        )
+    }
+
+    fn scope_with_thread(thread_id: Option<&str>) -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant-a").unwrap(),
+            user_id: UserId::new("user-a").unwrap(),
+            agent_id: Some(AgentId::new("agent-a").unwrap()),
+            project_id: Some(ProjectId::new("project-a").unwrap()),
+            mission_id: Some(MissionId::new("mission-a").unwrap()),
+            thread_id: thread_id.map(|id| ThreadId::new(id).unwrap()),
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    fn meta_probe_request(scope: ResourceScope, input: Value) -> McpClientRequest {
+        McpClientRequest {
+            provider: ExtensionId::new("agent-market").unwrap(),
+            capability_id: CapabilityId::new("agent-market.search_agents").unwrap(),
+            scope,
+            transport: "http".to_string(),
+            command: None,
+            args: Vec::new(),
+            url: Some("https://mcp.example.test/rpc".to_string()),
+            input,
+            max_output_bytes: 1_000_000,
+        }
+    }
+
+    /// The outbound `params` object that `plan_json_rpc` actually encodes.
+    fn planned_params(
+        client: &McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner>,
+        request: &McpClientRequest,
+        method: McpJsonRpcMethod,
+        params: Option<Value>,
+    ) -> Value {
+        let planned = client
+            .plan_json_rpc(request, Some(1), method, params)
+            .expect("planning succeeds");
+        let decoded: Value = serde_json::from_slice(&planned.body).expect("body is JSON");
+        decoded.get("params").cloned().unwrap_or(Value::Null)
+    }
+
+    #[test]
+    fn tools_call_stamps_sep414_thread_attribution_on_the_wire() {
+        let client = planning_client();
+        let request =
+            meta_probe_request(scope_with_thread(Some("thread-a")), json!({"limit": 10}));
+
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::ToolsCall,
+            Some(json!({ "name": "search_agents", "arguments": { "limit": 10 } })),
+        );
+
+        // Attribution is carried in `_meta`, never derived from arguments — this
+        // is what lets one stable per-user token serve concurrent jobs without a
+        // buyer seeing another buyer's connector.
+        assert_eq!(params["_meta"]["io.ironclaw/threadId"], json!("thread-a"));
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+        assert!(params["_meta"]["io.ironclaw/invocationId"].is_string());
+        // Original tool arguments survive the merge untouched.
+        assert_eq!(params["name"], json!("search_agents"));
+        assert_eq!(params["arguments"], json!({ "limit": 10 }));
+    }
+
+    #[test]
+    fn tools_list_stamps_sep414_thread_attribution_even_without_other_params() {
+        let client = planning_client();
+        let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
+
+        // `tools/list` carries no other params (`None`) — the block must still
+        // materialize so per-turn discovery is attributed to its thread.
+        let params = planned_params(&client, &request, McpJsonRpcMethod::ToolsList, None);
+
+        assert_eq!(params["_meta"]["io.ironclaw/threadId"], json!("thread-a"));
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+    }
+
+    #[test]
+    fn initialize_handshake_is_not_stamped_with_attribution() {
+        let client = planning_client();
+        let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
+
+        // The handshake predates any turn attribution; stamping it would corrupt
+        // the exact `initialize` params contract.
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::Initialize,
+            Some(json!({ "protocolVersion": "2025-06-18" })),
+        );
+
+        assert!(params.get("_meta").is_none());
+        assert_eq!(params["protocolVersion"], json!("2025-06-18"));
+    }
+
+    #[test]
+    fn thread_less_scope_omits_thread_id_but_keeps_user_attribution() {
+        let client = planning_client();
+        let request = meta_probe_request(scope_with_thread(None), Value::Null);
+
+        let params = planned_params(&client, &request, McpJsonRpcMethod::ToolsList, None);
+
+        // A non-threaded runtime sends no thread key (absent, not empty) but is
+        // still user-attributed.
+        assert!(params["_meta"].get("io.ironclaw/threadId").is_none());
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+    }
 
     #[test]
     fn mcp_auth_context_preserves_product_auth_oauth_setup() {


### PR DESCRIPTION
Hosted-MCP providers currently cannot tell which principal a `tools/list` or `tools/call` came from, so a multi-tenant server has to guess or serve everyone the same surface. This stamps SEP-414 `_meta` attribution on outbound hosted-MCP calls, strictly opt-in per provider manifest.

**Needs a rebase before review:** `main` has since moved these crates (`ironclaw_mcp` → `crates/lanes/`, extensions → `crates/extensions/`), so the diff points at paths that no longer exist. Happy to re-port — checking first whether you want this contract in tree at all.

### What changed
- `ironclaw_mcp` attaches `_meta` attribution (SEP-414) to outbound `tools/list` and `tools/call`.
- Opt-in per provider: a manifest declares `mcp_attribution`, and nothing is stamped without it, so existing providers see byte-identical requests.
- Manifest v2/v3 both carry the flag; `resolved.rs` threads it to the call site.
- `manifest_v3_contract` test pins the declaration, so the flag cannot drift from the wire behaviour.

### Verify
```
cargo test -p ironclaw_mcp
cargo test -p ironclaw_extensions --test manifest_v3_contract
```

### Risk
No behaviour change for any provider that does not declare the flag — that was the outcome of the first review round, which asked for exactly this. For providers that do, requests grow by a small `_meta` object. Rollback is a revert.

<details><summary>Background</summary>

We run a marketplace where one hosted-MCP server backs several principals (a per-account concierge plus managed worker agents), and without attribution the server cannot scope a tool catalog per caller — the concrete failure is described in #6778.

Earlier attempts: #6365 and #6683 carried this alongside a per-user discovery overlay. Those were closed once we moved to a per-hire user model, and attribution was split out here as the one piece of our fork the hosted-provider contract still needs.

</details>
