### PR TITLE
test(e2e): replay each mutating journey alone nightly

### DIFF
--- a/.github/workflows/nightly-deep-ci.yml
+++ b/.github/workflows/nightly-deep-ci.yml
@@ -86,6 +86,10 @@ jobs:
       # reversing them can expose state leaking from a different journey.
       # Too slow to repeat per PR, cheap once a night.
       reversed_journey_order: true
+      # Workstream 3 of #6524: proves each mutating journey stands on its own,
+      # which the shared ordinary lane cannot show. One server start per
+      # journey, so nightly only.
+      alone_journey_replay: true
 
 # Failure reporting: nightly-watchdog.yml checks this workflow's latest
 # scheduled run from outside and posts failures to Slack. An in-run alert

--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -16,6 +16,15 @@ on:
         required: false
         default: false
         type: boolean
+      alone_journey_replay:
+        description: >-
+          Also replay each mutating provider journey in its own pytest
+          process, proving it passes with no other journey before it. Off for
+          pull requests (one server start per journey); the nightly deep run
+          turns it on.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
   # pull_request deliberately has no `paths:` filter: the "Reborn E2E"
   # roll-up must report on every PR so it can be a required status check (a
@@ -248,6 +257,27 @@ jobs:
           tests/e2e/scenarios/test_reborn_qa_trace_full_path.py::test_mutating_qa_journeys_replay_in_reverse_against_shared_provider_world
           -v
           --timeout=120
+
+      - name: Replay each mutating journey alone
+        if: inputs.alone_journey_replay
+        env:
+          IRONCLAW_EMULATE_CLI: ${{ github.workspace }}/.emulate/packages/emulate/dist/index.js
+        run: |
+          set -euo pipefail
+          # One pytest process per journey: a journey that only passes because
+          # an earlier one left Reborn or a provider in some state fails here,
+          # and nowhere in the ordinary lane. The list is pinned by
+          # test_alone_lane_lists_every_mutating_journey, so an empty loop
+          # cannot quietly pass.
+          mapfile -t journeys < <(python scripts/ci/list_mutating_journeys.py)
+          echo "replaying ${#journeys[@]} journeys alone"
+          for journey in "${journeys[@]}"; do
+            echo "::group::alone: $journey"
+            pytest tests/e2e/scenarios/test_reborn_qa_trace_full_path.py \
+              -k "$journey and not isolated" \
+              -v --timeout=120
+            echo "::endgroup::"
+          done
 
       - name: Run Reborn Responses API E2E
         run: |

--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -269,7 +269,12 @@ jobs:
           # and nowhere in the ordinary lane. The list is pinned by
           # test_alone_lane_lists_every_mutating_journey, so an empty loop
           # cannot quietly pass.
-          mapfile -t journeys < <(python scripts/ci/list_mutating_journeys.py)
+          journey_list="$(python scripts/ci/list_mutating_journeys.py)"
+          if [[ -z "${journey_list//[[:space:]]/}" ]]; then
+            echo "mutating journey list is empty" >&2
+            exit 1
+          fi
+          mapfile -t journeys <<<"${journey_list}"
           echo "replaying ${#journeys[@]} journeys alone"
           for journey in "${journeys[@]}"; do
             echo "::group::alone: $journey"

--- a/scripts/ci/list_mutating_journeys.py
+++ b/scripts/ci/list_mutating_journeys.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Print the mutating provider journeys, one id per line.
+
+Used by the nightly "each journey passes alone" lane, which runs one pytest
+process per id. That loop is only as good as this list: if it ever printed
+nothing, the loop would iterate zero times, the step would exit 0, and the
+proof would be retired without a single failing check. So an empty list is an
+error here rather than an empty stdout for the caller to notice.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+E2E_ROOT = Path(__file__).resolve().parents[2] / "tests/e2e"
+
+
+def mutating_journey_ids() -> list[str]:
+    sys.path.insert(0, str(E2E_ROOT))
+    from journey_cases import PROVIDER_JOURNEY_CASES
+
+    return [
+        case.case_id
+        for case in PROVIDER_JOURNEY_CASES
+        if case.mutable_provider_worlds
+    ]
+
+
+def main() -> int:
+    ids = mutating_journey_ids()
+    if not ids:
+        print(
+            "no mutating provider journeys found; the alone-lane would test "
+            "nothing and pass",
+            file=sys.stderr,
+        )
+        return 1
+    print("\n".join(ids))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -1,6 +1,7 @@
 """Completeness gate for typed whole-path journey evidence."""
 
 import ast
+import importlib.util
 import json
 import re
 import tomllib
