### PR TITLE
feat(signing): attested gate resolve on the capability-dispatch model

### DIFF
--- a/crates/ironclaw_attested_runtime/src/driver.rs
+++ b/crates/ironclaw_attested_runtime/src/driver.rs
@@ -325,6 +325,75 @@ pub struct BindingOwner<'a> {
     pub user_id: &'a str,
 }
 
+/// The continuation surface the resume path drives, erased over the
+/// broadcaster / ledger / signer monomorphization.
+///
+/// [`AttestedSignerContinuationDriver`] is generic over its persistence
+/// backends, so a composition that holds it concretely can only ever hold ONE
+/// backend shape — which is what pinned the runtime to the in-memory stores and
+/// kept the durable PostgreSQL / libSQL compositions unreachable. This trait is
+/// the seam that lets the runtime hold any of them behind one type.
+///
+/// Deliberately narrow: exactly the three calls the resume path makes, in the
+/// order it makes them. It is not a general handle on the driver — widening it
+/// would let callers reach past the ownership assertion into verify/broadcast.
+#[async_trait::async_trait]
+pub trait SignerContinuationDriver: Send + Sync {
+    /// Assert the caller owns the binding, BEFORE any verify / claim /
+    /// broadcast. Fails closed indistinguishably from a missing binding.
+    async fn assert_binding_owner(
+        &self,
+        gate_ref: &GateRef,
+        caller: BindingOwner<'_>,
+    ) -> Result<(), ContinuationError>;
+
+    /// Verify the proof, claim the one-shot grant, and sign. Runs BEFORE the
+    /// turn transitions, so a forged proof never reaches `AttestedResolved`.
+    async fn verify_and_sign(
+        &self,
+        gate_ref: &GateRef,
+        proof: &SigningProof,
+    ) -> Result<VerifiedContinuation, ContinuationError>;
+
+    /// Broadcast an already-verified continuation. Never re-verifies and never
+    /// re-claims — the [`VerifiedContinuation`] is the only way in.
+    async fn broadcast_signed_continuation(
+        &self,
+        verified: VerifiedContinuation,
+    ) -> Result<SignerContinuationOutcome, ContinuationError>;
+}
+
+#[async_trait::async_trait]
+impl<B, L, S> SignerContinuationDriver for AttestedSignerContinuationDriver<B, L, S>
+where
+    B: Broadcaster + Send + Sync + 'static,
+    L: SigningLedger + Send + Sync + 'static,
+    S: CustodialSignerLike + Send + Sync + 'static,
+{
+    async fn assert_binding_owner(
+        &self,
+        gate_ref: &GateRef,
+        caller: BindingOwner<'_>,
+    ) -> Result<(), ContinuationError> {
+        AttestedSignerContinuationDriver::assert_binding_owner(self, gate_ref, caller).await
+    }
+
+    async fn verify_and_sign(
+        &self,
+        gate_ref: &GateRef,
+        proof: &SigningProof,
+    ) -> Result<VerifiedContinuation, ContinuationError> {
+        AttestedSignerContinuationDriver::verify_and_sign(self, gate_ref, proof).await
+    }
+
+    async fn broadcast_signed_continuation(
+        &self,
+        verified: VerifiedContinuation,
+    ) -> Result<SignerContinuationOutcome, ContinuationError> {
+        AttestedSignerContinuationDriver::broadcast_signed_continuation(self, verified).await
+    }
+}
+
 impl<B, L, S> AttestedSignerContinuationDriver<B, L, S>
 where
     B: Broadcaster,

--- a/crates/ironclaw_attested_runtime/src/lib.rs
+++ b/crates/ironclaw_attested_runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub use device_signature::{DeviceSignatureError, signable_digest, verify_device_
 pub use driver::{
     AttestedSignerContinuationDriver, BindingOwner, BroadcastDisposition, BroadcastOutcome,
     Broadcaster, ContinuationError, CustodialSignerLike, EvmSignable, ProviderRegistry,
-    RebuildError, SignerContinuationOutcome, VerifiedContinuation,
+    RebuildError, SignerContinuationDriver, SignerContinuationOutcome, VerifiedContinuation,
 };
 pub use intent_signer::{
     InMemorySealedAgentKeyStore, SealedAgentKey, SealedAgentKeyStore, SecretsIntentSigner,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -105,6 +105,35 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
             "required": ["command"],
             "additionalProperties": false
         }),
