### PR TITLE
feat(signing): attested signer-continuation runtime + composition seam (4/8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_attested_runtime"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "async-trait",
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "ironclaw_attestation",
+ "ironclaw_chain_signing",
+ "ironclaw_host_api",
+ "ironclaw_secrets",
+ "ironclaw_signing_provider",
+ "ironclaw_turns",
+ "ironclaw_wallet_external",
+ "k256",
+ "secrecy",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ironclaw_auth"
 version = "0.1.0"
 dependencies = [
@@ -5343,11 +5367,14 @@ dependencies = [
 name = "ironclaw_reborn_composition"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
  "async-trait",
  "axum 0.8.9",
  "base64 0.22.1",
  "chrono",
  "deadpool-postgres",
+ "ed25519-dalek",
  "fs4",
  "futures",
  "hex",
@@ -5356,9 +5383,12 @@ dependencies = [
  "http-body-util",
  "ironclaw_approvals",
  "ironclaw_attachments",
+ "ironclaw_attestation",
+ "ironclaw_attested_runtime",
  "ironclaw_auth",
  "ironclaw_authorization",
  "ironclaw_capabilities",
+ "ironclaw_chain_signing",
  "ironclaw_common",
  "ironclaw_conversations",
  "ironclaw_event_projections",
@@ -5398,13 +5428,16 @@ dependencies = [
  "ironclaw_runtime_policy",
  "ironclaw_safety",
  "ironclaw_secrets",
+ "ironclaw_signing_provider",
  "ironclaw_skills",
  "ironclaw_slack_extension",
  "ironclaw_threads",
  "ironclaw_triggers",
  "ironclaw_trust",
  "ironclaw_turns",
+ "ironclaw_wallet_external",
  "ironclaw_webui",
+ "k256",
  "libc",
  "libsql",
  "lru",

--- a/crates/ironclaw_attestation/Cargo.toml
+++ b/crates/ironclaw_attestation/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ironclaw_attestation"
 version = "0.1.0"
+publish = false  # internal substrate crate; not yet released to crates.io
 edition = "2024"
 rust-version = "1.92"
 description = "Canonical signing-bytes + ApprovedTxHash core for the IronClaw attested-signing substrate (chain-SDK-free, no secrets/webauthn)"
@@ -8,10 +9,6 @@ authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
-# Internal workspace crate, never published to crates.io. Setting this lets the
-# cargo-deny `bans` wildcard check pass without an allow-list entry (matches the
-# `ironclaw_turns` convention — this is the PR where the crate is born).
-publish = false
 
 [package.metadata.dist]
 dist = false

--- a/crates/ironclaw_attested_runtime/Cargo.toml
+++ b/crates/ironclaw_attested_runtime/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+name = "ironclaw_attested_runtime"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92"
+description = "Composition-layer runtime glue for the IronClaw attested-signing substrate: AttestedResumePort impl, signer-continuation driver, and the custodial-mainnet ship-gate (attested-signing PR10)"
+authors = ["NEAR AI <support@near.ai>"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/nearai/ironclaw"
+repository = "https://github.com/nearai/ironclaw"
+publish = false
+
+[package.metadata.dist]
+dist = false
+
+[package.metadata.ironclaw]
+# Signer-continuation driver + resume port. Depends on ironclaw_turns, so
+# it sits at kernel — above the attestation/chain-signing substrates it
+# drives, and below composition which wires it.
+layer = "kernel"
+
+[dependencies]
+async-trait = "0.1"
+# Structured diagnostics for the broadcast-failure recovery path (a non-benign
+# ledger error must surface in release builds, not be swallowed by debug_assert).
+tracing = "0.1"
+
+# Crypto-free turn-coordination contract (the AttestedResumePort trait lives here).
+ironclaw_turns = { path = "../ironclaw_turns" }
+
+# Attested-signing substrate stack (PR1-PR9).
+ironclaw_signing_provider = { path = "../ironclaw_signing_provider" }
+ironclaw_attestation = { path = "../ironclaw_attestation" }
+ironclaw_chain_signing = { path = "../ironclaw_chain_signing" }
+ironclaw_wallet_external = { path = "../ironclaw_wallet_external" }
+# ResourceScope is the authoritative custodial keystore/AAD owner carried on the
+# gate binding (host-api is already in the chain-signing dependency closure).
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+# The driver reconstructs the EVM signable from the authoritative decoded
+# binding (byte-drift defense), signing only the approved bytes.
+alloy-consensus = "1"
+alloy-primitives = "1"
+alloy-eips = "1"
+
+[dev-dependencies]
+async-trait = "0.1"
+chrono = "0.4"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+hex = "0.4"
+ed25519-dalek = "2"
+# Already a normal dependency of `ironclaw_chain_signing` (in-tree); used here
+# only to derive the EVM address from a fixed test private key, mirroring the
+# `ironclaw_chain_signing` custodial tests. `evm::signing_key_from_bytes` became
+# crate-private, so the test constructs the `SigningKey` directly. Adds no new
+# transitive deps to the workspace tree.
+k256 = { version = "0.13", features = ["ecdsa"] }
+ironclaw_secrets = { path = "../ironclaw_secrets" }
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+secrecy = "0.10"

--- a/crates/ironclaw_attested_runtime/src/binding.rs
+++ b/crates/ironclaw_attested_runtime/src/binding.rs
@@ -1,0 +1,208 @@
+//! The authoritative attested-gate binding the resume path verifies against.
+//!
+//! When a `BlockedAttested` gate is raised, the composition layer persists the
+//! authoritative `(SigningContext, ApprovedTxHash, ProviderId, decoded tx,
+//! schema)` for that gate. The resume port and the signer-continuation driver
+//! both read this binding back by `gate_ref` rather than trusting any
+//! caller-supplied context (threats #2 / #3 / #4): the caller's resume payload
+//! only ever *attests* to the bound hash; it can never *redefine* it.
+//!
+//! In-memory only here (PR10). Durable PG / libSQL backends are PR12 — they
+//! must implement [`AttestedGateBindingStore`] with identical semantics and be
+//! dual-backend, so no single-backend persistence feature is added in this
+//! crate.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use ironclaw_attestation::{DecodedTransaction, RenderingSchemaVersion};
+use ironclaw_chain_signing::{ChainKeyId, recompute_approved_hash};
+use ironclaw_signing_provider::{ApprovedTxHash, GateRef, ProviderId, SigningContext};
+
+/// Errors a binding write can fail closed with. A binding is authoritative —
+/// the resume port and driver trust it — so creation is INSERT-ONLY (CAS) and
+/// fully validated at write time. None of these are recoverable: a rejected
+/// write means the caller tried to mutate or mis-bind an authoritative gate.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BindingError {
+    /// A binding already exists for this `gate_ref`. Bindings are immutable:
+    /// the first write wins and a later write can never mutate the binding the
+    /// port + driver already trust.
+    AlreadyExists,
+    /// The store key does not equal `binding.context.gate_ref` — the binding
+    /// would be retrievable under a gate_ref it does not describe.
+    GateRefMismatch,
+    /// The bound `approved_tx_hash` does not equal the hash recomputed from the
+    /// binding's own decoded tx + schema (the binding contradicts itself).
+    ApprovedHashMismatch,
+    /// The bound `chain` does not match the chain/network its own decoded tx
+    /// encodes (a testnet `chain` carrying a mainnet tx, or vice versa).
+    ChainMismatch,
+    /// The custodial signer/account context does not match the binding's
+    /// decoded transaction (currently the EVM recipient check is advisory; the
+    /// authoritative signer binding is the ecrecover check at sign time, so this
+    /// is reserved for chains that carry an explicit signer in the decoded tx).
+    SignerMismatch,
+    /// The lock was poisoned; fail closed.
+    Poisoned,
+}
+
+impl std::fmt::Display for BindingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyExists => write!(f, "a binding already exists for this gate_ref"),
+            Self::GateRefMismatch => write!(f, "store key does not match binding context gate_ref"),
+            Self::ApprovedHashMismatch => {
+                write!(f, "approved hash does not match the decoded transaction")
+            }
+            Self::ChainMismatch => write!(f, "bound chain does not match the decoded transaction"),
+            Self::SignerMismatch => {
+                write!(f, "bound signer does not match the decoded transaction")
+            }
+            Self::Poisoned => write!(f, "binding store lock poisoned"),
+        }
+    }
+}
+
+impl std::error::Error for BindingError {}
+
+/// Everything the resume path needs to verify and continue an attested-signing
+/// gate, persisted authoritatively when the gate is raised.
+#[derive(Debug, Clone)]
+pub struct AttestedGateBinding {
+    /// Which provider drove the ceremony (selects the verifier on resume).
+    pub provider_id: ProviderId,
+    /// The authoritative signing context (who/what/where/which gate).
+    pub context: SigningContext,
+    /// The `ApprovedTxHash` recorded at approval time — the one the resume
+    /// `expected_tx_hash` must equal and the wallet/authn must attest to.
+    pub approved_tx_hash: ApprovedTxHash,
+    /// The server-decoded transaction (PR2 model). The custodial signer
+    /// recomputes the hash from THIS; the broadcast path re-signs from it.
+    pub decoded: DecodedTransaction,
+    /// The chain key id the custodial path would consume (custodial only).
+    pub chain: ChainKeyId,
+    /// The authoritative keystore/AAD owner scope, persisted when the gate was
+    /// raised. Carried directly rather than reconstructed from `context` so the
+    /// custodial keystore lookup uses the exact validated scope (custodial
+    /// only; ignored on external-wallet paths).
+    pub scope: ironclaw_host_api::ResourceScope,
+    /// Schema version the approval was rendered under.
+    pub schema_version: RenderingSchemaVersion,
+}
+
+/// Validate a binding write before it is persisted. Run by every
+/// [`AttestedGateBindingStore`] implementation so the authoritative invariants
+/// hold regardless of backend (the in-memory store here and the durable PG /
+/// libSQL backends in PR12). Does NOT check for an existing key — that is the
+/// store's INSERT-ONLY CAS responsibility, which differs per backend.
+pub fn validate_binding(key: &GateRef, binding: &AttestedGateBinding) -> Result<(), BindingError> {
+    // The binding must be retrievable under exactly the gate_ref it describes.
+    if key.as_str() != binding.context.gate_ref.as_str() {
+        return Err(BindingError::GateRefMismatch);
+    }
+    // The bound approved hash must equal the hash recomputed from the binding's
+    // own decoded tx — a self-consistency check so a write cannot bind a hash
+    // that contradicts the tx the driver will later sign. The signer folded into
+    // the recompute is the GATE-BOUND signer from the binding's SigningContext
+    // (`context.key_or_account_id`), never the tx body — that is the WYSIWYS
+    // binding. Recompute is fallible (render/canonicalization can fail); a
+    // failure means the binding cannot be confirmed, so fail closed.
+    let recomputed = recompute_approved_hash(
+        &binding.decoded,
+        binding.context.key_or_account_id.as_str(),
+        binding.schema_version,
+    )
+    .map_err(|_| BindingError::ApprovedHashMismatch)?;
+    if recomputed != binding.approved_tx_hash {
+        return Err(BindingError::ApprovedHashMismatch);
+    }
+    // The bound chain must match the chain/network its own decoded tx encodes,
+    // so a testnet `chain` can never carry a mainnet tx past the ship-gate.
+    if binding.chain.as_str() != binding.decoded.chain_network() {
+        return Err(BindingError::ChainMismatch);
+    }
+    // For chains whose decoded tx carries an explicit signer (NEAR), the signer
+    // must match the context's account. EVM recovers the signer at sign time
+    // (ecrecover), so its decoded model has no authoritative `from` to bind here.
+    if let DecodedTransaction::Near(near) = &binding.decoded
+        && near.signer_id != binding.context.key_or_account_id.as_str()
+    {
+        return Err(BindingError::SignerMismatch);
+    }
+    Ok(())
+}
+
+/// Store of authoritative attested-gate bindings, keyed by `gate_ref`.
+///
+/// One binding per `gate_ref`, created when the gate is raised and then
+/// IMMUTABLE. The resume path and driver read it back and trust it, so writes
+/// are INSERT-ONLY (CAS) and fully validated ([`validate_binding`]); durable
+/// backends (PR12) carry identical semantics.
+#[async_trait]
+pub trait AttestedGateBindingStore: Send + Sync {
+    /// Persist the authoritative binding for a freshly-raised attested gate.
+    ///
+    /// INSERT-ONLY: errors [`BindingError::AlreadyExists`] if a binding already
+    /// exists for `gate_ref` (no overwrite, ever). Validates the binding
+    /// ([`validate_binding`]) before persisting.
+    async fn put(
+        &self,
+        gate_ref: GateRef,
+        binding: AttestedGateBinding,
+    ) -> Result<(), BindingError>;
+
+    /// Read the authoritative binding for `gate_ref`, if one exists.
+    async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding>;
+}
+
+/// In-memory [`AttestedGateBindingStore`].
+#[derive(Default)]
+pub struct InMemoryAttestedGateBindingStore {
+    bindings: Mutex<HashMap<GateRef, AttestedGateBinding>>,
+}
+
+impl InMemoryAttestedGateBindingStore {
+    /// Construct an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Synchronous read used by the resume port, which runs inside the turn
+    /// store's sync critical section and therefore cannot `.await`. The async
+    /// trait method is for the driver / ingress paths.
+    pub fn get_sync(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
+        self.bindings
+            .lock()
+            .ok()
+            .and_then(|map| map.get(gate_ref).cloned())
+    }
+}
+
+#[async_trait]
+impl AttestedGateBindingStore for InMemoryAttestedGateBindingStore {
+    async fn put(
+        &self,
+        gate_ref: GateRef,
+        binding: AttestedGateBinding,
+    ) -> Result<(), BindingError> {
+        // Validate before taking the lock so a malformed binding never even
+        // races for the slot.
+        validate_binding(&gate_ref, &binding)?;
+        let mut map = self.bindings.lock().map_err(|_| BindingError::Poisoned)?;
+        // INSERT-ONLY CAS: a binding is authoritative and immutable. The first
+        // write for a gate_ref wins; any later write fails closed so it can
+        // never mutate the binding the port + driver already trust.
+        if map.contains_key(&gate_ref) {
+            return Err(BindingError::AlreadyExists);
+        }
+        map.insert(gate_ref, binding);
+        Ok(())
+    }
+
+    async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
+        self.get_sync(gate_ref)
+    }
+}

--- a/crates/ironclaw_attested_runtime/src/driver.rs
+++ b/crates/ironclaw_attested_runtime/src/driver.rs
@@ -1,0 +1,849 @@
+//! The signer-continuation driver: the deterministic post-approval continuation
+//! that runs once the turn store transitions `BlockedAttested ->
+//! AttestedResolved`.
+//!
+//! This consumes the `// PR10:` handoff stubs left in PR7-PR9:
+//!
+//! * `crates/ironclaw_wallet_external/src/walletconnect/mod.rs` ("hand the
+//!   verified proof back to the gate / runner for the continuation") — the
+//!   driver routes a `WalletConnect` / `Injected` / `NearRedirect` resolved gate
+//!   to the matching [`SigningProvider::verify_resume`], turning the verified
+//!   proof into a ledger-guarded broadcast.
+//! * `src/channels/web/features/chat/attested.rs` ("build `ResumeTurnRequest {
+//!   attestation: Some(..) }` + dispatch the broadcast through the gate-resolve
+//!   path") — the broadcast half of that handoff lives here; the web ingress
+//!   that calls into it is PR11.
+//!
+//! ## Invariants enforced here
+//!
+//! * **Threat #1 (sealed-grant replay):** the authoritative one-shot grant is
+//!   claimed (atomic CAS) before any signing. The custodial path claims it
+//!   inside [`CustodialSigner`]; the external-wallet path claims it inside the
+//!   provider's `verify_resume`.
+//! * **Threats #6 / #7 (broadcast retry / `Stuck->InProgress` double-broadcast):**
+//!   every state move goes through the [`SigningLedger`], which refuses to
+//!   re-enter signing for a `gate_ref` already past `BroadcastSubmitted` — and
+//!   is keyed on ledger state, not job state, so a job recovery cannot
+//!   re-broadcast.
+//! * **Threat #16 (LLM-loop reinterpretation):** the driver is only reachable
+//!   from the `AttestedResolved` continuation; it validates + signs + broadcasts
+//!   and NEVER requeues the agent loop.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use ironclaw_attestation::{LedgerKey, SigningLedger, SigningLedgerState};
+use ironclaw_chain_signing::{
+    ChainSigningError, CustodialSignRequest, CustodialSigner, recompute_approved_hash,
+};
+
+mod rebuild;
+use ironclaw_signing_provider::{
+    GateRef, ProviderId, SigningContext, SigningProof, SigningProvider, SigningProviderError,
+    TrustModel,
+};
+pub use rebuild::{EvmSignable, RebuildError};
+
+use crate::binding::{AttestedGateBinding, AttestedGateBindingStore};
+
+/// Registry mapping a [`ProviderId`] to the external-wallet
+/// [`SigningProvider`] that verifies its proofs.
+///
+/// The custodial path is NOT in this registry — it is the
+/// [`CustodialSigner`], which both claims the grant and signs, and is wired
+/// separately into the driver.
+#[derive(Default)]
+pub struct ProviderRegistry {
+    providers: HashMap<ProviderId, Arc<dyn SigningProvider>>,
+}
+
+impl ProviderRegistry {
+    /// Construct an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an external-wallet provider under its own [`ProviderId`].
+    pub fn with_provider(mut self, provider: Arc<dyn SigningProvider>) -> Self {
+        self.providers.insert(provider.provider_id(), provider);
+        self
+    }
+
+    fn get(&self, id: ProviderId) -> Option<&Arc<dyn SigningProvider>> {
+        self.providers.get(&id)
+    }
+}
+
+/// Whether the continuation actually submitted the signed transaction to the
+/// chain, or signed-only (dry-run / local-dev). Kept TYPED and distinct so a
+/// non-broadcasting path can NEVER be mistaken for a real broadcast: a caller
+/// that wants a real submit must match on [`BroadcastDisposition::Submitted`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BroadcastDisposition {
+    /// The signed transaction was submitted to the chain. The ledger reached
+    /// `BroadcastSubmitted`.
+    Submitted {
+        /// Opaque chain transaction id / hash (never key material).
+        tx_id: String,
+    },
+    /// The transaction was signed but NOT submitted (a dry-run / local-dev
+    /// broadcaster). The ledger is left at `Signed` — it does NOT reach
+    /// `BroadcastSubmitted`, so the runtime never reports a successful broadcast
+    /// for a non-broadcast.
+    NotBroadcast {
+        /// Opaque reason the submit was skipped.
+        reason: String,
+    },
+}
+
+/// What a [`Broadcaster`] produced for one submit attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BroadcastOutcome {
+    /// The signed transaction was accepted by the chain.
+    Submitted {
+        /// Opaque chain transaction id / hash.
+        tx_id: String,
+    },
+    /// The broadcaster deliberately did not submit (dry-run / local-dev). This
+    /// is NOT an error and NOT a broadcast.
+    NotBroadcast {
+        /// Opaque reason the submit was skipped.
+        reason: String,
+    },
+}
+
+/// What the continuation produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignerContinuationOutcome {
+    /// The `gate_ref` that was continued.
+    pub gate_ref: GateRef,
+    /// The ledger state reached. `BroadcastSubmitted` ONLY when the signed tx
+    /// was actually submitted; a dry-run / non-broadcasting path leaves this at
+    /// `Signed`. The driver leaves finalization to the chain watcher.
+    pub ledger_state: SigningLedgerState,
+    /// Whether the signed tx was actually submitted to the chain.
+    pub broadcast: BroadcastDisposition,
+    /// The signer/account the broadcast was attributed to (public).
+    pub signer: String,
+}
+
+/// The product of the verify + claim + sign half of the continuation
+/// ([`AttestedSignerContinuationDriver::verify_and_sign`]). Holds everything the
+/// broadcast half needs and PROVES the heavyweight crypto already ran: the
+/// proof was verified, the one-shot sealed grant was claimed, and the signed
+/// bytes ready to broadcast were produced.
+///
+/// [`AttestedSignerContinuationDriver::broadcast_signed_continuation`] consumes
+/// it to advance the ledger to `BroadcastSubmitted` and submit. The signed
+/// bytes never re-trigger verification or a second grant claim: the heavyweight
+/// crypto runs exactly once, in `verify_and_sign`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedContinuation {
+    gate_ref: GateRef,
+    context: SigningContext,
+    signed: Vec<u8>,
+    signer: String,
+}
+
+impl VerifiedContinuation {
+    /// The gate this verified continuation belongs to.
+    pub fn gate_ref(&self) -> &GateRef {
+        &self.gate_ref
+    }
+
+    /// The signer/account the eventual broadcast is attributed to (public).
+    pub fn signer(&self) -> &str {
+        &self.signer
+    }
+}
+
+/// Errors the signer-continuation driver can surface. Every variant is
+/// fail-closed: the ledger is never advanced past where the failure occurred.
+#[derive(Debug)]
+pub enum ContinuationError {
+    /// No authoritative binding exists for the resolved `gate_ref`.
+    MissingBinding,
+    /// The calling identity does not own the binding addressed by `gate_ref`
+    /// (cross-user / cross-tenant IDOR). The binding's authoritative
+    /// `tenant`/`user` (recorded when the gate was raised by the original
+    /// raiser) does not match the caller resolving the gate. Fail-closed
+    /// BEFORE any provider verify / custodial sign / grant claim, so a member
+    /// who merely learns another user's `gate_ref` can never drive that user's
+    /// signing continuation. Surfaced to clients indistinguishably from
+    /// `MissingBinding` (a 404) so it is not an existence oracle.
+    OwnerMismatch,
+    /// The carried proof's provider does not match the bound provider, or no
+    /// provider is registered for it.
+    ProviderMismatch {
+        /// The bound provider id.
+        bound: ProviderId,
+    },
+    /// The external-wallet provider rejected the proof (signer mismatch, hash
+    /// mismatch, grant-claim failure, scope violation).
+    ProofRejected(SigningProviderError),
+    /// The custodial chain signer rejected or failed the signing.
+    ChainSigning(ChainSigningError),
+    /// A ledger transition was rejected (e.g. broadcast idempotency guard).
+    Ledger(ironclaw_attestation::LedgerError),
+    /// The sign-time approved-tx-hash re-check failed (threat #3): the hash
+    /// recomputed from the persisted decoded tx diverged from the bound hash.
+    ApprovedHashMismatch,
+    /// The binding's `chain` does not match the chain/network of its own decoded
+    /// transaction (a malformed / tampered binding). Fail-closed before any key
+    /// use so a testnet `chain` can never carry a mainnet decoded tx (or vice
+    /// versa) past the ship-gate.
+    BindingChainMismatch,
+    /// The authoritative decoded binding could not be reconstructed into a
+    /// signable transaction (unsupported chain/tx-type, or a field overflow).
+    Rebuild(RebuildError),
+    /// A broadcaster-side failure.
+    Broadcast {
+        /// Opaque description (never key material).
+        reason: String,
+    },
+    /// A broadcast-idempotency ledger row already exists for this `gate_ref`
+    /// (a prior continuation attempt). This is the one-shot guard firing on
+    /// re-entry — distinct from a generic invalid ledger transition. Carries the
+    /// existing ledger state for diagnostics.
+    LedgerRowExists {
+        /// The state the existing row is currently in.
+        current: SigningLedgerState,
+    },
+}
+
+impl std::fmt::Display for ContinuationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingBinding => write!(f, "no authoritative binding for the resolved gate"),
+            Self::OwnerMismatch => {
+                write!(
+                    f,
+                    "calling identity does not own the addressed gate binding"
+                )
+            }
+            Self::ProviderMismatch { bound } => {
+                write!(f, "provider mismatch: bound provider is {bound:?}")
+            }
+            Self::ProofRejected(e) => write!(f, "external-wallet proof rejected: {e}"),
+            Self::ChainSigning(e) => write!(f, "custodial chain signing failed: {e}"),
+            Self::Ledger(e) => write!(f, "signing-ledger transition rejected: {e}"),
+            Self::ApprovedHashMismatch => {
+                write!(f, "sign-time approved-tx-hash re-check failed")
+            }
+            Self::BindingChainMismatch => {
+                write!(f, "binding chain does not match its decoded transaction")
+            }
+            Self::Rebuild(e) => write!(f, "decoded-binding rebuild failed: {e}"),
+            Self::Broadcast { reason } => write!(f, "broadcast failed: {reason}"),
+            Self::LedgerRowExists { current } => {
+                write!(
+                    f,
+                    "broadcast-idempotency ledger row already exists (current state: {current:?})"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ContinuationError {}
+
+impl From<ironclaw_attestation::LedgerError> for ContinuationError {
+    fn from(value: ironclaw_attestation::LedgerError) -> Self {
+        Self::Ledger(value)
+    }
+}
+
+/// Broadcasts a signed transaction to its chain. Injected so the driver stays
+/// testable without real network I/O. PR12 / production wires a real
+/// per-chain broadcaster; the ledger guard around it is identical regardless.
+#[async_trait]
+pub trait Broadcaster: Send + Sync {
+    /// Whether this broadcaster actually submits to a chain. A real per-chain
+    /// broadcaster returns `true`; a dry-run / local-dev broadcaster returns
+    /// `false`. The driver consults this BEFORE advancing the ledger so a
+    /// non-broadcasting path never reaches `BroadcastSubmitted`.
+    fn submits(&self) -> bool;
+
+    /// Submit the signed transaction for `context`'s chain. Returns a typed
+    /// [`BroadcastOutcome`] so a deliberate non-submit ([`BroadcastOutcome::NotBroadcast`])
+    /// is distinguishable from a real submit and from an error.
+    async fn broadcast(
+        &self,
+        context: &SigningContext,
+        signed: &[u8],
+    ) -> Result<BroadcastOutcome, ContinuationError>;
+}
+
+/// The signer-continuation driver, wired with the authoritative binding store,
+/// the external-wallet provider registry, the custodial signer, the broadcast
+/// idempotency ledger, and a broadcaster.
+///
+/// `K`/`G`/`L` are the custodial signer's keystore / grant store / ledger
+/// types; the same ledger `L` is shared so the broadcast-idempotency guard
+/// covers both the custodial and external-wallet paths.
+pub struct AttestedSignerContinuationDriver<B, L, S> {
+    bindings: Arc<dyn AttestedGateBindingStore>,
+    providers: ProviderRegistry,
+    custodial_signer: Arc<S>,
+    ledger: Arc<L>,
+    broadcaster: Arc<B>,
+}
+
+/// The calling identity asserting ownership of an attested-gate binding on
+/// resume. Compared against the binding's authoritative `tenant`/`user`
+/// (recorded by the original raiser) before any verify/sign/claim, so a member
+/// who merely learns another user's `gate_ref` cannot drive that user's signing
+/// continuation (IDOR defense). Both axes must match.
+#[derive(Debug, Clone, Copy)]
+pub struct BindingOwner<'a> {
+    /// The caller's tenant boundary.
+    pub tenant_id: &'a str,
+    /// The caller's user identity.
+    pub user_id: &'a str,
+}
+
+impl<B, L, S> AttestedSignerContinuationDriver<B, L, S>
+where
+    B: Broadcaster,
+    L: SigningLedger,
+{
+    /// Construct the driver.
+    pub fn new(
+        bindings: Arc<dyn AttestedGateBindingStore>,
+        providers: ProviderRegistry,
+        custodial_signer: Arc<S>,
+        ledger: Arc<L>,
+        broadcaster: Arc<B>,
+    ) -> Self {
+        Self {
+            bindings,
+            providers,
+            custodial_signer,
+            ledger,
+            broadcaster,
+        }
+    }
+
+    /// Run the deterministic continuation for a gate that has reached
+    /// `AttestedResolved`. `proof` is the verified-proof payload carried back
+    /// from the ceremony (external-wallet paths) — for the custodial path the
+    /// proof is the WebAuthn assertion that authorized the in-house signer.
+    ///
+    /// The driver NEVER accepts a caller-supplied signable transaction: the
+    /// custodial path reconstructs the signable *from the authoritative decoded
+    /// binding* and signs exactly that, so a resolver cannot pass an unapproved
+    /// tx (or a mainnet tx aimed past a testnet `binding.chain` ship-gate) after
+    /// approval (byte-drift defense, same class as PR6's `CustodialSigner`).
+    ///
+    /// Steps, all fail-closed and ledger-guarded:
+    /// 1. Read the authoritative binding for `gate_ref` (never trust the
+    ///    caller).
+    /// 2. Create the ledger row (one-shot per `gate_ref`; an existing row from
+    ///    a prior broadcast attempt that is already past `Signed` makes any
+    ///    re-broadcast fail — threats #6 / #7).
+    /// 3. Route to the bound provider / custodial signer to verify + claim the
+    ///    sealed grant (threat #1) and produce the signature.
+    /// 4. Advance the ledger to `BroadcastSubmitted` (the in-flight marker) and
+    ///    broadcast. On a confirmed submit the row stays at `BroadcastSubmitted`;
+    ///    on a broadcast error / ambiguous outcome it moves to the `Unknown`
+    ///    terminal for out-of-band recovery (never auto-rebroadcast).
+    pub async fn continue_after_resolved(
+        &self,
+        gate_ref: &GateRef,
+        proof: &SigningProof,
+    ) -> Result<SignerContinuationOutcome, ContinuationError>
+    where
+        S: CustodialSignerLike,
+    {
+        // Legacy single-shot entrypoint, retained for the threat-matrix tests
+        // and any caller that drives both halves under one lock. The
+        // verify-before-resume facade (PR11 item B) instead calls
+        // [`Self::verify_and_sign`] BEFORE the turn transitions and
+        // [`Self::broadcast_signed_continuation`] AFTER, so the heavyweight
+        // verification + grant claim gate the `BlockedAttested ->
+        // AttestedResolved` transition. The crypto runs exactly once in either
+        // arrangement.
+        let verified = self.verify_and_sign(gate_ref, proof).await?;
+        self.broadcast_signed_continuation(verified).await
+    }
+
+    /// Verify + claim + sign half of the continuation. Runs BEFORE the turn
+    /// transitions to `AttestedResolved`, so the FULL cryptographic verification
+    /// and the one-shot grant claim gate the transition: a malformed or forged
+    /// proof is rejected here, with no broadcast and no `AttestedResolved`
+    /// transition (the facade only calls `resume_turn` after this returns `Ok`).
+    ///
+    /// The driver NEVER accepts a caller-supplied signable transaction: the
+    /// custodial path reconstructs the signable *from the authoritative decoded
+    /// binding* and signs exactly that, so a resolver cannot pass an unapproved
+    /// tx (or a mainnet tx aimed past a testnet `binding.chain` ship-gate) after
+    /// approval (byte-drift defense, same class as PR6's `CustodialSigner`).
+    ///
+    /// 1. Read the authoritative binding for `gate_ref` (never trust the
+    ///    caller).
+    /// 2. Route to the bound provider / custodial signer to verify + claim the
+    ///    sealed grant (threat #1) and produce the signature, under the
+    ///    broadcast-idempotency ledger guard (threats #6 / #7).
+    ///
+    /// Fail-closed retry semantics: each path creates / advances the ledger only
+    /// once verification is committed to, so a proof that fails verification
+    /// (malformed, forged, signer/hash mismatch) leaves NO blocking ledger row
+    /// and does NOT claim the grant — a follow-up VALID proof for the same gate
+    /// can still succeed. After a SUCCESSFUL verify+claim, the grant CAS and the
+    /// ledger row are both consumed, so a same-key retry fails closed (the
+    /// continuation is genuinely single-drive).
+    ///
+    /// The returned [`VerifiedContinuation`] is the only way to reach
+    /// [`Self::broadcast_signed_continuation`]; the broadcast half NEVER
+    /// re-verifies or re-claims.
+    pub async fn verify_and_sign(
+        &self,
+        gate_ref: &GateRef,
+        proof: &SigningProof,
+    ) -> Result<VerifiedContinuation, ContinuationError>
+    where
+        S: CustodialSignerLike,
+    {
+        let binding = self
+            .bindings
+            .get(gate_ref)
+            .await
+            .ok_or(ContinuationError::MissingBinding)?;
+
+        match binding.provider_id {
+            ProviderId::Custodial => self.sign_custodial(gate_ref, &binding).await,
+            external => {
+                self.verify_external_wallet(gate_ref, external, &binding, proof)
+                    .await
+            }
+        }
+    }
+
+    /// Assert the caller owns the binding addressed by `gate_ref` BEFORE any
+    /// verify / custodial sign / grant claim (IDOR defense).
+    ///
+    /// The binding's authoritative `SigningContext` carries the original
+    /// raiser's `tenant`/`user`. A second tenant member who learns another
+    /// user's `gate_ref` (returned in the gate-raise response) must not be able
+    /// to drive that user's signing continuation — most acutely on the
+    /// custodial path, where the proof payload is ignored and the driver signs
+    /// from the authoritative binding regardless of who presents the gate_ref.
+    ///
+    /// Fail-closed `OwnerMismatch` on either a missing binding *or* an identity
+    /// divergence, so the result is indistinguishable from a non-existent gate
+    /// (no existence oracle). Both tenant and user axes must match. The binding
+    /// is immutable once written, so re-reading it here (separately from
+    /// [`Self::verify_and_sign`]) is race-free; the sealed-grant CAS remains the
+    /// authoritative one-shot guard.
+    pub async fn assert_binding_owner(
+        &self,
+        gate_ref: &GateRef,
+        caller: BindingOwner<'_>,
+    ) -> Result<(), ContinuationError> {
+        let binding = self
+            .bindings
+            .get(gate_ref)
+            .await
+            .ok_or(ContinuationError::MissingBinding)?;
+        if binding.context.tenant.as_str() != caller.tenant_id
+            || binding.context.user.as_str() != caller.user_id
+        {
+            return Err(ContinuationError::OwnerMismatch);
+        }
+        Ok(())
+    }
+
+    /// One-shot broadcast-idempotency ledger create (threats #6 / #7): an
+    /// existing row for this `gate_ref` (a prior attempt) makes any re-entry fail
+    /// closed. Surfaced as a dedicated idempotency-guard error carrying the
+    /// existing state, rather than fabricating an `InvalidTransition` with a
+    /// synthetic `to` that never actually occurred.
+    async fn create_ledger_row(
+        &self,
+        tenant: &ironclaw_signing_provider::TenantId,
+        gate_ref: &GateRef,
+    ) -> Result<(), ContinuationError> {
+        match self
+            .ledger
+            .create(&LedgerKey::new(tenant.clone(), gate_ref.clone()))
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(ironclaw_attestation::LedgerError::AlreadyExists) => {
+                let current = self
+                    .ledger
+                    .state(&LedgerKey::new(tenant.clone(), gate_ref.clone()))
+                    .await?;
+                Err(ContinuationError::LedgerRowExists { current })
+            }
+            Err(other) => Err(other.into()),
+        }
+    }
+
+    /// Broadcast half of the continuation. Consumes a [`VerifiedContinuation`]
+    /// (proof already verified + grant already claimed in
+    /// [`Self::verify_and_sign`]) and broadcasts the signed bytes under the
+    /// ledger guard. This NEVER calls `verify_resume` and NEVER re-claims the
+    /// grant. The broadcast-failure recovery (item C) lives in the shared
+    /// [`Self::broadcast_signed`] tail: a network error / ambiguous outcome moves
+    /// the row to the `Unknown` terminal and surfaces a fail-closed error rather
+    /// than reporting a false success.
+    pub async fn broadcast_signed_continuation(
+        &self,
+        verified: VerifiedContinuation,
+    ) -> Result<SignerContinuationOutcome, ContinuationError> {
+        let VerifiedContinuation {
+            gate_ref,
+            context,
+            signed,
+            signer,
+        } = verified;
+        self.broadcast_signed(&gate_ref, &context, &signed, signer)
+            .await
+    }
+
+    /// External-wallet verify + claim: the wallet already signed natively. We
+    /// verify the proof through the bound provider (signer recovery + hash
+    /// binding + one-shot sealed-grant CAS) FIRST, so a rejected proof
+    /// (malformed, forged, signer/hash mismatch) never touches the ledger and
+    /// never claims the grant — leaving the gate cleanly retryable. Only after
+    /// the proof verifies + the grant is claimed do we create the
+    /// broadcast-idempotency ledger row and advance it `Approved -> Signing ->
+    /// Signed`. The wallet-signed bytes (the proof payload) become the
+    /// [`VerifiedContinuation`] to broadcast.
+    async fn verify_external_wallet(
+        &self,
+        gate_ref: &GateRef,
+        provider_id: ProviderId,
+        binding: &AttestedGateBinding,
+        proof: &SigningProof,
+    ) -> Result<VerifiedContinuation, ContinuationError> {
+        let provider = self
+            .providers
+            .get(provider_id)
+            .ok_or(ContinuationError::ProviderMismatch { bound: provider_id })?;
+        debug_assert_eq!(provider.trust_model(), TrustModel::ExternalWallet);
+
+        // Verify + claim the sealed one-shot grant (threat #1 lives inside
+        // `verify_resume`) BEFORE touching the ledger. A rejected proof returns
+        // here with no ledger row created and the grant unclaimed, so the gate
+        // stays cleanly retryable. Verify-before-advance keeps the transition
+        // atomic from the ledger's perspective — the row only moves once we hold
+        // a verified proof.
+        let verified = provider
+            .verify_resume(&binding.context, &binding.approved_tx_hash, proof)
+            .await
+            .map_err(ContinuationError::ProofRejected)?;
+
+        // Proof verified + grant claimed. Now open the broadcast-idempotency
+        // ledger row and advance it to `Signed`. The grant CAS already made this
+        // single-drive; the ledger guards broadcast retry (threats #6/#7).
+        self.create_ledger_row(&binding.context.tenant, gate_ref)
+            .await?;
+        self.ledger
+            .advance(
+                &LedgerKey::new(binding.context.tenant.clone(), gate_ref.clone()),
+                SigningLedgerState::Signing,
+            )
+            .await?;
+        self.ledger
+            .advance(
+                &LedgerKey::new(binding.context.tenant.clone(), gate_ref.clone()),
+                SigningLedgerState::Signed,
+            )
+            .await?;
+
+        let signer = binding.context.key_or_account_id.to_string();
+        Ok(VerifiedContinuation {
+            gate_ref: gate_ref.clone(),
+            context: binding.context.clone(),
+            signed: verified.proof().payload().to_vec(),
+            signer,
+        })
+    }
+
+    /// Custodial verify + sign: IronClaw holds the key. The driver reconstructs
+    /// the signable *from `binding.decoded`* (never from any caller-supplied tx)
+    /// and delegates to the [`CustodialSigner`], which runs the ship-gate,
+    /// claims the sealed grant (threat #1), re-checks the approved hash
+    /// (threat #3), and signs with the ecrecover binding check (threat #5). The
+    /// signer advances the ledger `Approved -> Signing -> Signed` itself; the
+    /// produced signature becomes the [`VerifiedContinuation`] to broadcast.
+    async fn sign_custodial(
+        &self,
+        gate_ref: &GateRef,
+        binding: &AttestedGateBinding,
+    ) -> Result<VerifiedContinuation, ContinuationError>
+    where
+        S: CustodialSignerLike,
+    {
+        // Pre-flight enforcement point #2 mirror (threat #3): re-check the hash
+        // from the persisted decoded tx before doing anything chain-side, so a
+        // mutated binding fails closed with a precise error. The signer folded
+        // into the recompute is the GATE-BOUND signer carried in the binding's
+        // SigningContext (`context.key_or_account_id`) — never the decoded tx
+        // body, which could have been mutated post-approval. This is the WYSIWYS
+        // binding. Recompute is fallible (render/canonicalization can fail);
+        // propagate that as a chain-signing error so it fails closed rather than
+        // proceeding against an under-described transaction.
+        let recomputed = recompute_approved_hash(
+            &binding.decoded,
+            binding.context.key_or_account_id.as_str(),
+            binding.schema_version,
+        )
+        .map_err(ContinuationError::ChainSigning)?;
+        if recomputed != binding.approved_tx_hash {
+            return Err(ContinuationError::ApprovedHashMismatch);
+        }
+
+        // The binding's authoritative `chain` must match the chain/network its
+        // OWN decoded tx encodes. This closes the testnet-chain / mainnet-tx
+        // smuggle: the ship-gate keys off `binding.chain`, so the tx we sign
+        // must belong to that exact chain. (The signer re-checks family; this
+        // adds the precise network identity check at the driver.)
+        if binding.chain.as_str() != binding.decoded.chain_network() {
+            return Err(ContinuationError::BindingChainMismatch);
+        }
+
+        // Reconstruct the signable from the approved decoded tx — the only tx
+        // the driver ever signs. No caller-supplied signable is accepted.
+        let signable =
+            rebuild::rebuild_evm_signable(&binding.decoded).map_err(ContinuationError::Rebuild)?;
+
+        // Open the broadcast-idempotency ledger row (threats #6/#7) before the
+        // custodial signer advances it `Approved -> Signing -> Signed` itself. A
+        // pre-existing row (a prior attempt) fails closed here.
+        self.create_ledger_row(&binding.context.tenant, gate_ref)
+            .await?;
+
+        let req = CustodialSignRequest {
+            context: binding.context.clone(),
+            scope: binding.scope.clone(),
+            chain: binding.chain.clone(),
+            decoded: binding.decoded.clone(),
+            approved_tx_hash: binding.approved_tx_hash,
+            schema_version: binding.schema_version,
+        };
+
+        let outcome = self
+            .custodial_signer
+            .sign_rebuilt_evm(&req, &signable)
+            .await
+            .map_err(ContinuationError::ChainSigning)?;
+
+        Ok(VerifiedContinuation {
+            gate_ref: gate_ref.clone(),
+            context: binding.context.clone(),
+            signed: outcome.signature,
+            signer: outcome.signer,
+        })
+    }
+
+    /// Shared broadcast tail. For a broadcaster that actually submits
+    /// ([`Broadcaster::submits`] == true), advance the ledger to
+    /// `BroadcastSubmitted` BEFORE the network submit so a `Stuck->InProgress`
+    /// recovery that re-enters here sees the row already at `BroadcastSubmitted`
+    /// and the guard refuses a second signing (threat #7). `BroadcastSubmitted`
+    /// here is the post-submit-attempt in-flight marker, NOT yet a confirmed
+    /// landing.
+    ///
+    /// **Broadcast-failure recovery (item C):** a network error, timeout, or an
+    /// ambiguous/contradictory outcome leaves the chain status genuinely unknown
+    /// (the tx may or may not have been accepted). Rather than leaving the row
+    /// stuck with no path forward, we move it to the [`SigningLedgerState::Unknown`]
+    /// terminal and carry the attempted-tx / error evidence in the surfaced
+    /// error. `Unknown` is terminal and is NEVER auto-retried with a fresh
+    /// nonce/blockhash — recovery requires explicit out-of-band resolution /
+    /// re-approval, so the one-shot + idempotency guarantees still hold (a
+    /// retried continuation against the existing row fails closed at `create`).
+    ///
+    /// We confirm the ledger to a SUCCESS-only terminal contract: the returned
+    /// outcome reports `BroadcastSubmitted` only on a confirmed
+    /// [`BroadcastOutcome::Submitted`] with a real tx id.
+    ///
+    /// Follow-up: `BroadcastSubmitted` currently doubles as the in-flight marker
+    /// because the `SigningLedger` state machine in `ironclaw_attestation` has no
+    /// distinct `Broadcasting` state. Adding one (so `BroadcastSubmitted` strictly
+    /// means "accepted by the network") is a cross-crate, additive change deferred
+    /// to a follow-up to avoid colliding with the PR11 driver refactor.
+    ///
+    /// For a non-broadcasting (dry-run / local-dev) broadcaster, the ledger is
+    /// left at `Signed` and the outcome is [`BroadcastDisposition::NotBroadcast`]:
+    /// the runtime never advances to `BroadcastSubmitted` for a non-broadcast,
+    /// so a signed-only continuation can never be reported as a real broadcast.
+    async fn broadcast_signed(
+        &self,
+        gate_ref: &GateRef,
+        context: &SigningContext,
+        signed: &[u8],
+        signer: String,
+    ) -> Result<SignerContinuationOutcome, ContinuationError> {
+        if self.broadcaster.submits() {
+            // Real submit: advance the ledger to the in-flight marker first
+            // (idempotency guard — a recovery re-entry now sees a broadcast row
+            // and is refused a second signing), then submit under the guard.
+            self.ledger
+                .advance(
+                    &LedgerKey::new(context.tenant.clone(), gate_ref.clone()),
+                    SigningLedgerState::BroadcastSubmitted,
+                )
+                .await?;
+            match self.broadcaster.broadcast(context, signed).await {
+                Ok(BroadcastOutcome::Submitted { tx_id }) => Ok(SignerContinuationOutcome {
+                    gate_ref: gate_ref.clone(),
+                    ledger_state: SigningLedgerState::BroadcastSubmitted,
+                    broadcast: BroadcastDisposition::Submitted { tx_id },
+                    signer,
+                }),
+                // A broadcaster that declared `submits() == true` but returned
+                // NotBroadcast is contradictory: we cannot trust that the tx did
+                // NOT go out, so treat it as an unknown-outcome failure and move
+                // to the terminal recovery state rather than reporting a false
+                // broadcast or a false non-broadcast.
+                Ok(BroadcastOutcome::NotBroadcast { reason }) => {
+                    self.recover_unknown(&context.tenant, gate_ref).await;
+                    Err(ContinuationError::Broadcast {
+                        reason: format!(
+                            "broadcaster declared submits()==true but did not broadcast: \
+                             {reason} (ledger moved to Unknown for recovery)"
+                        ),
+                    })
+                }
+                // A broadcast error (RPC timeout, rejected/invalid response). The
+                // tx may or may not have landed — genuinely unknown. Move the row
+                // to the Unknown terminal so it is never left stuck and never
+                // auto-rebroadcast, and surface the evidence.
+                Err(err) => {
+                    self.recover_unknown(&context.tenant, gate_ref).await;
+                    Err(Self::annotate_broadcast_failure(err))
+                }
+            }
+        } else {
+            // Dry-run / local-dev: never advance to BroadcastSubmitted. Record
+            // the intent but leave the ledger at Signed.
+            let reason = match self.broadcaster.broadcast(context, signed).await? {
+                BroadcastOutcome::NotBroadcast { reason } => reason,
+                // A non-submitting broadcaster that claims a real submit is
+                // contradictory; fail closed.
+                BroadcastOutcome::Submitted { .. } => {
+                    return Err(ContinuationError::Broadcast {
+                        reason: "broadcaster declared submits()==false but reported a submit"
+                            .to_string(),
+                    });
+                }
+            };
+            Ok(SignerContinuationOutcome {
+                gate_ref: gate_ref.clone(),
+                ledger_state: SigningLedgerState::Signed,
+                broadcast: BroadcastDisposition::NotBroadcast { reason },
+                signer,
+            })
+        }
+    }
+
+    /// Move a row that has reached the in-flight `BroadcastSubmitted` marker to
+    /// the [`SigningLedgerState::Unknown`] terminal after a failed/ambiguous
+    /// broadcast, so it is never left stuck and never auto-rebroadcast.
+    ///
+    /// Best-effort: the original broadcast failure is the authoritative error we
+    /// surface, so a secondary ledger error here (e.g. the row is already past
+    /// `BroadcastSubmitted` due to a concurrent finalize) must NOT mask it. We
+    /// only need the row to NOT be stuck at a non-terminal state; if the
+    /// transition is rejected the row was already at/heading to a terminal.
+    async fn recover_unknown(
+        &self,
+        tenant: &ironclaw_signing_provider::TenantId,
+        gate_ref: &GateRef,
+    ) {
+        if let Err(e) = self
+            .ledger
+            .advance(
+                &LedgerKey::new(tenant.clone(), gate_ref.clone()),
+                SigningLedgerState::Unknown,
+            )
+            .await
+        {
+            // An `InvalidTransition` is expected and benign here: the row is
+            // already at or past a terminal. Any OTHER ledger error (e.g. a
+            // backend failure) means we could NOT confirm the row is safely
+            // terminal. This recovery runs on the background broadcast-failure
+            // path, so per CLAUDE.md ("Background tasks must NEVER use `info!`
+            // — it breaks the interactive display"; the same applies to
+            // `warn!`) we log at `debug!` with a structured `recoverable` field
+            // rather than corrupting the REPL/TUI stream. The original
+            // broadcast error stays authoritative; a ledger row that could not
+            // be confirmed terminal is flagged here for operator triage via a
+            // structured field, not a user-facing warning.
+            let recoverable = matches!(
+                e,
+                ironclaw_attestation::LedgerError::InvalidTransition { .. }
+            );
+            tracing::debug!(
+                gate_ref = %gate_ref.as_str(),
+                recoverable,
+                "recover_unknown: ledger advance to Unknown terminal returned an error \
+                 ({e:?}); recoverable=true means the row was already terminal (benign), \
+                 recoverable=false means the row may be left non-terminal"
+            );
+        }
+    }
+
+    /// Annotate a broadcaster-side failure so the surfaced error records that the
+    /// ledger was moved to the `Unknown` terminal for recovery, preserving any
+    /// available evidence (the broadcaster's opaque reason / attempted tx hash)
+    /// without leaking key material.
+    fn annotate_broadcast_failure(err: ContinuationError) -> ContinuationError {
+        match err {
+            ContinuationError::Broadcast { reason } => ContinuationError::Broadcast {
+                reason: format!("{reason} (ledger moved to Unknown for recovery)"),
+            },
+            // A non-Broadcast error from the broadcaster path is unexpected but
+            // still fail-closed; pass it through unchanged.
+            other => other,
+        }
+    }
+}
+
+/// Abstracts the custodial signer so the driver is not generic over the
+/// concrete [`CustodialSigner`] type parameters and never has to accept a
+/// caller-supplied signable. The driver hands the signer the EVM signable it
+/// reconstructed from the authoritative decoded binding ([`rebuild::EvmSignable`]),
+/// and the signer runs both enforcement points and the ecrecover binding check.
+#[async_trait]
+pub trait CustodialSignerLike: Send + Sync {
+    /// Sign the EVM signable the driver rebuilt from `req.decoded`, dispatching
+    /// on its concrete tx type. Runs both enforcement points and the ecrecover
+    /// binding check.
+    async fn sign_rebuilt_evm(
+        &self,
+        req: &CustodialSignRequest,
+        signable: &rebuild::EvmSignable,
+    ) -> Result<ironclaw_chain_signing::CustodialSignOutcome, ChainSigningError>;
+}
+
+#[async_trait]
+impl<K, G, L> CustodialSignerLike for CustodialSigner<K, G, L>
+where
+    K: ironclaw_chain_signing::KeyStore,
+    G: ironclaw_attestation::SealedGrantStore,
+    L: SigningLedger,
+{
+    async fn sign_rebuilt_evm(
+        &self,
+        req: &CustodialSignRequest,
+        signable: &rebuild::EvmSignable,
+    ) -> Result<ironclaw_chain_signing::CustodialSignOutcome, ChainSigningError> {
+        // The custodial signer now RECONSTRUCTS the signable transaction itself
+        // from `req.decoded` (the authoritative decoded tx the approved hash was
+        // computed over), so it never accepts a caller-supplied signable that
+        // could drift from the approved one (chain_signing review finding #1).
+        // The driver's own pre-rebuild (`signable`) is retained as the fail-fast
+        // decodability check before any key access; it is not forwarded, because
+        // the signer rebuilds from the same `req.decoded` and re-checks the
+        // approved hash (enforcement point #2) internally.
+        let _ = signable;
+        CustodialSigner::sign_evm(self, req).await
+    }
+}

