### PR TITLE
test(e2e): stop a local run from quietly covering less than CI

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -230,6 +230,7 @@ jobs:
           tests/e2e/scenarios/test_journey_coverage.py
           tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
           tests/e2e/scenarios/test_provider_fault_proxy.py
+          tests/e2e/scenarios/test_emulate_build_parity.py
           tests/e2e/scenarios/test_reborn_qa_trace_replay.py
           tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
           -m

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -211,6 +211,45 @@ def _emulate_unavailable(reason: str) -> None:
     pytest.skip(reason)
 
 
+def emulate_build_label() -> str:
+    """Which Emulate this process talks to, for reporting."""
+    if globals()["EMULATE_CLI_PATH"]:
+        return f"pinned fork CLI at {EMULATE_CLI_PATH}"
+    return f"npm fallback {EMULATE_NPM_PACKAGE} (NOT what CI runs)"
+
+
+def skip_if_emulate_capability_absent(reason: str) -> None:
+    """Skip on the npm fallback; FAIL on the pinned build CI uses.
+
+    These guards exist because the npm package lacks endpoints the pinned
+    fork implements, so on the fallback a skip is the honest outcome. On the
+    pinned build the capability is expected to be there — a skip would mean
+    the fork regressed, and reporting that as "skipped" is how a coverage
+    loss hides in a green run.
+
+    Measured on `test_emulate_reborn_provider_contracts.py` against
+    unmodified main: the npm fallback gave 1 failed / 10 passed / 3 skipped,
+    the pinned fork gave 14 passed. A local run was quietly exercising less
+    than CI with nothing saying so.
+    """
+    if globals()["EMULATE_CLI_PATH"]:
+        pytest.fail(
+            f"{reason} — but this run uses the pinned Emulate fork, which is "
+            "expected to expose it. Treat as a capability regression in the "
+            "pinned build, not an environment quirk."
+        )
+    pytest.skip(f"{reason} (npm fallback; the pinned fork CI uses has it)")
+
+
+def pytest_report_header() -> str:
+    """Name the Emulate build in the pytest header.
+
+    Without this the fallback and the pinned fork produce identical-looking
+    runs, and "it passed locally" silently means something weaker than CI.
+    """
+    return f"emulate: {emulate_build_label()}"
+
+
 def _wasip2_target_missing() -> bool:
     try:
         installed = subprocess.run(

--- a/tests/e2e/scenarios/test_emulate_build_parity.py
+++ b/tests/e2e/scenarios/test_emulate_build_parity.py
@@ -1,0 +1,57 @@
+"""Local runs must not quietly cover less than CI (#6524 workstream 1).
+
+CI builds the pinned `serrrfirat/emulate` fork and points
+`IRONCLAW_EMULATE_CLI` at it. Without that variable `conftest.py` falls back
+to the `emulate@0.7.0` npm package, which is not the same build: measured on
+`test_emulate_reborn_provider_contracts.py` against unmodified main, the
+fallback gave 1 failed / 10 passed / 3 skipped where the pinned fork gave 14
+passed.
+
+So a local green could mean "14 checks passed" or "10 passed and 3 quietly
+didn't run", with nothing distinguishing them. These tests pin the two things
+that keep that honest: the run says which build it used, and a missing
+capability is a failure on the build that is supposed to have it.
+"""
+
+from __future__ import annotations
+
+import conftest
+import pytest
+from _pytest.outcomes import Failed, Skipped
+
+
+def test_report_header_names_the_emulate_build():
+    header = conftest.pytest_report_header()
+    assert header.startswith("emulate: ")
+    assert conftest.emulate_build_label() in header
+
+
+def test_fallback_label_says_it_is_not_what_ci_runs(monkeypatch):
+    """The label has to be readable as a warning, not trivia."""
+    monkeypatch.setattr(conftest, "EMULATE_CLI_PATH", None)
+    label = conftest.emulate_build_label()
+    assert conftest.EMULATE_NPM_PACKAGE in label
+    assert "NOT what CI runs" in label
+
+
+def test_pinned_label_names_the_cli_path(monkeypatch):
+    monkeypatch.setattr(conftest, "EMULATE_CLI_PATH", "/somewhere/dist/index.js")
+    assert "/somewhere/dist/index.js" in conftest.emulate_build_label()
+
+
+def test_missing_capability_fails_on_the_pinned_build(monkeypatch):
+    """The pinned fork is expected to have these endpoints.
+
+    A skip here would report a capability regression in the build CI depends
+    on as "skipped", which is how a coverage loss survives a green run.
+    """
+    monkeypatch.setattr(conftest, "EMULATE_CLI_PATH", "/somewhere/dist/index.js")
+    with pytest.raises(Failed, match="capability regression"):
+        conftest.skip_if_emulate_capability_absent("Docs API missing")
+
+
+def test_missing_capability_only_skips_on_the_npm_fallback(monkeypatch):
+    """On the fallback the endpoint genuinely is absent, so a skip is honest."""
+    monkeypatch.setattr(conftest, "EMULATE_CLI_PATH", None)
+    with pytest.raises(Skipped):
+        conftest.skip_if_emulate_capability_absent("Docs API missing")

--- a/tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
+++ b/tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py
@@ -11,6 +11,7 @@ import json
 import httpx
 import pytest
 
+from conftest import skip_if_emulate_capability_absent
 from emulate_provider import (
     github_json,
     github_headers,
@@ -252,7 +253,7 @@ async def test_emulate_google_covers_reborn_docs_contract(emulate_google_server)
             json={"title": marker},
         )
         if created.status_code == 404:
-            pytest.skip("Emulate 0.7.0 does not expose the Google Docs API")
+            skip_if_emulate_capability_absent("Emulate 0.7.0 does not expose the Google Docs API")
         created.raise_for_status()
         document_id = created.json()["documentId"]
         assert created.json()["title"] == marker
@@ -298,7 +299,7 @@ async def test_emulate_google_covers_reborn_sheets_contract(emulate_google_serve
             json={"properties": {"title": marker}},
         )
         if created.status_code == 404:
-            pytest.skip("Emulate 0.7.0 does not expose the Google Sheets API")
+            skip_if_emulate_capability_absent("Emulate 0.7.0 does not expose the Google Sheets API")
         created.raise_for_status()
         spreadsheet = created.json()
         spreadsheet_id = spreadsheet["spreadsheetId"]
@@ -495,7 +496,7 @@ async def test_emulate_slack_covers_reborn_search_messages(emulate_slack_server)
             params={"query": marker, "count": 20, "sort": "timestamp"},
         )
         if response.status_code == 404:
-            pytest.skip("Emulate 0.7.0 does not expose Slack search.messages")
+            skip_if_emulate_capability_absent("Emulate 0.7.0 does not expose Slack search.messages")
         response.raise_for_status()
         body = response.json()
         assert body["ok"] is True


### PR DESCRIPTION
## The problem

CI builds the pinned **`serrrfirat/emulate` fork at `c85da1e`** and points `IRONCLAW_EMULATE_CLI` at it. Without that variable, `conftest.py` falls back to the `emulate@0.7.0` npm package — and the two are not the same build.

Measured on `test_emulate_reborn_provider_contracts.py` against unmodified `main`:

| Emulate | result |
|---|---|
| npm fallback | 1 failed, 10 passed, **3 skipped** |
| pinned fork | **14 passed** |

So a local green meant either *"14 checks ran"* or *"10 ran and 3 quietly didn't"*, with nothing on screen telling them apart.

I hit this myself, which is how it surfaced: I verified #6763 and #6764 against the fallback, reported a "pre-existing failure" that does not exist on the pinned build, and described fork behaviour I had actually characterised on a different one.

## The fix

**1. The run names its build.** The pytest header now prints one of:

```
emulate: pinned fork CLI at /path/to/dist/index.js
emulate: npm fallback emulate@0.7.0 (NOT what CI runs)
```

**2. A missing capability fails on the build that should have it.** The three `"Emulate 0.7.0 does not expose ..."` guards now route through `skip_if_emulate_capability_absent`, which:

- **skips** on the npm fallback — the endpoint genuinely is missing there, so a skip is honest;
- **fails** on the pinned fork — which is expected to expose it, so a skip would report a capability regression in the build CI depends on as "skipped". That is precisely how a coverage loss survives a green run.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Dependencies

## Validation

Built the pinned fork locally (node 24, pnpm 11, `pnpm exec turbo build --filter=emulate...`) and ran against it:

- [x] `test_emulate_build_parity.py` + `test_emulate_reborn_provider_contracts.py` against the **pinned fork** — **19 passed**
- [x] Header verified in both modes by running `--collect-only` under each
- [x] Fallback still behaves as before (skips rather than fails) — confirmed by running without `IRONCLAW_EMULATE_CLI`
- [x] Escalation verified directly rather than incidentally: forcing a capability skip inside the real guard did **not** exercise it, because that branch only runs when the endpoint is actually absent. So the helper is unit-tested against both modes instead.

## Test Strategy

**User behaviour:** none changed. Test infrastructure only.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [ ] Cross-component behavior

Tests added: `tests/e2e/scenarios/test_emulate_build_parity.py` — five cases covering the header, that the fallback label reads as a warning rather than trivia, and that the escalation fires on the pinned build and only skips on the fallback. Wired into the existing Emulate CI step.

**What the tests prove.** Not that the guards exist — that the run says which build produced its result, and that a missing capability cannot be reported as a skip on the build CI actually uses.

## Reviewer notes

- `emulate_build_label()` and the guard read `EMULATE_CLI_PATH` through `globals()` rather than closing over the import-time constant. That is deliberate: it makes the escalation directly testable, instead of only reachable when an endpoint happens to be missing.
- This does not force anyone to build the fork locally. The fallback still works — it just stops pretending to be CI.
- Open question for a follow-up: whether the npm fallback should exist at all, or whether the harness should offer a one-command way to fetch and build the pinned fork. Left alone here because it changes every contributor's local workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
