### PR TITLE
feat(turns): every failure tells the model what to do next

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -3,20 +3,20 @@ use std::ops::ControlFlow;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    ApprovalRequestId, Blocked, CorrelationId, DenyReason, DependentRunResult, FailureKind,
-    INPUT_ENCODE_HUMAN_SUMMARY, LoopRef, ModelFailureDiagnostic, ModelInputIssue, Outcome,
-    Resolution, ResultProgress, ResumeToken, Suspension, ToolVerdict,
+    ApprovalRequestId, Blocked, CapabilityRecoveryHint, CorrelationId, DenyReason,
+    DependentRunResult, FailureKind, INPUT_ENCODE_HUMAN_SUMMARY, LoopRef, ModelFailureDiagnostic,
+    ModelInputIssue, Outcome, Resolution, ResultProgress, ResumeToken, SameCallRetryConstraint,
+    Suspension, ToolVerdict,
 };
 use ironclaw_turns::{
     LoopFailureKind, LoopGateRef, LoopResultRef,
     run_profile::{
         AuthResumeApprovalIdentity, CapabilityActivityId, CapabilityApprovalResume,
         CapabilityAuthResume, CapabilityCallCandidate, CapabilityFailure, CapabilityFailureDetail,
-        CapabilityInputIssue, CapabilityProgress, CapabilityRecoveryHint, CapabilityResultMessage,
-        CapabilityResumeToken, ContentDigest, LoopDriverNoteKind, LoopProcessRef,
-        LoopProgressEvent, LoopRequestBatch, MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
-        ModelVisibleToolObservation, ObservationTrust, SameCallRetryConstraint,
-        ToolObservationDetail, ToolObservationStatus, ToolRecoveryObservation,
+        CapabilityInputIssue, CapabilityProgress, CapabilityResultMessage, CapabilityResumeToken,
+        ContentDigest, LoopDriverNoteKind, LoopProcessRef, LoopProgressEvent, LoopRequestBatch,
+        MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION, ModelVisibleToolObservation,
+        ObservationTrust, ToolObservationDetail, ToolObservationStatus, ToolRecoveryObservation,
         VisibleCapabilitySurface,
     },
 };

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -12,10 +12,12 @@ use ironclaw_turns::{
     run_profile::{
         AuthResumeApprovalIdentity, CapabilityActivityId, CapabilityApprovalResume,
         CapabilityAuthResume, CapabilityCallCandidate, CapabilityFailure, CapabilityFailureDetail,
-        CapabilityInputIssue, CapabilityProgress, CapabilityResultMessage, CapabilityResumeToken,
-        ContentDigest, LoopDriverNoteKind, LoopProcessRef, LoopProgressEvent, LoopRequestBatch,
-        MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION, ModelVisibleToolObservation,
-        ObservationTrust, ToolObservationDetail, ToolObservationStatus, VisibleCapabilitySurface,
+        CapabilityInputIssue, CapabilityProgress, CapabilityRecoveryHint, CapabilityResultMessage,
+        CapabilityResumeToken, ContentDigest, LoopDriverNoteKind, LoopProcessRef,
+        LoopProgressEvent, LoopRequestBatch, MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
+        ModelVisibleToolObservation, ObservationTrust, SameCallRetryConstraint,
+        ToolObservationDetail, ToolObservationStatus, ToolRecoveryObservation,
+        VisibleCapabilitySurface,
     },
 };
 
@@ -748,15 +750,39 @@ impl CapabilityStage {
                     .unwrap_or_default();
                 let summary = CapabilityErrorSummary {
                     kind: FailureKind::PolicyDenied,
-                    safe_summary: capability_denied_summary(reason, safe_summary),
+                    safe_summary: capability_denied_summary(reason, safe_summary.clone()),
                     diagnostic_ref: None,
+                };
+                // Denials used to pass `None` here, so nothing actionable
+                // reached the model: no recovery, no retry constraint, no
+                // repairs. The reason #6781 made specific was legible only as
+                // text inside the summary. Carry it as structured recovery so
+                // the model can tell "authenticate" from "ask a human" from
+                // "this is permanently refused" (#6284 item 4).
+                let (same_call_retry, recovery_hint) =
+                    denial.reason_kind.map(deny_recovery).unwrap_or((
+                        SameCallRetryConstraint::Forbidden,
+                        CapabilityRecoveryHint::ReviseApproach,
+                    ));
+                let observation = ModelVisibleToolObservation {
+                    schema_version:
+                        ironclaw_turns::run_profile::MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
+                    status: ToolObservationStatus::Error,
+                    summary: capability_denied_observation_summary(reason),
+                    detail: ToolObservationDetail::GenericFailure {
+                        failure_kind: FailureKind::PolicyDenied,
+                        detail: denial_detail_text(&safe_summary),
+                    },
+                    artifacts: Vec::new(),
+                    recovery: Some(ToolRecoveryObservation::new(same_call_retry, recovery_hint)),
+                    trust: ObservationTrust::UntrustedToolOutput,
                 };
                 Box::pin(self.handle_capability_error(
                     ctx,
                     state,
                     call,
                     summary,
-                    None,
+                    Some(observation),
                     capability_batch,
                 ))
                 .await
@@ -1597,6 +1623,79 @@ fn capability_input_issue_from(issue: &ModelInputIssue) -> CapabilityInputIssue 
             .as_ref()
             .map(|value| value.as_str().to_string()),
     }
