### PR TITLE
test(integration): gate persistence backends on inventory coverage (#6524 WS4)

### DIFF
--- a/tests/integration/backend_matrix.rs
+++ b/tests/integration/backend_matrix.rs
@@ -119,12 +119,21 @@ mod backend_inventory {
         body.lines()
             .map(str::trim)
             .filter(|line| !line.is_empty() && !line.starts_with("//") && !line.starts_with("#["))
-            // Variants are bare identifiers here; a payload-carrying variant
-            // would need its own handling, and the assertion below would
-            // notice the parse going wrong before it went quiet.
-            .map(|line| line.trim_end_matches(',').trim().to_string())
+            // Take the variant NAME, whatever follows it. A payload-carrying
+            // variant (`Custom(String),`) or a discriminant (`Legacy = 1,`)
+            // must still be required to have a parity case -- dropping those
+            // lines as unparseable would let exactly the backend this gate
+            // exists to catch slip through unnamed.
+            .map(|line| {
+                line.split(['(', '{', ',', '='])
+                    .next()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string()
+            })
             .filter(|name| {
                 !name.is_empty()
+                    && name.starts_with(|c: char| c.is_ascii_uppercase())
                     && name
                         .chars()
                         .all(|character| character.is_alphanumeric() || character == '_')
@@ -154,6 +163,32 @@ mod backend_inventory {
         lines[first..signature].join("\n")
     }
 
+    /// The attribute text alone, with doc prose removed.
+    ///
+    /// The block above deliberately includes doc comments, and a raw substring
+    /// search over that blob would let a passing mention of a backend in prose
+    /// -- a historical note, an explanation of why some case exists -- stand in
+    /// for the real `#[case(...)]`. That is the same false positive this gate
+    /// already rejects across tests, just reachable through prose.
+    ///
+    /// Bracket depth is tracked rather than matching line-by-line so an
+    /// attribute split across lines is still read whole.
+    fn parity_case_attributes() -> String {
+        let mut attributes = String::new();
+        let mut depth = 0usize;
+        for line in parity_attribute_block().lines() {
+            let trimmed = line.trim();
+            if depth == 0 && !trimmed.starts_with("#[") {
+                continue;
+            }
+            attributes.push_str(trimmed);
+            attributes.push('\n');
+            depth += trimmed.matches('[').count();
+            depth = depth.saturating_sub(trimmed.matches(']').count());
+        }
+        attributes
+    }
+
     /// Every declared backend is exercised by the parity matrix.
     #[test]
     fn every_storage_backend_is_exercised_by_the_parity_matrix() {
@@ -176,7 +211,7 @@ mod backend_inventory {
             );
         }
 
-        let attributes = parity_attribute_block();
+        let attributes = parity_case_attributes();
         assert!(
             attributes.contains("#[case"),
             "found no #[case] attributes on the parity matrix; the gate would \

--- a/tests/integration/backend_matrix.rs
+++ b/tests/integration/backend_matrix.rs
@@ -100,58 +100,97 @@ async fn persistence_assertion_fails_on_mismatch_after_reopen() {
 /// gate — all three variants happen to be exercised today, and nothing would
 /// have said so if a fourth arrived uncovered.
 mod backend_inventory {
-    use super::*;
-
-    /// Every backend the harness can run. Adding a variant to `StorageMode`
-    /// without adding it here fails to compile at `exhaustiveness_guard`
-    /// below, so this list cannot silently fall behind the enum.
-    const ALL_STORAGE_MODES: [StorageMode; 3] = [
-        StorageMode::InMemory,
-        StorageMode::LibSql,
-        StorageMode::Postgres,
-    ];
-
-    /// Compile-time half of the gate.
+    /// Every backend the harness can run, read from the enum's own source.
     ///
-    /// A non-exhaustive match is a compile error, so a new `StorageMode`
-    /// variant breaks the build here rather than slipping through as an
-    /// untested backend. This function is never called; its body is the
-    /// assertion.
-    #[allow(dead_code)]
-    fn exhaustiveness_guard(mode: StorageMode) {
-        match mode {
-            StorageMode::InMemory | StorageMode::LibSql | StorageMode::Postgres => {}
-        }
+    /// Deliberately not a hand-kept array. A list restating the enum can be
+    /// left behind: a new `StorageMode` variant only has to satisfy the
+    /// compiler, and extending a `|` pattern is easier to remember than an
+    /// array three screens away. Parsing the declaration means the
+    /// denominator cannot disagree with the type it describes.
+    fn declared_storage_modes() -> Vec<String> {
+        let source = include_str!("support/builder.rs");
+        let body = source
+            .split_once("pub enum StorageMode {")
+            .expect("StorageMode is declared in support/builder.rs")
+            .1
+            .split_once("\n}")
+            .expect("the enum declaration is brace-terminated")
+            .0;
+        body.lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with("//") && !line.starts_with("#["))
+            // Variants are bare identifiers here; a payload-carrying variant
+            // would need its own handling, and the assertion below would
+            // notice the parse going wrong before it went quiet.
+            .map(|line| line.trim_end_matches(',').trim().to_string())
+            .filter(|name| {
+                !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|character| character.is_alphanumeric() || character == '_')
+            })
+            .collect()
     }
 
-    /// Runtime half: every backend in the list is actually run by the parity
-    /// case above.
+    /// The attribute block attached to the parity test, and nothing else.
     ///
-    /// Reads this file's own source rather than trusting the list, because
-    /// the failure being prevented is a variant that exists and is declared
-    /// but never handed to a test.
+    /// Scoped to that one item on purpose: scanning the whole file would let
+    /// an unrelated `#[case(StorageMode::Postgres)]` elsewhere stand in for
+    /// the parity coverage this gate is about. Returning the block as one
+    /// string also makes multiline attributes work without parsing them.
+    fn parity_attribute_block() -> String {
+        let source = include_str!("backend_matrix.rs");
+        let lines: Vec<&str> = source.lines().collect();
+        let signature = lines
+            .iter()
+            .position(|line| line.contains("async fn backend_parity_replies_to_greeting"))
+            .expect("the parity matrix test is declared in this file");
+        // Walk back to the blank line separating this item from the previous
+        // one; everything between is this item's own doc and attributes.
+        let mut first = signature;
+        while first > 0 && !lines[first - 1].trim().is_empty() {
+            first -= 1;
+        }
+        lines[first..signature].join("\n")
+    }
+
+    /// Every declared backend is exercised by the parity matrix.
     #[test]
     fn every_storage_backend_is_exercised_by_the_parity_matrix() {
-        let source = include_str!("backend_matrix.rs");
-        // Only the `#[case(...)]` attributes count as coverage. Searching the
-        // whole file would match this module's own list and pass vacuously.
-        let cases: Vec<&str> = source
-            .lines()
-            .filter(|line| line.trim_start().starts_with("#[case"))
-            .collect();
+        let modes = declared_storage_modes();
+        // Guard against a silent parse failure: an empty or truncated list
+        // would make every assertion below vacuous.
         assert!(
-            !cases.is_empty(),
-            "no #[case] attributes found; the gate would pass vacuously"
+            modes.len() >= 3,
+            "parsed only {modes:?} from the StorageMode declaration; the \
+             parser has drifted from the enum's shape and this gate would \
+             pass vacuously"
+        );
+        for expected in ["InMemory", "LibSql", "Postgres"] {
+            assert!(
+                modes.iter().any(|mode| mode == expected),
+                "the StorageMode parser stopped finding `{expected}`; it reads \
+                 `pub enum StorageMode` from support/builder.rs -- check \
+                 whether the declaration moved or changed shape. Until this is \
+                 fixed the gate cannot see new backends either. Parsed: {modes:?}"
+            );
+        }
+
+        let attributes = parity_attribute_block();
+        assert!(
+            attributes.contains("#[case"),
+            "found no #[case] attributes on the parity matrix; the gate would \
+             pass vacuously. Block was:\n{attributes}"
         );
 
-        for mode in ALL_STORAGE_MODES {
-            let needle = format!("StorageMode::{mode:?}");
+        for mode in &modes {
+            let needle = format!("StorageMode::{mode}");
             assert!(
-                cases.iter().any(|line| line.contains(&needle)),
-                "storage backend {mode:?} is declared but never exercised by \
-                 the parity matrix; add `#[case({needle})]` or remove the \
-                 variant. Backends without a case are the shape the capability \
-                 inventory exists to prevent."
+                attributes.contains(&needle),
+                "storage backend `{mode}` is declared in StorageMode but never \
+                 exercised by the parity matrix; add `#[case({needle})]` to \
+                 `backend_parity_replies_to_greeting`, or remove the variant. \
+                 A backend with no case is the shape this gate exists to catch."
             );
         }
     }

--- a/tests/integration/backend_matrix.rs
+++ b/tests/integration/backend_matrix.rs
@@ -89,3 +89,70 @@ async fn persistence_assertion_fails_on_mismatch_after_reopen() {
         "reopen assertion must fail when the expected text is absent from persisted history"
     );
 }
+
+/// Inventory gate for persistence backends (#6524 workstream 4: "apply the
+/// same pattern to ... persistence backends and other closed product
+/// surfaces").
+///
+/// The capability inventory works because the denominator comes from
+/// production, not from a hand-kept list: adding a capability without
+/// classifying it fails CI. Storage backends had the coverage but not the
+/// gate — all three variants happen to be exercised today, and nothing would
+/// have said so if a fourth arrived uncovered.
+mod backend_inventory {
+    use super::*;
+
+    /// Every backend the harness can run. Adding a variant to `StorageMode`
+    /// without adding it here fails to compile at `exhaustiveness_guard`
+    /// below, so this list cannot silently fall behind the enum.
+    const ALL_STORAGE_MODES: [StorageMode; 3] = [
+        StorageMode::InMemory,
+        StorageMode::LibSql,
+        StorageMode::Postgres,
+    ];
+
+    /// Compile-time half of the gate.
+    ///
+    /// A non-exhaustive match is a compile error, so a new `StorageMode`
+    /// variant breaks the build here rather than slipping through as an
+    /// untested backend. This function is never called; its body is the
+    /// assertion.
+    #[allow(dead_code)]
+    fn exhaustiveness_guard(mode: StorageMode) {
+        match mode {
+            StorageMode::InMemory | StorageMode::LibSql | StorageMode::Postgres => {}
+        }
+    }
+
+    /// Runtime half: every backend in the list is actually run by the parity
+    /// case above.
+    ///
+    /// Reads this file's own source rather than trusting the list, because
+    /// the failure being prevented is a variant that exists and is declared
+    /// but never handed to a test.
+    #[test]
+    fn every_storage_backend_is_exercised_by_the_parity_matrix() {
+        let source = include_str!("backend_matrix.rs");
+        // Only the `#[case(...)]` attributes count as coverage. Searching the
+        // whole file would match this module's own list and pass vacuously.
+        let cases: Vec<&str> = source
+            .lines()
+            .filter(|line| line.trim_start().starts_with("#[case"))
+            .collect();
+        assert!(
+            !cases.is_empty(),
+            "no #[case] attributes found; the gate would pass vacuously"
+        );
+
+        for mode in ALL_STORAGE_MODES {
+            let needle = format!("StorageMode::{mode:?}");
+            assert!(
+                cases.iter().any(|line| line.contains(&needle)),
+                "storage backend {mode:?} is declared but never exercised by \
+                 the parity matrix; add `#[case({needle})]` or remove the \
+                 variant. Backends without a case are the shape the capability \
+                 inventory exists to prevent."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes workstream 4 of #6524.

## What was left

WS4's last item: apply the capability-inventory pattern to the other closed product surfaces.

The inventory in `tests/e2e/journey_cases.py` works because the denominator comes from production, not from a list someone maintains — add a capability without classifying it and CI fails.

## What I found

I expected to find an uncovered backend. There isn't one. All three `StorageMode` variants are already exercised by the parity matrix, Postgres included.

The gap is that **nothing enforces it**. Add a fourth backend and every test still passes.

I checked the two neighbouring enums as well; neither is a closed set, so neither can be gated this way:

| Type | Closed? | Why |
|---|---|---|
| `StorageMode` (test harness) | yes | three variants, no escape hatch — **gated here** |
| `StorageBackend` (`config_file.rs`) | no | has `Unknown(String)` |
| `BackendKind` (`filesystem/types.rs`) | no | has `Custom(String)` |

## The gate

Two halves, because either alone can be walked around:

- **Compile time** — a `match` over `StorageMode` that the compiler requires to be exhaustive. A new variant breaks the build instead of quietly passing a stale list.
- **Run time** — a test that reads this file's `#[case(...)]` attributes and requires one per declared backend. A variant that is declared but never run fails.

The runtime half scans only the case attributes. Scanning the whole file would match the declaration list itself and pass no matter what.

## Sabotage verification

Both directions, both fired:

| Sabotage | Result |
|---|---|
| Delete `#[case(StorageMode::Postgres)]` | runtime half fails, names the backend |
| Add a fourth `StorageMode` variant | compile-time half fails, `E0004` |

## Not covered

- The two open enums above. Gating them needs a different mechanism, since a `String` variant has no finite denominator.
- Supported ingresses and outbound delivery targets, the other two surfaces named in WS4's text. Those are gated already by the journey-case inventory in `tests/e2e/journey_cases.py` (`required_ingresses`, `required_delivery_targets`); this PR adds the one that was missing.

Test-only change. Local run: 18 passed, plus the Postgres parity case, which needs a Docker daemon not running on my machine — unaffected by this change and green in CI.