### PR TITLE
test(integration): close the remaining workstream 9 invariants and dimension gaps

### DIFF
--- a/tests/integration/generated_gate_sequences.rs
+++ b/tests/integration/generated_gate_sequences.rs
@@ -40,6 +40,10 @@ use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
 use serde_json::json;
 
+/// The capability the gate guards. Named once so the effect-count assertion
+/// and the scripted call cannot drift apart.
+const GATED_CAPABILITY: &str = "builtin.write_file";
+
 /// One dimension of workstream 9's lifecycle axis: what a client can do to a
 /// run parked on an approval gate.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -103,7 +107,7 @@ impl Observed {
     }
 }
 
-async fn run_sequence(sequence: &[GateAction]) {
+async fn run_sequence(sequence: &[GateAction]) -> usize {
     let group = RebornIntegrationGroup::live_approvals()
         .await
         .expect("live-approvals group builds");
@@ -120,7 +124,7 @@ async fn run_sequence(sequence: &[GateAction]) {
         .thread(thread)
         .script([
             RebornScriptedReply::tool_call(
-                "builtin.write_file",
+                GATED_CAPABILITY,
                 json!({"path": "/workspace/generated.txt", "content": "generated"}),
             ),
             RebornScriptedReply::text("done"),
@@ -179,6 +183,37 @@ async fn run_sequence(sequence: &[GateAction]) {
         "{sequence:?} settled on {:?}",
         final_state.status
     );
+
+    // (4) no duplicate confirmed effect. The gated capability writes a file;
+    // resolving the same gate twice must not write it twice. This is the
+    // invariant the ApproveAgain action exists to attack, and status alone
+    // cannot express it — a double dispatch still ends Completed.
+    // Counted by RESULTS, not invocations: the gated attempt that raised the
+    // gate is itself recorded as an invocation, so a single approve shows two
+    // invocations and one effect. Counting invocations here reported a
+    // duplicate that never happened — the first version of this assertion did
+    // exactly that, and the run said so.
+    let effects = h
+        .capability_result_count(GATED_CAPABILITY)
+        .await
+        .unwrap_or_else(|err| panic!("{sequence:?}: capability results unreadable: {err:?}"));
+    assert!(
+        effects <= 1,
+        "{sequence:?}: gated capability produced {effects} effects; a \
+         resolved-twice gate must not perform the effect twice"
+    );
+
+    // A sequence that never approves must not perform the effect at all.
+    let approved = sequence
+        .iter()
+        .any(|action| matches!(action, GateAction::Approve | GateAction::ApproveAgain));
+    if !approved {
+        assert_eq!(
+            effects, 0,
+            "{sequence:?}: capability performed its effect without any approval"
+        );
+    }
+    effects
 }
 
 /// How long a sequence to enumerate. Pull requests get depth 2 (20 sequences,
@@ -223,9 +258,20 @@ async fn generated_gate_sequences_preserve_lifecycle_invariants() {
         "generated-gate-sequences: depth {depth}, {} sequences",
         sequences.len()
     );
+    let mut performed = 0usize;
     for sequence in sequences {
-        run_sequence(&sequence).await;
+        performed += run_sequence(&sequence).await;
     }
+
+    // Anti-vacuity: `effects <= 1` is also satisfied by an effect that never
+    // happens, which is what a harness misconfiguration would produce. At
+    // least one ordering must actually approve and perform the write, or the
+    // bound above proves nothing.
+    assert!(
+        performed > 0,
+        "no sequence performed the gated effect; the <=1 bound above would \
+         hold vacuously and this suite would be checking nothing"
+    );
 }
 
 /// The invariant checker is itself checked.
@@ -284,5 +330,128 @@ mod invariant_checker {
             TurnStatus::Running,
             TurnStatus::Completed,
         ]);
+    }
+}
+
+/// Cross-actor isolation under the same generated action alphabet.
+///
+/// The lifecycle sequences above drive one actor. This drives two over one
+/// shared coordinator and asserts the invariant the workstream names as "no
+/// cross-user leakage": whatever happens to A's run, B's is untouched until B
+/// acts on it.
+///
+/// `scenario_multi_actor_gate_isolation` already pins the approve arm. What it
+/// cannot show is that the OTHER actions are equally scoped — a cancel or a
+/// deny that reached across owners would pass every existing test, because no
+/// existing test applies those actions while a second actor is parked.
+#[tokio::test]
+async fn generated_actions_on_one_actor_never_disturb_another() {
+    for action in ALPHABET {
+        let group = RebornIntegrationGroup::multiuser_approvals()
+            .await
+            .expect("multiuser-approvals group builds");
+
+        let a = group
+            .thread(format!("gen-xuser-a-{action:?}").to_lowercase())
+            .script([
+                RebornScriptedReply::tool_call(
+                    GATED_CAPABILITY,
+                    json!({"path": "/workspace/gen-xuser-a.txt", "content": "a"}),
+                ),
+                RebornScriptedReply::text("a done"),
+            ])
+            .build()
+            .await
+            .expect("actor A thread builds");
+        let b = group
+            .thread(format!("gen-xuser-b-{action:?}").to_lowercase())
+            .with_actor_id("reborn-generated-actor-b")
+            .script([
+                RebornScriptedReply::tool_call(
+                    GATED_CAPABILITY,
+                    json!({"path": "/workspace/gen-xuser-b.txt", "content": "b"}),
+                ),
+                RebornScriptedReply::text("b done"),
+            ])
+            .build()
+            .await
+            .expect("actor B thread builds");
+
+        // Each actor's gate is scoped to its own owner, so auto-approve has to
+        // be disabled per owner rather than globally — otherwise the run
+        // dispatches straight through and never parks.
+        let owner_a = a
+            .binding
+            .subject_user_id
+            .as_ref()
+            .expect("actor A binding has a subject user id");
+        let owner_b = b
+            .binding
+            .subject_user_id
+            .as_ref()
+            .expect("actor B binding has a subject user id");
+        assert_ne!(owner_a, owner_b, "the two actors must be distinct owners");
+        group
+            .disable_auto_approve_for_owner(owner_a)
+            .await
+            .expect("auto-approve disabled for A");
+        group
+            .disable_auto_approve_for_owner(owner_b)
+            .await
+            .expect("auto-approve disabled for B");
+
+        let (run_a, gate_a) = a
+            .submit_turn_until_blocked("actor a writes")
+            .await
+            .expect("actor A parks");
+        let (run_b, gate_b) = b
+            .submit_turn_until_blocked("actor b writes")
+            .await
+            .expect("actor B parks");
+        assert_ne!(
+            gate_a, gate_b,
+            "the two actors must raise distinct gates, or this proves nothing"
+        );
+
+        // Act on A only.
+        match action {
+            GateAction::Approve | GateAction::ApproveAgain => {
+                let _ = a.approve_gate(run_a, &gate_a).await;
+            }
+            GateAction::Deny => {
+                let _ = a.deny_gate(run_a, &gate_a).await;
+            }
+            GateAction::Cancel => {
+                let _ = a.cancel_run(run_a).await;
+            }
+        }
+
+        // B is untouched: still parked on its own gate, and its effect has not
+        // been performed. Status alone is not enough — a leak that resolved B's
+        // gate and ran its write would be invisible if only A were inspected.
+        let b_state = b.run_state(run_b).await.expect("actor B state readable");
+        assert_eq!(
+            b_state.status,
+            TurnStatus::BlockedApproval,
+            "{action:?} on actor A moved actor B to {:?}",
+            b_state.status
+        );
+        let b_effects = b
+            .capability_result_count(GATED_CAPABILITY)
+            .await
+            .expect("actor B effect count readable");
+        assert_eq!(
+            b_effects, 0,
+            "{action:?} on actor A performed actor B's gated effect"
+        );
+
+        // ...and B can still resolve its own gate afterwards, so the isolation
+        // is not simply "B was wedged".
+        b.approve_gate(run_b, &gate_b)
+            .await
+            .expect("actor B resolves its own gate after A acted");
+        b.wait_for_terminal(run_b)
+            .await
+            .expect("actor B settles independently");
     }
 }

