### PR TITLE
test(reborn): complete WS9 generated state machines

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -11,7 +11,7 @@ on:
         description: >-
           Enumerate longer generated lifecycle sequences (#6524 workstream 9).
           Pull requests stay at the fast depth; the nightly deep run raises it.
-          Depth 3 is 84 sequences (~70s) against depth 2's 20 (~20s).
+          Depth 3 is 39 sequences against depth 2's 12.
         required: false
         default: false
         type: boolean

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,6 +243,10 @@ name = "reborn_generated_gate_sequences"
 path = "tests/integration/generated_gate_sequences.rs"
 
 [[test]]
+name = "reborn_generated_restart_sequences"
+path = "tests/integration/generated_restart_sequences.rs"
+
+[[test]]
 name = "reborn_group_journeys"
 path = "tests/integration/group_journeys/main.rs"
 

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2788,11 +2788,11 @@ pub async fn build_reborn_runtime(
 }
 
 pub async fn build_runtime(input: RebornRuntimeInput) -> Result<RebornRuntime, RebornRuntimeError> {
-    let (runtime, _) = build_runtime_with_authorities(input).await?;
+    let (runtime, _) = build_runtime_with_resource_governor(input).await?;
     Ok(runtime)
 }
 
-pub(crate) async fn build_runtime_with_authorities(
+pub(crate) async fn build_runtime_with_resource_governor(
     input: RebornRuntimeInput,
 ) -> Result<(RebornRuntime, Arc<dyn ironclaw_resources::ResourceGovernor>), RebornRuntimeError> {
     let RebornRuntimeInput {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2788,6 +2788,13 @@ pub async fn build_reborn_runtime(
 }
 
 pub async fn build_runtime(input: RebornRuntimeInput) -> Result<RebornRuntime, RebornRuntimeError> {
+    let (runtime, _) = build_runtime_with_authorities(input).await?;
+    Ok(runtime)
+}
+
+pub(crate) async fn build_runtime_with_authorities(
+    input: RebornRuntimeInput,
+) -> Result<(RebornRuntime, Arc<dyn ironclaw_resources::ResourceGovernor>), RebornRuntimeError> {
     let RebornRuntimeInput {
         services: services_input,
         llm,
@@ -4068,7 +4075,7 @@ pub async fn build_runtime(input: RebornRuntimeInput) -> Result<RebornRuntime, R
     if let Some(channel_connection) = runtime.generic_channel_connection_facade() {
         let _ = runtime.channel_facade_slot.set(channel_connection);
     }
-    Ok(runtime)
+    Ok((runtime, resource_governor))
 }
 
 /// Thin wrapper over

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -78,7 +78,7 @@ pub async fn build_runtime_with_resource_governor_for_test(
     ),
     crate::RebornRuntimeError,
 > {
-    crate::runtime::build_runtime_with_authorities(input).await
+    crate::runtime::build_runtime_with_resource_governor(input).await
 }
 
 mod automation;

--- a/crates/ironclaw_reborn_composition/src/test_support/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/test_support/mod.rs
@@ -62,6 +62,25 @@
 //!     same removal-cleanup slot production fills (C-SLACK-LIFECYCLE seam,
 //!     issue #6105).
 
+/// Build the production runtime and return the exact resource governor wired
+/// into its capability path.
+///
+/// This mirrors [`crate::build_runtime`] while keeping the lower substrate
+/// authority out of [`crate::RebornRuntime`]'s service-shaped public surface.
+/// Integration tests use the returned governor only for post-transition
+/// reservation read-back.
+pub async fn build_runtime_with_resource_governor_for_test(
+    input: crate::RebornRuntimeInput,
+) -> Result<
+    (
+        crate::RebornRuntime,
+        std::sync::Arc<dyn ironclaw_resources::ResourceGovernor>,
+    ),
+    crate::RebornRuntimeError,
+> {
+    crate::runtime::build_runtime_with_authorities(input).await
+}
+
 mod automation;
 mod budget_gateway;
 mod capability_io;

--- a/tests/e2e/scenarios/test_state_machine_coverage.py
+++ b/tests/e2e/scenarios/test_state_machine_coverage.py
@@ -63,6 +63,41 @@ def test_journey_projection_derives_lifecycle_claims_from_declared_assertions():
     assert trigger.invariants == (StateMachineInvariant.AT_MOST_ONCE_EFFECT,)
 
 
+def test_provider_effect_invariants_follow_operation_class():
+    reads = tuple(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if case.case_id
+        in {"provider_github_get_issue", "provider_google_sheets_read_values_empty"}
+    )
+    assert reads
+    assert all(
+        StateMachineInvariant.AT_MOST_ONCE_EFFECT not in case.invariants
+        for case in reads
+    )
+
+    writes = tuple(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if case.case_id
+        in {"provider_github_update_issue", "provider_github_create_issue"}
+    )
+    assert writes
+    assert all(
+        StateMachineInvariant.AT_MOST_ONCE_EFFECT in case.invariants for case in writes
+    )
+
+
+def test_approval_denial_uses_the_lifecycle_its_evidence_observes():
+    denial = next(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if case.case_id == "approval_denial_completes_without_effect"
+    )
+    assert denial.policy_state.value == "denied"
+    assert denial.lifecycle_state.value == "completed"
+
+
 def test_journey_projection_rejects_a_missing_supported_ingress():
     """Sabotage the generated journey projection, not a hand-built fixture."""
     sabotaged = tuple(

--- a/tests/e2e/scenarios/test_state_machine_coverage.py
+++ b/tests/e2e/scenarios/test_state_machine_coverage.py
@@ -1,0 +1,158 @@
+"""Fail-loud completeness gate for WS9 lifecycle equivalence evidence."""
+
+from dataclasses import replace
+
+from journey_types import PytestEvidence
+from state_machine_coverage import (
+    REQUIRED_EQUIVALENCE_PAIRS,
+    STATE_MACHINE_COVERAGE_CASES,
+    AuthState,
+    SequenceClass,
+    StateMachineInvariant,
+    coverage_gap_count,
+    dimension_gaps,
+    duplicate_case_ids,
+    invariant_gaps,
+    pairwise_gaps,
+    sequence_gaps,
+)
+
+from scenarios.test_journey_coverage import (
+    _assert_python_evidence,
+    _assert_rust_evidence,
+)
+
+
+def test_state_machine_registry_has_zero_coverage_gaps():
+    """All 7 dimensions, 6 sequences, 5 invariants, and selected pairs map."""
+    assert not duplicate_case_ids(STATE_MACHINE_COVERAGE_CASES)
+    assert not dimension_gaps(STATE_MACHINE_COVERAGE_CASES)
+    assert not pairwise_gaps(STATE_MACHINE_COVERAGE_CASES)
+    assert not sequence_gaps(STATE_MACHINE_COVERAGE_CASES)
+    assert not invariant_gaps(STATE_MACHINE_COVERAGE_CASES)
+    assert coverage_gap_count(STATE_MACHINE_COVERAGE_CASES) == 0
+
+
+def test_every_state_machine_claim_names_executable_evidence():
+    """Typed rows are claims only when their exact test still exists and runs."""
+    for case in STATE_MACHINE_COVERAGE_CASES:
+        if isinstance(case.evidence, PytestEvidence):
+            _assert_python_evidence(case, case.evidence)
+        else:
+            _assert_rust_evidence(case, case.evidence)
+
+
+def test_journey_projection_derives_lifecycle_claims_from_declared_assertions():
+    """Admission-only evidence cannot be credited with terminal stability."""
+    webhook = next(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if case.case_id
+        == "journey_generic_extension_webhook_signed_post_becomes_a_turn"
+    )
+    assert webhook.lifecycle_state.value == "running"
+    assert StateMachineInvariant.TERMINAL_STABILITY not in webhook.invariants
+
+    trigger = next(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if case.case_id
+        == "journey_scheduled_trigger_slack_delivery_default_and_explicit"
+    )
+    assert trigger.sequences == (SequenceClass.TRIGGER, SequenceClass.RESTART)
+    assert trigger.invariants == (StateMachineInvariant.AT_MOST_ONCE_EFFECT,)
+
+
+def test_journey_projection_rejects_a_missing_supported_ingress():
+    """Sabotage the generated journey projection, not a hand-built fixture."""
+    sabotaged = tuple(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if case.ingress.value != "extension_webhook"
+    )
+    assert dimension_gaps(sabotaged)["ingress"] == frozenset({"extension_webhook"})
+
+
+def test_dimension_checker_rejects_a_missing_auth_class():
+    sabotaged = tuple(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if case.auth_state is not AuthState.WRONG_SCOPE
+    )
+    assert dimension_gaps(sabotaged)["auth_state"] == frozenset({"wrong_scope"})
+
+
+def test_pairwise_checker_rejects_a_removed_critical_interaction():
+    target = (
+        "operation_class",
+        "non_idempotent_write",
+        "provider_outcome",
+        "committed_without_ack",
+    )
+    assert target in REQUIRED_EQUIVALENCE_PAIRS
+    sabotaged = tuple(
+        case
+        for case in STATE_MACHINE_COVERAGE_CASES
+        if not (
+            case.operation_class.value == "non_idempotent_write"
+            and case.provider_outcome == "committed_without_ack"
+        )
+    )
+    assert target in pairwise_gaps(sabotaged)
+
+
+def test_sequence_checker_rejects_a_missing_generated_sequence():
+    sabotaged = tuple(
+        replace(
+            case,
+            sequences=tuple(
+                sequence
+                for sequence in case.sequences
+                if sequence is not SequenceClass.CONCURRENT_DOUBLE_SUBMIT
+            ),
+        )
+        for case in STATE_MACHINE_COVERAGE_CASES
+    )
+    assert sequence_gaps(sabotaged) == frozenset(
+        {SequenceClass.CONCURRENT_DOUBLE_SUBMIT}
+    )
+
+
+def test_invariant_checker_rejects_removed_lease_wedge_truthfulness():
+    """The retained lease_wedge proof cannot be replaced by a weaker claim."""
+    sabotaged = tuple(
+        replace(
+            case,
+            invariants=tuple(
+                invariant
+                for invariant in case.invariants
+                if invariant is not StateMachineInvariant.TRUTHFUL_UNCERTAIN_OUTCOME
+            ),
+        )
+        for case in STATE_MACHINE_COVERAGE_CASES
+    )
+    assert invariant_gaps(sabotaged) == frozenset(
+        {StateMachineInvariant.TRUTHFUL_UNCERTAIN_OUTCOME}
+    )
+
+
+def test_duplicate_checker_rejects_a_generator_repeating_a_row():
+    first = STATE_MACHINE_COVERAGE_CASES[0]
+    sabotaged = (*STATE_MACHINE_COVERAGE_CASES, first)
+    assert duplicate_case_ids(sabotaged) == frozenset({first.case_id})
+
+
+def test_composite_gap_count_increases_for_each_sabotaged_denominator():
+    """The reported remaining-gap count cannot stay zero after lost coverage."""
+    without_restart = tuple(
+        replace(
+            case,
+            sequences=tuple(
+                sequence
+                for sequence in case.sequences
+                if sequence is not SequenceClass.RESTART
+            ),
+        )
+        for case in STATE_MACHINE_COVERAGE_CASES
+    )
+    assert coverage_gap_count(without_restart) > 0

--- a/tests/e2e/state_machine_coverage.py
+++ b/tests/e2e/state_machine_coverage.py
@@ -18,9 +18,13 @@ from journey_types import (
     ObservableAssertion,
     PytestEvidence,
 )
-from provider_fault_cases import PROVIDER_FAULT_CASES, ProviderFaultOutcome
+from provider_fault_cases import (
+    PROVIDER_FAULT_CASES,
+    ProviderFaultCase,
+    ProviderFaultOutcome,
+)
 from provider_operation_cases import PROVIDER_OPERATION_CASES
-from provider_operation_types import OutcomeClass
+from provider_operation_types import OutcomeClass, ProviderOperationCase
 
 
 class AuthState(StrEnum):
@@ -60,7 +64,6 @@ class LifecycleState(StrEnum):
     BLOCKED_AUTH = "blocked_auth"
     BLOCKED_APPROVAL = "blocked_approval"
     COMPLETED = "completed"
-    DENIED = "denied"
     CANCELLED = "cancelled"
     FAILED = "failed"
 
@@ -102,7 +105,12 @@ class StateMachineCoverageCase:
     evidence: Evidence
 
 
-def _cargo(source: str, test: str, target: str, manifest: str | None = None):
+def _cargo(
+    source: str,
+    test: str,
+    target: str,
+    manifest: str | None = None,
+) -> CargoEvidence:
     return CargoEvidence(
         source=source,
         test=test,
@@ -111,12 +119,12 @@ def _cargo(source: str, test: str, target: str, manifest: str | None = None):
     )
 
 
-def _operation(case_id: str):
+def _operation(case_id: str) -> ProviderOperationCase:
     """Select a typed provider operation; fail at import if it disappears."""
     return next(case for case in PROVIDER_OPERATION_CASES if case.case_id == case_id)
 
 
-def _fault(case_id: str):
+def _fault(case_id: str) -> ProviderFaultCase:
     """Select a typed provider fault; fail at import if it disappears."""
     return next(case for case in PROVIDER_FAULT_CASES if case.case_id == case_id)
 
@@ -180,6 +188,11 @@ def _provider_case(
     operation_class: OperationClass,
 ) -> StateMachineCoverageCase:
     operation = _operation(case_id)
+    invariants = (
+        ()
+        if operation_class is OperationClass.READ
+        else (StateMachineInvariant.AT_MOST_ONCE_EFFECT,)
+    )
     return StateMachineCoverageCase(
         case_id=f"provider_{case_id}",
         ingress=JourneyIngress.WEBUI,
@@ -190,7 +203,7 @@ def _provider_case(
         lifecycle_state=LifecycleState.COMPLETED,
         delivery_target=JourneyDeliveryTarget.WEBUI,
         sequences=(),
-        invariants=(StateMachineInvariant.AT_MOST_ONCE_EFFECT,),
+        invariants=invariants,
         evidence=_PROVIDER_PYTEST,
     )
 
@@ -274,13 +287,13 @@ STATE_MACHINE_COVERAGE_CASES = (
         evidence=_GENERATED_GATE_EVIDENCE,
     ),
     StateMachineCoverageCase(
-        case_id="approval_denial_is_terminal",
+        case_id="approval_denial_completes_without_effect",
         ingress=JourneyIngress.WEBUI,
         auth_state=AuthState.AUTHENTICATED,
         policy_state=PolicyState.DENIED,
         operation_class=OperationClass.IDEMPOTENT_WRITE,
         provider_outcome="unchanged",
-        lifecycle_state=LifecycleState.DENIED,
+        lifecycle_state=LifecycleState.COMPLETED,
         delivery_target=JourneyDeliveryTarget.WEBUI,
         sequences=(SequenceClass.DUPLICATE,),
         invariants=(
@@ -418,7 +431,7 @@ REQUIRED_EQUIVALENCE_PAIRS = frozenset(
             "lifecycle_state",
             "blocked_approval",
         ),
-        ("policy_state", "denied", "lifecycle_state", "denied"),
+        ("policy_state", "denied", "lifecycle_state", "completed"),
         ("delivery_target", "webui", "lifecycle_state", "completed"),
     }
 )

--- a/tests/e2e/state_machine_coverage.py
+++ b/tests/e2e/state_machine_coverage.py
@@ -1,0 +1,487 @@
+"""Typed, representative coverage for Reborn lifecycle equivalence classes.
+
+This is an evidence inventory, not a second state machine.  Each row points at
+an executable test owned by the relevant boundary.  The selected rows cover
+every supported value and the interactions most likely to hide lifecycle
+bugs, without constructing the full seven-dimensional Cartesian product.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Literal, TypeAlias
+
+from journey_cases import ALL_JOURNEY_CASES
+from journey_types import (
+    CargoEvidence,
+    JourneyDeliveryTarget,
+    JourneyIngress,
+    ObservableAssertion,
+    PytestEvidence,
+)
+from provider_fault_cases import PROVIDER_FAULT_CASES, ProviderFaultOutcome
+from provider_operation_cases import PROVIDER_OPERATION_CASES
+from provider_operation_types import OutcomeClass
+
+
+class AuthState(StrEnum):
+    AUTHENTICATED = "authenticated"
+    AUTH_REQUIRED = "auth_required"
+    WRONG_SCOPE = "wrong_scope"
+
+
+class PolicyState(StrEnum):
+    ALLOWED = "allowed"
+    APPROVAL_REQUIRED = "approval_required"
+    DENIED = "denied"
+
+
+class OperationClass(StrEnum):
+    READ = "read"
+    IDEMPOTENT_WRITE = "idempotent_write"
+    NON_IDEMPOTENT_WRITE = "non_idempotent_write"
+
+
+# Keep the provider vocabulary already exercised by provider operation and
+# fault cases.  ``uncertain`` is the additional scheduler/capability boundary
+# class proven by lease_wedge: the host cannot assert that the wedged external
+# operation did not happen, but it must not report a false success.
+ProviderOutcome: TypeAlias = OutcomeClass | ProviderFaultOutcome | Literal["uncertain"]
+SUPPORTED_PROVIDER_OUTCOMES: tuple[ProviderOutcome, ...] = (
+    "success",
+    "empty",
+    "unchanged",
+    "committed_without_ack",
+    "uncertain",
+)
+
+
+class LifecycleState(StrEnum):
+    RUNNING = "running"
+    BLOCKED_AUTH = "blocked_auth"
+    BLOCKED_APPROVAL = "blocked_approval"
+    COMPLETED = "completed"
+    DENIED = "denied"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class SequenceClass(StrEnum):
+    TRIGGER = "trigger"
+    RETRY = "retry"
+    CANCEL = "cancel"
+    DUPLICATE = "duplicate"
+    RESTART = "restart"
+    CONCURRENT_DOUBLE_SUBMIT = "concurrent_double_submit"
+
+
+class StateMachineInvariant(StrEnum):
+    TERMINAL_STABILITY = "terminal_stability"
+    AT_MOST_ONCE_EFFECT = "at_most_once_effect"
+    ACTOR_ISOLATION = "actor_isolation"
+    TRUTHFUL_UNCERTAIN_OUTCOME = "truthful_uncertain_outcome"
+    NO_ORPHAN_RUNS_OR_RESERVATIONS = "no_orphan_runs_or_reservations"
+
+
+Evidence: TypeAlias = PytestEvidence | CargoEvidence
+
+
+@dataclass(frozen=True)
+class StateMachineCoverageCase:
+    """One representative crossing of the seven supported dimensions."""
+
+    case_id: str
+    ingress: JourneyIngress
+    auth_state: AuthState
+    policy_state: PolicyState
+    operation_class: OperationClass
+    provider_outcome: ProviderOutcome
+    lifecycle_state: LifecycleState
+    delivery_target: JourneyDeliveryTarget
+    sequences: tuple[SequenceClass, ...]
+    invariants: tuple[StateMachineInvariant, ...]
+    evidence: Evidence
+
+
+def _cargo(source: str, test: str, target: str, manifest: str | None = None):
+    return CargoEvidence(
+        source=source,
+        test=test,
+        target=target,
+        manifest=manifest,
+    )
+
+
+def _operation(case_id: str):
+    """Select a typed provider operation; fail at import if it disappears."""
+    return next(case for case in PROVIDER_OPERATION_CASES if case.case_id == case_id)
+
+
+def _fault(case_id: str):
+    """Select a typed provider fault; fail at import if it disappears."""
+    return next(case for case in PROVIDER_FAULT_CASES if case.case_id == case_id)
+
+
+_PROVIDER_PYTEST = PytestEvidence(
+    source="tests/e2e/scenarios/test_reborn_qa_trace_full_path.py",
+    test="test_provider_operation_case_executes_with_provider_readback",
+)
+_FAULT_PYTEST = PytestEvidence(
+    source="tests/e2e/scenarios/test_reborn_qa_trace_full_path.py",
+    test="test_provider_fault_profile_preserves_safe_operation_outcomes",
+)
+_GENERATED_GATE_EVIDENCE = _cargo(
+    "tests/integration/generated_gate_sequences.rs",
+    "generated_gate_sequences_preserve_lifecycle_invariants",
+    "reborn_generated_gate_sequences",
+)
+
+
+def _journey_cases() -> tuple[StateMachineCoverageCase, ...]:
+    """Project the existing journey registry into the shared seven axes."""
+    projected = []
+    for journey in ALL_JOURNEY_CASES:
+        lifecycle = (
+            LifecycleState.COMPLETED
+            if ObservableAssertion.TRACE_REPLAY_COMPLETE in journey.assertions
+            else LifecycleState.RUNNING
+        )
+        is_trigger = journey.ingress is JourneyIngress.SCHEDULED_TRIGGER
+        sequences = []
+        if is_trigger:
+            sequences.append(SequenceClass.TRIGGER)
+        if ObservableAssertion.RESTART_IDEMPOTENCY in journey.assertions:
+            sequences.append(SequenceClass.RESTART)
+        invariants = []
+        if (
+            ObservableAssertion.EXACT_MUTATION_COUNT in journey.assertions
+            or ObservableAssertion.RESTART_IDEMPOTENCY in journey.assertions
+        ):
+            invariants.append(StateMachineInvariant.AT_MOST_ONCE_EFFECT)
+        projected.append(
+            StateMachineCoverageCase(
+                case_id=f"journey_{journey.case_id}",
+                ingress=journey.ingress,
+                auth_state=AuthState.AUTHENTICATED,
+                policy_state=PolicyState.ALLOWED,
+                operation_class=OperationClass.READ,
+                provider_outcome="success",
+                lifecycle_state=lifecycle,
+                delivery_target=journey.delivery_target,
+                sequences=tuple(sequences),
+                invariants=tuple(invariants),
+                evidence=journey.evidence,
+            )
+        )
+    return tuple(projected)
+
+
+def _provider_case(
+    case_id: str,
+    operation_class: OperationClass,
+) -> StateMachineCoverageCase:
+    operation = _operation(case_id)
+    return StateMachineCoverageCase(
+        case_id=f"provider_{case_id}",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.ALLOWED,
+        operation_class=operation_class,
+        provider_outcome=operation.outcome_class,
+        lifecycle_state=LifecycleState.COMPLETED,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(),
+        invariants=(StateMachineInvariant.AT_MOST_ONCE_EFFECT,),
+        evidence=_PROVIDER_PYTEST,
+    )
+
+
+def _fault_case(
+    case_id: str,
+    *,
+    auth_state: AuthState,
+    operation_class: OperationClass,
+    sequences: tuple[SequenceClass, ...] = (),
+) -> StateMachineCoverageCase:
+    fault = _fault(case_id)
+    return StateMachineCoverageCase(
+        case_id=f"provider_fault_{case_id}",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=auth_state,
+        policy_state=(
+            PolicyState.DENIED
+            if auth_state is AuthState.WRONG_SCOPE
+            else PolicyState.ALLOWED
+        ),
+        operation_class=operation_class,
+        provider_outcome=fault.expected_outcome,
+        lifecycle_state=LifecycleState.FAILED,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=sequences,
+        invariants=(StateMachineInvariant.AT_MOST_ONCE_EFFECT,),
+        evidence=_FAULT_PYTEST,
+    )
+
+
+STATE_MACHINE_COVERAGE_CASES = (
+    *_journey_cases(),
+    _provider_case("github_get_issue", OperationClass.READ),
+    _provider_case("google_sheets_read_values_empty", OperationClass.READ),
+    _provider_case("github_update_issue", OperationClass.IDEMPOTENT_WRITE),
+    _provider_case("github_create_issue", OperationClass.NON_IDEMPOTENT_WRITE),
+    _fault_case(
+        "idempotent_write_wrong_scope",
+        auth_state=AuthState.WRONG_SCOPE,
+        operation_class=OperationClass.IDEMPOTENT_WRITE,
+    ),
+    _fault_case(
+        "non_idempotent_write_lost_acknowledgement",
+        auth_state=AuthState.AUTHENTICATED,
+        operation_class=OperationClass.NON_IDEMPOTENT_WRITE,
+        sequences=(SequenceClass.DUPLICATE,),
+    ),
+    StateMachineCoverageCase(
+        case_id="auth_gate_requires_resolution",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTH_REQUIRED,
+        policy_state=PolicyState.APPROVAL_REQUIRED,
+        operation_class=OperationClass.READ,
+        provider_outcome="unchanged",
+        lifecycle_state=LifecycleState.BLOCKED_AUTH,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.RETRY,),
+        invariants=(StateMachineInvariant.TERMINAL_STABILITY,),
+        evidence=_cargo(
+            "tests/integration/group_journeys/main.rs",
+            "journeys_group_auth_convergence_e2e",
+            "reborn_group_journeys",
+        ),
+    ),
+    StateMachineCoverageCase(
+        case_id="approval_gate_is_blocked_before_resolution",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.APPROVAL_REQUIRED,
+        operation_class=OperationClass.IDEMPOTENT_WRITE,
+        provider_outcome="unchanged",
+        lifecycle_state=LifecycleState.BLOCKED_APPROVAL,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.CANCEL, SequenceClass.DUPLICATE),
+        invariants=(
+            StateMachineInvariant.TERMINAL_STABILITY,
+            StateMachineInvariant.AT_MOST_ONCE_EFFECT,
+            StateMachineInvariant.NO_ORPHAN_RUNS_OR_RESERVATIONS,
+        ),
+        evidence=_GENERATED_GATE_EVIDENCE,
+    ),
+    StateMachineCoverageCase(
+        case_id="approval_denial_is_terminal",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.DENIED,
+        operation_class=OperationClass.IDEMPOTENT_WRITE,
+        provider_outcome="unchanged",
+        lifecycle_state=LifecycleState.DENIED,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.DUPLICATE,),
+        invariants=(
+            StateMachineInvariant.TERMINAL_STABILITY,
+            StateMachineInvariant.AT_MOST_ONCE_EFFECT,
+        ),
+        evidence=_GENERATED_GATE_EVIDENCE,
+    ),
+    StateMachineCoverageCase(
+        case_id="approval_cancel_is_terminal",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.APPROVAL_REQUIRED,
+        operation_class=OperationClass.IDEMPOTENT_WRITE,
+        provider_outcome="unchanged",
+        lifecycle_state=LifecycleState.CANCELLED,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.CANCEL,),
+        invariants=(
+            StateMachineInvariant.TERMINAL_STABILITY,
+            StateMachineInvariant.NO_ORPHAN_RUNS_OR_RESERVATIONS,
+        ),
+        evidence=_GENERATED_GATE_EVIDENCE,
+    ),
+    StateMachineCoverageCase(
+        case_id="generated_actor_isolation",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.APPROVAL_REQUIRED,
+        operation_class=OperationClass.IDEMPOTENT_WRITE,
+        provider_outcome="success",
+        lifecycle_state=LifecycleState.COMPLETED,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.DUPLICATE,),
+        invariants=(StateMachineInvariant.ACTOR_ISOLATION,),
+        evidence=_cargo(
+            "tests/integration/generated_gate_sequences.rs",
+            "generated_actions_on_one_actor_never_disturb_another",
+            "reborn_generated_gate_sequences",
+        ),
+    ),
+    StateMachineCoverageCase(
+        case_id="lease_wedge_truthful_uncertainty",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.ALLOWED,
+        operation_class=OperationClass.READ,
+        provider_outcome="uncertain",
+        lifecycle_state=LifecycleState.FAILED,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.RETRY,),
+        invariants=(StateMachineInvariant.TRUTHFUL_UNCERTAIN_OUTCOME,),
+        evidence=_cargo(
+            "tests/integration/lease_wedge.rs",
+            "wedged_tool_call_is_reaped_by_lease_expiry_not_left_running_forever",
+            "reborn_integration_lease_wedge",
+        ),
+    ),
+    StateMachineCoverageCase(
+        case_id="generated_same_thread_double_submit",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.ALLOWED,
+        operation_class=OperationClass.READ,
+        provider_outcome="success",
+        lifecycle_state=LifecycleState.RUNNING,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.CONCURRENT_DOUBLE_SUBMIT,),
+        invariants=(
+            StateMachineInvariant.AT_MOST_ONCE_EFFECT,
+            StateMachineInvariant.NO_ORPHAN_RUNS_OR_RESERVATIONS,
+        ),
+        evidence=_cargo(
+            "tests/integration/generated_gate_sequences.rs",
+            "generated_same_thread_double_submit_interleavings_admit_one_run",
+            "reborn_generated_gate_sequences",
+        ),
+    ),
+    StateMachineCoverageCase(
+        case_id="generated_restart_sequence",
+        ingress=JourneyIngress.WEBUI,
+        auth_state=AuthState.AUTHENTICATED,
+        policy_state=PolicyState.APPROVAL_REQUIRED,
+        operation_class=OperationClass.IDEMPOTENT_WRITE,
+        provider_outcome="success",
+        lifecycle_state=LifecycleState.COMPLETED,
+        delivery_target=JourneyDeliveryTarget.WEBUI,
+        sequences=(SequenceClass.RESTART,),
+        invariants=(
+            StateMachineInvariant.TERMINAL_STABILITY,
+            StateMachineInvariant.AT_MOST_ONCE_EFFECT,
+            StateMachineInvariant.NO_ORPHAN_RUNS_OR_RESERVATIONS,
+        ),
+        evidence=_cargo(
+            "tests/integration/generated_restart_sequences.rs",
+            "generated_restart_sequences_preserve_gate_lifecycle_and_effect_count",
+            "reborn_generated_restart_sequences",
+        ),
+    ),
+)
+
+
+SUPPORTED_DIMENSIONS = {
+    "ingress": frozenset(JourneyIngress),
+    "auth_state": frozenset(AuthState),
+    "policy_state": frozenset(PolicyState),
+    "operation_class": frozenset(OperationClass),
+    "provider_outcome": frozenset(SUPPORTED_PROVIDER_OUTCOMES),
+    "lifecycle_state": frozenset(LifecycleState),
+    "delivery_target": frozenset(JourneyDeliveryTarget),
+}
+
+
+# Deliberately selected high-risk pairs.  This is the auditable denominator for
+# pairwise breadth; it does not imply every pair in the Cartesian product is
+# useful.  Values are strings so provider outcomes can retain their existing
+# Literal vocabulary while enum-backed dimensions use the same checker.
+REQUIRED_EQUIVALENCE_PAIRS = frozenset(
+    {
+        ("ingress", "scheduled_trigger", "delivery_target", "slack"),
+        ("ingress", "extension_webhook", "delivery_target", "none"),
+        ("auth_state", "auth_required", "policy_state", "approval_required"),
+        ("auth_state", "wrong_scope", "policy_state", "denied"),
+        ("auth_state", "wrong_scope", "provider_outcome", "unchanged"),
+        (
+            "operation_class",
+            "non_idempotent_write",
+            "provider_outcome",
+            "committed_without_ack",
+        ),
+        ("provider_outcome", "uncertain", "lifecycle_state", "failed"),
+        (
+            "policy_state",
+            "approval_required",
+            "lifecycle_state",
+            "blocked_approval",
+        ),
+        ("policy_state", "denied", "lifecycle_state", "denied"),
+        ("delivery_target", "webui", "lifecycle_state", "completed"),
+    }
+)
+
+
+def duplicate_case_ids(
+    cases: tuple[StateMachineCoverageCase, ...],
+) -> frozenset[str]:
+    ids = [case.case_id for case in cases]
+    return frozenset(case_id for case_id in ids if ids.count(case_id) > 1)
+
+
+def dimension_gaps(
+    cases: tuple[StateMachineCoverageCase, ...],
+) -> dict[str, frozenset[str]]:
+    """Return supported dimension values not represented by any row."""
+    gaps = {}
+    for dimension, required in SUPPORTED_DIMENSIONS.items():
+        covered = {getattr(case, dimension) for case in cases}
+        missing = {str(value) for value in required - covered}
+        if missing:
+            gaps[dimension] = frozenset(missing)
+    return gaps
+
+
+def pairwise_gaps(
+    cases: tuple[StateMachineCoverageCase, ...],
+) -> frozenset[tuple[str, str, str, str]]:
+    """Return selected critical interactions absent from the registry."""
+    missing = set()
+    for pair in REQUIRED_EQUIVALENCE_PAIRS:
+        left_axis, left_value, right_axis, right_value = pair
+        if not any(
+            str(getattr(case, left_axis)) == left_value
+            and str(getattr(case, right_axis)) == right_value
+            for case in cases
+        ):
+            missing.add(pair)
+    return frozenset(missing)
+
+
+def sequence_gaps(
+    cases: tuple[StateMachineCoverageCase, ...],
+) -> frozenset[SequenceClass]:
+    covered = {sequence for case in cases for sequence in case.sequences}
+    return frozenset(SequenceClass) - covered
+
+
+def invariant_gaps(
+    cases: tuple[StateMachineCoverageCase, ...],
+) -> frozenset[StateMachineInvariant]:
+    covered = {invariant for case in cases for invariant in case.invariants}
+    return frozenset(StateMachineInvariant) - covered
+
+
+def coverage_gap_count(
+    cases: tuple[StateMachineCoverageCase, ...],
+) -> int:
+    """Mechanical WS9 dimension × sequence × invariant remaining-gap count."""
+    return (
+        sum(len(values) for values in dimension_gaps(cases).values())
+        + len(pairwise_gaps(cases))
+        + len(sequence_gaps(cases))
+        + len(invariant_gaps(cases))
+        + len(duplicate_case_ids(cases))
+    )

--- a/tests/integration/CLAUDE.md
+++ b/tests/integration/CLAUDE.md
@@ -377,6 +377,8 @@ On a harness built from a `live_approvals` group:
 - `deny_gate(run_id, &gate_ref)` — resolves to `Denied` and resumes with `GateResumeDisposition::Denied`; the executor surfaces a non-retryable authorization failure to the model.
 - `wait_for_status(run_id, expected)` — polls the turn-state store until the run reaches `expected`; fails fast on a different terminal status.
 - `enable_auto_approve()` — flips the per-`(tenant, user)` CAS-persisted auto-approve toggle ON; the flip persists across threads in the group because the store is shared.
+- `assert_process_ownership(run_ids)` — validates the row-native process tree while a run may still be executing.
+- `assert_no_orphan_runs_or_reservations(run_ids)` — combines process ownership with zero capability-governor holds at a blocked or terminal quiescent boundary. Do not use the combined form while a capability is legitimately in flight.
 
 ### Test-support crate accessors
 
@@ -387,6 +389,7 @@ On a harness built from a `live_approvals` group:
 `ironclaw_reborn_composition::test_support` exposes:
 
 - `build_secret_store_for_test(root, scoped)` — constructs the `StandaloneSecretStore` used by production local-dev composition; for store read-back in secrets tests.
+- `build_runtime_with_resource_governor_for_test(input)` — builds the ordinary production-composed runtime and returns the exact `ResourceGovernor` wired into its capability path. Use only for reservation read-back; resource policy remains owned by `ironclaw_resources`.
 
 `RebornRuntime` (returned by `build_runtime`, methods defined in `crates/ironclaw_reborn_composition/src/runtime/test_support.rs`) exposes:
 
@@ -406,6 +409,14 @@ runtime. Cross-thread persistence is real — thread A
 writes, thread B sees it. Single-shot `test_default()` is a degenerate
 one-thread group (its own storage, baseline = 0); all existing tests are
 byte-identical after this refactor.
+
+For restart recovery tests, `restart_planned_runtime(self)` consumes a LibSQL
+group and reconstructs the scheduler, coordinator, executor, scope gateway,
+checkpoint adapters, and process journal over a fresh database connection.
+Every thread harness must be dropped first so no old coordinator remains live.
+The external capability backend is retained to model durable approval/host
+state. InMemory and Postgres modes fail loudly because they do not provide this
+hermetic fresh-connection restart recipe.
 
 ### When to use a group (vs a flat test)
 

--- a/tests/integration/coverage-floor.toml
+++ b/tests/integration/coverage-floor.toml
@@ -55,42 +55,44 @@
 
 [global]
 enforce = true
-# Recaptured from PR #6696's successful merged CI artifact before the behavioral
-# coverage additions in this PR: aggregate 307208 / 360961 = 85.11%. New tests
-# may raise this value; this floor prevents either test removal or denominator
-# shrinkage from returning to the previous permissive 80.81% baseline.
-floor_percent = 85.11
+# Recaptured from PR #6886's successful merged CI artifact at df5081ad4 after
+# the generated lifecycle, restart, and double-submit coverage additions:
+# aggregate 315436 / 368757 = 85.54%.
+floor_percent = 85.54
 tolerance_percent = 0.5
-captured_total_lines = 360961
-captured_date = "2026-07-28"
-captured_from = "cef5eab53f47b2fc603a6dffc6cdeb7e12ed9ef5"
+captured_total_lines = 368757
+captured_date = "2026-07-30"
+captured_from = "df5081ad4539e14da07a3b041735c35e6a795ac8"
 
 [[crate]]
 name = "ironclaw_runner"
-floor_percent = 83.58
-floor_covered_lines = 13083
+floor_percent = 86.87
+floor_covered_lines = 14669
 tolerance_percent = 0.5
 tolerance_lines = 20
-captured_total_lines = 15653
-captured_date = "2026-07-28"
-rationale = "Protects runner orchestration and await-edge caller paths after the process-journal migration."
+captured_total_lines = 16887
+captured_date = "2026-07-30"
+rationale = "Protects generated lifecycle, restart, and double-submit runner orchestration after the process-journal migration."
+issue = "https://github.com/nearai/ironclaw/issues/6524"
 
 [[crate]]
 name = "ironclaw_processes"
-floor_percent = 82.29
-floor_covered_lines = 5140
+floor_percent = 88.07
+floor_covered_lines = 5839
 tolerance_percent = 0.5
 tolerance_lines = 20
-captured_total_lines = 6246
-captured_date = "2026-07-28"
-rationale = "Protects the process journal state machine with both percentage and deletion-resistant covered-line floors."
+captured_total_lines = 6630
+captured_date = "2026-07-30"
+rationale = "Protects generated per-transition ownership checks in the process journal state machine."
+issue = "https://github.com/nearai/ironclaw/issues/6524"
 
 [[crate]]
 name = "ironclaw_turns"
-floor_percent = 85.36
-floor_covered_lines = 9181
+floor_percent = 86.21
+floor_covered_lines = 9453
 tolerance_percent = 0.5
 tolerance_lines = 20
-captured_total_lines = 10755
-captured_date = "2026-07-28"
-rationale = "Protects child submission, retry, admission, and process-projection behavior."
+captured_total_lines = 10965
+captured_date = "2026-07-30"
+rationale = "Protects generated restart, same-thread admission, retry, and process-projection behavior."
+issue = "https://github.com/nearai/ironclaw/issues/6524"

--- a/tests/integration/generated_gate_sequences.rs
+++ b/tests/integration/generated_gate_sequences.rs
@@ -230,6 +230,13 @@ async fn run_sequence(sequence: &[GateAction]) -> usize {
     // Asserting `is_terminal()` here would be tautological: `wait_for_terminal`
     // only returns on a terminal status.
     observed.record(final_state.status, sequence, sequence.len());
+    if sequence == [GateAction::Deny] {
+        assert_eq!(
+            final_state.status,
+            TurnStatus::Completed,
+            "a denied capability outcome is model-visible; the conversation should complete"
+        );
+    }
     h.assert_no_orphan_runs_or_reservations(&[run_id])
         .await
         .unwrap_or_else(|err| {

--- a/tests/integration/generated_gate_sequences.rs
+++ b/tests/integration/generated_gate_sequences.rs
@@ -191,14 +191,28 @@ async fn run_sequence(sequence: &[GateAction]) -> usize {
             .expect("run stays readable after every action")
             .status;
         observed.record(status, sequence, step + 1);
-        h.assert_no_orphan_runs_or_reservations(&[run_id])
+        h.assert_process_ownership(&[run_id])
             .await
             .unwrap_or_else(|err| {
                 panic!(
-                    "{sequence:?} step {}: orphan invariant failed: {err}",
+                    "{sequence:?} step {}: process ownership invariant failed: {err}",
                     step + 1
                 )
             });
+        if status.is_terminal()
+            || matches!(
+                status,
+                TurnStatus::BlockedApproval | TurnStatus::BlockedAuth
+            )
+        {
+            h.assert_no_capability_resource_reservations()
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "{sequence:?} step {}: quiescent reservation invariant failed: {err}",
+                        step + 1
+                    )
+                });
+        }
     }
 
     // (3) every sequence settles. Read through `wait_for_terminal` so a run
@@ -378,10 +392,20 @@ async fn generated_same_thread_double_submit_interleavings_admit_one_run() {
             .await
             .expect("live-approvals group builds");
         let gate = ParkingModelGate::new();
+        let workspace_file = format!("double-submit-{interleaving:?}.txt").to_ascii_lowercase();
         let h = group
             .thread(format!("double-submit-{interleaving:?}").to_lowercase())
             .park_model(gate.clone())
-            .script([RebornScriptedReply::text("winner completes")])
+            .script([
+                RebornScriptedReply::tool_call(
+                    GATED_CAPABILITY,
+                    json!({
+                        "path": format!("/workspace/{workspace_file}"),
+                        "content": "one admitted effect"
+                    }),
+                ),
+                RebornScriptedReply::text("winner completes"),
+            ])
             .build()
             .await
             .expect("double-submit thread builds");
@@ -440,12 +464,41 @@ async fn generated_same_thread_double_submit_interleavings_admit_one_run() {
             .unwrap_or_else(|err| panic!("{interleaving:?}: active invariant failed: {err}"));
 
         gate.release();
+        let blocked = h
+            .wait_for_status(admitted_run, TurnStatus::BlockedApproval)
+            .await
+            .unwrap_or_else(|err| {
+                panic!("{interleaving:?}: admitted run did not reach its effect gate: {err}")
+            });
+        let gate_ref = blocked
+            .gate_ref
+            .expect("blocked double-submit run names its approval gate");
+        h.assert_no_orphan_runs_or_reservations(&[admitted_run])
+            .await
+            .unwrap_or_else(|err| {
+                panic!("{interleaving:?}: blocked-effect invariant failed: {err}")
+            });
+        h.approve_gate(admitted_run, &gate_ref)
+            .await
+            .unwrap_or_else(|err| {
+                panic!("{interleaving:?}: admitted effect approval failed: {err}")
+            });
         h.wait_for_status(admitted_run, TurnStatus::Completed)
             .await
             .unwrap_or_else(|err| panic!("{interleaving:?}: admitted run did not complete: {err}"));
         h.assert_no_orphan_runs_or_reservations(&[admitted_run])
             .await
             .unwrap_or_else(|err| panic!("{interleaving:?}: terminal invariant failed: {err}"));
+        h.assert_capability_result_count(GATED_CAPABILITY, 1)
+            .await
+            .unwrap_or_else(|err| {
+                panic!("{interleaving:?}: admitted run did not emit exactly one effect: {err}")
+            });
+        h.assert_workspace_file_contains(&workspace_file, "one admitted effect")
+            .await
+            .unwrap_or_else(|err| {
+                panic!("{interleaving:?}: admitted effect read-back failed: {err}")
+            });
     }
 }
 
@@ -648,6 +701,23 @@ mod invariant_checker {
         .expect_err("a process whose parent is absent must trip the orphan invariant");
         assert!(
             error.to_string().contains("names missing parent"),
+            "wrong invariant branch fired: {error}"
+        );
+    }
+
+    #[test]
+    fn orphan_checker_rejects_an_expected_id_with_the_wrong_process_kind() {
+        use ironclaw_host_api::ProcessId;
+        use ironclaw_processes::ProcessKind;
+
+        let expected_process_id = ProcessId::new();
+        let error = reborn_support::assertions::validate_process_ownership(
+            &[(expected_process_id, ProcessKind::CapabilityInvocation, None)],
+            &[expected_process_id],
+        )
+        .expect_err("the expected agent-turn id under another kind must fail ownership");
+        assert!(
+            error.to_string().contains("not AgentTurn"),
             "wrong invariant branch fired: {error}"
         );
     }

--- a/tests/integration/generated_gate_sequences.rs
+++ b/tests/integration/generated_gate_sequences.rs
@@ -35,35 +35,23 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
-use ironclaw_turns::TurnStatus;
+use std::time::Duration;
+
+use ironclaw_product::ProductInboundAck;
+use ironclaw_turns::{TurnRunId, TurnStatus};
 use reborn_support::group::RebornIntegrationGroup;
 use reborn_support::reply::RebornScriptedReply;
+use reborn_support::scripted_provider::ParkingModelGate;
 use serde_json::json;
 
 /// The capability the gate guards. Named once so the effect-count assertion
 /// and the scripted call cannot drift apart.
 const GATED_CAPABILITY: &str = "builtin.write_file";
 
-// Where each dimension workstream 9 names is actually exercised.
-//
-// Listing them as a comment rather than inventing an enum per axis: a typed
-// `Ingress` with one variant that nothing matches on is decoration, and it
-// would read as coverage on a scan.
-//
-// | axis | exercised | where |
-// |---|---|---|
-// | lifecycle state | yes | `GateAction` below, enumerated |
-// | policy state | yes | auto-approve on/off, per owner, in the cross-actor case |
-// | auth state | partly | `auth/auth_gate.rs` + the expired-credential resume; not enumerated with the lifecycle axis |
-// | provider outcome | partly | `with_github_network_status` drives 401/5xx in the auth slice; not crossed with gate actions |
-// | operation class | no | read vs idempotent vs non-idempotent write is an E2E fault-matrix axis (`provider_fault_cases.py`) |
-// | ingress | no | one ingress at this tier; WebUI/Slack/Telegram are covered whole-path in E2E |
-// | delivery target | no | same — a delivery target needs a channel, which this tier does not run |
-//
-// The three "no" rows are not oversights: crossing them with the lifecycle
-// axis needs a tier that runs channels and providers, which is the E2E
-// journey suite, not this one. Recorded so the epic is not read as claiming
-// (table above documents the axes; the enum's own doc follows)
+// The complete seven-axis denominator and its selected pairwise crossings live
+// in `tests/e2e/state_machine_coverage.py`. This target supplies the executable
+// lifecycle, actor-isolation, double-submit, and orphan-invariant evidence;
+// channel/provider axes remain mapped to their owning whole-path suites.
 
 /// One dimension of workstream 9's lifecycle axis: what a client can do to a
 /// run parked on an approval gate.
@@ -177,6 +165,9 @@ async fn run_sequence(sequence: &[GateAction]) -> usize {
         .expect("parked run is readable")
         .status;
     observed.record(parked, sequence, 0);
+    h.assert_no_orphan_runs_or_reservations(&[run_id])
+        .await
+        .unwrap_or_else(|err| panic!("{sequence:?} step 0: orphan invariant failed: {err}"));
 
     for (step, action) in sequence.iter().enumerate() {
         // Deliberately unconditional: refusing an action that no longer
@@ -200,6 +191,14 @@ async fn run_sequence(sequence: &[GateAction]) -> usize {
             .expect("run stays readable after every action")
             .status;
         observed.record(status, sequence, step + 1);
+        h.assert_no_orphan_runs_or_reservations(&[run_id])
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "{sequence:?} step {}: orphan invariant failed: {err}",
+                    step + 1
+                )
+            });
     }
 
     // (3) every sequence settles. Read through `wait_for_terminal` so a run
@@ -217,6 +216,11 @@ async fn run_sequence(sequence: &[GateAction]) -> usize {
     // Asserting `is_terminal()` here would be tautological: `wait_for_terminal`
     // only returns on a terminal status.
     observed.record(final_state.status, sequence, sequence.len());
+    h.assert_no_orphan_runs_or_reservations(&[run_id])
+        .await
+        .unwrap_or_else(|err| {
+            panic!("{sequence:?} terminal observation: orphan invariant failed: {err}")
+        });
 
     // (4) no duplicate confirmed effect. The gated capability writes a file;
     // resolving the same gate twice must not write it twice. This is the
@@ -250,8 +254,8 @@ async fn run_sequence(sequence: &[GateAction]) -> usize {
     effects
 }
 
-/// How long a sequence to enumerate. Pull requests get depth 2 (20 sequences,
-/// ~20s); the nightly deep lane raises it.
+/// How long a sequence to enumerate. Pull requests get depth 2 (12 sequences);
+/// the nightly deep lane raises it to depth 3 (39 sequences).
 ///
 /// Parsed strictly rather than with `unwrap_or(2)`: a typo in the workflow
 /// would otherwise silently run the shallow lane while the job name still
@@ -311,6 +315,138 @@ async fn generated_gate_sequences_preserve_lifecycle_invariants() {
         "no sequence performed the gated effect; the <=1 bound above would \
          hold vacuously and this suite would be checking nothing"
     );
+}
+
+/// Representative scheduler interleavings for two submissions racing on the
+/// same durable thread. Both ordered edges matter in addition to a true
+/// simultaneous join: only checking one order can hide a payload-correlated
+/// winner or an admission check performed outside the atomic store boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DoubleSubmitInterleaving {
+    FirstThenSecond,
+    SecondThenFirst,
+    Simultaneous,
+}
+
+const DOUBLE_SUBMIT_INTERLEAVINGS: [DoubleSubmitInterleaving; 3] = [
+    DoubleSubmitInterleaving::FirstThenSecond,
+    DoubleSubmitInterleaving::SecondThenFirst,
+    DoubleSubmitInterleaving::Simultaneous,
+];
+
+fn accepted_and_busy_run(
+    left: ProductInboundAck,
+    right: ProductInboundAck,
+    interleaving: DoubleSubmitInterleaving,
+) -> TurnRunId {
+    match (left, right) {
+        (
+            ProductInboundAck::Accepted {
+                submitted_run_id, ..
+            },
+            ProductInboundAck::RejectedBusy {
+                active_run_id: Some(active_run_id),
+                ..
+            },
+        )
+        | (
+            ProductInboundAck::RejectedBusy {
+                active_run_id: Some(active_run_id),
+                ..
+            },
+            ProductInboundAck::Accepted {
+                submitted_run_id, ..
+            },
+        ) => {
+            assert_eq!(
+                active_run_id, submitted_run_id,
+                "{interleaving:?}: busy acknowledgement named a different active run"
+            );
+            submitted_run_id
+        }
+        (left, right) => panic!(
+            "{interleaving:?}: expected exactly one Accepted and one \
+             RejectedBusy acknowledgement, got {left:?} and {right:?}"
+        ),
+    }
+}
+
+#[tokio::test]
+async fn generated_same_thread_double_submit_interleavings_admit_one_run() {
+    for interleaving in DOUBLE_SUBMIT_INTERLEAVINGS {
+        let group = RebornIntegrationGroup::live_approvals()
+            .await
+            .expect("live-approvals group builds");
+        let gate = ParkingModelGate::new();
+        let h = group
+            .thread(format!("double-submit-{interleaving:?}").to_lowercase())
+            .park_model(gate.clone())
+            .script([RebornScriptedReply::text("winner completes")])
+            .build()
+            .await
+            .expect("double-submit thread builds");
+
+        let (left, right) = match interleaving {
+            DoubleSubmitInterleaving::FirstThenSecond => {
+                let left = h
+                    .submit_turn_ack("first payload")
+                    .await
+                    .expect("first submit returns an acknowledgement");
+                tokio::time::timeout(Duration::from_secs(10), gate.wait_until_parked())
+                    .await
+                    .expect("accepted first submit reaches the parked provider");
+                let right = h
+                    .submit_turn_ack("second payload")
+                    .await
+                    .expect("second submit returns an acknowledgement");
+                (left, right)
+            }
+            DoubleSubmitInterleaving::SecondThenFirst => {
+                let right = h
+                    .submit_turn_ack("second payload")
+                    .await
+                    .expect("second-labeled submit returns an acknowledgement");
+                tokio::time::timeout(Duration::from_secs(10), gate.wait_until_parked())
+                    .await
+                    .expect("accepted second-labeled submit reaches the parked provider");
+                let left = h
+                    .submit_turn_ack("first payload")
+                    .await
+                    .expect("first-labeled submit returns an acknowledgement");
+                (left, right)
+            }
+            DoubleSubmitInterleaving::Simultaneous => {
+                let acknowledgements = tokio::join!(
+                    h.submit_turn_ack("first payload"),
+                    h.submit_turn_ack("second payload")
+                );
+                (
+                    acknowledgements
+                        .0
+                        .expect("simultaneous first submit returns an acknowledgement"),
+                    acknowledgements
+                        .1
+                        .expect("simultaneous second submit returns an acknowledgement"),
+                )
+            }
+        };
+
+        let admitted_run = accepted_and_busy_run(left, right, interleaving);
+        tokio::time::timeout(Duration::from_secs(10), gate.wait_until_parked())
+            .await
+            .expect("admitted run reaches the parked provider");
+        h.assert_no_orphan_runs_or_reservations(&[admitted_run])
+            .await
+            .unwrap_or_else(|err| panic!("{interleaving:?}: active invariant failed: {err}"));
+
+        gate.release();
+        h.wait_for_status(admitted_run, TurnStatus::Completed)
+            .await
+            .unwrap_or_else(|err| panic!("{interleaving:?}: admitted run did not complete: {err}"));
+        h.assert_no_orphan_runs_or_reservations(&[admitted_run])
+            .await
+            .unwrap_or_else(|err| panic!("{interleaving:?}: terminal invariant failed: {err}"));
+    }
 }
 
 /// The invariant checker is itself checked.
@@ -374,12 +510,146 @@ mod invariant_checker {
     }
 
     #[test]
+    fn double_submit_generator_contains_both_orders_and_a_true_race() {
+        assert_eq!(
+            DOUBLE_SUBMIT_INTERLEAVINGS,
+            [
+                DoubleSubmitInterleaving::FirstThenSecond,
+                DoubleSubmitInterleaving::SecondThenFirst,
+                DoubleSubmitInterleaving::Simultaneous,
+            ],
+            "removing an ordering would silently shrink the interleaving generator"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected exactly one Accepted and one RejectedBusy")]
+    fn double_submit_checker_rejects_two_accepted_runs() {
+        use ironclaw_host_api::AcceptedMessageRef;
+
+        let ack = |message: &str| ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new(message)
+                .expect("sabotage message ref is valid"),
+            submitted_run_id: TurnRunId::new(),
+        };
+        accepted_and_busy_run(
+            ack("message:sabotage-a"),
+            ack("message:sabotage-b"),
+            DoubleSubmitInterleaving::Simultaneous,
+        );
+    }
+
+    #[test]
     fn accepts_an_ordinary_settling_sequence() {
         observed_with(&[
             TurnStatus::BlockedApproval,
             TurnStatus::Running,
             TurnStatus::Completed,
         ]);
+    }
+
+    #[tokio::test]
+    async fn orphan_checker_rejects_a_live_run_omitted_from_the_expected_set() {
+        let group = RebornIntegrationGroup::live_approvals()
+            .await
+            .expect("live-approvals group builds");
+        let h = group
+            .thread("orphan-checker-sabotage")
+            .script([RebornScriptedReply::tool_call(
+                GATED_CAPABILITY,
+                json!({"path": "/workspace/sabotage.txt", "content": "sabotage"}),
+            )])
+            .build()
+            .await
+            .expect("sabotage thread builds");
+        let (run_id, _) = h
+            .submit_turn_until_blocked("park for orphan sabotage")
+            .await
+            .expect("sabotage run parks");
+
+        let error = h
+            .assert_no_orphan_runs_or_reservations(&[])
+            .await
+            .expect_err("omitting the live run must trip the orphan invariant");
+        assert!(
+            error.to_string().contains("orphan agent-turn process"),
+            "wrong invariant branch fired: {error}"
+        );
+
+        h.cancel_run(run_id)
+            .await
+            .expect("sabotage run cancellation is accepted");
+        h.wait_for_status(run_id, TurnStatus::Cancelled)
+            .await
+            .expect("sabotage run settles after cancellation");
+    }
+
+    #[tokio::test]
+    async fn orphan_checker_rejects_a_capability_resource_hold() {
+        use ironclaw_host_api::{InvocationId, ResourceEstimate, ResourceScope};
+
+        let group = RebornIntegrationGroup::live_approvals()
+            .await
+            .expect("live-approvals group builds");
+        let h = group
+            .thread("resource-orphan-checker-sabotage")
+            .build()
+            .await
+            .expect("resource sabotage thread builds");
+        let governor = h
+            .capability_resource_governor_for_test()
+            .expect("production-composed governor is exposed");
+        let reservation = governor
+            .reserve(
+                ResourceScope {
+                    tenant_id: h.binding.tenant_id.clone(),
+                    user_id: h.binding.actor_user_id.clone(),
+                    agent_id: h.binding.agent_id.clone(),
+                    project_id: h.binding.project_id.clone(),
+                    mission_id: None,
+                    thread_id: Some(h.binding.thread_id.clone()),
+                    invocation_id: InvocationId::new(),
+                },
+                ResourceEstimate::default().set_concurrency_slots(1),
+            )
+            .expect("sabotage resource reservation succeeds");
+
+        let error = h
+            .assert_no_orphan_runs_or_reservations(&[])
+            .await
+            .expect_err("a live capability hold must trip the orphan invariant");
+        assert!(
+            error
+                .to_string()
+                .contains("orphan capability resource reservation"),
+            "wrong invariant branch fired: {error}"
+        );
+
+        governor
+            .release(reservation.id)
+            .expect("sabotage reservation releases");
+    }
+
+    #[test]
+    fn orphan_checker_rejects_a_process_with_a_missing_parent() {
+        use ironclaw_host_api::ProcessId;
+        use ironclaw_processes::ProcessKind;
+
+        let process_id = ProcessId::new();
+        let missing_parent = ProcessId::new();
+        let error = reborn_support::assertions::validate_process_ownership(
+            &[(
+                process_id,
+                ProcessKind::CapabilityInvocation,
+                Some(missing_parent),
+            )],
+            &[],
+        )
+        .expect_err("a process whose parent is absent must trip the orphan invariant");
+        assert!(
+            error.to_string().contains("names missing parent"),
+            "wrong invariant branch fired: {error}"
+        );
     }
 }
 

--- a/tests/integration/generated_restart_sequences.rs
+++ b/tests/integration/generated_restart_sequences.rs
@@ -30,49 +30,18 @@ enum PostRestartAction {
 
 impl PostRestartAction {
     const ALL: [Self; 3] = [Self::Approve, Self::Deny, Self::Cancel];
-
-    fn index(self) -> usize {
-        match self {
-            Self::Approve => 0,
-            Self::Deny => 1,
-            Self::Cancel => 2,
-        }
-    }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct RestartSequence {
-    action: PostRestartAction,
-}
-
-fn restart_sequences() -> Vec<RestartSequence> {
-    PostRestartAction::ALL
-        .into_iter()
-        .map(|action| RestartSequence { action })
-        .collect()
-}
-
-fn validate_restart_sequences(sequences: &[RestartSequence]) -> Result<(), String> {
-    let mut seen = [false; PostRestartAction::ALL.len()];
-    for sequence in sequences {
-        let slot = &mut seen[sequence.action.index()];
-        if *slot {
-            return Err(format!(
-                "duplicate generated restart action: {:?}",
-                sequence.action
-            ));
-        }
-        *slot = true;
-    }
-    let missing: Vec<_> = PostRestartAction::ALL
-        .into_iter()
-        .filter(|action| !seen[action.index()])
-        .collect();
-    if missing.is_empty() {
-        Ok(())
-    } else {
-        Err(format!("missing generated restart actions: {missing:?}"))
-    }
+fn assert_complete_restart_actions(actions: &[PostRestartAction]) {
+    assert_eq!(
+        actions,
+        [
+            PostRestartAction::Approve,
+            PostRestartAction::Deny,
+            PostRestartAction::Cancel,
+        ],
+        "restart action denominator changed"
+    );
 }
 
 async fn build_restarted_harness(
@@ -151,13 +120,12 @@ async fn build_restarted_harness(
 
 #[tokio::test]
 async fn generated_restart_sequences_preserve_gate_lifecycle_and_effect_count() {
-    let sequences = restart_sequences();
-    validate_restart_sequences(&sequences)
-        .unwrap_or_else(|error| panic!("restart generator is incomplete: {error}"));
+    assert_complete_restart_actions(&PostRestartAction::ALL);
 
-    for (case_index, sequence) in sequences.into_iter().enumerate() {
+    for (case_index, action) in PostRestartAction::ALL.into_iter().enumerate() {
         let (harness, run_id, gate_ref) = build_restarted_harness(case_index).await;
-        match sequence.action {
+        let workspace_file = format!("generated-restart-{case_index}.txt");
+        match action {
             PostRestartAction::Approve => {
                 harness
                     .approve_gate(run_id, &gate_ref)
@@ -185,19 +153,18 @@ async fn generated_restart_sequences_preserve_gate_lifecycle_and_effect_count() 
         harness
             .assert_no_orphan_runs_or_reservations(&[run_id])
             .await
-            .unwrap_or_else(|error| {
-                panic!(
-                    "{:?} left an orphan after restart: {error}",
-                    sequence.action
-                )
-            });
-        match sequence.action {
+            .unwrap_or_else(|error| panic!("{action:?} left an orphan after restart: {error}"));
+        match action {
             PostRestartAction::Approve => {
                 assert_eq!(terminal.status, TurnStatus::Completed);
                 harness
                     .assert_capability_result_count(GATED_CAPABILITY, 1)
                     .await
                     .expect("approved effect executes exactly once after restart");
+                harness
+                    .assert_workspace_file_contains(&workspace_file, "generated across restart")
+                    .await
+                    .expect("approved write persists the expected contents after restart");
             }
             PostRestartAction::Deny => {
                 // Denial is delivered back to the loop as a model-visible tool
@@ -209,6 +176,10 @@ async fn generated_restart_sequences_preserve_gate_lifecycle_and_effect_count() 
                     .assert_capability_result_count(GATED_CAPABILITY, 0)
                     .await
                     .expect("denied effect stays unexecuted after restart");
+                harness
+                    .assert_workspace_file_absent(&workspace_file)
+                    .await
+                    .expect("denied write leaves no persisted file after restart");
             }
             PostRestartAction::Cancel => {
                 assert_eq!(terminal.status, TurnStatus::Cancelled);
@@ -216,19 +187,17 @@ async fn generated_restart_sequences_preserve_gate_lifecycle_and_effect_count() 
                     .assert_capability_result_count(GATED_CAPABILITY, 0)
                     .await
                     .expect("cancelled effect stays unexecuted after restart");
+                harness
+                    .assert_workspace_file_absent(&workspace_file)
+                    .await
+                    .expect("cancelled write leaves no persisted file after restart");
             }
         }
     }
 }
 
 #[test]
+#[should_panic(expected = "restart action denominator changed")]
 fn restart_generator_sabotage_detects_a_missing_recovery_arm() {
-    let mut sabotaged = restart_sequences();
-    sabotaged.retain(|sequence| sequence.action != PostRestartAction::Deny);
-    let error = validate_restart_sequences(&sabotaged)
-        .expect_err("removing a recovery arm must fail the generator denominator");
-    assert!(
-        error.contains("Deny"),
-        "missing-arm diagnostic did not name the sabotaged branch: {error}"
-    );
+    assert_complete_restart_actions(&[PostRestartAction::Approve, PostRestartAction::Cancel]);
 }

--- a/tests/integration/generated_restart_sequences.rs
+++ b/tests/integration/generated_restart_sequences.rs
@@ -1,0 +1,234 @@
+//! Generated restart sequences over a durable approval-gated run (#6524 WS9).
+//!
+//! Unlike the independent store-reopen probes, these cases gracefully stop the
+//! old scheduler and rebuild the coordinator, executor, scheduler, scope
+//! gateway, checkpoint adapters, and process journal over a fresh LibSQL connection.
+//! The post-restart action is generated from the supported gate-resolution
+//! classes so every recovery arm is exercised reproducibly.
+
+#[allow(dead_code)]
+#[path = "support/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+use ironclaw_turns::{TurnRunId, TurnStatus};
+use reborn_support::builder::StorageMode;
+use reborn_support::group::RebornIntegrationGroup;
+use reborn_support::reply::RebornScriptedReply;
+use serde_json::json;
+
+const GATED_CAPABILITY: &str = "builtin.write_file";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PostRestartAction {
+    Approve,
+    Deny,
+    Cancel,
+}
+
+impl PostRestartAction {
+    const ALL: [Self; 3] = [Self::Approve, Self::Deny, Self::Cancel];
+
+    fn index(self) -> usize {
+        match self {
+            Self::Approve => 0,
+            Self::Deny => 1,
+            Self::Cancel => 2,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RestartSequence {
+    action: PostRestartAction,
+}
+
+fn restart_sequences() -> Vec<RestartSequence> {
+    PostRestartAction::ALL
+        .into_iter()
+        .map(|action| RestartSequence { action })
+        .collect()
+}
+
+fn validate_restart_sequences(sequences: &[RestartSequence]) -> Result<(), String> {
+    let mut seen = [false; PostRestartAction::ALL.len()];
+    for sequence in sequences {
+        let slot = &mut seen[sequence.action.index()];
+        if *slot {
+            return Err(format!(
+                "duplicate generated restart action: {:?}",
+                sequence.action
+            ));
+        }
+        *slot = true;
+    }
+    let missing: Vec<_> = PostRestartAction::ALL
+        .into_iter()
+        .filter(|action| !seen[action.index()])
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("missing generated restart actions: {missing:?}"))
+    }
+}
+
+async fn build_restarted_harness(
+    case_index: usize,
+) -> (
+    reborn_support::builder::RebornIntegrationHarness,
+    TurnRunId,
+    ironclaw_turns::GateRef,
+) {
+    let group = RebornIntegrationGroup::builder()
+        .storage(StorageMode::LibSql)
+        .live_approvals()
+        .await
+        .expect("durable live-approvals group builds");
+    let conversation_id = format!("generated-restart-{case_index}");
+    let before_restart = group
+        .thread(&conversation_id)
+        .script([
+            RebornScriptedReply::tool_call(
+                GATED_CAPABILITY,
+                json!({
+                    "path": format!("/workspace/generated-restart-{case_index}.txt"),
+                    "content": "generated across restart"
+                }),
+            ),
+            RebornScriptedReply::text("unreachable on the old runtime"),
+        ])
+        .build()
+        .await
+        .expect("pre-restart thread builds");
+    let (run_id, gate_ref) = before_restart
+        .submit_turn_until_blocked("write after a runtime restart")
+        .await
+        .expect("run parks before restart");
+    before_restart
+        .assert_no_orphan_runs_or_reservations(&[run_id])
+        .await
+        .expect("parked run owns every process and releases capability holds");
+
+    // Dropping this is part of the contract: a live thread harness owns the old
+    // coordinator. `restart_planned_runtime` rejects that dishonest shape.
+    drop(before_restart);
+    let restarted_group = group
+        .restart_planned_runtime()
+        .await
+        .expect("planned runtime restarts over durable state");
+    let after_restart = restarted_group
+        .thread(conversation_id)
+        // The first model reply was consumed before the restart. Resuming an
+        // approved run reaches its next model turn through this newly-built
+        // scope gateway.
+        .script([RebornScriptedReply::text("done after restart")])
+        .build()
+        .await
+        .expect("post-restart thread rebuilds the scope gateway");
+    let state = after_restart
+        .run_state(run_id)
+        .await
+        .expect("restarted process journal reads the durable run");
+    assert_eq!(
+        state.status,
+        TurnStatus::BlockedApproval,
+        "restart changed the parked lifecycle state"
+    );
+    assert_eq!(
+        state.gate_ref.as_ref(),
+        Some(&gate_ref),
+        "restart changed the durable gate identity"
+    );
+    after_restart
+        .assert_no_orphan_runs_or_reservations(&[run_id])
+        .await
+        .expect("restart preserves run and reservation ownership");
+    (after_restart, run_id, gate_ref)
+}
+
+#[tokio::test]
+async fn generated_restart_sequences_preserve_gate_lifecycle_and_effect_count() {
+    let sequences = restart_sequences();
+    validate_restart_sequences(&sequences)
+        .unwrap_or_else(|error| panic!("restart generator is incomplete: {error}"));
+
+    for (case_index, sequence) in sequences.into_iter().enumerate() {
+        let (harness, run_id, gate_ref) = build_restarted_harness(case_index).await;
+        match sequence.action {
+            PostRestartAction::Approve => {
+                harness
+                    .approve_gate(run_id, &gate_ref)
+                    .await
+                    .expect("approval resolves after restart");
+            }
+            PostRestartAction::Deny => {
+                harness
+                    .deny_gate(run_id, &gate_ref)
+                    .await
+                    .expect("denial resolves after restart");
+            }
+            PostRestartAction::Cancel => {
+                harness
+                    .cancel_run(run_id)
+                    .await
+                    .expect("cancellation resolves after restart");
+            }
+        }
+
+        let terminal = harness
+            .wait_for_terminal(run_id)
+            .await
+            .expect("post-restart action reaches a terminal state");
+        harness
+            .assert_no_orphan_runs_or_reservations(&[run_id])
+            .await
+            .unwrap_or_else(|error| {
+                panic!(
+                    "{:?} left an orphan after restart: {error}",
+                    sequence.action
+                )
+            });
+        match sequence.action {
+            PostRestartAction::Approve => {
+                assert_eq!(terminal.status, TurnStatus::Completed);
+                harness
+                    .assert_capability_result_count(GATED_CAPABILITY, 1)
+                    .await
+                    .expect("approved effect executes exactly once after restart");
+            }
+            PostRestartAction::Deny => {
+                // Denial is delivered back to the loop as a model-visible tool
+                // outcome, so the conversation itself may complete normally.
+                // Effect evidence, not terminal status, proves the write stayed
+                // denied.
+                assert_eq!(terminal.status, TurnStatus::Completed);
+                harness
+                    .assert_capability_result_count(GATED_CAPABILITY, 0)
+                    .await
+                    .expect("denied effect stays unexecuted after restart");
+            }
+            PostRestartAction::Cancel => {
+                assert_eq!(terminal.status, TurnStatus::Cancelled);
+                harness
+                    .assert_capability_result_count(GATED_CAPABILITY, 0)
+                    .await
+                    .expect("cancelled effect stays unexecuted after restart");
+            }
+        }
+    }
+}
+
+#[test]
+fn restart_generator_sabotage_detects_a_missing_recovery_arm() {
+    let mut sabotaged = restart_sequences();
+    sabotaged.retain(|sequence| sequence.action != PostRestartAction::Deny);
+    let error = validate_restart_sequences(&sabotaged)
+        .expect_err("removing a recovery arm must fail the generator denominator");
+    assert!(
+        error.contains("Deny"),
+        "missing-arm diagnostic did not name the sabotaged branch: {error}"
+    );
+}

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -18,14 +18,60 @@
 #![allow(dead_code)]
 
 use ironclaw_events::{SecurityBoundary, SecurityDecision};
+use ironclaw_host_api::ProcessId;
+use ironclaw_processes::ProcessKind;
 use ironclaw_reborn_config::BudgetDefaults;
-use ironclaw_resources::ResourceGovernor;
+use ironclaw_resources::{ResourceAccount, ResourceGovernor, ResourceTally};
+use ironclaw_turns::TurnRunId;
 use ironclaw_turns::run_profile::LoopHostMilestoneKind;
 use rust_decimal::Decimal;
 
 use super::builder::RebornIntegrationHarness;
 
 type HarnessResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+pub(crate) fn validate_process_ownership(
+    processes: &[(ProcessId, ProcessKind, Option<ProcessId>)],
+    expected_process_ids: &[ProcessId],
+) -> HarnessResult<()> {
+    for (process_id, _, _) in processes
+        .iter()
+        .filter(|(_, process_kind, _)| process_kind == &ProcessKind::AgentTurn)
+    {
+        if !expected_process_ids.contains(process_id) {
+            return Err(format!(
+                "orphan agent-turn process {process_id}; expected only {expected_process_ids:?}"
+            )
+            .into());
+        }
+    }
+
+    for expected in expected_process_ids {
+        if !processes
+            .iter()
+            .any(|(process_id, _, _)| process_id == expected)
+        {
+            return Err(format!(
+                "expected agent-turn process {expected} is missing from the process journal"
+            )
+            .into());
+        }
+    }
+
+    for (process_id, _, parent_process_id) in processes {
+        if let Some(parent_process_id) = parent_process_id
+            && !processes
+                .iter()
+                .any(|(candidate_id, _, _)| candidate_id == parent_process_id)
+        {
+            return Err(format!(
+                "orphan process {process_id} names missing parent {parent_process_id}"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
 
 /// The two model-visible tool-error outcome classes a capability can surface
 /// (`CapabilityOutcome::Failed` vs `Denied`). A `Failed` and a `Denied` outcome
@@ -53,6 +99,66 @@ impl ToolErrorClass {
 }
 
 impl RebornIntegrationHarness {
+    /// Assert the process journal and capability-path resource governor agree
+    /// that every agent-turn process belongs to `expected_run_ids`, every
+    /// process parent is present, and no resource hold remains.
+    ///
+    /// Since #6696, admission/active-lock state is updated atomically with the
+    /// process snapshot rather than stored as a second reservation record.
+    /// Exact process ownership therefore replaces the retired dual-store
+    /// orphan check; capability resource holds remain a separate authority and
+    /// are read back below.
+    ///
+    /// This deliberately reads the production-composed governor rather than a
+    /// test-owned imitation. A harness that cannot expose that authority fails
+    /// loudly instead of silently weakening the invariant.
+    pub async fn assert_no_orphan_runs_or_reservations(
+        &self,
+        expected_run_ids: &[TurnRunId],
+    ) -> HarnessResult<()> {
+        let snapshots = self
+            ._shared
+            .process_system
+            .runtime()
+            .process_snapshots(&self.turn_scope.to_resource_scope())
+            .await
+            .map_err(|err| format!("read process journal snapshots: {err}"))?;
+        let expected_process_ids: Vec<_> = expected_run_ids
+            .iter()
+            .copied()
+            .map(ironclaw_turns::process_projection::process_id_from_turn_run_id)
+            .collect();
+        let process_ownership: Vec<_> = snapshots
+            .iter()
+            .map(|process| {
+                (
+                    process.process_id,
+                    process.process_kind.clone(),
+                    process.parent_process_id,
+                )
+            })
+            .collect();
+        validate_process_ownership(&process_ownership, &expected_process_ids)?;
+
+        let governor = self.capability_recorder.resource_governor().ok_or(
+            "harness does not expose its production-composed capability resource governor",
+        )?;
+        let tenant_account = ResourceAccount::tenant(self.binding.tenant_id.clone());
+        if let Some(account) = governor
+            .account_snapshot(&tenant_account)
+            .map_err(|err| format!("read capability resource account: {err}"))?
+            && account.ledger.reserved != ResourceTally::default()
+        {
+            return Err(format!(
+                "orphan capability resource reservation remains for {tenant_account:?}: {:?}",
+                account.ledger.reserved
+            )
+            .into());
+        }
+
+        Ok(())
+    }
+
     /// Assert exactly `expected` Tier-2 HTTP egress requests were captured.
     pub async fn assert_egress_count(&self, expected: usize) -> HarnessResult<()> {
         let actual = self.captured_egress_requests().len();

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -47,12 +47,18 @@ pub(crate) fn validate_process_ownership(
     }
 
     for expected in expected_process_ids {
-        if !processes
+        let Some((_, process_kind, _)) = processes
             .iter()
-            .any(|(process_id, _, _)| process_id == expected)
-        {
+            .find(|(process_id, _, _)| process_id == expected)
+        else {
             return Err(format!(
                 "expected agent-turn process {expected} is missing from the process journal"
+            )
+            .into());
+        };
+        if process_kind != &ProcessKind::AgentTurn {
+            return Err(format!(
+                "expected process {expected} has kind {process_kind:?}, not AgentTurn"
             )
             .into());
         }
@@ -99,20 +105,13 @@ impl ToolErrorClass {
 }
 
 impl RebornIntegrationHarness {
-    /// Assert the process journal and capability-path resource governor agree
-    /// that every agent-turn process belongs to `expected_run_ids`, every
-    /// process parent is present, and no resource hold remains.
+    /// Assert every agent-turn process belongs to `expected_run_ids` and every
+    /// process parent is present.
     ///
     /// Since #6696, admission/active-lock state is updated atomically with the
     /// process snapshot rather than stored as a second reservation record.
-    /// Exact process ownership therefore replaces the retired dual-store
-    /// orphan check; capability resource holds remain a separate authority and
-    /// are read back below.
-    ///
-    /// This deliberately reads the production-composed governor rather than a
-    /// test-owned imitation. A harness that cannot expose that authority fails
-    /// loudly instead of silently weakening the invariant.
-    pub async fn assert_no_orphan_runs_or_reservations(
+    /// Exact process ownership replaces the retired dual-store orphan check.
+    pub async fn assert_process_ownership(
         &self,
         expected_run_ids: &[TurnRunId],
     ) -> HarnessResult<()> {
@@ -138,8 +137,15 @@ impl RebornIntegrationHarness {
                 )
             })
             .collect();
-        validate_process_ownership(&process_ownership, &expected_process_ids)?;
+        validate_process_ownership(&process_ownership, &expected_process_ids)
+    }
 
+    /// Assert the production-composed capability governor has no live holds.
+    ///
+    /// This deliberately reads the production-composed governor rather than a
+    /// test-owned imitation. A harness that cannot expose that authority fails
+    /// loudly instead of silently weakening the invariant.
+    pub fn assert_no_capability_resource_reservations(&self) -> HarnessResult<()> {
         let governor = self.capability_recorder.resource_governor().ok_or(
             "harness does not expose its production-composed capability resource governor",
         )?;
@@ -157,6 +163,20 @@ impl RebornIntegrationHarness {
         }
 
         Ok(())
+    }
+
+    /// Assert process ownership and zero capability holds at a quiescent
+    /// blocked or terminal boundary.
+    ///
+    /// Call [`Self::assert_process_ownership`] alone while a run is actively
+    /// executing: an in-flight capability reservation is legitimate until the
+    /// transition settles and must not be mislabeled as an orphan.
+    pub async fn assert_no_orphan_runs_or_reservations(
+        &self,
+        expected_run_ids: &[TurnRunId],
+    ) -> HarnessResult<()> {
+        self.assert_process_ownership(expected_run_ids).await?;
+        self.assert_no_capability_resource_reservations()
     }
 
     /// Assert exactly `expected` Tier-2 HTTP egress requests were captured.

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -1046,6 +1046,14 @@ impl RebornIntegrationHarness {
         ))
     }
 
+    /// Exact governor used by this thread's production-composed capability
+    /// path. Intended for invariant sabotage/read-back only.
+    pub(crate) fn capability_resource_governor_for_test(
+        &self,
+    ) -> Option<Arc<dyn ironclaw_resources::ResourceGovernor>> {
+        self.capability_recorder.resource_governor()
+    }
+
     /// Register a scripted model gateway for a scope OTHER than this
     /// harness thread's own (which is registered at build time): delivery
     /// proofs pre-resolve the vendor conversation's binding and register its
@@ -2155,7 +2163,7 @@ impl RebornIntegrationHarness {
 /// (`assert_reply_persists_after_reopen`, `assert_gate_survives_reopen`) —
 /// each builds its own higher-level store (thread service, turn-state store)
 /// over the fresh composite this returns.
-async fn reopen_fresh_libsql_composite(
+pub(crate) async fn reopen_fresh_libsql_composite(
     db_path: &Path,
 ) -> HarnessResult<Arc<CompositeRootFilesystem>> {
     let db = Arc::new(
@@ -2290,8 +2298,9 @@ pub(crate) fn postgres_pool(database_url: &str) -> HarnessResult<deadpool_postgr
         .map_err(|error| format!("Postgres pool must build: {error}").into())
 }
 
-/// Build a `ScopedFilesystem` that maps `/turns` → the turn-state path for
-/// `binding` inside the production composite.
+/// Build a `ScopedFilesystem` that maps `/processes` and the compatibility
+/// `/turns` alias to the row-native process path for `binding` inside the
+/// composite.
 ///
 /// Uses the production path prefix `""` (no `/engine` prefix) so turn state
 /// lands under `/tenants/...` inside the composite, where the database backend

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -163,6 +163,12 @@ pub type HarnessResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 /// Owned by `Arc<GroupSharedStorage>` so harnesses can outlive the group's
 /// stack frame (R6: `RebornIntegrationHarness` is `'static`).
 pub(crate) struct GroupSharedStorage {
+    /// Exact runtime-wiring recipe consumed by `restart_planned_runtime`.
+    ///
+    /// Retaining the configured builder prevents the restart harness from
+    /// silently falling back to defaults and thereby testing a different
+    /// runtime from the one that admitted the run.
+    pub(crate) restart_builder: RebornIntegrationGroupBuilder,
     /// Thread history + turn state composite, shared across all threads.
     pub(crate) composite: Arc<CompositeRootFilesystem>,
     /// Fresh-connection reopen handle per storage mode (SQLite file path /
@@ -457,6 +463,70 @@ impl RebornIntegrationGroup {
         }
     }
 
+    /// Gracefully stop and rebuild the group's complete planned runtime over a
+    /// genuinely fresh LibSQL connection to the same durable process rows.
+    ///
+    /// This consumes the group and requires every thread harness built from it
+    /// to have been dropped first. That requirement is intentional: a surviving
+    /// harness owns the old coordinator and would make a "restart" assertion
+    /// dishonest. The capability backend is retained because its durable gate
+    /// and approval stores model the external host state a restarted runner
+    /// reconnects to; the scheduler, coordinator, executor, scope gateway,
+    /// checkpoint adapters, and process journal are all reconstructed.
+    ///
+    /// Only LibSQL is supported because it is the hermetic integration backend
+    /// with an independent reopen recipe. Other storage modes fail loudly.
+    pub async fn restart_planned_runtime(self) -> HarnessResult<Self> {
+        let shared_count = Arc::strong_count(&self.shared);
+        let shared = Arc::try_unwrap(self.shared).map_err(|_| {
+            format!(
+                "restart_planned_runtime requires every thread harness to be dropped; \
+                 group shared state still has {shared_count} owners"
+            )
+        })?;
+        let GroupSharedStorage {
+            restart_builder,
+            storage_reopen,
+            turn_root,
+            product_harness,
+            capability,
+            canonical_binding,
+            scheduler_handle,
+            ..
+        } = shared;
+
+        // This awaits cancellation, aborts in-flight executor tasks, and
+        // relinquishes claimed runs before a replacement scheduler can claim
+        // them. Dropping the handle would only signal cancellation.
+        scheduler_handle.shutdown().await;
+
+        let composite = match &storage_reopen {
+            super::builder::StorageReopen::LibSql { db_path } => {
+                super::builder::reopen_fresh_libsql_composite(db_path).await?
+            }
+            super::builder::StorageReopen::None => {
+                return Err("restart_planned_runtime requires StorageMode::LibSql; \
+                     in-memory storage cannot survive a runtime restart"
+                    .into());
+            }
+            super::builder::StorageReopen::Postgres { .. } => {
+                return Err(
+                    "restart_planned_runtime does not yet have a fresh Postgres \
+                     composite reopen recipe"
+                        .into(),
+                );
+            }
+        };
+        let base = GroupBaseData {
+            product_harness,
+            composite,
+            storage_reopen,
+            turn_root,
+            canonical_binding,
+        };
+        restart_builder.into_group(base, capability).await
+    }
+
     /// Enabler (c): the trace scope key the production trace-capture sink was
     /// seeded with; `Some` only after `.with_trace_capture()`. Pair with
     /// `ironclaw_reborn_traces::contribution::queued_trace_envelope_paths_for_scope`
@@ -702,6 +772,7 @@ impl GroupBaseData {
 /// Builder for `RebornIntegrationGroup` with optional storage mode selection.
 /// Obtain via [`RebornIntegrationGroup::builder`]; defaults to
 /// `StorageMode::InMemory`.
+#[derive(Clone)]
 pub struct RebornIntegrationGroupBuilder {
     storage: StorageMode,
     safety_context: Option<InstructionSafetyContext>,
@@ -844,6 +915,7 @@ impl RebornIntegrationGroupBuilder {
         base: GroupBaseData,
         capability: GroupCapability,
     ) -> HarnessResult<RebornIntegrationGroup> {
+        let restart_builder = self.clone();
         // Harness-seam misuse guard (§7): fail fast instead of a silent no-op
         // if the override is set without Bridged mode also selected.
         if self.narrowed_bridged_allow_set.is_some()
@@ -1164,6 +1236,7 @@ impl RebornIntegrationGroupBuilder {
 
         Ok(RebornIntegrationGroup {
             shared: Arc::new(GroupSharedStorage {
+                restart_builder,
                 composite: base.composite,
                 storage_reopen: base.storage_reopen,
                 turn_root: base.turn_root,

--- a/tests/integration/support/harness/mod.rs
+++ b/tests/integration/support/harness/mod.rs
@@ -48,7 +48,6 @@ use ironclaw_product::{ProjectService, ResolvedBinding};
 use ironclaw_reborn_composition::test_support::SkillActivationTestSource;
 use ironclaw_reborn_composition::{
     OAuthClientConfig, ProductLiveCapabilityIo, RebornApprovalTestParts, RebornRuntimeInput,
-    build_runtime,
 };
 use ironclaw_trust::EffectiveTrustClass;
 use ironclaw_turns::{
@@ -205,6 +204,11 @@ pub(crate) struct HostRuntimeCapabilityHarness {
     /// this harness is already `Arc`'d — the same chicken-and-egg constraint
     /// `io`/`result_writer_io` document above `install_durable_capability_io`.
     runtime: Mutex<Arc<dyn HostRuntime>>,
+    /// Exact governor owned by composed Reborn capability wiring. `Some` for
+    /// `new_with_options` profiles, which build through production
+    /// composition; lower-level seam-specific runtimes leave it unavailable
+    /// rather than fabricating an equivalent authority.
+    resource_governor: Option<Arc<dyn ironclaw_resources::ResourceGovernor>>,
     approval_parts: Option<RebornApprovalTestParts>,
     /// The durable gate-record store BOTH this harness's capability port
     /// (`GateRecord::Auth` save) and the turn executor (render-from-record read)
@@ -767,7 +771,11 @@ impl HostRuntimeCapabilityHarness {
                     reply_target_binding_id: service_label.to_string(),
                 });
         }
-        let services = build_runtime(runtime_input).await?;
+        let (services, resource_governor) =
+            ironclaw_reborn_composition::test_support::build_runtime_with_resource_governor_for_test(
+                runtime_input,
+            )
+            .await?;
         if seed_extension_credentials {
             profiles::extension::seed_extension_lifecycle_credentials(&services, &user_id).await?;
         }
@@ -878,6 +886,7 @@ impl HostRuntimeCapabilityHarness {
         let runtime = services
             .host_runtime_for_test()
             .ok_or("local-dev Reborn services missing host runtime")?;
+        let resource_governor = Some(resource_governor);
         let runtime = Arc::new(RecordingHostRuntime::new(
             runtime,
             Arc::clone(&pending_approval_scopes),
@@ -891,6 +900,7 @@ impl HostRuntimeCapabilityHarness {
         let gate_record_store = resolve_harness_gate_record_store(&approval_parts);
         Ok(Self {
             runtime: Mutex::new(runtime),
+            resource_governor,
             approval_parts,
             gate_record_store,
             auto_approve_settings,
@@ -1342,6 +1352,13 @@ impl HostRuntimeCapabilityHarness {
         &self,
     ) -> Option<Arc<dyn ironclaw_approvals::GateRecordStorePort>> {
         Some(Arc::clone(&self.gate_record_store))
+    }
+
+    /// Exact composed capability-path governor, for invariant read-back.
+    pub(crate) fn resource_governor_for_test(
+        &self,
+    ) -> Option<Arc<dyn ironclaw_resources::ResourceGovernor>> {
+        self.resource_governor.clone()
     }
 
     /// The user id this capability harness's first-party tools execute under.

--- a/tests/integration/support/harness/profiles/core_builtin.rs
+++ b/tests/integration/support/harness/profiles/core_builtin.rs
@@ -313,6 +313,7 @@ fn core_builtin_tools_from_runtime(
     let (io, result_writer_io) = super::super::default_capability_io_pair();
     Ok(HostRuntimeCapabilityHarness {
         runtime: Mutex::new(runtime),
+        resource_governor: None,
         approval_parts: None,
         gate_record_store: super::super::fresh_in_memory_gate_record_store(),
         auto_approve_settings: None,

--- a/tests/integration/support/harness/profiles/github.rs
+++ b/tests/integration/support/harness/profiles/github.rs
@@ -151,6 +151,7 @@ fn github_issue_tools_with_credential_result(
     let (io, result_writer_io) = super::super::default_capability_io_pair();
     Ok(HostRuntimeCapabilityHarness {
         runtime: Mutex::new(runtime),
+        resource_governor: None,
         approval_parts: None,
         gate_record_store: super::super::fresh_in_memory_gate_record_store(),
         auto_approve_settings: None,

--- a/tests/integration/support/harness/profiles/mock_mcp.rs
+++ b/tests/integration/support/harness/profiles/mock_mcp.rs
@@ -58,6 +58,7 @@ pub(crate) async fn mock_mcp_tools(
     let (io, result_writer_io) = super::super::default_capability_io_pair();
     Ok(HostRuntimeCapabilityHarness {
         runtime: Mutex::new(runtime),
+        resource_governor: None,
         approval_parts: None,
         gate_record_store: super::super::fresh_in_memory_gate_record_store(),
         auto_approve_settings: None,

--- a/tests/integration/support/harness/profiles/qa_smoke.rs
+++ b/tests/integration/support/harness/profiles/qa_smoke.rs
@@ -95,6 +95,7 @@ pub(crate) async fn qa_smoke_tools() -> HarnessResult<HostRuntimeCapabilityHarne
     let (io, result_writer_io) = super::super::default_capability_io_pair();
     Ok(HostRuntimeCapabilityHarness {
         runtime: Mutex::new(runtime),
+        resource_governor: None,
         approval_parts: None,
         gate_record_store: super::super::fresh_in_memory_gate_record_store(),
         auto_approve_settings: None,

--- a/tests/integration/support/harness/profiles/web_access.rs
+++ b/tests/integration/support/harness/profiles/web_access.rs
@@ -46,6 +46,7 @@ pub(crate) async fn web_access_tools() -> HarnessResult<HostRuntimeCapabilityHar
     let (io, result_writer_io) = super::super::default_capability_io_pair();
     Ok(HostRuntimeCapabilityHarness {
         runtime: Mutex::new(runtime),
+        resource_governor: None,
         approval_parts: None,
         gate_record_store: super::super::fresh_in_memory_gate_record_store(),
         auto_approve_settings: None,

--- a/tests/integration/support/harness/recorder.rs
+++ b/tests/integration/support/harness/recorder.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{CapabilityId, ResourceScope, RuntimeHttpEgressRequest};
 use ironclaw_network::{NetworkHttpRequest, NetworkTransportRequest};
+use ironclaw_resources::ResourceGovernor;
 use ironclaw_turns::{GateRef, run_profile::LoopRequest};
 
 use super::super::doubles::RecordingTestCapabilityPort;
@@ -161,6 +162,15 @@ impl HarnessCapabilityRecorder {
         match self {
             Self::Recording(_) => None,
             Self::HostRuntime(harness) => harness.approval_requests_store(),
+        }
+    }
+
+    /// The exact resource governor composed into the production capability
+    /// path, when this recorder wraps that path.
+    pub(crate) fn resource_governor(&self) -> Option<Arc<dyn ResourceGovernor>> {
+        match self {
+            Self::Recording(_) => None,
+            Self::HostRuntime(harness) => harness.resource_governor_for_test(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Complete WS9’s typed seven-dimension equivalence model with 37 representative rows and 10 selected high-risk pairwise interactions, without a Cartesian explosion.
- Generate restart and concurrent same-thread double-submit/interleaving sequences alongside the existing trigger/retry/cancel/duplicate lifecycle generator.
- Assert process ownership and the exact production-composed capability resource governor after every transition; add sabotage cases for each new generator/invariant.
- Preserve the existing `lease_wedge` truthful uncertain-outcome proof and map it into the mechanical dimension × sequence × invariant registry. The registry reports 0 remaining WS9 gaps.

Overlap reconciliation: #6794 remains the source of the initial lifecycle/focused-boundary slice and is not duplicated. This branch was rebased and adapted after #6696 made the row-native process journal the sole lifecycle authority. Open #5981 and #6096 do not currently implement this same-thread generated restart/double-submit scope; #5981 may intentionally change the current busy-admission outcome later.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [x] Scoped zero-warning clippy for both touched packages: `cargo clippy -p ironclaw_reborn_composition -p ironclaw_reborn_integration_tests --tests --all-features -- -D warnings`
- [ ] `cargo build` — not applicable: compilation is covered by both integration targets and scoped all-feature clippy; no shipping build behavior changed.
- [x] Relevant tests pass: 29 generated gate tests, 15 restart tests, depth-3 generated gate run, lease-wedge/reopen integration targets, architecture suite, and 50 Python coverage/meta-tests listed below.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — not applicable: no database implementation/schema behavior changed; the targeted LibSQL restart integration target exercises the affected persistence seam.
- [ ] Manual testing — not applicable: deterministic test infrastructure only; no user interface or manual product workflow changed.
- [x] `pr-shepherd` maintainer-quality review completed before requesting review; its architecture/evidence findings were fixed and the focused validation was repeated on the final rebased head.

## Test Strategy

User behavior:
Generated Reborn runs retain one authoritative process tree and no leaked capability resource holds across trigger, retry, cancel, duplicate, restart, and concurrent same-thread double-submit interleavings. Durable approval outcomes remain recoverable after a real runtime restart.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `tests/e2e/scenarios/test_state_machine_coverage.py` mechanically checks all 7 dimensions, 37 representative rows, 10 required high-risk pairs, all 6 sequences, all 5 invariants, duplicate case-id rejection, and 0 retained gaps. Journey-derived claims require matching declared observable evidence, preventing admission-only journeys from being credited with terminal stability.
- Reborn integration: `reborn_generated_gate_sequences` checks per-transition ownership/resource invariants and all same-thread double-submit schedules; `reborn_generated_restart_sequences` rebuilds the coordinator/executor/scheduler/scope gateway/process journal on a fresh LibSQL connection for approve/deny/cancel after restart.
- Recorded fixture: Not applicable: no HTTP/provider fixture or recorded boundary changed.
- Browser E2E: Not applicable: no browser surface or frontend behavior changed.
- Backend or runtime: Targeted LibSQL restart integration plus production-composed capability-governor read-back through a feature-gated composition test-support builder.
- Live canary: Not applicable: no live provider, credential, network, or deployment behavior changed.

What the tests prove:

- Dimension coverage: 7/7 typed axes; representative equivalence rows cover each value and all selected high-risk pairs.
- Sequence coverage: 6/6 (`trigger`, `retry`, `cancel`, `duplicate`, `restart`, `concurrent_double_submit`).
- Invariant coverage: 5/5, checked mechanically and after generated transitions where applicable.
- Restart: gate identity/state survives a fresh LibSQL connection and rebuilt runtime; approve emits exactly one effect, deny/cancel emit none.
- Concurrent double-submit: first/second/simultaneous schedules yield exactly one accepted run and one busy result referencing that run.
- No orphans/reservations: every expected process ID is specifically an `AgentTurn`, every parent exists, no unexpected agent-turn process appears, and the exact production-composed governor has no leaked holds at quiescent blocked/terminal boundaries. In-flight transitions check process ownership without misclassifying a legitimate executing-capability reservation as an orphan.
- Truthful uncertainty: the existing `reborn_integration_lease_wedge` proof is the canonical evidence and is referenced by the registry rather than weakened or duplicated.
- Sabotage: missing restart-deny generation, two accepted submissions, omitted agent-turn ownership, an expected ID under the wrong process kind, a missing process parent, a leaked governor hold, unsupported journey evidence, and an incomplete composite registry all fail loudly.
- Effect evidence: restart approve reads back exact persisted file contents while deny/cancel prove file absence; every double-submit interleaving proves exactly one capability result plus durable file read-back.
- Depth policy: deterministic depth 2 remains the PR default (12 gate/lifecycle sequences plus 3 double-submit schedules); the nightly workflow uses reproducible depth 3. A depth-3 local run exercised 39 gate/lifecycle sequences.
- Remaining proven WS9 gap count: 0.

Commands run:

```text
cargo test -p ironclaw_reborn_integration_tests --test reborn_generated_gate_sequences --test reborn_generated_restart_sequences
IRONCLAW_GENERATED_SEQUENCE_DEPTH=3 cargo test -p ironclaw_reborn_integration_tests --test reborn_generated_gate_sequences generated_gate_sequences_preserve_lifecycle_invariants -- --nocapture
cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_lease_wedge --test reborn_integration_reopen_resume_through_gate
uv run --project tests/e2e pytest -q tests/e2e/scenarios/test_state_machine_coverage.py tests/e2e/scenarios/test_journey_coverage.py
uvx ruff check tests/e2e/state_machine_coverage.py tests/e2e/scenarios/test_state_machine_coverage.py
uvx ruff format --check tests/e2e/state_machine_coverage.py tests/e2e/scenarios/test_state_machine_coverage.py
cargo test -p ironclaw_architecture
cargo test -p ironclaw_architecture --test reborn_struct_test_support_ratchet reborn_production_struct_test_support_and_dead_code_members_do_not_grow -- --nocapture
cargo clippy -p ironclaw_reborn_composition -p ironclaw_reborn_integration_tests --tests --all-features -- -D warnings
cargo fmt --all -- --check
git diff --check
scripts/ci/reborn-coverage-ratchet.sh <PR-6886-merged.lcov> tests/integration/coverage-exemptions.toml tests/integration/coverage-floor.toml
```

Additional package-suite evidence:
- `cargo test -p ironclaw_reborn_composition`: 541 passed; four timeout-shaped failures passed when rerun individually. `observability::trace_capture::tests::capture_skips_when_policy_missing_or_disabled` fails identically on an untouched `origin/main` worktree, so it is a pre-existing, non-attributable base failure.
- The coverage floor was recaptured from PR #6886’s successful `df5081ad4` merged artifact: global 85.54% (315436/368757), runner 86.87% (14669/16887), processes 88.07% (5839/6630), and turns 86.21% (9453/10965). The ratchet passes against that exact artifact with the new floors.

## Security Impact

None. The only composition change is feature-gated to `test-support` and returns the exact already-composed resource governor alongside the runtime for read-only invariant assertions. It does not alter authorization, approvals, network mediation, secrets, sandboxing, or production capability dispatch.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new production trust-bearing types or construction paths.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: not applicable; no prompt/content ingress changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: not applicable; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: no variants added; targeted `rg` and compilation/clippy cover the touched runtime/test-support accessors.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: not applicable; no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: generator depth is explicitly bounded; the representative registry is finite and duplicate-checked.
- [x] Driver/operator-visible errors have stable class semantics: no production error classes changed; unsupported restart backends fail loudly in the harness.
- [x] Sandbox/native/host names accurately describe trust boundary: no production trust-boundary names changed; the seam returns the exact production-composed governor only under test support.

## Database Impact

None. No migration, schema, query contract, or backend implementation changes. The restart generator uses LibSQL because it is the hermetic backend with an independent reopen recipe; unsupported InMemory/Postgres restart modes fail loudly rather than pretending to restart.

## Blast Radius

Test infrastructure under `tests/e2e` and `tests/integration`, the Reborn test workflow’s documented generated counts, and a feature-gated composition test-support builder. The main review risks are keeping the representative registry synchronized with supported enums and preserving current same-thread busy-admission semantics if #5981 later changes them.

## Rollback Plan

Revert commits `50348a75c`, `7f78b108a`, and `513478eb1`. There is no migration, persisted format change, configuration change, or production default to roll back. CI would return to #6794’s prior generated coverage.

## Review Follow-Through

Maintainer self-review found and fixed two issues before readiness: the governor read seam initially grew the production runtime service shape, and generic journey rows initially inferred stronger lifecycle evidence than their declared assertions proved. The final seam is owned by composition test support, and the registry now derives lifecycle/sequence/invariant claims only from explicit observable evidence. If #5981 lands first and changes busy admission into queued steering, rebase and update the double-submit expected outcome deliberately rather than weakening the invariant.

The complete eight-reviewer `code-review-multi` pass then found eight actionable issues, all fixed: process-kind validation, in-flight reservation timing, restart and double-submit durable effect read-back, restart denominator simplification, coverage-floor recapture, owning-guide documentation, and private-helper naming. One additional suggestion—treating equal axes/evidence with different case IDs as duplicate rows—was reproduced and rejected because `case_id` is the executable parameter identity for distinct journey cases sharing one parametrized test.

Three pre-existing bot findings on the reviewed old head were also fixed and resolved: provider read rows no longer claim an effect-count invariant, approval denial now uses the actually observed `Completed` lifecycle with an explicit generated assertion, and the typed registry selector helpers have concrete return annotations.

### Checkbox-to-test/PR map

- [x] 7 typed dimensions + pairwise representatives → Python registry/meta-tests in this PR.
- [x] Restart sequences → `reborn_generated_restart_sequences` in this PR.
- [x] Concurrent double-submit/interleavings → generated gate target in this PR.
- [x] No orphan runs/reservations + exact resource governor → per-transition assertion helper and sabotage tests in this PR.
- [x] Truthful uncertain outcome → existing `reborn_integration_lease_wedge`, referenced mechanically by the registry.
- [x] Fast PR / deeper nightly reproducibility → default depth 2 and nightly depth 3 workflow; depth-3 evidence recorded above.
- [x] Remaining proven WS9 gaps → 0.

---

**Review track**: A (tests/CI infrastructure; production behavior unchanged)
