### PR TITLE
test(e2e): pin OAuth, rate-limit and membership isolation between cases

### DIFF
--- a/tests/e2e/scenarios/test_provider_world_isolation.py
+++ b/tests/e2e/scenarios/test_provider_world_isolation.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 import httpx
 import pytest
 from conftest import ResettableEmulateProviderWorld
-from emulate_provider import github_json, slack_post
+from emulate_provider import github_headers, github_json, slack_post
+from helpers import EMULATE_GITHUB_SECONDARY_BEARER
 
 ISSUES_PATH = "/repos/nearai/ironclaw/issues"
+GITHUB_TEAM_SLUG = "provider-contract"
+GITHUB_TEAM_MEMBERS_PATH = f"/orgs/nearai/teams/{GITHUB_TEAM_SLUG}/members"
 
 
 @pytest.fixture
@@ -135,3 +138,265 @@ async def test_reset_of_one_service_is_scoped_to_that_service(github_slack_world
     assert github_marker not in await _issue_titles(github_url)
     assert github_slack_world.servers["slack"]["url"] == slack_url
     assert any(message["text"] == slack_marker for message in history["messages"])
+
+
+@pytest.fixture
+async def slack_world():
+    world = ResettableEmulateProviderWorld()
+    await world.start({"slack"})
+    try:
+        yield world
+    finally:
+        await world.close()
+
+async def _team_member_logins(base_url: str) -> list[str]:
+    async with httpx.AsyncClient(timeout=15) as client:
+        members = await github_json(client, base_url, "GET", GITHUB_TEAM_MEMBERS_PATH)
+    assert isinstance(members, list), members
+    return [member["login"] for member in members]
+
+async def _remaining_rate_limit(client: httpx.AsyncClient, base_url: str) -> int:
+    """Read x-ratelimit-remaining off a real request, not the /rate_limit body.
+
+    Emulate's `/rate_limit` endpoint reports a value computed independently
+    of the header counter that guards every other route, so it does not
+    reflect requests already spent. The header is what a Reborn caller
+    actually sees hit its budget.
+    """
+    response = await client.get(f"{base_url}/user", headers=github_headers())
+    assert response.status_code == 200, response.text
+    return int(response.headers["x-ratelimit-remaining"])
+
+async def test_reset_restores_rate_limit_headroom_after_a_journey_burns_requests(
+    github_world,
+):
+    """A journey that eats into the 5000/hr budget must not hand the deficit on.
+
+    `x-ratelimit-remaining` decrements on every authenticated call. If reset
+    only wiped fixture data and left the counter running, a case scheduled
+    after a request-heavy journey would inherit its depleted budget and could
+    fail on a rate-limit error that has nothing to do with what it did.
+    """
+    base_url = github_world.servers["github"]["url"]
+    async with httpx.AsyncClient(timeout=15) as client:
+        readings = [await _remaining_rate_limit(client, base_url) for _ in range(5)]
+        assert readings == sorted(readings, reverse=True), readings
+        assert readings[-1] < readings[0], readings
+
+        await github_world.reset({"github"})
+
+        after_reset = await _remaining_rate_limit(client, base_url)
+
+    # A fresh process starts back near the 5000 ceiling; a leaked counter
+    # would instead continue downward from `readings[-1]`.
+    assert after_reset > readings[-1], (after_reset, readings)
+
+async def test_reset_invalidates_a_pending_oauth_authorization_code(github_world):
+    """A code minted by one journey's OAuth dance must not redeem in the next.
+
+    Emulate's `/login/oauth/authorize` -> `/login/oauth/callback` exchange
+    hands back a single-use `code`; `/login/oauth/access_token` looks it up
+    in an in-memory pending-codes table. If that table survived a reset, a
+    code leaked out of one journey's logs or fixtures could mint a live
+    token for a case that never ran the OAuth flow itself.
+    """
+    base_url = github_world.servers["github"]["url"]
+    form = {
+        "login": "reborn-dev",
+        "redirect_uri": "http://localhost/cb",
+        "scope": "",
+        "state": "isolation-check",
+        "client_id": "provider-world-isolation-test",
+    }
+    async with httpx.AsyncClient(timeout=15) as client:
+        callback = await client.post(f"{base_url}/login/oauth/callback", data=form)
+        assert callback.status_code == 302, callback.text
+        code = httpx.URL(callback.headers["location"]).params["code"]
+
+        await github_world.reset({"github"})
+
+        exchange = await client.post(
+            f"{base_url}/login/oauth/access_token",
+            data={
+                "client_id": form["client_id"],
+                "client_secret": "unused-in-emulate",
+                "code": code,
+                "redirect_uri": form["redirect_uri"],
+            },
+            headers={"Accept": "application/json"},
+        )
+    assert exchange.status_code == 200, exchange.text
+    body = exchange.json()
+    assert "access_token" not in body, body
+    assert body.get("error") == "bad_verification_code", body
+
+async def test_reset_of_team_membership_drops_grants_a_journey_added(github_world):
+    """Org/team membership a journey grants must not carry into the next case.
+
+    Every world start bootstraps `reborn-dev` onto the `Provider Contract`
+    team so the primary fixture actor has push access. A journey that grants
+    a second collaborator (e.g. to test review-assignment flows) must not
+    leave that grant in place for a case that never asked for it — that grant
+    is itself a capability the next case's assertions could be silently
+    depending on, or silently defeated by.
+    """
+    base_url = github_world.servers["github"]["url"]
+    async with httpx.AsyncClient(timeout=15) as client:
+        await github_json(
+            client,
+            base_url,
+            "PUT",
+            f"/orgs/nearai/teams/{GITHUB_TEAM_SLUG}/memberships/reborn-reviewer",
+            payload={"role": "member"},
+            token=EMULATE_GITHUB_SECONDARY_BEARER,
+        )
+    assert sorted(await _team_member_logins(base_url)) == [
+        "reborn-dev",
+        "reborn-reviewer",
+    ]
+
+    await github_world.reset({"github"})
+
+    # Reset re-bootstraps only the primary actor; the second grant is gone.
+    assert await _team_member_logins(base_url) == ["reborn-dev"]
+
+async def test_reset_clears_slack_messages_a_journey_posted(slack_world):
+    """A message a journey posts to a seeded channel must not outlive it.
+
+    Nothing in the Slack seed pre-populates `reborn-alerts` with messages, so
+    a message showing up in the next case's `conversations.history` can only
+    have leaked from this journey — the classic false-positive-attributed-
+    to-the-wrong-case failure this whole box exists to rule out.
+    """
+    base_url = slack_world.servers["slack"]["url"]
+    async with httpx.AsyncClient(timeout=15) as client:
+        channels = await slack_post(client, base_url, "conversations.list")
+        channel_id = next(
+            c["id"] for c in channels["channels"] if c["name"] == "reborn-alerts"
+        )
+        await slack_post(
+            client,
+            base_url,
+            "chat.postMessage",
+            {"channel": channel_id, "text": "left-behind-by-a-previous-journey"},
+        )
+        history = await slack_post(
+            client, base_url, "conversations.history", {"channel": channel_id}
+        )
+        assert [m["text"] for m in history["messages"]] == [
+            "left-behind-by-a-previous-journey"
+        ]
+
+        await slack_world.reset({"slack"})
+
+        # The restarted process assigns fresh channel ids from the same seed,
+        # so look the channel back up by name rather than reusing channel_id.
+        channels_after = await slack_post(client, base_url, "conversations.list")
+        channel_id_after = next(
+            c["id"] for c in channels_after["channels"] if c["name"] == "reborn-alerts"
+        )
+        history_after = await slack_post(
+            client, base_url, "conversations.history", {"channel": channel_id_after}
+        )
+    assert history_after["messages"] == []
+
+async def test_reset_clears_slack_channel_membership_a_journey_joined(slack_world):
+    """Joining a channel that isn't seeded-joined must not stick across a reset.
+
+    `general` seeds with only its creator as a member. A journey that joins
+    it (e.g. to test channel-discovery flows) changes both `is_member` and
+    `num_members` for that actor; a reset that only replayed fixture data
+    without restarting the process would leave that join in place.
+    """
+    base_url = slack_world.servers["slack"]["url"]
+    async with httpx.AsyncClient(timeout=15) as client:
+        channels = await slack_post(client, base_url, "conversations.list")
+        general = next(c for c in channels["channels"] if c["name"] == "general")
+        assert general["is_member"] is False
+        seeded_member_count = general["num_members"]
+
+        joined = await slack_post(
+            client, base_url, "conversations.join", {"channel": general["id"]}
+        )
+        assert joined["channel"]["is_member"] is True
+        assert joined["channel"]["num_members"] == seeded_member_count + 1
+
+        await slack_world.reset({"slack"})
+
+        channels_after = await slack_post(client, base_url, "conversations.list")
+        general_after = next(
+            c for c in channels_after["channels"] if c["name"] == "general"
+        )
+    assert general_after["is_member"] is False
+    assert general_after["num_members"] == seeded_member_count
+
+@pytest.fixture
+async def google_world():
+    world = ResettableEmulateProviderWorld()
+    await world.start({"google"})
+    try:
+        yield world
+    finally:
+        await world.close()
+
+async def _mint_google_refresh_token(base_url: str) -> str:
+    """Drive the real consent -> code -> token exchange and keep the refresh token."""
+    redirect_uri = "http://127.0.0.1:1/callback"
+    async with httpx.AsyncClient(timeout=15) as client:
+        callback = await client.post(
+            f"{base_url}/o/oauth2/v2/auth/callback",
+            data={
+                "email": "e2e.google@example.com",
+                "redirect_uri": redirect_uri,
+                "scope": "openid email profile",
+                "client_id": "",
+            },
+        )
+        assert callback.status_code == 302, callback.text
+        code = httpx.URL(callback.headers["location"]).params["code"]
+
+        exchanged = await client.post(
+            f"{base_url}/oauth2/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+        )
+        assert exchanged.status_code == 200, exchanged.text
+        refresh_token = exchanged.json().get("refresh_token")
+        assert refresh_token, exchanged.json()
+    return refresh_token
+
+async def test_reset_invalidates_a_google_refresh_token(google_world):
+    """A refresh token one journey obtained must not still work for the next.
+
+    This is the Google counterpart to the GitHub authorization-code case, and
+    it is the longer-lived half: an authorization code is single-use and
+    short-lived, while a refresh token is exactly the credential a journey
+    would keep using. If it survived a reset, a later journey could silently
+    mint access tokens against a grant it never performed — and would keep
+    passing while doing so.
+    """
+    base_url = google_world.servers["google"]["url"]
+    refresh_token = await _mint_google_refresh_token(base_url)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        # Redeemable before the reset, so the assertion after it is meaningful
+        # rather than passing because the token never worked at all.
+        before = await client.post(
+            f"{base_url}/oauth2/token",
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+        )
+        assert before.status_code == 200, before.text
+        assert before.json()["access_token"]
+
+    await google_world.reset({"google"})
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        after = await client.post(
+            f"{base_url}/oauth2/token",
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+        )
+    assert after.status_code == 400, after.text
+    assert after.json()["error"] == "invalid_grant", after.json()

--- a/tests/e2e/scenarios/test_provider_world_isolation.py
+++ b/tests/e2e/scenarios/test_provider_world_isolation.py
@@ -183,8 +183,9 @@ async def test_reset_restores_rate_limit_headroom_after_a_journey_burns_requests
         assert readings == sorted(readings, reverse=True), readings
         assert readings[-1] < readings[0], readings
 
-        await github_world.reset({"github"})
+    await github_world.reset({"github"})
 
+    async with httpx.AsyncClient(timeout=15) as client:
         after_reset = await _remaining_rate_limit(client, base_url)
 
     # A fresh process starts back near the 5000 ceiling; a leaked counter
@@ -209,18 +210,43 @@ async def test_reset_invalidates_a_pending_oauth_authorization_code(github_world
         "client_id": "provider-world-isolation-test",
     }
     async with httpx.AsyncClient(timeout=15) as client:
-        callback = await client.post(f"{base_url}/login/oauth/callback", data=form)
-        assert callback.status_code == 302, callback.text
-        code = httpx.URL(callback.headers["location"]).params["code"]
+        control_callback = await client.post(
+            f"{base_url}/login/oauth/callback", data=form
+        )
+        assert control_callback.status_code == 302, control_callback.text
+        control_code = httpx.URL(control_callback.headers["location"]).params[
+            "code"
+        ]
+        control_exchange = await client.post(
+            f"{base_url}/login/oauth/access_token",
+            data={
+                "client_id": form["client_id"],
+                "client_secret": "unused-in-emulate",
+                "code": control_code,
+                "redirect_uri": form["redirect_uri"],
+            },
+            headers={"Accept": "application/json"},
+        )
+        assert control_exchange.status_code == 200, control_exchange.text
+        assert control_exchange.json().get("access_token"), control_exchange.json()
 
-        await github_world.reset({"github"})
+        pending_callback = await client.post(
+            f"{base_url}/login/oauth/callback", data=form
+        )
+        assert pending_callback.status_code == 302, pending_callback.text
+        pending_code = httpx.URL(pending_callback.headers["location"]).params[
+            "code"
+        ]
 
+    await github_world.reset({"github"})
+
+    async with httpx.AsyncClient(timeout=15) as client:
         exchange = await client.post(
             f"{base_url}/login/oauth/access_token",
             data={
                 "client_id": form["client_id"],
                 "client_secret": "unused-in-emulate",
-                "code": code,
+                "code": pending_code,
                 "redirect_uri": form["redirect_uri"],
             },
             headers={"Accept": "application/json"},
@@ -287,8 +313,9 @@ async def test_reset_clears_slack_messages_a_journey_posted(slack_world):
             "left-behind-by-a-previous-journey"
         ]
 
-        await slack_world.reset({"slack"})
+    await slack_world.reset({"slack"})
 
+    async with httpx.AsyncClient(timeout=15) as client:
         # The restarted process assigns fresh channel ids from the same seed,
         # so look the channel back up by name rather than reusing channel_id.
         channels_after = await slack_post(client, base_url, "conversations.list")
@@ -321,8 +348,9 @@ async def test_reset_clears_slack_channel_membership_a_journey_joined(slack_worl
         assert joined["channel"]["is_member"] is True
         assert joined["channel"]["num_members"] == seeded_member_count + 1
 
-        await slack_world.reset({"slack"})
+    await slack_world.reset({"slack"})
 
+    async with httpx.AsyncClient(timeout=15) as client:
         channels_after = await slack_post(client, base_url, "conversations.list")
         general_after = next(
             c for c in channels_after["channels"] if c["name"] == "general"
@@ -339,8 +367,17 @@ async def google_world():
     finally:
         await world.close()
 
-async def _mint_google_refresh_token(base_url: str) -> str:
-    """Drive the real consent -> code -> token exchange and keep the refresh token."""
+async def test_reset_invalidates_a_google_refresh_token(google_world):
+    """A refresh token one journey obtained must not still work for the next.
+
+    This is the Google counterpart to the GitHub authorization-code case, and
+    it is the longer-lived half: an authorization code is single-use and
+    short-lived, while a refresh token is exactly the credential a journey
+    would keep using. If it survived a reset, a later journey could silently
+    mint access tokens against a grant it never performed — and would keep
+    passing while doing so.
+    """
+    base_url = google_world.servers["google"]["url"]
     redirect_uri = "http://127.0.0.1:1/callback"
     async with httpx.AsyncClient(timeout=15) as client:
         callback = await client.post(
@@ -366,22 +403,7 @@ async def _mint_google_refresh_token(base_url: str) -> str:
         assert exchanged.status_code == 200, exchanged.text
         refresh_token = exchanged.json().get("refresh_token")
         assert refresh_token, exchanged.json()
-    return refresh_token
 
-async def test_reset_invalidates_a_google_refresh_token(google_world):
-    """A refresh token one journey obtained must not still work for the next.
-
-    This is the Google counterpart to the GitHub authorization-code case, and
-    it is the longer-lived half: an authorization code is single-use and
-    short-lived, while a refresh token is exactly the credential a journey
-    would keep using. If it survived a reset, a later journey could silently
-    mint access tokens against a grant it never performed — and would keep
-    passing while doing so.
-    """
-    base_url = google_world.servers["google"]["url"]
-    refresh_token = await _mint_google_refresh_token(base_url)
-
-    async with httpx.AsyncClient(timeout=15) as client:
         # Redeemable before the reset, so the assertion after it is meaningful
         # rather than passing because the token never worked at all.
         before = await client.post(


### PR DESCRIPTION
## Summary

- Adds six hermetic provider-world isolation cases for OAuth state, rate-limit counters, team membership, Slack messages, and Slack channel membership.
- Strengthens the GitHub OAuth case with a successful pre-reset control exchange so the post-reset failure cannot pass when redemption is already broken.
- Uses a fresh HTTP client after every restarted provider and keeps the single-use Google OAuth flow inline.
- Builds on the three reset-baseline cases merged in #6756; the focused file now contains nine passing cases.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524. Builds on merged PR #6756.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build` — Not run separately: the all-feature clippy gate compiled the workspace.
- [x] Relevant tests pass: `IRONCLAW_EMULATE_CLI=/tmp/ironclaw-pr-6764-emulate-c85da1e/packages/emulate/dist/index.js /tmp/ironclaw-pr-6764-py311/bin/python -m pytest tests/e2e/scenarios/test_provider_world_isolation.py -v --timeout=120` — 9 passed against pinned Emulate commit `c85da1ed9b4e1c9cbdcd9b9ec7af2aac93f5ea9e`.
- [ ] `cargo test --workspace --lib` — 2 unchanged `ironclaw_host_runtime` Trace Commons tests fail locally with `NetworkDenied`; the focused rerun reproduces them, and `crates/ironclaw_host_runtime` has no diff in this PR. All other tests reached before that crate passed.
- [ ] `cargo test --features integration` — Not applicable: no database-backed or Rust integration behavior changed.
- [x] Manual testing: `bash scripts/pre-commit-safety.sh` and `git diff --check` passed.
- [x] Review feedback workflow inventoried every unresolved thread and verified each finding against the current head.

## Test Strategy

User behavior: None changed. This PR hardens the hermetic provider fixture contract that prevents one test journey's state from contaminating the next.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable: the contract depends on restarting the real pinned Emulate subprocess and observing its HTTP surface.
- Reborn integration: Not applicable: no Reborn product workflow changes.
- Recorded fixture: Not applicable: no model behavior or recorded trace changes.
- Browser E2E: Not applicable: the tests drive provider HTTP APIs directly and do not use a browser.
- Backend or runtime: Updated `tests/e2e/scenarios/test_provider_world_isolation.py`; all nine cases pass against the exact Emulate commit used by CI.
- Live canary: Not applicable: the pinned emulator provides deterministic evidence without real-provider credentials.

What the tests prove: Resetting a provider restores seed state, URL stability, rate-limit headroom, pending-code and refresh-token invalidation, team membership, Slack messages, and Slack channel membership. The OAuth cases first prove the credential works, preventing false positives from a broken exchange path.

Commands run:

```text
cargo fmt --all -- --check
cargo clippy --all --benches --tests --examples --all-features -- -D warnings
cargo test --workspace --lib
bash scripts/pre-commit-safety.sh
IRONCLAW_EMULATE_CLI=/tmp/ironclaw-pr-6764-emulate-c85da1e/packages/emulate/dist/index.js /tmp/ironclaw-pr-6764-py311/bin/python -m pytest tests/e2e/scenarios/test_provider_world_isolation.py -v --timeout=120
```

## Security Impact

None. Test-only HTTP clients and provider fixtures changed; no production permissions, network policy, secrets, file access, tool execution, or sandbox policy changed.

## Reborn Trust-Boundary Checklist

N/A: test-only provider-world coverage; no Reborn trust-bearing types, prompts, policy, runtime variants, queues, or host boundaries changed.

## Database Impact

None.

## Blast Radius

Limited to the Emulate-backed provider-world E2E suite. A regression could make this focused CI lane fail or become flaky; it cannot affect the shipping binary.

## Rollback Plan

Revert the review-fix commit to restore the prior test implementation. No migration, persisted state, or production compatibility step is involved.

## Review Follow-Through

Addressed all four unresolved CodeRabbit threads: added the GitHub OAuth control exchange, split GitHub/Slack client lifetimes around provider restarts, and inlined the single-use Google OAuth helper. The focused pinned-fork test suite is green.

---

**Review track**: A (tests/CI coverage only)
