### PR TITLE
feat(prompt): ground capability answers in published docs (#6734)

### DIFF
--- a/crates/ironclaw_reborn_composition/assets/prompts/default-system.md
+++ b/crates/ironclaw_reborn_composition/assets/prompts/default-system.md
@@ -10,10 +10,6 @@ You are IronClaw Agent, a secure autonomous assistant.
 
 For any non-trivial calculation — statistics, growth rates, regressions, aggregations, moving averages, unit or currency conversions — do not do the arithmetic in your head. Write the values into a short script and run it with the shell or code tool (e.g. `python3 -c ...`) so the result is exact, then report the computed value. Mental arithmetic over multi-step numeric work is error-prone.
 
-## Self-Knowledge
-
-When asked about IronClaw's own capabilities, configuration, tools, channels, or extensions, do not answer from memory. Fetch https://docs.ironclaw.com/llms.txt to locate the page that covers the question, then fetch that page's URL with `.md` appended for its full content (for example https://docs.ironclaw.com/capabilities/sandboxed-tools.md). If the fetch fails or the docs do not cover the question, say you could not verify it rather than guessing.
-
 ## Tool Continuation
 
 When a tool result is partial, truncated, failed, or otherwise shows the requested work is unfinished, adapt and continue autonomously. Ask the user only when progress requires external information, approval, or a product decision.

--- a/crates/ironclaw_reborn_composition/assets/prompts/default-system.md
+++ b/crates/ironclaw_reborn_composition/assets/prompts/default-system.md
@@ -10,6 +10,10 @@ You are IronClaw Agent, a secure autonomous assistant.
 
 For any non-trivial calculation — statistics, growth rates, regressions, aggregations, moving averages, unit or currency conversions — do not do the arithmetic in your head. Write the values into a short script and run it with the shell or code tool (e.g. `python3 -c ...`) so the result is exact, then report the computed value. Mental arithmetic over multi-step numeric work is error-prone.
 
+## Self-Knowledge
+
+When asked about IronClaw's own capabilities, configuration, tools, channels, or extensions, do not answer from memory. Fetch https://docs.ironclaw.com/llms.txt to locate the page that covers the question, then fetch that page's URL with `.md` appended for its full content (for example https://docs.ironclaw.com/capabilities/sandboxed-tools.md). If the fetch fails or the docs do not cover the question, say you could not verify it rather than guessing.
+
 ## Tool Continuation
 
 When a tool result is partial, truncated, failed, or otherwise shows the requested work is unfinished, adapt and continue autonomously. Ask the user only when progress requires external information, approval, or a product decision.

--- a/crates/ironclaw_reborn_composition/assets/prompts/self-knowledge.md
+++ b/crates/ironclaw_reborn_composition/assets/prompts/self-knowledge.md
@@ -1,0 +1,3 @@
+## Self-Knowledge
+
+When asked about IronClaw's own capabilities, configuration, tools, channels, or extensions, do not answer from memory. Fetch https://docs.ironclaw.com/llms.txt to locate the page that covers the question, then fetch that page's URL with `.md` appended for its full content (for example https://docs.ironclaw.com/capabilities/sandboxed-tools.md). If the fetch fails or the docs do not cover the question, say you could not verify it rather than guessing.

--- a/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
+++ b/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
@@ -368,6 +368,20 @@ mod tests {
                 .content
                 .contains("When a tool result is partial, truncated, failed")
         );
+        // Self-knowledge must be grounded in the published docs site rather than
+        // recalled from training data (#6734): the prompt has to name the
+        // llms.txt index and the `.md` raw-markdown suffix, or the model has no
+        // way to look its own capabilities up.
+        assert!(
+            content
+                .content
+                .contains("https://docs.ironclaw.com/llms.txt"),
+            "prompt must point capability questions at the docs index"
+        );
+        assert!(
+            content.content.contains(".md"),
+            "prompt must teach the raw-markdown `.md` suffix for docs pages"
+        );
         assert!(
             !content.content.contains("tool_search"),
             "disclosure-off prompt must not mention the bridge tools"

--- a/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
+++ b/crates/ironclaw_reborn_composition/src/root/default_system_prompt.rs
@@ -26,6 +26,15 @@ const DEFAULT_SYSTEM_PROMPT_EMBEDDED: &str = include_str!("../../assets/prompts/
 /// disclosure is off (no bridges exist on that surface).
 const TOOL_DISCLOSURE_PROTOCOL_EMBEDDED: &str =
     include_str!("../../assets/prompts/tool-disclosure-protocol.md");
+/// Docs-grounding self-knowledge protocol, appended to the system prompt
+/// unconditionally. This is ground knowledge about the running system, not a
+/// user preference: without it the model answers questions about IronClaw's own
+/// capabilities from training data instead of the published docs. Seeding it
+/// into the user-editable file would only reach fresh installs, so it is
+/// appended in memory on every resolve — the same mechanism the tool-disclosure
+/// protocol uses.
+const SELF_KNOWLEDGE_PROTOCOL_EMBEDDED: &str =
+    include_str!("../../assets/prompts/self-knowledge.md");
 const MAX_DEFAULT_SYSTEM_PROMPT_BYTES: u64 = 64 * 1024;
 
 #[derive(Debug, thiserror::Error)]
@@ -51,7 +60,8 @@ pub(crate) struct DefaultSystemPromptIdentitySource {
     /// When true, the progressive tool-disclosure protocol is appended to the
     /// system prompt so the model is told to discover deferred tools via
     /// `tool_search`. Set from the resolved tool-disclosure mode at build time;
-    /// off ⇒ the prompt content is byte-identical to the seeded file.
+    /// off ⇒ the prompt carries the file plus the unconditional self-knowledge
+    /// section, and nothing that references the bridge tools.
     disclosure_protocol_active: bool,
     loaded_identity_content: Arc<RwLock<HashMap<LoopMessageRef, HostIdentityMessageContent>>>,
 }
@@ -72,19 +82,14 @@ impl DefaultSystemPromptIdentitySource {
     }
 
     fn prompt_content(&self) -> Result<String, DefaultSystemPromptError> {
-        let base = read_default_system_prompt(&self.storage_root, &self.prompt_path)?;
-        if !self.disclosure_protocol_active {
-            return Ok(base);
+        // Append in memory (not to the seeded, user-editable file) so these
+        // sections are system invariants independent of user edits to SYSTEM.md
+        // — and so existing installs get them, not just freshly seeded ones.
+        let mut content = read_default_system_prompt(&self.storage_root, &self.prompt_path)?;
+        append_section(&mut content, SELF_KNOWLEDGE_PROTOCOL_EMBEDDED);
+        if self.disclosure_protocol_active {
+            append_section(&mut content, TOOL_DISCLOSURE_PROTOCOL_EMBEDDED);
         }
-        // Append in memory (not to the seeded, user-editable file) so the
-        // disclosure protocol is a system invariant whenever disclosure is on,
-        // independent of user edits to SYSTEM.md.
-        let mut content = base;
-        if !content.ends_with('\n') {
-            content.push('\n');
-        }
-        content.push('\n');
-        content.push_str(TOOL_DISCLOSURE_PROTOCOL_EMBEDDED);
         Ok(content)
     }
 
@@ -145,6 +150,17 @@ pub(crate) fn seed_default_system_prompt(
     }
     validate_default_system_prompt(storage_root, path)?;
     Ok(())
+}
+
+/// Append an embedded prompt section after `content`, separated by a blank line
+/// so the markdown heading always starts its own block regardless of how the
+/// user's file ends.
+fn append_section(content: &mut String, section: &str) {
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content.push('\n');
+    content.push_str(section);
 }
 
 fn read_default_system_prompt(
@@ -371,7 +387,15 @@ mod tests {
         // Self-knowledge must be grounded in the published docs site rather than
         // recalled from training data (#6734): the prompt has to name the
         // llms.txt index and the `.md` raw-markdown suffix, or the model has no
-        // way to look its own capabilities up.
+        // way to look its own capabilities up. The guidance is ground knowledge
+        // about the runtime, so it is appended in memory rather than seeded into
+        // the user-editable file — otherwise only fresh installs would get it.
+        assert!(
+            !std::fs::read_to_string(&prompt_path)
+                .expect("seeded prompt reads")
+                .contains("docs.ironclaw.com"),
+            "docs grounding must not be seeded into the user-editable prompt file"
+        );
         assert!(
             content
                 .content
@@ -481,7 +505,30 @@ mod tests {
             .expect("resolve edited content")
             .expect("edited content exists");
 
-        assert_eq!(content.content, "edited local-dev prompt");
+        // The user's edited base is preserved verbatim and stays first, but the
+        // docs-grounding self-knowledge section is ground knowledge about the
+        // runtime (#6734): it is appended unconditionally, so an install whose
+        // SYSTEM.md predates the guidance (or was edited to drop it) still tells
+        // the model to look its own capabilities up instead of guessing.
+        assert!(content.content.starts_with("edited local-dev prompt"));
+        assert!(
+            content.content.contains("## Self-Knowledge"),
+            "self-knowledge guidance must be appended even when SYSTEM.md omits it"
+        );
+        assert!(
+            content
+                .content
+                .contains("https://docs.ironclaw.com/llms.txt"),
+            "appended guidance must point capability questions at the docs index"
+        );
+        assert!(
+            content.content.contains(".md"),
+            "appended guidance must teach the raw-markdown `.md` suffix for docs pages"
+        );
+        assert!(
+            !content.content.contains("tool_search"),
+            "disclosure-off prompt must not mention the bridge tools"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/default_system_prompt.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/default_system_prompt.rs
@@ -150,6 +150,19 @@ async fn local_dev_runtime_uses_existing_edited_default_system_prompt() {
         }),
         "default-on disclosure should append the tool-search protocol to the edited prompt"
     );
+    // Docs grounding is ground knowledge about the runtime (#6734), not a seed
+    // default: an install whose SYSTEM.md never contained it must still be told
+    // to look IronClaw's own capabilities up in the published docs.
+    assert!(
+        recorded_requests[0].messages.iter().any(|message| {
+            message.role == HostManagedModelMessageRole::System
+                && message.content.starts_with("custom edited runtime prompt")
+                && message
+                    .content
+                    .contains("https://docs.ironclaw.com/llms.txt")
+        }),
+        "self-knowledge docs grounding should reach the model even for a custom system prompt"
+    );
 
     runtime.shutdown().await.expect("runtime shutdown");
 }


### PR DESCRIPTION
## Problem

Ask the running agent what it can do and it answers from training data. That produces confident, wrong claims about its own product — the motivating example in #6734 is the agent describing Slack Block Kit support it does not have. Every one of these is a support burden and a trust hit, and none of them is detectable by the user in the moment.

## Design choice: point at the published site, don't embed the docs

`docs.ironclaw.com` is already agent-ready:

- `https://docs.ironclaw.com/llms.txt` — an index of every page with a one-line description (verified 200, `text/plain`).
- Any page URL with `.md` appended returns raw markdown (e.g. `https://docs.ironclaw.com/capabilities/sandboxed-tools.md`, verified 200, `text/markdown`).

So the fix is a prompt instruction, not a data pipeline. The alternative — embedding a docs snapshot in the binary or a memory mount — costs context budget on every turn, goes stale the moment docs ship, and needs a sync job. Fetching the live site means the answer is always current and costs nothing when nobody asks.

The agent already has `http` and `web_search` in its always-advertised core tool set (`crates/ironclaw_runner/src/tool_disclosure.rs`), so no tool wiring was needed.

## Network-policy finding (no change required)

Traced `builtin.http` egress end to end:

- `crates/ironclaw_reborn_composition/src/builtin_capability_policy.toml` grants `builtin.http` the `dev_wildcard` network profile.
- `dev_wildcard_network_policy()` is `host_pattern = "*"` with `deny_private_ip_ranges = true`.
- That policy becomes the `ApplyNetworkPolicy` obligation in `ironclaw_authorization::obligations_for_grant`, is staged into `HostHttpEgressService`, and is enforced by `ironclaw_network::policy::network_policy_allows`.
- The same policy file is loaded by production wiring, not just local-dev.

So `https://docs.ironclaw.com` is reachable by default (public host, no private-IP overlap). **No allowlist entry is needed, and none was added** — keeping the PR to the prompt change alone.

## Change

A short `## Self-Knowledge` section telling the model to fetch `llms.txt`, then the relevant page with `.md` appended, and to say it could not verify rather than guess when the fetch fails or the docs don't cover the question.

**It reaches every install, not just fresh seeds.** The guidance is ground knowledge about the runtime, not a user preference, so it does *not* live in the once-seeded, user-editable `default-system.md`. It lives in its own `crates/ironclaw_reborn_composition/assets/prompts/self-knowledge.md` (per the repo convention that prompt text lives in files, not Rust strings), loaded via `include_str!()` and appended unconditionally in `DefaultSystemPromptIdentitySource::prompt_content` — the same in-memory mechanism that already appends the tool-disclosure protocol. Consequences:

- An install whose `SYSTEM.md` was seeded before this change still gets the guidance on the next turn.
- A user who edits or rewrites `SYSTEM.md` cannot silently drop it.
- Ordering: the user's file leads, then self-knowledge, then the (disclosure-conditional) tool-disclosure protocol, each separated by a blank line via a shared `append_section` helper so headings always start their own markdown block.
- The section was removed from the seeded asset, so a fresh install does not get it twice.

## Test evidence

Extended the existing prompt-assembly tests rather than adding new files (consolidate-don't-proliferate), and deliberately assert **through the append path, not the asset**:

- `root::default_system_prompt::tests::default_system_prompt_reloads_edited_prompt_for_new_candidates` now writes a custom `SYSTEM.md` that contains none of the guidance, and pins that the resolved prompt still starts with the user's content *and* carries `## Self-Knowledge`, the `llms.txt` index, and the `.md` suffix.
- `..._loads_and_resolves_as_identity_message` additionally pins that the on-disk user-editable file does **not** contain `docs.ironclaw.com` (the guidance must come from the append path).
- `runtime::default_system_prompt_tests::local_dev_runtime_uses_existing_edited_default_system_prompt` pins at the runtime tier that the docs index reaches the real model gateway even for a fully custom system prompt.

No live network fetch in any test.

Red run (tests updated, implementation unchanged):

```
test root::default_system_prompt::tests::default_system_prompt_reloads_edited_prompt_for_new_candidates ... FAILED
  self-knowledge guidance must be appended even when SYSTEM.md omits it
test root::default_system_prompt::tests::default_system_prompt_loads_and_resolves_as_identity_message ... FAILED
  docs grounding must not be seeded into the user-editable prompt file
test runtime::default_system_prompt_tests::local_dev_runtime_uses_existing_edited_default_system_prompt ... FAILED
  self-knowledge docs grounding should reach the model even for a custom system prompt
test result: FAILED. 4 passed; 3 failed
```

Green run (after moving the section into the appended content):

```
test result: ok. 7 passed; 0 failed; 0 ignored; 626 filtered out
```

Also run:

- `cargo fmt`
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p ironclaw_reborn_composition --lib --no-fail-fast` — 632 passed, 1 failed. That failure is **pre-existing and unrelated**: `observability::trace_capture::tests::capture_skips_when_policy_missing_or_disabled` fails identically on the clean tree with this branch stashed (machine-local trace-commons enrollment state). The other known flake, `runtime::tests::local_dev_runtime_webui_bundle_reuses_thread_and_turn_services` (a parallel-load timeout), passed on this run. No new failures.

Part of #6734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
