### PR TITLE
fix(webui): replace native confirmations with shared dialogs

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/logs/logs-page.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/logs/logs-page.test.ts
@@ -151,14 +151,15 @@ function firstValueMatching(node, predicate) {
   return undefined;
 }
 
-function visit(node, fn) {
+function visit(node, fn, visited = new WeakSet()) {
+  if (!node || typeof node !== "object" || visited.has(node)) return;
+  visited.add(node);
   if (Array.isArray(node)) {
-    for (const item of node) visit(item, fn);
+    for (const item of node) visit(item, fn, visited);
     return;
   }
-  if (!node || typeof node !== "object") return;
   fn(node);
-  visit(node.values, fn);
+  visit(node.values, fn, visited);
 }
 
 function componentProps(root, component) {
@@ -220,6 +221,18 @@ const SAMPLE_ENTRY = {
   message: "selectable log message body",
   threadId: "thread-1",
 };
+
+test("template visitor ignores circular references", () => {
+  const node = { values: [] };
+  node.values.push(node);
+  let visits = 0;
+
+  visit(node, () => {
+    visits += 1;
+  });
+
+  assert.equal(visits, 1);
+});
 
 // A log line's text must be user-selectable so it can be copied. The clickable
 // row previously carried Tailwind's `select-none` (→ user-select: none), which

--- a/crates/ironclaw_webui/frontend/src/pages/logs/logs-page.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/logs/logs-page.test.ts
@@ -17,7 +17,7 @@ function logsPageSourceForTest() {
   return `${lines.join("\n")}\nglobalThis.__testExports = { LogsPage, LogEntry };`;
 }
 
-function renderLogsPage(overrides = {}) {
+function createLogsPageHarness(overrides = {}) {
   const logs = {
     entries: [],
     totalCount: 0,
@@ -38,20 +38,52 @@ function renderLogsPage(overrides = {}) {
     needsThreadScope: false,
     ...overrides,
   };
+  const hookValues = [];
+  let hookCursor = 0;
+  function ConfirmDialog() {}
   const context = {
+    ConfirmDialog,
     globalThis: {},
     React: {
-      useRef: (initial) => ({ current: initial }),
+      useRef: (initial) => {
+        const index = hookCursor;
+        hookCursor += 1;
+        if (!(index in hookValues)) hookValues[index] = { current: initial };
+        return hookValues[index];
+      },
       useEffect: () => {},
       useCallback: (fn) => fn,
-      useState: (initial) => [typeof initial === "function" ? initial() : initial, () => {}],
+      useState: (initial) => {
+        const index = hookCursor;
+        hookCursor += 1;
+        if (!(index in hookValues)) {
+          hookValues[index] = typeof initial === "function" ? initial() : initial;
+        }
+        return [
+          hookValues[index],
+          (next) => {
+            hookValues[index] =
+              typeof next === "function" ? next(hookValues[index]) : next;
+          },
+        ];
+      },
     },
     useT: () => (key) => key,
     useOutletContext: () => ({ isAdmin: true, threadsState: null }),
     useLogs: () => logs,
   };
   vm.runInNewContext(logsPageSourceForTest(), context);
-  return context.globalThis.__testExports.LogsPage();
+  return {
+    ConfirmDialog,
+    render() {
+      hookCursor = 0;
+      return context.globalThis.__testExports.LogsPage();
+    },
+  };
+}
+
+function renderLogsPage(overrides = {}) {
+  return createLogsPageHarness(overrides).render();
 }
 
 // Render a single LogEntry with a mocked React context. Returns the captured
@@ -117,6 +149,43 @@ function firstValueMatching(node, predicate) {
     if (found) return found;
   }
   return undefined;
+}
+
+function visit(node, fn) {
+  if (Array.isArray(node)) {
+    for (const item of node) visit(item, fn);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  fn(node);
+  visit(node.values, fn);
+}
+
+function componentProps(root, component) {
+  const props = [];
+  visit(root, (node) => {
+    if (!Array.isArray(node.values)) return;
+    for (let index = 0; index < node.values.length; index += 1) {
+      if (node.values[index] !== component) continue;
+      const current = {};
+      for (let propIndex = index + 1; propIndex < node.values.length; propIndex += 1) {
+        const name = node.strings[propIndex]?.match(/([A-Za-z][A-Za-z0-9-]*)=\s*$/)?.[1];
+        if (name) current[name] = node.values[propIndex];
+      }
+      props.push(current);
+    }
+  });
+  return props;
+}
+
+function nativeNodeByText(root, tagName, text) {
+  let match;
+  visit(root, (node) => {
+    if (!match && node.type === tagName && flattenMarkup(node).includes(text)) {
+      match = node;
+    }
+  });
+  return match;
 }
 
 // Build a window stub whose getSelection() reports a selection rooted at the
@@ -224,4 +293,36 @@ test("LogsPage keeps the scrollable log output container", () => {
   const markup = flattenMarkup(renderLogsPage());
   // The inner output region is the actual scroll surface.
   assert.match(markup, /min-h-0 flex-1 overflow-y-auto/);
+});
+
+test("LogsPage clears entries only after confirming the shared dialog", () => {
+  let clearCount = 0;
+  const harness = createLogsPageHarness({
+    clearEntries: () => {
+      clearCount += 1;
+    },
+  });
+
+  let rendered = harness.render();
+  const clearButton = nativeNodeByText(rendered, "button", "logs.clear");
+  assert.ok(clearButton, "expected the clear logs button");
+  clearButton.props.onClick();
+  assert.equal(clearCount, 0);
+
+  rendered = harness.render();
+  let [dialog] = componentProps(rendered, harness.ConfirmDialog);
+  assert.equal(dialog.open, true);
+  assert.equal(dialog.title, "logs.confirmClear");
+
+  dialog.onCancel();
+  rendered = harness.render();
+  [dialog] = componentProps(rendered, harness.ConfirmDialog);
+  assert.equal(dialog.open, false);
+  assert.equal(clearCount, 0);
+
+  nativeNodeByText(rendered, "button", "logs.clear").props.onClick();
+  rendered = harness.render();
+  [dialog] = componentProps(rendered, harness.ConfirmDialog);
+  dialog.onConfirm();
+  assert.equal(clearCount, 1);
 });

--- a/crates/ironclaw_webui/frontend/src/pages/logs/logs-page.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/logs/logs-page.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { useOutletContext } from "react-router";
 import React from "react";
+import { ConfirmDialog } from "../../design-system/confirm-dialog";
 import { useT } from "../../lib/i18n";
 import { useLogs } from "./hooks/useLogs";
 
@@ -157,6 +158,7 @@ export function LogsPage() {
 
   const outputRef = React.useRef(null);
   const followLatestRef = React.useRef(true);
+  const [clearDialogOpen, setClearDialogOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (autoScroll && followLatestRef.current && outputRef.current) {
@@ -226,9 +228,8 @@ export function LogsPage() {
 
           {/* Clear */}
           <button
-            onClick={() => {
-              if (confirm(t("logs.confirmClear"))) clearEntries();
-            }}
+            type="button"
+            onClick={() => setClearDialogOpen(true)}
             className="h-8 rounded-[8px] border border-[var(--v2-panel-border)] px-3 text-xs text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
           >
             {t("logs.clear")}
@@ -332,6 +333,16 @@ export function LogsPage() {
               (entry) => (<LogEntry key={entry.id} entry={entry} />)
             )}
       </div>
+      <ConfirmDialog
+        open={clearDialogOpen}
+        title={t("logs.confirmClear")}
+        confirmLabel={t("logs.clear")}
+        onConfirm={() => {
+          clearEntries();
+          setClearDialogOpen(false);
+        }}
+        onCancel={() => setClearDialogOpen(false)}
+      />
     </div>
   );
 }

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-components.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-components.test.ts
@@ -114,10 +114,16 @@ function customProvider(id, overrides = {}) {
   };
 }
 
-function useProviderManagementActionsStub({ providers, activeProviderId }) {
+function useProviderManagementActionsStub({
+  providers,
+  activeProviderId,
+  providerToDelete = null,
+}) {
   return () => ({
     allProviderIds: providers.map((provider) => provider.id),
+    cancelDelete: () => {},
     closeDialog: () => {},
+    confirmDelete: () => {},
     dialogProvider: null,
     filteredProviders: providers,
     handleDelete: () => {},
@@ -126,6 +132,7 @@ function useProviderManagementActionsStub({ providers, activeProviderId }) {
     isDialogOpen: false,
     message: null,
     openDialog: () => {},
+    providerToDelete,
     providerState: {
       activeProviderId,
       builtinOverrides: {},
@@ -137,11 +144,18 @@ function useProviderManagementActionsStub({ providers, activeProviderId }) {
   });
 }
 
-function renderProviderManagement({ providers, activeProviderId = "nearai", searchQuery = "" }) {
+function renderProviderManagement({
+  providers,
+  activeProviderId = "nearai",
+  searchQuery = "",
+  providerToDelete = null,
+}) {
   const ProviderCard = "ProviderCard";
+  const ConfirmDialog = "ConfirmDialog";
   const context = {
     Button: "Button",
     Card: "Card",
+    ConfirmDialog,
     Icon: "Icon",
     ProviderCard,
     ProviderDialog: "ProviderDialog",
@@ -152,6 +166,7 @@ function renderProviderManagement({ providers, activeProviderId = "nearai", sear
     useProviderManagementActions: useProviderManagementActionsStub({
       providers,
       activeProviderId,
+      providerToDelete,
     }),
     useProviderLogin: () => ({
       codexBusy: false,
@@ -177,7 +192,7 @@ function renderProviderManagement({ providers, activeProviderId = "nearai", sear
   const cardProps = findComponentNodes(rendered, ProviderCard).map((node) =>
     componentProps(node, ProviderCard)
   );
-  return { rendered, cardProps };
+  return { ConfirmDialog, rendered, cardProps };
 }
 
 function evalIsLocalDevOrigin({ hostname }) {
@@ -401,6 +416,22 @@ test("ProviderManagement hides empty buckets after search filtering", () => {
     cardProps.map((props) => props.provider.id),
     ["openai"]
   );
+});
+
+test("ProviderManagement renders provider deletion through the shared dialog", () => {
+  const provider = customProvider("legacy-local");
+  const { ConfirmDialog, rendered, cardProps } = renderProviderManagement({
+    providers: [provider],
+    providerToDelete: provider,
+  });
+
+  assert.equal(cardProps[0].onDelete instanceof Function, true);
+  const [dialog] = findComponentNodes(rendered, ConfirmDialog).map((node) =>
+    componentProps(node, ConfirmDialog)
+  );
+  assert.equal(dialog.open, true);
+  assert.equal(dialog.title, "llm.confirmDelete");
+  assert.equal(dialog.confirmLabel, "common.delete");
 });
 
 test("ProviderCard disclosure responds to row, keyboard, and chevron controls", () => {

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-components.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-components.test.ts
@@ -149,6 +149,7 @@ function renderProviderManagement({
   activeProviderId = "nearai",
   searchQuery = "",
   providerToDelete = null,
+  t = (key) => key,
 }) {
   const ProviderCard = "ProviderCard";
   const ConfirmDialog = "ConfirmDialog";
@@ -175,7 +176,7 @@ function renderProviderManagement({
       startNearai: () => {},
       startNearaiWallet: () => {},
     }),
-    useT: () => (key) => key,
+    useT: () => t,
   };
 
   const exports = runVmModuleForTest(
@@ -419,10 +420,12 @@ test("ProviderManagement hides empty buckets after search filtering", () => {
 });
 
 test("ProviderManagement renders provider deletion through the shared dialog", () => {
-  const provider = customProvider("legacy-local");
+  const provider = customProvider("legacy-local", { name: "Legacy Local" });
   const { ConfirmDialog, rendered, cardProps } = renderProviderManagement({
     providers: [provider],
     providerToDelete: provider,
+    t: (key, params) =>
+      key === "llm.confirmDelete" ? `${key}:${params.id}` : key,
   });
 
   assert.equal(cardProps[0].onDelete instanceof Function, true);
@@ -430,7 +433,7 @@ test("ProviderManagement renders provider deletion through the shared dialog", (
     componentProps(node, ConfirmDialog)
   );
   assert.equal(dialog.open, true);
-  assert.equal(dialog.title, "llm.confirmDelete");
+  assert.equal(dialog.title, "llm.confirmDelete:Legacy Local");
   assert.equal(dialog.confirmLabel, "common.delete");
 });
 

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-management.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-management.tsx
@@ -1,5 +1,6 @@
 import { Button } from "../../../design-system/button";
 import { Card } from "../../../design-system/card";
+import { ConfirmDialog } from "../../../design-system/confirm-dialog";
 import { Icon } from "../../../design-system/icons";
 import { useT } from "../../../lib/i18n";
 import { SettingsSearchEmpty } from "./settings-search-empty";
@@ -140,6 +141,14 @@ export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }
         onSave={actions.handleSave}
         onTest={state.testConnection}
         onListModels={state.listModels}
+      />
+      <ConfirmDialog
+        open={Boolean(actions.providerToDelete)}
+        title={t("llm.confirmDelete", { id: actions.providerToDelete?.id })}
+        confirmLabel={t("common.delete")}
+        isConfirming={state.isBusy}
+        onConfirm={actions.confirmDelete}
+        onCancel={actions.cancelDelete}
       />
     </Card>
   );

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-management.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/provider-management.tsx
@@ -144,7 +144,9 @@ export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }
       />
       <ConfirmDialog
         open={Boolean(actions.providerToDelete)}
-        title={t("llm.confirmDelete", { id: actions.providerToDelete?.id })}
+        title={t("llm.confirmDelete", {
+          id: actions.providerToDelete?.name || actions.providerToDelete?.id,
+        })}
         confirmLabel={t("common.delete")}
         isConfirming={state.isBusy}
         onConfirm={actions.confirmDelete}

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/skills-tab.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/skills-tab.test.ts
@@ -1,0 +1,136 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { runVmModuleForTest } from "../../../test-support/vm-module-harness";
+
+function visit(node, fn) {
+  if (Array.isArray(node)) {
+    for (const item of node) visit(item, fn);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  fn(node);
+  visit(node.values, fn);
+}
+
+function componentProps(root, component) {
+  const props = [];
+  visit(root, (node) => {
+    if (!Array.isArray(node.values)) return;
+    for (let index = 0; index < node.values.length; index += 1) {
+      if (node.values[index] !== component) continue;
+      const current = {};
+      for (let propIndex = index + 1; propIndex < node.values.length; propIndex += 1) {
+        const name = node.strings[propIndex]?.match(/([A-Za-z][A-Za-z0-9-]*)=\s*$/)?.[1];
+        if (name) current[name] = node.values[propIndex];
+      }
+      props.push(current);
+    }
+  });
+  return props;
+}
+
+function createHarness() {
+  const hookValues = [];
+  let hookCursor = 0;
+  const removeCalls = [];
+  function ConfirmDialog() {}
+  function SkillCard() {}
+  const context = {
+    Button() {},
+    Card() {},
+    ConfirmDialog,
+    React: {
+      useCallback: (fn) => fn,
+      useState: (initial) => {
+        const index = hookCursor;
+        hookCursor += 1;
+        if (!(index in hookValues)) {
+          hookValues[index] = typeof initial === "function" ? initial() : initial;
+        }
+        return [
+          hookValues[index],
+          (next) => {
+            hookValues[index] =
+              typeof next === "function" ? next(hookValues[index]) : next;
+          },
+        ];
+      },
+    },
+    SettingsSearchEmpty() {},
+    SkillCard,
+    SkillInstallPanel() {},
+    matchesSearch: () => true,
+    useSkills: () => ({
+      skills: [{
+        name: "markdown-helper",
+        source_kind: "installed",
+        can_delete: true,
+      }],
+      query: { isLoading: false, error: null },
+      autoActivateLearned: true,
+      fetchSkillContent: () => {},
+      installSkill: () => {},
+      removeSkill: async (name) => {
+        removeCalls.push(name);
+        return { success: true };
+      },
+      updateSkill: () => {},
+      setSkillAutoActivate: () => {},
+      setAutoActivateLearned: () => {},
+      isInstalling: false,
+      isRemoving: false,
+      isUpdating: false,
+      isSettingAutoActivate: false,
+      isSettingAutoActivateLearned: false,
+    }),
+    useT: () => (key, params) =>
+      params?.name ? `${key}:${params.name}` : key,
+  };
+  const exports = runVmModuleForTest(
+    "./skills-tab.tsx",
+    ["SkillsTab", "SkillGroup"],
+    context,
+    import.meta.url
+  );
+  return {
+    ConfirmDialog,
+    SkillGroup: exports.SkillGroup,
+    removeCalls,
+    render() {
+      hookCursor = 0;
+      return exports.SkillsTab({});
+    },
+  };
+}
+
+test("SkillsTab removes a skill only after confirming the shared dialog", async () => {
+  const harness = createHarness();
+  let rendered = harness.render();
+  const [group] = componentProps(rendered, harness.SkillGroup);
+
+  group.onRemove("markdown-helper");
+  assert.deepEqual(harness.removeCalls, []);
+
+  rendered = harness.render();
+  let [dialog] = componentProps(rendered, harness.ConfirmDialog);
+  assert.equal(dialog.open, true);
+  assert.equal(dialog.title, "skills.confirmDelete:markdown-helper");
+
+  dialog.onCancel();
+  rendered = harness.render();
+  [dialog] = componentProps(rendered, harness.ConfirmDialog);
+  assert.equal(dialog.open, false);
+  assert.deepEqual(harness.removeCalls, []);
+
+  componentProps(rendered, harness.SkillGroup)[0].onRemove("markdown-helper");
+  rendered = harness.render();
+  [dialog] = componentProps(rendered, harness.ConfirmDialog);
+  await dialog.onConfirm();
+  assert.deepEqual(harness.removeCalls, ["markdown-helper"]);
+
+  rendered = harness.render();
+  [dialog] = componentProps(rendered, harness.ConfirmDialog);
+  assert.equal(dialog.open, false);
+});

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/skills-tab.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/skills-tab.test.ts
@@ -4,14 +4,15 @@ import { test } from "vitest";
 
 import { runVmModuleForTest } from "../../../test-support/vm-module-harness";
 
-function visit(node, fn) {
+function visit(node, fn, visited = new WeakSet()) {
+  if (!node || typeof node !== "object" || visited.has(node)) return;
+  visited.add(node);
   if (Array.isArray(node)) {
-    for (const item of node) visit(item, fn);
+    for (const item of node) visit(item, fn, visited);
     return;
   }
-  if (!node || typeof node !== "object") return;
   fn(node);
-  visit(node.values, fn);
+  visit(node.values, fn, visited);
 }
 
 function componentProps(root, component) {
@@ -104,6 +105,18 @@ function createHarness() {
     },
   };
 }
+
+test("template visitor ignores circular references", () => {
+  const node = { values: [] };
+  node.values.push(node);
+  let visits = 0;
+
+  visit(node, () => {
+    visits += 1;
+  });
+
+  assert.equal(visits, 1);
+});
 
 test("SkillsTab removes a skill only after confirming the shared dialog", async () => {
   const harness = createHarness();

--- a/crates/ironclaw_webui/frontend/src/pages/settings/components/skills-tab.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/components/skills-tab.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { Card } from "../../../design-system/card";
 import { Button } from "../../../design-system/button";
+import { ConfirmDialog } from "../../../design-system/confirm-dialog";
 import { useT } from "../../../lib/i18n";
 import { useSkills } from "../hooks/useSkills";
 import { matchesSearch } from "../lib/settings-search";
@@ -29,22 +30,25 @@ export function SkillsTab({ searchQuery = "" }) {
   } = useSkills();
   const [actionError, setActionError] = React.useState("");
   const [actionResult, setActionResult] = React.useState("");
+  const [skillToRemove, setSkillToRemove] = React.useState(null);
 
-  const handleRemove = React.useCallback(async (name) => {
-    if (!window.confirm(t("skills.confirmDelete", { name }))) return;
+  const handleConfirmRemove = React.useCallback(async () => {
+    if (!skillToRemove) return;
     setActionError("");
     setActionResult("");
     try {
-      const response = await removeSkill(name);
+      const response = await removeSkill(skillToRemove);
       if (!response?.success) {
         setActionError(response?.message || t("skills.removeFailed"));
         return;
       }
-      setActionResult(response.message || t("skills.removed", { name }));
+      setActionResult(response.message || t("skills.removed", { name: skillToRemove }));
     } catch (err) {
       setActionError(err.message || t("skills.removeFailed"));
+    } finally {
+      setSkillToRemove(null);
     }
-  }, [removeSkill, t]);
+  }, [removeSkill, skillToRemove, t]);
 
   const handleUpdate = React.useCallback(async (name, content) => {
     if (!content.trim()) {
@@ -157,7 +161,7 @@ export function SkillsTab({ searchQuery = "" }) {
                 title={t(group.labelKey)}
                 skills={group.skills}
                 onEdit={fetchSkillContent}
-                onRemove={handleRemove}
+                onRemove={setSkillToRemove}
                 onUpdate={handleUpdate}
                 onSetAutoActivate={handleSetAutoActivate}
                 isRemoving={isRemoving}
@@ -181,6 +185,14 @@ export function SkillsTab({ searchQuery = "" }) {
       <SkillInstallPanel onInstall={installSkill} isInstalling={isInstalling} />
       <SkillActionResult error={actionError} result={actionResult} />
       {body}
+      <ConfirmDialog
+        open={Boolean(skillToRemove)}
+        title={t("skills.confirmDelete", { name: skillToRemove })}
+        confirmLabel={t("skills.delete")}
+        isConfirming={isRemoving}
+        onConfirm={handleConfirmRemove}
+        onCancel={() => setSkillToRemove(null)}
+      />
     </div>
   );
 }

--- a/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useProviderManagementActions.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useProviderManagementActions.test.ts
@@ -84,3 +84,18 @@ test("provider deletion waits for the shared dialog confirmation", async () => {
   assert.equal(actions.message.tone, "success");
   assert.equal(actions.message.text, "llm.providerDeleted");
 });
+
+test("provider deletion can be canceled without invoking the delete action", () => {
+  const harness = createHarness();
+  const provider = { id: "legacy-local" };
+  let actions = harness.render();
+
+  actions.handleDelete(provider);
+  actions = harness.render();
+  assert.equal(actions.providerToDelete, provider);
+
+  actions.cancelDelete();
+  actions = harness.render();
+  assert.equal(actions.providerToDelete, null);
+  assert.deepEqual(harness.deleteCalls, []);
+});

--- a/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useProviderManagementActions.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useProviderManagementActions.test.ts
@@ -1,0 +1,86 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { runVmModuleForTest } from "../../../test-support/vm-module-harness";
+
+function createHarness() {
+  const hookValues = [];
+  let hookCursor = 0;
+  const deleteCalls = [];
+  const providerState = {
+    providers: [],
+    deleteCustomProvider: async (provider) => {
+      deleteCalls.push(provider.id);
+    },
+  };
+  const context = {
+    React: {
+      useCallback: (fn) => fn,
+      useEffect: () => {},
+      useRef: (initial) => {
+        const index = hookCursor;
+        hookCursor += 1;
+        if (!(index in hookValues)) hookValues[index] = { current: initial };
+        return hookValues[index];
+      },
+      useState: (initial) => {
+        const index = hookCursor;
+        hookCursor += 1;
+        if (!(index in hookValues)) {
+          hookValues[index] = typeof initial === "function" ? initial() : initial;
+        }
+        return [
+          hookValues[index],
+          (next) => {
+            hookValues[index] =
+              typeof next === "function" ? next(hookValues[index]) : next;
+          },
+        ];
+      },
+    },
+    useLlmProviders: () => providerState,
+    window: {
+      clearTimeout: () => {},
+      setTimeout: () => 1,
+    },
+  };
+  const exports = runVmModuleForTest(
+    "./useProviderManagementActions.ts",
+    ["useProviderManagementActions"],
+    context,
+    import.meta.url
+  );
+  return {
+    deleteCalls,
+    render() {
+      hookCursor = 0;
+      return exports.useProviderManagementActions({
+        settings: {},
+        gatewayStatus: {},
+        searchQuery: "",
+        t: (key) => key,
+      });
+    },
+  };
+}
+
+test("provider deletion waits for the shared dialog confirmation", async () => {
+  const harness = createHarness();
+  const provider = { id: "legacy-local" };
+  let actions = harness.render();
+
+  actions.handleDelete(provider);
+  assert.deepEqual(harness.deleteCalls, []);
+
+  actions = harness.render();
+  assert.equal(actions.providerToDelete, provider);
+
+  await actions.confirmDelete();
+  assert.deepEqual(harness.deleteCalls, ["legacy-local"]);
+
+  actions = harness.render();
+  assert.equal(actions.providerToDelete, null);
+  assert.equal(actions.message.tone, "success");
+  assert.equal(actions.message.text, "llm.providerDeleted");
+});

--- a/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useProviderManagementActions.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/settings/hooks/useProviderManagementActions.ts
@@ -13,6 +13,7 @@ export function useProviderManagementActions({ settings, gatewayStatus, searchQu
   const providerState = useLlmProviders({ settings, gatewayStatus });
   const [dialogProvider, setDialogProvider] = React.useState(null);
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
+  const [providerToDelete, setProviderToDelete] = React.useState(null);
   const [message, setMessage] = React.useState(null);
   const messageTimerRef = React.useRef(null);
 
@@ -68,22 +69,32 @@ export function useProviderManagementActions({ settings, gatewayStatus, searchQu
   );
 
   const handleDelete = React.useCallback(
-    async (provider) => {
-      if (!window.confirm(t("llm.confirmDelete", { id: provider.id }))) return;
+    (provider) => {
+      setProviderToDelete(provider);
+    },
+    []
+  );
+
+  const confirmDelete = React.useCallback(
+    async () => {
+      if (!providerToDelete) return;
       try {
-        await providerState.deleteCustomProvider(provider);
+        await providerState.deleteCustomProvider(providerToDelete);
         showMessage("success", t("llm.providerDeleted"));
       } catch (err) {
         showMessage("error", err.message);
+      } finally {
+        setProviderToDelete(null);
       }
     },
-    [providerState, showMessage, t]
+    [providerState, providerToDelete, showMessage, t]
   );
 
   return {
     providerState,
     dialogProvider,
     isDialogOpen,
+    providerToDelete,
     message,
     filteredProviders: providerState.providers.filter((provider) =>
       matchesProvider(provider, searchQuery)
@@ -94,5 +105,7 @@ export function useProviderManagementActions({ settings, gatewayStatus, searchQu
     handleUse,
     handleSave,
     handleDelete,
+    confirmDelete,
+    cancelDelete: () => setProviderToDelete(null),
   };
 }

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -227,6 +227,19 @@ EMULATE_GITHUB_SECONDARY_BEARER = "ghp_emulate_github_secondary_token"
 # which targets the legacy `ironclaw` web channel.
 REBORN_V2_AUTH_TOKEN = "e2e-reborn-v2-bearer-token-0123456789abcdef"
 
+
+def capture_native_dialogs(page) -> list[str]:
+    """Dismiss and record browser-native dialogs opened by a page."""
+    native_dialogs: list[str] = []
+
+    async def dismiss_native_dialog(dialog) -> None:
+        native_dialogs.append(dialog.type)
+        await dialog.dismiss()
+
+    page.on("dialog", dismiss_native_dialog)
+    return native_dialogs
+
+
 # Selectors for the Reborn WebUI v2 React SPA (served at /). The shell
 # DOM differs entirely from the legacy gateway in SEL, so keep these separate.
 SEL_V2 = {

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_settings_search.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_settings_search.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from playwright.async_api import expect
 
-from helpers import REBORN_V2_AUTH_TOKEN, SEL_V2
+from helpers import REBORN_V2_AUTH_TOKEN, SEL_V2, capture_native_dialogs
 from reborn_webui_harness import (
     reborn_v2_browser,  # noqa: F401 - imported fixture
     reborn_v2_server,  # noqa: F401 - imported fixture
@@ -454,13 +454,7 @@ async def test_reborn_legacy_settings_skills_search_empty_state(
     try:
         page = harness["page"]
         search = harness["search"]
-        native_dialogs: list[str] = []
-
-        async def dismiss_native_dialog(dialog) -> None:
-            native_dialogs.append(dialog.type)
-            await dialog.dismiss()
-
-        page.on("dialog", dismiss_native_dialog)
+        native_dialogs = capture_native_dialogs(page)
 
         await expect(page.get_by_text("markdown-helper", exact=True)).to_be_visible(
             timeout=5000
@@ -638,13 +632,7 @@ async def test_reborn_legacy_settings_inference_edit_and_delete_custom_provider(
     try:
         page = harness["page"]
         legacy_card = _provider_card(page, "legacy-local")
-        native_dialogs: list[str] = []
-
-        async def dismiss_native_dialog(dialog) -> None:
-            native_dialogs.append(dialog.type)
-            await dialog.dismiss()
-
-        page.on("dialog", dismiss_native_dialog)
+        native_dialogs = capture_native_dialogs(page)
         await expect(legacy_card).to_be_visible(timeout=5000)
 
         await legacy_card.get_by_test_id(SEL_V2["llm_provider_disclosure"]).click()
@@ -676,7 +664,7 @@ async def test_reborn_legacy_settings_inference_edit_and_delete_custom_provider(
 
         await legacy_card.get_by_role("button", name="Delete").click()
         confirmation = page.get_by_role(
-            "dialog", name='Delete provider "legacy-local"?'
+            "dialog", name='Delete provider "Legacy Local"?'
         )
         await expect(confirmation).to_be_visible()
         await confirmation.locator(SEL_V2["confirm_dialog_cancel"]).click()

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_settings_search.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_settings_search.py
@@ -114,6 +114,7 @@ async def _open_mocked_settings_page(
     tab: str,
     llm_state: dict | None = None,
     llm_requests: list[dict] | None = None,
+    skill_requests: list[str] | None = None,
 ):
     context = await reborn_v2_browser.new_context(viewport={"width": 1280, "height": 720})
     page = await context.new_page()
@@ -123,6 +124,7 @@ async def _open_mocked_settings_page(
         lambda message: browser_messages.append(f"{message.type}: {message.text}"),
     )
     page.on("pageerror", lambda error: browser_messages.append(f"pageerror: {error}"))
+    skills_state = [dict(skill) for skill in MOCK_SKILLS]
 
     async def fulfill_json(route, payload, status=200):
         await route.fulfill(
@@ -168,10 +170,26 @@ async def _open_mocked_settings_page(
             await fulfill_json(
                 route,
                 {
-                    "skills": MOCK_SKILLS,
-                    "count": len(MOCK_SKILLS),
+                    "skills": skills_state,
+                    "count": len(skills_state),
                     "auto_activate_learned": True,
                 },
+            )
+            return
+
+        if (
+            path.startswith("/api/webchat/v2/skills/")
+            and request.method == "DELETE"
+        ):
+            skill_name = path.removeprefix("/api/webchat/v2/skills/")
+            if skill_requests is not None:
+                skill_requests.append(skill_name)
+            skills_state[:] = [
+                skill for skill in skills_state if skill["name"] != skill_name
+            ]
+            await fulfill_json(
+                route,
+                {"success": True, "message": f'Removed skill "{skill_name}"'},
             )
             return
 
@@ -426,14 +444,23 @@ async def test_reborn_legacy_settings_tools_search_and_clear(
 async def test_reborn_legacy_settings_skills_search_empty_state(
     reborn_v2_server, reborn_v2_browser
 ):
+    skill_requests: list[str] = []
     harness = await _open_mocked_settings_page(
         reborn_v2_server,
         reborn_v2_browser,
         tab="skills",
+        skill_requests=skill_requests,
     )
     try:
         page = harness["page"]
         search = harness["search"]
+        native_dialogs: list[str] = []
+
+        async def dismiss_native_dialog(dialog) -> None:
+            native_dialogs.append(dialog.type)
+            await dialog.dismiss()
+
+        page.on("dialog", dismiss_native_dialog)
 
         await expect(page.get_by_text("markdown-helper", exact=True)).to_be_visible(
             timeout=5000
@@ -441,6 +468,23 @@ async def test_reborn_legacy_settings_skills_search_empty_state(
         await expect(page.get_by_text("workspace-helper", exact=True)).to_be_visible(
             timeout=5000
         )
+
+        skill_card = page.locator(".ext-card").filter(has_text="markdown-helper")
+        await skill_card.get_by_role("button", name="Delete").click()
+        confirmation = page.get_by_role(
+            "dialog", name='Delete skill "markdown-helper"?'
+        )
+        await expect(confirmation).to_be_visible()
+        await confirmation.locator(SEL_V2["confirm_dialog_cancel"]).click()
+        await expect(skill_card).to_be_visible()
+        assert skill_requests == []
+
+        await skill_card.get_by_role("button", name="Delete").click()
+        await expect(confirmation).to_be_visible()
+        await confirmation.locator(SEL_V2["confirm_dialog_confirm"]).click()
+        await expect(skill_card).to_have_count(0)
+        assert skill_requests == ["markdown-helper"]
+        assert native_dialogs == []
 
         await search.fill("workspace")
         await expect(page.get_by_text("workspace-helper", exact=True)).to_be_visible()
@@ -594,6 +638,13 @@ async def test_reborn_legacy_settings_inference_edit_and_delete_custom_provider(
     try:
         page = harness["page"]
         legacy_card = _provider_card(page, "legacy-local")
+        native_dialogs: list[str] = []
+
+        async def dismiss_native_dialog(dialog) -> None:
+            native_dialogs.append(dialog.type)
+            await dialog.dismiss()
+
+        page.on("dialog", dismiss_native_dialog)
         await expect(legacy_card).to_be_visible(timeout=5000)
 
         await legacy_card.get_by_test_id(SEL_V2["llm_provider_disclosure"]).click()
@@ -623,13 +674,24 @@ async def test_reborn_legacy_settings_inference_edit_and_delete_custom_provider(
         assert edit_request["payload"]["default_model"] == "legacy-v2"
         assert "api_key" not in edit_request["payload"]
 
-        page.once("dialog", lambda browser_dialog: browser_dialog.accept())
         await legacy_card.get_by_role("button", name="Delete").click()
+        confirmation = page.get_by_role(
+            "dialog", name='Delete provider "legacy-local"?'
+        )
+        await expect(confirmation).to_be_visible()
+        await confirmation.locator(SEL_V2["confirm_dialog_cancel"]).click()
+        await expect(legacy_card).to_be_visible()
+        assert not any(request["kind"] == "delete" for request in llm_requests)
+
+        await legacy_card.get_by_role("button", name="Delete").click()
+        await expect(confirmation).to_be_visible()
+        await confirmation.locator(SEL_V2["confirm_dialog_confirm"]).click()
         await expect(page.get_by_text("Provider deleted.")).to_be_visible(timeout=5000)
         await expect(_provider_card(page, "legacy-local")).to_have_count(0)
         assert {
             "kind": "delete",
             "payload": {"provider_id": "legacy-local"},
         } in llm_requests
+        assert native_dialogs == []
     finally:
         await harness["context"].close()

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -2082,6 +2082,28 @@ async def test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context(
         context.locator(SEL_V2["logs_context_chip"].format(key="source"))
     ).to_contain_text("slack")
 
+    native_dialogs: list[str] = []
+
+    async def dismiss_native_dialog(dialog) -> None:
+        native_dialogs.append(dialog.type)
+        await dialog.dismiss()
+
+    reborn_v2_page.on("dialog", dismiss_native_dialog)
+    clear_button = reborn_v2_page.get_by_role("button", name="Clear", exact=True)
+    await clear_button.click()
+    confirmation = reborn_v2_page.get_by_role(
+        "dialog", name="Clear all log entries?"
+    )
+    await expect(confirmation).to_be_visible()
+    await confirmation.locator(SEL_V2["confirm_dialog_cancel"]).click()
+    await expect(entry).to_be_visible()
+
+    await clear_button.click()
+    await expect(confirmation).to_be_visible()
+    await confirmation.locator(SEL_V2["confirm_dialog_confirm"]).click()
+    await expect(entry).to_have_count(0)
+    assert native_dialogs == []
+
 
 async def test_reborn_v2_logs_deep_link_loads_scoped_conversation_on_first_open(
     reborn_v2_server, reborn_v2_browser

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -34,7 +34,7 @@ import aiohttp
 import httpx
 import pytest
 from playwright.async_api import expect
-from helpers import REBORN_V2_AUTH_TOKEN, SEL_V2
+from helpers import REBORN_V2_AUTH_TOKEN, SEL_V2, capture_native_dialogs
 from reborn_webui_harness import (
     USER_ID,
     create_thread as _create_thread,
@@ -2082,13 +2082,7 @@ async def test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context(
         context.locator(SEL_V2["logs_context_chip"].format(key="source"))
     ).to_contain_text("slack")
 
-    native_dialogs: list[str] = []
-
-    async def dismiss_native_dialog(dialog) -> None:
-        native_dialogs.append(dialog.type)
-        await dialog.dismiss()
-
-    reborn_v2_page.on("dialog", dismiss_native_dialog)
+    native_dialogs = capture_native_dialogs(reborn_v2_page)
     clear_button = reborn_v2_page.get_by_role("button", name="Clear", exact=True)
     await clear_button.click()
     confirmation = reborn_v2_page.get_by_role(
@@ -2326,13 +2320,7 @@ async def test_reborn_v2_thread_delete_uses_shared_confirmation_dialog(
     async with httpx.AsyncClient(headers=headers) as client:
         thread_id = await _create_thread(client, reborn_v2_server)
 
-    native_dialogs: list[str] = []
-
-    async def dismiss_native_dialog(dialog) -> None:
-        native_dialogs.append(dialog.type)
-        await dialog.dismiss()
-
-    reborn_v2_page.on("dialog", dismiss_native_dialog)
+    native_dialogs = capture_native_dialogs(reborn_v2_page)
     await reborn_v2_page.goto(
         f"{reborn_v2_server}/chat?token={REBORN_V2_AUTH_TOKEN}"
     )


### PR DESCRIPTION
## Summary

- Replaces browser-native `confirm()` prompts with the shared `ConfirmDialog` on the Logs, Settings → Skills, and Settings → Inference surfaces.
- Preserves localized copy, destructive-action styling, pending states, and existing success/error handling.
- Adds component and hook regression coverage plus Playwright tests proving cancellation is side-effect free and confirmation performs the requested action without opening a native browser dialog.

<img width="573" height="284" alt="image" src="https://github.com/user-attachments/assets/8e8f1bb6-460d-4b4f-9dd8-fc82f8d0abb2" />
<img width="483" height="262" alt="image" src="https://github.com/user-attachments/assets/a4e758e6-9f37-4c86-b266-d5106ab85966" />
<img width="500" height="269" alt="image" src="https://github.com/user-attachments/assets/8a132855-25ec-420d-8060-787f43b0e0c0" />



## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #6851

## Validation

- [x] Relevant frontend unit and component tests pass
- [x] TypeScript typecheck and source convention checks pass
- [x] Production frontend build and bundle budgets pass
- [x] Targeted Playwright E2E tests pass
- [x] `cargo test -p ironclaw_webui --all-features`
- [x] `git diff --check`

## Test Strategy

User behavior:

Users receive the shared in-app confirmation dialog when clearing logs, deleting a skill, or deleting a custom LLM provider. Cancelling leaves state unchanged; confirming performs the original action.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Logs page, Skills tab, provider-management component, and provider-management hook regression tests.
- Reborn integration: Not applicable; no turn, runner, runtime, or product-orchestration behavior changed.
- Recorded fixture: Not applicable; no model behavior changed.
- Browser E2E: Logs clear, skill deletion, and provider deletion now verify cancel/confirm behavior and assert that no native browser dialog is emitted.
- Backend or runtime: Not applicable; no backend or runtime behavior changed.
- Live canary: Not applicable; the behavior is deterministic and fully covered locally.

What the tests prove:

- Destructive actions do not execute before confirmation.
- Cancelling preserves the current entries, skill, or provider.
- Confirming performs the original operation and updates the rendered UI.
- The three exposed surfaces use an accessible in-app dialog rather than `window.confirm()`.

Commands run:

- `TZ=UTC corepack pnpm test`
- `corepack pnpm lint:conventions`
- `corepack pnpm typecheck`
- `corepack pnpm exec vite build`
- `corepack pnpm check:bundle`
- Targeted Playwright tests for Logs, Skills, and Provider confirmation flows
- `cargo test -p ironclaw_webui --all-features`
- `git diff --check`

## Security Impact

None. This changes frontend confirmation presentation only and does not alter authentication, authorization, secrets, network access, or backend mutation contracts.

## Reborn Trust-Boundary Checklist

N/A: no Reborn trust boundary, runtime, persistence, or authority behavior changed.

## Database Impact

None. No schema, migration, PostgreSQL, or libSQL changes.

## Blast Radius

Limited to destructive confirmation interactions on the exposed Logs, Skills, and LLM Provider WebUI surfaces, plus their frontend and browser tests.

## Rollback Plan

Revert the two commits in this PR to restore the previous browser-native confirmation prompts and their prior E2E expectations.

## Review Follow-Through

Self-review completed. No outstanding findings or follow-up work identified. Overall risk is low because the change is frontend-only, uses an existing shared component, preserves the existing action handlers, and is covered at both component and browser levels.

---

**Review track**: B