--- a/tests/integration/generated_gate_sequences.rs
+++ b/tests/integration/generated_gate_sequences.rs
@@ -44,6 +44,27 @@ use serde_json::json;
 /// and the scripted call cannot drift apart.
 const GATED_CAPABILITY: &str = "builtin.write_file";
 
+/// Where each dimension workstream 9 names is actually exercised.
+///
+/// Listing them as a comment rather than inventing an enum per axis: a typed
+/// `Ingress` with one variant that nothing matches on is decoration, and it
+/// would read as coverage on a scan.
+///
+/// | axis | exercised | where |
+/// |---|---|---|
+/// | lifecycle state | yes | `GateAction` below, enumerated |
+/// | policy state | yes | auto-approve on/off, per owner, in the cross-actor case |
+/// | auth state | partly | `auth/auth_gate.rs` + the expired-credential resume; not enumerated with the lifecycle axis |
+/// | provider outcome | partly | `with_github_network_status` drives 401/5xx in the auth slice; not crossed with gate actions |
+/// | operation class | no | read vs idempotent vs non-idempotent write is an E2E fault-matrix axis (`provider_fault_cases.py`) |
+/// | ingress | no | one ingress at this tier; WebUI/Slack/Telegram are covered whole-path in E2E |
+/// | delivery target | no | same — a delivery target needs a channel, which this tier does not run |
+///
+/// The three "no" rows are not oversights: crossing them with the lifecycle
+/// axis needs a tier that runs channels and providers, which is the E2E
+/// journey suite, not this one. Recorded so the epic is not read as claiming
+/// this file covers all seven.
+
 /// One dimension of workstream 9's lifecycle axis: what a client can do to a
 /// run parked on an approval gate.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -1254,17 +1254,28 @@ impl RebornIntegrationHarness {
     /// Assert the named capability was invoked exactly `expected` times through
     /// the real capability path. Uses the same per-thread delta as
     /// [`Self::assert_tool_invoked`].
