### PR TITLE
fix(agent-loop): bound recovery per RUN, not just per stage (#6284 WS9)

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -3368,7 +3368,20 @@ async fn model_retry_success_clears_recovery_state() {
         "model retry must request a fresh host-built prompt bundle"
     );
     let final_state = final_staged_state(&host);
-    assert_eq!(final_state.recovery_state, Default::default());
+    // Per-class accounting is cleared on success, as before. The whole-run
+    // counter deliberately survives that reset — without it the run budget
+    // could never be exhausted, which is the #6284 WS9 defect.
+    assert!(final_state.recovery_state.attempts_by_class.is_empty());
+    assert!(
+        final_state
+            .recovery_state
+            .observation_attempted_by_class
+            .is_empty()
+    );
+    assert_eq!(
+        final_state.recovery_state.run_recovery_attempts, 1,
+        "the retry that preceded this success must still be charged to the run budget"
+    );
     assert_eq!(
         final_state.compaction_prompt.message_index,
         vec![
@@ -4558,7 +4571,11 @@ async fn retry_uses_single_call_invocation() {
             .expect("execute");
 
         assert!(matches!(exit, LoopExit::Completed(_)));
-        assert_eq!(final_staged_state(&host).recovery_state, Default::default());
+        // Per-class accounting clears on success; the whole-run counter does
+        // not (see `a_successful_call_does_not_refund_the_whole_run_budget`).
+        let recovery = final_staged_state(&host).recovery_state;
+        assert!(recovery.attempts_by_class.is_empty());
+        assert_eq!(recovery.run_recovery_attempts, 1);
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/state/slots.rs
+++ b/crates/ironclaw_agent_loop/src/state/slots.rs
@@ -207,6 +207,66 @@ pub enum IndexedMessageKind {
 }
 
 #[cfg(test)]
+mod run_recovery_budget_tests {
+    use super::{RecoveryAttemptClass, RecoveryStrategyState};
+
+    /// The whole-run budget must survive the per-stage reset.
+    ///
+    /// `cleared_attempts()` returned `Self::default()`, wiping every counter on
+    /// any successful model call. That bounds a single stage but leaves the RUN
+    /// unbounded: a run alternating success and failure re-earns its full
+    /// budget forever. The worst case was not the ~41 model calls one stage
+    /// permits — it was unlimited, with `RetryProvider` tripling each
+    /// underneath (#6284 WS9).
+    #[test]
+    fn a_successful_call_does_not_refund_the_whole_run_budget() {
+        let mut state = RecoveryStrategyState::default();
+
+        // Ten failure/success cycles: each failure counts an attempt, each
+        // success clears the per-stage counters.
+        for _ in 0..10 {
+            state = state.with_incremented_attempts_for(RecoveryAttemptClass::CapabilityTransient);
+            state = state.cleared_attempts();
+            assert_eq!(
+                state.attempts_for(RecoveryAttemptClass::CapabilityTransient),
+                0,
+                "the per-stage counter must still reset — that behavior is deliberate"
+            );
+        }
+
+        assert_eq!(
+            state.run_recovery_attempts, 10,
+            "the whole-run counter must survive `cleared_attempts()`, or the run \
+             budget can never be exhausted"
+        );
+        assert!(
+            state.run_recovery_budget_exhausted(10),
+            "ten attempts must exhaust a ten-attempt run budget"
+        );
+        assert!(
+            !state.run_recovery_budget_exhausted(11),
+            "the bound must not fire early"
+        );
+    }
+
+    /// The per-stage reset still does its own job: an unrelated later error
+    /// must not inherit a previous stage's consumed attempts.
+    #[test]
+    fn the_per_stage_reset_still_clears_per_class_accounting() {
+        let state = RecoveryStrategyState::default()
+            .with_incremented_attempts_for(RecoveryAttemptClass::CapabilityTransient)
+            .with_incremented_attempts_for(RecoveryAttemptClass::CapabilityTransient)
+            .cleared_attempts();
+
+        assert_eq!(
+            state.attempts_for(RecoveryAttemptClass::CapabilityTransient),
+            0
+        );
+        assert_eq!(state.run_recovery_attempts, 2);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -395,6 +455,23 @@ pub struct RecoveryStrategyState {
     /// observation from turning exhaustion into an infinite retry loop.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub observation_attempted_by_class: BTreeSet<ModelErrorObservationClass>,
+    /// Recovery attempts consumed across the WHOLE RUN, never reset.
+    ///
+    /// Every other counter here is per-stage and is wiped by
+    /// [`cleared_attempts`](Self::cleared_attempts) on any successful model
+    /// call. That bounds a single stage but leaves the RUN unbounded: a run
+    /// that alternates success and failure re-earns the full budget forever,
+    /// so the worst case is not the ~41 model calls one stage permits — it is
+    /// unlimited, with `RetryProvider` multiplying each by 3 underneath.
+    ///
+    /// This counter is deliberately excluded from that reset so exhausting the
+    /// run budget is possible at all (#6284 WS9).
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub run_recovery_attempts: u32,
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 impl RecoveryStrategyState {
@@ -414,6 +491,9 @@ impl RecoveryStrategyState {
         Self {
             attempts_by_class,
             observation_attempted_by_class: self.observation_attempted_by_class.clone(),
+            // Every per-class increment is also one attempt against the
+            // whole-run budget.
+            run_recovery_attempts: self.run_recovery_attempts.saturating_add(1),
         }
     }
 
@@ -423,6 +503,7 @@ impl RecoveryStrategyState {
         Self {
             attempts_by_class,
             observation_attempted_by_class: BTreeSet::new(),
+            run_recovery_attempts: attempts,
         }
     }
 
@@ -438,8 +519,27 @@ impl RecoveryStrategyState {
 
     /// Clears retry accounting after a terminal or non-retry decision so it
     /// cannot poison an unrelated later retryable error.
+    ///
+    /// Deliberately PRESERVES [`run_recovery_attempts`](Self::run_recovery_attempts):
+    /// that counter exists precisely to survive this reset. Returning a bare
+    /// `Self::default()` here is what left the per-run cost unbounded.
     pub fn cleared_attempts(&self) -> Self {
-        Self::default()
+        Self {
+            run_recovery_attempts: self.run_recovery_attempts,
+            ..Self::default()
+        }
+    }
+
+    /// Whether the run has spent its whole-run recovery budget.
+    pub fn run_recovery_budget_exhausted(&self, max_run_attempts: u32) -> bool {
+        self.run_recovery_attempts >= max_run_attempts
+    }
+
+    /// Count one recovery attempt against the whole-run budget.
+    pub fn with_incremented_run_recovery_attempts(&self) -> Self {
+        let mut next = self.clone();
+        next.run_recovery_attempts = next.run_recovery_attempts.saturating_add(1);
+        next
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -241,6 +241,17 @@ pub struct DefaultRecoveryStrategy {
     /// Default `12`, which with [`availability_backoff_for`] rides out
     /// roughly seven minutes of sustained provider failure.
     pub max_model_availability_attempts: u32,
+    /// Max recovery attempts across the WHOLE RUN. Default `120`.
+    ///
+    /// Every other bound here is per-stage and is wiped by `cleared_attempts()`
+    /// on any successful model call, so a run that alternates success and
+    /// failure re-earns its full budget indefinitely — the per-RUN cost was
+    /// unbounded even though each stage was capped (#6284 WS9).
+    ///
+    /// `120` is roughly three exhausted stages' worth of the availability
+    /// budget: generous enough that a long, hiccup-prone run is unaffected,
+    /// finite enough that a pathological loop stops.
+    pub max_run_recovery_attempts: u32,
 }
 
 impl Default for DefaultRecoveryStrategy {
@@ -248,6 +259,7 @@ impl Default for DefaultRecoveryStrategy {
         Self {
             max_attempts_per_class: 2,
             max_model_availability_attempts: 12,
+            max_run_recovery_attempts: 120,
         }
     }
 }
@@ -335,6 +347,7 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
                     state,
                     attempt_class,
                     self.max_attempts_per_class,
+                    self.max_run_recovery_attempts,
                     kind,
                     RetryScope::Iteration,
                     |_| None,
@@ -371,6 +384,7 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
                     state,
                     attempt_class,
                     self.max_model_availability_attempts,
+                    self.max_run_recovery_attempts,
                     kind,
                     RetryScope::Call,
                     |attempts| {
@@ -404,6 +418,7 @@ fn retry_or_abort(
     state: &LoopExecutionState,
     attempt_class: RecoveryAttemptClass,
     max_attempts_per_class: u32,
+    max_run_recovery_attempts: u32,
     failure_kind: LoopFailureKind,
     scope: RetryScope,
     alteration: impl FnOnce(u32) -> Option<RetryAlteration>,
@@ -412,6 +427,15 @@ fn retry_or_abort(
     let next = state
         .recovery_state
         .with_incremented_attempts_for(attempt_class);
+    // The whole-run bound is checked FIRST and survives `cleared_attempts()`,
+    // so a run alternating success and failure cannot re-earn its budget
+    // forever. Every per-stage bound below is reset on a successful model call.
+    if next.run_recovery_budget_exhausted(max_run_recovery_attempts) {
+        return RecoveryOutcome::Abort {
+            recovery: next,
+            failure_kind: LoopFailureKind::NoProgressDetected,
+        };
+    }
     if attempts >= max_attempts_per_class {
         RecoveryOutcome::Abort {
             recovery: next,

--- a/docs/internal/ws9-judgement.md
+++ b/docs/internal/ws9-judgement.md
@@ -1,0 +1,99 @@
+# WS9 (bound the recovery) — judgment calls
+
+Epic #6284, workstream 9. Recorded per instruction: every call I made where a
+reasonable engineer could have chosen differently.
+
+## 1. What I implemented vs audited
+
+WS9's eleven boxes are two different kinds of work. Boxes 1–3 are a concrete
+defect with a fix. Boxes 4–11 are an **audit** — "what happens when X fails?"
+— whose deliverable is findings, not code.
+
+I implemented 1–3 and audited 4–11. I did not write speculative fixes for
+surfaces the audit found already covered.
+
+## 2. The per-run budget bound (boxes 1–3) — implemented
+
+**The defect.** `cleared_attempts()` returned `Self::default()`, wiping every
+retry counter on any successful model call. That bounds a single stage but
+leaves the **run** unbounded: a run alternating success and failure re-earns its
+full budget forever. The worst case was never the ~41 model calls one stage
+permits — it was unlimited, with `RetryProvider` tripling each underneath.
+
+**Judgment: a monotonic counter rather than a redesign.** I added
+`run_recovery_attempts`, which `cleared_attempts()` deliberately preserves,
+instead of restructuring the per-class accounting. The per-stage reset exists
+for a real reason (a later unrelated error must not inherit a previous stage's
+attempts) and I did not want to disturb it. Cost: one more field on a
+serialized struct.
+
+**Judgment: default `120`.** Roughly three exhausted stages' worth of the
+availability budget. Chosen so a legitimately long, hiccup-prone run is
+unaffected while a pathological loop stops. **This number is a guess informed by
+the existing per-stage bounds, not by production data.** If runs are observed
+hitting it legitimately, raise it — the mechanism matters more than the value.
+
+**Judgment: reused `LoopFailureKind::NoProgressDetected` rather than adding a
+variant.** WS9 asks for "a terminal category for exhausting it that says so
+honestly", and strictly this deserves its own kind. I did not add one because
+`LoopFailureKind` is `#[non_exhaustive]` and crosses crates, so a new variant
+touches the runner's name mapping, the failure-lane canonical list, the retry
+disposition, and two user-facing summary tables — the exact chain that produced
+three separate CI failures earlier in this epic. `NoProgressDetected` is the
+closest honest existing meaning: the run consumed its recovery budget without
+progressing. **A reviewer who wants the distinct category should say so; it is a
+contained follow-up, not a rewrite.**
+
+**Judgment: the run bound is checked BEFORE the per-class bound.** Otherwise a
+class with remaining per-stage budget would retry past an exhausted run budget.
+
+## 3. Boxes 4–9 (wasm / mcp / process / filesystem / approvals / triggers) — audited, no fix needed
+
+Verified `RuntimeDispatchErrorKind` covers every shape these boxes name — guest
+trap (`Guest`), memory limit (`Memory`), nonzero exit (`ExitFailure`), fuel and
+quota (`Resource`), transport and server death (`Backend` / `Client` /
+`Network`), manifest and runtime mismatch (`Manifest` / `UnsupportedRunner` /
+`ExtensionRuntimeMismatch`).
+
+I then checked every kind for **production producers**, the same check that
+found `LlmError::ModelNotAvailable` dead in #6826. Result: all have producers
+(lowest are `Memory`=2, `ExitFailure`=2, `Guest`=4, `InvalidResult`=4).
+
+**Judgment: I did not write fault-injection tests per surface.** Proving that a
+real WASM trap or a real MCP server death reaches the right kind needs fault
+injection, which is exactly what #6134's fixture work is for. Asserting it with
+hand-built mocks would test my mock, not the runtime — the failure mode this
+epic has hit repeatedly. **The audit says the vocabulary and producers exist; it
+does not prove each real fault maps correctly, and I am not claiming it does.**
+
+## 4. Box 10 (hooks) — audited
+
+The hooks middleware fails closed to `Resolution::Denied` with
+`hook_gate_ref_unavailable`, which #6781 classified as
+`DenyReason::InternalInvariantViolation` and #6792 gave a recovery hint. A hook
+error surfaces to the model as a denial; it does not kill the run.
+
+## 5. Box 11 (panics) — audited, gap identified, not closed
+
+`scripts/check_no_panics.py` already exists, correctly excludes test modules,
+and is enforced in CI.
+
+**It only checks the diff** (`--base`/`--head`). Pre-existing panics on
+run-critical paths are grandfathered and nobody has swept them.
+
+**Judgment: I did not sweep the corpus.** Raw counts across the six
+run-critical crates are in the thousands, dominated by inline test modules that
+my grep could not exclude the way the real checker does. A credible sweep means
+running the existing checker corpus-wide, triaging what it reports, and fixing
+per-site — a workstream of its own, not a box to tick inside this PR. Filing it
+is the honest move; pretending a grep count is an audit is not.
+
+## 6. What I did not do
+
+- No new `LoopFailureKind` variant (§2).
+- No per-surface fault injection (§3).
+- No corpus-wide panic sweep (§5).
+- No change to the per-stage reset semantics.
+
+Each is a deliberate scope call, and each is stated above with its reason rather
+than left for a reviewer to discover.


### PR DESCRIPTION
## Summary

#6284 WS9. The workstream's eleven boxes are two kinds of work: boxes 1–3 are a concrete defect, boxes 4–11 are an **audit**. This implements the fix and reports the audit.

**The defect: recovery was bounded per stage, never per run.**

`cleared_attempts()` returned `Self::default()`, wiping every retry counter on any successful model call. That bounds a single stage and leaves the run unbounded — a run alternating success and failure re-earns its full budget indefinitely.

So the worst case was never the ~41 model calls one stage permits. **It was unlimited**, with `RetryProvider` tripling each underneath.

`run_recovery_attempts` is a monotonic per-run counter that `cleared_attempts()` deliberately preserves. That preservation *is* the fix — the counter is useless without it. The run bound is checked **before** the per-class bound, so a class with remaining per-stage budget cannot retry past an exhausted run.

The per-stage reset keeps doing its own job: an unrelated later error still does not inherit a previous stage's attempts.

## Change Type

- [x] Bug fix

## Linked Issue

Related #6284 (WS9). Closes boxes 1–3; boxes 4–10 audited clean; box 11 identified and scoped out (below).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_agent_loop --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo build`
- [x] Relevant tests: `ironclaw_agent_loop` + `ironclaw_turns` — **1,123 passed, 0 failed**
- [ ] `cargo test --features integration` — not applicable: in-memory retry accounting; the counter is serialized into checkpoints via the existing `RecoveryStrategyState` shape (additive, `skip_serializing_if`), no persistence behavior changed.
- [x] Manual testing: red-verified (below)

## The audit — boxes 4–11

**No second defect found.** What I checked and how:

| Box | Finding |
|---|---|
| wasm / mcp / process / filesystem / approvals / triggers | `RuntimeDispatchErrorKind` covers every shape those boxes name — guest trap, memory limit, nonzero exit, fuel/quota, transport failure, server death, manifest and runtime mismatch. I then ran the same **zero-producer check** that found `LlmError::ModelNotAvailable` dead in #6826. Every kind has production producers (lowest: `Memory`=2, `ExitFailure`=2, `Guest`=4). Nothing is dead. |
| hooks | A hook error surfaces as `Resolution::Denied`, classified by #6781 and given a recovery hint by #6792. It does not kill the run. |
| panics | `scripts/check_no_panics.py` exists, correctly excludes test modules, and is enforced in CI — **but only checks the diff**. Pre-existing panics on run-critical paths are grandfathered and unswept. Identified, **not closed**. |

**What the audit does NOT claim.** It shows the vocabulary and producers exist. It does **not** prove a real WASM trap or a real MCP server death maps to the right kind — that needs fault injection, which is what #6134's fixture work is for. Asserting it with hand-built mocks would test the mock, not the runtime.

## Test Strategy

**User behavior:** a pathological run that alternates success and failure now stops instead of retrying forever. Previously it could consume unbounded provider calls and spend.

Risk areas:
- [x] Model behavior
- [x] Persistence (counter is checkpointed)
- [x] Cross-component behavior

Tests added:
- `a_successful_call_does_not_refund_the_whole_run_budget` — ten failure/success cycles; asserts the run counter reaches 10 **while the per-class counter still resets each time**, so it pins both halves.
- `the_per_stage_reset_still_clears_per_class_accounting` — guards the fix from over-reaching into deliberate behavior.

Two existing executor tests asserted the whole state equals `default()`. They now assert the per-class fields are cleared **and** that the preceding retry is still charged to the run budget — the distinction the fix introduces.

**Red verification:** restoring `Self::default()` fails with *"the whole-run counter must survive `cleared_attempts()`, or the run budget can never be exhausted"*.

## Security Impact

None directly. The change makes a run **stop sooner** in a pathological case; it cannot cause a run to continue where it previously stopped. Resource exhaustion via unbounded retry is arguably the security-adjacent problem being closed.

## Reborn Trust-Boundary Checklist

- **`serde(default)` fails closed:** `run_recovery_attempts` defaults to `0` — a checkpoint written before this field existed resumes with a full run budget, matching today's behavior. It cannot resume with a *smaller* budget than intended.
- **New/changed variants — downstream audited:** no new variants; deliberately reused `LoopFailureKind::NoProgressDetected` (see judgment doc §2).
- **Bounds / overflow:** `saturating_add`; the counter cannot wrap into a fresh budget.
- **Trust-bearing types / untrusted content / hashes / sandbox naming:** N/A.

## Database Impact

None. Additive optional field on an already-serialized struct.

## Blast Radius

`ironclaw_agent_loop` recovery accounting. Runs that previously retried indefinitely now terminate at 120 recovery attempts with `NoProgressDetected`. No run that completes today should be affected — 120 is well above any healthy run's usage.

Worth flagging: if any legitimate long-running workload *does* hit this, it will now fail where it previously ground on. That is the intended trade, but the number is a guess (judgment doc §2) and worth watching.

## Rollback Plan

Revert the commit. The serialized field is optional and ignored by older builds.

## Review Follow-Through

**`docs/internal/ws9-judgement.md` records all six judgment calls.** The two most worth challenging:

1. **Reused `NoProgressDetected` instead of adding a failure kind.** WS9 asks for "a terminal category that says so honestly", and strictly this deserves its own. I did not add one because `LoopFailureKind` is `#[non_exhaustive]` and crosses crates — a new variant touches the runner's name mapping, the failure-lane canonical list, retry disposition, and two user-facing summary tables. That exact chain produced three separate CI failures earlier in this epic. If you want the distinct category, it is a contained follow-up.
2. **`120` is an informed guess, not data.** Derived from the existing per-stage bounds. If real runs hit it legitimately, raise it — the mechanism matters more than the value.

Also deliberately out of scope, with reasons in the doc: per-surface fault injection (§3), and the corpus-wide panic sweep (§5).

---

**Review track**: C (runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
