### PR TITLE
test(reborn-v2): cover tool turns and gates

### DIFF
--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -87,6 +87,7 @@ from `tests/e2e/` for the full, current set.
 | File | What it tests |
 |------|--------------|
 | `test_reborn_webui_v2_smoke.py` | Canonical v2 smoke: serve boots, SPA renders authed shell, bearer auth + `?token=` shim scope, text turn persists/streams, thread list/delete, timeline pagination, composer-while-running, approval-gate send block, **new-chat-while-a-run-is-active (the #5256 `submitBusyRef` deadlock regression)** |
+| `test_reborn_webui_v2_tool_gates.py` | Served capability smoke: tool-result persistence and final reply, in-flight cancellation, approval resolution, and manual-token auth-gate resume |
 | `test_reborn_gateway_smoke.py` | Legacy `ironclaw` web channel (`/api/chat/*`) under `ENGINE_V2` — NOT the reborn binary |
 | `test_reborn_v2_file_download.py` | Agent-produced workspace files are downloadable from the v2 UI |
 | `test_v2_activity_shell.py` | v2 activity shell rendering |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -54,6 +54,7 @@ Then Playwright drives a headless Chromium browser against the gateway, making D
 | `test_chat.py` | Send message, SSE streaming, response rendering |
 | `test_skills.py` | ClawHub search, skill install/remove |
 | `test_tool_approval.py` | Tool approval overlay (approve, deny, always, params toggle) |
+| `test_reborn_webui_v2_tool_gates.py` | Reborn served tool turn, cancellation, approval gate, and manual-token auth gate |
 | `test_sse_reconnect.py` | SSE reconnection handling, keepalive comments, restart recovery, stale reconnect IDs, and connection-limit coverage |
 | `test_html_injection.py` | HTML injection security |
 | `test_extensions.py` | Extensions tab: install, remove, configure, OAuth, auth card, activate |

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -807,6 +807,13 @@ TOOL_CALL_PATTERNS = [
             "content": f"approved {m.group('label')}\n",
         },
     ),
