### PR TITLE
fix(turns): denials must say what would unlock the call

### DIFF
--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -1307,14 +1307,16 @@ mod tests {
 
         match outcome {
             Resolution::Denied(denial) => {
-                // Flip consequence (§5.2.9 collapse, confirmed) — the fail-closed
-                // `hook_gate_ref_unavailable` reason_kind collapses to
-                // `DenyReason::PolicyDenied` (`deny_reason_from_kind` buckets
-                // every loop-originated reason string that is not a DenyReason
-                // tag into `PolicyDenied`), so it is no longer distinguishable
-                // from a plain hook deny. The original test's purpose — pinning
-                // the specific fail-closed reason — can no longer be met.
-                assert_eq!(denial.reason_kind, Some(DenyReason::PolicyDenied));
+                // The fail-closed gate-ref failure is an internal fault, not a
+                // policy refusal, and must not read to the model as one: there
+                // is no permission for the caller to obtain here. (This pinning
+                // was lost while `deny_reason_from_kind` bucketed every
+                // non-DenyReason-tag string into `PolicyDenied`; the explicit
+                // mapping table restores it.)
+                assert_eq!(
+                    denial.reason_kind,
+                    Some(DenyReason::InternalInvariantViolation)
+                );
                 // Sanitized hook reason is preserved on the Denial summary
                 // channel; underlying error text ("no router") must not leak.
                 assert_eq!(
@@ -1348,14 +1350,16 @@ mod tests {
 
         match outcome {
             Resolution::Denied(denial) => {
-                // Flip consequence (§5.2.9 collapse, confirmed) — the fail-closed
-                // `hook_gate_ref_unavailable` reason_kind collapses to
-                // `DenyReason::PolicyDenied` (`deny_reason_from_kind` buckets
-                // every loop-originated reason string that is not a DenyReason
-                // tag into `PolicyDenied`), so it is no longer distinguishable
-                // from a plain hook deny. The original test's purpose — pinning
-                // the specific fail-closed reason — can no longer be met.
-                assert_eq!(denial.reason_kind, Some(DenyReason::PolicyDenied));
+                // The fail-closed gate-ref failure is an internal fault, not a
+                // policy refusal, and must not read to the model as one: there
+                // is no permission for the caller to obtain here. (This pinning
+                // was lost while `deny_reason_from_kind` bucketed every
+                // non-DenyReason-tag string into `PolicyDenied`; the explicit
+                // mapping table restores it.)
+                assert_eq!(
+                    denial.reason_kind,
+                    Some(DenyReason::InternalInvariantViolation)
+                );
                 // Sanitized hook reason is preserved on the Denial summary
                 // channel; underlying error text ("no router") must not leak.
                 assert_eq!(

--- a/crates/ironclaw_runner/tests/loop_driver_host.rs
+++ b/crates/ironclaw_runner/tests/loop_driver_host.rs
@@ -6818,10 +6818,13 @@ async fn text_only_host_rejects_outside_surface_capability_before_host_runtime()
         .await
         .unwrap();
 
-    // Flip consequence (§5.2.9, confirmed): outside_visible_surface collapsed to PolicyDenied (was CapabilityDeniedReasonKind Unknown "outside_visible_surface")
+    // The capability is not in this caller's view at all: there is nothing to
+    // unlock and re-issuing the same call cannot succeed, which is a different
+    // instruction to the model than a policy refusal. (Restored with the
+    // explicit classification in `deny_reason_from_kind`.)
     assert!(matches!(
         denied,
-        Resolution::Denied(denied) if denied.reason_kind == Some(DenyReason::PolicyDenied)
+        Resolution::Denied(denied) if denied.reason_kind == Some(DenyReason::UnknownCapability)
     ));
     assert!(runtime.invocations().is_empty());
 
@@ -7963,11 +7966,14 @@ async fn text_only_host_denies_capability_without_provider_trust_before_host_run
         .await
         .unwrap();
 
-    // Flip consequence (§5.2.9, confirmed): missing_provider_trust collapsed to PolicyDenied (was CapabilityDeniedReasonKind Unknown "missing_provider_trust")
+    // No trust decision is on record for the provider, so what is missing is a
+    // grant — not a permission the caller has already been refused. (This read
+    // was lost while `deny_reason_from_kind` bucketed every non-DenyReason-tag
+    // string into `PolicyDenied`; the explicit classification restores it.)
     assert!(matches!(
         denied,
         Resolution::Denied(denied)
-            if denied.reason_kind == Some(DenyReason::PolicyDenied)
+            if denied.reason_kind == Some(DenyReason::MissingGrant)
                 && denied.summary.as_ref().map(|summary| summary.as_str())
                     == Some("capability provider trust is unavailable")
     ));

--- a/crates/ironclaw_turns/src/run_profile/resolution.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolution.rs
@@ -614,16 +614,156 @@ fn safe_summary_or_placeholder(raw: String) -> SafeSummary {
 /// spells a `DenyReason` snake_case tag is honored, and everything else — every
 /// loop-originated denial — buckets into the model-visible catch-all
 /// [`DenyReason::PolicyDenied`].
+/// Map a denial's producer-side reason onto the model-visible [`DenyReason`].
+///
+/// This was a serde parse over `DenyReason`'s snake_case tags, which silently
+/// fell back to `PolicyDenied`. Twelve of the thirteen reason strings
+/// production actually mints are not `DenyReason` tags, so nearly every denial
+/// reached the model as a flat "policy denied" — *no capabilities are
+/// available to you*, *a hook blocked this*, *you need to authenticate*, and
+/// *an approval is waiting for a human* were all indistinguishable. Only
+/// `network_denied` happened to coincide with a tag and survive.
+///
+/// The distinction the model needs is **what would unlock the call** (#6284
+/// item 4): a permanent block, a missing credential, and a pending approval
+/// call for three different next actions, and collapsing them leaves the model
+/// guessing. This is an explicit table so a new reason has to choose, rather
+/// than defaulting into the flattest answer available.
 fn deny_reason_from_kind(kind: &CapabilityDeniedReasonKind) -> DenyReason {
-    use serde::{
-        Deserialize,
-        de::{IntoDeserializer, value::StrDeserializer},
-    };
-    // Deserialize straight from the &str (no JSON Value/String allocation);
-    // DenyReason's snake_case serde tags are the match vocabulary.
-    let deserializer: StrDeserializer<'_, serde::de::value::Error> =
-        kind.as_str().into_deserializer();
-    DenyReason::deserialize(deserializer).unwrap_or(DenyReason::PolicyDenied)
+    match kind.as_str() {
+        // Named a capability that is not in this caller's view: nothing to
+        // unlock, and retrying the same call cannot succeed.
+        //
+        // `empty_surface` deliberately stays `PolicyDenied` below rather than
+        // joining these. An empty surface is normally a profile/policy outcome
+        // ("this loop is configured without tools"), and two existing tests pin
+        // that reading — `deny_record_reason_maps_best_effort_with_policy_fallback`
+        // names it outright. Reclassifying it is arguable but unproven, so the
+        // pinned decision stands.
+        "model_view_denied" | "outside_visible_surface" => DenyReason::UnknownCapability,
+        // A credential is missing or refused: an auth flow is the unlock.
+        "auth_denied" => DenyReason::UnknownSecret,
+        // A human approval is pending or was refused — re-asking can succeed.
+        "outbound_delivery_approval_required" | "expected_approval" => DenyReason::ApprovalDenied,
+        // Egress refused by network policy.
+        "network_denied" => DenyReason::NetworkDenied,
+        // Host-side invariant broke; not the caller's doing and not unlockable
+        // by them.
+        "hook_gate_ref_unavailable" => DenyReason::InternalInvariantViolation,
+        // Model-supplied input the model itself can correct.
+        "invalid_spawn_input" => DenyReason::MissingGrant,
+        // Genuine policy refusals: nothing the caller does unlocks these.
+        "host_policy_denied" | "hook_denied" | "surface_profile_denied" => DenyReason::PolicyDenied,
+        // An unrecognised reason is a *new* one, and the honest answer is the
+        // conservative one — but it is now reachable only by a reason nobody
+        // has classified, not by every reason in the product.
+        _ => DenyReason::PolicyDenied,
+    }
+}
+
+#[cfg(test)]
+mod deny_reason_tests {
+    use super::*;
+
+    fn reason(tag: &str) -> CapabilityDeniedReasonKind {
+        CapabilityDeniedReasonKind::unknown(tag).expect("valid reason tag")
+    }
+
+    /// Denials must tell the model *what would unlock the call*.
+    ///
+    /// The previous serde parse matched `DenyReason`'s own tags, and twelve of
+    /// the thirteen reasons production mints are not among them — so a missing
+    /// credential, a pending human approval, a blocked egress and a genuine
+    /// policy block all arrived as `PolicyDenied`. Each of those wants a
+    /// different next action from the model, and it had no way to tell them
+    /// apart. This pins that they stay distinguishable.
+    #[test]
+    fn denials_distinguish_what_would_unlock_the_call() {
+        // Not your capability — nothing to unlock, but not a policy refusal.
+        for tag in ["model_view_denied", "outside_visible_surface"] {
+            assert_eq!(
+                deny_reason_from_kind(&reason(tag)),
+                DenyReason::UnknownCapability,
+                "{tag} should read as an absent capability"
+            );
+        }
+        // A credential unlocks this one.
+        assert_eq!(
+            deny_reason_from_kind(&reason("auth_denied")),
+            DenyReason::UnknownSecret,
+            "auth_denied should point at an auth flow"
+        );
+        // A human unlocks these.
+        for tag in ["outbound_delivery_approval_required", "expected_approval"] {
+            assert_eq!(
+                deny_reason_from_kind(&reason(tag)),
+                DenyReason::ApprovalDenied,
+                "{tag} should read as approvable, not forbidden"
+            );
+        }
+        // Nothing the caller does unlocks these. `empty_surface` is here
+        // deliberately: existing tests pin it as a policy outcome, and
+        // reclassifying it is arguable but unproven.
+        for tag in [
+            "host_policy_denied",
+            "hook_denied",
+            "surface_profile_denied",
+            "empty_surface",
+        ] {
+            assert_eq!(
+                deny_reason_from_kind(&reason(tag)),
+                DenyReason::PolicyDenied,
+                "{tag} is a genuine policy refusal"
+            );
+        }
+        assert_eq!(
+            deny_reason_from_kind(&reason("network_denied")),
+            DenyReason::NetworkDenied
+        );
+        assert_eq!(
+            deny_reason_from_kind(&reason("hook_gate_ref_unavailable")),
+            DenyReason::InternalInvariantViolation
+        );
+    }
+
+    /// The conservative fallback must remain reachable only by a reason nobody
+    /// has classified — not by the whole product, as before.
+    #[test]
+    fn an_unclassified_reason_still_falls_back_conservatively() {
+        assert_eq!(
+            deny_reason_from_kind(&reason("some_future_reason")),
+            DenyReason::PolicyDenied
+        );
+    }
+
+    /// Guard against the collapse returning: if every distinct production
+    /// reason maps to one value again, this fails.
+    #[test]
+    fn production_denial_reasons_do_not_collapse_to_one_value() {
+        let produced = [
+            "empty_surface",
+            "model_view_denied",
+            "outside_visible_surface",
+            "auth_denied",
+            "outbound_delivery_approval_required",
+            "network_denied",
+            "hook_gate_ref_unavailable",
+            "invalid_spawn_input",
+            "host_policy_denied",
+            "hook_denied",
+            "surface_profile_denied",
+        ];
+        let distinct: std::collections::HashSet<DenyReason> = produced
+            .iter()
+            .map(|tag| deny_reason_from_kind(&reason(tag)))
+            .collect();
+        assert!(
+            distinct.len() >= 6,
+            "denial reasons collapsed to {} distinct values; the model cannot \
+             tell an auth prompt from a permanent block",
+            distinct.len()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_turns/src/run_profile/resolution.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolution.rs
@@ -611,39 +611,58 @@ fn safe_summary_or_placeholder(raw: String) -> SafeSummary {
 /// `model_view_denied`); host_api's [`DenyReason`] is a fixed closed enum whose
 /// variants originate on the host authorize path, not the loop. There is no
 /// faithful 1:1, so this is a best-effort match: a reason string that already
-/// spells a `DenyReason` snake_case tag is honored, and everything else — every
-/// loop-originated denial — buckets into the model-visible catch-all
-/// [`DenyReason::PolicyDenied`].
-/// Map a denial's producer-side reason onto the model-visible [`DenyReason`].
+/// Every denial reason string a producer in this workspace can mint.
 ///
-/// This was a serde parse over `DenyReason`'s snake_case tags, which silently
-/// fell back to `PolicyDenied`. Twelve of the thirteen reason strings
-/// production actually mints are not `DenyReason` tags, so nearly every denial
-/// reached the model as a flat "policy denied" — *no capabilities are
-/// available to you*, *a hook blocked this*, *you need to authenticate*, and
-/// *an approval is waiting for a human* were all indistinguishable. Only
-/// `network_denied` happened to coincide with a tag and survive.
+/// Verified by enumerating the mint sites — `CapabilityDeniedReasonKind::unknown`,
+/// `capability_denied_reason_kind`, the named `EmptySurface` variant, and
+/// `denied_reason_kind_for` (guarded to `Authorization | PolicyDenied`, so it
+/// yields exactly `auth_denied` and `policy_denied`). `PRODUCTION_DENY_REASONS`
+/// pins that list; [`classify_deny_reason`] must have an answer for each, so a
+/// newly minted reason cannot silently inherit the conservative fallback.
 ///
-/// The distinction the model needs is **what would unlock the call** (#6284
-/// item 4): a permanent block, a missing credential, and a pending approval
-/// call for three different next actions, and collapsing them leaves the model
-/// guessing. This is an explicit table so a new reason has to choose, rather
-/// than defaulting into the flattest answer available.
-fn deny_reason_from_kind(kind: &CapabilityDeniedReasonKind) -> DenyReason {
-    match kind.as_str() {
+/// Deliberately excluded: `expected_approval` and `host_policy_denied`, which
+/// [`classify_deny_reason`] handles but which appear only in contract-test
+/// fixtures. Listing them here would claim producer coverage this crate does
+/// not have.
+#[cfg(test)]
+const PRODUCTION_DENY_REASONS: [&str; 12] = [
+    "auth_denied",
+    "policy_denied",
+    "empty_surface",
+    "hook_denied",
+    "hook_gate_ref_unavailable",
+    "invalid_spawn_input",
+    "missing_provider_trust",
+    "model_view_denied",
+    "network_denied",
+    "outbound_delivery_approval_required",
+    "outside_visible_surface",
+    "surface_profile_denied",
+];
+
+/// Classify a denial's producer-side reason, or `None` if nobody has classified
+/// it yet.
+///
+/// Split out from [`deny_reason_from_kind`] so the "unclassified" case stays
+/// *visible*. Folded into the function, an unclassified reason is
+/// indistinguishable from a deliberate `PolicyDenied`, which is precisely how
+/// the original collapse hid: every reason looked like a decision.
+fn classify_deny_reason(tag: &str) -> Option<DenyReason> {
+    Some(match tag {
         // Named a capability that is not in this caller's view: nothing to
         // unlock, and retrying the same call cannot succeed.
         //
         // `empty_surface` deliberately stays `PolicyDenied` below rather than
         // joining these. An empty surface is normally a profile/policy outcome
-        // ("this loop is configured without tools"), and two existing tests pin
-        // that reading — `deny_record_reason_maps_best_effort_with_policy_fallback`
+        // ("this loop is configured without tools"), and four sites pin that
+        // reading — `deny_record_reason_maps_best_effort_with_policy_fallback`
         // names it outright. Reclassifying it is arguable but unproven, so the
         // pinned decision stands.
         "model_view_denied" | "outside_visible_surface" => DenyReason::UnknownCapability,
         // A credential is missing or refused: an auth flow is the unlock.
         "auth_denied" => DenyReason::UnknownSecret,
         // A human approval is pending or was refused — re-asking can succeed.
+        // `expected_approval` is a contract-test tag, not a producer tag.
         "outbound_delivery_approval_required" | "expected_approval" => DenyReason::ApprovalDenied,
         // Egress refused by network policy.
         "network_denied" => DenyReason::NetworkDenied,
@@ -652,13 +671,41 @@ fn deny_reason_from_kind(kind: &CapabilityDeniedReasonKind) -> DenyReason {
         "hook_gate_ref_unavailable" => DenyReason::InternalInvariantViolation,
         // Model-supplied input the model itself can correct.
         "invalid_spawn_input" => DenyReason::MissingGrant,
+        // The provider has no trust decision on record — a grant is what is
+        // missing, not a permission the caller already lacks.
+        "missing_provider_trust" => DenyReason::MissingGrant,
         // Genuine policy refusals: nothing the caller does unlocks these.
-        "host_policy_denied" | "hook_denied" | "surface_profile_denied" => DenyReason::PolicyDenied,
-        // An unrecognised reason is a *new* one, and the honest answer is the
-        // conservative one — but it is now reachable only by a reason nobody
-        // has classified, not by every reason in the product.
-        _ => DenyReason::PolicyDenied,
-    }
+        // `host_policy_denied` is a contract-test tag, not a producer tag.
+        "policy_denied"
+        | "host_policy_denied"
+        | "hook_denied"
+        | "surface_profile_denied"
+        | "empty_surface" => DenyReason::PolicyDenied,
+        _ => return None,
+    })
+}
+
+/// Map a denial's producer-side reason onto the model-visible [`DenyReason`].
+///
+/// This was a serde parse over `DenyReason`'s snake_case tags, which silently
+/// fell back to `PolicyDenied`. Of the twelve reason strings production
+/// actually mints, only `network_denied` and `policy_denied` coincide with a
+/// tag; the other ten fell through, so nearly every denial reached the model as
+/// a flat "policy denied" — *no capabilities are available to you*, *a hook
+/// blocked this*, *you need to authenticate*, and *an approval is waiting for a
+/// human* were all indistinguishable.
+///
+/// The distinction the model needs is **what would unlock the call** (#6284
+/// item 4): a permanent block, a missing credential, and a pending approval
+/// call for three different next actions, and collapsing them leaves the model
+/// guessing.
+///
+/// An unclassified reason still resolves to `PolicyDenied` — the honest
+/// conservative answer — but that path is now reachable only by a reason nobody
+/// has classified, and `every_production_deny_reason_is_classified` fails if a
+/// producer adds one without choosing.
+fn deny_reason_from_kind(kind: &CapabilityDeniedReasonKind) -> DenyReason {
+    classify_deny_reason(kind.as_str()).unwrap_or(DenyReason::PolicyDenied)
 }
 
 #[cfg(test)]
@@ -671,9 +718,9 @@ mod deny_reason_tests {
 
     /// Denials must tell the model *what would unlock the call*.
     ///
-    /// The previous serde parse matched `DenyReason`'s own tags, and twelve of
-    /// the thirteen reasons production mints are not among them — so a missing
-    /// credential, a pending human approval, a blocked egress and a genuine
+    /// The previous serde parse matched `DenyReason`'s own tags, and ten of the
+    /// twelve reasons production mints are not among them — so a missing
+    /// credential, a pending human approval, an absent grant and a genuine
     /// policy block all arrived as `PolicyDenied`. Each of those wants a
     /// different next action from the model, and it had no way to tell them
     /// apart. This pins that they stay distinguishable.
@@ -724,6 +771,74 @@ mod deny_reason_tests {
             deny_reason_from_kind(&reason("hook_gate_ref_unavailable")),
             DenyReason::InternalInvariantViolation
         );
+        // A grant is what is missing here, not a permission already refused.
+        for tag in ["invalid_spawn_input", "missing_provider_trust"] {
+            assert_eq!(
+                deny_reason_from_kind(&reason(tag)),
+                DenyReason::MissingGrant,
+                "{tag} should read as a missing grant"
+            );
+        }
+    }
+
+    /// Every reason a producer in this workspace can mint must be classified
+    /// deliberately. Without this, a new producer tag silently inherits the
+    /// conservative `PolicyDenied` fallback and is indistinguishable from a
+    /// real policy refusal — which is exactly how the original collapse hid.
+    ///
+    /// If this fails after adding a denial site, classify the new tag in
+    /// `classify_deny_reason` and add it to `PRODUCTION_DENY_REASONS`.
+    #[test]
+    fn every_production_deny_reason_is_classified() {
+        for tag in PRODUCTION_DENY_REASONS {
+            assert!(
+                classify_deny_reason(tag).is_some(),
+                "{tag} is minted by a producer but nobody classified it; it \
+                 would reach the model as an undifferentiated policy refusal"
+            );
+        }
+    }
+
+    /// Drive the real `denied()` constructor, not the mapper in isolation.
+    ///
+    /// `denied()` writes the reason to two places the model and the audit trail
+    /// read separately — `Resolution::Denied`'s `reason_kind` and the
+    /// `DenyRecord` — and a mapper-only test cannot catch either channel losing
+    /// the distinction or the two disagreeing. (`.claude/rules/testing.md`:
+    /// test through the caller.)
+    #[test]
+    fn denied_surfaces_the_distinction_on_both_channels() {
+        let matrix = [
+            ("model_view_denied", DenyReason::UnknownCapability),
+            ("auth_denied", DenyReason::UnknownSecret),
+            (
+                "outbound_delivery_approval_required",
+                DenyReason::ApprovalDenied,
+            ),
+            ("network_denied", DenyReason::NetworkDenied),
+            (
+                "hook_gate_ref_unavailable",
+                DenyReason::InternalInvariantViolation,
+            ),
+            ("missing_provider_trust", DenyReason::MissingGrant),
+            ("hook_denied", DenyReason::PolicyDenied),
+            ("some_future_reason", DenyReason::PolicyDenied),
+        ];
+        for (tag, expected) in matrix {
+            let result = denied(reason(tag), format!("denied: {tag}"));
+            match &result.resolution {
+                Resolution::Denied(denial) => assert_eq!(
+                    denial.reason_kind,
+                    Some(expected),
+                    "{tag}: the model-facing channel lost the distinction"
+                ),
+                other => panic!("{tag}: expected Denied, got {other:?}"),
+            }
+            assert_eq!(
+                result.deny_record.reason, expected,
+                "{tag}: the audit record lost the distinction"
+            );
+        }
     }
 
     /// The conservative fallback must remain reachable only by a reason nobody
@@ -740,20 +855,7 @@ mod deny_reason_tests {
     /// reason maps to one value again, this fails.
     #[test]
     fn production_denial_reasons_do_not_collapse_to_one_value() {
-        let produced = [
-            "empty_surface",
-            "model_view_denied",
-            "outside_visible_surface",
-            "auth_denied",
-            "outbound_delivery_approval_required",
-            "network_denied",
-            "hook_gate_ref_unavailable",
-            "invalid_spawn_input",
-            "host_policy_denied",
-            "hook_denied",
-            "surface_profile_denied",
-        ];
-        let distinct: std::collections::HashSet<DenyReason> = produced
+        let distinct: std::collections::HashSet<DenyReason> = PRODUCTION_DENY_REASONS
             .iter()
             .map(|tag| deny_reason_from_kind(&reason(tag)))
             .collect();


### PR DESCRIPTION
## Summary

- Denials reached the model as an undifferentiated "you are not allowed". `deny_reason_from_kind` serde-parsed the producer's reason string against `DenyReason`'s own wire tags; **ten of the twelve reasons production mints are not those tags**, so they all fell through to `PolicyDenied`.
- A missing credential, a pending human approval, an absent grant, an internal gate fault and a genuine policy refusal were indistinguishable — each wants a different next action from the model.
- Replaced with an explicit classification table. Auth denials point at an auth flow, approval denials read as approvable, internal faults read as internal, missing grants read as missing grants.
- The unclassified case is now a *distinct* outcome (`classify_deny_reason -> Option`), not silently identical to a deliberate `PolicyDenied`. A guard test fails when a producer adds a reason without classifying it.
- Restored two `ironclaw_hooks` tests whose comments recorded this collapse as damage they could not repair.

## Change Type

- [x] Bug fix

## Linked Issue

Related #6284 (item 4: errors must say what to do next).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy ... --all-targets --all-features` (affected crates, zero warnings)
- [x] `cargo build`
- [x] Relevant tests pass: every crate referencing `DenyReason` — `agent_loop`, `approvals`, `authorization`, `capabilities`, `event_projections`, `events`, `hooks`, `host_api`, `host_runtime`, `loop_host`, `runner`, `turns` — **4,537 passed, 0 failed**
- [ ] `cargo test --features integration` — not applicable: no database-backed or persistence behavior changed
- [x] Manual testing: red-verified each new test by reverting the fix and by deleting a single classification; see "Red verification" below

Workspace-wide `cargo test` does not complete in this worktree — `ironclaw_webui`'s build script fails on an npm registry signing-key mismatch (`Cannot find matching keyid`). Environmental, unrelated to this change; CI builds it.

**CI escape and correction:** the first gate covered five crates when twenty-one depend on `ironclaw_turns`, so two `ironclaw_runner` tests reached CI red. Both pinned the collapsed value and both carried the `Flip consequence (§5.2.9, confirmed): X collapsed to PolicyDenied` marker — recording the lost distinction, not defending it. Fixed in 17dedc161 and the gate widened to the full `DenyReason` risk set.

## Test Strategy

**User behavior:** when the agent is refused, it can now tell whether to log in, wait for a human, request a grant, or give up — instead of receiving the same flat refusal for all four.

Risk areas:
- [x] Model behavior
- [x] Security or permissions
- [x] Cross-component behavior

Tests added or updated:
- **Host-path (caller tier):** `text_only_host_denies_capability_without_provider_trust_before_host_runtime` and `text_only_host_rejects_outside_surface_capability_before_host_runtime` in `ironclaw_runner` now assert the specific reason through a real `invoke_capability` call.
- **Unit or contract:** `denials_distinguish_what_would_unlock_the_call`, `every_production_deny_reason_is_classified`, `an_unclassified_reason_still_falls_back_conservatively`, `production_denial_reasons_do_not_collapse_to_one_value`, `denied_surfaces_the_distinction_on_both_channels` (all in `run_profile::resolution::deny_reason_tests`); two restored assertions in `ironclaw_hooks::middleware::capability_port`.
- **Reborn integration:** none added. The change is a pure classification function; the caller-level test drives the real `denied()` constructor, and the existing `scenario_trigger_self_create_denied` already covers the policy-denial path end to end. Notably its comment claims "a different denial class cannot pass", which was **vacuous** while every class produced `PolicyDenied` — that assertion becomes real with this change.
- **Recorded fixture / Browser E2E / Backend / Live canary:** Not applicable: no wire format, UI, or provider behavior changed.

**What the tests prove:** (1) each production reason maps to the action that would actually unlock it; (2) the two channels a denial is written to — the model-facing `Resolution::Denied` and the `DenyRecord` audit row — agree and neither loses the distinction; (3) a newly minted producer reason cannot silently inherit the conservative fallback.

**Red verification:**
- Restoring the original serde parse → `denial reasons collapsed to 2 distinct values; the model cannot tell an auth prompt from a permanent block`
- Deleting one classification (`missing_provider_trust`) → three tests fail, each with the message it promises, including `missing_provider_trust is minted by a producer but nobody classified it`

**Commands run:**
```
cargo test -p ironclaw_turns -p ironclaw_hooks -p ironclaw_loop_host -p ironclaw_host_api -p ironclaw_agent_loop
cargo clippy -p ironclaw_turns -p ironclaw_hooks -p ironclaw_loop_host -p ironclaw_host_api -p ironclaw_agent_loop --all-targets --all-features
cargo fmt --all --check
```

## Security Impact

Denial reasons are model-visible, so this changes what a denial discloses. Every value emitted is drawn from the existing closed `DenyReason` enum — no new vocabulary, no free text, no producer detail added. The `SafeSummary` redaction path is untouched.

The change makes denials *more* specific, which is the point but is worth naming: the model can now distinguish "you need a credential" from "policy forbids this". That is intended — it is the information the model needs to stop retrying a call that cannot succeed — and it discloses no more than the reason tag the host already chose.

Direction of failure is unchanged: an unclassified reason still resolves to the most conservative value.

## Reborn Trust-Boundary Checklist

- **Public policy/evidence/trust-bearing types — who can construct them?** Unchanged. `DenyReason` is a closed enum in `ironclaw_host_api`; this only selects among existing variants.
- **Untrusted content into prompts:** N/A — no free text added; reason tags are host-authored constants.
- **Hashes:** N/A.
- **New/changed status, exit, policy, runtime, or error variants — downstream match sites audited:** No new variants. Existing `DenyReason` values now *reach* sites that previously only ever saw `PolicyDenied`. Audited every match on `reason_kind` / `deny_record.reason`; three tests pinned the collapse, two are corrected here (`ironclaw_hooks`) and one is unaffected (`ironclaw_agent_loop`, uses `empty_surface`). Command: `rg 'deny_reason_from_kind|DenyReason::|reason_kind' crates/ tests/`
- **`serde(default)` fields:** N/A — no serialized shape changed.
- **Bounds/overflow:** N/A.
- **Driver/operator-visible errors have stable class semantics:** this is the fix — denial classes were not stable, they were all `PolicyDenied`.
- **Sandbox/native/host names:** N/A.

## Database Impact

None.

## Blast Radius

`ironclaw_turns` denial resolution, consumed by `ironclaw_agent_loop`, `ironclaw_hooks`, and `ironclaw_loop_host`. Anything asserting a denial is `PolicyDenied` may now see a more specific value — that is the intended change, and the audit above enumerates every such site.

Worth flagging to whoever watches denial dashboards: denial reasons that were uniformly `PolicyDenied` will now spread across `UnknownSecret`, `ApprovalDenied`, `MissingGrant`, `UnknownCapability`, `NetworkDenied`, and `InternalInvariantViolation`. Same events, honest labels.

## Rollback Plan

Revert the two commits. The change is confined to one classification function plus its tests; no migration, no persisted state, no wire format.

## Review Follow-Through

Two review findings addressed in `38832abe9`:

1. **Producer-tag inventory** — the finding was right that the inventory was inconsistent, though not in the way stated (`expected_approval` is a contract-test fixture, not a producer, and was already mapped). Re-enumerating found two genuine errors of mine: the count was inflated by two test-only tags, and two real producer tags (`policy_denied`, `missing_provider_trust`) were missing. Both now classified, with a guard test so this cannot recur.
2. **Test through the caller** — correct and adopted. Added `denied_surfaces_the_distinction_on_both_channels` driving the real `denied()` path over a six-category matrix plus the fallback. The two `ironclaw_runner` tests corrected in 17dedc161 are stronger coverage of the same kind: they drive the real `invoke_capability` host path end to end.

**Reviewer judgment still wanted on one call:** I left `empty_surface -> PolicyDenied` alone. Reclassifying it to `UnknownCapability` is arguable, but four sites pin the current reading (one named `deny_record_reason_maps_best_effort_with_policy_fallback`), and an empty surface is normally a profile/policy outcome. I proved the *collapse* was wrong; I did not prove *that* mapping was, so I did not override it. If the pinned reading is wrong, it should change deliberately and separately.

---

**Review track**: C (runtime/security-adjacent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
