### PR TITLE
fix(filesystem): close local-backend TOCTOU escapes with fd-rooted traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Local filesystem backend now resolves via fd-rooted, kernel-enforced
+  containment (`openat2(RESOLVE_BENEATH)` on Linux; a portable fd-anchored
+  walk elsewhere) instead of path-string checks, closing a family of
+  TOCTOU containment escapes.** Three behavior changes are deliberate and
+  upgrade-affecting for the `local-dev` and, especially, `local-dev-yolo`
+  profiles (`--profile local-yolo --confirm-host-access`, which mounts the
+  user's real host home directory at `/host`):
+  - **Absolute symlink targets are now rejected outright**, even when the
+    target would resolve inside the mount (matching Linux's own
+    `openat2(RESOLVE_BENEATH)` semantics) — a real home directory routinely
+    has legitimate absolute symlinks that resolved before this change and
+    fail after it (pyenv version envs, chezmoi/stow in absolute mode,
+    cloud-sync placeholders). The error now names the offending symlink and
+    its target and states that absolute targets are unsupported, so the fix
+    (replace with a relative symlink) is discoverable without guessing.
+  - **Deleting a bare mount root now fails closed** instead of silently
+    succeeding as a side effect of the old path-based resolver.
+  - **Symlink chain depth is capped at 32 hops** per resolution (shared
+    across every hop the walk takes, not reset per path component); a
+    chain deeper than that — always either a cycle or pathological —
+    now fails closed instead of being followed indefinitely.
+  - Relative, in-bounds symlinks (the common case — package manager
+    layouts, git worktree links, monorepo aliases) now resolve correctly
+    where they previously did not.
 - **Extension persistence:** normalize filesystem-backed extension lifecycle
   state into typed installation (with the embedded, hash-pinned manifest
   definition), user-membership, and credential-binding records with bounded

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ dependencies = [
  "ironclaw_observability",
  "ironclaw_safety",
  "libsql",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/ironclaw_approvals/src/capability_permission.rs
+++ b/crates/ironclaw_approvals/src/capability_permission.rs
@@ -653,6 +653,13 @@ mod tests {
         async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
             self.inner.delete(path).await
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
+        }
     }
 
     struct ClearRacingBackend {
@@ -744,6 +751,13 @@ mod tests {
 
         async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
             self.inner.delete(path).await
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
         }
     }
 

--- a/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_deployment_mode_typename_ratchet.rs
@@ -110,6 +110,16 @@ const FROZEN_OTHER_MODE_TYPES: &[&str] = &[
     //   JUSTIFIED (Bucket-3 by meaning): "hook-local id" — an identifier local to
     //     one hook, a genuine domain concept, not a deployment tier.
     "HookLocalId",
+    //   JUSTIFIED (Bucket-3 by meaning): `ironclaw_filesystem::local::mount_registry`'s
+    //     "locally-mounted host directory" registration record (an fd-rooted
+    //     `DiskFilesystem` mount entry) — "local" here means "on the local
+    //     filesystem", the same sense as the crate's own `local.rs`/`DiskFilesystem`
+    //     naming, not the `LocalDev`/hosted-tier deployment-mode axis this ratchet
+    //     polices. Only newly `pub(super)`-visible (crossing into this ratchet's
+    //     scan) because FIX 4 (the mount-registry extraction) split it into its own
+    //     file, which needs the type nameable one module up; it was always this
+    //     name, just previously private and invisible to the scanner.
+    "LocalMount",
     //   RebornLocal* composition family — local-dev-as-type mode names in the
     //     composition surface; shrinks with Slice B (deployment mode becomes a
     //     `DeploymentConfig` value):

--- a/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
@@ -1,5 +1,6 @@
 //! Regression gate for the `DiskFilesystem` local backend's fd-rooted
-//! traversal fix (`crates/ironclaw_filesystem/src/local.rs`).
+//! traversal fix (`crates/ironclaw_filesystem/src/local.rs` and its
+//! `local/fd_resolve.rs` primitive submodule).
 //!
 //! The bug this fix closed had one shape every vulnerable function shared:
 //! resolve a path, check containment against the *resolved path string*,
@@ -24,12 +25,21 @@
 //! not matter *how* a forbidden call is spelled or imported — anything that
 //! isn't on the allowlist fails the same way.
 //!
-//! Scoped to the fd-rooted primitive module (`local.rs`), not the whole
-//! crate: `postgres.rs`/`libsql.rs`/`db/` have no local-filesystem
-//! containment surface, and widening the scan would either need per-file
-//! exceptions (rot magnet) or a false-positive-prone heuristic. If a future
-//! backend gains its own path-based local containment logic, it should get
-//! its own narrow gate rather than this one growing broad and brittle.
+//! **File scoping.** `local.rs`'s fd-rooted primitive layer was later
+//! extracted into `local/fd_resolve.rs` — a module with, by design, zero
+//! dependency on `DiskFilesystem`/`LocalMount`, so it has *even less* reason
+//! than `local.rs` to ever reach for `tokio::fs` or a second path-based
+//! lookup. Both files are gated here, each against the same allowlist;
+//! `fd_resolve.rs` has no `#[cfg(test)]` module of its own today, so its
+//! entire contents are scanned as production code (see
+//! [`GATED_FILES`]/[`GatedFile`]).
+//!
+//! Scoped to these two files, not the whole crate: `postgres.rs`/
+//! `libsql.rs`/`db/` have no local-filesystem containment surface, and
+//! widening the scan would either need per-file exceptions (rot magnet) or
+//! a false-positive-prone heuristic. If a future backend gains its own
+//! path-based local containment logic, it should get its own narrow gate
+//! rather than this one growing broad and brittle.
 
 use std::path::PathBuf;
 
@@ -50,38 +60,59 @@ fn read_gated_file(relative: &str) -> String {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
-/// Splits `source` into (production, test) at the file's outer
-/// `#[cfg(test)]` module boundary, so the allowlist below is enforced only
-/// against the fd-rooted resolution code that ships — not against test
-/// fixture setup, which legitimately uses `std::fs::create_dir_all` and
+/// One file this gate polices, and whether it is expected to carry its own
+/// `#[cfg(test)]` module.
+struct GatedFile {
+    relative_path: &'static str,
+    has_test_module: bool,
+}
+
+const GATED_FILES: &[GatedFile] = &[
+    GatedFile {
+        relative_path: "crates/ironclaw_filesystem/src/local.rs",
+        has_test_module: true,
+    },
+    GatedFile {
+        relative_path: "crates/ironclaw_filesystem/src/local/fd_resolve.rs",
+        has_test_module: false,
+    },
+];
+
+/// Returns the production-only slice of `source`: everything before the
+/// outer `#[cfg(test)]` module boundary when `has_test_module` is true (test
+/// fixture setup legitimately uses `std::fs::create_dir_all` and
 /// `std::os::unix::fs::symlink` on the *host* temp directory to construct
-/// escape scenarios, nothing to do with the production containment surface
-/// this gate exists to police.
+/// escape scenarios — nothing to do with the production containment surface
+/// this gate exists to police), or the whole file when it is false.
 ///
-/// Fails loud (rather than silently scanning nothing or scanning
-/// everything) if the marker isn't found, since a refactor that removes or
-/// renames the test module would otherwise make this split silently
-/// meaningless.
-fn split_production_and_test(source: &str) -> (&str, &str) {
+/// Fails loud (rather than silently scanning nothing or scanning too much)
+/// if `has_test_module` is true but the marker isn't found, since a refactor
+/// that removes or renames the test module would otherwise make this split
+/// silently meaningless.
+fn production_source(source: &str, has_test_module: bool) -> &str {
     const MARKER: &str = "#[cfg(test)]";
+    if !has_test_module {
+        return source;
+    }
     let index = source
         .find(MARKER)
         .unwrap_or_else(|| panic!("expected to find `{MARKER}` marking the test module boundary"));
-    (&source[..index], &source[index..])
+    &source[..index]
 }
 
 /// `std::fs::` function names permitted in production code, each with a
 /// documented, checked-at-review-time reason it is not part of the
 /// fd-rooted containment surface:
 ///
-/// - `canonicalize`: used exactly once, in `mount_local_impl`, which runs
-///   only at trusted mount-setup time (synchronous, not on the async
-///   per-request path) to resolve the host root a mount is pinned to. There
-///   is no request-time path string here for a symlink swap to race.
-/// - `File`: `std::fs::File::from(fd)` converts an already fd-rooted,
-///   already-verified `OwnedFd` into a `std::io::Read`/`Write` handle for
-///   the bytes underneath it — it never opens anything by path, so it
-///   cannot re-resolve or re-check containment.
+/// - `canonicalize`: used exactly once, in `local.rs`'s `mount_local_impl`,
+///   which runs only at trusted mount-setup time (synchronous, not on the
+///   async per-request path) to resolve the host root a mount is pinned to.
+///   There is no request-time path string here for a symlink swap to race.
+/// - `File`: `std::fs::File::from(fd)` (in `fd_resolve.rs`) converts an
+///   already fd-rooted, already-verified `OwnedFd` into a
+///   `std::io::Read`/`Write` handle for the bytes underneath it — it never
+///   opens anything by path, so it cannot re-resolve or re-check
+///   containment.
 ///
 /// Checked against comment-stripped source (see [`strip_line_comments`]),
 /// so doc-comment prose that merely *mentions* a `std::fs::*` name (e.g.
@@ -92,46 +123,47 @@ const ALLOWED_STD_FS_FUNCTIONS: &[&str] = &["canonicalize", "File"];
 
 /// The actual gate. Fails loud with a specific reason instead of a single
 /// generic message, so a future failure immediately tells the reader which
-/// primitive was reintroduced.
-fn assert_fd_rooted_allowlist(source: &str) {
-    let (production, _test) = split_production_and_test(source);
+/// file and which primitive was reintroduced.
+fn assert_fd_rooted_allowlist(relative_path: &str, source: &str, has_test_module: bool) {
+    let production = production_source(source, has_test_module);
     let production = strip_line_comments(production);
     let production = production.as_str();
 
     // `tokio::fs` is definitionally the vulnerable pattern: every
     // `tokio::fs::*` entry point takes a path, not a descriptor, and
-    // pathname-check-then-separate-syscall is exactly the bug this file
-    // exists to never reintroduce. Ban the substring `"tokio::fs"` (not
-    // `"tokio::fs::"`) so this also catches the import line of an
+    // pathname-check-then-separate-syscall is exactly the TOCTOU pattern
+    // the fd-rooted traversal fix closed. Ban the substring `"tokio::fs"`
+    // (not `"tokio::fs::"`) so this also catches the import line of an
     // aliasing evasion — `use tokio::fs as sneaky_alias;` — even though the
     // alias's own call sites (`sneaky_alias::read(...)`) contain no
     // `tokio::fs` text at all. The import is unconditionally banned because
     // production code never legitimately needs to import `tokio::fs` in
-    // this file — every operation goes through the `rustix`-backed
-    // primitives below.
+    // either gated file — every operation goes through the `rustix`-backed
+    // primitives in `fd_resolve.rs`.
     assert!(
         !production.contains("tokio::fs"),
-        "crates/ironclaw_filesystem/src/local.rs must never reference `tokio::fs` \
-         (including an aliased `use tokio::fs as X`) in production code: every \
-         tokio::fs::* entry point takes a path string, and re-resolving a path \
-         after an earlier containment check is exactly the TOCTOU pattern the \
-         fd-rooted traversal fix (openat/openat2 walked from an open root \
-         descriptor) closed. Resolve new operations through the existing \
-         open_one/resolve_walk/descend_creating primitives instead."
+        "{relative_path} must never reference `tokio::fs` (including an \
+         aliased `use tokio::fs as X`) in production code: every \
+         tokio::fs::* entry point takes a path string, and re-resolving a \
+         path after an earlier containment check is exactly the TOCTOU \
+         pattern the fd-rooted traversal fix (openat/openat2 walked from an \
+         open root descriptor) closed. Resolve new operations through the \
+         existing open_one/resolve_walk/descend_creating primitives \
+         instead."
     );
 
     // `std::os::unix::fs::*` (symlink, symlink_metadata's path-based
     // cousins, etc.) is entirely absent from production code today — every
-    // symlink decision in this file is made against an already-open fd via
+    // symlink decision here is made against an already-open fd via
     // `rustix::fs::statat`/`AtFlags::SYMLINK_NOFOLLOW`, never by asking the
     // OS to resolve a path a second time. There is no allowlist entry
     // because there is no legitimate production use to allow.
     assert!(
         !production.contains("std::os::unix::fs::"),
-        "crates/ironclaw_filesystem/src/local.rs must never call \
-         `std::os::unix::fs::*` in production code — every symlink check here \
-         must go through `open_one`'s fd-relative `O_NOFOLLOW`/`openat2` \
-         resolution, never a second path-based OS lookup."
+        "{relative_path} must never call `std::os::unix::fs::*` in \
+         production code — every symlink check here must go through \
+         `open_one`'s fd-relative `O_NOFOLLOW`/`openat2` resolution, never a \
+         second path-based OS lookup."
     );
 
     // Raw libc path syscalls bypass rustix's typed wrappers entirely and
@@ -140,22 +172,22 @@ fn assert_fd_rooted_allowlist(source: &str) {
     // deliberate, not an oversight.
     assert!(
         !production.contains("libc::"),
-        "crates/ironclaw_filesystem/src/local.rs must never call raw `libc::*` \
-         path syscalls in production code — use the `rustix` wrappers \
+        "{relative_path} must never call raw `libc::*` path syscalls in \
+         production code — use the `rustix` wrappers \
          (`openat`/`openat2`/`mkdirat`/`unlinkat`/`renameat`/`statat`/`fstat`) \
-         that back every existing primitive in this file."
+         that back every existing primitive in `fd_resolve.rs`."
     );
 
     // `std::fs::*` is the narrowest, most evadable-by-denylist case of all —
-    // it has two legitimate, already-audited uses in this file (see
-    // `ALLOWED_STD_FS_FUNCTIONS`'s doc). Rather than denylisting every other
-    // spelling, allowlist the function names actually permitted and fail on
-    // anything else.
+    // it has two legitimate, already-audited uses across these two files
+    // (see `ALLOWED_STD_FS_FUNCTIONS`'s doc). Rather than denylisting every
+    // other spelling, allowlist the function names actually permitted and
+    // fail on anything else.
     for function_name in find_std_fs_function_names(production) {
         assert!(
             ALLOWED_STD_FS_FUNCTIONS.contains(&function_name.as_str()),
-            "crates/ironclaw_filesystem/src/local.rs calls `std::fs::{function_name}` \
-             in production code, which is not on this gate's allowlist \
+            "{relative_path} calls `std::fs::{function_name}` in production \
+             code, which is not on this gate's allowlist \
              ({ALLOWED_STD_FS_FUNCTIONS:?}). Every path-based filesystem \
              operation here must resolve through the fd-rooted \
              open_one/resolve_walk/descend_creating primitives instead of a \
@@ -166,7 +198,7 @@ fn assert_fd_rooted_allowlist(source: &str) {
 
 /// Strips everything from the first `//` to the end of each line. A
 /// deliberately blunt, line-oriented pass (not a full Rust tokenizer) that
-/// is sufficient for this file: `local.rs` has no `//` inside a string
+/// is sufficient for these two files: neither has a `//` inside a string
 /// literal or path today, and the point is only to keep doc-comment prose
 /// (which legitimately discusses `tokio::fs`/`std::fs::*` by name when
 /// explaining what this module *doesn't* do) from being indistinguishable
@@ -203,22 +235,25 @@ fn find_std_fs_function_names(source: &str) -> Vec<String> {
 
 #[test]
 fn local_backend_never_reintroduces_banned_path_resolution() {
-    assert_fd_rooted_allowlist(&read_gated_file("crates/ironclaw_filesystem/src/local.rs"));
+    for gated in GATED_FILES {
+        let source = read_gated_file(gated.relative_path);
+        assert_fd_rooted_allowlist(gated.relative_path, &source, gated.has_test_module);
+    }
 }
 
 // ---------------------------------------------------------------------
 // Proof-of-binding: each of these plants exactly the evasion it claims to
-// catch into the *real*, already-gate-clean local.rs source, and asserts
-// the gate fails with the expected message. Each takes the real file
-// (proving no false positive against production code) and appends one
+// catch into the *real*, already-gate-clean source of a gated file, and
+// asserts the gate fails with the expected message. Each takes the real
+// file (proving no false positive against production code) and adds one
 // violation (proving no false negative against that violation's shape).
 // ---------------------------------------------------------------------
 
-/// Inserts `addition` immediately *before* the outer `#[cfg(test)]` module
-/// boundary — i.e. into the production half `split_production_and_test`
+/// Inserts `addition` immediately *before* `local.rs`'s outer `#[cfg(test)]`
+/// module boundary — i.e. into the production half `production_source`
 /// scans — rather than appending to the end of the file, which would land
 /// past that boundary (inside the discarded test half) and prove nothing.
-fn plant_in_production(addition: &str) -> String {
+fn plant_in_local_rs_production(addition: &str) -> String {
     let source = read_gated_file("crates/ironclaw_filesystem/src/local.rs");
     let index = source
         .find("#[cfg(test)]")
@@ -231,52 +266,48 @@ fn plant_in_production(addition: &str) -> String {
     planted
 }
 
-fn production_source_for_planting() -> String {
-    read_gated_file("crates/ironclaw_filesystem/src/local.rs")
-}
-
 /// The exact evasion the pre-fix gate was proven vulnerable to: aliasing
 /// `tokio::fs` on import so no call site spells out `tokio::fs::`.
 #[test]
 #[should_panic(expected = "must never reference `tokio::fs`")]
 fn gate_fails_on_tokio_fs_alias_evasion() {
-    let source = plant_in_production(
+    let source = plant_in_local_rs_production(
         "\nuse tokio::fs as sneaky_alias;\n\
          async fn planted_alias_regression(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {\n\
          \x20\x20\x20\x20sneaky_alias::read(path).await\n}\n",
     );
-    assert_fd_rooted_allowlist(&source);
+    assert_fd_rooted_allowlist("crates/ironclaw_filesystem/src/local.rs", &source, true);
 }
 
 /// The original, unaliased spelling must still be caught too.
 #[test]
 #[should_panic(expected = "must never reference `tokio::fs`")]
 fn gate_fails_on_direct_tokio_fs_call() {
-    let source = plant_in_production(
+    let source = plant_in_local_rs_production(
         "\nasync fn planted_regression(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {\n\
          \x20\x20\x20\x20tokio::fs::read(path).await\n}\n",
     );
-    assert_fd_rooted_allowlist(&source);
+    assert_fd_rooted_allowlist("crates/ironclaw_filesystem/src/local.rs", &source, true);
 }
 
 #[test]
 #[should_panic(expected = "must never call `std::os::unix::fs::*`")]
 fn gate_fails_on_planted_std_os_unix_fs_call() {
-    let source = plant_in_production(
+    let source = plant_in_local_rs_production(
         "\nfn planted_regression(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {\n\
          \x20\x20\x20\x20std::os::unix::fs::symlink(target, link)\n}\n",
     );
-    assert_fd_rooted_allowlist(&source);
+    assert_fd_rooted_allowlist("crates/ironclaw_filesystem/src/local.rs", &source, true);
 }
 
 #[test]
 #[should_panic(expected = "must never call raw `libc::*` path syscalls")]
 fn gate_fails_on_planted_raw_libc_call() {
-    let source = plant_in_production(
+    let source = plant_in_local_rs_production(
         "\nunsafe fn planted_regression(dirfd: i32, path: *const i8) -> i32 {\n\
          \x20\x20\x20\x20unsafe { libc::openat(dirfd, path, 0) }\n}\n",
     );
-    assert_fd_rooted_allowlist(&source);
+    assert_fd_rooted_allowlist("crates/ironclaw_filesystem/src/local.rs", &source, true);
 }
 
 /// `std::fs::*` outside the two allowlisted functions — e.g. a direct,
@@ -285,11 +316,11 @@ fn gate_fails_on_planted_raw_libc_call() {
 #[test]
 #[should_panic(expected = "calls `std::fs::remove_file` in production code")]
 fn gate_fails_on_planted_disallowed_std_fs_function() {
-    let source = plant_in_production(
+    let source = plant_in_local_rs_production(
         "\nfn planted_regression(path: &std::path::Path) -> std::io::Result<()> {\n\
          \x20\x20\x20\x20std::fs::remove_file(path)\n}\n",
     );
-    assert_fd_rooted_allowlist(&source);
+    assert_fd_rooted_allowlist("crates/ironclaw_filesystem/src/local.rs", &source, true);
 }
 
 /// The allowlisted `std::fs::canonicalize`/`std::fs::File` calls that
@@ -298,8 +329,30 @@ fn gate_fails_on_planted_disallowed_std_fs_function() {
 /// happens to fail closed for the wrong reason.
 #[test]
 fn gate_does_not_flag_allowlisted_std_fs_calls() {
-    let source = production_source_for_planting();
-    // Would panic (via assert!) if either allowlisted call were rejected;
-    // reaching the end of this function is the assertion.
-    assert_fd_rooted_allowlist(&source);
+    for gated in GATED_FILES {
+        let source = read_gated_file(gated.relative_path);
+        // Would panic (via assert!) if an allowlisted call were rejected;
+        // reaching the end of this loop is the assertion.
+        assert_fd_rooted_allowlist(gated.relative_path, &source, gated.has_test_module);
+    }
+}
+
+/// Proves the file-scoping actually extends to `fd_resolve.rs` — not just
+/// cosmetically listed in `GATED_FILES` — by planting a `tokio::fs` import
+/// directly into it (appended to the end of the file; `fd_resolve.rs` has
+/// no `#[cfg(test)]` boundary to land past) and confirming the gate still
+/// catches it there.
+#[test]
+#[should_panic(expected = "must never reference `tokio::fs`")]
+fn gate_fails_on_planted_tokio_fs_in_fd_resolve_module() {
+    let mut source = read_gated_file("crates/ironclaw_filesystem/src/local/fd_resolve.rs");
+    source.push_str(
+        "\nasync fn planted_regression(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {\n\
+         \x20\x20\x20\x20tokio::fs::read(path).await\n}\n",
+    );
+    assert_fd_rooted_allowlist(
+        "crates/ironclaw_filesystem/src/local/fd_resolve.rs",
+        &source,
+        false,
+    );
 }

--- a/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
@@ -3,77 +3,303 @@
 //!
 //! The bug this fix closed had one shape every vulnerable function shared:
 //! resolve a path, check containment against the *resolved path string*,
-//! then hand that string to a **separate** `tokio::fs::*` syscall (`read`,
-//! `OpenOptions::open`, `create_dir_all`, `remove_file`, …) that re-resolves
-//! it from scratch — reopening a TOCTOU window between the check and the
-//! act. The fix replaced every one of those with fd-relative `rustix`
-//! syscalls (`openat`/`openat2`/`mkdirat`/`unlinkat`/`renameat`/`fstat`)
-//! walked from an already-open, already-verified directory descriptor, so
-//! there is no longer a path string for a later syscall to re-resolve.
+//! then hand that string to a **separate** syscall that re-resolves it from
+//! scratch — reopening a TOCTOU window between the check and the act. The
+//! fix replaced every one of those with fd-relative `rustix` syscalls
+//! (`openat`/`openat2`/`mkdirat`/`unlinkat`/`renameat`/`fstat`) walked from
+//! an already-open, already-verified directory descriptor, so there is no
+//! longer a path string for a later syscall to re-resolve.
 //!
-//! `tokio::fs::*` is therefore not just *a* smell in this file — it is
-//! definitionally the vulnerable pattern, because every `tokio::fs::*`
-//! entry point takes a path, not a descriptor. Pinning its absence at zero
-//! is a narrow, mechanically-checkable proxy for "no pathname-check-then-
-//! separate-syscall reintroduced", without trying to parse call graphs or
-//! guess at future variations of the bug.
+//! **This is an allowlist, not a denylist**, on purpose. An earlier version
+//! of this gate checked for the single literal substring `"tokio::fs::"` —
+//! and was proven evadable in one line (`use tokio::fs as sneaky_alias;
+//! sneaky_alias::read(path).await` passed vacuously), on top of never
+//! catching `std::fs::*`, `std::os::unix::fs::*`, or raw `libc::openat` at
+//! all. This repo's *other* architecture gate
+//! (`reborn_tls_verification_escape_hatches.rs`) has silently failed to
+//! bind four times, always the same shape: a denylist of one spelling of a
+//! forbidden pattern, evaded by a different spelling of the same thing.
+//! Spelling denylists are exactly the failure mode; an allowlist of the
+//! sanctioned primitives is what's actually hard to evade, because it does
+//! not matter *how* a forbidden call is spelled or imported — anything that
+//! isn't on the allowlist fails the same way.
 //!
-//! Scoped to this one file, not the whole crate: `postgres.rs`/`libsql.rs`/
-//! `db/` have no local-filesystem containment surface, and widening the
-//! scan would either need per-file exceptions (rot magnet) or a
-//! false-positive-prone heuristic. If a future backend gains its own
-//! path-based local containment logic, it should get its own narrow gate
-//! rather than this one growing broad and brittle.
+//! Scoped to the fd-rooted primitive module (`local.rs`), not the whole
+//! crate: `postgres.rs`/`libsql.rs`/`db/` have no local-filesystem
+//! containment surface, and widening the scan would either need per-file
+//! exceptions (rot magnet) or a false-positive-prone heuristic. If a future
+//! backend gains its own path-based local containment logic, it should get
+//! its own narrow gate rather than this one growing broad and brittle.
 
 use std::path::PathBuf;
 
-fn local_backend_source() -> String {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(|path| path.parent())
-        .map(|workspace_root| {
-            workspace_root
-                .join("crates")
-                .join("ironclaw_filesystem")
-                .join("src")
-                .join("local.rs")
-        })
-        .unwrap_or_default();
+        .map(|path| path.to_path_buf())
+        .unwrap_or_default()
+}
+
+/// Reads the gated file's *full* source, panicking loudly (not silently
+/// passing) if the file is missing or unreadable — a gate that can't find
+/// its target must never be mistaken for a gate that passed.
+fn read_gated_file(relative: &str) -> String {
+    let path = workspace_root().join(relative);
     std::fs::read_to_string(&path)
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
-const VIOLATION_MESSAGE: &str = "crates/ironclaw_filesystem/src/local.rs must never call `tokio::fs::*` again: \
-     every `tokio::fs::*` entry point takes a path string, and re-resolving a path \
-     after an earlier containment check is exactly the TOCTOU pattern the fd-rooted \
-     traversal fix (openat/openat2 walked from an open root descriptor) closed. If \
-     you're adding a new local-backend operation, resolve it through the existing \
-     `open_one`/`resolve_walk`/`descend_creating` primitives instead.";
+/// Splits `source` into (production, test) at the file's outer
+/// `#[cfg(test)]` module boundary, so the allowlist below is enforced only
+/// against the fd-rooted resolution code that ships — not against test
+/// fixture setup, which legitimately uses `std::fs::create_dir_all` and
+/// `std::os::unix::fs::symlink` on the *host* temp directory to construct
+/// escape scenarios, nothing to do with the production containment surface
+/// this gate exists to police.
+///
+/// Fails loud (rather than silently scanning nothing or scanning
+/// everything) if the marker isn't found, since a refactor that removes or
+/// renames the test module would otherwise make this split silently
+/// meaningless.
+fn split_production_and_test(source: &str) -> (&str, &str) {
+    const MARKER: &str = "#[cfg(test)]";
+    let index = source
+        .find(MARKER)
+        .unwrap_or_else(|| panic!("expected to find `{MARKER}` marking the test module boundary"));
+    (&source[..index], &source[index..])
+}
 
-/// The actual gate: `source` must contain zero `tokio::fs::*` calls.
-fn assert_no_tokio_fs_path_resolution(source: &str) {
-    assert!(!source.contains("tokio::fs::"), "{VIOLATION_MESSAGE}");
+/// `std::fs::` function names permitted in production code, each with a
+/// documented, checked-at-review-time reason it is not part of the
+/// fd-rooted containment surface:
+///
+/// - `canonicalize`: used exactly once, in `mount_local_impl`, which runs
+///   only at trusted mount-setup time (synchronous, not on the async
+///   per-request path) to resolve the host root a mount is pinned to. There
+///   is no request-time path string here for a symlink swap to race.
+/// - `File`: `std::fs::File::from(fd)` converts an already fd-rooted,
+///   already-verified `OwnedFd` into a `std::io::Read`/`Write` handle for
+///   the bytes underneath it — it never opens anything by path, so it
+///   cannot re-resolve or re-check containment.
+///
+/// Checked against comment-stripped source (see [`strip_line_comments`]),
+/// so doc-comment prose that merely *mentions* a `std::fs::*` name (e.g.
+/// contrasting `remove_dir_all_fd` with `std::fs::remove_dir_all`'s
+/// equally-recursive, uncapped shape) never has to be allowlisted just to
+/// keep the gate green — only a live call counts.
+const ALLOWED_STD_FS_FUNCTIONS: &[&str] = &["canonicalize", "File"];
+
+/// The actual gate. Fails loud with a specific reason instead of a single
+/// generic message, so a future failure immediately tells the reader which
+/// primitive was reintroduced.
+fn assert_fd_rooted_allowlist(source: &str) {
+    let (production, _test) = split_production_and_test(source);
+    let production = strip_line_comments(production);
+    let production = production.as_str();
+
+    // `tokio::fs` is definitionally the vulnerable pattern: every
+    // `tokio::fs::*` entry point takes a path, not a descriptor, and
+    // pathname-check-then-separate-syscall is exactly the bug this file
+    // exists to never reintroduce. Ban the substring `"tokio::fs"` (not
+    // `"tokio::fs::"`) so this also catches the import line of an
+    // aliasing evasion — `use tokio::fs as sneaky_alias;` — even though the
+    // alias's own call sites (`sneaky_alias::read(...)`) contain no
+    // `tokio::fs` text at all. The import is unconditionally banned because
+    // production code never legitimately needs to import `tokio::fs` in
+    // this file — every operation goes through the `rustix`-backed
+    // primitives below.
+    assert!(
+        !production.contains("tokio::fs"),
+        "crates/ironclaw_filesystem/src/local.rs must never reference `tokio::fs` \
+         (including an aliased `use tokio::fs as X`) in production code: every \
+         tokio::fs::* entry point takes a path string, and re-resolving a path \
+         after an earlier containment check is exactly the TOCTOU pattern the \
+         fd-rooted traversal fix (openat/openat2 walked from an open root \
+         descriptor) closed. Resolve new operations through the existing \
+         open_one/resolve_walk/descend_creating primitives instead."
+    );
+
+    // `std::os::unix::fs::*` (symlink, symlink_metadata's path-based
+    // cousins, etc.) is entirely absent from production code today — every
+    // symlink decision in this file is made against an already-open fd via
+    // `rustix::fs::statat`/`AtFlags::SYMLINK_NOFOLLOW`, never by asking the
+    // OS to resolve a path a second time. There is no allowlist entry
+    // because there is no legitimate production use to allow.
+    assert!(
+        !production.contains("std::os::unix::fs::"),
+        "crates/ironclaw_filesystem/src/local.rs must never call \
+         `std::os::unix::fs::*` in production code — every symlink check here \
+         must go through `open_one`'s fd-relative `O_NOFOLLOW`/`openat2` \
+         resolution, never a second path-based OS lookup."
+    );
+
+    // Raw libc path syscalls bypass rustix's typed wrappers entirely and
+    // would not be caught by either check above. `libc` is not even a
+    // direct dependency of this crate today; the ban documents that this is
+    // deliberate, not an oversight.
+    assert!(
+        !production.contains("libc::"),
+        "crates/ironclaw_filesystem/src/local.rs must never call raw `libc::*` \
+         path syscalls in production code — use the `rustix` wrappers \
+         (`openat`/`openat2`/`mkdirat`/`unlinkat`/`renameat`/`statat`/`fstat`) \
+         that back every existing primitive in this file."
+    );
+
+    // `std::fs::*` is the narrowest, most evadable-by-denylist case of all —
+    // it has two legitimate, already-audited uses in this file (see
+    // `ALLOWED_STD_FS_FUNCTIONS`'s doc). Rather than denylisting every other
+    // spelling, allowlist the function names actually permitted and fail on
+    // anything else.
+    for function_name in find_std_fs_function_names(production) {
+        assert!(
+            ALLOWED_STD_FS_FUNCTIONS.contains(&function_name.as_str()),
+            "crates/ironclaw_filesystem/src/local.rs calls `std::fs::{function_name}` \
+             in production code, which is not on this gate's allowlist \
+             ({ALLOWED_STD_FS_FUNCTIONS:?}). Every path-based filesystem \
+             operation here must resolve through the fd-rooted \
+             open_one/resolve_walk/descend_creating primitives instead of a \
+             second, independently-resolved std::fs call."
+        );
+    }
+}
+
+/// Strips everything from the first `//` to the end of each line. A
+/// deliberately blunt, line-oriented pass (not a full Rust tokenizer) that
+/// is sufficient for this file: `local.rs` has no `//` inside a string
+/// literal or path today, and the point is only to keep doc-comment prose
+/// (which legitimately discusses `tokio::fs`/`std::fs::*` by name when
+/// explaining what this module *doesn't* do) from being indistinguishable
+/// from a live call to this allowlist scanner.
+fn strip_line_comments(source: &str) -> String {
+    source
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(index) => &line[..index],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Finds every `std::fs::<identifier>` occurrence in `source` and returns
+/// the identifier that follows. A tiny hand-rolled scanner rather than a
+/// regex dependency — this crate has no `regex` dev-dependency today and
+/// the pattern is simple enough not to need one.
+fn find_std_fs_function_names(source: &str) -> Vec<String> {
+    const PREFIX: &str = "std::fs::";
+    let mut names = Vec::new();
+    let mut rest = source;
+    while let Some(offset) = rest.find(PREFIX) {
+        let after = &rest[offset + PREFIX.len()..];
+        let end = after
+            .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .unwrap_or(after.len());
+        names.push(after[..end].to_string());
+        rest = &after[end..];
+    }
+    names
 }
 
 #[test]
-fn local_backend_never_reintroduces_tokio_fs_path_based_resolution() {
-    assert_no_tokio_fs_path_resolution(&local_backend_source());
+fn local_backend_never_reintroduces_banned_path_resolution() {
+    assert_fd_rooted_allowlist(&read_gated_file("crates/ironclaw_filesystem/src/local.rs"));
 }
 
-/// Proves `assert_no_tokio_fs_path_resolution` — the exact function the test
-/// above calls against the real file — actually fails on the pattern it
-/// exists to catch, rather than passing vacuously. Takes the *real*
-/// `local.rs` source (already gate-clean) and reintroduces one planted
-/// `tokio::fs::*` call, matching the shape of the original bug
-/// (`resolve_existing` handing a checked path to a separate `tokio::fs::read`
-/// rather than acting on the fd it already has).
+// ---------------------------------------------------------------------
+// Proof-of-binding: each of these plants exactly the evasion it claims to
+// catch into the *real*, already-gate-clean local.rs source, and asserts
+// the gate fails with the expected message. Each takes the real file
+// (proving no false positive against production code) and appends one
+// violation (proving no false negative against that violation's shape).
+// ---------------------------------------------------------------------
+
+/// Inserts `addition` immediately *before* the outer `#[cfg(test)]` module
+/// boundary — i.e. into the production half `split_production_and_test`
+/// scans — rather than appending to the end of the file, which would land
+/// past that boundary (inside the discarded test half) and prove nothing.
+fn plant_in_production(addition: &str) -> String {
+    let source = read_gated_file("crates/ironclaw_filesystem/src/local.rs");
+    let index = source
+        .find("#[cfg(test)]")
+        .expect("expected to find the `#[cfg(test)]` module boundary in local.rs");
+    let mut planted = String::with_capacity(source.len() + addition.len());
+    planted.push_str(&source[..index]);
+    planted.push_str(addition);
+    planted.push('\n');
+    planted.push_str(&source[index..]);
+    planted
+}
+
+fn production_source_for_planting() -> String {
+    read_gated_file("crates/ironclaw_filesystem/src/local.rs")
+}
+
+/// The exact evasion the pre-fix gate was proven vulnerable to: aliasing
+/// `tokio::fs` on import so no call site spells out `tokio::fs::`.
 #[test]
-#[should_panic(expected = "must never call `tokio::fs::*` again")]
-fn gate_fails_on_a_planted_tokio_fs_reintroduction() {
-    let mut source = local_backend_source();
-    source.push_str(
-        "\nasync fn planted_regression(path: PathBuf) -> std::io::Result<Vec<u8>> {\n\
+#[should_panic(expected = "must never reference `tokio::fs`")]
+fn gate_fails_on_tokio_fs_alias_evasion() {
+    let source = plant_in_production(
+        "\nuse tokio::fs as sneaky_alias;\n\
+         async fn planted_alias_regression(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {\n\
+         \x20\x20\x20\x20sneaky_alias::read(path).await\n}\n",
+    );
+    assert_fd_rooted_allowlist(&source);
+}
+
+/// The original, unaliased spelling must still be caught too.
+#[test]
+#[should_panic(expected = "must never reference `tokio::fs`")]
+fn gate_fails_on_direct_tokio_fs_call() {
+    let source = plant_in_production(
+        "\nasync fn planted_regression(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {\n\
          \x20\x20\x20\x20tokio::fs::read(path).await\n}\n",
     );
-    assert_no_tokio_fs_path_resolution(&source);
+    assert_fd_rooted_allowlist(&source);
+}
+
+#[test]
+#[should_panic(expected = "must never call `std::os::unix::fs::*`")]
+fn gate_fails_on_planted_std_os_unix_fs_call() {
+    let source = plant_in_production(
+        "\nfn planted_regression(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {\n\
+         \x20\x20\x20\x20std::os::unix::fs::symlink(target, link)\n}\n",
+    );
+    assert_fd_rooted_allowlist(&source);
+}
+
+#[test]
+#[should_panic(expected = "must never call raw `libc::*` path syscalls")]
+fn gate_fails_on_planted_raw_libc_call() {
+    let source = plant_in_production(
+        "\nunsafe fn planted_regression(dirfd: i32, path: *const i8) -> i32 {\n\
+         \x20\x20\x20\x20unsafe { libc::openat(dirfd, path, 0) }\n}\n",
+    );
+    assert_fd_rooted_allowlist(&source);
+}
+
+/// `std::fs::*` outside the two allowlisted functions — e.g. a direct,
+/// path-based `std::fs::remove_file` reintroduced by a future edit — must
+/// fail even though `std::fs::` itself is not universally banned.
+#[test]
+#[should_panic(expected = "calls `std::fs::remove_file` in production code")]
+fn gate_fails_on_planted_disallowed_std_fs_function() {
+    let source = plant_in_production(
+        "\nfn planted_regression(path: &std::path::Path) -> std::io::Result<()> {\n\
+         \x20\x20\x20\x20std::fs::remove_file(path)\n}\n",
+    );
+    assert_fd_rooted_allowlist(&source);
+}
+
+/// The allowlisted `std::fs::canonicalize`/`std::fs::File` calls that
+/// already exist in production code must not themselves trip the gate —
+/// otherwise the allowlist would be indistinguishable from a ban that
+/// happens to fail closed for the wrong reason.
+#[test]
+fn gate_does_not_flag_allowlisted_std_fs_calls() {
+    let source = production_source_for_planting();
+    // Would panic (via assert!) if either allowlisted call were rejected;
+    // reaching the end of this function is the assertion.
+    assert_fd_rooted_allowlist(&source);
 }

--- a/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
@@ -34,11 +34,9 @@
 //! `MountTarget`) was later extracted again into `local/mount_registry.rs`
 //! once the cross-tenant symlink-escape wiring fix and its fd-growth bound
 //! added enough logic to that one area to earn its own file. All three files
-//! are gated here, each against the same allowlist; `fd_resolve.rs` has no
-//! `#[cfg(test)]` module of its own today, so its entire contents are
-//! scanned as production code, while `mount_registry.rs` (like `local.rs`)
-//! does have one, so only its production half is scanned (see
-//! [`GATED_FILES`]/[`GatedFile`]).
+//! are gated here, each against the same allowlist; all three now carry a
+//! `#[cfg(test)]` module of their own, so only each file's production half
+//! is scanned (see [`GATED_FILES`]/[`GatedFile`]).
 //!
 //! Scoped to these two files, not the whole crate: `postgres.rs`/
 //! `libsql.rs`/`db/` have no local-filesystem containment surface, and
@@ -80,7 +78,7 @@ const GATED_FILES: &[GatedFile] = &[
     },
     GatedFile {
         relative_path: "crates/ironclaw_filesystem/src/local/fd_resolve.rs",
-        has_test_module: false,
+        has_test_module: true,
     },
     GatedFile {
         relative_path: "crates/ironclaw_filesystem/src/local/mount_registry.rs",
@@ -99,11 +97,27 @@ const GATED_FILES: &[GatedFile] = &[
 /// if `has_test_module` is true but the marker isn't found, since a refactor
 /// that removes or renames the test module would otherwise make this split
 /// silently meaningless.
+///
+/// Takes already comment-stripped `source` (see [`strip_line_comments`]),
+/// not raw source: locating the marker before stripping comments would let
+/// a doc comment above the real test module that happens to mention the
+/// literal attribute — plausible in files this comment-dense, including
+/// this one's own module doc — truncate the scan early and pass vacuously
+/// over everything after it (PR #6817 review follow-up). Also asserts the
+/// marker appears exactly once, so a second occurrence fails loudly instead
+/// of silently shrinking the scan.
 fn production_source(source: &str, has_test_module: bool) -> &str {
     const MARKER: &str = "#[cfg(test)]";
     if !has_test_module {
         return source;
     }
+    let marker_count = source.matches(MARKER).count();
+    assert_eq!(
+        marker_count, 1,
+        "expected exactly one `{MARKER}` marking the test module boundary in \
+         comment-stripped source, found {marker_count} — a second occurrence \
+         would silently shrink this gate's scan"
+    );
     let index = source
         .find(MARKER)
         .unwrap_or_else(|| panic!("expected to find `{MARKER}` marking the test module boundary"));
@@ -118,26 +132,29 @@ fn production_source(source: &str, has_test_module: bool) -> &str {
 ///   which runs only at trusted mount-setup time (synchronous, not on the
 ///   async per-request path) to resolve the host root a mount is pinned to.
 ///   There is no request-time path string here for a symlink swap to race.
-/// - `File`: `std::fs::File::from(fd)` (in `fd_resolve.rs`) converts an
-///   already fd-rooted, already-verified `OwnedFd` into a
+/// - `File::from`: `std::fs::File::from(fd)` (in `fd_resolve.rs`) converts
+///   an already fd-rooted, already-verified `OwnedFd` into a
 ///   `std::io::Read`/`Write` handle for the bytes underneath it — it never
 ///   opens anything by path, so it cannot re-resolve or re-check
-///   containment.
+///   containment. Allowlisted as the specific associated function, not the
+///   bare `File` type name: `std::fs::File::open`/`std::fs::File::create`
+///   are fully path-based, TOCTOU-shaped constructors that must stay
+///   banned, and both would otherwise pass under a type-name-only entry
+///   (PR #6817 review follow-up).
 ///
 /// Checked against comment-stripped source (see [`strip_line_comments`]),
 /// so doc-comment prose that merely *mentions* a `std::fs::*` name (e.g.
 /// contrasting `remove_dir_all_fd` with `std::fs::remove_dir_all`'s
 /// equally-recursive, uncapped shape) never has to be allowlisted just to
 /// keep the gate green — only a live call counts.
-const ALLOWED_STD_FS_FUNCTIONS: &[&str] = &["canonicalize", "File"];
+const ALLOWED_STD_FS_FUNCTIONS: &[&str] = &["canonicalize", "File::from"];
 
 /// The actual gate. Fails loud with a specific reason instead of a single
 /// generic message, so a future failure immediately tells the reader which
 /// file and which primitive was reintroduced.
 fn assert_fd_rooted_allowlist(relative_path: &str, source: &str, has_test_module: bool) {
-    let production = production_source(source, has_test_module);
-    let production = strip_line_comments(production);
-    let production = production.as_str();
+    let stripped = strip_line_comments(source);
+    let production = production_source(&stripped, has_test_module);
 
     // `tokio::fs` is definitionally the vulnerable pattern: every
     // `tokio::fs::*` entry point takes a path, not a descriptor, and
@@ -225,9 +242,14 @@ fn strip_line_comments(source: &str) -> String {
 }
 
 /// Finds every `std::fs::<identifier>` occurrence in `source` and returns
-/// the identifier that follows. A tiny hand-rolled scanner rather than a
-/// regex dependency — this crate has no `regex` dev-dependency today and
-/// the pattern is simple enough not to need one.
+/// the identifier that follows — including a `::`-qualified associated
+/// function (`File::open`, not just `File`), so the allowlist can be scoped
+/// to the exact call actually audited rather than the type name alone (PR
+/// #6817 review follow-up: `std::fs::File::open`/`std::fs::File::create`
+/// must not pass under the same entry as `std::fs::File::from`). A tiny
+/// hand-rolled scanner rather than a regex dependency — this crate has no
+/// `regex` dev-dependency today and the pattern is simple enough not to
+/// need one.
 fn find_std_fs_function_names(source: &str) -> Vec<String> {
     const PREFIX: &str = "std::fs::";
     let mut names = Vec::new();
@@ -235,9 +257,9 @@ fn find_std_fs_function_names(source: &str) -> Vec<String> {
     while let Some(offset) = rest.find(PREFIX) {
         let after = &rest[offset + PREFIX.len()..];
         let end = after
-            .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == ':'))
             .unwrap_or(after.len());
-        names.push(after[..end].to_string());
+        names.push(after[..end].trim_end_matches(':').to_string());
         rest = &after[end..];
     }
     names
@@ -263,9 +285,9 @@ fn local_backend_never_reintroduces_banned_path_resolution() {
 /// `#[cfg(test)]` module boundary — i.e. into the production half
 /// `production_source` scans — rather than appending to the end of the
 /// file, which would land past that boundary (inside the discarded test
-/// half) and prove nothing. Shared by every gated file that carries its own
-/// test module (`local.rs`, `mount_registry.rs`); `fd_resolve.rs` has none,
-/// so its own proof-of-binding test appends directly instead.
+/// half) and prove nothing. Shared by every gated file — all three
+/// (`local.rs`, `mount_registry.rs`, `fd_resolve.rs`) carry their own
+/// `#[cfg(test)]` module.
 fn plant_in_production(relative_path: &str, addition: &str) -> String {
     let source = read_gated_file(relative_path);
     let index = source.find("#[cfg(test)]").unwrap_or_else(|| {
@@ -342,7 +364,31 @@ fn gate_fails_on_planted_disallowed_std_fs_function() {
     assert_fd_rooted_allowlist("crates/ironclaw_filesystem/src/local.rs", &source, true);
 }
 
-/// The allowlisted `std::fs::canonicalize`/`std::fs::File` calls that
+/// `find_std_fs_function_names` used to capture only the identifier
+/// directly after `std::fs::`, so `std::fs::File::open(path)` and
+/// `std::fs::File::create(path)` — both fully path-based, TOCTOU-shaped
+/// constructors — yielded the bare name `"File"` and passed under the same
+/// allowlist entry that exists for the benign `std::fs::File::from(fd)`
+/// conversion. Pins that the allowlist is scoped to the actual audited
+/// associated function, not the type name.
+#[test]
+#[should_panic(expected = "std::fs::File::open")]
+fn gate_fails_on_planted_std_fs_file_open_evasion() {
+    // The return type deliberately avoids a second bare `std::fs::File`
+    // mention (e.g. `-> std::io::Result<std::fs::File>`) — that would be
+    // scanned as its own, earlier `std::fs::` occurrence and fail the gate
+    // for the wrong reason (a bare `File` no longer on the allowlist) before
+    // ever reaching the actual `std::fs::File::open` evasion this test
+    // means to pin.
+    let source = plant_in_local_rs_production(
+        "\nfn planted_regression(path: &std::path::Path) -> std::io::Result<()> {\n\
+         \x20\x20\x20\x20std::fs::File::open(path)?;\n\
+         \x20\x20\x20\x20Ok(())\n}\n",
+    );
+    assert_fd_rooted_allowlist("crates/ironclaw_filesystem/src/local.rs", &source, true);
+}
+
+/// The allowlisted `std::fs::canonicalize`/`std::fs::File::from` calls that
 /// already exist in production code must not themselves trip the gate —
 /// otherwise the allowlist would be indistinguishable from a ban that
 /// happens to fail closed for the wrong reason.
@@ -357,22 +403,27 @@ fn gate_does_not_flag_allowlisted_std_fs_calls() {
 }
 
 /// Proves the file-scoping actually extends to `fd_resolve.rs` — not just
-/// cosmetically listed in `GATED_FILES` — by planting a `tokio::fs` import
-/// directly into it (appended to the end of the file; `fd_resolve.rs` has
-/// no `#[cfg(test)]` boundary to land past) and confirming the gate still
-/// catches it there.
+/// cosmetically listed in `GATED_FILES` — by planting a direct `tokio::fs`
+/// call into its production half (before the `#[cfg(test)]` boundary, via
+/// [`plant_in_production`]) and confirming the gate still catches it there.
+/// `fd_resolve.rs` gained its own `#[cfg(test)]` module (a deterministic
+/// regression for the recursive-delete symlink race, PR #6817 follow-up),
+/// so this can no longer append past the end of the file the way it used
+/// to — appending now would land inside the discarded test half and prove
+/// nothing, exactly the silent-under-scan failure this gate exists to
+/// avoid elsewhere.
 #[test]
 #[should_panic(expected = "must never reference `tokio::fs`")]
 fn gate_fails_on_planted_tokio_fs_in_fd_resolve_module() {
-    let mut source = read_gated_file("crates/ironclaw_filesystem/src/local/fd_resolve.rs");
-    source.push_str(
+    let source = plant_in_production(
+        "crates/ironclaw_filesystem/src/local/fd_resolve.rs",
         "\nasync fn planted_regression(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {\n\
          \x20\x20\x20\x20tokio::fs::read(path).await\n}\n",
     );
     assert_fd_rooted_allowlist(
         "crates/ironclaw_filesystem/src/local/fd_resolve.rs",
         &source,
-        false,
+        true,
     );
 }
 

--- a/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
@@ -29,9 +29,15 @@
 //! extracted into `local/fd_resolve.rs` — a module with, by design, zero
 //! dependency on `DiskFilesystem`/`LocalMount`, so it has *even less* reason
 //! than `local.rs` to ever reach for `tokio::fs` or a second path-based
-//! lookup. Both files are gated here, each against the same allowlist;
-//! `fd_resolve.rs` has no `#[cfg(test)]` module of its own today, so its
-//! entire contents are scanned as production code (see
+//! lookup — and its mount-registration layer (`mount_local`,
+//! `ensure_scoped_mount`, `resolve_mount_target`, `LocalMount`/
+//! `MountTarget`) was later extracted again into `local/mount_registry.rs`
+//! once the cross-tenant symlink-escape wiring fix and its fd-growth bound
+//! added enough logic to that one area to earn its own file. All three files
+//! are gated here, each against the same allowlist; `fd_resolve.rs` has no
+//! `#[cfg(test)]` module of its own today, so its entire contents are
+//! scanned as production code, while `mount_registry.rs` (like `local.rs`)
+//! does have one, so only its production half is scanned (see
 //! [`GATED_FILES`]/[`GatedFile`]).
 //!
 //! Scoped to these two files, not the whole crate: `postgres.rs`/
@@ -75,6 +81,10 @@ const GATED_FILES: &[GatedFile] = &[
     GatedFile {
         relative_path: "crates/ironclaw_filesystem/src/local/fd_resolve.rs",
         has_test_module: false,
+    },
+    GatedFile {
+        relative_path: "crates/ironclaw_filesystem/src/local/mount_registry.rs",
+        has_test_module: true,
     },
 ];
 
@@ -249,21 +259,30 @@ fn local_backend_never_reintroduces_banned_path_resolution() {
 // violation (proving no false negative against that violation's shape).
 // ---------------------------------------------------------------------
 
-/// Inserts `addition` immediately *before* `local.rs`'s outer `#[cfg(test)]`
-/// module boundary — i.e. into the production half `production_source`
-/// scans — rather than appending to the end of the file, which would land
-/// past that boundary (inside the discarded test half) and prove nothing.
-fn plant_in_local_rs_production(addition: &str) -> String {
-    let source = read_gated_file("crates/ironclaw_filesystem/src/local.rs");
-    let index = source
-        .find("#[cfg(test)]")
-        .expect("expected to find the `#[cfg(test)]` module boundary in local.rs");
+/// Inserts `addition` immediately *before* a gated file's outer
+/// `#[cfg(test)]` module boundary — i.e. into the production half
+/// `production_source` scans — rather than appending to the end of the
+/// file, which would land past that boundary (inside the discarded test
+/// half) and prove nothing. Shared by every gated file that carries its own
+/// test module (`local.rs`, `mount_registry.rs`); `fd_resolve.rs` has none,
+/// so its own proof-of-binding test appends directly instead.
+fn plant_in_production(relative_path: &str, addition: &str) -> String {
+    let source = read_gated_file(relative_path);
+    let index = source.find("#[cfg(test)]").unwrap_or_else(|| {
+        panic!("expected to find the `#[cfg(test)]` module boundary in {relative_path}")
+    });
     let mut planted = String::with_capacity(source.len() + addition.len());
     planted.push_str(&source[..index]);
     planted.push_str(addition);
     planted.push('\n');
     planted.push_str(&source[index..]);
     planted
+}
+
+/// `local.rs`-specific alias retained for the existing tests below; equivalent
+/// to `plant_in_production("crates/ironclaw_filesystem/src/local.rs", ...)`.
+fn plant_in_local_rs_production(addition: &str) -> String {
+    plant_in_production("crates/ironclaw_filesystem/src/local.rs", addition)
 }
 
 /// The exact evasion the pre-fix gate was proven vulnerable to: aliasing
@@ -354,5 +373,26 @@ fn gate_fails_on_planted_tokio_fs_in_fd_resolve_module() {
         "crates/ironclaw_filesystem/src/local/fd_resolve.rs",
         &source,
         false,
+    );
+}
+
+/// Proves the file-scoping extends to the newest gated file,
+/// `mount_registry.rs` (extracted from `local.rs` for FIX 4) — not just
+/// cosmetically listed in `GATED_FILES` — by planting a direct `tokio::fs`
+/// call into its production half (before the `#[cfg(test)]` boundary, via
+/// [`plant_in_production`], since unlike `fd_resolve.rs` this file does have
+/// its own test module) and confirming the gate still catches it there.
+#[test]
+#[should_panic(expected = "must never reference `tokio::fs`")]
+fn gate_fails_on_planted_tokio_fs_in_mount_registry_module() {
+    let source = plant_in_production(
+        "crates/ironclaw_filesystem/src/local/mount_registry.rs",
+        "\nasync fn planted_regression(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {\n\
+         \x20\x20\x20\x20tokio::fs::read(path).await\n}\n",
+    );
+    assert_fd_rooted_allowlist(
+        "crates/ironclaw_filesystem/src/local/mount_registry.rs",
+        &source,
+        true,
     );
 }

--- a/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_local_filesystem_fd_rooted_gate.rs
@@ -1,0 +1,79 @@
+//! Regression gate for the `DiskFilesystem` local backend's fd-rooted
+//! traversal fix (`crates/ironclaw_filesystem/src/local.rs`).
+//!
+//! The bug this fix closed had one shape every vulnerable function shared:
+//! resolve a path, check containment against the *resolved path string*,
+//! then hand that string to a **separate** `tokio::fs::*` syscall (`read`,
+//! `OpenOptions::open`, `create_dir_all`, `remove_file`, …) that re-resolves
+//! it from scratch — reopening a TOCTOU window between the check and the
+//! act. The fix replaced every one of those with fd-relative `rustix`
+//! syscalls (`openat`/`openat2`/`mkdirat`/`unlinkat`/`renameat`/`fstat`)
+//! walked from an already-open, already-verified directory descriptor, so
+//! there is no longer a path string for a later syscall to re-resolve.
+//!
+//! `tokio::fs::*` is therefore not just *a* smell in this file — it is
+//! definitionally the vulnerable pattern, because every `tokio::fs::*`
+//! entry point takes a path, not a descriptor. Pinning its absence at zero
+//! is a narrow, mechanically-checkable proxy for "no pathname-check-then-
+//! separate-syscall reintroduced", without trying to parse call graphs or
+//! guess at future variations of the bug.
+//!
+//! Scoped to this one file, not the whole crate: `postgres.rs`/`libsql.rs`/
+//! `db/` have no local-filesystem containment surface, and widening the
+//! scan would either need per-file exceptions (rot magnet) or a
+//! false-positive-prone heuristic. If a future backend gains its own
+//! path-based local containment logic, it should get its own narrow gate
+//! rather than this one growing broad and brittle.
+
+use std::path::PathBuf;
+
+fn local_backend_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .map(|workspace_root| {
+            workspace_root
+                .join("crates")
+                .join("ironclaw_filesystem")
+                .join("src")
+                .join("local.rs")
+        })
+        .unwrap_or_default();
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+const VIOLATION_MESSAGE: &str = "crates/ironclaw_filesystem/src/local.rs must never call `tokio::fs::*` again: \
+     every `tokio::fs::*` entry point takes a path string, and re-resolving a path \
+     after an earlier containment check is exactly the TOCTOU pattern the fd-rooted \
+     traversal fix (openat/openat2 walked from an open root descriptor) closed. If \
+     you're adding a new local-backend operation, resolve it through the existing \
+     `open_one`/`resolve_walk`/`descend_creating` primitives instead.";
+
+/// The actual gate: `source` must contain zero `tokio::fs::*` calls.
+fn assert_no_tokio_fs_path_resolution(source: &str) {
+    assert!(!source.contains("tokio::fs::"), "{VIOLATION_MESSAGE}");
+}
+
+#[test]
+fn local_backend_never_reintroduces_tokio_fs_path_based_resolution() {
+    assert_no_tokio_fs_path_resolution(&local_backend_source());
+}
+
+/// Proves `assert_no_tokio_fs_path_resolution` — the exact function the test
+/// above calls against the real file — actually fails on the pattern it
+/// exists to catch, rather than passing vacuously. Takes the *real*
+/// `local.rs` source (already gate-clean) and reintroduces one planted
+/// `tokio::fs::*` call, matching the shape of the original bug
+/// (`resolve_existing` handing a checked path to a separate `tokio::fs::read`
+/// rather than acting on the fd it already has).
+#[test]
+#[should_panic(expected = "must never call `tokio::fs::*` again")]
+fn gate_fails_on_a_planted_tokio_fs_reintroduction() {
+    let mut source = local_backend_source();
+    source.push_str(
+        "\nasync fn planted_regression(path: PathBuf) -> std::io::Result<Vec<u8>> {\n\
+         \x20\x20\x20\x20tokio::fs::read(path).await\n}\n",
+    );
+    assert_no_tokio_fs_path_resolution(&source);
+}

--- a/crates/ironclaw_extension_host/src/available_extension_import.rs
+++ b/crates/ironclaw_extension_host/src/available_extension_import.rs
@@ -538,6 +538,14 @@ output_schema_ref = "schemas/search.output.json"
                 reason: "disk unavailable".to_string(),
             })
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
+        }
     }
 
     fn importable_tool_bundle_files(id: &str) -> Vec<(String, Vec<u8>)> {
@@ -776,6 +784,14 @@ output_schema_ref = "schemas/run.output.json"
 
         async fn read_file(&self, _path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
             Ok(b"asset".to_vec())
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
         }
     }
 }

--- a/crates/ironclaw_extension_host/src/available_extensions.rs
+++ b/crates/ironclaw_extension_host/src/available_extensions.rs
@@ -2490,6 +2490,14 @@ credential_handle = "channel_ext_token"
                 .insert(path.as_str().to_string(), bytes.to_vec());
             Ok(())
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
+        }
     }
 
     fn test_extension_package() -> AvailableExtensionPackage {

--- a/crates/ironclaw_extensions/tests/discovery_manifest_bound.rs
+++ b/crates/ironclaw_extensions/tests/discovery_manifest_bound.rs
@@ -55,6 +55,14 @@ impl RootFilesystem for OversizedManifestFs {
             path.as_str()
         );
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Test fixture with no storage to narrow.
+        Ok(())
+    }
 }
 
 #[tokio::test]
@@ -119,6 +127,14 @@ async fn discovery_within_bound_proceeds_to_read() {
                 path: path.clone(),
                 operation: FilesystemOperation::ReadFile,
             })
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
         }
     }
 
@@ -256,6 +272,14 @@ impl RootFilesystem for CountingManifestFs {
             })),
             None => Ok(None),
         }
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Test fixture with no storage to narrow.
+        Ok(())
     }
 }
 
@@ -406,6 +430,14 @@ async fn tolerant_discovery_propagates_root_list_failure() {
                 path: path.clone(),
                 operation: FilesystemOperation::ReadFile,
             })
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
         }
     }
 

--- a/crates/ironclaw_extensions/tests/installations_contract.rs
+++ b/crates/ironclaw_extensions/tests/installations_contract.rs
@@ -2051,6 +2051,13 @@ impl RootFilesystem for QueryCountingBackend {
         self.inner.capabilities()
     }
 
+    async fn ensure_scoped_mount(
+        &self,
+        virtual_root: &VirtualPath,
+    ) -> Result<(), ironclaw_filesystem::FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
+
     async fn put(
         &self,
         path: &VirtualPath,

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -31,6 +31,12 @@ ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_observability = { path = "../ironclaw_observability" }
 ironclaw_safety = { path = "../ironclaw_safety", version = "0.2.2" }
 libsql = { version = "0.9", default-features = false, features = ["core", "replication", "remote", "tls"] }
+# fd-rooted (openat/openat2-beneath) local-backend traversal — see
+# `src/local.rs`. Pinned to `=1.1.4`: that's the version already resolved
+# transitively (via wasmtime-wasi's cap-net-ext), so pinning keeps this crate
+# on that single resolved version instead of letting a direct-dep version
+# range pull a second copy into the lockfile.
+rustix = { version = "=1.1.4", default-features = false, features = ["std", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/ironclaw_filesystem/src/cas/tests.rs
+++ b/crates/ironclaw_filesystem/src/cas/tests.rs
@@ -183,6 +183,10 @@ impl RootFilesystem for CasWithoutDeleteBackend {
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         self.inner.stat(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[tokio::test]
@@ -271,6 +275,10 @@ impl RootFilesystem for NonCasBackend {
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         self.inner.stat(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 // ─── A backend that always reports VersionMismatch on put ───────────────────
@@ -330,6 +338,10 @@ impl RootFilesystem for AlwaysMismatchBackend {
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         self.inner.stat(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 // ─── A backend whose `get` hangs forever ─────────────────────────────────────
@@ -371,6 +383,14 @@ impl RootFilesystem for HangingBackend {
 
     async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         unimplemented!("HangingBackend::stat is unreachable in this test")
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // In-memory test fixture with no OS path to narrow.
+        Ok(())
     }
 }
 
@@ -714,6 +734,14 @@ impl RootFilesystem for UnsupportedWriteBackend {
     async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         unimplemented!("UnsupportedWriteBackend::stat is unreachable in this test")
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // In-memory test fixture with no OS path to narrow.
+        Ok(())
+    }
 }
 
 #[tokio::test]
@@ -807,6 +835,14 @@ impl RootFilesystem for MalformedBodyBackend {
     async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         unimplemented!("MalformedBodyBackend::stat is unreachable in this test")
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // In-memory test fixture with no OS path to narrow.
+        Ok(())
+    }
 }
 
 // ─── A CAS-capable backend that tracks whether `put` was invoked ──────────────
@@ -859,6 +895,14 @@ impl RootFilesystem for PutTrackingBackend {
 
     async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         unimplemented!("PutTrackingBackend::stat is unreachable in this test")
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // In-memory test fixture with no OS path to narrow.
+        Ok(())
     }
 }
 
@@ -1085,6 +1129,14 @@ impl RootFilesystem for KindGatedByteOnlyBackend {
 
     async fn stat(&self, _path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         unimplemented!("KindGatedByteOnlyBackend::stat is unreachable in this test")
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // In-memory test fixture with no OS path to narrow.
+        Ok(())
     }
 }
 

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -261,13 +261,16 @@ impl RootFilesystem for CompositeRootFilesystem {
     }
 
     /// Routes to the matching mount's backend, exactly like every other
-    /// method here. This override is load-bearing, not cosmetic: without
-    /// it, `CompositeRootFilesystem` — the actual `F` behind
+    /// method here. This override is load-bearing, not cosmetic:
+    /// `ensure_scoped_mount` has no default implementation, so without it
+    /// `CompositeRootFilesystem` — the actual `F` behind
     /// `Arc<ScopedFilesystem<CompositeRootFilesystem>>` in production
-    /// composition (`ironclaw_reborn_composition::factory`) — would
-    /// silently inherit the trait's no-op default instead of reaching
-    /// whichever mounted backend (e.g. a `DiskFilesystem` mounted at
-    /// `/projects`) actually needs its containment narrowed.
+    /// composition (`ironclaw_reborn_composition::factory`) — would fail to
+    /// compile rather than reach whichever mounted backend (e.g. a
+    /// `DiskFilesystem` mounted at `/projects`) actually needs its
+    /// containment narrowed. This is the required routing that makes the
+    /// composite forward to the right mount instead of, say, always
+    /// narrowing the first-registered one.
     async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
         self.matching_mount(virtual_root)?
             .backend

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -260,6 +260,21 @@ impl RootFilesystem for CompositeRootFilesystem {
         self.matching_mount(path)?.backend.begin(path).await
     }
 
+    /// Routes to the matching mount's backend, exactly like every other
+    /// method here. This override is load-bearing, not cosmetic: without
+    /// it, `CompositeRootFilesystem` — the actual `F` behind
+    /// `Arc<ScopedFilesystem<CompositeRootFilesystem>>` in production
+    /// composition (`ironclaw_reborn_composition::factory`) — would
+    /// silently inherit the trait's no-op default instead of reaching
+    /// whichever mounted backend (e.g. a `DiskFilesystem` mounted at
+    /// `/projects`) actually needs its containment narrowed.
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.matching_mount(virtual_root)?
+            .backend
+            .ensure_scoped_mount(virtual_root)
+            .await
+    }
+
     // ── Event plane ──
 
     async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {

--- a/crates/ironclaw_filesystem/src/fault.rs
+++ b/crates/ironclaw_filesystem/src/fault.rs
@@ -410,6 +410,16 @@ where
         self.gate(FilesystemOperation::CreateDirAll, path)?;
         self.inner.create_dir_all(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        // Decorator over `self.inner` like every other method here — must
+        // forward so containment narrowing still reaches the wrapped
+        // backend through fault injection. Not fault-gated: tests wrap a
+        // real backend to inject storage-op faults, not to simulate mount
+        // failures, and gating this would make `ensure_scoped_mount` calls
+        // silently fail under fault rules aimed at read/write/delete.
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_filesystem/src/hsm.rs
+++ b/crates/ironclaw_filesystem/src/hsm.rs
@@ -125,6 +125,15 @@ impl RootFilesystem for HsmBackend {
         // same as every other unified-entry-plane method on this wrapper.
         self.inner.delete_if_version(path, expected_version).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        // HsmBackend wraps an InMemoryBackend (see `inner` above); this is a
+        // delegating wrapper like every other unified-entry-plane method on
+        // it, not a distinct storage root, so it must forward rather than
+        // no-op even though the inner backend itself has no OS path to
+        // narrow.
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -509,6 +509,16 @@ impl RootFilesystem for InMemoryBackend {
         );
         Ok(())
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // In-memory storage has no OS path to anchor an fd on; containment
+        // is enforced by key-prefix scoping in the entries map, not by a
+        // narrowable mount, so there is nothing to do here.
+        Ok(())
+    }
 }
 
 fn check_cas(

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -1114,6 +1114,16 @@ impl RootFilesystem for LibSqlRootFilesystem {
             }
         }
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // libSQL rows are scoped by virtual-path prefix, not by an OS
+        // directory fd; containment is enforced by that row scoping, so
+        // there is no mount to narrow here.
+        Ok(())
+    }
 }
 async fn put_libsql_inner(
     conn: &libsql::Connection,

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -636,6 +636,13 @@ mod tests {
     }
 
     fn make_fifo(path: &std::path::Path) {
+        // Deliberately *not* `rustix::fs::mkfifoat` (review suggestion):
+        // that function is `#[cfg(not(apple, ...))]` in the pinned rustix
+        // `1.1.4` — unavailable on macOS, a platform this module's own
+        // fallback path explicitly supports (see the module doc). Shelling
+        // out to the portable `mkfifo(1)` binary (present on every
+        // Unix-like CI/dev image this crate targets) is the one that
+        // actually works everywhere `cargo test` runs for this crate.
         let status = std::process::Command::new("mkfifo")
             .arg(path)
             .status()

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -154,76 +154,6 @@ impl DiskFilesystem {
         Ok(())
     }
 
-    /// Dynamically registers a mount rooted exactly *at* `virtual_root`, if
-    /// one is not already registered there — idempotent, so a repeated call
-    /// for the same `virtual_root` (the usual shape: called on every request
-    /// for a given scope) is a cheap no-op after the first. Unlike
-    /// [`mount_local`](Self::mount_local) (boot-time only, exclusive
-    /// `&mut self`), this takes `&self` so it can be called per request from
-    /// behind a shared `Arc<DiskFilesystem>`.
-    ///
-    /// This is the mechanism that closes a same-storage-root cross-tenant/
-    /// cross-user symlink escape for a mount whose containment root is wider
-    /// than the subtree a specific caller is actually granted (e.g. `/projects`
-    /// mounted once over the whole local-dev storage root, while a caller's
-    /// `/skills` grant only authorizes `/projects/tenants/<t>/users/<u>/skills`).
-    /// The composition layer already knows that exact boundary — it is the
-    /// `MountGrant::target` a scope-aware `MountView` builder computes from
-    /// typed `ResourceScope` fields, not something this crate derives by
-    /// counting path segments. Registering a *second*, narrower mount at that
-    /// literal target makes [`resolve_mount_target`]'s existing
-    /// longest-prefix-wins matching pick it over the wide mount for anything
-    /// under it, so `RESOLVE_BENEATH` (or the portable fallback) enforces
-    /// containment against the caller's own subtree — exactly that subtree,
-    /// no more — rather than the shared parent every caller's subtree lives
-    /// under.
-    ///
-    /// No host path is taken as input: `virtual_root` is resolved through the
-    /// *existing* (necessarily wider) mount that already covers it, via the
-    /// same fd-rooted [`descend_creating`] every other write path in this
-    /// crate uses (creating the directory if this is a brand-new leaf's first
-    /// access, exactly like `descend_creating`'s other callers) — never a
-    /// second, independently-resolved `std::fs` path lookup. The resulting,
-    /// already-open fd becomes the new mount's `root_fd` directly.
-    pub async fn ensure_scoped_mount(
-        &self,
-        virtual_root: VirtualPath,
-    ) -> Result<(), FilesystemError> {
-        if self.has_mount(&virtual_root) {
-            return Ok(());
-        }
-        let target = self.resolve_mount_target(&virtual_root)?;
-        let path = virtual_root.clone();
-        let anchor_fd = run_blocking(path.clone(), FilesystemOperation::MountLocal, move || {
-            descend_creating(target.root_fd.as_fd(), &target.components).map_err(|error| {
-                resolve_error_to_filesystem_error(&path, FilesystemOperation::MountLocal, error)
-            })
-        })
-        .await?;
-
-        let mut mounts = self
-            .mounts
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // Re-check under the write lock: two concurrent first-callers for
-        // the same scope must not both push a mount for the same
-        // `virtual_root` (that would leave two entries with the same
-        // longest-prefix key — harmless for correctness since both point at
-        // the same host directory, but wasteful and worth avoiding).
-        if mounts
-            .iter()
-            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
-        {
-            return Ok(());
-        }
-        mounts.push(LocalMount {
-            virtual_root,
-            root_fd: Arc::new(anchor_fd),
-            leaf_scoped: false,
-        });
-        Ok(())
-    }
-
     fn has_mount(&self, virtual_root: &VirtualPath) -> bool {
         let mounts = self
             .mounts
@@ -692,6 +622,76 @@ impl RootFilesystem for DiskFilesystem {
                 })
         })
         .await
+    }
+
+    /// Dynamically registers a mount rooted exactly *at* `virtual_root`, if
+    /// one is not already registered there — idempotent, so a repeated call
+    /// for the same `virtual_root` (the usual shape: called on every request
+    /// for a given scope, now automatically via
+    /// [`ScopedFilesystem`](crate::ScopedFilesystem)'s permission-resolution
+    /// path) is a cheap no-op after the first. Unlike
+    /// [`mount_local`](Self::mount_local) (boot-time only, exclusive
+    /// `&mut self`), this takes `&self` so it can be called per request from
+    /// behind a shared `Arc<DiskFilesystem>`.
+    ///
+    /// This is the mechanism that closes a same-storage-root cross-tenant/
+    /// cross-user symlink escape for a mount whose containment root is wider
+    /// than the subtree a specific caller is actually granted (e.g. `/projects`
+    /// mounted once over the whole local-dev storage root, while a caller's
+    /// `/skills` grant only authorizes `/projects/tenants/<t>/users/<u>/skills`).
+    /// The composition layer already knows that exact boundary — it is the
+    /// `MountGrant::target` a scope-aware `MountView` builder computes from
+    /// typed `ResourceScope` fields, not something this crate derives by
+    /// counting path segments. Registering a *second*, narrower mount at that
+    /// literal target makes [`resolve_mount_target`]'s existing
+    /// longest-prefix-wins matching pick it over the wide mount for anything
+    /// under it, so `RESOLVE_BENEATH` (or the portable fallback) enforces
+    /// containment against the caller's own subtree — exactly that subtree,
+    /// no more — rather than the shared parent every caller's subtree lives
+    /// under.
+    ///
+    /// No host path is taken as input: `virtual_root` is resolved through the
+    /// *existing* (necessarily wider) mount that already covers it, via the
+    /// same fd-rooted [`descend_creating`] every other write path in this
+    /// crate uses (creating the directory if this is a brand-new leaf's first
+    /// access, exactly like `descend_creating`'s other callers) — never a
+    /// second, independently-resolved `std::fs` path lookup. The resulting,
+    /// already-open fd becomes the new mount's `root_fd` directly.
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        if self.has_mount(virtual_root) {
+            return Ok(());
+        }
+        let virtual_root = virtual_root.clone();
+        let target = self.resolve_mount_target(&virtual_root)?;
+        let path = virtual_root.clone();
+        let anchor_fd = run_blocking(path.clone(), FilesystemOperation::MountLocal, move || {
+            descend_creating(target.root_fd.as_fd(), &target.components).map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::MountLocal, error)
+            })
+        })
+        .await?;
+
+        let mut mounts = self
+            .mounts
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Re-check under the write lock: two concurrent first-callers for
+        // the same scope must not both push a mount for the same
+        // `virtual_root` (that would leave two entries with the same
+        // longest-prefix key — harmless for correctness since both point at
+        // the same host directory, but wasteful and worth avoiding).
+        if mounts
+            .iter()
+            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
+        {
+            return Ok(());
+        }
+        mounts.push(LocalMount {
+            virtual_root,
+            root_fd: Arc::new(anchor_fd),
+            leaf_scoped: false,
+        });
+        Ok(())
     }
 }
 

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -87,10 +87,16 @@ fn anchor_for_target(
     let Some((leaf, rest)) = target.components.split_first() else {
         // `resolve_mount_target` already fails a leaf-scoped mount closed on
         // an empty tail (`PathOutsideMount`) before a `MountTarget` is ever
-        // built, so this arm is unreachable in practice; handled without
-        // `.unwrap()`/`.expect()` regardless, matching the rest of this
-        // module's no-panic discipline.
-        return Ok((dup_owned_fd(target.root_fd.as_fd())?, Vec::new()));
+        // built, and `VirtualPath::new` (the type's sole constructor, used
+        // even by `Deserialize`) strips every `.` segment before any path
+        // reaches this crate, so a `.`-only tail like `/tmp/.` can never
+        // arrive here either — confirmed by
+        // `leaf_scoped_mount_rejects_dot_only_bare_mount_root_request`.
+        // Fail closed anyway rather than widening to the shared root: a
+        // leaf-scoped mount has no safe anchor without a leaf, and this arm
+        // should never depend on an invariant enforced by a different
+        // crate to stay safe.
+        return Err(ResolveError::Escape);
     };
     let leaf_components = std::slice::from_ref(leaf);
     let anchor = if create_if_missing {

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -102,6 +102,13 @@ fn anchor_for_target(
     let anchor = if create_if_missing {
         descend_creating(target.root_fd.as_fd(), leaf_components)?.0
     } else {
+        // PR #6817 follow-up (macOS `RESOLVE_NO_XDEV` parity): the shared
+        // mount root's own device, captured once here — the same
+        // once-per-resolution shape `resolve_walk`/`descend_creating` use
+        // internally for their own anchor.
+        let anchor_dev = rustix::fs::fstat(target.root_fd.as_fd())
+            .map_err(|errno| ResolveError::Io(errno.into()))?
+            .st_dev;
         open_one(
             target.root_fd.as_fd(),
             &[],
@@ -110,6 +117,7 @@ fn anchor_for_target(
             OFlags::DIRECTORY,
             Mode::empty(),
             &SymlinkBudget::new(),
+            anchor_dev,
         )?
     };
     Ok((anchor, rest.to_vec()))
@@ -259,6 +267,17 @@ impl RootFilesystem for DiskFilesystem {
             // (PR #6817 review follow-up — `descend_creating` now returns
             // it): a `..` in a symlink discovered at `leaf` resolves past
             // `parent_fd`'s own parent instead of failing closed.
+            // PR #6817 follow-up (macOS `RESOLVE_NO_XDEV` parity): `anchor`'s
+            // own device, captured once here — mirroring `resolve_walk`/
+            // `descend_creating`'s internal once-per-resolution capture,
+            // since this leaf open is itself a one-component resolution
+            // anchored at `anchor` (via `parent_fd`).
+            let anchor_dev = rustix::fs::fstat(anchor.as_fd())
+                .map_err(|errno| ResolveError::Io(errno.into()))
+                .map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
+                })?
+                .st_dev;
             let fd = open_one(
                 anchor.as_fd(),
                 &parent_ancestors,
@@ -267,6 +286,7 @@ impl RootFilesystem for DiskFilesystem {
                 OFlags::WRONLY | OFlags::APPEND | OFlags::CREATE,
                 new_file_mode(),
                 &SymlinkBudget::new(),
+                anchor_dev,
             )
             .map_err(|error| {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -3,7 +3,10 @@ mod fd_resolve;
 use std::{
     ffi::{OsStr, OsString},
     os::unix::ffi::OsStrExt,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use async_trait::async_trait;
@@ -34,7 +37,46 @@ pub struct DiskFilesystem {
     mounts: std::sync::RwLock<Vec<LocalMount>>,
 }
 
-#[derive(Debug, Clone)]
+/// Upper bound on how many *dynamically*-registered scoped mounts (see
+/// [`DiskFilesystem::ensure_scoped_mount`]) this backend keeps open directory
+/// fds for at once. Boot-time static mounts ([`DiskFilesystem::mount_local`]/
+/// [`mount_local_per_leaf`](DiskFilesystem::mount_local_per_leaf)) are never
+/// counted against this bound or evicted — there are only a handful of them,
+/// fixed at process startup, and every future virtual path under one
+/// resolves through it, so evicting one would break resolution for its whole
+/// subtree with no way to recreate it from a later request.
+///
+/// Once `ensure_scoped_mount` is reachable from the production request path
+/// (the fix this constant ships alongside), one dynamic mount is registered
+/// per distinct `MountGrant::target` a caller resolves through — in
+/// practice, one per active (tenant, user) scope touching a
+/// wide-mount-backed grant like `/skills`. Left unbounded, that is one open
+/// directory fd per distinct scope for the process's entire lifetime: a
+/// slow leak against `RLIMIT_NOFILE` on a long-lived, multi-tenant host.
+///
+/// 512 is chosen against a default Linux soft `RLIMIT_NOFILE` of 1024:
+/// even if every slot is a live fd, this cache alone cannot claim more than
+/// half of a stock default limit, leaving headroom for sockets, log files,
+/// the boot-time static mounts, and every other fd the process needs.
+/// Exceeding the bound evicts the least-recently-touched dynamic entry
+/// rather than failing the request — see [`DiskFilesystem::ensure_scoped_mount`].
+const MAX_DYNAMIC_MOUNTS: usize = 512;
+
+/// Process-wide logical clock for dynamic-mount LRU recency. A simple
+/// monotonically increasing counter (not wall-clock time) is enough: only
+/// the *relative order* of touches across entries in one `DiskFilesystem`'s
+/// mount list matters for picking an eviction victim, and a counter avoids
+/// any dependency on clock resolution or monotonicity guarantees. Shared
+/// across every `DiskFilesystem` instance in the process — harmless, since
+/// each instance only ever compares its own entries' values against each
+/// other, never against another instance's.
+static DYNAMIC_MOUNT_CLOCK: AtomicU64 = AtomicU64::new(0);
+
+fn next_touch() -> u64 {
+    DYNAMIC_MOUNT_CLOCK.fetch_add(1, Ordering::Relaxed)
+}
+
+#[derive(Debug)]
 struct LocalMount {
     virtual_root: VirtualPath,
     /// An open directory descriptor on the mount's canonical host root,
@@ -86,6 +128,23 @@ struct LocalMount {
     /// rather than resolving to the shared parent every caller's leaf lives
     /// under. See [`DiskFilesystem::resolve_mount_target`].
     leaf_scoped: bool,
+    /// `true` for a mount registered by [`DiskFilesystem::ensure_scoped_mount`]
+    /// (a caller-scoped anchor, e.g. one per (tenant, user) `/skills` grant);
+    /// `false` for a boot-time [`mount_local`](DiskFilesystem::mount_local)/
+    /// [`mount_local_per_leaf`](DiskFilesystem::mount_local_per_leaf) mount.
+    /// Only `dynamic` entries count against [`MAX_DYNAMIC_MOUNTS`] and are
+    /// eligible for LRU eviction — static entries are exempt (see
+    /// `MAX_DYNAMIC_MOUNTS`'s doc for why).
+    dynamic: bool,
+    /// Logical-clock recency stamp for LRU eviction among `dynamic` entries
+    /// only (see [`next_touch`]); meaningless and never read for a static
+    /// entry. An `AtomicU64` rather than a plain field so
+    /// [`DiskFilesystem::resolve_mount_target`] can update recency through a
+    /// shared `&self`/read-lock reference on every request that resolves
+    /// through this mount, without needing the write lock just to record
+    /// "this was used" — the field is interior-mutable, the `Vec` slot
+    /// itself is not relocated by a touch.
+    last_used: AtomicU64,
 }
 
 impl DiskFilesystem {
@@ -150,6 +209,8 @@ impl DiskFilesystem {
             virtual_root,
             root_fd: Arc::new(root_fd),
             leaf_scoped,
+            dynamic: false,
+            last_used: AtomicU64::new(0),
         });
         Ok(())
     }
@@ -180,6 +241,16 @@ impl DiskFilesystem {
             .filter(|mount| path_prefix_matches(mount.virtual_root.as_str(), path.as_str()))
             .max_by_key(|mount| mount.virtual_root.as_str().len())
             .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })?;
+
+        // Recency touch for LRU eviction (see `MAX_DYNAMIC_MOUNTS`). Every
+        // real filesystem operation routes through here, so this is the true
+        // usage signal — a no-op for a static mount (its `last_used` is
+        // never read), and for a dynamic mount it keeps an actively-used
+        // scope's entry from looking idle just because no *new* registration
+        // happened recently.
+        if mount.dynamic {
+            mount.last_used.store(next_touch(), Ordering::Relaxed);
+        }
 
         let tail = path
             .as_str()
@@ -686,10 +757,44 @@ impl RootFilesystem for DiskFilesystem {
         {
             return Ok(());
         }
+
+        // Bound the dynamic-mount population (`MAX_DYNAMIC_MOUNTS`) before
+        // adding one more: evict the least-recently-touched dynamic entry if
+        // we are at capacity. Still under the same write-lock guard as the
+        // push below, so no other caller can register a mount, race this
+        // eviction, or observe a moment where capacity is exceeded.
+        //
+        // Safety of eviction: dropping a `LocalMount` here only drops the
+        // registry's own `Arc<OwnedFd>` reference. A request already
+        // in-flight against this mount captured its own clone of that `Arc`
+        // in a `MountTarget` (`resolve_mount_target` does `Arc::clone`, not a
+        // move) before this eviction could ever run — the write lock held
+        // here cannot be held concurrently with `resolve_mount_target`'s read
+        // lock, but the in-flight request's *clone* was already taken and
+        // handed off to the blocking closure by an earlier, already-released
+        // read-lock critical section. So eviction only ever drops the
+        // registry's reference; the underlying open file description stays
+        // open until every clone — including any in-flight one — is dropped,
+        // per ordinary `Arc` semantics. No in-use fd is ever closed by this.
+        let dynamic_count = mounts.iter().filter(|mount| mount.dynamic).count();
+        if dynamic_count >= MAX_DYNAMIC_MOUNTS {
+            let evict_index = mounts
+                .iter()
+                .enumerate()
+                .filter(|(_, mount)| mount.dynamic)
+                .min_by_key(|(_, mount)| mount.last_used.load(Ordering::Relaxed))
+                .map(|(index, _)| index);
+            if let Some(evict_index) = evict_index {
+                mounts.remove(evict_index);
+            }
+        }
+
         mounts.push(LocalMount {
             virtual_root,
             root_fd: Arc::new(anchor_fd),
             leaf_scoped: false,
+            dynamic: true,
+            last_used: AtomicU64::new(next_touch()),
         });
         Ok(())
     }
@@ -1096,5 +1201,106 @@ mod tests {
             "expected SymlinkEscape, got: {error:?}"
         );
         assert!(!leaf_b.join("planted.txt").exists());
+    }
+
+    fn dynamic_mount_count(root: &DiskFilesystem) -> usize {
+        root.mounts
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .filter(|mount| mount.dynamic)
+            .count()
+    }
+
+    /// FIX 2 regression: registering more distinct scopes than
+    /// `MAX_DYNAMIC_MOUNTS` must evict rather than grow unbounded — proving
+    /// the fd-leak bound actually holds, not just that the constant exists.
+    /// Registers `MAX_DYNAMIC_MOUNTS + 5` distinct scoped mounts (each opens
+    /// its own directory fd) and asserts the live dynamic-mount population
+    /// never exceeds the cap.
+    #[tokio::test]
+    async fn ensure_scoped_mount_caps_dynamic_mount_population() {
+        let storage = tempdir().unwrap();
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        for i in 0..(MAX_DYNAMIC_MOUNTS + 5) {
+            let target = VirtualPath::new(format!("/projects/scope-{i}")).unwrap();
+            root.ensure_scoped_mount(&target)
+                .await
+                .unwrap_or_else(|error| panic!("ensure_scoped_mount({i}) failed: {error:?}"));
+            assert!(
+                dynamic_mount_count(&root) <= MAX_DYNAMIC_MOUNTS,
+                "dynamic mount population exceeded MAX_DYNAMIC_MOUNTS after registering scope {i}"
+            );
+        }
+
+        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
+    }
+
+    /// FIX 2 regression, second half: a scope evicted to make room for newer
+    /// ones must still resolve correctly once it is touched again — eviction
+    /// only drops the registry's own `Arc<OwnedFd>` clone (see
+    /// `ensure_scoped_mount`'s eviction comment), never an fd a concurrent or
+    /// later request is relying on, so re-registering the same virtual root
+    /// must transparently re-open it and behave exactly like the first time.
+    #[tokio::test]
+    async fn ensure_scoped_mount_evicted_scope_still_resolves_after_reregistration() {
+        let storage = tempdir().unwrap();
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let first_scope = VirtualPath::new("/projects/scope-0").unwrap();
+        root.ensure_scoped_mount(&first_scope)
+            .await
+            .expect("register scope-0 first");
+        root.write_file(
+            &VirtualPath::new("/projects/scope-0/marker.txt").unwrap(),
+            b"first-registration",
+        )
+        .await
+        .expect("write through scope-0 before eviction");
+
+        // Push scope-0 out: fill past the cap with fresh scopes, none of
+        // which ever touch scope-0 again, so it is the oldest-by-recency
+        // entry and the eviction victim.
+        for i in 1..=MAX_DYNAMIC_MOUNTS {
+            let target = VirtualPath::new(format!("/projects/scope-{i}")).unwrap();
+            root.ensure_scoped_mount(&target)
+                .await
+                .unwrap_or_else(|error| panic!("ensure_scoped_mount({i}) failed: {error:?}"));
+        }
+        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
+
+        // scope-0's file is still on disk (eviction only drops the fd
+        // *cache* entry, never the underlying host directory or its
+        // contents) — reading it forces `ensure_scoped_mount` to
+        // re-register the mount from scratch.
+        let bytes = root
+            .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
+            .await
+            .expect("scope-0 must still resolve correctly after eviction and re-registration");
+        assert_eq!(bytes, b"first-registration");
+
+        root.write_file(
+            &VirtualPath::new("/projects/scope-0/marker.txt").unwrap(),
+            b"second-registration",
+        )
+        .await
+        .expect("write through re-registered scope-0");
+        let bytes = root
+            .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"second-registration");
+        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
     }
 }

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -13,8 +13,9 @@ use rustix::fd::{AsFd, OwnedFd};
 use rustix::fs::{AtFlags, Mode, OFlags};
 
 use self::fd_resolve::{
-    atomic_write_file, descend_creating, map_file_type, new_file_mode, open_one, read_all,
-    remove_dir_all_fd, resolve_error_to_filesystem_error, resolve_walk, write_all,
+    ResolveError, atomic_write_file, descend_creating, map_file_type, new_file_mode, open_one,
+    read_all, remove_dir_all_fd, resolve_error_to_filesystem_error, resolve_walk,
+    resolve_write_leaf, write_all,
 };
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, RecordVersion,
@@ -37,13 +38,17 @@ pub struct DiskFilesystem {
 struct LocalMount {
     virtual_root: VirtualPath,
     /// An open directory descriptor on the mount's canonical host root,
-    /// opened once at mount time. Every request resolves *from this fd*,
-    /// component by component, with `O_NOFOLLOW` (or the single-syscall
-    /// `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` equivalent on
-    /// Linux) — so a symlink swapped in after any earlier check is never
-    /// followed, closing the pathname-check-then-separate-syscall TOCTOU
-    /// window `resolve_existing` / `resolve_for_write` /
-    /// `resolve_for_create_dir_all` used to leave open. See [`open_one`].
+    /// opened once at mount time. Every request resolves *from this fd*
+    /// (or, for a `leaf_scoped` mount, from a fresh per-call anchor fd
+    /// opened beneath it — see [`anchor_for_target`]), component by
+    /// component, following an in-bounds symlink and refusing an escaping
+    /// one atomically — via the single-syscall `openat2(RESOLVE_BENEATH)`
+    /// on Linux, or this crate's own bounded fd-anchored walk everywhere
+    /// else. A symlink swapped in after any earlier check is never handed
+    /// to a later, independent path-based syscall, closing the
+    /// pathname-check-then-separate-syscall TOCTOU window `resolve_existing`
+    /// / `resolve_for_write` / `resolve_for_create_dir_all` used to leave
+    /// open. See [`open_one`].
     ///
     /// Wrapped in `Arc` (not re-opened per request): cloning an `Arc<OwnedFd>`
     /// shares the same underlying open file description rather than
@@ -65,19 +70,21 @@ struct LocalMount {
     /// e.g. the sandboxed-profile `/workspace` mount, where every user's
     /// `MountView` target is `/workspace/<digest>`).
     ///
-    /// Containment no longer needs a *narrower* boundary for this mount kind
-    /// than for an ordinary one: because [`open_one`] refuses to traverse
-    /// **any** symlink anywhere in a resolved path (not just one that would
-    /// land outside the mount), a symlink planted in one caller's leaf can
-    /// never be followed into a sibling leaf either — the whole attack class
-    /// this flag used to need a bespoke `containment_root`/
-    /// `ensure_existing_ancestor_contained` bootstrap-boundary calculation
-    /// for is closed by the same no-symlink-traversal rule that protects
-    /// ordinary mounts. `leaf_scoped` now exists purely to preserve one
-    /// policy decision: a request against the bare mount root (no leaf
-    /// segment at all) must still fail closed rather than resolving to the
-    /// shared parent every caller's leaf lives under. See
-    /// [`DiskFilesystem::resolve_mount_target`].
+    /// `leaf_scoped` still needs a *narrower* containment boundary than an
+    /// ordinary mount: now that [`open_one`] follows an in-bounds symlink
+    /// instead of rejecting every symlink outright, a symlink planted in one
+    /// caller's leaf that resolves into a sibling leaf would stay "beneath"
+    /// the wide, shared mount root and pass containment there. So for a
+    /// `leaf_scoped` mount, every request is anchored not at `root_fd` but
+    /// at a fresh fd opened *at the caller's own leaf directory* (see
+    /// [`anchor_for_target`]) before any further walking happens —
+    /// `RESOLVE_BENEATH` (or the portable fallback's escape check) then
+    /// enforces containment against that narrower anchor, so a symlink can
+    /// never step from one caller's leaf into a sibling leaf. `leaf_scoped`
+    /// additionally still preserves the original policy that a request
+    /// against the bare mount root (no leaf segment at all) must fail closed
+    /// rather than resolving to the shared parent every caller's leaf lives
+    /// under. See [`DiskFilesystem::resolve_mount_target`].
     leaf_scoped: bool,
 }
 
@@ -216,8 +223,13 @@ impl DiskFilesystem {
         Ok(MountTarget {
             root_fd: Arc::clone(&mount.root_fd),
             components,
+            leaf_scoped: mount.leaf_scoped,
         })
     }
+}
+
+fn dup_owned_fd(fd: rustix::fd::BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
+    rustix::io::dup(fd).map_err(|errno| ResolveError::Io(errno.into()))
 }
 
 /// A mount plus the path components to walk under its `root_fd`. Carries no
@@ -225,6 +237,60 @@ impl DiskFilesystem {
 struct MountTarget {
     root_fd: Arc<OwnedFd>,
     components: Vec<OsString>,
+    /// Mirrors [`LocalMount::leaf_scoped`] — carried through so the blocking
+    /// closures below can anchor containment at the caller's own leaf (see
+    /// [`anchor_for_target`]) instead of the shared mount root now that
+    /// [`open_one`] follows in-bounds symlinks. Without this, a symlink
+    /// planted inside one caller's leaf that resolves into a sibling leaf
+    /// would pass containment (both stay "beneath" the wide, shared mount
+    /// root) even though it must not.
+    leaf_scoped: bool,
+}
+
+/// For a `leaf_scoped` mount, opens the caller's own leaf directory
+/// (`target.components[0]`) as a fresh anchor fd and returns it alongside
+/// the remaining tail components: every subsequent walk resolves
+/// `RESOLVE_BENEATH` *this* anchor, not the wide, shared mount root, so an
+/// in-bounds symlink can never step from one caller's leaf into a sibling
+/// leaf. Non-leaf-scoped mounts pass the mount root straight through,
+/// unchanged.
+///
+/// `create_if_missing` mirrors [`descend_creating`]'s bootstrap semantics —
+/// a brand-new leaf's directory does not exist yet on its first write, so
+/// write paths must create it as they anchor; read paths must not (a read
+/// against a leaf that has never been written must still report
+/// `NotFound`/`MountNotFound`, not silently fabricate the directory).
+fn anchor_for_target(
+    target: &MountTarget,
+    create_if_missing: bool,
+) -> Result<(OwnedFd, Vec<OsString>), ResolveError> {
+    if !target.leaf_scoped {
+        return Ok((
+            dup_owned_fd(target.root_fd.as_fd())?,
+            target.components.clone(),
+        ));
+    }
+    let Some((leaf, rest)) = target.components.split_first() else {
+        // `resolve_mount_target` already fails a leaf-scoped mount closed on
+        // an empty tail (`PathOutsideMount`) before a `MountTarget` is ever
+        // built, so this arm is unreachable in practice; handled without
+        // `.unwrap()`/`.expect()` regardless, matching the rest of this
+        // module's no-panic discipline.
+        return Ok((dup_owned_fd(target.root_fd.as_fd())?, Vec::new()));
+    };
+    let leaf_components = std::slice::from_ref(leaf);
+    let anchor = if create_if_missing {
+        descend_creating(target.root_fd.as_fd(), leaf_components)?
+    } else {
+        open_one(
+            target.root_fd.as_fd(),
+            target.root_fd.as_fd(),
+            leaf,
+            OFlags::DIRECTORY,
+            Mode::empty(),
+        )?
+    };
+    Ok((anchor, rest.to_vec()))
 }
 
 #[async_trait]
@@ -280,14 +346,13 @@ impl RootFilesystem for DiskFilesystem {
         let target = self.resolve_mount_target(path)?;
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::ReadFile, move || {
-            let (fd, _parent) = resolve_walk(
-                target.root_fd.as_fd(),
-                &target.components,
-                OFlags::RDONLY,
-            )
-            .map_err(|error| {
+            let (anchor, rest) = anchor_for_target(&target, false).map_err(|error| {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::ReadFile, error)
             })?;
+            let (fd, _parent) =
+                resolve_walk(anchor.as_fd(), &rest, OFlags::RDONLY).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::ReadFile, error)
+                })?;
             let stat = rustix::fs::fstat(&fd).map_err(|errno| {
                 io_error(path.clone(), FilesystemOperation::ReadFile, errno.into())
             })?;
@@ -314,14 +379,13 @@ impl RootFilesystem for DiskFilesystem {
         let target = self.resolve_mount_target(path)?;
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::ReadFile, move || {
-            let (fd, _parent) = resolve_walk(
-                target.root_fd.as_fd(),
-                &target.components,
-                OFlags::RDONLY,
-            )
-            .map_err(|error| {
+            let (anchor, rest) = anchor_for_target(&target, false).map_err(|error| {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::ReadFile, error)
             })?;
+            let (fd, _parent) =
+                resolve_walk(anchor.as_fd(), &rest, OFlags::RDONLY).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::ReadFile, error)
+                })?;
             let stat = rustix::fs::fstat(&fd).map_err(|errno| {
                 io_error(path.clone(), FilesystemOperation::ReadFile, errno.into())
             })?;
@@ -354,15 +418,23 @@ impl RootFilesystem for DiskFilesystem {
 
     async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         let target = self.resolve_mount_target(path)?;
-        let (parent_components, leaf) = split_leaf(&target.components, path)?;
         let bytes = bytes.to_vec();
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::AppendFile, move || {
+            let (anchor, rest) = anchor_for_target(&target, true).map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
+            })?;
+            let (parent_components, leaf) = split_leaf(&rest, &path)?;
             let parent_fd =
-                descend_creating(target.root_fd.as_fd(), &parent_components).map_err(|error| {
+                descend_creating(anchor.as_fd(), &parent_components).map_err(|error| {
                     resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
                 })?;
+            // `open_one` already follows an in-bounds symlink at `leaf`
+            // transparently (unlike `write_file`'s rename-based atomic
+            // install, a plain `open`-and-append writes straight through
+            // one), so no separate `resolve_write_leaf` chase is needed here.
             let fd = open_one(
+                anchor.as_fd(),
                 parent_fd.as_fd(),
                 &leaf,
                 OFlags::WRONLY | OFlags::APPEND | OFlags::CREATE,
@@ -389,14 +461,13 @@ impl RootFilesystem for DiskFilesystem {
         let target = self.resolve_mount_target(path)?;
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::ListDir, move || {
-            let (fd, _parent) = resolve_walk(
-                target.root_fd.as_fd(),
-                &target.components,
-                OFlags::RDONLY,
-            )
-            .map_err(|error| {
+            let (anchor, rest) = anchor_for_target(&target, false).map_err(|error| {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::ListDir, error)
             })?;
+            let (fd, _parent) =
+                resolve_walk(anchor.as_fd(), &rest, OFlags::RDONLY).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::ListDir, error)
+                })?;
             let mut listing = rustix::fs::Dir::read_from(fd.as_fd()).map_err(|errno| {
                 io_error(path.clone(), FilesystemOperation::ListDir, errno.into())
             })?;
@@ -442,12 +513,13 @@ impl RootFilesystem for DiskFilesystem {
         let target = self.resolve_mount_target(path)?;
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::Stat, move || {
+            let (anchor, rest) = anchor_for_target(&target, false).map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::Stat, error)
+            })?;
             let (fd, _parent) =
-                resolve_walk(target.root_fd.as_fd(), &target.components, OFlags::RDONLY).map_err(
-                    |error| {
-                        resolve_error_to_filesystem_error(&path, FilesystemOperation::Stat, error)
-                    },
-                )?;
+                resolve_walk(anchor.as_fd(), &rest, OFlags::RDONLY).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::Stat, error)
+                })?;
             let stat = rustix::fs::fstat(&fd)
                 .map_err(|errno| io_error(path.clone(), FilesystemOperation::Stat, errno.into()))?;
             let len = if stat.st_size < 0 {
@@ -487,22 +559,45 @@ impl RootFilesystem for DiskFilesystem {
         }
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::Delete, move || {
+            let (anchor, rest) = anchor_for_target(&target, false).map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::Delete, error)
+            })?;
+            if rest.is_empty() {
+                // Same "cannot delete the resolution root" policy as the
+                // bare-mount-root check above, restated post-anchor: for a
+                // leaf-scoped mount, `rest` empty means the request named
+                // the caller's own leaf directory itself (anchoring already
+                // consumed it as `target.components[0]`), which has no
+                // fd-relative parent inside this resolution either.
+                return Err(FilesystemError::PathOutsideMount { path: path.clone() });
+            }
             let (fd, parent) =
-                resolve_walk(target.root_fd.as_fd(), &target.components, OFlags::RDONLY).map_err(
-                    |error| {
-                        resolve_error_to_filesystem_error(&path, FilesystemOperation::Delete, error)
-                    },
-                )?;
+                resolve_walk(anchor.as_fd(), &rest, OFlags::RDONLY).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::Delete, error)
+                })?;
             let Some((parent_fd, name)) = parent else {
                 return Err(FilesystemError::PathOutsideMount { path: path.clone() });
             };
-            let stat = rustix::fs::fstat(&fd).map_err(|errno| {
-                io_error(path.clone(), FilesystemOperation::Delete, errno.into())
-            })?;
             drop(fd);
-            if rustix::fs::FileType::from_raw_mode(stat.st_mode) == rustix::fs::FileType::Directory
+            // Determine the *entry's own* type via an `AT_SYMLINK_NOFOLLOW`
+            // stat against `parent_fd`/`name` — not `fstat` of `fd` (which,
+            // now that `open_one` follows in-bounds symlinks, may have
+            // opened straight through a symlink to a directory target).
+            // `std::fs::remove_dir_all`/`remove_file` never follow a
+            // symlink at the entry being removed — a symlink is always
+            // unlinked as itself, never traversed into — and this module
+            // promises the same contract; using `fd`'s (possibly-followed)
+            // type here would recurse into and delete the *target*
+            // directory's contents before failing on the final
+            // `unlinkat(..., REMOVEDIR)` (which POSIX refuses on a symlink).
+            let entry_stat =
+                rustix::fs::statat(parent_fd.as_fd(), &name, AtFlags::SYMLINK_NOFOLLOW).map_err(
+                    |errno| io_error(path.clone(), FilesystemOperation::Delete, errno.into()),
+                )?;
+            if rustix::fs::FileType::from_raw_mode(entry_stat.st_mode)
+                == rustix::fs::FileType::Directory
             {
-                remove_dir_all_fd(parent_fd.as_fd(), &name)
+                remove_dir_all_fd(anchor.as_fd(), parent_fd.as_fd(), &name)
                     .map_err(|error| io_error(path.clone(), FilesystemOperation::Delete, error))
             } else {
                 rustix::fs::unlinkat(parent_fd.as_fd(), &name, AtFlags::empty()).map_err(|errno| {
@@ -517,7 +612,10 @@ impl RootFilesystem for DiskFilesystem {
         let target = self.resolve_mount_target(path)?;
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::CreateDirAll, move || {
-            descend_creating(target.root_fd.as_fd(), &target.components)
+            let (anchor, rest) = anchor_for_target(&target, true).map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::CreateDirAll, error)
+            })?;
+            descend_creating(anchor.as_fd(), &rest)
                 .map(|_fd| ())
                 .map_err(|error| {
                     resolve_error_to_filesystem_error(
@@ -539,15 +637,27 @@ impl DiskFilesystem {
         cas: CasExpectation,
     ) -> Result<(), FilesystemError> {
         let target = self.resolve_mount_target(path)?;
-        let (parent_components, leaf) = split_leaf(&target.components, path)?;
         let bytes = bytes.to_vec();
         let path = path.clone();
         run_blocking(path.clone(), FilesystemOperation::WriteFile, move || {
+            let (anchor, rest) = anchor_for_target(&target, true).map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
+            })?;
+            let (parent_components, leaf) = split_leaf(&rest, &path)?;
             let parent_fd =
-                descend_creating(target.root_fd.as_fd(), &parent_components).map_err(|error| {
+                descend_creating(anchor.as_fd(), &parent_components).map_err(|error| {
                     resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
                 })?;
-            atomic_write_file(&path, parent_fd.as_fd(), &leaf, &bytes, cas)
+            // `rename`/`link` (how `atomic_write_file` installs bytes) never
+            // follow a symlink at the destination name — resolve any
+            // in-bounds symlink chain at `leaf` ourselves first so the
+            // install lands at the symlink's ultimate target, not over the
+            // symlink entry itself.
+            let (write_parent_fd, write_leaf) =
+                resolve_write_leaf(anchor.as_fd(), parent_fd.as_fd(), &leaf).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
+                })?;
+            atomic_write_file(&path, write_parent_fd.as_fd(), &write_leaf, &bytes, cas)
         })
         .await
     }

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -16,9 +16,9 @@ use rustix::fd::{AsFd, OwnedFd};
 use rustix::fs::{AtFlags, Mode, OFlags};
 
 use self::fd_resolve::{
-    ResolveError, atomic_write_file, descend_creating, map_file_type, new_file_mode, open_one,
-    read_all, remove_dir_all_fd, resolve_error_to_filesystem_error, resolve_walk,
-    resolve_write_leaf, write_all,
+    ResolveError, SymlinkBudget, atomic_write_file, descend_creating, map_file_type,
+    new_file_mode, open_one, read_all, remove_dir_all_fd, resolve_error_to_filesystem_error,
+    resolve_walk, resolve_write_leaf, write_all,
 };
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, RecordVersion,
@@ -355,6 +355,7 @@ fn anchor_for_target(
             leaf,
             OFlags::DIRECTORY,
             Mode::empty(),
+            &SymlinkBudget::new(),
         )?
     };
     Ok((anchor, rest.to_vec()))
@@ -506,6 +507,7 @@ impl RootFilesystem for DiskFilesystem {
                 &leaf,
                 OFlags::WRONLY | OFlags::APPEND | OFlags::CREATE,
                 new_file_mode(),
+                &SymlinkBudget::new(),
             )
             .map_err(|error| {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -1,28 +1,24 @@
 mod fd_resolve;
+mod mount_registry;
 
-use std::{
-    ffi::{OsStr, OsString},
-    os::unix::ffi::OsStrExt,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-};
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStrExt;
 
 use async_trait::async_trait;
-use ironclaw_host_api::{HostPath, VirtualPath};
+use ironclaw_host_api::VirtualPath;
 use ironclaw_safety::sensitive_paths::is_sensitive_path_str;
 use rustix::fd::{AsFd, OwnedFd};
 use rustix::fs::{AtFlags, Mode, OFlags};
 
 use self::fd_resolve::{
-    ResolveError, SymlinkBudget, atomic_write_file, descend_creating, map_file_type,
-    new_file_mode, open_one, read_all, remove_dir_all_fd, resolve_error_to_filesystem_error,
-    resolve_walk, resolve_write_leaf, write_all,
+    ResolveError, SymlinkBudget, atomic_write_file, descend_creating, map_file_type, new_file_mode,
+    open_one, read_all, remove_dir_all_fd, resolve_error_to_filesystem_error, resolve_walk,
+    resolve_write_leaf, write_all,
 };
+use self::mount_registry::{LocalMount, MountTarget};
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, RecordVersion,
-    RootFilesystem, VersionedEntry, path_prefix_matches,
+    RootFilesystem, VersionedEntry,
 };
 
 /// The on-disk `RootFilesystem` backend, mounted into the virtual namespace.
@@ -32,286 +28,26 @@ use crate::{
 /// Renamed from `LocalFilesystem` because `Local` read like a deployment tier
 /// while this is simply the disk backend a `DeploymentConfig` may select
 /// (arch-simplification §4.4 Bucket 2).
+///
+/// Mount registration and routing (`mount_local`, `mount_local_per_leaf`,
+/// `ensure_scoped_mount_dynamic`, `resolve_mount_target`, `LocalMount`,
+/// `MountTarget`) live in [`mount_registry`](self::mount_registry) — a second
+/// `impl DiskFilesystem` block in its own file. This impl block stays here:
+/// the `RootFilesystem` trait impl (below) is Rust's one-impl-block-per-trait
+/// rule, so it cannot itself be split across files.
 #[derive(Debug, Default)]
 pub struct DiskFilesystem {
     mounts: std::sync::RwLock<Vec<LocalMount>>,
-}
-
-/// Upper bound on how many *dynamically*-registered scoped mounts (see
-/// [`DiskFilesystem::ensure_scoped_mount`]) this backend keeps open directory
-/// fds for at once. Boot-time static mounts ([`DiskFilesystem::mount_local`]/
-/// [`mount_local_per_leaf`](DiskFilesystem::mount_local_per_leaf)) are never
-/// counted against this bound or evicted — there are only a handful of them,
-/// fixed at process startup, and every future virtual path under one
-/// resolves through it, so evicting one would break resolution for its whole
-/// subtree with no way to recreate it from a later request.
-///
-/// Once `ensure_scoped_mount` is reachable from the production request path
-/// (the fix this constant ships alongside), one dynamic mount is registered
-/// per distinct `MountGrant::target` a caller resolves through — in
-/// practice, one per active (tenant, user) scope touching a
-/// wide-mount-backed grant like `/skills`. Left unbounded, that is one open
-/// directory fd per distinct scope for the process's entire lifetime: a
-/// slow leak against `RLIMIT_NOFILE` on a long-lived, multi-tenant host.
-///
-/// 512 is chosen against a default Linux soft `RLIMIT_NOFILE` of 1024:
-/// even if every slot is a live fd, this cache alone cannot claim more than
-/// half of a stock default limit, leaving headroom for sockets, log files,
-/// the boot-time static mounts, and every other fd the process needs.
-/// Exceeding the bound evicts the least-recently-touched dynamic entry
-/// rather than failing the request — see [`DiskFilesystem::ensure_scoped_mount`].
-const MAX_DYNAMIC_MOUNTS: usize = 512;
-
-/// Process-wide logical clock for dynamic-mount LRU recency. A simple
-/// monotonically increasing counter (not wall-clock time) is enough: only
-/// the *relative order* of touches across entries in one `DiskFilesystem`'s
-/// mount list matters for picking an eviction victim, and a counter avoids
-/// any dependency on clock resolution or monotonicity guarantees. Shared
-/// across every `DiskFilesystem` instance in the process — harmless, since
-/// each instance only ever compares its own entries' values against each
-/// other, never against another instance's.
-static DYNAMIC_MOUNT_CLOCK: AtomicU64 = AtomicU64::new(0);
-
-fn next_touch() -> u64 {
-    DYNAMIC_MOUNT_CLOCK.fetch_add(1, Ordering::Relaxed)
-}
-
-#[derive(Debug)]
-struct LocalMount {
-    virtual_root: VirtualPath,
-    /// An open directory descriptor on the mount's canonical host root,
-    /// opened once at mount time. Every request resolves *from this fd*
-    /// (or, for a `leaf_scoped` mount, from a fresh per-call anchor fd
-    /// opened beneath it — see [`anchor_for_target`]), component by
-    /// component, following an in-bounds symlink and refusing an escaping
-    /// one atomically — via the single-syscall `openat2(RESOLVE_BENEATH)`
-    /// on Linux, or this crate's own bounded fd-anchored walk everywhere
-    /// else. A symlink swapped in after any earlier check is never handed
-    /// to a later, independent path-based syscall, closing the
-    /// pathname-check-then-separate-syscall TOCTOU window `resolve_existing`
-    /// / `resolve_for_write` / `resolve_for_create_dir_all` used to leave
-    /// open. See [`open_one`].
-    ///
-    /// Wrapped in `Arc` (not re-opened per request): cloning an `Arc<OwnedFd>`
-    /// shares the same underlying open file description rather than
-    /// `dup`-ing a new fd, which is exactly what we want here — directory
-    /// fds used only for relative `openat`/`mkdirat`/`unlinkat`/`fstatat`
-    /// lookups carry no mutable per-fd state (no seek offset, no O_APPEND
-    /// cursor) that a concurrent "clone" could corrupt, so many callers
-    /// reading `self.mounts` concurrently and cloning this `Arc` is safe
-    /// without any lock. `LocalMount` derives `Clone` for the same reason
-    /// this crate never needed a lock around `mounts: Vec<LocalMount>`
-    /// before: nothing here ever mutates a mount after `mount_local`/
-    /// `mount_local_per_leaf` pushes it, so concurrent readers only ever see
-    /// a fully-constructed, immutable `LocalMount` — cloning is cheap
-    /// (refcount bump) and never races.
-    root_fd: Arc<OwnedFd>,
-    /// When `true`, this mount is shared by many callers who are each only
-    /// ever granted a single leaf subtree of it (one [`MountGrant`] target
-    /// per caller, narrowed by the composition-layer `MountView` resolver —
-    /// e.g. the sandboxed-profile `/workspace` mount, where every user's
-    /// `MountView` target is `/workspace/<digest>`).
-    ///
-    /// `leaf_scoped` still needs a *narrower* containment boundary than an
-    /// ordinary mount: now that [`open_one`] follows an in-bounds symlink
-    /// instead of rejecting every symlink outright, a symlink planted in one
-    /// caller's leaf that resolves into a sibling leaf would stay "beneath"
-    /// the wide, shared mount root and pass containment there. So for a
-    /// `leaf_scoped` mount, every request is anchored not at `root_fd` but
-    /// at a fresh fd opened *at the caller's own leaf directory* (see
-    /// [`anchor_for_target`]) before any further walking happens —
-    /// `RESOLVE_BENEATH` (or the portable fallback's escape check) then
-    /// enforces containment against that narrower anchor, so a symlink can
-    /// never step from one caller's leaf into a sibling leaf. `leaf_scoped`
-    /// additionally still preserves the original policy that a request
-    /// against the bare mount root (no leaf segment at all) must fail closed
-    /// rather than resolving to the shared parent every caller's leaf lives
-    /// under. See [`DiskFilesystem::resolve_mount_target`].
-    leaf_scoped: bool,
-    /// `true` for a mount registered by [`DiskFilesystem::ensure_scoped_mount`]
-    /// (a caller-scoped anchor, e.g. one per (tenant, user) `/skills` grant);
-    /// `false` for a boot-time [`mount_local`](DiskFilesystem::mount_local)/
-    /// [`mount_local_per_leaf`](DiskFilesystem::mount_local_per_leaf) mount.
-    /// Only `dynamic` entries count against [`MAX_DYNAMIC_MOUNTS`] and are
-    /// eligible for LRU eviction — static entries are exempt (see
-    /// `MAX_DYNAMIC_MOUNTS`'s doc for why).
-    dynamic: bool,
-    /// Logical-clock recency stamp for LRU eviction among `dynamic` entries
-    /// only (see [`next_touch`]); meaningless and never read for a static
-    /// entry. An `AtomicU64` rather than a plain field so
-    /// [`DiskFilesystem::resolve_mount_target`] can update recency through a
-    /// shared `&self`/read-lock reference on every request that resolves
-    /// through this mount, without needing the write lock just to record
-    /// "this was used" — the field is interior-mutable, the `Vec` slot
-    /// itself is not relocated by a touch.
-    last_used: AtomicU64,
 }
 
 impl DiskFilesystem {
     pub fn new() -> Self {
         Self::default()
     }
-
-    /// Mounts a host directory during trusted setup.
-    ///
-    /// This API is intentionally synchronous because it mutates in-memory mount
-    /// configuration and is not part of the async runtime operation path. Async
-    /// file operations after mount setup use fd-relative syscalls (see
-    /// [`open_one`]) run on the blocking pool.
-    pub fn mount_local(
-        &mut self,
-        virtual_root: VirtualPath,
-        host_root: HostPath,
-    ) -> Result<(), FilesystemError> {
-        self.mount_local_impl(virtual_root, host_root, false)
-    }
-
-    /// Mounts a host directory shared across many callers, each of whom is
-    /// only ever granted (via their own `MountView`) a single leaf subtree
-    /// of it — e.g. the `HostedSingleTenantVolumeSandboxed` profile's
-    /// `/workspace` mount, whose shared parent holds every user's leaf
-    /// sandbox-workspace directory. See [`LocalMount::leaf_scoped`] for why
-    /// this no longer needs a distinct containment boundary from
-    /// [`mount_local`](Self::mount_local).
-    pub fn mount_local_per_leaf(
-        &mut self,
-        virtual_root: VirtualPath,
-        host_root: HostPath,
-    ) -> Result<(), FilesystemError> {
-        self.mount_local_impl(virtual_root, host_root, true)
-    }
-
-    fn mount_local_impl(
-        &mut self,
-        virtual_root: VirtualPath,
-        host_root: HostPath,
-        leaf_scoped: bool,
-    ) -> Result<(), FilesystemError> {
-        // `&mut self`, so `get_mut` never actually contends a lock — this
-        // still goes through the same `RwLock<Vec<LocalMount>>` storage
-        // `ensure_scoped_mount` uses for its `&self` dynamic registration,
-        // rather than keeping two separate storage shapes in sync.
-        let mounts = self
-            .mounts
-            .get_mut()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if mounts
-            .iter()
-            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
-        {
-            return Err(FilesystemError::MountConflict { path: virtual_root });
-        }
-
-        let (canonical_root, root_fd) = open_mount_root(&virtual_root, &host_root)?;
-        let _ = canonical_root;
-
-        mounts.push(LocalMount {
-            virtual_root,
-            root_fd: Arc::new(root_fd),
-            leaf_scoped,
-            dynamic: false,
-            last_used: AtomicU64::new(0),
-        });
-        Ok(())
-    }
-
-    fn has_mount(&self, virtual_root: &VirtualPath) -> bool {
-        let mounts = self
-            .mounts
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        mounts
-            .iter()
-            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
-    }
-
-    /// Routes `path` to its mount and splits the tail into path components
-    /// under that mount's `root_fd`. No filesystem access happens here —
-    /// this is pure string/virtual-path routing, unchanged in shape from
-    /// before this fix, and is not part of the TOCTOU surface: the actual
-    /// containment enforcement now happens fd-relatively in [`open_one`] as
-    /// each returned component is walked.
-    fn resolve_mount_target(&self, path: &VirtualPath) -> Result<MountTarget, FilesystemError> {
-        let mounts = self
-            .mounts
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mount = mounts
-            .iter()
-            .filter(|mount| path_prefix_matches(mount.virtual_root.as_str(), path.as_str()))
-            .max_by_key(|mount| mount.virtual_root.as_str().len())
-            .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })?;
-
-        // Recency touch for LRU eviction (see `MAX_DYNAMIC_MOUNTS`). Every
-        // real filesystem operation routes through here, so this is the true
-        // usage signal — a no-op for a static mount (its `last_used` is
-        // never read), and for a dynamic mount it keeps an actively-used
-        // scope's entry from looking idle just because no *new* registration
-        // happened recently.
-        if mount.dynamic {
-            mount.last_used.store(next_touch(), Ordering::Relaxed);
-        }
-
-        let tail = path
-            .as_str()
-            .strip_prefix(mount.virtual_root.as_str())
-            .unwrap_or_default()
-            .trim_start_matches('/');
-
-        if tail.is_empty() && mount.leaf_scoped {
-            // A leaf-scoped mount has no safe target for the bare mount path
-            // itself — that would be "every caller's leaf", the shared-parent
-            // boundary this mount kind exists to eliminate. The
-            // composition-layer `MountView` always supplies a leaf, but that
-            // invariant is enforced one layer up, so fail closed here.
-            return Err(FilesystemError::PathOutsideMount { path: path.clone() });
-        }
-
-        let mut components = Vec::new();
-        for segment in tail.split('/').filter(|segment| !segment.is_empty()) {
-            // The virtual-path layer (`ScopedPath::new`) already rejects
-            // literal `..` segments before a caller-controlled path ever
-            // reaches this crate, but `VirtualPath` itself does not enforce
-            // that (this crate's own tests construct arbitrary
-            // `VirtualPath` values), and every component below is handed
-            // directly to `openat`/`mkdirat` — which *do* interpret a `..`
-            // component as "go to the parent directory". Reject it here,
-            // defensively, before any fd work: this is the one place a
-            // literal `..` could turn into a real directory-fd escape.
-            if segment == ".." {
-                return Err(FilesystemError::PathOutsideMount { path: path.clone() });
-            }
-            if segment == "." {
-                continue;
-            }
-            components.push(OsString::from(segment));
-        }
-
-        Ok(MountTarget {
-            root_fd: Arc::clone(&mount.root_fd),
-            components,
-            leaf_scoped: mount.leaf_scoped,
-        })
-    }
 }
 
 fn dup_owned_fd(fd: rustix::fd::BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
     rustix::io::dup(fd).map_err(|errno| ResolveError::Io(errno.into()))
-}
-
-/// A mount plus the path components to walk under its `root_fd`. Carries no
-/// host path — every subsequent step is fd-relative.
-struct MountTarget {
-    root_fd: Arc<OwnedFd>,
-    components: Vec<OsString>,
-    /// Mirrors [`LocalMount::leaf_scoped`] — carried through so the blocking
-    /// closures below can anchor containment at the caller's own leaf (see
-    /// [`anchor_for_target`]) instead of the shared mount root now that
-    /// [`open_one`] follows in-bounds symlinks. Without this, a symlink
-    /// planted inside one caller's leaf that resolves into a sibling leaf
-    /// would pass containment (both stay "beneath" the wide, shared mount
-    /// root) even though it must not.
-    leaf_scoped: bool,
 }
 
 /// For a `leaf_scoped` mount, opens the caller's own leaf directory
@@ -697,108 +433,16 @@ impl RootFilesystem for DiskFilesystem {
         .await
     }
 
-    /// Dynamically registers a mount rooted exactly *at* `virtual_root`, if
-    /// one is not already registered there — idempotent, so a repeated call
-    /// for the same `virtual_root` (the usual shape: called on every request
-    /// for a given scope, now automatically via
-    /// [`ScopedFilesystem`](crate::ScopedFilesystem)'s permission-resolution
-    /// path) is a cheap no-op after the first. Unlike
-    /// [`mount_local`](Self::mount_local) (boot-time only, exclusive
-    /// `&mut self`), this takes `&self` so it can be called per request from
-    /// behind a shared `Arc<DiskFilesystem>`.
-    ///
-    /// This is the mechanism that closes a same-storage-root cross-tenant/
-    /// cross-user symlink escape for a mount whose containment root is wider
-    /// than the subtree a specific caller is actually granted (e.g. `/projects`
-    /// mounted once over the whole local-dev storage root, while a caller's
-    /// `/skills` grant only authorizes `/projects/tenants/<t>/users/<u>/skills`).
-    /// The composition layer already knows that exact boundary — it is the
-    /// `MountGrant::target` a scope-aware `MountView` builder computes from
-    /// typed `ResourceScope` fields, not something this crate derives by
-    /// counting path segments. Registering a *second*, narrower mount at that
-    /// literal target makes [`resolve_mount_target`]'s existing
-    /// longest-prefix-wins matching pick it over the wide mount for anything
-    /// under it, so `RESOLVE_BENEATH` (or the portable fallback) enforces
-    /// containment against the caller's own subtree — exactly that subtree,
-    /// no more — rather than the shared parent every caller's subtree lives
-    /// under.
-    ///
-    /// No host path is taken as input: `virtual_root` is resolved through the
-    /// *existing* (necessarily wider) mount that already covers it, via the
-    /// same fd-rooted [`descend_creating`] every other write path in this
-    /// crate uses (creating the directory if this is a brand-new leaf's first
-    /// access, exactly like `descend_creating`'s other callers) — never a
-    /// second, independently-resolved `std::fs` path lookup. The resulting,
-    /// already-open fd becomes the new mount's `root_fd` directly.
+    /// One-line delegation to [`DiskFilesystem::ensure_scoped_mount_dynamic`]
+    /// (defined in [`mount_registry`](self::mount_registry), a second
+    /// `impl DiskFilesystem` block in its own file). The actual logic lives
+    /// there because Rust allows an inherent `impl` to be split across
+    /// multiple blocks/files but not a single trait impl — this
+    /// `impl RootFilesystem for DiskFilesystem` block is one block, so every
+    /// one of its methods must be written here, even when (as here) the body
+    /// is a single call out to mount-registry logic that lives elsewhere.
     async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
-        if self.has_mount(virtual_root) {
-            return Ok(());
-        }
-        let virtual_root = virtual_root.clone();
-        let target = self.resolve_mount_target(&virtual_root)?;
-        let path = virtual_root.clone();
-        let anchor_fd = run_blocking(path.clone(), FilesystemOperation::MountLocal, move || {
-            descend_creating(target.root_fd.as_fd(), &target.components).map_err(|error| {
-                resolve_error_to_filesystem_error(&path, FilesystemOperation::MountLocal, error)
-            })
-        })
-        .await?;
-
-        let mut mounts = self
-            .mounts
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // Re-check under the write lock: two concurrent first-callers for
-        // the same scope must not both push a mount for the same
-        // `virtual_root` (that would leave two entries with the same
-        // longest-prefix key — harmless for correctness since both point at
-        // the same host directory, but wasteful and worth avoiding).
-        if mounts
-            .iter()
-            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
-        {
-            return Ok(());
-        }
-
-        // Bound the dynamic-mount population (`MAX_DYNAMIC_MOUNTS`) before
-        // adding one more: evict the least-recently-touched dynamic entry if
-        // we are at capacity. Still under the same write-lock guard as the
-        // push below, so no other caller can register a mount, race this
-        // eviction, or observe a moment where capacity is exceeded.
-        //
-        // Safety of eviction: dropping a `LocalMount` here only drops the
-        // registry's own `Arc<OwnedFd>` reference. A request already
-        // in-flight against this mount captured its own clone of that `Arc`
-        // in a `MountTarget` (`resolve_mount_target` does `Arc::clone`, not a
-        // move) before this eviction could ever run — the write lock held
-        // here cannot be held concurrently with `resolve_mount_target`'s read
-        // lock, but the in-flight request's *clone* was already taken and
-        // handed off to the blocking closure by an earlier, already-released
-        // read-lock critical section. So eviction only ever drops the
-        // registry's reference; the underlying open file description stays
-        // open until every clone — including any in-flight one — is dropped,
-        // per ordinary `Arc` semantics. No in-use fd is ever closed by this.
-        let dynamic_count = mounts.iter().filter(|mount| mount.dynamic).count();
-        if dynamic_count >= MAX_DYNAMIC_MOUNTS {
-            let evict_index = mounts
-                .iter()
-                .enumerate()
-                .filter(|(_, mount)| mount.dynamic)
-                .min_by_key(|(_, mount)| mount.last_used.load(Ordering::Relaxed))
-                .map(|(index, _)| index);
-            if let Some(evict_index) = evict_index {
-                mounts.remove(evict_index);
-            }
-        }
-
-        mounts.push(LocalMount {
-            virtual_root,
-            root_fd: Arc::new(anchor_fd),
-            leaf_scoped: false,
-            dynamic: true,
-            last_used: AtomicU64::new(next_touch()),
-        });
-        Ok(())
+        self.ensure_scoped_mount_dynamic(virtual_root).await
     }
 }
 
@@ -906,50 +550,6 @@ pub(super) fn io_error(
     }
 }
 
-fn io_reason(error: std::io::Error) -> String {
-    error.kind().to_string()
-}
-
-/// Canonicalizes `host_root` and opens it `O_DIRECTORY | O_NOFOLLOW`, the
-/// shared "turn a host path into a verified mount root fd" step both
-/// `mount_local_impl` (boot-time, static mounts) and `ensure_scoped_mount`
-/// (per-request, dynamic mounts) need. The returned canonical `PathBuf` is
-/// not retained by either caller — only the fd is; this crate never
-/// re-resolves a path string against anything after mount time (see the
-/// `fd_resolve` module doc).
-fn open_mount_root(
-    virtual_root: &VirtualPath,
-    host_root: &HostPath,
-) -> Result<(std::path::PathBuf, OwnedFd), FilesystemError> {
-    let canonical_root =
-        std::fs::canonicalize(host_root.as_path()).map_err(|error| FilesystemError::Backend {
-            path: virtual_root.clone(),
-            operation: FilesystemOperation::MountLocal,
-            reason: io_reason(error),
-        })?;
-
-    if !canonical_root.is_dir() {
-        return Err(FilesystemError::Backend {
-            path: virtual_root.clone(),
-            operation: FilesystemOperation::MountLocal,
-            reason: "host root is not a directory".to_string(),
-        });
-    }
-
-    let root_fd = rustix::fs::open(
-        &canonical_root,
-        OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
-        Mode::empty(),
-    )
-    .map_err(|errno| FilesystemError::Backend {
-        path: virtual_root.clone(),
-        operation: FilesystemOperation::MountLocal,
-        reason: io_reason(errno.into()),
-    })?;
-
-    Ok((canonical_root, root_fd))
-}
-
 fn stat_modified(secs: i64, nanos: impl TryInto<u32>) -> Option<std::time::SystemTime> {
     let nanos = nanos.try_into().unwrap_or(0);
     if secs >= 0 {
@@ -962,6 +562,7 @@ fn stat_modified(secs: i64, nanos: impl TryInto<u32>) -> Option<std::time::Syste
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_host_api::HostPath;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -1000,309 +601,5 @@ mod tests {
 
         assert!(matches!(error, FilesystemError::Backend { .. }));
         assert!(logs_contain("local filesystem backend error"));
-    }
-
-    /// A `mount_local_per_leaf` mount's containment boundary is the caller's
-    /// own leaf (`host_root/<first-tail-segment>`), derived from the tail —
-    /// there is no safe containment root for the bare mount path itself
-    /// (that would mean "every caller's leaf", the exact shared-parent
-    /// boundary `mount_local_per_leaf` exists to eliminate). Today every
-    /// legitimate grant against such a mount always resolves to a
-    /// leaf-prefixed target (`sandbox_user_workspace_mount_view` in
-    /// `ironclaw_reborn_composition`), but that is an invariant enforced one
-    /// layer up, not by this crate — so a bare-root request must fail closed
-    /// here rather than silently fall back to the full shared parent.
-    #[tokio::test]
-    async fn leaf_scoped_mount_rejects_bare_mount_root_request() {
-        let storage = tempdir().unwrap();
-        let mut root = DiskFilesystem::new();
-        root.mount_local_per_leaf(
-            VirtualPath::new("/tmp").unwrap(),
-            HostPath::from_path_buf(storage.path().to_path_buf()),
-        )
-        .unwrap();
-
-        let error = root
-            .read_file(&VirtualPath::new("/tmp").unwrap())
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(error, FilesystemError::PathOutsideMount { .. }),
-            "expected PathOutsideMount, got: {error:?}"
-        );
-    }
-
-    /// The actual escape `leaf_scoped` containment exists to close: two
-    /// callers share one `mount_local_per_leaf` `host_root`, each confined to
-    /// their own leaf (`leaf-a`, `leaf-b`). A symlink planted inside
-    /// `leaf-a` pointing at `../leaf-b/secret.txt` stays within the shared
-    /// `host_root` — a plain `mount_local` containment check (host_root
-    /// only) would let it resolve — but leaves `leaf-a`'s own containment
-    /// root, so it must be rejected here.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn leaf_scoped_mount_rejects_cross_leaf_symlink_escape() {
-        let storage = tempdir().unwrap();
-        let host_root = storage.path();
-
-        let leaf_a = host_root.join("leaf-a");
-        let leaf_b = host_root.join("leaf-b");
-        std::fs::create_dir_all(&leaf_a).unwrap();
-        std::fs::create_dir_all(&leaf_b).unwrap();
-        std::fs::write(leaf_b.join("secret.txt"), b"leaf-b secret").unwrap();
-        std::os::unix::fs::symlink("../leaf-b/secret.txt", leaf_a.join("escape.txt")).unwrap();
-
-        let mut root = DiskFilesystem::new();
-        root.mount_local_per_leaf(
-            VirtualPath::new("/tmp").unwrap(),
-            HostPath::from_path_buf(host_root.to_path_buf()),
-        )
-        .unwrap();
-
-        let error = root
-            .read_file(&VirtualPath::new("/tmp/leaf-a/escape.txt").unwrap())
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(error, FilesystemError::SymlinkEscape { .. }),
-            "expected SymlinkEscape, got: {error:?}"
-        );
-    }
-
-    /// First-use path for a brand-new leaf: nothing under `host_root` exists
-    /// yet for this caller, so the nearest *existing* ancestor of the target
-    /// is the shared `host_root` itself, not the (not-yet-created)
-    /// containment root `host_root/<leaf>`. Regression for the bug where
-    /// `ensure_existing_ancestor_contained` rejected that shared root as an
-    /// escape, permanently blocking every new leaf's first write.
-    #[tokio::test]
-    async fn leaf_scoped_mount_creates_a_brand_new_leaf_on_first_write() {
-        let storage = tempdir().unwrap();
-        let host_root = storage.path();
-
-        let mut root = DiskFilesystem::new();
-        root.mount_local_per_leaf(
-            VirtualPath::new("/tmp").unwrap(),
-            HostPath::from_path_buf(host_root.to_path_buf()),
-        )
-        .unwrap();
-
-        root.write_file(
-            &VirtualPath::new("/tmp/new-leaf/file.txt").unwrap(),
-            b"hello",
-        )
-        .await
-        .unwrap();
-
-        let bytes = root
-            .read_file(&VirtualPath::new("/tmp/new-leaf/file.txt").unwrap())
-            .await
-            .unwrap();
-        assert_eq!(bytes, b"hello");
-    }
-
-    /// Same first-use bootstrap, but through `create_dir_all` rather than
-    /// `write_file` — the two callers of `ensure_existing_ancestor_contained`
-    /// must both accept the shared `host_root` as a bootstrap ancestor.
-    #[tokio::test]
-    async fn leaf_scoped_mount_create_dir_all_bootstraps_a_brand_new_leaf() {
-        let storage = tempdir().unwrap();
-        let host_root = storage.path();
-
-        let mut root = DiskFilesystem::new();
-        root.mount_local_per_leaf(
-            VirtualPath::new("/tmp").unwrap(),
-            HostPath::from_path_buf(host_root.to_path_buf()),
-        )
-        .unwrap();
-
-        root.create_dir_all(&VirtualPath::new("/tmp/new-leaf/nested").unwrap())
-            .await
-            .unwrap();
-
-        assert!(host_root.join("new-leaf").join("nested").is_dir());
-    }
-
-    /// Bootstrapping a new leaf must not reopen the cross-leaf symlink
-    /// escape the write path closes: a *pre-existing* sibling leaf's
-    /// symlink must still be rejected by `resolve_for_write`
-    /// (`append_file`/`write_file`), not just by `read_file`.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn leaf_scoped_mount_rejects_cross_leaf_symlink_escape_on_write() {
-        let storage = tempdir().unwrap();
-        let host_root = storage.path();
-
-        let leaf_a = host_root.join("leaf-a");
-        let leaf_b = host_root.join("leaf-b");
-        std::fs::create_dir_all(&leaf_a).unwrap();
-        std::fs::create_dir_all(&leaf_b).unwrap();
-        std::os::unix::fs::symlink("../leaf-b", leaf_a.join("escape")).unwrap();
-
-        let mut root = DiskFilesystem::new();
-        root.mount_local_per_leaf(
-            VirtualPath::new("/tmp").unwrap(),
-            HostPath::from_path_buf(host_root.to_path_buf()),
-        )
-        .unwrap();
-
-        let error = root
-            .write_file(
-                &VirtualPath::new("/tmp/leaf-a/escape/planted.txt").unwrap(),
-                b"planted",
-            )
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(error, FilesystemError::SymlinkEscape { .. }),
-            "expected SymlinkEscape, got: {error:?}"
-        );
-        assert!(!leaf_b.join("planted.txt").exists());
-    }
-
-    /// A *dangling* final symlink — the entry exists but its target does
-    /// not — must still be rejected. Naively treating "target doesn't
-    /// resolve" as "brand new file in this leaf" would let `write_file`/
-    /// `append_file` open through the symlink (the OS creates the target on
-    /// `O_CREAT`), writing into whatever sibling leaf (or worse) the symlink
-    /// points at. `atomic_write_file`'s pre-install probe (`open_one` with
-    /// `O_NOFOLLOW`) is what catches this now: it never resolves the
-    /// dangling target at all, so "does the target exist" never comes up.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn leaf_scoped_mount_rejects_dangling_final_symlink_escape_on_write() {
-        let storage = tempdir().unwrap();
-        let host_root = storage.path();
-
-        let leaf_a = host_root.join("leaf-a");
-        let leaf_b = host_root.join("leaf-b");
-        std::fs::create_dir_all(&leaf_a).unwrap();
-        std::fs::create_dir_all(&leaf_b).unwrap();
-        std::os::unix::fs::symlink("../leaf-b/planted.txt", leaf_a.join("escape.txt")).unwrap();
-
-        let mut root = DiskFilesystem::new();
-        root.mount_local_per_leaf(
-            VirtualPath::new("/tmp").unwrap(),
-            HostPath::from_path_buf(host_root.to_path_buf()),
-        )
-        .unwrap();
-
-        let error = root
-            .write_file(
-                &VirtualPath::new("/tmp/leaf-a/escape.txt").unwrap(),
-                b"planted",
-            )
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(error, FilesystemError::SymlinkEscape { .. }),
-            "expected SymlinkEscape, got: {error:?}"
-        );
-        assert!(!leaf_b.join("planted.txt").exists());
-    }
-
-    fn dynamic_mount_count(root: &DiskFilesystem) -> usize {
-        root.mounts
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .iter()
-            .filter(|mount| mount.dynamic)
-            .count()
-    }
-
-    /// FIX 2 regression: registering more distinct scopes than
-    /// `MAX_DYNAMIC_MOUNTS` must evict rather than grow unbounded — proving
-    /// the fd-leak bound actually holds, not just that the constant exists.
-    /// Registers `MAX_DYNAMIC_MOUNTS + 5` distinct scoped mounts (each opens
-    /// its own directory fd) and asserts the live dynamic-mount population
-    /// never exceeds the cap.
-    #[tokio::test]
-    async fn ensure_scoped_mount_caps_dynamic_mount_population() {
-        let storage = tempdir().unwrap();
-        let mut root = DiskFilesystem::new();
-        root.mount_local(
-            VirtualPath::new("/projects").unwrap(),
-            HostPath::from_path_buf(storage.path().to_path_buf()),
-        )
-        .unwrap();
-
-        for i in 0..(MAX_DYNAMIC_MOUNTS + 5) {
-            let target = VirtualPath::new(format!("/projects/scope-{i}")).unwrap();
-            root.ensure_scoped_mount(&target)
-                .await
-                .unwrap_or_else(|error| panic!("ensure_scoped_mount({i}) failed: {error:?}"));
-            assert!(
-                dynamic_mount_count(&root) <= MAX_DYNAMIC_MOUNTS,
-                "dynamic mount population exceeded MAX_DYNAMIC_MOUNTS after registering scope {i}"
-            );
-        }
-
-        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
-    }
-
-    /// FIX 2 regression, second half: a scope evicted to make room for newer
-    /// ones must still resolve correctly once it is touched again — eviction
-    /// only drops the registry's own `Arc<OwnedFd>` clone (see
-    /// `ensure_scoped_mount`'s eviction comment), never an fd a concurrent or
-    /// later request is relying on, so re-registering the same virtual root
-    /// must transparently re-open it and behave exactly like the first time.
-    #[tokio::test]
-    async fn ensure_scoped_mount_evicted_scope_still_resolves_after_reregistration() {
-        let storage = tempdir().unwrap();
-        let mut root = DiskFilesystem::new();
-        root.mount_local(
-            VirtualPath::new("/projects").unwrap(),
-            HostPath::from_path_buf(storage.path().to_path_buf()),
-        )
-        .unwrap();
-
-        let first_scope = VirtualPath::new("/projects/scope-0").unwrap();
-        root.ensure_scoped_mount(&first_scope)
-            .await
-            .expect("register scope-0 first");
-        root.write_file(
-            &VirtualPath::new("/projects/scope-0/marker.txt").unwrap(),
-            b"first-registration",
-        )
-        .await
-        .expect("write through scope-0 before eviction");
-
-        // Push scope-0 out: fill past the cap with fresh scopes, none of
-        // which ever touch scope-0 again, so it is the oldest-by-recency
-        // entry and the eviction victim.
-        for i in 1..=MAX_DYNAMIC_MOUNTS {
-            let target = VirtualPath::new(format!("/projects/scope-{i}")).unwrap();
-            root.ensure_scoped_mount(&target)
-                .await
-                .unwrap_or_else(|error| panic!("ensure_scoped_mount({i}) failed: {error:?}"));
-        }
-        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
-
-        // scope-0's file is still on disk (eviction only drops the fd
-        // *cache* entry, never the underlying host directory or its
-        // contents) — reading it forces `ensure_scoped_mount` to
-        // re-register the mount from scratch.
-        let bytes = root
-            .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
-            .await
-            .expect("scope-0 must still resolve correctly after eviction and re-registration");
-        assert_eq!(bytes, b"first-registration");
-
-        root.write_file(
-            &VirtualPath::new("/projects/scope-0/marker.txt").unwrap(),
-            b"second-registration",
-        )
-        .await
-        .expect("write through re-registered scope-0");
-        let bytes = root
-            .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
-            .await
-            .unwrap();
-        assert_eq!(bytes, b"second-registration");
-        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
     }
 }

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -655,21 +655,50 @@ fn open_one(
     #[cfg(target_os = "linux")]
     {
         use rustix::fs::{ResolveFlags, openat2};
-        match openat2(
-            dir,
-            name,
-            oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC,
-            mode,
-            ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
-        ) {
-            Ok(fd) => return Ok(fd),
-            // Kernel predates openat2 (< 5.6), or a seccomp/container policy
-            // denies the syscall outright. Fall through to the portable
-            // per-component path below rather than failing closed on a
-            // syscall the fallback doesn't need.
-            Err(Errno::NOSYS) => {}
-            Err(Errno::LOOP) | Err(Errno::XDEV) => return Err(ResolveError::Escape),
-            Err(errno) => return Err(ResolveError::Io(errno.into())),
+
+        // `openat2(2)` documents `EAGAIN` for "a resolution restart was
+        // necessary, e.g. because of concurrent rename or unlink of a path
+        // component" — a *legitimate* concurrent mutation (an editor's
+        // atomic save, `git checkout`, a parallel build touching the same
+        // subtree), not an attack. Without a retry, a real, benign rename
+        // racing an unrelated open makes `openat2` spuriously fail and the
+        // caller sees an opaque `Backend` error for an operation that would
+        // have succeeded a moment later. Retry a small, fixed number of
+        // times — each retry is a fresh kernel-side resolution, not a busy
+        // spin on our own state, so the bound only needs to outlast one
+        // rename's duration, not any unbounded contention; the loop always
+        // terminates within `MAX_AGAIN_RETRIES + 1` attempts, never spins
+        // unbounded. What happens when the bound is exhausted is documented
+        // at the `Err(Errno::AGAIN) => break` arm below.
+        const MAX_AGAIN_RETRIES: u8 = 4;
+        let mut retries = 0;
+        loop {
+            match openat2(
+                dir,
+                name,
+                oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                mode,
+                ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
+            ) {
+                Ok(fd) => return Ok(fd),
+                // Kernel predates openat2 (< 5.6), or a seccomp/container
+                // policy denies the syscall outright. Fall through to the
+                // portable per-component path below rather than failing
+                // closed on a syscall the fallback doesn't need.
+                Err(Errno::NOSYS) => break,
+                Err(Errno::AGAIN) if retries < MAX_AGAIN_RETRIES => {
+                    retries += 1;
+                    continue;
+                }
+                // Retries exhausted (a pathological, sustained-rename case
+                // rather than one atomic swap): fall through to the
+                // portable per-component path below instead of surfacing an
+                // opaque `Backend` error, since that path does not share
+                // `openat2`'s whole-path-restart-on-`EAGAIN` failure mode.
+                Err(Errno::AGAIN) => break,
+                Err(Errno::LOOP) | Err(Errno::XDEV) => return Err(ResolveError::Escape),
+                Err(errno) => return Err(ResolveError::Io(errno.into())),
+            }
         }
     }
     match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -100,7 +100,7 @@ fn anchor_for_target(
     };
     let leaf_components = std::slice::from_ref(leaf);
     let anchor = if create_if_missing {
-        descend_creating(target.root_fd.as_fd(), leaf_components)?
+        descend_creating(target.root_fd.as_fd(), leaf_components)?.0
     } else {
         open_one(
             target.root_fd.as_fd(),
@@ -247,7 +247,7 @@ impl RootFilesystem for DiskFilesystem {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
             })?;
             let (parent_components, leaf) = split_leaf(&rest, &path)?;
-            let parent_fd =
+            let (parent_fd, parent_ancestors) =
                 descend_creating(anchor.as_fd(), &parent_components).map_err(|error| {
                     resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
                 })?;
@@ -255,13 +255,13 @@ impl RootFilesystem for DiskFilesystem {
             // transparently (unlike `write_file`'s rename-based atomic
             // install, a plain `open`-and-append writes straight through
             // one), so no separate `resolve_write_leaf` chase is needed here.
-            // Empty ancestors: `descend_creating` does not expose its own
-            // internal ancestor stack past `parent_fd` (see its doc comment)
-            // — a `..` in a symlink discovered at `leaf` fails closed rather
-            // than resolving past `parent_fd`'s own parent.
+            // `parent_ancestors` is `parent_fd`'s own ancestor stack
+            // (PR #6817 review follow-up — `descend_creating` now returns
+            // it): a `..` in a symlink discovered at `leaf` resolves past
+            // `parent_fd`'s own parent instead of failing closed.
             let fd = open_one(
                 anchor.as_fd(),
-                &[],
+                &parent_ancestors,
                 parent_fd.as_fd(),
                 &leaf,
                 OFlags::WRONLY | OFlags::APPEND | OFlags::CREATE,
@@ -444,7 +444,7 @@ impl RootFilesystem for DiskFilesystem {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::CreateDirAll, error)
             })?;
             descend_creating(anchor.as_fd(), &rest)
-                .map(|_fd| ())
+                .map(|(_fd, _ancestors)| ())
                 .map_err(|error| {
                     resolve_error_to_filesystem_error(
                         &path,
@@ -484,7 +484,7 @@ impl DiskFilesystem {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
             })?;
             let (parent_components, leaf) = split_leaf(&rest, &path)?;
-            let parent_fd =
+            let (parent_fd, parent_ancestors) =
                 descend_creating(anchor.as_fd(), &parent_components).map_err(|error| {
                     resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
                 })?;
@@ -492,19 +492,20 @@ impl DiskFilesystem {
             // follow a symlink at the destination name — resolve any
             // in-bounds symlink chain at `leaf` ourselves first so the
             // install lands at the symlink's ultimate target, not over the
-            // symlink entry itself. Empty ancestors: see the empty-slice
-            // note at `append_file`'s `open_one` call above — `parent_fd`'s
-            // own ancestor stack past itself is not exposed by
-            // `descend_creating`.
-            let (write_parent_fd, write_leaf) = resolve_write_leaf(
-                anchor.as_fd(),
-                &[],
-                parent_fd.as_fd(),
-                &leaf,
-            )
-            .map_err(|error| {
-                resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
-            })?;
+            // symlink entry itself. `parent_ancestors` is `parent_fd`'s own
+            // ancestor stack (PR #6817 review follow-up — `descend_creating`
+            // now returns it): a `..` in a symlink discovered at `leaf`
+            // resolves past `parent_fd`'s own parent instead of failing
+            // closed.
+            let (write_parent_fd, write_leaf) =
+                resolve_write_leaf(anchor.as_fd(), &parent_ancestors, parent_fd.as_fd(), &leaf)
+                    .map_err(|error| {
+                        resolve_error_to_filesystem_error(
+                            &path,
+                            FilesystemOperation::WriteFile,
+                            error,
+                        )
+                    })?;
             atomic_write_file(&path, write_parent_fd.as_fd(), &write_leaf, &bytes, cas)
         })
         .await
@@ -632,5 +633,87 @@ mod tests {
 
         assert!(matches!(error, FilesystemError::Backend { .. }));
         assert!(logs_contain("local filesystem backend error"));
+    }
+
+    fn make_fifo(path: &std::path::Path) {
+        let status = std::process::Command::new("mkfifo")
+            .arg(path)
+            .status()
+            .expect("mkfifo command must be available on this platform");
+        assert!(status.success(), "mkfifo failed for {path:?}");
+    }
+
+    /// PR #6817 review follow-up: `resolve_walk`'s leaf open used to be a
+    /// plain blocking `OFlags::RDONLY` open with no `O_NONBLOCK`. A FIFO with
+    /// no writer, planted under any writable mount, blocks the tokio
+    /// blocking-pool thread that opens it *indefinitely* — repeated, that
+    /// exhausts the pool and wedges the whole process. This pins that
+    /// `read_file` must not block on a no-writer FIFO: it must either error
+    /// promptly (the expected outcome — the FIFO fails the "must be a
+    /// regular file" check right after open) within a small, generous
+    /// timeout, never hang.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_file_on_fifo_with_no_writer_does_not_block_forever() {
+        let storage = tempdir().unwrap();
+        let fifo_path = storage.path().join("blocking.fifo");
+        make_fifo(&fifo_path);
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            root.read_file(&VirtualPath::new("/projects/blocking.fifo").unwrap()),
+        )
+        .await;
+
+        assert!(
+            outcome.is_ok(),
+            "read_file on a FIFO with no writer must not block the blocking-pool \
+             thread indefinitely (timed out — this is the FIFO-DoS regression)"
+        );
+        // The FIFO is rejected as "not a file" once opened non-blocking — the
+        // point being pinned here is that we *get an answer promptly*, not
+        // which particular error variant it is.
+        assert!(outcome.unwrap().is_err());
+    }
+
+    /// Same DoS shape as `read_file_on_fifo_with_no_writer_does_not_block_forever`,
+    /// but for the write path: `append_file`'s leaf `open_one` call
+    /// (`O_WRONLY | O_APPEND | O_CREATE`) is just as exposed — opening a FIFO
+    /// for write-only with no reader present blocks under the same missing
+    /// `O_NONBLOCK`. A fix that only covers the read side is not a fix.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn append_file_on_fifo_with_no_reader_does_not_block_forever() {
+        let storage = tempdir().unwrap();
+        let fifo_path = storage.path().join("blocking-write.fifo");
+        make_fifo(&fifo_path);
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            root.append_file(
+                &VirtualPath::new("/projects/blocking-write.fifo").unwrap(),
+                b"payload",
+            ),
+        )
+        .await;
+
+        assert!(
+            outcome.is_ok(),
+            "append_file on a FIFO with no reader must not block the blocking-pool \
+             thread indefinitely (timed out — this is the FIFO-DoS regression)"
+        );
+        assert!(outcome.unwrap().is_err());
     }
 }

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -11,9 +11,9 @@ use rustix::fd::{AsFd, OwnedFd};
 use rustix::fs::{AtFlags, Mode, OFlags};
 
 use self::fd_resolve::{
-    ResolveError, SymlinkBudget, atomic_write_file, descend_creating, map_file_type, new_file_mode,
-    open_one, read_all, remove_dir_all_fd, resolve_error_to_filesystem_error, resolve_walk,
-    resolve_write_leaf, write_all,
+    ResolveContext, ResolveError, SymlinkBudget, atomic_write_file, descend_creating,
+    map_file_type, new_file_mode, open_one, read_all, remove_dir_all_fd,
+    resolve_error_to_filesystem_error, resolve_walk, resolve_write_leaf, write_all,
 };
 use self::mount_registry::{LocalMount, MountTarget};
 use crate::{
@@ -109,6 +109,11 @@ fn anchor_for_target(
         let anchor_dev = rustix::fs::fstat(target.root_fd.as_fd())
             .map_err(|errno| ResolveError::Io(errno.into()))?
             .st_dev;
+        let budget = SymlinkBudget::new();
+        let ctx = ResolveContext {
+            budget: &budget,
+            anchor_dev,
+        };
         open_one(
             target.root_fd.as_fd(),
             &[],
@@ -116,8 +121,7 @@ fn anchor_for_target(
             leaf,
             OFlags::DIRECTORY,
             Mode::empty(),
-            &SymlinkBudget::new(),
-            anchor_dev,
+            &ctx,
         )?
     };
     Ok((anchor, rest.to_vec()))
@@ -278,6 +282,11 @@ impl RootFilesystem for DiskFilesystem {
                     resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
                 })?
                 .st_dev;
+            let budget = SymlinkBudget::new();
+            let ctx = ResolveContext {
+                budget: &budget,
+                anchor_dev,
+            };
             let fd = open_one(
                 anchor.as_fd(),
                 &parent_ancestors,
@@ -285,8 +294,7 @@ impl RootFilesystem for DiskFilesystem {
                 &leaf,
                 OFlags::WRONLY | OFlags::APPEND | OFlags::CREATE,
                 new_file_mode(),
-                &SymlinkBudget::new(),
-                anchor_dev,
+                &ctx,
             )
             .map_err(|error| {
                 resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -31,7 +31,7 @@ use crate::{
 /// (arch-simplification §4.4 Bucket 2).
 #[derive(Debug, Default)]
 pub struct DiskFilesystem {
-    mounts: Vec<LocalMount>,
+    mounts: std::sync::RwLock<Vec<LocalMount>>,
 }
 
 #[derive(Debug, Clone)]
@@ -128,47 +128,110 @@ impl DiskFilesystem {
         host_root: HostPath,
         leaf_scoped: bool,
     ) -> Result<(), FilesystemError> {
-        if self
+        // `&mut self`, so `get_mut` never actually contends a lock — this
+        // still goes through the same `RwLock<Vec<LocalMount>>` storage
+        // `ensure_scoped_mount` uses for its `&self` dynamic registration,
+        // rather than keeping two separate storage shapes in sync.
+        let mounts = self
             .mounts
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if mounts
             .iter()
             .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
         {
             return Err(FilesystemError::MountConflict { path: virtual_root });
         }
 
-        let canonical_root = std::fs::canonicalize(host_root.as_path()).map_err(|error| {
-            FilesystemError::Backend {
-                path: virtual_root.clone(),
-                operation: FilesystemOperation::MountLocal,
-                reason: io_reason(error),
-            }
-        })?;
+        let (canonical_root, root_fd) = open_mount_root(&virtual_root, &host_root)?;
+        let _ = canonical_root;
 
-        if !canonical_root.is_dir() {
-            return Err(FilesystemError::Backend {
-                path: virtual_root,
-                operation: FilesystemOperation::MountLocal,
-                reason: "host root is not a directory".to_string(),
-            });
-        }
-
-        let root_fd = rustix::fs::open(
-            &canonical_root,
-            OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
-            Mode::empty(),
-        )
-        .map_err(|errno| FilesystemError::Backend {
-            path: virtual_root.clone(),
-            operation: FilesystemOperation::MountLocal,
-            reason: io_reason(errno.into()),
-        })?;
-
-        self.mounts.push(LocalMount {
+        mounts.push(LocalMount {
             virtual_root,
             root_fd: Arc::new(root_fd),
             leaf_scoped,
         });
         Ok(())
+    }
+
+    /// Dynamically registers a mount rooted exactly *at* `virtual_root`, if
+    /// one is not already registered there — idempotent, so a repeated call
+    /// for the same `virtual_root` (the usual shape: called on every request
+    /// for a given scope) is a cheap no-op after the first. Unlike
+    /// [`mount_local`](Self::mount_local) (boot-time only, exclusive
+    /// `&mut self`), this takes `&self` so it can be called per request from
+    /// behind a shared `Arc<DiskFilesystem>`.
+    ///
+    /// This is the mechanism that closes a same-storage-root cross-tenant/
+    /// cross-user symlink escape for a mount whose containment root is wider
+    /// than the subtree a specific caller is actually granted (e.g. `/projects`
+    /// mounted once over the whole local-dev storage root, while a caller's
+    /// `/skills` grant only authorizes `/projects/tenants/<t>/users/<u>/skills`).
+    /// The composition layer already knows that exact boundary — it is the
+    /// `MountGrant::target` a scope-aware `MountView` builder computes from
+    /// typed `ResourceScope` fields, not something this crate derives by
+    /// counting path segments. Registering a *second*, narrower mount at that
+    /// literal target makes [`resolve_mount_target`]'s existing
+    /// longest-prefix-wins matching pick it over the wide mount for anything
+    /// under it, so `RESOLVE_BENEATH` (or the portable fallback) enforces
+    /// containment against the caller's own subtree — exactly that subtree,
+    /// no more — rather than the shared parent every caller's subtree lives
+    /// under.
+    ///
+    /// No host path is taken as input: `virtual_root` is resolved through the
+    /// *existing* (necessarily wider) mount that already covers it, via the
+    /// same fd-rooted [`descend_creating`] every other write path in this
+    /// crate uses (creating the directory if this is a brand-new leaf's first
+    /// access, exactly like `descend_creating`'s other callers) — never a
+    /// second, independently-resolved `std::fs` path lookup. The resulting,
+    /// already-open fd becomes the new mount's `root_fd` directly.
+    pub async fn ensure_scoped_mount(
+        &self,
+        virtual_root: VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        if self.has_mount(&virtual_root) {
+            return Ok(());
+        }
+        let target = self.resolve_mount_target(&virtual_root)?;
+        let path = virtual_root.clone();
+        let anchor_fd = run_blocking(path.clone(), FilesystemOperation::MountLocal, move || {
+            descend_creating(target.root_fd.as_fd(), &target.components).map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::MountLocal, error)
+            })
+        })
+        .await?;
+
+        let mut mounts = self
+            .mounts
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Re-check under the write lock: two concurrent first-callers for
+        // the same scope must not both push a mount for the same
+        // `virtual_root` (that would leave two entries with the same
+        // longest-prefix key — harmless for correctness since both point at
+        // the same host directory, but wasteful and worth avoiding).
+        if mounts
+            .iter()
+            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
+        {
+            return Ok(());
+        }
+        mounts.push(LocalMount {
+            virtual_root,
+            root_fd: Arc::new(anchor_fd),
+            leaf_scoped: false,
+        });
+        Ok(())
+    }
+
+    fn has_mount(&self, virtual_root: &VirtualPath) -> bool {
+        let mounts = self
+            .mounts
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        mounts
+            .iter()
+            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
     }
 
     /// Routes `path` to its mount and splits the tail into path components
@@ -178,8 +241,11 @@ impl DiskFilesystem {
     /// containment enforcement now happens fd-relatively in [`open_one`] as
     /// each returned component is walked.
     fn resolve_mount_target(&self, path: &VirtualPath) -> Result<MountTarget, FilesystemError> {
-        let mount = self
+        let mounts = self
             .mounts
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mount = mounts
             .iter()
             .filter(|mount| path_prefix_matches(mount.virtual_root.as_str(), path.as_str()))
             .max_by_key(|mount| mount.virtual_root.as_str().len())
@@ -735,6 +801,46 @@ pub(super) fn io_error(
 
 fn io_reason(error: std::io::Error) -> String {
     error.kind().to_string()
+}
+
+/// Canonicalizes `host_root` and opens it `O_DIRECTORY | O_NOFOLLOW`, the
+/// shared "turn a host path into a verified mount root fd" step both
+/// `mount_local_impl` (boot-time, static mounts) and `ensure_scoped_mount`
+/// (per-request, dynamic mounts) need. The returned canonical `PathBuf` is
+/// not retained by either caller — only the fd is; this crate never
+/// re-resolves a path string against anything after mount time (see the
+/// `fd_resolve` module doc).
+fn open_mount_root(
+    virtual_root: &VirtualPath,
+    host_root: &HostPath,
+) -> Result<(std::path::PathBuf, OwnedFd), FilesystemError> {
+    let canonical_root =
+        std::fs::canonicalize(host_root.as_path()).map_err(|error| FilesystemError::Backend {
+            path: virtual_root.clone(),
+            operation: FilesystemOperation::MountLocal,
+            reason: io_reason(error),
+        })?;
+
+    if !canonical_root.is_dir() {
+        return Err(FilesystemError::Backend {
+            path: virtual_root.clone(),
+            operation: FilesystemOperation::MountLocal,
+            reason: "host root is not a directory".to_string(),
+        });
+    }
+
+    let root_fd = rustix::fs::open(
+        &canonical_root,
+        OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|errno| FilesystemError::Backend {
+        path: virtual_root.clone(),
+        operation: FilesystemOperation::MountLocal,
+        reason: io_reason(errno.into()),
+    })?;
+
+    Ok((canonical_root, root_fd))
 }
 
 fn stat_modified(secs: i64, nanos: impl TryInto<u32>) -> Option<std::time::SystemTime> {

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -1,23 +1,25 @@
+mod fd_resolve;
+
 use std::{
     ffi::{OsStr, OsString},
     os::unix::ffi::OsStrExt,
     sync::Arc,
-    sync::atomic::{AtomicU64, Ordering},
 };
 
 use async_trait::async_trait;
 use ironclaw_host_api::{HostPath, VirtualPath};
 use ironclaw_safety::sensitive_paths::is_sensitive_path_str;
-use rustix::fd::{AsFd, BorrowedFd, OwnedFd};
+use rustix::fd::{AsFd, OwnedFd};
 use rustix::fs::{AtFlags, Mode, OFlags};
-use rustix::io::Errno;
 
-use crate::{
-    CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError, FilesystemOperation,
-    RecordVersion, RootFilesystem, VersionedEntry, path_prefix_matches,
+use self::fd_resolve::{
+    atomic_write_file, descend_creating, map_file_type, new_file_mode, open_one, read_all,
+    remove_dir_all_fd, resolve_error_to_filesystem_error, resolve_walk, write_all,
 };
-
-static LOCAL_WRITE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+use crate::{
+    CasExpectation, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, RecordVersion,
+    RootFilesystem, VersionedEntry, path_prefix_matches,
+};
 
 /// The on-disk `RootFilesystem` backend, mounted into the virtual namespace.
 ///
@@ -595,449 +597,11 @@ where
     }
 }
 
-// ---------------------------------------------------------------------
-// fd-rooted, symlink-free traversal primitives
-// ---------------------------------------------------------------------
-//
-// Every function below operates purely on file descriptors and path
-// *components* (never a joined host path string). `open_one` is the one
-// place a directory-entry lookup happens, and it refuses to follow a
-// symlink anywhere in the walk. Because resolution never hands back a path
-// for a later, independent syscall to re-open, there is no window between
-// "checked" and "acted on" for an attacker to swap the entry in.
-
-/// The outcome of a failed fd-relative resolution step: either a genuine I/O
-/// error (propagated as-is), or a symlink/`..`-past-root escape attempt.
-enum ResolveError {
-    Escape,
-    Io(std::io::Error),
-}
-
-fn resolve_error_to_filesystem_error(
-    path: &VirtualPath,
-    operation: FilesystemOperation,
-    error: ResolveError,
-) -> FilesystemError {
-    match error {
-        ResolveError::Escape => FilesystemError::SymlinkEscape { path: path.clone() },
-        ResolveError::Io(io_err) => io_error(path.clone(), operation, io_err),
-    }
-}
-
-/// Opens exactly one path component beneath `dir`, refusing to follow a
-/// symlink at that component.
-///
-/// On Linux, this is one syscall via `openat2(RESOLVE_BENEATH |
-/// RESOLVE_NO_SYMLINKS)` when the kernel supports it (falling back below on
-/// `ENOSYS` — an older kernel, or a container/seccomp profile that denies
-/// `openat2` outright). Everywhere else, including macOS (which has no
-/// `openat2` at all), a plain `openat` with `O_NOFOLLOW`.
-///
-/// **macOS asymmetry, documented rather than silent:** both paths reject the
-/// same attack class — a symlink at any resolved path component, ancestor or
-/// leaf — because `O_NOFOLLOW` and `RESOLVE_NO_SYMLINKS` both refuse to
-/// traverse a symlink; the security property (no symlink traversal escapes
-/// the mount root) holds identically on both platforms. What macOS's
-/// fallback does *not* get is `RESOLVE_BENEATH`'s single-syscall,
-/// kernel-enforced resolution step: each `open_one` call is independently
-/// safe (it either opens the real, non-symlink entry or fails), but the
-/// *sequence* of `open_one` calls that make up a full path walk on macOS is
-/// coordinated by this module's own loop (`walk`/`resolve_walk`/
-/// `descend_creating`), not by one kernel-verified decision the way
-/// `RESOLVE_BENEATH` verifies a whole relative path in a single syscall on
-/// Linux. Both close the same escape; only the mechanism differs.
-fn open_one(
-    dir: BorrowedFd<'_>,
-    name: &OsStr,
-    oflags: OFlags,
-    mode: Mode,
-) -> Result<OwnedFd, ResolveError> {
-    #[cfg(target_os = "linux")]
-    {
-        use rustix::fs::{ResolveFlags, openat2};
-
-        // `openat2(2)` documents `EAGAIN` for "a resolution restart was
-        // necessary, e.g. because of concurrent rename or unlink of a path
-        // component" — a *legitimate* concurrent mutation (an editor's
-        // atomic save, `git checkout`, a parallel build touching the same
-        // subtree), not an attack. Without a retry, a real, benign rename
-        // racing an unrelated open makes `openat2` spuriously fail and the
-        // caller sees an opaque `Backend` error for an operation that would
-        // have succeeded a moment later. Retry a small, fixed number of
-        // times — each retry is a fresh kernel-side resolution, not a busy
-        // spin on our own state, so the bound only needs to outlast one
-        // rename's duration, not any unbounded contention; the loop always
-        // terminates within `MAX_AGAIN_RETRIES + 1` attempts, never spins
-        // unbounded. What happens when the bound is exhausted is documented
-        // at the `Err(Errno::AGAIN) => break` arm below.
-        const MAX_AGAIN_RETRIES: u8 = 4;
-        let mut retries = 0;
-        loop {
-            match openat2(
-                dir,
-                name,
-                oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC,
-                mode,
-                ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
-            ) {
-                Ok(fd) => return Ok(fd),
-                // Kernel predates openat2 (< 5.6), or a seccomp/container
-                // policy denies the syscall outright. Fall through to the
-                // portable per-component path below rather than failing
-                // closed on a syscall the fallback doesn't need.
-                Err(Errno::NOSYS) => break,
-                Err(Errno::AGAIN) if retries < MAX_AGAIN_RETRIES => {
-                    retries += 1;
-                    continue;
-                }
-                // Retries exhausted (a pathological, sustained-rename case
-                // rather than one atomic swap): fall through to the
-                // portable per-component path below instead of surfacing an
-                // opaque `Backend` error, since that path does not share
-                // `openat2`'s whole-path-restart-on-`EAGAIN` failure mode.
-                Err(Errno::AGAIN) => break,
-                Err(Errno::LOOP) | Err(Errno::XDEV) => return Err(ResolveError::Escape),
-                Err(errno) => return Err(ResolveError::Io(errno.into())),
-            }
-        }
-    }
-    match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {
-        Ok(fd) => Ok(fd),
-        Err(Errno::LOOP) => Err(ResolveError::Escape),
-        // Some platforms (observed on macOS) report `ENOTDIR` rather than
-        // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
-        // kernel checks "is this a directory" before "did NOFOLLOW block
-        // it", and a symlink is never a directory itself. `ENOTDIR` is
-        // ambiguous on its own (a plain non-directory file blocking descent
-        // hits it too), so disambiguate with one `AT_SYMLINK_NOFOLLOW`
-        // `fstatat` rather than guessing either way.
-        Err(Errno::NOTDIR) if oflags.contains(OFlags::DIRECTORY) => {
-            match rustix::fs::statat(dir, name, AtFlags::SYMLINK_NOFOLLOW) {
-                Ok(stat)
-                    if rustix::fs::FileType::from_raw_mode(stat.st_mode)
-                        == rustix::fs::FileType::Symlink =>
-                {
-                    Err(ResolveError::Escape)
-                }
-                _ => Err(ResolveError::Io(Errno::NOTDIR.into())),
-            }
-        }
-        Err(errno) => Err(ResolveError::Io(errno.into())),
-    }
-}
-
-fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
-    rustix::io::dup(fd).map_err(|errno| ResolveError::Io(errno.into()))
-}
-
-/// Walks `components` from `root`, refusing every symlink along the way, and
-/// returns the final entry's fd plus — when `components` is non-empty — the
-/// fd of its immediate parent directory and its own name (needed by callers
-/// that must act on the parent, e.g. `unlinkat`/`renameat`, rather than on
-/// the entry itself, which POSIX has no "act on this fd regardless of its
-/// name" primitive for).
-///
-/// `components` empty resolves to the mount root itself (`root` duplicated),
-/// with no parent — the mount root has no fd-relative parent inside this
-/// mount's sandbox, by design (see [`DiskFilesystem::delete`]).
-fn resolve_walk(
-    root: BorrowedFd<'_>,
-    components: &[OsString],
-    final_oflags: OFlags,
-) -> Result<(OwnedFd, Option<(OwnedFd, OsString)>), ResolveError> {
-    let Some((leaf, ancestors)) = components.split_last() else {
-        return Ok((dup_fd(root)?, None));
-    };
-    let mut cur = dup_fd(root)?;
-    for component in ancestors {
-        cur = open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?;
-    }
-    let fd = open_one(cur.as_fd(), leaf, final_oflags, Mode::empty())?;
-    Ok((fd, Some((cur, leaf.clone()))))
-}
-
-/// Walks `components` from `root`, creating any missing directory along the
-/// way (`mkdir -p` semantics), and returns the final directory's fd. Used
-/// by `write_file`/`append_file` (parent-only — matching the previous
-/// implementation's "always create the parent chain" behavior) and by
-/// `create_dir_all` (full path, leaf included).
-///
-/// Each level is still resolved through [`open_one`], so a symlink swapped
-/// into any not-yet-existing ancestor between one level's `mkdirat` and the
-/// next level's `open_one` is rejected exactly like any other symlink in the
-/// walk — there is no separate "check ancestor, then mkdir, then check
-/// again" gap here, because creation and the next level's containment check
-/// are the same `open_one` call the next loop iteration makes.
-fn descend_creating(
-    root: BorrowedFd<'_>,
-    components: &[OsString],
-) -> Result<OwnedFd, ResolveError> {
-    let mut cur = dup_fd(root)?;
-    for component in components {
-        cur = match open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty()) {
-            Ok(fd) => fd,
-            Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {
-                match rustix::fs::mkdirat(cur.as_fd(), component.as_os_str(), new_dir_mode()) {
-                    Ok(()) => {}
-                    Err(Errno::EXIST) => {}
-                    Err(errno) => return Err(ResolveError::Io(errno.into())),
-                }
-                open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?
-            }
-            Err(other) => return Err(other),
-        };
-    }
-    Ok(cur)
-}
-
-/// Maximum nesting depth [`remove_dir_all_fd`] will descend into before
-/// failing closed, rather than recursing without limit.
-///
-/// This is genuinely recursive Rust code running on a tokio blocking-pool
-/// thread — not a regression (`std::fs::remove_dir_all` is also recursive
-/// and has no cap of its own), but a deep tree can now be created entirely
-/// inside a sandboxed shell's own writable mount, i.e. by someone who will
-/// deliberately try to break it. 512 levels comfortably survives on a
-/// default thread stack (each frame here is a handful of small locals, no
-/// large stack arrays) while still failing far short of any real stack
-/// limit if a caller does manage to create a tree this deep. `remove_dir_contents`
-/// only `unlinkat`s a symlink entry directly (`AtFlags::empty()`, never
-/// following it) and never recurses through one, so cycles via symlinks are
-/// not a concern here — depth is bounded purely by real, non-symlink
-/// directory nesting.
-const MAX_REMOVE_DIR_DEPTH: usize = 512;
-
-/// Recursively removes `name` (found directly under `parent`) and everything
-/// beneath it, never following a symlink into whatever it points at — a
-/// symlinked child is unlinked as itself, exactly like `std::fs::remove_dir_all`,
-/// never traversed into.
-fn remove_dir_all_fd(parent: BorrowedFd<'_>, name: &OsStr) -> Result<(), std::io::Error> {
-    remove_dir_all_fd_bounded(parent, name, 0)
-}
-
-fn remove_dir_all_fd_bounded(
-    parent: BorrowedFd<'_>,
-    name: &OsStr,
-    depth: usize,
-) -> Result<(), std::io::Error> {
-    if depth >= MAX_REMOVE_DIR_DEPTH {
-        return Err(std::io::Error::other(format!(
-            "directory tree exceeds maximum removal depth of {MAX_REMOVE_DIR_DEPTH} levels; refusing to delete"
-        )));
-    }
-    let dir_fd =
-        open_one(parent, name, OFlags::DIRECTORY, Mode::empty()).map_err(resolve_error_to_io)?;
-    remove_dir_contents(dir_fd.as_fd(), depth + 1)?;
-    rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(std::io::Error::from)
-}
-
-fn remove_dir_contents(dir: BorrowedFd<'_>, depth: usize) -> Result<(), std::io::Error> {
-    let mut entries = Vec::new();
-    {
-        let listing = rustix::fs::Dir::read_from(dir)?;
-        for entry in listing {
-            let entry = entry?;
-            let name_bytes = entry.file_name().to_bytes();
-            if name_bytes == b"." || name_bytes == b".." {
-                continue;
-            }
-            let name = OsStr::from_bytes(name_bytes).to_os_string();
-            let stat = rustix::fs::statat(dir, &name, AtFlags::SYMLINK_NOFOLLOW)?;
-            let is_dir = rustix::fs::FileType::from_raw_mode(stat.st_mode)
-                == rustix::fs::FileType::Directory;
-            entries.push((name, is_dir));
-        }
-    }
-    for (name, is_dir) in entries {
-        if is_dir {
-            remove_dir_all_fd_bounded(dir, &name, depth)?;
-        } else {
-            rustix::fs::unlinkat(dir, &name, AtFlags::empty())?;
-        }
-    }
-    Ok(())
-}
-
-fn resolve_error_to_io(error: ResolveError) -> std::io::Error {
-    match error {
-        ResolveError::Escape => std::io::Error::other("symlink escape"),
-        ResolveError::Io(io_err) => io_err,
-    }
-}
-
-fn read_all(fd: OwnedFd) -> Result<Vec<u8>, std::io::Error> {
-    use std::io::Read;
-    let mut file = std::fs::File::from(fd);
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)?;
-    Ok(bytes)
-}
-
-fn write_all(fd: OwnedFd, bytes: &[u8]) -> Result<(), std::io::Error> {
-    use std::io::Write;
-    let mut file = std::fs::File::from(fd);
-    file.write_all(bytes)?;
-    file.flush()
-}
-
-fn new_file_mode() -> Mode {
-    Mode::RUSR | Mode::WUSR | Mode::RGRP | Mode::WGRP | Mode::ROTH | Mode::WOTH
-}
-
-fn new_dir_mode() -> Mode {
-    Mode::RWXU | Mode::RWXG | Mode::RWXO
-}
-
-fn map_file_type(kind: rustix::fs::FileType) -> FileType {
-    match kind {
-        rustix::fs::FileType::RegularFile => FileType::File,
-        rustix::fs::FileType::Directory => FileType::Directory,
-        rustix::fs::FileType::Symlink => FileType::Symlink,
-        _ => FileType::Other,
-    }
-}
-
-fn stat_modified(secs: i64, nanos: impl TryInto<u32>) -> Option<std::time::SystemTime> {
-    let nanos = nanos.try_into().unwrap_or(0);
-    if secs >= 0 {
-        std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::new(secs as u64, nanos))
-    } else {
-        std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::new((-secs) as u64, 0))
-    }
-}
-
-/// Atomically installs `bytes` as `leaf` under `parent`, via a temp file
-/// created in the same directory and then renamed (`CasExpectation::Any`) or
-/// hard-linked into place (`CasExpectation::Absent`) — unchanged in
-/// approach from before this fix, just fd-relative (`renameat`/`linkat`
-/// against `parent`, an already fd-resolved, already-verified directory)
-/// instead of path-relative. `rename`/`link` never follow a symlink at the
-/// destination name (they replace/create the directory entry itself), so
-/// this step was never part of the TOCTOU surface `resolve_for_write` left
-/// open; only `append_file`'s direct `open` of the leaf was.
-fn atomic_write_file(
-    virtual_path: &VirtualPath,
-    parent: BorrowedFd<'_>,
-    leaf: &OsStr,
-    bytes: &[u8],
-    cas: CasExpectation,
-) -> Result<(), FilesystemError> {
-    // `rename`/`link` never follow a symlink at the destination name (see
-    // the function doc), so the install step below can never be tricked
-    // into writing through one — but silently *replacing* a symlink entry
-    // that's still sitting at the leaf (dangling or not) is a real content
-    // loss surprise for whatever legitimately created it, and this crate's
-    // steady-state contract is "reject a pre-existing symlink at a write
-    // target", not "clobber it". Probe with the same `O_NOFOLLOW` primitive
-    // every other lookup in this module uses, immediately before the
-    // install below — both run inside the same non-yielding blocking
-    // closure, so there is no `.await` for a swap to land between the probe
-    // and the install.
-    match open_one(parent, leaf, OFlags::RDONLY, Mode::empty()) {
-        Ok(_existing) => {}
-        Err(ResolveError::Escape) => {
-            return Err(FilesystemError::SymlinkEscape {
-                path: virtual_path.clone(),
-            });
-        }
-        Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(ResolveError::Io(io_err)) => {
-            return Err(io_error(
-                virtual_path.clone(),
-                FilesystemOperation::WriteFile,
-                io_err,
-            ));
-        }
-    }
-
-    let counter = LOCAL_WRITE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let mut temp_name = OsString::from(".");
-    temp_name.push(leaf);
-    temp_name.push(format!(".tmp.{counter}"));
-
-    let temp_fd = open_one(
-        parent,
-        &temp_name,
-        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL,
-        new_file_mode(),
-    )
-    .map_err(|error| {
-        resolve_error_to_filesystem_error(virtual_path, FilesystemOperation::WriteFile, error)
-    })?;
-
-    let write_result = (|| -> std::io::Result<()> {
-        use std::io::Write;
-        let mut file = std::fs::File::from(temp_fd);
-        file.write_all(bytes)?;
-        file.sync_all()
-    })();
-    if let Err(error) = write_result {
-        let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
-        return Err(io_error(
-            virtual_path.clone(),
-            FilesystemOperation::WriteFile,
-            error,
-        ));
-    }
-
-    let install_result = match cas {
-        CasExpectation::Any => {
-            rustix::fs::renameat(parent, &temp_name, parent, leaf).map_err(|errno| {
-                io_error(
-                    virtual_path.clone(),
-                    FilesystemOperation::WriteFile,
-                    errno.into(),
-                )
-            })
-        }
-        CasExpectation::Absent => {
-            match rustix::fs::linkat(parent, &temp_name, parent, leaf, AtFlags::empty()) {
-                Ok(()) => {
-                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
-                    Ok(())
-                }
-                Err(Errno::EXIST) => {
-                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
-                    Err(FilesystemError::VersionMismatch {
-                        path: virtual_path.clone(),
-                        expected: None,
-                        found: Some(RecordVersion::from_backend(0)),
-                    })
-                }
-                Err(errno) => {
-                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
-                    Err(io_error(
-                        virtual_path.clone(),
-                        FilesystemOperation::WriteFile,
-                        errno.into(),
-                    ))
-                }
-            }
-        }
-        CasExpectation::Version(_) => Err(FilesystemError::Unsupported {
-            path: virtual_path.clone(),
-            operation: FilesystemOperation::WriteFile,
-        }),
-    };
-
-    install_result?;
-
-    // Best-effort durability: fsync the parent directory so the rename/link
-    // above survives a crash. Not part of the containment/TOCTOU surface —
-    // failure here is reported but the write itself already succeeded.
-    let parent_file = std::fs::File::from(
-        dup_fd(parent)
-            .map_err(resolve_error_to_io)
-            .map_err(|error| {
-                io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)
-            })?,
-    );
-    parent_file
-        .sync_all()
-        .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))
-}
-
-fn io_error(
+/// `pub(super)`: also called from the [`fd_resolve`] submodule, which has no
+/// dependency on `DiskFilesystem` itself but does need this shared
+/// `io::Error -> FilesystemError` mapping (the majority of call sites are
+/// still here, in the `RootFilesystem` impl above).
+pub(super) fn io_error(
     path: VirtualPath,
     operation: FilesystemOperation,
     error: std::io::Error,
@@ -1061,6 +625,15 @@ fn io_error(
 
 fn io_reason(error: std::io::Error) -> String {
     error.kind().to_string()
+}
+
+fn stat_modified(secs: i64, nanos: impl TryInto<u32>) -> Option<std::time::SystemTime> {
+    let nanos = nanos.try_into().unwrap_or(0);
+    if secs >= 0 {
+        std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::new(secs as u64, nanos))
+    } else {
+        std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::new((-secs) as u64, 0))
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -38,6 +38,17 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct DiskFilesystem {
     mounts: std::sync::RwLock<Vec<LocalMount>>,
+    /// Every virtual root ever passed to
+    /// [`ensure_scoped_mount_dynamic`](DiskFilesystem::ensure_scoped_mount_dynamic),
+    /// retained permanently (never evicted, unlike `mounts`). Backs the
+    /// PR #6817 cross-tenant fix in `mount_registry`'s `resolve_mount_target`:
+    /// once a virtual root has ever been narrowed, every future resolution
+    /// under it must find a live matching dynamic mount or fail closed,
+    /// rather than silently matching a wider ancestor mount whose
+    /// containment boundary the narrowing was meant to replace. Only
+    /// strings, not fds, so it does not reopen the `RLIMIT_NOFILE` leak
+    /// `MAX_DYNAMIC_MOUNTS` exists to bound.
+    narrow_scoped_roots: std::sync::RwLock<std::collections::HashSet<String>>,
 }
 
 impl DiskFilesystem {
@@ -87,6 +98,7 @@ fn anchor_for_target(
     } else {
         open_one(
             target.root_fd.as_fd(),
+            &[],
             target.root_fd.as_fd(),
             leaf,
             OFlags::DIRECTORY,
@@ -237,8 +249,13 @@ impl RootFilesystem for DiskFilesystem {
             // transparently (unlike `write_file`'s rename-based atomic
             // install, a plain `open`-and-append writes straight through
             // one), so no separate `resolve_write_leaf` chase is needed here.
+            // Empty ancestors: `descend_creating` does not expose its own
+            // internal ancestor stack past `parent_fd` (see its doc comment)
+            // — a `..` in a symlink discovered at `leaf` fails closed rather
+            // than resolving past `parent_fd`'s own parent.
             let fd = open_one(
                 anchor.as_fd(),
+                &[],
                 parent_fd.as_fd(),
                 &leaf,
                 OFlags::WRONLY | OFlags::APPEND | OFlags::CREATE,
@@ -469,11 +486,19 @@ impl DiskFilesystem {
             // follow a symlink at the destination name — resolve any
             // in-bounds symlink chain at `leaf` ourselves first so the
             // install lands at the symlink's ultimate target, not over the
-            // symlink entry itself.
-            let (write_parent_fd, write_leaf) =
-                resolve_write_leaf(anchor.as_fd(), parent_fd.as_fd(), &leaf).map_err(|error| {
-                    resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
-                })?;
+            // symlink entry itself. Empty ancestors: see the empty-slice
+            // note at `append_file`'s `open_one` call above — `parent_fd`'s
+            // own ancestor stack past itself is not exposed by
+            // `descend_creating`.
+            let (write_parent_fd, write_leaf) = resolve_write_leaf(
+                anchor.as_fd(),
+                &[],
+                parent_fd.as_fd(),
+                &leaf,
+            )
+            .map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
+            })?;
             atomic_write_file(&path, write_parent_fd.as_fd(), &write_leaf, &bytes, cas)
         })
         .await

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -790,18 +790,48 @@ fn descend_creating(
     Ok(cur)
 }
 
+/// Maximum nesting depth [`remove_dir_all_fd`] will descend into before
+/// failing closed, rather than recursing without limit.
+///
+/// This is genuinely recursive Rust code running on a tokio blocking-pool
+/// thread — not a regression (`std::fs::remove_dir_all` is also recursive
+/// and has no cap of its own), but a deep tree can now be created entirely
+/// inside a sandboxed shell's own writable mount, i.e. by someone who will
+/// deliberately try to break it. 512 levels comfortably survives on a
+/// default thread stack (each frame here is a handful of small locals, no
+/// large stack arrays) while still failing far short of any real stack
+/// limit if a caller does manage to create a tree this deep. `remove_dir_contents`
+/// only `unlinkat`s a symlink entry directly (`AtFlags::empty()`, never
+/// following it) and never recurses through one, so cycles via symlinks are
+/// not a concern here — depth is bounded purely by real, non-symlink
+/// directory nesting.
+const MAX_REMOVE_DIR_DEPTH: usize = 512;
+
 /// Recursively removes `name` (found directly under `parent`) and everything
 /// beneath it, never following a symlink into whatever it points at — a
 /// symlinked child is unlinked as itself, exactly like `std::fs::remove_dir_all`,
 /// never traversed into.
 fn remove_dir_all_fd(parent: BorrowedFd<'_>, name: &OsStr) -> Result<(), std::io::Error> {
+    remove_dir_all_fd_bounded(parent, name, 0)
+}
+
+fn remove_dir_all_fd_bounded(
+    parent: BorrowedFd<'_>,
+    name: &OsStr,
+    depth: usize,
+) -> Result<(), std::io::Error> {
+    if depth >= MAX_REMOVE_DIR_DEPTH {
+        return Err(std::io::Error::other(format!(
+            "directory tree exceeds maximum removal depth of {MAX_REMOVE_DIR_DEPTH} levels; refusing to delete"
+        )));
+    }
     let dir_fd =
         open_one(parent, name, OFlags::DIRECTORY, Mode::empty()).map_err(resolve_error_to_io)?;
-    remove_dir_contents(dir_fd.as_fd())?;
+    remove_dir_contents(dir_fd.as_fd(), depth + 1)?;
     rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(std::io::Error::from)
 }
 
-fn remove_dir_contents(dir: BorrowedFd<'_>) -> Result<(), std::io::Error> {
+fn remove_dir_contents(dir: BorrowedFd<'_>, depth: usize) -> Result<(), std::io::Error> {
     let mut entries = Vec::new();
     {
         let listing = rustix::fs::Dir::read_from(dir)?;
@@ -820,7 +850,7 @@ fn remove_dir_contents(dir: BorrowedFd<'_>) -> Result<(), std::io::Error> {
     }
     for (name, is_dir) in entries {
         if is_dir {
-            remove_dir_all_fd(dir, &name)?;
+            remove_dir_all_fd_bounded(dir, &name, depth)?;
         } else {
             rustix::fs::unlinkat(dir, &name, AtFlags::empty())?;
         }

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -1,12 +1,16 @@
 use std::{
-    path::{Path, PathBuf},
+    ffi::{OsStr, OsString},
+    os::unix::ffi::OsStrExt,
+    sync::Arc,
     sync::atomic::{AtomicU64, Ordering},
 };
 
 use async_trait::async_trait;
 use ironclaw_host_api::{HostPath, VirtualPath};
-use ironclaw_safety::sensitive_paths::is_sensitive_path;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use ironclaw_safety::sensitive_paths::is_sensitive_path_str;
+use rustix::fd::{AsFd, BorrowedFd, OwnedFd};
+use rustix::fs::{AtFlags, Mode, OFlags};
+use rustix::io::Errno;
 
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError, FilesystemOperation,
@@ -30,21 +34,48 @@ pub struct DiskFilesystem {
 #[derive(Debug, Clone)]
 struct LocalMount {
     virtual_root: VirtualPath,
-    host_root: PathBuf,
+    /// An open directory descriptor on the mount's canonical host root,
+    /// opened once at mount time. Every request resolves *from this fd*,
+    /// component by component, with `O_NOFOLLOW` (or the single-syscall
+    /// `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` equivalent on
+    /// Linux) — so a symlink swapped in after any earlier check is never
+    /// followed, closing the pathname-check-then-separate-syscall TOCTOU
+    /// window `resolve_existing` / `resolve_for_write` /
+    /// `resolve_for_create_dir_all` used to leave open. See [`open_one`].
+    ///
+    /// Wrapped in `Arc` (not re-opened per request): cloning an `Arc<OwnedFd>`
+    /// shares the same underlying open file description rather than
+    /// `dup`-ing a new fd, which is exactly what we want here — directory
+    /// fds used only for relative `openat`/`mkdirat`/`unlinkat`/`fstatat`
+    /// lookups carry no mutable per-fd state (no seek offset, no O_APPEND
+    /// cursor) that a concurrent "clone" could corrupt, so many callers
+    /// reading `self.mounts` concurrently and cloning this `Arc` is safe
+    /// without any lock. `LocalMount` derives `Clone` for the same reason
+    /// this crate never needed a lock around `mounts: Vec<LocalMount>`
+    /// before: nothing here ever mutates a mount after `mount_local`/
+    /// `mount_local_per_leaf` pushes it, so concurrent readers only ever see
+    /// a fully-constructed, immutable `LocalMount` — cloning is cheap
+    /// (refcount bump) and never races.
+    root_fd: Arc<OwnedFd>,
     /// When `true`, this mount is shared by many callers who are each only
     /// ever granted a single leaf subtree of it (one [`MountGrant`] target
     /// per caller, narrowed by the composition-layer `MountView` resolver —
     /// e.g. the sandboxed-profile `/workspace` mount, where every user's
-    /// `MountView` target is `/workspace/<digest>`). Containment for such a
-    /// mount is pinned to `host_root/<first-tail-segment>` rather than the
-    /// full `host_root`: the physical [`DiskFilesystem`] mount table is
-    /// boot-time-fixed and cannot register a distinct `host_root` per caller,
-    /// but the first path segment after `virtual_root` is never
-    /// caller-controlled — it comes from the server-computed `MountGrant`
-    /// target, not from the caller's tail — so pinning containment to it
-    /// closes a same-mount cross-leaf symlink escape (one caller's symlink
-    /// resolving into a sibling leaf) without weakening containment for any
-    /// other mount. See `ensure_contained`.
+    /// `MountView` target is `/workspace/<digest>`).
+    ///
+    /// Containment no longer needs a *narrower* boundary for this mount kind
+    /// than for an ordinary one: because [`open_one`] refuses to traverse
+    /// **any** symlink anywhere in a resolved path (not just one that would
+    /// land outside the mount), a symlink planted in one caller's leaf can
+    /// never be followed into a sibling leaf either — the whole attack class
+    /// this flag used to need a bespoke `containment_root`/
+    /// `ensure_existing_ancestor_contained` bootstrap-boundary calculation
+    /// for is closed by the same no-symlink-traversal rule that protects
+    /// ordinary mounts. `leaf_scoped` now exists purely to preserve one
+    /// policy decision: a request against the bare mount root (no leaf
+    /// segment at all) must still fail closed rather than resolving to the
+    /// shared parent every caller's leaf lives under. See
+    /// [`DiskFilesystem::resolve_mount_target`].
     leaf_scoped: bool,
 }
 
@@ -57,7 +88,8 @@ impl DiskFilesystem {
     ///
     /// This API is intentionally synchronous because it mutates in-memory mount
     /// configuration and is not part of the async runtime operation path. Async
-    /// file operations after mount setup use `tokio::fs`.
+    /// file operations after mount setup use fd-relative syscalls (see
+    /// [`open_one`]) run on the blocking pool.
     pub fn mount_local(
         &mut self,
         virtual_root: VirtualPath,
@@ -70,12 +102,9 @@ impl DiskFilesystem {
     /// only ever granted (via their own `MountView`) a single leaf subtree
     /// of it — e.g. the `HostedSingleTenantVolumeSandboxed` profile's
     /// `/workspace` mount, whose shared parent holds every user's leaf
-    /// sandbox-workspace directory. Containment for paths resolved through
-    /// this mount is pinned per-request to `host_root/<leaf>`, where `<leaf>`
-    /// is the first path segment after `virtual_root` — closing a symlink
-    /// planted inside one caller's leaf from resolving into a sibling leaf,
-    /// which a plain [`mount_local`](Self::mount_local) mount (containment at
-    /// the full shared `host_root`) would not catch. See [`LocalMount::leaf_scoped`].
+    /// sandbox-workspace directory. See [`LocalMount::leaf_scoped`] for why
+    /// this no longer needs a distinct containment boundary from
+    /// [`mount_local`](Self::mount_local).
     pub fn mount_local_per_leaf(
         &mut self,
         virtual_root: VirtualPath,
@@ -114,149 +143,32 @@ impl DiskFilesystem {
             });
         }
 
+        let root_fd = rustix::fs::open(
+            &canonical_root,
+            OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+            Mode::empty(),
+        )
+        .map_err(|errno| FilesystemError::Backend {
+            path: virtual_root.clone(),
+            operation: FilesystemOperation::MountLocal,
+            reason: io_reason(errno.into()),
+        })?;
+
         self.mounts.push(LocalMount {
             virtual_root,
-            host_root: canonical_root,
+            root_fd: Arc::new(root_fd),
             leaf_scoped,
         });
         Ok(())
     }
 
-    async fn resolve_existing(
-        &self,
-        path: &VirtualPath,
-        operation: FilesystemOperation,
-    ) -> Result<PathBuf, FilesystemError> {
-        let resolved = self.resolve_joined(path)?;
-        let canonical = tokio::fs::canonicalize(&resolved.joined)
-            .await
-            .map_err(|error| io_error(path.clone(), operation, error))?;
-        ensure_contained(path, &resolved.containment_root, &canonical, true)?;
-        Ok(canonical)
-    }
-
-    async fn resolve_for_write(
-        &self,
-        path: &VirtualPath,
-        operation: FilesystemOperation,
-    ) -> Result<PathBuf, FilesystemError> {
-        let resolved = self.resolve_joined(path)?;
-
-        // `symlink_metadata` (lstat) reports whether a directory entry
-        // exists at this path at all, without following a final symlink —
-        // unlike `try_exists`, which follows symlinks and reports `false`
-        // for a *dangling* one (target missing). Using `try_exists` here
-        // would let a pre-existing dangling symlink fall through to the
-        // "brand new file in this leaf" bootstrap path below, which hands
-        // back an unchecked path through the symlink; `write_file`/
-        // `append_file` open with `O_CREAT` and the OS creates the file at
-        // wherever the symlink points, bypassing containment entirely.
-        match tokio::fs::symlink_metadata(&resolved.joined).await {
-            Ok(metadata) => {
-                match tokio::fs::canonicalize(&resolved.joined).await {
-                    Ok(canonical) => {
-                        ensure_contained(path, &resolved.containment_root, &canonical, true)?;
-                        return Ok(canonical);
-                    }
-                    Err(error) if metadata.file_type().is_symlink() => {
-                        // The entry is a symlink whose target can't be
-                        // resolved (dangling, or a broken intermediate
-                        // component). Fail closed: we cannot verify
-                        // containment of a target we can't resolve, and
-                        // silently falling through would let a write
-                        // escape via the symlink.
-                        let _ = error;
-                        return Err(FilesystemError::SymlinkEscape { path: path.clone() });
-                    }
-                    Err(error) => return Err(io_error(path.clone(), operation, error)),
-                }
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(io_error(path.clone(), operation, error)),
-        }
-
-        let parent = resolved
-            .joined
-            .parent()
-            .ok_or_else(|| FilesystemError::PathOutsideMount { path: path.clone() })?;
-        ensure_existing_ancestor_contained(
-            path,
-            &resolved.containment_root,
-            resolved.bootstrap_root,
-            parent,
-            operation,
-        )
-        .await?;
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
-        let canonical_parent = tokio::fs::canonicalize(parent)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
-        // `joined` is constructed from validated virtual path segments under the
-        // backend root. If its canonical parent leaves the backend root, an
-        // existing symlink in the parent chain caused the escape.
-        ensure_contained(path, &resolved.containment_root, &canonical_parent, true)?;
-        // Re-root the final path on the canonicalized, containment-checked
-        // parent rather than returning `joined` (which still contains the
-        // un-canonicalized ancestor components). This narrows the TOCTOU
-        // window between the containment check and the eventual write — a
-        // later swap of an ancestor symlink does not change the path we hand
-        // back. Robust defense (openat / O_NOFOLLOW / cap-std) is tracked as a
-        // follow-up; see PR #2996 review.
-        let file_name = resolved
-            .joined
-            .file_name()
-            .ok_or_else(|| FilesystemError::PathOutsideMount { path: path.clone() })?;
-        Ok(canonical_parent.join(file_name))
-    }
-
-    async fn resolve_for_create_dir_all(
-        &self,
-        path: &VirtualPath,
-    ) -> Result<PathBuf, FilesystemError> {
-        let resolved = self.resolve_joined(path)?;
-        ensure_existing_ancestor_contained(
-            path,
-            &resolved.containment_root,
-            resolved.bootstrap_root,
-            &resolved.joined,
-            FilesystemOperation::CreateDirAll,
-        )
-        .await?;
-        // Same residual TOCTOU window as `resolve_for_write` (see the
-        // comment at that function's re-rooting step): the ancestor check
-        // above and this `create_dir_all` are two syscalls, not one atomic
-        // operation, so a symlink swapped into the parent chain between
-        // them is not caught until the post-creation `ensure_contained`
-        // below — by which point `create_dir_all` may already have created
-        // directories at the swapped-in location. Closing this fully needs
-        // the same descriptor/capability-rooted traversal (openat /
-        // O_NOFOLLOW / cap-std) tracked as a follow-up in PR #2996 review;
-        // this function's defense-in-depth is the post-creation containment
-        // check, which still fails closed rather than silently succeeding.
-        tokio::fs::create_dir_all(&resolved.joined)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
-        let canonical = tokio::fs::canonicalize(&resolved.joined)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
-        ensure_contained(path, &resolved.containment_root, &canonical, true)?;
-        Ok(canonical)
-    }
-
-    /// Resolves `path` to its host-side join point plus the containment
-    /// invariant callers must enforce against it.
-    ///
-    /// Bundled into one typed [`ResolvedMountPath`] — rather than a
-    /// positional tuple with `bootstrap_root` re-derived per caller — because
-    /// the three fields are one invariant, not three independent values: a
-    /// caller that threads `joined`/`containment_root` from one mount but
-    /// `bootstrap_root` from another (or forgets it for a leaf-scoped mount)
-    /// would silently reopen the bootstrap containment gap this type exists
-    /// to close. Computing all three together, once, in the one place that
-    /// knows which mount `path` resolved to removes that chance entirely.
-    fn resolve_joined(&self, path: &VirtualPath) -> Result<ResolvedMountPath<'_>, FilesystemError> {
+    /// Routes `path` to its mount and splits the tail into path components
+    /// under that mount's `root_fd`. No filesystem access happens here —
+    /// this is pure string/virtual-path routing, unchanged in shape from
+    /// before this fix, and is not part of the TOCTOU surface: the actual
+    /// containment enforcement now happens fd-relatively in [`open_one`] as
+    /// each returned component is walked.
+    fn resolve_mount_target(&self, path: &VirtualPath) -> Result<MountTarget, FilesystemError> {
         let mount = self
             .mounts
             .iter()
@@ -270,49 +182,47 @@ impl DiskFilesystem {
             .unwrap_or_default()
             .trim_start_matches('/');
 
-        let mut joined = mount.host_root.clone();
-        let mut containment_root = mount.host_root.clone();
-        if tail.is_empty() {
-            // A leaf-scoped mount has no safe containment root for the bare
-            // mount path itself — that would be "every caller's leaf", the
-            // shared-parent boundary this mount kind exists to eliminate.
-            // The composition-layer `MountView` always supplies a leaf, but
-            // that invariant is enforced one layer up, so fail closed here.
-            if mount.leaf_scoped {
+        if tail.is_empty() && mount.leaf_scoped {
+            // A leaf-scoped mount has no safe target for the bare mount path
+            // itself — that would be "every caller's leaf", the shared-parent
+            // boundary this mount kind exists to eliminate. The
+            // composition-layer `MountView` always supplies a leaf, but that
+            // invariant is enforced one layer up, so fail closed here.
+            return Err(FilesystemError::PathOutsideMount { path: path.clone() });
+        }
+
+        let mut components = Vec::new();
+        for segment in tail.split('/').filter(|segment| !segment.is_empty()) {
+            // The virtual-path layer (`ScopedPath::new`) already rejects
+            // literal `..` segments before a caller-controlled path ever
+            // reaches this crate, but `VirtualPath` itself does not enforce
+            // that (this crate's own tests construct arbitrary
+            // `VirtualPath` values), and every component below is handed
+            // directly to `openat`/`mkdirat` — which *do* interpret a `..`
+            // component as "go to the parent directory". Reject it here,
+            // defensively, before any fd work: this is the one place a
+            // literal `..` could turn into a real directory-fd escape.
+            if segment == ".." {
                 return Err(FilesystemError::PathOutsideMount { path: path.clone() });
             }
-        } else {
-            for (index, segment) in tail.split('/').enumerate() {
-                joined.push(segment);
-                if mount.leaf_scoped && index == 0 {
-                    containment_root.push(segment);
-                }
+            if segment == "." {
+                continue;
             }
+            components.push(OsString::from(segment));
         }
-        Ok(ResolvedMountPath {
-            joined,
-            containment_root,
-            bootstrap_root: leaf_bootstrap_root(mount),
+
+        Ok(MountTarget {
+            root_fd: Arc::clone(&mount.root_fd),
+            components,
         })
     }
 }
 
-/// The host-side join point for a resolved `VirtualPath` plus the
-/// containment invariant every write/read caller must enforce against it —
-/// see [`DiskFilesystem::resolve_joined`] for why these three fields travel
-/// together instead of as a positional tuple.
-struct ResolvedMountPath<'a> {
-    /// The host path `path` joins to under the mount's `host_root`,
-    /// pre-canonicalization.
-    joined: PathBuf,
-    /// The boundary [`ensure_contained`] checks the canonicalized path
-    /// against: `host_root` for an ordinary mount, or `host_root` plus the
-    /// caller's own leaf segment for a [`LocalMount::leaf_scoped`] mount —
-    /// see [`DiskFilesystem::resolve_joined`].
-    containment_root: PathBuf,
-    /// `Some(host_root)` for a leaf-scoped mount, `None` otherwise — see
-    /// [`leaf_bootstrap_root`] for the bootstrap gap this covers.
-    bootstrap_root: Option<&'a Path>,
+/// A mount plus the path components to walk under its `root_fd`. Carries no
+/// host path — every subsequent step is fd-relative.
+struct MountTarget {
+    root_fd: Arc<OwnedFd>,
+    components: Vec<OsString>,
 }
 
 #[async_trait]
@@ -365,12 +275,33 @@ impl RootFilesystem for DiskFilesystem {
     }
 
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        let resolved = self
-            .resolve_existing(path, FilesystemOperation::ReadFile)
-            .await?;
-        tokio::fs::read(resolved)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))
+        let target = self.resolve_mount_target(path)?;
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::ReadFile, move || {
+            let (fd, _parent) = resolve_walk(
+                target.root_fd.as_fd(),
+                &target.components,
+                OFlags::RDONLY,
+            )
+            .map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::ReadFile, error)
+            })?;
+            let stat = rustix::fs::fstat(&fd).map_err(|errno| {
+                io_error(path.clone(), FilesystemOperation::ReadFile, errno.into())
+            })?;
+            if rustix::fs::FileType::from_raw_mode(stat.st_mode)
+                != rustix::fs::FileType::RegularFile
+            {
+                return Err(FilesystemError::Backend {
+                    path: path.clone(),
+                    operation: FilesystemOperation::ReadFile,
+                    reason: "not a file".to_string(),
+                });
+            }
+            read_all(fd)
+                .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))
+        })
+        .await
     }
 
     async fn read_file_bounded(
@@ -378,36 +309,40 @@ impl RootFilesystem for DiskFilesystem {
         path: &VirtualPath,
         max_bytes: usize,
     ) -> Result<Option<Vec<u8>>, FilesystemError> {
-        let resolved = self
-            .resolve_existing(path, FilesystemOperation::ReadFile)
-            .await?;
-        let file = tokio::fs::File::open(&resolved)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
-        let metadata = file
-            .metadata()
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
-        if !metadata.is_file() {
-            return Err(FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ReadFile,
-                reason: "not a file".to_string(),
-            });
-        }
-        if metadata.len() > max_bytes as u64 {
-            return Ok(None);
-        }
-
-        let mut bytes = Vec::with_capacity(max_bytes.min(metadata.len() as usize));
-        file.take((max_bytes as u64).saturating_add(1))
-            .read_to_end(&mut bytes)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
-        if bytes.len() > max_bytes {
-            return Ok(None);
-        }
-        Ok(Some(bytes))
+        let target = self.resolve_mount_target(path)?;
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::ReadFile, move || {
+            let (fd, _parent) = resolve_walk(
+                target.root_fd.as_fd(),
+                &target.components,
+                OFlags::RDONLY,
+            )
+            .map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::ReadFile, error)
+            })?;
+            let stat = rustix::fs::fstat(&fd).map_err(|errno| {
+                io_error(path.clone(), FilesystemOperation::ReadFile, errno.into())
+            })?;
+            if rustix::fs::FileType::from_raw_mode(stat.st_mode)
+                != rustix::fs::FileType::RegularFile
+            {
+                return Err(FilesystemError::Backend {
+                    path: path.clone(),
+                    operation: FilesystemOperation::ReadFile,
+                    reason: "not a file".to_string(),
+                });
+            }
+            if stat.st_size < 0 || stat.st_size as u64 > max_bytes as u64 {
+                return Ok(None);
+            }
+            let bytes = read_all(fd)
+                .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+            if bytes.len() > max_bytes {
+                return Ok(None);
+            }
+            Ok(Some(bytes))
+        })
+        .await
     }
 
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
@@ -416,22 +351,28 @@ impl RootFilesystem for DiskFilesystem {
     }
 
     async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        let resolved = self
-            .resolve_for_write(path, FilesystemOperation::AppendFile)
-            .await?;
-        let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .write(true)
-            .open(resolved)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::AppendFile, error))?;
-        file.write_all(bytes)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::AppendFile, error))?;
-        file.flush()
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::AppendFile, error))
+        let target = self.resolve_mount_target(path)?;
+        let (parent_components, leaf) = split_leaf(&target.components, path)?;
+        let bytes = bytes.to_vec();
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::AppendFile, move || {
+            let parent_fd =
+                descend_creating(target.root_fd.as_fd(), &parent_components).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
+                })?;
+            let fd = open_one(
+                parent_fd.as_fd(),
+                &leaf,
+                OFlags::WRONLY | OFlags::APPEND | OFlags::CREATE,
+                new_file_mode(),
+            )
+            .map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::AppendFile, error)
+            })?;
+            write_all(fd, &bytes)
+                .map_err(|error| io_error(path.clone(), FilesystemOperation::AppendFile, error))
+        })
+        .await
     }
 
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
@@ -443,80 +384,148 @@ impl RootFilesystem for DiskFilesystem {
         path: &VirtualPath,
         max_entries: usize,
     ) -> Result<Vec<DirEntry>, FilesystemError> {
-        let resolved = self
-            .resolve_existing(path, FilesystemOperation::ListDir)
-            .await?;
-        let mut read_dir = tokio::fs::read_dir(resolved)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::ListDir, error))?;
-        let mut entries = Vec::new();
-        while entries.len() < max_entries {
-            let Some(entry) = read_dir
-                .next_entry()
-                .await
-                .map_err(|error| io_error(path.clone(), FilesystemOperation::ListDir, error))?
-            else {
-                break;
-            };
-            let name = entry.file_name().to_string_lossy().to_string();
-            let entry_path =
-                VirtualPath::new(format!("{}/{}", path.as_str().trim_end_matches('/'), name))?;
-            let metadata = entry
-                .metadata()
-                .await
-                .map_err(|error| io_error(entry_path.clone(), FilesystemOperation::Stat, error))?;
-            entries.push(DirEntry {
-                name,
-                path: entry_path,
-                file_type: file_type_from_metadata(&metadata),
-            });
-        }
-        entries.sort_by(|left, right| left.name.cmp(&right.name));
-        Ok(entries)
+        let target = self.resolve_mount_target(path)?;
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::ListDir, move || {
+            let (fd, _parent) = resolve_walk(
+                target.root_fd.as_fd(),
+                &target.components,
+                OFlags::RDONLY,
+            )
+            .map_err(|error| {
+                resolve_error_to_filesystem_error(&path, FilesystemOperation::ListDir, error)
+            })?;
+            let mut listing = rustix::fs::Dir::read_from(fd.as_fd()).map_err(|errno| {
+                io_error(path.clone(), FilesystemOperation::ListDir, errno.into())
+            })?;
+            let mut entries = Vec::new();
+            while entries.len() < max_entries {
+                let Some(raw_entry) = listing.next() else {
+                    break;
+                };
+                let raw_entry = raw_entry.map_err(|errno| {
+                    io_error(path.clone(), FilesystemOperation::ListDir, errno.into())
+                })?;
+                let name_bytes = raw_entry.file_name().to_bytes();
+                if name_bytes == b"." || name_bytes == b".." {
+                    continue;
+                }
+                let name = OsStr::from_bytes(name_bytes);
+                let name_str = name.to_string_lossy().to_string();
+                let entry_path = VirtualPath::new(format!(
+                    "{}/{}",
+                    path.as_str().trim_end_matches('/'),
+                    name_str
+                ))?;
+                // `AT_SYMLINK_NOFOLLOW`: report a symlink child as a symlink,
+                // never resolve through it to describe whatever it points
+                // at (which may be outside the mount entirely).
+                let stat = rustix::fs::statat(fd.as_fd(), name, AtFlags::SYMLINK_NOFOLLOW)
+                    .map_err(|errno| {
+                        io_error(entry_path.clone(), FilesystemOperation::Stat, errno.into())
+                    })?;
+                entries.push(DirEntry {
+                    name: name_str,
+                    path: entry_path,
+                    file_type: map_file_type(rustix::fs::FileType::from_raw_mode(stat.st_mode)),
+                });
+            }
+            entries.sort_by(|left, right| left.name.cmp(&right.name));
+            Ok(entries)
+        })
+        .await
     }
 
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        let resolved = self
-            .resolve_existing(path, FilesystemOperation::Stat)
-            .await?;
-        let metadata = tokio::fs::metadata(&resolved)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::Stat, error))?;
-        Ok(FileStat {
-            path: path.clone(),
-            file_type: file_type_from_metadata(&metadata),
-            len: metadata.len(),
-            modified: metadata.modified().ok(),
-            sensitive: is_sensitive_path(&resolved),
+        let target = self.resolve_mount_target(path)?;
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::Stat, move || {
+            let (fd, _parent) =
+                resolve_walk(target.root_fd.as_fd(), &target.components, OFlags::RDONLY).map_err(
+                    |error| {
+                        resolve_error_to_filesystem_error(&path, FilesystemOperation::Stat, error)
+                    },
+                )?;
+            let stat = rustix::fs::fstat(&fd)
+                .map_err(|errno| io_error(path.clone(), FilesystemOperation::Stat, errno.into()))?;
+            let len = if stat.st_size < 0 {
+                0
+            } else {
+                stat.st_size as u64
+            };
+            Ok(FileStat {
+                path: path.clone(),
+                file_type: map_file_type(rustix::fs::FileType::from_raw_mode(stat.st_mode)),
+                len,
+                modified: stat_modified(stat.st_mtime, stat.st_mtime_nsec),
+                // No host path to check anymore (by design — see the module
+                // doc): the string-only, filesystem-access-free
+                // `is_sensitive_path_str` checks the same filename patterns
+                // (`.env`, `.pem`, …) against the virtual path's leaf
+                // component, which is identical to the host path's leaf
+                // component for every mount (mounting only ever renames the
+                // path *prefix*).
+                sensitive: is_sensitive_path_str(path.as_str()),
+            })
         })
+        .await
     }
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        // `resolved` is the canonicalized, containment-checked path from
-        // `resolve_existing`, but the check and the removal below are still
-        // two syscalls: an ancestor symlink swapped in between them is the
-        // same residual TOCTOU window documented on `resolve_for_write`
-        // (local.rs) and not closed until descriptor/capability-rooted
-        // traversal lands (PR #2996 review follow-up). `remove_dir_all` and
-        // `remove_file` operate on the already-canonical `resolved` path
-        // rather than re-walking `path`'s original components, which keeps
-        // this in line with the other mutating operations in this file.
-        let resolved = self
-            .resolve_existing(path, FilesystemOperation::Delete)
-            .await?;
-        let metadata = tokio::fs::metadata(&resolved)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::Delete, error))?;
-        let result = if metadata.is_dir() {
-            tokio::fs::remove_dir_all(resolved).await
-        } else {
-            tokio::fs::remove_file(resolved).await
-        };
-        result.map_err(|error| io_error(path.clone(), FilesystemOperation::Delete, error))
+        let target = self.resolve_mount_target(path)?;
+        if target.components.is_empty() {
+            // Removing an entire mount's root by virtual-path traversal was
+            // never an intentional capability (the old path-based
+            // implementation happened to allow it as a side effect of
+            // `resolve_existing` resolving the bare mount root). The
+            // fd-rooted resolver has no parent fd for the mount root itself
+            // — by design, it never holds an fd outside `root_fd` — so this
+            // fails closed instead.
+            return Err(FilesystemError::PathOutsideMount { path: path.clone() });
+        }
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::Delete, move || {
+            let (fd, parent) =
+                resolve_walk(target.root_fd.as_fd(), &target.components, OFlags::RDONLY).map_err(
+                    |error| {
+                        resolve_error_to_filesystem_error(&path, FilesystemOperation::Delete, error)
+                    },
+                )?;
+            let Some((parent_fd, name)) = parent else {
+                return Err(FilesystemError::PathOutsideMount { path: path.clone() });
+            };
+            let stat = rustix::fs::fstat(&fd).map_err(|errno| {
+                io_error(path.clone(), FilesystemOperation::Delete, errno.into())
+            })?;
+            drop(fd);
+            if rustix::fs::FileType::from_raw_mode(stat.st_mode) == rustix::fs::FileType::Directory
+            {
+                remove_dir_all_fd(parent_fd.as_fd(), &name)
+                    .map_err(|error| io_error(path.clone(), FilesystemOperation::Delete, error))
+            } else {
+                rustix::fs::unlinkat(parent_fd.as_fd(), &name, AtFlags::empty()).map_err(|errno| {
+                    io_error(path.clone(), FilesystemOperation::Delete, errno.into())
+                })
+            }
+        })
+        .await
     }
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.resolve_for_create_dir_all(path).await.map(|_| ())
+        let target = self.resolve_mount_target(path)?;
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::CreateDirAll, move || {
+            descend_creating(target.root_fd.as_fd(), &target.components)
+                .map(|_fd| ())
+                .map_err(|error| {
+                    resolve_error_to_filesystem_error(
+                        &path,
+                        FilesystemOperation::CreateDirAll,
+                        error,
+                    )
+                })
+        })
+        .await
     }
 }
 
@@ -527,85 +536,425 @@ impl DiskFilesystem {
         bytes: &[u8],
         cas: CasExpectation,
     ) -> Result<(), FilesystemError> {
-        let resolved = self
-            .resolve_for_write(path, FilesystemOperation::WriteFile)
-            .await?;
-        if matches!(cas, CasExpectation::Absent)
-            && tokio::fs::try_exists(&resolved)
-                .await
-                .map_err(|error| io_error(path.clone(), FilesystemOperation::WriteFile, error))?
-        {
-            return Err(FilesystemError::VersionMismatch {
-                path: path.clone(),
-                expected: None,
-                found: Some(RecordVersion::from_backend(0)),
-            });
-        }
-        atomic_write_file(path, &resolved, bytes, cas).await
+        let target = self.resolve_mount_target(path)?;
+        let (parent_components, leaf) = split_leaf(&target.components, path)?;
+        let bytes = bytes.to_vec();
+        let path = path.clone();
+        run_blocking(path.clone(), FilesystemOperation::WriteFile, move || {
+            let parent_fd =
+                descend_creating(target.root_fd.as_fd(), &parent_components).map_err(|error| {
+                    resolve_error_to_filesystem_error(&path, FilesystemOperation::WriteFile, error)
+                })?;
+            atomic_write_file(&path, parent_fd.as_fd(), &leaf, &bytes, cas)
+        })
+        .await
     }
 }
 
-async fn atomic_write_file(
+/// Splits `components` into its parent directory components and its final
+/// (leaf) component, for operations that create or open a specific file —
+/// distinct from [`resolve_walk`], which is used by read-only operations
+/// that may legitimately target the bare mount root.
+fn split_leaf(
+    components: &[OsString],
+    path: &VirtualPath,
+) -> Result<(Vec<OsString>, OsString), FilesystemError> {
+    match components.split_last() {
+        Some((leaf, parent)) => Ok((parent.to_vec(), leaf.clone())),
+        None => Err(FilesystemError::PathOutsideMount { path: path.clone() }),
+    }
+}
+
+/// Runs a synchronous, fd-rooted resolve-and-act closure on the blocking
+/// pool, and flattens the `JoinError` case into a `FilesystemError`.
+///
+/// This is the structural fix's shape: everything inside `body` — walking
+/// component-by-component from the mount's open root fd, and then acting on
+/// the fd that walk produced — runs without ever crossing back through the
+/// async scheduler. There is no `.await` between "resolve" and "act" for a
+/// TOCTOU race to land in, because there is no longer a separate "resolve"
+/// step that hands back a path string for a later, independent syscall to
+/// re-resolve. The resolved fd itself, not a path, is what every subsequent
+/// operation in `body` touches.
+async fn run_blocking<T, F>(
+    path: VirtualPath,
+    operation: FilesystemOperation,
+    body: F,
+) -> Result<T, FilesystemError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, FilesystemError> + Send + 'static,
+{
+    match tokio::task::spawn_blocking(body).await {
+        Ok(result) => result,
+        Err(join_error) => Err(FilesystemError::Backend {
+            path,
+            operation,
+            reason: format!("local filesystem blocking task panicked: {join_error}"),
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------
+// fd-rooted, symlink-free traversal primitives
+// ---------------------------------------------------------------------
+//
+// Every function below operates purely on file descriptors and path
+// *components* (never a joined host path string). `open_one` is the one
+// place a directory-entry lookup happens, and it refuses to follow a
+// symlink anywhere in the walk. Because resolution never hands back a path
+// for a later, independent syscall to re-open, there is no window between
+// "checked" and "acted on" for an attacker to swap the entry in.
+
+/// The outcome of a failed fd-relative resolution step: either a genuine I/O
+/// error (propagated as-is), or a symlink/`..`-past-root escape attempt.
+enum ResolveError {
+    Escape,
+    Io(std::io::Error),
+}
+
+fn resolve_error_to_filesystem_error(
+    path: &VirtualPath,
+    operation: FilesystemOperation,
+    error: ResolveError,
+) -> FilesystemError {
+    match error {
+        ResolveError::Escape => FilesystemError::SymlinkEscape { path: path.clone() },
+        ResolveError::Io(io_err) => io_error(path.clone(), operation, io_err),
+    }
+}
+
+/// Opens exactly one path component beneath `dir`, refusing to follow a
+/// symlink at that component.
+///
+/// On Linux, this is one syscall via `openat2(RESOLVE_BENEATH |
+/// RESOLVE_NO_SYMLINKS)` when the kernel supports it (falling back below on
+/// `ENOSYS` — an older kernel, or a container/seccomp profile that denies
+/// `openat2` outright). Everywhere else, including macOS (which has no
+/// `openat2` at all), a plain `openat` with `O_NOFOLLOW`.
+///
+/// **macOS asymmetry, documented rather than silent:** both paths reject the
+/// same attack class — a symlink at any resolved path component, ancestor or
+/// leaf — because `O_NOFOLLOW` and `RESOLVE_NO_SYMLINKS` both refuse to
+/// traverse a symlink; the security property (no symlink traversal escapes
+/// the mount root) holds identically on both platforms. What macOS's
+/// fallback does *not* get is `RESOLVE_BENEATH`'s single-syscall,
+/// kernel-enforced resolution step: each `open_one` call is independently
+/// safe (it either opens the real, non-symlink entry or fails), but the
+/// *sequence* of `open_one` calls that make up a full path walk on macOS is
+/// coordinated by this module's own loop (`walk`/`resolve_walk`/
+/// `descend_creating`), not by one kernel-verified decision the way
+/// `RESOLVE_BENEATH` verifies a whole relative path in a single syscall on
+/// Linux. Both close the same escape; only the mechanism differs.
+fn open_one(
+    dir: BorrowedFd<'_>,
+    name: &OsStr,
+    oflags: OFlags,
+    mode: Mode,
+) -> Result<OwnedFd, ResolveError> {
+    #[cfg(target_os = "linux")]
+    {
+        use rustix::fs::{ResolveFlags, openat2};
+        match openat2(
+            dir,
+            name,
+            oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            mode,
+            ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
+        ) {
+            Ok(fd) => return Ok(fd),
+            // Kernel predates openat2 (< 5.6), or a seccomp/container policy
+            // denies the syscall outright. Fall through to the portable
+            // per-component path below rather than failing closed on a
+            // syscall the fallback doesn't need.
+            Err(Errno::NOSYS) => {}
+            Err(Errno::LOOP) | Err(Errno::XDEV) => return Err(ResolveError::Escape),
+            Err(errno) => return Err(ResolveError::Io(errno.into())),
+        }
+    }
+    match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {
+        Ok(fd) => Ok(fd),
+        Err(Errno::LOOP) => Err(ResolveError::Escape),
+        // Some platforms (observed on macOS) report `ENOTDIR` rather than
+        // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
+        // kernel checks "is this a directory" before "did NOFOLLOW block
+        // it", and a symlink is never a directory itself. `ENOTDIR` is
+        // ambiguous on its own (a plain non-directory file blocking descent
+        // hits it too), so disambiguate with one `AT_SYMLINK_NOFOLLOW`
+        // `fstatat` rather than guessing either way.
+        Err(Errno::NOTDIR) if oflags.contains(OFlags::DIRECTORY) => {
+            match rustix::fs::statat(dir, name, AtFlags::SYMLINK_NOFOLLOW) {
+                Ok(stat)
+                    if rustix::fs::FileType::from_raw_mode(stat.st_mode)
+                        == rustix::fs::FileType::Symlink =>
+                {
+                    Err(ResolveError::Escape)
+                }
+                _ => Err(ResolveError::Io(Errno::NOTDIR.into())),
+            }
+        }
+        Err(errno) => Err(ResolveError::Io(errno.into())),
+    }
+}
+
+fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
+    rustix::io::dup(fd).map_err(|errno| ResolveError::Io(errno.into()))
+}
+
+/// Walks `components` from `root`, refusing every symlink along the way, and
+/// returns the final entry's fd plus — when `components` is non-empty — the
+/// fd of its immediate parent directory and its own name (needed by callers
+/// that must act on the parent, e.g. `unlinkat`/`renameat`, rather than on
+/// the entry itself, which POSIX has no "act on this fd regardless of its
+/// name" primitive for).
+///
+/// `components` empty resolves to the mount root itself (`root` duplicated),
+/// with no parent — the mount root has no fd-relative parent inside this
+/// mount's sandbox, by design (see [`DiskFilesystem::delete`]).
+fn resolve_walk(
+    root: BorrowedFd<'_>,
+    components: &[OsString],
+    final_oflags: OFlags,
+) -> Result<(OwnedFd, Option<(OwnedFd, OsString)>), ResolveError> {
+    let Some((leaf, ancestors)) = components.split_last() else {
+        return Ok((dup_fd(root)?, None));
+    };
+    let mut cur = dup_fd(root)?;
+    for component in ancestors {
+        cur = open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?;
+    }
+    let fd = open_one(cur.as_fd(), leaf, final_oflags, Mode::empty())?;
+    Ok((fd, Some((cur, leaf.clone()))))
+}
+
+/// Walks `components` from `root`, creating any missing directory along the
+/// way (`mkdir -p` semantics), and returns the final directory's fd. Used
+/// by `write_file`/`append_file` (parent-only — matching the previous
+/// implementation's "always create the parent chain" behavior) and by
+/// `create_dir_all` (full path, leaf included).
+///
+/// Each level is still resolved through [`open_one`], so a symlink swapped
+/// into any not-yet-existing ancestor between one level's `mkdirat` and the
+/// next level's `open_one` is rejected exactly like any other symlink in the
+/// walk — there is no separate "check ancestor, then mkdir, then check
+/// again" gap here, because creation and the next level's containment check
+/// are the same `open_one` call the next loop iteration makes.
+fn descend_creating(
+    root: BorrowedFd<'_>,
+    components: &[OsString],
+) -> Result<OwnedFd, ResolveError> {
+    let mut cur = dup_fd(root)?;
+    for component in components {
+        cur = match open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty()) {
+            Ok(fd) => fd,
+            Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {
+                match rustix::fs::mkdirat(cur.as_fd(), component.as_os_str(), new_dir_mode()) {
+                    Ok(()) => {}
+                    Err(Errno::EXIST) => {}
+                    Err(errno) => return Err(ResolveError::Io(errno.into())),
+                }
+                open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?
+            }
+            Err(other) => return Err(other),
+        };
+    }
+    Ok(cur)
+}
+
+/// Recursively removes `name` (found directly under `parent`) and everything
+/// beneath it, never following a symlink into whatever it points at — a
+/// symlinked child is unlinked as itself, exactly like `std::fs::remove_dir_all`,
+/// never traversed into.
+fn remove_dir_all_fd(parent: BorrowedFd<'_>, name: &OsStr) -> Result<(), std::io::Error> {
+    let dir_fd =
+        open_one(parent, name, OFlags::DIRECTORY, Mode::empty()).map_err(resolve_error_to_io)?;
+    remove_dir_contents(dir_fd.as_fd())?;
+    rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(std::io::Error::from)
+}
+
+fn remove_dir_contents(dir: BorrowedFd<'_>) -> Result<(), std::io::Error> {
+    let mut entries = Vec::new();
+    {
+        let listing = rustix::fs::Dir::read_from(dir)?;
+        for entry in listing {
+            let entry = entry?;
+            let name_bytes = entry.file_name().to_bytes();
+            if name_bytes == b"." || name_bytes == b".." {
+                continue;
+            }
+            let name = OsStr::from_bytes(name_bytes).to_os_string();
+            let stat = rustix::fs::statat(dir, &name, AtFlags::SYMLINK_NOFOLLOW)?;
+            let is_dir = rustix::fs::FileType::from_raw_mode(stat.st_mode)
+                == rustix::fs::FileType::Directory;
+            entries.push((name, is_dir));
+        }
+    }
+    for (name, is_dir) in entries {
+        if is_dir {
+            remove_dir_all_fd(dir, &name)?;
+        } else {
+            rustix::fs::unlinkat(dir, &name, AtFlags::empty())?;
+        }
+    }
+    Ok(())
+}
+
+fn resolve_error_to_io(error: ResolveError) -> std::io::Error {
+    match error {
+        ResolveError::Escape => std::io::Error::other("symlink escape"),
+        ResolveError::Io(io_err) => io_err,
+    }
+}
+
+fn read_all(fd: OwnedFd) -> Result<Vec<u8>, std::io::Error> {
+    use std::io::Read;
+    let mut file = std::fs::File::from(fd);
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn write_all(fd: OwnedFd, bytes: &[u8]) -> Result<(), std::io::Error> {
+    use std::io::Write;
+    let mut file = std::fs::File::from(fd);
+    file.write_all(bytes)?;
+    file.flush()
+}
+
+fn new_file_mode() -> Mode {
+    Mode::RUSR | Mode::WUSR | Mode::RGRP | Mode::WGRP | Mode::ROTH | Mode::WOTH
+}
+
+fn new_dir_mode() -> Mode {
+    Mode::RWXU | Mode::RWXG | Mode::RWXO
+}
+
+fn map_file_type(kind: rustix::fs::FileType) -> FileType {
+    match kind {
+        rustix::fs::FileType::RegularFile => FileType::File,
+        rustix::fs::FileType::Directory => FileType::Directory,
+        rustix::fs::FileType::Symlink => FileType::Symlink,
+        _ => FileType::Other,
+    }
+}
+
+fn stat_modified(secs: i64, nanos: impl TryInto<u32>) -> Option<std::time::SystemTime> {
+    let nanos = nanos.try_into().unwrap_or(0);
+    if secs >= 0 {
+        std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::new(secs as u64, nanos))
+    } else {
+        std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::new((-secs) as u64, 0))
+    }
+}
+
+/// Atomically installs `bytes` as `leaf` under `parent`, via a temp file
+/// created in the same directory and then renamed (`CasExpectation::Any`) or
+/// hard-linked into place (`CasExpectation::Absent`) — unchanged in
+/// approach from before this fix, just fd-relative (`renameat`/`linkat`
+/// against `parent`, an already fd-resolved, already-verified directory)
+/// instead of path-relative. `rename`/`link` never follow a symlink at the
+/// destination name (they replace/create the directory entry itself), so
+/// this step was never part of the TOCTOU surface `resolve_for_write` left
+/// open; only `append_file`'s direct `open` of the leaf was.
+fn atomic_write_file(
     virtual_path: &VirtualPath,
-    target: &Path,
+    parent: BorrowedFd<'_>,
+    leaf: &OsStr,
     bytes: &[u8],
     cas: CasExpectation,
 ) -> Result<(), FilesystemError> {
-    let parent = target
-        .parent()
-        .ok_or_else(|| FilesystemError::PathOutsideMount {
-            path: virtual_path.clone(),
-        })?;
-    let temp = unique_temp_path(virtual_path, parent, target)?;
-    let mut file = tokio::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&temp)
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))?;
-    file.write_all(bytes)
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))?;
-    file.sync_all()
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))?;
-    drop(file);
+    // `rename`/`link` never follow a symlink at the destination name (see
+    // the function doc), so the install step below can never be tricked
+    // into writing through one — but silently *replacing* a symlink entry
+    // that's still sitting at the leaf (dangling or not) is a real content
+    // loss surprise for whatever legitimately created it, and this crate's
+    // steady-state contract is "reject a pre-existing symlink at a write
+    // target", not "clobber it". Probe with the same `O_NOFOLLOW` primitive
+    // every other lookup in this module uses, immediately before the
+    // install below — both run inside the same non-yielding blocking
+    // closure, so there is no `.await` for a swap to land between the probe
+    // and the install.
+    match open_one(parent, leaf, OFlags::RDONLY, Mode::empty()) {
+        Ok(_existing) => {}
+        Err(ResolveError::Escape) => {
+            return Err(FilesystemError::SymlinkEscape {
+                path: virtual_path.clone(),
+            });
+        }
+        Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(ResolveError::Io(io_err)) => {
+            return Err(io_error(
+                virtual_path.clone(),
+                FilesystemOperation::WriteFile,
+                io_err,
+            ));
+        }
+    }
+
+    let counter = LOCAL_WRITE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut temp_name = OsString::from(".");
+    temp_name.push(leaf);
+    temp_name.push(format!(".tmp.{counter}"));
+
+    let temp_fd = open_one(
+        parent,
+        &temp_name,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL,
+        new_file_mode(),
+    )
+    .map_err(|error| {
+        resolve_error_to_filesystem_error(virtual_path, FilesystemOperation::WriteFile, error)
+    })?;
+
+    let write_result = (|| -> std::io::Result<()> {
+        use std::io::Write;
+        let mut file = std::fs::File::from(temp_fd);
+        file.write_all(bytes)?;
+        file.sync_all()
+    })();
+    if let Err(error) = write_result {
+        let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+        return Err(io_error(
+            virtual_path.clone(),
+            FilesystemOperation::WriteFile,
+            error,
+        ));
+    }
 
     let install_result = match cas {
-        CasExpectation::Any => tokio::fs::rename(&temp, target)
-            .await
-            .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)),
-        CasExpectation::Absent => match tokio::fs::hard_link(&temp, target).await {
-            Ok(()) => tokio::fs::remove_file(&temp).await.map_err(|error| {
-                io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)
-            }),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                if let Err(cleanup_error) = tokio::fs::remove_file(&temp).await {
-                    tracing::debug!(
-                        error = ?cleanup_error,
-                        "best-effort cleanup of write temp file failed after CAS conflict"
-                    );
-                }
-                Err(FilesystemError::VersionMismatch {
-                    path: virtual_path.clone(),
-                    expected: None,
-                    found: Some(RecordVersion::from_backend(0)),
-                })
-            }
-            Err(error) => {
-                if let Err(cleanup_error) = tokio::fs::remove_file(&temp).await {
-                    tracing::debug!(
-                        error = ?cleanup_error,
-                        "best-effort cleanup of write temp file failed after hard-link error"
-                    );
-                }
-                Err(io_error(
+        CasExpectation::Any => {
+            rustix::fs::renameat(parent, &temp_name, parent, leaf).map_err(|errno| {
+                io_error(
                     virtual_path.clone(),
                     FilesystemOperation::WriteFile,
-                    error,
-                ))
+                    errno.into(),
+                )
+            })
+        }
+        CasExpectation::Absent => {
+            match rustix::fs::linkat(parent, &temp_name, parent, leaf, AtFlags::empty()) {
+                Ok(()) => {
+                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+                    Ok(())
+                }
+                Err(Errno::EXIST) => {
+                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+                    Err(FilesystemError::VersionMismatch {
+                        path: virtual_path.clone(),
+                        expected: None,
+                        found: Some(RecordVersion::from_backend(0)),
+                    })
+                }
+                Err(errno) => {
+                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+                    Err(io_error(
+                        virtual_path.clone(),
+                        FilesystemOperation::WriteFile,
+                        errno.into(),
+                    ))
+                }
             }
-        },
+        }
         CasExpectation::Version(_) => Err(FilesystemError::Unsupported {
             path: virtual_path.clone(),
             operation: FilesystemOperation::WriteFile,
@@ -613,123 +962,20 @@ async fn atomic_write_file(
     };
 
     install_result?;
-    sync_parent_dir(virtual_path, parent).await
-}
 
-fn unique_temp_path(
-    virtual_path: &VirtualPath,
-    parent: &Path,
-    target: &Path,
-) -> Result<PathBuf, FilesystemError> {
-    let name = target
-        .file_name()
-        .ok_or_else(|| FilesystemError::PathOutsideMount {
-            path: virtual_path.clone(),
-        })?
-        .to_string_lossy();
-    let counter = LOCAL_WRITE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    Ok(parent.join(format!(".{name}.tmp.{counter}")))
-}
-
-async fn sync_parent_dir(virtual_path: &VirtualPath, parent: &Path) -> Result<(), FilesystemError> {
-    let dir = tokio::fs::File::open(parent)
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))?;
-    dir.sync_all()
-        .await
+    // Best-effort durability: fsync the parent directory so the rename/link
+    // above survives a crash. Not part of the containment/TOCTOU surface —
+    // failure here is reported but the write itself already succeeded.
+    let parent_file = std::fs::File::from(
+        dup_fd(parent)
+            .map_err(resolve_error_to_io)
+            .map_err(|error| {
+                io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)
+            })?,
+    );
+    parent_file
+        .sync_all()
         .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error))
-}
-
-/// For a [`LocalMount::leaf_scoped`] mount, the shared `host_root` one level
-/// above the caller's own leaf — the one ancestor
-/// [`ensure_existing_ancestor_contained`] must accept even though it sits
-/// outside the leaf's `containment_root`, because it is exactly what a
-/// brand-new leaf's nearest *existing* ancestor looks like before that leaf
-/// has ever been created (see the "reject brand-new leaf" fix this
-/// accompanies). `None` for an ordinary mount, where `containment_root` is
-/// already `host_root` and no such gap exists.
-fn leaf_bootstrap_root(mount: &LocalMount) -> Option<&Path> {
-    mount.leaf_scoped.then_some(mount.host_root.as_path())
-}
-
-/// Walks up from `candidate` to the nearest ancestor that actually exists on
-/// disk, canonicalizes it, and checks containment. Two shapes are accepted:
-/// the ordinary case (the existing ancestor is already under
-/// `containment_root`), and — for a leaf-scoped mount only — the bootstrap
-/// case where the existing ancestor is exactly `bootstrap_root`, the shared
-/// mount root one level above a leaf that does not exist yet. The bootstrap
-/// case is safe because the leaf segment itself is never caller-controlled
-/// (it comes from the server-computed `MountView` grant, not the caller's
-/// tail — see [`DiskFilesystem::resolve_joined`]); once the caller's own
-/// leaf directory is created, the caller of this function re-canonicalizes
-/// and re-checks containment against `containment_root` on the
-/// now-existing path, so the bootstrap exception never itself becomes the
-/// final containment decision.
-async fn ensure_existing_ancestor_contained(
-    virtual_path: &VirtualPath,
-    containment_root: &Path,
-    bootstrap_root: Option<&Path>,
-    candidate: &Path,
-    operation: FilesystemOperation,
-) -> Result<(), FilesystemError> {
-    let mut ancestor = candidate.to_path_buf();
-    while !tokio::fs::try_exists(&ancestor)
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), operation, error))?
-    {
-        ancestor = ancestor
-            .parent()
-            .ok_or_else(|| FilesystemError::PathOutsideMount {
-                path: virtual_path.clone(),
-            })?
-            .to_path_buf();
-    }
-    let canonical = tokio::fs::canonicalize(&ancestor)
-        .await
-        .map_err(|error| io_error(virtual_path.clone(), operation, error))?;
-    if bootstrap_root.is_some_and(|bootstrap_root| canonical == bootstrap_root) {
-        return Ok(());
-    }
-    ensure_contained(virtual_path, containment_root, &canonical, true)
-}
-
-/// Checks `candidate` (an already-canonicalized host path) is contained
-/// within `containment_root`. For a plain mount, `containment_root` is the
-/// mount's `host_root`; for a [`LocalMount::leaf_scoped`] mount it is the
-/// caller's own leaf under `host_root` (see [`DiskFilesystem::resolve_joined`]),
-/// so a symlink that escapes the caller's leaf — even while staying inside
-/// the shared `host_root` — is rejected here exactly like an escape past
-/// `host_root` itself.
-fn ensure_contained(
-    virtual_path: &VirtualPath,
-    containment_root: &Path,
-    candidate: &Path,
-    existing_target: bool,
-) -> Result<(), FilesystemError> {
-    if candidate.starts_with(containment_root) {
-        Ok(())
-    } else if existing_target {
-        Err(FilesystemError::SymlinkEscape {
-            path: virtual_path.clone(),
-        })
-    } else {
-        Err(FilesystemError::PathOutsideMount {
-            path: virtual_path.clone(),
-        })
-    }
-}
-
-fn file_type_from_metadata(metadata: &std::fs::Metadata) -> FileType {
-    let file_type = metadata.file_type();
-    if file_type.is_file() {
-        FileType::File
-    } else if file_type.is_dir() {
-        FileType::Directory
-    } else if file_type.is_symlink() {
-        FileType::Symlink
-    } else {
-        FileType::Other
-    }
 }
 
 fn io_error(
@@ -963,12 +1209,13 @@ mod tests {
     }
 
     /// A *dangling* final symlink — the entry exists but its target does
-    /// not — must still be rejected. `tokio::fs::try_exists` follows
-    /// symlinks and reports `false` for a target that doesn't exist yet, so
-    /// naively treating "not exists" as "brand new file in this leaf" would
-    /// let `write_file`/`append_file` open through the symlink (the OS
-    /// creates the target on `O_CREAT`), writing into whatever sibling leaf
-    /// (or worse) the symlink points at.
+    /// not — must still be rejected. Naively treating "target doesn't
+    /// resolve" as "brand new file in this leaf" would let `write_file`/
+    /// `append_file` open through the symlink (the OS creates the target on
+    /// `O_CREAT`), writing into whatever sibling leaf (or worse) the symlink
+    /// points at. `atomic_write_file`'s pre-install probe (`open_one` with
+    /// `O_NOFOLLOW`) is what catches this now: it never resolves the
+    /// dangling target at all, so "does the target exist" never comes up.
     #[cfg(unix)]
     #[tokio::test]
     async fn leaf_scoped_mount_rejects_dangling_final_symlink_escape_on_write() {

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -73,7 +73,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use ironclaw_host_api::VirtualPath;
 use rustix::fd::{AsFd, BorrowedFd, OwnedFd};
-use rustix::fs::{AtFlags, Mode, OFlags};
+use rustix::fs::{AtFlags, Dev, Mode, OFlags};
 use rustix::io::Errno;
 
 use crate::{CasExpectation, FileType, FilesystemError, FilesystemOperation, RecordVersion};
@@ -150,6 +150,7 @@ impl SymlinkBudget {
 /// (replace the symlink with a relative one) — see
 /// `resolve_error_to_filesystem_error` and
 /// `FilesystemError::SymlinkEscape`'s `detail` field.
+#[derive(Debug)]
 pub(super) enum ResolveError {
     Escape,
     AbsoluteSymlinkTarget {
@@ -187,6 +188,29 @@ pub(super) fn resolve_error_to_filesystem_error(
 
 fn io_err(errno: Errno) -> ResolveError {
     ResolveError::Io(errno.into())
+}
+
+/// Rejects `fd` (fail closed, `ResolveError::Escape`) if its device differs
+/// from `anchor_dev` — the portable-fallback (macOS, and the Linux
+/// `openat2`-unsupported fallback) equivalent of Linux's
+/// `openat2(RESOLVE_BENEATH)`, which implies `RESOLVE_NO_XDEV` and rejects a
+/// mount crossing at the kernel level (PR #6817 follow-up: macOS
+/// `RESOLVE_NO_XDEV` parity). Without this, a bind mount or mounted volume
+/// nested anywhere inside a mount's root — lexically "beneath" it, so every
+/// other check in this module accepts it — was silently traversable on
+/// macOS (and on the Linux fallback) while an identical layout is rejected
+/// on the Linux fast path, a platform-dependent containment gap.
+///
+/// One extra `fstat` per opened fd, called from [`open_one_inner`]'s
+/// portable `openat` branch — the single choke point every fresh open in
+/// this module's portable path goes through — so every directory hop and
+/// every leaf, not just the final component, is checked.
+fn check_same_device(anchor_dev: Dev, fd: BorrowedFd<'_>) -> Result<(), ResolveError> {
+    let stat = rustix::fs::fstat(fd).map_err(io_err)?;
+    if stat.st_dev != anchor_dev {
+        return Err(ResolveError::Escape);
+    }
+    Ok(())
 }
 
 /// Opens exactly one path component beneath `dir`, following it if it is a
@@ -258,8 +282,9 @@ pub(super) fn open_one(
     oflags: OFlags,
     mode: Mode,
     budget: &SymlinkBudget,
+    anchor_dev: Dev,
 ) -> Result<OwnedFd, ResolveError> {
-    open_one_inner(root, ancestors, dir, name, oflags, mode, budget)
+    open_one_inner(root, ancestors, dir, name, oflags, mode, budget, anchor_dev)
 }
 
 /// Outcome of the Linux `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`
@@ -351,13 +376,20 @@ fn open_one_inner(
     oflags: OFlags,
     mode: Mode,
     budget: &SymlinkBudget,
+    anchor_dev: Dev,
 ) -> Result<OwnedFd, ResolveError> {
     #[cfg(target_os = "linux")]
     {
+        // `openat2(RESOLVE_BENEATH)` implies `RESOLVE_NO_XDEV` (see
+        // `open_one_beneath_no_symlinks`'s `Errno::XDEV` arm), so the kernel
+        // itself already rejects a mount crossing on this fast path — no
+        // additional `check_same_device` call is needed here.
         match open_one_beneath_no_symlinks(dir, name, oflags, mode) {
             FastOpenOutcome::Opened(fd) => return Ok(fd),
             FastOpenOutcome::IsSymlink => {
-                return follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget);
+                return follow_symlink_component(
+                    root, ancestors, dir, name, oflags, mode, budget, anchor_dev,
+                );
             }
             FastOpenOutcome::Failed(error) => return Err(error),
             // Fall through to the portable per-component path below instead
@@ -371,13 +403,22 @@ fn open_one_inner(
         oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
         mode,
     ) {
-        Ok(fd) => Ok(fd),
+        // Portable fallback (macOS always; Linux when `openat2` is
+        // unsupported) — no kernel-enforced `RESOLVE_NO_XDEV` here, so this
+        // module must check the opened fd's device itself before handing it
+        // back (PR #6817 follow-up: macOS `RESOLVE_NO_XDEV` parity). Fails
+        // closed exactly like every other containment rejection in this
+        // module — never falls back to a wider root or a path-string check.
+        Ok(fd) => {
+            check_same_device(anchor_dev, fd.as_fd())?;
+            Ok(fd)
+        }
         // With `O_NOFOLLOW` set, `ELOOP` from a single-component open
         // unambiguously means "this entry is a symlink" (the kernel never
         // attempts to expand it, so a genuine cycle cannot be observed
         // here) — follow it ourselves, fd-anchored and budget-bounded.
         Err(Errno::LOOP) => {
-            follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget)
+            follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget, anchor_dev)
         }
         // Some platforms (observed on macOS) report `ENOTDIR` rather than
         // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
@@ -392,7 +433,9 @@ fn open_one_inner(
                     if rustix::fs::FileType::from_raw_mode(stat.st_mode)
                         == rustix::fs::FileType::Symlink =>
                 {
-                    follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget)
+                    follow_symlink_component(
+                        root, ancestors, dir, name, oflags, mode, budget, anchor_dev,
+                    )
                 }
                 _ => Err(io_err(Errno::NOTDIR)),
             }
@@ -416,11 +459,19 @@ fn follow_symlink_component(
     oflags: OFlags,
     mode: Mode,
     budget: &SymlinkBudget,
+    anchor_dev: Dev,
 ) -> Result<OwnedFd, ResolveError> {
     budget.consume()?;
     let target = rustix::fs::readlinkat(dir, name, Vec::new()).map_err(io_err)?;
-    let (new_ancestors, anchor, last) =
-        walk_symlink_target(root, ancestors, dir, name, target.as_bytes(), budget)?;
+    let (new_ancestors, anchor, last) = walk_symlink_target(
+        root,
+        ancestors,
+        dir,
+        name,
+        target.as_bytes(),
+        budget,
+        anchor_dev,
+    )?;
     match last {
         Some(final_name) => open_one_inner(
             root,
@@ -430,6 +481,7 @@ fn follow_symlink_component(
             oflags,
             mode,
             budget,
+            anchor_dev,
         ),
         // Target had no final component (e.g. "/" or ""): it resolves to
         // the anchor directory itself.
@@ -499,6 +551,7 @@ fn walk_symlink_target(
     symlink_name: &OsStr,
     target: &[u8],
     budget: &SymlinkBudget,
+    anchor_dev: Dev,
 ) -> Result<(Vec<OwnedFd>, OwnedFd, Option<OsString>), ResolveError> {
     if target.starts_with(b"/") {
         // PR #6817 review follow-up: report exactly which symlink and
@@ -548,6 +601,7 @@ fn walk_symlink_target(
             OFlags::DIRECTORY,
             Mode::empty(),
             budget,
+            anchor_dev,
         )?;
         stack.push(cur);
         cur = next;
@@ -586,6 +640,16 @@ pub(super) fn resolve_walk(
         return Ok((dup_fd(root)?, None));
     };
     let budget = SymlinkBudget::new();
+    // Captured once per resolution, not re-`fstat`'d per component (PR
+    // #6817 follow-up: macOS `RESOLVE_NO_XDEV` parity) — mirroring
+    // `SymlinkBudget`'s own per-resolution-not-per-component construction
+    // just above. Caching this at mount-open time instead (on `LocalMount`)
+    // would not actually save anything: a `leaf_scoped` mount's anchor is a
+    // *fresh* fd opened per call (see `anchor_for_target` in `local.rs`), so
+    // its device still has to be read per resolution regardless of where the
+    // non-leaf-scoped case's value came from. One `fstat` per request is the
+    // real floor either way.
+    let anchor_dev = rustix::fs::fstat(root).map_err(io_err)?.st_dev;
     let mut cur = dup_fd(root)?;
     let mut ancestors: Vec<OwnedFd> = Vec::with_capacity(ancestor_components.len());
     for component in ancestor_components {
@@ -597,6 +661,7 @@ pub(super) fn resolve_walk(
             OFlags::DIRECTORY,
             Mode::empty(),
             &budget,
+            anchor_dev,
         )?;
         ancestors.push(cur);
         cur = next;
@@ -609,6 +674,7 @@ pub(super) fn resolve_walk(
         final_oflags,
         Mode::empty(),
         &budget,
+        anchor_dev,
     )?;
     Ok((fd, Some((cur, leaf.clone()))))
 }
@@ -654,6 +720,9 @@ pub(super) fn descend_creating(
     components: &[OsString],
 ) -> Result<(OwnedFd, Vec<OwnedFd>), ResolveError> {
     let budget = SymlinkBudget::new();
+    // See `resolve_walk`'s matching comment: captured once per resolution,
+    // not per component.
+    let anchor_dev = rustix::fs::fstat(root).map_err(io_err)?.st_dev;
     let mut cur = dup_fd(root)?;
     let mut ancestors: Vec<OwnedFd> = Vec::new();
     for component in components {
@@ -665,6 +734,7 @@ pub(super) fn descend_creating(
             OFlags::DIRECTORY,
             Mode::empty(),
             &budget,
+            anchor_dev,
         ) {
             Ok(fd) => {
                 ancestors.push(cur);
@@ -689,6 +759,7 @@ pub(super) fn descend_creating(
                     OFlags::DIRECTORY,
                     Mode::empty(),
                     &budget,
+                    anchor_dev,
                 )?;
                 ancestors.push(cur);
                 fd
@@ -736,6 +807,9 @@ pub(super) fn resolve_write_leaf(
     leaf: &OsStr,
 ) -> Result<(OwnedFd, OsString), ResolveError> {
     let budget = SymlinkBudget::new();
+    // See `resolve_walk`'s matching comment: captured once per resolution,
+    // not per component.
+    let anchor_dev = rustix::fs::fstat(root).map_err(io_err)?.st_dev;
     let mut cur_ancestors: Vec<OwnedFd> = Vec::with_capacity(ancestors.len());
     for ancestor in ancestors {
         cur_ancestors.push(dup_fd(ancestor.as_fd())?);
@@ -771,6 +845,7 @@ pub(super) fn resolve_write_leaf(
             &cur_leaf,
             target.as_bytes(),
             &budget,
+            anchor_dev,
         )?;
         let Some(new_leaf) = new_leaf else {
             // Symlink target has no final path component (e.g. "/" or ""):
@@ -1065,6 +1140,144 @@ mod tests {
     use tempfile::tempdir;
 
     use super::remove_dir_all_fd;
+
+    /// Deterministic, platform-independent pin on the mount-crossing check's
+    /// own contract (PR #6817 follow-up, macOS `RESOLVE_NO_XDEV` parity):
+    /// given an anchor device that differs from an opened fd's device, the
+    /// resolver must fail closed with `ResolveError::Escape` — never fall
+    /// back to a path-string check or a wider root. This does not exercise a
+    /// *real* mount crossing (see the `#[cfg(target_os = "macos")]` test
+    /// below for that); it pins `check_same_device`'s own logic so the
+    /// contract is covered even on a CI runner where a real bind mount can't
+    /// be constructed.
+    #[test]
+    fn check_same_device_rejects_mismatched_device() {
+        let storage = tempdir().unwrap();
+        let fd = openat(
+            rustix::fs::CWD,
+            storage.path(),
+            OFlags::DIRECTORY | OFlags::RDONLY,
+            Mode::empty(),
+        )
+        .unwrap();
+        let real_dev = rustix::fs::fstat(&fd).unwrap().st_dev;
+
+        // Same device: must pass.
+        assert!(super::check_same_device(real_dev, fd.as_fd()).is_ok());
+
+        // A device value that cannot match the real one: must fail closed.
+        let bogus_dev = real_dev.wrapping_add(1).max(1);
+        assert!(matches!(
+            super::check_same_device(bogus_dev, fd.as_fd()),
+            Err(super::ResolveError::Escape)
+        ));
+    }
+
+    /// Real cross-device traversal regression for the macOS/portable-fallback
+    /// `RESOLVE_NO_XDEV` parity gap (PR #6817 follow-up): on Linux,
+    /// `openat2(RESOLVE_BENEATH)` implies `RESOLVE_NO_XDEV` and rejects a
+    /// bind-mount crossing inside the resolution root — but the portable
+    /// fallback `open_one_inner` uses on macOS (and as the Linux
+    /// `openat2`-unsupported fallback) had zero `st_dev` check, so a mounted
+    /// volume nested inside a mount's root was traversable there and
+    /// rejected on Linux for an identical layout.
+    ///
+    /// This mounts a real APFS disk image (via `hdiutil`, no root required)
+    /// at a subdirectory of a tempdir-backed resolution root, then asserts
+    /// `resolve_walk` refuses to walk into it. A genuine, kernel-level device
+    /// boundary — not a simulated one.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_walk_rejects_real_mount_crossing_on_macos() {
+        use std::os::unix::fs::MetadataExt;
+        use std::process::Command;
+
+        let storage = tempdir().unwrap();
+        let root_path = storage.path();
+        let mount_point = root_path.join("crossing");
+        std::fs::create_dir_all(&mount_point).unwrap();
+
+        let dmg_dir = tempdir().unwrap();
+        let dmg_path = dmg_dir.path().join("xdev_test.dmg");
+
+        let create_status = Command::new("hdiutil")
+            .args([
+                "create",
+                "-size",
+                "5m",
+                "-fs",
+                "APFS",
+                "-volname",
+                "xdevtest",
+                dmg_path.to_str().unwrap(),
+            ])
+            .status()
+            .expect("hdiutil create must run on macOS test hosts");
+        assert!(create_status.success(), "hdiutil create failed");
+
+        // `hdiutil create` appends `.dmg` if not already present in some
+        // macOS versions' output naming; locate the actual produced file.
+        let actual_dmg = if dmg_path.exists() {
+            dmg_path
+        } else {
+            dmg_dir.path().join("xdev_test.dmg.dmg")
+        };
+
+        let attach_status = Command::new("hdiutil")
+            .args([
+                "attach",
+                actual_dmg.to_str().unwrap(),
+                "-mountpoint",
+                mount_point.to_str().unwrap(),
+                "-nobrowse",
+            ])
+            .status()
+            .expect("hdiutil attach must run on macOS test hosts");
+        assert!(attach_status.success(), "hdiutil attach failed");
+
+        // Ensure the volume is detached even if an assertion below panics.
+        struct DetachGuard(std::path::PathBuf);
+        impl Drop for DetachGuard {
+            fn drop(&mut self) {
+                let _ = Command::new("hdiutil")
+                    .args(["detach", self.0.to_str().unwrap(), "-force"])
+                    .status();
+            }
+        }
+        let _detach = DetachGuard(mount_point.clone());
+
+        // Sanity-check the mount actually crossed a device boundary before
+        // trusting the resolver's rejection of it.
+        let root_dev = std::fs::metadata(root_path).unwrap().dev();
+        let mounted_dev = std::fs::metadata(&mount_point).unwrap().dev();
+        assert_ne!(
+            root_dev, mounted_dev,
+            "test setup did not actually cross a device boundary"
+        );
+
+        let root_fd = openat(
+            rustix::fs::CWD,
+            root_path,
+            OFlags::DIRECTORY | OFlags::RDONLY,
+            Mode::empty(),
+        )
+        .unwrap();
+
+        let result = super::resolve_walk(
+            root_fd.as_fd(),
+            &[
+                std::ffi::OsString::from("crossing"),
+                std::ffi::OsString::from("anything"),
+            ],
+            OFlags::RDONLY,
+        );
+
+        assert!(
+            matches!(result, Err(super::ResolveError::Escape)),
+            "resolving into a mounted volume nested inside the resolution root must fail \
+             closed with Escape, matching Linux's RESOLVE_NO_XDEV behavior — got {result:?}"
+        );
+    }
 
     /// Deterministic (non-timing-dependent) regression for the recursive
     /// `delete` symlink race flagged in PR #6817 review: `remove_dir_all_fd`

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -428,7 +428,14 @@ pub(super) fn resolve_walk(
             &budget,
         )?;
     }
-    let fd = open_one(root, cur.as_fd(), leaf, final_oflags, Mode::empty(), &budget)?;
+    let fd = open_one(
+        root,
+        cur.as_fd(),
+        leaf,
+        final_oflags,
+        Mode::empty(),
+        &budget,
+    )?;
     Ok((fd, Some((cur, leaf.clone()))))
 }
 

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -1,0 +1,451 @@
+//! fd-rooted, symlink-free traversal primitives for the local disk backend.
+//!
+//! Every function below operates purely on file descriptors and path
+//! *components* (never a joined host path string). `open_one` is the one
+//! place a directory-entry lookup happens, and it refuses to follow a
+//! symlink anywhere in the walk. Because resolution never hands back a path
+//! for a later, independent syscall to re-open, there is no window between
+//! "checked" and "acted on" for an attacker to swap the entry in.
+//!
+//! This module is deliberately self-contained: nothing here depends on
+//! `DiskFilesystem`/`LocalMount`/the `RootFilesystem` impl in the parent
+//! `local` module — every function operates on `BorrowedFd`/`OwnedFd` and
+//! `OsStr`/`OsString` only, plus the crate's error/path vocabulary
+//! (`FilesystemError`, `FilesystemOperation`, `VirtualPath`). That is also
+//! why this module has no reason to ever import `tokio::fs` (or any other
+//! path-based filesystem API): its whole job is to be the fd-relative
+//! alternative to one.
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStrExt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ironclaw_host_api::VirtualPath;
+use rustix::fd::{AsFd, BorrowedFd, OwnedFd};
+use rustix::fs::{AtFlags, Mode, OFlags};
+use rustix::io::Errno;
+
+use crate::{CasExpectation, FileType, FilesystemError, FilesystemOperation, RecordVersion};
+
+static LOCAL_WRITE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// The outcome of a failed fd-relative resolution step: either a genuine I/O
+/// error (propagated as-is), or a symlink/`..`-past-root escape attempt.
+pub(super) enum ResolveError {
+    Escape,
+    Io(std::io::Error),
+}
+
+pub(super) fn resolve_error_to_filesystem_error(
+    path: &VirtualPath,
+    operation: FilesystemOperation,
+    error: ResolveError,
+) -> FilesystemError {
+    match error {
+        ResolveError::Escape => FilesystemError::SymlinkEscape { path: path.clone() },
+        ResolveError::Io(io_err) => super::io_error(path.clone(), operation, io_err),
+    }
+}
+
+/// Opens exactly one path component beneath `dir`, refusing to follow a
+/// symlink at that component.
+///
+/// On Linux, this is one syscall via `openat2(RESOLVE_BENEATH |
+/// RESOLVE_NO_SYMLINKS)` when the kernel supports it (falling back below on
+/// `ENOSYS` — an older kernel, or a container/seccomp profile that denies
+/// `openat2` outright). Everywhere else, including macOS (which has no
+/// `openat2` at all), a plain `openat` with `O_NOFOLLOW`.
+///
+/// **macOS asymmetry, documented rather than silent:** both paths reject the
+/// same attack class — a symlink at any resolved path component, ancestor or
+/// leaf — because `O_NOFOLLOW` and `RESOLVE_NO_SYMLINKS` both refuse to
+/// traverse a symlink; the security property (no symlink traversal escapes
+/// the mount root) holds identically on both platforms. What macOS's
+/// fallback does *not* get is `RESOLVE_BENEATH`'s single-syscall,
+/// kernel-enforced resolution step: each `open_one` call is independently
+/// safe (it either opens the real, non-symlink entry or fails), but the
+/// *sequence* of `open_one` calls that make up a full path walk on macOS is
+/// coordinated by this module's own loop (`walk`/`resolve_walk`/
+/// `descend_creating`), not by one kernel-verified decision the way
+/// `RESOLVE_BENEATH` verifies a whole relative path in a single syscall on
+/// Linux. Both close the same escape; only the mechanism differs.
+pub(super) fn open_one(
+    dir: BorrowedFd<'_>,
+    name: &OsStr,
+    oflags: OFlags,
+    mode: Mode,
+) -> Result<OwnedFd, ResolveError> {
+    #[cfg(target_os = "linux")]
+    {
+        use rustix::fs::{ResolveFlags, openat2};
+
+        // `openat2(2)` documents `EAGAIN` for "a resolution restart was
+        // necessary, e.g. because of concurrent rename or unlink of a path
+        // component" — a *legitimate* concurrent mutation (an editor's
+        // atomic save, `git checkout`, a parallel build touching the same
+        // subtree), not an attack. Without a retry, a real, benign rename
+        // racing an unrelated open makes `openat2` spuriously fail and the
+        // caller sees an opaque `Backend` error for an operation that would
+        // have succeeded a moment later. Retry a small, fixed number of
+        // times — each retry is a fresh kernel-side resolution, not a busy
+        // spin on our own state, so the bound only needs to outlast one
+        // rename's duration, not any unbounded contention; the loop always
+        // terminates within `MAX_AGAIN_RETRIES + 1` attempts, never spins
+        // unbounded. What happens when the bound is exhausted is documented
+        // at the `Err(Errno::AGAIN) => break` arm below.
+        const MAX_AGAIN_RETRIES: u8 = 4;
+        let mut retries = 0;
+        loop {
+            match openat2(
+                dir,
+                name,
+                oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                mode,
+                ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
+            ) {
+                Ok(fd) => return Ok(fd),
+                // Kernel predates openat2 (< 5.6), or a seccomp/container
+                // policy denies the syscall outright. Fall through to the
+                // portable per-component path below rather than failing
+                // closed on a syscall the fallback doesn't need.
+                Err(Errno::NOSYS) => break,
+                Err(Errno::AGAIN) if retries < MAX_AGAIN_RETRIES => {
+                    retries += 1;
+                    continue;
+                }
+                // Retries exhausted (a pathological, sustained-rename case
+                // rather than one atomic swap): fall through to the
+                // portable per-component path below instead of surfacing an
+                // opaque `Backend` error, since that path does not share
+                // `openat2`'s whole-path-restart-on-`EAGAIN` failure mode.
+                Err(Errno::AGAIN) => break,
+                Err(Errno::LOOP) | Err(Errno::XDEV) => return Err(ResolveError::Escape),
+                Err(errno) => return Err(ResolveError::Io(errno.into())),
+            }
+        }
+    }
+    match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {
+        Ok(fd) => Ok(fd),
+        Err(Errno::LOOP) => Err(ResolveError::Escape),
+        // Some platforms (observed on macOS) report `ENOTDIR` rather than
+        // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
+        // kernel checks "is this a directory" before "did NOFOLLOW block
+        // it", and a symlink is never a directory itself. `ENOTDIR` is
+        // ambiguous on its own (a plain non-directory file blocking descent
+        // hits it too), so disambiguate with one `AT_SYMLINK_NOFOLLOW`
+        // `fstatat` rather than guessing either way.
+        Err(Errno::NOTDIR) if oflags.contains(OFlags::DIRECTORY) => {
+            match rustix::fs::statat(dir, name, AtFlags::SYMLINK_NOFOLLOW) {
+                Ok(stat)
+                    if rustix::fs::FileType::from_raw_mode(stat.st_mode)
+                        == rustix::fs::FileType::Symlink =>
+                {
+                    Err(ResolveError::Escape)
+                }
+                _ => Err(ResolveError::Io(Errno::NOTDIR.into())),
+            }
+        }
+        Err(errno) => Err(ResolveError::Io(errno.into())),
+    }
+}
+
+fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
+    rustix::io::dup(fd).map_err(|errno| ResolveError::Io(errno.into()))
+}
+
+/// Walks `components` from `root`, refusing every symlink along the way, and
+/// returns the final entry's fd plus — when `components` is non-empty — the
+/// fd of its immediate parent directory and its own name (needed by callers
+/// that must act on the parent, e.g. `unlinkat`/`renameat`, rather than on
+/// the entry itself, which POSIX has no "act on this fd regardless of its
+/// name" primitive for).
+///
+/// `components` empty resolves to the mount root itself (`root` duplicated),
+/// with no parent — the mount root has no fd-relative parent inside this
+/// mount's sandbox, by design (see `DiskFilesystem::delete`).
+pub(super) fn resolve_walk(
+    root: BorrowedFd<'_>,
+    components: &[OsString],
+    final_oflags: OFlags,
+) -> Result<(OwnedFd, Option<(OwnedFd, OsString)>), ResolveError> {
+    let Some((leaf, ancestors)) = components.split_last() else {
+        return Ok((dup_fd(root)?, None));
+    };
+    let mut cur = dup_fd(root)?;
+    for component in ancestors {
+        cur = open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?;
+    }
+    let fd = open_one(cur.as_fd(), leaf, final_oflags, Mode::empty())?;
+    Ok((fd, Some((cur, leaf.clone()))))
+}
+
+/// Walks `components` from `root`, creating any missing directory along the
+/// way (`mkdir -p` semantics), and returns the final directory's fd. Used
+/// by `write_file`/`append_file` (parent-only — matching the previous
+/// implementation's "always create the parent chain" behavior) and by
+/// `create_dir_all` (full path, leaf included).
+///
+/// Each level is still resolved through [`open_one`], so a symlink swapped
+/// into any not-yet-existing ancestor between one level's `mkdirat` and the
+/// next level's `open_one` is rejected exactly like any other symlink in the
+/// walk — there is no separate "check ancestor, then mkdir, then check
+/// again" gap here, because creation and the next level's containment check
+/// are the same `open_one` call the next loop iteration makes.
+pub(super) fn descend_creating(
+    root: BorrowedFd<'_>,
+    components: &[OsString],
+) -> Result<OwnedFd, ResolveError> {
+    let mut cur = dup_fd(root)?;
+    for component in components {
+        cur = match open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty()) {
+            Ok(fd) => fd,
+            Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {
+                match rustix::fs::mkdirat(cur.as_fd(), component.as_os_str(), new_dir_mode()) {
+                    Ok(()) => {}
+                    Err(Errno::EXIST) => {}
+                    Err(errno) => return Err(ResolveError::Io(errno.into())),
+                }
+                open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?
+            }
+            Err(other) => return Err(other),
+        };
+    }
+    Ok(cur)
+}
+
+/// Maximum nesting depth [`remove_dir_all_fd`] will descend into before
+/// failing closed, rather than recursing without limit.
+///
+/// This is genuinely recursive Rust code running on a tokio blocking-pool
+/// thread — not a regression (`std::fs::remove_dir_all` is also recursive
+/// and has no cap of its own), but a deep tree can now be created entirely
+/// inside a sandboxed shell's own writable mount, i.e. by someone who will
+/// deliberately try to break it. 512 levels comfortably survives on a
+/// default thread stack (each frame here is a handful of small locals, no
+/// large stack arrays) while still failing far short of any real stack
+/// limit if a caller does manage to create a tree this deep. `remove_dir_contents`
+/// only `unlinkat`s a symlink entry directly (`AtFlags::empty()`, never
+/// following it) and never recurses through one, so cycles via symlinks are
+/// not a concern here — depth is bounded purely by real, non-symlink
+/// directory nesting.
+const MAX_REMOVE_DIR_DEPTH: usize = 512;
+
+/// Recursively removes `name` (found directly under `parent`) and everything
+/// beneath it, never following a symlink into whatever it points at — a
+/// symlinked child is unlinked as itself, exactly like `std::fs::remove_dir_all`,
+/// never traversed into.
+pub(super) fn remove_dir_all_fd(
+    parent: BorrowedFd<'_>,
+    name: &OsStr,
+) -> Result<(), std::io::Error> {
+    remove_dir_all_fd_bounded(parent, name, 0)
+}
+
+fn remove_dir_all_fd_bounded(
+    parent: BorrowedFd<'_>,
+    name: &OsStr,
+    depth: usize,
+) -> Result<(), std::io::Error> {
+    if depth >= MAX_REMOVE_DIR_DEPTH {
+        return Err(std::io::Error::other(format!(
+            "directory tree exceeds maximum removal depth of {MAX_REMOVE_DIR_DEPTH} levels; refusing to delete"
+        )));
+    }
+    let dir_fd =
+        open_one(parent, name, OFlags::DIRECTORY, Mode::empty()).map_err(resolve_error_to_io)?;
+    remove_dir_contents(dir_fd.as_fd(), depth + 1)?;
+    rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(std::io::Error::from)
+}
+
+fn remove_dir_contents(dir: BorrowedFd<'_>, depth: usize) -> Result<(), std::io::Error> {
+    let mut entries = Vec::new();
+    {
+        let listing = rustix::fs::Dir::read_from(dir)?;
+        for entry in listing {
+            let entry = entry?;
+            let name_bytes = entry.file_name().to_bytes();
+            if name_bytes == b"." || name_bytes == b".." {
+                continue;
+            }
+            let name = OsStr::from_bytes(name_bytes).to_os_string();
+            let stat = rustix::fs::statat(dir, &name, AtFlags::SYMLINK_NOFOLLOW)?;
+            let is_dir = rustix::fs::FileType::from_raw_mode(stat.st_mode)
+                == rustix::fs::FileType::Directory;
+            entries.push((name, is_dir));
+        }
+    }
+    for (name, is_dir) in entries {
+        if is_dir {
+            remove_dir_all_fd_bounded(dir, &name, depth)?;
+        } else {
+            rustix::fs::unlinkat(dir, &name, AtFlags::empty())?;
+        }
+    }
+    Ok(())
+}
+
+fn resolve_error_to_io(error: ResolveError) -> std::io::Error {
+    match error {
+        ResolveError::Escape => std::io::Error::other("symlink escape"),
+        ResolveError::Io(io_err) => io_err,
+    }
+}
+
+pub(super) fn read_all(fd: OwnedFd) -> Result<Vec<u8>, std::io::Error> {
+    use std::io::Read;
+    let mut file = std::fs::File::from(fd);
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+pub(super) fn write_all(fd: OwnedFd, bytes: &[u8]) -> Result<(), std::io::Error> {
+    use std::io::Write;
+    let mut file = std::fs::File::from(fd);
+    file.write_all(bytes)?;
+    file.flush()
+}
+
+pub(super) fn new_file_mode() -> Mode {
+    Mode::RUSR | Mode::WUSR | Mode::RGRP | Mode::WGRP | Mode::ROTH | Mode::WOTH
+}
+
+fn new_dir_mode() -> Mode {
+    Mode::RWXU | Mode::RWXG | Mode::RWXO
+}
+
+pub(super) fn map_file_type(kind: rustix::fs::FileType) -> FileType {
+    match kind {
+        rustix::fs::FileType::RegularFile => FileType::File,
+        rustix::fs::FileType::Directory => FileType::Directory,
+        rustix::fs::FileType::Symlink => FileType::Symlink,
+        _ => FileType::Other,
+    }
+}
+
+/// Atomically installs `bytes` as `leaf` under `parent`, via a temp file
+/// created in the same directory and then renamed (`CasExpectation::Any`) or
+/// hard-linked into place (`CasExpectation::Absent`) — unchanged in
+/// approach from before this fix, just fd-relative (`renameat`/`linkat`
+/// against `parent`, an already fd-resolved, already-verified directory)
+/// instead of path-relative. `rename`/`link` never follow a symlink at the
+/// destination name (they replace/create the directory entry itself), so
+/// this step was never part of the TOCTOU surface `resolve_for_write` left
+/// open; only `append_file`'s direct `open` of the leaf was.
+pub(super) fn atomic_write_file(
+    virtual_path: &VirtualPath,
+    parent: BorrowedFd<'_>,
+    leaf: &OsStr,
+    bytes: &[u8],
+    cas: CasExpectation,
+) -> Result<(), FilesystemError> {
+    // `rename`/`link` never follow a symlink at the destination name (see
+    // the function doc), so the install step below can never be tricked
+    // into writing through one — but silently *replacing* a symlink entry
+    // that's still sitting at the leaf (dangling or not) is a real content
+    // loss surprise for whatever legitimately created it, and this crate's
+    // steady-state contract is "reject a pre-existing symlink at a write
+    // target", not "clobber it". Probe with the same `O_NOFOLLOW` primitive
+    // every other lookup in this module uses, immediately before the
+    // install below — both run inside the same non-yielding blocking
+    // closure, so there is no `.await` for a swap to land between the probe
+    // and the install.
+    match open_one(parent, leaf, OFlags::RDONLY, Mode::empty()) {
+        Ok(_existing) => {}
+        Err(ResolveError::Escape) => {
+            return Err(FilesystemError::SymlinkEscape {
+                path: virtual_path.clone(),
+            });
+        }
+        Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(ResolveError::Io(io_err)) => {
+            return Err(super::io_error(
+                virtual_path.clone(),
+                FilesystemOperation::WriteFile,
+                io_err,
+            ));
+        }
+    }
+
+    let counter = LOCAL_WRITE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut temp_name = OsString::from(".");
+    temp_name.push(leaf);
+    temp_name.push(format!(".tmp.{counter}"));
+
+    let temp_fd = open_one(
+        parent,
+        &temp_name,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL,
+        new_file_mode(),
+    )
+    .map_err(|error| {
+        resolve_error_to_filesystem_error(virtual_path, FilesystemOperation::WriteFile, error)
+    })?;
+
+    let write_result = (|| -> std::io::Result<()> {
+        use std::io::Write;
+        let mut file = std::fs::File::from(temp_fd);
+        file.write_all(bytes)?;
+        file.sync_all()
+    })();
+    if let Err(error) = write_result {
+        let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+        return Err(super::io_error(
+            virtual_path.clone(),
+            FilesystemOperation::WriteFile,
+            error,
+        ));
+    }
+
+    let install_result = match cas {
+        CasExpectation::Any => {
+            rustix::fs::renameat(parent, &temp_name, parent, leaf).map_err(|errno| {
+                super::io_error(
+                    virtual_path.clone(),
+                    FilesystemOperation::WriteFile,
+                    errno.into(),
+                )
+            })
+        }
+        CasExpectation::Absent => {
+            match rustix::fs::linkat(parent, &temp_name, parent, leaf, AtFlags::empty()) {
+                Ok(()) => {
+                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+                    Ok(())
+                }
+                Err(Errno::EXIST) => {
+                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+                    Err(FilesystemError::VersionMismatch {
+                        path: virtual_path.clone(),
+                        expected: None,
+                        found: Some(RecordVersion::from_backend(0)),
+                    })
+                }
+                Err(errno) => {
+                    let _ = rustix::fs::unlinkat(parent, &temp_name, AtFlags::empty());
+                    Err(super::io_error(
+                        virtual_path.clone(),
+                        FilesystemOperation::WriteFile,
+                        errno.into(),
+                    ))
+                }
+            }
+        }
+        CasExpectation::Version(_) => Err(FilesystemError::Unsupported {
+            path: virtual_path.clone(),
+            operation: FilesystemOperation::WriteFile,
+        }),
+    };
+
+    install_result?;
+
+    // Best-effort durability: fsync the parent directory so the rename/link
+    // above survives a crash. Not part of the containment/TOCTOU surface —
+    // failure here is reported but the write itself already succeeded.
+    let parent_file = std::fs::File::from(dup_fd(parent).map_err(resolve_error_to_io).map_err(
+        |error| super::io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error),
+    )?);
+    parent_file.sync_all().map_err(|error| {
+        super::io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)
+    })
+}

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -4,11 +4,13 @@
 //! *components* (never a joined host path string). `open_one` is the one
 //! place a directory-entry lookup happens. It now **follows** a symlink that
 //! stays inside the resolution root, and refuses (fails closed) one that
-//! would step outside it — on Linux via a single kernel-enforced
-//! `openat2(RESOLVE_BENEATH)` call, on other platforms via this module's own
-//! bounded, fd-anchored walk. Because resolution never hands back a path for
-//! a later, independent syscall to re-open, there is no window between
-//! "checked" and "acted on" for an attacker to swap the entry in.
+//! would step outside it — on Linux via a kernel-enforced
+//! `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` call for the (common,
+//! no-symlink) fast case, falling back to this module's own bounded,
+//! fd-anchored walk the instant a symlink is actually encountered — on other
+//! platforms always via that same walk. Because resolution never hands back
+//! a path for a later, independent syscall to re-open, there is no window
+//! between "checked" and "acted on" for an attacker to swap the entry in.
 //!
 //! **Invariant every step in this module preserves:** no step ever resolves
 //! a path *string* against anything other than an fd this module already
@@ -27,6 +29,42 @@
 //! why this module has no reason to ever import `tokio::fs` (or any other
 //! path-based filesystem API): its whole job is to be the fd-relative
 //! alternative to one.
+//!
+//! **Why the Linux fast path no longer lets the kernel silently follow a
+//! symlink (`RESOLVE_NO_SYMLINKS` added, PR #6817 follow-up):** a bare
+//! `openat2(dir, name, RESOLVE_BENEATH)` call's containment boundary is
+//! `dir` — the *immediate* parent of the one component being opened — not
+//! this mount's true root. That composes correctly across a chain of plain
+//! (non-symlink) directories, since each step's `dir` is itself beneath its
+//! own parent's already-verified boundary. It does **not** compose for a
+//! *parent-relative* symlink: `dir/link -> ../sibling`, where `sibling` is
+//! still safely inside the mount root but the `..` in the target text steps
+//! above `dir` itself. `RESOLVE_BENEATH` rejects that with `EXDEV`
+//! regardless of where `sibling` actually is, because the kernel has no way
+//! to know this process's notion of "the true root" — only `RESOLVE_BENEATH`'s
+//! own `dir` argument. This is exactly the shape a real pnpm `node_modules`
+//! layout uses (`node_modules/@types/react ->
+//! ../.pnpm/react@.../node_modules/react`), so silently deferring every
+//! symlink to the kernel's own resolution would make this module reject
+//! (or, worse, sometimes accept via a coincidentally-matching boundary and
+//! sometimes reject) exactly the layouts the "follow in-bounds symlinks"
+//! policy change exists to support — and would do so only on Linux, silently
+//! diverging from the portable fallback below, which has always tracked the
+//! true root correctly (see [`walk_symlink_target`]).
+//!
+//! The fix: `open_one_inner`'s Linux arm adds `RESOLVE_NO_SYMLINKS` to its
+//! `openat2` flags. That makes the kernel refuse to follow *any* symlink at
+//! all (single-component call, so "any" only ever means "this one entry"),
+//! reporting `ELOOP` — at which point control falls to
+//! [`follow_symlink_component`], the exact same fd-anchored, budget-bounded,
+//! true-root-tracking walk the portable fallback always used. A plain
+//! directory/file component still resolves in one kernel-enforced syscall,
+//! at full speed; only the (uncommon) symlink case now pays for a handful of
+//! extra syscalls to resolve it correctly and portably. This also closes the
+//! [`SymlinkBudget`] gap tracked below: since every symlink hop, on every
+//! platform, now flows through [`follow_symlink_component`]'s
+//! `budget.consume()` call, the shared per-resolution cap actually bounds
+//! Linux resolution too, not just the portable fallback.
 
 use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
@@ -42,21 +80,23 @@ use crate::{CasExpectation, FileType, FilesystemError, FilesystemOperation, Reco
 
 static LOCAL_WRITE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Cap on symlink expansion during a single resolution — both the number of
-/// symlink hops `open_one`'s portable fallback will follow while descending
-/// a walk, and the number of hops [`resolve_write_leaf`] will chase at a
-/// write target. Chosen to match the ballpark of a typical kernel
-/// `SYMLOOP_MAX` (Linux and macOS both default to 40) without depending on
-/// the host's actual `sysconf` value: a legitimate directory structure never
-/// nests this many symlinks, so hitting the cap always means a cycle (or a
-/// pathological chain worth failing closed on rather than resolving), never
-/// a benign deep structure.
+/// Cap on symlink expansion during a single resolution — the number of
+/// symlink hops [`follow_symlink_component`] will follow while descending a
+/// walk, on *every* platform (see the module doc for why the Linux fast path
+/// now reaches this too, not just the portable fallback). Chosen to match
+/// the ballpark of a typical kernel `SYMLOOP_MAX` (Linux and macOS both
+/// default to 40) without depending on the host's actual `sysconf` value: a
+/// legitimate directory structure never nests this many symlinks, so hitting
+/// the cap always means a cycle (or a pathological chain worth failing
+/// closed on rather than resolving), never a benign deep structure.
 const MAX_SYMLINK_DEPTH: u8 = 32;
 
-/// A single-resolution symlink-hop budget, shared across every `open_one`
-/// call [`resolve_walk`]/[`descend_creating`]/[`resolve_write_leaf`] make
-/// while walking their (possibly multi-component) path — never reset
-/// per-component.
+/// A single-resolution symlink-hop budget, shared across every
+/// [`follow_symlink_component`] hop [`resolve_walk`]/[`descend_creating`]/
+/// [`resolve_write_leaf`] make while walking their (possibly
+/// multi-component) path — never reset per-component, and never reset
+/// per-platform: the Linux fast path and the portable fallback draw on the
+/// exact same budget for the exact same reason (see the module doc).
 ///
 /// Before this type existed, [`open_one`] always started a fresh
 /// [`MAX_SYMLINK_DEPTH`]-hop budget (`open_one_depth(..., 0)`), and
@@ -64,18 +104,10 @@ const MAX_SYMLINK_DEPTH: u8 = 32;
 /// component in a loop. That let a 10-component path with a
 /// `MAX_SYMLINK_DEPTH`-hop chain planted at *each* component accumulate
 /// roughly `10 * MAX_SYMLINK_DEPTH` total hops in one resolution — looser
-/// than the real `openat2(RESOLVE_BENEATH)` kernel fast path, which applies
-/// its own internal cap (Linux's `SYMLOOP_MAX`, effectively ~40) *once per
-/// whole resolution*, not per path component. Still bounded (no DoS) either
-/// way, but this type makes the portable fallback match that per-resolution
-/// semantics instead of a looser per-component one: one `SymlinkBudget` is
+/// than a per-resolution cap should allow. One `SymlinkBudget` is
 /// constructed at the top of each of those three functions and threaded by
 /// reference through every `open_one`/symlink-following call the walk makes,
 /// so the whole resolution shares one `MAX_SYMLINK_DEPTH`-hop ceiling.
-///
-/// The Linux `openat2` fast path is unaffected: it is a single syscall per
-/// component and the kernel enforces its own bound *inside* that syscall,
-/// with no dependency on this type at all.
 ///
 /// A `Cell`, not an `AtomicU8`: every caller of these functions runs the
 /// whole walk synchronously on one blocking-pool thread with no `.await` in
@@ -126,45 +158,137 @@ fn io_err(errno: Errno) -> ResolveError {
 }
 
 /// Opens exactly one path component beneath `dir`, following it if it is a
-/// symlink whose resolution stays inside `root`'s tree, and failing closed
-/// (`ResolveError::Escape`) if it would step outside `root` or exceed
-/// [`MAX_SYMLINK_DEPTH`].
+/// symlink whose resolution stays inside the true mount root, and failing
+/// closed (`ResolveError::Escape`) if it would step outside the root or
+/// exceed [`MAX_SYMLINK_DEPTH`].
 ///
-/// On Linux, this is one syscall via `openat2(RESOLVE_BENEATH)` when the
-/// kernel supports it (falling back below on `ENOSYS`). `RESOLVE_BENEATH`
-/// alone — without `RESOLVE_NO_SYMLINKS` — is already race-free and
-/// kernel-enforced: it follows a symlink whose resolution stays beneath
-/// `dir`'s own tree and refuses, atomically, one that would not.
-/// `RESOLVE_BENEATH`'s containment composes transitively across the calls
-/// [`resolve_walk`]/[`descend_creating`] make one component at a time (each
-/// step beneath its immediate parent, which is itself beneath its parent,
-/// …), so this function does not need `root` on the Linux fast path — only
-/// the portable fallback below does, to resolve an *absolute* symlink
-/// target against the correct anchor.
+/// `ancestors` is every already-open, already-verified directory fd strictly
+/// above `dir`, root-first (root itself is *not* included — callers that
+/// start at the root pass `&[]`). It exists solely to answer a `..`
+/// component inside a followed symlink's target text (see
+/// [`walk_symlink_target`]) without ever performing a live, name-based
+/// `openat(fd, "..")` lookup: popping this slice hands back an fd this
+/// module itself opened and is still holding, which a concurrent rename
+/// anywhere in the tree cannot invalidate (an open fd is immune to renames
+/// of the directory entry that produced it — see the module-level TOCTOU
+/// invariant). Forward (non-`..`) resolution never touches `ancestors` at
+/// all.
 ///
-/// Everywhere else (including macOS, which has no `openat2`), a
-/// per-component `openat` with `O_NOFOLLOW` detects a symlink and this
-/// module's own bounded walk ([`follow_symlink_component`]) resolves it —
-/// fd-anchored at every step, per the module invariant.
-/// Opens a single path component, following an in-bounds symlink against the
-/// shared per-resolution `budget` (see [`SymlinkBudget`]). Callers resolving
-/// a single, standalone component (not part of a multi-component walk) may
-/// pass a fresh `&SymlinkBudget::new()` — [`resolve_walk`]/
-/// [`descend_creating`] construct one `SymlinkBudget` and pass the *same*
-/// reference to every component's `open_one` call instead.
+/// On Linux, this is one syscall via
+/// `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` for the common case
+/// where `name` is not itself a symlink (falling back below on `ENOSYS`, or
+/// on an exhausted `EAGAIN` retry budget). `RESOLVE_NO_SYMLINKS` is the
+/// deliberate difference from a bare `RESOLVE_BENEATH`: it makes the kernel
+/// refuse to expand `name` even if it *is* a symlink whose resolution would
+/// have stayed within `dir`'s own tree, reporting `ELOOP` instead — at which
+/// point control falls through to [`follow_symlink_component`], the same
+/// fd-anchored, true-root-tracking walk the portable fallback always uses.
+/// See the module doc for why letting the kernel silently follow a symlink
+/// itself (the old, `RESOLVE_NO_SYMLINKS`-less behavior) breaks containment
+/// for a parent-relative symlink target and silently diverges from the
+/// portable fallback's correct behavior.
+///
+/// Everywhere else (including macOS, which has no `openat2`, and the Linux
+/// symlink case above), a per-component `openat` with `O_NOFOLLOW` detects a
+/// symlink and this module's own bounded walk
+/// ([`follow_symlink_component`]) resolves it — fd-anchored at every step,
+/// per the module invariant.
 pub(super) fn open_one(
     root: BorrowedFd<'_>,
+    ancestors: &[OwnedFd],
     dir: BorrowedFd<'_>,
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
     budget: &SymlinkBudget,
 ) -> Result<OwnedFd, ResolveError> {
-    open_one_inner(root, dir, name, oflags, mode, budget)
+    open_one_inner(root, ancestors, dir, name, oflags, mode, budget)
+}
+
+/// Outcome of the Linux `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`
+/// fast-path attempt (see [`open_one`]).
+#[cfg(target_os = "linux")]
+enum FastOpenOutcome {
+    /// Opened directly — `name` was not a symlink.
+    Opened(OwnedFd),
+    /// `name` is itself a symlink (kernel refused to expand it because of
+    /// `RESOLVE_NO_SYMLINKS`); the caller must resolve it via
+    /// [`follow_symlink_component`].
+    IsSymlink,
+    /// The kernel doesn't support `openat2` (`ENOSYS`), or the retry budget
+    /// for a benign concurrent-rename `EAGAIN` was exhausted; the caller
+    /// must fall back to the portable `O_NOFOLLOW` path below, which does
+    /// not share `openat2`'s whole-path-restart-on-`EAGAIN` failure mode.
+    Unsupported,
+    /// A genuine error (including a real containment/mount-crossing
+    /// rejection), to propagate as-is.
+    Failed(ResolveError),
+}
+
+#[cfg(target_os = "linux")]
+fn open_one_beneath_no_symlinks(
+    dir: BorrowedFd<'_>,
+    name: &OsStr,
+    oflags: OFlags,
+    mode: Mode,
+) -> FastOpenOutcome {
+    use rustix::fs::{ResolveFlags, openat2};
+
+    // `openat2(2)` documents `EAGAIN` for "a resolution restart was
+    // necessary, e.g. because of concurrent rename or unlink of a path
+    // component" — a *legitimate* concurrent mutation (an editor's atomic
+    // save, `git checkout`, a parallel build touching the same subtree), not
+    // an attack. Without a retry, a real, benign rename racing an unrelated
+    // open makes `openat2` spuriously fail and the caller sees an opaque
+    // `Backend` error for an operation that would have succeeded a moment
+    // later. Retry a small, fixed number of times — each retry is a fresh
+    // kernel-side resolution, not a busy spin on our own state, so the bound
+    // only needs to outlast one rename's duration, not any unbounded
+    // contention; the loop always terminates within `MAX_AGAIN_RETRIES + 1`
+    // attempts, never spins unbounded.
+    const MAX_AGAIN_RETRIES: u8 = 4;
+    let mut retries = 0;
+    loop {
+        match openat2(
+            dir,
+            name,
+            oflags | OFlags::CLOEXEC,
+            mode,
+            ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
+        ) {
+            Ok(fd) => return FastOpenOutcome::Opened(fd),
+            // Kernel predates openat2 (< 5.6), or a seccomp/container policy
+            // denies the syscall outright.
+            Err(Errno::NOSYS) => return FastOpenOutcome::Unsupported,
+            Err(Errno::AGAIN) if retries < MAX_AGAIN_RETRIES => {
+                retries += 1;
+                continue;
+            }
+            Err(Errno::AGAIN) => return FastOpenOutcome::Unsupported,
+            // `RESOLVE_BENEATH` implies `RESOLVE_NO_XDEV`: a mountpoint
+            // crossing anywhere in the resolution — even one that stays
+            // lexically "inside" the tree, e.g. a bind mount planted under a
+            // leaf directory — fails here too. Both a genuine
+            // beneath-root escape and an in-tree mount crossing report
+            // `EXDEV`; the kernel gives no way to tell them apart from the
+            // errno alone, and both are exactly the class this function
+            // exists to fail closed on, so both map to `Escape`.
+            Err(Errno::XDEV) => return FastOpenOutcome::Failed(ResolveError::Escape),
+            // With `RESOLVE_NO_SYMLINKS` set, `ELOOP` from a single-component
+            // resolution unambiguously means "this entry is a symlink" (the
+            // kernel never attempts to expand it, so a genuine cycle cannot
+            // be observed here, exactly like the portable `O_NOFOLLOW` path
+            // below) — hand it to the caller to follow via
+            // `follow_symlink_component`.
+            Err(Errno::LOOP) => return FastOpenOutcome::IsSymlink,
+            Err(errno) => return FastOpenOutcome::Failed(io_err(errno)),
+        }
+    }
 }
 
 fn open_one_inner(
     root: BorrowedFd<'_>,
+    ancestors: &[OwnedFd],
     dir: BorrowedFd<'_>,
     name: &OsStr,
     oflags: OFlags,
@@ -173,74 +297,15 @@ fn open_one_inner(
 ) -> Result<OwnedFd, ResolveError> {
     #[cfg(target_os = "linux")]
     {
-        use rustix::fs::{ResolveFlags, openat2};
-
-        // `openat2(2)` documents `EAGAIN` for "a resolution restart was
-        // necessary, e.g. because of concurrent rename or unlink of a path
-        // component" — a *legitimate* concurrent mutation (an editor's
-        // atomic save, `git checkout`, a parallel build touching the same
-        // subtree), not an attack. Without a retry, a real, benign rename
-        // racing an unrelated open makes `openat2` spuriously fail and the
-        // caller sees an opaque `Backend` error for an operation that would
-        // have succeeded a moment later. Retry a small, fixed number of
-        // times — each retry is a fresh kernel-side resolution, not a busy
-        // spin on our own state, so the bound only needs to outlast one
-        // rename's duration, not any unbounded contention; the loop always
-        // terminates within `MAX_AGAIN_RETRIES + 1` attempts, never spins
-        // unbounded. What happens when the bound is exhausted is documented
-        // at the `Err(Errno::AGAIN) => break` arm below.
-        const MAX_AGAIN_RETRIES: u8 = 4;
-        let mut retries = 0;
-        loop {
-            match openat2(
-                dir,
-                name,
-                oflags | OFlags::CLOEXEC,
-                mode,
-                ResolveFlags::BENEATH,
-            ) {
-                Ok(fd) => return Ok(fd),
-                // Kernel predates openat2 (< 5.6), or a seccomp/container
-                // policy denies the syscall outright. Fall through to the
-                // portable per-component path below rather than failing
-                // closed on a syscall the fallback doesn't need.
-                Err(Errno::NOSYS) => break,
-                Err(Errno::AGAIN) if retries < MAX_AGAIN_RETRIES => {
-                    retries += 1;
-                    continue;
-                }
-                // Retries exhausted (a pathological, sustained-rename case
-                // rather than one atomic swap): fall through to the
-                // portable per-component path below instead of surfacing an
-                // opaque `Backend` error, since that path does not share
-                // `openat2`'s whole-path-restart-on-`EAGAIN` failure mode.
-                Err(Errno::AGAIN) => break,
-                // `RESOLVE_BENEATH` implies `RESOLVE_NO_XDEV`: a mountpoint
-                // crossing anywhere in the resolution — even one that stays
-                // lexically "inside" the tree, e.g. a bind mount planted
-                // under a leaf directory — fails here too. Both a genuine
-                // beneath-root escape and an in-tree mount crossing report
-                // `EXDEV`; the kernel gives no way to tell them apart from
-                // the errno alone, and both are exactly the class this
-                // function exists to fail closed on (a mount crossing is
-                // itself a potential escape vector — the mounted filesystem
-                // is not something this mount's containment promise covers)
-                // — so both map to `Escape`, surfaced to callers as
-                // `FilesystemError::SymlinkEscape`, which is the crate's one
-                // "containment rejected this" vocabulary rather than a
-                // confusing raw `EXDEV` `Backend` error.
-                Err(Errno::XDEV) => return Err(ResolveError::Escape),
-                // With `RESOLVE_NO_SYMLINKS` no longer set, `ELOOP` here
-                // means the kernel's own resolution hit a genuine symlink
-                // *cycle* (or a chain deep enough to trip its internal
-                // bound) while expanding an in-bounds symlink — a real
-                // filesystem condition, not a containment escape. Report it
-                // as a plain I/O error rather than `Escape` so it is never
-                // conflated with — or mistaken for evidence of — an escape
-                // attempt.
-                Err(Errno::LOOP) => return Err(io_err(Errno::LOOP)),
-                Err(errno) => return Err(io_err(errno)),
+        match open_one_beneath_no_symlinks(dir, name, oflags, mode) {
+            FastOpenOutcome::Opened(fd) => return Ok(fd),
+            FastOpenOutcome::IsSymlink => {
+                return follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget);
             }
+            FastOpenOutcome::Failed(error) => return Err(error),
+            // Fall through to the portable per-component path below instead
+            // of surfacing an opaque `Backend` error.
+            FastOpenOutcome::Unsupported => {}
         }
     }
     match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {
@@ -249,7 +314,9 @@ fn open_one_inner(
         // unambiguously means "this entry is a symlink" (the kernel never
         // attempts to expand it, so a genuine cycle cannot be observed
         // here) — follow it ourselves, fd-anchored and budget-bounded.
-        Err(Errno::LOOP) => follow_symlink_component(root, dir, name, oflags, mode, budget),
+        Err(Errno::LOOP) => {
+            follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget)
+        }
         // Some platforms (observed on macOS) report `ENOTDIR` rather than
         // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
         // kernel checks "is this a directory" before "did NOFOLLOW block
@@ -263,7 +330,7 @@ fn open_one_inner(
                     if rustix::fs::FileType::from_raw_mode(stat.st_mode)
                         == rustix::fs::FileType::Symlink =>
                 {
-                    follow_symlink_component(root, dir, name, oflags, mode, budget)
+                    follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget)
                 }
                 _ => Err(io_err(Errno::NOTDIR)),
             }
@@ -274,12 +341,14 @@ fn open_one_inner(
 
 /// Follows the symlink at `name` (found directly under `dir`), fd-anchored
 /// and budget-bounded (see [`SymlinkBudget`]), and finishes opening its
-/// ultimate target with the caller's original `oflags`/`mode`. Used only by
-/// the portable fallback (macOS, or a Linux host whose `openat2` is
-/// unavailable) — on Linux with `openat2`, the kernel does this same job for
-/// us inside a single `RESOLVE_BENEATH` call.
+/// ultimate target with the caller's original `oflags`/`mode`. Reached from
+/// both the Linux fast path (once `RESOLVE_NO_SYMLINKS` reports `ELOOP`) and
+/// the portable `O_NOFOLLOW` path — see the module doc for why both now
+/// share this exact walk instead of the Linux side ever letting the kernel
+/// expand a symlink itself.
 fn follow_symlink_component(
     root: BorrowedFd<'_>,
+    ancestors: &[OwnedFd],
     dir: BorrowedFd<'_>,
     name: &OsStr,
     oflags: OFlags,
@@ -288,9 +357,18 @@ fn follow_symlink_component(
 ) -> Result<OwnedFd, ResolveError> {
     budget.consume()?;
     let target = rustix::fs::readlinkat(dir, name, Vec::new()).map_err(io_err)?;
-    let (anchor, last) = walk_symlink_target(root, dir, target.as_bytes(), budget)?;
+    let (new_ancestors, anchor, last) =
+        walk_symlink_target(root, ancestors, dir, target.as_bytes(), budget)?;
     match last {
-        Some(final_name) => open_one_inner(root, anchor.as_fd(), &final_name, oflags, mode, budget),
+        Some(final_name) => open_one_inner(
+            root,
+            &new_ancestors,
+            anchor.as_fd(),
+            &final_name,
+            oflags,
+            mode,
+            budget,
+        ),
         // Target had no final component (e.g. "/" or ""): it resolves to
         // the anchor directory itself.
         None => Ok(anchor),
@@ -298,9 +376,11 @@ fn follow_symlink_component(
 }
 
 /// Walks every component of a symlink's `target` text except the last,
-/// fd-anchored throughout, and returns the resulting directory fd plus the
-/// final component's own name (left un-opened — the caller decides how to
-/// use it: as a final `open_one` leaf, or as a bare name for `atomic_write_file`).
+/// fd-anchored throughout, and returns the resulting ancestor stack
+/// (everything above the returned directory fd, root-first), that directory
+/// fd, plus the final component's own name (left un-opened — the caller
+/// decides how to use it: as a final `open_one` leaf, or as a bare name for
+/// `atomic_write_file`).
 ///
 /// **Absolute targets are rejected outright (`Escape`), unconditionally —
 /// this deliberately matches Linux's native `openat2(RESOLVE_BENEATH)`
@@ -310,39 +390,62 @@ fn follow_symlink_component(
 /// because the kernel has no concept of "this process's virtual mount root"
 /// to reinterpret it against — only `RESOLVE_IN_ROOT` does that, a
 /// materially different (chroot-emulating) primitive this module does not
-/// use. Reinterpreting an absolute target against `root` here on the
-/// portable fallback would (a) diverge from Linux's real, kernel-enforced
-/// behavior for the identical symlink, and (b) not even help in practice: a
-/// symlink created by any real tool (`ln -s`, an editor, a package manager)
-/// stores the *real host absolute path*, which reinterpreted against a
-/// mount's `root_fd` is essentially never the intended target — it is
-/// coincidence, not signal. Both platforms therefore agree: an absolute
-/// symlink target is always an escape attempt.
+/// use. Reinterpreting an absolute target against the root here would (a)
+/// diverge from Linux's real, kernel-enforced behavior for the identical
+/// symlink, and (b) not even help in practice: a symlink created by any real
+/// tool (`ln -s`, an editor, a package manager) stores the *real host
+/// absolute path*, which reinterpreted against a mount's root is essentially
+/// never the intended target — it is coincidence, not signal. Both platforms
+/// therefore agree: an absolute symlink target is always an escape attempt.
 ///
 /// A relative target resolves from `dir` (the directory the symlink itself
-/// lives in). `..` components are handled by literally `openat`-ing the
-/// parent (fd-relative, no string trust involved), but only after
-/// confirming the *current* position is not already `root`:
-/// `openat(root_fd, "..", …)` would happily open the real host parent of
-/// the mount, so a `..` that would step above `root` is refused (`Escape`)
-/// instead. Every forward (non-`.`/`..`) component goes back through
-/// [`open_one_inner`], so a symlink nested inside another symlink's target
-/// is itself resolved through this exact same escape/budget-bounded
-/// machinery, never treated as plain text — and consumes budget from the
-/// same shared [`SymlinkBudget`] as everything else in the resolution.
+/// lives in). **`..` components are answered by popping `ancestors` — never
+/// by a live, name-based `openat(fd, "..")` lookup.** An earlier version of
+/// this function did exactly that: capture `cur`'s `(device, inode)`
+/// identity, compare it against the root's to decide whether to refuse, and
+/// only then call `openat(cur, "..", …)`. That check answers "is `cur`
+/// itself the root" correctly, but it does not close the actual race: `..`
+/// is *always* a live, name-based lookup, resolved by the kernel at the
+/// moment of the syscall against whatever `cur`'s *current* parent directory
+/// entry is — not a snapshot from whenever the identity check ran. A
+/// concurrent rename of the directory `cur` refers to (e.g. `mv realdir
+/// /outside/newname`, executed by another thread between the identity check
+/// and the `openat` call) changes what `..` resolves to without changing
+/// `cur`'s own `(device, inode)` at all, so no ordering of that check
+/// relative to the `openat` call closes the window — confirmed with a
+/// working exploit (a test-only sleep widening the window let a concurrent
+/// rename make a read return bytes from outside the mount). Popping
+/// `ancestors` instead never asks the kernel to re-derive a parent by name
+/// at all: every element on the stack is an fd this module already opened
+/// and is still holding open, and an open fd's target is fixed regardless of
+/// what happens to the directory entries that were used to reach it — no
+/// concurrent rename anywhere in the tree can change what a pop yields. "Am
+/// I already at the root" becomes `ancestors.is_empty()`, a pure in-process
+/// check with no syscall (and therefore no race window) at all, replacing
+/// the old `fd_identity(root) == fd_identity(cur)` `fstat` comparison.
+///
+/// Every forward (non-`.`/`..`) component goes back through
+/// [`open_one_inner`] (pushing the fd it steps off of onto the stack before
+/// moving on), so a symlink nested inside another symlink's target is itself
+/// resolved through this exact same escape/budget-bounded machinery, never
+/// treated as plain text — and consumes budget from the same shared
+/// [`SymlinkBudget`] as everything else in the resolution.
 fn walk_symlink_target(
     root: BorrowedFd<'_>,
+    ancestors: &[OwnedFd],
     dir: BorrowedFd<'_>,
     target: &[u8],
     budget: &SymlinkBudget,
-) -> Result<(OwnedFd, Option<OsString>), ResolveError> {
+) -> Result<(Vec<OwnedFd>, OwnedFd, Option<OsString>), ResolveError> {
     if target.starts_with(b"/") {
         return Err(ResolveError::Escape);
     }
+    let mut stack: Vec<OwnedFd> = Vec::with_capacity(ancestors.len());
+    for ancestor in ancestors {
+        stack.push(dup_fd(ancestor.as_fd())?);
+    }
     let mut cur = dup_fd(dir)?;
-    let rest = target;
-    let root_id = fd_identity(root)?;
-    let mut components = rest
+    let mut components = target
         .split(|byte| *byte == b'/')
         .filter(|component| !component.is_empty())
         .peekable();
@@ -353,40 +456,32 @@ fn walk_symlink_target(
             continue;
         }
         if component == ".." {
-            if fd_identity(cur.as_fd())? == root_id {
-                return Err(ResolveError::Escape);
+            match stack.pop() {
+                Some(parent) => cur = parent,
+                // Nothing left to pop means we are already at (or above,
+                // which cannot happen by construction) the root — refuse
+                // exactly like the old identity check did, just without a
+                // syscall to race.
+                None => return Err(ResolveError::Escape),
             }
-            cur = rustix::fs::openat(
-                cur.as_fd(),
-                "..",
-                OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
-                Mode::empty(),
-            )
-            .map_err(io_err)?;
             continue;
         }
         if is_last {
-            return Ok((cur, Some(component.to_os_string())));
+            return Ok((stack, cur, Some(component.to_os_string())));
         }
-        cur = open_one_inner(
+        let next = open_one_inner(
             root,
+            &stack,
             cur.as_fd(),
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
             budget,
         )?;
+        stack.push(cur);
+        cur = next;
     }
-    Ok((cur, None))
-}
-
-/// `(device, inode)` identity of `fd`, used to detect "we are already at
-/// `root`" before honoring a `..` component in a symlink target — the one
-/// place this module cannot lean on `RESOLVE_BENEATH`/`openat2` and must
-/// enforce the "never above root" boundary itself.
-fn fd_identity(fd: BorrowedFd<'_>) -> Result<(u64, u64), ResolveError> {
-    let stat = rustix::fs::fstat(fd).map_err(io_err)?;
-    Ok((stat.st_dev as u64, stat.st_ino as u64))
+    Ok((stack, cur, None))
 }
 
 fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
@@ -406,30 +501,38 @@ fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
 ///
 /// One [`SymlinkBudget`] is constructed here and shared across every
 /// component's `open_one` call — the whole multi-component walk shares one
-/// [`MAX_SYMLINK_DEPTH`]-hop ceiling, not a fresh one per component (see
-/// `SymlinkBudget`'s doc for why that distinction matters).
+/// [`MAX_SYMLINK_DEPTH`]-hop ceiling, not a fresh one per component. An
+/// ancestor stack (see [`open_one`]'s `ancestors` parameter) is built up
+/// alongside it, so a symlink discovered at any depth can answer a `..` in
+/// its own target text by popping an already-open fd from *this* walk's own
+/// history, never by a live `openat(fd, "..")` lookup.
 pub(super) fn resolve_walk(
     root: BorrowedFd<'_>,
     components: &[OsString],
     final_oflags: OFlags,
 ) -> Result<(OwnedFd, Option<(OwnedFd, OsString)>), ResolveError> {
-    let Some((leaf, ancestors)) = components.split_last() else {
+    let Some((leaf, ancestor_components)) = components.split_last() else {
         return Ok((dup_fd(root)?, None));
     };
     let budget = SymlinkBudget::new();
     let mut cur = dup_fd(root)?;
-    for component in ancestors {
-        cur = open_one(
+    let mut ancestors: Vec<OwnedFd> = Vec::with_capacity(ancestor_components.len());
+    for component in ancestor_components {
+        let next = open_one(
             root,
+            &ancestors,
             cur.as_fd(),
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
             &budget,
         )?;
+        ancestors.push(cur);
+        cur = next;
     }
     let fd = open_one(
         root,
+        &ancestors,
         cur.as_fd(),
         leaf,
         final_oflags,
@@ -440,10 +543,25 @@ pub(super) fn resolve_walk(
 }
 
 /// Walks `components` from `root`, creating any missing directory along the
-/// way (`mkdir -p` semantics), and returns the final directory's fd. Used
-/// by `write_file`/`append_file` (parent-only — matching the previous
+/// way (`mkdir -p` semantics), and returns the final directory's fd. Used by
+/// `write_file`/`append_file` (parent-only — matching the previous
 /// implementation's "always create the parent chain" behavior) and by
 /// `create_dir_all` (full path, leaf included).
+///
+/// Builds its own ancestor stack internally (root-first, not including the
+/// returned fd) so its *own* walk can answer a `..` inside any symlink it
+/// follows along the way by popping an already-open fd rather than a live
+/// `openat(fd, "..")` lookup (see [`walk_symlink_target`]) — but does not
+/// expose that stack to the caller: the only two callers that chase a
+/// symlink chain past the fd this returns
+/// ([`resolve_write_leaf`]/`append_file`'s own `open_one` call, both in
+/// `local.rs`) pass an empty ancestor slice instead, which means a `..` in a
+/// symlink discovered *at that position* fails closed rather than
+/// (correctly, but not yet wired end to end) resolving past this
+/// directory's own parent. No existing symlink test exercises a `..` at a
+/// write-leaf/append position, so this is a conservative gap, not a
+/// regression — see the module's write-side call sites in `local.rs` for
+/// the exact scope.
 ///
 /// Each level is still resolved through [`open_one`], so a symlink swapped
 /// into any not-yet-existing ancestor between one level's `mkdirat` and the
@@ -461,30 +579,43 @@ pub(super) fn descend_creating(
 ) -> Result<OwnedFd, ResolveError> {
     let budget = SymlinkBudget::new();
     let mut cur = dup_fd(root)?;
+    let mut ancestors: Vec<OwnedFd> = Vec::new();
     for component in components {
         cur = match open_one(
             root,
+            &ancestors,
             cur.as_fd(),
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
             &budget,
         ) {
-            Ok(fd) => fd,
+            Ok(fd) => {
+                ancestors.push(cur);
+                fd
+            }
             Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {
                 match rustix::fs::mkdirat(cur.as_fd(), component.as_os_str(), new_dir_mode()) {
                     Ok(()) => {}
                     Err(Errno::EXIST) => {}
                     Err(errno) => return Err(ResolveError::Io(errno.into())),
                 }
-                open_one(
+                // Re-open through the same `open_one`/`ancestors`-aware path
+                // rather than assuming the freshly created entry is safe to
+                // use directly: a concurrent swap between the `mkdirat`
+                // above and this re-open is rejected exactly like any other
+                // escaping symlink in the walk (see the doc above).
+                let fd = open_one(
                     root,
+                    &ancestors,
                     cur.as_fd(),
                     component,
                     OFlags::DIRECTORY,
                     Mode::empty(),
                     &budget,
-                )?
+                )?;
+                ancestors.push(cur);
+                fd
             }
             Err(other) => return Err(other),
         };
@@ -495,6 +626,15 @@ pub(super) fn descend_creating(
 /// Resolves `leaf` under `parent` to the `(parent, leaf-name)` pair a write
 /// should actually land at, chasing a chain of in-bounds symlinks *at the
 /// leaf position* (bounded by [`MAX_SYMLINK_DEPTH`]).
+///
+/// `ancestors` is `parent`'s own ancestor stack (root-first, not including
+/// `parent` itself) — normally the second element of
+/// [`descend_creating`]'s return value, since `parent` is typically exactly
+/// the directory `descend_creating` just resolved/created. It is required
+/// for the same reason [`open_one`]'s `ancestors` parameter is: a `..` in a
+/// leaf-position symlink's target must be answered by popping an
+/// already-open fd, never by a live `openat(fd, "..")` lookup (see
+/// [`walk_symlink_target`]).
 ///
 /// `rename`/`link` — how [`atomic_write_file`] installs bytes — never follow
 /// a symlink at the destination name; they replace/create the directory
@@ -515,10 +655,15 @@ pub(super) fn descend_creating(
 /// symlink transparently.
 pub(super) fn resolve_write_leaf(
     root: BorrowedFd<'_>,
+    ancestors: &[OwnedFd],
     parent: BorrowedFd<'_>,
     leaf: &OsStr,
 ) -> Result<(OwnedFd, OsString), ResolveError> {
     let budget = SymlinkBudget::new();
+    let mut cur_ancestors: Vec<OwnedFd> = Vec::with_capacity(ancestors.len());
+    for ancestor in ancestors {
+        cur_ancestors.push(dup_fd(ancestor.as_fd())?);
+    }
     let mut cur_parent = dup_fd(parent)?;
     let mut cur_leaf = leaf.to_os_string();
     loop {
@@ -543,14 +688,20 @@ pub(super) fn resolve_write_leaf(
         budget.consume()?;
         let target =
             rustix::fs::readlinkat(cur_parent.as_fd(), &cur_leaf, Vec::new()).map_err(io_err)?;
-        let (new_parent, new_leaf) =
-            walk_symlink_target(root, cur_parent.as_fd(), target.as_bytes(), &budget)?;
+        let (new_ancestors, new_parent, new_leaf) = walk_symlink_target(
+            root,
+            &cur_ancestors,
+            cur_parent.as_fd(),
+            target.as_bytes(),
+            &budget,
+        )?;
         let Some(new_leaf) = new_leaf else {
             // Symlink target has no final path component (e.g. "/" or ""):
             // there is no meaningful write-target name. Fail closed rather
             // than guess.
             return Err(ResolveError::Escape);
         };
+        cur_ancestors = new_ancestors;
         cur_parent = new_parent;
         cur_leaf = new_leaf;
     }
@@ -584,7 +735,9 @@ const MAX_REMOVE_DIR_DEPTH: usize = 512;
 /// `remove_dir_contents` only ever calls back in here for an
 /// `AT_SYMLINK_NOFOLLOW`-confirmed real directory) symlink-following path
 /// inside `open_one`, kept for signature uniformity with the rest of this
-/// module rather than smuggling in a path-based fallback.
+/// module rather than smuggling in a path-based fallback. Passes an empty
+/// ancestor stack to `open_one` for the same reason: that path is never
+/// actually taken, so there is no `..`-in-a-symlink-target case to answer.
 pub(super) fn remove_dir_all_fd(
     root: BorrowedFd<'_>,
     parent: BorrowedFd<'_>,
@@ -606,6 +759,7 @@ fn remove_dir_all_fd_bounded(
     }
     let dir_fd = open_one(
         root,
+        &[],
         parent,
         name,
         OFlags::DIRECTORY,

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -137,8 +137,25 @@ impl SymlinkBudget {
 /// The outcome of a failed fd-relative resolution step: either a genuine I/O
 /// error (propagated as-is), or a symlink/`..`-past-root escape attempt (or
 /// a symlink chain deep enough to be indistinguishable from a cycle).
+///
+/// `AbsoluteSymlinkTarget` (PR #6817 review follow-up) is a distinct variant
+/// from the bare `Escape` every other rejection in this module reports —
+/// not a different *outcome* (both still fail the resolution closed,
+/// unconditionally; see [`walk_symlink_target`]'s doc comment for why an
+/// absolute target is always rejected, never reinterpreted against the
+/// root), only a richer one: at the one call site that produces it, this
+/// module already knows exactly which symlink and exactly what target text
+/// caused the rejection, and that is enough to turn an opaque "symlink
+/// escapes backend mount" into something a user can actually act on
+/// (replace the symlink with a relative one) — see
+/// `resolve_error_to_filesystem_error` and
+/// `FilesystemError::SymlinkEscape`'s `detail` field.
 pub(super) enum ResolveError {
     Escape,
+    AbsoluteSymlinkTarget {
+        symlink_name: OsString,
+        target: OsString,
+    },
     Io(std::io::Error),
 }
 
@@ -148,7 +165,22 @@ pub(super) fn resolve_error_to_filesystem_error(
     error: ResolveError,
 ) -> FilesystemError {
     match error {
-        ResolveError::Escape => FilesystemError::SymlinkEscape { path: path.clone() },
+        ResolveError::Escape => FilesystemError::SymlinkEscape {
+            path: path.clone(),
+            detail: None,
+        },
+        ResolveError::AbsoluteSymlinkTarget {
+            symlink_name,
+            target,
+        } => FilesystemError::SymlinkEscape {
+            path: path.clone(),
+            detail: Some(format!(
+                "symlink {symlink_name:?} has an absolute target {target:?}; absolute \
+                 symlink targets are not supported by this filesystem backend, even when \
+                 the target would resolve inside the mount — replace it with a relative \
+                 symlink target"
+            )),
+        },
         ResolveError::Io(io_err) => super::io_error(path.clone(), operation, io_err),
     }
 }
@@ -388,7 +420,7 @@ fn follow_symlink_component(
     budget.consume()?;
     let target = rustix::fs::readlinkat(dir, name, Vec::new()).map_err(io_err)?;
     let (new_ancestors, anchor, last) =
-        walk_symlink_target(root, ancestors, dir, target.as_bytes(), budget)?;
+        walk_symlink_target(root, ancestors, dir, name, target.as_bytes(), budget)?;
     match last {
         Some(final_name) => open_one_inner(
             root,
@@ -464,11 +496,20 @@ fn walk_symlink_target(
     root: BorrowedFd<'_>,
     ancestors: &[OwnedFd],
     dir: BorrowedFd<'_>,
+    symlink_name: &OsStr,
     target: &[u8],
     budget: &SymlinkBudget,
 ) -> Result<(Vec<OwnedFd>, OwnedFd, Option<OsString>), ResolveError> {
     if target.starts_with(b"/") {
-        return Err(ResolveError::Escape);
+        // PR #6817 review follow-up: report exactly which symlink and
+        // exactly what (attacker/user-supplied, already-on-disk-in-their-
+        // own-mount) target text caused the rejection, instead of the bare
+        // `Escape` every other rejection in this module reports — see
+        // `ResolveError::AbsoluteSymlinkTarget`'s doc comment.
+        return Err(ResolveError::AbsoluteSymlinkTarget {
+            symlink_name: symlink_name.to_os_string(),
+            target: OsStr::from_bytes(target).to_os_string(),
+        });
     }
     let mut stack: Vec<OwnedFd> = Vec::with_capacity(ancestors.len());
     for ancestor in ancestors {
@@ -727,6 +768,7 @@ pub(super) fn resolve_write_leaf(
             root,
             &cur_ancestors,
             cur_parent.as_fd(),
+            &cur_leaf,
             target.as_bytes(),
             &budget,
         )?;
@@ -846,6 +888,13 @@ fn remove_dir_contents(
 fn resolve_error_to_io(error: ResolveError) -> std::io::Error {
     match error {
         ResolveError::Escape => std::io::Error::other("symlink escape"),
+        ResolveError::AbsoluteSymlinkTarget {
+            symlink_name,
+            target,
+        } => std::io::Error::other(format!(
+            "symlink {symlink_name:?} has an absolute target {target:?}, which is not \
+             supported"
+        )),
         ResolveError::Io(io_err) => io_err,
     }
 }

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -193,6 +193,31 @@ fn io_err(errno: Errno) -> ResolveError {
 /// symlink and this module's own bounded walk
 /// ([`follow_symlink_component`]) resolves it — fd-anchored at every step,
 /// per the module invariant.
+///
+/// **Every `open`/`openat2` call this function (transitively) makes —
+/// including `open_one_beneath_no_symlinks`, the portable `openat` in
+/// `open_one_inner`, and `remove_dir_all_fd`'s own directory open — passes
+/// `O_NONBLOCK` (PR #6817 review follow-up).** Without it, opening a FIFO
+/// with no writer present blocks the calling thread indefinitely — and
+/// because every caller here runs on the tokio *blocking pool*
+/// (`spawn_blocking`, see `run_blocking` in `local.rs`), that thread is gone
+/// for good from the pool's perspective; a handful of concurrent requests
+/// against attacker-plantable FIFOs (any writable mount, any path
+/// component — a FIFO can sit at an intermediate directory-walk position
+/// too, since the kernel's own FIFO-open blocking happens before the
+/// `O_DIRECTORY`/`ENOTDIR` check completes) exhausts the pool and wedges the
+/// whole process. `O_NONBLOCK` is a documented no-op for regular files and
+/// directories (the kernel never blocks opening or reading/writing them for
+/// this reason), so it costs nothing on the overwhelmingly common path; it
+/// only changes behavior for FIFOs (open returns immediately — successfully
+/// for O_RDONLY with no writer, or with `ENXIO` for O_WRONLY with no
+/// reader — instead of blocking) and certain blocking character devices.
+/// Every caller that goes on to read/write the resulting fd already
+/// classifies it via an `AT_SYMLINK_NOFOLLOW` `fstat`/`statat` and rejects
+/// anything that isn't the expected type before touching its data (see
+/// `read_file`/`read_file_bounded` in `local.rs`), so a FIFO that manages to
+/// open non-blocking is still refused — just without ever blocking a thread
+/// to find that out.
 pub(super) fn open_one(
     root: BorrowedFd<'_>,
     ancestors: &[OwnedFd],
@@ -252,7 +277,7 @@ fn open_one_beneath_no_symlinks(
         match openat2(
             dir,
             name,
-            oflags | OFlags::CLOEXEC,
+            oflags | OFlags::CLOEXEC | OFlags::NONBLOCK,
             mode,
             ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
         ) {
@@ -308,7 +333,12 @@ fn open_one_inner(
             FastOpenOutcome::Unsupported => {}
         }
     }
-    match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {
+    match rustix::fs::openat(
+        dir,
+        name,
+        oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+        mode,
+    ) {
         Ok(fd) => Ok(fd),
         // With `O_NOFOLLOW` set, `ELOOP` from a single-component open
         // unambiguously means "this entry is a symlink" (the kernel never
@@ -543,25 +573,30 @@ pub(super) fn resolve_walk(
 }
 
 /// Walks `components` from `root`, creating any missing directory along the
-/// way (`mkdir -p` semantics), and returns the final directory's fd. Used by
-/// `write_file`/`append_file` (parent-only — matching the previous
-/// implementation's "always create the parent chain" behavior) and by
-/// `create_dir_all` (full path, leaf included).
+/// way (`mkdir -p` semantics), and returns the final directory's fd *plus*
+/// the ancestor stack that got it there (root-first, not including the
+/// returned fd itself — the same shape [`open_one`]'s `ancestors` parameter
+/// expects). Used by `write_file`/`append_file` (parent-only — matching the
+/// previous implementation's "always create the parent chain" behavior) and
+/// by `create_dir_all` (full path, leaf included).
 ///
-/// Builds its own ancestor stack internally (root-first, not including the
-/// returned fd) so its *own* walk can answer a `..` inside any symlink it
-/// follows along the way by popping an already-open fd rather than a live
-/// `openat(fd, "..")` lookup (see [`walk_symlink_target`]) — but does not
-/// expose that stack to the caller: the only two callers that chase a
-/// symlink chain past the fd this returns
-/// ([`resolve_write_leaf`]/`append_file`'s own `open_one` call, both in
-/// `local.rs`) pass an empty ancestor slice instead, which means a `..` in a
-/// symlink discovered *at that position* fails closed rather than
-/// (correctly, but not yet wired end to end) resolving past this
-/// directory's own parent. No existing symlink test exercises a `..` at a
-/// write-leaf/append position, so this is a conservative gap, not a
-/// regression — see the module's write-side call sites in `local.rs` for
-/// the exact scope.
+/// **PR #6817 review follow-up (`mount_registry.rs`, `local.rs`,
+/// `fd_resolve.rs`, `filesystem_contract.rs` review threads — one root
+/// cause, fixed together here):** this function used to build the ancestor
+/// stack purely for its *own* internal `..`-in-a-followed-symlink resolution
+/// and then discard it, returning only the final fd. That forced
+/// `write_file`/`append_file`'s own leaf resolution
+/// ([`resolve_write_leaf`]/`open_one`, both called from `local.rs`) to pass
+/// an empty ancestor slice, so a `..` inside a symlink discovered *at the
+/// write leaf itself* failed closed instead of resolving past the parent
+/// directory `descend_creating` had already opened and verified — a
+/// (deliberate, documented, but no longer necessary) usability gap: it fails
+/// closed, so it was never a containment hole, just a spurious rejection of
+/// an otherwise-legitimate layout. Returning the stack lets every write-side
+/// caller thread it into its own leaf resolution, closing the gap. Every
+/// existing caller of this function that only needed the final fd
+/// (`create_dir_all`, `ensure_scoped_mount_dynamic`) simply takes `.0` and
+/// ignores `.1` — this is purely additive.
 ///
 /// Each level is still resolved through [`open_one`], so a symlink swapped
 /// into any not-yet-existing ancestor between one level's `mkdirat` and the
@@ -576,7 +611,7 @@ pub(super) fn resolve_walk(
 pub(super) fn descend_creating(
     root: BorrowedFd<'_>,
     components: &[OsString],
-) -> Result<OwnedFd, ResolveError> {
+) -> Result<(OwnedFd, Vec<OwnedFd>), ResolveError> {
     let budget = SymlinkBudget::new();
     let mut cur = dup_fd(root)?;
     let mut ancestors: Vec<OwnedFd> = Vec::new();
@@ -620,7 +655,7 @@ pub(super) fn descend_creating(
             Err(other) => return Err(other),
         };
     }
-    Ok(cur)
+    Ok((cur, ancestors))
 }
 
 /// Resolves `leaf` under `parent` to the `(parent, leaf-name)` pair a write
@@ -769,7 +804,7 @@ fn remove_dir_all_fd_bounded(
     let dir_fd = rustix::fs::openat(
         parent,
         name,
-        OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
         Mode::empty(),
     )
     .map_err(std::io::Error::from)?;

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -41,7 +41,7 @@
 //! still safely inside the mount root but the `..` in the target text steps
 //! above `dir` itself. `RESOLVE_BENEATH` rejects that with `EXDEV`
 //! regardless of where `sibling` actually is, because the kernel has no way
-//! to know this process's notion of "the true root" — only `RESOLVE_BENEATH`'s
+//! to know this process's concept of "the true root" — only `RESOLVE_BENEATH`'s
 //! own `dir` argument. This is exactly the shape a real pnpm `node_modules`
 //! layout uses (`node_modules/@types/react ->
 //! ../.pnpm/react@.../node_modules/react`), so silently deferring every
@@ -731,13 +731,22 @@ const MAX_REMOVE_DIR_DEPTH: usize = 512;
 /// Recursively removes `name` (found directly under `parent`) and everything
 /// beneath it, never following a symlink into whatever it points at — a
 /// symlinked child is unlinked as itself, exactly like `std::fs::remove_dir_all`,
-/// never traversed into. `root` anchors the (never actually taken, since
-/// `remove_dir_contents` only ever calls back in here for an
-/// `AT_SYMLINK_NOFOLLOW`-confirmed real directory) symlink-following path
-/// inside `open_one`, kept for signature uniformity with the rest of this
-/// module rather than smuggling in a path-based fallback. Passes an empty
-/// ancestor stack to `open_one` for the same reason: that path is never
-/// actually taken, so there is no `..`-in-a-symlink-target case to answer.
+/// never traversed into.
+///
+/// This does **not** use [`open_one`] (PR #6817 review follow-up): a caller
+/// (`DiskFilesystem::delete`, and this function's own recursion via
+/// `remove_dir_contents`) classifies `name` as a real directory via an
+/// `AT_SYMLINK_NOFOLLOW` `statat` *before* calling in here — but `open_one`
+/// deliberately follows an in-bounds symlink, so a concurrent writer that
+/// swaps `name` for a symlink to another in-bounds directory in the gap
+/// between that classification and this function's own lookup would have
+/// this function recurse into and delete the symlink's *target*, only
+/// failing (safely, but too late) on the trailing `unlinkat(REMOVEDIR)`
+/// below once the target's contents are already gone. Opening with
+/// `O_DIRECTORY | O_NOFOLLOW` directly instead makes the open itself the
+/// (re-)classification: a symlink now fails the open with `ELOOP`/`ENOTDIR`
+/// and is never traversed, closing the gap structurally rather than relying
+/// on the classify-and-open pair being too fast to race in practice.
 pub(super) fn remove_dir_all_fd(
     root: BorrowedFd<'_>,
     parent: BorrowedFd<'_>,
@@ -757,16 +766,13 @@ fn remove_dir_all_fd_bounded(
             "directory tree exceeds maximum removal depth of {MAX_REMOVE_DIR_DEPTH} levels; refusing to delete"
         )));
     }
-    let dir_fd = open_one(
-        root,
-        &[],
+    let dir_fd = rustix::fs::openat(
         parent,
         name,
-        OFlags::DIRECTORY,
+        OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
         Mode::empty(),
-        &SymlinkBudget::new(),
     )
-    .map_err(resolve_error_to_io)?;
+    .map_err(std::io::Error::from)?;
     remove_dir_contents(root, dir_fd.as_fd(), depth + 1)?;
     rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(std::io::Error::from)
 }
@@ -964,4 +970,76 @@ pub(super) fn atomic_write_file(
     parent_file.sync_all().map_err(|error| {
         super::io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    use rustix::fd::AsFd;
+    use rustix::fs::{Mode, OFlags, openat};
+    use tempfile::tempdir;
+
+    use super::remove_dir_all_fd;
+
+    /// Deterministic (non-timing-dependent) regression for the recursive
+    /// `delete` symlink race flagged in PR #6817 review: `remove_dir_all_fd`
+    /// is only ever called by a caller that has already classified `name` as
+    /// a real directory via a `SYMLINK_NOFOLLOW` `statat` — but this
+    /// function then re-looks-up `name` itself via `open_one`, which
+    /// deliberately follows in-bounds symlinks. Rather than racing that gap
+    /// against a background thread (tried, and could not reliably win it —
+    /// the classify-then-open window in `DiskFilesystem::delete` is a
+    /// handful of back-to-back syscalls with no intervening work), this
+    /// pins the function's *own* contract directly: called with `name`
+    /// already pointing at a symlink to a sibling directory (modeling "the
+    /// race already landed"), it must never recurse into and delete that
+    /// sibling's contents.
+    #[test]
+    fn remove_dir_all_fd_never_deletes_through_a_symlink_at_the_target_name() {
+        let storage = tempdir().unwrap();
+        let root_path = storage.path();
+
+        let target_dir = root_path.join("target-dir");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let precious = target_dir.join("precious.txt");
+        std::fs::write(&precious, b"PRECIOUS-CONTENT").unwrap();
+
+        // `victim` is a symlink to `target-dir`, not a real directory —
+        // modeling the post-swap state a caller's earlier
+        // `statat(SYMLINK_NOFOLLOW)` classification can no longer see by
+        // the time this function's own `open_one` call runs.
+        symlink("target-dir", root_path.join("victim")).unwrap();
+
+        let root_fd = openat(
+            rustix::fs::CWD,
+            root_path,
+            OFlags::DIRECTORY | OFlags::RDONLY,
+            Mode::empty(),
+        )
+        .unwrap();
+        let parent_fd = openat(
+            &root_fd,
+            ".",
+            OFlags::DIRECTORY | OFlags::RDONLY,
+            Mode::empty(),
+        )
+        .unwrap();
+
+        // Whether this returns `Ok` or `Err` is not the contract being
+        // pinned here — either is an acceptable way to refuse recursing
+        // through the symlink. Losing `precious.txt` is not.
+        let _ = remove_dir_all_fd(
+            root_fd.as_fd(),
+            parent_fd.as_fd(),
+            std::ffi::OsStr::new("victim"),
+        );
+
+        assert_eq!(
+            std::fs::read(&precious).unwrap(),
+            b"PRECIOUS-CONTENT",
+            "remove_dir_all_fd must never delete a sibling directory's contents by \
+             following a symlink planted at the name it was asked to remove"
+        );
+    }
 }

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -28,6 +28,7 @@
 //! path-based filesystem API): its whole job is to be the fd-relative
 //! alternative to one.
 
+use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -51,6 +52,55 @@ static LOCAL_WRITE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// pathological chain worth failing closed on rather than resolving), never
 /// a benign deep structure.
 const MAX_SYMLINK_DEPTH: u8 = 32;
+
+/// A single-resolution symlink-hop budget, shared across every `open_one`
+/// call [`resolve_walk`]/[`descend_creating`]/[`resolve_write_leaf`] make
+/// while walking their (possibly multi-component) path — never reset
+/// per-component.
+///
+/// Before this type existed, [`open_one`] always started a fresh
+/// [`MAX_SYMLINK_DEPTH`]-hop budget (`open_one_depth(..., 0)`), and
+/// `resolve_walk`/`descend_creating` called `open_one` once per path
+/// component in a loop. That let a 10-component path with a
+/// `MAX_SYMLINK_DEPTH`-hop chain planted at *each* component accumulate
+/// roughly `10 * MAX_SYMLINK_DEPTH` total hops in one resolution — looser
+/// than the real `openat2(RESOLVE_BENEATH)` kernel fast path, which applies
+/// its own internal cap (Linux's `SYMLOOP_MAX`, effectively ~40) *once per
+/// whole resolution*, not per path component. Still bounded (no DoS) either
+/// way, but this type makes the portable fallback match that per-resolution
+/// semantics instead of a looser per-component one: one `SymlinkBudget` is
+/// constructed at the top of each of those three functions and threaded by
+/// reference through every `open_one`/symlink-following call the walk makes,
+/// so the whole resolution shares one `MAX_SYMLINK_DEPTH`-hop ceiling.
+///
+/// The Linux `openat2` fast path is unaffected: it is a single syscall per
+/// component and the kernel enforces its own bound *inside* that syscall,
+/// with no dependency on this type at all.
+///
+/// A `Cell`, not an `AtomicU8`: every caller of these functions runs the
+/// whole walk synchronously on one blocking-pool thread with no `.await` in
+/// between (see the module doc's TOCTOU invariant) and never shares a
+/// `SymlinkBudget` across threads, so plain interior mutability is
+/// sufficient and avoids the unnecessary atomic-ordering ceremony.
+pub(super) struct SymlinkBudget(Cell<u8>);
+
+impl SymlinkBudget {
+    pub(super) fn new() -> Self {
+        Self(Cell::new(MAX_SYMLINK_DEPTH))
+    }
+
+    /// Consumes one hop of the remaining budget; fails closed
+    /// (`ResolveError::Escape`) once it is exhausted, exactly like the old
+    /// `depth >= MAX_SYMLINK_DEPTH` check it replaces.
+    fn consume(&self) -> Result<(), ResolveError> {
+        let remaining = self.0.get();
+        if remaining == 0 {
+            return Err(ResolveError::Escape);
+        }
+        self.0.set(remaining - 1);
+        Ok(())
+    }
+}
 
 /// The outcome of a failed fd-relative resolution step: either a genuine I/O
 /// error (propagated as-is), or a symlink/`..`-past-root escape attempt (or
@@ -96,23 +146,30 @@ fn io_err(errno: Errno) -> ResolveError {
 /// per-component `openat` with `O_NOFOLLOW` detects a symlink and this
 /// module's own bounded walk ([`follow_symlink_component`]) resolves it —
 /// fd-anchored at every step, per the module invariant.
+/// Opens a single path component, following an in-bounds symlink against the
+/// shared per-resolution `budget` (see [`SymlinkBudget`]). Callers resolving
+/// a single, standalone component (not part of a multi-component walk) may
+/// pass a fresh `&SymlinkBudget::new()` — [`resolve_walk`]/
+/// [`descend_creating`] construct one `SymlinkBudget` and pass the *same*
+/// reference to every component's `open_one` call instead.
 pub(super) fn open_one(
     root: BorrowedFd<'_>,
     dir: BorrowedFd<'_>,
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
+    budget: &SymlinkBudget,
 ) -> Result<OwnedFd, ResolveError> {
-    open_one_depth(root, dir, name, oflags, mode, 0)
+    open_one_inner(root, dir, name, oflags, mode, budget)
 }
 
-fn open_one_depth(
+fn open_one_inner(
     root: BorrowedFd<'_>,
     dir: BorrowedFd<'_>,
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
-    depth: u8,
+    budget: &SymlinkBudget,
 ) -> Result<OwnedFd, ResolveError> {
     #[cfg(target_os = "linux")]
     {
@@ -186,17 +243,13 @@ fn open_one_depth(
             }
         }
     }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = depth;
-    }
     match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {
         Ok(fd) => Ok(fd),
         // With `O_NOFOLLOW` set, `ELOOP` from a single-component open
         // unambiguously means "this entry is a symlink" (the kernel never
         // attempts to expand it, so a genuine cycle cannot be observed
-        // here) — follow it ourselves, fd-anchored and depth-bounded.
-        Err(Errno::LOOP) => follow_symlink_component(root, dir, name, oflags, mode, depth),
+        // here) — follow it ourselves, fd-anchored and budget-bounded.
+        Err(Errno::LOOP) => follow_symlink_component(root, dir, name, oflags, mode, budget),
         // Some platforms (observed on macOS) report `ENOTDIR` rather than
         // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
         // kernel checks "is this a directory" before "did NOFOLLOW block
@@ -210,7 +263,7 @@ fn open_one_depth(
                     if rustix::fs::FileType::from_raw_mode(stat.st_mode)
                         == rustix::fs::FileType::Symlink =>
                 {
-                    follow_symlink_component(root, dir, name, oflags, mode, depth)
+                    follow_symlink_component(root, dir, name, oflags, mode, budget)
                 }
                 _ => Err(io_err(Errno::NOTDIR)),
             }
@@ -220,28 +273,24 @@ fn open_one_depth(
 }
 
 /// Follows the symlink at `name` (found directly under `dir`), fd-anchored
-/// and depth-bounded, and finishes opening its ultimate target with the
-/// caller's original `oflags`/`mode`. Used only by the portable fallback
-/// (macOS, or a Linux host whose `openat2` is unavailable) — on Linux with
-/// `openat2`, the kernel does this same job for us inside a single
-/// `RESOLVE_BENEATH` call.
+/// and budget-bounded (see [`SymlinkBudget`]), and finishes opening its
+/// ultimate target with the caller's original `oflags`/`mode`. Used only by
+/// the portable fallback (macOS, or a Linux host whose `openat2` is
+/// unavailable) — on Linux with `openat2`, the kernel does this same job for
+/// us inside a single `RESOLVE_BENEATH` call.
 fn follow_symlink_component(
     root: BorrowedFd<'_>,
     dir: BorrowedFd<'_>,
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
-    depth: u8,
+    budget: &SymlinkBudget,
 ) -> Result<OwnedFd, ResolveError> {
-    if depth >= MAX_SYMLINK_DEPTH {
-        return Err(ResolveError::Escape);
-    }
+    budget.consume()?;
     let target = rustix::fs::readlinkat(dir, name, Vec::new()).map_err(io_err)?;
-    let (anchor, last) = walk_symlink_target(root, dir, target.as_bytes(), depth + 1)?;
+    let (anchor, last) = walk_symlink_target(root, dir, target.as_bytes(), budget)?;
     match last {
-        Some(final_name) => {
-            open_one_depth(root, anchor.as_fd(), &final_name, oflags, mode, depth + 1)
-        }
+        Some(final_name) => open_one_inner(root, anchor.as_fd(), &final_name, oflags, mode, budget),
         // Target had no final component (e.g. "/" or ""): it resolves to
         // the anchor directory itself.
         None => Ok(anchor),
@@ -277,14 +326,15 @@ fn follow_symlink_component(
 /// `openat(root_fd, "..", …)` would happily open the real host parent of
 /// the mount, so a `..` that would step above `root` is refused (`Escape`)
 /// instead. Every forward (non-`.`/`..`) component goes back through
-/// [`open_one_depth`], so a symlink nested inside another symlink's target
-/// is itself resolved through this exact same escape/depth-bounded
-/// machinery, never treated as plain text.
+/// [`open_one_inner`], so a symlink nested inside another symlink's target
+/// is itself resolved through this exact same escape/budget-bounded
+/// machinery, never treated as plain text — and consumes budget from the
+/// same shared [`SymlinkBudget`] as everything else in the resolution.
 fn walk_symlink_target(
     root: BorrowedFd<'_>,
     dir: BorrowedFd<'_>,
     target: &[u8],
-    depth: u8,
+    budget: &SymlinkBudget,
 ) -> Result<(OwnedFd, Option<OsString>), ResolveError> {
     if target.starts_with(b"/") {
         return Err(ResolveError::Escape);
@@ -318,13 +368,13 @@ fn walk_symlink_target(
         if is_last {
             return Ok((cur, Some(component.to_os_string())));
         }
-        cur = open_one_depth(
+        cur = open_one_inner(
             root,
             cur.as_fd(),
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
-            depth,
+            budget,
         )?;
     }
     Ok((cur, None))
@@ -353,6 +403,11 @@ fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
 /// `components` empty resolves to the mount root itself (`root` duplicated),
 /// with no parent — the mount root has no fd-relative parent inside this
 /// mount's sandbox, by design (see `DiskFilesystem::delete`).
+///
+/// One [`SymlinkBudget`] is constructed here and shared across every
+/// component's `open_one` call — the whole multi-component walk shares one
+/// [`MAX_SYMLINK_DEPTH`]-hop ceiling, not a fresh one per component (see
+/// `SymlinkBudget`'s doc for why that distinction matters).
 pub(super) fn resolve_walk(
     root: BorrowedFd<'_>,
     components: &[OsString],
@@ -361,6 +416,7 @@ pub(super) fn resolve_walk(
     let Some((leaf, ancestors)) = components.split_last() else {
         return Ok((dup_fd(root)?, None));
     };
+    let budget = SymlinkBudget::new();
     let mut cur = dup_fd(root)?;
     for component in ancestors {
         cur = open_one(
@@ -369,9 +425,10 @@ pub(super) fn resolve_walk(
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
+            &budget,
         )?;
     }
-    let fd = open_one(root, cur.as_fd(), leaf, final_oflags, Mode::empty())?;
+    let fd = open_one(root, cur.as_fd(), leaf, final_oflags, Mode::empty(), &budget)?;
     Ok((fd, Some((cur, leaf.clone()))))
 }
 
@@ -388,10 +445,14 @@ pub(super) fn resolve_walk(
 /// then check again" gap here, because creation and the next level's
 /// containment check are the same `open_one` call the next loop iteration
 /// makes.
+///
+/// Like [`resolve_walk`], one [`SymlinkBudget`] is shared across the whole
+/// multi-component walk rather than reset per component.
 pub(super) fn descend_creating(
     root: BorrowedFd<'_>,
     components: &[OsString],
 ) -> Result<OwnedFd, ResolveError> {
+    let budget = SymlinkBudget::new();
     let mut cur = dup_fd(root)?;
     for component in components {
         cur = match open_one(
@@ -400,6 +461,7 @@ pub(super) fn descend_creating(
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
+            &budget,
         ) {
             Ok(fd) => fd,
             Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {
@@ -414,6 +476,7 @@ pub(super) fn descend_creating(
                     component,
                     OFlags::DIRECTORY,
                     Mode::empty(),
+                    &budget,
                 )?
             }
             Err(other) => return Err(other),
@@ -448,9 +511,10 @@ pub(super) fn resolve_write_leaf(
     parent: BorrowedFd<'_>,
     leaf: &OsStr,
 ) -> Result<(OwnedFd, OsString), ResolveError> {
+    let budget = SymlinkBudget::new();
     let mut cur_parent = dup_fd(parent)?;
     let mut cur_leaf = leaf.to_os_string();
-    for depth in 0..MAX_SYMLINK_DEPTH {
+    loop {
         let is_symlink =
             match rustix::fs::statat(cur_parent.as_fd(), &cur_leaf, AtFlags::SYMLINK_NOFOLLOW) {
                 Ok(stat) => {
@@ -465,10 +529,15 @@ pub(super) fn resolve_write_leaf(
         if !is_symlink {
             return Ok((cur_parent, cur_leaf));
         }
+        // Consumes from the same shared budget `walk_symlink_target` below
+        // draws on for any non-final components of this hop's target text —
+        // one ceiling for the whole chase, matching `resolve_walk`/
+        // `descend_creating`'s per-resolution (not per-hop) budget.
+        budget.consume()?;
         let target =
             rustix::fs::readlinkat(cur_parent.as_fd(), &cur_leaf, Vec::new()).map_err(io_err)?;
         let (new_parent, new_leaf) =
-            walk_symlink_target(root, cur_parent.as_fd(), target.as_bytes(), depth)?;
+            walk_symlink_target(root, cur_parent.as_fd(), target.as_bytes(), &budget)?;
         let Some(new_leaf) = new_leaf else {
             // Symlink target has no final path component (e.g. "/" or ""):
             // there is no meaningful write-target name. Fail closed rather
@@ -478,7 +547,6 @@ pub(super) fn resolve_write_leaf(
         cur_parent = new_parent;
         cur_leaf = new_leaf;
     }
-    Err(ResolveError::Escape)
 }
 
 /// Maximum nesting depth [`remove_dir_all_fd`] will descend into before
@@ -529,8 +597,15 @@ fn remove_dir_all_fd_bounded(
             "directory tree exceeds maximum removal depth of {MAX_REMOVE_DIR_DEPTH} levels; refusing to delete"
         )));
     }
-    let dir_fd = open_one(root, parent, name, OFlags::DIRECTORY, Mode::empty())
-        .map_err(resolve_error_to_io)?;
+    let dir_fd = open_one(
+        root,
+        parent,
+        name,
+        OFlags::DIRECTORY,
+        Mode::empty(),
+        &SymlinkBudget::new(),
+    )
+    .map_err(resolve_error_to_io)?;
     remove_dir_contents(root, dir_fd.as_fd(), depth + 1)?;
     rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(std::io::Error::from)
 }

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -1,11 +1,23 @@
-//! fd-rooted, symlink-free traversal primitives for the local disk backend.
+//! fd-rooted traversal primitives for the local disk backend.
 //!
 //! Every function below operates purely on file descriptors and path
 //! *components* (never a joined host path string). `open_one` is the one
-//! place a directory-entry lookup happens, and it refuses to follow a
-//! symlink anywhere in the walk. Because resolution never hands back a path
-//! for a later, independent syscall to re-open, there is no window between
+//! place a directory-entry lookup happens. It now **follows** a symlink that
+//! stays inside the resolution root, and refuses (fails closed) one that
+//! would step outside it — on Linux via a single kernel-enforced
+//! `openat2(RESOLVE_BENEATH)` call, on other platforms via this module's own
+//! bounded, fd-anchored walk. Because resolution never hands back a path for
+//! a later, independent syscall to re-open, there is no window between
 //! "checked" and "acted on" for an attacker to swap the entry in.
+//!
+//! **Invariant every step in this module preserves:** no step ever resolves
+//! a path *string* against anything other than an fd this module already
+//! holds and has itself verified (the mount's root fd, or an fd this module
+//! opened moments earlier in the same walk). A symlink target is text an
+//! attacker controls; it is only ever handed to `openat`-family calls
+//! anchored on such a verified fd — component by component — never to a
+//! path-based syscall (`open`, `std::fs::*`, `canonicalize`) that would let
+//! the kernel re-resolve it from scratch against the real host root.
 //!
 //! This module is deliberately self-contained: nothing here depends on
 //! `DiskFilesystem`/`LocalMount`/the `RootFilesystem` impl in the parent
@@ -29,8 +41,20 @@ use crate::{CasExpectation, FileType, FilesystemError, FilesystemOperation, Reco
 
 static LOCAL_WRITE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Cap on symlink expansion during a single resolution — both the number of
+/// symlink hops `open_one`'s portable fallback will follow while descending
+/// a walk, and the number of hops [`resolve_write_leaf`] will chase at a
+/// write target. Chosen to match the ballpark of a typical kernel
+/// `SYMLOOP_MAX` (Linux and macOS both default to 40) without depending on
+/// the host's actual `sysconf` value: a legitimate directory structure never
+/// nests this many symlinks, so hitting the cap always means a cycle (or a
+/// pathological chain worth failing closed on rather than resolving), never
+/// a benign deep structure.
+const MAX_SYMLINK_DEPTH: u8 = 32;
+
 /// The outcome of a failed fd-relative resolution step: either a genuine I/O
-/// error (propagated as-is), or a symlink/`..`-past-root escape attempt.
+/// error (propagated as-is), or a symlink/`..`-past-root escape attempt (or
+/// a symlink chain deep enough to be indistinguishable from a cycle).
 pub(super) enum ResolveError {
     Escape,
     Io(std::io::Error),
@@ -47,33 +71,48 @@ pub(super) fn resolve_error_to_filesystem_error(
     }
 }
 
-/// Opens exactly one path component beneath `dir`, refusing to follow a
-/// symlink at that component.
+fn io_err(errno: Errno) -> ResolveError {
+    ResolveError::Io(errno.into())
+}
+
+/// Opens exactly one path component beneath `dir`, following it if it is a
+/// symlink whose resolution stays inside `root`'s tree, and failing closed
+/// (`ResolveError::Escape`) if it would step outside `root` or exceed
+/// [`MAX_SYMLINK_DEPTH`].
 ///
-/// On Linux, this is one syscall via `openat2(RESOLVE_BENEATH |
-/// RESOLVE_NO_SYMLINKS)` when the kernel supports it (falling back below on
-/// `ENOSYS` — an older kernel, or a container/seccomp profile that denies
-/// `openat2` outright). Everywhere else, including macOS (which has no
-/// `openat2` at all), a plain `openat` with `O_NOFOLLOW`.
+/// On Linux, this is one syscall via `openat2(RESOLVE_BENEATH)` when the
+/// kernel supports it (falling back below on `ENOSYS`). `RESOLVE_BENEATH`
+/// alone — without `RESOLVE_NO_SYMLINKS` — is already race-free and
+/// kernel-enforced: it follows a symlink whose resolution stays beneath
+/// `dir`'s own tree and refuses, atomically, one that would not.
+/// `RESOLVE_BENEATH`'s containment composes transitively across the calls
+/// [`resolve_walk`]/[`descend_creating`] make one component at a time (each
+/// step beneath its immediate parent, which is itself beneath its parent,
+/// …), so this function does not need `root` on the Linux fast path — only
+/// the portable fallback below does, to resolve an *absolute* symlink
+/// target against the correct anchor.
 ///
-/// **macOS asymmetry, documented rather than silent:** both paths reject the
-/// same attack class — a symlink at any resolved path component, ancestor or
-/// leaf — because `O_NOFOLLOW` and `RESOLVE_NO_SYMLINKS` both refuse to
-/// traverse a symlink; the security property (no symlink traversal escapes
-/// the mount root) holds identically on both platforms. What macOS's
-/// fallback does *not* get is `RESOLVE_BENEATH`'s single-syscall,
-/// kernel-enforced resolution step: each `open_one` call is independently
-/// safe (it either opens the real, non-symlink entry or fails), but the
-/// *sequence* of `open_one` calls that make up a full path walk on macOS is
-/// coordinated by this module's own loop (`walk`/`resolve_walk`/
-/// `descend_creating`), not by one kernel-verified decision the way
-/// `RESOLVE_BENEATH` verifies a whole relative path in a single syscall on
-/// Linux. Both close the same escape; only the mechanism differs.
+/// Everywhere else (including macOS, which has no `openat2`), a
+/// per-component `openat` with `O_NOFOLLOW` detects a symlink and this
+/// module's own bounded walk ([`follow_symlink_component`]) resolves it —
+/// fd-anchored at every step, per the module invariant.
 pub(super) fn open_one(
+    root: BorrowedFd<'_>,
     dir: BorrowedFd<'_>,
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
+) -> Result<OwnedFd, ResolveError> {
+    open_one_depth(root, dir, name, oflags, mode, 0)
+}
+
+fn open_one_depth(
+    root: BorrowedFd<'_>,
+    dir: BorrowedFd<'_>,
+    name: &OsStr,
+    oflags: OFlags,
+    mode: Mode,
+    depth: u8,
 ) -> Result<OwnedFd, ResolveError> {
     #[cfg(target_os = "linux")]
     {
@@ -99,9 +138,9 @@ pub(super) fn open_one(
             match openat2(
                 dir,
                 name,
-                oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                oflags | OFlags::CLOEXEC,
                 mode,
-                ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
+                ResolveFlags::BENEATH,
             ) {
                 Ok(fd) => return Ok(fd),
                 // Kernel predates openat2 (< 5.6), or a seccomp/container
@@ -119,14 +158,45 @@ pub(super) fn open_one(
                 // opaque `Backend` error, since that path does not share
                 // `openat2`'s whole-path-restart-on-`EAGAIN` failure mode.
                 Err(Errno::AGAIN) => break,
-                Err(Errno::LOOP) | Err(Errno::XDEV) => return Err(ResolveError::Escape),
-                Err(errno) => return Err(ResolveError::Io(errno.into())),
+                // `RESOLVE_BENEATH` implies `RESOLVE_NO_XDEV`: a mountpoint
+                // crossing anywhere in the resolution — even one that stays
+                // lexically "inside" the tree, e.g. a bind mount planted
+                // under a leaf directory — fails here too. Both a genuine
+                // beneath-root escape and an in-tree mount crossing report
+                // `EXDEV`; the kernel gives no way to tell them apart from
+                // the errno alone, and both are exactly the class this
+                // function exists to fail closed on (a mount crossing is
+                // itself a potential escape vector — the mounted filesystem
+                // is not something this mount's containment promise covers)
+                // — so both map to `Escape`, surfaced to callers as
+                // `FilesystemError::SymlinkEscape`, which is the crate's one
+                // "containment rejected this" vocabulary rather than a
+                // confusing raw `EXDEV` `Backend` error.
+                Err(Errno::XDEV) => return Err(ResolveError::Escape),
+                // With `RESOLVE_NO_SYMLINKS` no longer set, `ELOOP` here
+                // means the kernel's own resolution hit a genuine symlink
+                // *cycle* (or a chain deep enough to trip its internal
+                // bound) while expanding an in-bounds symlink — a real
+                // filesystem condition, not a containment escape. Report it
+                // as a plain I/O error rather than `Escape` so it is never
+                // conflated with — or mistaken for evidence of — an escape
+                // attempt.
+                Err(Errno::LOOP) => return Err(io_err(Errno::LOOP)),
+                Err(errno) => return Err(io_err(errno)),
             }
         }
     }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = depth;
+    }
     match rustix::fs::openat(dir, name, oflags | OFlags::NOFOLLOW | OFlags::CLOEXEC, mode) {
         Ok(fd) => Ok(fd),
-        Err(Errno::LOOP) => Err(ResolveError::Escape),
+        // With `O_NOFOLLOW` set, `ELOOP` from a single-component open
+        // unambiguously means "this entry is a symlink" (the kernel never
+        // attempts to expand it, so a genuine cycle cannot be observed
+        // here) — follow it ourselves, fd-anchored and depth-bounded.
+        Err(Errno::LOOP) => follow_symlink_component(root, dir, name, oflags, mode, depth),
         // Some platforms (observed on macOS) report `ENOTDIR` rather than
         // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
         // kernel checks "is this a directory" before "did NOFOLLOW block
@@ -140,25 +210,145 @@ pub(super) fn open_one(
                     if rustix::fs::FileType::from_raw_mode(stat.st_mode)
                         == rustix::fs::FileType::Symlink =>
                 {
-                    Err(ResolveError::Escape)
+                    follow_symlink_component(root, dir, name, oflags, mode, depth)
                 }
-                _ => Err(ResolveError::Io(Errno::NOTDIR.into())),
+                _ => Err(io_err(Errno::NOTDIR)),
             }
         }
-        Err(errno) => Err(ResolveError::Io(errno.into())),
+        Err(errno) => Err(io_err(errno)),
     }
 }
 
-fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
-    rustix::io::dup(fd).map_err(|errno| ResolveError::Io(errno.into()))
+/// Follows the symlink at `name` (found directly under `dir`), fd-anchored
+/// and depth-bounded, and finishes opening its ultimate target with the
+/// caller's original `oflags`/`mode`. Used only by the portable fallback
+/// (macOS, or a Linux host whose `openat2` is unavailable) — on Linux with
+/// `openat2`, the kernel does this same job for us inside a single
+/// `RESOLVE_BENEATH` call.
+fn follow_symlink_component(
+    root: BorrowedFd<'_>,
+    dir: BorrowedFd<'_>,
+    name: &OsStr,
+    oflags: OFlags,
+    mode: Mode,
+    depth: u8,
+) -> Result<OwnedFd, ResolveError> {
+    if depth >= MAX_SYMLINK_DEPTH {
+        return Err(ResolveError::Escape);
+    }
+    let target = rustix::fs::readlinkat(dir, name, Vec::new()).map_err(io_err)?;
+    let (anchor, last) = walk_symlink_target(root, dir, target.as_bytes(), depth + 1)?;
+    match last {
+        Some(final_name) => {
+            open_one_depth(root, anchor.as_fd(), &final_name, oflags, mode, depth + 1)
+        }
+        // Target had no final component (e.g. "/" or ""): it resolves to
+        // the anchor directory itself.
+        None => Ok(anchor),
+    }
 }
 
-/// Walks `components` from `root`, refusing every symlink along the way, and
-/// returns the final entry's fd plus — when `components` is non-empty — the
-/// fd of its immediate parent directory and its own name (needed by callers
-/// that must act on the parent, e.g. `unlinkat`/`renameat`, rather than on
-/// the entry itself, which POSIX has no "act on this fd regardless of its
-/// name" primitive for).
+/// Walks every component of a symlink's `target` text except the last,
+/// fd-anchored throughout, and returns the resulting directory fd plus the
+/// final component's own name (left un-opened — the caller decides how to
+/// use it: as a final `open_one` leaf, or as a bare name for `atomic_write_file`).
+///
+/// **Absolute targets are rejected outright (`Escape`), unconditionally —
+/// this deliberately matches Linux's native `openat2(RESOLVE_BENEATH)`
+/// behavior, not the "reinterpret against the mount root" scheme a first
+/// draft of this module attempted.** `RESOLVE_BENEATH` disallows *any*
+/// absolute symlink target, regardless of where it would resolve, precisely
+/// because the kernel has no concept of "this process's virtual mount root"
+/// to reinterpret it against — only `RESOLVE_IN_ROOT` does that, a
+/// materially different (chroot-emulating) primitive this module does not
+/// use. Reinterpreting an absolute target against `root` here on the
+/// portable fallback would (a) diverge from Linux's real, kernel-enforced
+/// behavior for the identical symlink, and (b) not even help in practice: a
+/// symlink created by any real tool (`ln -s`, an editor, a package manager)
+/// stores the *real host absolute path*, which reinterpreted against a
+/// mount's `root_fd` is essentially never the intended target — it is
+/// coincidence, not signal. Both platforms therefore agree: an absolute
+/// symlink target is always an escape attempt.
+///
+/// A relative target resolves from `dir` (the directory the symlink itself
+/// lives in). `..` components are handled by literally `openat`-ing the
+/// parent (fd-relative, no string trust involved), but only after
+/// confirming the *current* position is not already `root`:
+/// `openat(root_fd, "..", …)` would happily open the real host parent of
+/// the mount, so a `..` that would step above `root` is refused (`Escape`)
+/// instead. Every forward (non-`.`/`..`) component goes back through
+/// [`open_one_depth`], so a symlink nested inside another symlink's target
+/// is itself resolved through this exact same escape/depth-bounded
+/// machinery, never treated as plain text.
+fn walk_symlink_target(
+    root: BorrowedFd<'_>,
+    dir: BorrowedFd<'_>,
+    target: &[u8],
+    depth: u8,
+) -> Result<(OwnedFd, Option<OsString>), ResolveError> {
+    if target.starts_with(b"/") {
+        return Err(ResolveError::Escape);
+    }
+    let mut cur = dup_fd(dir)?;
+    let rest = target;
+    let root_id = fd_identity(root)?;
+    let mut components = rest
+        .split(|byte| *byte == b'/')
+        .filter(|component| !component.is_empty())
+        .peekable();
+    while let Some(component) = components.next() {
+        let is_last = components.peek().is_none();
+        let component = OsStr::from_bytes(component);
+        if component == "." {
+            continue;
+        }
+        if component == ".." {
+            if fd_identity(cur.as_fd())? == root_id {
+                return Err(ResolveError::Escape);
+            }
+            cur = rustix::fs::openat(
+                cur.as_fd(),
+                "..",
+                OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                Mode::empty(),
+            )
+            .map_err(io_err)?;
+            continue;
+        }
+        if is_last {
+            return Ok((cur, Some(component.to_os_string())));
+        }
+        cur = open_one_depth(
+            root,
+            cur.as_fd(),
+            component,
+            OFlags::DIRECTORY,
+            Mode::empty(),
+            depth,
+        )?;
+    }
+    Ok((cur, None))
+}
+
+/// `(device, inode)` identity of `fd`, used to detect "we are already at
+/// `root`" before honoring a `..` component in a symlink target — the one
+/// place this module cannot lean on `RESOLVE_BENEATH`/`openat2` and must
+/// enforce the "never above root" boundary itself.
+fn fd_identity(fd: BorrowedFd<'_>) -> Result<(u64, u64), ResolveError> {
+    let stat = rustix::fs::fstat(fd).map_err(io_err)?;
+    Ok((stat.st_dev as u64, stat.st_ino as u64))
+}
+
+fn dup_fd(fd: BorrowedFd<'_>) -> Result<OwnedFd, ResolveError> {
+    rustix::io::dup(fd).map_err(io_err)
+}
+
+/// Walks `components` from `root`, following an in-bounds symlink anywhere
+/// along the way (see [`open_one`]) and returns the final entry's fd plus —
+/// when `components` is non-empty — the fd of its immediate parent directory
+/// and its own name (needed by callers that must act on the parent, e.g.
+/// `unlinkat`/`renameat`, rather than on the entry itself, which POSIX has no
+/// "act on this fd regardless of its name" primitive for).
 ///
 /// `components` empty resolves to the mount root itself (`root` duplicated),
 /// with no parent — the mount root has no fd-relative parent inside this
@@ -173,9 +363,15 @@ pub(super) fn resolve_walk(
     };
     let mut cur = dup_fd(root)?;
     for component in ancestors {
-        cur = open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?;
+        cur = open_one(
+            root,
+            cur.as_fd(),
+            component,
+            OFlags::DIRECTORY,
+            Mode::empty(),
+        )?;
     }
-    let fd = open_one(cur.as_fd(), leaf, final_oflags, Mode::empty())?;
+    let fd = open_one(root, cur.as_fd(), leaf, final_oflags, Mode::empty())?;
     Ok((fd, Some((cur, leaf.clone()))))
 }
 
@@ -187,17 +383,24 @@ pub(super) fn resolve_walk(
 ///
 /// Each level is still resolved through [`open_one`], so a symlink swapped
 /// into any not-yet-existing ancestor between one level's `mkdirat` and the
-/// next level's `open_one` is rejected exactly like any other symlink in the
-/// walk — there is no separate "check ancestor, then mkdir, then check
-/// again" gap here, because creation and the next level's containment check
-/// are the same `open_one` call the next loop iteration makes.
+/// next level's `open_one` is rejected exactly like any other escaping
+/// symlink in the walk — there is no separate "check ancestor, then mkdir,
+/// then check again" gap here, because creation and the next level's
+/// containment check are the same `open_one` call the next loop iteration
+/// makes.
 pub(super) fn descend_creating(
     root: BorrowedFd<'_>,
     components: &[OsString],
 ) -> Result<OwnedFd, ResolveError> {
     let mut cur = dup_fd(root)?;
     for component in components {
-        cur = match open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty()) {
+        cur = match open_one(
+            root,
+            cur.as_fd(),
+            component,
+            OFlags::DIRECTORY,
+            Mode::empty(),
+        ) {
             Ok(fd) => fd,
             Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {
                 match rustix::fs::mkdirat(cur.as_fd(), component.as_os_str(), new_dir_mode()) {
@@ -205,12 +408,77 @@ pub(super) fn descend_creating(
                     Err(Errno::EXIST) => {}
                     Err(errno) => return Err(ResolveError::Io(errno.into())),
                 }
-                open_one(cur.as_fd(), component, OFlags::DIRECTORY, Mode::empty())?
+                open_one(
+                    root,
+                    cur.as_fd(),
+                    component,
+                    OFlags::DIRECTORY,
+                    Mode::empty(),
+                )?
             }
             Err(other) => return Err(other),
         };
     }
     Ok(cur)
+}
+
+/// Resolves `leaf` under `parent` to the `(parent, leaf-name)` pair a write
+/// should actually land at, chasing a chain of in-bounds symlinks *at the
+/// leaf position* (bounded by [`MAX_SYMLINK_DEPTH`]).
+///
+/// `rename`/`link` — how [`atomic_write_file`] installs bytes — never follow
+/// a symlink at the destination name; they replace/create the directory
+/// entry itself. That is exactly right for the entry-replacement case, but
+/// wrong for "write through an in-bounds symlink," which callers now expect
+/// (a benign in-bounds symlink at a write target is no longer rejected — see
+/// the module-level policy change). This function bridges the gap: it
+/// resolves the symlink chain itself (fd-anchored, via the same
+/// [`walk_symlink_target`] escape/depth-bounded machinery `open_one` uses)
+/// down to the ultimate non-symlink `(parent, leaf)` pair, so the caller's
+/// `atomic_write_file` rename/link installs the bytes at the symlink's
+/// *target*, not over the symlink entry itself. An escaping symlink, or a
+/// chain exceeding the depth cap, fails closed (`Escape`) exactly like every
+/// other resolution step in this module.
+///
+/// `append_file`/`write_file`'s non-atomic siblings don't need this: they
+/// `open_one` the leaf directly, and `open_one` already follows an in-bounds
+/// symlink transparently.
+pub(super) fn resolve_write_leaf(
+    root: BorrowedFd<'_>,
+    parent: BorrowedFd<'_>,
+    leaf: &OsStr,
+) -> Result<(OwnedFd, OsString), ResolveError> {
+    let mut cur_parent = dup_fd(parent)?;
+    let mut cur_leaf = leaf.to_os_string();
+    for depth in 0..MAX_SYMLINK_DEPTH {
+        let is_symlink =
+            match rustix::fs::statat(cur_parent.as_fd(), &cur_leaf, AtFlags::SYMLINK_NOFOLLOW) {
+                Ok(stat) => {
+                    rustix::fs::FileType::from_raw_mode(stat.st_mode)
+                        == rustix::fs::FileType::Symlink
+                }
+                // Not found (nothing at the leaf yet) or any other stat error:
+                // nothing to chase through — hand the pair back as-is and let
+                // the caller's own probe/creation logic report it.
+                Err(_) => false,
+            };
+        if !is_symlink {
+            return Ok((cur_parent, cur_leaf));
+        }
+        let target =
+            rustix::fs::readlinkat(cur_parent.as_fd(), &cur_leaf, Vec::new()).map_err(io_err)?;
+        let (new_parent, new_leaf) =
+            walk_symlink_target(root, cur_parent.as_fd(), target.as_bytes(), depth)?;
+        let Some(new_leaf) = new_leaf else {
+            // Symlink target has no final path component (e.g. "/" or ""):
+            // there is no meaningful write-target name. Fail closed rather
+            // than guess.
+            return Err(ResolveError::Escape);
+        };
+        cur_parent = new_parent;
+        cur_leaf = new_leaf;
+    }
+    Err(ResolveError::Escape)
 }
 
 /// Maximum nesting depth [`remove_dir_all_fd`] will descend into before
@@ -225,23 +493,33 @@ pub(super) fn descend_creating(
 /// large stack arrays) while still failing far short of any real stack
 /// limit if a caller does manage to create a tree this deep. `remove_dir_contents`
 /// only `unlinkat`s a symlink entry directly (`AtFlags::empty()`, never
-/// following it) and never recurses through one, so cycles via symlinks are
-/// not a concern here — depth is bounded purely by real, non-symlink
-/// directory nesting.
+/// following it) and never recurses through one — it decides "is this a
+/// directory to recurse into, or a leaf entry to unlink" from an
+/// `AT_SYMLINK_NOFOLLOW` `statat` on the entry itself, so a symlink is never
+/// mistaken for the (possibly in-bounds, now-followable) directory it might
+/// point at. That check is unaffected by this module's new
+/// symlink-following policy — depth here is still bounded purely by real,
+/// non-symlink directory nesting.
 const MAX_REMOVE_DIR_DEPTH: usize = 512;
 
 /// Recursively removes `name` (found directly under `parent`) and everything
 /// beneath it, never following a symlink into whatever it points at — a
 /// symlinked child is unlinked as itself, exactly like `std::fs::remove_dir_all`,
-/// never traversed into.
+/// never traversed into. `root` anchors the (never actually taken, since
+/// `remove_dir_contents` only ever calls back in here for an
+/// `AT_SYMLINK_NOFOLLOW`-confirmed real directory) symlink-following path
+/// inside `open_one`, kept for signature uniformity with the rest of this
+/// module rather than smuggling in a path-based fallback.
 pub(super) fn remove_dir_all_fd(
+    root: BorrowedFd<'_>,
     parent: BorrowedFd<'_>,
     name: &OsStr,
 ) -> Result<(), std::io::Error> {
-    remove_dir_all_fd_bounded(parent, name, 0)
+    remove_dir_all_fd_bounded(root, parent, name, 0)
 }
 
 fn remove_dir_all_fd_bounded(
+    root: BorrowedFd<'_>,
     parent: BorrowedFd<'_>,
     name: &OsStr,
     depth: usize,
@@ -251,13 +529,17 @@ fn remove_dir_all_fd_bounded(
             "directory tree exceeds maximum removal depth of {MAX_REMOVE_DIR_DEPTH} levels; refusing to delete"
         )));
     }
-    let dir_fd =
-        open_one(parent, name, OFlags::DIRECTORY, Mode::empty()).map_err(resolve_error_to_io)?;
-    remove_dir_contents(dir_fd.as_fd(), depth + 1)?;
+    let dir_fd = open_one(root, parent, name, OFlags::DIRECTORY, Mode::empty())
+        .map_err(resolve_error_to_io)?;
+    remove_dir_contents(root, dir_fd.as_fd(), depth + 1)?;
     rustix::fs::unlinkat(parent, name, AtFlags::REMOVEDIR).map_err(std::io::Error::from)
 }
 
-fn remove_dir_contents(dir: BorrowedFd<'_>, depth: usize) -> Result<(), std::io::Error> {
+fn remove_dir_contents(
+    root: BorrowedFd<'_>,
+    dir: BorrowedFd<'_>,
+    depth: usize,
+) -> Result<(), std::io::Error> {
     let mut entries = Vec::new();
     {
         let listing = rustix::fs::Dir::read_from(dir)?;
@@ -276,7 +558,7 @@ fn remove_dir_contents(dir: BorrowedFd<'_>, depth: usize) -> Result<(), std::io:
     }
     for (name, is_dir) in entries {
         if is_dir {
-            remove_dir_all_fd_bounded(dir, &name, depth)?;
+            remove_dir_all_fd_bounded(root, dir, &name, depth)?;
         } else {
             rustix::fs::unlinkat(dir, &name, AtFlags::empty())?;
         }
@@ -325,13 +607,16 @@ pub(super) fn map_file_type(kind: rustix::fs::FileType) -> FileType {
 
 /// Atomically installs `bytes` as `leaf` under `parent`, via a temp file
 /// created in the same directory and then renamed (`CasExpectation::Any`) or
-/// hard-linked into place (`CasExpectation::Absent`) — unchanged in
-/// approach from before this fix, just fd-relative (`renameat`/`linkat`
-/// against `parent`, an already fd-resolved, already-verified directory)
-/// instead of path-relative. `rename`/`link` never follow a symlink at the
-/// destination name (they replace/create the directory entry itself), so
-/// this step was never part of the TOCTOU surface `resolve_for_write` left
-/// open; only `append_file`'s direct `open` of the leaf was.
+/// hard-linked into place (`CasExpectation::Absent`) — fd-relative
+/// (`renameat`/`linkat` against `parent`, an already fd-resolved,
+/// already-verified directory) instead of path-relative.
+///
+/// Callers that want "write through an in-bounds symlink" must resolve the
+/// symlink chain at `leaf` themselves first (see [`resolve_write_leaf`]) and
+/// pass the *resolved* `(parent, leaf)` pair here — `rename`/`link` never
+/// follow a symlink at the destination name (they replace/create the
+/// directory entry itself), so by the time bytes are installed, `leaf` must
+/// already name the real, non-symlink target.
 pub(super) fn atomic_write_file(
     virtual_path: &VirtualPath,
     parent: BorrowedFd<'_>,
@@ -339,30 +624,21 @@ pub(super) fn atomic_write_file(
     bytes: &[u8],
     cas: CasExpectation,
 ) -> Result<(), FilesystemError> {
-    // `rename`/`link` never follow a symlink at the destination name (see
-    // the function doc), so the install step below can never be tricked
-    // into writing through one — but silently *replacing* a symlink entry
-    // that's still sitting at the leaf (dangling or not) is a real content
-    // loss surprise for whatever legitimately created it, and this crate's
-    // steady-state contract is "reject a pre-existing symlink at a write
-    // target", not "clobber it". Probe with the same `O_NOFOLLOW` primitive
-    // every other lookup in this module uses, immediately before the
-    // install below — both run inside the same non-yielding blocking
-    // closure, so there is no `.await` for a swap to land between the probe
-    // and the install.
-    match open_one(parent, leaf, OFlags::RDONLY, Mode::empty()) {
+    // A pre-existing entry at `leaf` was already resolved by the caller
+    // (`resolve_write_leaf`) if it was a symlink, so by construction `leaf`
+    // here never names a symlink itself — this probe exists only to
+    // distinguish "create" from "overwrite" for the CAS/temp-file dance
+    // below, not to police symlinks (that already happened upstream). Both
+    // run inside the same non-yielding blocking closure, so there is no
+    // `.await` for a swap to land between the probe and the install.
+    match rustix::fs::statat(parent, leaf, AtFlags::SYMLINK_NOFOLLOW) {
         Ok(_existing) => {}
-        Err(ResolveError::Escape) => {
-            return Err(FilesystemError::SymlinkEscape {
-                path: virtual_path.clone(),
-            });
-        }
-        Err(ResolveError::Io(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(ResolveError::Io(io_err)) => {
+        Err(Errno::NOENT) => {}
+        Err(errno) => {
             return Err(super::io_error(
                 virtual_path.clone(),
                 FilesystemOperation::WriteFile,
-                io_err,
+                errno.into(),
             ));
         }
     }
@@ -372,14 +648,18 @@ pub(super) fn atomic_write_file(
     temp_name.push(leaf);
     temp_name.push(format!(".tmp.{counter}"));
 
-    let temp_fd = open_one(
+    let temp_fd = rustix::fs::openat(
         parent,
         &temp_name,
-        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC,
         new_file_mode(),
     )
-    .map_err(|error| {
-        resolve_error_to_filesystem_error(virtual_path, FilesystemOperation::WriteFile, error)
+    .map_err(|errno| {
+        super::io_error(
+            virtual_path.clone(),
+            FilesystemOperation::WriteFile,
+            errno.into(),
+        )
     })?;
 
     let write_result = (|| -> std::io::Result<()> {

--- a/crates/ironclaw_filesystem/src/local/fd_resolve.rs
+++ b/crates/ironclaw_filesystem/src/local/fd_resolve.rs
@@ -134,6 +134,25 @@ impl SymlinkBudget {
     }
 }
 
+/// Per-resolution state every fd-opening step in this module needs, bundled
+/// into one reference so the growing family of `open_one`/`open_one_inner`/
+/// `follow_symlink_component`/`walk_symlink_target` signatures doesn't keep
+/// gaining one more standalone parameter each time a new per-resolution
+/// invariant is added (clippy's `too_many_arguments` at 8; this keeps the
+/// count at 7). Both fields share the same lifecycle: constructed once at
+/// the top of [`resolve_walk`]/[`descend_creating`]/[`resolve_write_leaf`]/
+/// `anchor_for_target` (never per-component, never per-symlink-hop), then
+/// threaded by reference through the whole walk.
+///
+/// - `budget`: see [`SymlinkBudget`].
+/// - `anchor_dev`: the resolution anchor's own device, captured once via one
+///   `fstat` (not re-`fstat`'d per component) — see [`check_same_device`]
+///   (PR #6817 follow-up: macOS `RESOLVE_NO_XDEV` parity).
+pub(super) struct ResolveContext<'a> {
+    pub(super) budget: &'a SymlinkBudget,
+    pub(super) anchor_dev: Dev,
+}
+
 /// The outcome of a failed fd-relative resolution step: either a genuine I/O
 /// error (propagated as-is), or a symlink/`..`-past-root escape attempt (or
 /// a symlink chain deep enough to be indistinguishable from a cycle).
@@ -281,10 +300,9 @@ pub(super) fn open_one(
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
-    budget: &SymlinkBudget,
-    anchor_dev: Dev,
+    ctx: &ResolveContext<'_>,
 ) -> Result<OwnedFd, ResolveError> {
-    open_one_inner(root, ancestors, dir, name, oflags, mode, budget, anchor_dev)
+    open_one_inner(root, ancestors, dir, name, oflags, mode, ctx)
 }
 
 /// Outcome of the Linux `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`
@@ -375,8 +393,7 @@ fn open_one_inner(
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
-    budget: &SymlinkBudget,
-    anchor_dev: Dev,
+    ctx: &ResolveContext<'_>,
 ) -> Result<OwnedFd, ResolveError> {
     #[cfg(target_os = "linux")]
     {
@@ -387,9 +404,7 @@ fn open_one_inner(
         match open_one_beneath_no_symlinks(dir, name, oflags, mode) {
             FastOpenOutcome::Opened(fd) => return Ok(fd),
             FastOpenOutcome::IsSymlink => {
-                return follow_symlink_component(
-                    root, ancestors, dir, name, oflags, mode, budget, anchor_dev,
-                );
+                return follow_symlink_component(root, ancestors, dir, name, oflags, mode, ctx);
             }
             FastOpenOutcome::Failed(error) => return Err(error),
             // Fall through to the portable per-component path below instead
@@ -410,16 +425,14 @@ fn open_one_inner(
         // closed exactly like every other containment rejection in this
         // module — never falls back to a wider root or a path-string check.
         Ok(fd) => {
-            check_same_device(anchor_dev, fd.as_fd())?;
+            check_same_device(ctx.anchor_dev, fd.as_fd())?;
             Ok(fd)
         }
         // With `O_NOFOLLOW` set, `ELOOP` from a single-component open
         // unambiguously means "this entry is a symlink" (the kernel never
         // attempts to expand it, so a genuine cycle cannot be observed
         // here) — follow it ourselves, fd-anchored and budget-bounded.
-        Err(Errno::LOOP) => {
-            follow_symlink_component(root, ancestors, dir, name, oflags, mode, budget, anchor_dev)
-        }
+        Err(Errno::LOOP) => follow_symlink_component(root, ancestors, dir, name, oflags, mode, ctx),
         // Some platforms (observed on macOS) report `ENOTDIR` rather than
         // `ELOOP` when `O_DIRECTORY | O_NOFOLLOW` hits a symlink — the
         // kernel checks "is this a directory" before "did NOFOLLOW block
@@ -433,9 +446,7 @@ fn open_one_inner(
                     if rustix::fs::FileType::from_raw_mode(stat.st_mode)
                         == rustix::fs::FileType::Symlink =>
                 {
-                    follow_symlink_component(
-                        root, ancestors, dir, name, oflags, mode, budget, anchor_dev,
-                    )
+                    follow_symlink_component(root, ancestors, dir, name, oflags, mode, ctx)
                 }
                 _ => Err(io_err(Errno::NOTDIR)),
             }
@@ -458,20 +469,12 @@ fn follow_symlink_component(
     name: &OsStr,
     oflags: OFlags,
     mode: Mode,
-    budget: &SymlinkBudget,
-    anchor_dev: Dev,
+    ctx: &ResolveContext<'_>,
 ) -> Result<OwnedFd, ResolveError> {
-    budget.consume()?;
+    ctx.budget.consume()?;
     let target = rustix::fs::readlinkat(dir, name, Vec::new()).map_err(io_err)?;
-    let (new_ancestors, anchor, last) = walk_symlink_target(
-        root,
-        ancestors,
-        dir,
-        name,
-        target.as_bytes(),
-        budget,
-        anchor_dev,
-    )?;
+    let (new_ancestors, anchor, last) =
+        walk_symlink_target(root, ancestors, dir, name, target.as_bytes(), ctx)?;
     match last {
         Some(final_name) => open_one_inner(
             root,
@@ -480,8 +483,7 @@ fn follow_symlink_component(
             &final_name,
             oflags,
             mode,
-            budget,
-            anchor_dev,
+            ctx,
         ),
         // Target had no final component (e.g. "/" or ""): it resolves to
         // the anchor directory itself.
@@ -550,8 +552,7 @@ fn walk_symlink_target(
     dir: BorrowedFd<'_>,
     symlink_name: &OsStr,
     target: &[u8],
-    budget: &SymlinkBudget,
-    anchor_dev: Dev,
+    ctx: &ResolveContext<'_>,
 ) -> Result<(Vec<OwnedFd>, OwnedFd, Option<OsString>), ResolveError> {
     if target.starts_with(b"/") {
         // PR #6817 review follow-up: report exactly which symlink and
@@ -600,8 +601,7 @@ fn walk_symlink_target(
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
-            budget,
-            anchor_dev,
+            ctx,
         )?;
         stack.push(cur);
         cur = next;
@@ -650,6 +650,10 @@ pub(super) fn resolve_walk(
     // non-leaf-scoped case's value came from. One `fstat` per request is the
     // real floor either way.
     let anchor_dev = rustix::fs::fstat(root).map_err(io_err)?.st_dev;
+    let ctx = ResolveContext {
+        budget: &budget,
+        anchor_dev,
+    };
     let mut cur = dup_fd(root)?;
     let mut ancestors: Vec<OwnedFd> = Vec::with_capacity(ancestor_components.len());
     for component in ancestor_components {
@@ -660,8 +664,7 @@ pub(super) fn resolve_walk(
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
-            &budget,
-            anchor_dev,
+            &ctx,
         )?;
         ancestors.push(cur);
         cur = next;
@@ -673,8 +676,7 @@ pub(super) fn resolve_walk(
         leaf,
         final_oflags,
         Mode::empty(),
-        &budget,
-        anchor_dev,
+        &ctx,
     )?;
     Ok((fd, Some((cur, leaf.clone()))))
 }
@@ -723,6 +725,10 @@ pub(super) fn descend_creating(
     // See `resolve_walk`'s matching comment: captured once per resolution,
     // not per component.
     let anchor_dev = rustix::fs::fstat(root).map_err(io_err)?.st_dev;
+    let ctx = ResolveContext {
+        budget: &budget,
+        anchor_dev,
+    };
     let mut cur = dup_fd(root)?;
     let mut ancestors: Vec<OwnedFd> = Vec::new();
     for component in components {
@@ -733,8 +739,7 @@ pub(super) fn descend_creating(
             component,
             OFlags::DIRECTORY,
             Mode::empty(),
-            &budget,
-            anchor_dev,
+            &ctx,
         ) {
             Ok(fd) => {
                 ancestors.push(cur);
@@ -758,8 +763,7 @@ pub(super) fn descend_creating(
                     component,
                     OFlags::DIRECTORY,
                     Mode::empty(),
-                    &budget,
-                    anchor_dev,
+                    &ctx,
                 )?;
                 ancestors.push(cur);
                 fd
@@ -810,6 +814,10 @@ pub(super) fn resolve_write_leaf(
     // See `resolve_walk`'s matching comment: captured once per resolution,
     // not per component.
     let anchor_dev = rustix::fs::fstat(root).map_err(io_err)?.st_dev;
+    let ctx = ResolveContext {
+        budget: &budget,
+        anchor_dev,
+    };
     let mut cur_ancestors: Vec<OwnedFd> = Vec::with_capacity(ancestors.len());
     for ancestor in ancestors {
         cur_ancestors.push(dup_fd(ancestor.as_fd())?);
@@ -835,7 +843,7 @@ pub(super) fn resolve_write_leaf(
         // draws on for any non-final components of this hop's target text —
         // one ceiling for the whole chase, matching `resolve_walk`/
         // `descend_creating`'s per-resolution (not per-hop) budget.
-        budget.consume()?;
+        ctx.budget.consume()?;
         let target =
             rustix::fs::readlinkat(cur_parent.as_fd(), &cur_leaf, Vec::new()).map_err(io_err)?;
         let (new_ancestors, new_parent, new_leaf) = walk_symlink_target(
@@ -844,8 +852,7 @@ pub(super) fn resolve_write_leaf(
             cur_parent.as_fd(),
             &cur_leaf,
             target.as_bytes(),
-            &budget,
-            anchor_dev,
+            &ctx,
         )?;
         let Some(new_leaf) = new_leaf else {
             // Symlink target has no final path component (e.g. "/" or ""):

--- a/crates/ironclaw_filesystem/src/local/mount_registry.rs
+++ b/crates/ironclaw_filesystem/src/local/mount_registry.rs
@@ -67,6 +67,49 @@ use crate::{FilesystemError, FilesystemOperation, path_prefix_matches};
 /// [`DiskFilesystem::ensure_scoped_mount_dynamic`].
 const MAX_DYNAMIC_MOUNTS: usize = 512;
 
+/// Upper bound on how many path components a single [`VirtualPath`] tail may
+/// resolve into beneath a mount (PR #6817 review follow-up — "unbounded
+/// ancestor-fd retention").
+///
+/// `resolve_walk`/`descend_creating` (`local/fd_resolve.rs`) hold one open
+/// ancestor directory fd per path component *simultaneously* for the
+/// duration of a single resolution — they need every one of them live at
+/// once so a `..` inside a followed symlink can answer by popping an
+/// already-open fd rather than a live, racy `openat(fd, "..")` lookup (see
+/// `fd_resolve.rs`'s module doc). Unlike [`MAX_DYNAMIC_MOUNTS`] (which bounds
+/// a *cache* with an LRU-eviction release valve), there was no cap at all on
+/// a single request's own component count: every component of `path` is
+/// caller-supplied (a `VirtualPath` has no length or depth limit of its
+/// own — see `ironclaw_host_api::path`), so an attacker could send one
+/// pathologically deep path and force this backend to hold thousands of
+/// open fds for the lifetime of that one resolution — exhaustion that is
+/// process-wide (`RLIMIT_NOFILE`), not scoped to the offending request.
+///
+/// **Fails closed, never wide.** This check runs in
+/// [`resolve_mount_route`](DiskFilesystem::resolve_mount_route) *before* any
+/// fd is opened — the earliest possible point, before `MountTarget` is even
+/// constructed — and rejects with [`FilesystemError::PathTooDeep`] outright.
+/// There is deliberately no fallback path (no "widen to a shorter prefix",
+/// no "truncate and continue"): the PR history already has one proven
+/// cross-tenant escape from a bound that silently fell back to a wider
+/// scope on eviction (the now-removed LRU-fallback shape a different
+/// structure in this crate used before PR #6817) — this cap does the
+/// opposite by construction: exceeding it is always a hard `Err`, never a
+/// change in which (narrower or wider) boundary a request resolves against.
+///
+/// 2048 is chosen well above both any real virtual-path shape this crate's
+/// own callers ever construct (`/projects/tenants/<t>/users/<u>/skills/...`
+/// tops out at a double-digit component count even for a deeply nested
+/// project) *and* the deepest deliberately-deep tree this crate's own test
+/// suite builds via `create_dir_all`/`delete`
+/// (`local_backend_delete_of_tree_exceeding_max_depth_fails_cleanly` goes to
+/// 600+2 components, one past `MAX_REMOVE_DIR_DEPTH`, to pin the *separate*
+/// recursive-delete stack-depth cap) — so this cap only ever fires on a
+/// component count no legitimate caller or existing regression test
+/// approaches, while still bounding a single resolution's simultaneous fd
+/// cost to a small, fixed number rather than an attacker-chosen one.
+pub(super) const MAX_PATH_COMPONENTS: usize = 2048;
+
 /// Process-wide logical clock for dynamic-mount LRU recency. A simple
 /// monotonically increasing counter (not wall-clock time) is enough: only
 /// the *relative order* of touches across entries in one `DiskFilesystem`'s
@@ -355,6 +398,17 @@ impl DiskFilesystem {
             }
             if segment == "." {
                 continue;
+            }
+            // Bound the per-resolution ancestor-fd budget before any fd is
+            // opened (`MAX_PATH_COMPONENTS` — PR #6817 review follow-up).
+            // Fails closed with a dedicated error, never widens or
+            // truncates: see the constant's doc comment for why a fallback
+            // shape is exactly what this must not do.
+            if components.len() >= MAX_PATH_COMPONENTS {
+                return Err(FilesystemError::PathTooDeep {
+                    path: path.clone(),
+                    max_components: MAX_PATH_COMPONENTS,
+                });
             }
             components.push(OsString::from(segment));
         }

--- a/crates/ironclaw_filesystem/src/local/mount_registry.rs
+++ b/crates/ironclaw_filesystem/src/local/mount_registry.rs
@@ -588,6 +588,37 @@ mod tests {
         );
     }
 
+    /// Same containment gap as `leaf_scoped_mount_rejects_bare_mount_root_request`,
+    /// reached via a `.`-only tail instead of an empty one: `tail.is_empty()`
+    /// is checked *before* `.` segments are stripped out of the tail below,
+    /// so `/tmp/.` produces a non-empty raw tail (`"."`) that sails past the
+    /// bare-root guard and only then normalizes to zero components. Without
+    /// this fix, `anchor_for_target` in `local.rs` treats that as "no leaf"
+    /// and hands back the wide, shared mount root instead of failing closed
+    /// — `list_dir("/tmp/.")` would enumerate every caller's leaf directory
+    /// names under the shared root, exactly the boundary this mount kind
+    /// exists to eliminate.
+    #[tokio::test]
+    async fn leaf_scoped_mount_rejects_dot_only_bare_mount_root_request() {
+        let storage = tempdir().unwrap();
+        let mut root = DiskFilesystem::new();
+        root.mount_local_per_leaf(
+            VirtualPath::new("/tmp").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let error = root
+            .list_dir(&VirtualPath::new("/tmp/.").unwrap())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, FilesystemError::PathOutsideMount { .. }),
+            "expected PathOutsideMount, got: {error:?}"
+        );
+    }
+
     /// The actual escape `leaf_scoped` containment exists to close: two
     /// callers share one `mount_local_per_leaf` `host_root`, each confined to
     /// their own leaf (`leaf-a`, `leaf-b`). A symlink planted inside

--- a/crates/ironclaw_filesystem/src/local/mount_registry.rs
+++ b/crates/ironclaw_filesystem/src/local/mount_registry.rs
@@ -1,0 +1,786 @@
+//! Mount-registry layer for the local disk backend: registering (static and
+//! dynamic) mounts, and routing a [`VirtualPath`] to the [`MountTarget`] a
+//! caller resolves it against.
+//!
+//! Extracted out of `local.rs` (mirroring the existing `local/fd_resolve.rs`
+//! extraction) once FIX 1 (wiring `ensure_scoped_mount` into the production
+//! request path) and FIX 2 (bounding its dynamic-mount fd growth) added
+//! enough logic to this exact area that it earned its own file. Unlike
+//! `fd_resolve.rs`, this module is NOT independent of `DiskFilesystem` — it
+//! *is* `DiskFilesystem`'s mount bookkeeping, split into a second `impl
+//! DiskFilesystem` block in its own file (Rust allows an inherent `impl`
+//! to be split across multiple blocks/files; it does not allow that for a
+//! single trait impl, which is why `RootFilesystem for DiskFilesystem`
+//! itself — including the one-line `ensure_scoped_mount` trait method that
+//! delegates to [`DiskFilesystem::ensure_scoped_mount_dynamic`] here — stays
+//! in `local.rs`).
+//!
+//! What moved here: [`DiskFilesystem::mount_local`]/
+//! [`mount_local_per_leaf`](DiskFilesystem::mount_local_per_leaf) (boot-time
+//! static mount registration), [`DiskFilesystem::ensure_scoped_mount_dynamic`]
+//! (per-request dynamic mount registration, LRU-bounded), the routing helper
+//! [`DiskFilesystem::resolve_mount_target`], and the [`LocalMount`]/
+//! [`MountTarget`] types themselves. What stayed in `local.rs`:
+//! `anchor_for_target` (needs `MountTarget`'s fields, but is about
+//! *resolving inside* an already-routed mount, not registry bookkeeping) and
+//! the `RootFilesystem` trait impl (every operation's entry point).
+
+use std::{
+    ffi::OsString,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use ironclaw_host_api::{HostPath, VirtualPath};
+use rustix::fd::{AsFd, OwnedFd};
+use rustix::fs::{Mode, OFlags};
+
+use super::DiskFilesystem;
+use crate::{FilesystemError, FilesystemOperation, path_prefix_matches};
+
+/// Upper bound on how many *dynamically*-registered scoped mounts (see
+/// [`DiskFilesystem::ensure_scoped_mount_dynamic`]) this backend keeps open
+/// directory fds for at once. Boot-time static mounts
+/// ([`DiskFilesystem::mount_local`]/
+/// [`mount_local_per_leaf`](DiskFilesystem::mount_local_per_leaf)) are never
+/// counted against this bound or evicted — there are only a handful of them,
+/// fixed at process startup, and every future virtual path under one
+/// resolves through it, so evicting one would break resolution for its whole
+/// subtree with no way to recreate it from a later request.
+///
+/// Once `ensure_scoped_mount` is reachable from the production request path
+/// (the fix this constant ships alongside), one dynamic mount is registered
+/// per distinct `MountGrant::target` a caller resolves through — in
+/// practice, one per active (tenant, user) scope touching a
+/// wide-mount-backed grant like `/skills`. Left unbounded, that is one open
+/// directory fd per distinct scope for the process's entire lifetime: a
+/// slow leak against `RLIMIT_NOFILE` on a long-lived, multi-tenant host.
+///
+/// 512 is chosen against a default Linux soft `RLIMIT_NOFILE` of 1024:
+/// even if every slot is a live fd, this cache alone cannot claim more than
+/// half of a stock default limit, leaving headroom for sockets, log files,
+/// the boot-time static mounts, and every other fd the process needs.
+/// Exceeding the bound evicts the least-recently-touched dynamic entry
+/// rather than failing the request — see
+/// [`DiskFilesystem::ensure_scoped_mount_dynamic`].
+const MAX_DYNAMIC_MOUNTS: usize = 512;
+
+/// Process-wide logical clock for dynamic-mount LRU recency. A simple
+/// monotonically increasing counter (not wall-clock time) is enough: only
+/// the *relative order* of touches across entries in one `DiskFilesystem`'s
+/// mount list matters for picking an eviction victim, and a counter avoids
+/// any dependency on clock resolution or monotonicity guarantees. Shared
+/// across every `DiskFilesystem` instance in the process — harmless, since
+/// each instance only ever compares its own entries' values against each
+/// other, never against another instance's.
+static DYNAMIC_MOUNT_CLOCK: AtomicU64 = AtomicU64::new(0);
+
+fn next_touch() -> u64 {
+    DYNAMIC_MOUNT_CLOCK.fetch_add(1, Ordering::Relaxed)
+}
+
+#[derive(Debug)]
+pub(super) struct LocalMount {
+    pub(super) virtual_root: VirtualPath,
+    /// An open directory descriptor on the mount's canonical host root,
+    /// opened once at mount time. Every request resolves *from this fd*
+    /// (or, for a `leaf_scoped` mount, from a fresh per-call anchor fd
+    /// opened beneath it — see `anchor_for_target`), component by
+    /// component, following an in-bounds symlink and refusing an escaping
+    /// one atomically — via the single-syscall `openat2(RESOLVE_BENEATH)`
+    /// on Linux, or this crate's own bounded fd-anchored walk everywhere
+    /// else. A symlink swapped in after any earlier check is never handed
+    /// to a later, independent path-based syscall, closing the
+    /// pathname-check-then-separate-syscall TOCTOU window `resolve_existing`
+    /// / `resolve_for_write` / `resolve_for_create_dir_all` used to leave
+    /// open.
+    ///
+    /// Wrapped in `Arc` (not re-opened per request): cloning an `Arc<OwnedFd>`
+    /// shares the same underlying open file description rather than
+    /// `dup`-ing a new fd, which is exactly what we want here — directory
+    /// fds used only for relative `openat`/`mkdirat`/`unlinkat`/`fstatat`
+    /// lookups carry no mutable per-fd state (no seek offset, no O_APPEND
+    /// cursor) that a concurrent "clone" could corrupt, so many callers
+    /// reading `self.mounts` concurrently and cloning this `Arc` is safe
+    /// without any lock.
+    pub(super) root_fd: Arc<OwnedFd>,
+    /// When `true`, this mount is shared by many callers who are each only
+    /// ever granted a single leaf subtree of it (one `MountGrant` target
+    /// per caller, narrowed by the composition-layer `MountView` resolver —
+    /// e.g. the sandboxed-profile `/workspace` mount, where every user's
+    /// `MountView` target is `/workspace/<digest>`).
+    ///
+    /// `leaf_scoped` still needs a *narrower* containment boundary than an
+    /// ordinary mount: now that `open_one` follows an in-bounds symlink
+    /// instead of rejecting every symlink outright, a symlink planted in one
+    /// caller's leaf that resolves into a sibling leaf would stay "beneath"
+    /// the wide, shared mount root and pass containment there. So for a
+    /// `leaf_scoped` mount, every request is anchored not at `root_fd` but
+    /// at a fresh fd opened *at the caller's own leaf directory* (see
+    /// `anchor_for_target`) before any further walking happens —
+    /// `RESOLVE_BENEATH` (or the portable fallback's escape check) then
+    /// enforces containment against that narrower anchor, so a symlink can
+    /// never step from one caller's leaf into a sibling leaf. `leaf_scoped`
+    /// additionally still preserves the original policy that a request
+    /// against the bare mount root (no leaf segment at all) must fail closed
+    /// rather than resolving to the shared parent every caller's leaf lives
+    /// under. See [`DiskFilesystem::resolve_mount_target`].
+    pub(super) leaf_scoped: bool,
+    /// `true` for a mount registered by
+    /// [`DiskFilesystem::ensure_scoped_mount_dynamic`] (a caller-scoped
+    /// anchor, e.g. one per (tenant, user) `/skills` grant); `false` for a
+    /// boot-time [`mount_local`](DiskFilesystem::mount_local)/
+    /// [`mount_local_per_leaf`](DiskFilesystem::mount_local_per_leaf) mount.
+    /// Only `dynamic` entries count against [`MAX_DYNAMIC_MOUNTS`] and are
+    /// eligible for LRU eviction — static entries are exempt (see
+    /// `MAX_DYNAMIC_MOUNTS`'s doc for why).
+    pub(super) dynamic: bool,
+    /// Logical-clock recency stamp for LRU eviction among `dynamic` entries
+    /// only (see [`next_touch`]); meaningless and never read for a static
+    /// entry. An `AtomicU64` rather than a plain field so
+    /// [`DiskFilesystem::resolve_mount_target`] can update recency through a
+    /// shared `&self`/read-lock reference on every request that resolves
+    /// through this mount, without needing the write lock just to record
+    /// "this was used" — the field is interior-mutable, the `Vec` slot
+    /// itself is not relocated by a touch.
+    pub(super) last_used: AtomicU64,
+}
+
+/// A mount plus the path components to walk under its `root_fd`. Carries no
+/// host path — every subsequent step is fd-relative.
+pub(super) struct MountTarget {
+    pub(super) root_fd: Arc<OwnedFd>,
+    pub(super) components: Vec<OsString>,
+    /// Mirrors [`LocalMount::leaf_scoped`] — carried through so `local.rs`'s
+    /// `anchor_for_target` can anchor containment at the caller's own leaf
+    /// instead of the shared mount root now that `open_one` follows
+    /// in-bounds symlinks. Without this, a symlink planted inside one
+    /// caller's leaf that resolves into a sibling leaf would pass
+    /// containment (both stay "beneath" the wide, shared mount root) even
+    /// though it must not.
+    pub(super) leaf_scoped: bool,
+}
+
+impl DiskFilesystem {
+    /// Mounts a host directory during trusted setup.
+    ///
+    /// This API is intentionally synchronous because it mutates in-memory mount
+    /// configuration and is not part of the async runtime operation path. Async
+    /// file operations after mount setup use fd-relative syscalls run on the
+    /// blocking pool.
+    pub fn mount_local(
+        &mut self,
+        virtual_root: VirtualPath,
+        host_root: HostPath,
+    ) -> Result<(), FilesystemError> {
+        self.mount_local_impl(virtual_root, host_root, false)
+    }
+
+    /// Mounts a host directory shared across many callers, each of whom is
+    /// only ever granted (via their own `MountView`) a single leaf subtree
+    /// of it — e.g. the `HostedSingleTenantVolumeSandboxed` profile's
+    /// `/workspace` mount, whose shared parent holds every user's leaf
+    /// sandbox-workspace directory. See [`LocalMount::leaf_scoped`] for why
+    /// this no longer needs a distinct containment boundary from
+    /// [`mount_local`](Self::mount_local).
+    pub fn mount_local_per_leaf(
+        &mut self,
+        virtual_root: VirtualPath,
+        host_root: HostPath,
+    ) -> Result<(), FilesystemError> {
+        self.mount_local_impl(virtual_root, host_root, true)
+    }
+
+    fn mount_local_impl(
+        &mut self,
+        virtual_root: VirtualPath,
+        host_root: HostPath,
+        leaf_scoped: bool,
+    ) -> Result<(), FilesystemError> {
+        // `&mut self`, so `get_mut` never actually contends a lock — this
+        // still goes through the same `RwLock<Vec<LocalMount>>` storage
+        // `ensure_scoped_mount_dynamic` uses for its `&self` dynamic
+        // registration, rather than keeping two separate storage shapes in
+        // sync.
+        let mounts = self
+            .mounts
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if mounts
+            .iter()
+            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
+        {
+            return Err(FilesystemError::MountConflict { path: virtual_root });
+        }
+
+        let (canonical_root, root_fd) = open_mount_root(&virtual_root, &host_root)?;
+        let _ = canonical_root;
+
+        mounts.push(LocalMount {
+            virtual_root,
+            root_fd: Arc::new(root_fd),
+            leaf_scoped,
+            dynamic: false,
+            last_used: AtomicU64::new(0),
+        });
+        Ok(())
+    }
+
+    fn has_mount(&self, virtual_root: &VirtualPath) -> bool {
+        let mounts = self
+            .mounts
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        mounts
+            .iter()
+            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
+    }
+
+    /// Routes `path` to its mount and splits the tail into path components
+    /// under that mount's `root_fd`. No filesystem access happens here —
+    /// this is pure string/virtual-path routing, and is not part of the
+    /// TOCTOU surface: the actual containment enforcement happens
+    /// fd-relatively in `open_one` as each returned component is walked.
+    pub(super) fn resolve_mount_target(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<MountTarget, FilesystemError> {
+        let mounts = self
+            .mounts
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mount = mounts
+            .iter()
+            .filter(|mount| path_prefix_matches(mount.virtual_root.as_str(), path.as_str()))
+            .max_by_key(|mount| mount.virtual_root.as_str().len())
+            .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })?;
+
+        // Recency touch for LRU eviction (see `MAX_DYNAMIC_MOUNTS`). Every
+        // real filesystem operation routes through here, so this is the true
+        // usage signal — a no-op for a static mount (its `last_used` is
+        // never read), and for a dynamic mount it keeps an actively-used
+        // scope's entry from looking idle just because no *new* registration
+        // happened recently.
+        if mount.dynamic {
+            mount.last_used.store(next_touch(), Ordering::Relaxed);
+        }
+
+        let tail = path
+            .as_str()
+            .strip_prefix(mount.virtual_root.as_str())
+            .unwrap_or_default()
+            .trim_start_matches('/');
+
+        if tail.is_empty() && mount.leaf_scoped {
+            // A leaf-scoped mount has no safe target for the bare mount path
+            // itself — that would be "every caller's leaf", the shared-parent
+            // boundary this mount kind exists to eliminate. The
+            // composition-layer `MountView` always supplies a leaf, but that
+            // invariant is enforced one layer up, so fail closed here.
+            return Err(FilesystemError::PathOutsideMount { path: path.clone() });
+        }
+
+        let mut components = Vec::new();
+        for segment in tail.split('/').filter(|segment| !segment.is_empty()) {
+            // The virtual-path layer (`ScopedPath::new`) already rejects
+            // literal `..` segments before a caller-controlled path ever
+            // reaches this crate, but `VirtualPath` itself does not enforce
+            // that (this crate's own tests construct arbitrary
+            // `VirtualPath` values), and every component below is handed
+            // directly to `openat`/`mkdirat` — which *do* interpret a `..`
+            // component as "go to the parent directory". Reject it here,
+            // defensively, before any fd work: this is the one place a
+            // literal `..` could turn into a real directory-fd escape.
+            if segment == ".." {
+                return Err(FilesystemError::PathOutsideMount { path: path.clone() });
+            }
+            if segment == "." {
+                continue;
+            }
+            components.push(OsString::from(segment));
+        }
+
+        Ok(MountTarget {
+            root_fd: Arc::clone(&mount.root_fd),
+            components,
+            leaf_scoped: mount.leaf_scoped,
+        })
+    }
+
+    /// Dynamically registers a mount rooted exactly *at* `virtual_root`, if
+    /// one is not already registered there — idempotent, so a repeated call
+    /// for the same `virtual_root` (the usual shape: called on every request
+    /// for a given scope, automatically via
+    /// [`ScopedFilesystem`](crate::ScopedFilesystem)'s permission-resolution
+    /// path) is a cheap no-op after the first. Unlike
+    /// [`mount_local`](Self::mount_local) (boot-time only, exclusive
+    /// `&mut self`), this takes `&self` so it can be called per request from
+    /// behind a shared `Arc<DiskFilesystem>`. Named distinctly from the
+    /// `RootFilesystem::ensure_scoped_mount` trait method (`local.rs`,
+    /// one-line delegation to this) rather than sharing the name: an
+    /// inherent and a trait method of the same name on the same type would
+    /// still resolve correctly (inherent wins), but a distinct name here
+    /// avoids relying on a reader noticing that shadowing rather than
+    /// misreading the trait impl's delegating call as infinite recursion.
+    ///
+    /// This is the mechanism that closes a same-storage-root cross-tenant/
+    /// cross-user symlink escape for a mount whose containment root is wider
+    /// than the subtree a specific caller is actually granted (e.g. `/projects`
+    /// mounted once over the whole local-dev storage root, while a caller's
+    /// `/skills` grant only authorizes `/projects/tenants/<t>/users/<u>/skills`).
+    /// The composition layer already knows that exact boundary — it is the
+    /// `MountGrant::target` a scope-aware `MountView` builder computes from
+    /// typed `ResourceScope` fields, not something this crate derives by
+    /// counting path segments. Registering a *second*, narrower mount at that
+    /// literal target makes [`resolve_mount_target`](Self::resolve_mount_target)'s
+    /// existing longest-prefix-wins matching pick it over the wide mount for
+    /// anything under it, so `RESOLVE_BENEATH` (or the portable fallback)
+    /// enforces containment against the caller's own subtree — exactly that
+    /// subtree, no more — rather than the shared parent every caller's
+    /// subtree lives under.
+    ///
+    /// No host path is taken as input: `virtual_root` is resolved through the
+    /// *existing* (necessarily wider) mount that already covers it, via the
+    /// same fd-rooted `descend_creating` every other write path in this
+    /// crate uses (creating the directory if this is a brand-new leaf's first
+    /// access, exactly like `descend_creating`'s other callers) — never a
+    /// second, independently-resolved `std::fs` path lookup. The resulting,
+    /// already-open fd becomes the new mount's `root_fd` directly.
+    pub(super) async fn ensure_scoped_mount_dynamic(
+        &self,
+        virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        if self.has_mount(virtual_root) {
+            return Ok(());
+        }
+        let virtual_root = virtual_root.clone();
+        let target = self.resolve_mount_target(&virtual_root)?;
+        let path = virtual_root.clone();
+        let anchor_fd =
+            super::run_blocking(path.clone(), FilesystemOperation::MountLocal, move || {
+                super::fd_resolve::descend_creating(target.root_fd.as_fd(), &target.components)
+                    .map_err(|error| {
+                        super::fd_resolve::resolve_error_to_filesystem_error(
+                            &path,
+                            FilesystemOperation::MountLocal,
+                            error,
+                        )
+                    })
+            })
+            .await?;
+
+        let mut mounts = self
+            .mounts
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Re-check under the write lock: two concurrent first-callers for
+        // the same scope must not both push a mount for the same
+        // `virtual_root` (that would leave two entries with the same
+        // longest-prefix key — harmless for correctness since both point at
+        // the same host directory, but wasteful and worth avoiding).
+        if mounts
+            .iter()
+            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
+        {
+            return Ok(());
+        }
+
+        // Bound the dynamic-mount population (`MAX_DYNAMIC_MOUNTS`) before
+        // adding one more: evict the least-recently-touched dynamic entry if
+        // we are at capacity. Still under the same write-lock guard as the
+        // push below, so no other caller can register a mount, race this
+        // eviction, or observe a moment where capacity is exceeded.
+        //
+        // Safety of eviction: dropping a `LocalMount` here only drops the
+        // registry's own `Arc<OwnedFd>` reference. A request already
+        // in-flight against this mount captured its own clone of that `Arc`
+        // in a `MountTarget` (`resolve_mount_target` does `Arc::clone`, not a
+        // move) before this eviction could ever run — the write lock held
+        // here cannot be held concurrently with `resolve_mount_target`'s read
+        // lock, but the in-flight request's *clone* was already taken and
+        // handed off to the blocking closure by an earlier, already-released
+        // read-lock critical section. So eviction only ever drops the
+        // registry's reference; the underlying open file description stays
+        // open until every clone — including any in-flight one — is dropped,
+        // per ordinary `Arc` semantics. No in-use fd is ever closed by this.
+        let dynamic_count = mounts.iter().filter(|mount| mount.dynamic).count();
+        if dynamic_count >= MAX_DYNAMIC_MOUNTS {
+            let evict_index = mounts
+                .iter()
+                .enumerate()
+                .filter(|(_, mount)| mount.dynamic)
+                .min_by_key(|(_, mount)| mount.last_used.load(Ordering::Relaxed))
+                .map(|(index, _)| index);
+            if let Some(evict_index) = evict_index {
+                mounts.remove(evict_index);
+            }
+        }
+
+        mounts.push(LocalMount {
+            virtual_root,
+            root_fd: Arc::new(anchor_fd),
+            leaf_scoped: false,
+            dynamic: true,
+            last_used: AtomicU64::new(next_touch()),
+        });
+        Ok(())
+    }
+}
+
+fn io_reason(error: std::io::Error) -> String {
+    error.kind().to_string()
+}
+
+/// Canonicalizes `host_root` and opens it `O_DIRECTORY | O_NOFOLLOW`, the
+/// shared "turn a host path into a verified mount root fd" step both
+/// `mount_local_impl` (boot-time, static mounts) and
+/// `ensure_scoped_mount_dynamic` (per-request, dynamic mounts) need. The
+/// returned canonical `PathBuf` is not retained by either caller — only the
+/// fd is; this crate never re-resolves a path string against anything after
+/// mount time (see the `fd_resolve` module doc).
+fn open_mount_root(
+    virtual_root: &VirtualPath,
+    host_root: &HostPath,
+) -> Result<(std::path::PathBuf, OwnedFd), FilesystemError> {
+    let canonical_root =
+        std::fs::canonicalize(host_root.as_path()).map_err(|error| FilesystemError::Backend {
+            path: virtual_root.clone(),
+            operation: FilesystemOperation::MountLocal,
+            reason: io_reason(error),
+        })?;
+
+    if !canonical_root.is_dir() {
+        return Err(FilesystemError::Backend {
+            path: virtual_root.clone(),
+            operation: FilesystemOperation::MountLocal,
+            reason: "host root is not a directory".to_string(),
+        });
+    }
+
+    let root_fd = rustix::fs::open(
+        &canonical_root,
+        OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|errno| FilesystemError::Backend {
+        path: virtual_root.clone(),
+        operation: FilesystemOperation::MountLocal,
+        reason: io_reason(errno.into()),
+    })?;
+
+    Ok((canonical_root, root_fd))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RootFilesystem;
+    use tempfile::tempdir;
+
+    /// A `mount_local_per_leaf` mount's containment boundary is the caller's
+    /// own leaf (`host_root/<first-tail-segment>`), derived from the tail —
+    /// there is no safe containment root for the bare mount path itself
+    /// (that would mean "every caller's leaf", the exact shared-parent
+    /// boundary `mount_local_per_leaf` exists to eliminate). Today every
+    /// legitimate grant against such a mount always resolves to a
+    /// leaf-prefixed target (`sandbox_user_workspace_mount_view` in
+    /// `ironclaw_reborn_composition`), but that is an invariant enforced one
+    /// layer up, not by this crate — so a bare-root request must fail closed
+    /// here rather than silently fall back to the full shared parent.
+    #[tokio::test]
+    async fn leaf_scoped_mount_rejects_bare_mount_root_request() {
+        let storage = tempdir().unwrap();
+        let mut root = DiskFilesystem::new();
+        root.mount_local_per_leaf(
+            VirtualPath::new("/tmp").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let error = root
+            .read_file(&VirtualPath::new("/tmp").unwrap())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, FilesystemError::PathOutsideMount { .. }),
+            "expected PathOutsideMount, got: {error:?}"
+        );
+    }
+
+    /// The actual escape `leaf_scoped` containment exists to close: two
+    /// callers share one `mount_local_per_leaf` `host_root`, each confined to
+    /// their own leaf (`leaf-a`, `leaf-b`). A symlink planted inside
+    /// `leaf-a` pointing at `../leaf-b/secret.txt` stays within the shared
+    /// `host_root` — a plain `mount_local` containment check (host_root
+    /// only) would let it resolve — but leaves `leaf-a`'s own containment
+    /// root, so it must be rejected here.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn leaf_scoped_mount_rejects_cross_leaf_symlink_escape() {
+        let storage = tempdir().unwrap();
+        let host_root = storage.path();
+
+        let leaf_a = host_root.join("leaf-a");
+        let leaf_b = host_root.join("leaf-b");
+        std::fs::create_dir_all(&leaf_a).unwrap();
+        std::fs::create_dir_all(&leaf_b).unwrap();
+        std::fs::write(leaf_b.join("secret.txt"), b"leaf-b secret").unwrap();
+        std::os::unix::fs::symlink("../leaf-b/secret.txt", leaf_a.join("escape.txt")).unwrap();
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local_per_leaf(
+            VirtualPath::new("/tmp").unwrap(),
+            HostPath::from_path_buf(host_root.to_path_buf()),
+        )
+        .unwrap();
+
+        let error = root
+            .read_file(&VirtualPath::new("/tmp/leaf-a/escape.txt").unwrap())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, FilesystemError::SymlinkEscape { .. }),
+            "expected SymlinkEscape, got: {error:?}"
+        );
+    }
+
+    /// First-use path for a brand-new leaf: nothing under `host_root` exists
+    /// yet for this caller, so the nearest *existing* ancestor of the target
+    /// is the shared `host_root` itself, not the (not-yet-created)
+    /// containment root `host_root/<leaf>`. Regression for the bug where
+    /// `ensure_existing_ancestor_contained` rejected that shared root as an
+    /// escape, permanently blocking every new leaf's first write.
+    #[tokio::test]
+    async fn leaf_scoped_mount_creates_a_brand_new_leaf_on_first_write() {
+        let storage = tempdir().unwrap();
+        let host_root = storage.path();
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local_per_leaf(
+            VirtualPath::new("/tmp").unwrap(),
+            HostPath::from_path_buf(host_root.to_path_buf()),
+        )
+        .unwrap();
+
+        root.write_file(
+            &VirtualPath::new("/tmp/new-leaf/file.txt").unwrap(),
+            b"hello",
+        )
+        .await
+        .unwrap();
+
+        let bytes = root
+            .read_file(&VirtualPath::new("/tmp/new-leaf/file.txt").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"hello");
+    }
+
+    /// Same first-use bootstrap, but through `create_dir_all` rather than
+    /// `write_file` — the two callers of `ensure_existing_ancestor_contained`
+    /// must both accept the shared `host_root` as a bootstrap ancestor.
+    #[tokio::test]
+    async fn leaf_scoped_mount_create_dir_all_bootstraps_a_brand_new_leaf() {
+        let storage = tempdir().unwrap();
+        let host_root = storage.path();
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local_per_leaf(
+            VirtualPath::new("/tmp").unwrap(),
+            HostPath::from_path_buf(host_root.to_path_buf()),
+        )
+        .unwrap();
+
+        root.create_dir_all(&VirtualPath::new("/tmp/new-leaf/nested").unwrap())
+            .await
+            .unwrap();
+
+        assert!(host_root.join("new-leaf").join("nested").is_dir());
+    }
+
+    /// Bootstrapping a new leaf must not reopen the cross-leaf symlink
+    /// escape the write path closes: a *pre-existing* sibling leaf's
+    /// symlink must still be rejected by `resolve_for_write`
+    /// (`append_file`/`write_file`), not just by `read_file`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn leaf_scoped_mount_rejects_cross_leaf_symlink_escape_on_write() {
+        let storage = tempdir().unwrap();
+        let host_root = storage.path();
+
+        let leaf_a = host_root.join("leaf-a");
+        let leaf_b = host_root.join("leaf-b");
+        std::fs::create_dir_all(&leaf_a).unwrap();
+        std::fs::create_dir_all(&leaf_b).unwrap();
+        std::os::unix::fs::symlink("../leaf-b", leaf_a.join("escape")).unwrap();
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local_per_leaf(
+            VirtualPath::new("/tmp").unwrap(),
+            HostPath::from_path_buf(host_root.to_path_buf()),
+        )
+        .unwrap();
+
+        let error = root
+            .write_file(
+                &VirtualPath::new("/tmp/leaf-a/escape/planted.txt").unwrap(),
+                b"planted",
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, FilesystemError::SymlinkEscape { .. }),
+            "expected SymlinkEscape, got: {error:?}"
+        );
+        assert!(!leaf_b.join("planted.txt").exists());
+    }
+
+    /// A *dangling* final symlink — the entry exists but its target does
+    /// not — must still be rejected. Naively treating "target doesn't
+    /// resolve" as "brand new file in this leaf" would let `write_file`/
+    /// `append_file` open through the symlink (the OS creates the target on
+    /// `O_CREAT`), writing into whatever sibling leaf (or worse) the symlink
+    /// points at. `atomic_write_file`'s pre-install probe (`open_one` with
+    /// `O_NOFOLLOW`) is what catches this now: it never resolves the
+    /// dangling target at all, so "does the target exist" never comes up.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn leaf_scoped_mount_rejects_dangling_final_symlink_escape_on_write() {
+        let storage = tempdir().unwrap();
+        let host_root = storage.path();
+
+        let leaf_a = host_root.join("leaf-a");
+        let leaf_b = host_root.join("leaf-b");
+        std::fs::create_dir_all(&leaf_a).unwrap();
+        std::fs::create_dir_all(&leaf_b).unwrap();
+        std::os::unix::fs::symlink("../leaf-b/planted.txt", leaf_a.join("escape.txt")).unwrap();
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local_per_leaf(
+            VirtualPath::new("/tmp").unwrap(),
+            HostPath::from_path_buf(host_root.to_path_buf()),
+        )
+        .unwrap();
+
+        let error = root
+            .write_file(
+                &VirtualPath::new("/tmp/leaf-a/escape.txt").unwrap(),
+                b"planted",
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, FilesystemError::SymlinkEscape { .. }),
+            "expected SymlinkEscape, got: {error:?}"
+        );
+        assert!(!leaf_b.join("planted.txt").exists());
+    }
+
+    fn dynamic_mount_count(root: &DiskFilesystem) -> usize {
+        root.mounts
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .filter(|mount| mount.dynamic)
+            .count()
+    }
+
+    /// FIX 2 regression: registering more distinct scopes than
+    /// `MAX_DYNAMIC_MOUNTS` must evict rather than grow unbounded — proving
+    /// the fd-leak bound actually holds, not just that the constant exists.
+    /// Registers `MAX_DYNAMIC_MOUNTS + 5` distinct scoped mounts (each opens
+    /// its own directory fd) and asserts the live dynamic-mount population
+    /// never exceeds the cap.
+    #[tokio::test]
+    async fn ensure_scoped_mount_caps_dynamic_mount_population() {
+        let storage = tempdir().unwrap();
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        for i in 0..(MAX_DYNAMIC_MOUNTS + 5) {
+            let target = VirtualPath::new(format!("/projects/scope-{i}")).unwrap();
+            root.ensure_scoped_mount_dynamic(&target)
+                .await
+                .unwrap_or_else(|error| panic!("ensure_scoped_mount({i}) failed: {error:?}"));
+            assert!(
+                dynamic_mount_count(&root) <= MAX_DYNAMIC_MOUNTS,
+                "dynamic mount population exceeded MAX_DYNAMIC_MOUNTS after registering scope {i}"
+            );
+        }
+
+        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
+    }
+
+    /// FIX 2 regression, second half: a scope evicted to make room for newer
+    /// ones must still resolve correctly once it is touched again — eviction
+    /// only drops the registry's own `Arc<OwnedFd>` clone (see
+    /// `ensure_scoped_mount_dynamic`'s eviction comment), never an fd a
+    /// concurrent or later request is relying on, so re-registering the same
+    /// virtual root must transparently re-open it and behave exactly like the
+    /// first time.
+    #[tokio::test]
+    async fn ensure_scoped_mount_evicted_scope_still_resolves_after_reregistration() {
+        let storage = tempdir().unwrap();
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let first_scope = VirtualPath::new("/projects/scope-0").unwrap();
+        root.ensure_scoped_mount_dynamic(&first_scope)
+            .await
+            .expect("register scope-0 first");
+        root.write_file(
+            &VirtualPath::new("/projects/scope-0/marker.txt").unwrap(),
+            b"first-registration",
+        )
+        .await
+        .expect("write through scope-0 before eviction");
+
+        // Push scope-0 out: fill past the cap with fresh scopes, none of
+        // which ever touch scope-0 again, so it is the oldest-by-recency
+        // entry and the eviction victim.
+        for i in 1..=MAX_DYNAMIC_MOUNTS {
+            let target = VirtualPath::new(format!("/projects/scope-{i}")).unwrap();
+            root.ensure_scoped_mount_dynamic(&target)
+                .await
+                .unwrap_or_else(|error| panic!("ensure_scoped_mount({i}) failed: {error:?}"));
+        }
+        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
+
+        // scope-0's file is still on disk (eviction only drops the fd
+        // *cache* entry, never the underlying host directory or its
+        // contents) — reading it forces `ensure_scoped_mount_dynamic` to
+        // re-register the mount from scratch.
+        let bytes = root
+            .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
+            .await
+            .expect("scope-0 must still resolve correctly after eviction and re-registration");
+        assert_eq!(bytes, b"first-registration");
+
+        root.write_file(
+            &VirtualPath::new("/projects/scope-0/marker.txt").unwrap(),
+            b"second-registration",
+        )
+        .await
+        .expect("write through re-registered scope-0");
+        let bytes = root
+            .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"second-registration");
+        assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
+    }
+}

--- a/crates/ironclaw_filesystem/src/local/mount_registry.rs
+++ b/crates/ironclaw_filesystem/src/local/mount_registry.rs
@@ -439,6 +439,7 @@ impl DiskFilesystem {
         let anchor_fd =
             super::run_blocking(path.clone(), FilesystemOperation::MountLocal, move || {
                 super::fd_resolve::descend_creating(target.root_fd.as_fd(), &target.components)
+                    .map(|(fd, _ancestors)| fd)
                     .map_err(|error| {
                         super::fd_resolve::resolve_error_to_filesystem_error(
                             &path,

--- a/crates/ironclaw_filesystem/src/local/mount_registry.rs
+++ b/crates/ironclaw_filesystem/src/local/mount_registry.rs
@@ -243,10 +243,66 @@ impl DiskFilesystem {
     /// this is pure string/virtual-path routing, and is not part of the
     /// TOCTOU surface: the actual containment enforcement happens
     /// fd-relatively in `open_one` as each returned component is walked.
+    ///
+    /// This is the public routing entry point every real filesystem
+    /// operation (`read_file`, `write_file`, ... in `local.rs`) resolves
+    /// through, so it is where the PR #6817 fix applies: see
+    /// [`Self::narrowing_lost`] for the fail-closed check layered on top of
+    /// the raw routing in [`Self::resolve_mount_route`]. Internal bootstrap
+    /// callers that must legitimately resolve through a *wider* ancestor
+    /// mount before a narrower one exists — namely
+    /// `ensure_scoped_mount_dynamic` descending from the parent mount to
+    /// open its own narrow anchor — call `resolve_mount_route` directly to
+    /// bypass this check.
     pub(super) fn resolve_mount_target(
         &self,
         path: &VirtualPath,
     ) -> Result<MountTarget, FilesystemError> {
+        let (target, matched_virtual_root) = self.resolve_mount_route(path)?;
+        if self.narrowing_lost(path, &matched_virtual_root) {
+            // A virtual root at least as specific as this path was, at some
+            // point, established as this backend's own containment boundary
+            // for that scope (`ensure_scoped_mount_dynamic`) — but no mount
+            // that specific is live right now, only a shorter/wider
+            // ancestor (`matched_virtual_root`). Matching the ancestor here
+            // would silently re-widen containment for whatever caller
+            // narrowed this scope, reopening the same-storage-root
+            // cross-tenant symlink escape narrowing exists to close (PR
+            // #6817). Fail loudly instead: the caller must re-establish
+            // narrowing (`ensure_scoped_mount`) before this path resolves
+            // again, exactly like a first-time access.
+            return Err(FilesystemError::MountNotFound { path: path.clone() });
+        }
+        Ok(target)
+    }
+
+    /// `true` when `path` requires narrowing (some virtual root at least as
+    /// specific as `matched_virtual_root` was previously established via
+    /// `ensure_scoped_mount_dynamic`) but the mount that actually matched in
+    /// `resolve_mount_route` is not that narrow root itself — i.e. narrowing
+    /// was lost (typically: LRU-evicted) and never re-established.
+    fn narrowing_lost(&self, path: &VirtualPath, matched_virtual_root: &str) -> bool {
+        let narrow_roots = self
+            .narrow_scoped_roots
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        narrow_roots.iter().any(|root| {
+            root.len() > matched_virtual_root.len() && path_prefix_matches(root, path.as_str())
+        })
+    }
+
+    /// The raw longest-prefix routing `resolve_mount_target` wraps with the
+    /// narrowing-lost check — used directly, without that check, by
+    /// `ensure_scoped_mount_dynamic`'s own bootstrap resolution (it must be
+    /// able to resolve through a wider ancestor mount precisely in order to
+    /// *create* the narrower one; requiring the narrow mount to already
+    /// exist to resolve through it would be circular). Returns the matched
+    /// mount's own `virtual_root` alongside the target so callers can tell
+    /// which mount actually satisfied the routing.
+    fn resolve_mount_route(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<(MountTarget, String), FilesystemError> {
         let mounts = self
             .mounts
             .read()
@@ -267,6 +323,7 @@ impl DiskFilesystem {
             mount.last_used.store(next_touch(), Ordering::Relaxed);
         }
 
+        let matched_virtual_root = mount.virtual_root.as_str().to_string();
         let tail = path
             .as_str()
             .strip_prefix(mount.virtual_root.as_str())
@@ -302,11 +359,14 @@ impl DiskFilesystem {
             components.push(OsString::from(segment));
         }
 
-        Ok(MountTarget {
-            root_fd: Arc::clone(&mount.root_fd),
-            components,
-            leaf_scoped: mount.leaf_scoped,
-        })
+        Ok((
+            MountTarget {
+                root_fd: Arc::clone(&mount.root_fd),
+                components,
+                leaf_scoped: mount.leaf_scoped,
+            },
+            matched_virtual_root,
+        ))
     }
 
     /// Dynamically registers a mount rooted exactly *at* `virtual_root`, if
@@ -352,11 +412,29 @@ impl DiskFilesystem {
         &self,
         virtual_root: &VirtualPath,
     ) -> Result<(), FilesystemError> {
+        // Record *before* the idempotent short-circuit and before any
+        // eviction can happen: from this point on, `virtual_root` is a
+        // containment boundary some caller relies on, permanently — even
+        // across a later LRU eviction of the live entry below. See
+        // `DiskFilesystem::narrow_scoped_roots` and
+        // `resolve_mount_target`/`narrowing_lost` (PR #6817 fix).
+        self.narrow_scoped_roots
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(virtual_root.as_str().to_string());
+
         if self.has_mount(virtual_root) {
             return Ok(());
         }
         let virtual_root = virtual_root.clone();
-        let target = self.resolve_mount_target(&virtual_root)?;
+        // Raw routing, not `resolve_mount_target`: this call resolves
+        // through the (necessarily wider) *ancestor* mount to descend into
+        // `virtual_root` and open its own anchor fd — `virtual_root` itself
+        // has no live mount yet, that is exactly what this function is
+        // registering. Going through `resolve_mount_target` here would
+        // wrongly fail closed on `virtual_root`'s own just-recorded
+        // narrowing requirement.
+        let (target, _matched_virtual_root) = self.resolve_mount_route(&virtual_root)?;
         let path = virtual_root.clone();
         let anchor_fd =
             super::run_blocking(path.clone(), FilesystemOperation::MountLocal, move || {
@@ -722,12 +800,21 @@ mod tests {
     }
 
     /// FIX 2 regression, second half: a scope evicted to make room for newer
-    /// ones must still resolve correctly once it is touched again — eviction
-    /// only drops the registry's own `Arc<OwnedFd>` clone (see
-    /// `ensure_scoped_mount_dynamic`'s eviction comment), never an fd a
-    /// concurrent or later request is relying on, so re-registering the same
-    /// virtual root must transparently re-open it and behave exactly like the
-    /// first time.
+    /// ones must still resolve correctly once its narrowing is properly
+    /// re-established — eviction only drops the registry's own
+    /// `Arc<OwnedFd>` clone (see `ensure_scoped_mount_dynamic`'s eviction
+    /// comment), never an fd a concurrent or later request is relying on,
+    /// nor the underlying host directory or its contents.
+    ///
+    /// Updated for the PR #6817 fix: a bare `read_file`/`write_file` call no
+    /// longer transparently re-widens through the ancestor mount after
+    /// eviction (see `evicted_narrow_mount_fails_closed_instead_of_reopening_cross_tenant_symlink_escape`
+    /// below) — that silent widening *was* the bug. The realistic "reused"
+    /// path, matching every real caller (`ScopedFilesystem` always calls
+    /// `ensure_scoped_mount` immediately before each op), is to
+    /// re-`ensure_scoped_mount_dynamic` the scope first; this test proves
+    /// that path still transparently re-opens the evicted scope and behaves
+    /// exactly like the first registration.
     #[tokio::test]
     async fn ensure_scoped_mount_evicted_scope_still_resolves_after_reregistration() {
         let storage = tempdir().unwrap();
@@ -760,14 +847,30 @@ mod tests {
         }
         assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
 
-        // scope-0's file is still on disk (eviction only drops the fd
-        // *cache* entry, never the underlying host directory or its
-        // contents) — reading it forces `ensure_scoped_mount_dynamic` to
-        // re-register the mount from scratch.
+        // A bare read against the evicted scope, without re-establishing
+        // narrowing, must now fail closed (PR #6817 fix) rather than
+        // silently resolving through the wide `/projects` ancestor.
+        let error = root
+            .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
+            .await
+            .expect_err("read against an evicted, non-re-narrowed scope must fail closed");
+        assert!(
+            matches!(error, FilesystemError::MountNotFound { .. }),
+            "expected MountNotFound after eviction with no re-narrowing, got: {error:?}"
+        );
+
+        // The realistic reuse path: re-establish narrowing, exactly as
+        // `ScopedFilesystem` does before every op. scope-0's file is still
+        // on disk (eviction only drops the fd *cache* entry, never the
+        // underlying host directory or its contents), so re-registering
+        // must transparently re-open it.
+        root.ensure_scoped_mount_dynamic(&first_scope)
+            .await
+            .expect("re-register scope-0 after eviction");
         let bytes = root
             .read_file(&VirtualPath::new("/projects/scope-0/marker.txt").unwrap())
             .await
-            .expect("scope-0 must still resolve correctly after eviction and re-registration");
+            .expect("scope-0 must resolve correctly once narrowing is re-established");
         assert_eq!(bytes, b"first-registration");
 
         root.write_file(
@@ -782,5 +885,85 @@ mod tests {
             .unwrap();
         assert_eq!(bytes, b"second-registration");
         assert_eq!(dynamic_mount_count(&root), MAX_DYNAMIC_MOUNTS);
+    }
+
+    /// PROVEN cross-tenant escape (PR #6817), permanent regression test.
+    ///
+    /// `ensure_scoped_mount_dynamic` narrows containment to exactly one
+    /// caller's own scope (here `/projects/scope-a`) so a symlink escaping
+    /// that scope — even while staying under the wider `/projects` mount —
+    /// is rejected. But that narrow mount is one of `MAX_DYNAMIC_MOUNTS`
+    /// LRU-bounded entries: if it is evicted (one attacker can self-trigger
+    /// this by forcing `MAX_DYNAMIC_MOUNTS` registrations) before the
+    /// narrowed caller's own operation resolves, `resolve_mount_target` used
+    /// to silently fall back to the wider `/projects` mount — reopening the
+    /// exact escape narrowing exists to close, with no error and no signal
+    /// that narrowing was lost.
+    ///
+    /// This exercises the *real* production trigger (an actual
+    /// `MAX_DYNAMIC_MOUNTS`-entry LRU eviction), not a hand-removed mount
+    /// entry.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn evicted_narrow_mount_fails_closed_instead_of_reopening_cross_tenant_symlink_escape() {
+        let storage = tempdir().unwrap();
+        let host_root = storage.path();
+
+        let scope_a = host_root.join("scope-a");
+        let scope_b = host_root.join("scope-b");
+        std::fs::create_dir_all(&scope_a).unwrap();
+        std::fs::create_dir_all(&scope_b).unwrap();
+        std::fs::write(scope_b.join("secret.txt"), b"scope-b secret").unwrap();
+        std::os::unix::fs::symlink("../scope-b/secret.txt", scope_a.join("escape.txt")).unwrap();
+
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(host_root.to_path_buf()),
+        )
+        .unwrap();
+
+        let narrow_target = VirtualPath::new("/projects/scope-a").unwrap();
+        let escape_path = VirtualPath::new("/projects/scope-a/escape.txt").unwrap();
+
+        // Narrow mount live: containment is anchored at scope-a's own leaf,
+        // so the symlink escaping to scope-b is rejected.
+        root.ensure_scoped_mount_dynamic(&narrow_target)
+            .await
+            .expect("establish narrow mount for scope-a");
+        let error = root.read_file(&escape_path).await.unwrap_err();
+        assert!(
+            matches!(error, FilesystemError::SymlinkEscape { .. }),
+            "expected SymlinkEscape with the narrow mount live, got: {error:?}"
+        );
+
+        // Force scope-a's narrow mount out of the real LRU cache without
+        // ever re-narrowing for it — the exact production trigger: a busy
+        // multi-tenant host (or one attacker) registering
+        // `MAX_DYNAMIC_MOUNTS` distinct scopes evicts an unrelated caller's
+        // narrow mount mid-request.
+        for i in 0..MAX_DYNAMIC_MOUNTS {
+            let target = VirtualPath::new(format!("/projects/filler-{i}")).unwrap();
+            root.ensure_scoped_mount_dynamic(&target)
+                .await
+                .unwrap_or_else(|error| {
+                    panic!("ensure_scoped_mount(filler-{i}) failed: {error:?}")
+                });
+        }
+        assert!(
+            !root.has_mount(&narrow_target),
+            "scope-a's narrow mount must have been evicted by the fill loop"
+        );
+
+        // The identical read, with narrowing lost and never re-established,
+        // must now fail closed rather than silently falling back to the
+        // wide `/projects` mount and returning scope-b's file content.
+        let error = root.read_file(&escape_path).await.expect_err(
+            "read after narrow-mount eviction must fail closed, not resolve through the wider mount",
+        );
+        assert!(
+            matches!(error, FilesystemError::MountNotFound { .. }),
+            "expected MountNotFound (fail-closed) after narrowing was lost, got: {error:?}"
+        );
     }
 }

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -882,6 +882,16 @@ impl RootFilesystem for PostgresRootFilesystem {
             .map_err(|error| db_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
         Ok(())
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Postgres rows are scoped by virtual-path prefix, not by an OS
+        // directory fd; containment is enforced by that row scoping, so
+        // there is no mount to narrow here.
+        Ok(())
+    }
 }
 impl PostgresRootFilesystem {
     async fn exact_entry_with_client(

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -124,6 +124,33 @@ pub trait RootFilesystem: Send + Sync {
         unsupported(path, FilesystemOperation::EnsureIndex)
     }
 
+    /// Dynamically registers (idempotently) a scoped mount rooted exactly at
+    /// `virtual_root`, narrowing this backend's containment boundary to that
+    /// exact subtree for every subsequent operation under it.
+    ///
+    /// Exists to close a same-storage-root cross-tenant/cross-user symlink
+    /// escape for a backend whose containment root is wider than the subtree
+    /// a specific caller is actually granted — e.g. a `/projects` mount
+    /// spanning the whole local-dev storage root, while a caller's `/skills`
+    /// [`ironclaw_host_api::MountGrant`] only authorizes
+    /// `/projects/tenants/<t>/users/<u>/skills`. [`ScopedFilesystem`](crate::ScopedFilesystem)
+    /// calls this on every permission-checked resolution, passing the exact
+    /// `MountGrant::target` it already holds, so no caller can reach the
+    /// backend without first narrowing containment to its own grant.
+    ///
+    /// Default impl is a no-op: mirrors the backend-optionality pattern
+    /// [`put`](Self::put)/[`get`](Self::get) use. Only a backend with
+    /// OS-level directory-fd containment (the local disk backend,
+    /// `DiskFilesystem`) has a wider-than-granted containment root that
+    /// needs narrowing this way. Row/prefix-scoped backends (Postgres,
+    /// libSQL, in-memory) have no OS path to anchor an fd on and enforce
+    /// containment through their own per-row/prefix scoping instead, so
+    /// inheriting the no-op here is correct for them, not a placeholder
+    /// oversight.
+    async fn ensure_scoped_mount(&self, _virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        Ok(())
+    }
+
     /// Returns metadata for a canonical virtual path without revealing raw host paths.
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError>;
 

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -147,7 +147,10 @@ pub trait RootFilesystem: Send + Sync {
     /// containment through their own per-row/prefix scoping instead, so
     /// inheriting the no-op here is correct for them, not a placeholder
     /// oversight.
-    async fn ensure_scoped_mount(&self, _virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
         Ok(())
     }
 

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -138,21 +138,19 @@ pub trait RootFilesystem: Send + Sync {
     /// `MountGrant::target` it already holds, so no caller can reach the
     /// backend without first narrowing containment to its own grant.
     ///
-    /// Default impl is a no-op: mirrors the backend-optionality pattern
-    /// [`put`](Self::put)/[`get`](Self::get) use. Only a backend with
+    /// No default impl: this is a security control, not an optional
+    /// capability, so every implementor must make an explicit containment
+    /// decision instead of silently inheriting a no-op. Only a backend with
     /// OS-level directory-fd containment (the local disk backend,
-    /// `DiskFilesystem`) has a wider-than-granted containment root that
-    /// needs narrowing this way. Row/prefix-scoped backends (Postgres,
-    /// libSQL, in-memory) have no OS path to anchor an fd on and enforce
-    /// containment through their own per-row/prefix scoping instead, so
-    /// inheriting the no-op here is correct for them, not a placeholder
-    /// oversight.
-    async fn ensure_scoped_mount(
-        &self,
-        _virtual_root: &VirtualPath,
-    ) -> Result<(), FilesystemError> {
-        Ok(())
-    }
+    /// `DiskFilesystem`) actually narrows anything here. Row/prefix-scoped
+    /// backends (Postgres, libSQL, in-memory) have no OS path to anchor an fd
+    /// on and enforce containment through their own per-row/prefix scoping
+    /// instead — those must still implement this method, returning `Ok(())`
+    /// with a comment explaining why there is nothing to narrow. Any backend
+    /// that wraps or delegates to another `RootFilesystem` MUST forward this
+    /// call to the inner backend rather than no-op, or containment narrowing
+    /// silently stops propagating through the wrapper.
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError>;
 
     /// Returns metadata for a canonical virtual path without revealing raw host paths.
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError>;
@@ -455,6 +453,14 @@ mod tests {
                     payload: vec![seq as u8],
                 })
                 .collect())
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Unit-struct fixture with no storage to narrow.
+            Ok(())
         }
     }
 

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -276,8 +276,9 @@ where
     ) -> Result<RecordVersion, FilesystemError> {
         let started_at = live_latency_started_at();
         let bytes = entry.body.len();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::WriteFile).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::WriteFile)
+            .await?;
         let result = self.root.put(&virtual_path, entry, cas).await;
         trace_fs_latency("put", path, started_at, &result, Some(bytes));
         result
@@ -290,8 +291,9 @@ where
         path: &ScopedPath,
     ) -> Result<Option<VersionedEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::ReadFile)
+            .await?;
         let result = self.root.get(&virtual_path).await;
         trace_fs_latency("get", path, started_at, &result, None);
         result
@@ -306,8 +308,9 @@ where
         page: Page,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, prefix, FilesystemOperation::Query).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, prefix, FilesystemOperation::Query)
+            .await?;
         let result = self.root.query(&virtual_path, filter, page).await;
         trace_fs_latency("query", prefix, started_at, &result, None);
         result
@@ -321,8 +324,9 @@ where
         spec: &IndexSpec,
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, prefix, FilesystemOperation::EnsureIndex).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, prefix, FilesystemOperation::EnsureIndex)
+            .await?;
         let result = self.root.ensure_index(&virtual_path, spec).await;
         trace_fs_latency("ensure_index", prefix, started_at, &result, None);
         result
@@ -342,9 +346,13 @@ where
     ) -> Result<Box<dyn StorageTxn>, FilesystemError> {
         let started_at = live_latency_started_at();
         let view = self.mount_view(scope)?;
-        let virtual_path =
-            resolve_with_permission_view(self.root.as_ref(), &view, prefix, FilesystemOperation::BeginTxn)
-                .await?;
+        let virtual_path = resolve_with_permission_view(
+            self.root.as_ref(),
+            &view,
+            prefix,
+            FilesystemOperation::BeginTxn,
+        )
+        .await?;
         let result = self.root.begin(&virtual_path).await;
         trace_fs_latency("begin", prefix, started_at, &result, None);
         let inner = result?;
@@ -367,8 +375,9 @@ where
     ) -> Result<SeqNo, FilesystemError> {
         let started_at = live_latency_started_at();
         let bytes = payload.len();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Append).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::Append)
+            .await?;
         let result = self.root.append(&virtual_path, payload).await;
         trace_fs_latency("append", path, started_at, &result, Some(bytes));
         result
@@ -386,8 +395,9 @@ where
     ) -> Result<Vec<SeqNo>, FilesystemError> {
         let started_at = live_latency_started_at();
         let bytes = payloads.iter().map(Vec::len).sum();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Append).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::Append)
+            .await?;
         let result = self.root.append_batch(&virtual_path, payloads).await;
         trace_fs_latency("append_batch", path, started_at, &result, Some(bytes));
         result
@@ -401,7 +411,9 @@ where
         from: SeqNo,
     ) -> Result<Vec<EventRecord>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Tail).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::Tail)
+            .await?;
         let result = self.root.tail(&virtual_path, from).await;
         trace_fs_latency("tail", path, started_at, &result, None);
         result
@@ -416,7 +428,9 @@ where
         max_records: usize,
     ) -> Result<Vec<EventRecord>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Tail).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::Tail)
+            .await?;
         let result = self
             .root
             .tail_bounded(&virtual_path, from, max_records)
@@ -435,8 +449,9 @@ where
         from: SeqNo,
     ) -> Result<Option<SeqNo>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::HeadSeq).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::HeadSeq)
+            .await?;
         let result = self.root.head_seq(&virtual_path, from).await;
         trace_fs_latency("head_seq", path, started_at, &result, None);
         result
@@ -449,8 +464,9 @@ where
         path: &ScopedPath,
     ) -> Result<SeqNo, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReserveSeq).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::ReserveSeq)
+            .await?;
         let result = self.root.reserve_sequence(&virtual_path).await;
         trace_fs_latency("reserve_sequence", path, started_at, &result, None);
         result
@@ -466,8 +482,9 @@ where
         path: &ScopedPath,
     ) -> Result<Vec<u8>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::ReadFile)
+            .await?;
         let result = self.root.read_file(&virtual_path).await;
         trace_fs_latency("read_file", path, started_at, &result, None);
         result
@@ -482,8 +499,9 @@ where
         bytes: &[u8],
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::WriteFile).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::WriteFile)
+            .await?;
         let result = self.root.write_file(&virtual_path, bytes).await;
         trace_fs_latency("write_file", path, started_at, &result, Some(bytes.len()));
         result
@@ -501,9 +519,13 @@ where
         bytes: &[u8],
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            resolve_with_permission_view(self.root.as_ref(), view, path, FilesystemOperation::WriteFile)
-                .await?;
+        let virtual_path = resolve_with_permission_view(
+            self.root.as_ref(),
+            view,
+            path,
+            FilesystemOperation::WriteFile,
+        )
+        .await?;
         let result = self
             .root
             .put(
@@ -533,8 +555,9 @@ where
         bytes: &[u8],
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::AppendFile).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::AppendFile)
+            .await?;
         let result = self.root.append_file(&virtual_path, bytes).await;
         trace_fs_latency("append_file", path, started_at, &result, Some(bytes.len()));
         result
@@ -546,8 +569,9 @@ where
         path: &ScopedPath,
     ) -> Result<Vec<DirEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ListDir).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::ListDir)
+            .await?;
         let result = self.root.list_dir(&virtual_path).await;
         trace_fs_latency("list_dir", path, started_at, &result, None);
         result
@@ -560,8 +584,9 @@ where
         max_entries: usize,
     ) -> Result<Vec<DirEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ListDir).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::ListDir)
+            .await?;
         let result = self.root.list_dir_bounded(&virtual_path, max_entries).await;
         trace_fs_latency("list_dir_bounded", path, started_at, &result, None);
         result
@@ -573,7 +598,9 @@ where
         path: &ScopedPath,
     ) -> Result<FileStat, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Stat).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::Stat)
+            .await?;
         let result = self.root.stat(&virtual_path).await;
         trace_fs_latency("stat", path, started_at, &result, None);
         result
@@ -585,8 +612,9 @@ where
         path: &ScopedPath,
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Delete).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::Delete)
+            .await?;
         let result = self.root.delete(&virtual_path).await;
         trace_fs_latency("delete", path, started_at, &result, None);
         result
@@ -601,8 +629,9 @@ where
         expected_version: RecordVersion,
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Delete).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::Delete)
+            .await?;
         let result = self
             .root
             .delete_if_version(&virtual_path, expected_version)
@@ -619,8 +648,9 @@ where
         path: &ScopedPath,
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::CreateDirAll).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::CreateDirAll)
+            .await?;
         let result = self.root.create_dir_all(&virtual_path).await;
         trace_fs_latency("create_dir_all", path, started_at, &result, None);
         result
@@ -638,8 +668,9 @@ where
         match self.get(scope, path).await? {
             Some(versioned) => Ok(versioned.entry.body),
             None => {
-                let virtual_path =
-                    self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
+                let virtual_path = self
+                    .resolve_with_permission(scope, path, FilesystemOperation::ReadFile)
+                    .await?;
                 Err(FilesystemError::NotFound {
                     path: virtual_path,
                     operation: FilesystemOperation::ReadFile,
@@ -656,8 +687,9 @@ where
         path: &ScopedPath,
         max_bytes: usize,
     ) -> Result<Option<Vec<u8>>, FilesystemError> {
-        let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
+        let virtual_path = self
+            .resolve_with_permission(scope, path, FilesystemOperation::ReadFile)
+            .await?;
         self.root.read_file_bounded(&virtual_path, max_bytes).await
     }
 

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -729,9 +729,11 @@ where
 /// so no consumer — the skill-management port, a future `MountGrant`-scoped
 /// store, anything holding a `ScopedFilesystem` — can reach the backend
 /// without the backend first anchoring to the caller's own granted subtree.
-/// For backends without OS-level containment to narrow (Postgres, libSQL,
-/// in-memory), `ensure_scoped_mount`'s default no-op makes this an
-/// unconditional but free extra call.
+/// `ensure_scoped_mount` has no default implementation — every
+/// `RootFilesystem` implementor, including backends without OS-level
+/// containment to narrow (Postgres, libSQL, in-memory), must supply its own
+/// (typically an explicit `Ok(())`), so this call is unconditional but free
+/// for those backends rather than silently inherited.
 async fn resolve_with_permission_view<F>(
     root: &F,
     view: &MountView,

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -155,6 +155,7 @@ fn filesystem_error_kind(error: &FilesystemError) -> &'static str {
         FilesystemError::MountNotFound { .. } => "mount_not_found",
         FilesystemError::NotFound { .. } => "not_found",
         FilesystemError::PathOutsideMount { .. } => "path_outside_mount",
+        FilesystemError::PathTooDeep { .. } => "path_too_deep",
         FilesystemError::SymlinkEscape { .. } => "symlink_escape",
         FilesystemError::MountConflict { .. } => "mount_conflict",
         FilesystemError::Backend { .. } => "backend",

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -277,7 +277,7 @@ where
         let started_at = live_latency_started_at();
         let bytes = entry.body.len();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::WriteFile)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::WriteFile).await?;
         let result = self.root.put(&virtual_path, entry, cas).await;
         trace_fs_latency("put", path, started_at, &result, Some(bytes));
         result
@@ -291,7 +291,7 @@ where
     ) -> Result<Option<VersionedEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
         let result = self.root.get(&virtual_path).await;
         trace_fs_latency("get", path, started_at, &result, None);
         result
@@ -307,7 +307,7 @@ where
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, prefix, FilesystemOperation::Query)?;
+            self.resolve_with_permission(scope, prefix, FilesystemOperation::Query).await?;
         let result = self.root.query(&virtual_path, filter, page).await;
         trace_fs_latency("query", prefix, started_at, &result, None);
         result
@@ -322,7 +322,7 @@ where
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, prefix, FilesystemOperation::EnsureIndex)?;
+            self.resolve_with_permission(scope, prefix, FilesystemOperation::EnsureIndex).await?;
         let result = self.root.ensure_index(&virtual_path, spec).await;
         trace_fs_latency("ensure_index", prefix, started_at, &result, None);
         result
@@ -343,7 +343,8 @@ where
         let started_at = live_latency_started_at();
         let view = self.mount_view(scope)?;
         let virtual_path =
-            resolve_with_permission_view(&view, prefix, FilesystemOperation::BeginTxn)?;
+            resolve_with_permission_view(self.root.as_ref(), &view, prefix, FilesystemOperation::BeginTxn)
+                .await?;
         let result = self.root.begin(&virtual_path).await;
         trace_fs_latency("begin", prefix, started_at, &result, None);
         let inner = result?;
@@ -367,7 +368,7 @@ where
         let started_at = live_latency_started_at();
         let bytes = payload.len();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Append)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::Append).await?;
         let result = self.root.append(&virtual_path, payload).await;
         trace_fs_latency("append", path, started_at, &result, Some(bytes));
         result
@@ -386,7 +387,7 @@ where
         let started_at = live_latency_started_at();
         let bytes = payloads.iter().map(Vec::len).sum();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Append)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::Append).await?;
         let result = self.root.append_batch(&virtual_path, payloads).await;
         trace_fs_latency("append_batch", path, started_at, &result, Some(bytes));
         result
@@ -400,7 +401,7 @@ where
         from: SeqNo,
     ) -> Result<Vec<EventRecord>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Tail)?;
+        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Tail).await?;
         let result = self.root.tail(&virtual_path, from).await;
         trace_fs_latency("tail", path, started_at, &result, None);
         result
@@ -415,7 +416,7 @@ where
         max_records: usize,
     ) -> Result<Vec<EventRecord>, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Tail)?;
+        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Tail).await?;
         let result = self
             .root
             .tail_bounded(&virtual_path, from, max_records)
@@ -435,7 +436,7 @@ where
     ) -> Result<Option<SeqNo>, FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::HeadSeq)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::HeadSeq).await?;
         let result = self.root.head_seq(&virtual_path, from).await;
         trace_fs_latency("head_seq", path, started_at, &result, None);
         result
@@ -449,7 +450,7 @@ where
     ) -> Result<SeqNo, FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReserveSeq)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::ReserveSeq).await?;
         let result = self.root.reserve_sequence(&virtual_path).await;
         trace_fs_latency("reserve_sequence", path, started_at, &result, None);
         result
@@ -466,7 +467,7 @@ where
     ) -> Result<Vec<u8>, FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
         let result = self.root.read_file(&virtual_path).await;
         trace_fs_latency("read_file", path, started_at, &result, None);
         result
@@ -482,7 +483,7 @@ where
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::WriteFile)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::WriteFile).await?;
         let result = self.root.write_file(&virtual_path, bytes).await;
         trace_fs_latency("write_file", path, started_at, &result, Some(bytes.len()));
         result
@@ -501,7 +502,8 @@ where
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            resolve_with_permission_view(view, path, FilesystemOperation::WriteFile)?;
+            resolve_with_permission_view(self.root.as_ref(), view, path, FilesystemOperation::WriteFile)
+                .await?;
         let result = self
             .root
             .put(
@@ -532,7 +534,7 @@ where
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::AppendFile)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::AppendFile).await?;
         let result = self.root.append_file(&virtual_path, bytes).await;
         trace_fs_latency("append_file", path, started_at, &result, Some(bytes.len()));
         result
@@ -545,7 +547,7 @@ where
     ) -> Result<Vec<DirEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ListDir)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::ListDir).await?;
         let result = self.root.list_dir(&virtual_path).await;
         trace_fs_latency("list_dir", path, started_at, &result, None);
         result
@@ -559,7 +561,7 @@ where
     ) -> Result<Vec<DirEntry>, FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ListDir)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::ListDir).await?;
         let result = self.root.list_dir_bounded(&virtual_path, max_entries).await;
         trace_fs_latency("list_dir_bounded", path, started_at, &result, None);
         result
@@ -571,7 +573,7 @@ where
         path: &ScopedPath,
     ) -> Result<FileStat, FilesystemError> {
         let started_at = live_latency_started_at();
-        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Stat)?;
+        let virtual_path = self.resolve_with_permission(scope, path, FilesystemOperation::Stat).await?;
         let result = self.root.stat(&virtual_path).await;
         trace_fs_latency("stat", path, started_at, &result, None);
         result
@@ -584,7 +586,7 @@ where
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Delete)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::Delete).await?;
         let result = self.root.delete(&virtual_path).await;
         trace_fs_latency("delete", path, started_at, &result, None);
         result
@@ -600,7 +602,7 @@ where
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::Delete)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::Delete).await?;
         let result = self
             .root
             .delete_if_version(&virtual_path, expected_version)
@@ -618,7 +620,7 @@ where
     ) -> Result<(), FilesystemError> {
         let started_at = live_latency_started_at();
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::CreateDirAll)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::CreateDirAll).await?;
         let result = self.root.create_dir_all(&virtual_path).await;
         trace_fs_latency("create_dir_all", path, started_at, &result, None);
         result
@@ -637,7 +639,7 @@ where
             Some(versioned) => Ok(versioned.entry.body),
             None => {
                 let virtual_path =
-                    self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile)?;
+                    self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
                 Err(FilesystemError::NotFound {
                     path: virtual_path,
                     operation: FilesystemOperation::ReadFile,
@@ -655,7 +657,7 @@ where
         max_bytes: usize,
     ) -> Result<Option<Vec<u8>>, FilesystemError> {
         let virtual_path =
-            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile)?;
+            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile).await?;
         self.root.read_file_bounded(&virtual_path, max_bytes).await
     }
 
@@ -674,22 +676,39 @@ where
 
     // ─── Internals ────────────────────────────────────────────────────────
 
-    fn resolve_with_permission(
+    async fn resolve_with_permission(
         &self,
         scope: &ResourceScope,
         path: &ScopedPath,
         operation: FilesystemOperation,
     ) -> Result<VirtualPath, FilesystemError> {
         let view = self.mount_view(scope)?;
-        resolve_with_permission_view(&view, path, operation)
+        resolve_with_permission_view(self.root.as_ref(), &view, path, operation).await
     }
 }
 
-fn resolve_with_permission_view(
+/// Resolves `path` against `view` and checks the operation against the
+/// resolved grant's permissions — then, before returning the caller-facing
+/// `VirtualPath`, narrows `root`'s containment to exactly the grant's own
+/// `target` via [`RootFilesystem::ensure_scoped_mount`].
+///
+/// This is the chokepoint: every `ScopedFilesystem` operation resolves
+/// through here (directly, or via [`ScopedFilesystem::resolve_with_permission`]),
+/// so no consumer — the skill-management port, a future `MountGrant`-scoped
+/// store, anything holding a `ScopedFilesystem` — can reach the backend
+/// without the backend first anchoring to the caller's own granted subtree.
+/// For backends without OS-level containment to narrow (Postgres, libSQL,
+/// in-memory), `ensure_scoped_mount`'s default no-op makes this an
+/// unconditional but free extra call.
+async fn resolve_with_permission_view<F>(
+    root: &F,
     view: &MountView,
     path: &ScopedPath,
     operation: FilesystemOperation,
-) -> Result<VirtualPath, FilesystemError> {
+) -> Result<VirtualPath, FilesystemError>
+where
+    F: RootFilesystem + ?Sized,
+{
     let (virtual_path, grant) = view.resolve_with_grant(path)?;
     if !operation_allowed(&grant.permissions, operation) {
         return Err(FilesystemError::PermissionDenied {
@@ -697,6 +716,7 @@ fn resolve_with_permission_view(
             operation,
         });
     }
+    root.ensure_scoped_mount(&grant.target).await?;
     Ok(virtual_path)
 }
 

--- a/crates/ironclaw_filesystem/src/scoped/tests.rs
+++ b/crates/ironclaw_filesystem/src/scoped/tests.rs
@@ -829,3 +829,75 @@ async fn scoped_txn_per_op_acl_blocks_delete_without_delete_permission() {
         other => panic!("expected Backend(permission), got {other:?}"),
     }
 }
+
+/// Wraps [`InMemoryBackend`] and always fails `ensure_scoped_mount`, while
+/// recording whether `get` (the default `read_file`'s own backend call) was
+/// ever reached — proving `resolve_with_permission_view`'s chokepoint
+/// (`scoped.rs`) propagates an `ensure_scoped_mount` error instead of
+/// dispatching to the backend operation anyway.
+struct EnsureScopedMountFailingBackend {
+    inner: InMemoryBackend,
+    get_called: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait]
+impl RootFilesystem for EnsureScopedMountFailingBackend {
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<crate::DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<crate::FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: virtual_root.clone(),
+            operation: FilesystemOperation::MountLocal,
+            reason: "planted ensure_scoped_mount failure".to_string(),
+        })
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.get_called
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.inner.get(path).await
+    }
+}
+
+#[tokio::test]
+async fn ensure_scoped_mount_failure_propagates_without_reaching_backend_operation() {
+    let backend = Arc::new(EnsureScopedMountFailingBackend {
+        inner: InMemoryBackend::new(),
+        get_called: std::sync::atomic::AtomicBool::new(false),
+    });
+    let scoped = ScopedFilesystem::with_fixed_view(
+        backend.clone(),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/engine/scoped_test").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap(),
+    );
+
+    let err = scoped
+        .read_file(
+            &test_scope(),
+            &ScopedPath::new("/workspace/file.txt").unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            &err,
+            FilesystemError::Backend { reason, .. } if reason == "planted ensure_scoped_mount failure"
+        ),
+        "expected the planted ensure_scoped_mount error to propagate unchanged, got {err:?}"
+    );
+    assert!(
+        !backend.get_called.load(std::sync::atomic::Ordering::SeqCst),
+        "read_file must not reach the backend's get() once ensure_scoped_mount fails"
+    );
+}

--- a/crates/ironclaw_filesystem/src/scoped/tests.rs
+++ b/crates/ironclaw_filesystem/src/scoped/tests.rs
@@ -690,6 +690,14 @@ impl RootFilesystem for TxnStubBackend {
     async fn begin(&self, _path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
         Ok(Box::new(StubTxn::default()))
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Stub fixture with no storage to narrow.
+        Ok(())
+    }
 }
 
 #[derive(Default)]

--- a/crates/ironclaw_filesystem/src/types.rs
+++ b/crates/ironclaw_filesystem/src/types.rs
@@ -93,8 +93,46 @@ pub enum FilesystemError {
     },
     #[error("virtual path escaped backend mount {path}")]
     PathOutsideMount { path: VirtualPath },
-    #[error("symlink escapes backend mount at virtual path {path}")]
-    SymlinkEscape { path: VirtualPath },
+    /// The local disk backend refused to resolve `path` because it has more
+    /// path components than the local disk backend's `MAX_PATH_COMPONENTS`
+    /// cap allows (PR #6817 review follow-up). `resolve_walk`/
+    /// `descend_creating` hold one open ancestor fd per path component
+    /// *simultaneously* for the duration of a resolution — an unbounded
+    /// component count is an unbounded, process-wide fd budget an attacker
+    /// fully controls (every path component is caller-supplied). Rejecting a
+    /// pathologically deep path before any fd is opened bounds that budget
+    /// without weakening containment: this check runs before the walk
+    /// starts, so it never changes which paths resolve *successfully*, only
+    /// whether an absurdly deep one is rejected up front instead of
+    /// consuming `max_components` fds to discover the same failure partway
+    /// through.
+    #[error(
+        "virtual path {path} has more than {max_components} path components; refusing to resolve"
+    )]
+    PathTooDeep {
+        path: VirtualPath,
+        max_components: usize,
+    },
+    /// `detail`, when present, names the specific escape reason the
+    /// resolver already knows (PR #6817 review follow-up — diagnosability
+    /// for the "absolute symlink target rejected even though it would land
+    /// in-bounds" case, the shape `local-dev-yolo`'s `/host` real-home-
+    /// directory mount hits routinely: pyenv version envs, chezmoi/stow in
+    /// absolute mode, cloud-sync placeholders). `None` for every other
+    /// escape reason (an out-of-bounds `..`, a mount-crossing rejection,
+    /// a symlink chain exceeding the depth cap, …), where the resolver has
+    /// no more specific information than "this fell outside the mount" to
+    /// offer. Never includes anything the caller did not themselves already
+    /// put on disk inside their own mount (the symlink's own name and its
+    /// own target text) — no host path outside the mount is ever named.
+    #[error(
+        "symlink escapes backend mount at virtual path {path}{}",
+        detail.as_deref().map(|detail| format!(": {detail}")).unwrap_or_default()
+    )]
+    SymlinkEscape {
+        path: VirtualPath,
+        detail: Option<String>,
+    },
     #[error("backend mount conflict at virtual path {path}")]
     MountConflict { path: VirtualPath },
     #[error("filesystem backend error during {operation} at {path}: {reason}")]

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -766,55 +766,190 @@ async fn local_backend_denies_write_through_symlinked_parent_escape() {
     assert!(!outside.path().join("new.txt").exists());
 }
 
-/// Every existing symlink-at-write-target test plants an *escaping*
-/// symlink (pointing outside the mount) and asserts `SymlinkEscape`. This
-/// pins the distinct, narrower case: a symlink that is fully *in-bounds* —
-/// its target lives inside the same mount, reachable on its own — planted
-/// at a write target. `atomic_write_file`'s pre-install probe
-/// (`local.rs:877-892`) rejects a pre-existing symlink at the leaf
-/// regardless of where it points, because silently clobbering *any*
-/// existing symlink entry is a real content-loss surprise for whatever
-/// legitimately created it — this crate's contract is "reject a
-/// pre-existing symlink at a write target", not "clobber it if it happens
-/// to be safe". Without this test, a future change that narrowed the probe
-/// to only reject *escaping* symlinks (a plausible-looking "fix" for an
-/// in-bounds false positive) would land with zero coverage catching it.
+/// Policy change (fd-rooted symlink-follow, #6723 follow-up): `RESOLVE_BENEATH`
+/// alone is already race-free and kernel-enforced — it follows an in-bounds
+/// symlink and refuses an escaping one, atomically. Rejecting *every*
+/// symlink (the old behavior this test used to pin) breaks real projects
+/// full of benign in-bounds symlinks (pnpm `node_modules`, `git worktree`
+/// `.git` links, monorepo aliases) for no containment benefit. This test now
+/// pins the inverted contract: a write through a benign, fully in-bounds
+/// symlink *resolves* — the bytes land at the symlink's target, not over the
+/// symlink entry itself (`rename`/`link` never follow a symlink at the
+/// destination name, so `write_file_with_cas` chases the chain itself first
+/// via `resolve_write_leaf` — see `local/fd_resolve.rs`). The escape case
+/// (`local_backend_denies_write_through_symlink_escape`, above) is unchanged
+/// and still rejected — this test's job is to prove the in-bounds case is no
+/// longer collateral damage from that rejection, not to weaken it.
 #[cfg(unix)]
 #[tokio::test]
-async fn local_backend_denies_write_through_benign_in_bounds_symlink() {
+async fn local_backend_resolves_write_through_benign_in_bounds_symlink() {
     use std::os::unix::fs::symlink;
 
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();
     std::fs::write(storage.path().join("project1/real.txt"), b"original").unwrap();
-    // In-bounds: points at another file inside the very same mount, not
-    // outside it.
-    symlink(
-        storage.path().join("project1/real.txt"),
-        storage.path().join("project1/alias.txt"),
-    )
-    .unwrap();
+    // In-bounds and relative — the realistic shape a project's own symlinks
+    // take (pnpm, git worktree, monorepo aliases all emit relative targets).
+    symlink("real.txt", storage.path().join("project1/alias.txt")).unwrap();
 
     let scoped = scoped_project_fs(storage.path(), MountPermissions::read_write());
-    let err = scoped
+    scoped
         .write_file(
             &ResourceScope::system(),
             &ScopedPath::new("/workspace/alias.txt").unwrap(),
             b"changed",
         )
         .await
+        .expect("write through an in-bounds symlink must resolve");
+
+    assert_eq!(
+        std::fs::read(storage.path().join("project1/real.txt")).unwrap(),
+        b"changed",
+        "the write must land at the symlink's real target"
+    );
+    assert!(
+        std::fs::symlink_metadata(storage.path().join("project1/alias.txt"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the symlink entry itself must survive the write, not be replaced by a plain file"
+    );
+}
+
+/// Read counterpart to the write-through test above: `read_file` through an
+/// in-bounds symlink must resolve to the target's bytes.
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_resolves_read_through_benign_in_bounds_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/real.txt"), b"hello").unwrap();
+    symlink("real.txt", storage.path().join("project1/alias.txt")).unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_only());
+    let bytes = scoped
+        .read_file(
+            &ResourceScope::system(),
+            &ScopedPath::new("/workspace/alias.txt").unwrap(),
+        )
+        .await
+        .expect("read through an in-bounds symlink must resolve");
+
+    assert_eq!(bytes, b"hello");
+}
+
+/// A relative in-bounds symlink chain (`link -> mid -> real.txt`, each hop
+/// relative) must resolve all the way through.
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_resolves_read_through_relative_symlink_chain() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/real.txt"), b"chained").unwrap();
+    symlink("real.txt", storage.path().join("project1/mid")).unwrap();
+    symlink("mid", storage.path().join("project1/link")).unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_only());
+    let bytes = scoped
+        .read_file(
+            &ResourceScope::system(),
+            &ScopedPath::new("/workspace/link").unwrap(),
+        )
+        .await
+        .expect("a relative in-bounds symlink chain must resolve");
+
+    assert_eq!(bytes, b"chained");
+}
+
+/// An absolute symlink target is rejected outright (`Escape`), unconditionally
+/// — even when, interpreted as real bytes, it happens to land inside the
+/// mount. This deliberately matches Linux's native
+/// `openat2(RESOLVE_BENEATH)`, which disallows *any* absolute symlink target
+/// regardless of where it points (only `RESOLVE_IN_ROOT` — a different,
+/// chroot-emulating primitive this module does not use — reinterprets one).
+/// See the `walk_symlink_target` doc comment in `local/fd_resolve.rs` for
+/// the full reasoning, including why a "reinterpret against the mount root"
+/// scheme would not even help for symlinks any real tool creates (they store
+/// the real host absolute path, which essentially never coincides with the
+/// mount root by construction).
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_denies_absolute_symlink_even_when_bytes_would_land_in_mount() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/real.txt"), b"original").unwrap();
+    symlink(
+        storage.path().join("project1/real.txt"),
+        storage.path().join("project1/absolute-alias.txt"),
+    )
+    .unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_only());
+    let err = scoped
+        .read_file(
+            &ResourceScope::system(),
+            &ScopedPath::new("/workspace/absolute-alias.txt").unwrap(),
+        )
+        .await
         .unwrap_err();
 
     assert!(
         matches!(err, FilesystemError::SymlinkEscape { .. }),
-        "a benign, fully in-bounds symlink at a write target must still be \
-         rejected, not just an escaping one: got {err:?}"
+        "expected SymlinkEscape, got: {err:?}"
     );
-    assert_eq!(
-        std::fs::read(storage.path().join("project1/real.txt")).unwrap(),
-        b"original",
-        "the symlink's real target must be untouched — the write must never \
-         have followed through"
+}
+
+/// A symlink chain within the depth cap (`MAX_SYMLINK_DEPTH = 32`) still
+/// resolves; one exceeding it fails cleanly instead of spinning. Builds a
+/// chain of 20 relative hops (`link19 -> link18 -> … -> real.txt`), well
+/// under the cap, then a cyclic pair (`cycle-a -> cycle-b -> cycle-a`) that
+/// can never terminate on its own.
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_resolves_symlink_chain_within_cap_and_fails_cycle_cleanly() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/real.txt"), b"end of chain").unwrap();
+
+    const CHAIN_LEN: usize = 20;
+    let mut previous = "real.txt".to_string();
+    for i in 0..CHAIN_LEN {
+        let name = format!("link{i}");
+        symlink(&previous, storage.path().join("project1").join(&name)).unwrap();
+        previous = name;
+    }
+    symlink("cycle-b", storage.path().join("project1/cycle-a")).unwrap();
+    symlink("cycle-a", storage.path().join("project1/cycle-b")).unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_only());
+
+    let bytes = scoped
+        .read_file(
+            &ResourceScope::system(),
+            &ScopedPath::new(format!("/workspace/{previous}")).unwrap(),
+        )
+        .await
+        .expect("a symlink chain within the depth cap must resolve");
+    assert_eq!(bytes, b"end of chain");
+
+    let cycle_err = scoped
+        .read_file(
+            &ResourceScope::system(),
+            &ScopedPath::new("/workspace/cycle-a").unwrap(),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        !matches!(cycle_err, FilesystemError::NotFound { .. }),
+        "a genuine symlink cycle must fail cleanly (bounded), not report NotFound: {cycle_err:?}"
     );
 }
 

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -916,6 +916,33 @@ async fn local_backend_resolves_parent_relative_symlink_pnpm_layout() {
              must resolve, not be rejected as an escape",
         );
     assert_eq!(bytes, b"module.exports = {}");
+
+    // PR #6817 review follow-up (discussion_r3669792305 / r3670294887): the
+    // write side goes through a different resolver (`descend_creating` ->
+    // `resolve_write_leaf`, not `resolve_walk`) than the read assertion
+    // above, so it needs its own coverage rather than inheriting the read
+    // path's pass — `descend_creating` used to discard the ancestor stack it
+    // built, which made this identical parent-relative symlink fail closed
+    // as `SymlinkEscape` on write even though the read resolved it fine
+    // (fixed in 234c1c82e: `descend_creating` now returns its ancestor stack
+    // and `write_file_with_cas` threads it into `resolve_write_leaf`).
+    scoped
+        .write_file(
+            &ResourceScope::system(),
+            &ScopedPath::new("/workspace/node_modules/@types/react/index.js").unwrap(),
+            b"module.exports = { updated: true }",
+        )
+        .await
+        .expect(
+            "writing through the same in-bounds parent-relative symlink must succeed, not be \
+             rejected as an escape",
+        );
+    assert_eq!(
+        std::fs::read(pnpm_real_dir.join("index.js")).unwrap(),
+        b"module.exports = { updated: true }",
+        "the write must land at the symlink's real target, not create a shadow file at the \
+         symlink's own path"
+    );
 }
 
 /// An absolute symlink target is rejected outright (`Escape`), unconditionally

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -766,6 +766,122 @@ async fn local_backend_denies_write_through_symlinked_parent_escape() {
     assert!(!outside.path().join("new.txt").exists());
 }
 
+/// Every existing symlink-at-write-target test plants an *escaping*
+/// symlink (pointing outside the mount) and asserts `SymlinkEscape`. This
+/// pins the distinct, narrower case: a symlink that is fully *in-bounds* —
+/// its target lives inside the same mount, reachable on its own — planted
+/// at a write target. `atomic_write_file`'s pre-install probe
+/// (`local.rs:877-892`) rejects a pre-existing symlink at the leaf
+/// regardless of where it points, because silently clobbering *any*
+/// existing symlink entry is a real content-loss surprise for whatever
+/// legitimately created it — this crate's contract is "reject a
+/// pre-existing symlink at a write target", not "clobber it if it happens
+/// to be safe". Without this test, a future change that narrowed the probe
+/// to only reject *escaping* symlinks (a plausible-looking "fix" for an
+/// in-bounds false positive) would land with zero coverage catching it.
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_denies_write_through_benign_in_bounds_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/real.txt"), b"original").unwrap();
+    // In-bounds: points at another file inside the very same mount, not
+    // outside it.
+    symlink(
+        storage.path().join("project1/real.txt"),
+        storage.path().join("project1/alias.txt"),
+    )
+    .unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    let err = scoped
+        .write_file(
+            &ResourceScope::system(),
+            &ScopedPath::new("/workspace/alias.txt").unwrap(),
+            b"changed",
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, FilesystemError::SymlinkEscape { .. }),
+        "a benign, fully in-bounds symlink at a write target must still be \
+         rejected, not just an escaping one: got {err:?}"
+    );
+    assert_eq!(
+        std::fs::read(storage.path().join("project1/real.txt")).unwrap(),
+        b"original",
+        "the symlink's real target must be untouched — the write must never \
+         have followed through"
+    );
+}
+
+/// Deleting the bare root of an *ordinary* mount (no leaf segment, no
+/// sub-path) must fail closed rather than silently deleting the mount's
+/// entire on-disk tree. `DiskFilesystem::delete` (`local.rs:474-485`) has no
+/// fd-relative parent for the mount root itself by design — `resolve_walk`
+/// only ever hands back `parent: None` for an empty component list — so this
+/// pins that the bare-root case is rejected with `PathOutsideMount`, not
+/// merely "would panic on the `None` parent" or (worse) silently succeed via
+/// some other code path.
+#[tokio::test]
+async fn local_backend_delete_of_bare_ordinary_mount_root_fails_closed() {
+    let storage = tempdir().unwrap();
+    std::fs::write(storage.path().join("keep-me.txt"), b"still here").unwrap();
+
+    let root = local_root_with_projects_mount(storage.path());
+
+    let err = root
+        .delete(&VirtualPath::new("/projects").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, FilesystemError::PathOutsideMount { .. }),
+        "expected PathOutsideMount, got: {err:?}"
+    );
+    assert!(
+        storage.path().join("keep-me.txt").exists(),
+        "the mount root's contents must survive a rejected bare-root delete"
+    );
+}
+
+/// Same fail-closed contract for a `mount_local_per_leaf` mount: deleting
+/// the bare mount path (no leaf segment at all) is not just "unsafe for this
+/// caller's leaf" but has no well-defined target — it would mean "every
+/// caller's leaf" — so it must be rejected exactly like the bare-root
+/// `read_file` case `leaf_scoped_mount_rejects_bare_mount_root_request`
+/// already pins in `local.rs`, but for `delete`.
+#[tokio::test]
+async fn local_backend_delete_of_bare_leaf_scoped_mount_root_fails_closed() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("leaf-a")).unwrap();
+    std::fs::write(storage.path().join("leaf-a/file.txt"), b"leaf-a data").unwrap();
+
+    let mut root = DiskFilesystem::new();
+    root.mount_local_per_leaf(
+        VirtualPath::new("/tmp").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let err = root
+        .delete(&VirtualPath::new("/tmp").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, FilesystemError::PathOutsideMount { .. }),
+        "expected PathOutsideMount, got: {err:?}"
+    );
+    assert!(
+        storage.path().join("leaf-a/file.txt").exists(),
+        "no caller's leaf may be wiped by a rejected bare-root delete"
+    );
+}
+
 /// Builds a virtual path with `depth` synthetic single-directory-name
 /// segments under `/projects/project1`. Deliberately built and walked
 /// through the fd-rooted `DiskFilesystem` API end to end (`create_dir_all`,

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -790,3 +790,264 @@ fn scoped_project_fs(
         .unwrap(),
     )
 }
+
+/// TOCTOU escape coverage for the `DiskFilesystem` local backend.
+///
+/// `local_backend_denies_symlink_escape` (above) and its write-path/parent
+/// siblings plant a symlink *before* the call under test — they pin the
+/// steady-state containment check but cannot exercise a race between that
+/// check and the later syscall the checked path is handed to. These tests
+/// plant a **legitimate** entry, let the resolver's containment check pass
+/// against it, and then swap in a symlink-to-outside from a second OS thread
+/// *while the async call under test is in flight* — reproducing the actual
+/// pathname-check-then-separate-syscall gap described in
+/// `crates/ironclaw_filesystem/src/local.rs`.
+///
+/// Per `crates/ironclaw_filesystem/CLAUDE.md`'s sanctioned pattern for tests
+/// that need a read/write interleaving barrier, this is a tiny test-only
+/// delegating harness (`Racer`), not a fault fake and not a production hook.
+/// There is no seam inside `local.rs` to pause mid-resolution from outside,
+/// so the harness drives a *real* OS-thread race: a background thread spins
+/// tightly, alternating the on-disk entry between "real file/dir" (so the
+/// resolver's check succeeds) and "symlink to outside the mount" for the
+/// entire wall-clock duration of the call under test, which is real syscall
+/// latency on tokio's blocking pool — exactly the window the production code
+/// documents at `local.rs:172,204,230`. Iterating the race many times makes
+/// a genuine TOCTOU gap observable without needing a deterministic pause
+/// hook; a race-free implementation (this PR's fd-rooted fix) cannot lose
+/// this race no matter how many iterations run, because containment is
+/// re-verified against an already-open fd rather than a path string.
+#[cfg(unix)]
+mod toctou_escape {
+    use std::os::unix::fs::symlink;
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use ironclaw_filesystem::*;
+    use ironclaw_host_api::*;
+    use tempfile::tempdir;
+
+    /// How many times to retry the check-then-swap race before concluding a
+    /// vulnerable implementation would have leaked. Each iteration is a real
+    /// (fast) filesystem call, so this bound keeps the test's wall-clock cost
+    /// reasonable while giving the racer many shots at the narrow window.
+    const RACE_ITERATIONS: usize = 400;
+
+    /// Runs `attempt` under a background thread that repeatedly swaps
+    /// `target` between a real entry (created by `reset`) and a symlink to
+    /// `outside_target` for the duration of the call. Returns `true` the
+    /// first time `attempt` reports the escape happened (via its own return
+    /// value), or `false` if no iteration ever won the race.
+    fn race<F>(target: &Path, outside_target: &Path, reset: impl Fn(), mut attempt: F) -> bool
+    where
+        F: FnMut() -> bool,
+    {
+        for _ in 0..RACE_ITERATIONS {
+            reset();
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let racer_stop = Arc::clone(&stop);
+            let racer_target = target.to_path_buf();
+            let racer_outside = outside_target.to_path_buf();
+            let racer = std::thread::spawn(move || {
+                while !racer_stop.load(Ordering::Relaxed) {
+                    // Best-effort: the swap only needs to land during the
+                    // window; failures (e.g. racing our own reset) are fine.
+                    let _ = std::fs::remove_file(&racer_target)
+                        .or_else(|_| std::fs::remove_dir_all(&racer_target));
+                    let _ = symlink(&racer_outside, &racer_target);
+                }
+            });
+
+            let escaped = attempt();
+            stop.store(true, Ordering::Relaxed);
+            let _ = racer.join();
+
+            if escaped {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn disk_fs(mount_root: &Path) -> DiskFilesystem {
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(mount_root.to_path_buf()),
+        )
+        .unwrap();
+        root
+    }
+
+    /// (a) `resolve_existing`: the leaf is swapped from a real file to a
+    /// symlink-to-outside between the containment check and the caller's
+    /// `read`. A vulnerable resolver hands back a checked-then-stale path;
+    /// the later `tokio::fs::read` re-resolves that path from scratch and
+    /// follows the now-planted symlink, returning the outside secret's
+    /// bytes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn resolve_existing_leaf_swap_leaks_outside_file_on_read() {
+        let storage = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let project = storage.path().join("project1");
+        std::fs::create_dir_all(&project).unwrap();
+        let outside_secret = outside.path().join("secret.txt");
+        std::fs::write(&outside_secret, b"outside-secret-contents").unwrap();
+
+        let target = project.join("target.txt");
+        let root = disk_fs(storage.path());
+        let path = VirtualPath::new("/projects/project1/target.txt").unwrap();
+
+        let escaped = race(
+            &target,
+            &outside_secret,
+            || {
+                let _ = std::fs::remove_file(&target);
+                std::fs::write(&target, b"legit-contents").unwrap();
+            },
+            || {
+                let root = &root;
+                let path = &path;
+                futures_block_on(async {
+                    matches!(
+                        root.read_file(path).await,
+                        Ok(bytes) if bytes == b"outside-secret-contents"
+                    )
+                })
+            },
+        );
+
+        assert!(
+            !escaped,
+            "resolve_existing must never hand read_file bytes from outside the mount, \
+             even when the leaf is swapped to a symlink after the containment check"
+        );
+    }
+
+    /// (b) `resolve_for_write`: the parent is checked and re-verified, but
+    /// the *leaf* itself is never re-checked (`local.rs:177-211`) — a
+    /// symlink planted at the leaf name after the parent check, before
+    /// `append_file`'s unguarded `OpenOptions::open`, is followed straight
+    /// through into the outside file. Distinct from (a): the ancestor chain
+    /// here is legitimate throughout; only the leaf is swapped.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn resolve_for_write_leaf_swap_leaks_outside_file_on_append() {
+        let storage = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let project = storage.path().join("project1");
+        std::fs::create_dir_all(&project).unwrap();
+        let outside_secret = outside.path().join("secret.txt");
+        std::fs::write(&outside_secret, b"original-outside").unwrap();
+
+        let target = project.join("newfile.txt");
+        let root = disk_fs(storage.path());
+        let path = VirtualPath::new("/projects/project1/newfile.txt").unwrap();
+
+        let escaped = race(
+            &target,
+            &outside_secret,
+            || {
+                // The legitimate steady state for a brand-new leaf is
+                // "doesn't exist yet" — resolve_for_write's bootstrap path
+                // is what a swap here exploits.
+                let _ = std::fs::remove_file(&target);
+            },
+            || {
+                let root = &root;
+                let path = &path;
+                let ok = futures_block_on(async {
+                    root.append_file(path, b"attacker-controlled").await.is_ok()
+                });
+                ok && std::fs::read(&outside_secret)
+                    .map(|bytes| bytes != b"original-outside")
+                    .unwrap_or(false)
+            },
+        );
+
+        assert!(
+            !escaped,
+            "resolve_for_write must never let append_file write through a leaf \
+             symlink planted after the parent containment check"
+        );
+        assert_eq!(
+            std::fs::read(&outside_secret).unwrap(),
+            b"original-outside",
+            "outside file must be untouched once the race loop completes"
+        );
+    }
+
+    /// (c)/(d) `resolve_for_create_dir_all` and its shared
+    /// `ensure_existing_ancestor_contained` ancestor walk: the nearest
+    /// *existing* ancestor (`project1`) is legitimate, but the next,
+    /// not-yet-existing path component is swapped to a symlink-to-outside
+    /// between that ancestor check and `create_dir_all`'s mkdir — pinning
+    /// the mkdir-before-recheck ordering documented at `local.rs:227-237`.
+    ///
+    /// This collapses `ensure_existing_ancestor_contained`'s own case (d)
+    /// into this scenario rather than adding a fourth standalone test:
+    /// `resolve_for_write`'s call to the same ancestor-walk helper is
+    /// provably not independently exploitable, because `resolve_for_write`
+    /// re-canonicalizes and re-checks the parent *after* its
+    /// `create_dir_all(parent)` call (`local.rs:193-199`) — closing exactly
+    /// the window this helper's ancestor check alone would otherwise leave
+    /// open. `resolve_for_create_dir_all` has no such re-check between the
+    /// ancestor walk and its own `create_dir_all`, so it is the only
+    /// reachable caller where swapping the helper's verified ancestor
+    /// matters, and this test exercises that call path directly.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn resolve_for_create_dir_all_ancestor_swap_escapes_mount() {
+        let storage = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let project = storage.path().join("project1");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(outside.path()).unwrap();
+
+        // The not-yet-existing ancestor component that gets swapped.
+        let newdir = project.join("newdir");
+        let root = disk_fs(storage.path());
+        let path = VirtualPath::new("/projects/project1/newdir/leaf").unwrap();
+        let outside_leaf_marker = outside.path().join("leaf");
+
+        let escaped = race(
+            &newdir,
+            outside.path(),
+            || {
+                let _ = std::fs::remove_dir_all(&newdir);
+                let _ = std::fs::remove_file(&newdir);
+                let _ = std::fs::remove_dir_all(&outside_leaf_marker);
+            },
+            || {
+                let root = &root;
+                let path = &path;
+                let _ = futures_block_on(async { root.create_dir_all(path).await });
+                outside_leaf_marker.is_dir()
+            },
+        );
+
+        assert!(
+            !escaped,
+            "resolve_for_create_dir_all must never create a directory outside the \
+             mount when a not-yet-existing ancestor is swapped to a symlink after \
+             the ancestor containment check"
+        );
+        assert!(
+            !outside_leaf_marker.exists(),
+            "outside directory must not gain a leftover 'leaf' entry once the race \
+             loop completes"
+        );
+    }
+
+    /// Blocks the current worker thread on `future`, handing the async
+    /// `DiskFilesystem` call to the surrounding multi-threaded
+    /// `#[tokio::test]` runtime. `block_in_place` (not a bare
+    /// `Handle::block_on`) is required here: it parks this task off its
+    /// worker thread so the runtime can keep servicing the racer's own
+    /// blocking-pool work (`tokio::fs::*` inside the call under test)
+    /// without deadlocking against the synchronous `attempt` closure shape
+    /// shared with the plain `reset`/racer-thread code above.
+    fn futures_block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+    }
+}

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -956,6 +956,26 @@ async fn local_backend_denies_absolute_symlink_even_when_bytes_would_land_in_mou
         matches!(err, FilesystemError::SymlinkEscape { .. }),
         "expected SymlinkEscape, got: {err:?}"
     );
+    // PR #6817 review follow-up: this rejection must be *actionable*, not
+    // just correct — a `local-dev-yolo` user hitting this on a real pyenv/
+    // chezmoi/cloud-sync symlink under their mounted home directory needs
+    // to know which symlink and what target caused it, and that absolute
+    // targets specifically (not symlinks in general) are unsupported, so
+    // they can fix it (replace with a relative link) instead of guessing.
+    let message = err.to_string();
+    assert!(
+        message.contains("absolute-alias.txt"),
+        "error message must name the offending symlink, got: {message:?}"
+    );
+    assert!(
+        message.contains("real.txt"),
+        "error message must show the symlink's absolute target, got: {message:?}"
+    );
+    assert!(
+        message.contains("absolute") && message.contains("not supported"),
+        "error message must state that absolute symlink targets are unsupported, \
+         got: {message:?}"
+    );
 }
 
 /// A symlink chain within the depth cap (`MAX_SYMLINK_DEPTH = 32`) still
@@ -1211,6 +1231,47 @@ async fn local_backend_delete_of_tree_exceeding_max_depth_fails_cleanly() {
     assert!(
         matches!(err, FilesystemError::Backend { .. }),
         "expected a clean Backend error for a too-deep tree, got: {err:?}"
+    );
+}
+
+/// PR #6817 review follow-up ("unbounded ancestor-fd retention"):
+/// `resolve_walk`/`descend_creating` hold one open ancestor directory fd per
+/// path component *simultaneously* for the duration of a single resolution,
+/// and (before this fix) `VirtualPath`/`MountTarget.components` had no cap
+/// on component count at all — every component is caller-supplied, so a
+/// pathologically deep single virtual path could force this backend to hold
+/// an attacker-chosen number of open fds for one request, a process-wide
+/// (`RLIMIT_NOFILE`) exhaustion vector, not one scoped to the offending
+/// request. This pins that a virtual path past
+/// `mount_registry::MAX_PATH_COMPONENTS` fails closed with a dedicated,
+/// diagnosable error *before* any fd work happens — never by silently
+/// widening to a shorter prefix or truncating the walk (see the
+/// constant's doc comment for why a fallback shape is exactly the wrong
+/// move here, per the PR's own earlier LRU-fallback cross-tenant escape).
+#[tokio::test]
+async fn local_backend_rejects_path_components_past_the_ancestor_fd_cap() {
+    let storage = tempdir().unwrap();
+    let root = local_root_with_projects_mount(storage.path());
+
+    // Comfortably past MAX_PATH_COMPONENTS (2048) — and, crucially, past
+    // every legitimately-deep tree this suite itself builds elsewhere (the
+    // deepest, `local_backend_delete_of_tree_exceeding_max_depth_fails_cleanly`,
+    // goes to 600 components) — so this is unambiguously the pathological
+    // case the cap exists for, not a false positive on a real deep layout.
+    let too_deep = deep_virtual_dir(3000);
+
+    let err = root.create_dir_all(&too_deep).await.unwrap_err();
+
+    assert!(
+        matches!(err, FilesystemError::PathTooDeep { .. }),
+        "expected PathTooDeep for a path far past the component cap, got: {err:?}"
+    );
+
+    // Fails closed, not merely "differently": nothing must have been
+    // created on disk by the rejected walk.
+    assert!(
+        !storage.path().join("project1/d0").exists(),
+        "a PathTooDeep rejection must not partially create the tree"
     );
 }
 

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -766,6 +766,84 @@ async fn local_backend_denies_write_through_symlinked_parent_escape() {
     assert!(!outside.path().join("new.txt").exists());
 }
 
+/// Builds a virtual path with `depth` synthetic single-directory-name
+/// segments under `/projects/project1`. Deliberately built and walked
+/// through the fd-rooted `DiskFilesystem` API end to end (`create_dir_all`,
+/// then `write_file`) rather than via a single joined `std::fs` host path:
+/// a several-thousand-character joined path string would hit the *host
+/// OS's* `PATH_MAX` on a single syscall (unrelated to anything under test
+/// here), whereas the fd-rooted resolver never constructs a joined path at
+/// all — it walks one component per `openat` call — so it has no such
+/// limit and is exactly the code path these tests exist to exercise.
+fn deep_virtual_path(depth: usize, leaf: &str) -> VirtualPath {
+    let mut raw = String::from("/projects/project1");
+    for level in 0..depth {
+        raw.push_str(&format!("/d{level}"));
+    }
+    raw.push('/');
+    raw.push_str(leaf);
+    VirtualPath::new(raw).unwrap()
+}
+
+fn deep_virtual_dir(depth: usize) -> VirtualPath {
+    let mut raw = String::from("/projects/project1");
+    for level in 0..depth {
+        raw.push_str(&format!("/d{level}"));
+    }
+    VirtualPath::new(raw).unwrap()
+}
+
+/// `remove_dir_all_fd` is genuinely recursive Rust code on the blocking
+/// pool; a tree deep enough would stack-overflow a naive implementation.
+/// This pins two things at once: a tree comfortably within the depth cap
+/// (`local.rs::MAX_REMOVE_DIR_DEPTH`, currently 512) still deletes
+/// successfully end to end, and a tree that exceeds the cap fails cleanly
+/// — a `Backend` error, not a crash — rather than being silently truncated
+/// or panicking the blocking-pool thread.
+#[tokio::test]
+async fn local_backend_delete_of_deep_but_in_bounds_tree_succeeds() {
+    let storage = tempdir().unwrap();
+    let root = local_root_with_projects_mount(storage.path());
+
+    // Comfortably within MAX_REMOVE_DIR_DEPTH (512).
+    let deep_dir = deep_virtual_dir(300);
+    let leaf = deep_virtual_path(300, "leaf.txt");
+    root.create_dir_all(&deep_dir).await.unwrap();
+    root.write_file(&leaf, b"deep file").await.unwrap();
+
+    root.delete(&VirtualPath::new("/projects/project1").unwrap())
+        .await
+        .unwrap();
+
+    let err = root
+        .stat(&VirtualPath::new("/projects/project1").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, FilesystemError::NotFound { .. }));
+}
+
+#[tokio::test]
+async fn local_backend_delete_of_tree_exceeding_max_depth_fails_cleanly() {
+    let storage = tempdir().unwrap();
+    let root = local_root_with_projects_mount(storage.path());
+
+    // One level deeper than MAX_REMOVE_DIR_DEPTH (512): the deletion walk
+    // must refuse to descend that far rather than overflowing the
+    // blocking-pool thread's stack.
+    let deep_dir = deep_virtual_dir(600);
+    root.create_dir_all(&deep_dir).await.unwrap();
+
+    let err = root
+        .delete(&VirtualPath::new("/projects/project1").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, FilesystemError::Backend { .. }),
+        "expected a clean Backend error for a too-deep tree, got: {err:?}"
+    );
+}
+
 fn local_root_with_projects_mount(path: &std::path::Path) -> DiskFilesystem {
     let mut root = DiskFilesystem::new();
     root.mount_local(

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -953,6 +953,72 @@ async fn local_backend_resolves_symlink_chain_within_cap_and_fails_cycle_cleanly
     );
 }
 
+/// FIX 3 regression: the symlink-hop budget is per-*resolution*, not
+/// per-*component*. Builds a 4-component path where each individual
+/// component resolves through its own 10-hop symlink chain (well under
+/// `MAX_SYMLINK_DEPTH = 32` on its own), but the combined total across all
+/// four components is 40 hops — over the cap.
+///
+/// Before this fix, `open_one` reset to a fresh `MAX_SYMLINK_DEPTH`-hop
+/// budget for every component `resolve_walk` called it on, so a 10-hop
+/// chain at each of 4 components would resolve without ever tripping the
+/// cap (40 total hops, but never more than 10 in any single component's own
+/// budget) — looser than the real `openat2(RESOLVE_BENEATH)` kernel fast
+/// path, which applies its cap once per whole resolution. After this fix, a
+/// single `SymlinkBudget` is shared across the whole `resolve_walk` walk, so
+/// this same path must fail closed once cumulative hops exceed the cap,
+/// matching `SYMLOOP_MAX` semantics.
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_rejects_path_whose_combined_per_component_symlink_chains_exceed_global_budget()
+ {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    const LEVELS: usize = 4;
+    const HOPS_PER_LEVEL: usize = 10;
+
+    // Builds a `HOPS_PER_LEVEL`-hop symlink chain inside `dir` terminating at
+    // a real subdirectory of `dir`, and returns (the chain's outermost link
+    // name, the real subdirectory's path) — mirroring the chain-building
+    // pattern `local_backend_resolves_symlink_chain_within_cap_and_fails_cycle_cleanly`
+    // uses, just nested one level deeper per call.
+    fn build_chain_level(dir: &std::path::Path, level: usize) -> (String, std::path::PathBuf) {
+        let real_name = format!("level{level}_real");
+        let real_dir = dir.join(&real_name);
+        std::fs::create_dir_all(&real_dir).unwrap();
+        let mut previous = real_name;
+        for hop in 0..HOPS_PER_LEVEL {
+            let name = format!("level{level}_link{hop}");
+            symlink(&previous, dir.join(&name)).unwrap();
+            previous = name;
+        }
+        (previous, real_dir)
+    }
+
+    let mut current_dir = storage.path().to_path_buf();
+    let mut path_components = Vec::new();
+    for level in 0..LEVELS {
+        let (chain_head, real_dir) = build_chain_level(&current_dir, level);
+        path_components.push(chain_head);
+        current_dir = real_dir;
+    }
+    std::fs::write(current_dir.join("file.txt"), b"deep file").unwrap();
+    path_components.push("file.txt".to_string());
+
+    let root = local_root_with_projects_mount(storage.path());
+    let virtual_path =
+        VirtualPath::new(format!("/projects/{}", path_components.join("/"))).unwrap();
+
+    let error = root.read_file(&virtual_path).await.unwrap_err();
+    assert!(
+        matches!(error, FilesystemError::SymlinkEscape { .. }),
+        "a path whose combined per-component symlink chains exceed the \
+         global MAX_SYMLINK_DEPTH budget must fail closed as SymlinkEscape, \
+         got: {error:?}"
+    );
+}
+
 /// Deleting the bare root of an *ordinary* mount (no leaf segment, no
 /// sub-path) must fail closed rather than silently deleting the mount's
 /// entire on-disk tree. `DiskFilesystem::delete` (`local.rs:474-485`) has no

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -865,6 +865,59 @@ async fn local_backend_resolves_read_through_relative_symlink_chain() {
     assert_eq!(bytes, b"chained");
 }
 
+/// PR #6817 follow-up finding (Task 1): a real pnpm `node_modules` layout
+/// places a *parent-relative* symlink — `node_modules/@types/react ->
+/// ../.pnpm/react@x.y.z/node_modules/react` — one directory level up from
+/// where the symlink itself lives, then back down into a sibling subtree.
+/// The target is still fully inside the mount root throughout. A resolver
+/// whose containment boundary for the fast path is the symlink's *immediate
+/// parent* directory (rather than the true mount root) rejects this: `..`
+/// steps above that immediate parent, so a bare `RESOLVE_BENEATH`-style
+/// check on the immediate parent alone reports "escape" even though the
+/// fully-resolved target never leaves the mount. This test pins that a
+/// parent-relative, fully in-bounds symlink chain — including one whose
+/// target's directory doesn't exist yet as a distinct virtual path component
+/// until the symlink is followed — resolves correctly for both read and
+/// write, on every platform this crate ships on (this is the general,
+/// cross-platform regression pin; `local_backend_linux_openat2_...` below is
+/// the Linux-specific execution evidence for why the fast path needed to
+/// change to make this true).
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_resolves_parent_relative_symlink_pnpm_layout() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    let project = storage.path().join("project1");
+    // node_modules/.pnpm/react@1.0.0/node_modules/react/index.js  (the real file)
+    let pnpm_real_dir = project.join("node_modules/.pnpm/react@1.0.0/node_modules/react");
+    std::fs::create_dir_all(&pnpm_real_dir).unwrap();
+    std::fs::write(pnpm_real_dir.join("index.js"), b"module.exports = {}").unwrap();
+    // node_modules/@types  (the symlink's own directory)
+    let types_dir = project.join("node_modules/@types");
+    std::fs::create_dir_all(&types_dir).unwrap();
+    // node_modules/@types/react -> ../.pnpm/react@1.0.0/node_modules/react
+    // ("..": step out of @types back into node_modules, then descend).
+    symlink(
+        "../.pnpm/react@1.0.0/node_modules/react",
+        types_dir.join("react"),
+    )
+    .unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    let bytes = scoped
+        .read_file(
+            &ResourceScope::system(),
+            &ScopedPath::new("/workspace/node_modules/@types/react/index.js").unwrap(),
+        )
+        .await
+        .expect(
+            "a parent-relative, fully in-bounds symlink (the real pnpm node_modules shape) \
+             must resolve, not be rejected as an escape",
+        );
+    assert_eq!(bytes, b"module.exports = {}");
+}
+
 /// An absolute symlink target is rejected outright (`Escape`), unconditionally
 /// — even when, interpreted as real bytes, it happens to land inside the
 /// mount. This deliberately matches Linux's native
@@ -1431,6 +1484,90 @@ mod toctou_escape {
             !outside_leaf_marker.exists(),
             "outside directory must not gain a leftover 'leaf' entry once the race \
              loop completes"
+        );
+    }
+
+    /// (e) PR #6817 follow-up (Task 2): `walk_symlink_target`'s old defense
+    /// against stepping above the mount root captured `fd_identity(cur)` and
+    /// compared it to the root's identity *before* calling
+    /// `openat(cur.as_fd(), "..", …)` — but `..` is always a live,
+    /// name-based lookup, resolved by the kernel at the moment of that
+    /// `openat` call against whatever `cur`'s *current* parent directory
+    /// entry is, not a snapshot from whenever the identity check ran.
+    /// Renaming the directory `cur` refers to (its own `(device, inode)` is
+    /// unaffected by a rename — only its parent link changes) to a location
+    /// outside the mount, concurrently with that `openat` call, makes `..`
+    /// resolve to the new, outside parent no matter when the identity check
+    /// ran relative to it.
+    ///
+    /// This doesn't reuse the `race()` helper above: those three cases swap
+    /// a *leaf* entry for a symlink-to-outside; this one instead renames an
+    /// already-open **ancestor** directory (`project1/subdir`, which holds
+    /// the symlink `link -> ../secret.txt`) so its live parent link flips
+    /// between "inside the mount" and "under `outside`", for the entire
+    /// real-syscall-latency duration of a `read_file` call — the same
+    /// many-real-fast-iterations technique, just racing a rename of the
+    /// resolver's own already-open ancestor fd's parent instead of a leaf
+    /// swap-to-symlink.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn walk_symlink_target_dotdot_rename_race_never_leaks_outside_file() {
+        let storage = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let project = storage.path().join("project1");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("secret.txt"), b"legit-content").unwrap();
+        std::fs::write(outside.path().join("secret.txt"), b"OUTSIDE SECRET").unwrap();
+
+        let subdir_in = project.join("subdir");
+        let subdir_out = outside.path().join("subdir");
+
+        let root = disk_fs(storage.path());
+        let path = VirtualPath::new("/projects/project1/subdir/link").unwrap();
+
+        const RACE_ITERATIONS: usize = 2000;
+        let mut escaped = false;
+        for _ in 0..RACE_ITERATIONS {
+            let _ = std::fs::remove_dir_all(&subdir_out);
+            let _ = std::fs::remove_dir_all(&subdir_in);
+            std::fs::create_dir_all(&subdir_in).unwrap();
+            symlink("../secret.txt", subdir_in.join("link")).unwrap();
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let racer_stop = Arc::clone(&stop);
+            let racer_in = subdir_in.clone();
+            let racer_out = subdir_out.clone();
+            let racer = std::thread::spawn(move || {
+                while !racer_stop.load(Ordering::Relaxed) {
+                    // Best-effort, exactly like the other racers above:
+                    // failures here just mean we lost this particular
+                    // sub-iteration's timing, not a bug.
+                    let _ = std::fs::rename(&racer_in, &racer_out);
+                    let _ = std::fs::rename(&racer_out, &racer_in);
+                }
+            });
+
+            let root = &root;
+            let path = &path;
+            let result = futures_block_on(async { root.read_file(path).await });
+            stop.store(true, Ordering::Relaxed);
+            let _ = racer.join();
+
+            if matches!(result, Ok(bytes) if bytes == b"OUTSIDE SECRET") {
+                escaped = true;
+                break;
+            }
+        }
+        // Restore a stable on-disk shape before the tempdirs drop, so
+        // cleanup never has to contend with the racer thread's last swap.
+        let _ = std::fs::remove_dir_all(&subdir_out);
+
+        assert!(
+            !escaped,
+            "resolving `..` inside a followed symlink target must never leak bytes \
+             from outside the mount, even when a concurrent rename moves the \
+             resolver's own already-open ancestor directory to a different, \
+             outside parent between the identity check and the old \
+             `openat(cur, \"..\")` call"
         );
     }
 

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -1487,6 +1487,68 @@ mod toctou_escape {
         );
     }
 
+    /// (d2) Recursive `delete` re-looks-up a classified child by name instead
+    /// of treating the classification as the open: `DiskFilesystem::delete`
+    /// (and, identically, `remove_dir_contents`'s own recursion) calls
+    /// `statat(..., SYMLINK_NOFOLLOW)` to decide "is this a directory to
+    /// recurse into", then separately calls `remove_dir_all_fd` ->
+    /// `open_one`, which — now that this module follows in-bounds symlinks
+    /// — happily opens straight through a symlink planted at that name in
+    /// the gap between the two calls. Recursion then empties the symlink's
+    /// *target* directory before the trailing `unlinkat(..., REMOVEDIR)`
+    /// fails closed on what is now a symlink, not a directory: the data is
+    /// already gone by the time that final unlink fails.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn delete_recursive_never_follows_a_classified_directory_swapped_to_a_symlink() {
+        let storage = tempdir().unwrap();
+        let project = storage.path().join("project1");
+        std::fs::create_dir_all(&project).unwrap();
+
+        // An in-bounds sibling directory holding data that must survive —
+        // the actual thing `remove_dir_contents`'s no-follow-open fix
+        // protects, distinct from `outside_target` in the other cases here
+        // (which model an out-of-mount escape): this is an *in-mount*
+        // symlink target, exactly the shape this module's "follow in-bounds
+        // symlinks" policy makes reachable.
+        let target_dir = project.join("target-dir");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let precious = target_dir.join("precious.txt");
+        std::fs::write(&precious, b"PRECIOUS-CONTENT").unwrap();
+
+        let victim = project.join("victim");
+        let root = disk_fs(storage.path());
+        let path = VirtualPath::new("/projects/project1/victim").unwrap();
+
+        let escaped = race(
+            &victim,
+            &target_dir,
+            || {
+                let _ = std::fs::remove_dir_all(&victim);
+                let _ = std::fs::remove_file(&victim);
+                std::fs::create_dir_all(&victim).unwrap();
+            },
+            || {
+                let root = &root;
+                let path = &path;
+                let _ = futures_block_on(async { root.delete(path).await });
+                !precious.exists()
+            },
+        );
+
+        assert!(
+            !escaped,
+            "recursive delete must never empty a sibling in-mount directory reached \
+             by following a symlink planted at the classified entry's name after \
+             the SYMLINK_NOFOLLOW statat that classified it as a real directory"
+        );
+        assert_eq!(
+            std::fs::read(&precious).unwrap(),
+            b"PRECIOUS-CONTENT",
+            "target directory's contents must be untouched once the race loop \
+             completes"
+        );
+    }
+
     /// (e) PR #6817 follow-up (Task 2): `walk_symlink_target`'s old defense
     /// against stepping above the mount root captured `fd_identity(cur)` and
     /// compared it to the root's identity *before* calling

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -608,6 +608,15 @@ impl RootFilesystem for MountScopedRootFilesystem {
         let path = self.resolve(path, FilesystemOperation::CreateDirAll)?;
         self.root.create_dir_all(&path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        // This wrapper is a mount-permission view over `self.root`, not a
+        // distinct storage root — it must forward to the underlying
+        // filesystem so containment narrowing actually reaches whichever
+        // backend is doing the real work (e.g. DiskFilesystem's fd-anchored
+        // mount), instead of silently discarding it here.
+        self.root.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 fn validate_network_plan(plan: &ExecutionPlan) -> Result<(), InvocationServicesError> {

--- a/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -592,6 +592,114 @@ async fn hosted_scoped_virtual_filesystem_delete_if_version_delegates_to_inner_b
     assert_permission_denied(denied, FilesystemOperation::Delete);
 }
 
+/// Records every `ensure_scoped_mount` call it receives, delegating
+/// everything else to an inner `InMemoryBackend`. Used below to prove
+/// `MountScopedRootFilesystem::ensure_scoped_mount` actually forwards to the
+/// wrapped backend instead of silently no-op'ing — the fd-rooted-traversal
+/// gap this trait method exists to close.
+#[derive(Default)]
+struct EnsureScopedMountRecordingBackend {
+    inner: InMemoryBackend,
+    recorded: std::sync::Mutex<Vec<VirtualPath>>,
+}
+
+impl EnsureScopedMountRecordingBackend {
+    fn recorded_roots(&self) -> Vec<VirtualPath> {
+        self.recorded
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for EnsureScopedMountRecordingBackend {
+    fn capabilities(&self) -> ironclaw_filesystem::BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn list_dir(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Vec<ironclaw_filesystem::DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<ironclaw_filesystem::FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.recorded
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(virtual_root.clone());
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
+}
+
+#[tokio::test]
+async fn hosted_scoped_virtual_filesystem_ensure_scoped_mount_delegates_to_inner_backend() {
+    // Proves the confirmed latent gap this task closes: MountScopedRootFilesystem
+    // wraps `Arc<dyn RootFilesystem>` and, before this change, inherited the
+    // trait's now-removed default no-op for `ensure_scoped_mount` instead of
+    // forwarding to `self.root`. It is non-exploitable in production only
+    // because every real caller routes a fixed constant grant target that
+    // already has a static DiskFilesystem mount pre-registered — not because
+    // this wrapper narrows anything itself. Drive it with an arbitrary,
+    // non-preregistered grant target and assert the call actually reaches
+    // the wrapped backend (recorded, not merely `Ok(())` from a stub).
+    let recording_backend = Arc::new(EnsureScopedMountRecordingBackend::default());
+    let resolver =
+        resolver_with_filesystem(Arc::clone(&recording_backend) as Arc<dyn RootFilesystem>);
+    let mut plan = plan(
+        ProcessBackendKind::None,
+        false,
+        false,
+        NetworkMode::Deny,
+        false,
+    );
+    plan.deployment = DeploymentMode::HostedMultiTenant;
+    plan.resolved_profile = RuntimeProfile::SecureDefault;
+    plan.requires_filesystem = true;
+    plan.filesystem_backend = FilesystemBackendKind::ScopedVirtual;
+
+    // An arbitrary tenant/agent-scoped grant target with no static mount
+    // registered anywhere — proving the forward is unconditional, not an
+    // artifact of a specific pre-wired path.
+    let dynamic_target = vpath("/tenants/acme/agents/agent_7/skills/scratch");
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/skills".to_string()).expect("mount alias"),
+        dynamic_target.clone(),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("mount view");
+
+    let services = resolver
+        .resolve(InvocationServicesResolutionRequest {
+            plan: &plan,
+            scope: &ResourceScope::system(),
+            mounts: Some(&mounts),
+        })
+        .expect("hosted scoped virtual filesystem should resolve with explicit mounts");
+
+    services
+        .filesystem
+        .ensure_scoped_mount(&dynamic_target)
+        .await
+        .expect("ensure_scoped_mount must succeed against the inner in-memory backend");
+
+    assert_eq!(
+        recording_backend.recorded_roots(),
+        vec![dynamic_target],
+        "MountScopedRootFilesystem::ensure_scoped_mount must forward the exact \
+         virtual_root to the wrapped backend, not silently no-op"
+    );
+}
+
 #[tokio::test]
 async fn hosted_scoped_virtual_filesystem_delete_if_version_denies_when_delete_missing() {
     // Round-C review (PR #5749): the sibling `scoped/tests.rs` suite in

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -1861,6 +1861,10 @@ impl RootFilesystem for StatLenOverrideFilesystem {
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.create_dir_all(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 /// KEPT (not folded to `ironclaw_filesystem::FaultInjecting`): the coding
@@ -1905,6 +1909,10 @@ impl RootFilesystem for WriteFailureFilesystem {
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.create_dir_all(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 /// KEPT (not folded to `ironclaw_filesystem::FaultInjecting`): this fake returns
@@ -1943,6 +1951,10 @@ impl RootFilesystem for ReadInfrastructureFailureFilesystem {
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.create_dir_all(path).await
+    }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
     }
 }
 
@@ -1999,6 +2011,14 @@ impl RootFilesystem for ManySkippedEntriesFilesystem {
             operation: FilesystemOperation::CreateDirAll,
             reason: "unexpected mkdir".to_string(),
         })
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Unit-struct test fixture with no storage to narrow.
+        Ok(())
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -1996,6 +1996,14 @@ impl RootFilesystem for OversizedReadFilesystem {
     ) -> Result<Option<Vec<u8>>, FilesystemError> {
         Ok(Some(vec![b'a'; max_bytes + 1]))
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Unit-struct test fixture with no storage to narrow.
+        Ok(())
+    }
 }
 
 fn runtime_with(

--- a/crates/ironclaw_loop_host/src/checkpoint_state_store.rs
+++ b/crates/ironclaw_loop_host/src/checkpoint_state_store.rs
@@ -397,6 +397,14 @@ mod tests {
                 sensitive: false,
             })
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // In-memory test fixture with no OS path to narrow.
+            Ok(())
+        }
     }
 
     fn scoped_legacy_fs() -> ScopedFilesystem<LegacyBytesFilesystem> {

--- a/crates/ironclaw_loop_host/src/filesystem_skill_bundle_source.rs
+++ b/crates/ironclaw_loop_host/src/filesystem_skill_bundle_source.rs
@@ -649,6 +649,13 @@ mod tests {
             }
             self.inner.read_file_bounded(path, max_bytes).await
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
+        }
     }
 
     #[tokio::test]

--- a/crates/ironclaw_loop_host/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_loop_host/tests/checkpoint_state_store_contract.rs
@@ -144,6 +144,10 @@ impl RootFilesystem for DiskFullFilesystem {
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         self.inner.stat(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[tokio::test]

--- a/crates/ironclaw_memory_native/src/filesystem.rs
+++ b/crates/ironclaw_memory_native/src/filesystem.rs
@@ -475,6 +475,16 @@ impl RootFilesystem for MemoryBackendFilesystemAdapter {
             sensitive: false,
         })
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Backed by an in-process `MemoryBackend` keyed by prefix, not an OS
+        // path; containment is enforced by that key scoping, so there is no
+        // mount to narrow here.
+        Ok(())
+    }
 }
 
 /// [`RootFilesystem`] backend exposing DB-backed memory documents as virtual files.
@@ -881,5 +891,15 @@ impl RootFilesystem for MemoryDocumentFilesystem {
             modified: None,
             sensitive: false,
         })
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Backed by a `MemoryDocumentRepository` keyed by relative path, not
+        // an OS path; containment is enforced by that repository's own
+        // scoping, so there is no mount to narrow here.
+        Ok(())
     }
 }

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -1921,6 +1921,10 @@ impl RootFilesystem for VersionRacingBackend {
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.delete(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 /// Synchronization decorator for deterministic two-store conditional-delete
@@ -2053,6 +2057,10 @@ impl RootFilesystem for DeletePauseBackend {
             }
         }
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 /// Test backend that mimics a mount that cannot honor CAS writes for critical
@@ -2138,6 +2146,10 @@ impl RootFilesystem for UnsupportedCriticalCasBackend {
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.delete(path).await
+    }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
@@ -313,7 +313,7 @@ async fn skills_shared_mount_cross_tenant_symlink_read() {
             .expect("virtual path");
 
     filesystem
-        .ensure_scoped_mount(grant.target.clone())
+        .ensure_scoped_mount(&grant.target)
         .await
         .expect("anchor mount for tenant A's own skills leaf");
 
@@ -402,7 +402,7 @@ async fn skills_shared_mount_same_tenant_cross_user_symlink_read() {
             .expect("virtual path");
 
     filesystem
-        .ensure_scoped_mount(grant.target.clone())
+        .ensure_scoped_mount(&grant.target)
         .await
         .expect("anchor mount for user A's own skills leaf");
 
@@ -423,6 +423,118 @@ async fn skills_shared_mount_same_tenant_cross_user_symlink_read() {
                 "SAME-TENANT CROSS-USER ESCAPE CONFIRMED: user A's /skills grant read user B's \
                  data through a symlink: {:?}",
                 String::from_utf8_lossy(&bytes)
+            );
+        }
+    }
+}
+
+/// The deliverable regression: the two tests above prove `ensure_scoped_mount`
+/// itself closes the escape, but they call it directly on a hand-built
+/// `DiskFilesystem` — never the production entry point. Production skill
+/// reads go through `ScopedSkillManagementPort::read_content_for_scope`,
+/// which builds a `SkillManagementContext` wrapping the filesystem in
+/// `ScopedFilesystem` and never touched `ensure_scoped_mount` before this
+/// fix (`ScopedSkillManagementPort`'s only filesystem handle is a
+/// type-erased `Arc<dyn RootFilesystem>`, which has zero production callers
+/// of the primitive — see the fix commit message). This test drives that
+/// exact production call chain — `ScopedSkillManagementPort` ->
+/// `SkillManagementContext` -> `ScopedFilesystem` -> `CompositeRootFilesystem`
+/// -> `DiskFilesystem` — with no direct `ensure_scoped_mount` call anywhere
+/// in the test itself.
+///
+/// Before the `scoped.rs` wiring fix, this test is RED: tenant A's `evil`
+/// skill resolves through a relative symlink into tenant B's leaf and
+/// `read_content_for_scope` returns tenant B's real skill content. After the
+/// fix, `ScopedFilesystem::resolve_with_permission` calls
+/// `ensure_scoped_mount(&grant.target)` on every resolution (including the
+/// `stat`/`read_bytes_bounded` calls `read_skill_content` makes), narrowing
+/// containment to tenant A's own leaf before either syscall — the escape is
+/// rejected and the call errors instead of leaking tenant B's bytes.
+#[tokio::test]
+async fn skills_shared_mount_cross_tenant_symlink_read_through_scoped_skill_management_port() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("local-dev");
+    std::fs::create_dir_all(&root).expect("root");
+    let workspace_root = root.join("workspace");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root");
+    std::fs::create_dir_all(root.join("system/extensions")).expect("system extensions root");
+    std::fs::create_dir_all(root.join("system/skills")).expect("system skills root");
+
+    let filesystem: std::sync::Arc<dyn ironclaw_filesystem::RootFilesystem> =
+        std::sync::Arc::new(
+            local_dev_project_filesystem(&root, &workspace_root, None)
+                .expect("local-dev project filesystem, production shape"),
+        );
+
+    let scope_a = owner_scope_from_runtime_identity(
+        ironclaw_host_api::UserId::new("user-a").expect("user id"),
+        ironclaw_host_api::TenantId::new("tenant-a").expect("tenant id"),
+        ironclaw_host_api::AgentId::new("agent").expect("agent id"),
+    );
+
+    let skills_dir_for = |scope: &ironclaw_host_api::ResourceScope| {
+        root.join("tenants")
+            .join(scope.tenant_id.as_str())
+            .join("users")
+            .join(scope.user_id.as_str())
+            .join("skills")
+    };
+    let skills_a = skills_dir_for(&scope_a);
+    let skills_b = root
+        .join("tenants")
+        .join("tenant-b")
+        .join("users")
+        .join("user-b")
+        .join("skills");
+    std::fs::create_dir_all(&skills_a).expect("tenant a skills dir");
+    let secret_skill_dir = skills_b.join("secret-skill");
+    std::fs::create_dir_all(&secret_skill_dir).expect("tenant b secret skill dir");
+    std::fs::write(
+        secret_skill_dir.join("SKILL.md"),
+        b"TENANT-B-SECRET-SKILL-CONTENT",
+    )
+    .expect("tenant b secret skill file");
+
+    // Tenant A's own skills leaf gets a *real* directory named "evil"
+    // (`validate_skill_name` requires a plain alnum/`.`/`-`/`_` name, so the
+    // escape cannot itself be the leaf-named entry) containing a symlinked
+    // `SKILL.md`. `evil/` is one level deeper than `skills_a` itself, so
+    // reaching `tenants` from inside it takes 5 `..` (vs. the 4 the sibling
+    // tests above use directly inside `skills_a`).
+    #[cfg(unix)]
+    {
+        let evil_dir = skills_a.join("evil");
+        std::fs::create_dir_all(&evil_dir).expect("tenant a evil skill dir");
+        std::os::unix::fs::symlink(
+            "../../../../../tenant-b/users/user-b/skills/secret-skill/SKILL.md",
+            evil_dir.join("SKILL.md"),
+        )
+        .expect("plant cross-tenant symlink inside tenant A's own skills leaf");
+    }
+
+    let port = ironclaw_skills::ScopedSkillManagementPort::new_with_mount_resolver(
+        scope_a.user_id.clone(),
+        filesystem,
+        std::sync::Arc::new(crate::local_dev_mounts::scoped_skill_management_mount_view),
+    );
+
+    let escape = port.read_content_for_scope(scope_a, "evil").await;
+
+    match escape {
+        Err(_error) => {
+            // Any error is the closed-escape outcome: `stat`/`read_bytes_bounded`
+            // surface `SymlinkEscape` once containment is narrowed, and
+            // `ScopedSkillManagementPort` maps every `FilesystemError` through
+            // its own error type rather than passing it through verbatim, so
+            // the specific variant is an internal implementation detail this
+            // test does not pin — only "did not leak tenant B's bytes" does.
+        }
+        Ok(result) => {
+            panic!(
+                "CROSS-TENANT ESCAPE CONFIRMED THROUGH THE PRODUCTION PATH: \
+                 ScopedSkillManagementPort::read_content_for_scope returned \
+                 tenant B's data: {:?}",
+                result.content
             );
         }
     }

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
@@ -460,11 +460,10 @@ async fn skills_shared_mount_cross_tenant_symlink_read_through_scoped_skill_mana
     std::fs::create_dir_all(root.join("system/extensions")).expect("system extensions root");
     std::fs::create_dir_all(root.join("system/skills")).expect("system skills root");
 
-    let filesystem: std::sync::Arc<dyn ironclaw_filesystem::RootFilesystem> =
-        std::sync::Arc::new(
-            local_dev_project_filesystem(&root, &workspace_root, None)
-                .expect("local-dev project filesystem, production shape"),
-        );
+    let filesystem: std::sync::Arc<dyn ironclaw_filesystem::RootFilesystem> = std::sync::Arc::new(
+        local_dev_project_filesystem(&root, &workspace_root, None)
+            .expect("local-dev project filesystem, production shape"),
+    );
 
     let scope_a = owner_scope_from_runtime_identity(
         ironclaw_host_api::UserId::new("user-a").expect("user id"),

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
@@ -231,3 +231,199 @@ fn filesystem_root() -> std::path::PathBuf {
     }
     path
 }
+
+/// CONFIRMED cross-tenant skills escape (ported from a prior audit, sandbox
+/// credential-firewall program): unlike a `mount_local_per_leaf` mount, the
+/// `/projects` disk mount backing `scoped_skill_management_mount_view`'s
+/// `/skills` grant (`local_dev_project_filesystem`) is a plain `mount_local`
+/// — its containment root is the ENTIRE local-dev storage root, not the
+/// caller's own `tenants/{tenant}/users/{user}/skills` leaf. A symlink
+/// planted inside tenant A's skills directory pointing at tenant B's skills
+/// directory stays within the shared storage root, so containment checked
+/// against the whole root (not a per-tenant leaf) does not catch it.
+///
+/// RED before the fix: the read succeeds and returns tenant B's bytes.
+/// GREEN after: `ensure_scoped_mount` (`ironclaw_filesystem::DiskFilesystem`)
+/// registers a mount rooted exactly at the resolved `/skills` grant target
+/// before the read, so `RESOLVE_BENEATH` is anchored at that leaf and the
+/// escape is rejected.
+#[tokio::test]
+async fn skills_shared_mount_cross_tenant_symlink_read() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("local-dev");
+    std::fs::create_dir_all(&root).expect("root");
+    let workspace_root = root.join("workspace");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root");
+    std::fs::create_dir_all(root.join("system/extensions")).expect("system extensions root");
+    std::fs::create_dir_all(root.join("system/skills")).expect("system skills root");
+
+    let filesystem = local_dev_project_filesystem(&root, &workspace_root, None)
+        .expect("local-dev project filesystem, production shape");
+
+    let scope_a = owner_scope_from_runtime_identity(
+        ironclaw_host_api::UserId::new("user-a").expect("user id"),
+        ironclaw_host_api::TenantId::new("tenant-a").expect("tenant id"),
+        ironclaw_host_api::AgentId::new("agent").expect("agent id"),
+    );
+    let scope_b = owner_scope_from_runtime_identity(
+        ironclaw_host_api::UserId::new("user-b").expect("user id"),
+        ironclaw_host_api::TenantId::new("tenant-b").expect("tenant id"),
+        ironclaw_host_api::AgentId::new("agent").expect("agent id"),
+    );
+
+    let skills_dir_for = |scope: &ironclaw_host_api::ResourceScope| {
+        root.join("tenants")
+            .join(scope.tenant_id.as_str())
+            .join("users")
+            .join(scope.user_id.as_str())
+            .join("skills")
+    };
+    let skills_a = skills_dir_for(&scope_a);
+    let skills_b = skills_dir_for(&scope_b);
+    std::fs::create_dir_all(&skills_a).expect("tenant a skills dir");
+    std::fs::create_dir_all(&skills_b).expect("tenant b skills dir");
+    std::fs::write(skills_b.join("secret.txt"), b"tenant-b-only").expect("tenant b secret file");
+
+    // Relative, not absolute: an absolute-target symlink is already rejected
+    // outright by the fd-rooted traversal's symlink policy regardless of
+    // where it points (see `ironclaw_filesystem::local::fd_resolve`'s
+    // `walk_symlink_target`), so an absolute-path reproduction here would
+    // pass even without this test's fix and prove nothing about the
+    // cross-tenant containment boundary specifically. A relative target —
+    // exactly what a real symlink authored *inside* the sandboxed tree would
+    // use — is the actual escape vector this test exists to close: `skills_a`
+    // is `tenants/tenant-a/users/user-a/skills` (4 levels below `tenants`),
+    // so 4 `..` reach `tenants` and the walk descends into tenant B's leaf.
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        "../../../../tenant-b/users/user-b/skills/secret.txt",
+        skills_a.join("evil-read"),
+    )
+    .expect("plant cross-tenant symlink inside tenant A's own skills leaf");
+
+    let view = crate::local_dev_mounts::scoped_skill_management_mount_view(&scope_a)
+        .expect("valid skill mounts");
+    let grant = view
+        .mounts
+        .iter()
+        .find(|mount| mount.alias.as_str() == "/skills")
+        .expect("/skills grant present");
+    let target_path =
+        ironclaw_host_api::VirtualPath::new(format!("{}/evil-read", grant.target.as_str()))
+            .expect("virtual path");
+
+    filesystem
+        .ensure_scoped_mount(grant.target.clone())
+        .await
+        .expect("anchor mount for tenant A's own skills leaf");
+
+    let escape = filesystem.read_file(&target_path).await;
+
+    match escape {
+        Err(error) => {
+            assert!(
+                matches!(
+                    error,
+                    ironclaw_filesystem::FilesystemError::SymlinkEscape { .. }
+                ),
+                "expected SymlinkEscape if rejected, got: {error:?}"
+            );
+        }
+        Ok(bytes) => {
+            panic!(
+                "CROSS-TENANT ESCAPE CONFIRMED: tenant A's /skills grant read tenant B's data \
+                 through a symlink: {:?}",
+                String::from_utf8_lossy(&bytes)
+            );
+        }
+    }
+}
+
+/// Same-tenant CROSS-USER variant — the case a naive single-level
+/// `mount_local_per_leaf`-style mirror (anchoring only at the tenant
+/// segment) would NOT have caught, since two users under the SAME tenant
+/// would still share that tenant-level anchor. `ensure_scoped_mount` closes
+/// this too because the anchor is the grant's *full* target
+/// (`tenants/{t}/users/{u}/skills`), not a fixed single segment.
+#[tokio::test]
+async fn skills_shared_mount_same_tenant_cross_user_symlink_read() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("local-dev");
+    std::fs::create_dir_all(&root).expect("root");
+    let workspace_root = root.join("workspace");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root");
+    std::fs::create_dir_all(root.join("system/extensions")).expect("system extensions root");
+    std::fs::create_dir_all(root.join("system/skills")).expect("system skills root");
+
+    let filesystem = local_dev_project_filesystem(&root, &workspace_root, None)
+        .expect("local-dev project filesystem, production shape");
+
+    let scope_a = owner_scope_from_runtime_identity(
+        ironclaw_host_api::UserId::new("user-a").expect("user id"),
+        ironclaw_host_api::TenantId::new("shared-tenant").expect("tenant id"),
+        ironclaw_host_api::AgentId::new("agent").expect("agent id"),
+    );
+    let scope_b = owner_scope_from_runtime_identity(
+        ironclaw_host_api::UserId::new("user-b").expect("user id"),
+        ironclaw_host_api::TenantId::new("shared-tenant").expect("tenant id"),
+        ironclaw_host_api::AgentId::new("agent").expect("agent id"),
+    );
+
+    let skills_dir_for = |scope: &ironclaw_host_api::ResourceScope| {
+        root.join("tenants")
+            .join(scope.tenant_id.as_str())
+            .join("users")
+            .join(scope.user_id.as_str())
+            .join("skills")
+    };
+    let skills_a = skills_dir_for(&scope_a);
+    let skills_b = skills_dir_for(&scope_b);
+    std::fs::create_dir_all(&skills_a).expect("user a skills dir");
+    std::fs::create_dir_all(&skills_b).expect("user b skills dir");
+    std::fs::write(skills_b.join("secret.txt"), b"user-b-only").expect("user b secret file");
+
+    // Relative (see the cross-tenant test above for why): `skills_a` is
+    // `tenants/shared-tenant/users/user-a/skills`, so 2 `..` reach
+    // `tenants/shared-tenant/users` and the walk descends into user B's leaf
+    // — same tenant, sibling user.
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("../../user-b/skills/secret.txt", skills_a.join("evil-read"))
+        .expect("plant cross-user symlink inside user A's own skills leaf, same tenant");
+
+    let view = crate::local_dev_mounts::scoped_skill_management_mount_view(&scope_a)
+        .expect("valid skill mounts");
+    let grant = view
+        .mounts
+        .iter()
+        .find(|mount| mount.alias.as_str() == "/skills")
+        .expect("/skills grant present");
+    let target_path =
+        ironclaw_host_api::VirtualPath::new(format!("{}/evil-read", grant.target.as_str()))
+            .expect("virtual path");
+
+    filesystem
+        .ensure_scoped_mount(grant.target.clone())
+        .await
+        .expect("anchor mount for user A's own skills leaf");
+
+    let escape = filesystem.read_file(&target_path).await;
+
+    match escape {
+        Err(error) => {
+            assert!(
+                matches!(
+                    error,
+                    ironclaw_filesystem::FilesystemError::SymlinkEscape { .. }
+                ),
+                "expected SymlinkEscape if rejected, got: {error:?}"
+            );
+        }
+        Ok(bytes) => {
+            panic!(
+                "SAME-TENANT CROSS-USER ESCAPE CONFIRMED: user A's /skills grant read user B's \
+                 data through a symlink: {:?}",
+                String::from_utf8_lossy(&bytes)
+            );
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/observability/hooks/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/observability/hooks/tests.rs
@@ -865,6 +865,14 @@ async fn unreadable_extension_root_falls_back_to_builtin_only() {
                 operation: FilesystemOperation::Stat,
             })
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Unit-struct test fixture with no storage to narrow.
+            Ok(())
+        }
     }
 
     let tenant = ironclaw_host_api::TenantId::new("alpha").expect("tenant");

--- a/crates/ironclaw_reborn_composition/tests/third_party_hook_projection.rs
+++ b/crates/ironclaw_reborn_composition/tests/third_party_hook_projection.rs
@@ -114,6 +114,14 @@ impl RootFilesystem for FakeExtensionFs {
             version: RecordVersion::from_backend(0),
         }))
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        _virtual_root: &VirtualPath,
+    ) -> Result<(), FilesystemError> {
+        // Test fixture with no storage to narrow.
+        Ok(())
+    }
 }
 
 // ── Manifest builders ────────────────────────────────────────────────────────

--- a/crates/ironclaw_resources/src/cas_snapshot.rs
+++ b/crates/ironclaw_resources/src/cas_snapshot.rs
@@ -581,6 +581,13 @@ mod tests {
         async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
             self.inner.stat(path).await
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
+        }
     }
 
     fn scoped(backend: Arc<SlowGetBackend>) -> Arc<ScopedFilesystem<SlowGetBackend>> {

--- a/crates/ironclaw_resources/src/filesystem_governor/journal.rs
+++ b/crates/ironclaw_resources/src/filesystem_governor/journal.rs
@@ -571,6 +571,14 @@ mod tests {
         async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
             Err(unsupported(path, FilesystemOperation::Stat))
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
+        }
     }
 
     #[async_trait]
@@ -612,6 +620,14 @@ mod tests {
 
         async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
             Err(unsupported(path, FilesystemOperation::Stat))
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
         }
     }
 
@@ -657,6 +673,14 @@ mod tests {
         async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
             Err(unsupported(path, FilesystemOperation::Stat))
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
+        }
     }
 
     #[async_trait]
@@ -687,6 +711,14 @@ mod tests {
 
         async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
             Err(unsupported(path, FilesystemOperation::Stat))
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            _virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            // Test fixture with no storage to narrow.
+            Ok(())
         }
     }
 

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -143,6 +143,13 @@ where
             operation: ironclaw_filesystem::FilesystemOperation::Append,
         })
     }
+
+    async fn ensure_scoped_mount(
+        &self,
+        virtual_root: &VirtualPath,
+    ) -> Result<(), ironclaw_filesystem::FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 struct BlockFirstAppendFilesystem<F> {
@@ -256,6 +263,13 @@ where
     ) -> Result<Vec<ironclaw_filesystem::SeqNo>, ironclaw_filesystem::FilesystemError> {
         self.maybe_block_first_append();
         self.inner.append_batch(path, payloads).await
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        virtual_root: &VirtualPath,
+    ) -> Result<(), ironclaw_filesystem::FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
     }
 }
 
@@ -1919,6 +1933,13 @@ impl ironclaw_filesystem::RootFilesystem for PersistentVersionMismatchBackend {
         spec: &ironclaw_filesystem::IndexSpec,
     ) -> Result<(), ironclaw_filesystem::FilesystemError> {
         self.inner.ensure_index(path, spec).await
+    }
+
+    async fn ensure_scoped_mount(
+        &self,
+        virtual_root: &VirtualPath,
+    ) -> Result<(), ironclaw_filesystem::FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
     }
 }
 

--- a/crates/ironclaw_run_state/tests/run_state_contract.rs
+++ b/crates/ironclaw_run_state/tests/run_state_contract.rs
@@ -1356,6 +1356,10 @@ impl RootFilesystem for RaceApproveOnFirstRead {
 
         result
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 struct ConcurrentMissingReadFilesystem {
@@ -1441,6 +1445,10 @@ impl RootFilesystem for ConcurrentMissingReadFilesystem {
         }
         result
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 struct DisappearingApprovalReadFilesystem {
@@ -1523,6 +1531,10 @@ impl RootFilesystem for DisappearingApprovalReadFilesystem {
             return Ok(None);
         }
         self.inner.get(path).await
+    }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
     }
 }
 

--- a/crates/ironclaw_runner/src/subagent/await_edge/boot_recovery.rs
+++ b/crates/ironclaw_runner/src/subagent/await_edge/boot_recovery.rs
@@ -513,6 +513,13 @@ mod tests {
         ) -> Result<(), FilesystemError> {
             self.inner.delete_if_version(path, expected_version).await
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
+        }
     }
 
     // External review finding on this PR: `check_scope_recovered`'s claim

--- a/crates/ironclaw_secrets/src/secret_store.rs
+++ b/crates/ironclaw_secrets/src/secret_store.rs
@@ -1661,6 +1661,13 @@ mod tests {
         ) -> Result<(), FilesystemError> {
             self.inner.ensure_index(path, spec).await
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
+        }
     }
 
     #[tokio::test]
@@ -2225,6 +2232,13 @@ mod tests {
         ) -> Result<(), FilesystemError> {
             self.inner.ensure_index(path, spec).await
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
+        }
     }
 
     /// Sibling of [`VersionRacingBackend`] for CAS-exhaustion tests: races
@@ -2308,6 +2322,13 @@ mod tests {
         ) -> Result<(), FilesystemError> {
             self.inner.ensure_index(path, spec).await
         }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
+        }
     }
 
     /// Sibling of [`VersionRacingBackend`]/[`AlwaysRacingBackend`] for the
@@ -2376,6 +2397,13 @@ mod tests {
             spec: &IndexSpec,
         ) -> Result<(), FilesystemError> {
             self.inner.ensure_index(path, spec).await
+        }
+
+        async fn ensure_scoped_mount(
+            &self,
+            virtual_root: &VirtualPath,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_scoped_mount(virtual_root).await
         }
     }
 

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -109,14 +109,12 @@ impl RootFilesystem for SkillManagementRootFilesystem {
         self.inner.capabilities()
     }
 
-    /// Forwards to `self.inner` explicitly rather than inheriting the trait's
-    /// no-op default: `inner` is a type-erased `Arc<dyn RootFilesystem>` that
-    /// may be a `DiskFilesystem` with a real containment-narrowing override,
-    /// but the compiler cannot see through the erasure to prove that — if
-    /// this wrapper silently inherited the default instead of delegating,
-    /// every skill-management op would sail through with the mount never
-    /// narrowed, regardless of what `inner` actually does. Forwarding is
-    /// what makes `ScopedFilesystem`'s automatic call
+    /// Forwards to `self.inner` explicitly: `ensure_scoped_mount` has no
+    /// default implementation, and `inner` is a type-erased
+    /// `Arc<dyn RootFilesystem>` that may be a `DiskFilesystem` with a real
+    /// containment-narrowing override the compiler cannot see through the
+    /// erasure to reach on its own — this wrapper's own required override
+    /// is what makes `ScopedFilesystem`'s automatic call
     /// (`scoped.rs::resolve_with_permission_view`) actually reach
     /// `DiskFilesystem::ensure_scoped_mount` through this wrapper.
     async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -109,6 +109,20 @@ impl RootFilesystem for SkillManagementRootFilesystem {
         self.inner.capabilities()
     }
 
+    /// Forwards to `self.inner` explicitly rather than inheriting the trait's
+    /// no-op default: `inner` is a type-erased `Arc<dyn RootFilesystem>` that
+    /// may be a `DiskFilesystem` with a real containment-narrowing override,
+    /// but the compiler cannot see through the erasure to prove that — if
+    /// this wrapper silently inherited the default instead of delegating,
+    /// every skill-management op would sail through with the mount never
+    /// narrowed, regardless of what `inner` actually does. Forwarding is
+    /// what makes `ScopedFilesystem`'s automatic call
+    /// (`scoped.rs::resolve_with_permission_view`) actually reach
+    /// `DiskFilesystem::ensure_scoped_mount` through this wrapper.
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
+
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
         self.inner.list_dir(path).await
     }

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -1050,6 +1050,10 @@ impl RootFilesystem for CleanupDeleteDenyingFilesystem {
             operation: FilesystemOperation::Delete,
         })
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 fn skill_mounts() -> MountView {

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -3348,6 +3348,10 @@ impl RootFilesystem for QueryCountingBackend {
     async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
         self.inner.reserve_sequence(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[async_trait]
@@ -3406,6 +3410,10 @@ impl RootFilesystem for TransactionalRaceBackend {
             staged_puts: HashMap::new(),
         }))
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[async_trait]
@@ -3453,6 +3461,10 @@ impl RootFilesystem for ConcurrentToolResultWriteBackend {
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.delete(path).await
+    }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
     }
 }
 

--- a/crates/ironclaw_turns/tests/row_store_crash_consistency.rs
+++ b/crates/ironclaw_turns/tests/row_store_crash_consistency.rs
@@ -403,6 +403,13 @@ impl RootFilesystem for FaultBackend {
         self.record(RecordedOp::ReserveSequence { path: path.clone() });
         Ok(seq)
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        // Not fault-gated: faults here target durable-write op paths, not
+        // mount scoping, matching the pattern in `ironclaw_filesystem`'s
+        // own `FaultInjecting` decorator.
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/ironclaw_turns/tests/turn_state_row_store_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_state_row_store_contract.rs
@@ -168,6 +168,10 @@ impl RootFilesystem for CountingFilesystem {
     ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
         self.inner.tail_bounded(path, from, max_records).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 /// Wrap a [`RootFilesystem`] in a [`ScopedFilesystem`] that exposes the
@@ -516,6 +520,10 @@ where
     ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
         self.inner.tail_bounded(path, from, max_records).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[async_trait]
@@ -588,6 +596,10 @@ where
     ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
         self.inner.tail_bounded(path, from, max_records).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[async_trait]
@@ -658,6 +670,10 @@ where
     ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
         self.inner.tail_bounded(path, from, max_records).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }
 
 #[async_trait]
@@ -723,6 +739,10 @@ where
         max_records: usize,
     ) -> Result<Vec<ironclaw_filesystem::EventRecord>, FilesystemError> {
         self.inner.tail_bounded(path, from, max_records).await
+    }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
     }
 }
 

--- a/tests/integration/support/filesystem.rs
+++ b/tests/integration/support/filesystem.rs
@@ -208,4 +208,8 @@ where
     async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
         self.inner.reserve_sequence(path).await
     }
+
+    async fn ensure_scoped_mount(&self, virtual_root: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.ensure_scoped_mount(virtual_root).await
+    }
 }


### PR DESCRIPTION
## What this fixes

`crates/ironclaw_filesystem/src/local.rs` (`DiskFilesystem`) had **four TOCTOU containment escapes**, all one family: a pathname check (`canonicalize` + `starts_with`) followed by a *separate* syscall that re-resolves the same path string. Between the two, the path can change meaning.

| # | Function | Race |
|---|---|---|
| 1 | `resolve_existing` | check, then caller separately does `read`/`open`/`read_dir`/`remove_*` |
| 2 | `resolve_for_write` | validates the **parent** only; the leaf is never re-checked |
| 3 | `resolve_for_create_dir_all` | `create_dir_all` runs, *then* re-canonicalizes — the mkdir already happened |
| 4 | `ensure_existing_ancestor_contained` | checks the nearest *existing* ancestor; never-yet-existing tail components are unchecked by definition |

The code already admitted the gap (`local.rs:172`, `lib.rs:9-15` naming `openat2`/`RESOLVE_BENEATH`/cap-std as the production fix).

**All three RED tests reproduced the escape on the first race iteration** — outside bytes read, outside file mutated on append, `outside/leaf` created. Not a theoretical window.

While closing this, a **second, independent escape was found, confirmed, and fixed**: `/projects` is mounted wide (containment root = whole storage root) while `/skills` grants map to `tenants/{tenant}/users/{user}/skills`, so a symlink from one tenant's leaf into another's passed containment. Proven through the real production path (`ScopedSkillManagementPort → SkillManagementContext → ScopedFilesystem → CompositeRootFilesystem → DiskFilesystem`):

```
CROSS-TENANT ESCAPE CONFIRMED THROUGH THE PRODUCTION PATH: "TENANT-B-SECRET-SKILL-CONTENT"
```

Scope: the **`local-dev` and `local-dev-yolo` profiles** (hosted production mounts these on DB-backed filesystems with no OS paths). Not tool-reachable in either profile — `RootFilesystem` has no symlink-creation primitive, so planting requires prior host write access. `local-dev-yolo` (`--profile local-yolo --confirm-host-access`) is the higher-exposure variant: it mounts the user's **real host home directory** at `/host` (`crates/ironclaw_reborn_composition/src/factory.rs`, `build_workspace_filesystems`'s `host_home_root`; documented in `docs/reborn-binary.md` and `docs/reborn/contracts/runtime-profiles.md`), which routinely contains pre-existing, in-bounds absolute symlinks the user did not create for this tool (pyenv version envs, chezmoi/stow in absolute mode, cloud-sync placeholders) — see "Review follow-ups" below for the diagnosability fix this landed for that case.

## Approach

**`rustix` + `openat2(RESOLVE_BENEATH)`, not cap-std.** Both are already in `Cargo.lock`; the deciding factor was concurrency shape, not dependencies. cap-std's `Dir` ops are blocking, and using them correctly requires one `spawn_blocking` closure per *logical* operation (open-dir-then-open-file must not round-trip the async scheduler between steps, or the TOCTOU window reopens) — a structural rewrite of the sole disk backend, against this repo's documented blocking-in-async lock-convoy history.

**The structural fix:** resolution no longer returns a `PathBuf` that a separate `tokio::fs` call consumes. It returns an already-open, already-verified fd. That collapses check-then-act rather than decorating it. Measured: this is a **net reduction** in blocking-pool hops versus the code it replaces (old `resolve_for_write` did up to 4 `tokio::fs` calls before the caller's own write).

**In-bounds symlinks are followed.** `RESOLVE_BENEATH` alone is race-free and kernel-enforced; `RESOLVE_NO_SYMLINKS` adds strictness, not security. Rejecting all symlinks would have broken real user project trees (`/projects/workspace` fronts actual repos) — verified empirically against this repo's own pnpm install: **267 symlinks, 0 absolute, 267 relative**. Absolute targets are rejected on both platforms, matching `openat2`'s real semantics (reinterpreting them is `RESOLVE_IN_ROOT`, a different primitive).

**macOS asymmetry is documented, not silent.** No `openat2`, so the fallback is per-component `openat` + `O_NOFOLLOW` with `readlink` + re-walk from the correct anchor and a per-resolution hop budget. Both platforms reject the attack class; only Linux gets single-syscall boundary enforcement. Documented at the platform-split point.

## The chokepoint change

`ensure_scoped_mount` started as a `RootFilesystem` default no-op. **That was wrong for a security control** — a delegating wrapper silently opts out by doing nothing, and neither the type system nor the tests complain. Two wrappers (`CompositeRootFilesystem`, `SkillManagementRootFilesystem`) hit exactly this; without explicit overrides the entire fix would have been inert in production while compiling and passing its own tests.

An architecture-test ratchet was considered and rejected: a text-scan gate depends on staying in scope to keep working, and this repo has **five recorded instances of gates that silently stopped binding**. A required trait method has no binding step to lose.

Making it required flushed **~48 impl sites**, of which **~10 were delegating wrappers** that would have silently no-op'd — including `FaultInjecting<F>`, which is *not* `#[cfg(test)]` and is reused across many crates' suites. The static investigation had predicted one.

## Test Strategy

| Tier | Coverage |
|---|---|
| Crate (`ironclaw_filesystem`) | 3 TOCTOU race tests via the sanctioned delegating-filesystem barrier (400 iterations each), verified discriminating by running against the pre-fix backend; in-bounds/relative/absolute/chain/cycle symlink cases; depth-cap and LRU-eviction tests |
| Contract (`filesystem_contract.rs`) | pre-existing steady-state escape tests kept untouched as regression coverage; new `toctou_escape` module is additive |
| Composition (`local_dev_host_tests.rs`) | cross-tenant **and** same-tenant-cross-user escape, driven through the production path — RED before the wiring commit, GREEN after |
| Architecture | `reborn_local_filesystem_fd_rooted_gate.rs` — **allowlist**, not a denylist (the denylist version was evadable in one line via `use tokio::fs as x`); 9 tests plant violations in both directions, including in the extracted modules |
| Cross-compile | `cargo check --target x86_64-unknown-linux-gnu` gates the `openat2` path, which does not compile on macOS hosts |

Every fix in this PR landed RED-first with the failure captured.

## Trust boundary

Containment is now anchored to an open root fd rather than a path prefix. For leaf-scoped mounts the anchor is opened at the caller's own leaf; for grant-scoped access it is opened at the grant target, at whatever depth — which is what closes the two-level `tenants/{t}/users/{u}` case that one-level `leaf_scoped` could not express.

## Blast radius

`RootFilesystem`/`ScopedFilesystem` trait signatures and `mount_local`/`mount_local_per_leaf` are unchanged. Two production `DiskFilesystem` call sites (`factory.rs:2193`, `factory.rs:2411`) are untouched. The required-method change is mechanical and compiler-enumerated.

Behavior changes, all deliberate and pinned by tests:
- `write_file`/`append_file` reject a pre-existing **escaping** symlink at the write target instead of replacing it
- deleting a bare mount root fails closed (`PathOutsideMount`)
- absolute symlink targets are rejected

## Rollback

Revert the branch. The four escapes return; no data migration, no schema change, no persisted-format change.

## Review follow-ups (landed on this branch)

- **FIFO blocks the blocking pool (DoS):** every `open`/`openat2` call in `fd_resolve.rs` now sets `O_NONBLOCK` — a no-op for regular files/directories, but it turns a no-writer/no-reader FIFO planted anywhere under a writable mount (including at an intermediate directory-walk position, not just the leaf) from an indefinite blocking-pool thread hang into a prompt error. Covers both `resolve_walk` (read path) and `append_file`'s leaf open (write path).
- **Unbounded ancestor-fd retention:** added `mount_registry::MAX_PATH_COMPONENTS` (2048), checked before any fd is opened; a virtual path past the cap fails closed with a dedicated `FilesystemError::PathTooDeep`, never widens or truncates. Without this, a single pathologically deep virtual path could stack-overflow the process outright (reproduced).
- **Write-side ancestor-stack gap:** `descend_creating` now returns its ancestor stack alongside the final fd, and `write_file`/`append_file` thread it into their own leaf resolution instead of `&[]` — a `..` inside a symlink at a write-leaf position now resolves instead of failing closed (this was a usability gap, not a containment hole: it always failed closed).
- **Absolute-symlink rejection is now actionable:** `FilesystemError::SymlinkEscape` gained an `Option<String> detail`, populated for the absolute-target case with the symlink's own name and target text, and a statement that absolute targets are unsupported — so a `local-dev-yolo` user hitting this on a real `/host` symlink can fix it (replace with a relative link) instead of guessing. The rejection itself is unchanged.

## Known limits

- macOS lacks `RESOLVE_BENEATH`'s single-syscall enforcement (documented at the split point)
- ~~macOS mount-crossing parity gap~~ **closed (commit 10ef77a89):** the portable `openat` fallback (macOS always; Linux when `openat2` is unavailable) now `fstat`s every freshly opened fd and fails closed (`ResolveError::Escape`, matching Linux's `EXDEV -> Escape` mapping) if its device differs from the resolution anchor's — captured once per resolution, not re-`fstat`'d per component. Covered by a deterministic contract test on every platform plus a macOS-only test that mounts a real APFS disk image via `hdiutil` (no root required) and asserts the walk refuses to cross into it.
- dynamic scoped mounts are LRU-capped at 512 to bound open fds against `RLIMIT_NOFILE`; a busy multi-tenant host evicting frequently would re-open anchors more often
- `MountScopedRootFilesystem` now delegates, but is not currently reachable with a narrower-than-physical grant; that is routing, not enforcement, so it is pinned by a delegation test rather than an escape test