--- a/crates/ironclaw_attested_runtime/src/driver/rebuild.rs
+++ b/crates/ironclaw_attested_runtime/src/driver/rebuild.rs
@@ -1,0 +1,355 @@
+//! Reconstruct a chain-native signable transaction *from the authoritative
+//! decoded binding* so the custodial signer signs exactly what was approved.
+//!
+//! This is the byte-drift defense for the custodial continuation (the same
+//! class PR6 fixed in `CustodialSigner`): the driver never signs a
+//! caller-supplied signable. It rebuilds the EVM transaction deterministically
+//! from `binding.decoded` — the server-decoded model the `ApprovedTxHash` was
+//! computed over — so the bytes that get signed cannot diverge from the bytes
+//! that were approved, and a mainnet tx cannot be smuggled past a testnet
+//! `binding.chain` ship-gate by passing a different signable after approval.
+//!
+//! Only EVM is reconstructed here; Solana / NEAR custodial signing land with
+//! their own per-chain rebuild in a later slice and currently return
+//! [`RebuildError::UnsupportedChain`] (fail-closed).
+
+use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy};
+use alloy_eips::eip2930::{AccessList, AccessListItem};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+
+use ironclaw_attestation::{DecodedTransaction, EvmAccessListEntry, EvmTransaction};
+
+/// Errors that can occur reconstructing a signable from the decoded binding.
+#[derive(Debug)]
+pub enum RebuildError {
+    /// The decoded binding is for a chain family that has no custodial rebuild
+    /// path yet (Solana / NEAR custodial signing is a later slice).
+    UnsupportedChain {
+        /// The chain tag of the decoded binding.
+        chain: &'static str,
+    },
+    /// A scalar field in the decoded model was wider than its chain-native type
+    /// can hold (e.g. an EVM fee field with more than 16 big-endian bytes).
+    FieldOverflow {
+        /// Which field overflowed.
+        field: &'static str,
+    },
+    /// The decoded EVM tx carried a transaction type this rebuild path does not
+    /// reconstruct (e.g. EIP-4844 blob txs).
+    UnsupportedTxType {
+        /// The EIP-2718 type byte.
+        tx_type: u8,
+    },
+    /// A required field for the decoded tx type was missing.
+    MissingField {
+        /// Which field was missing.
+        field: &'static str,
+    },
+}
+
+impl std::fmt::Display for RebuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedChain { chain } => {
+                write!(f, "no custodial rebuild path for chain family {chain}")
+            }
+            Self::FieldOverflow { field } => write!(f, "decoded field {field} overflowed"),
+            Self::UnsupportedTxType { tx_type } => {
+                write!(f, "unsupported EVM tx type {tx_type}")
+            }
+            Self::MissingField { field } => write!(f, "missing decoded field {field}"),
+        }
+    }
+}
+
+impl std::error::Error for RebuildError {}
+
+/// A reconstructed EVM signable. Mirrors the alloy typed-tx shapes the decoder
+/// (`evm::decode_*`) produces, so a round-trip rebuild is byte-identical.
+pub enum EvmSignable {
+    /// EIP-1559 fee-market transaction.
+    Eip1559(TxEip1559),
+    /// Legacy transaction.
+    Legacy(TxLegacy),
+    /// EIP-2930 access-list transaction.
+    Eip2930(TxEip2930),
+}
+
+/// Reconstruct the EVM signable from the authoritative decoded binding.
+pub(crate) fn rebuild_evm_signable(
+    decoded: &DecodedTransaction,
+) -> Result<EvmSignable, RebuildError> {
+    match decoded {
+        DecodedTransaction::Evm(evm) => rebuild_evm(evm),
+        other => Err(RebuildError::UnsupportedChain {
+            chain: other.chain_tag(),
+        }),
+    }
+}
+
+fn rebuild_evm(evm: &EvmTransaction) -> Result<EvmSignable, RebuildError> {
+    let to = match &evm.to {
+        Some(addr) => TxKind::Call(Address::from(addr.0)),
+        None => TxKind::Create,
+    };
+    let value = be_u256(&evm.value);
+    let input = Bytes::from(evm.data.clone());
+    let access_list = rebuild_access_list(&evm.access_list);
+
+    match evm.tx_type {
+        2 => {
+            let max_fee = be_u128(
+                evm.max_fee_per_gas
+                    .as_deref()
+                    .ok_or(RebuildError::MissingField {
+                        field: "max_fee_per_gas",
+                    })?,
+                "max_fee_per_gas",
+            )?;
+            let max_prio = be_u128(
+                evm.max_priority_fee_per_gas
+                    .as_deref()
+                    .ok_or(RebuildError::MissingField {
+                        field: "max_priority_fee_per_gas",
+                    })?,
+                "max_priority_fee_per_gas",
+            )?;
+            Ok(EvmSignable::Eip1559(TxEip1559 {
+                chain_id: evm.chain_id,
+                nonce: evm.nonce,
+                gas_limit: evm.gas_limit,
+                max_fee_per_gas: max_fee,
+                max_priority_fee_per_gas: max_prio,
+                to,
+                value,
+                access_list,
+                input,
+            }))
+        }
+        0 => {
+            let gas_price = be_u128(
+                evm.gas_price
+                    .as_deref()
+                    .ok_or(RebuildError::MissingField { field: "gas_price" })?,
+                "gas_price",
+            )?;
+            // Decoder maps a missing EIP-155 chain id to 0; preserve that.
+            let chain_id = if evm.chain_id == 0 {
+                None
+            } else {
+                Some(evm.chain_id)
+            };
+            Ok(EvmSignable::Legacy(TxLegacy {
+                chain_id,
+                nonce: evm.nonce,
+                gas_price,
+                gas_limit: evm.gas_limit,
+                to,
+                value,
+                input,
+            }))
+        }
+        1 => {
+            let gas_price = be_u128(
+                evm.gas_price
+                    .as_deref()
+                    .ok_or(RebuildError::MissingField { field: "gas_price" })?,
+                "gas_price",
+            )?;
+            Ok(EvmSignable::Eip2930(TxEip2930 {
+                chain_id: evm.chain_id,
+                nonce: evm.nonce,
+                gas_price,
+                gas_limit: evm.gas_limit,
+                to,
+                value,
+                access_list,
+                input,
+            }))
+        }
+        other => Err(RebuildError::UnsupportedTxType { tx_type: other }),
+    }
+}
+
+fn rebuild_access_list(entries: &[EvmAccessListEntry]) -> AccessList {
+    AccessList(
+        entries
+            .iter()
+            .map(|entry| AccessListItem {
+                address: Address::from(entry.address.0),
+                storage_keys: entry.storage_keys.iter().map(|k| B256::from(k.0)).collect(),
+            })
+            .collect(),
+    )
+}
+
+/// Parse a big-endian minimal-byte `value` field into a `U256`. An empty slice
+/// is zero (matching the decoder's minimal encoding). Overflow (more than 32
+/// bytes) is impossible for a 32-byte source, but we guard anyway.
+fn be_u256(bytes: &[u8]) -> U256 {
+    U256::from_be_slice(bytes)
+}
+
+/// Parse a big-endian minimal-byte fee field into a `u128`, failing closed on
+/// overflow (a fee field wider than 16 bytes cannot be a valid EVM fee).
+fn be_u128(bytes: &[u8], field: &'static str) -> Result<u128, RebuildError> {
+    if bytes.len() > 16 {
+        return Err(RebuildError::FieldOverflow { field });
+    }
+    let mut buf = [0u8; 16];
+    buf[16 - bytes.len()..].copy_from_slice(bytes);
+    Ok(u128::from_be_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::SignableTransaction;
+    use alloy_primitives::Signature;
+    use ironclaw_chain_signing::evm;
+
+    fn sample_1559() -> TxEip1559 {
+        TxEip1559 {
+            chain_id: 11155111,
+            nonce: 7,
+            gas_limit: 21_000,
+            max_fee_per_gas: 30_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            to: TxKind::Call(Address::repeat_byte(0xbb)),
+            value: U256::from(1_000u64),
+            input: Bytes::from(vec![0xde, 0xad]),
+            access_list: Default::default(),
+        }
+    }
+
+    /// The rebuild must round-trip byte-identically: decode -> rebuild produces
+    /// a signable with the SAME signature hash as the original.
+    #[test]
+    fn eip1559_rebuild_roundtrips_signature_hash() {
+        let original = sample_1559();
+        let decoded = evm::decode_eip1559(&original);
+        let EvmSignable::Eip1559(rebuilt) = rebuild_evm_signable(&decoded).unwrap() else {
+            panic!("expected eip1559");
+        };
+        let h1 = SignableTransaction::<Signature>::signature_hash(&original);
+        let h2 = SignableTransaction::<Signature>::signature_hash(&rebuilt);
+        assert_eq!(h1, h2, "rebuilt tx must hash identically to the original");
+    }
+
+    #[test]
+    fn legacy_rebuild_roundtrips_signature_hash() {
+        let original = TxLegacy {
+            chain_id: Some(11155111),
+            nonce: 3,
+            gas_price: 20_000_000_000,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::repeat_byte(0xcc)),
+            value: U256::from(42u64),
+            input: Bytes::new(),
+        };
+        let decoded = evm::decode_legacy(&original);
+        let EvmSignable::Legacy(rebuilt) = rebuild_evm_signable(&decoded).unwrap() else {
+            panic!("expected legacy");
+        };
+        let h1 = SignableTransaction::<Signature>::signature_hash(&original);
+        let h2 = SignableTransaction::<Signature>::signature_hash(&rebuilt);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn eip2930_rebuild_roundtrips_signature_hash() {
+        let original = TxEip2930 {
+            chain_id: 11155111,
+            nonce: 5,
+            gas_price: 25_000_000_000,
+            gas_limit: 50_000,
+            to: TxKind::Call(Address::repeat_byte(0xdd)),
+            value: U256::from(7u64),
+            access_list: AccessList(vec![AccessListItem {
+                address: Address::repeat_byte(0xee),
+                storage_keys: vec![B256::repeat_byte(0x11), B256::repeat_byte(0x22)],
+            }]),
+            input: Bytes::from(vec![0xca, 0xfe]),
+        };
+        let decoded = evm::decode_eip2930(&original);
+        let EvmSignable::Eip2930(rebuilt) = rebuild_evm_signable(&decoded).unwrap() else {
+            panic!("expected eip2930");
+        };
+        let h1 = SignableTransaction::<Signature>::signature_hash(&original);
+        let h2 = SignableTransaction::<Signature>::signature_hash(&rebuilt);
+        assert_eq!(
+            h1, h2,
+            "rebuilt eip2930 must hash identically to the original"
+        );
+    }
+
+    // `EvmSignable` is intentionally not `Debug` (it wraps signable txs), so the
+    // error-path tests assert on the `Result` via `matches!` rather than
+    // `expect_err` (which would require `Debug` on the `Ok` variant).
+
+    #[test]
+    fn unsupported_tx_type_fails_closed() {
+        // Start from a valid 1559 decode, then mutate the tx_type to an
+        // unsupported value (e.g. EIP-4844 blob = 3).
+        let DecodedTransaction::Evm(mut evm) = evm::decode_eip1559(&sample_1559()) else {
+            panic!("expected evm");
+        };
+        evm.tx_type = 3;
+        let result = rebuild_evm_signable(&DecodedTransaction::Evm(evm));
+        assert!(matches!(
+            result,
+            Err(RebuildError::UnsupportedTxType { tx_type: 3 })
+        ));
+    }
+
+    #[test]
+    fn missing_fee_field_fails_closed() {
+        // A 1559 tx with its max_fee_per_gas stripped must fail closed.
+        let DecodedTransaction::Evm(mut evm) = evm::decode_eip1559(&sample_1559()) else {
+            panic!("expected evm");
+        };
+        evm.max_fee_per_gas = None;
+        let result = rebuild_evm_signable(&DecodedTransaction::Evm(evm));
+        assert!(matches!(
+            result,
+            Err(RebuildError::MissingField {
+                field: "max_fee_per_gas"
+            })
+        ));
+    }
+
+    #[test]
+    fn overflowing_fee_field_fails_closed() {
+        // A fee field wider than 16 bytes cannot be a valid EVM u128 fee.
+        let DecodedTransaction::Evm(mut evm) = evm::decode_eip1559(&sample_1559()) else {
+            panic!("expected evm");
+        };
+        evm.max_fee_per_gas = Some(vec![0xffu8; 17]);
+        let result = rebuild_evm_signable(&DecodedTransaction::Evm(evm));
+        assert!(matches!(
+            result,
+            Err(RebuildError::FieldOverflow {
+                field: "max_fee_per_gas"
+            })
+        ));
+    }
+
+    #[test]
+    fn non_evm_chain_fails_closed() {
+        // A non-EVM decoded tx has no custodial rebuild path yet.
+        let near = DecodedTransaction::Near(ironclaw_attestation::NearTransaction {
+            network: "testnet".to_string(),
+            signer_id: "alice.near".to_string(),
+            public_key: ironclaw_attestation::NearPublicKey {
+                key_type: 0,
+                data: vec![0u8; 32],
+            },
+            receiver_id: "bob.near".to_string(),
+            nonce: 1,
+            block_hash: ironclaw_attestation::Bytes32([0u8; 32]),
+            actions: vec![],
+        });
+        let result = rebuild_evm_signable(&near);
+        assert!(matches!(result, Err(RebuildError::UnsupportedChain { .. })));
+    }
+}

--- a/crates/ironclaw_attested_runtime/src/lib.rs
+++ b/crates/ironclaw_attested_runtime/src/lib.rs
@@ -1,0 +1,68 @@
+//! Composition-layer runtime glue for the IronClaw attested-signing substrate.
+//!
+//! This is **PR10 of the 10-PR attested-signing stack** (see
+//! `docs/plans/2026-05-23-attested-signing-substrate.md`). It is the
+//! *composition glue* the binary-boundary rule requires to live outside `src/`:
+//! it is the single place where the crypto-free turn store
+//! ([`ironclaw_turns`]), the provider-agnostic trait
+//! ([`ironclaw_signing_provider`]), the external-wallet providers
+//! ([`ironclaw_wallet_external`]), and the custodial chain signer
+//! ([`ironclaw_chain_signing`]) are wired together.
+//!
+//! It ships three deliverables:
+//!
+//! 1. [`RuntimeAttestedResumePort`] — the production
+//!    [`ironclaw_turns::AttestedResumePort`] implementation. It runs inside the
+//!    turn store's synchronous resume critical section, so it is strictly
+//!    non-blocking: it re-checks the persisted gate binding against the
+//!    `expected_tx_hash` the gate was raised with and claims a synchronous
+//!    one-shot **resume guard** (threats #1 / #16 at the resume boundary). The
+//!    heavyweight async work (provider `verify_resume`, the authoritative
+//!    sealed-grant CAS, and the chain sign + broadcast) happens *after* the
+//!    store transitions `BlockedAttested -> AttestedResolved`, in the
+//!    [`AttestedSignerContinuationDriver`].
+//!
+//! 2. [`AttestedSignerContinuationDriver`] — drives the deterministic
+//!    post-approval continuation once the turn reaches
+//!    [`ironclaw_turns::TurnStatus::AttestedResolved`]: routes to the correct
+//!    [`ironclaw_signing_provider::SigningProvider`] (or the custodial chain
+//!    signer) to verify the proof + claim the sealed grant, then performs the
+//!    real sign + broadcast honoring the broadcast-idempotency
+//!    [`ironclaw_attestation::SigningLedger`]. It NEVER re-enters the agent loop
+//!    (threat #16) and NEVER re-broadcasts a `gate_ref` already past
+//!    `BroadcastSubmitted` (threats #6 / #7).
+//!
+//! 3. [`CustodialMainnetShipGate`] — the `CUSTODIAL_MAINNET_ENABLED` env gate
+//!    (mirroring the `HOOKS_THIRD_PARTY_ENABLED` ship-gate pattern). It builds
+//!    the chain-signing [`ironclaw_chain_signing::ShipGate`] from the operator
+//!    opt-in and an optionally-wired KMS backend, refusing real-value /
+//!    mainnet custodial signing unless secure custody is wired (threat #18).
+//!
+//! ## Boundary invariants
+//!
+//! * `ironclaw_turns` stays crypto-free: this crate depends on `ironclaw_turns`
+//!   but never the reverse. All chain/crypto convergence happens *here*, at the
+//!   composition layer, which is the legitimate place for it.
+//! * This crate is a library outside `src/`; it carries no dependency on the
+//!   binary.
+#![warn(unreachable_pub)]
+#![forbid(unsafe_code)]
+
+mod binding;
+mod driver;
+mod port;
+mod ship_gate;
+
+pub use binding::{
+    AttestedGateBinding, AttestedGateBindingStore, BindingError, InMemoryAttestedGateBindingStore,
+    validate_binding,
+};
+pub use driver::{
+    AttestedSignerContinuationDriver, BindingOwner, BroadcastDisposition, BroadcastOutcome,
+    Broadcaster, ContinuationError, CustodialSignerLike, EvmSignable, ProviderRegistry,
+    RebuildError, SignerContinuationOutcome, VerifiedContinuation,
+};
+pub use port::{
+    InMemoryResumeGuard, ResumeGuard, RuntimeAttestedResumePort, approved_tx_hash_ref_hex,
+};
+pub use ship_gate::{CUSTODIAL_MAINNET_ENABLED_ENV, CustodialMainnetShipGate};

--- a/crates/ironclaw_attested_runtime/src/port.rs
+++ b/crates/ironclaw_attested_runtime/src/port.rs
@@ -1,0 +1,214 @@
+//! The production [`AttestedResumePort`] — the synchronous binding re-check the
+//! turn store runs while resolving a `BlockedAttested` gate.
+//!
+//! ## Why this is synchronous and lightweight
+//!
+//! `ironclaw_turns::InMemoryTurnStateStore` calls
+//! [`AttestedResumePort::verify_attested_resume`] **inside its resume mutex**
+//! (see `crates/ironclaw_turns/src/memory.rs`: `resume_turn` holds
+//! `lock_inner()` across `resume_turn_once`). Blocking on a tokio runtime there
+//! would deadlock the store. So the port does only non-blocking work:
+//!
+//! 1. **Binding re-check (threats #2 / #3 / #4):** look up the authoritative
+//!    [`AttestedGateBinding`] persisted when the gate was raised and confirm
+//!    its `ApprovedTxHash` equals the `expected_tx_hash` the store recorded on
+//!    the run. The caller never supplies the hash; it only attests to it.
+//! 2. **One-shot resume guard (threats #1 / #16):** atomically claim a
+//!    synchronous per-`gate_ref` guard so a replayed resume of an
+//!    already-resolved gate fails closed at the boundary, and the LLM loop is
+//!    never re-entered.
+//!
+//! The heavyweight verification (provider `verify_resume`, the authoritative
+//! sealed-grant CAS) and the sign + broadcast happen *after* the store
+//! transitions to `AttestedResolved`, in
+//! [`crate::AttestedSignerContinuationDriver`]. Two independent one-shot guards
+//! (this resume guard and the sealed grant claimed in the driver) is defense in
+//! depth, not redundancy: either alone fails a replay closed.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use ironclaw_signing_provider::GateRef as SigningGateRef;
+use ironclaw_turns::{AttestedResumePort, AttestedResumeRejection, AttestedResumeRequest};
+
+use crate::binding::InMemoryAttestedGateBindingStore;
+
+/// A synchronous one-shot guard claimed at resume time, keyed by `gate_ref`.
+///
+/// `claim` is an atomic compare-and-set: the first claim of a gate wins; every
+/// later claim fails. This guarantees a `BlockedAttested` gate can be resolved
+/// at most once even before the async sealed-grant claim runs in the driver.
+pub trait ResumeGuard: Send + Sync {
+    /// Atomically claim the one-shot guard for `gate_ref`. Returns `true` if
+    /// this caller won (first claim), `false` if it was already claimed.
+    fn claim(&self, gate_ref: &str) -> bool;
+}
+
+/// Maximum number of claimed gate refs retained by [`InMemoryResumeGuard`].
+///
+/// Bounded so a long-lived local runtime cannot grow this set without limit
+/// (one entry per attested gate, never released). Eviction is safe here and
+/// does NOT restore replayability: as the module doc states, the resume guard
+/// and the sealed-grant CAS are two *independent* one-shot controls and either
+/// alone fails a replay closed. An evicted gate that is replayed still hits the
+/// authoritative sealed-grant CAS in the driver and is refused there — the
+/// guard is defense in depth, not the primary control.
+const MAX_CLAIMED_GATES: usize = 8192;
+
+/// In-memory [`ResumeGuard`]. A single mutex makes claim atomic.
+///
+/// Bounded by [`MAX_CLAIMED_GATES`] with FIFO eviction of the oldest claims.
+#[derive(Debug, Default)]
+pub struct InMemoryResumeGuard {
+    claimed: Mutex<(HashSet<String>, VecDeque<String>)>,
+}
+
+impl InMemoryResumeGuard {
+    /// Construct an empty guard.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ResumeGuard for InMemoryResumeGuard {
+    fn claim(&self, gate_ref: &str) -> bool {
+        match self.claimed.lock() {
+            Ok(mut guard) => {
+                let (set, order) = &mut *guard;
+                // `insert` returns true iff the value was newly inserted, i.e.
+                // this caller won the one-shot race.
+                if !set.insert(gate_ref.to_string()) {
+                    return false;
+                }
+                order.push_back(gate_ref.to_string());
+                // FIFO-evict the oldest claims past the cap. Safe: see
+                // `MAX_CLAIMED_GATES` — the sealed-grant CAS remains the
+                // authoritative one-shot control for an evicted gate.
+                while order.len() > MAX_CLAIMED_GATES {
+                    if let Some(oldest) = order.pop_front() {
+                        set.remove(&oldest);
+                    }
+                }
+                true
+            }
+            // A poisoned lock fails closed: refuse the claim.
+            Err(_) => false,
+        }
+    }
+}
+
+/// The production [`AttestedResumePort`] for the reborn composition.
+pub struct RuntimeAttestedResumePort {
+    bindings: Arc<InMemoryAttestedGateBindingStore>,
+    resume_guard: Arc<dyn ResumeGuard>,
+}
+
+impl RuntimeAttestedResumePort {
+    /// Build the port over the authoritative gate-binding store and the
+    /// one-shot resume guard. Both are shared with the driver (which reads the
+    /// same binding to verify + broadcast).
+    pub fn new(
+        bindings: Arc<InMemoryAttestedGateBindingStore>,
+        resume_guard: Arc<dyn ResumeGuard>,
+    ) -> Self {
+        Self {
+            bindings,
+            resume_guard,
+        }
+    }
+}
+
+impl AttestedResumePort for RuntimeAttestedResumePort {
+    fn verify_attested_resume(
+        &self,
+        request: AttestedResumeRequest<'_>,
+    ) -> Result<(), AttestedResumeRejection> {
+        let gate_ref_str = request.gate_ref.as_str();
+
+        // 1. Authoritative binding re-check. The binding was persisted from the
+        //    server-decoded transaction when the gate was raised; the caller's
+        //    resume never gets to define the hash, only attest to it.
+        let signing_gate_ref = SigningGateRef::new(gate_ref_str);
+        let binding = self
+            .bindings
+            .get_sync(&signing_gate_ref)
+            .ok_or(AttestedResumeRejection::InvalidClaim)?;
+
+        // The store-recorded `expected_tx_hash` (an opaque ref) must match the
+        // authoritative bound hash. We compare the lowercase-hex of the bound
+        // hash against the recorded ref string. A mismatch is a caller-supplied
+        // hash attempt (threat #3) and fails closed.
+        let bound_hex = hex_lower(binding.approved_tx_hash.as_bytes());
+        if request.expected_tx_hash.as_str() != bound_hex {
+            return Err(AttestedResumeRejection::BindingMismatch);
+        }
+
+        // The attestation claim carried on the wire must itself attest to the
+        // bound hash. The claim ref is the lowercase-hex of the attested hash;
+        // it must equal the bound hash. (The cryptographic proof verification —
+        // signer recovery, grant CAS — runs in the driver against this same
+        // bound hash; here we only reject an attestation that does not even
+        // claim the right hash.)
+        if request.attestation.as_str() != bound_hex {
+            return Err(AttestedResumeRejection::BindingMismatch);
+        }
+
+        // 2. One-shot resume guard (threats #1 / #16): a replayed resume of an
+        //    already-resolved gate fails closed before the loop could ever be
+        //    re-entered.
+        if !self.resume_guard.claim(gate_ref_str) {
+            return Err(AttestedResumeRejection::EvidenceRejected);
+        }
+
+        Ok(())
+    }
+}
+
+/// Lowercase-hex encode (inline; no dependency).
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // Lookup table rather than `from_digit(..).unwrap_or('0')`: the fallback
+        // was unreachable (both nibbles are < 16) but it is the pattern that
+        // silently emits WRONG data if the surrounding arithmetic ever changes,
+        // and this rendering is compared against a binding — a silent '0' would
+        // corrupt a comparison rather than fail it.
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Public helper so the driver / binding writers produce the exact ref strings
+/// the port expects for `expected_tx_hash` and `attestation`.
+pub fn approved_tx_hash_ref_hex(bytes: &[u8]) -> String {
+    hex_lower(bytes)
+}
+
+#[cfg(test)]
+mod bounded_guard_tests {
+    use super::*;
+
+    #[test]
+    fn resume_guard_is_one_shot_and_bounded() {
+        let guard = InMemoryResumeGuard::default();
+
+        // One-shot: the first claim wins, the replay loses.
+        assert!(guard.claim("gate-a"), "first claim must win");
+        assert!(!guard.claim("gate-a"), "replay must be refused");
+
+        // Bounded: claiming past the cap evicts oldest entries rather than
+        // growing without limit (#3994 review).
+        for i in 0..MAX_CLAIMED_GATES + 16 {
+            guard.claim(&format!("gate-fill-{i}"));
+        }
+        let (set, order) = &*guard.claimed.lock().expect("lock");
+        assert!(
+            set.len() <= MAX_CLAIMED_GATES && order.len() <= MAX_CLAIMED_GATES,
+            "guard must stay bounded, got set={} order={}",
+            set.len(),
+            order.len()
+        );
+    }
+}

--- a/crates/ironclaw_attested_runtime/src/ship_gate.rs
+++ b/crates/ironclaw_attested_runtime/src/ship_gate.rs
@@ -1,0 +1,108 @@
+//! The `CUSTODIAL_MAINNET_ENABLED` ship-gate (threat #18).
+//!
+//! Mirrors the `HOOKS_THIRD_PARTY_ENABLED` env-gate pattern: a dangerous
+//! capability (here, custodial *mainnet* / real-value signing with keys
+//! IronClaw holds) is refused unless an operator explicitly opts in **and** a
+//! secure-custody HSM/KMS backend is wired. The opt-in flag alone is never
+//! sufficient — a hot key in process memory can only ever sign testnet / dev
+//! value (compromised-host hot-key threat).
+//!
+//! This wraps the lower-level [`ironclaw_chain_signing::ShipGate`] (which
+//! encodes the actual allow/deny logic and the mainnet-vs-testnet
+//! classification) and adds the env-driven construction so the composition
+//! layer reads one flag and hands a built gate to the custodial signer.
+
+use ironclaw_chain_signing::{HsmKmsBackend, ShipGate};
+
+/// The environment variable that opts a deployment into custodial mainnet
+/// signing. Necessary but NOT sufficient: secure custody is still required.
+pub const CUSTODIAL_MAINNET_ENABLED_ENV: &str = "CUSTODIAL_MAINNET_ENABLED";
+
+/// The composition-layer custodial-mainnet ship-gate.
+///
+/// Reads the `CUSTODIAL_MAINNET_ENABLED` opt-in and builds the chain-signing
+/// [`ShipGate`] from it plus the wired KMS backend (if any).
+pub struct CustodialMainnetShipGate {
+    opt_in: bool,
+}
+
+impl CustodialMainnetShipGate {
+    /// Build from an explicit opt-in flag (used by tests / callers that own the
+    /// config).
+    pub fn new(opt_in: bool) -> Self {
+        Self { opt_in }
+    }
+
+    /// Build by reading the `CUSTODIAL_MAINNET_ENABLED` env var. Anything other
+    /// than a truthy value (`1`, `true`, `yes`, case-insensitive) is treated as
+    /// opted-out — fail-closed default.
+    pub fn from_env() -> Self {
+        Self {
+            opt_in: parse_opt_in(std::env::var(CUSTODIAL_MAINNET_ENABLED_ENV).ok().as_deref()),
+        }
+    }
+
+    /// Whether the operator opted into mainnet custodial signing.
+    pub fn mainnet_opt_in(&self) -> bool {
+        self.opt_in
+    }
+
+    /// Build the lower-level chain-signing [`ShipGate`] for the custodial
+    /// signer, binding the operator opt-in to the wired KMS backend.
+    ///
+    /// A `None` backend (no KMS) or a hot-key backend
+    /// (`is_secure_custody() == false`) cannot satisfy the mainnet requirement,
+    /// regardless of the opt-in (threat #18). Testnet / dev signing is always
+    /// allowed.
+    pub fn build_chain_ship_gate(&self, kms: Option<&dyn HsmKmsBackend>) -> ShipGate {
+        ShipGate::new(self.opt_in, kms)
+    }
+}
+
+/// Parse the `CUSTODIAL_MAINNET_ENABLED` value into an opt-in flag. Anything
+/// other than a truthy value (`1`, `true`, `yes`, case-insensitive, trimmed) —
+/// including an absent var — is opted-out (fail-closed default).
+fn parse_opt_in(value: Option<&str>) -> bool {
+    matches!(
+        value.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1" | "true" | "yes")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_env_truthy_values_opt_in() {
+        for v in ["1", "true", "TRUE", "Yes", " yes ", "tRuE"] {
+            assert!(
+                parse_opt_in(Some(v)),
+                "value {v:?} must be treated as opted-in"
+            );
+        }
+    }
+
+    #[test]
+    fn from_env_falsy_and_unset_default_to_opted_out() {
+        for v in ["0", "false", "no", "", "nope", "2", "  "] {
+            assert!(
+                !parse_opt_in(Some(v)),
+                "value {v:?} must be treated as opted-out (fail-closed)"
+            );
+        }
+        // An absent var also fails closed.
+        assert!(!parse_opt_in(None), "unset must default to opted-out");
+    }
+
+    /// The public `from_env` constructor wires `parse_opt_in`; with the var
+    /// absent (the harness does not set it) it must report opted-out.
+    #[test]
+    fn from_env_constructor_defaults_opted_out_when_absent() {
+        // We do not mutate the process env (the crate forbids unsafe); we only
+        // assert the safe default, which holds whenever the var is unset.
+        if std::env::var(CUSTODIAL_MAINNET_ENABLED_ENV).is_err() {
+            assert!(!CustodialMainnetShipGate::from_env().mainnet_opt_in());
+        }
+    }
+}

--- a/crates/ironclaw_attested_runtime/tests/threat_matrix.rs
+++ b/crates/ironclaw_attested_runtime/tests/threat_matrix.rs
@@ -1,0 +1,1433 @@
+//! Threat-matrix integration tests for the attested-signing reborn runtime
+//! (PR10).
+//!
+//! These drive the REAL composition pieces — the [`RuntimeAttestedResumePort`]
+//! through the actual `ironclaw_turns` resume path, and the
+//! [`AttestedSignerContinuationDriver`] through the real `ironclaw_chain_signing`
+//! custodial signer / `ironclaw_wallet_external` provider and the
+//! `ironclaw_attestation` sealed-grant + ledger stores — rather than testing a
+//! helper in isolation (CLAUDE.md "Test Through the Caller").
+//!
+//! Coverage maps to the threat matrix in
+//! `docs/plans/2026-05-23-attested-signing-substrate.md`:
+//!
+//! * #1  sealed-grant replay rejected
+//! * #3  caller-supplied hash rejected
+//! * #5  EVM `from` spoof caught via ecrecover
+//! * #6  broadcast retry blocked by the ledger
+//! * #7  `Stuck -> InProgress` double-broadcast blocked (ledger-state-keyed)
+//! * #16 LLM-loop never re-entered on resume (resume yields AttestedResolved,
+//!   never Queued)
+//! * #18 ship-gate refuses custodial mainnet without KMS
+
+use std::sync::Arc;
+
+use alloy_consensus::TxEip1559;
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+
+use ironclaw_attestation::{
+    AttestedSigningGrant, DecodedTransaction, GrantKey, InMemorySealedGrantStore,
+    InMemorySigningLedger, LedgerKey, RenderingSchemaVersion, SealedGrantStore, SigningLedger,
+    SigningLedgerState,
+};
+use ironclaw_attested_runtime::{
+    AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver,
+    ContinuationError, CustodialMainnetShipGate, InMemoryAttestedGateBindingStore,
+    InMemoryResumeGuard, ProviderRegistry, ResumeGuard, RuntimeAttestedResumePort,
+    approved_tx_hash_ref_hex,
+};
+use ironclaw_chain_signing::{
+    ChainKeyBinding, ChainKeyId, ChainSigningError, CustodialSigner, DenyFirstCustodyPolicy,
+    KeyStore, SecretsKeyStore, evm,
+};
+use ironclaw_host_api::{InvocationId, ProjectId, ResourceScope, TenantId, UserId};
+use ironclaw_secrets::SecretsCrypto;
+use ironclaw_signing_provider::{
+    ActorId, ApprovedTxHash, ChainId, GateRef as SigningGateRef, KeyOrAccountId, ProviderId, RunId,
+    ScopeId, SigningContext, SigningProof, TenantId as SigningTenantId, UserId as SigningUserId,
+};
+use ironclaw_turns::{
+    ApprovedTxHashRef, AttestationClaimRef, AttestedResumePort, AttestedResumeRejection,
+    AttestedResumeRequest, GateRef as TurnsGateRef,
+};
+use secrecy::SecretString;
+
+// ── shared fixtures ──────────────────────────────────────────────────────
+
+const GATE: &str = "gate:threat-matrix";
+const DEV_TESTNET_CHAIN: &str = "eip155:11155111"; // sepolia (testnet)
+const MASTER_KEY: &str = "0123456789abcdef0123456789ABCDEF";
+
+fn owner_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("default").unwrap(),
+        user_id: UserId::new("alice").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("bootstrap").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn signing_context(account_hex_no_prefix: &str) -> SigningContext {
+    SigningContext {
+        tenant: SigningTenantId::new("default"),
+        user: SigningUserId::new("alice"),
+        scope: ScopeId::new("scope-x"),
+        actor: ActorId::new("actor-7"),
+        run_id: RunId::new("run-42"),
+        gate_ref: SigningGateRef::new(GATE),
+        chain_id: ChainId::new(DEV_TESTNET_CHAIN),
+        key_or_account_id: KeyOrAccountId::new(account_hex_no_prefix),
+    }
+}
+
+/// Build a sample EIP-1559 transaction + its decoded form + the binding hash.
+///
+/// The approved hash is computed with the GATE-BOUND signer (`signer`) folded
+/// in explicitly — the same account the test's `SigningContext.key_or_account_id`
+/// carries — never the tx body. This mirrors the production WYSIWYS binding so
+/// the driver's resume-time recompute (which uses `binding.context
+/// .key_or_account_id`) reproduces the bound hash.
+fn sample_evm(signer: &str) -> (TxEip1559, DecodedTransaction, ApprovedTxHash) {
+    let tx = TxEip1559 {
+        chain_id: 11155111,
+        nonce: 7,
+        gas_limit: 21_000,
+        max_fee_per_gas: 30_000_000_000,
+        max_priority_fee_per_gas: 1_000_000_000,
+        to: TxKind::Call(Address::repeat_byte(0xbb)),
+        value: U256::from(1_000u64),
+        input: Bytes::new(),
+        access_list: Default::default(),
+    };
+    let decoded = evm::decode_eip1559(&tx);
+    let hash = ironclaw_chain_signing::recompute_approved_hash(
+        &decoded,
+        signer,
+        RenderingSchemaVersion::CURRENT,
+    )
+    .expect("recompute approved hash in test");
+    (tx, decoded, hash)
+}
+
+/// An EVM keystore bound to the address derived from `priv_bytes`, plus the
+/// lowercase-hex (no `0x`) bound account string.
+async fn keystore_with_evm_key(priv_bytes: &[u8; 32]) -> (Arc<SecretsKeyStore>, String) {
+    let crypto = SecretsCrypto::new(SecretString::from(MASTER_KEY.to_string())).unwrap();
+    let keystore = Arc::new(SecretsKeyStore::new(crypto));
+    let key = k256::ecdsa::SigningKey::from_slice(priv_bytes).unwrap();
+    let address = evm::address_of(&key);
+    let addr_hex = hex::encode(address.as_slice());
+    let binding = ChainKeyBinding {
+        chain: ChainKeyId::new(DEV_TESTNET_CHAIN).expect("valid chain id in test"),
+        public_address_hex: addr_hex.clone(),
+        evm_chain_id: Some(11155111),
+        derivation_path: "m/44'/60'/0'/0/0".to_string(),
+        // Hot-key custody: no KMS handle. The testnet ship-gate permits this;
+        // mainnet would require `Some(..)`.
+        kms_key_ref: None,
+    };
+    keystore
+        .bind(&owner_scope(), binding, priv_bytes.to_vec())
+        .await
+        .unwrap();
+    (keystore, addr_hex)
+}
+
+/// The concrete custodial driver type assembled by [`custodial_driver`].
+type TestCustodialDriver = AttestedSignerContinuationDriver<
+    ironclaw_reborn_noop::NoopBroadcaster,
+    InMemorySigningLedger,
+    CustodialSigner<SecretsKeyStore, InMemorySealedGrantStore, InMemorySigningLedger>,
+>;
+
+/// Assemble a custodial driver with shared grant + ledger stores. Returns the
+/// driver, the shared grant store, the shared ledger, and the binding store.
+fn custodial_driver(
+    keystore: Arc<SecretsKeyStore>,
+    bindings: Arc<InMemoryAttestedGateBindingStore>,
+) -> (
+    TestCustodialDriver,
+    Arc<InMemorySealedGrantStore>,
+    Arc<InMemorySigningLedger>,
+) {
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    // Testnet chain => ship-gate permits hot-key custodial without a KMS.
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        Arc::clone(&bindings) as Arc<dyn AttestedGateBindingStore>,
+        ProviderRegistry::new(),
+        signer,
+        Arc::clone(&ledger),
+        Arc::new(ironclaw_reborn_noop::NoopBroadcaster),
+    );
+    (driver, grants, ledger)
+}
+
+/// A local no-op broadcaster mirroring the composition crate's
+/// `NoopBroadcaster` so the driver's ledger guard is exercised without network
+/// I/O.
+mod ironclaw_reborn_noop {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct NoopBroadcaster;
+
+    #[async_trait::async_trait]
+    impl ironclaw_attested_runtime::Broadcaster for NoopBroadcaster {
+        fn submits(&self) -> bool {
+            false
+        }
+
+        async fn broadcast(
+            &self,
+            _context: &SigningContext,
+            _signed: &[u8],
+        ) -> Result<ironclaw_attested_runtime::BroadcastOutcome, ContinuationError> {
+            Ok(ironclaw_attested_runtime::BroadcastOutcome::NotBroadcast {
+                reason: "test noop".to_string(),
+            })
+        }
+    }
+}
+
+/// A broadcaster that REALLY submits (reports `submits() == true`) and counts
+/// every submit, so a test can assert true broadcast idempotency: a replayed
+/// continuation must produce ZERO additional submit calls, not merely a
+/// returned ledger error.
+mod recording {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Default)]
+    pub struct RecordingBroadcaster {
+        pub calls: AtomicUsize,
+    }
+
+    impl RecordingBroadcaster {
+        pub fn count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ironclaw_attested_runtime::Broadcaster for RecordingBroadcaster {
+        fn submits(&self) -> bool {
+            true
+        }
+
+        async fn broadcast(
+            &self,
+            _context: &SigningContext,
+            _signed: &[u8],
+        ) -> Result<ironclaw_attested_runtime::BroadcastOutcome, ContinuationError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ironclaw_attested_runtime::BroadcastOutcome::Submitted {
+                tx_id: "recorded-tx".to_string(),
+            })
+        }
+    }
+}
+
+/// A broadcaster that REALLY submits (reports `submits() == true`) and counts
+/// every submit, but always fails the submit with a broadcast error (e.g. an
+/// RPC timeout). Used to exercise broadcast-failure recovery (item C): the
+/// ledger must move to a terminal recovery state and a retry must not
+/// double-broadcast.
+mod failing {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Default)]
+    pub struct FailingBroadcaster {
+        pub calls: AtomicUsize,
+    }
+
+    impl FailingBroadcaster {
+        pub fn count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ironclaw_attested_runtime::Broadcaster for FailingBroadcaster {
+        fn submits(&self) -> bool {
+            true
+        }
+
+        async fn broadcast(
+            &self,
+            _context: &SigningContext,
+            _signed: &[u8],
+        ) -> Result<ironclaw_attested_runtime::BroadcastOutcome, ContinuationError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(ContinuationError::Broadcast {
+                reason: "rpc timeout after send".to_string(),
+            })
+        }
+    }
+}
+
+/// The concrete custodial driver type backed by a [`recording::RecordingBroadcaster`].
+type RecordingCustodialDriver = AttestedSignerContinuationDriver<
+    recording::RecordingBroadcaster,
+    InMemorySigningLedger,
+    CustodialSigner<SecretsKeyStore, InMemorySealedGrantStore, InMemorySigningLedger>,
+>;
+
+/// The concrete custodial driver type backed by a [`failing::FailingBroadcaster`].
+type FailingCustodialDriver = AttestedSignerContinuationDriver<
+    failing::FailingBroadcaster,
+    InMemorySigningLedger,
+    CustodialSigner<SecretsKeyStore, InMemorySealedGrantStore, InMemorySigningLedger>,
+>;
+
+/// Assemble a custodial driver wired to a shared failing broadcaster so a test
+/// can assert broadcast-failure recovery and that a retry does not
+/// double-broadcast.
+fn custodial_driver_failing(
+    keystore: Arc<SecretsKeyStore>,
+    bindings: Arc<InMemoryAttestedGateBindingStore>,
+    broadcaster: Arc<failing::FailingBroadcaster>,
+) -> (
+    FailingCustodialDriver,
+    Arc<InMemorySealedGrantStore>,
+    Arc<InMemorySigningLedger>,
+) {
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        Arc::clone(&bindings) as Arc<dyn AttestedGateBindingStore>,
+        ProviderRegistry::new(),
+        signer,
+        Arc::clone(&ledger),
+        broadcaster,
+    );
+    (driver, grants, ledger)
+}
+
+/// Assemble a custodial driver wired to a shared recording broadcaster so a
+/// test can assert how many real submits happened.
+fn custodial_driver_recording(
+    keystore: Arc<SecretsKeyStore>,
+    bindings: Arc<InMemoryAttestedGateBindingStore>,
+    broadcaster: Arc<recording::RecordingBroadcaster>,
+) -> (
+    RecordingCustodialDriver,
+    Arc<InMemorySealedGrantStore>,
+    Arc<InMemorySigningLedger>,
+) {
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        Arc::clone(&bindings) as Arc<dyn AttestedGateBindingStore>,
+        ProviderRegistry::new(),
+        signer,
+        Arc::clone(&ledger),
+        broadcaster,
+    );
+    (driver, grants, ledger)
+}
+
+async fn seal_grant(grants: &InMemorySealedGrantStore, ctx: &SigningContext, hash: ApprovedTxHash) {
+    let key = GrantKey::from_context(ctx, hash);
+    grants
+        .seal(AttestedSigningGrant::new(key, 0, None).expect("valid grant"))
+        .await
+        .expect("seal");
+}
+
+async fn put_binding(
+    bindings: &InMemoryAttestedGateBindingStore,
+    ctx: &SigningContext,
+    decoded: DecodedTransaction,
+    hash: ApprovedTxHash,
+) {
+    put_binding_res(bindings, ctx, decoded, hash)
+        .await
+        .expect("binding insert succeeds");
+}
+
+async fn put_binding_res(
+    bindings: &InMemoryAttestedGateBindingStore,
+    ctx: &SigningContext,
+    decoded: DecodedTransaction,
+    hash: ApprovedTxHash,
+) -> Result<(), ironclaw_attested_runtime::BindingError> {
+    bindings
+        .put(
+            SigningGateRef::new(GATE),
+            AttestedGateBinding {
+                provider_id: ProviderId::Custodial,
+                context: ctx.clone(),
+                approved_tx_hash: hash,
+                decoded,
+                chain: ChainKeyId::new(DEV_TESTNET_CHAIN).expect("valid chain id in test"),
+                scope: owner_scope(),
+                schema_version: RenderingSchemaVersion::CURRENT,
+            },
+        )
+        .await
+}
+
+// ── Threat #18: ship-gate refuses custodial mainnet without KMS ───────────
+
+/// Ledger key for the tests' fixed tenant ("default").
+fn lk(gate: &SigningGateRef) -> LedgerKey {
+    LedgerKey::new(SigningTenantId::new("default"), gate.clone())
+}
+
+#[test]
+fn threat_18_ship_gate_refuses_custodial_mainnet_without_kms() {
+    // Opt-in TRUE but no KMS backend: mainnet must still be refused.
+    let gate = CustodialMainnetShipGate::new(true).build_chain_ship_gate(None);
+    let err = gate
+        .authorize_chain("eip155:1")
+        .expect_err("mainnet custodial must be refused without secure custody");
+    assert!(matches!(err, ChainSigningError::ShipGateRefused { .. }));
+
+    // Testnet is always allowed (hot-key dev signing).
+    assert!(gate.authorize_chain(DEV_TESTNET_CHAIN).is_ok());
+
+    // Opt-out (default) also refuses mainnet.
+    let gate_off = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    assert!(gate_off.authorize_chain("eip155:1").is_err());
+}
+
+// ── Threat #1 + #6: grant replay & broadcast retry both fail closed ───────
+
+#[tokio::test]
+async fn threat_1_and_6_custodial_replay_and_broadcast_retry_blocked() {
+    let priv_bytes = [0x11u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let broadcaster = Arc::new(recording::RecordingBroadcaster::default());
+    let (driver, grants, _ledger) = custodial_driver_recording(
+        Arc::clone(&keystore),
+        Arc::clone(&bindings),
+        Arc::clone(&broadcaster),
+    );
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let proof = SigningProof::WebAuthnAssertionProof(vec![]);
+
+    // First continuation: signs the tx REBUILT FROM THE BINDING + really
+    // broadcasts (one submit), advancing the ledger to BroadcastSubmitted.
+    let outcome = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect("first continuation succeeds");
+    assert_eq!(outcome.ledger_state, SigningLedgerState::BroadcastSubmitted);
+    assert_eq!(broadcaster.count(), 1, "exactly one real broadcast");
+
+    // Second continuation of the SAME gate: the ledger row already exists and
+    // is past Signed, so the deterministic continuation is refused (threats
+    // #6/#7). The sealed grant was also already claimed (threat #1) — either
+    // guard alone fails the replay closed.
+    let err = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect_err("replay/broadcast-retry must fail closed");
+    assert!(
+        matches!(
+            err,
+            ContinuationError::Ledger(_) | ContinuationError::LedgerRowExists { .. }
+        ),
+        "expected ledger guard rejection, got {err:?}"
+    );
+    // TRUE idempotency: the replay produced ZERO additional broadcast calls.
+    assert_eq!(
+        broadcaster.count(),
+        1,
+        "replay must not produce a second broadcast"
+    );
+}
+
+// ── Threat #1 directly: a second grant claim is AlreadyClaimed ────────────
+
+#[tokio::test]
+async fn threat_1_sealed_grant_one_shot_claim() {
+    let priv_bytes = [0x12u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, _decoded, hash) = sample_evm(&account);
+
+    let grants = InMemorySealedGrantStore::new();
+    seal_grant(&grants, &ctx, hash).await;
+    let key = GrantKey::from_context(&ctx, hash);
+    grants.claim(&key).await.expect("first claim wins");
+    let err = grants.claim(&key).await.expect_err("second claim fails");
+    assert_eq!(err, ironclaw_attestation::GrantError::AlreadyClaimed);
+    let _ = keystore; // keep the bound key alive for parity with other cases
+}
+
+// ── Threat #3: caller-supplied hash rejected ──────────────────────────────
+//
+// Two layers, both fail-closed:
+//   (a) the binding store refuses to PERSIST a binding whose approved hash does
+//       not match its own decoded tx (immutable, validated write — fix #2); and
+//   (b) the driver RE-CHECKS the hash from the decoded tx at sign time (defense
+//       in depth, so a durable backend that somehow holds an inconsistent row
+//       still fails closed — exercised in `driver_rechecks_inconsistent_binding`).
+
+#[tokio::test]
+async fn threat_3_inconsistent_binding_write_rejected() {
+    let priv_bytes = [0x13u8; 32];
+    let (_keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, real_hash) = sample_evm(&account);
+
+    // A caller-asserted hash that does not match the decoded tx.
+    let bogus_hash = ApprovedTxHash::from_bytes([0x99u8; 32]);
+    assert_ne!(bogus_hash, real_hash);
+
+    let bindings = InMemoryAttestedGateBindingStore::new();
+    let err = put_binding_res(&bindings, &ctx, decoded, bogus_hash)
+        .await
+        .expect_err("inconsistent binding write must be rejected");
+    assert_eq!(
+        err,
+        ironclaw_attested_runtime::BindingError::ApprovedHashMismatch
+    );
+}
+
+/// Driver-level defense in depth (fix #1 / #3): even if a backend somehow holds
+/// a binding whose stored hash diverges from its decoded tx, the driver
+/// re-checks at sign time and fails closed BEFORE any key use. Uses a tiny
+/// store mock that returns an inconsistent binding (the validated in-memory
+/// store would never persist one).
+#[tokio::test]
+async fn driver_rechecks_inconsistent_binding() {
+    use async_trait::async_trait;
+    use ironclaw_attested_runtime::AttestedGateBinding;
+
+    struct InconsistentStore(AttestedGateBinding);
+    #[async_trait]
+    impl AttestedGateBindingStore for InconsistentStore {
+        async fn put(
+            &self,
+            _gate_ref: SigningGateRef,
+            _binding: AttestedGateBinding,
+        ) -> Result<(), ironclaw_attested_runtime::BindingError> {
+            Ok(())
+        }
+        async fn get(&self, _gate_ref: &SigningGateRef) -> Option<AttestedGateBinding> {
+            Some(self.0.clone())
+        }
+    }
+
+    let priv_bytes = [0x13u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, real_hash) = sample_evm(&account);
+    let bogus_hash = ApprovedTxHash::from_bytes([0x99u8; 32]);
+    assert_ne!(bogus_hash, real_hash);
+
+    let inconsistent = AttestedGateBinding {
+        provider_id: ProviderId::Custodial,
+        context: ctx.clone(),
+        approved_tx_hash: bogus_hash, // diverges from `decoded`
+        decoded,
+        chain: ChainKeyId::new(DEV_TESTNET_CHAIN).expect("valid chain id in test"),
+        scope: owner_scope(),
+        schema_version: RenderingSchemaVersion::CURRENT,
+    };
+    let store: Arc<dyn AttestedGateBindingStore> = Arc::new(InconsistentStore(inconsistent));
+
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    seal_grant(&grants, &ctx, bogus_hash).await;
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        store,
+        ProviderRegistry::new(),
+        signer,
+        ledger,
+        Arc::new(ironclaw_reborn_noop::NoopBroadcaster),
+    );
+
+    let gate = SigningGateRef::new(GATE);
+    let err = driver
+        .continue_after_resolved(&gate, &SigningProof::WebAuthnAssertionProof(vec![]))
+        .await
+        .expect_err("driver must re-check and reject inconsistent binding");
+    assert!(
+        matches!(err, ContinuationError::ApprovedHashMismatch),
+        "expected approved-hash mismatch, got {err:?}"
+    );
+}
+
+// Note: the "approve-A / sign-B" caller-tx WYSIWYS threat is now structurally
+// impossible and so has no dedicated test here: the driver NEVER accepts a
+// caller-supplied signable transaction — it reconstructs the signable purely
+// from the authoritative `binding.decoded` (the same decoded tx the approved
+// hash was computed over). The equivalent attack surface (a tampered binding)
+// is covered by `threat_3_inconsistent_binding_write_rejected` and
+// `driver_rechecks_inconsistent_binding`.
+
+// ── Threat #5: EVM `from` spoof caught via ecrecover binding ──────────────
+
+#[tokio::test]
+async fn threat_5_evm_from_spoof_caught_via_ecrecover() {
+    // Bind the keystore account to an address that is NOT the address of the
+    // private key actually stored. The custodial signer recovers the signer
+    // from the signature (ecrecover) and compares it to the bound address; a
+    // mismatch fails closed. We construct this by binding a wrong public
+    // address against the real private key.
+    let priv_bytes = [0x14u8; 32];
+    let crypto = SecretsCrypto::new(SecretString::from(MASTER_KEY.to_string())).unwrap();
+    let keystore = Arc::new(SecretsKeyStore::new(crypto));
+    // Wrong bound address (all 0xCD), not the address of priv_bytes.
+    let wrong_addr_hex = hex::encode([0xCDu8; 20]);
+    let binding = ChainKeyBinding {
+        chain: ChainKeyId::new(DEV_TESTNET_CHAIN).expect("valid chain id in test"),
+        public_address_hex: wrong_addr_hex.clone(),
+        evm_chain_id: Some(11155111),
+        derivation_path: "m/44'/60'/0'/0/0".to_string(),
+        kms_key_ref: None,
+    };
+    keystore
+        .bind(&owner_scope(), binding, priv_bytes.to_vec())
+        .await
+        .unwrap();
+
+    let ctx = signing_context(&wrong_addr_hex);
+    let (_tx, decoded, hash) = sample_evm(&wrong_addr_hex);
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let (driver, grants, _ledger) = custodial_driver(Arc::clone(&keystore), Arc::clone(&bindings));
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let err = driver
+        .continue_after_resolved(&gate, &SigningProof::WebAuthnAssertionProof(vec![]))
+        .await
+        .expect_err("ecrecover binding mismatch must fail closed");
+    assert!(
+        matches!(
+            err,
+            ContinuationError::ChainSigning(ChainSigningError::SignerMismatch)
+        ),
+        "expected ecrecover SignerMismatch, got {err:?}"
+    );
+}
+
+// ── Threat #7: Stuck->InProgress double-broadcast blocked (ledger-keyed) ──
+
+#[tokio::test]
+async fn threat_7_double_broadcast_blocked_by_ledger_state() {
+    // Simulate a job that already broadcast: the ledger row for this gate_ref
+    // is at BroadcastSubmitted. A recovery worker re-driving the continuation
+    // must be refused — the guard is keyed on LEDGER state, not job state.
+    let priv_bytes = [0x15u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let (driver, grants, ledger) = custodial_driver(Arc::clone(&keystore), Arc::clone(&bindings));
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    // Pre-advance the ledger to BroadcastSubmitted, as if a prior attempt
+    // already broadcast.
+    ledger.create(&lk(&gate)).await.unwrap();
+    ledger
+        .advance(&lk(&gate), SigningLedgerState::Signing)
+        .await
+        .unwrap();
+    ledger
+        .advance(&lk(&gate), SigningLedgerState::Signed)
+        .await
+        .unwrap();
+    ledger
+        .advance(&lk(&gate), SigningLedgerState::BroadcastSubmitted)
+        .await
+        .unwrap();
+
+    // The recovery re-drive must be refused (the create fails AlreadyExists and
+    // the row is already broadcast).
+    let err = driver
+        .continue_after_resolved(&gate, &SigningProof::WebAuthnAssertionProof(vec![]))
+        .await
+        .expect_err("double-broadcast after recovery must fail closed");
+    assert!(
+        matches!(
+            err,
+            ContinuationError::Ledger(_) | ContinuationError::LedgerRowExists { .. }
+        ),
+        "expected ledger guard rejection, got {err:?}"
+    );
+    // Ledger never regressed out of BroadcastSubmitted.
+    assert_eq!(
+        ledger.state(&lk(&gate)).await.unwrap(),
+        SigningLedgerState::BroadcastSubmitted
+    );
+}
+
+// ── Item C: broadcast-failure recovery (ledger -> Unknown, no double-cast) ──
+
+/// A broadcast error must NOT leave the ledger stuck. The row moves to the
+/// `Unknown` terminal (genuinely unknown whether the tx landed) and the driver
+/// surfaces a `Broadcast` error carrying the evidence.
+#[tokio::test]
+async fn broadcast_error_moves_ledger_to_unknown_not_stuck() {
+    let priv_bytes = [0x21u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let broadcaster = Arc::new(failing::FailingBroadcaster::default());
+    let (driver, grants, ledger) = custodial_driver_failing(
+        Arc::clone(&keystore),
+        Arc::clone(&bindings),
+        Arc::clone(&broadcaster),
+    );
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let proof = SigningProof::WebAuthnAssertionProof(vec![]);
+
+    let err = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect_err("a broadcast error must surface, not silently succeed");
+    assert!(
+        matches!(err, ContinuationError::Broadcast { .. }),
+        "expected a Broadcast error, got {err:?}"
+    );
+    // Exactly one submit attempt was made.
+    assert_eq!(broadcaster.count(), 1, "exactly one submit attempt");
+    // The ledger is at the Unknown terminal — NOT stuck at Signing/Signed/
+    // BroadcastSubmitted.
+    let state = ledger.state(&lk(&gate)).await.unwrap();
+    assert_eq!(
+        state,
+        SigningLedgerState::Unknown,
+        "failed broadcast must move the ledger to the Unknown terminal"
+    );
+    assert!(state.is_terminal(), "Unknown is terminal");
+}
+
+/// A retried continuation after a broadcast failure must NOT double-broadcast.
+/// The ledger row already exists (now at the `Unknown` terminal), so the
+/// one-shot `create` fails closed and the broadcaster is never called again.
+#[tokio::test]
+async fn retry_after_broadcast_failure_does_not_double_broadcast() {
+    let priv_bytes = [0x22u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let broadcaster = Arc::new(failing::FailingBroadcaster::default());
+    let (driver, grants, ledger) = custodial_driver_failing(
+        Arc::clone(&keystore),
+        Arc::clone(&bindings),
+        Arc::clone(&broadcaster),
+    );
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let proof = SigningProof::WebAuthnAssertionProof(vec![]);
+
+    // First attempt: broadcast fails -> ledger moves to Unknown.
+    let _ = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect_err("first attempt fails the broadcast");
+    assert_eq!(broadcaster.count(), 1, "one submit attempt so far");
+    assert_eq!(
+        ledger.state(&lk(&gate)).await.unwrap(),
+        SigningLedgerState::Unknown
+    );
+
+    // Retry / recovery re-drive: the one-shot ledger row already exists, so the
+    // continuation is refused fail-closed and the broadcaster is NOT called
+    // again. Recovery from `Unknown` requires explicit out-of-band re-approval,
+    // never an automatic re-broadcast.
+    let err = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect_err("retry after a failed broadcast must fail closed");
+    assert!(
+        matches!(
+            err,
+            ContinuationError::Ledger(_) | ContinuationError::LedgerRowExists { .. }
+        ),
+        "expected ledger guard rejection on retry, got {err:?}"
+    );
+    assert_eq!(
+        broadcaster.count(),
+        1,
+        "retry must NOT produce a second broadcast"
+    );
+    // The terminal state is preserved (no regression out of Unknown).
+    assert_eq!(
+        ledger.state(&lk(&gate)).await.unwrap(),
+        SigningLedgerState::Unknown
+    );
+}
+
+/// A confirmed submission advances the ledger to `BroadcastSubmitted` and
+/// reports a `Submitted` disposition with the real tx id (success contract).
+#[tokio::test]
+async fn confirmed_submission_reaches_broadcast_submitted() {
+    let priv_bytes = [0x23u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let broadcaster = Arc::new(recording::RecordingBroadcaster::default());
+    let (driver, grants, ledger) = custodial_driver_recording(
+        Arc::clone(&keystore),
+        Arc::clone(&bindings),
+        Arc::clone(&broadcaster),
+    );
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let proof = SigningProof::WebAuthnAssertionProof(vec![]);
+
+    let outcome = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect("confirmed submission succeeds");
+    assert_eq!(outcome.ledger_state, SigningLedgerState::BroadcastSubmitted);
+    assert_eq!(
+        outcome.broadcast,
+        ironclaw_attested_runtime::BroadcastDisposition::Submitted {
+            tx_id: "recorded-tx".to_string()
+        }
+    );
+    assert_eq!(broadcaster.count(), 1);
+    assert_eq!(
+        ledger.state(&lk(&gate)).await.unwrap(),
+        SigningLedgerState::BroadcastSubmitted
+    );
+}
+
+// ── Threats #1/#16 via the resume PORT (drives the turns resume boundary) ──
+
+#[test]
+fn threat_16_resume_port_validates_then_one_shot_no_loop_reentry() {
+    // The port runs synchronously inside the turn store's resume critical
+    // section: it re-checks the bound hash and claims a one-shot resume guard.
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let resume_guard: Arc<dyn ResumeGuard> = Arc::new(InMemoryResumeGuard::new());
+    let port = RuntimeAttestedResumePort::new(Arc::clone(&bindings), Arc::clone(&resume_guard));
+
+    let ctx = signing_context(&hex::encode([0xAAu8; 20]));
+    let (_tx, decoded, hash) = sample_evm(&hex::encode([0xAAu8; 20]));
+    // Persist the authoritative binding (as PR11 ingress would on raising).
+    bindings.get_sync(&SigningGateRef::new(GATE)); // no-op read
+    // SAFETY: synchronous put via the sync helper-equivalent (use blocking put
+    // through a tiny runtime since put is async).
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    rt.block_on(put_binding(&bindings, &ctx, decoded, hash));
+
+    let hash_ref = approved_tx_hash_ref_hex(hash.as_bytes());
+    let gate = TurnsGateRef::new(GATE).unwrap();
+    let attestation = AttestationClaimRef::new(hash_ref.clone()).unwrap();
+    let expected = ApprovedTxHashRef::new(hash_ref).unwrap();
+
+    // First resume verifies (binding matches; guard claimed).
+    port.verify_attested_resume(AttestedResumeRequest {
+        gate_ref: &gate,
+        attestation: &attestation,
+        expected_tx_hash: &expected,
+    })
+    .expect("first attested resume verifies");
+
+    // Replay of the same gate is refused one-shot (threat #1 at the resume
+    // boundary). The turn would already be AttestedResolved, never re-queued
+    // onto the agent loop (threat #16) — the port only ever returns Ok once.
+    let err = port
+        .verify_attested_resume(AttestedResumeRequest {
+            gate_ref: &gate,
+            attestation: &attestation,
+            expected_tx_hash: &expected,
+        })
+        .expect_err("replayed resume must fail closed");
+    assert_eq!(err, AttestedResumeRejection::EvidenceRejected);
+}
+
+// ── Threat #3 at the resume boundary: caller-supplied hash on resume ──────
+
+#[test]
+fn threat_3_resume_port_rejects_mismatched_expected_hash() {
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let resume_guard: Arc<dyn ResumeGuard> = Arc::new(InMemoryResumeGuard::new());
+    let port = RuntimeAttestedResumePort::new(Arc::clone(&bindings), resume_guard);
+
+    let ctx = signing_context(&hex::encode([0xABu8; 20]));
+    let (_tx, decoded, hash) = sample_evm(&hex::encode([0xABu8; 20]));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    rt.block_on(put_binding(&bindings, &ctx, decoded, hash));
+
+    let gate = TurnsGateRef::new(GATE).unwrap();
+    // A caller-supplied expected hash that does NOT match the bound hash.
+    let bogus = ApprovedTxHashRef::new("00".repeat(32)).unwrap();
+    let attestation = AttestationClaimRef::new(approved_tx_hash_ref_hex(hash.as_bytes())).unwrap();
+    let err = port
+        .verify_attested_resume(AttestedResumeRequest {
+            gate_ref: &gate,
+            attestation: &attestation,
+            expected_tx_hash: &bogus,
+        })
+        .expect_err("mismatched expected hash must be rejected");
+    assert_eq!(err, AttestedResumeRejection::BindingMismatch);
+}
+
+// ── Fix #2: authoritative binding writes are immutable + validated ────────
+
+#[tokio::test]
+async fn binding_write_is_insert_only_duplicate_rejected() {
+    let priv_bytes = [0x21u8; 32];
+    let (_keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = InMemoryAttestedGateBindingStore::new();
+    put_binding_res(&bindings, &ctx, decoded.clone(), hash)
+        .await
+        .expect("first write wins");
+    // A second write for the same gate_ref must fail closed — bindings are
+    // immutable, so a later write can never mutate the trusted binding.
+    let err = put_binding_res(&bindings, &ctx, decoded, hash)
+        .await
+        .expect_err("duplicate write must be rejected");
+    assert_eq!(err, ironclaw_attested_runtime::BindingError::AlreadyExists);
+}
+
+#[tokio::test]
+async fn binding_write_rejects_key_context_gate_ref_mismatch() {
+    use ironclaw_attested_runtime::{AttestedGateBinding, validate_binding};
+
+    let priv_bytes = [0x22u8; 32];
+    let (_keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    // Context's gate_ref is GATE, but we will key the binding under a DIFFERENT
+    // gate_ref. The store must reject it.
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+    let binding = AttestedGateBinding {
+        provider_id: ProviderId::Custodial,
+        context: ctx,
+        approved_tx_hash: hash,
+        decoded,
+        chain: ChainKeyId::new(DEV_TESTNET_CHAIN).expect("valid chain id in test"),
+        scope: owner_scope(),
+        schema_version: RenderingSchemaVersion::CURRENT,
+    };
+    let wrong_key = SigningGateRef::new("gate:some-other-gate");
+    let err = validate_binding(&wrong_key, &binding)
+        .expect_err("key/context gate_ref mismatch must be rejected");
+    assert_eq!(
+        err,
+        ironclaw_attested_runtime::BindingError::GateRefMismatch
+    );
+}
+
+#[tokio::test]
+async fn binding_write_rejects_chain_mismatch() {
+    use ironclaw_attested_runtime::AttestedGateBinding;
+
+    let priv_bytes = [0x23u8; 32];
+    let (_keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    // The decoded tx is on eip155:11155111 (testnet); bind a MAINNET chain. The
+    // store must reject this so a testnet/mainnet smuggle never persists.
+    let binding = AttestedGateBinding {
+        provider_id: ProviderId::Custodial,
+        context: ctx,
+        approved_tx_hash: hash,
+        decoded,
+        chain: ChainKeyId::new("eip155:1").expect("valid chain id in test"),
+        scope: owner_scope(),
+        schema_version: RenderingSchemaVersion::CURRENT,
+    };
+    let bindings = InMemoryAttestedGateBindingStore::new();
+    let err = bindings
+        .put(SigningGateRef::new(GATE), binding)
+        .await
+        .expect_err("chain mismatch must be rejected");
+    assert_eq!(err, ironclaw_attested_runtime::BindingError::ChainMismatch);
+}
+
+// ── External-wallet continuation path (drives `continue_external_wallet`) ──
+
+/// A mock external-wallet [`SigningProvider`] whose `verify_resume` outcome is
+/// configurable, so the driver's external-wallet continuation path can be
+/// exercised without a real wallet ceremony.
+mod ext_provider {
+    use super::*;
+    use async_trait::async_trait;
+    use ironclaw_signing_provider::{
+        DecodedTransaction, InitiationOutcome, RenderedTx, SigningProvider, SigningProviderError,
+        TrustModel, VerifiedProof,
+    };
+
+    pub struct MockExternalProvider {
+        pub id: ProviderId,
+        /// When `true`, `verify_resume` returns `Ok`; when `false` it rejects.
+        pub verifies: bool,
+    }
+
+    #[async_trait]
+    impl SigningProvider for MockExternalProvider {
+        fn provider_id(&self) -> ProviderId {
+            self.id
+        }
+        fn trust_model(&self) -> TrustModel {
+            TrustModel::ExternalWallet
+        }
+        async fn initiate(
+            &self,
+            _context: &SigningContext,
+            _decoded: &DecodedTransaction,
+            _rendered: &RenderedTx,
+            _approved_tx_hash: &ApprovedTxHash,
+        ) -> Result<InitiationOutcome, SigningProviderError> {
+            Ok(InitiationOutcome::AwaitingUserAction { directive: vec![] })
+        }
+        async fn verify_resume(
+            &self,
+            _context: &SigningContext,
+            approved_tx_hash: &ApprovedTxHash,
+            proof: &SigningProof,
+        ) -> Result<VerifiedProof, SigningProviderError> {
+            if self.verifies {
+                Ok(VerifiedProof::new(self, *approved_tx_hash, proof.clone()))
+            } else {
+                Err(SigningProviderError::ProofInvalid {
+                    reason: "mock external provider rejects".to_string(),
+                })
+            }
+        }
+    }
+}
+
+/// Build an external-wallet driver bound to `provider_id`, with a mock provider
+/// whose verification outcome is `verifies`. Returns the driver, the shared
+/// grant store, the ledger, and the recording broadcaster.
+async fn external_wallet_driver(
+    provider_id: ProviderId,
+    verifies: bool,
+) -> (
+    RecordingExternalDriver,
+    Arc<InMemoryAttestedGateBindingStore>,
+    Arc<InMemorySealedGrantStore>,
+    Arc<InMemorySigningLedger>,
+    Arc<recording::RecordingBroadcaster>,
+) {
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let broadcaster = Arc::new(recording::RecordingBroadcaster::default());
+
+    let registry =
+        ProviderRegistry::new().with_provider(Arc::new(ext_provider::MockExternalProvider {
+            id: provider_id,
+            verifies,
+        }));
+
+    // A custodial signer is still required by the driver constructor even though
+    // the external-wallet path never reaches it.
+    let crypto = SecretsCrypto::new(SecretString::from(MASTER_KEY.to_string())).unwrap();
+    let keystore = Arc::new(SecretsKeyStore::new(crypto));
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        Arc::clone(&bindings) as Arc<dyn AttestedGateBindingStore>,
+        registry,
+        signer,
+        Arc::clone(&ledger),
+        Arc::clone(&broadcaster),
+    );
+    (driver, bindings, grants, ledger, broadcaster)
+}
+
+type RecordingExternalDriver = AttestedSignerContinuationDriver<
+    recording::RecordingBroadcaster,
+    InMemorySigningLedger,
+    CustodialSigner<SecretsKeyStore, InMemorySealedGrantStore, InMemorySigningLedger>,
+>;
+
+async fn put_external_binding(
+    bindings: &InMemoryAttestedGateBindingStore,
+    provider_id: ProviderId,
+    ctx: &SigningContext,
+    decoded: DecodedTransaction,
+    hash: ApprovedTxHash,
+) {
+    bindings
+        .put(
+            SigningGateRef::new(GATE),
+            AttestedGateBinding {
+                provider_id,
+                context: ctx.clone(),
+                approved_tx_hash: hash,
+                decoded,
+                chain: ChainKeyId::new(DEV_TESTNET_CHAIN).expect("valid chain id in test"),
+                scope: owner_scope(),
+                schema_version: RenderingSchemaVersion::CURRENT,
+            },
+        )
+        .await
+        .expect("external binding insert succeeds");
+}
+
+/// Verify-before-resume: when the external-wallet provider REJECTS the proof,
+/// the ledger must NOT be stranded at `Signing`. Because the continuation is
+/// one-shot per gate_ref, a row left at the in-flight `Signing` state could
+/// never be re-entered and would be stuck permanently. The split driver
+/// verifies + claims the grant BEFORE creating the ledger row, so a rejected
+/// proof leaves NO ledger row at all (cleaner than a row stranded at any
+/// non-terminal state), and the broadcaster is never called. A follow-up VALID
+/// proof for the same gate is therefore still drivable.
+#[tokio::test]
+async fn external_wallet_verify_failure_does_not_strand_ledger_at_signing() {
+    let ctx = signing_context(&hex::encode([0x31u8; 20]));
+    let (_tx, decoded, hash) = sample_evm(&hex::encode([0x31u8; 20]));
+    let (driver, bindings, grants, ledger, broadcaster) =
+        external_wallet_driver(ProviderId::Injected, /* verifies */ false).await;
+    seal_grant(&grants, &ctx, hash).await;
+    put_external_binding(&bindings, ProviderId::Injected, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let proof = SigningProof::InjectedProof(vec![1, 2, 3]);
+    let err = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect_err("a rejected external-wallet proof must fail closed");
+    assert!(
+        matches!(err, ContinuationError::ProofRejected(_)),
+        "expected ProofRejected, got {err:?}"
+    );
+    // Verify-before-resume: a rejected proof must leave NO ledger row at all
+    // (the row is only created after verify + grant claim succeed), so it can
+    // never be stranded at an in-flight state.
+    assert_eq!(
+        ledger.state(&lk(&gate)).await,
+        Err(ironclaw_attestation::LedgerError::NotFound),
+        "rejected proof must not create a ledger row at all"
+    );
+    assert_eq!(broadcaster.count(), 0, "broadcaster must not be called");
+}
+
+/// The happy external-wallet path: a verifying provider advances the ledger
+/// through `Signing -> Signed` and broadcasts the wallet-signed bytes.
+#[tokio::test]
+async fn external_wallet_verify_success_signs_and_broadcasts() {
+    let ctx = signing_context(&hex::encode([0x32u8; 20]));
+    let (_tx, decoded, hash) = sample_evm(&hex::encode([0x32u8; 20]));
+    let (driver, bindings, grants, ledger, broadcaster) =
+        external_wallet_driver(ProviderId::Injected, /* verifies */ true).await;
+    seal_grant(&grants, &ctx, hash).await;
+    put_external_binding(&bindings, ProviderId::Injected, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let proof = SigningProof::InjectedProof(vec![9, 9, 9]);
+    let outcome = driver
+        .continue_after_resolved(&gate, &proof)
+        .await
+        .expect("verifying external-wallet proof must continue");
+    assert_eq!(outcome.ledger_state, SigningLedgerState::BroadcastSubmitted);
+    assert_eq!(broadcaster.count(), 1);
+    assert_eq!(
+        ledger.state(&lk(&gate)).await.unwrap(),
+        SigningLedgerState::BroadcastSubmitted
+    );
+}
+
+/// A resolved gate bound to a provider that is NOT registered fails closed with
+/// `ProviderMismatch` BEFORE the ledger advances past `Approved`.
+#[tokio::test]
+async fn external_wallet_unregistered_provider_is_provider_mismatch() {
+    let ctx = signing_context(&hex::encode([0x33u8; 20]));
+    let (_tx, decoded, hash) = sample_evm(&hex::encode([0x33u8; 20]));
+    // Register Injected, but bind WalletConnect -> mismatch.
+    let (driver, bindings, grants, ledger, broadcaster) =
+        external_wallet_driver(ProviderId::Injected, true).await;
+    seal_grant(&grants, &ctx, hash).await;
+    put_external_binding(&bindings, ProviderId::WalletConnect, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let err = driver
+        .continue_after_resolved(&gate, &SigningProof::InjectedProof(vec![]))
+        .await
+        .expect_err("unregistered provider must fail closed");
+    assert!(
+        matches!(err, ContinuationError::ProviderMismatch { .. }),
+        "expected ProviderMismatch, got {err:?}"
+    );
+    // Verify-before-resume: a provider mismatch is detected before any ledger
+    // row is created, so no row exists.
+    assert_eq!(
+        ledger.state(&lk(&gate)).await,
+        Err(ironclaw_attestation::LedgerError::NotFound),
+        "provider mismatch must not create a ledger row"
+    );
+    assert_eq!(broadcaster.count(), 0);
+}
+
+// ── Tests/Medium: driver-level BindingChainMismatch re-check ──────────────
+
+/// The custodial continuation re-checks that the binding's authoritative chain
+/// matches the chain its OWN decoded tx encodes (testnet-chain / mainnet-tx
+/// smuggle defense). A divergence fails closed with `BindingChainMismatch`. We
+/// drive this through a store mock that returns a binding whose `chain` differs
+/// from its decoded tx's network (the validated store would never persist one).
+#[tokio::test]
+async fn driver_rejects_binding_chain_mismatch() {
+    use async_trait::async_trait;
+
+    struct ChainMismatchStore(AttestedGateBinding);
+    #[async_trait]
+    impl AttestedGateBindingStore for ChainMismatchStore {
+        async fn put(
+            &self,
+            _gate_ref: SigningGateRef,
+            _binding: AttestedGateBinding,
+        ) -> Result<(), ironclaw_attested_runtime::BindingError> {
+            Ok(())
+        }
+        async fn get(&self, _gate_ref: &SigningGateRef) -> Option<AttestedGateBinding> {
+            Some(self.0.clone())
+        }
+    }
+
+    let priv_bytes = [0x41u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account); // decoded encodes eip155:11155111
+
+    // Binding's authoritative chain is MAINNET while the decoded tx is testnet:
+    // the driver's pre-flight network identity check must reject this. The hash
+    // is recomputed from `decoded`, so we keep it consistent with `decoded`.
+    let mismatched = AttestedGateBinding {
+        provider_id: ProviderId::Custodial,
+        context: ctx.clone(),
+        approved_tx_hash: hash,
+        decoded,
+        chain: ChainKeyId::new("eip155:1").expect("valid chain id in test"),
+        scope: owner_scope(),
+        schema_version: RenderingSchemaVersion::CURRENT,
+    };
+    let store: Arc<dyn AttestedGateBindingStore> = Arc::new(ChainMismatchStore(mismatched));
+
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    seal_grant(&grants, &ctx, hash).await;
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        store,
+        ProviderRegistry::new(),
+        signer,
+        ledger,
+        Arc::new(ironclaw_reborn_noop::NoopBroadcaster),
+    );
+
+    let gate = SigningGateRef::new(GATE);
+    let err = driver
+        .continue_after_resolved(&gate, &SigningProof::WebAuthnAssertionProof(vec![]))
+        .await
+        .expect_err("driver must reject a binding whose chain diverges from its decoded tx");
+    assert!(
+        matches!(err, ContinuationError::BindingChainMismatch),
+        "expected BindingChainMismatch, got {err:?}"
+    );
+}
+
+// ── Tests/Medium: contradictory broadcaster behavior paths ────────────────
+
+/// A broadcaster that declares `submits() == false` (dry-run) but reports a real
+/// `Submitted` outcome is contradictory and must fail closed rather than report
+/// a false broadcast.
+#[tokio::test]
+async fn non_submitting_broadcaster_reporting_submit_fails_closed() {
+    use async_trait::async_trait;
+
+    struct LyingDryRunBroadcaster;
+    #[async_trait]
+    impl ironclaw_attested_runtime::Broadcaster for LyingDryRunBroadcaster {
+        fn submits(&self) -> bool {
+            false
+        }
+        async fn broadcast(
+            &self,
+            _context: &SigningContext,
+            _signed: &[u8],
+        ) -> Result<ironclaw_attested_runtime::BroadcastOutcome, ContinuationError> {
+            Ok(ironclaw_attested_runtime::BroadcastOutcome::Submitted {
+                tx_id: "phantom".to_string(),
+            })
+        }
+    }
+
+    let priv_bytes = [0x42u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        Arc::clone(&bindings) as Arc<dyn AttestedGateBindingStore>,
+        ProviderRegistry::new(),
+        signer,
+        Arc::clone(&ledger),
+        Arc::new(LyingDryRunBroadcaster),
+    );
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let err = driver
+        .continue_after_resolved(&gate, &SigningProof::WebAuthnAssertionProof(vec![]))
+        .await
+        .expect_err("a non-submitting broadcaster that reports a submit is contradictory");
+    assert!(
+        matches!(err, ContinuationError::Broadcast { .. }),
+        "expected Broadcast error, got {err:?}"
+    );
+}
+
+/// A broadcaster that declares `submits() == true` but returns `NotBroadcast` is
+/// contradictory: we cannot trust the tx did NOT go out, so the row moves to the
+/// `Unknown` terminal (recovery) and a `Broadcast` error is surfaced.
+#[tokio::test]
+async fn submitting_broadcaster_returns_not_broadcast_unknown() {
+    use async_trait::async_trait;
+
+    struct ContradictorySubmitter;
+    #[async_trait]
+    impl ironclaw_attested_runtime::Broadcaster for ContradictorySubmitter {
+        fn submits(&self) -> bool {
+            true
+        }
+        async fn broadcast(
+            &self,
+            _context: &SigningContext,
+            _signed: &[u8],
+        ) -> Result<ironclaw_attested_runtime::BroadcastOutcome, ContinuationError> {
+            Ok(ironclaw_attested_runtime::BroadcastOutcome::NotBroadcast {
+                reason: "claims it submits but did not".to_string(),
+            })
+        }
+    }
+
+    let priv_bytes = [0x43u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let ctx = signing_context(&account);
+    let (_tx, decoded, hash) = sample_evm(&account);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+    let signer = Arc::new(CustodialSigner::new(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ship_gate,
+        Arc::new(DenyFirstCustodyPolicy),
+    ));
+    let driver = AttestedSignerContinuationDriver::new(
+        Arc::clone(&bindings) as Arc<dyn AttestedGateBindingStore>,
+        ProviderRegistry::new(),
+        signer,
+        Arc::clone(&ledger),
+        Arc::new(ContradictorySubmitter),
+    );
+    seal_grant(&grants, &ctx, hash).await;
+    put_binding(&bindings, &ctx, decoded, hash).await;
+
+    let gate = SigningGateRef::new(GATE);
+    let err = driver
+        .continue_after_resolved(&gate, &SigningProof::WebAuthnAssertionProof(vec![]))
+        .await
+        .expect_err("a submitting broadcaster returning NotBroadcast is contradictory");
+    assert!(
+        matches!(err, ContinuationError::Broadcast { .. }),
+        "expected Broadcast error, got {err:?}"
+    );
+    // The row moved to the Unknown terminal for out-of-band recovery.
+    let state = ledger.state(&lk(&gate)).await.unwrap();
+    assert_eq!(state, SigningLedgerState::Unknown);
+    assert!(state.is_terminal());
+}

--- a/crates/ironclaw_product/src/attested_continuation.rs
+++ b/crates/ironclaw_product/src/attested_continuation.rs
@@ -1,0 +1,220 @@
+//! Crypto-free attested-signing continuation port for the WebUI facade
+//! (attested-signing PR11).
+//!
+//! `ironclaw_product` is a product-facing facade crate that must stay
+//! crypto-free: it never names a chain SDK, a signing provider, a sealed grant,
+//! or a broadcast ledger. But the WebUI `resolve_gate` path needs to drive the
+//! deterministic sign + broadcast continuation once a `BlockedAttested` gate has
+//! been resolved to `AttestedResolved`.
+//!
+//! The bridge is this injected port. The facade (atomic verify-before-resume,
+//! PR11 item B):
+//!
+//! 1. Translates the browser-supplied attested-proof resolution into an opaque
+//!    [`AttestedProofClaim`] (all fields are strings / JSON — no crypto types).
+//! 2. Calls [`AttestedGateContinuationPort::verify_and_claim`] BEFORE touching
+//!    the turn store. This runs the FULL cryptographic verification (real
+//!    signature recovery / WebAuthn assertion) AND claims the one-shot sealed
+//!    grant. On ANY failure the turn is left `BlockedAttested` with zero
+//!    state-machine mutation — the facade never calls `resume_turn`.
+//! 3. Only on success, builds a `ResumeTurnRequest { attestation: Some(..) }`
+//!    whose [`ironclaw_turns::AttestationClaimRef`] is the proof's bound-hash
+//!    claim, and calls `resume_turn`. The injected `AttestedResumePort` (wired
+//!    in the composition layer, outside `src/`) runs the synchronous binding
+//!    re-check + one-shot resume guard (defense in depth — it does NOT re-claim)
+//!    and transitions the turn to `AttestedResolved`.
+//! 4. Calls [`AttestedGateContinuationPort::broadcast_resolved`] with the
+//!    [`VerifiedAttestedContinuation`] handle from step 2 to drive the
+//!    sign-output broadcast. No re-verification, no re-claim.
+//!
+//! The production implementation lives in `ironclaw_reborn_composition` over
+//! `ironclaw_attested_runtime`'s driver; this crate declares only the
+//! crypto-free contract and the opaque DTOs/handle. Mirrors how the turn store
+//! already takes an injected `AttestedResumePort`.
+
+use std::any::Any;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use ironclaw_turns::{GateRef, TurnActor, TurnRunId, TurnScope};
+
+/// The proof family carried on an attested gate resolution. Mirrors the legacy
+/// monolith `GateResolutionPayload` variants for wire compatibility; the
+/// composition-layer port maps each kind onto the matching
+/// `ironclaw_signing_provider::SigningProof` it knows how to verify.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttestedProofKind {
+    /// Browser injected wallet (`window.ethereum` / `window.solana`).
+    InjectedWallet,
+    /// NEAR wallet redirect callback proof.
+    NearRedirect,
+    /// WalletConnect v2 session proof.
+    WalletConnect,
+}
+
+impl AttestedProofKind {
+    /// Sanitized, snake_case category for diagnostics and error mapping.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InjectedWallet => "injected_wallet",
+            Self::NearRedirect => "near_redirect",
+            Self::WalletConnect => "wallet_connect",
+        }
+    }
+}
+
+/// The opaque attested-proof claim the facade forwards to the continuation port.
+///
+/// Every field is a string or JSON value: this crate confers no trust and holds
+/// no crypto type. The composition-layer port re-decodes `proof_json` into the
+/// concrete provider proof and verifies it against the authoritative gate
+/// binding (which it persisted when the gate was raised — never trusting these
+/// caller-supplied fields to *define* the binding, only to attest to it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttestedProofClaim {
+    /// Which proof family this claim belongs to.
+    pub kind: AttestedProofKind,
+    /// Lowercase-hex of the approved-tx hash the wallet attests to. This becomes
+    /// the `AttestationClaimRef` on the resume request, so the synchronous
+    /// resume-port binding re-check can reject a claim that does not even name
+    /// the bound hash before any async verification runs.
+    pub approved_tx_hash_hex: String,
+    /// The opaque, provider-specific proof payload (signature, signer, scheme,
+    /// public key, scope, state echo, …). Re-decoded by the port; never
+    /// interpreted here.
+    pub proof_json: serde_json::Value,
+}
+
+/// Sanitized outcome of a continuation. Carries no chain, signer, or ledger
+/// internals beyond the public broadcast attribution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttestedContinuationOutcome {
+    /// Public signer/account the broadcast was attributed to.
+    pub signer: String,
+}
+
+/// Sanitized rejection taxonomy for an attested continuation. Mirrors the
+/// crypto-free spirit of [`ironclaw_turns::AttestedResumeRejection`]: categories
+/// only, no ceremony detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AttestedContinuationRejection {
+    /// No authoritative binding exists for the resolved gate (it was never
+    /// raised, or the binding store lost it).
+    MissingBinding,
+    /// The proof family or its provider did not match the bound provider.
+    ProviderMismatch,
+    /// The provider rejected the proof (signer/hash mismatch, grant-claim
+    /// failure, scope violation), or the custodial signer failed.
+    ProofRejected,
+    /// A broadcast-idempotency / ledger guard refused the transition (e.g. the
+    /// gate was already broadcast).
+    LedgerGuard,
+    /// The proof payload was malformed and could not be decoded.
+    MalformedProof,
+    /// The continuation port is not wired on this deployment.
+    Unavailable,
+}
+
+impl AttestedContinuationRejection {
+    /// Sanitized, snake_case category for diagnostics and error mapping.
+    pub fn category(&self) -> &'static str {
+        match self {
+            Self::MissingBinding => "attested_missing_binding",
+            Self::ProviderMismatch => "attested_provider_mismatch",
+            Self::ProofRejected => "attested_proof_rejected",
+            Self::LedgerGuard => "attested_ledger_guard",
+            Self::MalformedProof => "attested_malformed_proof",
+            Self::Unavailable => "attested_unavailable",
+        }
+    }
+}
+
+/// Opaque, crypto-free handle proving that [`AttestedGateContinuationPort::verify_and_claim`]
+/// ran successfully: the proof's full signature was verified and the one-shot
+/// sealed grant was claimed. The facade holds it between `verify_and_claim` and
+/// [`AttestedGateContinuationPort::broadcast_resolved`] without inspecting it —
+/// the composition-layer implementation downcasts it back to its concrete
+/// verified-continuation type. This crate confers no trust and names no crypto
+/// type; the handle is just an opaque token.
+pub struct VerifiedAttestedContinuation {
+    inner: Box<dyn Any + Send>,
+}
+
+impl VerifiedAttestedContinuation {
+    /// Wrap a composition-layer verified continuation as an opaque handle.
+    pub fn new<T: Any + Send>(inner: T) -> Self {
+        Self {
+            inner: Box::new(inner),
+        }
+    }
+
+    /// Recover the concrete verified continuation. Returns the boxed value back
+    /// on a type mismatch so the caller can fail closed rather than panic.
+    pub fn downcast<T: Any + Send>(self) -> Result<Box<T>, VerifiedAttestedContinuation> {
+        match self.inner.downcast::<T>() {
+            Ok(value) => Ok(value),
+            Err(inner) => Err(Self { inner }),
+        }
+    }
+}
+
+impl std::fmt::Debug for VerifiedAttestedContinuation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VerifiedAttestedContinuation").finish()
+    }
+}
+
+/// Injected, crypto-free continuation port for attested-signing gate resolution.
+///
+/// Implementations live outside this crate (composition / reborn layer). The
+/// facade (atomic verify-before-resume, PR11 item B) calls
+/// [`Self::verify_and_claim`] BEFORE `resume_turn` and
+/// [`Self::broadcast_resolved`] AFTER. The full cryptographic verification and
+/// the one-shot sealed-grant claim run in `verify_and_claim`, so they gate the
+/// `BlockedAttested -> AttestedResolved` transition; the broadcast half never
+/// re-verifies or re-claims.
+#[async_trait]
+pub trait AttestedGateContinuationPort: Send + Sync {
+    /// Run the FULL cryptographic verification (real signature recovery /
+    /// WebAuthn assertion) AND claim the one-shot sealed grant for the resolved
+    /// gate — all BEFORE the turn transitions. On success returns an opaque
+    /// [`VerifiedAttestedContinuation`] handle the facade passes back to
+    /// [`Self::broadcast_resolved`] after `resume_turn`.
+    ///
+    /// On ANY failure (malformed/forged proof, signer/hash mismatch, provider
+    /// mismatch, grant already claimed, missing binding) it returns a sanitized
+    /// rejection and MUST leave the turn `BlockedAttested` with NO
+    /// run/mission/gate state-machine mutation: the facade never calls
+    /// `resume_turn` for a claim that fails here. (A failed claim may have
+    /// advanced the implementation's own ledger/grant fail-closed state; that is
+    /// internal one-shot bookkeeping, never a turn-state transition, and means a
+    /// retry of the same gate is refused rather than double-driven.)
+    /// `actor` carries the calling user identity; the implementation MUST
+    /// verify the addressed gate binding is owned by `(scope.tenant_id,
+    /// actor.user_id)` before any cryptographic work, failing closed
+    /// indistinguishably from a missing binding so a member who merely learns
+    /// another user's `gate_ref` cannot drive that user's signing continuation
+    /// (IDOR defense).
+    async fn verify_and_claim(
+        &self,
+        scope: &TurnScope,
+        actor: &TurnActor,
+        run_id: TurnRunId,
+        gate_ref: &GateRef,
+        claim: &AttestedProofClaim,
+    ) -> Result<VerifiedAttestedContinuation, AttestedContinuationRejection>;
+
+    /// Drive the sign-output broadcast for a gate whose proof was already
+    /// verified + grant-claimed in [`Self::verify_and_claim`]. Consumes the
+    /// opaque handle; performs NO re-verification and NO re-claim.
+    async fn broadcast_resolved(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        gate_ref: &GateRef,
+        verified: VerifiedAttestedContinuation,
+    ) -> Result<AttestedContinuationOutcome, AttestedContinuationRejection>;
+}

