### PR TITLE
ci(integration): run deeper generated sequences nightly

### DIFF
--- a/.github/workflows/nightly-deep-ci.yml
+++ b/.github/workflows/nightly-deep-ci.yml
@@ -76,6 +76,9 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ github.sha }}
+      # Workstream 9 of #6524: longer generated lifecycle orderings than a
+      # pull request can afford (84 sequences vs 20).
+      deep_generations: true
 
   reborn-e2e:
     name: Reborn E2E

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -7,6 +7,14 @@ on:
         description: Commit SHA or ref to test
         required: false
         type: string
+      deep_generations:
+        description: >-
+          Enumerate longer generated lifecycle sequences (#6524 workstream 9).
+          Pull requests stay at the fast depth; the nightly deep run raises it.
+          Depth 3 is 84 sequences (~70s) against depth 2's 20 (~20s).
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       ref:
@@ -39,6 +47,12 @@ env:
   # cfg!(test) covers unit tests; this covers integration/e2e that link the
   # non-cfg(test) library.
   IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+  # Generated-sequence depth for tests/integration/generated_gate_sequences.rs.
+  # Evaluates to the fast depth on every trigger except a workflow_call that
+  # explicitly asks for more, so a PR never pays the nightly cost. The test
+  # parses this strictly and fails on a bad value rather than falling back,
+  # so a typo here cannot silently downgrade the nightly lane.
+  IRONCLAW_GENERATED_SEQUENCE_DEPTH: ${{ inputs.deep_generations && '3' || '2' }}
   # Pin wall-clock rendering inputs so a test cannot pass or fail on the
   # runner's locale. Reborn renders model-visible time slices, and date/number
   # formatting differs by locale, so an unpinned runner turns a formatting

--- a/tests/integration/generated_gate_sequences.rs
+++ b/tests/integration/generated_gate_sequences.rs
@@ -181,13 +181,46 @@ async fn run_sequence(sequence: &[GateAction]) {
     );
 }
 
+/// How long a sequence to enumerate. Pull requests get depth 2 (20 sequences,
+/// ~20s); the nightly deep lane raises it.
+///
+/// Parsed strictly rather than with `unwrap_or(2)`: a typo in the workflow
+/// would otherwise silently run the shallow lane while the job name still
+/// claimed a deep one, which is the failure this epic keeps finding.
+const SEQUENCE_DEPTH_ENV: &str = "IRONCLAW_GENERATED_SEQUENCE_DEPTH";
+const DEFAULT_SEQUENCE_DEPTH: usize = 2;
+
+fn sequence_depth() -> usize {
+    match std::env::var(SEQUENCE_DEPTH_ENV) {
+        Err(std::env::VarError::NotPresent) => DEFAULT_SEQUENCE_DEPTH,
+        Err(err) => panic!("{SEQUENCE_DEPTH_ENV} is not readable: {err}"),
+        Ok(raw) => {
+            let depth: usize = raw.trim().parse().unwrap_or_else(|err| {
+                panic!("{SEQUENCE_DEPTH_ENV}={raw:?} is not a number: {err}")
+            });
+            assert!(
+                (1..=4).contains(&depth),
+                "{SEQUENCE_DEPTH_ENV}={depth} is out of range; depth 0 would \
+                 test nothing and above 4 is {} sequences",
+                ALPHABET.len().pow(5)
+            );
+            depth
+        }
+    }
+}
+
 #[tokio::test]
 async fn generated_gate_sequences_preserve_lifecycle_invariants() {
-    let sequences = sequences(2);
+    let depth = sequence_depth();
+    let sequences = sequences(depth);
     assert!(
         sequences.len() >= ALPHABET.len(),
-        "enumeration produced {} sequences; an empty or truncated list would \
-         pass this test while checking nothing",
+        "enumeration produced {} sequences at depth {depth}; an empty or \
+         truncated list would pass this test while checking nothing",
+        sequences.len()
+    );
+    eprintln!(
+        "generated-gate-sequences: depth {depth}, {} sequences",
         sequences.len()
     );
     for sequence in sequences {
@@ -235,6 +268,13 @@ mod invariant_checker {
     #[should_panic(expected = "a cancelled run reported Completed")]
     fn rejects_a_cancelled_run_completing() {
         observed_with(&[TurnStatus::Cancelled, TurnStatus::Completed]);
+    }
+
+    #[test]
+    fn default_depth_enumerates_more_than_the_alphabet() {
+        // Depth 1 alone would only ever exercise single actions, never an
+        // ordering — which is the entire point of this suite.
+        assert!(sequences(DEFAULT_SEQUENCE_DEPTH).len() > ALPHABET.len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the **last box** of workstream 9 in #6524: *"run fast deterministic generations on pull requests and larger stress/soak generations nightly."* Stacked on #6787.

| lane | depth | sequences | time |
|---|---|---|---|
| pull request | 2 (default) | 20 | ~20s |
| nightly deep | 3 | 84 | ~70s |

## Strict parsing, on purpose

The depth comes from `IRONCLAW_GENERATED_SEQUENCE_DEPTH`, parsed **strictly** rather than with `unwrap_or(2)`.

A typo in the workflow would otherwise run the shallow lane while the job name still claimed a deep one — the silent-downgrade shape this epic keeps turning up (the reverse-order lane in #6728, the `--deselect` that matched nothing, the uniform generator in #6782 that passed with the safety cap removed). A non-numeric value panics naming the variable, and the range is bounded at both ends: **depth 0 would enumerate nothing and pass**, depth 5 is over a thousand harness builds.

The run also prints its depth and sequence count, so a nightly log says what it did rather than leaving it inferred from duration.

## No CI registration needed

Integration targets are discovered from the workspace `Cargo.toml` `[[test]]` entries, not a filesystem walk. The target added in #6787 is already selected — verified against `scripts/ci/reborn-coverage-int-tier-tests.sh`, which lists it among 116.

That script's own header records why: an earlier `find -maxdepth 1` walk could not see domain-folder bins, so six `tests/integration/auth/` suites ran in **no** PR or merge-queue lane. Worth not repeating, hence checking rather than assuming.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Dependencies

## Validation

All three paths run locally:

- [x] default — 20 sequences, `test result: ok`
- [x] `IRONCLAW_GENERATED_SEQUENCE_DEPTH=3` — prints `depth 3, 84 sequences`, passes in 70s
- [x] `IRONCLAW_GENERATED_SEQUENCE_DEPTH=oops` — fails with `is not a number`, does **not** fall back
- [x] `cargo fmt --all` and `cargo clippy -p ironclaw_reborn_integration_tests --features integration --tests -- -D warnings` — clean (the disk exhaustion that blocked clippy on #6787 is resolved; it is clean here and covers that PR's code too)
- [x] Both workflows parse; the env expression and the nightly input verified by parsing rather than reading

## Test Strategy

**User behaviour:** none changed. CI configuration and one test-side constant.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior (the sequences themselves, from #6787)

Adds `default_depth_enumerates_more_than_the_alphabet`: depth 1 would exercise single actions only and never an *ordering*, which is the entire point of the suite.

## Reviewer notes

- The env expression evaluates to `'2'` on every trigger except a `workflow_call` that explicitly asks for more, so a pull request never pays the nightly cost.
- Depth 4 is permitted by the range check but not wired anywhere: 340 sequences, roughly five minutes. Available for a soak lane without another code change.
- **This completes workstream 9.** Merge order for the stack: #6782 → #6783 → #6784 → #6787 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
