### PR TITLE
fix(agent-loop): remove retired recovery diagnostic ref

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/checkpoint.rs
+++ b/crates/ironclaw_agent_loop/src/executor/checkpoint.rs
@@ -299,7 +299,6 @@ fn recovery_event_host_error(error: AgentLoopHostError) -> AgentLoopExecutorErro
         kind: error.kind,
         safe_summary,
         reason_kind: error.reason_kind,
-        diagnostic_ref: error.diagnostic_ref,
         detail: error.detail.or(rejected_summary_detail),
     }
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -179,14 +179,16 @@ async fn recovery_event_append_failure_stops_before_model_retry() {
         .await
         .expect_err("recovery cannot proceed without its durable numerator event");
 
-    assert!(matches!(
-        error,
+    match error {
         AgentLoopExecutorError::HostUnavailableWithDiagnostics {
             stage: HostStage::Checkpoint,
             kind: AgentLoopHostErrorKind::Unavailable,
-            ..
-        }
-    ));
+            safe_summary,
+            reason_kind: None,
+            detail: None,
+        } => assert_eq!(safe_summary.as_str(), "progress sink unavailable"),
+        other => panic!("expected checkpoint diagnostics, got {other:?}"),
+    }
     assert_eq!(
         host.model_requests().len(),
         1,


### PR DESCRIPTION
## Summary

- Remove the stale `diagnostic_ref` assignment from recovery-event host error mapping after the field was retired in #6847.
- Strengthen the existing recovery-event regression test to exhaustively validate the current diagnostic variant and preserved safe summary.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run workspace-wide; the owning crate passed with all targets and features.
- [x] `cargo build` — verified with the exact failing dist command.
- [x] Relevant tests pass: `cargo test -p ironclaw_agent_loop` (479 tests across crate targets)
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — not applicable; no database or integration behavior changed.
- [ ] Manual testing: not applicable; this is a compile-time contract mismatch.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: Main builds successfully again, including the shipping `ironclaw` binary under the `dist` profile.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Strengthened `recovery_event_append_failure_stops_before_model_retry` to exhaustively match the current executor diagnostic fields and assert the preserved safe summary.
- Reborn integration: Not applicable: the defect is a compile-time mismatch in a crate-local mapper; the existing executor caller test reaches the affected path.
- Recorded fixture: Not applicable: no model selection or request-shape behavior changed.
- Browser E2E: Not applicable: no browser-visible behavior changed.
- Backend or runtime: Not applicable: no backend or runtime-lane behavior changed.
- Live canary: Not applicable: no provider behavior changed.

What the tests prove: A durable recovery-event append failure maps to `HostUnavailableWithDiagnostics` using the current inline diagnostic contract and prevents the retry side effect. The exact production build proves the stale field no longer breaks the shipping binary.

Commands run:

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_agent_loop recovery_event_append_failure_stops_before_model_retry`
- `cargo test -p ironclaw_agent_loop`
- `cargo clippy -p ironclaw_agent_loop --all-targets --all-features -- -D warnings`
- `cargo build --profile dist --package ironclaw --bin ironclaw`
- `git diff --check`

## Security Impact

None. No permissions, network calls, secrets, file access, tool execution, or sandbox policy changed.

## Reborn Trust-Boundary Checklist

N/A: this removes a reference to an already-retired field and does not add or change any public policy, evidence, trust-bearing type, serialization field, status, error variant, queue, or trust boundary.

## Database Impact

None. No migrations, schemas, PostgreSQL behavior, or libSQL behavior changed.

## Blast Radius

Limited to recovery-event host error mapping in `ironclaw_agent_loop` and its regression assertion. Runtime semantics remain on the existing `detail` diagnostic channel.

## Rollback Plan

Revert commit `de5c250b9`. This would restore the compile failure and should only be done together with a compatible contract change.

## Review Follow-Through

No known follow-up. The merge-order conflict between #6847 and #6844 is fully resolved by this patch.

---

**Review track**: C (runtime recovery-path build fix)