+    # Reborn WebUI v2 auth-gate smoke (#4633): installation parks on GitHub's
+    # required manual-token credential, then resumes through product auth.
+    (
+        re.compile(r"reborn install github for auth gate", re.IGNORECASE),
+        "builtin__extension_install",
+        lambda _: {"extension_id": "github"},
+    ),
     (
         re.compile(
             r"reborn create automation rename target (?P<label>[a-z0-9_-]+)",

--- a/tests/e2e/reborn_coverage_tests.txt
+++ b/tests/e2e/reborn_coverage_tests.txt
@@ -14,6 +14,7 @@
 # provider-fixture or model-tool-choice coverage that should stay in the normal
 # E2E suite but not in this Reborn binary coverage gate.
 tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+tests/e2e/scenarios/test_reborn_webui_v2_tool_gates.py
 tests/e2e/scenarios/test_reborn_webui_v2_legacy_pending_messages.py::test_reborn_legacy_send_failure_renders_inline_error_not_toast
 tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_permissions.py::test_reborn_legacy_tool_permission_menu_persists_after_reload
 tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_permissions.py::test_reborn_legacy_tool_permission_retains_selection_while_saving

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_permissions.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_tool_permissions.py
@@ -517,10 +517,14 @@ async def test_reborn_legacy_always_approve_survives_reborn_restart(
         base_url = state["base_url"]
         reset = await client.post(
             f"{base_url}/api/webchat/v2/settings/tools/{capability_id}",
-            json={"state": "default"},
+            # The profile default is allowed to evolve. This scenario needs a
+            # deterministic first gate before it can prove that "always allow"
+            # survives restart, so pin that precondition explicitly.
+            json={"state": "ask_each_time"},
             timeout=15,
         )
         reset.raise_for_status()
+        assert reset.json()["entry"]["value"]["state"] == "ask_each_time"
         thread_id = await create_thread(client, base_url)
 
     first_prompt = await _wait_for_gate_prompt_after_send(

--- a/tests/e2e/scenarios/test_reborn_webui_v2_tool_gates.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_tool_gates.py
@@ -1,0 +1,350 @@
+"""Served Reborn WebUI v2 smoke coverage for tools and run gates.
+
+The canonical smoke module proves text-only turns. These tests exercise the
+remaining live ``ironclaw serve`` path through the deterministic mock model:
+tool dispatch, cancellation, approval resolution, and manual-token auth
+resolution. No route or SSE frame is stubbed.
+
+Tracks nearai/ironclaw#4633.
+"""
+
+import asyncio
+import json
+import uuid
+from urllib.parse import quote
+
+import aiohttp
+import httpx
+
+from helpers import REBORN_V2_AUTH_TOKEN
+from reborn_webui_harness import (
+    client_action_id,
+    create_thread,
+    fetch_timeline,
+    reborn_bearer_headers,
+    reborn_v2_server,  # noqa: F401 - imported fixture
+    reborn_v2_yolo_server,  # noqa: F401 - imported fixture
+    send_message,
+    wait_for_assistant_message,
+)
+
+
+def _events_url(base_url: str, thread_id: str) -> str:
+    return (
+        f"{base_url}/api/webchat/v2/threads/{thread_id}/events"
+        f"?token={REBORN_V2_AUTH_TOKEN}"
+    )
+
+
+async def _wait_for_sse_event(
+    response,
+    *event_types: str,
+    timeout: float = 60.0,
+    match=None,
+) -> dict:
+    """Return the first complete JSON SSE frame with a requested event type."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    current_event = ""
+    data_lines: list[str] = []
+    seen_events: list[str] = []
+
+    while asyncio.get_running_loop().time() < deadline:
+        remaining = deadline - asyncio.get_running_loop().time()
+        try:
+            raw = await asyncio.wait_for(response.content.readline(), timeout=remaining)
+        except asyncio.TimeoutError:
+            break
+        if not raw:
+            raise AssertionError(
+                "SSE stream closed before a matching event arrived; "
+                f"wanted={event_types}, seen={seen_events}"
+            )
+
+        line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+        if line.startswith("event:"):
+            current_event = line.removeprefix("event:").strip()
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line.removeprefix("data:").strip())
+            continue
+        if line or not data_lines:
+            continue
+
+        try:
+            payload = json.loads("\n".join(data_lines))
+        except json.JSONDecodeError:
+            current_event = ""
+            data_lines = []
+            continue
+
+        event_type = current_event or payload.get("type", "")
+        seen_events.append(event_type)
+        if event_type in event_types and (
+            match is None or match(event_type, payload)
+        ):
+            return payload
+        current_event = ""
+        data_lines = []
+
+    raise AssertionError(
+        f"Timed out waiting for SSE event {event_types}; seen={seen_events}"
+    )
+
+
+async def _set_llm_delay(mock_llm_server: str, marker: str) -> None:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{mock_llm_server}/__mock/llm_faults",
+            json={
+                "faults": [
+                    {
+                        "match": marker,
+                        "actions": [{"type": "delay", "seconds": 10.0}],
+                    }
+                ]
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+
+
+async def _wait_for_mock_request(
+    mock_llm_server: str,
+    marker: str,
+    *,
+    timeout: float = 20.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    async with httpx.AsyncClient() as client:
+        while asyncio.get_running_loop().time() < deadline:
+            response = await client.get(
+                f"{mock_llm_server}/__mock/chat_requests",
+                timeout=10,
+            )
+            response.raise_for_status()
+            for request in response.json().get("requests", []):
+                if marker in json.dumps(request):
+                    return
+            await asyncio.sleep(0.25)
+    raise AssertionError(f"Mock LLM never received request marker {marker!r}")
+
+
+def _tool_result_references(timeline: dict) -> list[dict]:
+    return [
+        message
+        for message in timeline.get("messages", [])
+        if message.get("kind") == "tool_result_reference"
+    ]
+
+
+async def test_reborn_v2_tool_turn_records_result_and_final_reply(
+    reborn_v2_yolo_server,
+):
+    marker = f"tool-turn-{uuid.uuid4().hex[:8]}"
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, reborn_v2_yolo_server)
+        await send_message(
+            client,
+            reborn_v2_yolo_server,
+            thread_id,
+            f"reborn builtin echo {marker}",
+        )
+        assistant = await wait_for_assistant_message(
+            client,
+            reborn_v2_yolo_server,
+            thread_id,
+            timeout=60,
+        )
+        timeline = await fetch_timeline(client, reborn_v2_yolo_server, thread_id)
+
+    references = _tool_result_references(timeline)
+    assert references, timeline
+    assert any(reference.get("tool_result_ref") for reference in references), references
+    assert assistant.get("status") == "finalized", assistant
+    assert (assistant.get("content") or "").strip(), assistant
+
+
+async def test_reborn_v2_cancel_in_flight_turn_ends_cancelled(
+    reborn_v2_server,
+    mock_llm_server,
+):
+    marker = f"cancel-in-flight-{uuid.uuid4().hex[:8]}"
+    await _set_llm_delay(mock_llm_server, marker)
+
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, reborn_v2_server)
+
+        timeout = aiohttp.ClientTimeout(total=75, sock_read=75)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                _events_url(reborn_v2_server, thread_id),
+                headers={"Accept": "text/event-stream"},
+            ) as stream:
+                assert stream.status == 200
+                submitted = await client.post(
+                    f"{reborn_v2_server}/api/webchat/v2/threads/{thread_id}/messages",
+                    json={
+                        "client_action_id": client_action_id(),
+                        "content": f"{marker}: hold this response",
+                    },
+                    timeout=30,
+                )
+                assert submitted.status_code in (200, 202), submitted.text
+                run_id = submitted.json()["run_id"]
+                await _wait_for_mock_request(mock_llm_server, marker)
+
+                cancelled = await client.post(
+                    f"{reborn_v2_server}/api/webchat/v2/threads/{thread_id}"
+                    f"/runs/{run_id}/cancel",
+                    json={
+                        "client_action_id": client_action_id(),
+                        "reason": "user_requested",
+                    },
+                    timeout=15,
+                )
+                assert cancelled.status_code == 200, cancelled.text
+                assert cancelled.json()["run_id"] == run_id
+
+                def is_cancelled(event_type: str, payload: dict) -> bool:
+                    if event_type == "cancelled":
+                        response = payload.get("response") or {}
+                        return (
+                            response.get("run_id") == run_id
+                            and response.get("status") == "Cancelled"
+                        )
+                    for item in payload.get("state", {}).get("items", []):
+                        status = item.get("run_status") or {}
+                        if status.get("status") == "cancelled":
+                            return True
+                    return False
+
+                event = await _wait_for_sse_event(
+                    stream,
+                    "cancelled",
+                    "projection_snapshot",
+                    "projection_update",
+                    timeout=45,
+                    match=is_cancelled,
+                )
+                assert is_cancelled(event.get("type", "projection_update"), event)
+
+
+async def test_reborn_v2_approval_gate_resolves_and_resumes(
+    reborn_v2_server,
+):
+    marker = f"approval-{uuid.uuid4().hex[:8]}"
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        permission = await client.post(
+            f"{reborn_v2_server}/api/webchat/v2/settings/tools/builtin.echo",
+            json={"state": "ask_each_time"},
+            timeout=15,
+        )
+        assert permission.status_code == 200, permission.text
+        thread_id = await create_thread(client, reborn_v2_server)
+
+        timeout = aiohttp.ClientTimeout(total=90, sock_read=90)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                _events_url(reborn_v2_server, thread_id),
+                headers={"Accept": "text/event-stream"},
+            ) as stream:
+                assert stream.status == 200
+                submitted = await client.post(
+                    f"{reborn_v2_server}/api/webchat/v2/threads/{thread_id}/messages",
+                    json={
+                        "client_action_id": client_action_id(),
+                        "content": f"reborn builtin echo {marker}",
+                    },
+                    timeout=30,
+                )
+                assert submitted.status_code in (200, 202), submitted.text
+
+                event = await _wait_for_sse_event(stream, "gate", timeout=60)
+                prompt = event["prompt"]
+                assert prompt["approval_context"]["tool_name"] == "builtin.echo"
+
+                resolved = await client.post(
+                    f"{reborn_v2_server}/api/webchat/v2/threads/{thread_id}"
+                    f"/runs/{prompt['turn_run_id']}"
+                    f"/gates/{quote(prompt['gate_ref'], safe='')}/resolve",
+                    json={
+                        "client_action_id": client_action_id(),
+                        "resolution": "approved",
+                        "always": False,
+                    },
+                    timeout=15,
+                )
+                assert resolved.status_code == 200, resolved.text
+                assert resolved.json()["outcome"] == "resumed", resolved.text
+
+        assistant = await wait_for_assistant_message(
+            client,
+            reborn_v2_server,
+            thread_id,
+            timeout=60,
+        )
+        timeline = await fetch_timeline(client, reborn_v2_server, thread_id)
+
+    assert assistant.get("status") == "finalized", assistant
+    assert _tool_result_references(timeline), timeline
+
+
+async def test_reborn_v2_manual_token_auth_gate_resolves_and_resumes(
+    reborn_v2_yolo_server,
+):
+    raw_token = f"ghp_e2e_{uuid.uuid4().hex}"
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await create_thread(client, reborn_v2_yolo_server)
+
+        timeout = aiohttp.ClientTimeout(total=120, sock_read=120)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                _events_url(reborn_v2_yolo_server, thread_id),
+                headers={"Accept": "text/event-stream"},
+            ) as stream:
+                assert stream.status == 200
+                submitted = await client.post(
+                    f"{reborn_v2_yolo_server}/api/webchat/v2/threads/{thread_id}/messages",
+                    json={
+                        "client_action_id": client_action_id(),
+                        "content": "reborn install github for auth gate",
+                    },
+                    timeout=30,
+                )
+                assert submitted.status_code in (200, 202), submitted.text
+
+                event = await _wait_for_sse_event(stream, "auth_required", timeout=75)
+                prompt = event["prompt"]
+                assert prompt["provider"] == "github", prompt
+                assert prompt["challenge_kind"] == "manual_token", prompt
+
+                token_submit = await client.post(
+                    f"{reborn_v2_yolo_server}"
+                    "/api/reborn/product-auth/manual-token/submit",
+                    json={
+                        "provider": "github",
+                        "account_label": "Reborn E2E GitHub",
+                        "token": raw_token,
+                        "thread_id": thread_id,
+                        "run_id": prompt["turn_run_id"],
+                        "gate_ref": prompt["auth_request_ref"],
+                    },
+                    timeout=15,
+                )
+                assert token_submit.status_code == 200, token_submit.text
+                token_body = token_submit.json()
+                assert token_body["credential_ref"], token_body
+                assert token_body["continuation"]["type"] == "turn_gate_resume"
+                assert raw_token not in token_submit.text
+
+        assistant = await wait_for_assistant_message(
+            client,
+            reborn_v2_yolo_server,
+            thread_id,
+            timeout=75,
+        )
+        timeline = await fetch_timeline(client, reborn_v2_yolo_server, thread_id)
+
+    assert assistant.get("status") == "finalized", assistant
+    assert _tool_result_references(timeline), timeline
+    assert raw_token not in json.dumps(timeline)


### PR DESCRIPTION
## Summary

- Adds served Reborn WebUI v2 smoke coverage for tool dispatch, persisted
  `tool_result_reference` records, and finalized assistant replies.
- Covers in-flight run cancellation, approval-gate resolution, and manual-token
  auth-gate resume through the real `ironclaw serve` HTTP/SSE path.
- Adds the scenario to the required Reborn E2E coverage manifest and makes the
  existing approval restart test independent of profile-default permission drift.
- Keeps credentials redacted and uses deterministic mock-model triggers without
  external network dependencies.

## Linked Issue

Closes #4633

## Validation

- `pytest -q --timeout=120 tests/e2e/scenarios/test_reborn_webui_v2_tool_gates.py -s`
  - 4 passed
- Approval restart regression plus the new module
  - 5 passed
- `pytest --collect-only -q tests/e2e/scenarios/test_reborn_webui_v2_tool_gates.py`
  - 4 tests collected
- `bash scripts/ci/test-classify-test-scope.sh`
- `git diff --check`

## Security Impact

No production security behavior changes. The E2E auth scenario uses a generated
fake token and asserts that neither API responses nor timeline projections expose it.

## Database Impact

None. No schema or migration changes.

## Blast Radius

Limited to the deterministic mock LLM, Reborn WebUI v2 E2E scenarios, coverage
manifest, and E2E documentation.

## Rollback Plan

Revert commit `cabbf911f` to remove the additional coverage and mock trigger.

---

**Review track**: A