### PR TITLE
fix(threads): align provider replay metadata limit

### DIFF
--- a/crates/ironclaw_loop_host/tests/thread_loop_host_contract.rs
+++ b/crates/ironclaw_loop_host/tests/thread_loop_host_contract.rs
@@ -2382,6 +2382,13 @@ async fn transcript_port_appends_tool_result_reference_envelope_idempotently() {
         fixture.run_context.clone(),
     );
     let result_ref = LoopResultRef::new("result:demo-tool").unwrap();
+    // Provider validation has accepted metadata above 4 KiB since #5001.
+    // This exercises the transcript caller that used to retain the stale
+    // 4 KiB bound and terminate otherwise successful reasoning-heavy runs.
+    let response_reasoning = "response reasoning ".repeat(256);
+    let call_reasoning = "call reasoning ".repeat(320);
+    assert!(response_reasoning.len() > 4096);
+    assert!(call_reasoning.len() > 4096);
 
     let first_ref = adapter
         .append_capability_result_ref(AppendCapabilityResultRef {
@@ -2396,8 +2403,8 @@ async fn transcript_port_appends_tool_result_reference_envelope_idempotently() {
                     provider_tool_name: ProviderToolName::new("demo__echo")
                         .expect("provider tool name"),
                     arguments: serde_json::json!({"message":"hello"}),
-                    response_reasoning: Some("provider reasoning".to_string()),
-                    reasoning: Some("provider reasoning".to_string()),
+                    response_reasoning: Some(response_reasoning.clone()),
+                    reasoning: Some(call_reasoning.clone()),
                     signature: Some("sig-1".to_string()),
                 },
                 capability_id: CapabilityId::new("demo.echo").unwrap(),
@@ -2470,11 +2477,11 @@ async fn transcript_port_appends_tool_result_reference_envelope_idempotently() {
     );
     assert_eq!(
         provider_call.response_reasoning.as_deref(),
-        Some("provider reasoning")
+        Some(response_reasoning.as_str())
     );
     assert_eq!(
         provider_call.reasoning.as_deref(),
-        Some("provider reasoning")
+        Some(call_reasoning.as_str())
     );
     assert_eq!(provider_call.signature.as_deref(), Some("sig-1"));
 }

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -1,8 +1,9 @@
 // arch-exempt: large_file, validator+markers+schema checks pending split, plan #6310
 use ironclaw_host_api::{CapabilityId, INPUT_ENCODE_HUMAN_SUMMARY, ProviderToolName};
 use ironclaw_safety::{
-    validate_optional_provider_metadata_text, validate_provider_arguments,
-    validate_provider_identity, validate_provider_token, validate_provider_tool_name,
+    PROVIDER_METADATA_TEXT_MAX_BYTES, validate_optional_provider_metadata_text,
+    validate_provider_arguments, validate_provider_identity, validate_provider_token,
+    validate_provider_tool_name,
 };
 use serde::{Deserialize, Serialize};
 
@@ -166,10 +167,18 @@ impl ProviderToolCallReferenceEnvelope {
         validate_optional_provider_text(
             &self.response_reasoning,
             "provider response reasoning",
-            4096,
+            PROVIDER_METADATA_TEXT_MAX_BYTES,
         )?;
-        validate_optional_provider_text(&self.reasoning, "provider reasoning", 4096)?;
-        validate_optional_provider_text(&self.signature, "provider signature", 4096)?;
+        validate_optional_provider_text(
+            &self.reasoning,
+            "provider reasoning",
+            PROVIDER_METADATA_TEXT_MAX_BYTES,
+        )?;
+        validate_optional_provider_text(
+            &self.signature,
+            "provider signature",
+            PROVIDER_METADATA_TEXT_MAX_BYTES,
+        )?;
         Ok(())
     }
 }
