### PR TITLE
fix(agent-loop): recover disabled capability calls

### DIFF
--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -177,8 +177,11 @@ pub(crate) enum RecoveryOutcome {
     ToolErrorResult {
         recovery: RecoveryStrategyState,
     },
-    /// Retry once with a typed, host-authored model-error observation after
-    /// the ordinary per-class retry budget has been exhausted.
+    /// Retry once with a typed, host-authored model-error observation.
+    ///
+    /// Most errors reach this after exhausting their per-class retry budget;
+    /// `OutsideCapabilitySurface` uses it immediately so the model can repair
+    /// its capability choice without blind retries.
     ModelErrorObservation {
         recovery: RecoveryStrategyState,
         scope: RetryScope,
@@ -217,8 +220,10 @@ pub(crate) enum RetryScope {
 /// - Retries capability transient, unavailable, and internal errors up to
 ///   [`Self::max_attempts_per_class`] times with `Backoff`, then returns a
 ///   model-visible tool error result.
-/// - Retries model invalid-output errors up to the same budget, then gives the
-///   model one typed observation-assisted repair attempt before aborting.
+/// - Gives `OutsideCapabilitySurface` invalid output one immediate typed
+///   observation-assisted repair attempt. Other invalid-output errors first
+///   retry up to the same per-class budget, then get one typed observation
+///   before aborting.
 /// - Retries model transient, unavailable, and internal errors on the much
 ///   deeper [`Self::max_model_availability_attempts`] budget with a
 ///   longer-capped backoff schedule, then aborts the run. Provider outages

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -350,6 +350,16 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
             ModelErrorClass::InvalidOutput => {
                 let reason =
                     ModelInvalidOutputDetailReason::from_safe_summary(err.safe_summary.as_str());
+                if reason == Some(ModelInvalidOutputDetailReason::OutsideCapabilitySurface) {
+                    // A blind shape-repair retry cannot tell the model which
+                    // advertised-tool constraint it violated. Spend the one
+                    // typed observation attempt immediately instead.
+                    return observe_once_or_abort(
+                        state,
+                        RetryScope::Call,
+                        ModelErrorRecoveryObservation::invalid_output(reason),
+                    );
+                }
                 retry_observe_or_abort(
                     state,
                     self.max_attempts_per_class,
@@ -988,8 +998,8 @@ mod tests {
     mod default_recovery_strategy {
         use ironclaw_host_api::{TenantId, ThreadId};
         use ironclaw_turns::{
-            AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId,
-            TurnScope,
+            AgentLoopDriverDescriptor, ModelInvalidOutputDetailReason, RunProfileId,
+            RunProfileVersion, TurnId, TurnRunId, TurnScope,
             run_profile::{
                 CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy,
                 CheckpointSchemaId, ConcurrencyClass, ContextProfileId, LoopDriverId,
@@ -1551,6 +1561,50 @@ mod tests {
                 .await;
             assert!(matches!(
                 outcome,
+                RecoveryOutcome::Abort {
+                    failure_kind: LoopFailureKind::InvalidModelOutput,
+                    ..
+                }
+            ));
+        }
+
+        #[tokio::test]
+        async fn model_outside_capability_surface_observes_immediately_before_abort() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let error = ModelErrorSummary {
+                class: ModelErrorClass::InvalidOutput,
+                safe_summary: SanitizedStrategySummary::from_trusted_static(
+                    ModelInvalidOutputDetailReason::OutsideCapabilitySurface.safe_summary(),
+                ),
+                diagnostic_ref: None,
+            };
+
+            let outcome = strategy
+                .on_model_error(&state_with_no_attempts(), &error)
+                .await;
+            let recovery = match outcome {
+                RecoveryOutcome::ModelErrorObservation {
+                    recovery,
+                    scope,
+                    alter,
+                    observation,
+                } => {
+                    assert_eq!(scope, RetryScope::Call);
+                    assert_eq!(alter, None);
+                    assert_eq!(
+                        observation.model_instruction(),
+                        "model error observation: invalid_output \
+                         reason=outside_capability_surface; repair the response and continue"
+                    );
+                    recovery
+                }
+                other => panic!("expected immediate model-visible observation, got {other:?}"),
+            };
+
+            let mut state = state_with_no_attempts();
+            state.recovery_state = recovery;
+            assert!(matches!(
+                strategy.on_model_error(&state, &error).await,
                 RecoveryOutcome::Abort {
                     failure_kind: LoopFailureKind::InvalidModelOutput,
                     ..

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -463,49 +463,46 @@ async fn disabled_spawn_subagent_capability_is_stripped_from_model_surface() {
 
 /// A model that calls the disabled `builtin.spawn_subagent` anyway is rejected
 /// at the gateway (`CapabilitySurfaceDenyFilter`, before
-/// `register_provider_tool_call` ever stages an invocation) — the whole
-/// provider response fails with `InvalidOutput` → `Unavailable`, reaching a
-/// terminal `TurnStatus::Failed`/`"model_unavailable"` after exactly one
-/// scripted turn. No `ToolResultReference` is persisted; `assert_tool_invoked`
-/// returning `Err` proves the capability was never dispatched.
+/// `register_provider_tool_call` ever stages an invocation). The loop must
+/// surface the precise `outside_capability_surface` observation to the model,
+/// let it repair the response on the next call, and complete without ever
+/// dispatching or reporting the rejected call as successful.
 #[tokio::test]
-async fn disabled_spawn_subagent_capability_call_anyway_fails_the_run() {
+async fn disabled_spawn_subagent_capability_call_recovers_without_dispatch() {
     let h = RebornIntegrationHarness::test_default()
         .with_builtin_http_tools()
-        .script([RebornScriptedReply::tool_call(
-            "builtin.spawn_subagent",
-            json!({"goal": "test"}),
-        )])
+        .script([
+            RebornScriptedReply::tool_call("builtin.spawn_subagent", json!({"goal": "test"})),
+            RebornScriptedReply::text(
+                "I cannot use that capability, so I will continue without it.",
+            ),
+        ])
         .build()
         .await
         .expect("harness builds");
 
-    let run_id = h
-        .submit_turn_async("spawn a subagent")
+    h.submit_turn("spawn a subagent")
         .await
-        .expect("turn submitted");
-    let state = h
-        .wait_for_status(run_id, ironclaw_turns::TurnStatus::Failed)
+        .expect("run recovers from the disabled capability call");
+    h.assert_reply_contains("continue without it")
         .await
-        .expect("run reaches Failed after the disabled capability is rejected at the gateway");
-    let failure = state
-        .failure
-        .as_ref()
-        .expect("a Failed run must carry a failure detail");
-    assert_eq!(
-        failure.category(),
-        "model_unavailable",
-        "expected the Unavailable fidelity category (InvalidOutput -> Unavailable), got {failure:?}"
-    );
+        .expect("repaired reply is finalized");
+    h.assert_model_request_contains(
+        "model error observation: invalid_output reason=outside_capability_surface; \
+         repair the response and continue",
+    )
+    .await
+    .expect("the retry tells the model precisely why its tool call was rejected");
 
-    // No side effect: the capability was rejected before dispatch, so it was
-    // never invoked.
     assert!(
         h.assert_tool_invoked("builtin.spawn_subagent")
             .await
             .is_err(),
-        "disabled capability must never be dispatched, even when the model calls it anyway"
+        "the rejected capability must never be dispatched or recorded as successful"
     );
+    h.assert_capability_result_count("builtin.spawn_subagent", 0)
+        .await
+        .expect("the rejected call must not produce a successful capability result");
 }
 
 /// A `read_file` result large enough to exceed `TOOL_RESULT_RECORD_READ_MAX_BYTES`

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -494,12 +494,9 @@ async fn disabled_spawn_subagent_capability_call_recovers_without_dispatch() {
     .await
     .expect("the retry tells the model precisely why its tool call was rejected");
 
-    assert!(
-        h.assert_tool_invoked("builtin.spawn_subagent")
-            .await
-            .is_err(),
-        "the rejected capability must never be dispatched or recorded as successful"
-    );
+    h.assert_tool_not_invoked("builtin.spawn_subagent")
+        .await
+        .expect("the rejected capability must never be dispatched");
     h.assert_capability_result_count("builtin.spawn_subagent", 0)
         .await
         .expect("the rejected call must not produce a successful capability result");


### PR DESCRIPTION
## Summary

- Give `outside_capability_surface` model-output failures an immediate typed recovery observation instead of spending generic blind retries first.
- Invert the disabled `spawn_subagent` integration pin so the run completes after a corrective model turn while proving zero dispatch and zero successful capability results.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #5583
Related #6284

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run: targeted clippy was selected for the changed crate and integration binary.
- [ ] `cargo build` — Not run separately: both test suites compiled the affected production and integration paths.
- [x] Relevant tests pass: `ironclaw_agent_loop` and `reborn_integration_tool_call`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: no database or feature-gated backend behavior changed.
- [ ] Manual testing — Not applicable: behavior is covered through the hermetic whole-turn Reborn harness.
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Equivalent multi-agent review completed across eight lenses; both findings were fixed and revalidated.

## Test Strategy

User behavior: A hallucinated call to a disabled capability receives a precise model-visible observation, gets one corrective model turn, and completes without reporting or executing the rejected call.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added recovery-policy coverage proving `OutsideCapabilitySurface` observes immediately and aborts if repeated.
- Reborn integration: Inverted the existing `tool_call.rs` scenario through the real product, runner, loop, gateway, and capability-surface chain.
- Recorded fixture: Not applicable: model tool choice is scripted; the host recovery contract is under test.
- Browser E2E: Not applicable: no browser-visible surface changed.
- Backend or runtime: Not applicable: no database, WASM, Docker, or external runtime behavior changed.
- Live canary: Not applicable: deterministic host recovery behavior does not require provider drift coverage.

What the tests prove:

- The second model request contains `reason=outside_capability_surface`.
- The repaired assistant reply is finalized and the run survives.
- The disabled capability is neither dispatched nor recorded as a successful result.
- Other invalid-output reasons retain their existing bounded retry policy.

Commands run:

```text
cargo fmt --all -- --check
cargo test -p ironclaw_agent_loop
cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_tool_call
cargo clippy -p ironclaw_agent_loop --all-targets -- -D warnings
cargo clippy -p ironclaw_reborn_integration_tests --test reborn_integration_tool_call -- -D warnings
git diff --check
```

## Security Impact

Capability-surface enforcement is unchanged and still rejects the disabled call before registration or dispatch. This changes only the model recovery policy after that rejection, using a typed host-authored observation with no provider-supplied detail.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: Not applicable; no public types or constructors changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: the new path reuses the existing typed `ModelErrorRecoveryObservation` control message.
- [x] Hashes declare purpose: Not applicable; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: Not applicable; no variants changed. Sibling search: `rg -n "OutsideCapabilitySurface|outside_capability_surface" crates tests/integration`.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: Not applicable; no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: the existing single observation-attempt budget remains the bound.
- [x] Driver/operator-visible errors have stable class semantics: `InvalidOutput(OutsideCapabilitySurface)` remains unchanged.
- [x] Sandbox/native/host names accurately describe trust boundary: Not applicable; no sandbox or host naming changed.

## Database Impact

None.

## Blast Radius

Limited to agent-loop recovery for the already typed `OutsideCapabilitySurface` invalid-output reason and its existing whole-turn integration scenario. Gateway filtering, capability registration, dispatch, result persistence, and other invalid-output recovery classes are unchanged.

## Rollback Plan

Revert this PR (commits `8ad550fcb` and `1a91968a2`). This restores the prior generic invalid-output retry policy and the old terminal integration pin without schema or compatibility work.

## Review Follow-Through

Reviewer judgment requested on the deliberate one-attempt policy: a repeated outside-surface violation remains terminal after the model has received the precise correction once. No known follow-up is required in this scope.

---

**Review track**: C (runtime error-recovery behavior)
