### PR TITLE
fix(filesystem): seek the path index for libSQL prefix queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **libSQL prefix queries scanned the whole table:** record reads, subtree
+  deletes, and FTS backfill matched descendants with `path LIKE ? ESCAPE '!'`,
+  which cannot use the primary key, so every one of them scanned all of
+  `root_filesystem_entries`. Their cost therefore grew with the total size of
+  the database — threads, turns, memory, events — rather than with what the
+  caller asked for. They now use the same `path >= ? AND path < ?` bounds the
+  Postgres backend and libSQL's own `list_dir` already used, so each seeks the
+  path index. Measured end-to-end on a 200k-row database:
+  `/api/webchat/v2/extensions` 260ms -> 28ms and `.../extensions/registry`
+  380ms -> 20ms. This is what made the hosted Extensions page take seconds and
+  left removed extensions on screen until a manual refresh: the page's
+  post-removal refetch was aborted before the server answered.
+
+- **Extension list issued a query per installation:** normalizing the
+  aggregate into child rows made `list_installations` read each installation's
+  membership and credential-binding rows separately, costing `1 + 2N` round
+  trips. Both child collections are now read once and joined in memory (`3`
+  queries regardless of installation count).
+
 - **Agent-loop termination recovery:** tell the model when no-progress or the
   iteration limit would otherwise stop a run, preserve that one-shot warning
   across checkpoints, and allow one normal capability-enabled recovery turn

