### PR TITLE
test(e2e): derive provider-world writes from production manifests (#6524 WS3)

### DIFF
--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -167,6 +167,44 @@ All fixtures are defined in `tests/e2e/conftest.py`. Running `pytest scenarios/`
 
 The function-scoped `page` fixture means **each test gets a clean browser context** (cookies, storage, etc.) but reuses the same ironclaw server and browser process. Tests that need the server URL directly (e.g., `test_auth_rejection`) accept `ironclaw_server` as an additional parameter.
 
+### Provider world isolation: why the fixtures are shaped this way
+
+Three questions come up every time someone touches these fixtures. The
+answers are measured, not assumed.
+
+**Why aren't the provider processes function-scoped?** Because the Reborn
+process under test is configured with the provider base URLs when it starts,
+and it outlives any one test. A function-scoped provider would hand each test
+a new port, leaving the running server pointed at a dead socket. The suite
+gets the same isolation a different way: module-scoped processes on *stable
+reserved ports*, restarting only the services a test actually mutated. That
+restart is a real process restart from the seed file, so it is as clean as a
+fresh process. `scenarios/test_provider_world_isolation.py` pins the URL
+stability directly -- if you convert these fixtures to `scope="function"`,
+that test is the one that will tell you why you cannot.
+
+**Is a reset/snapshot endpoint worth adding to Emulate?** No, on current
+numbers. Emulate starts in ~0.2s, and a full reset through
+`ResettableEmulateProviderWorld` (kill, restart from seed, re-bind the
+reserved port) measures ~0.55s. The provider-operation lane performs roughly
+one reset per case, so resets cost it about a minute in total. Revisit this
+only if that lane grows several-fold; process startup is not what makes the
+suite slow. (Measured on an M-series laptop against the pinned fork, three
+runs per service: slack 0.18s, google 0.19s, github 0.20s.)
+
+**How does a journey get a known baseline?** By declaring the provider worlds
+it mutates, which is what makes the fixture reset them afterwards. That
+declaration is derived, not written by hand: `journey_cases.py` reads the
+`external_write` effect from the shipped manifests
+(`crates/ironclaw_first_party_extensions/assets/*/manifest.toml`), so a tool
+that writes to a provider is treated as mutating whether or not anyone
+remembered to list it. Two gates in
+`scenarios/test_journey_coverage.py` keep that honest: one fails when a
+production write belongs to no world the harness can reset, and one fails if
+the derivation stops finding the writes it replaced -- a manifest key rename
+would otherwise empty the mapping, skip every reset, and leave the suite
+green.
+
 ### Emulate provider coverage
 
 Use Emulate for provider APIs that map directly to Reborn features already in

--- a/tests/e2e/journey_cases.py
+++ b/tests/e2e/journey_cases.py
@@ -40,13 +40,76 @@ _TOOL_WORLD_PREFIXES = {
 _HTTP_WORLD_HOSTS = {
     "api.github.com": ProviderWorld.GITHUB,
 }
-_MUTATING_PROVIDER_TOOLS = {
-    "gmail__send_message": ProviderWorld.GOOGLE,
-    "google-docs__create_document": ProviderWorld.GOOGLE,
-    "google-sheets__create_spreadsheet": ProviderWorld.GOOGLE,
-    "google-sheets__append_values": ProviderWorld.GOOGLE,
-    "slack__send_message": ProviderWorld.SLACK,
-}
+# The five tools this set used to name by hand. Kept only as a regression
+# floor: if the derivation below ever stops finding them, it has broken.
+_HISTORICAL_MUTATING_PROVIDER_TOOLS = frozenset(
+    {
+        "gmail__send_message",
+        "google-docs__create_document",
+        "google-sheets__create_spreadsheet",
+        "google-sheets__append_values",
+        "slack__send_message",
+    }
+)
+
+
+def _production_mutating_tools() -> dict[str, ProviderWorld]:
+    """Provider-world writes, taken from the shipped manifests.
+
+    A journey that mutates a provider world must declare that world so the
+    harness resets it afterwards; otherwise whatever the journey created
+    survives into the next test. Which tools mutate is not a judgement call --
+    production already states it, as the `external_write` effect on each tool
+    (`crates/ironclaw_first_party_extensions/assets/*/manifest.toml`).
+
+    This used to be a hand-kept list of five names while production declared
+    seventy such tools. Every one of the other sixty-five -- `github__create_issue`,
+    `google-drive__upload_file`, and so on -- would have run without marking its
+    world mutable, so no reset fired and the leak guards this workstream added
+    never got the chance to.
+    """
+    mutating: dict[str, ProviderWorld] = {}
+    for manifest_path in sorted(ASSET_ROOT.glob("*/manifest.toml")):
+        with manifest_path.open("rb") as manifest_file:
+            manifest = tomllib.load(manifest_file)
+        for tool in manifest.get("tools", []) or []:
+            if "external_write" not in (tool.get("effects") or []):
+                continue
+            # Manifest ids are `github.create_issue`; traces record
+            # `github__create_issue`.
+            tool_name = str(tool["id"]).replace(".", "__", 1)
+            world = next(
+                (
+                    world
+                    for prefix, world in _TOOL_WORLD_PREFIXES.items()
+                    if tool_name.startswith(prefix)
+                ),
+                None,
+            )
+            # Tools outside a world the harness can reset (web-access, nearai)
+            # are not skipped silently -- `unreset_mutating_tools()` below is
+            # what reports them.
+            if world is not None:
+                mutating[tool_name] = world
+    return mutating
+
+
+_MUTATING_PROVIDER_TOOLS = _production_mutating_tools()
+
+
+def unreset_mutating_tools() -> frozenset[str]:
+    """Production writes whose provider world no fixture can reset."""
+    unreset = set()
+    for manifest_path in sorted(ASSET_ROOT.glob("*/manifest.toml")):
+        with manifest_path.open("rb") as manifest_file:
+            manifest = tomllib.load(manifest_file)
+        for tool in manifest.get("tools", []) or []:
+            if "external_write" not in (tool.get("effects") or []):
+                continue
+            tool_name = str(tool["id"]).replace(".", "__", 1)
+            if tool_name not in _MUTATING_PROVIDER_TOOLS:
+                unreset.add(tool_name)
+    return frozenset(unreset)
 _REPEAT_AFTER_RESET = {
     "qa_5d_slack_strategy_doc_answer",
     "qa_10f_slack_mention_encoding",

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import pytest
 
 from journey_cases import (
+    _HISTORICAL_MUTATING_PROVIDER_TOOLS,
+    _MUTATING_PROVIDER_TOOLS,
     ALL_JOURNEY_CASES,
     JOURNEY_ORDER_ENV,
     PROVIDER_JOURNEY_CASES,
@@ -21,6 +23,7 @@ from journey_cases import (
     required_ingresses,
     shared_world_provider_journey_runs,
     uncovered_surfaces,
+    unreset_mutating_tools,
 )
 from journey_types import (
     CargoEvidence,
@@ -781,3 +784,59 @@ def test_cargo_evidence_counts_an_empty_lib_table_as_a_manual_target(
             source_path,
             root=tmp_path,
         )
+
+
+# ---------------------------------------------------------------------------
+# Provider-world baseline gate (#6524 workstream 3)
+#
+# A journey that writes to a provider world must declare that world, because
+# the declaration is what triggers the reset afterwards. Without it, whatever
+# the journey created survives into the next test and the leak guards this
+# workstream added never run.
+#
+# Which tools write is not a judgement call: production says so, as the
+# `external_write` effect on each manifest tool. The harness used to restate
+# that as a hand-kept list of five names while production declared seventy.
+# Nothing detected the drift, because a journey using an undeclared write
+# simply resets nothing and passes.
+# ---------------------------------------------------------------------------
+
+
+def test_every_production_provider_write_maps_to_a_resettable_world():
+    """No production write can run without a world that gets reset."""
+    unreset = unreset_mutating_tools()
+    assert not unreset, (
+        "these production tools declare `external_write` but belong to no "
+        f"provider world the harness can reset: {sorted(unreset)}. A journey "
+        "using one would mutate a world that nothing restores, and the next "
+        "test would inherit the result. Add the world to _TOOL_WORLD_PREFIXES "
+        "with a reset path, or give the tool a world that has one."
+    )
+
+
+def test_provider_write_derivation_still_finds_the_tools_it_replaced():
+    """The derivation cannot quietly collapse to nothing.
+
+    This is the gate on the gate. Deriving the set from manifests removes the
+    drift risk but adds a worse one: a manifest key rename would empty the
+    mapping, every journey would declare no mutable world, every reset would
+    be skipped, and the whole suite would still pass. The five names below are
+    the ones the hand-kept list carried, so they are a floor the derivation
+    must always clear.
+    """
+    missing = sorted(_HISTORICAL_MUTATING_PROVIDER_TOOLS - set(_MUTATING_PROVIDER_TOOLS))
+    assert not missing, (
+        f"the derivation stopped recognising known provider writes: {missing}. "
+        "It reads the `external_write` effect from "
+        "crates/ironclaw_first_party_extensions/assets/*/manifest.toml -- check "
+        "whether that key or the tool ids were renamed. Until this is fixed no "
+        "journey resets its provider world."
+    )
+    # A floor of five would still pass if the manifests shrank to just those.
+    # Production declares dozens; a collapse to single digits is the symptom
+    # worth failing on.
+    assert len(_MUTATING_PROVIDER_TOOLS) >= 20, (
+        f"only {len(_MUTATING_PROVIDER_TOOLS)} provider writes were derived from "
+        "the shipped manifests; production declares far more. The derivation "
+        "is probably reading the wrong manifests or the wrong key."
+    )

--- a/tests/e2e/scenarios/test_journey_coverage.py
+++ b/tests/e2e/scenarios/test_journey_coverage.py
@@ -14,6 +14,7 @@ import pytest
 from journey_cases import (
     _HISTORICAL_MUTATING_PROVIDER_TOOLS,
     _MUTATING_PROVIDER_TOOLS,
+    _TOOL_WORLD_PREFIXES,
     ALL_JOURNEY_CASES,
     JOURNEY_ORDER_ENV,
     PROVIDER_JOURNEY_CASES,
@@ -832,11 +833,31 @@ def test_provider_write_derivation_still_finds_the_tools_it_replaced():
         "whether that key or the tool ids were renamed. Until this is fixed no "
         "journey resets its provider world."
     )
-    # A floor of five would still pass if the manifests shrank to just those.
-    # Production declares dozens; a collapse to single digits is the symptom
-    # worth failing on.
-    assert len(_MUTATING_PROVIDER_TOOLS) >= 20, (
+    # A count alone is a weak check: discovery could break for one provider
+    # and still clear any global floor on the strength of the others. Assert
+    # per world instead, so a single provider's manifests going unread fails
+    # here and names that provider.
+    derived_by_world: dict[str, list[str]] = {}
+    for tool_name, world in _MUTATING_PROVIDER_TOOLS.items():
+        derived_by_world.setdefault(str(world), []).append(tool_name)
+    resettable_worlds = {str(world) for world in _TOOL_WORLD_PREFIXES.values()}
+    empty_worlds = sorted(resettable_worlds - set(derived_by_world))
+    assert not empty_worlds, (
+        f"no provider writes were derived for {empty_worlds}, but every world "
+        "the harness can reset ships write tools. Journeys touching those "
+        "providers would declare no mutable world and skip their reset. Check "
+        "whether those manifests moved or their tool ids were renamed."
+    )
+
+    # Production currently declares 70 provider writes. Hold the floor close
+    # to that rather than at a token value: a partial discovery failure that
+    # still finds most tools is exactly what a low floor would wave through.
+    # Deliberately removing write tools should require moving this number, and
+    # noticing that you are.
+    assert len(_MUTATING_PROVIDER_TOOLS) >= 60, (
         f"only {len(_MUTATING_PROVIDER_TOOLS)} provider writes were derived from "
-        "the shipped manifests; production declares far more. The derivation "
-        "is probably reading the wrong manifests or the wrong key."
+        "the shipped manifests; production declares about 70. Either the "
+        "derivation is reading the wrong manifests or key, or write tools were "
+        "removed -- if the removal is intentional, lower this floor in the same "
+        "change so the drop is reviewed rather than absorbed."
     )


### PR DESCRIPTION
Closes workstream 3 of #6524. Three open items; one was a real hole, two turned out to be answerable with a measurement.

## The hole

A journey declares which provider worlds it mutates, and that declaration is what makes the fixture reset them afterwards. The mechanism was fine. The input wasn't.

| | tools treated as writing to a provider |
|---|---|
| production manifests (`external_write` effect) | **70** |
| test harness hand-kept list | **5** |

The other 65 — `github__create_issue`, `google-drive__upload_file`, and so on — would have run without marking their world mutable. No reset would fire, and whatever they created would survive into the next test. The leak guards this workstream landed in #6738, #6756 and #6764 would never have got the chance to run.

**No journey is affected today.** The current set happens to use only those five tools; the mutable-world declarations are byte-identical before and after this change. I verified that rather than assuming it. This closes a latent hole, not an active bug — worth saying plainly, because the diff looks scarier than its blast radius.

`_MUTATING_PROVIDER_TOOLS` is now derived from the shipped manifests, so a tool that writes to a provider counts as mutating whether or not anyone remembered to list it.

## Two gates, because deriving trades one risk for a worse one

Drift is gone, but a manifest key rename would now empty the mapping, skip every reset, and leave the suite green. That is precisely the "machinery that silently does nothing" failure the epic's harness-self-test bullet exists for, so both directions are gated:

- `test_every_production_provider_write_maps_to_a_resettable_world` — fails when a production write belongs to no world the harness can reset.
- `test_provider_write_derivation_still_finds_the_tools_it_replaced` — fails if the derivation stops finding the five it replaced, or collapses to a suspiciously small set.

| Sabotage | Result |
|---|---|
| Rename `external_write` in the manifests | derivation gate fails, lists all five by name |
| Move a write tool into a world with no reset path | other gate fails, names `pagerduty__send_message` |

## The other two items were questions, not work

**"Add test-only Emulate reset/snapshot support *if* process startup makes the suite too slow."** It doesn't. Measured against the pinned fork, three runs per service: Emulate starts in **0.2s** (slack 0.18, google 0.19, github 0.20), and a full reset through the real `ResettableEmulateProviderWorld` — kill, restart from seed, re-bind the reserved port — is **0.55s**. The provider-operation lane runs about one reset per case, so resets cost it roughly a minute total. Not the bottleneck. No repo had any timing data before this; the 60-second startup ceiling in `conftest.py` is a timeout, not a measurement.

**"Prefer function-scoped provider processes."** Doing this literally would break the suite. The Reborn process under test is configured with the provider base URLs when it starts and outlives any one test; a function-scoped provider hands each test a new port and leaves the server pointed at a dead socket. The suite already gets the same isolation a better way — module-scoped processes on *stable reserved ports*, restarting only the services a test mutated, which is a real restart from the seed file. `test_provider_world_isolation.py` pins that URL stability on purpose.

Both answers are now written down in `tests/e2e/CLAUDE.md` with the numbers, so the next person doesn't re-litigate them.

## Not covered

- **Telegram has no Emulate world.** It is covered by a hand-written fake (`fake_telegram_api.py`) plus Cargo evidence, so it never enters this reset path. Giving it a real seeded world is separate work.
- **GitHub still has no journey-level baseline assertion**, unlike Google and Slack. It needs one before a journey declares GitHub mutable — which nothing does yet, and which this change now makes possible. Worth a follow-up rather than speculative code today.
- The derivation only sees first-party manifests under `assets/`. A third-party extension declaring `external_write` would not be picked up; it also cannot appear in a harvested journey today.

Test-only change. 59 static gate tests pass; the 9 provider-world isolation tests pass against the pinned Emulate fork built locally.