### PR TITLE
fix(agent-loop,threads): a severed cause must say so, and must not take the advice with it

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capability_helpers.rs
@@ -27,6 +27,20 @@ use super::{AgentLoopExecutorError, capability_host_error};
 const MAX_MODEL_OBSERVATION_INPUT_ISSUES: usize = 3;
 const MAX_MODEL_OBSERVATION_TEXT_BYTES: usize = 256;
 
+/// Appended to any model-visible text this module had to cut short.
+///
+/// Both cutters below used to slice to a UTF-8 boundary and return, leaving no
+/// sign the value was severed. A stack trace or compiler error cut mid-frame
+/// then reached the model looking complete, and the model would fix the wrong
+/// thing with confidence — worse than receiving no detail at all. This is the
+/// whole point of #6284 item 3's truncation box.
+///
+/// Free text rather than a structured flag because this channel *is* text: the
+/// model reads it directly, so an inline marker needs no rendering support and
+/// cannot be dropped by a consumer that ignores an unknown field. The marker is
+/// counted against the cap, never added on top of it.
+const TRUNCATION_MARKER: &str = " […truncated]";
+
 pub(super) fn capability_invocation_from_candidate(
     call: CapabilityCallCandidate,
     approval_resume: Option<CapabilityApprovalResume>,
@@ -400,14 +414,34 @@ pub(super) fn model_visible_capability_failure_observation(
 /// a UTF-8 boundary. The diagnostic is already secret-scrubbed by the producer.
 fn bounded_diagnostic_detail(value: &str) -> String {
     const MAX: usize = ironclaw_turns::run_profile::MODEL_OBSERVATION_DETAIL_MAX_BYTES;
-    if value.len() <= MAX {
+    truncate_marked(value, MAX)
+}
+
+/// Cut `value` to `max_bytes` **including** a [`TRUNCATION_MARKER`], on a UTF-8
+/// boundary. Text that already fits is returned unchanged and unmarked — a
+/// marker on a complete value would defeat the distinction this exists to draw.
+fn truncate_marked(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
         return value.to_string();
     }
-    let mut end = MAX;
+    // Reserve room for the marker so the result still honors the cap. If the
+    // cap cannot even hold the marker, fall back to a bare cut: an unmarked
+    // fragment beats overflowing a bound the persistence validator enforces.
+    let Some(budget) = max_bytes.checked_sub(TRUNCATION_MARKER.len()) else {
+        return cut_on_boundary(value, max_bytes).to_string();
+    };
+    format!("{}{TRUNCATION_MARKER}", cut_on_boundary(value, budget))
+}
+
+fn cut_on_boundary(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
     while end > 0 && !value.is_char_boundary(end) {
         end -= 1;
     }
-    value[..end].to_string() // safety: `end` reduced to a valid UTF-8 boundary.
+    &value[..end] // safety: `end` reduced to a valid UTF-8 boundary.
 }
 
 fn model_visible_failure_summary(error_kind: FailureKind) -> String {
@@ -441,14 +475,7 @@ fn bounded_input_issues(issues: &[CapabilityInputIssue]) -> Vec<CapabilityInputI
 }
 
 fn truncate_model_observation_text(value: &str) -> String {
-    if value.len() <= MAX_MODEL_OBSERVATION_TEXT_BYTES {
-        return value.to_string();
-    }
-    let mut end = MAX_MODEL_OBSERVATION_TEXT_BYTES;
-    while end > 0 && !value.is_char_boundary(end) {
-        end -= 1;
-    }
-    value[..end].to_string() // safety: `end` is reduced until it lands on a valid UTF-8 boundary.
+    truncate_marked(value, MAX_MODEL_OBSERVATION_TEXT_BYTES)
 }
 
 fn invalid_input_observation(issues: Vec<CapabilityInputIssue>) -> ModelVisibleToolObservation {
@@ -694,6 +721,68 @@ pub(super) fn push_completed_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A severed diagnostic must say it was severed.
+    ///
+    /// Both cutters sliced to a UTF-8 boundary and returned, with no marker of
+    /// any kind — so a stack trace or compiler error cut mid-frame reached the
+    /// model looking complete. That is worse than no detail: the model fixes
+    /// the wrong line with confidence. (#6284 item 3. Contrary to the epic's
+    /// note, the sibling summary path did NOT append `"..."` either — no
+    /// truncation marker existed anywhere in the product. The structured
+    /// `next_offset`/`total_bytes` on the *preview* path is a different
+    /// mechanism and does not cover free-text diagnostics.)
+    #[test]
+    fn a_severed_diagnostic_says_it_was_severed() {
+        let long = "E0308: mismatched types at src/main.rs:42 ".repeat(500);
+        let bounded = bounded_diagnostic_detail(&long);
+
+        assert!(
+            bounded.len() <= ironclaw_turns::run_profile::MODEL_OBSERVATION_DETAIL_MAX_BYTES,
+            "the marker must fit inside the cap, not push past it"
+        );
+        assert!(
+            bounded.ends_with(TRUNCATION_MARKER),
+            "a truncated diagnostic must be marked; got tail {:?}",
+            &bounded[bounded.len().saturating_sub(40)..]
+        );
+        // The real cause still leads.
+        assert!(bounded.starts_with("E0308: mismatched types"));
+    }
+
+    /// The same rule for the bounded per-field observation text.
+    #[test]
+    fn a_severed_observation_field_says_it_was_severed() {
+        let long = "a".repeat(MAX_MODEL_OBSERVATION_TEXT_BYTES * 3);
+        let bounded = truncate_model_observation_text(&long);
+
+        assert!(bounded.len() <= MAX_MODEL_OBSERVATION_TEXT_BYTES);
+        assert!(
+            bounded.ends_with(TRUNCATION_MARKER),
+            "a truncated observation field must be marked"
+        );
+    }
+
+    /// Text that fits is returned untouched — no marker on a complete value,
+    /// or the model cannot tell complete from severed after all.
+    #[test]
+    fn text_that_fits_is_never_marked() {
+        let short = "E0425: cannot find value `x` in this scope";
+        assert_eq!(bounded_diagnostic_detail(short), short);
+        assert_eq!(truncate_model_observation_text(short), short);
+    }
+
+    /// A multi-byte character must not be split by making room for the marker.
+    #[test]
+    fn marking_a_truncation_respects_utf8_boundaries() {
+        let long = "\u{e9}".repeat(ironclaw_turns::run_profile::MODEL_OBSERVATION_DETAIL_MAX_BYTES);
+        let bounded = bounded_diagnostic_detail(&long);
+        assert!(bounded.ends_with(TRUNCATION_MARKER));
+        // Round-trips as valid UTF-8 by construction; assert no replacement
+        // character crept in from a split boundary.
+        assert!(!bounded.contains('\u{fffd}'));
+    }
+
     use crate::test_support::test_run_context;
     use ironclaw_turns::run_profile::{CapabilityProgress, CapabilitySurfaceVersion};
 

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -347,7 +347,8 @@ fn normalized_model_observation(
         Ok(()) => Some(model_observation),
         Err(error) => {
             let repaired = strip_unsafe_result_reference_preview(&mut model_observation)
-                || strip_unsafe_invalid_input_issue_text(&mut model_observation);
+                || strip_unsafe_invalid_input_issue_text(&mut model_observation)
+                || strip_unstorable_generic_failure_detail(&mut model_observation);
             if repaired && validate_model_observation(&model_observation).is_ok() {
                 tracing::debug!(
                     reason = %error,
@@ -380,6 +381,31 @@ fn observation_detail_of_kind<'a>(
         .and_then(|observation| observation.get_mut("detail"))
         .and_then(serde_json::Value::as_object_mut)
         .filter(|detail| detail.get("kind").and_then(serde_json::Value::as_str) == Some(kind))
+}
+
+/// Drop a `generic_failure`'s free-text diagnostic when it cannot be stored,
+/// keeping the observation itself.
+///
+/// The last-resort repair. Without it, a failure whose *text* fails validation
+/// took the whole observation down with it — `failure_kind`, `status` and the
+/// recovery guidance included — so the model lost the advice as well as the
+/// cause. That is worst for agent-authored code: a skill or generated program
+/// fails as `generic_failure` carrying a raw traceback, which is exactly the
+/// text most likely to trip the untrusted content scan.
+///
+/// The text is optional in the schema, so removing it yields a valid
+/// observation. Losing the cause is a real loss; losing the cause *and* the
+/// next move is a worse one.
+fn strip_unstorable_generic_failure_detail(observation: &mut serde_json::Value) -> bool {
+    observation_detail_of_kind(observation, "generic_failure")
+        .filter(|detail| {
+            detail
+                .get("detail")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(observation_text_needs_repair)
+        })
+        .and_then(|detail| detail.remove("detail"))
+        .is_some()
 }
 
 fn strip_unsafe_result_reference_preview(observation: &mut serde_json::Value) -> bool {
@@ -1200,6 +1226,80 @@ mod tests {
         INPUT_ENCODE_HUMAN_SUMMARY, ProviderToolCallReferenceEnvelope, ToolResultReferenceEnvelope,
         ToolResultSafeSummary,
     };
+
+    /// A failure whose *text* cannot be stored must not take the *guidance*
+    /// with it.
+    ///
+    /// When validation failed and neither narrow repair applied, the whole
+    /// observation was dropped — recovery hint included. That is worst exactly
+    /// where it hurts most: agent-authored code (a skill, a generated program)
+    /// fails with `generic_failure` carrying a raw traceback, which is the text
+    /// most likely to trip the content scan. The model then lost both the cause
+    /// *and* the advice. Degrade the text, keep the structure (#6284 item 3).
+    #[test]
+    fn an_unstorable_diagnostic_degrades_instead_of_dropping_the_guidance() {
+        use super::normalized_model_observation;
+
+        // A traceback carrying a marker word the untrusted content scan
+        // rejects. This is the realistic agent-built-code failure.
+        let observation = serde_json::json!({
+            "schema_version": 1,
+            "status": "error",
+            "summary": "Capability failed with exit_failure.",
+            "detail": {
+                "kind": "generic_failure",
+                "failure_kind": "exit_failure",
+                "detail": "Traceback: auth failed, password = hunter2\u{0}"
+            },
+            "recovery": {
+                "same_call_retry": "allowed",
+                "recovery_hint": "respect_failure_constraint"
+            },
+            "trust": "untrusted_tool_output"
+        });
+
+        let normalized = normalized_model_observation("result:skill-crash", observation)
+            .expect("the observation must survive with its guidance intact");
+
+        // The unsafe text is gone...
+        assert!(
+            normalized["detail"].get("detail").is_none(),
+            "the unstorable diagnostic text must be dropped"
+        );
+        // ...but everything the model can still act on survives.
+        assert_eq!(normalized["detail"]["failure_kind"], "exit_failure");
+        assert_eq!(
+            normalized["recovery"]["recovery_hint"], "respect_failure_constraint",
+            "the recovery guidance must not be dropped with the text"
+        );
+        assert_eq!(normalized["status"], "error");
+    }
+
+    /// A clean diagnostic is untouched — the degrade path must not fire on
+    /// text that was storable all along.
+    #[test]
+    fn a_storable_diagnostic_keeps_its_text() {
+        use super::normalized_model_observation;
+
+        let observation = serde_json::json!({
+            "schema_version": 1,
+            "status": "error",
+            "summary": "Capability failed with exit_failure.",
+            "detail": {
+                "kind": "generic_failure",
+                "failure_kind": "exit_failure",
+                "detail": "E0308: mismatched types at src/main.rs:42"
+            },
+            "trust": "untrusted_tool_output"
+        });
+
+        let normalized = normalized_model_observation("result:skill-ok", observation)
+            .expect("a clean observation survives");
+        assert_eq!(
+            normalized["detail"]["detail"],
+            "E0308: mismatched types at src/main.rs:42"
+        );
+    }
 
     #[test]
     fn sensitive_markers_match_on_word_boundary_not_substring() {


### PR DESCRIPTION
## Summary

Stacked on #6792 — **base that PR first**, or review the second commit only.

#6284 item 3, the two boxes that matter when *agent-authored code* fails. For a missing credential the failure category is the fix ("log in" is complete advice). For a skill or generated program that crashes, the category tells the model nothing — the compiler error or traceback **is** the fix. Both defects below silently damaged exactly that text.

- **Truncation was unmarked.** A traceback cut mid-frame reached the model looking complete, so it would fix the wrong line with confidence — worse than no detail at all.
- **An unstorable diagnostic dropped the whole observation**, discarding the failure kind, status and recovery guidance along with the offending text.

## Change Type

- [x] Bug fix

## Linked Issue

Related #6284 (item 3). Closes its truncation box and its degrade-detail box.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features` on the changed crates, zero warnings
- [x] `cargo build`
- [x] Relevant tests: `threads`, `agent_loop`, `turns`, `loop_host`, `runner`, `hooks`, `host_api` — **3,184 passed, 0 failed**
- [ ] `cargo test --features integration` — not applicable: no schema or persistence shape changed. The stored observation gains no field; one optional field is now *dropped* in a case that previously stored nothing at all.
- [x] Manual testing: both fixes red-verified (below)

`SKIP_FRONTEND_BUILD=1` locally — `ironclaw_webui`'s build script fails here on an npm signing-key mismatch, unrelated.

## The two fixes

### 1. A severed cause says it was severed

`bounded_diagnostic_detail` and `truncate_model_observation_text` each sliced to a UTF-8 boundary and returned. No marker.

Both now route through `truncate_marked`, which appends `" […truncated]"` **inside** the cap rather than on top of it, so the persistence validator's bound still holds. Text that fits is returned unmarked — a marker on a complete value would defeat the distinction the fix exists to draw. Multi-byte characters are not split when making room.

A free-text marker rather than a structured flag because this channel *is* text: the model reads it directly, so an inline marker needs no rendering support and cannot be dropped by a consumer that ignores an unknown field.

**Correction to the epic's framing.** It states the sibling *summary* path appends `"..."`. It does not — `truncate_summary_detail` cuts silently too, and **no truncation marker existed anywhere in the product**. The structured `next_offset`/`total_bytes` on the *preview* path is a different mechanism that never covered free-text diagnostics.

### 2. Unstorable text no longer takes the guidance with it

`normalized_model_observation` had two narrow repairs; when neither applied it returned `None` — discarding `failure_kind`, `status` and the recovery hint along with the text that failed validation.

This is worst exactly where it hurts most: agent-authored code fails as `generic_failure` carrying a raw traceback, which is the text most likely to trip the untrusted content scan. The model lost the cause **and** the next move.

`strip_unstorable_generic_failure_detail` is a third, last-resort repair that drops only the free text. The field is optional in the schema, so the result is a valid observation still carrying the kind and the recovery hint.

## Test Strategy

**User behavior:** when a skill or generated program crashes, the agent now (a) can tell a complete error from a truncated one, and (b) still receives the failure kind and recovery guidance even when the raw error text cannot be stored.

Risk areas:
- [x] Model behavior
- [x] Persistence
- [x] Security or permissions (the scan that rejects the text is a leak guard)

Tests added:
- `a_severed_diagnostic_says_it_was_severed`, `a_severed_observation_field_says_it_was_severed` — marker present and the cap still honored.
- `text_that_fits_is_never_marked` — the complete/severed distinction stays meaningful.
- `marking_a_truncation_respects_utf8_boundaries` — no replacement character from a split boundary.
- `an_unstorable_diagnostic_degrades_instead_of_dropping_the_guidance` — the caller-level pin.
- `a_storable_diagnostic_keeps_its_text` — the degrade path must not fire on clean text.

**Red verification.** The degrade test fails on the old code with *"the observation must survive with its guidance intact"*. The marker tests fail with the unmarked tail.

## Security Impact

**No change to what is redacted.** The content scan that rejects unsafe text is untouched; fix 2 changes only what happens *after* it rejects — previously the whole observation was discarded, now the rejected text is discarded and the structured remainder survives. Nothing that failed the scan is stored.

Fix 1 adds a fixed host-authored marker string. It carries no capability output.

Worth naming: a model that previously saw a clean-looking truncated trace now sees it marked, which is strictly more information about host behavior — but it reveals only that a bound was hit, which the byte cap already implies.

## Reborn Trust-Boundary Checklist

- **Trust-bearing types:** unchanged. No new public type; `TRUNCATION_MARKER` is a private const.
- **Untrusted content into prompts:** unchanged path; fix 2 strictly *removes* untrusted text that failed validation.
- **New/changed variants — downstream audited:** no variants added. `rg 'bounded_diagnostic_detail|truncate_model_observation_text|normalized_model_observation'` is confined to the two crates in this PR.
- **`serde(default)` fails closed:** the degraded observation omits an optional field, which already deserialized as `None`.
- **Bounds:** the marker is counted against the cap, never added to it — pinned by assertion in both marker tests.
- **Hashes / sandbox naming:** N/A.

## Database Impact

None. No schema change. A stored observation may now omit a `detail` string in a case where previously *no observation was stored at all*.

## Blast Radius

`ironclaw_agent_loop` truncation helpers and `ironclaw_threads` observation normalization. Anything asserting exact truncated text will see the marker; anything asserting that an invalid observation yields `None` will now see a degraded observation for the `generic_failure` case specifically.

## Rollback Plan

Revert the commit. No migration, no persisted shape change; observations written by this build load unchanged on the previous one.

## Review Follow-Through

- **Marker text and placement** — `" […truncated]"` inside the cap. If there is a house convention for this I did not find one; there was no prior marker anywhere in the product to match.
- **Scope of the third repair** — deliberately narrow: `generic_failure` free text only. `invalid_input` and `result_reference` keep their existing targeted repairs. If other detail kinds should degrade rather than drop, that is a follow-up rather than a widening here.
- Remaining item-3 boxes untouched and still open: deleting `LoopDiagnosticRef`, and the sweep of producers that return `detail: None`.

---

**Review track**: C (runtime/security-adjacent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