+        // Mirrors `RequestSignatureParams` in the composition raise hook
+        // (`ironclaw_reborn_composition::attested_raise`), which is the only
+        // consumer of this body. `decoded` is left as a free-form object on
+        // purpose: it is the chain-tagged `DecodedTransaction` projection the
+        // host decoder produced upstream, and pinning its shape here would
+        // duplicate a chain-aware schema into a chain-free layer. The hook
+        // parses it strictly and fails closed (`InputEncode`) on any mismatch,
+        // so this schema guides the model without becoming a second source of
+        // truth about transaction shape.
+        "schemas/builtin/request_signature.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "provider_hint": {
+                    "type": "string",
+                    "enum": ["custodial", "injected", "near_redirect", "wallet_connect"],
+                    "description": "Which signing trust model to raise the gate for."
+                },
+                "signer_account": {
+                    "type": "string",
+                    "description": "Account the signature is requested for (lowercase hex without 0x for EVM)."
+                },
+                "decoded": {
+                    "type": "object",
+                    "description": "The server-decoded, chain-tagged transaction to be signed."
+                }
+            },
+            "required": ["provider_hint", "signer_account", "decoded"],
+            "additionalProperties": false
+        }),
         // NOTE: this schema is published by the host_runtime first-party
         // capability registry (consumed by `surface.rs::resolve_builtin_input_schema_ref`).
         // The decorator path (`ironclaw_loop_host::build_spawn_subagent_parameters_schema`)

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -489,7 +489,7 @@ impl HostRuntime for DefaultHostRuntime {
         // that `DefaultHostRuntime` maps to `AttestedSigningRequired` — the
         // same shape `ApprovalRequired` / `AuthRequired` already use (authority
         // first, typed suspension after). The kernel stays free of any
-        // attested/chain/crypto types. Tracked separately; until it lands,
+        // attested/chain/crypto types. Tracked in nearai/ironclaw#6860; until it lands,
         // `attested_raise_hook` is held but intentionally not dispatched.
 
         // Credential pre-flight and the persistent-approval re-authorize fold now

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -95,14 +95,14 @@ fn trace_capability_latency_error<E: ?Sized>(
 }
 
 use crate::{
-    AttestedRaiseHook, AttestedRaiseRequest, BuiltinObligationHandler, BuiltinObligationServices,
+    AttestedRaiseHook, BuiltinObligationHandler, BuiltinObligationServices,
     CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime,
-    HostRuntimeError, HostRuntimeHealth, HostRuntimeStatus, REQUEST_SIGNATURE_CAPABILITY_ID,
-    RuntimeApprovalGate, RuntimeApprovalResume, RuntimeAuthGate, RuntimeAuthResume,
-    RuntimeBackendHealth, RuntimeBlockedReason, RuntimeCapabilityCompleted,
-    RuntimeCapabilityFailure, RuntimeCapabilityOutcome, RuntimeGateId, RuntimeInvocation,
-    RuntimeStatusRequest, RuntimeWorkId, RuntimeWorkSummary, VisibleCapabilityRequest,
-    VisibleCapabilitySurface, obligations::secret_owner_scope, surface::CapabilityCatalog,
+    HostRuntimeError, HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate,
+    RuntimeApprovalResume, RuntimeAuthGate, RuntimeAuthResume, RuntimeBackendHealth,
+    RuntimeBlockedReason, RuntimeCapabilityCompleted, RuntimeCapabilityFailure,
+    RuntimeCapabilityOutcome, RuntimeGateId, RuntimeInvocation, RuntimeStatusRequest,
+    RuntimeWorkId, RuntimeWorkSummary, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    obligations::secret_owner_scope, surface::CapabilityCatalog,
 };
 
 /// Default production wiring for [`HostRuntime`].
@@ -462,40 +462,35 @@ impl HostRuntime for DefaultHostRuntime {
             return Err(HostRuntimeError::invalid_request(error.to_string()));
         }
 
-        // Attested-signing raise (attested-signing PR14): a `request_signature`
-        // invocation does not sign — it routes to the composition-owned raise
-        // hook, which builds + binds + seals the gate and returns
-        // `AttestedSigningRequired` (or `Failed`, fail-closed), short-circuiting
-        // before the kernel dispatch below. The capability declares
-        // `PermissionMode::Ask` and the attested gate it raises IS the
-        // human-in-the-loop boundary; the capability-surface authorization layer
-        // gates the `request_signature` dispatch before this runtime is invoked.
-        // NOTE (rebase): main moved trust/policy/credential authorization into
-        // the kernel `authorize()` fold inside `host.invoke_json`; this intercept
-        // sits before that fold, so `request_signature` does not pass the kernel
-        // authorization path — acceptable because the raise only persists a gate
-        // and seals a one-shot grant (no signing/broadcast) and fails closed.
-        if capability_id.as_str() == REQUEST_SIGNATURE_CAPABILITY_ID
-            && let Some(hook) = self.attested_raise_hook.clone()
-        {
-            let outcome = hook
-                .raise(AttestedRaiseRequest::new(
-                    capability_id.clone(),
-                    context.clone(),
-                    input.clone(),
-                ))
-                .await;
-            trace_capability_latency_ok(
-                "invoke_capability",
-                &capability_id,
-                &scope,
-                total_started_at,
-            );
-            return Ok(outcome);
-        }
-        // When `request_signature` has no raise hook wired, fall through to the
-        // fail-closed first-party handler, which refuses (never silently
-        // succeeds).
+        // NO `request_signature` INTERCEPT HERE — deliberately.
+        //
+        // An earlier revision short-circuited `request_signature` to the
+        // composition-owned raise hook at this point, before `invoke_json`
+        // below. That was a rebase artifact: authorization used to run before
+        // `invoke_capability`, and it since moved into the kernel's
+        // `authorize()` fold *inside* `invoke_json`. An intercept here
+        // therefore skipped trust classification, capability grants, runtime
+        // policy, credential pre-flight, persistent approval, and the sealed
+        // `Authorized` witness — a caller with an EMPTY grant set reached the
+        // raise hook and could mint a human-facing approval prompt for a
+        // transaction of its choosing (prompt-injection reachable). The human
+        // approval boundary still stood, but a signing capability must not
+        // depend on it as its only gate.
+        //
+        // Fail-closed for now: with no intercept, `request_signature` flows
+        // through the fold like every other capability and reaches the
+        // deliberately-refusing handler in `first_party_tools::request_signature`
+        // only if authorized. Raising is therefore unavailable rather than
+        // unauthorized.
+        //
+        // The fix is to raise as an AUTHORIZED DISPATCH RESULT: invoke the hook
+        // from the dispatcher, which already receives the sealed `Authorized`,
+        // and carry the gate back through a neutral typed "deferred" channel
+        // that `DefaultHostRuntime` maps to `AttestedSigningRequired` — the
+        // same shape `ApprovalRequired` / `AuthRequired` already use (authority
+        // first, typed suspension after). The kernel stays free of any
+        // attested/chain/crypto types. Tracked separately; until it lands,
+        // `attested_raise_hook` is held but intentionally not dispatched.
 
         // Credential pre-flight and the persistent-approval re-authorize fold now
         // run inside the capability kernel's `authorize()` fold (§5.2.7/§5.3.2),

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -87,6 +87,9 @@ async fn builtin_first_party_package_declares_expected_capabilities() {
             HTTP_CAPABILITY_ID
             | HTTP_SAVE_CAPABILITY_ID
             | SHELL_CAPABILITY_ID
+            // The raise ceremony is itself the human-in-the-loop boundary, so
+            // the capability asks before it runs.
+            | REQUEST_SIGNATURE_CAPABILITY_ID
             | SPAWN_SUBAGENT_CAPABILITY_ID
             | SKILL_INSTALL_CAPABILITY_ID
             | SKILL_UPDATE_CAPABILITY_ID
@@ -9527,6 +9530,9 @@ fn all_builtin_capability_ids() -> Vec<&'static str> {
         HTTP_CAPABILITY_ID,
         HTTP_SAVE_CAPABILITY_ID,
         SHELL_CAPABILITY_ID,
+        // Declared by the builtin package in registry order (right after
+        // `shell`), so the expected list must name it here.
+        REQUEST_SIGNATURE_CAPABILITY_ID,
         SPAWN_SUBAGENT_CAPABILITY_ID,
         TRACE_COMMONS_ONBOARD_CAPABILITY_ID,
         TRACE_COMMONS_STATUS_CAPABILITY_ID,
@@ -10265,10 +10271,30 @@ impl ironclaw_host_runtime::AttestedRaiseHook for RecordingAttestedRaiseHook {
     }
 }
 
-/// `request_signature` is routed to the injected raise hook instead of being
-/// dispatched to its (fail-closed) first-party handler.
+/// A wired raise hook is NOT dispatched from `invoke_capability`, even for an
+/// authorized caller — raising is currently unavailable by design.
+///
+/// This test used to assert the opposite. `invoke_capability` intercepted
+/// `request_signature` and called the hook directly, BEFORE `invoke_json` ran
+/// the kernel `authorize()` fold. That skipped trust classification, capability
+/// grants, runtime policy, credential pre-flight, persistent approval, and the
+/// sealed `Authorized` witness, so a caller with an empty grant set could reach
+/// the hook and mint a human-facing approval prompt for a transaction of its
+/// choosing. The intercept was removed and `request_signature` now flows
+/// through the fold like every other capability, reaching only the
+/// deliberately-refusing first-party handler.
+///
+/// The caller here IS granted the capability, which is what makes the assertion
+/// meaningful: the hook stays untouched because nothing dispatches it, not
+/// because authorization refused.
+///
+/// WHEN THE AUTHORIZED-DISPATCH REWORK LANDS, THIS TEST MUST FLIP: the hook
+/// should then be invoked from the dispatcher (which already receives the
+/// sealed `Authorized`) and this should assert `AttestedSigningRequired` plus
+/// exactly one recorded call with the params unmodified. Until then, a passing
+/// assertion here means the bypass has not returned.
 #[tokio::test]
-async fn request_signature_routes_to_the_attested_raise_hook() {
+async fn request_signature_does_not_reach_the_raise_hook_before_authorization() {
     let hook = Arc::new(RecordingAttestedRaiseHook::default());
     let runtime = HostRuntimeServices::new(
         Arc::new(registry()),
@@ -10297,17 +10323,22 @@ async fn request_signature_routes_to_the_attested_raise_hook() {
         .await
         .unwrap();
 
-    let RuntimeCapabilityOutcome::AttestedSigningRequired(gate) = outcome else {
-        panic!("expected AttestedSigningRequired, got {outcome:?}");
-    };
-    assert_eq!(gate.capability_id.as_str(), REQUEST_SIGNATURE_CAPABILITY_ID);
-    assert_eq!(gate.expected_tx_hash, "deadbeef");
+    assert!(
+        !matches!(
+            outcome,
+            RuntimeCapabilityOutcome::AttestedSigningRequired(_)
+        ),
+        "no gate may be raised from `invoke_capability`: reaching the hook here \
+         means it ran ahead of the kernel authorization fold, got {outcome:?}"
+    );
 
-    // The hook saw the raw params, unmodified, under the request_signature id.
     let seen = hook.seen.lock().unwrap().clone();
-    assert_eq!(seen.len(), 1, "the hook is called exactly once");
-    assert_eq!(seen[0].0.as_str(), REQUEST_SIGNATURE_CAPABILITY_ID);
-    assert_eq!(seen[0].1, input);
+    assert!(
+        seen.is_empty(),
+        "the raise hook must not be dispatched ahead of authorization; it was \
+         called {} time(s)",
+        seen.len()
+    );
 }
 
 /// With NO raise hook wired, `request_signature` must NOT silently succeed: it

--- a/crates/ironclaw_product/src/product_surface_inbound.rs
+++ b/crates/ironclaw_product/src/product_surface_inbound.rs
@@ -325,6 +325,19 @@ pub struct ProductResolveGateRequest {
     pub always: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_ref: Option<String>,
+    /// Attested-signing proof family for `resolution = "attested"`: one of
+    /// `injected_wallet`, `near_redirect`, `wallet_connect`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attested_proof_kind: Option<String>,
+    /// Lowercase hex of the approved-tx hash the wallet attests to. Carried as
+    /// an untrusted claim; the authoritative binding persisted at gate raise is
+    /// what the proof is actually verified against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attested_approved_tx_hash: Option<String>,
+    /// Opaque, provider-specific proof payload. Re-decoded by the continuation
+    /// port; never interpreted here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attested_proof: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -349,7 +362,9 @@ impl From<ProductCancelReason> for SanitizedCancelReason {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// `Attested` carries an opaque `serde_json::Value` proof payload, which is
+// `PartialEq` but not `Eq`; the enum therefore drops the `Eq` derive.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "resolution", rename_all = "snake_case")]
 pub enum ProductGateResolution {
     Approved {
@@ -361,10 +376,21 @@ pub enum ProductGateResolution {
     Declined,
     /// A host-stored credential reference, not a raw secret/token.
     CredentialProvided { credential_ref: String },
+    /// An external-wallet / custodial attested-signing proof for a
+    /// `BlockedAttested` gate. Validated-shape strings and JSON only — no trust
+    /// is conferred here; the continuation port verifies against the
+    /// authoritative binding.
+    Attested {
+        kind: String,
+        approved_tx_hash_hex: String,
+        proof_json: serde_json::Value,
+    },
 }
 
 /// Canonical route-independent WebUI command produced after validation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// `ResolveGate` carries a `ProductGateResolution`, whose `Attested` variant
+// holds a non-`Eq` proof payload, so this enum drops `Eq` as well.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
 pub enum ProductInboundCommand {
     CreateThread {
@@ -496,7 +522,14 @@ impl ProductResolveGateRequest {
         let thread_id = parse_thread_id(self.thread_id)?;
         let run_id = parse_run_id(self.run_id)?;
         let gate_ref = parse_gate_ref(self.gate_ref)?;
-        let resolution = parse_gate_resolution(self.resolution, self.always, self.credential_ref)?;
+        let resolution = parse_gate_resolution(
+            self.resolution,
+            self.always,
+            self.credential_ref,
+            self.attested_proof_kind,
+            self.attested_approved_tx_hash,
+            self.attested_proof,
+        )?;
 
         Ok(ProductInboundCommand::ResolveGate {
             scope: caller.turn_scope(thread_id),
@@ -577,6 +610,9 @@ fn parse_gate_resolution(
     resolution: Option<String>,
     always: Option<bool>,
     credential_ref: Option<String>,
+    attested_proof_kind: Option<String>,
+    attested_approved_tx_hash: Option<String>,
+    attested_proof: Option<serde_json::Value>,
 ) -> Result<ProductGateResolution, ProductSurfaceError> {
     let resolution = required_text("resolution", resolution, 64, TextMode::Token)?;
     match resolution.as_str() {
@@ -591,6 +627,23 @@ fn parse_gate_resolution(
                 CREDENTIAL_REF_MAX_BYTES,
                 TextMode::Token,
             )?,
+        }),
+        "attested" => Ok(ProductGateResolution::Attested {
+            kind: required_text(
+                "attested_proof_kind",
+                attested_proof_kind,
+                64,
+                TextMode::Token,
+            )?,
+            approved_tx_hash_hex: required_text(
+                "attested_approved_tx_hash",
+                attested_approved_tx_hash,
+                128,
+                TextMode::Token,
+            )?,
+            proof_json: attested_proof.ok_or_else(|| {
+                validation_error("attested_proof", ProductSurfaceValidationCode::MissingField)
+            })?,
         }),
         _ => Err(validation_error(
             "resolution",
@@ -643,4 +696,111 @@ fn validate_text_value(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod attested_resolution_tests {
+    use super::*;
+
+    fn request(resolution: &str) -> ProductResolveGateRequest {
+        ProductResolveGateRequest {
+            client_action_id: Some("client-1".to_string()),
+            thread_id: Some("thread-1".to_string()),
+            run_id: Some("11111111-1111-4111-8111-111111111111".to_string()),
+            gate_ref: Some("gate:attested-1".to_string()),
+            resolution: Some(resolution.to_string()),
+            always: None,
+            credential_ref: None,
+            attested_proof_kind: Some("injected_wallet".to_string()),
+            attested_approved_tx_hash: Some("ab".repeat(32)),
+            attested_proof: Some(serde_json::json!({ "signature": "0xdead" })),
+        }
+    }
+
+    #[test]
+    fn an_attested_resolution_parses_into_the_attested_variant() {
+        let parsed = parse_gate_resolution(
+            Some("attested".to_string()),
+            None,
+            None,
+            Some("injected_wallet".to_string()),
+            Some("ab".repeat(32)),
+            Some(serde_json::json!({ "signature": "0xdead" })),
+        )
+        .expect("attested resolution parses");
+        let ProductGateResolution::Attested {
+            kind,
+            approved_tx_hash_hex,
+            proof_json,
+        } = parsed
+        else {
+            panic!("expected the attested variant");
+        };
+        assert_eq!(kind, "injected_wallet");
+        assert_eq!(approved_tx_hash_hex, "ab".repeat(32));
+        assert_eq!(proof_json["signature"], "0xdead");
+    }
+
+    /// Every attested field is required. A partially-specified proof must be a
+    /// validation error, never a silently-defaulted claim the resolver would
+    /// then carry to the device path.
+    #[test]
+    fn a_partial_attested_resolution_is_refused() {
+        for (kind, hash, proof) in [
+            (None, Some("ab".repeat(32)), Some(serde_json::json!({}))),
+            (
+                Some("injected_wallet".to_string()),
+                None,
+                Some(serde_json::json!({})),
+            ),
+            (
+                Some("injected_wallet".to_string()),
+                Some("ab".repeat(32)),
+                None,
+            ),
+        ] {
+            assert!(
+                parse_gate_resolution(Some("attested".to_string()), None, None, kind, hash, proof)
+                    .is_err(),
+                "a partial attested resolution must fail validation"
+            );
+        }
+    }
+
+    /// The proof payload is opaque: this layer must not interpret it, so an
+    /// arbitrary JSON shape passes through untouched to the continuation port.
+    #[test]
+    fn the_proof_payload_passes_through_uninterpreted() {
+        let odd = serde_json::json!({ "nested": { "a": [1, 2, 3] }, "unknown_field": true });
+        let parsed = parse_gate_resolution(
+            Some("attested".to_string()),
+            None,
+            None,
+            Some("wallet_connect".to_string()),
+            Some("cd".repeat(32)),
+            Some(odd.clone()),
+        )
+        .expect("parses");
+        let ProductGateResolution::Attested { proof_json, .. } = parsed else {
+            panic!("expected attested");
+        };
+        assert_eq!(proof_json, odd, "the payload must not be reshaped here");
+    }
+
+    #[test]
+    fn a_non_attested_resolution_ignores_the_attested_fields() {
+        let mut req = request("declined");
+        req.resolution = Some("declined".to_string());
+        let caller = ProductSurfaceCaller::new(
+            ironclaw_host_api::TenantId::new("tenant-a").expect("tenant"),
+            ironclaw_host_api::UserId::new("alice").expect("user"),
+            None,
+            None,
+        );
+        let command = req.into_command(caller).expect("declined parses");
+        let ProductInboundCommand::ResolveGate { resolution, .. } = command else {
+            panic!("expected ResolveGate");
+        };
+        assert_eq!(resolution, ProductGateResolution::Declined);
+    }
 }

--- a/crates/ironclaw_product/src/reborn_services.rs
+++ b/crates/ironclaw_product/src/reborn_services.rs
@@ -1134,6 +1134,10 @@ impl AutomationProductService for UnsupportedAutomationProductService {
 enum GateResolutionRoute {
     Approval,
     Auth,
+    /// Attested-signing ceremony. Folded into this one resolver rather than a
+    /// parallel dispatch branch, so every gate family is classified in exactly
+    /// one place.
+    Attested,
     Generic,
 }
 
@@ -1161,6 +1165,14 @@ impl GateResolutionRoute {
                 )?;
                 Ok(Self::Auth)
             }
+            TurnStatus::BlockedAttested => {
+                validate_current_gate_ref(
+                    parked_gate_ref,
+                    requested_gate_ref,
+                    ProductSurfaceErrorKind::Conflict,
+                )?;
+                Ok(Self::Attested)
+            }
             status if status.is_terminal() => Err(ProductSurfaceError::from_status_kind(
                 ProductSurfaceErrorCode::Conflict,
                 ProductSurfaceErrorKind::Conflict,
@@ -1172,6 +1184,17 @@ impl GateResolutionRoute {
     }
 
     fn from_gate_shape(gate_ref: &GateRef, resolution: &ProductGateResolution) -> Self {
+        // An attested resolution routes to the attested resolver even when the
+        // run could not be read (e.g. a cross-user `ScopeNotFound`): that
+        // resolver performs its own owner-scoped verify-and-claim and fails
+        // closed indistinguishably from a missing gate. Falling through to
+        // `Generic` would instead reject the resolution SHAPE with a 400 and so
+        // leak that the request was attested-shaped at all — the cross-user
+        // IDOR contract.
+        if matches!(resolution, ProductGateResolution::Attested { .. }) {
+            return Self::Attested;
+        }
+
         match (
             is_approval_gate_ref(gate_ref.as_str()),
             is_auth_gate_ref(gate_ref.as_str()),
@@ -2282,6 +2305,10 @@ pub struct RebornServices<
     view_provider: V,
     thread_service: Arc<dyn SessionThreadService>,
     turn_coordinator: Arc<dyn TurnCoordinator>,
+    /// Injected, crypto-free attested-signing continuation port. When wired, an
+    /// `attested` gate resolution verifies + claims BEFORE the turn resumes,
+    /// then drives the deterministic sign + broadcast continuation.
+    attested_continuation: Option<Arc<dyn crate::AttestedGateContinuationPort>>,
     inbound_attachments: Option<Arc<dyn InboundAttachmentLander>>,
     project_filesystem: Option<Arc<dyn ProjectFilesystemReader>>,
     filesystem_browser: Option<Arc<dyn FilesystemBrowseReader>>,
@@ -2358,6 +2385,7 @@ where
             view_provider,
             thread_service,
             turn_coordinator,
+            attested_continuation: None,
             inbound_attachments: None,
             project_filesystem: None,
             filesystem_browser: None,
@@ -4356,6 +4384,17 @@ where
             )
             .await?
         {
+            GateResolutionRoute::Attested => {
+                self.resolve_attested_gate(
+                    access.scope,
+                    access.run_actor,
+                    run_id,
+                    gate_ref,
+                    client_action_id,
+                    resolution,
+                )
+                .await
+            }
             GateResolutionRoute::Approval => {
                 self.resolve_approval_gate(
                     access.scope,
@@ -5754,6 +5793,11 @@ where
         resolution: ProductGateResolution,
     ) -> Result<RebornResolveGateResponse, ProductSurfaceError> {
         let decision = match resolution {
+            ProductGateResolution::Attested { .. } => {
+                // An attested proof presented against an approval gate is a
+                // wiring fault; the attested resolver owns that family.
+                return Err(blocked_authentication_unavailable());
+            }
             ProductGateResolution::Approved { always } => {
                 if always {
                     ApprovalInteractionDecision::AlwaysAllow
@@ -5823,6 +5867,112 @@ where
         )
     }
 
+    /// Inject the attested-signing continuation port.
+    ///
+    /// Without it an `attested` resolution has nothing to verify against and is
+    /// refused — the fail-closed default, since resuming a signing turn on an
+    /// unverified proof is the one outcome this whole path exists to prevent.
+    pub fn with_attested_continuation(
+        mut self,
+        port: Arc<dyn crate::AttestedGateContinuationPort>,
+    ) -> Self {
+        self.attested_continuation = Some(port);
+        self
+    }
+
+    /// Resolve a `BlockedAttested` gate.
+    ///
+    /// Order is the contract: verify + claim the one-shot grant BEFORE the turn
+    /// transitions, resume only on success, then broadcast. A rejected proof
+    /// leaves the turn `BlockedAttested` with no state-machine mutation, so the
+    /// gate stays cleanly retryable and an unverified proof never advances a
+    /// signing turn.
+    async fn resolve_attested_gate(
+        &self,
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+        gate_ref: GateRef,
+        client_action_id: IdempotencyKey,
+        resolution: ProductGateResolution,
+    ) -> Result<RebornResolveGateResponse, ProductSurfaceError> {
+        let ProductGateResolution::Attested {
+            kind,
+            approved_tx_hash_hex,
+            proof_json,
+        } = resolution
+        else {
+            return Err(blocked_authentication_unavailable());
+        };
+        let Some(port) = self.attested_continuation.as_ref() else {
+            return Err(blocked_authentication_unavailable());
+        };
+        let kind = match kind.as_str() {
+            "injected_wallet" => crate::AttestedProofKind::InjectedWallet,
+            "near_redirect" => crate::AttestedProofKind::NearRedirect,
+            "wallet_connect" => crate::AttestedProofKind::WalletConnect,
+            _ => {
+                return Err(ProductSurfaceError::validation(
+                    "attested_proof_kind",
+                    ProductSurfaceValidationCode::InvalidValue,
+                ));
+            }
+        };
+        let claim = crate::AttestedProofClaim {
+            kind,
+            approved_tx_hash_hex: approved_tx_hash_hex.clone(),
+            proof_json,
+        };
+
+        // Verify + claim BEFORE any turn transition.
+        let verified = port
+            .verify_and_claim(&scope, &actor, run_id, &gate_ref, &claim)
+            .await
+            .map_err(map_attested_continuation_rejection)?;
+
+        let binding_id = webui_gate_binding_id(&scope, &gate_ref_string(&gate_ref));
+        let response = self
+            .turn_coordinator
+            .resume_turn(ResumeTurnRequest {
+                scope: scope.clone(),
+                actor: actor.clone(),
+                run_id,
+                gate_resolution_ref: gate_ref.clone(),
+                source_binding_ref: webui_source_binding_ref_from_raw(
+                    "webui-gate-src",
+                    &binding_id,
+                )?,
+                reply_target_binding_ref: webui_reply_target_binding_ref_from_raw(
+                    "webui-gate-reply",
+                    &binding_id,
+                )?,
+                idempotency_key: client_action_id,
+                precondition: ResumeTurnPrecondition::default(),
+                resume_disposition: None,
+                // The untrusted claim the synchronous resume-port re-check binds
+                // against the authoritative approved hash.
+                attestation: Some(
+                    ironclaw_turns::AttestationClaimRef::new(&approved_tx_hash_hex).map_err(
+                        |_| {
+                            ProductSurfaceError::validation(
+                                "attested_approved_tx_hash",
+                                ProductSurfaceValidationCode::InvalidValue,
+                            )
+                        },
+                    )?,
+                ),
+            })
+            .await
+            .map_err(map_turn_error)?;
+
+        // Signed and claimed; now broadcast. No re-verification, no re-claim.
+        port.broadcast_resolved(&scope, run_id, &gate_ref, verified)
+            .await
+            .map_err(map_attested_continuation_rejection)?;
+
+        Ok(RebornResolveGateResponse::Resumed(response.into()))
+    }
+
     async fn resolve_auth_gate(
         &self,
         scope: TurnScope,
@@ -5841,6 +5991,11 @@ where
             }
             ProductGateResolution::Declined => AuthInteractionDecision::Deny,
             ProductGateResolution::Approved { .. } => {
+                return Err(blocked_authentication_unavailable());
+            }
+            ProductGateResolution::Attested { .. } => {
+                // An attested proof presented against an auth gate is a wiring
+                // fault, not a caller-resolvable state.
                 return Err(blocked_authentication_unavailable());
             }
         };
@@ -5876,6 +6031,13 @@ where
         resolution: ProductGateResolution,
     ) -> Result<RebornResolveGateResponse, ProductSurfaceError> {
         match resolution {
+            ProductGateResolution::Attested { .. } => {
+                // The generic fallback has only one-shot `resume_turn`; an
+                // attested gate needs verify-and-claim BEFORE the turn moves.
+                // Refusing here rather than resuming is what stops an
+                // unverified proof advancing a signing turn.
+                Err(blocked_authentication_unavailable())
+            }
             ProductGateResolution::Approved { always } => {
                 reject_generic_auth_gate_resolution(self.turn_coordinator.as_ref(), &scope, run_id)
                     .await?;
@@ -6511,6 +6673,30 @@ fn blocked_approval_unavailable() -> ProductSurfaceError {
     persistent_approval_unavailable()
 }
 
+/// Map a sanitized continuation rejection onto the product error surface.
+///
+/// Every rejection collapses to one of two shapes on purpose. A caller must not
+/// be able to tell a missing binding from a forged proof from an
+/// already-claimed grant — that distinction is an oracle for which gates exist
+/// and which have been driven. Backend unavailability is the one case that is
+/// genuinely the server's fault and is reported as such.
+fn map_attested_continuation_rejection(
+    rejection: crate::AttestedContinuationRejection,
+) -> ProductSurfaceError {
+    use crate::AttestedContinuationRejection as R;
+    match rejection {
+        R::Unavailable | R::BackendUnavailable => {
+            ProductSurfaceError::internal_from("attested-signing continuation is unavailable")
+        }
+        R::MissingBinding
+        | R::ProviderMismatch
+        | R::ProofRejected
+        | R::LedgerGuard
+        | R::MalformedProof
+        | R::ContextMismatch => blocked_authentication_unavailable(),
+    }
+}
+
 fn blocked_authentication_unavailable() -> ProductSurfaceError {
     ProductSurfaceError::from_status_kind(
         ProductSurfaceErrorCode::Unavailable,
@@ -7006,5 +7192,80 @@ mod tests {
             !unavailable.retryable,
             "false-arg sentinel is non-retryable"
         );
+    }
+}
+
+#[cfg(test)]
+mod attested_route_tests {
+    use super::*;
+
+    fn attested() -> ProductGateResolution {
+        ProductGateResolution::Attested {
+            kind: "injected_wallet".to_string(),
+            approved_tx_hash_hex: "ab".repeat(32),
+            proof_json: serde_json::json!({}),
+        }
+    }
+
+    /// The cross-user IDOR contract. When the run cannot be read — which is
+    /// what a cross-user request looks like — an attested resolution must still
+    /// route to the attested resolver, because that resolver runs its own
+    /// owner-scoped check and fails closed indistinguishably from a missing
+    /// gate. Falling through to `Generic` would reject the resolution SHAPE and
+    /// so confirm the request was attested-shaped at all.
+    #[test]
+    fn an_attested_resolution_routes_to_the_attested_resolver_even_without_run_state() {
+        let gate = GateRef::new("gate:not-an-approval-or-auth-shape").expect("gate ref");
+        assert!(matches!(
+            GateResolutionRoute::from_gate_shape(&gate, &attested()),
+            GateResolutionRoute::Attested
+        ));
+    }
+
+    /// Even a gate ref shaped like an approval gate must not divert an attested
+    /// resolution into the approval resolver, which would resume the turn
+    /// without verifying the proof.
+    #[test]
+    fn gate_ref_shape_cannot_divert_an_attested_resolution() {
+        for raw in ["gate:approval-abc", "gate:auth-abc", "gate:whatever"] {
+            let gate = GateRef::new(raw).expect("gate ref");
+            assert!(
+                matches!(
+                    GateResolutionRoute::from_gate_shape(&gate, &attested()),
+                    GateResolutionRoute::Attested
+                ),
+                "{raw} must not divert an attested resolution"
+            );
+        }
+    }
+
+    /// A BlockedAttested turn classifies to the attested resolver.
+    #[test]
+    fn a_blocked_attested_turn_routes_to_the_attested_resolver() {
+        let gate = GateRef::new("gate:attested-1").expect("gate ref");
+        let route = GateResolutionRoute::from_run_state(
+            TurnStatus::BlockedAttested,
+            Some(&gate),
+            &gate,
+            &attested(),
+        )
+        .expect("classifies");
+        assert!(matches!(route, GateResolutionRoute::Attested));
+    }
+
+    /// Non-attested resolutions keep their existing routes — the new variant
+    /// must not capture traffic that belongs elsewhere.
+    #[test]
+    fn non_attested_resolutions_keep_their_routes() {
+        let approval = GateRef::new("gate:approval-abc").expect("gate ref");
+        assert!(matches!(
+            GateResolutionRoute::from_gate_shape(&approval, &ProductGateResolution::Declined),
+            GateResolutionRoute::Approval
+        ));
+        let auth = GateRef::new("gate:auth-abc").expect("gate ref");
+        assert!(matches!(
+            GateResolutionRoute::from_gate_shape(&auth, &ProductGateResolution::Declined),
+            GateResolutionRoute::Auth
+        ));
     }
 }

--- a/crates/ironclaw_product/tests/product_surface_inbound_contract.rs
+++ b/crates/ironclaw_product/tests/product_surface_inbound_contract.rs
@@ -407,6 +407,9 @@ fn invalid_gate_resolution_returns_stable_validation_error() {
         resolution: Some("not_a_resolution".to_string()),
         always: None,
         credential_ref: None,
+        attested_proof_kind: None,
+        attested_approved_tx_hash: None,
+        attested_proof: None,
     };
 
     let err = request

--- a/crates/ironclaw_reborn_composition/src/attested.rs
+++ b/crates/ironclaw_reborn_composition/src/attested.rs
@@ -80,11 +80,6 @@ pub(crate) type ComposedCustodialSigner<G, L> = CustodialSigner<SecretsKeyStore,
 pub(crate) type ComposedContinuationDriver<B, G, L> =
     AttestedSignerContinuationDriver<B, L, ComposedCustodialSigner<G, L>>;
 
-/// The local-dev / test monomorphization of [`RebornAttestedComposition`] the
-/// `RebornRuntime` holds (in-memory stores + no-op broadcaster).
-pub(crate) type InMemoryContinuationDriver =
-    ComposedContinuationDriver<NoopBroadcaster, InMemorySealedGrantStore, InMemorySigningLedger>;
-
 pub type InMemoryAttestedComposition =
     RebornAttestedComposition<NoopBroadcaster, InMemorySealedGrantStore, InMemorySigningLedger>;
 
@@ -135,6 +130,48 @@ impl Broadcaster for NoopBroadcaster {
 ///
 /// Generic over the durable-vs-in-memory grant store `G`, ledger `L`, and
 /// broadcaster `B`.
+/// The attested-signing graph, erased over its persistence backends.
+///
+/// [`RebornAttestedComposition`] is generic over broadcaster / grant store /
+/// ledger, so naming it concretely pins a holder to exactly one backend shape.
+/// That is why `RebornRuntime` could only ever hold the in-memory
+/// monomorphization, leaving the durable PostgreSQL and libSQL compositions
+/// assembled-but-unreachable. Holding this trait instead lets the runtime carry
+/// whichever backend the deployment configured.
+///
+/// The surface is the two handles the product layer needs — the authoritative
+/// bindings and the continuation driver — and nothing else. Raise-path methods
+/// stay off it deliberately: the raise hook holds the concrete composition, so
+/// widening this to `register_attested_gate` would hand every holder of the
+/// erased graph the ability to seal grants.
+#[async_trait::async_trait]
+pub trait AttestedComposition: Send + Sync {
+    /// The authoritative gate-binding store. The same store the driver reads,
+    /// so a caller-supplied identity can be checked against what the raiser
+    /// recorded.
+    fn bindings(&self) -> &Arc<dyn AttestedGateBindingStore>;
+
+    /// The signer-continuation driver, itself erased over its backends.
+    fn driver(&self) -> Arc<dyn ironclaw_attested_runtime::SignerContinuationDriver>;
+}
+
+#[async_trait::async_trait]
+impl<B, G, L> AttestedComposition for RebornAttestedComposition<B, G, L>
+where
+    B: Broadcaster + Send + Sync + 'static,
+    G: SealedGrantStore + Send + Sync + 'static,
+    L: SigningLedger + Send + Sync + 'static,
+    ComposedCustodialSigner<G, L>: ironclaw_attested_runtime::CustodialSignerLike,
+{
+    fn bindings(&self) -> &Arc<dyn AttestedGateBindingStore> {
+        &self.bindings
+    }
+
+    fn driver(&self) -> Arc<dyn ironclaw_attested_runtime::SignerContinuationDriver> {
+        Arc::clone(&self.driver) as Arc<dyn ironclaw_attested_runtime::SignerContinuationDriver>
+    }
+}
+
 pub struct RebornAttestedComposition<B, G, L>
 where
     B: Broadcaster + 'static,

--- a/crates/ironclaw_reborn_composition/src/attested.rs
+++ b/crates/ironclaw_reborn_composition/src/attested.rs
@@ -33,7 +33,7 @@ use ironclaw_attestation::{
 use ironclaw_attested_runtime::{
     AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver, BindingError,
     BindingKey, BroadcastOutcome, Broadcaster, ContinuationError, InMemoryAttestedGateBindingStore,
-    ProviderRegistry,
+    ProviderRegistry, SyncBindingRead,
 };
 use ironclaw_chain_signing::{CustodialSigner, DenyFirstCustodyPolicy, SecretsKeyStore, ShipGate};
 use ironclaw_signing_provider::{GateRef, SigningContext};
@@ -153,6 +153,22 @@ pub trait AttestedComposition: Send + Sync {
 
     /// The signer-continuation driver, itself erased over its backends.
     fn driver(&self) -> Arc<dyn ironclaw_attested_runtime::SignerContinuationDriver>;
+
+    /// Whether this graph's broadcaster actually submits to a chain.
+    ///
+    /// The in-memory fallback wires the [`NoopBroadcaster`], which signs and
+    /// deliberately never submits (the driver then leaves the ledger at
+    /// `Signed` and reports `NotBroadcast`, so a dry run can never be mistaken
+    /// for a real broadcast). A durable deployment wires the real per-chain
+    /// broadcaster. Exposed because "signed but silently never broadcast" is
+    /// the one failure this path cannot detect from the outside.
+    fn broadcasts(&self) -> bool;
+
+    /// The sync view of the SAME binding store, for the resume port. Exposed
+    /// here so the port is built from the composition rather than from a
+    /// separately-constructed store -- which is what keeps the port from
+    /// admitting a resume the driver cannot verify.
+    fn sync_bindings(&self) -> Arc<dyn SyncBindingRead>;
 }
 
 #[async_trait::async_trait]
@@ -170,6 +186,14 @@ where
     fn driver(&self) -> Arc<dyn ironclaw_attested_runtime::SignerContinuationDriver> {
         Arc::clone(&self.driver) as Arc<dyn ironclaw_attested_runtime::SignerContinuationDriver>
     }
+
+    fn sync_bindings(&self) -> Arc<dyn SyncBindingRead> {
+        Arc::clone(&self.sync_bindings)
+    }
+
+    fn broadcasts(&self) -> bool {
+        self.broadcasts
+    }
 }
 
 pub struct RebornAttestedComposition<B, G, L>
@@ -179,6 +203,13 @@ where
     L: SigningLedger + 'static,
 {
     bindings: Arc<dyn AttestedGateBindingStore>,
+    /// The SAME binding store as `bindings`, kept as its sync view so the
+    /// resume port can read inside the turn store's non-blocking critical
+    /// section. Never a second store -- `assemble` derives both from one value.
+    sync_bindings: Arc<dyn SyncBindingRead>,
+    /// Captured from the broadcaster at assembly time, so the selected backend
+    /// is observable without reaching into the driver.
+    broadcasts: bool,
     /// Shared sealed-grant store. Held so `register_attested_gate` (the raise
     /// path) seals into the SAME store the driver's custodial signer claims from
     /// — the one-shot CAS is authoritative across raise and continuation.
@@ -206,15 +237,29 @@ where
     // driver; needs an AttestedSigningServices bundle,
     // plan docs/plans/2026-05-23-attested-signing-substrate.md
     #[allow(clippy::too_many_arguments)]
-    pub fn assemble(
-        bindings: Arc<dyn AttestedGateBindingStore>,
+    /// Takes the binding store **typed** rather than as two erased handles.
+    ///
+    /// The composition needs two views of it: the async
+    /// [`AttestedGateBindingStore`] the driver reads, and the sync
+    /// [`SyncBindingRead`] the resume port reads inside the turn store's
+    /// non-blocking critical section. Deriving both from one concrete value
+    /// makes them the same object by construction — two parameters could be
+    /// handed different stores, and a resume port that admits a gate the driver
+    /// cannot verify is exactly the divergence this path must not have.
+    pub fn assemble<Bind>(
+        bindings: Arc<Bind>,
         keystore: Arc<SecretsKeyStore>,
         ship_gate: ShipGate,
         grants: Arc<G>,
         ledger: Arc<L>,
         broadcaster: Arc<B>,
         providers: ProviderRegistry,
-    ) -> Self {
+    ) -> Self
+    where
+        Bind: AttestedGateBindingStore + SyncBindingRead + 'static,
+    {
+        let sync_bindings = Arc::clone(&bindings) as Arc<dyn SyncBindingRead>;
+        let bindings = bindings as Arc<dyn AttestedGateBindingStore>;
         let custodial_signer = Arc::new(CustodialSigner::new(
             keystore,
             Arc::clone(&grants),
@@ -222,6 +267,7 @@ where
             ship_gate,
             Arc::new(DenyFirstCustodyPolicy),
         ));
+        let broadcasts = broadcaster.submits();
         let driver = Arc::new(AttestedSignerContinuationDriver::new(
             Arc::clone(&bindings),
             providers,
@@ -231,6 +277,8 @@ where
         ));
         Self {
             bindings,
+            sync_bindings,
+            broadcasts,
             grants,
             driver,
         }
@@ -336,7 +384,7 @@ impl RebornAttestedComposition<NoopBroadcaster, InMemorySealedGrantStore, InMemo
     ) -> Self {
         let ledger = Arc::new(InMemorySigningLedger::new());
         Self::assemble(
-            bindings as Arc<dyn AttestedGateBindingStore>,
+            bindings,
             keystore,
             ship_gate,
             grants,

--- a/crates/ironclaw_reborn_composition/src/attested_config.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_config.rs
@@ -487,8 +487,12 @@ impl AttestedProvidersConfig {
 /// returned string is the raw (un-trimmed) value so the validated constructors
 /// can apply their own trimming + checks.
 pub(crate) fn present_env(key: &str) -> Option<String> {
-    match std::env::var(key) {
-        Ok(value) if !value.trim().is_empty() => Some(value),
+    // Reads through the shared runtime-env seam rather than `std::env::var`
+    // directly, so attested config honours the same override mechanism as the
+    // rest of the composition — and so tests can drive backend selection
+    // without `set_var` (this crate forbids unsafe).
+    match ironclaw_common::env_helpers::env_or_override(key) {
+        Some(value) if !value.trim().is_empty() => Some(value),
         _ => None,
     }
 }

--- a/crates/ironclaw_reborn_composition/src/attested_continuation.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_continuation.rs
@@ -51,14 +51,12 @@ use ironclaw_wallet_external::{
 };
 use serde::Deserialize;
 
-use crate::attested::{InMemoryAttestedComposition, InMemoryContinuationDriver};
-
 /// Composition-layer [`AttestedGateContinuationPort`].
 ///
 /// Holds the assembled signer-continuation driver shared with the reborn
 /// runtime (the same driver + binding store + ledger the resume port reads).
 pub struct RebornAttestedContinuation {
-    driver: Arc<InMemoryContinuationDriver>,
+    driver: Arc<dyn ironclaw_attested_runtime::SignerContinuationDriver>,
     /// The same authoritative gate-binding store the driver reads. Held here so
     /// this port can assert the caller-supplied turn scope / run / gate_ref
     /// against the persisted `binding.context` BEFORE claiming the grant /
@@ -119,9 +117,13 @@ impl RebornAttestedContinuation {
     }
 
     /// Build the port over the runtime's attested-signing composition.
-    pub fn new(composition: &InMemoryAttestedComposition) -> Self {
+    ///
+    /// Takes the composition erased, so this port works over the in-memory
+    /// graph and the durable PostgreSQL / libSQL ones alike -- the persistence
+    /// backend is not something the resume path should be able to observe.
+    pub fn new(composition: &Arc<dyn crate::attested::AttestedComposition>) -> Self {
         Self {
-            driver: Arc::clone(composition.driver()),
+            driver: composition.driver(),
             bindings: Arc::clone(composition.bindings()),
             intents: None,
         }

--- a/crates/ironclaw_reborn_composition/src/attested_durable.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_durable.rs
@@ -259,7 +259,7 @@ mod libsql_assembly {
         );
 
         Ok(RebornAttestedComposition::assemble(
-            bindings as Arc<dyn ironclaw_attested_runtime::AttestedGateBindingStore>,
+            bindings,
             custody.keystore,
             custody.ship_gate,
             grants,
@@ -330,7 +330,7 @@ mod postgres_assembly {
         );
 
         Ok(RebornAttestedComposition::assemble(
-            bindings as Arc<dyn ironclaw_attested_runtime::AttestedGateBindingStore>,
+            bindings,
             custody.keystore,
             custody.ship_gate,
             grants,

--- a/crates/ironclaw_reborn_composition/src/attested_raise.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_raise.rs
@@ -60,6 +60,13 @@ use ironclaw_attestation::{
 
 use crate::attested::RebornAttestedComposition;
 
+/// Env var holding the base URL the signature-review link is built on.
+///
+/// Server-fixed config, never a request value: the minted token is appended to
+/// this base, so an attacker who could influence it would control where an
+/// approver is sent to authorize a signature.
+pub const INTENT_REVIEW_URL_BASE_ENV: &str = "ATTESTED_INTENT_REVIEW_URL_BASE";
+
 /// Everything the raise needs to mint, sign, and persist a [`SignedIntent`]
 /// alongside the gate (§B3).
 ///

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1594,14 +1594,187 @@ where
 /// The stores are in-memory, which is fail-closed rather than merely
 /// non-durable: grants, claims, and bindings share a lifetime, so a restart
 /// drops a pending gate entirely (it can no longer be resolved) instead of
-/// leaving a resolvable grant whose claim record was lost. Swapping in the
-/// durable backends assembled by [`crate::attested_durable`] additionally
-/// requires erasing `RebornRuntime.attested_signing` behind a trait — it is
-/// typed to the in-memory monomorphization today — which is its own change.
+/// leaving a resolvable grant whose claim record was lost.
+///
+/// This is the fallback shape. When the deployment configured a durable
+/// backend AND chain RPC endpoints, [`build_attested_graph`] selects the
+/// durable composition instead.
 ///
 /// Present-but-invalid provider config is a hard startup error, not a weakened
 /// verifier; absent config leaves a provider unregistered and therefore
 /// fail-closed (`ProviderMismatch`).
+/// The assembled attested-signing graph plus the two things the runtime wires
+/// off it.
+///
+/// Bundled because the raise hook can only be built where the composition's
+/// CONCRETE backend types are still known — the erased
+/// [`AttestedComposition`](crate::attested::AttestedComposition) deliberately
+/// does not expose `register_attested_gate`, so nothing downstream of backend
+/// selection could construct the hook. Selecting the backend and building the
+/// hook therefore happen in the same place.
+struct AttestedGraph {
+    /// The graph, erased over its persistence backends.
+    composition: Arc<dyn crate::attested::AttestedComposition>,
+    /// Routes `request_signature` to the raise path.
+    raise_hook: Arc<dyn ironclaw_host_runtime::AttestedRaiseHook>,
+    /// The intent store the raise hook mints review links into. The SAME
+    /// instance, so the continuation port's lifecycle projection finds the
+    /// intent it settles.
+    intents: Arc<dyn ironclaw_attestation::IntentStore>,
+}
+
+/// Finish a graph from a concrete composition: erase it, build the raise hook
+/// against it, and surface the intent store.
+fn finish_attested_graph<B, G, L>(
+    composition: crate::attested::RebornAttestedComposition<B, G, L>,
+    minting: crate::attested_raise::IntentMinting,
+) -> AttestedGraph
+where
+    B: ironclaw_attested_runtime::Broadcaster + Send + Sync + 'static,
+    G: ironclaw_attestation::SealedGrantStore + Send + Sync + 'static,
+    L: ironclaw_attestation::SigningLedger + Send + Sync + 'static,
+    crate::attested::RebornAttestedComposition<B, G, L>: crate::attested::AttestedComposition,
+{
+    let intents = Arc::clone(minting.intents());
+    let composition = Arc::new(composition);
+    let raise_hook: Arc<dyn ironclaw_host_runtime::AttestedRaiseHook> = Arc::new(
+        crate::attested_raise::RebornAttestedRaiseHook::new(Arc::clone(&composition))
+            .with_intent_minting(minting),
+    );
+    AttestedGraph {
+        composition: composition as Arc<dyn crate::attested::AttestedComposition>,
+        raise_hook,
+        intents,
+    }
+}
+
+/// Dispatch durable assembly on the configured database backend.
+///
+/// Mirrors every other reborn store: backend choice follows the configured
+/// database, and both arms build the identical security envelope (shared
+/// sealed-grant store for the one-shot CAS, shared signing ledger for the
+/// broadcast-idempotency guard) — only the persistence differs.
+#[cfg(all(
+    feature = "attested-broadcast",
+    any(feature = "libsql", feature = "postgres")
+))]
+async fn assemble_durable_attested(
+    backend: &DurableBackend,
+    custody: crate::attested_durable::DurableCustody,
+    endpoints: ironclaw_attested_store::ChainRpcEndpoints,
+    providers: crate::attested_config::AttestedProvidersConfig,
+    minting: crate::attested_raise::IntentMinting,
+) -> Result<AttestedGraph, RebornBuildError> {
+    let to_build_error =
+        |error: ironclaw_attested_runtime::ContinuationError| RebornBuildError::InvalidConfig {
+            reason: format!("durable attested composition: {error}"),
+        };
+    match backend {
+        #[cfg(feature = "libsql")]
+        DurableBackend::LibSql(db) => {
+            let composition = crate::attested_durable::assemble_libsql(
+                Arc::clone(db),
+                custody,
+                endpoints,
+                providers,
+            )
+            .await
+            .map_err(to_build_error)?;
+            Ok(finish_attested_graph(composition, minting))
+        }
+        #[cfg(feature = "postgres")]
+        DurableBackend::Postgres(pool) => {
+            let composition = crate::attested_durable::assemble_postgres(
+                pool.clone(),
+                custody,
+                endpoints,
+                providers,
+            )
+            .await
+            .map_err(to_build_error)?;
+            Ok(finish_attested_graph(composition, minting))
+        }
+        // Reachable only when the build carries `attested-broadcast` but not the
+        // matching backend feature. Fail closed rather than silently composing a
+        // different graph than the deployment configured.
+        #[allow(unreachable_patterns)]
+        _ => Err(RebornBuildError::InvalidConfig {
+            reason: "durable attested signing requires the matching database backend feature"
+                .to_string(),
+        }),
+    }
+}
+
+/// Select and assemble the attested-signing graph for this deployment.
+///
+/// Durable when the deployment supplies a database handle AND the build carries
+/// the `attested-broadcast` feature AND at least one chain RPC endpoint is
+/// configured; in-memory otherwise. All three are required together because a
+/// durable graph without a broadcaster would persist grants for signatures it
+/// can never submit — durable bookkeeping around a dead end.
+///
+/// Selection is fail-closed in the direction that matters: an unconfigured
+/// chain family cannot broadcast (the `MultiChainBroadcaster` errors) and an
+/// unconfigured provider stays unregistered (`ProviderMismatch`). Falling back
+/// to in-memory never *weakens* a check — it narrows durability, and a restart
+/// then drops pending gates entirely rather than leaving them half-resolvable.
+///
+/// ## Custodial keys are process-scoped even on the durable path
+///
+/// The durable path takes the same freshly-minted custodial keystore as the
+/// in-memory one, so custodial keys do not survive a restart while grants,
+/// ledger rows, and bindings do. That is deliberate rather than overlooked:
+/// custodial mainnet signing is already refused without a KMS backend
+/// (threat #18), so the durable path exists for the **external-wallet**
+/// ceremonies (Ledger and friends), which hold no key here at all. Wiring a
+/// durable custodial keystore means wiring KMS, which is its own change.
+async fn build_attested_graph(
+    backend: &Option<DurableBackend>,
+) -> Result<AttestedGraph, RebornBuildError> {
+    let minting = build_intent_minting()?;
+
+    // A build without `attested-broadcast` (or without a database backend
+    // feature) has no durable graph to select, so the handle goes unread.
+    #[cfg(not(all(
+        feature = "attested-broadcast",
+        any(feature = "libsql", feature = "postgres")
+    )))]
+    let _ = backend;
+
+    #[cfg(all(
+        feature = "attested-broadcast",
+        any(feature = "libsql", feature = "postgres")
+    ))]
+    if let Some(backend) = backend.as_ref() {
+        use ironclaw_chain_signing::SecretsKeyStore;
+        use ironclaw_secrets::SecretsCrypto;
+
+        let endpoints = crate::attested_durable::chain_rpc_endpoints_from_env();
+        // At least one chain family must be reachable. With none configured a
+        // durable graph could seal grants it can never broadcast, so fall
+        // through to in-memory rather than persist a dead end.
+        if endpoints.evm.is_some() || endpoints.solana.is_some() || endpoints.near.is_some() {
+            let custody = crate::attested_durable::DurableCustody::from_keystore(Arc::new(
+                SecretsKeyStore::new(SecretsCrypto::generate()),
+            ));
+            let providers =
+                crate::attested_config::AttestedProvidersConfig::from_env().map_err(|error| {
+                    RebornBuildError::InvalidConfig {
+                        reason: format!("attested provider config: {error}"),
+                    }
+                })?;
+            return assemble_durable_attested(backend, custody, endpoints, providers, minting)
+                .await;
+        }
+    }
+
+    let bindings = Arc::new(ironclaw_attested_runtime::InMemoryAttestedGateBindingStore::new());
+    Ok(finish_attested_graph(
+        build_attested_composition(bindings)?,
+        minting,
+    ))
+}
+
 fn build_attested_composition(
     bindings: Arc<ironclaw_attested_runtime::InMemoryAttestedGateBindingStore>,
 ) -> Result<crate::attested::InMemoryAttestedComposition, RebornBuildError> {
@@ -3851,6 +4024,10 @@ async fn build_local_storage_production_shaped(
             ironclaw_reborn_event_store::RebornEventStoreConfig::PostgresPool { pool: pool.clone() }
         }
     };
+    // Captured before the bundle is partially moved below. The attested graph
+    // rides the SAME database handle as every other reborn store rather than
+    // opening a second one to the same file.
+    let attested_backend = Some(filesystem_bundle.durable_backend);
     let filesystem = filesystem_bundle.filesystem;
     context.workspace_filesystems = Some(build_workspace_filesystems(
         Arc::clone(&filesystem),
@@ -3882,6 +4059,7 @@ async fn build_local_storage_production_shaped(
         context,
         stores,
         trigger_repository,
+        attested_backend,
         match refresh_lock_pool {
             Some(pool) => ironclaw_auth::CredentialRefreshLeaderLock::for_postgres(pool),
             None => ironclaw_auth::CredentialRefreshLeaderLock::always_leader_for_single_writer(),
@@ -4523,6 +4701,10 @@ async fn build_backend_production(
     context: RebornProductionBuildContext,
     stores: ProductionStoreBundle,
     trigger_repository: Arc<dyn TriggerRepository>,
+    // The deployment's database handle, when it has one, so the attested graph
+    // can persist grants / ledger / bindings on the same backend as every other
+    // reborn store. `None` composes the in-memory graph.
+    attested_backend: Option<DurableBackend>,
     // Leader lock for the background credential keepalive worker. The worker
     // uses this to elect one process per tick as the sweep leader. `None`
     // pool → always-leader (libsql / single-process). Stays private.
@@ -4703,19 +4885,15 @@ async fn build_backend_production(
         broadcast_budget_event_sink,
         ..
     } = build_budget_sinks();
-    // Attested-signing graph. The binding store is created HERE, before both
-    // the composition and the resume port, because both must read the same
-    // authoritative bindings: the driver verifies against the binding recorded
-    // when the gate was raised, and the resume port admits a resume only for a
-    // binding it can see. Two stores would let a gate be resumed that the
-    // driver cannot verify.
-    let attested_bindings =
-        Arc::new(ironclaw_attested_runtime::InMemoryAttestedGateBindingStore::new());
-    let attested_signing = Arc::new(build_attested_composition(Arc::clone(&attested_bindings))?);
-    let intent_minting = build_intent_minting()?;
+    // Attested-signing graph. Durable when the deployment configured one,
+    // in-memory otherwise; either way the resume port is built FROM the
+    // composition, so it reads the very binding store the driver verifies
+    // against. A separately-constructed store could let a gate be resumed that
+    // the driver cannot verify.
+    let attested_graph = build_attested_graph(&attested_backend).await?;
     let attested_resume_port: Arc<dyn AttestedResumePort> =
         Arc::new(ironclaw_attested_runtime::RuntimeAttestedResumePort::new(
-            Arc::clone(&attested_bindings) as Arc<dyn ironclaw_attested_runtime::SyncBindingRead>,
+            attested_graph.composition.sync_bindings(),
             Arc::new(ironclaw_attested_runtime::InMemoryResumeGuard::new()),
         ));
     let turn_state = Arc::new(production_turn_state_store(
@@ -5641,10 +5819,7 @@ async fn build_backend_production(
     // it the invocation falls through to the deliberately fail-closed handler
     // in `first_party_tools::request_signature`, so no gate is ever raised and
     // the entire attested path is unreachable from the agent loop.
-    let attested_raise_hook: Arc<dyn ironclaw_host_runtime::AttestedRaiseHook> = Arc::new(
-        crate::attested_raise::RebornAttestedRaiseHook::new(Arc::clone(&attested_signing))
-            .with_intent_minting(intent_minting.clone()),
-    );
+    let attested_raise_hook = Arc::clone(&attested_graph.raise_hook);
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> = if uses_local_host_runtime {
         Arc::new(services.host_runtime_for_local_testing())
     } else {
@@ -5659,8 +5834,8 @@ async fn build_backend_production(
         // The attested graph and its intent store are handed over together:
         // `product_surface` registers the attested continuation only when both
         // are present, so a half-wired pair yields no attested surface at all.
-        intent_store: Some(Arc::clone(intent_minting.intents())),
-        attested_signing: Some(attested_signing),
+        intent_store: Some(Arc::clone(&attested_graph.intents)),
+        attested_signing: Some(Arc::clone(&attested_graph.composition)),
         host_runtime,
         #[cfg(test)]
         turn_coordinator,
@@ -5752,6 +5927,7 @@ async fn finish_production_backend(
     context: RebornProductionBuildContext,
     filesystem: Arc<CompositeRootFilesystem>,
     trigger_repository: Arc<dyn TriggerRepository>,
+    attested_backend: Option<DurableBackend>,
     secret_master_key: ironclaw_secrets::SecretMaterial,
     event_store_config: ironclaw_reborn_event_store::RebornEventStoreConfig,
     leader_lock: ironclaw_auth::CredentialRefreshLeaderLock,
@@ -5764,7 +5940,14 @@ async fn finish_production_backend(
         event_store_config,
     )
     .await?;
-    build_backend_production(context, stores, trigger_repository, leader_lock).await
+    build_backend_production(
+        context,
+        stores,
+        trigger_repository,
+        attested_backend,
+        leader_lock,
+    )
+    .await
 }
 
 async fn build_libsql_production(
@@ -5780,6 +5963,9 @@ async fn build_libsql_production(
     ensure_libsql_resource_governor_authority_for_build(process_local_resource_governor_singleton)?;
     let database_filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&db)));
     database_filesystem.run_migrations().await?;
+    // Cloned before `db` is moved into the trigger repository: the attested
+    // graph shares the deployment's libSQL handle.
+    let attested_backend = Some(DurableBackend::LibSql(Arc::clone(&db)));
     let trigger_repository = Arc::new(ironclaw_triggers::LibSqlTriggerRepository::new(db));
     trigger_repository
         .run_migrations()
@@ -5793,6 +5979,7 @@ async fn build_libsql_production(
         context,
         filesystem,
         trigger_repository,
+        attested_backend,
         secret_master_key,
         ironclaw_reborn_event_store::RebornEventStoreConfig::Libsql {
             path_or_url,
@@ -5838,6 +6025,7 @@ async fn build_postgres_production(
         context,
         filesystem,
         trigger_repository,
+        Some(DurableBackend::Postgres(pool.clone())),
         secret_master_key,
         ironclaw_reborn_event_store::RebornEventStoreConfig::PostgresPool { pool },
         ironclaw_auth::CredentialRefreshLeaderLock::for_postgres(pool_for_refresh_lock),
@@ -5876,3 +6064,136 @@ mod tests;
 mod auth_tests;
 #[cfg(test)]
 mod local_dev_host_tests;
+
+/// Backend selection for the attested-signing graph.
+///
+/// Gated on the durable feature set: without it there is no durable graph to
+/// select, so the selection these cases pin does not exist to be tested.
+///
+/// Selection reads process env, so each case takes the shared env lock. The
+/// cases are sync and `block_on` the build: holding the env guard across an
+/// `.await` in an async test would pin it across scheduler yields.
+#[cfg(all(test, feature = "libsql", feature = "attested-broadcast"))]
+mod attested_backend_selection_tests {
+    use super::*;
+
+    /// Override `key` for the guard's lifetime, restoring the prior value.
+    ///
+    /// Goes through the runtime-env override seam rather than `set_var`: this
+    /// crate forbids unsafe, and `present_env` reads that same seam.
+    struct EnvVarGuard {
+        snapshot: ironclaw_common::env_helpers::RuntimeEnvSnapshot,
+    }
+
+    impl EnvVarGuard {
+        // env-hermetic: callers hold `ironclaw_common::env_helpers::lock_env()`
+        // for the whole scope in which this guard lives.
+        fn set(key: &'static str, value: &str) -> Self {
+            let snapshot = ironclaw_common::env_helpers::snapshot_runtime_env(key);
+            ironclaw_common::env_helpers::set_runtime_env(key, value);
+            Self { snapshot }
+        }
+
+        // env-hermetic: as above.
+        fn clear(key: &'static str) -> Self {
+            let snapshot = ironclaw_common::env_helpers::snapshot_runtime_env(key);
+            ironclaw_common::env_helpers::mask_runtime_env(key);
+            Self { snapshot }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            ironclaw_common::env_helpers::restore_runtime_env(self.snapshot.clone());
+        }
+    }
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
+    }
+
+    async fn libsql_backend(dir: &std::path::Path, name: &str) -> DurableBackend {
+        DurableBackend::LibSql(Arc::new(
+            libsql::Builder::new_local(dir.join(name))
+                .build()
+                .await
+                .expect("libsql db"),
+        ))
+    }
+
+    /// With no database handle there is nothing durable to select, so the graph
+    /// falls back to in-memory — and `broadcasts()` is `false`, which is what
+    /// stops a dry run from being mistaken for a real broadcast.
+    #[test]
+    fn without_a_database_handle_the_graph_is_in_memory_and_does_not_broadcast() {
+        let _env = ironclaw_common::env_helpers::lock_env();
+        // Endpoints ARE configured, isolating the handle as the missing piece.
+        let _rpc = EnvVarGuard::set(
+            crate::attested_durable::EVM_RPC_URL_ENV,
+            "https://rpc.invalid/evm",
+        );
+
+        let graph = block_on(build_attested_graph(&None)).expect("in-memory graph assembles");
+
+        assert!(
+            !graph.composition.broadcasts(),
+            "with no durable backend the graph must wire the non-submitting \
+             broadcaster; `true` here would mean a dry-run path could report a \
+             successful broadcast"
+        );
+    }
+
+    /// A database handle is NOT on its own enough: with no chain RPC endpoint a
+    /// durable graph would persist grants for signatures it could never submit,
+    /// so selection falls back rather than build that.
+    #[test]
+    fn a_database_handle_without_rpc_endpoints_still_falls_back_to_in_memory() {
+        let _env = ironclaw_common::env_helpers::lock_env();
+        let _evm = EnvVarGuard::clear(crate::attested_durable::EVM_RPC_URL_ENV);
+        let _sol = EnvVarGuard::clear(crate::attested_durable::SOLANA_RPC_URL_ENV);
+        let _near = EnvVarGuard::clear(crate::attested_durable::NEAR_RPC_URL_ENV);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let graph = block_on(async {
+            let backend = libsql_backend(dir.path(), "attested-selection.db").await;
+            build_attested_graph(&Some(backend)).await
+        })
+        .expect("graph assembles");
+
+        assert!(
+            !graph.composition.broadcasts(),
+            "a durable backend with no reachable chain must not select the \
+             durable graph: it would seal grants for signatures it can never \
+             broadcast"
+        );
+    }
+
+    /// The payoff: a database handle AND a configured chain endpoint select the
+    /// durable graph, whose real broadcaster submits. Paired with the two cases
+    /// above, this pins the discriminator in both directions.
+    #[test]
+    fn a_database_handle_with_an_rpc_endpoint_selects_the_durable_graph() {
+        let _env = ironclaw_common::env_helpers::lock_env();
+        let _rpc = EnvVarGuard::set(
+            crate::attested_durable::EVM_RPC_URL_ENV,
+            "https://rpc.invalid/evm",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let graph = block_on(async {
+            let backend = libsql_backend(dir.path(), "attested-durable.db").await;
+            build_attested_graph(&Some(backend)).await
+        })
+        .expect("durable graph assembles");
+
+        assert!(
+            graph.composition.broadcasts(),
+            "a configured durable backend must select the durable graph and its \
+             real per-chain broadcaster"
+        );
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1582,6 +1582,73 @@ where
     )))
 }
 
+/// Assemble the attested-signing signer-continuation composition.
+///
+/// Self-contained: mints a custodial keystore, reads the mainnet ship-gate from
+/// the environment, and registers the external-wallet providers over the SAME
+/// sealed-grant store the custodial signer claims from, so the one-shot CAS is
+/// authoritative across every path (threat #1). `bindings` is shared with the
+/// resume port injected into the turn state store, so a raised gate's binding
+/// is visible to the continuation driver.
+///
+/// The stores are in-memory, which is fail-closed rather than merely
+/// non-durable: grants, claims, and bindings share a lifetime, so a restart
+/// drops a pending gate entirely (it can no longer be resolved) instead of
+/// leaving a resolvable grant whose claim record was lost. Swapping in the
+/// durable backends assembled by [`crate::attested_durable`] additionally
+/// requires erasing `RebornRuntime.attested_signing` behind a trait — it is
+/// typed to the in-memory monomorphization today — which is its own change.
+///
+/// Present-but-invalid provider config is a hard startup error, not a weakened
+/// verifier; absent config leaves a provider unregistered and therefore
+/// fail-closed (`ProviderMismatch`).
+fn build_attested_composition(
+    bindings: Arc<ironclaw_attested_runtime::InMemoryAttestedGateBindingStore>,
+) -> Result<crate::attested::InMemoryAttestedComposition, RebornBuildError> {
+    use ironclaw_attestation::{InMemorySealedGrantStore, SealedGrantStore};
+    use ironclaw_attested_runtime::CustodialMainnetShipGate;
+    use ironclaw_chain_signing::SecretsKeyStore;
+    use ironclaw_secrets::SecretsCrypto;
+
+    let keystore = Arc::new(SecretsKeyStore::new(SecretsCrypto::generate()));
+    // No KMS backend here, so custodial mainnet signing stays refused
+    // (threat #18) regardless of what the environment asks for.
+    let ship_gate = CustodialMainnetShipGate::from_env().build_chain_ship_gate(None);
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let providers = crate::attested_config::AttestedProvidersConfig::from_env()
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("attested provider config: {error}"),
+        })?
+        .build_provider_registry(Arc::clone(&grants) as Arc<dyn SealedGrantStore>);
+    Ok(crate::attested::InMemoryAttestedComposition::new_in_memory(
+        bindings, keystore, ship_gate, grants, providers,
+    ))
+}
+
+/// Assemble the signed-intent minting used by the raise hook to mint the
+/// review link a human opens to approve a signature.
+fn build_intent_minting() -> Result<crate::attested_raise::IntentMinting, RebornBuildError> {
+    use ironclaw_attestation::{
+        DEFAULT_INTENT_TTL_MS, InMemoryAgentSigningKeyStore, InMemoryIntentStore,
+    };
+    use ironclaw_attested_runtime::{InMemorySealedAgentKeyStore, SecretsIntentSigner};
+    use ironclaw_secrets::SecretsCrypto;
+
+    let signer = Arc::new(SecretsIntentSigner::new(
+        Arc::new(SecretsCrypto::generate()),
+        Arc::new(InMemorySealedAgentKeyStore::new()),
+        Arc::new(InMemoryAgentSigningKeyStore::new()),
+    ));
+    let review_url_base = std::env::var(crate::attested_raise::INTENT_REVIEW_URL_BASE_ENV)
+        .unwrap_or_else(|_| "http://127.0.0.1:8080/intent".to_string());
+    Ok(crate::attested_raise::IntentMinting::new(
+        signer,
+        Arc::new(InMemoryIntentStore::new()),
+        DEFAULT_INTENT_TTL_MS,
+        review_url_base,
+    ))
+}
+
 fn production_turn_state_store<F>(
     filesystem: Arc<ScopedFilesystem<F>>,
     limits: ironclaw_turns::TurnStateStoreLimits,
@@ -4636,10 +4703,25 @@ async fn build_backend_production(
         broadcast_budget_event_sink,
         ..
     } = build_budget_sinks();
+    // Attested-signing graph. The binding store is created HERE, before both
+    // the composition and the resume port, because both must read the same
+    // authoritative bindings: the driver verifies against the binding recorded
+    // when the gate was raised, and the resume port admits a resume only for a
+    // binding it can see. Two stores would let a gate be resumed that the
+    // driver cannot verify.
+    let attested_bindings =
+        Arc::new(ironclaw_attested_runtime::InMemoryAttestedGateBindingStore::new());
+    let attested_signing = Arc::new(build_attested_composition(Arc::clone(&attested_bindings))?);
+    let intent_minting = build_intent_minting()?;
+    let attested_resume_port: Arc<dyn AttestedResumePort> =
+        Arc::new(ironclaw_attested_runtime::RuntimeAttestedResumePort::new(
+            Arc::clone(&attested_bindings) as Arc<dyn ironclaw_attested_runtime::SyncBindingRead>,
+            Arc::new(ironclaw_attested_runtime::InMemoryResumeGuard::new()),
+        ));
     let turn_state = Arc::new(production_turn_state_store(
         Arc::clone(&turn_state_filesystem),
         turn_state_store_limits,
-        None,
+        Some(attested_resume_port),
     ));
     // Rebindable source-turn-state slot for the trigger delivery-target
     // service — same repoint seam as the sibling snapshot slot below.
@@ -5555,18 +5637,30 @@ async fn build_backend_production(
     #[cfg(test)]
     let local_dev_wasm_runtime_credential_provider_captured =
         services.wasm_runtime_credential_provider_captured_for_test();
+    // Routes `request_signature` to the composition-owned raise hook. Without
+    // it the invocation falls through to the deliberately fail-closed handler
+    // in `first_party_tools::request_signature`, so no gate is ever raised and
+    // the entire attested path is unreachable from the agent loop.
+    let attested_raise_hook: Arc<dyn ironclaw_host_runtime::AttestedRaiseHook> = Arc::new(
+        crate::attested_raise::RebornAttestedRaiseHook::new(Arc::clone(&attested_signing))
+            .with_intent_minting(intent_minting.clone()),
+    );
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> = if uses_local_host_runtime {
         Arc::new(services.host_runtime_for_local_testing())
     } else {
-        Arc::new(services.host_runtime_for_production(&wiring_config)?)
+        Arc::new(
+            services
+                .host_runtime_for_production(&wiring_config)?
+                .with_attested_raise_hook(attested_raise_hook),
+        )
     };
 
     Ok(RebornRuntimeStores {
-        // Production composes no attested backend yet: the durable stores are a
-        // later group, and `None` means the gate ingress has nothing to
-        // dispatch to and refuses, rather than half-resolving a signature.
-        attested_signing: None,
-        intent_store: None,
+        // The attested graph and its intent store are handed over together:
+        // `product_surface` registers the attested continuation only when both
+        // are present, so a half-wired pair yields no attested surface at all.
+        intent_store: Some(Arc::clone(intent_minting.intents())),
+        attested_signing: Some(attested_signing),
         host_runtime,
         #[cfg(test)]
         turn_coordinator,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1008,7 +1008,7 @@ pub(crate) struct RebornRuntimeStores {
     /// binding store plus the assembled driver, dispatched by the gate/resolve
     /// ingress once a turn reaches `AttestedResolved`. `None` on production
     /// profiles until the durable attested backends are wired.
-    pub(crate) attested_signing: Option<Arc<crate::attested::InMemoryAttestedComposition>>,
+    pub(crate) attested_signing: Option<Arc<dyn crate::attested::AttestedComposition>>,
     /// The intent store the raise hook mints into, shared with the continuation
     /// port so the lifecycle projection settles the very record the raise wrote.
     /// `None` on production until the durable attested backends are wired.

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -93,7 +93,7 @@ pub use attested_durable::{
     DurableCustody, EVM_RPC_URL_ENV, NEAR_RPC_URL_ENV, SOLANA_RPC_URL_ENV,
     chain_rpc_endpoints_from_env,
 };
-pub use attested_raise::{IntentMinting, RebornAttestedRaiseHook};
+pub use attested_raise::{INTENT_REVIEW_URL_BASE_ENV, IntentMinting, RebornAttestedRaiseHook};
 pub use automation::service::RebornAutomationProductService;
 pub use automation::trigger_poller::PostSubmitDeliveryHook;
 pub use error::RebornBuildError;

--- a/crates/ironclaw_reborn_composition/src/product_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/product_surface.rs
@@ -84,6 +84,17 @@ pub(crate) fn build_product_surface_with_channel_connection(
     )
     .with_approval_interactions(runtime.webui_approval_interaction_service())
     .with_auth_interactions(runtime.webui_auth_interaction_service());
+
+    // Attested-signing continuation: wired only when this runtime composed an
+    // attested signing graph AND an intent store. Without it an `attested`
+    // resolution is refused rather than resumed — resuming a signing turn on an
+    // unverified proof is the one outcome the whole path exists to prevent.
+    if let (Some(attested), Some(intents)) = (runtime.attested_signing(), runtime.intent_store()) {
+        api = api.with_attested_continuation(Arc::new(
+            crate::attested_continuation::RebornAttestedContinuation::new(attested)
+                .with_intent_store(Arc::clone(intents)),
+        ));
+    }
     // Admin user-management surface: the directory and secret provisioner are
     // core runtime handles; only token minting is deployment-supplied.
     if let Some(minter) = runtime.reborn_admin_token_minter() {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -695,7 +695,7 @@ pub struct RebornRuntime {
     /// `None` on production profiles until the durable attested backends are
     /// wired — the gate ingress then has nothing to dispatch to and fails
     /// closed, rather than half-resolving a signature.
-    pub(crate) attested_signing: Option<Arc<crate::attested::InMemoryAttestedComposition>>,
+    pub(crate) attested_signing: Option<Arc<dyn crate::attested::AttestedComposition>>,
     /// The intent store the raise hook mints into; the review routes read it.
     pub(crate) intent_store: Option<Arc<dyn ironclaw_attestation::IntentStore>>,
     /// Lazily-built clear-signing descriptor cache (see `clear_signing_source`).
@@ -1456,7 +1456,7 @@ impl RebornRuntime {
     /// authoritative binding store through this one handle, rather than
     /// assembling them from runtime internals — so there is exactly one place a
     /// signing continuation can be obtained.
-    pub fn attested_signing(&self) -> Option<&Arc<crate::attested::InMemoryAttestedComposition>> {
+    pub fn attested_signing(&self) -> Option<&Arc<dyn crate::attested::AttestedComposition>> {
         self.attested_signing.as_ref()
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -5965,6 +5965,9 @@ async fn local_dev_webui_bundle_routes_approval_gates_into_interaction_service()
             resolution: Some("approved".to_string()),
             always: None,
             credential_ref: None,
+            attested_proof_kind: None,
+            attested_approved_tx_hash: None,
+            attested_proof: None,
         },
     )
     .await
@@ -6035,6 +6038,9 @@ async fn local_dev_webui_bundle_routes_auth_gates_into_interaction_service() {
             resolution: Some("declined".to_string()),
             always: None,
             credential_ref: None,
+            attested_proof_kind: None,
+            attested_approved_tx_hash: None,
+            attested_proof: None,
         },
     )
     .await

--- a/crates/ironclaw_reborn_composition/tests/durable_attested_composition.rs
+++ b/crates/ironclaw_reborn_composition/tests/durable_attested_composition.rs
@@ -11,8 +11,7 @@
 use std::sync::Arc;
 
 use ironclaw_attested_runtime::{
-    AttestedGateBindingStore, CustodialMainnetShipGate, InMemoryAttestedGateBindingStore,
-    ProviderRegistry,
+    CustodialMainnetShipGate, InMemoryAttestedGateBindingStore, ProviderRegistry,
 };
 use ironclaw_attested_store::{
     ChainRpcEndpoints, LibSqlSealedGrantStore, LibSqlSigningLedger, MultiChainBroadcaster,
@@ -53,8 +52,12 @@ async fn durable_libsql_attested_composition_assembles() {
     .expect("master key");
     let keystore = Arc::new(SecretsKeyStore::new(crypto));
     let ship_gate = CustodialMainnetShipGate::from_env().build_chain_ship_gate(None);
-    let bindings: Arc<dyn AttestedGateBindingStore> =
-        Arc::new(InMemoryAttestedGateBindingStore::new());
+    // Typed, not erased: `assemble` needs the concrete store so it can derive
+    // both the async and sync views from ONE value. This test covers the
+    // durable grant/ledger/broadcaster monomorphization; the durable *binding*
+    // store is covered by `assemble_libsql`, which builds it internally and is
+    // the path production takes.
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
 
     let composition: LibSqlAttestedComposition = RebornAttestedComposition::assemble(
         bindings,

--- a/crates/ironclaw_reborn_composition/tests/production_runtime_attested_signing.rs
+++ b/crates/ironclaw_reborn_composition/tests/production_runtime_attested_signing.rs
@@ -1,0 +1,228 @@
+//! Integration test: a production-shaped `RebornRuntime` actually composes the
+//! attested-signing graph.
+//!
+//! Regression for a total-inertness gap. Every piece of the attested-signing
+//! path shipped and was unit-tested, but the shipping runtime constructed none
+//! of it — `build_backend_production` hardcoded `attested_signing: None` and
+//! `intent_store: None`, and no `AttestedRaiseHook` was ever handed to the host
+//! runtime. The consequences compounded across four seams:
+//!
+//! 1. `product_surface.rs` registers the attested continuation only when BOTH
+//!    `attested_signing()` and `intent_store()` are `Some`, so the resolve-gate
+//!    ingress had nothing to dispatch to and refused every attested resolution.
+//! 2. `production_turn_state_store` received `attested_resume_port: None`, so
+//!    the turn store never admitted an attested resume.
+//! 3. With no `AttestedRaiseHook` registered, `request_signature` fell through
+//!    to the deliberately fail-closed handler in
+//!    `first_party_tools/request_signature.rs` — whose own doc comment says it
+//!    is "only reachable when no [`AttestedRaiseHook`] is" set.
+//!
+//! Net effect: no gate could be raised, and no gate could be resolved. The
+//! behaviour of each piece was covered (see `attested_request_signature_raise`
+//! and the driver's own suites); what was missing was that anything ever built
+//! them. This test asserts the composition, which is the only thing those
+//! suites cannot see.
+//!
+//! Lives in its own integration-test binary (mirroring
+//! `production_runtime_identity.rs`) so the CPU-heavy production build does not
+//! starve the lib unit tests' timeout budgets, and needs the libSQL substrate
+//! the production-runtime path requires.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ironclaw_host_api::runtime_policy::{
+    ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
+    NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+};
+use ironclaw_host_api::{
+    CapabilityId, CapabilitySet, CorrelationId, ExecutionContext, ExtensionId, FailureKind,
+    InvocationId, InvocationOrigin, MountView, ProjectId, ResourceEstimate, ResourceScope, RunId,
+    RuntimeKind, TenantId, TrustClass, UserId,
+};
+use ironclaw_host_runtime::{
+    CommandExecutionOutput, CommandExecutionRequest, RuntimeCapabilityOutcome, RuntimeProcessError,
+    SandboxCommandTransport, TenantSandboxProcessPort,
+};
+use ironclaw_reborn_composition::{
+    RebornCompositionProfile, RebornHostBindings, RebornRuntimeIdentity, RebornRuntimeInput,
+    RebornRuntimeProcessBinding, build_reborn_runtime,
+};
+use serde_json::json;
+
+#[path = "support/first_party.rs"]
+mod first_party_support;
+
+#[derive(Debug)]
+struct RecordingSandboxTransport;
+
+#[async_trait]
+impl SandboxCommandTransport for RecordingSandboxTransport {
+    async fn run_command(
+        &self,
+        _request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        Ok(CommandExecutionOutput {
+            output: String::new(),
+            saved_output: None,
+            exit_code: 0,
+            sandboxed: true,
+            duration: Duration::ZERO,
+        })
+    }
+}
+
+/// The production build composes the attested-signing graph and the intent
+/// store, so the gate ingress has something to dispatch to and
+/// `request_signature` reaches the raise hook rather than the fail-closed
+/// handler.
+#[tokio::test]
+async fn production_runtime_composes_the_attested_signing_graph() {
+    // The custodial keystore is minted through `ironclaw_secrets`; without this
+    // the build reaches for the OS keychain under test.
+    unsafe { std::env::set_var("IRONCLAW_DISABLE_OS_KEYCHAIN", "1") };
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.path().join("reborn.db"))
+            .build()
+            .await
+            .expect("libsql db"),
+    );
+
+    let input = RebornRuntimeInput::from_build_input(
+        RebornHostBindings::libsql(
+            RebornCompositionProfile::Production,
+            "prod-attested-owner",
+            db,
+            dir.path().join("events.db").to_string_lossy(),
+            None,
+            ironclaw_secrets::SecretMaterial::from("01234567890123456789012345678901"),
+        )
+        .with_first_party_bundles(first_party_support::test_first_party_bundles())
+        .with_runtime_policy(EffectiveRuntimePolicy {
+            deployment: DeploymentMode::HostedMultiTenant,
+            requested_profile: RuntimeProfile::SecureDefault,
+            resolved_profile: RuntimeProfile::SecureDefault,
+            filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+            process_backend: ProcessBackendKind::TenantSandbox,
+            network_mode: NetworkMode::Deny,
+            secret_mode: SecretMode::BrokeredHandles,
+            approval_policy: ApprovalPolicy::AskAlways,
+            audit_mode: AuditMode::Standard,
+        })
+        .with_runtime_process_binding(RebornRuntimeProcessBinding::tenant_sandbox(Arc::new(
+            TenantSandboxProcessPort::new(Arc::new(RecordingSandboxTransport)),
+        ))),
+    )
+    .with_identity(RebornRuntimeIdentity {
+        tenant_id: "prod-attested-runtime-tenant".to_string(),
+        agent_id: "prod-attested-runtime-agent".to_string(),
+        source_binding_id: "prod-attested-source".to_string(),
+        reply_target_binding_id: "prod-attested-reply".to_string(),
+    });
+
+    let runtime = build_reborn_runtime(input)
+        .await
+        .expect("production runtime builds");
+
+    // (1) THE ATTESTED GRAPH. `product_surface.rs` gates the whole attested
+    // continuation on this being `Some`; `None` here means every attested gate
+    // resolution is refused no matter how correct the ingress is.
+    assert!(
+        runtime.attested_signing().is_some(),
+        "the production build must compose an attested-signing graph — without \
+         it the resolve-gate ingress has nothing to dispatch to and refuses \
+         every attested resolution"
+    );
+
+    // (2) THE INTENT STORE. The other half of that same `if let (Some, Some)`.
+    // A composed graph with no intent store still yields no attested surface,
+    // and no review link is ever minted for a raised gate.
+    assert!(
+        runtime.intent_store().is_some(),
+        "the production build must compose an intent store — the attested \
+         continuation is registered only when both it and the signing graph \
+         are present"
+    );
+
+    // (3) THE RAISE HOOK, asserted through the capability path the agent loop
+    // actually takes rather than through an accessor.
+    //
+    // `DefaultHostRuntime` intercepts `request_signature` and routes it to the
+    // hook BEFORE the kernel authorization fold; with no hook the invocation
+    // falls through into that fold instead. Deliberately malformed input
+    // separates the two without needing a provisioned chain key: only the hook
+    // can produce `InputEncode`. Verified by mutation — dropping
+    // `with_attested_raise_hook` in the factory fails this assertion with
+    // `Authorization` (the fold rejecting the empty grant set, having never
+    // reached the fail-closed first-party handler behind it).
+    let host_runtime = runtime
+        .host_runtime_for_test()
+        .expect("production runtime exposes its host runtime");
+    let capability_id = CapabilityId::new("builtin.request_signature").expect("capability id");
+    let outcome = host_runtime
+        .invoke_capability((
+            execution_context(owner_scope()),
+            capability_id.clone(),
+            ResourceEstimate::default(),
+            json!({ "provider_hint": "custodial" }),
+        ))
+        .await
+        .expect("invocation reaches the runtime");
+
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => assert_eq!(
+            failure.kind,
+            FailureKind::InputEncode,
+            "malformed input must be rejected BY THE RAISE HOOK; \
+             `UnsupportedRunner` here means no hook is wired and every \
+             `request_signature` refuses, making the attested path unreachable \
+             from the agent loop"
+        ),
+        other => panic!("expected the raise hook to reject malformed input, got {other:?}"),
+    }
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}
+
+fn owner_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("default").expect("tenant"),
+        user_id: UserId::new("alice").expect("user"),
+        agent_id: None,
+        project_id: Some(ProjectId::new("bootstrap").expect("project")),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+/// The host execution context a raise reads identities from. A
+/// `request_signature` only ever originates inside an agent-loop turn-run —
+/// that is the origin whose gate the ceremony later resumes.
+fn execution_context(scope: ResourceScope) -> ExecutionContext {
+    let run_id = RunId::new();
+    ExecutionContext {
+        invocation_id: scope.invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: None,
+        thread_id: None,
+        extension_id: ExtensionId::new("builtin").expect("extension"),
+        runtime: RuntimeKind::Wasm,
+        trust: TrustClass::UserTrusted,
+        grants: CapabilitySet { grants: vec![] },
+        mounts: MountView::default(),
+        resource_scope: scope,
+        authenticated_actor_user_id: None,
+        origin: Some(InvocationOrigin::LoopRun(run_id)),
+        run_id: Some(run_id),
+    }
+}

--- a/crates/ironclaw_reborn_composition/tests/production_runtime_attested_signing.rs
+++ b/crates/ironclaw_reborn_composition/tests/production_runtime_attested_signing.rs
@@ -85,10 +85,6 @@ impl SandboxCommandTransport for RecordingSandboxTransport {
 /// handler.
 #[tokio::test]
 async fn production_runtime_composes_the_attested_signing_graph() {
-    // The custodial keystore is minted through `ironclaw_secrets`; without this
-    // the build reaches for the OS keychain under test.
-    unsafe { std::env::set_var("IRONCLAW_DISABLE_OS_KEYCHAIN", "1") };
-
     let dir = tempfile::tempdir().expect("tempdir");
     let db = Arc::new(
         libsql::Builder::new_local(dir.path().join("reborn.db"))

--- a/crates/ironclaw_reborn_composition/tests/production_runtime_attested_signing.rs
+++ b/crates/ironclaw_reborn_composition/tests/production_runtime_attested_signing.rs
@@ -17,11 +17,17 @@
 //!    `first_party_tools/request_signature.rs` — whose own doc comment says it
 //!    is "only reachable when no [`AttestedRaiseHook`] is" set.
 //!
-//! Net effect: no gate could be raised, and no gate could be resolved. The
+//! Net effect: no gate could be resolved, and no gate could be raised. The
 //! behaviour of each piece was covered (see `attested_request_signature_raise`
 //! and the driver's own suites); what was missing was that anything ever built
 //! them. This test asserts the composition, which is the only thing those
 //! suites cannot see.
+//!
+//! Cases (1) and (2) pin that composition. Case (3) pins something different
+//! and is the more important of the two: `request_signature` must not reach the
+//! raise hook without passing the kernel authorization fold. Raising is
+//! currently unavailable-by-design pending the authorized-dispatch rework — see
+//! the case comment and `DefaultHostRuntime::invoke_capability`.
 //!
 //! Lives in its own integration-test binary (mirroring
 //! `production_runtime_identity.rs`) so the CPU-heavy production build does not
@@ -147,17 +153,26 @@ async fn production_runtime_composes_the_attested_signing_graph() {
          are present"
     );
 
-    // (3) THE RAISE HOOK, asserted through the capability path the agent loop
-    // actually takes rather than through an accessor.
+    // (3) AN UNGRANTED CALLER IS REFUSED BY THE AUTHORIZATION FOLD.
     //
-    // `DefaultHostRuntime` intercepts `request_signature` and routes it to the
-    // hook BEFORE the kernel authorization fold; with no hook the invocation
-    // falls through into that fold instead. Deliberately malformed input
-    // separates the two without needing a provisioned chain key: only the hook
-    // can produce `InputEncode`. Verified by mutation — dropping
-    // `with_attested_raise_hook` in the factory fails this assertion with
-    // `Authorization` (the fold rejecting the empty grant set, having never
-    // reached the fail-closed first-party handler behind it).
+    // This is the regression guard for a HIGH-severity bypass. `invoke_capability`
+    // used to intercept `request_signature` and route it straight to the raise
+    // hook BEFORE `invoke_json` ran the kernel's `authorize()` fold — so trust
+    // classification, capability grants, runtime policy, credential pre-flight,
+    // persistent approval, and the sealed `Authorized` witness were all skipped.
+    // This exact call, with an EMPTY grant set, reached the hook and could mint
+    // a human-facing approval prompt for an attacker-chosen transaction.
+    //
+    // The context below carries `CapabilitySet { grants: vec![] }`, so the fold
+    // must refuse. `Authorization` here means the fold ran; `InputEncode` would
+    // mean the raise hook was reached and parsed the body, i.e. the bypass is
+    // back. Nothing downstream is asserted because nothing downstream should
+    // happen: no gate raised, no grant sealed, no intent minted.
+    //
+    // Raising is therefore currently *unavailable* rather than *unauthorized*.
+    // Restoring it means dispatching the hook from behind the fold (as an
+    // authorized dispatch result), at which point this assertion should become
+    // "an ungranted caller is refused AND a granted one reaches the hook".
     let host_runtime = runtime
         .host_runtime_for_test()
         .expect("production runtime exposes its host runtime");
@@ -175,13 +190,15 @@ async fn production_runtime_composes_the_attested_signing_graph() {
     match outcome {
         RuntimeCapabilityOutcome::Failed(failure) => assert_eq!(
             failure.kind,
-            FailureKind::InputEncode,
-            "malformed input must be rejected BY THE RAISE HOOK; \
-             `UnsupportedRunner` here means no hook is wired and every \
-             `request_signature` refuses, making the attested path unreachable \
-             from the agent loop"
+            FailureKind::Authorization,
+            "a caller with no capability grants must be refused by the kernel \
+             authorization fold; `InputEncode` here means the raise hook was \
+             reached without authorization — the bypass has returned"
         ),
-        other => panic!("expected the raise hook to reject malformed input, got {other:?}"),
+        other => panic!(
+            "an ungranted `request_signature` must be refused, got {other:?} — \
+             anything else means the authorization fold did not run"
+        ),
     }
 
     runtime.shutdown().await.expect("runtime shutdown");


### PR DESCRIPTION
## What

The **attested gate/resolve ingress**, deferred from #6769 and now re-expressed for current `main`. Stacks on #6818.

The old stack routed this through a WebUI-inbound facade that main **deleted outright** — `webui_inbound` has zero references there — and replaced with capability/command dispatch. Since `RESOLVE_GATE_COMMAND` already exists, an attested resolve is **a gate resolution carrying a claim**, not a new command. It therefore inherits the existing authorization, audit, and safety pipeline instead of standing up a second dispatch surface.

## The cross-user IDOR contract — the load-bearing part

An attested resolution routes to the attested resolver **even when the run cannot be read** — which is exactly what a cross-user request looks like. That resolver runs its own owner-scoped verify-and-claim and fails closed *indistinguishably from a missing gate*.

Falling through to the generic route would instead reject the resolution **shape** with a 400 — confirming to the caller that the request was attested-shaped at all. Gate-ref shape cannot divert it either.

**Mutation-verified:** removing the early route makes two tests fail.

## Ordering is the other contract

Verify + claim the one-shot grant **before** the turn transitions; resume only on success; then broadcast. A rejected proof leaves the turn `BlockedAttested` with no state-machine mutation, so the gate stays cleanly retryable and an unverified proof never advances a signing turn.

The approval resolver, the auth resolver, and the generic fallback all **refuse** an attested resolution rather than resuming it — the generic path has only one-shot `resume_turn` and no verification, so resuming there would be the exact failure this design prevents.

## Sanitized rejections

Every rejection collapses to one of two shapes on the way out. A caller must not be able to distinguish a missing binding from a forged proof from an already-claimed grant — that distinction is an oracle for which gates exist and which have been driven. Backend unavailability is the one genuinely-our-fault case and is reported as such.

## Wire shape

`ProductResolveGateRequest` gains three optional attested fields, parsed into a `ProductGateResolution::Attested` variant. All three are **required together** — a partial proof is a validation error, never a silently-defaulted claim carried on to the device path. The payload is opaque and passes through uninterpreted; a test pins that an arbitrary JSON shape is not reshaped here.

`ProductGateResolution` and `ProductInboundCommand` drop their `Eq` derives: the proof payload is `serde_json::Value`, which is `PartialEq` but not `Eq`.

The port is wired in composition only when the runtime composed **both** an attested signing graph and an intent store; absent either, an attested resolution is refused.

## Verification

8 new tests (4 wire-layer, 4 routing/IDOR), full `ironclaw_product` suite, `ironclaw_architecture` 100%, whole workspace compiles including tests, `fmt`, `clippy --tests` zero warnings, `check_no_panics.py`, `check-hermetic-env.sh` — all clean against current `main`.