@@ -405,6 +406,28 @@ def test_journey_order_env_selects_the_reversed_lane(monkeypatch, value, expecte
     else:
         monkeypatch.setenv(JOURNEY_ORDER_ENV, value)
     assert journey_order_is_reversed() is expected
+
+
+def test_alone_lane_lists_every_mutating_journey():
+    """The alone-lane loop is only as good as the list it iterates.
+
+    An empty or drifted list would make the nightly step iterate fewer times,
+    exit 0, and retire the proof with nothing failing — so pin the list
+    against the case inventory rather than trusting the script's own output.
+    """
+    script = ROOT / "scripts/ci/list_mutating_journeys.py"
+    assert script.is_file(), script
+    spec = importlib.util.spec_from_file_location("list_mutating_journeys", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    expected = [
+        case.case_id
+        for case in PROVIDER_JOURNEY_CASES
+        if case.mutable_provider_worlds
+    ]
+    assert expected, "no mutating journeys: the alone lane would test nothing"
+    assert module.mutating_journey_ids() == expected
 
 
 def test_every_journey_has_complete_typed_executable_evidence():

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -3,7 +3,9 @@
 import ast
 import importlib.util
 import json
+import os
 import re
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -428,6 +430,49 @@ def test_alone_lane_lists_every_mutating_journey():
     ]
     assert expected, "no mutating journeys: the alone lane would test nothing"
     assert module.mutating_journey_ids() == expected
+
+
+@pytest.mark.parametrize(
+    ("stub_body", "expected_returncode"),
+    [
+        ("exit 23\n", 23),
+        ("exit 0\n", 1),
+    ],
+)
+def test_alone_lane_rejects_failed_or_empty_inventory(
+    tmp_path,
+    stub_body,
+    expected_returncode,
+):
+    """The workflow must fail closed before replaying an invalid inventory."""
+    workflow = (ROOT / ".github/workflows/reborn-e2e.yml").read_text(encoding="utf-8")
+    step = re.search(
+        r"      - name: Replay each mutating journey alone\n"
+        r"(?:        .*\n)*?"
+        r"        run: \|\n"
+        r"(?P<script>(?:          .*\n)+)",
+        workflow,
+    )
+    assert step, "missing isolated journey replay workflow step"
+    script = "\n".join(
+        line.removeprefix("          ")
+        for line in step.group("script").splitlines()
+    )
+
+    python_stub = tmp_path / "python"
+    python_stub.write_text(
+        f"#!/usr/bin/env bash\n{stub_body}",
+        encoding="utf-8",
+    )
+    python_stub.chmod(0o755)
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=ROOT,
+        env={**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"},
+        check=False,
+    )
+
+    assert result.returncode == expected_returncode
 
 
 def test_every_journey_has_complete_typed_executable_evidence():


### PR DESCRIPTION
## Summary

- Add an optional nightly lane that replays each of the six mutating provider journeys in its own pytest process, proving each passes from a clean start.
- Derive the replay inventory from the typed journey cases and fail closed if inventory generation fails or yields no journeys.
- Keep the expensive replay nightly-only through the dedicated `alone_journey_replay` input.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build` — Not run separately: all-feature Clippy compiled the workspace.
- [x] Relevant tests pass: `test_journey_coverage.py` (36 passed), including fail-closed workflow regression cases.
- [ ] `cargo test --features integration` — Not applicable: no database-backed or runtime behavior changed.
- [x] Manual testing: inventory lists six IDs; workflow YAML parses; failing and empty inventory stubs both stop the replay step before pytest.
- [ ] Agent review workflow — Not run; review feedback was validated directly and the final diff was checked manually.

The broad `cargo test --workspace --lib` diagnostic is blocked by two unrelated `ironclaw_host_runtime` tests (`dispatch_profile_{set,token}_without_enrollment_returns_onboard_guidance`) that pass when selected alone but fail after the rest of that crate with `NetworkDenied`. No Rust files are changed by this PR update.

## Test Strategy

User behavior: No product UI behavior changes. Nightly CI must not report a successful isolated replay when journey inventory generation fails or returns no work.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `test_alone_lane_rejects_failed_or_empty_inventory` executes the actual workflow shell block against non-zero and empty inventory stubs; `test_alone_lane_lists_every_mutating_journey` pins the six IDs to the typed case inventory.
- Reborn integration: Not applicable: the change is CI orchestration around the existing Reborn E2E suite.
- Recorded fixture: Not applicable: model selection and request shape are unchanged.
- Browser E2E: Not applicable: no WebUI behavior changed.
- Backend or runtime: Not applicable: no storage or runtime contract changed.
- Live canary: Not applicable: deterministic workflow and inventory checks cover the changed contract; the full isolated replay remains nightly.

What the tests prove: inventory command failures propagate, whitespace-only output is rejected, the replay list is complete and non-empty, and every valid mutating journey remains selected exactly once per isolated pytest process.

Commands run:

- `uv run --isolated --project tests/e2e --python /Users/firatsertgoz/.local/bin/python3.11 pytest tests/e2e/scenarios/test_journey_coverage.py -q` — 36 passed.
- `/Users/firatsertgoz/.local/bin/python3.11 scripts/ci/list_mutating_journeys.py` — six IDs.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — passed.
- `bash scripts/pre-commit-safety.sh` — passed.
- Workflow YAML parse and `git diff --check` — passed.
- `cargo test --workspace --lib` — partial; unrelated host-runtime shared-state failures described above, with both failures passing when run alone.

## Security Impact

None. No permissions, network policy, secrets, file access, tool execution, or sandbox behavior changed.

## Reborn Trust-Boundary Checklist

N/A: this PR changes CI orchestration and test inventory only; no Reborn trust-bearing types or runtime boundaries change.

## Database Impact

None.

## Blast Radius

Limited to the optional `alone_journey_replay` job step in `.github/workflows/reborn-e2e.yml` and its nightly caller. Pull-request runs keep the input disabled.

## Rollback Plan

Revert the PR commits or disable `alone_journey_replay` in `.github/workflows/nightly-deep-ci.yml`; the ordinary provider-journey lane remains unchanged.

## Review Follow-Through

Addressed both review threads about process substitution hiding inventory-script failures in commit `bbf0f87f`; added caller-level regression coverage and resolved the threads after push.

## Reviewer Notes

- The first nightly replay is intentionally informative: green means all six journeys stand alone; red identifies a journey that depended on predecessor state.
- Six pytest processes each start their own Reborn, so this is nightly-only work. If wall-clock cost becomes a problem, adjust the typed mutating-journey classification rather than sampling the list.

---

**Review track**: C (CI/infrastructure)
