### PR TITLE
test(slack): property-test the webhook ingress boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4763,6 +4763,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ironclaw_host_api",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/ironclaw_slack_extension/Cargo.toml
+++ b/crates/ironclaw_slack_extension/Cargo.toml
@@ -23,6 +23,8 @@ thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]
+# Property testing for the ingress boundary (#6524 workstream 9).
+proptest = "1"
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0", features = ["test-support", "host-auth-mint"] }
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ironclaw_slack_extension/proptest-regressions/payload.txt
+++ b/crates/ironclaw_slack_extension/proptest-regressions/payload.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 14556344b03eed7baacf9dd7582b8ad652dc94053501ea8987c8e9246e304ddb # shrinks to raw = []

--- a/crates/ironclaw_slack_extension/src/payload.rs
+++ b/crates/ironclaw_slack_extension/src/payload.rs
@@ -1284,3 +1284,127 @@ mod tests {
         }
     }
 }
+
+/// Property tests for the Slack ingress boundary (#6524 workstream 9:
+/// "focused fuzzing for untrusted ingress").
+///
+/// Everything here arrives over the public webhook endpoint before any
+/// signature has been trusted, so these functions see whatever the internet
+/// sends. The example tests above cover payload shapes Slack documents; these
+/// cover the ones it does not.
+#[cfg(test)]
+mod ingress_properties {
+    use super::*;
+    use ironclaw_host_api::product_adapter::auth::mark_request_signature_verified;
+    use proptest::prelude::*;
+
+    fn verified_evidence() -> ProtocolAuthEvidence {
+        mark_request_signature_verified(
+            "X-Slack-Signature",
+            Some("X-Slack-Request-Timestamp".to_string()),
+            "T123",
+        )
+    }
+
+    fn unverified_evidence() -> ProtocolAuthEvidence {
+        ProtocolAuthEvidence::failed(
+            ironclaw_host_api::product_adapter::ProtocolAuthFailure::Missing,
+        )
+    }
+
+    fn install() -> AdapterInstallationId {
+        AdapterInstallationId::new("slack_install_property").expect("valid")
+    }
+
+    /// Payload bytes: mostly Slack-shaped, plus arbitrary noise.
+    ///
+    /// Biased on purpose. Uniform random bytes are rejected by the JSON parser
+    /// almost immediately, so they exercise only the outermost guard — the
+    /// interesting branches need input that parses far enough to reach them.
+    fn payload_bytes() -> impl Strategy<Value = Vec<u8>> {
+        prop_oneof![
+            proptest::collection::vec(any::<u8>(), 0..256),
+            "\\PC{0,200}".prop_map(|s| s.into_bytes()),
+            (
+                "[a-z_]{0,16}",
+                "[A-Za-z0-9]{0,12}",
+                "[A-Za-z0-9]{0,12}",
+                "\\PC{0,40}"
+            )
+                .prop_map(|(kind, event_id, channel, text)| {
+                    serde_json::json!({
+                        "type": kind,
+                        "event_id": event_id,
+                        "event": {
+                            "type": "message",
+                            "channel": channel,
+                            "text": text,
+                        }
+                    })
+                    .to_string()
+                    .into_bytes()
+                }),
+            "\\{[^}]{0,80}".prop_map(|s| s.into_bytes()),
+        ]
+    }
+
+    proptest! {
+        /// No payload whatsoever is parsed without verified auth evidence.
+        ///
+        /// This is the security property of the pair: the signature check is
+        /// what stops anyone who can reach the endpoint from injecting a turn.
+        /// A parser that inspected the body first and only then checked the
+        /// evidence would still pass every example test in this file.
+        #[test]
+        fn unverified_evidence_rejects_every_payload(raw in payload_bytes()) {
+            let outcome = parse_slack_event(&raw, &unverified_evidence(), &install());
+            prop_assert!(
+                matches!(outcome, Err(SlackPayloadParseError::UnauthenticatedPayload)),
+                "unverified payload was not rejected: {outcome:?}"
+            );
+        }
+
+        /// Same for the URL-verification handshake, which runs before setup
+        /// completes and is therefore the most exposed entry point of all.
+        #[test]
+        fn unverified_evidence_rejects_every_challenge(raw in payload_bytes()) {
+            let outcome = parse_slack_url_verification_challenge(&raw, &unverified_evidence());
+            prop_assert!(
+                matches!(outcome, Err(SlackPayloadParseError::UnauthenticatedPayload)),
+                "unverified challenge was not rejected: {outcome:?}"
+            );
+        }
+
+        /// Verified evidence plus arbitrary bytes parses or errors, never panics.
+        #[test]
+        fn verified_evidence_never_panics(raw in payload_bytes()) {
+            let _ = parse_slack_event(&raw, &verified_evidence(), &install());
+            let _ = parse_slack_url_verification_challenge(&raw, &verified_evidence());
+            let _ = normalize_slack_event(&raw, &install());
+        }
+    }
+
+    /// Oversized bodies are refused on length, before any parsing.
+    ///
+    /// Checked with a real over-limit buffer rather than a generated one: the
+    /// limit is 1 MB, and a strategy that produced megabyte payloads would
+    /// dominate the runtime of the whole suite for one boundary.
+    #[test]
+    fn payloads_over_the_size_limit_are_rejected() {
+        let mut oversized = Vec::with_capacity(MAX_SLACK_PAYLOAD_BYTES + 32);
+        oversized.extend_from_slice(br#"{"type":"event_callback","event_id":"Ev1","padding":""#);
+        oversized.resize(MAX_SLACK_PAYLOAD_BYTES + 16, b'a');
+        oversized.extend_from_slice(br#""}"#);
+
+        for outcome in [
+            parse_slack_event(&oversized, &verified_evidence(), &install()).err(),
+            normalize_slack_event(&oversized, &install()).err(),
+        ] {
+            let err = outcome.expect("an over-limit payload must be rejected");
+            assert!(
+                matches!(err, SlackPayloadParseError::InvalidJson { .. }),
+                "unexpected rejection reason: {err:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of workstream 9 in #6524, closing the **untrusted ingress** half of the fuzzing box. Stacked on #6783.

`parse_slack_event`, `parse_slack_url_verification_challenge` and `normalize_slack_event` run on bytes from the public webhook endpoint *before any signature is trusted*. They see whatever the internet sends. The 22 example tests cover shapes Slack documents; these cover the ones it does not.

## The security property, and why it is not redundant

**No payload, of any shape, is parsed without verified auth evidence** — covering both entry points, including the URL-verification handshake, which runs before setup completes and is the more exposed of the two.

There is already an `unauthenticated_payload_is_rejected` test, so the fair question is what this adds. Demonstrated rather than asserted:

| sabotage | existing test | property |
|---|---|---|
| remove the auth guard entirely | ❌ fails | ❌ fails |
| enforce auth **only for payloads containing `"event_callback"`** | ✅ **passes** | ❌ fails |

The second is the realistic bug: a guard that ends up inside one branch rather than at the top. The existing test sends exactly an `event_callback` body, so it stays green while unauthenticated callers get through on every other shape.

## Also covered

- arbitrary bytes parse or error, never panic
- over-limit bodies are refused **on length, before parsing** — checked with a real 1 MB buffer rather than a generated one, so a single boundary does not dominate the suite's runtime

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [x] Dependencies (`proptest` dev-dependency for this crate)

## Validation

- [x] `cargo test -p ironclaw_slack_extension --lib` — **63 passed**
- [x] `cargo fmt --all` / `cargo clippy -p ironclaw_slack_extension --tests -- -D warnings` — clean
- [x] Sabotage-verified twice, as tabulated above

## Test Strategy

**User behaviour:** none changed. Tests only; no production code touched.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] **Security or permissions** — the signature check is what stops anyone who can reach the endpoint from injecting a turn
- [x] External provider
- [ ] Cross-component behavior

**What the tests prove.** Not that the documented payloads are handled — that the auth gate holds for payloads nobody documented.

## Reviewer notes

- The generator is biased toward Slack-shaped JSON deliberately. Uniform random bytes die at the JSON parser and exercise only the outermost guard — the same trap #6782 hit, where a uniform generator passed with the safety cap removed. A generator that cannot reach the branch proves nothing about it.
- Merge order: #6782 → #6783 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
