### PR TITLE
test(llm): property-test the Retry-After provider boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,6 +3969,7 @@ dependencies = [
  "ironclaw_common",
  "ironclaw_safety",
  "open",
+ "proptest",
  "rand 0.10.1",
  "regex",
  "reqwest 0.13.4",
@@ -6300,6 +6301,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6379,6 +6399,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -6538,6 +6564,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rangemap"
@@ -7164,6 +7199,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -8586,6 +8633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8756,6 +8809,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/ironclaw_llm/Cargo.toml
+++ b/crates/ironclaw_llm/Cargo.toml
@@ -61,6 +61,11 @@ aws-smithy-types       = { version = "1", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.46.3", features = ["yaml"] }
+# Property testing for provider-response parsing (#6524 workstream 9). Chosen
+# over a hand-rolled random loop because shrinking is the whole value: a
+# failure reports the minimal input that breaks the invariant, not whichever
+# 40-character string happened to trip it.
+proptest = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }
 tracing-test = "0.2"

--- a/crates/ironclaw_llm/proptest-regressions/retry.txt
+++ b/crates/ironclaw_llm/proptest-regressions/retry.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a8ce06e29940c62c21f989a933aed14c01fe56ddf90cb349ee95705505e3a33b # shrinks to secs = 3601, pad_left = 0, pad_right = 0
+cc 6c10371b85c3ce3617795e758189e4680236a098e0924a7bbf1011e49180b45a # shrinks to secs = 3601

--- a/crates/ironclaw_llm/src/retry.rs
+++ b/crates/ironclaw_llm/src/retry.rs
@@ -1088,3 +1088,110 @@ mod tests {
         );
     }
 }
+
+/// Property tests for the `Retry-After` boundary (#6524 workstream 9:
+/// "focused fuzzing for ... provider responses, and wire-format boundaries").
+///
+/// The example tests above pin specific values. These pin the invariant that
+/// makes the parser safe to point at a provider we do not control: whatever a
+/// provider sends — hostile, malformed, or absurd — the delay it can induce is
+/// bounded and the process does not panic. An uncapped or panicking parse here
+/// is remotely triggerable by anything we call.
+#[cfg(test)]
+mod retry_after_properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Header values shaped like what a provider actually sends, plus noise.
+    ///
+    /// Weighted toward the numeric and date forms the parser has branches
+    /// for, because those are the only inputs that can produce a large delay.
+    fn retry_after_value() -> impl Strategy<Value = String> {
+        prop_oneof![
+            // Plain delay-seconds, including values past the cap.
+            any::<u64>().prop_map(|n| n.to_string()),
+            // Small values around the cap boundary, where off-by-one lives.
+            (3595u64..3605).prop_map(|n| n.to_string()),
+            // Padded numerics: providers are inconsistent about whitespace.
+            (any::<u64>(), 0usize..3, 0usize..3).prop_map(|(n, l, r)| format!(
+                "{}{}{}",
+                " ".repeat(l),
+                n,
+                " ".repeat(r)
+            )),
+            // Signed and float-ish shapes the parser must reject cleanly.
+            any::<i64>().prop_map(|n| n.to_string()),
+            "[0-9]{1,25}(\\.[0-9]{1,3})?",
+            // Date forms, both directions in time.
+            Just(chrono::Utc::now().to_rfc2822()),
+            (1i64..100_000)
+                .prop_map(|s| (chrono::Utc::now() + chrono::Duration::seconds(s)).to_rfc2822()),
+            // Arbitrary text, so nothing above narrows the space to only
+            // well-formed input.
+            "\\PC{0,32}",
+        ]
+    }
+
+    proptest! {
+        /// No header value can make the parser panic or exceed the cap.
+        ///
+        /// The generator is deliberately biased rather than uniformly random.
+        /// Purely random bytes essentially never parse as a large integer, so
+        /// a naive `vec(any::<u8>())` strategy explores none of the space this
+        /// property exists to defend — verified: with the cap removed, the
+        /// uniform version still passed while the numeric cases failed at
+        /// 3601. A generator that cannot reach the failure is decorative no
+        /// matter how many cases it runs.
+        #[test]
+        fn arbitrary_header_values_stay_bounded(value in retry_after_value()) {
+            let Ok(header) = reqwest::header::HeaderValue::from_bytes(value.as_bytes()) else {
+                // Not a legal header value; reqwest would never hand us one.
+                return Ok(());
+            };
+            let delay = parse_retry_after_value(&header);
+            prop_assert!(delay <= Duration::from_secs(MAX_RETRY_AFTER_SECS), "{delay:?}");
+        }
+
+        /// A numeric delay-seconds value is capped, never truncated or wrapped.
+        #[test]
+        fn delay_seconds_are_capped_not_wrapped(secs in any::<u64>()) {
+            let header = reqwest::header::HeaderValue::from_str(&secs.to_string())
+                .expect("digits are a legal header value");
+            let delay = parse_retry_after_value(&header);
+            let expected = Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS));
+            prop_assert_eq!(delay, expected);
+        }
+
+        /// Surrounding whitespace must not change the parse.
+        ///
+        /// Providers pad values inconsistently, and a parser that only handled
+        /// the trimmed form would silently fall back to the 60s default —
+        /// which looks like a working retry rather than a parse failure.
+        #[test]
+        fn whitespace_padding_does_not_change_the_delay(
+            secs in 0u64..7200,
+            pad_left in 0usize..4,
+            pad_right in 0usize..4,
+        ) {
+            let padded = format!("{}{}{}", " ".repeat(pad_left), secs, " ".repeat(pad_right));
+            let Ok(header) = reqwest::header::HeaderValue::from_str(&padded) else {
+                return Ok(());
+            };
+            prop_assert_eq!(
+                parse_retry_after_value(&header),
+                Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS))
+            );
+        }
+
+        /// An HTTP-date already in the past yields no delay, never a negative
+        /// one wrapping into a huge sleep.
+        #[test]
+        fn past_http_dates_never_wrap_into_a_long_sleep(secs_ago in 1i64..1_000_000) {
+            let past = chrono::Utc::now() - chrono::Duration::seconds(secs_ago);
+            let header = reqwest::header::HeaderValue::from_str(&past.to_rfc2822())
+                .expect("rfc2822 dates are legal header values");
+            let delay = parse_retry_after_value(&header);
+            prop_assert!(delay <= Duration::from_secs(MAX_RETRY_AFTER_SECS), "{delay:?}");
+        }
+    }
+}