+}
+
+/// What the model should do about a denial, and whether re-issuing the same
+/// call could ever work.
+///
+/// Denials reached the model with `model_observation: None` — no recovery, no
+/// retry constraint, no repairs — so a denial meaning *authenticate and this
+/// succeeds* was indistinguishable from a permanent block (#6284 item 4).
+/// #6781 made the *reason* specific; this makes the reason **actionable**.
+///
+/// Exhaustive and wildcard-free: a new [`DenyReason`] cannot compile until its
+/// next move is chosen.
+fn deny_recovery(reason: DenyReason) -> (SameCallRetryConstraint, CapabilityRecoveryHint) {
+    match reason {
+        // A credential unlocks it — the same call succeeds afterwards.
+        DenyReason::UnknownSecret => (
+            SameCallRetryConstraint::Forbidden,
+            CapabilityRecoveryHint::AuthenticateThenRetry,
+        ),
+        // A human unlocks it. Worth asking; the same call may then succeed.
+        DenyReason::ApprovalDenied => (
+            SameCallRetryConstraint::Forbidden,
+            CapabilityRecoveryHint::RequestApproval,
+        ),
+        // A grant is missing. Not the model's to fix by rewording.
+        DenyReason::MissingGrant => (
+            SameCallRetryConstraint::Forbidden,
+            CapabilityRecoveryHint::RequestApproval,
+        ),
+        // Not this caller's capability; re-calling cannot succeed.
+        DenyReason::UnknownCapability => (
+            SameCallRetryConstraint::Forbidden,
+            CapabilityRecoveryHint::UseDifferentCapability,
+        ),
+        // The model named a path it can correct.
+        DenyReason::InvalidPath | DenyReason::PathOutsideMount => (
+            SameCallRetryConstraint::RequiresChangedInput,
+            CapabilityRecoveryHint::CorrectArgumentsBeforeRetry,
+        ),
+        // Capacity, not permission: waiting is the move.
+        DenyReason::BudgetDenied | DenyReason::ResourceLimitExceeded => (
+            SameCallRetryConstraint::AllowedAfterDelay,
+            CapabilityRecoveryHint::WaitThenRetry,
+        ),
+        // Permanently refused.
+        DenyReason::NetworkDenied | DenyReason::PolicyDenied => (
+            SameCallRetryConstraint::Forbidden,
+            CapabilityRecoveryHint::ReviseApproach,
+        ),
+        // A host fault, not a refusal. Nothing the model can unlock, but the
+        // same call is not forbidden on principle.
+        DenyReason::InternalInvariantViolation => (
+            SameCallRetryConstraint::NotUseful,
+            CapabilityRecoveryHint::RespectFailureConstraint,
+        ),
+    }
+}
+
+/// Fixed, host-authored one-line summary for a denial observation.
+///
+/// Deliberately not the capability's own text: the summary channel is strictly
+/// validated and a denial's `safe_summary` may degrade to a placeholder. The
+/// untrusted cause rides `detail` instead, where the lenient validator applies.
+fn capability_denied_observation_summary(reason_kind: &str) -> String {
+    format!("The capability was denied ({reason_kind}).")
+}
+
+/// The denial's own text, when there is any, for the model-visible detail
+/// channel. Empty summaries degrade to `None` rather than an empty string,
+/// which the observation validator rejects.
+fn denial_detail_text(safe_summary: &str) -> Option<String> {
+    let trimmed = safe_summary.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 fn deny_reason_tag(reason: DenyReason) -> &'static str {

--- a/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
@@ -27,6 +27,20 @@ use super::{AgentLoopExecutorError, capability_host_error};
 const MAX_MODEL_OBSERVATION_INPUT_ISSUES: usize = 3;
 const MAX_MODEL_OBSERVATION_TEXT_BYTES: usize = 256;
 
+/// Appended to any model-visible text this module had to cut short.
+///
+/// Both cutters below used to slice to a UTF-8 boundary and return, leaving no
+/// sign the value was severed. A stack trace or compiler error cut mid-frame
+/// then reached the model looking complete, and the model would fix the wrong
+/// thing with confidence — worse than receiving no detail at all. This is the
+/// whole point of #6284 item 3's truncation box.
+///
+/// Free text rather than a structured flag because this channel *is* text: the
+/// model reads it directly, so an inline marker needs no rendering support and
+/// cannot be dropped by a consumer that ignores an unknown field. The marker is
+/// counted against the cap, never added on top of it.
+const TRUNCATION_MARKER: &str = " […truncated]";
+
 pub(super) fn capability_invocation_from_candidate(
     call: CapabilityCallCandidate,
     approval_resume: Option<CapabilityApprovalResume>,
@@ -400,14 +414,34 @@ pub(super) fn model_visible_capability_failure_observation(
 /// a UTF-8 boundary. The diagnostic is already secret-scrubbed by the producer.
 fn bounded_diagnostic_detail(value: &str) -> String {
     const MAX: usize = ironclaw_turns::run_profile::MODEL_OBSERVATION_DETAIL_MAX_BYTES;
-    if value.len() <= MAX {
+    truncate_marked(value, MAX)
+}
+
+/// Cut `value` to `max_bytes` **including** a [`TRUNCATION_MARKER`], on a UTF-8
+/// boundary. Text that already fits is returned unchanged and unmarked — a
+/// marker on a complete value would defeat the distinction this exists to draw.
+fn truncate_marked(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
         return value.to_string();
     }
-    let mut end = MAX;
+    // Reserve room for the marker so the result still honors the cap. If the
+    // cap cannot even hold the marker, fall back to a bare cut: an unmarked
+    // fragment beats overflowing a bound the persistence validator enforces.
+    let Some(budget) = max_bytes.checked_sub(TRUNCATION_MARKER.len()) else {
+        return cut_on_boundary(value, max_bytes).to_string();
+    };
+    format!("{}{TRUNCATION_MARKER}", cut_on_boundary(value, budget))
+}
+
+fn cut_on_boundary(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
     while end > 0 && !value.is_char_boundary(end) {
         end -= 1;
     }
-    value[..end].to_string() // safety: `end` reduced to a valid UTF-8 boundary.
+    &value[..end] // safety: `end` reduced to a valid UTF-8 boundary.
 }
 
 fn model_visible_failure_summary(error_kind: FailureKind) -> String {
@@ -441,14 +475,7 @@ fn bounded_input_issues(issues: &[CapabilityInputIssue]) -> Vec<CapabilityInputI
 }
 
 fn truncate_model_observation_text(value: &str) -> String {
-    if value.len() <= MAX_MODEL_OBSERVATION_TEXT_BYTES {
-        return value.to_string();
-    }
-    let mut end = MAX_MODEL_OBSERVATION_TEXT_BYTES;
-    while end > 0 && !value.is_char_boundary(end) {
-        end -= 1;
-    }
-    value[..end].to_string() // safety: `end` is reduced until it lands on a valid UTF-8 boundary.
+    truncate_marked(value, MAX_MODEL_OBSERVATION_TEXT_BYTES)
 }
 
 fn invalid_input_observation(issues: Vec<CapabilityInputIssue>) -> ModelVisibleToolObservation {
@@ -694,6 +721,68 @@ pub(super) fn push_completed_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A severed diagnostic must say it was severed.
+    ///
+    /// Both cutters sliced to a UTF-8 boundary and returned, with no marker of
+    /// any kind — so a stack trace or compiler error cut mid-frame reached the
+    /// model looking complete. That is worse than no detail: the model fixes
+    /// the wrong line with confidence. (#6284 item 3. Contrary to the epic's
+    /// note, the sibling summary path did NOT append `"..."` either — no
+    /// truncation marker existed anywhere in the product. The structured
+    /// `next_offset`/`total_bytes` on the *preview* path is a different
+    /// mechanism and does not cover free-text diagnostics.)
+    #[test]
+    fn a_severed_diagnostic_says_it_was_severed() {
+        let long = "E0308: mismatched types at src/main.rs:42 ".repeat(500);
+        let bounded = bounded_diagnostic_detail(&long);
+
+        assert!(
+            bounded.len() <= ironclaw_turns::run_profile::MODEL_OBSERVATION_DETAIL_MAX_BYTES,
+            "the marker must fit inside the cap, not push past it"
+        );
+        assert!(
+            bounded.ends_with(TRUNCATION_MARKER),
+            "a truncated diagnostic must be marked; got tail {:?}",
+            &bounded[bounded.len().saturating_sub(40)..]
+        );
+        // The real cause still leads.
+        assert!(bounded.starts_with("E0308: mismatched types"));
+    }
+
+    /// The same rule for the bounded per-field observation text.
+    #[test]
+    fn a_severed_observation_field_says_it_was_severed() {
+        let long = "a".repeat(MAX_MODEL_OBSERVATION_TEXT_BYTES * 3);
+        let bounded = truncate_model_observation_text(&long);
+
+        assert!(bounded.len() <= MAX_MODEL_OBSERVATION_TEXT_BYTES);
+        assert!(
+            bounded.ends_with(TRUNCATION_MARKER),
+            "a truncated observation field must be marked"
+        );
+    }
+
+    /// Text that fits is returned untouched — no marker on a complete value,
+    /// or the model cannot tell complete from severed after all.
+    #[test]
+    fn text_that_fits_is_never_marked() {
+        let short = "E0425: cannot find value `x` in this scope";
+        assert_eq!(bounded_diagnostic_detail(short), short);
+        assert_eq!(truncate_model_observation_text(short), short);
+    }
+
+    /// A multi-byte character must not be split by making room for the marker.
+    #[test]
+    fn marking_a_truncation_respects_utf8_boundaries() {
+        let long = "\u{e9}".repeat(ironclaw_turns::run_profile::MODEL_OBSERVATION_DETAIL_MAX_BYTES);
+        let bounded = bounded_diagnostic_detail(&long);
+        assert!(bounded.ends_with(TRUNCATION_MARKER));
+        // Round-trips as valid UTF-8 by construction; assert no replacement
+        // character crept in from a split boundary.
+        assert!(!bounded.contains('\u{fffd}'));
+    }
+
     use crate::test_support::test_run_context;
     use ironclaw_turns::run_profile::{CapabilityProgress, CapabilitySurfaceVersion};
 

--- a/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
@@ -1,16 +1,19 @@
 use std::collections::{HashMap, HashSet};
 
-use ironclaw_host_api::{CapabilityId, DispatchInputIssueCode, FailureKind};
+use ironclaw_host_api::{
+    CapabilityId, CapabilityRecoveryHint, DispatchInputIssueCode, FailureKind,
+    SameCallRetryConstraint,
+};
 use ironclaw_turns::{
     LoopResultRef,
     run_profile::{
         AgentLoopDriverHost, AppendCapabilityResultRef, CapabilityApprovalResume,
         CapabilityAuthResume, CapabilityCallCandidate, CapabilityDescriptorView, CapabilityFailure,
         CapabilityFailureDetail, CapabilityInputIssue, CapabilityInputRepair,
-        CapabilityRecoveryHint, CapabilityResultMessage, CapabilitySurfaceVersion, LoopRequest,
+        CapabilityResultMessage, CapabilitySurfaceVersion, LoopRequest,
         ModelVisibleToolObservation, ObservationTrust, ProviderToolCall, ProviderToolCallReference,
-        RegisterProviderToolCallRequest, SameCallRetryConstraint, ToolObservationDetail,
-        ToolObservationStatus, ToolRecoveryObservation, VisibleCapabilitySurface,
+        RegisterProviderToolCallRequest, ToolObservationDetail, ToolObservationStatus,
+        ToolRecoveryObservation, VisibleCapabilitySurface,
     },
 };
 

--- a/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
@@ -459,11 +459,13 @@ fn invalid_input_observation(issues: Vec<CapabilityInputIssue>) -> ModelVisibleT
         summary: "Tool input failed schema validation.".to_string(),
         detail: ToolObservationDetail::InvalidInput { issues },
         artifacts: Vec::new(),
-        recovery: Some(ToolRecoveryObservation {
-            same_call_retry: SameCallRetryConstraint::RequiresChangedInput,
-            repairs,
-            recovery_hint: CapabilityRecoveryHint::CorrectArgumentsBeforeRetry,
-        }),
+        recovery: Some(
+            ToolRecoveryObservation::new(
+                SameCallRetryConstraint::RequiresChangedInput,
+                CapabilityRecoveryHint::CorrectArgumentsBeforeRetry,
+            )
+            .with_repairs(repairs),
+        ),
         trust: ObservationTrust::UntrustedToolOutput,
     }
 }
@@ -515,11 +517,13 @@ fn generic_failure_recovery(error_kind: FailureKind) -> ToolRecoveryObservation 
         | FailureKind::Unclassified
         | FailureKind::StaleSurface => SameCallRetryConstraint::Allowed,
     };
-    ToolRecoveryObservation {
+    ToolRecoveryObservation::new(
         same_call_retry,
-        repairs: Vec::new(),
-        recovery_hint: CapabilityRecoveryHint::RespectFailureConstraint,
-    }
+        // Was a hardcoded `RespectFailureConstraint` for every kind — the model
+        // was told to obey a retry rule and nothing else. The hint now comes
+        // from the kind itself (#6284 item 4).
+        CapabilityRecoveryHint::for_failure_kind(error_kind),
+    )
 }
 
 fn input_issue_repair(issue: &CapabilityInputIssue) -> CapabilityInputRepair {

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -2,7 +2,8 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use ironclaw_host_api::{
-    ApprovalRequestId, CorrelationId, DispatchInputIssueCode, FailureKind, ProviderToolName,
+    ApprovalRequestId, CapabilityRecoveryHint, CorrelationId, DispatchInputIssueCode, FailureKind,
+    ProviderToolName, SameCallRetryConstraint,
 };
 use ironclaw_turns::{
     CapabilityActivityId, GateResumeDisposition, LoopCancelledReasonKind, LoopCompletionKind,
@@ -10,15 +11,14 @@ use ironclaw_turns::{
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, CapabilityApprovalResume, CapabilityAuthResume,
         CapabilityCallCandidate, CapabilityFailureDetail, CapabilityInputIssue, CapabilityInputRef,
-        CapabilityInputRepair, CapabilityRecoveryHint, CapabilityResumeToken, LoopCancelReasonKind,
-        LoopCancellationSignal, LoopCheckpointKind, LoopCompactionError, LoopCompactionOutcome,
-        LoopCompactionResponse, LoopContextCompactionKind, LoopInput, LoopInputAckToken,
-        LoopInputBatch, LoopInputCursor, LoopInterruptKind, LoopModelCapabilityView,
-        LoopProcessRef, LoopProgressEvent, LoopRunInfoPort, LoopSafeSummary, LoopSummaryArtifactId,
+        CapabilityInputRepair, CapabilityResumeToken, LoopCancelReasonKind, LoopCancellationSignal,
+        LoopCheckpointKind, LoopCompactionError, LoopCompactionOutcome, LoopCompactionResponse,
+        LoopContextCompactionKind, LoopInput, LoopInputAckToken, LoopInputBatch, LoopInputCursor,
+        LoopInterruptKind, LoopModelCapabilityView, LoopProcessRef, LoopProgressEvent,
+        LoopRunInfoPort, LoopSafeSummary, LoopSummaryArtifactId,
         MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION, ModelVisibleToolObservation,
         ObservationTrust, ParentLoopOutput, PromptMode, ProviderToolCallReplay,
-        SameCallRetryConstraint, ToolObservationDetail, ToolObservationStatus,
-        VisibleCapabilityRequest, resolution,
+        ToolObservationDetail, ToolObservationStatus, VisibleCapabilityRequest, resolution,
     },
 };
 
@@ -4572,8 +4572,6 @@ async fn retry_uses_single_call_invocation() {
 /// naming the next move.
 #[tokio::test]
 async fn a_denial_tells_the_model_what_would_unlock_it() {
-    use ironclaw_turns::run_profile::{CapabilityRecoveryHint, SameCallRetryConstraint};
-
     // `auth_denied` is minted by the capability port for a real authorization
     // failure; #6781 maps it to `DenyReason::UnknownSecret`. Provider replay
     // metadata is required for a denial to mint a result ref, so this uses the

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -4562,6 +4562,81 @@ async fn retry_uses_single_call_invocation() {
     }
 }
 
+/// A denial must reach the model with something it can act on.
+///
+/// Denials passed `model_observation: None`, so the model got a summary string
+/// and nothing structured — no recovery, no retry constraint, no repairs. A
+/// denial meaning *authenticate and this works* was indistinguishable from a
+/// permanent block (#6284 item 4). This drives a real denial through the
+/// executor and asserts the appended result carries a recovery observation
+/// naming the next move.
+#[tokio::test]
+async fn a_denial_tells_the_model_what_would_unlock_it() {
+    use ironclaw_turns::run_profile::{CapabilityRecoveryHint, SameCallRetryConstraint};
+
+    // `auth_denied` is minted by the capability port for a real authorization
+    // failure; #6781 maps it to `DenyReason::UnknownSecret`. Provider replay
+    // metadata is required for a denial to mint a result ref, so this uses the
+    // two-provider-call shape (one completed, one denied) that
+    // `denied_provider_call_appends_failure_tool_result_for_replay` uses.
+    let result_ref = LoopResultRef::new("result:denial-hint-ok").expect("valid");
+    let host = MockHost::new(vec![provider_two_calls_response(), reply_response()])
+        .with_batch_outcomes(vec![ironclaw_host_api::ResolutionBatch {
+            resolutions: vec![
+                resolution::completed(
+                    result_ref.clone(),
+                    "provider call completed".to_string(),
+                    ironclaw_turns::run_profile::CapabilityProgress::MadeProgress,
+                    true,
+                    0,
+                    None,
+                    None,
+                ),
+                resolution::denied(
+                    ironclaw_turns::run_profile::CapabilityDeniedReasonKind::unknown("auth_denied")
+                        .expect("valid reason tag"),
+                    // Deliberately avoids the word "credential": the summary
+                    // channel's credential-marker guard would scrub it to a
+                    // placeholder, which is orthogonal to what this pins.
+                    "sign-in required for this provider".to_string(),
+                )
+                .resolution,
+            ],
+            stopped_on_suspension: false,
+        }]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    let appended = host.appended_result_refs();
+    assert_eq!(appended.len(), 2, "completed call plus the denial");
+    let denial_result = &appended[1];
+    let observation = denial_result
+        .model_observation
+        .as_ref()
+        .expect("a denial must carry a model observation, not None");
+    let recovery = observation
+        .recovery
+        .as_ref()
+        .expect("a denial observation must carry recovery guidance");
+
+    // The specific action, not a generic "obey the constraint".
+    assert_eq!(
+        recovery.recovery_hint,
+        CapabilityRecoveryHint::AuthenticateThenRetry,
+        "a credential-missing denial must point the model at an auth flow"
+    );
+    assert!(
+        recovery.recovery_hint.names_an_action(),
+        "the denial hint must name a concrete next move"
+    );
+    assert_eq!(recovery.same_call_retry, SameCallRetryConstraint::Forbidden);
+}
+
 #[tokio::test]
 async fn policy_denied_capability_error_honors_retry_recovery() {
     let host = MockHost::new(vec![calls_response()])

--- a/crates/ironclaw_host_api/src/result_meta.rs
+++ b/crates/ironclaw_host_api/src/result_meta.rs
@@ -280,6 +280,161 @@ declare_failure_kinds! {
     Cancelled => "cancelled",
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SameCallRetryConstraint {
+    Allowed,
+    AllowedAfterDelay,
+    RequiresChangedInput,
+    NotUseful,
+    Forbidden,
+}
+
+/// What the model should actually *do* about a failure.
+///
+/// Before #6284 item 4 this had two variants and one of them was a constant:
+/// every kind except `InputEncode` got [`RespectFailureConstraint`], which says
+/// only "obey the retry rule you were already given" — it names no action. A
+/// missing credential, a pending approval, an absent runtime and a permanent
+/// refusal were all told the same nothing.
+///
+/// Each variant below names a *different next move*. They are assigned beside
+/// the failure kind in a wildcard-free match ([`FailureKind::recovery_hint`]),
+/// so a new kind cannot compile until someone decides what the model should do
+/// about it.
+///
+/// [`RespectFailureConstraint`]: Self::RespectFailureConstraint
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityRecoveryHint {
+    /// The input was wrong and the model can fix it — see `repairs`.
+    CorrectArgumentsBeforeRetry,
+    /// No action names itself: obey `same_call_retry` and use judgment.
+    ///
+    /// Retained as the honest answer for genuinely unclassifiable failures.
+    /// It is no longer the default for everything else.
+    RespectFailureConstraint,
+    /// A credential is missing or was refused. Completing an auth flow for the
+    /// provider is what unlocks this call.
+    AuthenticateThenRetry,
+    /// A human can approve this. Asking is worthwhile; the same call may
+    /// succeed once approval lands.
+    RequestApproval,
+    /// The world hiccuped. Wait — see `retry_after_ms` when the provider told
+    /// us how long — and re-issue the same call.
+    WaitThenRetry,
+    /// The runtime or configuration this capability needs is absent. A setup
+    /// step outside the run must happen first; the accompanying
+    /// `HostRemediation` detail carries it when one is known.
+    CompleteSetup,
+    /// This capability is not available to this caller and re-calling it cannot
+    /// succeed. Reach the goal a different way.
+    UseDifferentCapability,
+    /// Permanently refused. Neither this call nor a variation of it will be
+    /// permitted; change the plan rather than the arguments.
+    ReviseApproach,
+}
+
+impl CapabilityRecoveryHint {
+    /// The action the model should take for a given failure kind.
+    ///
+    /// Exhaustive and wildcard-free over the closed [`FailureKind`] vocabulary
+    /// (it is deliberately not `#[non_exhaustive]`), so adding a kind refuses
+    /// to compile until its next move is chosen here — the same compile-forcing
+    /// discipline [`FailureKind::fate`] uses for the retry/terminal decision.
+    ///
+    /// `fate()` answers *what the loop does*; this answers *what the model
+    /// does*. They are deliberately separate: `Unavailable` is retried by the
+    /// host **and**, once retries are spent, tells the model to wait.
+    pub fn for_failure_kind(kind: FailureKind) -> Self {
+        match kind {
+            // A credential is the unlock.
+            FailureKind::Authorization
+            | FailureKind::AuthRequired
+            | FailureKind::SecretDenied => Self::AuthenticateThenRetry,
+
+            // A human is the unlock.
+            FailureKind::GateDeclined => Self::RequestApproval,
+
+            // The world hiccuped; the same call can succeed later.
+            FailureKind::Network
+            | FailureKind::Transient
+            | FailureKind::Unavailable
+            | FailureKind::Backend
+            | FailureKind::Internal
+            | FailureKind::Resource => Self::WaitThenRetry,
+
+            // The model wrote something it can rewrite.
+            FailureKind::InputEncode
+            | FailureKind::OutputTooLarge
+            | FailureKind::OutputDecode
+            | FailureKind::InvalidResult => Self::CorrectArgumentsBeforeRetry,
+
+            // Not available to this caller; another route is needed.
+            FailureKind::MethodMissing
+            | FailureKind::UndeclaredCapability
+            | FailureKind::UnknownCapability
+            | FailureKind::UnknownProvider
+            | FailureKind::StaleSurface => Self::UseDifferentCapability,
+
+            // Something outside the run must be installed or configured.
+            FailureKind::MissingRuntime
+            | FailureKind::MissingRuntimeBackend
+            | FailureKind::UnsupportedRunner
+            | FailureKind::RuntimeMismatch
+            | FailureKind::ExtensionRuntimeMismatch
+            | FailureKind::Manifest => Self::CompleteSetup,
+
+            // Refused, and no amount of rewording changes that.
+            FailureKind::PolicyDenied
+            | FailureKind::NetworkDenied
+            | FailureKind::FilesystemDenied => Self::ReviseApproach,
+
+            // The extension is broken or the operation genuinely failed. The
+            // model may reasonably try something else, but no specific action
+            // names itself, so it gets the constraint and its own judgment.
+            FailureKind::OperationFailed
+            | FailureKind::Guest
+            | FailureKind::ExitFailure
+            | FailureKind::Memory
+            | FailureKind::Client
+            | FailureKind::Executor
+            | FailureKind::Cancelled
+            // Unclassifiable by construction: this is the one honest use of
+            // the old blanket answer.
+            | FailureKind::Unclassified => Self::RespectFailureConstraint,
+        }
+    }
+
+    /// Every variant, for cross-crate conformance checks.
+    ///
+    /// `ironclaw_threads` re-declares this vocabulary as a JSON allowlist (the
+    /// two crates are siblings; neither can import the other), and a hint
+    /// missing from that list does not fail validation loudly — it silently
+    /// drops the entire observation. `ironclaw_loop_host` owns the test that
+    /// walks this array through the real persistence path.
+    pub const ALL: &'static [Self] = &[
+        Self::CorrectArgumentsBeforeRetry,
+        Self::RespectFailureConstraint,
+        Self::AuthenticateThenRetry,
+        Self::RequestApproval,
+        Self::WaitThenRetry,
+        Self::CompleteSetup,
+        Self::UseDifferentCapability,
+        Self::ReviseApproach,
+    ];
+
+    /// Whether this hint names a concrete next move.
+    ///
+    /// [`RespectFailureConstraint`](Self::RespectFailureConstraint) does not —
+    /// it defers to the retry constraint. The conformance test
+    /// `only_genuinely_unclassifiable_failures_may_decline_to_name_an_action`
+    /// uses this to pin the small set of kinds allowed to answer that way.
+    pub fn names_an_action(self) -> bool {
+        !matches!(self, Self::RespectFailureConstraint)
+    }
+}
+
 /// What the loop does with a [`FailureKind`] — the single fate decision,
 /// decided once beside the enum instead of re-derived per layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/ironclaw_loop_host/src/lib.rs
+++ b/crates/ironclaw_loop_host/src/lib.rs
@@ -2613,4 +2613,68 @@ mod tests {
         );
         assert_eq!(personal_context_source_label("///"), None);
     }
+
+    /// Every recovery hint the loop can emit must survive persistence.
+    ///
+    /// The vocabulary now has a single home (`host_api`) and `ironclaw_threads`
+    /// deserializes that enum rather than re-declaring its variants, so drift is
+    /// structurally impossible. This test guards the seam anyway, because the
+    /// *failure mode* is what makes it worth a test: an unaccepted value does
+    /// not surface a validation error to anyone — the caller **drops the whole
+    /// observation**, so the model loses the cause *and* the guidance and sees
+    /// only a bare summary.
+    ///
+    /// That is not hypothetical. #6284 item 4 added six hints while the
+    /// vocabulary was still duplicated by hand, missed the copy, and every
+    /// denial it was meant to improve persisted with no observation at all.
+    /// Crate-level tests all passed; only the persistence seam revealed it.
+    ///
+    /// This crate is the lowest one that sees both the emitting and persisting
+    /// sides. Driven through the real envelope constructor, not the validator,
+    /// so it pins what production actually stores.
+    #[test]
+    fn every_recovery_hint_the_loop_can_emit_survives_persistence() {
+        use ironclaw_host_api::{CapabilityRecoveryHint, SameCallRetryConstraint};
+        use ironclaw_threads::{ToolResultReferenceEnvelope, ToolResultSafeSummary};
+        use ironclaw_turns::run_profile::{
+            MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION, ModelVisibleToolObservation,
+            ObservationTrust, ToolObservationDetail, ToolObservationStatus,
+            ToolRecoveryObservation,
+        };
+
+        for hint in CapabilityRecoveryHint::ALL {
+            let observation = ModelVisibleToolObservation {
+                schema_version: MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
+                status: ToolObservationStatus::Error,
+                summary: "The capability failed.".to_string(),
+                detail: ToolObservationDetail::GenericFailure {
+                    failure_kind: ironclaw_host_api::FailureKind::PolicyDenied,
+                    detail: None,
+                },
+                artifacts: Vec::new(),
+                recovery: Some(
+                    ToolRecoveryObservation::new(SameCallRetryConstraint::Forbidden, *hint)
+                        // Exercise the optional delay field too: it is a key on
+                        // the same object, and an unknown KEY is rejected the
+                        // same silent way an unknown hint is.
+                        .with_retry_after(Some(30_000)),
+                ),
+                trust: ObservationTrust::UntrustedToolOutput,
+            };
+            let value = serde_json::to_value(&observation).expect("observation serializes");
+
+            let envelope = ToolResultReferenceEnvelope::new_best_effort_model_observation(
+                "result:hint-conformance",
+                ToolResultSafeSummary::new("The capability failed.").expect("summary"),
+                Some(value),
+            )
+            .expect("envelope constructs");
+
+            assert!(
+                envelope.model_observation.is_some(),
+                "recovery hint {hint:?} does not survive persistence, so storing it DROPS THE \
+                 WHOLE OBSERVATION — the model would lose the cause and the guidance."
+            );
+        }
+    }
 }

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -975,31 +975,41 @@ fn validate_model_observation_recovery(value: &serde_json::Value) -> Result<(), 
     let object = expect_object(value, "model observation recovery")?;
     validate_object_keys(
         object,
-        &["same_call_retry", "repairs", "recovery_hint"],
+        &[
+            "same_call_retry",
+            "repairs",
+            "recovery_hint",
+            "retry_after_ms",
+        ],
         "model observation recovery",
     )?;
-    validate_enum_string(
-        required_string(object, "same_call_retry", "model observation recovery")?,
-        &[
-            "allowed",
-            "allowed_after_delay",
-            "requires_changed_input",
-            "not_useful",
-            "forbidden",
-        ],
-        "model observation same-call retry",
-    )?;
+    // Parse against the OWNING enums in `host_api` rather than re-declaring
+    // their variants here.
+    //
+    // This used to be two hand-copied string lists. Nothing kept them in step
+    // with `host_api`, and the failure mode was silent and total: an unknown
+    // value did not surface as a validation error to anyone — the caller
+    // DROPPED THE WHOLE OBSERVATION, so the model lost the cause *and* the
+    // recovery guidance and saw only a bare summary. #6284 item 4 added six
+    // recovery hints, missed the copy here, and every denial it was meant to
+    // improve persisted with no observation at all.
+    //
+    // Deserializing the real type makes that drift impossible: a variant added
+    // in `host_api` is accepted here the moment it exists.
+    let retry = required_string(object, "same_call_retry", "model observation recovery")?;
+    serde_json::from_value::<ironclaw_host_api::SameCallRetryConstraint>(
+        serde_json::Value::String(retry.to_string()),
+    )
+    .map_err(|_| format!("model observation same-call retry `{retry}` is unsupported"))?;
     if let Some(repairs) = object.get("repairs") {
         validate_model_observation_repairs(repairs)?;
     }
-    validate_enum_string(
-        required_string(object, "recovery_hint", "model observation recovery")?,
-        &[
-            "correct_arguments_before_retry",
-            "respect_failure_constraint",
-        ],
-        "model observation recovery hint",
-    )
+    let hint = required_string(object, "recovery_hint", "model observation recovery")?;
+    serde_json::from_value::<ironclaw_host_api::CapabilityRecoveryHint>(serde_json::Value::String(
+        hint.to_string(),
+    ))
+    .map_err(|_| format!("model observation recovery hint `{hint}` is unsupported"))?;
+    Ok(())
 }
 
 fn validate_model_observation_repairs(value: &serde_json::Value) -> Result<(), String> {
@@ -1238,8 +1248,6 @@ mod tests {
     /// *and* the advice. Degrade the text, keep the structure (#6284 item 3).
     #[test]
     fn an_unstorable_diagnostic_degrades_instead_of_dropping_the_guidance() {
-        use super::normalized_model_observation;
-
         // A traceback carrying a marker word the untrusted content scan
         // rejects. This is the realistic agent-built-code failure.
         let observation = serde_json::json!({
@@ -1258,7 +1266,19 @@ mod tests {
             "trust": "untrusted_tool_output"
         });
 
-        let normalized = normalized_model_observation("result:skill-crash", observation)
+        // Driven through the public constructor, not `normalized_model_observation`
+        // directly: the normalizer is a transform gating what gets persisted,
+        // with a wrapper between it and that effect, so a helper-only test does
+        // not satisfy `.claude/rules/testing.md` ("Test through the caller").
+        let envelope = ToolResultReferenceEnvelope::new_best_effort_model_observation(
+            "result:skill-crash",
+            ToolResultSafeSummary::new("Capability failed with exit_failure.").expect("summary"),
+            Some(observation),
+        )
+        .expect("envelope constructs");
+        let normalized = envelope
+            .model_observation
+            .as_ref()
             .expect("the observation must survive with its guidance intact");
 
         // The unsafe text is gone...
@@ -1279,8 +1299,6 @@ mod tests {
     /// text that was storable all along.
     #[test]
     fn a_storable_diagnostic_keeps_its_text() {
-        use super::normalized_model_observation;
-
         let observation = serde_json::json!({
             "schema_version": 1,
             "status": "error",
@@ -1293,7 +1311,15 @@ mod tests {
             "trust": "untrusted_tool_output"
         });
 
-        let normalized = normalized_model_observation("result:skill-ok", observation)
+        let envelope = ToolResultReferenceEnvelope::new_best_effort_model_observation(
+            "result:skill-ok",
+            ToolResultSafeSummary::new("Capability failed with exit_failure.").expect("summary"),
+            Some(observation),
+        )
+        .expect("envelope constructs");
+        let normalized = envelope
+            .model_observation
+            .as_ref()
             .expect("a clean observation survives");
         assert_eq!(
             normalized["detail"]["detail"],

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -347,7 +347,8 @@ fn normalized_model_observation(
         Ok(()) => Some(model_observation),
         Err(error) => {
             let repaired = strip_unsafe_result_reference_preview(&mut model_observation)
-                || strip_unsafe_invalid_input_issue_text(&mut model_observation);
+                || strip_unsafe_invalid_input_issue_text(&mut model_observation)
+                || strip_unstorable_generic_failure_detail(&mut model_observation);
             if repaired && validate_model_observation(&model_observation).is_ok() {
                 tracing::debug!(
                     reason = %error,
@@ -380,6 +381,31 @@ fn observation_detail_of_kind<'a>(
         .and_then(|observation| observation.get_mut("detail"))
         .and_then(serde_json::Value::as_object_mut)
         .filter(|detail| detail.get("kind").and_then(serde_json::Value::as_str) == Some(kind))
+}
+
+/// Drop a `generic_failure`'s free-text diagnostic when it cannot be stored,
+/// keeping the observation itself.
+///
+/// The last-resort repair. Without it, a failure whose *text* fails validation
+/// took the whole observation down with it — `failure_kind`, `status` and the
+/// recovery guidance included — so the model lost the advice as well as the
+/// cause. That is worst for agent-authored code: a skill or generated program
+/// fails as `generic_failure` carrying a raw traceback, which is exactly the
+/// text most likely to trip the untrusted content scan.
+///
+/// The text is optional in the schema, so removing it yields a valid
+/// observation. Losing the cause is a real loss; losing the cause *and* the
+/// next move is a worse one.
+fn strip_unstorable_generic_failure_detail(observation: &mut serde_json::Value) -> bool {
+    observation_detail_of_kind(observation, "generic_failure")
+        .filter(|detail| {
+            detail
+                .get("detail")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(observation_text_needs_repair)
+        })
+        .and_then(|detail| detail.remove("detail"))
+        .is_some()
 }
 
 fn strip_unsafe_result_reference_preview(observation: &mut serde_json::Value) -> bool {
@@ -1200,6 +1226,80 @@ mod tests {
         INPUT_ENCODE_HUMAN_SUMMARY, ProviderToolCallReferenceEnvelope, ToolResultReferenceEnvelope,
         ToolResultSafeSummary,
     };
+
+    /// A failure whose *text* cannot be stored must not take the *guidance*
+    /// with it.
+    ///
+    /// When validation failed and neither narrow repair applied, the whole
+    /// observation was dropped — recovery hint included. That is worst exactly
+    /// where it hurts most: agent-authored code (a skill, a generated program)
+    /// fails with `generic_failure` carrying a raw traceback, which is the text
+    /// most likely to trip the content scan. The model then lost both the cause
+    /// *and* the advice. Degrade the text, keep the structure (#6284 item 3).
+    #[test]
+    fn an_unstorable_diagnostic_degrades_instead_of_dropping_the_guidance() {
+        use super::normalized_model_observation;
+
+        // A traceback carrying a marker word the untrusted content scan
+        // rejects. This is the realistic agent-built-code failure.
+        let observation = serde_json::json!({
+            "schema_version": 1,
+            "status": "error",
+            "summary": "Capability failed with exit_failure.",
+            "detail": {
+                "kind": "generic_failure",
+                "failure_kind": "exit_failure",
+                "detail": "Traceback: auth failed, password = hunter2\u{0}"
+            },
+            "recovery": {
+                "same_call_retry": "allowed",
+                "recovery_hint": "respect_failure_constraint"
+            },
+            "trust": "untrusted_tool_output"
+        });
+
+        let normalized = normalized_model_observation("result:skill-crash", observation)
+            .expect("the observation must survive with its guidance intact");
+
+        // The unsafe text is gone...
+        assert!(
+            normalized["detail"].get("detail").is_none(),
+            "the unstorable diagnostic text must be dropped"
+        );
+        // ...but everything the model can still act on survives.
+        assert_eq!(normalized["detail"]["failure_kind"], "exit_failure");
+        assert_eq!(
+            normalized["recovery"]["recovery_hint"], "respect_failure_constraint",
+            "the recovery guidance must not be dropped with the text"
+        );
+        assert_eq!(normalized["status"], "error");
+    }
+
+    /// A clean diagnostic is untouched — the degrade path must not fire on
+    /// text that was storable all along.
+    #[test]
+    fn a_storable_diagnostic_keeps_its_text() {
+        use super::normalized_model_observation;
+
+        let observation = serde_json::json!({
+            "schema_version": 1,
+            "status": "error",
+            "summary": "Capability failed with exit_failure.",
+            "detail": {
+                "kind": "generic_failure",
+                "failure_kind": "exit_failure",
+                "detail": "E0308: mismatched types at src/main.rs:42"
+            },
+            "trust": "untrusted_tool_output"
+        });
+
+        let normalized = normalized_model_observation("result:skill-ok", observation)
+            .expect("a clean observation survives");
+        assert_eq!(
+            normalized["detail"]["detail"],
+            "E0308: mismatched types at src/main.rs:42"
+        );
+    }
 
     #[test]
     fn sensitive_markers_match_on_word_boundary_not_substring() {

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -91,11 +91,10 @@ pub use model::{
     NoOpBudgetAccountant, NoOpPolicyGuard,
 };
 pub use model_observation::{
-    CapabilityFailureDetail, CapabilityInputIssue, CapabilityInputRepair, CapabilityRecoveryHint,
+    CapabilityFailureDetail, CapabilityInputIssue, CapabilityInputRepair,
     MODEL_OBSERVATION_DETAIL_MAX_BYTES, MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
-    ModelVisibleArtifact, ModelVisibleToolObservation, ObservationTrust, SameCallRetryConstraint,
-    ToolObservationDetail, ToolObservationStatus, ToolRecoveryObservation,
-    validate_model_observation_detail,
+    ModelVisibleArtifact, ModelVisibleToolObservation, ObservationTrust, ToolObservationDetail,
+    ToolObservationStatus, ToolRecoveryObservation, validate_model_observation_detail,
 };
 pub use model_work::{ModelWorkKind, ModelWorkOutcome, ModelWorkRequest, ModelWorkUsage};
 pub use policy::{

--- a/crates/ironclaw_turns/src/run_profile/model_observation.rs
+++ b/crates/ironclaw_turns/src/run_profile/model_observation.rs
@@ -1,4 +1,12 @@
-use ironclaw_host_api::{DispatchInputIssueCode, FailureKind, HostRemediation};
+// `CapabilityRecoveryHint` and `SameCallRetryConstraint` live in `host_api`
+// beside `FailureKind`, not here. Both this crate and `ironclaw_threads` (which
+// validates the persisted form) depend on `host_api` but not on each other, so
+// a home below both is the only one where the vocabulary can have a single
+// definition instead of a hand-maintained copy per crate.
+use ironclaw_host_api::{
+    CapabilityRecoveryHint, DispatchInputIssueCode, FailureKind, HostRemediation,
+    SameCallRetryConstraint,
+};
 use serde::{Deserialize, Serialize};
 const MODEL_OBSERVATION_SUMMARY_MAX_BYTES: usize = 512;
 const MODEL_OBSERVATION_ARTIFACTS_MAX: usize = 16;
@@ -333,143 +341,6 @@ impl CapabilityInputRepair {
                 validate_optional_text(expected.as_deref(), "model observation repair expected")
             }
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SameCallRetryConstraint {
-    Allowed,
-    AllowedAfterDelay,
-    RequiresChangedInput,
-    NotUseful,
-    Forbidden,
-}
-
-/// What the model should actually *do* about a failure.
-///
-/// Before #6284 item 4 this had two variants and one of them was a constant:
-/// every kind except `InputEncode` got [`RespectFailureConstraint`], which says
-/// only "obey the retry rule you were already given" — it names no action. A
-/// missing credential, a pending approval, an absent runtime and a permanent
-/// refusal were all told the same nothing.
-///
-/// Each variant below names a *different next move*. They are assigned beside
-/// the failure kind in a wildcard-free match ([`FailureKind::recovery_hint`]),
-/// so a new kind cannot compile until someone decides what the model should do
-/// about it.
-///
-/// [`RespectFailureConstraint`]: Self::RespectFailureConstraint
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CapabilityRecoveryHint {
-    /// The input was wrong and the model can fix it — see `repairs`.
-    CorrectArgumentsBeforeRetry,
-    /// No action names itself: obey `same_call_retry` and use judgment.
-    ///
-    /// Retained as the honest answer for genuinely unclassifiable failures.
-    /// It is no longer the default for everything else.
-    RespectFailureConstraint,
-    /// A credential is missing or was refused. Completing an auth flow for the
-    /// provider is what unlocks this call.
-    AuthenticateThenRetry,
-    /// A human can approve this. Asking is worthwhile; the same call may
-    /// succeed once approval lands.
-    RequestApproval,
-    /// The world hiccuped. Wait — see `retry_after_ms` when the provider told
-    /// us how long — and re-issue the same call.
-    WaitThenRetry,
-    /// The runtime or configuration this capability needs is absent. A setup
-    /// step outside the run must happen first; the accompanying
-    /// `HostRemediation` detail carries it when one is known.
-    CompleteSetup,
-    /// This capability is not available to this caller and re-calling it cannot
-    /// succeed. Reach the goal a different way.
-    UseDifferentCapability,
-    /// Permanently refused. Neither this call nor a variation of it will be
-    /// permitted; change the plan rather than the arguments.
-    ReviseApproach,
-}
-
-impl CapabilityRecoveryHint {
-    /// The action the model should take for a given failure kind.
-    ///
-    /// Exhaustive and wildcard-free over the closed [`FailureKind`] vocabulary
-    /// (it is deliberately not `#[non_exhaustive]`), so adding a kind refuses
-    /// to compile until its next move is chosen here — the same compile-forcing
-    /// discipline [`FailureKind::fate`] uses for the retry/terminal decision.
-    ///
-    /// `fate()` answers *what the loop does*; this answers *what the model
-    /// does*. They are deliberately separate: `Unavailable` is retried by the
-    /// host **and**, once retries are spent, tells the model to wait.
-    pub fn for_failure_kind(kind: FailureKind) -> Self {
-        match kind {
-            // A credential is the unlock.
-            FailureKind::Authorization
-            | FailureKind::AuthRequired
-            | FailureKind::SecretDenied => Self::AuthenticateThenRetry,
-
-            // A human is the unlock.
-            FailureKind::GateDeclined => Self::RequestApproval,
-
-            // The world hiccuped; the same call can succeed later.
-            FailureKind::Network
-            | FailureKind::Transient
-            | FailureKind::Unavailable
-            | FailureKind::Backend
-            | FailureKind::Internal
-            | FailureKind::Resource => Self::WaitThenRetry,
-
-            // The model wrote something it can rewrite.
-            FailureKind::InputEncode
-            | FailureKind::OutputTooLarge
-            | FailureKind::OutputDecode
-            | FailureKind::InvalidResult => Self::CorrectArgumentsBeforeRetry,
-
-            // Not available to this caller; another route is needed.
-            FailureKind::MethodMissing
-            | FailureKind::UndeclaredCapability
-            | FailureKind::UnknownCapability
-            | FailureKind::UnknownProvider
-            | FailureKind::StaleSurface => Self::UseDifferentCapability,
-
-            // Something outside the run must be installed or configured.
-            FailureKind::MissingRuntime
-            | FailureKind::MissingRuntimeBackend
-            | FailureKind::UnsupportedRunner
-            | FailureKind::RuntimeMismatch
-            | FailureKind::ExtensionRuntimeMismatch
-            | FailureKind::Manifest => Self::CompleteSetup,
-
-            // Refused, and no amount of rewording changes that.
-            FailureKind::PolicyDenied
-            | FailureKind::NetworkDenied
-            | FailureKind::FilesystemDenied => Self::ReviseApproach,
-
-            // The extension is broken or the operation genuinely failed. The
-            // model may reasonably try something else, but no specific action
-            // names itself, so it gets the constraint and its own judgment.
-            FailureKind::OperationFailed
-            | FailureKind::Guest
-            | FailureKind::ExitFailure
-            | FailureKind::Memory
-            | FailureKind::Client
-            | FailureKind::Executor
-            | FailureKind::Cancelled
-            // Unclassifiable by construction: this is the one honest use of
-            // the old blanket answer.
-            | FailureKind::Unclassified => Self::RespectFailureConstraint,
-        }
-    }
-
-    /// Whether this hint names a concrete next move.
-    ///
-    /// [`RespectFailureConstraint`](Self::RespectFailureConstraint) does not —
-    /// it defers to the retry constraint. The conformance test
-    /// `only_genuinely_unclassifiable_failures_may_decline_to_name_an_action`
-    /// uses this to pin the small set of kinds allowed to answer that way.
-    pub fn names_an_action(self) -> bool {
-        !matches!(self, Self::RespectFailureConstraint)
     }
 }
 

--- a/crates/ironclaw_turns/src/run_profile/model_observation.rs
+++ b/crates/ironclaw_turns/src/run_profile/model_observation.rs
@@ -232,9 +232,52 @@ pub struct ToolRecoveryObservation {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repairs: Vec<CapabilityInputRepair>,
     pub recovery_hint: CapabilityRecoveryHint,
+    /// How long to wait before re-issuing, when the provider told us.
+    ///
+    /// [`SameCallRetryConstraint::AllowedAfterDelay`] says *wait* without
+    /// saying *how long*, so the model had to guess and the provider's own
+    /// `Retry-After` was discarded. The value lives here rather than inside the
+    /// constraint variant so the addition stays wire-compatible: the constraint
+    /// keeps serializing as a bare string, and observations persisted before
+    /// this field existed still deserialize (pinned by
+    /// `recovery_observation_without_a_delay_still_loads`).
+    ///
+    /// Only meaningful alongside `AllowedAfterDelay`; `None` means the provider
+    /// gave no hint, not "retry immediately".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
 }
 
 impl ToolRecoveryObservation {
+    /// A recovery observation carrying no repairs and no delay.
+    ///
+    /// Every construction site goes through this or [`Self::with_retry_after`],
+    /// so adding a field to the struct cannot silently leave a producer
+    /// defaulting it.
+    pub fn new(
+        same_call_retry: SameCallRetryConstraint,
+        recovery_hint: CapabilityRecoveryHint,
+    ) -> Self {
+        Self {
+            same_call_retry,
+            repairs: Vec::new(),
+            recovery_hint,
+            retry_after_ms: None,
+        }
+    }
+
+    /// Attach the provider's requested wait.
+    pub fn with_retry_after(mut self, retry_after_ms: Option<u64>) -> Self {
+        self.retry_after_ms = retry_after_ms;
+        self
+    }
+
+    /// Attach model-actionable input repairs.
+    pub fn with_repairs(mut self, repairs: Vec<CapabilityInputRepair>) -> Self {
+        self.repairs = repairs;
+        self
+    }
+
     fn validate(&self) -> Result<(), String> {
         validate_len(
             self.repairs.len(),
@@ -303,11 +346,131 @@ pub enum SameCallRetryConstraint {
     Forbidden,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// What the model should actually *do* about a failure.
+///
+/// Before #6284 item 4 this had two variants and one of them was a constant:
+/// every kind except `InputEncode` got [`RespectFailureConstraint`], which says
+/// only "obey the retry rule you were already given" — it names no action. A
+/// missing credential, a pending approval, an absent runtime and a permanent
+/// refusal were all told the same nothing.
+///
+/// Each variant below names a *different next move*. They are assigned beside
+/// the failure kind in a wildcard-free match ([`FailureKind::recovery_hint`]),
+/// so a new kind cannot compile until someone decides what the model should do
+/// about it.
+///
+/// [`RespectFailureConstraint`]: Self::RespectFailureConstraint
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CapabilityRecoveryHint {
+    /// The input was wrong and the model can fix it — see `repairs`.
     CorrectArgumentsBeforeRetry,
+    /// No action names itself: obey `same_call_retry` and use judgment.
+    ///
+    /// Retained as the honest answer for genuinely unclassifiable failures.
+    /// It is no longer the default for everything else.
     RespectFailureConstraint,
+    /// A credential is missing or was refused. Completing an auth flow for the
+    /// provider is what unlocks this call.
+    AuthenticateThenRetry,
+    /// A human can approve this. Asking is worthwhile; the same call may
+    /// succeed once approval lands.
+    RequestApproval,
+    /// The world hiccuped. Wait — see `retry_after_ms` when the provider told
+    /// us how long — and re-issue the same call.
+    WaitThenRetry,
+    /// The runtime or configuration this capability needs is absent. A setup
+    /// step outside the run must happen first; the accompanying
+    /// `HostRemediation` detail carries it when one is known.
+    CompleteSetup,
+    /// This capability is not available to this caller and re-calling it cannot
+    /// succeed. Reach the goal a different way.
+    UseDifferentCapability,
+    /// Permanently refused. Neither this call nor a variation of it will be
+    /// permitted; change the plan rather than the arguments.
+    ReviseApproach,
+}
+
+impl CapabilityRecoveryHint {
+    /// The action the model should take for a given failure kind.
+    ///
+    /// Exhaustive and wildcard-free over the closed [`FailureKind`] vocabulary
+    /// (it is deliberately not `#[non_exhaustive]`), so adding a kind refuses
+    /// to compile until its next move is chosen here — the same compile-forcing
+    /// discipline [`FailureKind::fate`] uses for the retry/terminal decision.
+    ///
+    /// `fate()` answers *what the loop does*; this answers *what the model
+    /// does*. They are deliberately separate: `Unavailable` is retried by the
+    /// host **and**, once retries are spent, tells the model to wait.
+    pub fn for_failure_kind(kind: FailureKind) -> Self {
+        match kind {
+            // A credential is the unlock.
+            FailureKind::Authorization
+            | FailureKind::AuthRequired
+            | FailureKind::SecretDenied => Self::AuthenticateThenRetry,
+
+            // A human is the unlock.
+            FailureKind::GateDeclined => Self::RequestApproval,
+
+            // The world hiccuped; the same call can succeed later.
+            FailureKind::Network
+            | FailureKind::Transient
+            | FailureKind::Unavailable
+            | FailureKind::Backend
+            | FailureKind::Internal
+            | FailureKind::Resource => Self::WaitThenRetry,
+
+            // The model wrote something it can rewrite.
+            FailureKind::InputEncode
+            | FailureKind::OutputTooLarge
+            | FailureKind::OutputDecode
+            | FailureKind::InvalidResult => Self::CorrectArgumentsBeforeRetry,
+
+            // Not available to this caller; another route is needed.
+            FailureKind::MethodMissing
+            | FailureKind::UndeclaredCapability
+            | FailureKind::UnknownCapability
+            | FailureKind::UnknownProvider
+            | FailureKind::StaleSurface => Self::UseDifferentCapability,
+
+            // Something outside the run must be installed or configured.
+            FailureKind::MissingRuntime
+            | FailureKind::MissingRuntimeBackend
+            | FailureKind::UnsupportedRunner
+            | FailureKind::RuntimeMismatch
+            | FailureKind::ExtensionRuntimeMismatch
+            | FailureKind::Manifest => Self::CompleteSetup,
+
+            // Refused, and no amount of rewording changes that.
+            FailureKind::PolicyDenied
+            | FailureKind::NetworkDenied
+            | FailureKind::FilesystemDenied => Self::ReviseApproach,
+
+            // The extension is broken or the operation genuinely failed. The
+            // model may reasonably try something else, but no specific action
+            // names itself, so it gets the constraint and its own judgment.
+            FailureKind::OperationFailed
+            | FailureKind::Guest
+            | FailureKind::ExitFailure
+            | FailureKind::Memory
+            | FailureKind::Client
+            | FailureKind::Executor
+            | FailureKind::Cancelled
+            // Unclassifiable by construction: this is the one honest use of
+            // the old blanket answer.
+            | FailureKind::Unclassified => Self::RespectFailureConstraint,
+        }
+    }
+
+    /// Whether this hint names a concrete next move.
+    ///
+    /// [`RespectFailureConstraint`](Self::RespectFailureConstraint) does not —
+    /// it defers to the retry constraint. The conformance test
+    /// `only_genuinely_unclassifiable_failures_may_decline_to_name_an_action`
+    /// uses this to pin the small set of kinds allowed to answer that way.
+    pub fn names_an_action(self) -> bool {
+        !matches!(self, Self::RespectFailureConstraint)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -417,13 +580,15 @@ mod tests {
                 }],
             },
             artifacts: Vec::new(),
-            recovery: Some(ToolRecoveryObservation {
-                same_call_retry: SameCallRetryConstraint::RequiresChangedInput,
-                repairs: vec![CapabilityInputRepair::ProvideRequiredField {
+            recovery: Some(
+                ToolRecoveryObservation::new(
+                    SameCallRetryConstraint::RequiresChangedInput,
+                    CapabilityRecoveryHint::CorrectArgumentsBeforeRetry,
+                )
+                .with_repairs(vec![CapabilityInputRepair::ProvideRequiredField {
                     path: "file_path".to_string(),
-                }],
-                recovery_hint: CapabilityRecoveryHint::CorrectArgumentsBeforeRetry,
-            }),
+                }]),
+            ),
             trust: ObservationTrust::UntrustedToolOutput,
         };
 
@@ -551,5 +716,99 @@ mod tests {
         );
         let back: CapabilityFailureDetail = serde_json::from_value(value).expect("deserialize");
         assert_eq!(back, detail);
+    }
+
+    /// The conformance rule for #6284 item 4: **no failure may reach the model
+    /// without naming what to do about it**.
+    ///
+    /// Before this, `CapabilityRecoveryHint` had two variants and one was a
+    /// constant — 18 of 19 kinds got `RespectFailureConstraint`, which names no
+    /// action. This pins that only kinds that are genuinely unclassifiable, or
+    /// whose cause is opaque to the host, may answer that way. Every other kind
+    /// must name a move.
+    ///
+    /// If this fails after adding a kind, give it a real hint in
+    /// `for_failure_kind` rather than widening this list.
+    #[test]
+    fn only_genuinely_unclassifiable_failures_may_decline_to_name_an_action() {
+        // Opaque by nature: the extension broke, the operation genuinely
+        // failed, or the run was stopped. No specific action follows.
+        let may_defer = [
+            FailureKind::OperationFailed,
+            FailureKind::Guest,
+            FailureKind::ExitFailure,
+            FailureKind::Memory,
+            FailureKind::Client,
+            FailureKind::Executor,
+            FailureKind::Cancelled,
+            FailureKind::Unclassified,
+        ];
+        for kind in FailureKind::ALL {
+            let hint = CapabilityRecoveryHint::for_failure_kind(*kind);
+            if may_defer.contains(kind) {
+                continue;
+            }
+            assert!(
+                hint.names_an_action(),
+                "{} reaches the model with no action to take; give it a hint in \
+                 for_failure_kind",
+                kind.as_str()
+            );
+        }
+    }
+
+    /// Guard against the hint collapsing back into one answer. If every kind
+    /// maps to the same value again, the vocabulary is decorative.
+    #[test]
+    fn recovery_hints_stay_distinguishable_across_kinds() {
+        let distinct: std::collections::HashSet<CapabilityRecoveryHint> = FailureKind::ALL
+            .iter()
+            .map(|kind| CapabilityRecoveryHint::for_failure_kind(*kind))
+            .collect();
+        assert!(
+            distinct.len() >= 6,
+            "recovery hints collapsed to {} distinct values; the model cannot \
+             tell an auth prompt from a setup step from a permanent refusal",
+            distinct.len()
+        );
+    }
+
+    /// The delay payload is additive: observations persisted before
+    /// `retry_after_ms` existed must still load. (LLM data is never deleted —
+    /// stored observations outlive the schema that wrote them.)
+    #[test]
+    fn recovery_observation_without_a_delay_still_loads() {
+        let legacy = serde_json::json!({
+            "same_call_retry": "allowed_after_delay",
+            "recovery_hint": "respect_failure_constraint"
+        });
+        let observation: ToolRecoveryObservation =
+            serde_json::from_value(legacy).expect("pre-retry_after_ms observation deserializes");
+        assert_eq!(observation.retry_after_ms, None);
+        assert_eq!(
+            observation.same_call_retry,
+            SameCallRetryConstraint::AllowedAfterDelay
+        );
+
+        // And the constraint itself still serializes as a bare string, so a
+        // new writer stays readable by an old reader.
+        assert_eq!(
+            serde_json::to_value(SameCallRetryConstraint::AllowedAfterDelay).expect("serialize"),
+            serde_json::json!("allowed_after_delay")
+        );
+    }
+
+    /// A provider-supplied wait survives the round trip.
+    #[test]
+    fn recovery_observation_carries_the_providers_requested_wait() {
+        let observation = ToolRecoveryObservation::new(
+            SameCallRetryConstraint::AllowedAfterDelay,
+            CapabilityRecoveryHint::WaitThenRetry,
+        )
+        .with_retry_after(Some(30_000));
+        let value = serde_json::to_value(&observation).expect("serialize");
+        assert_eq!(value["retry_after_ms"], serde_json::json!(30_000));
+        let back: ToolRecoveryObservation = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back, observation);
     }
 }

--- a/tests/integration/hooks.rs
+++ b/tests/integration/hooks.rs
@@ -181,6 +181,13 @@ async fn hook_deny_blocks_capability_without_wedging_run() {
     h.assert_tool_error(ToolErrorClass::Denied, HOOK_TEST_DENY_REASON)
         .await
         .expect("hook deny reason must be reported in the persisted tool-error summary");
+    // #6284 item 4: the denial must also tell the model what to DO. A hook deny
+    // is a genuine policy refusal, so the honest advice is to change the plan
+    // rather than the arguments. Denials carried `model_observation: None`
+    // before #6792, so nothing actionable was persisted at all.
+    h.assert_denial_recovery_hint("revise_approach")
+        .await
+        .expect("a persisted denial must carry a recovery hint the model can act on");
     h.assert_security_audit_event_recorded(
         SecurityBoundary::HookDeny,
         SecurityDecision::Blocked,

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -763,6 +763,52 @@ impl RebornIntegrationHarness {
         )
     }
 
+    /// Assert the most recent persisted denial tells the model what would
+    /// unlock the call.
+    ///
+    /// Reads the recovery hint off the persisted `ToolResultReference`
+    /// envelope — the same bytes the model is handed on the next turn — so it
+    /// pins the whole path: denial -> `DenyReason` -> recovery observation ->
+    /// persistence. Denials carried `model_observation: None` before #6792,
+    /// so this asserted nothing that existed.
+    pub async fn assert_denial_recovery_hint(&self, expected: &str) -> HarnessResult<()> {
+        let hints = self.persisted_tool_recovery_hints().await?;
+        if hints.iter().any(|hint| hint.as_deref() == Some(expected)) {
+            return Ok(());
+        }
+        Err(
+            format!("no persisted tool result carried recovery hint {expected:?}; saw {hints:?}")
+                .into(),
+        )
+    }
+
+    /// Every persisted `ToolResultReference`'s `model_observation.recovery
+    /// .recovery_hint`, in thread order. `None` where an observation or its
+    /// recovery block is absent.
+    async fn persisted_tool_recovery_hints(&self) -> HarnessResult<Vec<Option<String>>> {
+        let history = self
+            .thread_harness
+            .history(self.binding.thread_id.clone())
+            .await?;
+        Ok(history
+            .iter()
+            .filter(|message| message.kind == ironclaw_threads::MessageKind::ToolResultReference)
+            .filter_map(|message| message.content.as_deref())
+            .filter_map(|content| {
+                serde_json::from_str::<ironclaw_threads::ToolResultReferenceEnvelope>(content).ok()
+            })
+            .map(|envelope| {
+                envelope
+                    .model_observation
+                    .as_ref()
+                    .and_then(|observation| observation.get("recovery"))
+                    .and_then(|recovery| recovery.get("recovery_hint"))
+                    .and_then(|hint| hint.as_str())
+                    .map(str::to_string)
+            })
+            .collect())
+    }
+
     /// Every persisted `ToolResultReference`'s `(safe_summary,
     /// observation_status)` pair, where `observation_status` is the envelope's
     /// parsed `model_observation.status` (`"success"` / `"error"`) when an


### PR DESCRIPTION
## Summary

- `CapabilityRecoveryHint` had **two variants and one was a constant**: 18 of 19 failure kinds got `RespectFailureConstraint` with an always-empty `repairs` vec. That tells the model "obey the retry rule you already have" — it names no action.
- Six new variants, each a different next move: `AuthenticateThenRetry`, `RequestApproval`, `WaitThenRetry`, `CompleteSetup`, `UseDifferentCapability`, `ReviseApproach`. Assigned per kind in a wildcard-free match, so a new `FailureKind` cannot compile until someone decides what the model should do about it.
- **Denials carried no observation at all** (`model_observation: None`). #6781 made the denial *reason* specific; it was legible only as text inside a summary string. Denials now carry structured recovery derived from the `DenyReason`.
- A wire-compatible `retry_after_ms` payload for `AllowedAfterDelay`. **Nothing fills it yet** — see Scope below; I would rather ship the honest gap than a plumbed field that is always `None` and looks wired.

## Change Type

- [x] Bug fix
- [x] New feature

## Linked Issue

Related #6284 (item 4). Closes three of its four boxes; the fourth is scoped below.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features` on every affected crate, zero warnings
- [x] `cargo build`
- [x] Relevant tests: `turns`, `agent_loop`, `hooks`, `loop_host`, `runner`, `host_api`, `threads` — **3,178 passed, 0 failed**
- [ ] `cargo test --features integration` — not applicable: no persistence or database behavior changed. The observation *shape* changed, which is covered by the two wire-contract tests below.
- [x] Manual testing: every new test red-verified (details below)

`SKIP_FRONTEND_BUILD=1` was needed locally — `ironclaw_webui`'s build script fails here on an npm registry signing-key mismatch, unrelated to this change.

## Test Strategy

**User behavior:** when a tool call fails, the agent is now told *what to do* — log in, ask a human, wait, install something, pick another tool, or give up — instead of being told to respect a constraint it was already given.

Risk areas:
- [x] Model behavior
- [x] Persistence (observation shape is stored)
- [x] Security or permissions (denials)
- [x] Cross-component behavior

Tests added:
- **Conformance (the rule item 4 asks for):** `only_genuinely_unclassifiable_failures_may_decline_to_name_an_action` — every kind outside a small explicitly-opaque set must name an action.
- **Collapse guard:** `recovery_hints_stay_distinguishable_across_kinds`.
- **Caller tier:** `a_denial_tells_the_model_what_would_unlock_it` drives a real denial through `execute_family` and asserts the appended result carries recovery guidance. It asserted `None` before.
- **Wire contract, both directions:** `recovery_observation_without_a_delay_still_loads` (old payloads still deserialize) and `recovery_observation_carries_the_providers_requested_wait`.

**Red verification.** Reverting `for_failure_kind` to the old `_ => RespectFailureConstraint` fails both conformance tests. The denial test failed on `a denial must carry a model observation, not None` before the fix.

## Scope: the one box I did not close

The epic asks to "give `AllowedAfterDelay` a payload and thread retry-after into it." **The payload is here; the threading has no source.** I swept for a producer:

- `LlmError::RateLimited { retry_after }` — model-provider path, not the capability path.
- `ScopeRecoveryInProgress::retry_after_hint` — consumed internally as backoff, never reaches the model.
- No capability-side code parses a `Retry-After` header at all.

Threading a real value needs a carrier on `RuntimeCapabilityFailure` / `CapabilityFailure` **and** a producer that captures the header. Plumbing an always-`None` field through four crates would look wired without being wired, so I stopped at the payload and am filing the rest.

## Security Impact

Denials now disclose more: the model can tell "you need a credential" from "permanently refused". That is the intent — it stops the model retrying calls that cannot succeed — and every value comes from the existing closed `DenyReason` and `FailureKind` vocabularies. No free text is added; the denial's own text rides the existing lenient `detail` channel and the summary stays host-authored and fixed. `ObservationTrust::UntrustedToolOutput` is set, so every downstream text guard still applies.

## Reborn Trust-Boundary Checklist

- **Who can construct the new types?** `CapabilityRecoveryHint` is a plain closed enum; `ToolRecoveryObservation::new` is now the single constructor, so adding a field cannot leave a producer silently defaulting it.
- **Untrusted content into prompts:** the denial observation's `summary` is a fixed host-authored template; the capability's own text goes only to `detail`, which the lenient validator already governs.
- **New/changed variants — downstream match sites audited:** `rg 'ToolRecoveryObservation|CapabilityRecoveryHint|SameCallRetryConstraint'` returns only `ironclaw_turns` and `ironclaw_agent_loop`; both are in this PR and gated.
- **`serde(default)` fails closed:** `retry_after_ms` defaults to `None`, meaning "no hint given", not "retry immediately".
- **Hashes / bounds / sandbox naming:** N/A.

## Database Impact

None. The observation is stored inside existing thread records; the added field is optional and skipped when absent.

## Blast Radius

`ironclaw_turns` observation vocabulary and the `ironclaw_agent_loop` executor. Any consumer asserting `recovery_hint == RespectFailureConstraint` for a specific kind will now see a more specific value — intended, and the audit above shows the only two crates involved.

Worth flagging: denial results that previously had **no** observation now have one. Anything counting observations, or asserting their absence on the denial path, will see the difference.

## Rollback Plan

Revert the commit. Additive on the wire, so observations written by this build still load on the previous one (unknown fields are ignored, and the new hint variants only appear on failures that previously carried no hint at all — worth noting a downgrade would fail to parse the new hint strings, so roll back before rolling forward if that matters).

## Review Follow-Through

Two judgment calls worth a reviewer's eye:

1. **The opaque set** in the conformance test — `OperationFailed`, `Guest`, `ExitFailure`, `Memory`, `Client`, `Executor`, `Cancelled`, `Unclassified` are allowed to decline to name an action. I think each is genuinely opaque to the host, but that list is the whole strength of the rule, so it deserves a second opinion.
2. **`MissingGrant` → `RequestApproval`.** A missing grant and a denied approval both mean "a human can unlock this", so they share a hint. If grants are obtained through a different flow than approvals, this should split.

---

**Review track**: C (runtime/security-adjacent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