--- a/crates/ironclaw_extensions/src/installations.rs
+++ b/crates/ironclaw_extensions/src/installations.rs
@@ -2314,8 +2314,13 @@ impl ExtensionInstallationStore {
             let record = parse_v2_membership_entry(row.entry, &path)?;
             // Same integrity check the per-installation read makes: the body's
             // installation id must agree with the parent the row is filed under.
-            let expected_root = self.v2_membership_root(&record.installation_id)?;
-            if !path.as_str().starts_with(expected_root.as_str()) {
+            // Match the full directory boundary, not a bare string prefix.
+            // Today's row tokens are fixed-length hashes so a prefix collision
+            // is unreachable, but that is a property of the path scheme rather
+            // than of this check -- pin the boundary so the check stays exact
+            // if the scheme ever changes.
+            let expected_root = format!("{}/", self.v2_membership_root(&record.installation_id)?);
+            if !path.as_str().starts_with(&expected_root) {
                 return Err(invalid_installation_error(
                     "v2 membership row installation id did not match its parent",
                 ));
@@ -2347,8 +2352,11 @@ impl ExtensionInstallationStore {
         for row in rows {
             let path = row.path.clone();
             let record = parse_v2_credential_binding_entry(row.entry, &path)?;
-            let expected_root = self.v2_credential_binding_root(&record.installation_id)?;
-            if !path.as_str().starts_with(expected_root.as_str()) {
+            let expected_root = format!(
+                "{}/",
+                self.v2_credential_binding_root(&record.installation_id)?
+            );
+            if !path.as_str().starts_with(&expected_root) {
                 return Err(invalid_installation_error(
                     "v2 credential binding installation id did not match its parent",
                 ));

--- a/crates/ironclaw_extensions/src/installations.rs
+++ b/crates/ironclaw_extensions/src/installations.rs
@@ -1,5 +1,5 @@
 // arch-exempt: large_file, the three-state lifecycle collapse remains with the installation aggregate pending its planned split, plan #6175
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::sync::Arc;
 
@@ -2292,6 +2292,85 @@ impl ExtensionInstallationStore {
             ));
         }
         let all_memberships = self.query_v2_memberships(&core.installation_id).await?;
+        let all_bindings = self
+            .query_v2_credential_bindings(&core.installation_id)
+            .await?;
+        Self::assemble_v2_installation(core, all_memberships, all_bindings)
+    }
+
+    /// Group every membership row under the shared prefix by its installation.
+    ///
+    /// One query for the whole collection instead of one per installation:
+    /// listing is a hot read and the per-installation shape made it O(N)
+    /// round trips.
+    async fn query_v2_memberships_by_installation(
+        &self,
+    ) -> Result<HashMap<ExtensionInstallationId, Vec<V2MembershipRecord>>, ExtensionInstallationError>
+    {
+        let rows = query_all(&self.filesystem, &self.v2_memberships_root()?, &Filter::All).await?;
+        let mut grouped: HashMap<ExtensionInstallationId, Vec<V2MembershipRecord>> = HashMap::new();
+        for row in rows {
+            let path = row.path.clone();
+            let record = parse_v2_membership_entry(row.entry, &path)?;
+            // Same integrity check the per-installation read makes: the body's
+            // installation id must agree with the parent the row is filed under.
+            let expected_root = self.v2_membership_root(&record.installation_id)?;
+            if !path.as_str().starts_with(expected_root.as_str()) {
+                return Err(invalid_installation_error(
+                    "v2 membership row installation id did not match its parent",
+                ));
+            }
+            grouped
+                .entry(record.installation_id.clone())
+                .or_default()
+                .push(record);
+        }
+        Ok(grouped)
+    }
+
+    /// Credential-binding counterpart of
+    /// [`Self::query_v2_memberships_by_installation`].
+    async fn query_v2_credential_bindings_by_installation(
+        &self,
+    ) -> Result<
+        HashMap<ExtensionInstallationId, Vec<V2CredentialBindingRecord>>,
+        ExtensionInstallationError,
+    > {
+        let rows = query_all(
+            &self.filesystem,
+            &self.v2_credential_bindings_root()?,
+            &Filter::All,
+        )
+        .await?;
+        let mut grouped: HashMap<ExtensionInstallationId, Vec<V2CredentialBindingRecord>> =
+            HashMap::new();
+        for row in rows {
+            let path = row.path.clone();
+            let record = parse_v2_credential_binding_entry(row.entry, &path)?;
+            let expected_root = self.v2_credential_binding_root(&record.installation_id)?;
+            if !path.as_str().starts_with(expected_root.as_str()) {
+                return Err(invalid_installation_error(
+                    "v2 credential binding installation id did not match its parent",
+                ));
+            }
+            grouped
+                .entry(record.installation_id.clone())
+                .or_default()
+                .push(record);
+        }
+        Ok(grouped)
+    }
+
+    /// Rebuild one aggregate from a core row and its already-loaded children.
+    ///
+    /// Pure assembly: the caller decides whether the children came from a
+    /// per-installation read or a batched one, so a list can load every child
+    /// collection once.
+    fn assemble_v2_installation(
+        core: &V2InstallationRecord,
+        all_memberships: Vec<V2MembershipRecord>,
+        all_bindings: Vec<V2CredentialBindingRecord>,
+    ) -> Result<ExtensionInstallation, ExtensionInstallationError> {
         let membership_updated_at = all_memberships.iter().map(|record| record.updated_at).max();
         let memberships = all_memberships
             .into_iter()
@@ -2307,9 +2386,6 @@ impl ExtensionInstallationStore {
                     .collect(),
             )?
         };
-        let all_bindings = self
-            .query_v2_credential_bindings(&core.installation_id)
-            .await?;
         let binding_updated_at = all_bindings.iter().map(|record| record.updated_at).max();
         let mut bindings = all_bindings
             .into_iter()
@@ -2343,17 +2419,39 @@ impl ExtensionInstallationStore {
         })
     }
 
+    /// Load every visible installation with a constant number of queries.
+    ///
+    /// The normalized layout stores each aggregate's members and credential
+    /// bindings as child rows, so reconstructing them one installation at a
+    /// time costs `1 + 2N` round trips. That is invisible on a local disk and
+    /// dominates on network-attached storage, so both child collections are
+    /// read once and joined in memory instead.
     async fn query_v2_installations(
         &self,
         filter: &Filter,
     ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError> {
         let rows = query_all(&self.filesystem, &self.v2_installations_root()?, filter).await?;
-        let mut installations = Vec::new();
+        let mut cores = Vec::new();
         for row in rows {
             let core = parse_v2_installation_entry(row.entry, &row.path)?;
             if core.is_visible() {
-                installations.push(self.reconstruct_v2_installation(&core).await?);
+                cores.push(core);
             }
+        }
+        if cores.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut memberships = self.query_v2_memberships_by_installation().await?;
+        let mut bindings = self.query_v2_credential_bindings_by_installation().await?;
+        let mut installations = Vec::with_capacity(cores.len());
+        for core in &cores {
+            installations.push(Self::assemble_v2_installation(
+                core,
+                memberships
+                    .remove(&core.installation_id)
+                    .unwrap_or_default(),
+                bindings.remove(&core.installation_id).unwrap_or_default(),
+            )?);
         }
         Ok(installations)
     }

--- a/crates/ironclaw_extensions/tests/installations_contract.rs
+++ b/crates/ironclaw_extensions/tests/installations_contract.rs
@@ -1946,3 +1946,186 @@ async fn failed_install_debris_is_not_granted_to_a_later_installer() {
         "debris from alice's failed install must not grant her membership"
     );
 }
+
+/// Perf contract: listing installations must not issue a query per
+/// installation. The normalized layout split one aggregate row into an
+/// installation row plus child membership/binding rows, and reconstructing
+/// each installation with its own child queries makes `list_installations`
+/// O(N) round trips. On a local SSD that is invisible (fractions of a
+/// millisecond); on network-attached storage it dominates -- it took the
+/// hosted `/api/webchat/v2/extensions` read to ~2s. Pinning "the query count
+/// does not grow with the number of installations" is what catches a
+/// regression here, because wall-clock on a dev machine never will.
+#[tokio::test]
+async fn listing_installations_does_not_issue_a_query_per_installation() {
+    async fn queries_to_list(installation_count: usize) -> usize {
+        let counting = Arc::new(QueryCountingBackend::new(InMemoryBackend::new()));
+        let filesystem: Arc<dyn RootFilesystem> = counting.clone();
+        let store = ExtensionInstallationStore::load_at(
+            Arc::clone(&filesystem),
+            VirtualPath::new("/system/extensions/.installations/query-count").unwrap(),
+            HostPortCatalog::empty(),
+            contracts(),
+        )
+        .await
+        .unwrap();
+
+        for index in 0..installation_count {
+            let ext = format!("acme-tools-{index}");
+            let toml = raw_capability_provider_manifest()
+                .replace("id = \"acme-tools\"", &format!("id = \"{ext}\""))
+                .replace("acme-tools.echo", &format!("{ext}.echo"));
+            let record = ExtensionManifestRecord::from_toml(
+                toml,
+                ManifestSource::HostBundled,
+                &HostPortCatalog::empty(),
+                Some(manifest_hash("sha256:abc")),
+                &contracts(),
+            )
+            .unwrap();
+            let installation = ExtensionInstallation::new(
+                installation_id(&ext),
+                extension_id(&ext),
+                ExtensionManifestRef::new(extension_id(&ext), Some(manifest_hash("sha256:abc"))),
+                vec![ExtensionCredentialBinding::new(
+                    ExtensionCredentialHandle::new("api-token").unwrap(),
+                    SecretHandle::new("secret-api-token").unwrap(),
+                )],
+                Utc::now(),
+                InstallationOwner::user(UserId::new("alice").unwrap()),
+            )
+            .unwrap();
+            store
+                .upsert_manifest_and_installation(record, installation)
+                .await
+                .unwrap();
+        }
+
+        counting.reset();
+        let listed = store.list_installations().await.unwrap();
+        assert_eq!(listed.len(), installation_count, "all installations listed");
+        // every listed aggregate is still fully reconstructed
+        for installation in &listed {
+            assert_eq!(installation.credential_bindings().len(), 1);
+            assert_eq!(installation.owner().members().unwrap().len(), 1);
+        }
+        counting.queries()
+    }
+
+    let few = queries_to_list(2).await;
+    let many = queries_to_list(8).await;
+    assert_eq!(
+        few, many,
+        "list_installations must issue a constant number of queries; \
+         got {few} for 2 installations and {many} for 8 (O(N) round trips)"
+    );
+}
+
+/// Counts `query` calls so a test can assert round-trip complexity rather
+/// than wall-clock, which is meaningless on a local disk.
+struct QueryCountingBackend {
+    inner: InMemoryBackend,
+    queries: std::sync::atomic::AtomicUsize,
+}
+
+impl QueryCountingBackend {
+    fn new(inner: InMemoryBackend) -> Self {
+        Self {
+            inner,
+            queries: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.queries.store(0, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn queries(&self) -> usize {
+        self.queries.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl RootFilesystem for QueryCountingBackend {
+    fn capabilities(&self) -> ironclaw_filesystem::BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: ironclaw_filesystem::Entry,
+        cas: CasExpectation,
+    ) -> Result<ironclaw_filesystem::RecordVersion, ironclaw_filesystem::FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Option<ironclaw_filesystem::VersionedEntry>, ironclaw_filesystem::FilesystemError>
+    {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Vec<ironclaw_filesystem::DirEntry>, ironclaw_filesystem::FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<ironclaw_filesystem::VersionedEntry>, ironclaw_filesystem::FilesystemError>
+    {
+        self.queries
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.inner.query(path, filter, page).await
+    }
+
+    async fn list_dir_bounded(
+        &self,
+        path: &VirtualPath,
+        max_entries: usize,
+    ) -> Result<Vec<ironclaw_filesystem::DirEntry>, ironclaw_filesystem::FilesystemError> {
+        self.inner.list_dir_bounded(path, max_entries).await
+    }
+
+    async fn ensure_index(
+        &self,
+        prefix: &VirtualPath,
+        spec: &ironclaw_filesystem::IndexSpec,
+    ) -> Result<(), ironclaw_filesystem::FilesystemError> {
+        self.inner.ensure_index(prefix, spec).await
+    }
+
+    async fn stat(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<ironclaw_filesystem::FileStat, ironclaw_filesystem::FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), ironclaw_filesystem::FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn begin(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Box<dyn ironclaw_filesystem::StorageTxn>, ironclaw_filesystem::FilesystemError>
+    {
+        self.inner.begin(path).await
+    }
+
+    async fn reserve_sequence(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<ironclaw_filesystem::SeqNo, ironclaw_filesystem::FilesystemError> {
+        self.inner.reserve_sequence(path).await
+    }
+}

--- a/crates/ironclaw_filesystem/src/db.rs
+++ b/crates/ironclaw_filesystem/src/db.rs
@@ -71,20 +71,6 @@ pub(crate) fn descendant_path_range(path: &VirtualPath) -> (String, String) {
     // in the normalized virtual path alphabet used by these storage paths.
     (format!("{prefix}/"), format!("{prefix}0"))
 }
-pub(crate) fn child_path_like_pattern(path: &VirtualPath) -> String {
-    let mut pattern = String::new();
-    for character in path.as_str().trim_end_matches('/').chars() {
-        match character {
-            '!' | '%' | '_' => {
-                pattern.push('!');
-                pattern.push(character);
-            }
-            _ => pattern.push(character),
-        }
-    }
-    pattern.push_str("/%");
-    pattern
-}
 pub(crate) fn not_found(path: VirtualPath, operation: FilesystemOperation) -> FilesystemError {
     FilesystemError::NotFound { path, operation }
 }

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2153,7 +2153,7 @@ mod tests {
     #[tokio::test]
     async fn record_query_seeks_the_path_index_instead_of_scanning() {
         let (fs, _dir) = fresh_backend().await;
-        let parent = VirtualPath::new("/system/extensions/.installations/v2/memberships").unwrap();
+        let parent = VirtualPath::new("/memory/extensions/.installations/v2/memberships").unwrap();
         let (prefix_lower, prefix_upper) = descendant_path_range(&parent);
         let conn = fs.connect().await.unwrap();
         for sql in [RECORD_QUERY_PREFIX_SQL, INDEXED_QUERY_PREFIX_SQL] {
@@ -2179,6 +2179,86 @@ mod tests {
                     .iter()
                     .any(|detail| detail.contains("root_filesystem_entries USING")),
                 "record query must use the path index, plan: {details:?}"
+            );
+        }
+    }
+
+    /// Differential proof that the range bounds select exactly what the
+    /// `LIKE ... ESCAPE` predicate they replaced selected. The range form is
+    /// only equivalent because '/' (0x2F) and '0' (0x30) are adjacent under
+    /// the BINARY collation `path` uses, so ["{prefix}/", "{prefix}0") is
+    /// precisely the descendant set. That argument is easy to state and easy
+    /// to get wrong, so assert it against an adversarial corpus instead:
+    /// sibling prefixes, LIKE metacharacters (`%`, `_`, and the `!` escape
+    /// itself), the boundary code points either side of '/', and multi-byte
+    /// paths. Both predicates must return identical rows for every prefix.
+    #[tokio::test]
+    async fn range_bounds_select_exactly_what_the_like_predicate_did() {
+        let (fs, _dir) = fresh_backend().await;
+        let conn = fs.connect().await.unwrap();
+        let corpus = [
+            "/memory/a",
+            "/memory/a/b",
+            "/memory/a/b/c",
+            "/memory/a/b/c/d",
+            "/memory/a/bc", // sibling whose name extends the prefix
+            "/memory/a/b-2",
+            "/memory/a/b.hidden", // '.' is 0x2E, immediately below '/'
+            "/memory/a/b0",       // '0' is 0x30, immediately above '/'
+            "/memory/a/b0/child",
+            "/memory/a/b1",
+            "/memory/ab",
+            "/memory/a%pct", // LIKE wildcard in a real path
+            "/memory/a%pct/child",
+            "/memory/a_us", // LIKE single-char wildcard
+            "/memory/a_us/child",
+            "/memory/a!bang", // the ESCAPE character itself
+            "/memory/a!bang/child",
+            "/memory/a/b/%",
+            "/memory/a/b/_",
+            "/memory/a/b/!",
+            "/memory/a/ünïcode",
+            "/memory/a/ünïcode/child",
+            "/memory/a/b/\u{10FFFF}",
+        ];
+        for path in corpus {
+            conn.execute(
+                "INSERT INTO root_filesystem_entries(path, contents, is_dir, content_type, \
+                 kind, indexed, version) VALUES (?1, X'', 0, 'application/json', NULL, '{}', 1)",
+                libsql::params![path],
+            )
+            .await
+            .unwrap();
+        }
+
+        async fn rows(conn: &libsql::Connection, sql: &str, params: Vec<String>) -> Vec<String> {
+            let params: Vec<libsql::Value> = params.into_iter().map(libsql::Value::Text).collect();
+            let mut out = Vec::new();
+            let mut rows = conn.query(sql, params).await.unwrap();
+            while let Some(row) = rows.next().await.unwrap() {
+                out.push(row.get::<String>(0).unwrap());
+            }
+            out.sort();
+            out
+        }
+
+        const LIKE_SQL: &str = "SELECT path FROM root_filesystem_entries \
+             WHERE is_dir = 0 AND (path = ?1 OR path LIKE ?2 ESCAPE '!')";
+        const RANGE_SQL: &str = "SELECT path FROM root_filesystem_entries \
+             WHERE is_dir = 0 AND (path = ?1 OR (path >= ?2 AND path < ?3))";
+
+        for prefix in corpus {
+            let vpath = VirtualPath::new(prefix).unwrap();
+            let (lower, upper) = descendant_path_range(&vpath);
+            let legacy_pattern =
+                crate::db::escape_like_with_trailing_wildcard(&format!("{prefix}/%"));
+
+            let via_like = rows(&conn, LIKE_SQL, vec![prefix.to_string(), legacy_pattern]).await;
+            let via_range = rows(&conn, RANGE_SQL, vec![prefix.to_string(), lower, upper]).await;
+
+            assert_eq!(
+                via_like, via_range,
+                "range bounds must select exactly the LIKE match set for prefix {prefix:?}"
             );
         }
     }

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -6,11 +6,10 @@ use ironclaw_host_api::VirtualPath;
 
 use crate::backend::EventRecord;
 use crate::db::{
-    child_path_like_pattern, descendant_path_range, direct_children, directory_append_error,
-    directory_write_error, escape_like_literal, escape_like_with_trailing_wildcard,
-    infrastructure_libsql_error, is_not_found, libsql_db_error, not_found, page_offset_to_i64,
-    record_version_from_i64, record_version_to_i64, sql_index_name, system_time_from_unix_seconds,
-    virtual_path_prefixes,
+    descendant_path_range, direct_children, directory_append_error, directory_write_error,
+    escape_like_literal, escape_like_with_trailing_wildcard, infrastructure_libsql_error,
+    is_not_found, libsql_db_error, not_found, page_offset_to_i64, record_version_from_i64,
+    record_version_to_i64, sql_index_name, system_time_from_unix_seconds, virtual_path_prefixes,
 };
 use crate::libsql_pool::{LibSqlPool, PooledLibSqlConnection, build_libsql_pool};
 use crate::vector::{cosine_similarity, decode_embedding_blob};
@@ -31,6 +30,19 @@ const LIBSQL_HAS_CHILD_ENTRY_SQL: &str = "SELECT 1 \
     FROM root_filesystem_entries \
     WHERE path >= ?1 AND path < ?2 \
     LIMIT 1";
+// Descendant-prefix predicates for record reads. A range over the primary key
+// seeks the path index; `LIKE ... ESCAPE` cannot use it, so the same predicate
+// degrades to a full scan of `root_filesystem_entries` whose cost grows with
+// the total row count of the database rather than with what the caller asked
+// for. `descendant_path_range` supplies the bounds: '/' sorts before '0', so
+// ["{prefix}/", "{prefix}0") is exactly the descendant set under the BINARY
+// collation these paths use -- and it needs no LIKE escaping at all.
+const RECORD_QUERY_PREFIX_SQL: &str = "SELECT path, contents, content_type, kind, indexed, version \
+     FROM root_filesystem_entries \
+     WHERE is_dir = 0 AND (path = ?1 OR (path >= ?2 AND path < ?3))";
+const INDEXED_QUERY_PREFIX_SQL: &str = "SELECT path, indexed, version \
+     FROM root_filesystem_entries \
+     WHERE is_dir = 0 AND (path = ?1 OR (path >= ?2 AND path < ?3))";
 impl LibSqlRootFilesystem {
     pub fn new(db: Arc<libsql::Database>) -> Self {
         Self {
@@ -439,13 +451,14 @@ impl RootFilesystem for LibSqlRootFilesystem {
                      SELECT path, COALESCE(json_extract(indexed, '$.{fts_key}'), '') \
                      FROM root_filesystem_entries \
                      WHERE is_dir = 0 \
-                       AND (path = ?1 OR path LIKE ?2 ESCAPE '!') \
+                       AND (path = ?1 OR (path >= ?2 AND path < ?3)) \
                        AND NOT EXISTS \
                            (SELECT 1 FROM {fts_table} WHERE {fts_table}.path = root_filesystem_entries.path)"
                 );
+                let (backfill_lower, backfill_upper) = descendant_path_range(path);
                 conn.execute(
                     &backfill,
-                    libsql::params![path_prefix, trailing_pattern.clone()],
+                    libsql::params![path_prefix, backfill_lower, backfill_upper],
                 )
                 .await
                 .map_err(|error| {
@@ -491,19 +504,14 @@ impl RootFilesystem for LibSqlRootFilesystem {
         }
         let fts_tables = self.discover_fts_tables_for_filter(path, filter).await?;
         let mut params: Vec<libsql::Value> = vec![libsql::Value::Text(path.as_str().to_string())];
-        let prefix_pattern = format!("{}/%", path.as_str());
-        params.push(libsql::Value::Text(escape_like_with_trailing_wildcard(
-            &prefix_pattern,
-        )));
+        let (prefix_lower, prefix_upper) = descendant_path_range(path);
+        params.push(libsql::Value::Text(prefix_lower));
+        params.push(libsql::Value::Text(prefix_upper));
 
         let mut conditions = String::new();
         translate_filter(path, filter, &mut conditions, &mut params, &fts_tables)?;
 
-        let mut sql = String::from(
-            "SELECT path, contents, content_type, kind, indexed, version \
-             FROM root_filesystem_entries \
-             WHERE is_dir = 0 AND (path = ?1 OR path LIKE ?2 ESCAPE '!')",
-        );
+        let mut sql = String::from(RECORD_QUERY_PREFIX_SQL);
         if !conditions.is_empty() {
             sql.push_str(" AND ");
             sql.push_str(&conditions);
@@ -773,10 +781,16 @@ impl RootFilesystem for LibSqlRootFilesystem {
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let conn = self.connect().await?;
+        // Range bounds rather than LIKE for the same reason reads use them:
+        // `root_filesystem_entries` and `_sequences` key on path and
+        // `_events` carries `idx_root_filesystem_events_path_seq`, so a
+        // subtree delete seeks each index instead of scanning every table.
+        let (prefix_lower, prefix_upper) = descendant_path_range(path);
         let deleted = conn
             .execute(
-                "DELETE FROM root_filesystem_entries WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'",
-                libsql::params![path.as_str(), child_path_like_pattern(path)],
+                "DELETE FROM root_filesystem_entries \
+                 WHERE path = ?1 OR (path >= ?2 AND path < ?3)",
+                libsql::params![path.as_str(), prefix_lower.clone(), prefix_upper.clone()],
             )
             .await
             .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
@@ -788,8 +802,9 @@ impl RootFilesystem for LibSqlRootFilesystem {
         // delete/recreate of the same thread would otherwise replay stale
         // history from the old log. Mirrors the entries-delete predicate above.
         conn.execute(
-            "DELETE FROM root_filesystem_events WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'",
-            libsql::params![path.as_str(), child_path_like_pattern(path)],
+            "DELETE FROM root_filesystem_events \
+             WHERE path = ?1 OR (path >= ?2 AND path < ?3)",
+            libsql::params![path.as_str(), prefix_lower.clone(), prefix_upper.clone()],
         )
         .await
         .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
@@ -797,8 +812,9 @@ impl RootFilesystem for LibSqlRootFilesystem {
         // a delete/recreate restarts sequences from 1 rather than resuming
         // stale state. Mirrors the entries-delete predicate above.
         conn.execute(
-            "DELETE FROM root_filesystem_sequences WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'",
-            libsql::params![path.as_str(), child_path_like_pattern(path)],
+            "DELETE FROM root_filesystem_sequences \
+             WHERE path = ?1 OR (path >= ?2 AND path < ?3)",
+            libsql::params![path.as_str(), prefix_lower.clone(), prefix_upper.clone()],
         )
         .await
         .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
@@ -1608,13 +1624,12 @@ impl LibSqlRootFilesystem {
         limit: u32,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let conn = self.connect().await?;
-        let prefix_pattern = format!("{}/%", path.as_str());
-        let escaped = escape_like_with_trailing_wildcard(&prefix_pattern);
-        let sql = "SELECT path, indexed, version \
-                   FROM root_filesystem_entries \
-                   WHERE is_dir = 0 AND (path = ?1 OR path LIKE ?2 ESCAPE '!')";
+        let (prefix_lower, prefix_upper) = descendant_path_range(path);
         let mut rows = conn
-            .query(sql, libsql::params![path.as_str(), escaped.clone()])
+            .query(
+                INDEXED_QUERY_PREFIX_SQL,
+                libsql::params![path.as_str(), prefix_lower, prefix_upper],
+            )
             .await
             .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Query, error))?;
         let mut ranked: Vec<(VirtualPath, RecordVersion, f32)> = Vec::new();
@@ -2123,6 +2138,47 @@ mod tests {
                     .iter()
                     .all(|detail| !detail.contains("SCAN root_filesystem_entries")),
                 "descendant lookup must not scan the complete path index, plan: {details:?}"
+            );
+        }
+    }
+
+    /// The record `query` path is the hot read for every domain store, and it
+    /// must seek the path index like `list_dir` already does. `LIKE ... ESCAPE`
+    /// cannot use the primary key, so the prefix predicate degrades to a full
+    /// scan of `root_filesystem_entries` -- the cost then grows with total rows
+    /// in the database (threads, turns, memory, events), independent of how
+    /// much data the caller actually asked for. That is invisible on a local
+    /// disk and dominates on network-attached storage: it took the hosted
+    /// Extensions page to ~2s across ~40 such queries per load.
+    #[tokio::test]
+    async fn record_query_seeks_the_path_index_instead_of_scanning() {
+        let (fs, _dir) = fresh_backend().await;
+        let parent = VirtualPath::new("/system/extensions/.installations/v2/memberships").unwrap();
+        let (prefix_lower, prefix_upper) = descendant_path_range(&parent);
+        let conn = fs.connect().await.unwrap();
+        for sql in [RECORD_QUERY_PREFIX_SQL, INDEXED_QUERY_PREFIX_SQL] {
+            let mut rows = conn
+                .query(
+                    &format!("EXPLAIN QUERY PLAN {sql}"),
+                    libsql::params![parent.as_str(), prefix_lower.clone(), prefix_upper.clone()],
+                )
+                .await
+                .unwrap();
+            let mut details = Vec::new();
+            while let Some(row) = rows.next().await.unwrap() {
+                details.push(row.get::<String>(3).unwrap());
+            }
+            assert!(
+                details
+                    .iter()
+                    .all(|detail| !detail.contains("SCAN root_filesystem_entries")),
+                "record query must not scan every row, plan: {details:?}"
+            );
+            assert!(
+                details
+                    .iter()
+                    .any(|detail| detail.contains("root_filesystem_entries USING")),
+                "record query must use the path index, plan: {details:?}"
             );
         }
     }


### PR DESCRIPTION
## The bug

libSQL matched descendants with `path LIKE ? ESCAPE '!'`:

```sql
WHERE is_dir = 0 AND (path = ?1 OR path LIKE ?2 ESCAPE '!')   -- SCAN root_filesystem_entries
```

`LIKE ... ESCAPE` cannot use the primary key, so **every record query, subtree delete, and FTS backfill scanned the whole `root_filesystem_entries` table**. Their cost grew with the total size of the database — threads, turns, memory, events — rather than with what the caller asked for. A page issuing tens of reads therefore got slower as the deployment accumulated *any* data, not as its own data grew.

The Postgres backend already uses `(path = $1 OR (path >= $2 AND path < $3))` at every equivalent site, and libSQL's own `list_dir` uses the same bounds via `descendant_path_range`. Only the libSQL record paths were left behind — and the hosted QA deployment runs libSQL.

## Measurements

End-to-end, identical 200k-row databases, same machine, one binary per column:

| endpoint | before | after | |
|---|---|---|---|
| `/api/webchat/v2/extensions` | 260 ms | **28 ms** | 9.3× |
| `/api/webchat/v2/extensions/registry` | 380 ms | **20 ms** | 18.8× |

That is on local NVMe. On network-attached storage each scan costs far more: on the hosted deployment the same endpoints measured ~2.1 s and ~1.4 s, against a ~100 ms network baseline (`/session`). Varying the installed-extension count there showed ~45 ms per storage query, implying ~40 queries per page load — each one a full table scan.

This is also why removals appeared to hang and left rows on screen: the UI's post-removal refetch was aborted (HTTP 499) before the server answered, so the list never refreshed until a manual reload.

## Changes

1. **Range predicates in libSQL** (`db017e1dd`) — record query, vector-candidate query, all three subtree deletes (`entries`, `events`, `sequences`; all three have a path index), and FTS backfill. `'/'` (0x2F) and `'0'` (0x30) are adjacent and `path` is BINARY-collated, so `["{prefix}/", "{prefix}0")` is exactly the descendant set. A range also needs no LIKE escaping, so this removes an escaping surface rather than adding one. Drops the now-dead `child_path_like_pattern` helper.

2. **Constant-query installation listing** (`97b6a493f`) — `list_installations` reconstructed each installation with its own membership and credential-binding reads (`1 + 2N` round trips). Both child collections are now read once and joined in memory (3 queries regardless of N). Much smaller than the scan fix — at one installed extension it changes nothing — but it removes the O(N) growth.

## Tests

Both regressions are pinned by **structure, not wall-clock**, because on a local SSD the difference is under a millisecond and any timing assertion would be both flaky and blind:

- `record_query_seeks_the_path_index_instead_of_scanning` — asserts `EXPLAIN QUERY PLAN` shows `SEARCH ... USING` and never `SCAN root_filesystem_entries`, mirroring the existing guard on the `list_dir` queries.
- `listing_installations_does_not_issue_a_query_per_installation` — asserts the query count is equal for 2 and 8 installations, via a counting filesystem decorator.

## Verification

`cargo fmt --check`, `ironclaw_filesystem` (252 tests incl. the cross-backend contract suite), `ironclaw_extensions`, `ironclaw_extension_host`, `ironclaw_threads`, `ironclaw_product`, the two Reborn integration suites, `clippy --all-targets --all-features -D warnings`, and `pre-commit-safety.sh` all pass.

`ironclaw_reborn_composition --lib` has one intermittent failure, `local_dev_runtime_safe_preview_observer_receives_bounded_payload`, which times out against a 3 s poll budget under full-suite parallelism. It is pre-existing and unrelated: it passes in isolation, passes on repeat runs of the full suite, and reproduces on `main` under equal load. This change only makes storage reads faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)