--- a/crates/ironclaw_llm/src/retry.rs
+++ b/crates/ironclaw_llm/src/retry.rs
@@ -1191,7 +1191,7 @@ mod retry_after_properties {
             let header = reqwest::header::HeaderValue::from_str(&past.to_rfc2822())
                 .expect("rfc2822 dates are legal header values");
             let delay = parse_retry_after_value(&header);
-            prop_assert!(delay <= Duration::from_secs(MAX_RETRY_AFTER_SECS), "{delay:?}");
+            prop_assert_eq!(delay, Duration::ZERO);
         }
     }
 }

--- a/crates/ironclaw_llm/tests/retry_after_provider.rs
+++ b/crates/ironclaw_llm/tests/retry_after_provider.rs
@@ -1,0 +1,126 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use ironclaw_llm::{
+    ChatMessage, CompletionRequest, LlmError, LlmProvider, NearAiChatProvider, NearAiConfig,
+    SessionConfig, SessionManager,
+};
+use secrecy::SecretString;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(3600);
+
+fn test_config(base_url: String) -> NearAiConfig {
+    NearAiConfig {
+        model: "test-model".to_string(),
+        base_url,
+        api_key: Some(SecretString::from("test-key".to_string())),
+        cheap_model: None,
+        fallback_model: None,
+        max_retries: 0,
+        circuit_breaker_threshold: None,
+        circuit_breaker_recovery_secs: 30,
+        response_cache_enabled: false,
+        response_cache_ttl_secs: 3600,
+        response_cache_max_entries: 1000,
+        failover_cooldown_secs: 300,
+        failover_cooldown_threshold: 3,
+        smart_routing_cascade: true,
+    }
+}
+
+async fn read_request_head(socket: &mut TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        let bytes_read = socket.read(&mut chunk).await.expect("read request");
+        assert!(bytes_read > 0, "connection closed before request headers");
+        request.extend_from_slice(&chunk[..bytes_read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            return String::from_utf8_lossy(&request).into_owned();
+        }
+    }
+}
+
+async fn serve_provider_error(listener: TcpListener, status_line: &'static str) {
+    loop {
+        let (mut socket, _) = listener.accept().await.expect("accept request");
+        let request = read_request_head(&mut socket).await;
+        if !request.starts_with("POST /v1/chat/completions ") {
+            let body = r#"{"models":[]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                 content-length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write pricing response");
+            continue;
+        }
+
+        let body = r#"{"error":"upstream unavailable"}"#;
+        let response = format!(
+            "HTTP/1.1 {status_line}\r\ncontent-type: application/json\r\n\
+             retry-after: 999999\r\ncontent-length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write provider error response");
+        return;
+    }
+}
+
+async fn complete_against(status_line: &'static str) -> LlmError {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let base_url = format!(
+        "http://{}",
+        listener.local_addr().expect("test server address")
+    );
+    let server_task = tokio::spawn(serve_provider_error(listener, status_line));
+    let provider = NearAiChatProvider::new(
+        test_config(base_url),
+        Arc::new(SessionManager::new(SessionConfig::default())),
+    )
+    .expect("provider");
+
+    let error = provider
+        .complete(CompletionRequest::new(vec![ChatMessage::user("hello")]))
+        .await
+        .expect_err("provider error response should fail completion");
+    server_task.await.expect("server task");
+    error
+}
+
+#[tokio::test]
+async fn retry_after_header_is_capped_across_provider_error_branches() {
+    match complete_against("429 Too Many Requests").await {
+        LlmError::RateLimited {
+            provider,
+            retry_after,
+        } => {
+            assert_eq!(provider, "nearai_chat");
+            assert_eq!(retry_after, Some(MAX_RETRY_AFTER));
+        }
+        other => panic!("expected rate-limit error, got {other:?}"),
+    }
+
+    match complete_against("503 Service Unavailable").await {
+        LlmError::BadGateway {
+            provider,
+            status,
+            retry_after,
+        } => {
+            assert_eq!(provider, "nearai_chat");
+            assert_eq!(status, 503);
+            assert_eq!(retry_after, Some(MAX_RETRY_AFTER));
+        }
+        other => panic!("expected bad-gateway error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

First slice of workstream 9 in #6524: *"focused fuzzing for untrusted ingress, fixture parsing, provider responses, and wire-format boundaries."*

`Retry-After` is the clearest such boundary in the LLM lane: input from a service we do not run, which decides **how long we sleep**. The existing tests pin specific values. These pin the invariant that makes the parser safe to point at anything — no header value, however malformed, can exceed `MAX_RETRY_AFTER_SECS` or panic the process.

Four parser properties:

- arbitrary values stay bounded
- delay-seconds are **capped, not wrapped**
- whitespace padding does not silently degrade to the 60s default (which would look like a working retry rather than a parse failure)
- a past HTTP-date yields no delay, never a negative one wrapping into a long sleep

Review follow-up adds a caller-boundary test that sends constructed 429 and 503 provider responses through `NearAiChatProvider::complete` and verifies both error variants preserve the one-hour cap.

## Why proptest, and why the generator is biased

Shrinking is the point. With the cap removed it reports `secs = 3601` — one second over the boundary — instead of whichever 40-character string happened to trip it.

**The generator being biased toward numeric and date shapes is not cosmetic, and this is the part worth reviewing.** My first version drew uniform random bytes. With the cap removed, *it still passed*: random bytes essentially never parse as a large integer, so it explored none of the space the property exists to defend. It would have shipped as a fuzz test that could not fail.

Biased toward the shapes the parser actually branches on, it now shrinks to a future RFC2822 date. **A generator that cannot reach the failure is decorative no matter how many cases it runs** — worth stating because "it's a property test" reads as thorough by default.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [x] Dependencies (`proptest` dev-dependency)

## Validation

- [x] `cargo test -p ironclaw_llm --lib` — **967 passed**
- [x] `cargo test -p ironclaw_llm --test retry_after_provider` — **1 passed**
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p ironclaw_llm --tests -- -D warnings` — clean
- [x] Sabotage-verified: removing the cap in `cap_retry_after` fails **three of four** properties. The fourth covers past dates, which yield zero either way, so it correctly does not fire — noted rather than "fixed" by making it fire artificially.

## Test Strategy

**User behaviour:** none changed. Tests plus one dev-dependency; no production code touched.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider (this is the parser that trusts provider input)
- [ ] Cross-component behavior

**What the tests prove.** The properties bound every parser input the generator can reach, while the provider-boundary test verifies the real 429 and 5xx call-site contract carries the capped delay into `RateLimited` and `BadGateway` errors.

## Reviewer notes

- **`proptest` is a new dev-dependency.** The epic explicitly calls for `proptest`/`quickcheck` over a hand-rolled random loop precisely because of shrinking; the June Hermes investigation says the same. Dev-only, no production build impact.
- **`proptest-regressions/retry.txt` is checked in on purpose.** Its two seeds shrink to `secs = 3601` — the exact cap boundary — so that case is re-run first on every future run. They were produced by the sabotage above rather than a live bug, but the input they encode is exactly the one you would want pinned forever.
- Natural follow-ups in the same box: fixture/trace parsing and channel ingress payloads. This PR deliberately does one boundary properly rather than three shallowly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