@@ -1231,6 +1240,7 @@ fn is_disallowed_control_character(character: char) -> bool {
 #[cfg(test)]
 mod tests {
     use ironclaw_host_api::{CapabilityId, ProviderToolName};
+    use ironclaw_safety::PROVIDER_METADATA_TEXT_MAX_BYTES;
 
     use super::{
         INPUT_ENCODE_HUMAN_SUMMARY, ProviderToolCallReferenceEnvelope, ToolResultReferenceEnvelope,
@@ -2152,6 +2162,27 @@ mod tests {
         let mut envelope = provider_reference();
         envelope.arguments = serde_json::json!({});
         envelope.validate().expect("safe provider metadata");
+    }
+
+    #[test]
+    fn provider_reference_validation_uses_shared_metadata_limit() {
+        let mut envelope = provider_reference();
+        envelope.response_reasoning = Some("r".repeat(PROVIDER_METADATA_TEXT_MAX_BYTES));
+        envelope.reasoning = Some("c".repeat(PROVIDER_METADATA_TEXT_MAX_BYTES));
+        envelope.signature = Some("s".repeat(PROVIDER_METADATA_TEXT_MAX_BYTES));
+        envelope
+            .validate()
+            .expect("metadata at the shared provider limit should remain replayable");
+
+        envelope.response_reasoning =
+            Some("r".repeat(PROVIDER_METADATA_TEXT_MAX_BYTES.saturating_add(1)));
+        let error = envelope
+            .validate()
+            .expect_err("metadata beyond the shared provider limit must remain bounded");
+        assert_eq!(
+            error,
+            format!("provider response reasoning exceeds {PROVIDER_METADATA_TEXT_MAX_BYTES} bytes")
+        );
     }
 
     fn provider_reference() -> ProviderToolCallReferenceEnvelope {


### PR DESCRIPTION
## Summary

- Align transcript persistence with the shared 16 KiB provider-metadata validation limit.
- Prevent successful reasoning-heavy tool calls from terminating with `TranscriptWriteFailed` after model output was already accepted.
- Add boundary and loop-host caller regressions for reasoning payloads above the stale 4 KiB limit.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_threads`; `cargo test -p ironclaw_loop_host --test thread_loop_host_contract transcript_port_appends_tool_result_reference_envelope_idempotently`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: validation happens before backend dispatch and uses the same envelope for every backend.
- [x] Manual testing: inspected two production failures and traced both from successful GLM 5.2 tool responses to the stale transcript serialization bound.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; this PR remains a draft.

Additional check: `cargo clippy -p ironclaw_threads -p ironclaw_loop_host --all-targets -- -D warnings`.

## Test Strategy

User behavior:

Given a provider emits valid tool calls with 4–16 KiB of reasoning metadata, when the capability result is appended to the transcript, then the metadata is durably retained and the run is not terminated by a transcript serialization error.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `provider_reference_validation_uses_shared_metadata_limit` accepts the shared limit and rejects one byte above it.
- Reborn integration: Not applicable: the existing loop-host transcript contract drives the real caller and persistent transcript service at the exact failing seam without requiring a whole-turn harness.
- Recorded fixture: Not applicable: model tool choice and request shape are unchanged; only accepted metadata persistence changes.
- Browser E2E: Not applicable: no WebUI behavior changes.
- Backend or runtime: Not applicable: the rejected envelope was validated before backend-specific persistence, so the caller contract covers all backends.
- Live canary: Not applicable: deterministic reasoning payloads reproduce the failure without provider credentials.

What the tests prove:

The transcript boundary derives its cap from the same shared provider validator used before tool-call registration, preserves accepted reasoning through append/readback, remains bounded at 16 KiB, and rejects oversized metadata.

Commands run:

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_threads`
- `cargo test -p ironclaw_loop_host --test thread_loop_host_contract transcript_port_appends_tool_result_reference_envelope_idempotently`
- `cargo clippy -p ironclaw_threads -p ironclaw_loop_host --all-targets -- -D warnings`
- `git diff --check`

## Security Impact

None. Existing control-character and secret-leak validation remains unchanged. Metadata remains bounded; this change replaces a stale private 4 KiB cap with the existing shared 16 KiB provider-metadata cap.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A — no type or construction authority changes.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive — unchanged; provider metadata continues through the validated replay envelope.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check — N/A, no hashing changes.
- [x] New/changed status, exit, policy, runtime, or error variants: N/A — no variants changed. Command: `git diff --check` and final diff inspection.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests — N/A, no serialization fields or defaults changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic — provider metadata remains capped by `PROVIDER_METADATA_TEXT_MAX_BYTES` (16 KiB), with a one-byte-over-bound regression.
- [x] Driver/operator-visible errors have stable class semantics — no error classes changed; valid accepted metadata no longer produces `TranscriptWriteFailed`.
- [x] Sandbox/native/host names accurately describe trust boundary — N/A, no runtime or sandbox naming changes.

## Database Impact

None. No migrations or schema changes. The validation correction occurs before backend-specific persistence and applies equally to PostgreSQL, libSQL, filesystem, and in-memory implementations.

## Blast Radius

Provider tool-call replay metadata stored by `ironclaw_threads` and written through `ironclaw_loop_host`. Existing payloads at or below 4 KiB are unchanged; payloads from 4–16 KiB are newly accepted by persistence, matching the already-active ingress contract. Payloads above 16 KiB remain rejected.

## Rollback Plan

Revert commit `ce9acc5af`. This restores the previous 4 KiB transcript cap, but reasoning-heavy provider tool calls in the 4–16 KiB range will again fail after successful model completion.

## Review Follow-Through

No known follow-up. Reviewer judgment is requested on whether the shared 16 KiB provider-metadata contract should be documented outside its current safety-module comments.

---

**Review track**: C (persistence boundary)
