### PR TITLE
test: cover generic outbound registration

### DIFF
--- a/crates/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -3962,7 +3962,7 @@ async fn slack_approval_then_auth_resume_completes_without_second_approval() {
 
 use crate::channel_outbound_targets::{
     ChannelOutboundTargetIdentity, GenericChannelOutboundTargetDeps,
-    GenericChannelOutboundTargetProvider,
+    GenericChannelOutboundTargetProvider, register_generic_channel_outbound_targets,
 };
 use crate::channel_triggered_delivery::GenericTriggeredRunDeliveryHook;
 use ironclaw_extension_host::{FilesystemChannelDmTargetStore, dm_target_payload};
@@ -3985,11 +3985,11 @@ fn generic_dm_target_store() -> Arc<FilesystemChannelDmTargetStore> {
     ))
 }
 
-fn generic_outbound_target_provider(
+fn generic_outbound_target_deps(
     harness: &Harness,
     dm_targets: Arc<FilesystemChannelDmTargetStore>,
-) -> GenericChannelOutboundTargetProvider {
-    GenericChannelOutboundTargetProvider::new(GenericChannelOutboundTargetDeps {
+) -> GenericChannelOutboundTargetDeps {
+    GenericChannelOutboundTargetDeps {
         watch: harness.assembly.snapshot_watch(),
         assembly: Arc::clone(&harness.assembly),
         channel_config: Arc::clone(&harness.channel_config),
@@ -3999,7 +3999,14 @@ fn generic_outbound_target_provider(
             agent_id: AgentId::new(AGENT).expect("agent"), // safety: static test agent id is valid.
             project_id: Some(ProjectId::new(PROJECT).expect("project")), // safety: static test project id is valid.
         },
-    })
+    }
+}
+
+fn generic_outbound_target_provider(
+    harness: &Harness,
+    dm_targets: Arc<FilesystemChannelDmTargetStore>,
+) -> GenericChannelOutboundTargetProvider {
+    GenericChannelOutboundTargetProvider::new(generic_outbound_target_deps(harness, dm_targets))
 }
 
 fn operator_caller() -> OutboundDeliveryTargetScope {
@@ -4027,6 +4034,28 @@ async fn save_outbound_target_config(harness: &Harness) {
         )
         .await
         .expect("save outbound target config"); // safety: manifest declares the handles.
+}
+
+#[tokio::test]
+async fn generic_outbound_target_registration_exposes_provider_through_registry() {
+    let harness = build_harness(TurnMode::Running).await;
+    save_outbound_target_config(&harness).await;
+    let registry = ironclaw_outbound::MutableOutboundDeliveryTargetRegistry::default();
+
+    register_generic_channel_outbound_targets(
+        &registry,
+        generic_outbound_target_deps(&harness, generic_dm_target_store()),
+    );
+
+    let listed = registry
+        .list_outbound_delivery_targets(&operator_caller())
+        .await
+        .expect("registered provider should be queryable");
+    assert_eq!(
+        listed.len(),
+        1,
+        "registered provider should list one target"
+    );
 }
 
 /// The generic provider lists the operator's routed shared channel (from


### PR DESCRIPTION
## Summary

- Add a regression test that registers the generic channel outbound-target provider on a fresh mutable registry.
- Query the provider through the registry boundary, so turning `register_generic_channel_outbound_targets` into a no-op is detected.
- Reuse the existing channel-host harness and fixtures; production code is unchanged.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #6726

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `cargo +1.96.0 test -p ironclaw_extension_host --lib` (290 passed)
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable: test-only change exercised by the automated suite.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional scoped lint: `cargo +1.96.0 clippy -p ironclaw_extension_host --lib --tests --features test-support -- -D warnings`.

## Test Strategy

User behavior: No direct user-facing behavior changes. The test protects boot-time composition of generic outbound delivery targets.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added a channel-host contract test that registers the production provider and lists its target through `MutableOutboundDeliveryTargetRegistry`.
- Reborn integration: Not applicable: the existing in-crate channel-host harness exercises the composition boundary without a separate integration binary.
- Recorded fixture: Not applicable: no recorded external traffic.
- Browser E2E: Not applicable: no browser surface.
- Backend or runtime: Not applicable: no backend/runtime behavior changed.
- Live canary: Not applicable: the test uses deterministic in-memory fixtures.

What the tests prove: A fresh registry exposes one configured generic channel target after `register_generic_channel_outbound_targets` runs. As a mutation check, replacing that function body with a no-op made the new test fail with 0 targets; restoring the function made it pass.

Commands run:

```text
cargo +1.96.0 test -p ironclaw_extension_host --lib channel_host::e2e_tests::generic_outbound_target_registration_exposes_provider_through_registry -- --exact --nocapture
cargo +1.96.0 test -p ironclaw_extension_host --lib
cargo +1.96.0 fmt --all -- --check
cargo +1.96.0 build -p ironclaw_extension_host
cargo +1.96.0 clippy -p ironclaw_extension_host --lib --tests --features test-support -- -D warnings
scripts/pre-commit-safety.sh
git diff --check
```

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A: test-only change; no policy, evidence, prompt, serialization, queue, error, sandbox, or trust-boundary behavior changes.

## Database Impact

None.

## Blast Radius

Test-only changes inside the existing `ironclaw_extension_host` channel-host suite. A failure indicates the generic outbound provider is no longer reachable through the production registry boundary.

## Rollback Plan

Revert the test commit; production behavior is unchanged.

## Review Follow-Through

No known follow-up. Reviewer judgment is welcome on whether this is the preferred package-scoped mutation gate for the registration helper.

---

**Review track**: A (tests)