--- a/crates/ironclaw_product/src/lib.rs
+++ b/crates/ironclaw_product/src/lib.rs
@@ -28,6 +28,7 @@ mod action;
 pub mod adapter_registry;
 mod approval_interaction;
 mod approval_prompt;
+mod attested_continuation;
 mod auth_continuation;
 mod auth_interaction;
 mod auth_prompt;
@@ -76,6 +77,10 @@ pub use approval_interaction::{
 pub use approval_prompt::{
     ApprovalPromptLookup, ApprovalPromptLookupError, approval_prompt_context_view,
     approval_prompt_lookup,
+};
+pub use attested_continuation::{
+    AttestedContinuationOutcome, AttestedContinuationRejection, AttestedGateContinuationPort,
+    AttestedProofClaim, AttestedProofKind, VerifiedAttestedContinuation,
 };
 /// Concrete turn-gate resume dispatcher used by the Reborn composition crate to
 /// bridge product-auth continuations into the workflow-owned turn boundary.

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -99,6 +99,14 @@ nix = { version = "0.30", default-features = false, features = ["process"] }
 # `ironclaw_webui`; no longer a composition dependency.
 libsql = { version = "0.9", default-features = false, features = ["core", "replication", "remote", "tls"] }
 libc = "0.2"
+ironclaw_attested_runtime = { path = "../ironclaw_attested_runtime" }
+ironclaw_attestation = { path = "../ironclaw_attestation" }
+ironclaw_chain_signing = { path = "../ironclaw_chain_signing" }
+ironclaw_signing_provider = { path = "../ironclaw_signing_provider" }
+# External-wallet providers (PR7/8/9): the composition decodes the WebUI
+# attested-proof payload into the concrete provider proof and registers the
+# providers that verify it on the signer-continuation driver (PR11).
+ironclaw_wallet_external = { path = "../ironclaw_wallet_external" }
 # axum + tower middleware stack used by the `webui_serve` module. Each
 # entry is feature-gated so non-beta builds carry no HTTP surface code.
 axum = { version = "0.8" }
@@ -124,6 +132,17 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+# Crypto-real injected-wallet proof construction for the PR11 attested
+# gate/resolve end-to-end facade test (ed25519 Solana signature over the hash).
+ed25519-dalek = "2"
+
+# Attested-signing composition e2e test (real RebornAttestedComposition): derive
+# a bound EVM signer + proof. alloy/k256 are already in-tree via chain_signing.
+ironclaw_attestation = { path = "../ironclaw_attestation" }
+ironclaw_chain_signing = { path = "../ironclaw_chain_signing" }
+alloy-consensus = "1"
+alloy-primitives = "1"
+k256 = { version = "0.13", features = ["ecdsa"] }
 ironclaw_extension_host = { path = "../ironclaw_extension_host", features = ["test-support"] }
 # DEL-7: composition no longer links first-party extensions in production; the
 # binary injects them as neutral data. The dev-dependency stays so the crate's
@@ -190,6 +209,13 @@ name = "production_runtime_automations"
 
 [[test]]
 name = "resource_governor_libsql_contract"
+
+[build-dependencies]
+ironclaw_skills = { path = "../ironclaw_skills" }
+serde_json = "1"
+ironclaw_chain_signing = { path = "../ironclaw_chain_signing" }
+ironclaw_attestation = { path = "../ironclaw_attestation" }
+ironclaw_signing_provider = { path = "../ironclaw_signing_provider" }
 
 [lints]
 workspace = true

--- a/crates/ironclaw_reborn_composition/src/attested.rs
+++ b/crates/ironclaw_reborn_composition/src/attested.rs
@@ -1,0 +1,449 @@
+//! Attested-signing signer-continuation wiring for the reborn runtime (PR10).
+//!
+//! This is the composition seam that turns an `AttestedResolved` turn into a
+//! real, ledger-guarded sign + broadcast. It assembles the
+//! [`AttestedSignerContinuationDriver`] from the in-memory substrate stores
+//! (gate bindings shared with the resume port, sealed grants, broadcast ledger)
+//! and the external-wallet provider registry.
+//!
+//! The driver is constructed here rather than buried in the giant
+//! `RebornRuntime` struct so the runtime does not have to name the custodial
+//! signer's concrete keystore/grant/ledger generic parameters. PR11's web
+//! ingress (`/api/chat/gate/resolve`) calls
+//! [`RebornAttestedComposition::driver`] to continue a resolved gate; this
+//! module owns the deny-first default policy and the in-memory stores (durable
+//! backends are PR12).
+//!
+//! Why in-memory only: the prompt for this slice mandates the existing
+//! in-memory stores and explicitly defers durable PG/libSQL backends to PR12,
+//! so no single-backend persistence feature is introduced here (dual-backend
+//! rule).
+
+use std::sync::Arc;
+
+use ironclaw_attestation::{
+    AttestedSigningGrant, GrantError, GrantKey, InMemorySealedGrantStore, InMemorySigningLedger,
+    SealedGrantStore,
+};
+use ironclaw_attested_runtime::{
+    AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver, BindingError,
+    BroadcastOutcome, Broadcaster, ContinuationError, InMemoryAttestedGateBindingStore,
+    ProviderRegistry,
+};
+use ironclaw_chain_signing::{CustodialSigner, DenyFirstCustodyPolicy, SecretsKeyStore, ShipGate};
+use ironclaw_signing_provider::{GateRef, SigningContext};
+
+/// Error from [`RebornAttestedComposition::register_attested_gate`]. Distinct
+/// from [`ironclaw_attestation::GrantError`] so the gate-raise caller can tell
+/// a hardening rejection (mismatched gate_ref / duplicate raise) apart from a
+/// grant-store / binding-store backend failure.
+#[derive(Debug)]
+pub enum RegisterAttestedGateError {
+    /// The supplied `gate_ref` did not equal `binding.context.gate_ref`.
+    GateRefMismatch,
+    /// A binding (or sealed grant) already exists for this gate: registration is
+    /// insert-only and the first raise wins.
+    DuplicateBinding,
+    /// The underlying sealed-grant store failed.
+    Grant(GrantError),
+    /// The binding store rejected or could not record the binding (validation
+    /// failure or backend error). Fail closed — the gate is not registered.
+    BindingStore(BindingError),
+}
+
+impl std::fmt::Display for RegisterAttestedGateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GateRefMismatch => {
+                write!(f, "gate_ref does not match binding.context.gate_ref")
+            }
+            Self::DuplicateBinding => {
+                write!(f, "attested gate already registered (insert-only)")
+            }
+            Self::Grant(e) => write!(f, "sealed-grant store failed: {e}"),
+            Self::BindingStore(e) => write!(f, "binding store failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for RegisterAttestedGateError {}
+
+/// The concrete custodial signer type this composition assembles, with its
+/// generic parameters pinned here so the rest of the runtime never names them.
+///
+/// Named for the STORES it pins, not for a deployment mode: `LocalDev*` type
+/// names are banned by the typename ratchet because a deployment mode is a
+/// `DeploymentConfig` value, never a type. In-memory stores are also the
+/// accurate distinction — a durable composition differs by its stores, not by
+/// which environment happens to run it.
+pub(crate) type InMemoryCustodialSigner =
+    CustodialSigner<SecretsKeyStore, InMemorySealedGrantStore, InMemorySigningLedger>;
+
+/// The concrete driver type this composition assembles; see the signer
+/// alias above for why it is named for its stores.
+pub(crate) type InMemoryContinuationDriver = AttestedSignerContinuationDriver<
+    NoopBroadcaster,
+    InMemorySigningLedger,
+    InMemoryCustodialSigner,
+>;
+
+/// A dry-run broadcaster that records intent but performs NO network I/O and,
+/// critically, NEVER advances the ledger to `BroadcastSubmitted`.
+///
+/// It reports [`Broadcaster::submits`] == `false`, so the driver leaves the
+/// ledger at `Signed` and surfaces a
+/// [`ironclaw_attested_runtime::BroadcastDisposition::NotBroadcast`] outcome —
+/// the local-dev path can never be mislabeled as a real broadcast. A real
+/// per-chain broadcaster (PR12 / production) reports `submits() == true` and
+/// returns [`BroadcastOutcome::Submitted`].
+///
+/// # PRODUCTION WARNING
+///
+/// This broadcaster intentionally NEVER submits. It exists for local-dev /
+/// test wiring ONLY. Do NOT wire it into a production composition: a real
+/// deployment MUST inject a per-chain broadcaster whose `submits()` returns
+/// `true`. The `submits() -> false` contract is the compile-independent
+/// guard — the driver leaves the ledger at `Signed` and reports `NotBroadcast`
+/// rather than a false success — but a silent mis-wire here would mean
+/// transactions are signed and never broadcast. PR13/PR14 production wiring
+/// must select the real broadcaster, not this one.
+#[derive(Debug, Default)]
+pub struct NoopBroadcaster;
+
+#[async_trait::async_trait]
+impl Broadcaster for NoopBroadcaster {
+    fn submits(&self) -> bool {
+        false
+    }
+
+    async fn broadcast(
+        &self,
+        _context: &SigningContext,
+        _signed: &[u8],
+    ) -> Result<BroadcastOutcome, ContinuationError> {
+        // Deliberately does not submit. The driver will NOT advance the ledger
+        // to BroadcastSubmitted for a NotBroadcast outcome.
+        Ok(BroadcastOutcome::NotBroadcast {
+            reason: "local-dev noop broadcaster: signed but not submitted".to_string(),
+        })
+    }
+}
+
+/// Bundles the attested-signing composition the reborn runtime exposes to the
+/// PR11 ingress: the shared binding store, the shared sealed-grant store (so
+/// external-wallet providers can be registered against the SAME one-shot CAS
+/// the driver uses), and the assembled continuation driver.
+pub struct RebornAttestedComposition {
+    bindings: Arc<InMemoryAttestedGateBindingStore>,
+    grants: Arc<InMemorySealedGrantStore>,
+    driver: Arc<InMemoryContinuationDriver>,
+}
+
+impl RebornAttestedComposition {
+    /// Assemble the composition for local-dev from the gate-binding store the
+    /// resume port already shares, a custodial keystore, the operator
+    /// ship-gate, and the shared sealed-grant store.
+    ///
+    /// `build_providers` is the **provider-registration seam**: it is handed the
+    /// shared sealed-grant store and returns the external-wallet
+    /// [`ProviderRegistry`] to wire into the driver. Building the registry here
+    /// — BEFORE the driver is constructed, over the exact `grants` the custodial
+    /// signer also uses — guarantees the one-shot CAS (threat #1) is
+    /// authoritative across BOTH the custodial signer and every external-wallet
+    /// provider, so external-wallet continuations cannot fail `ProviderMismatch`
+    /// and cannot claim a grant out of a different store. PR13's
+    /// `AttestedProvidersConfig` / provider registration layers cleanly on top:
+    /// it implements `build_providers` to register WalletConnect / Injected /
+    /// NEAR providers over this shared store.
+    pub fn new(
+        bindings: Arc<InMemoryAttestedGateBindingStore>,
+        keystore: Arc<SecretsKeyStore>,
+        ship_gate: ShipGate,
+        grants: Arc<InMemorySealedGrantStore>,
+        build_providers: impl FnOnce(&Arc<InMemorySealedGrantStore>) -> ProviderRegistry,
+    ) -> Self {
+        let providers = build_providers(&grants);
+        let ledger = Arc::new(InMemorySigningLedger::new());
+        let custodial_signer = Arc::new(CustodialSigner::new(
+            keystore,
+            Arc::clone(&grants),
+            Arc::clone(&ledger),
+            ship_gate,
+            Arc::new(DenyFirstCustodyPolicy),
+        ));
+        let driver = Arc::new(AttestedSignerContinuationDriver::new(
+            Arc::clone(&bindings) as Arc<dyn ironclaw_attested_runtime::AttestedGateBindingStore>,
+            providers,
+            custodial_signer,
+            ledger,
+            Arc::new(NoopBroadcaster),
+        ));
+        Self {
+            bindings,
+            grants,
+            driver,
+        }
+    }
+
+    /// Register an attested gate: seal its one-shot grant and persist its
+    /// authoritative binding. This is the PR11 ingress entry point invoked when
+    /// a gate is raised.
+    ///
+    /// In-memory only (PR11); durable PG / libSQL backends are PR12.
+    ///
+    /// Hardening invariants enforced here:
+    /// - The supplied `gate_ref` MUST equal `binding.context.gate_ref`. A
+    ///   mismatch would let the binding be filed under a key that names a
+    ///   different gate than the one the authoritative context describes — the
+    ///   resume port and driver both look the binding up by `gate_ref`, so a
+    ///   mismatch is a binding-confusion vector. Fail closed.
+    /// - Registration is INSERT-ONLY: an existing binding for the same gate
+    ///   (request id) is never overwritten. The first raise wins; a second raise
+    ///   for the same gate is refused so an attacker cannot redefine the
+    ///   authoritative `(hash, signer, decoded tx)` after the fact (threats
+    ///   #2/#3/#4). The grant seal is likewise one-shot.
+    pub async fn register_attested_gate(
+        &self,
+        gate_ref: GateRef,
+        binding: AttestedGateBinding,
+        created_at_ms: i64,
+        expiry_ms: Option<i64>,
+    ) -> Result<(), RegisterAttestedGateError> {
+        // gate_ref must match the authoritative context's gate_ref.
+        if binding.context.gate_ref.as_str() != gate_ref.as_str() {
+            return Err(RegisterAttestedGateError::GateRefMismatch);
+        }
+
+        // Seal the one-shot grant first. The seal is an atomic CAS
+        // (`AlreadySealed` on a second seal of the same key), so it is the gate
+        // that serializes concurrent raises of the same gate: at most one caller
+        // wins the seal and reaches the binding insert below. A duplicate seal
+        // means the gate was already raised; surface it as a duplicate rather
+        // than proceeding to (re)write the binding.
+        let grant_key = GrantKey::from_context(&binding.context, binding.approved_tx_hash);
+        match self
+            .grants
+            .seal(
+                AttestedSigningGrant::new(grant_key, created_at_ms, expiry_ms)
+                    .map_err(RegisterAttestedGateError::Grant)?,
+            )
+            .await
+        {
+            Ok(()) => {}
+            Err(GrantError::AlreadySealed) => {
+                return Err(RegisterAttestedGateError::DuplicateBinding);
+            }
+            Err(other) => return Err(RegisterAttestedGateError::Grant(other)),
+        }
+
+        // Insert-only, ATOMIC + VALIDATED: the store's `put` is insert-only (the
+        // existence check and the insert happen under a single critical section,
+        // closing the check-then-act TOCTOU window) and fully validates the
+        // binding (`gate_ref`/hash/chain/signer self-consistency) before
+        // persisting. An existing binding for this gate fails closed with
+        // `AlreadyExists` — treat it as a duplicate, consistent with the grant
+        // CAS above; any other validation/backend error fails closed too.
+        match self.bindings.put(gate_ref, binding).await {
+            Ok(()) => Ok(()),
+            Err(BindingError::AlreadyExists) => Err(RegisterAttestedGateError::DuplicateBinding),
+            Err(other) => Err(RegisterAttestedGateError::BindingStore(other)),
+        }
+    }
+
+    /// The authoritative gate-binding store. The PR11 ingress persists a
+    /// binding here when it raises an attested gate, and the driver reads it
+    /// back on continuation.
+    pub fn bindings(&self) -> &Arc<InMemoryAttestedGateBindingStore> {
+        &self.bindings
+    }
+
+    /// The shared sealed-grant store. Exposed so downstream provider
+    /// registration (PR13) can build providers that claim grants out of the
+    /// exact same store the driver's custodial signer uses (shared one-shot CAS,
+    /// threat #1).
+    pub fn grants(&self) -> &Arc<InMemorySealedGrantStore> {
+        &self.grants
+    }
+
+    /// The assembled signer-continuation driver dispatched when a turn reaches
+    /// `AttestedResolved`.
+    pub fn driver(&self) -> &Arc<InMemoryContinuationDriver> {
+        &self.driver
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use alloy_consensus::TxEip1559;
+    use alloy_primitives::{Address, Bytes, TxKind, U256};
+    use ironclaw_attestation::{
+        AttestedSigningGrant, DecodedTransaction, GrantKey, RenderingSchemaVersion,
+        SealedGrantStore,
+    };
+    use ironclaw_attested_runtime::{
+        AttestedGateBinding, AttestedGateBindingStore, BroadcastDisposition, ContinuationError,
+        CustodialMainnetShipGate,
+    };
+    use ironclaw_chain_signing::{ChainKeyBinding, ChainKeyId, KeyStore, evm};
+    use ironclaw_host_api::{InvocationId, ProjectId, ResourceScope, TenantId, UserId};
+    use ironclaw_secrets::SecretsCrypto;
+    use ironclaw_signing_provider::{
+        ActorId, ChainId, GateRef, KeyOrAccountId, ProviderId, RunId, ScopeId, SigningContext,
+        SigningProof, TenantId as SigningTenantId, UserId as SigningUserId,
+    };
+    use secrecy::SecretString;
+
+    const GATE: &str = "gate:reborn-attested-e2e";
+    const TESTNET: &str = "eip155:11155111";
+
+    /// End-to-end test driving the REAL `RebornAttestedComposition` (not a
+    /// hand-assembled driver): a custodial continuation signs the tx rebuilt
+    /// from the authoritative binding and, because local-dev wires the dry-run
+    /// `NoopBroadcaster`, reports `NotBroadcast` with the ledger left at
+    /// `Signed` — never a false `BroadcastSubmitted`. A replay then fails closed.
+    #[tokio::test]
+    async fn reborn_composition_signs_and_does_not_falsely_broadcast() {
+        // Custodial keystore with a bound EVM key.
+        let crypto = SecretsCrypto::new(SecretString::from(
+            "0123456789abcdef0123456789ABCDEF".to_string(),
+        ))
+        .unwrap();
+        let keystore = Arc::new(SecretsKeyStore::new(crypto));
+        let priv_bytes = [0x31u8; 32];
+        let key = k256::ecdsa::SigningKey::from_slice(&priv_bytes).unwrap();
+        let addr_hex = hex::encode(evm::address_of(&key).as_slice());
+        let scope = ResourceScope {
+            tenant_id: TenantId::new("default").unwrap(),
+            user_id: UserId::new("alice").unwrap(),
+            agent_id: None,
+            project_id: Some(ProjectId::new("bootstrap").unwrap()),
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        };
+        keystore
+            .bind(
+                &scope,
+                ChainKeyBinding {
+                    chain: ChainKeyId::new(TESTNET).expect("valid chain id in test"),
+                    public_address_hex: addr_hex.clone(),
+                    evm_chain_id: Some(11155111),
+                    derivation_path: "m/44'/60'/0'/0/0".to_string(),
+                    kms_key_ref: None,
+                },
+                priv_bytes.to_vec(),
+            )
+            .await
+            .unwrap();
+
+        let tx = TxEip1559 {
+            chain_id: 11155111,
+            nonce: 1,
+            gas_limit: 21_000,
+            max_fee_per_gas: 30_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            to: TxKind::Call(Address::repeat_byte(0x11)),
+            value: U256::from(5u64),
+            input: Bytes::new(),
+            access_list: Default::default(),
+        };
+        let decoded: DecodedTransaction = evm::decode_eip1559(&tx);
+        // Fold in the SAME gate-bound signer the SigningContext below carries
+        // (`addr_hex`) — WYSIWYS — so the driver's resume-time recompute (which
+        // reads `binding.context.key_or_account_id`) reproduces this hash.
+        let hash = ironclaw_chain_signing::recompute_approved_hash(
+            &decoded,
+            &addr_hex,
+            RenderingSchemaVersion::CURRENT,
+        )
+        .expect("recompute approved hash in test");
+
+        let ctx = SigningContext {
+            tenant: SigningTenantId::new("default"),
+            user: SigningUserId::new("alice"),
+            scope: ScopeId::new("scope"),
+            actor: ActorId::new("actor"),
+            run_id: RunId::new("run"),
+            gate_ref: GateRef::new(GATE),
+            chain_id: ChainId::new(TESTNET),
+            key_or_account_id: KeyOrAccountId::new(addr_hex.clone()),
+        };
+
+        let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+        let ship_gate = CustodialMainnetShipGate::new(false).build_chain_ship_gate(None);
+        let grants = Arc::new(InMemorySealedGrantStore::new());
+
+        let composition = RebornAttestedComposition::new(
+            Arc::clone(&bindings),
+            keystore,
+            ship_gate,
+            Arc::clone(&grants),
+            |_grants| ProviderRegistry::new(),
+        );
+
+        // Seal the grant the custodial signer will claim, over the SHARED store.
+        let grant_key = GrantKey::from_context(&ctx, hash);
+        composition
+            .grants()
+            .seal(AttestedSigningGrant::new(grant_key, 0, None).expect("valid grant"))
+            .await
+            .unwrap();
+
+        // Persist the authoritative binding (as the PR11 ingress would).
+        composition
+            .bindings()
+            .put(
+                GateRef::new(GATE),
+                AttestedGateBinding {
+                    provider_id: ProviderId::Custodial,
+                    context: ctx.clone(),
+                    approved_tx_hash: hash,
+                    decoded,
+                    chain: ChainKeyId::new(TESTNET).expect("valid chain id in test"),
+                    scope,
+                    schema_version: RenderingSchemaVersion::CURRENT,
+                },
+            )
+            .await
+            .expect("binding insert succeeds");
+
+        let gate = GateRef::new(GATE);
+        let proof = SigningProof::WebAuthnAssertionProof(vec![]);
+
+        let outcome = composition
+            .driver()
+            .continue_after_resolved(&gate, &proof)
+            .await
+            .expect("custodial continuation signs");
+
+        // The local-dev path signs but NEVER reports a real broadcast.
+        assert!(
+            matches!(outcome.broadcast, BroadcastDisposition::NotBroadcast { .. }),
+            "noop path must not report a real broadcast, got {:?}",
+            outcome.broadcast
+        );
+        assert_eq!(
+            outcome.ledger_state,
+            ironclaw_attestation::SigningLedgerState::Signed,
+            "noop path must leave the ledger at Signed, not BroadcastSubmitted"
+        );
+
+        // Replay fails closed (grant already claimed / ledger guard).
+        let err = composition
+            .driver()
+            .continue_after_resolved(&gate, &proof)
+            .await
+            .expect_err("replay must fail closed");
+        assert!(
+            matches!(
+                err,
+                ContinuationError::Ledger(_)
+                    | ContinuationError::LedgerRowExists { .. }
+                    | ContinuationError::ChainSigning(_)
+            ),
+            "expected fail-closed replay, got {err:?}"
+        );
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/attested_continuation.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_continuation.rs
@@ -1,0 +1,603 @@
+//! Composition-layer implementation of the crypto-free
+//! [`AttestedGateContinuationPort`] (attested-signing PR11).
+//!
+//! This is the bridge between the crypto-free WebUI facade
+//! ([`ironclaw_product`]) and the attested-signing signer-continuation
+//! driver assembled in [`crate::attested`] over [`ironclaw_attested_runtime`].
+//!
+//! Atomic verify-before-resume (PR11 item B): this port runs the heavyweight
+//! cryptographic half in two phases, straddling the turn transition.
+//!
+//! 1. [`AttestedGateContinuationPort::verify_and_claim`] (BEFORE the turn
+//!    transitions): decode the opaque [`AttestedProofClaim`] into the concrete
+//!    [`ironclaw_signing_provider::SigningProof`] for its proof family (mirrors
+//!    the legacy monolith decode in
+//!    `src/channels/web/features/chat/attested.rs`), then call
+//!    [`AttestedSignerContinuationDriver::verify_and_sign`], which reads the
+//!    authoritative binding, claims the sealed one-shot grant, and verifies the
+//!    proof through the bound provider. On any failure the turn is left
+//!    `BlockedAttested` (the facade never resumes). On success it returns an
+//!    opaque verified handle.
+//! 2. [`AttestedGateContinuationPort::broadcast_resolved`] (AFTER `resume_turn`
+//!    drove the turn to `AttestedResolved`): consume the verified handle and
+//!    call [`AttestedSignerContinuationDriver::broadcast_signed_continuation`]
+//!    to perform the ledger-guarded broadcast. No re-verification, no re-claim.
+//!
+//! All verification (signer/hash binding, sealed-grant CAS, ledger idempotency)
+//! lives in `ironclaw_attested_runtime` / the providers — this module is decode
+//! + dispatch only.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use ironclaw_attested_runtime::{BindingOwner, ContinuationError, VerifiedContinuation};
+use ironclaw_product::{
+    AttestedContinuationOutcome, AttestedContinuationRejection, AttestedGateContinuationPort,
+    AttestedProofClaim, AttestedProofKind, VerifiedAttestedContinuation,
+};
+use ironclaw_signing_provider::{
+    ApprovedTxHash, GateRef as SigningGateRef, SigningProof, SigningProviderError,
+};
+use ironclaw_turns::{GateRef, TurnActor, TurnRunId, TurnScope};
+use ironclaw_wallet_external::{
+    InjectedProofPayload, InjectedScheme, NearAccessKeyScope, NearRedirectProofPayload,
+    WalletConnectProofPayload, encode_injected_proof, encode_near_redirect_proof,
+    encode_walletconnect_proof,
+};
+use serde::Deserialize;
+
+use crate::attested::{InMemoryContinuationDriver, RebornAttestedComposition};
+
+/// Composition-layer [`AttestedGateContinuationPort`].
+///
+/// Holds the assembled signer-continuation driver shared with the reborn
+/// runtime (the same driver + binding store + ledger the resume port reads).
+pub struct RebornAttestedContinuation {
+    driver: Arc<InMemoryContinuationDriver>,
+}
+
+impl RebornAttestedContinuation {
+    /// Build the port over the runtime's attested-signing composition.
+    pub fn new(composition: &RebornAttestedComposition) -> Self {
+        Self {
+            driver: Arc::clone(composition.driver()),
+        }
+    }
+}
+
+#[async_trait]
+impl AttestedGateContinuationPort for RebornAttestedContinuation {
+    async fn verify_and_claim(
+        &self,
+        scope: &TurnScope,
+        actor: &TurnActor,
+        _run_id: TurnRunId,
+        gate_ref: &GateRef,
+        claim: &AttestedProofClaim,
+    ) -> Result<VerifiedAttestedContinuation, AttestedContinuationRejection> {
+        let signing_gate_ref = SigningGateRef::new(gate_ref.as_str());
+
+        // IDOR DEFENSE (threat #2): assert the calling identity owns the
+        // authoritative binding BEFORE any decode / provider verify / custodial
+        // sign / grant claim. The driver reconstructs and signs the custodial
+        // path from the authoritative binding regardless of who presents the
+        // `gate_ref`, so without this check a second tenant member who learns
+        // another user's `gate_ref` could drive that user's signing
+        // continuation. The thread-ownership probe upstream only proves the
+        // caller owns *their own* thread, not the gate. Fail closed
+        // indistinguishably from a missing binding (no existence oracle).
+        self.driver
+            .assert_binding_owner(
+                &signing_gate_ref,
+                BindingOwner {
+                    tenant_id: scope.tenant_id.as_str(),
+                    user_id: actor.user_id.as_str(),
+                },
+            )
+            .await
+            .map_err(map_continuation_error)?;
+
+        // FULL verification + one-shot grant claim, run BEFORE the facade
+        // transitions the turn. A malformed proof fails closed here at decode; a
+        // forged signature / signer mismatch / already-claimed grant fails closed
+        // inside the driver's `verify_and_sign` (provider `verify_resume` + the
+        // sealed-grant CAS) — all before any `AttestedResolved` transition. The
+        // driver reads the authoritative binding itself and re-checks the bound
+        // hash against the proof, so the caller can only attest to the bound hash
+        // (threat #3), never redefine it.
+        let proof = decode_proof(claim)?;
+
+        // External-wallet path only: the wallet already signed, so no custodial
+        // EVM transaction is supplied. The custodial path is selected purely by
+        // the authoritative binding's `provider_id` (never by the caller).
+        let verified = self
+            .driver
+            .verify_and_sign(&signing_gate_ref, &proof)
+            .await
+            .map_err(map_continuation_error)?;
+
+        Ok(VerifiedAttestedContinuation::new(verified))
+    }
+
+    async fn broadcast_resolved(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+        _gate_ref: &GateRef,
+        verified: VerifiedAttestedContinuation,
+    ) -> Result<AttestedContinuationOutcome, AttestedContinuationRejection> {
+        // Recover the concrete verified continuation produced by
+        // `verify_and_claim`. A type mismatch (only possible if a different port
+        // implementation produced the handle) fails closed rather than panicking.
+        let verified = *verified
+            .downcast::<VerifiedContinuation>()
+            .map_err(|_| AttestedContinuationRejection::ProofRejected)?;
+
+        // Broadcast only — the proof is already verified and the grant already
+        // claimed. No re-verification, no re-claim.
+        let outcome = self
+            .driver
+            .broadcast_signed_continuation(verified)
+            .await
+            .map_err(map_continuation_error)?;
+
+        Ok(AttestedContinuationOutcome {
+            signer: outcome.signer,
+        })
+    }
+}
+
+/// Upper bound on the serialized size of a single attested-proof blob. The
+/// `proof_json` arrives as an opaque `serde_json::Value` from the browser and
+/// is NOT subject to the `USER_MESSAGE_TEXT_MAX_BYTES` message limit, so an
+/// explicit ceiling keeps a syntactically-valid but pathologically large proof
+/// (and the `parse_input` clone it forces) bounded. Every real proof family
+/// (injected / NEAR-redirect / WalletConnect) is a small fixed struct of
+/// hex/string fields; 16 KiB is generous headroom.
+const ATTESTED_PROOF_MAX_BYTES: usize = 16 * 1024;
+
+/// Upper bound on a WalletConnect `session_topic`. WalletConnect topic ids are
+/// 32-byte hex (64 chars); 256 is generous headroom while bounding an
+/// untrusted, persisted browser-supplied string (finding #5).
+const WALLETCONNECT_SESSION_TOPIC_MAX_LEN: usize = 256;
+
+/// Decode the opaque WebUI proof claim into the concrete provider proof for its
+/// family. Mirrors the legacy monolith wire contract
+/// (`src/channels/web/features/chat/attested.rs`): every byte field arrives as
+/// lowercase-hex (optionally `0x`-prefixed) and the hash as hex, so we parse the
+/// JSON via explicit input structs rather than the payload types directly (the
+/// payload's `ApprovedTxHash` serde is a raw byte array, not the hex wire form).
+/// A malformed payload fails closed as `MalformedProof`.
+fn decode_proof(claim: &AttestedProofClaim) -> Result<SigningProof, AttestedContinuationRejection> {
+    // Bound the untrusted proof blob before any clone/parse work.
+    let serialized_len = serde_json::to_vec(&claim.proof_json)
+        .map(|v| v.len())
+        .map_err(|_| AttestedContinuationRejection::MalformedProof)?;
+    if serialized_len > ATTESTED_PROOF_MAX_BYTES {
+        return Err(AttestedContinuationRejection::MalformedProof);
+    }
+    match claim.kind {
+        AttestedProofKind::InjectedWallet => {
+            let input: InjectedWalletProofInput = parse_input(&claim.proof_json)?;
+            let scheme = match input.scheme.as_str() {
+                "evm" => InjectedScheme::Evm,
+                "solana" => InjectedScheme::Solana,
+                _ => return Err(AttestedContinuationRejection::MalformedProof),
+            };
+            let payload = InjectedProofPayload {
+                scheme,
+                approved_tx_hash: parse_hash(&input.approved_tx_hash)?,
+                claimed_signer: input.claimed_signer,
+                signature: parse_hex(&input.signature)?,
+                public_key: input.public_key.as_deref().map(parse_hex).transpose()?,
+            };
+            Ok(SigningProof::InjectedProof(
+                encode_injected_proof(&payload)
+                    .map_err(|_| AttestedContinuationRejection::MalformedProof)?,
+            ))
+        }
+        AttestedProofKind::NearRedirect => {
+            let input: NearRedirectProofInput = parse_input(&claim.proof_json)?;
+            let access_key_scope = match input.access_key_scope {
+                NearAccessKeyScopeInput::FullAccess => NearAccessKeyScope::FullAccess,
+                NearAccessKeyScopeInput::FunctionCall {
+                    receiver_id,
+                    method_names,
+                } => NearAccessKeyScope::FunctionCall {
+                    receiver_id,
+                    method_names,
+                },
+            };
+            let payload = NearRedirectProofPayload {
+                approved_tx_hash: parse_hash(&input.approved_tx_hash)?,
+                account_id: input.account_id,
+                public_key: parse_hex(&input.public_key)?,
+                signature: parse_hex(&input.signature)?,
+                access_key_scope,
+                state: input.state,
+            };
+            Ok(SigningProof::NearRedirectProof(
+                encode_near_redirect_proof(&payload)
+                    .map_err(|_| AttestedContinuationRejection::MalformedProof)?,
+            ))
+        }
+        AttestedProofKind::WalletConnect => {
+            let input: WalletConnectProofInput = parse_input(&claim.proof_json)?;
+            if input.session_topic.len() > WALLETCONNECT_SESSION_TOPIC_MAX_LEN {
+                return Err(AttestedContinuationRejection::MalformedProof);
+            }
+            let payload = WalletConnectProofPayload {
+                session_topic: input.session_topic,
+                approved_tx_hash: parse_hash(&input.approved_tx_hash)?,
+                claimed_signer: input.claimed_signer,
+                nonce: parse_hex(&input.nonce)?,
+                signed_payload: parse_hex(&input.signed_payload)?,
+                signature: parse_hex(&input.signature)?,
+                public_key: input.public_key.as_deref().map(parse_hex).transpose()?,
+            };
+            Ok(SigningProof::WalletConnectProof(
+                encode_walletconnect_proof(&payload)
+                    .map_err(|_| AttestedContinuationRejection::MalformedProof)?,
+            ))
+        }
+    }
+}
+
+fn parse_input<T: for<'de> Deserialize<'de>>(
+    value: &serde_json::Value,
+) -> Result<T, AttestedContinuationRejection> {
+    serde_json::from_value(value.clone()).map_err(|_| AttestedContinuationRejection::MalformedProof)
+}
+
+/// Parse a 32-byte hex (optionally `0x`-prefixed) approved-tx hash.
+fn parse_hash(s: &str) -> Result<ApprovedTxHash, AttestedContinuationRejection> {
+    let bytes = parse_hex(s)?;
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| AttestedContinuationRejection::MalformedProof)?;
+    Ok(ApprovedTxHash::from_bytes(arr))
+}
+
+/// Decode a hex string (optionally `0x`-prefixed) to bytes.
+///
+/// Operates over raw bytes after validating the input is pure ASCII-hex, so a
+/// multibyte-Unicode JSON value can never trigger a non-char-boundary slice
+/// panic — a malformed (non-ASCII-hex or odd-length) input fails closed as
+/// [`AttestedContinuationRejection::MalformedProof`].
+fn parse_hex(s: &str) -> Result<Vec<u8>, AttestedContinuationRejection> {
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    let bytes = s.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return Err(AttestedContinuationRejection::MalformedProof);
+    }
+    bytes
+        .chunks_exact(2)
+        .map(|pair| {
+            let hi = hex_nibble(pair[0])?;
+            let lo = hex_nibble(pair[1])?;
+            Ok((hi << 4) | lo)
+        })
+        .collect()
+}
+
+/// Decode a single ASCII-hex digit to its nibble value, fail-closed.
+fn hex_nibble(byte: u8) -> Result<u8, AttestedContinuationRejection> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(AttestedContinuationRejection::MalformedProof),
+    }
+}
+
+/// Wire input for an injected-wallet proof (lowercase-hex fields). Mirrors the
+/// legacy `InjectedWalletProofInput`.
+#[derive(Debug, Deserialize)]
+struct InjectedWalletProofInput {
+    scheme: String,
+    claimed_signer: String,
+    signature: String,
+    approved_tx_hash: String,
+    #[serde(default)]
+    public_key: Option<String>,
+}
+
+/// Wire input for a NEAR redirect proof. Mirrors the legacy
+/// `NearRedirectProofInput`.
+#[derive(Debug, Deserialize)]
+struct NearRedirectProofInput {
+    account_id: String,
+    public_key: String,
+    signature: String,
+    approved_tx_hash: String,
+    access_key_scope: NearAccessKeyScopeInput,
+    state: String,
+}
+
+/// Wire form of the NEAR access-key scope. Mirrors the legacy
+/// `NearAccessKeyScopeInput`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+enum NearAccessKeyScopeInput {
+    FullAccess,
+    FunctionCall {
+        receiver_id: String,
+        #[serde(default)]
+        method_names: Vec<String>,
+    },
+}
+
+/// Wire input for a WalletConnect v2 proof.
+#[derive(Debug, Deserialize)]
+struct WalletConnectProofInput {
+    session_topic: String,
+    claimed_signer: String,
+    nonce: String,
+    signature: String,
+    approved_tx_hash: String,
+    /// The exact bytes the wallet's chain signature covers (the EVM sighash /
+    /// Solana message), as lowercase hex. Bound to the recorded expectation by
+    /// the provider before any signature work (WYSIWYS, #1).
+    signed_payload: String,
+    #[serde(default)]
+    public_key: Option<String>,
+}
+
+/// Map the driver's [`ContinuationError`] to the sanitized facade rejection.
+/// Categories only — no chain, signer, or ledger internals cross this boundary.
+fn map_continuation_error(error: ContinuationError) -> AttestedContinuationRejection {
+    match error {
+        // A cross-user/cross-tenant gate_ref is surfaced identically to a
+        // non-existent binding (404) so it is not an existence oracle (IDOR
+        // defense, threat #2).
+        ContinuationError::MissingBinding | ContinuationError::OwnerMismatch => {
+            AttestedContinuationRejection::MissingBinding
+        }
+        ContinuationError::ProviderMismatch { .. } => {
+            AttestedContinuationRejection::ProviderMismatch
+        }
+        ContinuationError::ProofRejected(SigningProviderError::GrantClaimFailed) => {
+            // A replayed proof for an already-claimed grant is an idempotency
+            // guard outcome, surfaced as a conflict to the client.
+            AttestedContinuationRejection::LedgerGuard
+        }
+        // A tampered/inconsistent authoritative binding (sign-time hash re-check
+        // mismatch, the binding's chain not matching its own decoded tx, or a
+        // decoded tx that cannot be rebuilt into a signable) all fail closed
+        // BEFORE any signing. None are retryable as-is; surface them as a proof
+        // rejection rather than a recoverable infra failure.
+        ContinuationError::ProofRejected(_)
+        | ContinuationError::ApprovedHashMismatch
+        | ContinuationError::BindingChainMismatch
+        | ContinuationError::Rebuild(_) => AttestedContinuationRejection::ProofRejected,
+        ContinuationError::Ledger(_) | ContinuationError::LedgerRowExists { .. } => {
+            AttestedContinuationRejection::LedgerGuard
+        }
+        ContinuationError::ChainSigning(_) => AttestedContinuationRejection::ProofRejected,
+        // A broadcast failure is a POST-verification, server-side (recoverable)
+        // infrastructure failure: the proof was already verified and the grant
+        // claimed. Surfacing it as ProofRejected (400) would wrongly imply the
+        // client's proof was bad; map it to Unavailable (503) so the client can
+        // retry the broadcast tail instead.
+        ContinuationError::Broadcast { .. } => AttestedContinuationRejection::Unavailable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hex_rejects_multibyte_unicode_without_panicking() {
+        // A multibyte-Unicode string whose byte length is even: the old
+        // byte-offset `&s[i..i+2]` slice would panic on a non-char-boundary.
+        // It must fail closed as MalformedProof instead.
+        let result = parse_hex("déadbeef");
+        assert!(matches!(
+            result,
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+
+        // Other Unicode shapes (odd byte length, emoji) must also fail closed.
+        assert!(matches!(
+            parse_hex("é"),
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+        assert!(matches!(
+            parse_hex("🦀🦀"),
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+    }
+
+    #[test]
+    fn parse_hex_accepts_valid_hex_with_optional_prefix() {
+        assert_eq!(parse_hex("00ff").unwrap(), vec![0x00, 0xff]);
+        assert_eq!(parse_hex("0xDEAD").unwrap(), vec![0xde, 0xad]);
+        assert_eq!(parse_hex("").unwrap(), Vec::<u8>::new());
+    }
+
+    fn hash_hex_64() -> String {
+        "11".repeat(32)
+    }
+
+    #[test]
+    fn decode_injected_wallet_proof() {
+        let claim = AttestedProofClaim {
+            kind: AttestedProofKind::InjectedWallet,
+            approved_tx_hash_hex: hash_hex_64(),
+            proof_json: serde_json::json!({
+                "scheme": "evm",
+                "claimed_signer": "0xabc",
+                "signature": "deadbeef",
+                "approved_tx_hash": hash_hex_64(),
+            }),
+        };
+        assert!(matches!(
+            decode_proof(&claim),
+            Ok(SigningProof::InjectedProof(_))
+        ));
+    }
+
+    #[test]
+    fn decode_near_redirect_proof() {
+        let claim = AttestedProofClaim {
+            kind: AttestedProofKind::NearRedirect,
+            approved_tx_hash_hex: hash_hex_64(),
+            proof_json: serde_json::json!({
+                "account_id": "alice.near",
+                "public_key": "aa",
+                "signature": "bbcc",
+                "approved_tx_hash": hash_hex_64(),
+                "access_key_scope": { "kind": "full_access" },
+                "state": "opaque-state",
+            }),
+        };
+        assert!(matches!(
+            decode_proof(&claim),
+            Ok(SigningProof::NearRedirectProof(_))
+        ));
+
+        // FunctionCall scope variant also decodes.
+        let claim_fc = AttestedProofClaim {
+            kind: AttestedProofKind::NearRedirect,
+            approved_tx_hash_hex: hash_hex_64(),
+            proof_json: serde_json::json!({
+                "account_id": "alice.near",
+                "public_key": "aa",
+                "signature": "bbcc",
+                "approved_tx_hash": hash_hex_64(),
+                "access_key_scope": {
+                    "kind": "function_call",
+                    "receiver_id": "contract.near",
+                    "method_names": ["do_thing"],
+                },
+                "state": "opaque-state",
+            }),
+        };
+        assert!(matches!(
+            decode_proof(&claim_fc),
+            Ok(SigningProof::NearRedirectProof(_))
+        ));
+    }
+
+    #[test]
+    fn decode_walletconnect_proof() {
+        let claim = AttestedProofClaim {
+            kind: AttestedProofKind::WalletConnect,
+            approved_tx_hash_hex: hash_hex_64(),
+            proof_json: serde_json::json!({
+                "session_topic": "topic-123",
+                "claimed_signer": "0xabc",
+                "nonce": "0011",
+                "signed_payload": "cafe",
+                "signature": "deadbeef",
+                "approved_tx_hash": hash_hex_64(),
+            }),
+        };
+        assert!(matches!(
+            decode_proof(&claim),
+            Ok(SigningProof::WalletConnectProof(_))
+        ));
+    }
+
+    #[test]
+    fn decode_proof_rejects_malformed_payload() {
+        // Missing required fields for the family fails closed.
+        let claim = AttestedProofClaim {
+            kind: AttestedProofKind::WalletConnect,
+            approved_tx_hash_hex: hash_hex_64(),
+            proof_json: serde_json::json!({ "session_topic": "only-this" }),
+        };
+        assert!(matches!(
+            decode_proof(&claim),
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+    }
+
+    #[test]
+    fn broadcast_failure_maps_to_unavailable_not_proof_rejected() {
+        // A broadcast / RPC failure is a post-verification, server-side
+        // (recoverable) infrastructure failure — it must NOT be surfaced as
+        // ProofRejected (which implies the proof was bad and maps to 400). It
+        // maps to Unavailable (503) so clients can retry.
+        let rejection = map_continuation_error(ContinuationError::Broadcast {
+            reason: "rpc timeout".to_string(),
+        });
+        assert!(matches!(
+            rejection,
+            AttestedContinuationRejection::Unavailable
+        ));
+    }
+
+    #[test]
+    fn custodial_signing_failure_still_maps_to_proof_rejected() {
+        // A custodial signer failure happens during verification/signing (before
+        // broadcast) and remains a client-facing rejection.
+        let rejection = map_continuation_error(ContinuationError::ChainSigning(
+            ironclaw_chain_signing::ChainSigningError::SignerMismatch,
+        ));
+        assert!(matches!(
+            rejection,
+            AttestedContinuationRejection::ProofRejected
+        ));
+    }
+
+    #[test]
+    fn decode_proof_rejects_oversized_blob() {
+        // A syntactically valid but pathologically large proof blob must be
+        // rejected before any clone/parse work (finding #3).
+        let big = "a".repeat(ATTESTED_PROOF_MAX_BYTES + 1);
+        let claim = AttestedProofClaim {
+            kind: AttestedProofKind::InjectedWallet,
+            approved_tx_hash_hex: hash_hex_64(),
+            proof_json: serde_json::json!({
+                "scheme": "evm",
+                "claimed_signer": "0xabc",
+                "signature": "deadbeef",
+                "approved_tx_hash": hash_hex_64(),
+                "public_key": big,
+            }),
+        };
+        assert!(matches!(
+            decode_proof(&claim),
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+    }
+
+    #[test]
+    fn decode_walletconnect_rejects_oversized_session_topic() {
+        // An over-long session_topic must fail closed (finding #5) while a
+        // bounded one still decodes.
+        let long_topic = "t".repeat(WALLETCONNECT_SESSION_TOPIC_MAX_LEN + 1);
+        let claim = AttestedProofClaim {
+            kind: AttestedProofKind::WalletConnect,
+            approved_tx_hash_hex: hash_hex_64(),
+            proof_json: serde_json::json!({
+                "session_topic": long_topic,
+                "claimed_signer": "0xabc",
+                "nonce": "0011",
+                "signed_payload": "cafe",
+                "signature": "deadbeef",
+                "approved_tx_hash": hash_hex_64(),
+            }),
+        };
+        assert!(matches!(
+            decode_proof(&claim),
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+    }
+
+    #[test]
+    fn parse_hash_rejects_unicode_and_wrong_length() {
+        assert!(matches!(
+            parse_hash("déadbeef"),
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+        // Valid hex but not 32 bytes.
+        assert!(matches!(
+            parse_hash("00ff"),
+            Err(AttestedContinuationRejection::MalformedProof)
+        ));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -164,6 +164,7 @@ use ironclaw_triggers::{
     TriggerRepository,
 };
 use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
+use ironclaw_turns::AttestedResumePort;
 use ironclaw_turns::TurnStateRowStore;
 use ironclaw_turns::{
     CheckpointStateStorePort, ExternalToolCatalog, InMemoryExternalToolCatalog, LoopCheckpointStore,
@@ -1003,6 +1004,11 @@ where
 }
 
 pub(crate) struct RebornRuntimeStores {
+    /// Attested-signing signer-continuation composition: the shared gate
+    /// binding store plus the assembled driver, dispatched by the gate/resolve
+    /// ingress once a turn reaches `AttestedResolved`. `None` on production
+    /// profiles until the durable attested backends are wired.
+    pub(crate) attested_signing: Option<Arc<crate::attested::RebornAttestedComposition>>,
     pub(crate) host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime>,
     #[cfg(test)]
     pub(crate) turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator>,
@@ -1575,11 +1581,19 @@ where
 fn production_turn_state_store<F>(
     filesystem: Arc<ScopedFilesystem<F>>,
     limits: ironclaw_turns::TurnStateStoreLimits,
+    // `None` on the production paths until the durable attested backends are
+    // wired: without a port the store simply never admits an attested resume,
+    // which is the correct fail-closed default rather than a silent no-op.
+    attested_resume_port: Option<Arc<dyn AttestedResumePort>>,
 ) -> TurnStateRowStore<F>
 where
     F: RootFilesystem + 'static,
 {
-    TurnStateRowStore::new(filesystem).with_limits(limits)
+    let store = TurnStateRowStore::new(filesystem).with_limits(limits);
+    match attested_resume_port {
+        Some(port) => store.with_attested_resume_port(port),
+        None => store,
+    }
 }
 
 async fn local_dev_trigger_repository(
@@ -4166,6 +4180,7 @@ where
     let turn_state = Arc::new(production_turn_state_store(
         Arc::clone(&turn_state_filesystem),
         ironclaw_turns::TurnStateStoreLimits::default(),
+        None,
     ));
     let process_services = ProcessServices::filesystem(Arc::clone(&scoped_filesystem));
     let secret_credentials = build_filesystem_secret_credential_stores(
@@ -4620,6 +4635,7 @@ async fn build_backend_production(
     let turn_state = Arc::new(production_turn_state_store(
         Arc::clone(&turn_state_filesystem),
         turn_state_store_limits,
+        None,
     ));
     // Rebindable source-turn-state slot for the trigger delivery-target
     // service — same repoint seam as the sibling snapshot slot below.
@@ -5542,6 +5558,10 @@ async fn build_backend_production(
     };
 
     Ok(RebornRuntimeStores {
+        // Production composes no attested backend yet: the durable stores are a
+        // later group, and `None` means the gate ingress has nothing to
+        // dispatch to and refuses, rather than half-resolving a signature.
+        attested_signing: None,
         host_runtime,
         #[cfg(test)]
         turn_coordinator,

--- a/crates/ironclaw_reborn_composition/src/factory/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/tests.rs
@@ -110,8 +110,11 @@ async fn production_turn_state_store_uses_row_layout() {
     // `TurnStateRowStore` by type, so "production uses the row
     // layout" is now a compile-time guarantee. This exercises the factory
     // end-to-end and confirms the constructed store answers reads.
-    let store =
-        production_turn_state_store(filesystem, ironclaw_turns::TurnStateStoreLimits::default());
+    let store = production_turn_state_store(
+        filesystem,
+        ironclaw_turns::TurnStateStoreLimits::default(),
+        None,
+    );
 
     let snapshot = store.persistence_snapshot().await.expect("read snapshot");
     assert!(snapshot.runs.is_empty());

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -22,6 +22,8 @@ mod admin_token;
 mod admin_user_directory;
 #[cfg(test)]
 mod approval_test_support;
+mod attested;
+mod attested_continuation;
 mod automation;
 mod blocked_auth_resume;
 mod builtin_capability_policy;
@@ -58,6 +60,8 @@ mod trigger_fire_access;
 mod turn_run_snapshot;
 
 pub use admin_token::AdminApiTokenMinter;
+pub use attested::{NoopBroadcaster, RebornAttestedComposition, RegisterAttestedGateError};
+pub use attested_continuation::RebornAttestedContinuation;
 pub use automation::service::RebornAutomationProductService;
 pub use automation::trigger_poller::PostSubmitDeliveryHook;
 pub use error::RebornBuildError;

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -691,6 +691,11 @@ impl From<DefaultPlannedRuntimeBuildError> for RebornRuntimeError {
 /// [`build_reborn_runtime`]. Downstream code never reaches into the substrate
 /// or worker machinery: it talks to the runtime through task-level methods.
 pub struct RebornRuntime {
+    /// Attested-signing signer-continuation composition, when one was composed.
+    /// `None` on production profiles until the durable attested backends are
+    /// wired — the gate ingress then has nothing to dispatch to and fails
+    /// closed, rather than half-resolving a signature.
+    pub(crate) attested_signing: Option<Arc<crate::attested::RebornAttestedComposition>>,
     pub(crate) host_runtime: Arc<dyn HostRuntime>,
     pub(crate) product_auth: Arc<RebornProductAuthServices>,
     pub(crate) readiness: RebornReadiness,
@@ -1432,6 +1437,17 @@ fn approval_turn_locator_unavailable() -> ironclaw_product::ProductSurfaceFailur
 impl RebornRuntime {
     pub fn readiness(&self) -> &RebornReadiness {
         &self.readiness
+    }
+
+    /// The attested-signing signer-continuation composition, when this runtime
+    /// composed one.
+    ///
+    /// The gate/resolve ingress reaches the assembled driver and the
+    /// authoritative binding store through this one handle, rather than
+    /// assembling them from runtime internals — so there is exactly one place a
+    /// signing continuation can be obtained.
+    pub fn attested_signing(&self) -> Option<&Arc<crate::attested::RebornAttestedComposition>> {
+        self.attested_signing.as_ref()
     }
 
     /// Build the canonical product surface over this runtime graph.
@@ -4708,6 +4724,7 @@ pub async fn build_runtime(input: RebornRuntimeInput) -> Result<RebornRuntime, R
     }
 
     let runtime = RebornRuntime {
+        attested_signing: services.attested_signing.clone(),
         host_runtime: services.host_runtime.clone(),
         product_auth: services.product_auth.clone(),
         readiness: services.readiness.clone(),

--- a/crates/ironclaw_secrets/src/crypto.rs
+++ b/crates/ironclaw_secrets/src/crypto.rs
@@ -88,6 +88,31 @@ impl SecretsCrypto {
         salt
     }
 
+    /// Mint a fresh, cryptographically-random in-process master key.
+    ///
+    /// Intended for ephemeral / in-memory keystores (local-dev, tests) where no
+    /// secret must be persisted in source and no stable key is needed across
+    /// restarts. The key is a hex-encoded 32-byte `OsRng` draw, which always
+    /// satisfies the length + distinct-byte validation in [`Self::new`].
+    /// Durable deployments must still source the master key from the OS
+    /// keychain / KMS, never from this generator.
+    pub fn generate() -> Self {
+        let mut key = [0u8; KEY_SIZE];
+        // Match the crate's rand 0.9 usage: prefer the OS RNG, fall back to the
+        // thread RNG (both CSPRNG-backed) exactly as `from_random_master_key`.
+        use rand::{RngExt as _, TryRng as _};
+        if rand::rngs::SysRng.try_fill_bytes(&mut key).is_err() {
+            rand::rng().fill(&mut key);
+        }
+        let mut hex = String::with_capacity(KEY_SIZE * 2);
+        for b in key {
+            use std::fmt::Write as _;
+            // Infallible: writing to a String never errors.
+            let _ = write!(hex, "{b:02x}");
+        }
+        Self::from_valid_master_key(hex)
+    }
+
     /// Encrypt `plaintext` and authenticate it against `aad`.
     ///
     /// The `aad` (additional authenticated data) is *not* encrypted but is

--- a/crates/ironclaw_wallet_external/Cargo.toml
+++ b/crates/ironclaw_wallet_external/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "ironclaw_wallet_external"
 version = "0.1.0"
+# Internal workspace crate (path-deps on sibling substrate crates) — not
+# published; satisfies cargo-deny wildcards=deny (allow-wildcard-paths only
+# exempts publish=false crates).
+publish = false
 edition = "2024"
 rust-version = "1.92"
 description = "External-wallet signing providers (browser injected window.ethereum / window.solana) for the IronClaw attested-signing substrate"
@@ -8,10 +12,6 @@ authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
-# Internal workspace crate — not published to crates.io. cargo-deny's
-# allow-wildcard-paths exemption is skipped for publishable crates (crates.io
-# disallows path deps), so this crate's path deps would otherwise be flagged.
-publish = false
 
 [package.metadata.dist]
 dist = false
@@ -50,10 +50,12 @@ sha2 = "0.10"
 base64 = "0.22"
 
 # WalletConnect v2 relay transport (PR9). The fork at
-# tracecommons/walletconnect-rs @ c6b528e defaults to rustls (openssl-free); we
+# tracecommons/walletconnect-rs @ 7078fd3 defaults to rustls (openssl-free); we
 # take DEFAULT features for relay_client and DO NOT enable relay_rpc's `cacao`
 # feature (it pulls alloy 0.3.6 -> reqwest default-tls -> openssl). The
 # architecture boundary test `workspace_graph_is_openssl_free` enforces this.
+# Rev 7078fd3 moves relay_rpc to jsonwebtoken 9 (ring 0.17), dropping the yanked
+# ring 0.16.20 that cargo-deny rejects as unlicensed — matches the clean stack tip.
 relay_client = { git = "https://github.com/tracecommons/walletconnect-rs", rev = "7078fd303cc521cceeed919e3d452f45eeb115e8", package = "relay_client" }
 relay_rpc = { git = "https://github.com/tracecommons/walletconnect-rs", rev = "7078fd303cc521cceeed919e3d452f45eeb115e8", package = "relay_rpc" }
 

--- a/docs/plans/composition-pubuse.snapshot
+++ b/docs/plans/composition-pubuse.snapshot
@@ -1,4 +1,6 @@
 pub use admin_token::AdminApiTokenMinter;
+pub use attested::{NoopBroadcaster, RebornAttestedComposition, RegisterAttestedGateError};
+pub use attested_continuation::RebornAttestedContinuation;
 pub use automation::service::RebornAutomationProductService;
 pub use automation::trigger_poller::PostSubmitDeliveryHook;
 pub use error::RebornBuildError;


### PR DESCRIPTION
## What

**Group 4 of 8.** Stacks on #6755. The `ironclaw_attested_runtime` crate — resume port, signer-continuation driver, custodial mainnet ship-gate — plus the composition seam that reaches it.

## Scope change worth flagging

This group was planned as "runtime + WebUI ingress". **The ingress is deferred to its own PR.** Main deleted `webui_inbound` entirely (zero references) and replaced it with a capability/command-constant dispatch model. So the attested gate/resolve ingress needs *re-expressing* in that vocabulary, not porting — and `RESOLVE_GATE_COMMAND` already exists, so the attested resolve is a gate resolution carrying a claim rather than a new command. That is design work with an authorization boundary in it (the cross-user IDOR contract lives there), and it does not belong bundled with runtime plumbing.

What lands here is the plumbing the ingress will attach to, complete and green.

## Ported onto restructured main

- **`attested_signing` threads stores → `RebornRuntime` → accessor.** Main flattened `RebornServices` out of `RebornRuntime`, so it is a field rather than a nested lookup. Production wires `None`: with no durable attested backend, the gate ingress has nothing to dispatch to and refuses, rather than half-resolving a signature.
- **`production_turn_state_store` takes an optional `AttestedResumePort`.** Without a port the store never admits an attested resume — the fail-closed default, not a silent no-op.
- **`factory.rs` was not merged.** Git aligned its conflicts against unrelated regions — one 1,390-line hunk paired flow-record wiring against test-support attachment ports — because main restructured that file wholesale. The actual change is **73 insertions**, so it was applied by hand at the correct anchors.

## Two ratchets, both genuine

- **`ironclaw_attested_runtime` declared no layer.** Now `kernel`: it depends on `ironclaw_turns`, so it sits above the substrates it drives and below the composition that wires it.
- **`LocalDevContinuationDriver` / `LocalDevCustodialSigner`** tripped the `LocalDev` typename ratchet, which bans mode-shaped type names because a deployment mode is a `DeploymentConfig` value. Renamed **`InMemoryContinuationDriver` / `InMemoryCustodialSigner`** — named for the stores they pin, which is also the accurate distinction: a durable composition differs by its *stores*, not by which environment runs it.

## Deliberately not included

`build_attested_composition`. Main moved local-dev composition out of this crate, so nothing here would call it, and dead code in a signing path is worse than its absence. It lands with the group that wires the durable backends.

## Verification

`ironclaw_architecture` 100% (both ratchets green), `ironclaw_attested_runtime` suite green, **whole workspace compiles including tests**, `fmt`, `clippy --tests` (zero warnings), `check_no_panics.py`, `check-hermetic-env.sh` — all against current `main`. The composition pub-use snapshot is regenerated for the two new attested exports.

## Supersedes

#3994 (reborn runtime). #3995's ingress content moves to the follow-up PR described above.