+    /// How many times `capability_id` was dispatched through the real
+    /// capability path since this thread's baseline.
+    ///
+    /// The assertion below answers "was it exactly N"; a generated sequence
+    /// needs the number itself, because the bound it checks ("at most once,
+    /// and zero unless something approved") depends on the sequence rather
+    /// than being a fixed expectation.
+    pub async fn tool_invocation_count(&self, capability_id: &str) -> HarnessResult<usize> {
+        let all = self.capability_recorder.invocations();
+        let delta = &all[self.baseline_invocation_count..];
+        Ok(delta
+            .iter()
+            .filter(|invocation| invocation.capability_id.as_str() == capability_id)
+            .count())
+    }
+
     pub async fn assert_tool_invocation_count(
         &self,
         capability_id: &str,
         expected: usize,
     ) -> HarnessResult<()> {
-        let all = self.capability_recorder.invocations();
-        let delta = &all[self.baseline_invocation_count..];
-        let actual = delta
-            .iter()
-            .filter(|invocation| invocation.capability_id.as_str() == capability_id)
-            .count();
+        let actual = self.tool_invocation_count(capability_id).await?;
         if actual == expected {
             return Ok(());
         }
@@ -1325,16 +1336,28 @@ impl RebornIntegrationHarness {
     /// as an invocation attempt before the gate parks the run (no result is
     /// written yet), so `invocations()` legitimately counts 2 for any
     /// gate-then-resume flow — that is not a double-execution signal.
+    /// How many recorded RESULTS `capability_id` produced.
+    ///
+    /// Distinct from `tool_invocation_count`, and the distinction matters for
+    /// effect counting: a gated attempt is recorded as an invocation but
+    /// produces no result, so a single approve-then-resume shows two
+    /// invocations and one result. "Was the effect performed" is the result
+    /// count; the invocation count would report a duplicate that never
+    /// happened.
+    pub async fn capability_result_count(&self, capability_id: &str) -> HarnessResult<usize> {
+        Ok(self
+            .captured_capability_results()
+            .iter()
+            .filter(|result| result.capability_id.as_str() == capability_id)
+            .count())
+    }
+
     pub async fn assert_capability_result_count(
         &self,
         capability_id: &str,
         expected: usize,
     ) -> HarnessResult<()> {
-        let results = self.captured_capability_results();
-        let actual = results
-            .iter()
-            .filter(|result| result.capability_id.as_str() == capability_id)
-            .count();
+        let actual = self.capability_result_count(capability_id).await?;
         if actual == expected {
             return Ok(());
         }


### PR DESCRIPTION
## Summary

You called out that I ticked workstream 9's boxes more generously than the text warranted. This closes what is reachable and states plainly what is not. Stacked on #6789.

## What this adds

**No duplicate confirmed effects.** Every generated sequence now asserts the gated capability performed its effect **at most once**, and **not at all** unless something approved. This is what `ApproveAgain` was added to attack and what status can never express — a double dispatch still ends `Completed`.

The first version counted *invocations* and immediately reported a duplicate on a plain single `Approve`. That was my metric being wrong, not the product: the gated **attempt** that raises the gate is itself recorded as an invocation, so approve-then-resume is two invocations and one effect. Counting **results** — which a gated attempt never produces — measures the effect. `capability_result_count` is added beside `tool_invocation_count` with the distinction documented, because it is exactly what the next person will get wrong.

Followed by an anti-vacuity check: at least one ordering must actually perform the write, since "at most once" also holds for an effect that never happens.

**No cross-user leakage.** Each action is applied to actor A while actor B sits parked on its own gate over the same coordinator. B must stay blocked, B's effect must not fire, and B must still resolve its own gate afterwards — so the isolation is not merely "B was wedged". `scenario_multi_actor_gate_isolation` pins the approve arm; nothing showed deny and cancel are equally scoped, because no test applies those while a second actor is parked.

**Dimension map.** A table beside the alphabet recording which of the seven axes are exercised here and which belong to another tier — deliberately a comment, not an enum per axis. A typed `Ingress` with one variant nothing matches on is decoration, and on a scan it reads as coverage.

## What is still NOT covered — and why

| gap | status |
|---|---|
| **orphan runs/reservations** | **not covered.** Needs a harness change: the capability-path `InMemoryResourceGovernor` is constructed inline at five sites in `support/harness/assembly.rs` and retained nowhere a test can read. Asserting it means threading a handle out through shared assembly used by every integration target. |
| **truthful uncertain outcomes** | covered, but **elsewhere** — `lease_wedge.rs` already asserts a wedged run is reaped to `Failed` with the `lease_expired` category rather than claiming success. Not re-implemented here. |
| **restart / concurrency actions** | not in the alphabet. `park_tool_dispatch` + lease expiry gives a restart-shaped path, but wiring it into the enumeration means every sequence pays the lease timeout. |
| **operation class / ingress / delivery target** | E2E-tier axes; this tier runs neither channels nor providers. |

I would rather leave those visible than tick them.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Dependencies

## Validation

- [x] `cargo test -p ironclaw_reborn_integration_tests --features integration --test reborn_generated_gate_sequences` — **20 passed**
- [x] `cargo fmt --all` / `cargo clippy -p ironclaw_reborn_integration_tests --features integration --tests -- -D warnings` — clean
- [x] The duplicate-effect invariant demonstrated it was live by failing on the wrong metric before it was corrected
- [x] Cross-user case verified across all four actions

## Test Strategy

**User behaviour:** none changed. Test tier plus two harness accessors.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect (duplicate-effect counting is the point)
- [ ] Persistence
- [x] Security or permissions (cross-actor gate isolation)
- [ ] External provider
- [x] Cross-component behavior

## Reviewer notes

- **Workstream 9 is not fully closed by this**, and the epic should not be read as if it is. The orphan-reservation box is the real remainder; say the word and I will do the assembly change as its own PR, since it touches shared harness wiring used by every integration target and deserves separate review.
- Merge order: #6782 → #6783 → #6784 → #6787 → #6789 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
