### PR TITLE
fix(reborn): harden run-path panic recovery

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           CHANGED_FILES="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|Dockerfile|\.gitignore$|scripts/ci/|\.githooks/|scripts/check_no_panics\.py$|\.github/scripts/(pr-labeler|test-pr-labeler)\.sh$|\.github/workflows/code_style\.yml$)'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|Dockerfile|\.gitignore$|scripts/ci/|\.githooks/|scripts/check_no_panics\.py$|scripts/no_panics_reborn_baseline\.txt$|\.github/scripts/(pr-labeler|test-pr-labeler)\.sh$|\.github/workflows/code_style\.yml$)'; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_code=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -382,10 +382,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - name: Check for .unwrap(), .expect(), assert!() in production code
+      - name: Self-test panic checker
+        run: python3 scripts/check_no_panics.py --self-test
+      - name: Check Reborn production panic baseline
+        run: python3 scripts/check_no_panics.py --reborn-baseline
+      - name: Check changed production code for panic-style calls
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: python3 scripts/check_no_panics.py --base "$BASE_SHA" --head HEAD

--- a/crates/ironclaw_llm/src/circuit_breaker.rs
+++ b/crates/ironclaw_llm/src/circuit_breaker.rs
@@ -167,16 +167,14 @@ impl CircuitBreakerProvider {
                 }
             }
             CircuitState::Open => {
-                debug_assert!(
-                    false,
-                    "BUG: record_success() called while circuit breaker is Open — \
-                     check_allowed() was bypassed for provider {}",
-                    self.inner.model_name()
+                // Another request can fail after this request passes
+                // `check_allowed()` but before it completes. Its failure opens
+                // the breaker; this older success must not erase that newer
+                // state or panic the in-flight run.
+                tracing::debug!(
+                    provider = self.inner.model_name(),
+                    "Circuit breaker: ignoring late success from a request admitted before Open"
                 );
-                // Shouldn't get here (check_allowed blocks Open), but recover
-                state.state = CircuitState::Closed;
-                state.consecutive_failures = 0;
-                state.opened_at = None;
             }
         }
     }
