### PR TITLE
test(state): actually pin the from_wire inverse

### DIFF
--- a/crates/ironclaw_host_api/src/state.rs
+++ b/crates/ironclaw_host_api/src/state.rs
@@ -169,6 +169,19 @@ mod tests {
                 serde_json::to_value(state).unwrap(),
                 serde_json::Value::String(expected.to_string())
             );
+            // The doc comment on `from_wire` claims this test pins the
+            // inverse. It did not until now -- only `as_str` and the serde
+            // form were asserted, so `from_wire` could drift from either.
+            assert_eq!(
+                InstallationState::from_wire(expected),
+                Some(state),
+                "from_wire must invert as_str for {expected}"
+            );
         }
+        assert_eq!(
+            InstallationState::from_wire("not_a_state"),
+            None,
+            "an unknown wire value must not resolve to a checkpoint"
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #6737 — one test-only change that missed the merge window.

`InstallationState::from_wire`'s doc comment claims the inverse is pinned by
`installation_state_wire_form_matches_str`. It was not: that test asserted
`as_str()` and the serde form only, so `from_wire` could drift from either and
the suite would stay green.

Extended the existing test rather than adding a second one — every variant now
round-trips, and an unknown wire value must resolve to `None`. The doc claim is
now true rather than softened.

Verified: mutating one arm of `from_wire` (`"configured" => Some(Self::Installed)`)
fails the test; restored, it passes.

Reported by CodeRabbit on #6737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)