@@ -319,9 +317,12 @@ impl LlmProvider for CircuitBreakerProvider {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
 
     use crate::testing::StubLlm;
+    use tokio::sync::{Notify, mpsc};
 
     fn make_request() -> CompletionRequest {
         CompletionRequest::new(vec![crate::ChatMessage::user("hello")])
@@ -657,6 +658,104 @@ mod tests {
         let result = cb.complete(make_request()).await;
         assert!(result.is_ok());
         assert_eq!(cb.circuit_state().await, CircuitState::Closed);
+    }
+
+    struct ConcurrentOutcomeProvider {
+        call_index: AtomicUsize,
+        started: mpsc::UnboundedSender<usize>,
+        release_failure: Notify,
+        release_success: Notify,
+    }
+
+    #[async_trait]
+    impl LlmProvider for ConcurrentOutcomeProvider {
+        fn model_name(&self) -> &str {
+            "concurrent-outcomes"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            let call_index = self.call_index.fetch_add(1, Ordering::SeqCst);
+            let _ = self.started.send(call_index);
+            match call_index {
+                0 => {
+                    self.release_failure.notified().await;
+                    Err(LlmError::RequestFailed {
+                        provider: self.model_name().to_string(),
+                        reason: "controlled failure".to_string(),
+                    })
+                }
+                1 => {
+                    self.release_success.notified().await;
+                    Ok(CompletionResponse {
+                        content: "controlled success".to_string(),
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        finish_reason: crate::FinishReason::Stop,
+                        reasoning: None,
+                        cache_read_input_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                    })
+                }
+                other => panic!("unexpected concurrent test call {other}"),
+            }
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _request: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            panic!("concurrent circuit-breaker regression uses complete()");
+        }
+    }
+
+    #[tokio::test]
+    async fn late_success_does_not_close_breaker_opened_by_concurrent_failure() {
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let inner = Arc::new(ConcurrentOutcomeProvider {
+            call_index: AtomicUsize::new(0),
+            started: started_tx,
+            release_failure: Notify::new(),
+            release_success: Notify::new(),
+        });
+        let cb = Arc::new(CircuitBreakerProvider::new(
+            Arc::clone(&inner) as Arc<dyn LlmProvider>,
+            CircuitBreakerConfig {
+                failure_threshold: 1,
+                recovery_timeout: Duration::from_secs(60),
+                half_open_successes_needed: 1,
+            },
+        ));
+
+        let first = {
+            let cb = Arc::clone(&cb);
+            tokio::spawn(async move { cb.complete(make_request()).await })
+        };
+        assert_eq!(started_rx.recv().await, Some(0));
+
+        let second = {
+            let cb = Arc::clone(&cb);
+            tokio::spawn(async move { cb.complete(make_request()).await })
+        };
+        assert_eq!(started_rx.recv().await, Some(1));
+
+        inner.release_failure.notify_one();
+        assert!(first.await.expect("failure task must not panic").is_err());
+        assert_eq!(cb.circuit_state().await, CircuitState::Open);
+
+        inner.release_success.notify_one();
+        assert!(second.await.expect("success task must not panic").is_ok());
+        assert_eq!(
+            cb.circuit_state().await,
+            CircuitState::Open,
+            "a success admitted before the failure must not erase the open state"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_llm/src/circuit_breaker.rs
+++ b/crates/ironclaw_llm/src/circuit_breaker.rs
@@ -60,6 +60,7 @@ pub enum CircuitState {
 /// Internal mutable state.
 struct BreakerState {
     state: CircuitState,
+    generation: u64,
     consecutive_failures: u32,
     opened_at: Option<Instant>,
     half_open_successes: u32,
@@ -69,10 +70,38 @@ impl BreakerState {
     fn new() -> Self {
         Self {
             state: CircuitState::Closed,
+            generation: 0,
             consecutive_failures: 0,
             opened_at: None,
             half_open_successes: 0,
         }
+    }
+
+    fn transition_to(&mut self, state: CircuitState) {
+        if self.state != state {
+            self.state = state;
+            self.generation = self.generation.wrapping_add(1);
+        }
+    }
+}
+
+/// Identifies the state-machine epoch in which a request was admitted.
+#[derive(Debug, Clone, Copy)]
+struct AdmissionToken {
+    state: CircuitState,
+    generation: u64,
+}
+
+impl AdmissionToken {
+    fn new(state: &BreakerState) -> Self {
+        Self {
+            state: state.state,
+            generation: state.generation,
+        }
+    }
+
+    fn is_current(self, state: &BreakerState) -> bool {
+        self.state == state.state && self.generation == state.generation
     }
 }
 
@@ -108,20 +137,20 @@ impl CircuitBreakerProvider {
     }
 
     /// Pre-flight: is a call allowed right now?
-    async fn check_allowed(&self) -> Result<(), LlmError> {
+    async fn check_allowed(&self) -> Result<AdmissionToken, LlmError> {
         let mut state = self.state.lock().await;
         match state.state {
-            CircuitState::Closed | CircuitState::HalfOpen => Ok(()),
+            CircuitState::Closed | CircuitState::HalfOpen => Ok(AdmissionToken::new(&state)),
             CircuitState::Open => {
                 if let Some(opened_at) = state.opened_at {
                     if opened_at.elapsed() >= self.config.recovery_timeout {
-                        state.state = CircuitState::HalfOpen;
+                        state.transition_to(CircuitState::HalfOpen);
                         state.half_open_successes = 0;
                         tracing::info!(
                             provider = self.inner.model_name(),
                             "Circuit breaker: Open -> HalfOpen, allowing probe"
                         );
-                        Ok(())
+                        Ok(AdmissionToken::new(&state))
                     } else {
                         let remaining = self
                             .config
@@ -140,16 +169,28 @@ impl CircuitBreakerProvider {
                     }
                 } else {
                     // opened_at should always be Some when Open; recover gracefully
-                    state.state = CircuitState::Closed;
-                    Ok(())
+                    state.transition_to(CircuitState::Closed);
+                    Ok(AdmissionToken::new(&state))
                 }
             }
         }
     }
 
     /// Record a successful call.
-    async fn record_success(&self) {
+    async fn record_success(&self, admission: AdmissionToken) {
         let mut state = self.state.lock().await;
+        if !admission.is_current(&state) {
+            tracing::debug!(
+                provider = self.inner.model_name(),
+                admitted_state = ?admission.state,
+                admitted_generation = admission.generation,
+                current_state = ?state.state,
+                current_generation = state.generation,
+                "Circuit breaker: ignoring success from a stale admission"
+            );
+            return;
+        }
+
         match state.state {
             CircuitState::Closed => {
                 state.consecutive_failures = 0;
@@ -157,7 +198,7 @@ impl CircuitBreakerProvider {
             CircuitState::HalfOpen => {
                 state.half_open_successes += 1;
                 if state.half_open_successes >= self.config.half_open_successes_needed {
-                    state.state = CircuitState::Closed;
+                    state.transition_to(CircuitState::Closed);
                     state.consecutive_failures = 0;
                     state.opened_at = None;
                     tracing::info!(
@@ -166,31 +207,34 @@ impl CircuitBreakerProvider {
                     );
                 }
             }
-            CircuitState::Open => {
-                // Another request can fail after this request passes
-                // `check_allowed()` but before it completes. Its failure opens
-                // the breaker; this older success must not erase that newer
-                // state or panic the in-flight run.
-                tracing::debug!(
-                    provider = self.inner.model_name(),
-                    "Circuit breaker: ignoring late success from a request admitted before Open"
-                );
-            }
+            CircuitState::Open => {}
         }
     }
 
     /// Record a failed call; only transient errors count toward the threshold.
-    async fn record_failure(&self, err: &LlmError) {
+    async fn record_failure(&self, admission: AdmissionToken, err: &LlmError) {
         if !is_transient(err) {
             return;
         }
 
         let mut state = self.state.lock().await;
+        if !admission.is_current(&state) {
+            tracing::debug!(
+                provider = self.inner.model_name(),
+                admitted_state = ?admission.state,
+                admitted_generation = admission.generation,
+                current_state = ?state.state,
+                current_generation = state.generation,
+                "Circuit breaker: ignoring failure from a stale admission"
+            );
+            return;
+        }
+
         match state.state {
             CircuitState::Closed => {
                 state.consecutive_failures += 1;
                 if state.consecutive_failures >= self.config.failure_threshold {
-                    state.state = CircuitState::Open;
+                    state.transition_to(CircuitState::Open);
                     state.opened_at = Some(Instant::now());
                     tracing::warn!(
                         provider = self.inner.model_name(),
@@ -200,7 +244,7 @@ impl CircuitBreakerProvider {
                 }
             }
             CircuitState::HalfOpen => {
-                state.state = CircuitState::Open;
+                state.transition_to(CircuitState::Open);
                 state.opened_at = Some(Instant::now());
                 state.half_open_successes = 0;
                 tracing::warn!(
@@ -260,14 +304,14 @@ impl LlmProvider for CircuitBreakerProvider {
     }
 
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        self.check_allowed().await?;
+        let admission = self.check_allowed().await?;
         match self.inner.complete(request).await {
             Ok(resp) => {
-                self.record_success().await;
+                self.record_success(admission).await;
                 Ok(resp)
             }
             Err(err) => {
-                self.record_failure(&err).await;
+                self.record_failure(admission, &err).await;
                 Err(err)
             }
         }
@@ -277,14 +321,14 @@ impl LlmProvider for CircuitBreakerProvider {
         &self,
         request: ToolCompletionRequest,
     ) -> Result<ToolCompletionResponse, LlmError> {
-        self.check_allowed().await?;
+        let admission = self.check_allowed().await?;
         match self.inner.complete_with_tools(request).await {
             Ok(resp) => {
-                self.record_success().await;
+                self.record_success(admission).await;
                 Ok(resp)
             }
             Err(err) => {
-                self.record_failure(&err).await;
+                self.record_failure(admission, &err).await;
                 Err(err)
             }
         }
@@ -665,6 +709,24 @@ mod tests {
         started: mpsc::UnboundedSender<usize>,
         release_failure: Notify,
         release_success: Notify,
+        release_probe: Notify,
+    }
+
+    const CONCURRENT_TEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+    async fn next_started_call(started: &mut mpsc::UnboundedReceiver<usize>) -> Option<usize> {
+        tokio::time::timeout(CONCURRENT_TEST_TIMEOUT, started.recv())
+            .await
+            .expect("provider call must start before the test timeout")
+    }
+
+    async fn finish_call(
+        call: tokio::task::JoinHandle<Result<CompletionResponse, LlmError>>,
+    ) -> Result<CompletionResponse, LlmError> {
+        tokio::time::timeout(CONCURRENT_TEST_TIMEOUT, call)
+            .await
+            .expect("provider call must finish before the test timeout")
+            .expect("provider call task must not panic")
     }
 
     #[async_trait]
@@ -703,6 +765,18 @@ mod tests {
                         cache_creation_input_tokens: 0,
                     })
                 }
+                2 => {
+                    self.release_probe.notified().await;
+                    Ok(CompletionResponse {
+                        content: "recovery probe success".to_string(),
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        finish_reason: crate::FinishReason::Stop,
+                        reasoning: None,
+                        cache_read_input_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                    })
+                }
                 other => panic!("unexpected concurrent test call {other}"),
             }
         }
@@ -723,6 +797,7 @@ mod tests {
             started: started_tx,
             release_failure: Notify::new(),
             release_success: Notify::new(),
+            release_probe: Notify::new(),
         });
         let cb = Arc::new(CircuitBreakerProvider::new(
             Arc::clone(&inner) as Arc<dyn LlmProvider>,
@@ -737,24 +812,101 @@ mod tests {
             let cb = Arc::clone(&cb);
             tokio::spawn(async move { cb.complete(make_request()).await })
         };
-        assert_eq!(started_rx.recv().await, Some(0));
+        assert_eq!(next_started_call(&mut started_rx).await, Some(0));
 
         let second = {
             let cb = Arc::clone(&cb);
             tokio::spawn(async move { cb.complete(make_request()).await })
         };
-        assert_eq!(started_rx.recv().await, Some(1));
+        assert_eq!(next_started_call(&mut started_rx).await, Some(1));
 
         inner.release_failure.notify_one();
-        assert!(first.await.expect("failure task must not panic").is_err());
+        assert!(finish_call(first).await.is_err());
         assert_eq!(cb.circuit_state().await, CircuitState::Open);
 
         inner.release_success.notify_one();
-        assert!(second.await.expect("success task must not panic").is_ok());
+        assert!(finish_call(second).await.is_ok());
         assert_eq!(
             cb.circuit_state().await,
             CircuitState::Open,
             "a success admitted before the failure must not erase the open state"
+        );
+
+        let blocked = cb
+            .complete(make_request())
+            .await
+            .expect_err("a caller must be rejected while the breaker is Open");
+        assert!(
+            matches!(
+                blocked,
+                LlmError::RequestFailed { ref reason, .. }
+                    if reason.contains("Circuit breaker open")
+            ),
+            "caller should receive the typed circuit-breaker error, got {blocked:?}"
+        );
+        assert_eq!(
+            inner.call_index.load(Ordering::SeqCst),
+            2,
+            "an Open breaker must reject the caller without invoking the provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_closed_success_does_not_count_as_half_open_recovery() {
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let inner = Arc::new(ConcurrentOutcomeProvider {
+            call_index: AtomicUsize::new(0),
+            started: started_tx,
+            release_failure: Notify::new(),
+            release_success: Notify::new(),
+            release_probe: Notify::new(),
+        });
+        let cb = Arc::new(CircuitBreakerProvider::new(
+            Arc::clone(&inner) as Arc<dyn LlmProvider>,
+            CircuitBreakerConfig {
+                failure_threshold: 1,
+                recovery_timeout: Duration::ZERO,
+                half_open_successes_needed: 1,
+            },
+        ));
+
+        let failure = {
+            let cb = Arc::clone(&cb);
+            tokio::spawn(async move { cb.complete(make_request()).await })
+        };
+        assert_eq!(next_started_call(&mut started_rx).await, Some(0));
+
+        let stale_success = {
+            let cb = Arc::clone(&cb);
+            tokio::spawn(async move { cb.complete(make_request()).await })
+        };
+        assert_eq!(next_started_call(&mut started_rx).await, Some(1));
+
+        inner.release_failure.notify_one();
+        assert!(finish_call(failure).await.is_err());
+        assert_eq!(cb.circuit_state().await, CircuitState::Open);
+
+        let recovery_probe = {
+            let cb = Arc::clone(&cb);
+            tokio::spawn(async move { cb.complete(make_request()).await })
+        };
+        assert_eq!(next_started_call(&mut started_rx).await, Some(2));
+        assert_eq!(cb.circuit_state().await, CircuitState::HalfOpen);
+
+        inner.release_success.notify_one();
+        assert!(finish_call(stale_success).await.is_ok());
+        assert_eq!(
+            cb.circuit_state().await,
+            CircuitState::HalfOpen,
+            "only the admitted recovery probe may close the circuit"
+        );
+
+        inner.release_probe.notify_one();
+        assert!(finish_call(recovery_probe).await.is_ok());
+        assert_eq!(
+            cb.circuit_state().await,
+            CircuitState::Closed,
+            "the admitted recovery probe should restore caller access"
         );
     }
 

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -549,6 +549,7 @@ def run_cargo_metadata() -> dict:
             "--format-version",
             "1",
             "--all-features",
+            "--locked",
         ],
         cwd=REPO_ROOT,
         check=True,
@@ -662,6 +663,11 @@ def module_edges(
                         )
                     )
                     break
+            else:
+                raise RuntimeError(
+                    f"{scan.path}: could not resolve `mod {module.group(1)};`; "
+                    f"tried {[str(candidate) for candidate in candidates]}"
+                )
             pending_path = None
             pending_path_directory = None
             continue
@@ -770,9 +776,6 @@ def scan_violations(
             continue
         if scan.test_contexts[line_index]:
             continue
-        comment = scan.line_comments[line_index]
-        if comment is not None and SAFETY_RATIONALE_PATTERN.search(comment):
-            continue
         for match in PANIC_PATTERN.finditer(code):
             first_code_column = len(scan.lines[line_index]) - len(
                 scan.lines[line_index].lstrip()
@@ -783,6 +786,12 @@ def scan_violations(
                 first_code_column,
                 match.end(),
             )
+            span_end = line_index + invocation.count("\n")
+            if any(
+                comment is not None and SAFETY_RATIONALE_PATTERN.search(comment)
+                for comment in scan.line_comments[line_index : span_end + 1]
+            ):
+                continue
             fingerprint = violation_fingerprint(
                 path,
                 scan.item_contexts[line_index],
@@ -816,7 +825,7 @@ def load_reborn_baseline(
                 f"{path}:{line_no}: expected non-empty "
                 "path<TAB>fingerprint<TAB>reason"
             )
-        approved[(fields[0], fields[1])] += 1
+        approved[(fields[0], normalized_source_line(fields[1]))] += 1
     return approved
 
 
@@ -1177,6 +1186,20 @@ class CheckNoPanicsTests(unittest.TestCase):
             self.assertEqual(len(violations), 1)
             self.assertIn('panic!("caught")', violations[0][2])
 
+    def test_multiline_safety_rationale_on_closing_line_suppresses(self) -> None:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as directory:
+            source = pathlib.Path(directory) / "lib.rs"
+            source.write_text(
+                "fn invariant() {\n"
+                "    value.expect(\n"
+                '        "validated invariant",\n'
+                "    ); // safety: construction validates the invariant\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(collect_file_violations({source}), [])
+
     def test_nested_inline_module_resolves_out_of_line_children(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = pathlib.Path(directory)
@@ -1199,6 +1222,28 @@ class CheckNoPanicsTests(unittest.TestCase):
             )
 
             self.assertIn((nested_root / "nested.rs").resolve(), production)
+
+    def test_unresolved_default_module_edge_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = pathlib.Path(directory) / "lib.rs"
+            source.write_text("mod missing;\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, r"mod missing;"):
+                discover_reachable_rust_files([source])
+
+    def test_unresolved_nested_path_module_edge_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = pathlib.Path(directory) / "lib.rs"
+            source.write_text(
+                "mod outer {\n"
+                '    #[path = "missing.rs"]\n'
+                "    mod missing;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, r"outer/missing.rs"):
+                discover_reachable_rust_files([source])
 
     def test_out_of_line_test_modules_are_excluded_transitively(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -1246,6 +1291,38 @@ class CheckNoPanicsTests(unittest.TestCase):
             self.assertIn((source_root / "tests_out.rs").resolve(), tests)
             self.assertIn((source_root / "nested_fixture.rs").resolve(), tests)
 
+    def test_production_reachability_reclassifies_transitive_children(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source_root = pathlib.Path(directory)
+            (source_root / "lib.rs").write_text(
+                '#[path = "shared.rs"]\n'
+                "mod production_shared;\n"
+                "#[cfg(test)]\n"
+                '#[path = "shared.rs"]\n'
+                "mod test_shared;\n",
+                encoding="utf-8",
+            )
+            (source_root / "shared.rs").write_text(
+                "mod child;\n",
+                encoding="utf-8",
+            )
+            (source_root / "shared" / "child.rs").parent.mkdir()
+            (source_root / "shared" / "child.rs").write_text(
+                "pub fn reachable() {}\n",
+                encoding="utf-8",
+            )
+
+            production, tests = discover_reachable_rust_files(
+                [source_root / "lib.rs"]
+            )
+
+            shared = (source_root / "shared.rs").resolve()
+            child = (source_root / "shared" / "child.rs").resolve()
+            self.assertIn(shared, production)
+            self.assertIn(child, production)
+            self.assertNotIn(shared, tests)
+            self.assertNotIn(child, tests)
+
     def test_baseline_comparison_rejects_new_and_stale_entries(self) -> None:
         fingerprint = 'fn invariant :: unreachable!("static invariant")'
         approved = collections.Counter(
@@ -1277,6 +1354,31 @@ class CheckNoPanicsTests(unittest.TestCase):
         new, stale = compare_reborn_baseline(changed, approved)
         self.assertEqual(new, changed)
         self.assertEqual(stale, approved)
+
+    def test_baseline_loader_normalizes_and_counts_duplicate_fingerprints(self) -> None:
+        path = "crates/example/src/lib.rs"
+        normalized = 'fn invariant :: panic!("static invariant")'
+        record = (
+            f"{path}\t  fn   invariant ::   panic!(\"static invariant\")  "
+            "\treviewed invariant\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            baseline = pathlib.Path(directory) / "baseline.txt"
+            baseline.write_text(record + record, encoding="utf-8")
+
+            approved = load_reborn_baseline(baseline)
+
+        self.assertEqual(approved[(path, normalized)], 2)
+        violations = [
+            (path, 10, normalized),
+            (path, 20, normalized),
+        ]
+        new, stale = compare_reborn_baseline(violations, approved)
+        self.assertEqual(new, [])
+        self.assertEqual(stale, collections.Counter())
+
+        _new, stale = compare_reborn_baseline(violations[:1], approved)
+        self.assertEqual(stale[(path, normalized)], 1)
 
     def test_multiline_fingerprint_uses_complete_call_and_item_context(self) -> None:
         with tempfile.TemporaryDirectory(dir=REPO_ROOT) as directory:

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -2,15 +2,23 @@
 # Requires Python 3.10+ for PEP 604 union syntax such as `int | None`.
 
 import argparse
+import collections
+import json
 import pathlib
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from dataclasses import dataclass
 
 
-PANIC_PATTERN = re.compile(r"\.(?:unwrap|expect)\(|(?<!_)assert(?:_eq|_ne)?!")
+PANIC_PATTERN = re.compile(
+    r"\.(?:unwrap|expect)\("
+    r"|(?<!_)assert(?:_eq|_ne)?!"
+    r"|(?<![A-Za-z0-9_])(?:panic|unreachable|unimplemented|todo)!"
+)
+SAFETY_RATIONALE_PATTERN = re.compile(r"//\s*safety:\s*\S", re.IGNORECASE)
 TEST_ATTR_PATTERN = re.compile(
     r"^\s*#\s*\[\s*(?:"
     r"test"
@@ -26,6 +34,20 @@ ITEM_PATTERN = re.compile(
     r"(?:(?:async|unsafe|const)\s+)*"
     r"(fn|mod|struct|enum|trait|union|impl)\b"
     r"(?:\s+([A-Za-z_][A-Za-z0-9_]*))?"
+)
+OUT_OF_LINE_MOD_PATTERN = re.compile(
+    r"^\s*"
+    r"(?:(?:pub(?:\([^)]*\))?|crate)\s+)?"
+    r"mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
+PATH_ATTR_PATTERN = re.compile(
+    r'^\s*#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]'
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+REBORN_BASELINE_PATH = REPO_ROOT / "scripts" / "no_panics_reborn_baseline.txt"
+SHIPPING_PACKAGE_MANIFEST = (
+    REPO_ROOT / "crates" / "ironclaw_reborn_cli" / "Cargo.toml"
 )
 
 
@@ -251,6 +273,221 @@ def is_test_only_path(path: str) -> bool:
     return bool(suffix) and (suffix[0] == "test_support" or suffix == ("test_support.rs",))
 
 
+def run_cargo_metadata() -> dict:
+    result = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--format-version",
+            "1",
+            "--all-features",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def shipping_reborn_source_roots(metadata: dict) -> list[pathlib.Path]:
+    """Return production target roots in the shipping Reborn dependency closure.
+
+    The shipping binary's normal-dependency graph is the owned scope. This is
+    deliberately derived from Cargo instead of a hand-maintained crate list so
+    a newly wired runtime/persistence/transport crate enters the gate
+    automatically. External packages and non-production targets (tests,
+    examples, benches, build scripts) are excluded.
+    """
+
+    packages = {package["id"]: package for package in metadata["packages"]}
+    shipping_manifest = SHIPPING_PACKAGE_MANIFEST.resolve()
+    shipping_ids = [
+        package_id
+        for package_id, package in packages.items()
+        if pathlib.Path(package["manifest_path"]).resolve() == shipping_manifest
+    ]
+    if len(shipping_ids) != 1:
+        raise RuntimeError(
+            "expected exactly one shipping Reborn package at "
+            f"{shipping_manifest}, found {len(shipping_ids)}"
+        )
+
+    resolve = metadata.get("resolve")
+    if not resolve:
+        raise RuntimeError("cargo metadata did not return a dependency graph")
+    nodes = {node["id"]: node for node in resolve["nodes"]}
+    reachable: set[str] = set()
+    pending = list(shipping_ids)
+    while pending:
+        package_id = pending.pop()
+        if package_id in reachable:
+            continue
+        reachable.add(package_id)
+        node = nodes.get(package_id)
+        if node is None:
+            continue
+        for dependency in node["deps"]:
+            if any(kind.get("kind") is None for kind in dependency["dep_kinds"]):
+                pending.append(dependency["pkg"])
+
+    roots: set[pathlib.Path] = set()
+    crates_root = (REPO_ROOT / "crates").resolve()
+    for package_id in reachable:
+        package = packages[package_id]
+        manifest = pathlib.Path(package["manifest_path"]).resolve()
+        if manifest.parent.parent != crates_root:
+            continue
+        for target in package["targets"]:
+            if not ({"lib", "bin"} & set(target["kind"])):
+                continue
+            source = pathlib.Path(target["src_path"]).resolve()
+            if source.suffix == ".rs":
+                roots.add(source)
+    return sorted(roots)
+
+
+def default_module_candidates(source: pathlib.Path, name: str) -> tuple[pathlib.Path, ...]:
+    if source.name in {"lib.rs", "main.rs", "mod.rs"}:
+        module_dir = source.parent
+    else:
+        module_dir = source.parent / source.stem
+    return module_dir / f"{name}.rs", module_dir / name / "mod.rs"
+
+
+def module_edges(
+    source: pathlib.Path,
+    inherited_test_only: bool,
+) -> list[tuple[pathlib.Path, bool]]:
+    lines = source.read_text(encoding="utf-8").splitlines()
+    contexts = line_test_contexts(lines)
+    lexer = LexerState()
+    pending_path: str | None = None
+    edges: list[tuple[pathlib.Path, bool]] = []
+
+    for raw, local_test_context in zip(lines, contexts):
+        code = sanitize_line(raw, lexer)
+        path_attr = PATH_ATTR_PATTERN.match(raw)
+        if path_attr and code.lstrip().startswith("#["):
+            pending_path = path_attr.group(1)
+            continue
+
+        module = OUT_OF_LINE_MOD_PATTERN.match(code)
+        if module:
+            if pending_path is not None:
+                candidates = (source.parent / pending_path,)
+            else:
+                candidates = default_module_candidates(source, module.group(1))
+            for candidate in candidates:
+                if candidate.is_file():
+                    edges.append(
+                        (
+                            candidate.resolve(),
+                            inherited_test_only
+                            or local_test_context
+                            or is_test_only_path(candidate.as_posix()),
+                        )
+                    )
+                    break
+            pending_path = None
+            continue
+
+        stripped = code.strip()
+        if stripped and not stripped.startswith("#["):
+            pending_path = None
+
+    return edges
+
+
+def discover_reachable_rust_files(
+    roots: list[pathlib.Path],
+) -> tuple[set[pathlib.Path], set[pathlib.Path]]:
+    """Follow Rust module edges, retaining whether each file is test-only."""
+
+    states: dict[pathlib.Path, bool] = {}
+    pending: list[tuple[pathlib.Path, bool]] = [
+        (path.resolve(), False) for path in roots
+    ]
+    while pending:
+        source, test_only = pending.pop()
+        previous = states.get(source)
+        if previous is False or previous == test_only:
+            continue
+        states[source] = test_only
+        pending.extend(module_edges(source, test_only))
+
+    production = {path for path, test_only in states.items() if not test_only}
+    tests = {path for path, test_only in states.items() if test_only}
+    return production, tests
+
+
+def repository_relative(path: pathlib.Path) -> str:
+    return path.resolve().relative_to(REPO_ROOT).as_posix()
+
+
+def normalized_source_line(line: str) -> str:
+    return " ".join(line.strip().split())
+
+
+def violation_fingerprint(path: str, line: str) -> tuple[str, str]:
+    return path, normalized_source_line(line)
+
+
+def collect_file_violations(
+    paths: set[pathlib.Path],
+) -> list[tuple[str, int, str]]:
+    violations: list[tuple[str, int, str]] = []
+    for path in sorted(paths):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        contexts = line_test_contexts(lines)
+        lexer = LexerState()
+        for line_no, (raw, test_context) in enumerate(zip(lines, contexts), 1):
+            code = sanitize_line(raw, lexer)
+            if test_context or SAFETY_RATIONALE_PATTERN.search(raw):
+                continue
+            if PANIC_PATTERN.search(code):
+                violations.append(
+                    (repository_relative(path), line_no, raw.rstrip())
+                )
+    return violations
+
+
+def load_reborn_baseline(
+    path: pathlib.Path,
+) -> collections.Counter[tuple[str, str]]:
+    approved: collections.Counter[tuple[str, str]] = collections.Counter()
+    for line_no, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        fields = raw.split("\t", 2)
+        if len(fields) != 3 or not fields[2].strip():
+            raise RuntimeError(
+                f"{path}:{line_no}: expected path<TAB>source<TAB>non-empty reason"
+            )
+        approved[(fields[0], fields[1])] += 1
+    return approved
+
+
+def compare_reborn_baseline(
+    violations: list[tuple[str, int, str]],
+    approved: collections.Counter[tuple[str, str]],
+) -> tuple[
+    list[tuple[str, int, str]],
+    collections.Counter[tuple[str, str]],
+]:
+    remaining = approved.copy()
+    new: list[tuple[str, int, str]] = []
+    for path, line_no, line in violations:
+        fingerprint = violation_fingerprint(path, line)
+        if remaining[fingerprint]:
+            remaining[fingerprint] -= 1
+            if remaining[fingerprint] == 0:
+                del remaining[fingerprint]
+        else:
+            new.append((path, line_no, line))
+    return new, remaining
+
+
 def changed_rust_files(base: str, head: str) -> list[pathlib.Path]:
     output = run_git("diff", "--name-only", f"{base}...{head}", "--", "src", "crates")
     files = []
@@ -306,7 +543,7 @@ def collect_violations(base: str, head: str) -> list[tuple[str, int, str]]:
                 continue
             if contexts[line_no - 1]:
                 continue
-            if "// safety:" in lines[line_no - 1]:
+            if SAFETY_RATIONALE_PATTERN.search(lines[line_no - 1]):
                 continue
             if PANIC_PATTERN.search(sanitized[line_no - 1]):
                 violations.append((str(path), line_no, lines[line_no - 1].rstrip()))
@@ -319,12 +556,51 @@ def main() -> int:
     parser.add_argument("--base", required=False, default="origin/staging")
     parser.add_argument("--head", required=False, default="HEAD")
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument(
+        "--reborn-baseline",
+        action="store_true",
+        help=(
+            "scan the complete production module graph in the shipping Reborn "
+            "normal-dependency closure and compare it with the audited baseline"
+        ),
+    )
     args = parser.parse_args()
 
     if args.self_test:
         suite = unittest.defaultTestLoader.loadTestsFromTestCase(CheckNoPanicsTests)
         result = unittest.TextTestRunner(verbosity=2).run(suite)
         return 0 if result.wasSuccessful() else 1
+
+    if args.reborn_baseline:
+        roots = shipping_reborn_source_roots(run_cargo_metadata())
+        production, _tests = discover_reachable_rust_files(roots)
+        violations = collect_file_violations(production)
+        approved = load_reborn_baseline(REBORN_BASELINE_PATH)
+        new, stale = compare_reborn_baseline(violations, approved)
+        if not new and not stale:
+            print(
+                "OK: Reborn production panic baseline matches "
+                f"({len(production)} files, {len(violations)} reviewed invariant(s))."
+            )
+            return 0
+
+        print("::error::Reborn production panic baseline changed.")
+        if new:
+            print("")
+            print("New or changed panic-style calls:")
+            for path, line_no, line in new[:20]:
+                print(f"{path}:{line_no}: {line}")
+            if len(new) > 20:
+                print(f"... and {len(new) - 20} more")
+        if stale:
+            print("")
+            print("Stale baseline entries (remove them to ratchet downward):")
+            for (path, source), count in list(stale.items())[:20]:
+                suffix = f" (x{count})" if count > 1 else ""
+                print(f"{path}: {source}{suffix}")
+            if len(stale) > 20:
+                print(f"... and {len(stale) - 20} more")
+        return 1
 
     violations = collect_violations(args.base, args.head)
     if not violations:
@@ -478,6 +754,114 @@ class CheckNoPanicsTests(unittest.TestCase):
         contexts = line_test_contexts(lines)
 
         self.assertTrue(all(contexts))
+
+    def test_all_panic_style_macros_are_detected(self) -> None:
+        sources = [
+            'value.unwrap();',
+            'value.expect("reason");',
+            'assert!(ready);',
+            'assert_eq!(left, right);',
+            'assert_ne!(left, right);',
+            'panic!("boom");',
+            'unreachable!("invariant");',
+            'unimplemented!("missing");',
+            'todo!("later");',
+        ]
+        for source in sources:
+            with self.subTest(source=source):
+                lexer = LexerState()
+                self.assertIsNotNone(PANIC_PATTERN.search(sanitize_line(source, lexer)))
+
+        lexer = LexerState()
+        self.assertIsNone(
+            PANIC_PATTERN.search(sanitize_line("debug_assert!(ready);", lexer))
+        )
+
+    def test_safety_suppression_requires_a_reason(self) -> None:
+        self.assertIsNone(SAFETY_RATIONALE_PATTERN.search("panic!(); // safety:"))
+        self.assertIsNone(SAFETY_RATIONALE_PATTERN.search("panic!(); // safety:   "))
+        self.assertIsNotNone(
+            SAFETY_RATIONALE_PATTERN.search(
+                "panic!(); // safety: fixed static literal is validated"
+            )
+        )
+
+    def test_out_of_line_test_modules_are_excluded_transitively(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            source_root = root / "src"
+            source_root.mkdir()
+            (source_root / "lib.rs").write_text(
+                "mod production;\n"
+                '#[cfg(feature = "test-support")]\n'
+                "mod test_support;\n"
+                "#[cfg(test)]\n"
+                "#[path = \"tests_out.rs\"]\n"
+                "mod tests_out;\n",
+                encoding="utf-8",
+            )
+            (source_root / "production.rs").write_text(
+                "pub fn value() -> u8 { 1 }\n",
+                encoding="utf-8",
+            )
+            (source_root / "test_support.rs").write_text(
+                'fn fixture() { panic!("feature-gated test support"); }\n',
+                encoding="utf-8",
+            )
+            (source_root / "tests_out.rs").write_text(
+                "#[path = \"nested_fixture.rs\"]\n"
+                "mod nested_fixture;\n",
+                encoding="utf-8",
+            )
+            (source_root / "nested_fixture.rs").write_text(
+                'fn fixture() { panic!("test-only"); }\n',
+                encoding="utf-8",
+            )
+
+            production, tests = discover_reachable_rust_files(
+                [source_root / "lib.rs"]
+            )
+
+            self.assertIn((source_root / "production.rs").resolve(), production)
+            self.assertNotIn((source_root / "test_support.rs").resolve(), production)
+            self.assertNotIn((source_root / "tests_out.rs").resolve(), production)
+            self.assertNotIn(
+                (source_root / "nested_fixture.rs").resolve(), production
+            )
+            self.assertIn((source_root / "test_support.rs").resolve(), tests)
+            self.assertIn((source_root / "tests_out.rs").resolve(), tests)
+            self.assertIn((source_root / "nested_fixture.rs").resolve(), tests)
+
+    def test_baseline_comparison_rejects_new_and_stale_entries(self) -> None:
+        approved = collections.Counter(
+            {
+                (
+                    "crates/example/src/lib.rs",
+                    'unreachable!("static invariant")',
+                ): 1
+            }
+        )
+        matching = [
+            (
+                "crates/example/src/lib.rs",
+                10,
+                '    unreachable!("static invariant")',
+            )
+        ]
+        new, stale = compare_reborn_baseline(matching, approved)
+        self.assertEqual(new, [])
+        self.assertEqual(stale, collections.Counter())
+
+        changed = [
+            (
+                "crates/example/src/lib.rs",
+                10,
+                '    panic!("runtime input")',
+            )
+        ]
+        new, stale = compare_reborn_baseline(changed, approved)
+        self.assertEqual(new, changed)
+        self.assertEqual(stale, approved)
 
 
 if __name__ == "__main__":

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -3,6 +3,8 @@
 
 import argparse
 import collections
+import contextlib
+import io
 import json
 import pathlib
 import re
@@ -11,6 +13,7 @@ import sys
 import tempfile
 import unittest
 from dataclasses import dataclass
+from unittest import mock
 
 
 PANIC_PATTERN = re.compile(
@@ -18,16 +21,16 @@ PANIC_PATTERN = re.compile(
     r"|(?<!_)assert(?:_eq|_ne)?!"
     r"|(?<![A-Za-z0-9_])(?:panic|unreachable|unimplemented|todo)!"
 )
-SAFETY_RATIONALE_PATTERN = re.compile(r"//\s*safety:\s*\S", re.IGNORECASE)
+SAFETY_RATIONALE_PATTERN = re.compile(r"^\s*safety:\s*\S", re.IGNORECASE)
 TEST_ATTR_PATTERN = re.compile(
     r"^\s*#\s*\[\s*(?:"
     r"test"
     r"|tokio::test(?:\s*\([^]]*\))?"
     r"|rstest(?:\s*\([^]]*\))?"
     r"|test_case(?:\s*\([^]]*\))?"
-    r"|cfg\s*\([^]]*\btest\b[^]]*\)"
     r")\s*\]"
 )
+CFG_ATTR_PATTERN = re.compile(r"^\s*#\s*\[\s*cfg\s*\((.*)\)\s*\]\s*$")
 ITEM_PATTERN = re.compile(
     r"^\s*"
     r"(?:(?:pub(?:\([^)]*\))?|crate)\s+)?"
@@ -35,10 +38,20 @@ ITEM_PATTERN = re.compile(
     r"(fn|mod|struct|enum|trait|union|impl)\b"
     r"(?:\s+([A-Za-z_][A-Za-z0-9_]*))?"
 )
+CONST_STATIC_ITEM_PATTERN = re.compile(
+    r"^\s*"
+    r"(?:(?:pub(?:\([^)]*\))?|crate)\s+)?"
+    r"(const|static)\s+(?:mut\s+)?([A-Za-z_][A-Za-z0-9_]*)\b"
+)
 OUT_OF_LINE_MOD_PATTERN = re.compile(
     r"^\s*"
     r"(?:(?:pub(?:\([^)]*\))?|crate)\s+)?"
     r"mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
+INLINE_MOD_PATTERN = re.compile(
+    r"^\s*"
+    r"(?:(?:pub(?:\([^)]*\))?|crate)\s+)?"
+    r"mod\s+([A-Za-z_][A-Za-z0-9_]*)\b"
 )
 PATH_ATTR_PATTERN = re.compile(
     r'^\s*#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]'
@@ -61,6 +74,44 @@ class LexerState:
     raw_string_hashes: int | None = None
 
 
+@dataclass(frozen=True)
+class SourceScan:
+    path: pathlib.Path
+    lines: tuple[str, ...]
+    code: tuple[str, ...]
+    line_comments: tuple[str | None, ...]
+    test_contexts: tuple[bool, ...]
+    item_contexts: tuple[str, ...]
+    module_directories: tuple[pathlib.Path, ...]
+
+
+class RustScanner:
+    """Read and lex each Rust source once for discovery and violation checks."""
+
+    def __init__(self) -> None:
+        self._cache: dict[pathlib.Path, SourceScan] = {}
+
+    def scan(self, path: pathlib.Path) -> SourceScan:
+        resolved = path.resolve()
+        cached = self._cache.get(resolved)
+        if cached is not None:
+            return cached
+
+        lines = tuple(resolved.read_text(encoding="utf-8").splitlines())
+        code, comments = lex_lines(lines)
+        scan = SourceScan(
+            path=resolved,
+            lines=lines,
+            code=code,
+            line_comments=comments,
+            test_contexts=tuple(line_test_contexts_from_code(code, lines)),
+            item_contexts=tuple(line_item_contexts(code)),
+            module_directories=tuple(line_module_directories(resolved, code)),
+        )
+        self._cache[resolved] = scan
+        return scan
+
+
 def run_git(*args: str) -> str:
     result = subprocess.run(
         ["git", *args],
@@ -71,9 +122,10 @@ def run_git(*args: str) -> str:
     return result.stdout
 
 
-def sanitize_line(line: str, state: LexerState) -> str:
+def lex_line(line: str, state: LexerState) -> tuple[str, str | None]:
     chars = list(line)
     out = [" "] * len(chars)
+    line_comment: str | None = None
     i = 0
 
     while i < len(chars):
@@ -127,6 +179,7 @@ def sanitize_line(line: str, state: LexerState) -> str:
             continue
 
         if ch == "/" and nxt == "/":
+            line_comment = line[i + 2 :]
             break
         if ch == "/" and nxt == "*":
             state.block_comment_depth += 1
@@ -175,32 +228,172 @@ def sanitize_line(line: str, state: LexerState) -> str:
         state.in_char = False
         state.char_escape = False
 
-    return "".join(out)
+    return "".join(out), line_comment
+
+
+def sanitize_line(line: str, state: LexerState) -> str:
+    return lex_line(line, state)[0]
+
+
+def lex_lines(
+    lines: tuple[str, ...] | list[str],
+) -> tuple[tuple[str, ...], tuple[str | None, ...]]:
+    lexer = LexerState()
+    code: list[str] = []
+    comments: list[str | None] = []
+    for line in lines:
+        sanitized, comment = lex_line(line, lexer)
+        code.append(sanitized)
+        comments.append(comment)
+    return tuple(code), tuple(comments)
+
+
+class CfgParser:
+    """Parse enough cfg syntax to identify test-only Reborn source."""
+
+    TOKEN_PATTERN = re.compile(
+        r'\s*(?:([A-Za-z_][A-Za-z0-9_]*)|("(?:\\.|[^"])*")|([(),=]))'
+    )
+
+    def __init__(self, source: str) -> None:
+        self.tokens: list[str] = []
+        position = 0
+        while position < len(source):
+            match = self.TOKEN_PATTERN.match(source, position)
+            if match is None:
+                self.tokens = []
+                break
+            self.tokens.append(next(group for group in match.groups() if group))
+            position = match.end()
+        self.position = 0
+
+    def parse(self) -> tuple | None:
+        expression = self._expression()
+        if expression is None or self.position != len(self.tokens):
+            return None
+        return expression
+
+    def _expression(self) -> tuple | None:
+        if self.position >= len(self.tokens):
+            return None
+        name = self.tokens[self.position]
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            return None
+        self.position += 1
+
+        if self._consume("="):
+            if self.position >= len(self.tokens):
+                return None
+            value = self.tokens[self.position]
+            self.position += 1
+            if name == "feature" and value == '"test-support"':
+                return ("test-support",)
+            return ("unknown",)
+
+        if not self._consume("("):
+            return ("test",) if name == "test" else ("unknown",)
+
+        arguments: list[tuple] = []
+        if not self._peek(")"):
+            while True:
+                argument = self._expression()
+                if argument is None:
+                    return None
+                arguments.append(argument)
+                if not self._consume(","):
+                    break
+        if not self._consume(")"):
+            return None
+        if name in {"all", "any", "not"}:
+            if name == "not" and len(arguments) != 1:
+                return None
+            return (name, tuple(arguments))
+        return ("unknown",)
+
+    def _peek(self, token: str) -> bool:
+        return self.position < len(self.tokens) and self.tokens[self.position] == token
+
+    def _consume(self, token: str) -> bool:
+        if not self._peek(token):
+            return False
+        self.position += 1
+        return True
+
+
+def cfg_possible_values(expression: tuple) -> set[bool]:
+    kind = expression[0]
+    if kind == "test":
+        return {False}
+    if kind == "test-support":
+        return {False}
+    if kind == "unknown":
+        return {False, True}
+
+    arguments = expression[1]
+    values = [cfg_possible_values(argument) for argument in arguments]
+    if kind == "not":
+        return {not value for value in values[0]}
+    if kind == "all":
+        possible: set[bool] = set()
+        if all(True in value for value in values):
+            possible.add(True)
+        if any(False in value for value in values):
+            possible.add(False)
+        return possible
+    if kind == "any":
+        possible = set()
+        if any(True in value for value in values):
+            possible.add(True)
+        if all(False in value for value in values):
+            possible.add(False)
+        return possible
+    return {False, True}
+
+
+def attribute_is_test_only(line: str) -> bool:
+    if TEST_ATTR_PATTERN.match(line):
+        return True
+    match = CFG_ATTR_PATTERN.match(line)
+    if match is None:
+        return False
+    expression = CfgParser(match.group(1)).parse()
+    return expression is not None and True not in cfg_possible_values(expression)
+
+
+def item_kind_and_name(line: str) -> tuple[str, str | None] | None:
+    match = ITEM_PATTERN.match(line)
+    if match is not None:
+        return match.groups()
+    const_or_static = CONST_STATIC_ITEM_PATTERN.match(line)
+    if const_or_static is not None:
+        return const_or_static.groups()
+    return None
 
 
 def is_test_item(line: str, pending_test_attr: bool) -> tuple[bool, bool]:
-    match = ITEM_PATTERN.match(line)
-    if not match:
+    item = item_kind_and_name(line)
+    if item is None:
         return False, False
 
-    kind, name = match.groups()
+    kind, name = item
     named_tests_module = kind == "mod" and name == "tests"
     return True, pending_test_attr or named_tests_module
 
 
-def line_test_contexts(lines: list[str]) -> list[bool]:
-    contexts = [False] * len(lines)
-    lexer = LexerState()
+def line_test_contexts_from_code(
+    code_lines: tuple[str, ...],
+    raw_lines: tuple[str, ...] | list[str],
+) -> list[bool]:
+    contexts = [False] * len(code_lines)
     block_stack: list[bool] = []
     pending_test_attr = False
     pending_block_context: bool | None = None
 
-    for idx, raw in enumerate(lines):
-        code = sanitize_line(raw, lexer)
+    for idx, code in enumerate(code_lines):
         stripped = code.strip()
         current_context = block_stack[-1] if block_stack else False
 
-        if TEST_ATTR_PATTERN.match(stripped):
+        if stripped.startswith("#[") and attribute_is_test_only(raw_lines[idx].strip()):
             pending_test_attr = True
 
         item_found, item_is_test = is_test_item(code, pending_test_attr)
@@ -224,6 +417,81 @@ def line_test_contexts(lines: list[str]) -> list[bool]:
 
         if stripped.endswith(";"):
             pending_block_context = None
+
+    return contexts
+
+
+def line_test_contexts(lines: list[str]) -> list[bool]:
+    code, _comments = lex_lines(lines)
+    return line_test_contexts_from_code(code, lines)
+
+
+def root_module_directory(source: pathlib.Path) -> pathlib.Path:
+    if source.name in {"lib.rs", "main.rs", "mod.rs"}:
+        return source.parent
+    return source.parent / source.stem
+
+
+def line_module_directories(
+    source: pathlib.Path,
+    code_lines: tuple[str, ...],
+) -> list[pathlib.Path]:
+    root = root_module_directory(source)
+    directories: list[pathlib.Path] = []
+    block_stack: list[pathlib.Path] = []
+    pending_inline: pathlib.Path | None = None
+
+    for code in code_lines:
+        current = block_stack[-1] if block_stack else root
+        directories.append(current)
+        module = INLINE_MOD_PATTERN.match(code)
+        if module is not None and OUT_OF_LINE_MOD_PATTERN.match(code) is None:
+            pending_inline = current / module.group(1)
+
+        for char in code:
+            if char == "{":
+                block_stack.append(pending_inline or current)
+                pending_inline = None
+            elif char == "}" and block_stack:
+                block_stack.pop()
+                current = block_stack[-1] if block_stack else root
+
+        stripped = code.strip()
+        if pending_inline is not None and stripped.endswith(";"):
+            pending_inline = None
+
+    return directories
+
+
+def line_item_contexts(code_lines: tuple[str, ...]) -> list[str]:
+    contexts: list[str] = []
+    block_stack: list[str | None] = []
+    pending_item: str | None = None
+
+    for code in code_lines:
+        item = item_kind_and_name(code)
+        if item is not None:
+            kind, name = item
+            pending_item = (
+                f"{kind} {name}"
+                if name is not None
+                else normalized_source_line(code.split("{", 1)[0])
+            )
+
+        active = [label for label in block_stack if label is not None]
+        if pending_item is not None:
+            active.append(pending_item)
+        contexts.append("::".join(active) if active else "<module>")
+
+        for char in code:
+            if char == "{":
+                block_stack.append(pending_item)
+                pending_item = None
+            elif char == "}" and block_stack:
+                block_stack.pop()
+
+        if code.strip().endswith(";"):
+            pending_item = None
 
     return contexts
 
@@ -347,37 +615,42 @@ def shipping_reborn_source_roots(metadata: dict) -> list[pathlib.Path]:
     return sorted(roots)
 
 
-def default_module_candidates(source: pathlib.Path, name: str) -> tuple[pathlib.Path, ...]:
-    if source.name in {"lib.rs", "main.rs", "mod.rs"}:
-        module_dir = source.parent
-    else:
-        module_dir = source.parent / source.stem
+def default_module_candidates(
+    module_dir: pathlib.Path,
+    name: str,
+) -> tuple[pathlib.Path, ...]:
     return module_dir / f"{name}.rs", module_dir / name / "mod.rs"
 
 
 def module_edges(
-    source: pathlib.Path,
+    scan: SourceScan,
     inherited_test_only: bool,
 ) -> list[tuple[pathlib.Path, bool]]:
-    lines = source.read_text(encoding="utf-8").splitlines()
-    contexts = line_test_contexts(lines)
-    lexer = LexerState()
     pending_path: str | None = None
+    pending_path_directory: pathlib.Path | None = None
     edges: list[tuple[pathlib.Path, bool]] = []
 
-    for raw, local_test_context in zip(lines, contexts):
-        code = sanitize_line(raw, lexer)
+    for raw, code, local_test_context, module_dir in zip(
+        scan.lines,
+        scan.code,
+        scan.test_contexts,
+        scan.module_directories,
+    ):
         path_attr = PATH_ATTR_PATTERN.match(raw)
         if path_attr and code.lstrip().startswith("#["):
             pending_path = path_attr.group(1)
+            pending_path_directory = module_dir
             continue
 
         module = OUT_OF_LINE_MOD_PATTERN.match(code)
         if module:
             if pending_path is not None:
-                candidates = (source.parent / pending_path,)
+                path_directory = pending_path_directory or module_dir
+                if path_directory == root_module_directory(scan.path):
+                    path_directory = scan.path.parent
+                candidates = (path_directory / pending_path,)
             else:
-                candidates = default_module_candidates(source, module.group(1))
+                candidates = default_module_candidates(module_dir, module.group(1))
             for candidate in candidates:
                 if candidate.is_file():
                     edges.append(
@@ -390,20 +663,24 @@ def module_edges(
                     )
                     break
             pending_path = None
+            pending_path_directory = None
             continue
 
         stripped = code.strip()
         if stripped and not stripped.startswith("#["):
             pending_path = None
+            pending_path_directory = None
 
     return edges
 
 
 def discover_reachable_rust_files(
     roots: list[pathlib.Path],
+    scanner: RustScanner | None = None,
 ) -> tuple[set[pathlib.Path], set[pathlib.Path]]:
     """Follow Rust module edges, retaining whether each file is test-only."""
 
+    scanner = scanner or RustScanner()
     states: dict[pathlib.Path, bool] = {}
     pending: list[tuple[pathlib.Path, bool]] = [
         (path.resolve(), False) for path in roots
@@ -414,7 +691,7 @@ def discover_reachable_rust_files(
         if previous is False or previous == test_only:
             continue
         states[source] = test_only
-        pending.extend(module_edges(source, test_only))
+        pending.extend(module_edges(scanner.scan(source), test_only))
 
     production = {path for path, test_only in states.items() if not test_only}
     tests = {path for path, test_only in states.items() if test_only}
@@ -429,26 +706,100 @@ def normalized_source_line(line: str) -> str:
     return " ".join(line.strip().split())
 
 
-def violation_fingerprint(path: str, line: str) -> tuple[str, str]:
-    return path, normalized_source_line(line)
+def invocation_source(
+    scan: SourceScan,
+    start_line: int,
+    start_column: int,
+    match_end: int,
+) -> str:
+    open_line = start_line
+    open_column = match_end
+    if match_end > 0 and scan.code[start_line][match_end - 1] == "(":
+        open_column = match_end - 1
+    while open_line < len(scan.code):
+        found = scan.code[open_line].find("(", open_column)
+        if found >= 0:
+            open_column = found
+            break
+        open_line += 1
+        open_column = 0
+    else:
+        return scan.lines[start_line][start_column:]
+
+    depth = 0
+    end_line = open_line
+    end_column = len(scan.lines[open_line]) - 1
+    found_end = False
+    for line_index in range(open_line, len(scan.code)):
+        column = open_column if line_index == open_line else 0
+        for column_index in range(column, len(scan.code[line_index])):
+            char = scan.code[line_index][column_index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    end_line = line_index
+                    end_column = column_index
+                    found_end = True
+                    break
+        if found_end:
+            break
+
+    pieces: list[str] = []
+    for line_index in range(start_line, end_line + 1):
+        left = start_column if line_index == start_line else 0
+        right = end_column + 1 if line_index == end_line else len(scan.lines[line_index])
+        pieces.append(scan.lines[line_index][left:right])
+    return "\n".join(pieces)
+
+
+def violation_fingerprint(path: str, context: str, invocation: str) -> tuple[str, str]:
+    return path, f"{context} :: {normalized_source_line(invocation)}"
+
+
+def scan_violations(
+    scan: SourceScan,
+    included_lines: set[int] | None = None,
+) -> list[tuple[str, int, str]]:
+    path = repository_relative(scan.path)
+    violations: list[tuple[str, int, str]] = []
+    for line_index, code in enumerate(scan.code):
+        line_no = line_index + 1
+        if included_lines is not None and line_no not in included_lines:
+            continue
+        if scan.test_contexts[line_index]:
+            continue
+        comment = scan.line_comments[line_index]
+        if comment is not None and SAFETY_RATIONALE_PATTERN.search(comment):
+            continue
+        for match in PANIC_PATTERN.finditer(code):
+            first_code_column = len(scan.lines[line_index]) - len(
+                scan.lines[line_index].lstrip()
+            )
+            invocation = invocation_source(
+                scan,
+                line_index,
+                first_code_column,
+                match.end(),
+            )
+            fingerprint = violation_fingerprint(
+                path,
+                scan.item_contexts[line_index],
+                invocation,
+            )[1]
+            violations.append((path, line_no, fingerprint))
+    return violations
 
 
 def collect_file_violations(
     paths: set[pathlib.Path],
+    scanner: RustScanner | None = None,
 ) -> list[tuple[str, int, str]]:
+    scanner = scanner or RustScanner()
     violations: list[tuple[str, int, str]] = []
     for path in sorted(paths):
-        lines = path.read_text(encoding="utf-8").splitlines()
-        contexts = line_test_contexts(lines)
-        lexer = LexerState()
-        for line_no, (raw, test_context) in enumerate(zip(lines, contexts), 1):
-            code = sanitize_line(raw, lexer)
-            if test_context or SAFETY_RATIONALE_PATTERN.search(raw):
-                continue
-            if PANIC_PATTERN.search(code):
-                violations.append(
-                    (repository_relative(path), line_no, raw.rstrip())
-                )
+        violations.extend(scan_violations(scanner.scan(path)))
     return violations
 
 
@@ -459,10 +810,11 @@ def load_reborn_baseline(
     for line_no, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
         if not raw.strip() or raw.lstrip().startswith("#"):
             continue
-        fields = raw.split("\t", 2)
-        if len(fields) != 3 or not fields[2].strip():
+        fields = raw.split("\t")
+        if len(fields) != 3 or any(not field.strip() for field in fields):
             raise RuntimeError(
-                f"{path}:{line_no}: expected path<TAB>source<TAB>non-empty reason"
+                f"{path}:{line_no}: expected non-empty "
+                "path<TAB>fingerprint<TAB>reason"
             )
         approved[(fields[0], fields[1])] += 1
     return approved
@@ -477,14 +829,14 @@ def compare_reborn_baseline(
 ]:
     remaining = approved.copy()
     new: list[tuple[str, int, str]] = []
-    for path, line_no, line in violations:
-        fingerprint = violation_fingerprint(path, line)
+    for path, line_no, fingerprint_source in violations:
+        fingerprint = (path, fingerprint_source)
         if remaining[fingerprint]:
             remaining[fingerprint] -= 1
             if remaining[fingerprint] == 0:
                 del remaining[fingerprint]
         else:
-            new.append((path, line_no, line))
+            new.append((path, line_no, fingerprint_source))
     return new, remaining
 
 
@@ -525,6 +877,7 @@ def added_lines_for_file(base: str, head: str, path: pathlib.Path) -> set[int]:
 
 def collect_violations(base: str, head: str) -> list[tuple[str, int, str]]:
     violations: list[tuple[str, int, str]] = []
+    scanner = RustScanner()
 
     for path in changed_rust_files(base, head):
         if not path.exists():
@@ -533,22 +886,42 @@ def collect_violations(base: str, head: str) -> list[tuple[str, int, str]]:
         if not added_lines:
             continue
 
-        lines = path.read_text(encoding="utf-8").splitlines()
-        contexts = line_test_contexts(lines)
-        lexer = LexerState()
-        sanitized = [sanitize_line(line, lexer) for line in lines]
-
-        for line_no in sorted(added_lines):
-            if line_no < 1 or line_no > len(lines):
-                continue
-            if contexts[line_no - 1]:
-                continue
-            if SAFETY_RATIONALE_PATTERN.search(lines[line_no - 1]):
-                continue
-            if PANIC_PATTERN.search(sanitized[line_no - 1]):
-                violations.append((str(path), line_no, lines[line_no - 1].rstrip()))
+        scan = scanner.scan(path)
+        violations.extend(scan_violations(scan, added_lines))
 
     return violations
+
+
+def report_reborn_baseline(
+    production_count: int,
+    violations: list[tuple[str, int, str]],
+    approved: collections.Counter[tuple[str, str]],
+) -> int:
+    new, stale = compare_reborn_baseline(violations, approved)
+    if not new and not stale:
+        print(
+            "OK: Reborn production panic baseline matches "
+            f"({production_count} files, {len(violations)} reviewed invariant(s))."
+        )
+        return 0
+
+    print("::error::Reborn production panic baseline changed.")
+    if new:
+        print("")
+        print("New or changed panic-style calls:")
+        for path, line_no, fingerprint in new[:20]:
+            print(f"{path}:{line_no}: {fingerprint}")
+        if len(new) > 20:
+            print(f"... and {len(new) - 20} more")
+    if stale:
+        print("")
+        print("Stale baseline entries (remove them to ratchet downward):")
+        for (path, fingerprint), count in list(stale.items())[:20]:
+            suffix = f" (x{count})" if count > 1 else ""
+            print(f"{path}: {fingerprint}{suffix}")
+        if len(stale) > 20:
+            print(f"... and {len(stale) - 20} more")
+    return 1
 
 
 def main() -> int:
@@ -572,35 +945,12 @@ def main() -> int:
         return 0 if result.wasSuccessful() else 1
 
     if args.reborn_baseline:
+        scanner = RustScanner()
         roots = shipping_reborn_source_roots(run_cargo_metadata())
-        production, _tests = discover_reachable_rust_files(roots)
-        violations = collect_file_violations(production)
+        production, _tests = discover_reachable_rust_files(roots, scanner)
+        violations = collect_file_violations(production, scanner)
         approved = load_reborn_baseline(REBORN_BASELINE_PATH)
-        new, stale = compare_reborn_baseline(violations, approved)
-        if not new and not stale:
-            print(
-                "OK: Reborn production panic baseline matches "
-                f"({len(production)} files, {len(violations)} reviewed invariant(s))."
-            )
-            return 0
-
-        print("::error::Reborn production panic baseline changed.")
-        if new:
-            print("")
-            print("New or changed panic-style calls:")
-            for path, line_no, line in new[:20]:
-                print(f"{path}:{line_no}: {line}")
-            if len(new) > 20:
-                print(f"... and {len(new) - 20} more")
-        if stale:
-            print("")
-            print("Stale baseline entries (remove them to ratchet downward):")
-            for (path, source), count in list(stale.items())[:20]:
-                suffix = f" (x{count})" if count > 1 else ""
-                print(f"{path}: {source}{suffix}")
-            if len(stale) > 20:
-                print(f"... and {len(stale) - 20} more")
-        return 1
+        return report_reborn_baseline(len(production), violations, approved)
 
     violations = collect_violations(args.base, args.head)
     if not violations:
@@ -684,6 +1034,28 @@ class CheckNoPanicsTests(unittest.TestCase):
                 self.assertTrue(contexts[2])
                 self.assertFalse(contexts[4])
                 self.assertFalse(contexts[5])
+
+    def test_cfg_only_excludes_items_that_logically_require_test(self) -> None:
+        cases = {
+            "cfg(test)": True,
+            "cfg(all(test, unix))": True,
+            "cfg(not(not(test)))": True,
+            "cfg(not(test))": False,
+            "cfg(any(test, unix))": False,
+            'cfg(all(feature = "test-support", unix))': True,
+            'cfg(all(feature = "production-mode", unix))': False,
+        }
+
+        for attribute, expected in cases.items():
+            with self.subTest(attribute=attribute):
+                lines = [
+                    f"#[{attribute}]\n",
+                    "fn candidate() {\n",
+                    '    value.expect("classified by cfg");\n',
+                    "}\n",
+                ]
+                contexts = line_test_contexts(lines)
+                self.assertEqual(contexts[2], expected)
 
     def test_test_only_path_detection(self) -> None:
         self.assertTrue(is_test_only_path("src/channels/web/tests/multi_tenant.rs"))
@@ -778,13 +1150,55 @@ class CheckNoPanicsTests(unittest.TestCase):
         )
 
     def test_safety_suppression_requires_a_reason(self) -> None:
-        self.assertIsNone(SAFETY_RATIONALE_PATTERN.search("panic!(); // safety:"))
-        self.assertIsNone(SAFETY_RATIONALE_PATTERN.search("panic!(); // safety:   "))
+        self.assertIsNone(SAFETY_RATIONALE_PATTERN.search(" safety:"))
+        self.assertIsNone(SAFETY_RATIONALE_PATTERN.search(" safety:   "))
         self.assertIsNotNone(
             SAFETY_RATIONALE_PATTERN.search(
-                "panic!(); // safety: fixed static literal is validated"
+                " safety: fixed static literal is validated"
             )
         )
+
+    def test_safety_rationale_must_be_an_actual_line_comment(self) -> None:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as directory:
+            root = pathlib.Path(directory)
+            source = root / "lib.rs"
+            source.write_text(
+                'fn string_is_not_a_rationale() {\n'
+                '    let note = "// safety: misleading string"; panic!("caught");\n'
+                "}\n"
+                "fn comment_is_a_rationale() {\n"
+                '    panic!("suppressed"); // safety: fixed invariant\n'
+                "}\n",
+                encoding="utf-8",
+            )
+
+            violations = collect_file_violations({source})
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn('panic!("caught")', violations[0][2])
+
+    def test_nested_inline_module_resolves_out_of_line_children(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            source_root = root / "src"
+            nested_root = source_root / "outer"
+            nested_root.mkdir(parents=True)
+            (source_root / "lib.rs").write_text(
+                "mod outer {\n"
+                "    mod nested;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            (nested_root / "nested.rs").write_text(
+                "pub fn reachable() {}\n",
+                encoding="utf-8",
+            )
+
+            production, _tests = discover_reachable_rust_files(
+                [source_root / "lib.rs"]
+            )
+
+            self.assertIn((nested_root / "nested.rs").resolve(), production)
 
     def test_out_of_line_test_modules_are_excluded_transitively(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -833,11 +1247,12 @@ class CheckNoPanicsTests(unittest.TestCase):
             self.assertIn((source_root / "nested_fixture.rs").resolve(), tests)
 
     def test_baseline_comparison_rejects_new_and_stale_entries(self) -> None:
+        fingerprint = 'fn invariant :: unreachable!("static invariant")'
         approved = collections.Counter(
             {
                 (
                     "crates/example/src/lib.rs",
-                    'unreachable!("static invariant")',
+                    fingerprint,
                 ): 1
             }
         )
@@ -845,7 +1260,7 @@ class CheckNoPanicsTests(unittest.TestCase):
             (
                 "crates/example/src/lib.rs",
                 10,
-                '    unreachable!("static invariant")',
+                fingerprint,
             )
         ]
         new, stale = compare_reborn_baseline(matching, approved)
@@ -856,12 +1271,227 @@ class CheckNoPanicsTests(unittest.TestCase):
             (
                 "crates/example/src/lib.rs",
                 10,
-                '    panic!("runtime input")',
+                'fn invariant :: panic!("runtime input")',
             )
         ]
         new, stale = compare_reborn_baseline(changed, approved)
         self.assertEqual(new, changed)
         self.assertEqual(stale, approved)
+
+    def test_multiline_fingerprint_uses_complete_call_and_item_context(self) -> None:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as directory:
+            source = pathlib.Path(directory) / "lib.rs"
+            source.write_text(
+                "fn first() {\n"
+                "    value.expect(\n"
+                '        "same reason",\n'
+                "    );\n"
+                "}\n"
+                "fn second() {\n"
+                "    value.expect(\n"
+                '        "same reason",\n'
+                "    );\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            violations = collect_file_violations({source})
+
+            self.assertEqual(len(violations), 2)
+            first = violations[0]
+            second = violations[1]
+            self.assertIn('.expect( "same reason", )', first[2])
+            self.assertIn("fn first", first[2])
+            self.assertIn("fn second", second[2])
+            approved = collections.Counter({(first[0], first[2]): 1})
+            new, stale = compare_reborn_baseline([second], approved)
+            self.assertEqual(new, [second])
+            self.assertEqual(stale, approved)
+
+    def test_fingerprint_includes_receiver_and_match_arm_prefix(self) -> None:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as directory:
+            source = pathlib.Path(directory) / "lib.rs"
+            source.write_text(
+                "fn same_item(value: Option<u8>) {\n"
+                '    left.unwrap();\n'
+                '    right.unwrap();\n'
+                "    match value {\n"
+                "        None => unreachable!(),\n"
+                '        Some(_) => unreachable!("different arm"),\n'
+                "    }\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            fingerprints = [
+                violation[2] for violation in collect_file_violations({source})
+            ]
+
+            self.assertEqual(len(fingerprints), 4)
+            self.assertIn("left.unwrap()", fingerprints[0])
+            self.assertIn("right.unwrap()", fingerprints[1])
+            self.assertIn("None => unreachable!()", fingerprints[2])
+            self.assertIn('Some(_) => unreachable!("different arm")', fingerprints[3])
+            self.assertEqual(len(set(fingerprints)), 4)
+
+    def test_module_level_const_and_static_are_named_fingerprint_contexts(self) -> None:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as directory:
+            source = pathlib.Path(directory) / "lib.rs"
+            source.write_text(
+                'const DEFAULT: u8 = value.expect("const");\n'
+                'static FALLBACK: u8 = value.expect("static");\n',
+                encoding="utf-8",
+            )
+
+            fingerprints = [
+                violation[2] for violation in collect_file_violations({source})
+            ]
+
+            self.assertIn("const DEFAULT ::", fingerprints[0])
+            self.assertIn("static FALLBACK ::", fingerprints[1])
+
+    def test_scanner_reuses_lexed_source_for_discovery_and_detection(self) -> None:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as directory:
+            root = pathlib.Path(directory)
+            source = root / "lib.rs"
+            source.write_text('fn invariant() { panic!("one scan"); }\n', encoding="utf-8")
+            scanner = RustScanner()
+            original_read_text = pathlib.Path.read_text
+            with mock.patch.object(
+                pathlib.Path,
+                "read_text",
+                autospec=True,
+                side_effect=original_read_text,
+            ) as read_text:
+                production, _tests = discover_reachable_rust_files([source], scanner)
+                violations = collect_file_violations(production, scanner)
+
+            source_reads = [
+                call
+                for call in read_text.call_args_list
+                if pathlib.Path(call.args[0]).resolve() == source.resolve()
+            ]
+            self.assertEqual(len(source_reads), 1)
+            self.assertEqual(len(violations), 1)
+
+    def test_shipping_roots_follow_normal_dependencies_and_lib_bin_targets(self) -> None:
+        shipping_id = "shipping"
+        normal_id = "normal"
+        dev_id = "dev"
+        build_id = "build"
+
+        def package(
+            package_id: str,
+            crate_name: str,
+            target_kinds: list[str],
+        ) -> dict:
+            crate_root = REPO_ROOT / "crates" / crate_name
+            return {
+                "id": package_id,
+                "manifest_path": str(crate_root / "Cargo.toml"),
+                "targets": [
+                    {
+                        "kind": [kind],
+                        "src_path": str(
+                            crate_root / "src" / ("main.rs" if kind == "bin" else f"{kind}.rs")
+                        ),
+                    }
+                    for kind in target_kinds
+                ],
+            }
+
+        shipping = package(
+            shipping_id,
+            "ironclaw_reborn_cli",
+            ["lib", "bin", "test", "custom-build"],
+        )
+        metadata = {
+            "packages": [
+                shipping,
+                package(normal_id, "normal_dependency", ["lib", "bin"]),
+                package(dev_id, "dev_dependency", ["lib"]),
+                package(build_id, "build_dependency", ["lib"]),
+            ],
+            "resolve": {
+                "nodes": [
+                    {
+                        "id": shipping_id,
+                        "deps": [
+                            {"pkg": normal_id, "dep_kinds": [{"kind": None}]},
+                            {"pkg": dev_id, "dep_kinds": [{"kind": "dev"}]},
+                            {"pkg": build_id, "dep_kinds": [{"kind": "build"}]},
+                        ],
+                    },
+                    {"id": normal_id, "deps": []},
+                    {"id": dev_id, "deps": []},
+                    {"id": build_id, "deps": []},
+                ]
+            },
+        }
+
+        roots = shipping_reborn_source_roots(metadata)
+
+        self.assertEqual(
+            roots,
+            sorted(
+                [
+                    (REPO_ROOT / "crates/ironclaw_reborn_cli/src/lib.rs").resolve(),
+                    (REPO_ROOT / "crates/ironclaw_reborn_cli/src/main.rs").resolve(),
+                    (REPO_ROOT / "crates/normal_dependency/src/lib.rs").resolve(),
+                    (REPO_ROOT / "crates/normal_dependency/src/main.rs").resolve(),
+                ]
+            ),
+        )
+
+    def test_malformed_baseline_records_are_rejected(self) -> None:
+        malformed = [
+            "missing-tabs",
+            "\tfingerprint\treason",
+            "crates/example/src/lib.rs\t\treason",
+            "crates/example/src/lib.rs\tfingerprint\t",
+            "crates/example/src/lib.rs\tfingerprint\treason\textra",
+        ]
+        for record in malformed:
+            with self.subTest(record=record):
+                with tempfile.TemporaryDirectory() as directory:
+                    baseline = pathlib.Path(directory) / "baseline.txt"
+                    baseline.write_text(record + "\n", encoding="utf-8")
+                    with self.assertRaises(RuntimeError):
+                        load_reborn_baseline(baseline)
+
+    def test_reborn_report_returns_nonzero_for_new_and_stale_entries(self) -> None:
+        violation = (
+            "crates/example/src/lib.rs",
+            7,
+            'fn new_call :: panic!("new")',
+        )
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            new_result = report_reborn_baseline(
+                1,
+                [violation],
+                collections.Counter(),
+            )
+        self.assertEqual(new_result, 1)
+        self.assertIn("New or changed panic-style calls", output.getvalue())
+
+        approved = collections.Counter(
+            {
+                (
+                    "crates/example/src/lib.rs",
+                    'fn removed :: panic!("old")',
+                ): 1
+            }
+        )
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            stale_result = report_reborn_baseline(1, [], approved)
+        self.assertEqual(stale_result, 1)
+        self.assertIn("Stale baseline entries", output.getvalue())
+
+    def test_has_code_classifier_includes_reborn_baseline(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/code_style.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("scripts/no_panics_reborn_baseline\\.txt$", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/no_panics_reborn_baseline.txt
+++ b/scripts/no_panics_reborn_baseline.txt
@@ -1,0 +1,67 @@
+# Audited panic-style calls in the shipping Reborn production dependency closure.
+#
+# Format: repository path<TAB>normalized source line<TAB>review rationale
+# Duplicate source lines are repeated because the checker compares this as a multiset.
+# Remove an entry when its invariant is eliminated; CI rejects both new and stale entries.
+
+crates/ironclaw_agent_loop/src/executor/capabilities.rs	_ => unreachable!("guarded to RecoverableFailure"),	Exhaustive match after the recoverable-failure arm returns to the model.
+crates/ironclaw_agent_loop/src/strategies/recovery.rs	Err(reason) => panic!("invalid trusted static strategy summary: {reason}"),	Compile-time-owned recovery strategy text is validated during construction.
+crates/ironclaw_auth/src/credential.rs	unreachable!("single account recovery cannot produce account selection required")	Single-account recovery cannot construct the multi-account selection outcome.
+crates/ironclaw_auth/src/domain.rs	unreachable!("single account recovery cannot produce account selection required")	Single-account recovery cannot construct the multi-account selection outcome.
+crates/ironclaw_authorization/src/lib.rs	unreachable!("authorization index key `tenant_id` must be a simple identifier")	The fixed ASCII index key is validated by the typed constructor.
+crates/ironclaw_authorization/src/lib.rs	unreachable!(	The fixed ASCII authorization index name is validated by the typed constructor.
+crates/ironclaw_capabilities/src/helpers.rs	(false, false) => unreachable!("resume context mismatch kind called without mismatch"),	The mismatch classifier is called only after at least one compared field differs.
+crates/ironclaw_capabilities/src/host.rs	unreachable!("matched AuthRequired above")	The preceding match arm handles every AuthRequired outcome.
+crates/ironclaw_conversations/src/conversation_state_store.rs	.unwrap_or_else(|_| unreachable!("tenant_ids is a simple ascii identifier"))	The fixed ASCII index name is validated by the typed constructor.
+crates/ironclaw_extension_host/src/extension_ingress.rs	None => unreachable!(),	The None branch is excluded by the preceding optional-input guard.
+crates/ironclaw_extension_host/src/extension_ingress.rs	None => unreachable!(),	The None branch is excluded by the preceding optional-input guard.
+crates/ironclaw_filesystem/src/libsql_pool.rs	Err(error) => unreachable!("libSQL pool build cannot fail: {error}"),	The libSQL pool builder has no fallible runtime configuration inputs.
+crates/ironclaw_hooks/src/dispatch/mod.rs	unreachable!(	The dispatch branch is selected only after the corresponding hook payload variant is matched.
+crates/ironclaw_hooks/src/dispatch/mod.rs	unreachable!(	The dispatch branch is selected only after the corresponding hook payload variant is matched.
+crates/ironclaw_hooks/src/dispatch/mod.rs	unreachable!(	The dispatch branch is selected only after the corresponding hook payload variant is matched.
+crates/ironclaw_hooks/src/wasm/runtime.rs	None => unreachable!(),	The result is checked for absence immediately before extraction.
+crates/ironclaw_host_api/src/decision.rs	_ => unreachable!("extract_inject_handle called for {kind:?}"),	The helper is private to inject-decision variants that carry handles.
+crates/ironclaw_host_runtime/src/services.rs	panic!("LocalSingleUser + LocalDev runtime policy must resolve for local testing: {error}")	The fixed local-testing policy combination is a host startup invariant.
+crates/ironclaw_llm/src/recording.rs	_ => unreachable!(),	The provider-event variant is selected by the immediately preceding classification.
+crates/ironclaw_loop_host/src/budget_accountant.rs	.unwrap_or_else(|_| panic!("internal budget-accountant invariant: {reason}"))	Only internally computed bounded budget values reach this typed conversion.
+crates/ironclaw_loop_host/src/compaction_task.rs	Err(reason) => unreachable!("invalid static system prompt id {value}: {reason}"),	The system prompt identifier is a fixed source literal.
+crates/ironclaw_loop_host/src/compaction_task.rs	_ => unreachable!(),	The task outcome variant is narrowed by the preceding match.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("`memory_document` is a valid record kind"))	The record kind is a fixed valid source literal.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("`memory_chunk` is a valid record kind"))	The record kind is a fixed valid source literal.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("`memory_document_version` is a valid record kind"))	The record kind is a fixed valid source literal.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	IndexKey::new(name).unwrap_or_else(|_| unreachable!("{name} is a valid index key"))	Callers supply only fixed schema-owned index keys.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("valid index name")),	The index name is fixed by the memory schema.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("valid index name")),	The index name is fixed by the memory schema.
+crates/ironclaw_operator/src/llm_admin/nearai_login_serve.rs	None => unreachable!(),	The option is checked before the OAuth login response is assembled.
+crates/ironclaw_operator/src/llm_admin/nearai_login_serve.rs	None => unreachable!(),	The option is checked before the OAuth login response is assembled.
+crates/ironclaw_operator/src/operator_service_lifecycle.rs	ServicePlatform::Unsupported => unreachable!("handled above"),	The unsupported-platform branch returns before platform dispatch.
+crates/ironclaw_outbound/src/outbound_state_store.rs	Err(_) => unreachable!(	The fixed outbound index identifier is validated by the typed constructor.
+crates/ironclaw_outbound/src/outbound_state_store.rs	Err(_) => unreachable!(	The fixed outbound index identifier is validated by the typed constructor.
+crates/ironclaw_process_sandbox/src/plan.rs	unreachable!("non-header targets are rejected during sandbox credential validation")	Validation rejects non-header credential targets before plan construction.
+crates/ironclaw_processes/src/process_store.rs	.unwrap_or_else(|_| unreachable!("process index name {value} must be a simple identifier"))	The process index name comes from a fixed schema-owned literal.
+crates/ironclaw_processes/src/process_store.rs	.unwrap_or_else(|_| unreachable!("process index key {value} must be a simple identifier"))	The process index key comes from a fixed schema-owned literal.
+crates/ironclaw_product/src/reborn_services.rs	ToolPermissionState::AlwaysAllow => unreachable!(),	The always-allow state is returned before approval-request construction.
+crates/ironclaw_product/src/reborn_services.rs	ThreadId::new("generated-thread-fallback").unwrap_or_else(|_| unreachable!())	The fallback thread identifier is a fixed valid source literal.
+crates/ironclaw_product/src/run_delivery/triggered.rs	unreachable!("OAuthTargetNotDm is handled by the dedicated arm above")	The OAuth non-DM outcome is returned by the dedicated preceding arm.
+crates/ironclaw_reborn_cli/src/commands/config/set.rs	ConfigKey::WebuiToken => unreachable!("handled by execute_webui_token"),	The WebUI token key is dispatched to its dedicated handler first.
+crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("local-dev-yolo is a local runtime profile")	The deployment profile table fixes local-dev-yolo to a local runtime.
+crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("local-dev-yolo carries a runtime-policy request")	The deployment profile table always supplies this request.
+crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("{profile_name} uses the local-dev runtime policy shape")	The matched profile is defined with the local-dev policy shape.
+crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("{profile_name} carries a runtime-policy request")	The matched profile definition always carries this request.
+crates/ironclaw_runner/src/tool_disclosure.rs	panic!("invalid static bridge tool name: {error}");	The bridge tool name is a fixed runner-owned source literal.
+crates/ironclaw_runner/src/tool_disclosure.rs	panic!("invalid static bridge capability id: {error}");	The bridge capability identifier is a fixed runner-owned source literal.
+crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!(	The resolver intentionally fails loudly if a new deployment mode lacks an explicit policy.
+crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!("sandboxed_filesystem_for: unhandled DeploymentMode variant"),	The resolver intentionally fails loudly if a new deployment mode lacks an explicit filesystem policy.
+crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!("sandboxed_secret_for: unhandled DeploymentMode variant"),	The resolver intentionally fails loudly if a new deployment mode lacks an explicit secret policy.
+crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!("audit_for: unhandled DeploymentMode variant"),	The resolver intentionally fails loudly if a new deployment mode lacks an explicit audit policy.
+crates/ironclaw_secrets/src/secret_store.rs	unreachable!("secrets index key `tenant_id` must be a simple identifier")	The fixed ASCII secrets index key is validated by the typed constructor.
+crates/ironclaw_secrets/src/secret_store.rs	unreachable!("secrets index name `secrets_by_tenant` must be a simple identifier")	The fixed ASCII secrets index name is validated by the typed constructor.
+crates/ironclaw_turns/src/turn_state_row_store/turn_state_engine/transitions.rs	_ => unreachable!("status checked above"),	The transition checks and returns for disallowed statuses before mutation.
+crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/webui_rate_limit.rs	None => unreachable!(),	The selected limiter is guaranteed present by the preceding configuration branch.

--- a/scripts/no_panics_reborn_baseline.txt
+++ b/scripts/no_panics_reborn_baseline.txt
@@ -1,67 +1,67 @@
 # Audited panic-style calls in the shipping Reborn production dependency closure.
 #
-# Format: repository path<TAB>normalized source line<TAB>review rationale
-# Duplicate source lines are repeated because the checker compares this as a multiset.
+# Format: repository path<TAB>item context and normalized complete invocation<TAB>review rationale
+# Duplicate fingerprints are repeated because the checker compares this as a multiset.
 # Remove an entry when its invariant is eliminated; CI rejects both new and stale entries.
 
-crates/ironclaw_agent_loop/src/executor/capabilities.rs	_ => unreachable!("guarded to RecoverableFailure"),	Exhaustive match after the recoverable-failure arm returns to the model.
-crates/ironclaw_agent_loop/src/strategies/recovery.rs	Err(reason) => panic!("invalid trusted static strategy summary: {reason}"),	Compile-time-owned recovery strategy text is validated during construction.
-crates/ironclaw_auth/src/credential.rs	unreachable!("single account recovery cannot produce account selection required")	Single-account recovery cannot construct the multi-account selection outcome.
-crates/ironclaw_auth/src/domain.rs	unreachable!("single account recovery cannot produce account selection required")	Single-account recovery cannot construct the multi-account selection outcome.
-crates/ironclaw_authorization/src/lib.rs	unreachable!("authorization index key `tenant_id` must be a simple identifier")	The fixed ASCII index key is validated by the typed constructor.
-crates/ironclaw_authorization/src/lib.rs	unreachable!(	The fixed ASCII authorization index name is validated by the typed constructor.
-crates/ironclaw_capabilities/src/helpers.rs	(false, false) => unreachable!("resume context mismatch kind called without mismatch"),	The mismatch classifier is called only after at least one compared field differs.
-crates/ironclaw_capabilities/src/host.rs	unreachable!("matched AuthRequired above")	The preceding match arm handles every AuthRequired outcome.
-crates/ironclaw_conversations/src/conversation_state_store.rs	.unwrap_or_else(|_| unreachable!("tenant_ids is a simple ascii identifier"))	The fixed ASCII index name is validated by the typed constructor.
-crates/ironclaw_extension_host/src/extension_ingress.rs	None => unreachable!(),	The None branch is excluded by the preceding optional-input guard.
-crates/ironclaw_extension_host/src/extension_ingress.rs	None => unreachable!(),	The None branch is excluded by the preceding optional-input guard.
-crates/ironclaw_filesystem/src/libsql_pool.rs	Err(error) => unreachable!("libSQL pool build cannot fail: {error}"),	The libSQL pool builder has no fallible runtime configuration inputs.
-crates/ironclaw_hooks/src/dispatch/mod.rs	unreachable!(	The dispatch branch is selected only after the corresponding hook payload variant is matched.
-crates/ironclaw_hooks/src/dispatch/mod.rs	unreachable!(	The dispatch branch is selected only after the corresponding hook payload variant is matched.
-crates/ironclaw_hooks/src/dispatch/mod.rs	unreachable!(	The dispatch branch is selected only after the corresponding hook payload variant is matched.
-crates/ironclaw_hooks/src/wasm/runtime.rs	None => unreachable!(),	The result is checked for absence immediately before extraction.
-crates/ironclaw_host_api/src/decision.rs	_ => unreachable!("extract_inject_handle called for {kind:?}"),	The helper is private to inject-decision variants that carry handles.
-crates/ironclaw_host_runtime/src/services.rs	panic!("LocalSingleUser + LocalDev runtime policy must resolve for local testing: {error}")	The fixed local-testing policy combination is a host startup invariant.
-crates/ironclaw_llm/src/recording.rs	_ => unreachable!(),	The provider-event variant is selected by the immediately preceding classification.
-crates/ironclaw_loop_host/src/budget_accountant.rs	.unwrap_or_else(|_| panic!("internal budget-accountant invariant: {reason}"))	Only internally computed bounded budget values reach this typed conversion.
-crates/ironclaw_loop_host/src/compaction_task.rs	Err(reason) => unreachable!("invalid static system prompt id {value}: {reason}"),	The system prompt identifier is a fixed source literal.
-crates/ironclaw_loop_host/src/compaction_task.rs	_ => unreachable!(),	The task outcome variant is narrowed by the preceding match.
-crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("`memory_document` is a valid record kind"))	The record kind is a fixed valid source literal.
-crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("`memory_chunk` is a valid record kind"))	The record kind is a fixed valid source literal.
-crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("`memory_document_version` is a valid record kind"))	The record kind is a fixed valid source literal.
-crates/ironclaw_memory_native/src/repo/filesystem.rs	IndexKey::new(name).unwrap_or_else(|_| unreachable!("{name} is a valid index key"))	Callers supply only fixed schema-owned index keys.
-crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("valid index name")),	The index name is fixed by the memory schema.
-crates/ironclaw_memory_native/src/repo/filesystem.rs	.unwrap_or_else(|_| unreachable!("valid index name")),	The index name is fixed by the memory schema.
-crates/ironclaw_operator/src/llm_admin/nearai_login_serve.rs	None => unreachable!(),	The option is checked before the OAuth login response is assembled.
-crates/ironclaw_operator/src/llm_admin/nearai_login_serve.rs	None => unreachable!(),	The option is checked before the OAuth login response is assembled.
-crates/ironclaw_operator/src/operator_service_lifecycle.rs	ServicePlatform::Unsupported => unreachable!("handled above"),	The unsupported-platform branch returns before platform dispatch.
-crates/ironclaw_outbound/src/outbound_state_store.rs	Err(_) => unreachable!(	The fixed outbound index identifier is validated by the typed constructor.
-crates/ironclaw_outbound/src/outbound_state_store.rs	Err(_) => unreachable!(	The fixed outbound index identifier is validated by the typed constructor.
-crates/ironclaw_process_sandbox/src/plan.rs	unreachable!("non-header targets are rejected during sandbox credential validation")	Validation rejects non-header credential targets before plan construction.
-crates/ironclaw_processes/src/process_store.rs	.unwrap_or_else(|_| unreachable!("process index name {value} must be a simple identifier"))	The process index name comes from a fixed schema-owned literal.
-crates/ironclaw_processes/src/process_store.rs	.unwrap_or_else(|_| unreachable!("process index key {value} must be a simple identifier"))	The process index key comes from a fixed schema-owned literal.
-crates/ironclaw_product/src/reborn_services.rs	ToolPermissionState::AlwaysAllow => unreachable!(),	The always-allow state is returned before approval-request construction.
-crates/ironclaw_product/src/reborn_services.rs	ThreadId::new("generated-thread-fallback").unwrap_or_else(|_| unreachable!())	The fallback thread identifier is a fixed valid source literal.
-crates/ironclaw_product/src/run_delivery/triggered.rs	unreachable!("OAuthTargetNotDm is handled by the dedicated arm above")	The OAuth non-DM outcome is returned by the dedicated preceding arm.
-crates/ironclaw_reborn_cli/src/commands/config/set.rs	ConfigKey::WebuiToken => unreachable!("handled by execute_webui_token"),	The WebUI token key is dispatched to its dedicated handler first.
-crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("local-dev-yolo is a local runtime profile")	The deployment profile table fixes local-dev-yolo to a local runtime.
-crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("local-dev-yolo carries a runtime-policy request")	The deployment profile table always supplies this request.
-crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("{profile_name} uses the local-dev runtime policy shape")	The matched profile is defined with the local-dev policy shape.
-crates/ironclaw_reborn_composition/src/deployment.rs	unreachable!("{profile_name} carries a runtime-policy request")	The matched profile definition always carries this request.
-crates/ironclaw_runner/src/tool_disclosure.rs	panic!("invalid static bridge tool name: {error}");	The bridge tool name is a fixed runner-owned source literal.
-crates/ironclaw_runner/src/tool_disclosure.rs	panic!("invalid static bridge capability id: {error}");	The bridge capability identifier is a fixed runner-owned source literal.
-crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!(	The resolver intentionally fails loudly if a new deployment mode lacks an explicit policy.
-crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!("sandboxed_filesystem_for: unhandled DeploymentMode variant"),	The resolver intentionally fails loudly if a new deployment mode lacks an explicit filesystem policy.
-crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!("sandboxed_secret_for: unhandled DeploymentMode variant"),	The resolver intentionally fails loudly if a new deployment mode lacks an explicit secret policy.
-crates/ironclaw_runtime_policy/src/resolver.rs	_ => panic!("audit_for: unhandled DeploymentMode variant"),	The resolver intentionally fails loudly if a new deployment mode lacks an explicit audit policy.
-crates/ironclaw_secrets/src/secret_store.rs	unreachable!("secrets index key `tenant_id` must be a simple identifier")	The fixed ASCII secrets index key is validated by the typed constructor.
-crates/ironclaw_secrets/src/secret_store.rs	unreachable!("secrets index name `secrets_by_tenant` must be a simple identifier")	The fixed ASCII secrets index name is validated by the typed constructor.
-crates/ironclaw_turns/src/turn_state_row_store/turn_state_engine/transitions.rs	_ => unreachable!("status checked above"),	The transition checks and returns for disallowed statuses before mutation.
-crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
-crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
-crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
-crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
-crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
-crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
-crates/ironclaw_webui/src/product_auth/mod.rs	None => unreachable!(),	The option is checked before the product-auth response is assembled.
-crates/ironclaw_webui/src/webui_rate_limit.rs	None => unreachable!(),	The selected limiter is guaranteed present by the preceding configuration branch.
+crates/ironclaw_agent_loop/src/executor/capabilities.rs	impl CapabilityStage::fn handle_capability_error :: _ => unreachable!("guarded to RecoverableFailure")	Exhaustive match after the recoverable-failure arm returns to the model.
+crates/ironclaw_agent_loop/src/strategies/recovery.rs	impl SanitizedStrategySummary::fn from_trusted_static :: Err(reason) => panic!("invalid trusted static strategy summary: {reason}")	Compile-time-owned recovery strategy text is validated during construction.
+crates/ironclaw_auth/src/credential.rs	fn single_account_recovery :: unreachable!("single account recovery cannot produce account selection required")	Single-account recovery cannot construct the multi-account selection outcome.
+crates/ironclaw_auth/src/domain.rs	fn recovery_projection_for_single_account :: unreachable!("single account recovery cannot produce account selection required")	Single-account recovery cannot construct the multi-account selection outcome.
+crates/ironclaw_authorization/src/lib.rs	fn index_key_tenant_id :: unreachable!("authorization index key `tenant_id` must be a simple identifier")	The fixed ASCII index key is validated by the typed constructor.
+crates/ironclaw_authorization/src/lib.rs	fn index_name_authorization_tenant :: unreachable!( "authorization index name `authorization_by_tenant` must be a simple identifier" )	The fixed ASCII authorization index name is validated by the typed constructor.
+crates/ironclaw_capabilities/src/helpers.rs	fn resume_context_mismatch_kind :: (false, false) => unreachable!("resume context mismatch kind called without mismatch")	The mismatch classifier is called only after at least one compared field differs.
+crates/ironclaw_capabilities/src/host.rs	fn enrich_dispatch_error_credential_requirements :: unreachable!("matched AuthRequired above")	The preceding match arm handles every AuthRequired outcome.
+crates/ironclaw_conversations/src/conversation_state_store.rs	fn index_key_tenant_ids :: .unwrap_or_else(|_| unreachable!("tenant_ids is a simple ascii identifier")	The fixed ASCII index name is validated by the typed constructor.
+crates/ironclaw_extension_host/src/extension_ingress.rs	mod serve_mount::const PUBLIC_WEBHOOK_MAX_REQUESTS :: None => unreachable!()	The None branch is excluded by the preceding optional-input guard.
+crates/ironclaw_extension_host/src/extension_ingress.rs	mod serve_mount::const PUBLIC_WEBHOOK_WINDOW_SECONDS :: None => unreachable!()	The None branch is excluded by the preceding optional-input guard.
+crates/ironclaw_filesystem/src/libsql_pool.rs	fn build_libsql_pool_with_config :: Err(error) => unreachable!("libSQL pool build cannot fail: {error}")	The libSQL pool builder has no fallible runtime configuration inputs.
+crates/ironclaw_hooks/src/dispatch/mod.rs	impl HookDispatcher::fn run_before_capability_hook :: unreachable!( "RestrictedWasm is dispatched on its own path above; \ this branch is unreachable" )	The dispatch branch is selected only after the corresponding hook payload variant is matched.
+crates/ironclaw_hooks/src/dispatch/mod.rs	impl HookDispatcher::fn run_before_prompt_hook :: unreachable!( "wasm prompt hooks dispatched via early-return guard; \ this arm is unreachable" )	The dispatch branch is selected only after the corresponding hook payload variant is matched.
+crates/ironclaw_hooks/src/dispatch/mod.rs	impl HookDispatcher::fn run_observer_hook :: unreachable!( "wasm observer hooks dispatched via early-return guard; \ this arm is unreachable" )	The dispatch branch is selected only after the corresponding hook payload variant is matched.
+crates/ironclaw_hooks/src/wasm/runtime.rs	const MODULE_CACHE_CAPACITY :: None => unreachable!()	The result is checked for absence immediately before extraction.
+crates/ironclaw_host_api/src/decision.rs	fn extract_inject_handle :: _ => unreachable!("extract_inject_handle called for {kind:?}")	The helper is private to inject-decision variants that carry handles.
+crates/ironclaw_host_runtime/src/services.rs	fn local_testing_runtime_policy :: panic!("LocalSingleUser + LocalDev runtime policy must resolve for local testing: {error}")	The fixed local-testing policy combination is a host startup invariant.
+crates/ironclaw_llm/src/recording.rs	fn coerce_python_repr_to_json :: _ => unreachable!()	The provider-event variant is selected by the immediately preceding classification.
+crates/ironclaw_loop_host/src/budget_accountant.rs	fn internal_summary_error :: .unwrap_or_else(|_| panic!("internal budget-accountant invariant: {reason}")	Only internally computed bounded budget values reach this typed conversion.
+crates/ironclaw_loop_host/src/compaction_task.rs	fn static_system_prompt_id :: Err(reason) => unreachable!("invalid static system prompt id {value}: {reason}")	The system prompt identifier is a fixed source literal.
+crates/ironclaw_loop_host/src/compaction_task.rs	fn append_escaped_xml_checked :: _ => unreachable!()	The task outcome variant is narrowed by the preceding match.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	impl<F> FilesystemMemoryDocumentRepository<F>::fn document_kind :: .unwrap_or_else(|_| unreachable!("`memory_document` is a valid record kind")	The record kind is a fixed valid source literal.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	impl<F> FilesystemMemoryDocumentRepository<F>::fn chunk_kind :: .unwrap_or_else(|_| unreachable!("`memory_chunk` is a valid record kind")	The record kind is a fixed valid source literal.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	impl<F> FilesystemMemoryDocumentRepository<F>::fn version_kind :: .unwrap_or_else(|_| unreachable!("`memory_document_version` is a valid record kind")	The record kind is a fixed valid source literal.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	impl<F> FilesystemMemoryDocumentRepository<F>::fn index_key :: IndexKey::new(name).unwrap_or_else(|_| unreachable!("{name} is a valid index key")	Callers supply only fixed schema-owned index keys.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	impl<F> FilesystemMemoryDocumentRepository<F>::fn ensure_search_indexes :: .unwrap_or_else(|_| unreachable!("valid index name")	The index name is fixed by the memory schema.
+crates/ironclaw_memory_native/src/repo/filesystem.rs	impl<F> FilesystemMemoryDocumentRepository<F>::fn ensure_search_indexes :: .unwrap_or_else(|_| unreachable!("valid index name")	The index name is fixed by the memory schema.
+crates/ironclaw_operator/src/llm_admin/nearai_login_serve.rs	const NEARAI_CALLBACK_RATE_WINDOW_SECONDS :: None => unreachable!()	The option is checked before the OAuth login response is assembled.
+crates/ironclaw_operator/src/llm_admin/nearai_login_serve.rs	const NEARAI_CALLBACK_RATE_MAX :: None => unreachable!()	The option is checked before the OAuth login response is assembled.
+crates/ironclaw_operator/src/operator_service_lifecycle.rs	impl OperatorServiceLifecycle::fn install :: ServicePlatform::Unsupported => unreachable!("handled above")	The unsupported-platform branch returns before platform dispatch.
+crates/ironclaw_outbound/src/outbound_state_store.rs	fn tenant_id_index_key :: Err(_) => unreachable!( "TENANT_ID_INDEX_KEY must satisfy IndexKey::new grammar — \ update the constant or grammar" )	The fixed outbound index identifier is validated by the typed constructor.
+crates/ironclaw_outbound/src/outbound_state_store.rs	fn delivery_scope_index_key :: Err(_) => unreachable!( "DELIVERY_SCOPE_INDEX_KEY must satisfy IndexKey::new grammar — \ update the constant or grammar" )	The fixed outbound index identifier is validated by the typed constructor.
+crates/ironclaw_process_sandbox/src/plan.rs	impl SandboxCredentialBinding::fn header_name :: unreachable!("non-header targets are rejected during sandbox credential validation")	Validation rejects non-header credential targets before plan construction.
+crates/ironclaw_processes/src/process_store.rs	fn index_name :: .unwrap_or_else(|_| unreachable!("process index name {value} must be a simple identifier")	The process index name comes from a fixed schema-owned literal.
+crates/ironclaw_processes/src/process_store.rs	fn index_key :: .unwrap_or_else(|_| unreachable!("process index key {value} must be a simple identifier")	The process index key comes from a fixed schema-owned literal.
+crates/ironclaw_product/src/reborn_services.rs	fn apply_tool_permission_state :: ToolPermissionState::AlwaysAllow => unreachable!()	The always-allow state is returned before approval-request construction.
+crates/ironclaw_product/src/reborn_services.rs	fn generated_thread_id :: ThreadId::new("generated-thread-fallback").unwrap_or_else(|_| unreachable!()	The fallback thread identifier is a fixed valid source literal.
+crates/ironclaw_product/src/run_delivery/triggered.rs	fn deliver_triggered_run :: unreachable!("OAuthTargetNotDm is handled by the dedicated arm above")	The OAuth non-DM outcome is returned by the dedicated preceding arm.
+crates/ironclaw_reborn_cli/src/commands/config/set.rs	fn set_value_key :: ConfigKey::WebuiToken => unreachable!("handled by execute_webui_token")	The WebUI token key is dispatched to its dedicated handler first.
+crates/ironclaw_reborn_composition/src/deployment.rs	fn local_dev_yolo_runtime_policy :: unreachable!("local-dev-yolo is a local runtime profile")	The deployment profile table fixes local-dev-yolo to a local runtime.
+crates/ironclaw_reborn_composition/src/deployment.rs	fn local_dev_yolo_runtime_policy :: unreachable!("local-dev-yolo carries a runtime-policy request")	The deployment profile table always supplies this request.
+crates/ironclaw_reborn_composition/src/deployment.rs	fn local_runtime_policy_for_local_dev_shape :: unreachable!("{profile_name} uses the local-dev runtime policy shape")	The matched profile is defined with the local-dev policy shape.
+crates/ironclaw_reborn_composition/src/deployment.rs	fn local_runtime_policy_for_local_dev_shape :: unreachable!("{profile_name} carries a runtime-policy request")	The matched profile definition always carries this request.
+crates/ironclaw_runner/src/tool_disclosure.rs	fn bridge_tool_definition :: panic!("invalid static bridge tool name: {error}")	The bridge tool name is a fixed runner-owned source literal.
+crates/ironclaw_runner/src/tool_disclosure.rs	fn bridge_capability_id :: panic!("invalid static bridge capability id: {error}")	The bridge capability identifier is a fixed runner-owned source literal.
+crates/ironclaw_runtime_policy/src/resolver.rs	fn backends_for :: _ => panic!( "backends_for_profile: unhandled RuntimeProfile variant — update the resolver before adding new variants" )	The resolver intentionally fails loudly if a new deployment mode lacks an explicit audit policy.
+crates/ironclaw_runtime_policy/src/resolver.rs	fn sandboxed_filesystem_for :: _ => panic!("sandboxed_filesystem_for: unhandled DeploymentMode variant")	The resolver intentionally fails loudly if a new deployment mode lacks an explicit filesystem policy.
+crates/ironclaw_runtime_policy/src/resolver.rs	fn sandboxed_secret_for :: _ => panic!("sandboxed_secret_for: unhandled DeploymentMode variant")	The resolver intentionally fails loudly if a new deployment mode lacks an explicit secret policy.
+crates/ironclaw_runtime_policy/src/resolver.rs	fn audit_for :: _ => panic!("audit_for: unhandled DeploymentMode variant")	The resolver intentionally fails loudly if a new deployment mode lacks an explicit policy.
+crates/ironclaw_secrets/src/secret_store.rs	fn index_key_tenant_id :: unreachable!("secrets index key `tenant_id` must be a simple identifier")	The fixed ASCII secrets index key is validated by the typed constructor.
+crates/ironclaw_secrets/src/secret_store.rs	fn index_name_secrets_tenant :: unreachable!("secrets index name `secrets_by_tenant` must be a simple identifier")	The fixed ASCII secrets index name is validated by the typed constructor.
+crates/ironclaw_turns/src/turn_state_row_store/turn_state_engine/transitions.rs	impl Inner::fn relinquish_transition :: _ => unreachable!("status checked above")	The transition checks and returns for disallowed statuses before mutation.
+crates/ironclaw_webui/src/product_auth/mod.rs	const OAUTH_PKCE_VERIFIER_CACHE_CAPACITY :: None => unreachable!()	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	const PRODUCT_AUTH_MUTATION_BODY_LIMIT_BYTES :: None => unreachable!()	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	const PRODUCT_AUTH_MUTATION_MAX_REQUESTS :: None => unreachable!()	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	const ACCOUNTS_REFRESH_MAX_REQUESTS :: None => unreachable!()	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	const OAUTH_CALLBACK_MAX_REQUESTS :: None => unreachable!()	The option is checked before the OAuth login response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	const OAUTH_FLOW_STATUS_MAX_REQUESTS :: None => unreachable!()	The option is checked before the OAuth login response is assembled.
+crates/ironclaw_webui/src/product_auth/mod.rs	const OAUTH_RATE_WINDOW_SECONDS :: None => unreachable!()	The option is checked before the product-auth response is assembled.
+crates/ironclaw_webui/src/webui_rate_limit.rs	const RATE_LIMIT_PER_SHARD_CAPACITY :: None => unreachable!()	The selected limiter is guaranteed present by the preceding configuration branch.


### PR DESCRIPTION
## Summary

- Fix a reachable circuit-breaker race where completions admitted in an older state-machine generation could panic or mutate a newer Open/HalfOpen state.
- Carry private admission-generation tokens through both completion paths so stale successes and failures cannot masquerade as recovery probes.
- Add deterministic caller-path concurrency regressions proving Open gating and genuine HalfOpen recovery remain authoritative.
- Extend the no-panics checker from diff-only enforcement to the shipping Reborn normal-dependency and Rust-module closure.
- Harden the baseline gate for nested inline modules, cfg polarity, complete multiline fingerprints, real safety comments, locked dependency resolution, fail-closed module edges, target/dependency filtering, malformed and duplicate baselines, stale/new exits, and single-pass source scanning.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6284

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run workspace-wide; the touched crate passed `cargo clippy -p ironclaw_llm --all-targets --all-features -- -D warnings`.
- [ ] `cargo build` — Not applicable: the complete touched-crate test suite compiled the changed Rust target.
- [x] Relevant tests pass: `cargo test -p ironclaw_llm` (969 passed); circuit-breaker suite (19 passed); panic-checker self-tests (26 passed); Reborn baseline scan (1,139 production files, 61 reviewed invariants).
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: no persistence or database behavior changed.
- [ ] Manual testing — Not applicable: deterministic automated coverage reaches the changed provider decorator state transitions.
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — `code-review-multi` ran eight isolated review lenses; all concrete, valid findings were addressed.

## Test Strategy

User behavior: In-flight LLM results from an older breaker generation no longer panic or report false circuit recovery when a concurrent request has already advanced the breaker. The admitted request still receives its provider result, while later callers observe the authoritative Open/HalfOpen gate.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `late_success_does_not_close_breaker_opened_by_concurrent_failure` now verifies the typed caller error and that the provider is not invoked while Open. `stale_closed_success_does_not_count_as_half_open_recovery` proves only the admitted recovery probe may close HalfOpen.
- Reborn integration: Not applicable: the unit tests exercise the production decorator/caller seam directly; no cross-crate contract changed.
- Recorded fixture: Not applicable: no provider wire format or external response behavior changed.
- Browser E2E: Not applicable: no browser or WebUI behavior changed.
- Backend or runtime: The concurrency regressions cover state mutation, returned outcomes, provider-invocation gating, and recovery ownership.
- Live canary: Not applicable: the race is deterministic without an external provider.

What the tests prove: A transient failure can advance the breaker after concurrent calls were admitted; older results cannot mutate the newer generation. A true HalfOpen probe still restores access. Checker tests prove nested module reachability, fail-closed unresolved edges, test-only-to-production reconvergence, cfg polarity (including production `cfg(not(test))` and non-shipping `test-support`), complete/contextual fingerprints, multiline safety rationales, shipping target selection, normalized multiset baseline parsing/reporting, workflow classification, and one-pass scanning.

Commands run:

```text
cargo test -p ironclaw_llm circuit_breaker
cargo test -p ironclaw_llm
cargo clippy -p ironclaw_llm --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
python3.11 scripts/check_no_panics.py --self-test
python3.11 scripts/check_no_panics.py --reborn-baseline
python3.11 scripts/check_no_panics.py --base origin/main --head HEAD
python3.11 -m py_compile scripts/check_no_panics.py
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/code_style.yml"); puts "workflow yaml: OK"'
git diff --check
```

## Security Impact

None. This does not change permissions, network calls, secrets, file access, tool execution, or sandbox policy. It preserves the authoritative newer failure state instead of producing false recovery.

## Reborn Trust-Boundary Checklist

N/A: no public trust-bearing types, prompt content, hashing, status/error variants, serialization, queues, or runtime-lane boundaries changed. The existing typed `LlmError` and provider decorator contract are preserved.

## Database Impact

None. No migrations, schema, PostgreSQL, or libSQL behavior changed.

## Blast Radius

The runtime behavior change is private to concurrent completion ordering inside `CircuitBreakerProvider`. The CI change affects the no-panics job by invoking Cargo metadata and scanning 1,139 production files in the shipping Reborn closure. Existing reviewed invariants remain permitted only at exact item-context and complete-invocation fingerprints; removals must ratchet the baseline downward.

## Rollback Plan

Revert the three commits in this PR. This restores the former circuit-breaker behavior and diff-only CI checker; there are no schema, persisted-state, or compatibility migrations to undo.

## Review Follow-Through

The eight-lens review produced 15 raw findings, deduplicated to 12. All concrete findings were fixed. A subsequent complete PR-comment audit addressed all six valid CodeRabbit requests in `278ea2747`; all five inline threads were acknowledged and automatically resolved by CodeRabbit. One maintainability suggestion—to replace the central baseline with 61 inline production suppressions—was intentionally rejected because it would touch 61 production sites without strengthening enforcement and conflicts with this workstream's surgical scope. A separate startup-only finding remains outside this run-critical workstream in `ironclaw_secrets::keychain::hex_to_bytes`, where non-ASCII bootstrap input can cross a UTF-8 byte-slicing boundary.

---

**Review track**: C (runtime/CI)
