### PR TITLE
test: complete provider operation contracts

### DIFF
--- a/tests/e2e/fixtures/emulate/google_gmail.yaml
+++ b/tests/e2e/fixtures/emulate/google_gmail.yaml
@@ -131,6 +131,13 @@ google:
       parent_google_ids:
         - root
       data: Drive content seeded by Emulate for Reborn QA.
+    - id: drv_provider_contract_empty
+      user_email: e2e.google@example.com
+      name: Empty provider file.txt
+      mime_type: text/plain
+      parent_google_ids:
+        - root
+      data: ""
     - id: drv_pepsico_account_brief
       user_email: e2e.google@example.com
       name: PepsiCo Account Brief

--- a/tests/e2e/fixtures/emulate/slack.yaml
+++ b/tests/e2e/fixtures/emulate/slack.yaml
@@ -44,6 +44,13 @@ slack:
         - reactions:read
         - reactions:write
         - search:read
+    - token: emulate-slack-channel-token
+      user: reborn-user
+      scopes:
+        - chat:write
+        - channels:read
+        - channels:history
+        - channels:join
     - token: emulate-slack-limited-token
       user: qa-reviewer
       scopes:

--- a/tests/e2e/fixtures/provider_capability_coverage.toml
+++ b/tests/e2e/fixtures/provider_capability_coverage.toml
@@ -141,27 +141,52 @@ unsupported = []
 
 [[integration_evidence]]
 capability = "github.handle_webhook"
+outcome_class = "success"
 target = "reborn_integration_tool_call"
 source = "tests/integration/tool_call.rs"
 test = "github_webhook_normalization_dispatches_through_bundled_wasm"
 
 [[integration_evidence]]
 capability = "nearai.web_search"
+outcome_class = "success"
 target = "reborn_integration_mcp"
 source = "tests/integration/mcp.rs"
 test = "nearai_web_search_dispatches_through_bundled_hosted_mcp"
 
 [[integration_evidence]]
 capability = "web-access.get_content"
+outcome_class = "success"
 target = "reborn_integration_web_access"
 source = "tests/integration/web_access.rs"
 test = "get_content_dispatches_through_scripted_exa_mcp"
 
 [[integration_evidence]]
 capability = "web-access.search"
+outcome_class = "success"
 target = "reborn_integration_web_access"
 source = "tests/integration/web_access.rs"
 test = "web_search_dispatches_through_scripted_exa_mcp"
+
+[[integration_evidence]]
+capability = "nearai.web_search"
+outcome_class = "empty"
+target = "reborn_integration_mcp"
+source = "tests/integration/mcp.rs"
+test = "nearai_web_search_empty_result_dispatches_through_bundled_hosted_mcp"
+
+[[integration_evidence]]
+capability = "web-access.get_content"
+outcome_class = "empty"
+target = "reborn_integration_web_access"
+source = "tests/integration/web_access.rs"
+test = "get_content_empty_result_dispatches_through_scripted_exa_mcp"
+
+[[integration_evidence]]
+capability = "web-access.search"
+outcome_class = "empty"
+target = "reborn_integration_web_access"
+source = "tests/integration/web_access.rs"
+test = "web_search_empty_result_dispatches_through_scripted_exa_mcp"
 
 # Journey evidence: the capability is asserted with provider-side readback
 # inside a harvested full-path journey rather than a typed operation case.
@@ -202,83 +227,3 @@ capability = "slack.send_message"
 source = "tests/e2e/scenarios/test_reborn_qa_trace_full_path.py"
 test = "test_qa_journey_provider_leg_replays_through_emulate"
 assertion = "_assert_slack_provider_outcome"
-
-
-[[coverage_backlog]]
-rule = "read_requires_outcome_classes"
-owner = "@serrrfirat"
-reason = "Has a seeded success case but no empty-result case; the runtime is unproven to distinguish no results from a failed call."
-issue = "#6524"
-review_condition = "Add a ProviderOperationCase with outcome_class = empty."
-capabilities = [
-  "github.get_authenticated_user",
-  "github.get_combined_status",
-  "github.get_file_content",
-  "github.get_issue",
-  "github.get_job_logs",
-  "github.get_pull_request",
-  "github.get_pull_request_files",
-  "github.get_pull_request_reviews",
-  "github.get_repo",
-  "github.get_workflow_run_artifacts",
-  "github.get_workflow_run_jobs",
-  "github.get_workflow_runs",
-  "github.list_branches",
-  "github.list_issue_comments",
-  "github.list_issues",
-  "github.list_pull_request_comments",
-  "github.list_pull_request_review_threads",
-  "github.list_pull_requests",
-  "github.list_releases",
-  "github.list_repos",
-  "github.search_code",
-  "github.search_issues",
-  "github.search_issues_pull_requests",
-  "github.search_repositories",
-  "google-calendar.find_free_slots",
-  "google-calendar.get_event",
-  "google-calendar.list_calendars",
-  "google-docs.get_document",
-  "google-drive.get_file",
-  "google-drive.list_permissions",
-  "google-drive.list_shared_drives",
-  "google-sheets.batch_read_values",
-  "google-slides.get_presentation",
-  "google-slides.get_thumbnail",
-]
-
-[[coverage_backlog]]
-rule = "read_requires_outcome_classes"
-owner = "@serrrfirat"
-reason = "No typed operation case at all; evidence is a harvested tool-call name or a journey-specific branch, not a per-operation contract."
-issue = "#6524"
-review_condition = "Add seeded success and empty-result ProviderOperationCase entries."
-capabilities = [
-  "gmail.get_message",
-  "gmail.list_messages",
-  "google-calendar.list_events",
-  "google-docs.read_content",
-  "google-drive.download_file",
-  "google-drive.list_files",
-  "google-sheets.get_spreadsheet",
-  "slack.get_conversation_history",
-  "slack.get_conversation_info",
-  "slack.get_thread_replies",
-  "slack.get_user_info",
-  "slack.list_conversations",
-  "slack.search_messages",
-  "slack.whoami",
-]
-
-[[coverage_backlog]]
-rule = "read_requires_outcome_classes"
-owner = "@serrrfirat"
-reason = "Evidenced by a named Cargo integration test at a non-Emulate seam (local WASM, hosted MCP, Exa-backed web access), so there is no provider world in which to seed an empty result. integration_evidence names one executable test per capability and carries no outcome class, so it must not silently exempt these from the read rule."
-issue = "#6524"
-review_condition = "Make integration_evidence outcome-aware, or add a hermetic double for these seams, then require success and empty like every other read."
-capabilities = [
-  "github.handle_webhook",
-  "nearai.web_search",
-  "web-access.get_content",
-  "web-access.search",
-]

--- a/tests/e2e/provider_capability_inventory.py
+++ b/tests/e2e/provider_capability_inventory.py
@@ -1,6 +1,7 @@
 """Executable classification of the shipped provider capability surface."""
 
 from pathlib import Path
+
 import tomllib
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -63,19 +64,27 @@ def _production_extension_ids() -> set[str]:
 
 
 def _capability_operation_kinds() -> dict[str, str]:
-    """Read/write kind per capability, derived from shipped manifests.
+    """Provider operation kind per capability, derived from shipped manifests.
 
-    The manifests already declare `external_write` in each tool's `effects`,
-    so the kind is production-derived like the capability denominator itself
-    rather than a hand-maintained list that can drift from what ships.
+    `external_write` identifies mutations and `network` identifies provider
+    reads. Capabilities with neither effect are local operations, not provider
+    reads; requiring seeded provider outcomes for those would fabricate a
+    boundary that production never crosses.
     """
     kinds: dict[str, str] = {}
     for manifest_path in sorted(ASSET_ROOT.glob("*/manifest.toml")):
         with manifest_path.open("rb") as manifest_file:
             manifest = tomllib.load(manifest_file)
+        inherited_effects = manifest.get("mcp", {}).get("effects", [])
         for tool in manifest.get("tools", []):
-            effects = tool.get("effects", [])
-            kinds[tool["id"]] = "write" if "external_write" in effects else "read"
+            effects = [*inherited_effects, *tool.get("effects", [])]
+            if "external_write" in effects:
+                kind = "write"
+            elif "network" in effects:
+                kind = "read"
+            else:
+                kind = "local"
+            kinds[tool["id"]] = kind
     return kinds
 
 

--- a/tests/e2e/provider_capability_inventory.py
+++ b/tests/e2e/provider_capability_inventory.py
@@ -1,8 +1,7 @@
 """Executable classification of the shipped provider capability surface."""
 
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 INVENTORY_PATH = ROOT / "tests/e2e/fixtures/provider_capability_coverage.toml"

--- a/tests/e2e/provider_fault_proxy.py
+++ b/tests/e2e/provider_fault_proxy.py
@@ -271,6 +271,24 @@ class ProviderFaultProxy:
         return hashlib.sha256(authorization.encode()).hexdigest()[:12]
 
     @staticmethod
+    def _issued_bearer_fingerprint(response: web.Response) -> str | None:
+        try:
+            payload = json.loads(response.body or b"")
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        authenticated_user = payload.get("authed_user")
+        access_token = (
+            authenticated_user.get("access_token")
+            if isinstance(authenticated_user, dict)
+            else None
+        ) or payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return None
+        return hashlib.sha256(f"Bearer {access_token}".encode()).hexdigest()[:12]
+
+    @staticmethod
     def _abort_transport(request: web.Request) -> None:
         transport = request.transport
         if transport is not None:
@@ -320,6 +338,7 @@ class ProviderFaultProxy:
             "path": request.path,
             "query": request.query_string,
             "credential_fingerprint": self._credential_fingerprint(request.headers),
+            "issued_credential_fingerprint": None,
             "body_sha256": hashlib.sha256(body).hexdigest(),
             "fault": None if rule is None else rule["name"],
             "forwarded": False,
@@ -352,6 +371,9 @@ class ProviderFaultProxy:
         upstream = await self._forward(request, body)
         entry["forwarded"] = True
         entry["upstream_status"] = upstream.status
+        entry["issued_credential_fingerprint"] = self._issued_bearer_fingerprint(
+            upstream
+        )
 
         if rule is not None and rule["action"] == "disconnect_after_forward":
             self._abort_transport(request)

--- a/tests/e2e/provider_operation_cases.py
+++ b/tests/e2e/provider_operation_cases.py
@@ -1,10 +1,13 @@
 """Registry for typed full-path provider operation cases."""
 
-from provider_operation_github_issue_cases import (
-    GITHUB_ISSUE_PROVIDER_OPERATION_CASES,
-)
 from provider_operation_github_actions_cases import (
     GITHUB_ACTIONS_PROVIDER_OPERATION_CASES,
+)
+from provider_operation_github_empty_cases import (
+    GITHUB_EMPTY_PROVIDER_OPERATION_CASES,
+)
+from provider_operation_github_issue_cases import (
+    GITHUB_ISSUE_PROVIDER_OPERATION_CASES,
 )
 from provider_operation_github_pull_cases import (
     GITHUB_PULL_PROVIDER_OPERATION_CASES,
@@ -18,8 +21,13 @@ from provider_operation_google_calendar_cases import (
 )
 from provider_operation_google_docs_cases import GOOGLE_DOCS_PROVIDER_OPERATION_CASES
 from provider_operation_google_drive_cases import GOOGLE_DRIVE_PROVIDER_OPERATION_CASES
-from provider_operation_google_sheets_cases import GOOGLE_SHEETS_PROVIDER_OPERATION_CASES
-from provider_operation_google_slides_cases import GOOGLE_SLIDES_PROVIDER_OPERATION_CASES
+from provider_operation_google_sheets_cases import (
+    GOOGLE_SHEETS_PROVIDER_OPERATION_CASES,
+)
+from provider_operation_google_slides_cases import (
+    GOOGLE_SLIDES_PROVIDER_OPERATION_CASES,
+)
+from provider_operation_slack_cases import SLACK_PROVIDER_OPERATION_CASES
 
 PROVIDER_OPERATION_CASES = (
     *GMAIL_PROVIDER_OPERATION_CASES,
@@ -28,8 +36,10 @@ PROVIDER_OPERATION_CASES = (
     *GOOGLE_DRIVE_PROVIDER_OPERATION_CASES,
     *GOOGLE_SHEETS_PROVIDER_OPERATION_CASES,
     *GOOGLE_SLIDES_PROVIDER_OPERATION_CASES,
+    *GITHUB_EMPTY_PROVIDER_OPERATION_CASES,
     *GITHUB_ACTIONS_PROVIDER_OPERATION_CASES,
     *GITHUB_ISSUE_PROVIDER_OPERATION_CASES,
     *GITHUB_PULL_PROVIDER_OPERATION_CASES,
     *GITHUB_REPO_PROVIDER_OPERATION_CASES,
+    *SLACK_PROVIDER_OPERATION_CASES,
 )

--- a/tests/e2e/provider_operation_github_empty_cases.py
+++ b/tests/e2e/provider_operation_github_empty_cases.py
@@ -1,0 +1,261 @@
+"""GitHub empty-result contracts through the real extension boundary."""
+
+from provider_operation_github_common import REPO_PATH, github_request
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_output,
+    exact_text_output,
+    static_provider_json_response,
+    static_provider_text_response,
+)
+
+
+async def _seeded_repo_baseline(emulate_url: str) -> None:
+    repo = await github_request(emulate_url, "GET", REPO_PATH)
+    assert isinstance(repo, dict)
+    assert repo["full_name"] == "nearai/ironclaw", repo
+
+
+def _empty_case(
+    *,
+    case_id: str,
+    capability_id: str,
+    arguments: dict,
+    path: str,
+    payload,
+    method: str = "GET",
+    expected_output=None,
+) -> ProviderOperationCase:
+    return ProviderOperationCase(
+        case_id=case_id,
+        provider_service="github",
+        capability_id=capability_id,
+        arguments=arguments,
+        assert_baseline=_seeded_repo_baseline,
+        assert_outcome=exact_output(
+            payload if expected_output is None else expected_output
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method=method,
+            path=path,
+            payload=payload,
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    )
+
+
+EMPTY_SEARCH = {
+    "total_count": 0,
+    "incomplete_results": False,
+    "items": [],
+}
+
+GITHUB_EMPTY_PROVIDER_OPERATION_CASES = (
+    _empty_case(
+        case_id="github_get_authenticated_user_empty",
+        capability_id="github.get_authenticated_user",
+        arguments={},
+        path="/user",
+        payload={},
+    ),
+    _empty_case(
+        case_id="github_get_combined_status_empty",
+        capability_id="github.get_combined_status",
+        arguments={"owner": "nearai", "repo": "ironclaw", "ref": "main"},
+        path=f"{REPO_PATH}/commits/main/status",
+        payload={"state": "pending", "total_count": 0, "statuses": []},
+    ),
+    _empty_case(
+        case_id="github_get_file_content_empty",
+        capability_id="github.get_file_content",
+        arguments={
+            "owner": "nearai",
+            "repo": "ironclaw",
+            "path": "docs/provider-contract-empty.md",
+            "ref": "main",
+        },
+        path=f"{REPO_PATH}/contents/docs/provider-contract-empty.md",
+        payload={},
+    ),
+    _empty_case(
+        case_id="github_get_issue_empty",
+        capability_id="github.get_issue",
+        arguments={"owner": "nearai", "repo": "ironclaw", "issue_number": 999},
+        path=f"{REPO_PATH}/issues/999",
+        payload={},
+    ),
+    ProviderOperationCase(
+        case_id="github_get_job_logs_empty",
+        provider_service="github",
+        capability_id="github.get_job_logs",
+        arguments={"owner": "nearai", "repo": "ironclaw", "job_id": 999},
+        assert_baseline=_seeded_repo_baseline,
+        assert_outcome=exact_text_output('{"status":200}'),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_text_response(
+            method="GET",
+            path=f"{REPO_PATH}/actions/jobs/999/logs",
+            body="",
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    _empty_case(
+        case_id="github_get_pull_request_empty",
+        capability_id="github.get_pull_request",
+        arguments={"owner": "nearai", "repo": "ironclaw", "pr_number": 999},
+        path=f"{REPO_PATH}/pulls/999",
+        payload={},
+    ),
+    _empty_case(
+        case_id="github_get_pull_request_files_empty",
+        capability_id="github.get_pull_request_files",
+        arguments={"owner": "nearai", "repo": "ironclaw", "pr_number": 1},
+        path=f"{REPO_PATH}/pulls/1/files",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_get_pull_request_reviews_empty",
+        capability_id="github.get_pull_request_reviews",
+        arguments={"owner": "nearai", "repo": "ironclaw", "pr_number": 1},
+        path=f"{REPO_PATH}/pulls/1/reviews",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_get_repo_empty",
+        capability_id="github.get_repo",
+        arguments={"owner": "nearai", "repo": "provider-contract-empty"},
+        path="/repos/nearai/provider-contract-empty",
+        payload={},
+    ),
+    _empty_case(
+        case_id="github_get_workflow_run_artifacts_empty",
+        capability_id="github.get_workflow_run_artifacts",
+        arguments={"owner": "nearai", "repo": "ironclaw", "run_id": 1001},
+        path=f"{REPO_PATH}/actions/runs/1001/artifacts",
+        payload={"total_count": 0, "artifacts": []},
+    ),
+    _empty_case(
+        case_id="github_get_workflow_run_jobs_empty",
+        capability_id="github.get_workflow_run_jobs",
+        arguments={"owner": "nearai", "repo": "ironclaw", "run_id": 1001},
+        path=f"{REPO_PATH}/actions/runs/1001/jobs",
+        payload={"total_count": 0, "jobs": []},
+    ),
+    _empty_case(
+        case_id="github_get_workflow_runs_empty",
+        capability_id="github.get_workflow_runs",
+        arguments={"owner": "nearai", "repo": "ironclaw"},
+        path=f"{REPO_PATH}/actions/runs",
+        payload={"total_count": 0, "workflow_runs": []},
+    ),
+    _empty_case(
+        case_id="github_list_branches_empty",
+        capability_id="github.list_branches",
+        arguments={"owner": "nearai", "repo": "ironclaw"},
+        path=f"{REPO_PATH}/branches",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_list_issue_comments_empty",
+        capability_id="github.list_issue_comments",
+        arguments={"owner": "nearai", "repo": "ironclaw", "issue_number": 1},
+        path=f"{REPO_PATH}/issues/1/comments",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_list_issues_empty",
+        capability_id="github.list_issues",
+        arguments={"owner": "nearai", "repo": "ironclaw", "state": "closed"},
+        path=f"{REPO_PATH}/issues",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_list_pull_request_comments_empty",
+        capability_id="github.list_pull_request_comments",
+        arguments={"owner": "nearai", "repo": "ironclaw", "pr_number": 1},
+        path=f"{REPO_PATH}/pulls/1/comments",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_list_pull_request_review_threads_empty",
+        capability_id="github.list_pull_request_review_threads",
+        arguments={"owner": "nearai", "repo": "ironclaw", "pr_number": 1},
+        path="/graphql",
+        method="POST",
+        payload={
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "endCursor": None,
+                            },
+                        }
+                    }
+                }
+            }
+        },
+    ),
+    _empty_case(
+        case_id="github_list_pull_requests_empty",
+        capability_id="github.list_pull_requests",
+        arguments={"owner": "nearai", "repo": "ironclaw", "state": "closed"},
+        path=f"{REPO_PATH}/pulls",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_list_releases_empty",
+        capability_id="github.list_releases",
+        arguments={"owner": "nearai", "repo": "ironclaw"},
+        path=f"{REPO_PATH}/releases",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_list_repos_empty",
+        capability_id="github.list_repos",
+        arguments={"type": "member"},
+        path="/user/repos",
+        payload=[],
+    ),
+    _empty_case(
+        case_id="github_search_code_empty",
+        capability_id="github.search_code",
+        arguments={"query": "NO_SUCH_PROVIDER_CONTRACT_TOKEN repo:nearai/ironclaw"},
+        path="/search/code",
+        payload=EMPTY_SEARCH,
+    ),
+    _empty_case(
+        case_id="github_search_issues_empty",
+        capability_id="github.search_issues",
+        arguments={
+            "query": "NO_SUCH_PROVIDER_CONTRACT_TOKEN",
+            "repository": "nearai/ironclaw",
+            "type": "issue",
+        },
+        path="/search/issues",
+        payload=EMPTY_SEARCH,
+    ),
+    _empty_case(
+        case_id="github_search_issues_pull_requests_empty",
+        capability_id="github.search_issues_pull_requests",
+        arguments={
+            "query": "NO_SUCH_PROVIDER_CONTRACT_TOKEN",
+            "repository": "nearai/ironclaw",
+            "type": "pr",
+        },
+        path="/search/issues",
+        payload=EMPTY_SEARCH,
+    ),
+    _empty_case(
+        case_id="github_search_repositories_empty",
+        capability_id="github.search_repositories",
+        arguments={"query": "NO_SUCH_PROVIDER_CONTRACT_REPOSITORY"},
+        path="/search/repositories",
+        payload=EMPTY_SEARCH,
+    ),
+)

--- a/tests/e2e/provider_operation_github_empty_cases.py
+++ b/tests/e2e/provider_operation_github_empty_cases.py
@@ -24,7 +24,6 @@ def _empty_case(
     path: str,
     payload,
     method: str = "GET",
-    expected_output=None,
 ) -> ProviderOperationCase:
     return ProviderOperationCase(
         case_id=case_id,
@@ -32,9 +31,7 @@ def _empty_case(
         capability_id=capability_id,
         arguments=arguments,
         assert_baseline=_seeded_repo_baseline,
-        assert_outcome=exact_output(
-            payload if expected_output is None else expected_output
-        ),
+        assert_outcome=exact_output(payload),
         outcome_class="empty",
         setup_provider_proxy=static_provider_json_response(
             method=method,

--- a/tests/e2e/provider_operation_github_repo_cases.py
+++ b/tests/e2e/provider_operation_github_repo_cases.py
@@ -4,6 +4,7 @@ import base64
 import json
 
 import httpx
+
 from emulate_provider import github_headers
 from provider_operation_github_common import (
     BRANCH,

--- a/tests/e2e/provider_operation_github_repo_cases.py
+++ b/tests/e2e/provider_operation_github_repo_cases.py
@@ -4,7 +4,6 @@ import base64
 import json
 
 import httpx
-
 from emulate_provider import github_headers
 from provider_operation_github_common import (
     BRANCH,
@@ -283,6 +282,7 @@ GITHUB_REPO_PROVIDER_OPERATION_CASES = (
         },
         assert_baseline=_repo_baseline,
         assert_outcome=_create_branch_outcome,
+        expected_request_count=2,
     ),
     ProviderOperationCase(
         case_id="github_list_branches",

--- a/tests/e2e/provider_operation_gmail_cases.py
+++ b/tests/e2e/provider_operation_gmail_cases.py
@@ -3,6 +3,7 @@
 import json
 
 import httpx
+
 from emulate_provider import gmail_header, google_headers, raw_mime
 from provider_operation_types import (
     ProviderOperationCase,

--- a/tests/e2e/provider_operation_gmail_cases.py
+++ b/tests/e2e/provider_operation_gmail_cases.py
@@ -3,9 +3,13 @@
 import json
 
 import httpx
-
 from emulate_provider import gmail_header, google_headers, raw_mime
-from provider_operation_types import ProviderOperationCase
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_provider_http_output,
+    provider_http_body,
+    static_provider_json_response,
+)
 
 GMAIL_REPLY_MARKER = "REBORN_PROVIDER_CASE_REPLY"
 SEEDED_GMAIL_MESSAGE_ID = "<msg_emulate_unread@ironclaw.test>"
@@ -60,15 +64,29 @@ async def _gmail_message(emulate_url: str, message_id: str) -> dict:
     return response.json()
 
 
-async def _gmail_thread_messages(emulate_url: str, thread_id: str) -> list[dict]:
+async def _gmail_messages(
+    emulate_url: str,
+    *,
+    query: str | None = None,
+) -> list[dict]:
+    params: dict[str, str | int] = {
+        "includeSpamTrash": "true",
+        "maxResults": 100,
+    }
+    if query is not None:
+        params["q"] = query
     response = await _get(
         emulate_url,
         "/gmail/v1/users/me/messages",
-        params={"includeSpamTrash": "true", "maxResults": 100},
+        params=params,
     )
+    return response.json().get("messages", [])
+
+
+async def _gmail_thread_messages(emulate_url: str, thread_id: str) -> list[dict]:
     messages = [
         message
-        for message in response.json().get("messages", [])
+        for message in await _gmail_messages(emulate_url)
         if message["threadId"] == thread_id
     ]
     return [
@@ -122,7 +140,78 @@ async def _assert_gmail_trash_outcome(emulate_url: str, preview: dict) -> None:
     assert "msg_emulate_unread" in json.dumps(preview), preview
 
 
+async def _assert_gmail_get_message_outcome(
+    emulate_url: str, preview: dict
+) -> None:
+    message = await _gmail_message(emulate_url, "msg_emulate_unread")
+    assert gmail_header(message, "Subject") == SEEDED_GMAIL_SUBJECT, message
+    rendered = json.dumps(preview)
+    assert "msg_emulate_unread" in rendered, preview
+    assert SEEDED_GMAIL_SUBJECT in rendered, preview
+
+
+async def _assert_gmail_list_messages_outcome(
+    emulate_url: str, preview: dict
+) -> None:
+    messages = await _gmail_messages(emulate_url)
+    assert any(message["id"] == "msg_emulate_unread" for message in messages)
+    assert "msg_emulate_unread" in json.dumps(preview), preview
+
+
+EMPTY_GMAIL_QUERY = "subject:REBORN_PROVIDER_CASE_NO_SUCH_MESSAGE"
+
+
+async def _assert_gmail_list_messages_empty(
+    emulate_url: str, preview: dict
+) -> None:
+    assert await _gmail_messages(emulate_url, query=EMPTY_GMAIL_QUERY) == []
+    body = provider_http_body(preview)
+    assert body.get("messages", []) == [], body
+    assert body["resultSizeEstimate"] == 0, body
+
+
 GMAIL_PROVIDER_OPERATION_CASES = (
+    ProviderOperationCase(
+        case_id="gmail_get_message",
+        provider_service="google",
+        capability_id="gmail.get_message",
+        arguments={"message_id": "msg_emulate_unread"},
+        assert_baseline=_assert_gmail_reply_baseline,
+        assert_outcome=_assert_gmail_get_message_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="gmail_get_message_empty",
+        provider_service="google",
+        capability_id="gmail.get_message",
+        arguments={"message_id": "msg_provider_contract_empty"},
+        assert_baseline=_assert_gmail_reply_baseline,
+        assert_outcome=exact_provider_http_output({}),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/gmail/v1/users/me/messages/msg_provider_contract_empty",
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="gmail_list_messages",
+        provider_service="google",
+        capability_id="gmail.list_messages",
+        arguments={"max_results": 100},
+        assert_baseline=_assert_gmail_reply_baseline,
+        assert_outcome=_assert_gmail_list_messages_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="gmail_list_messages_empty",
+        provider_service="google",
+        capability_id="gmail.list_messages",
+        arguments={"query": EMPTY_GMAIL_QUERY, "max_results": 100},
+        assert_baseline=_assert_gmail_reply_baseline,
+        assert_outcome=_assert_gmail_list_messages_empty,
+        outcome_class="empty",
+    ),
     ProviderOperationCase(
         case_id="gmail_create_draft",
         provider_service="google",

--- a/tests/e2e/provider_operation_gmail_cases.py
+++ b/tests/e2e/provider_operation_gmail_cases.py
@@ -12,6 +12,8 @@ from provider_operation_types import (
 )
 
 GMAIL_REPLY_MARKER = "REBORN_PROVIDER_CASE_REPLY"
+GMAIL_SEND_MARKER = "REBORN_PROVIDER_CASE_SEND"
+GMAIL_SEND_SUBJECT = "Reborn provider operation send contract"
 SEEDED_GMAIL_MESSAGE_ID = "<msg_emulate_unread@ironclaw.test>"
 SEEDED_GMAIL_SUBJECT = "Emulate seeded unread"
 SEEDED_GMAIL_THREAD_ID = "thr_emulate_unread"
@@ -170,6 +172,27 @@ async def _assert_gmail_list_messages_empty(
     assert body["resultSizeEstimate"] == 0, body
 
 
+async def _assert_gmail_send_baseline(emulate_url: str) -> None:
+    assert not await _gmail_messages(
+        emulate_url, query=f"subject:{GMAIL_SEND_SUBJECT}"
+    ), "provider world already contains the send-message contract email"
+
+
+async def _assert_gmail_send_outcome(emulate_url: str, preview: dict) -> None:
+    messages = await _gmail_messages(
+        emulate_url, query=f"subject:{GMAIL_SEND_SUBJECT}"
+    )
+    assert len(messages) == 1, messages
+    message = await _gmail_message(emulate_url, messages[0]["id"])
+    assert "SENT" in message["labelIds"], message
+    assert gmail_header(message, "To") == "contract-recipient@example.com", message
+    assert gmail_header(message, "Subject") == GMAIL_SEND_SUBJECT, message
+    assert GMAIL_SEND_MARKER in message["snippet"], message
+    body = provider_http_body(preview)
+    assert body["id"] == message["id"], (body, message)
+    assert body["threadId"] == message["threadId"], (body, message)
+
+
 GMAIL_PROVIDER_OPERATION_CASES = (
     ProviderOperationCase(
         case_id="gmail_get_message",
@@ -211,6 +234,25 @@ GMAIL_PROVIDER_OPERATION_CASES = (
         assert_baseline=_assert_gmail_reply_baseline,
         assert_outcome=_assert_gmail_list_messages_empty,
         outcome_class="empty",
+    ),
+    ProviderOperationCase(
+        case_id="gmail_send_message",
+        provider_service="google",
+        capability_id="gmail.send_message",
+        arguments={
+            "message": {
+                "raw": raw_mime(
+                    to="contract-recipient@example.com",
+                    subject=GMAIL_SEND_SUBJECT,
+                    body=(
+                        f"{GMAIL_SEND_MARKER}: sent through the typed provider "
+                        "operation contract."
+                    ),
+                )
+            }
+        },
+        assert_baseline=_assert_gmail_send_baseline,
+        assert_outcome=_assert_gmail_send_outcome,
     ),
     ProviderOperationCase(
         case_id="gmail_create_draft",

--- a/tests/e2e/provider_operation_google_calendar_cases.py
+++ b/tests/e2e/provider_operation_google_calendar_cases.py
@@ -258,7 +258,7 @@ GOOGLE_CALENDAR_PROVIDER_OPERATION_CASES = (
         setup_provider_proxy=static_provider_json_response(
             method="GET",
             path=(
-                "/calendar/v3/calendars/primary/events/"
+                f"/calendar/v3/calendars/{CALENDAR_ID}/events/"
                 "evt_provider_contract_empty"
             ),
             payload={},

--- a/tests/e2e/provider_operation_google_calendar_cases.py
+++ b/tests/e2e/provider_operation_google_calendar_cases.py
@@ -3,7 +3,12 @@
 import json
 
 from emulate_provider import google_json
-from provider_operation_types import ProviderOperationCase
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_provider_http_output,
+    provider_http_body,
+    static_provider_json_response,
+)
 
 CALENDAR_ID = "primary"
 EVENT_ID = "evt_reborn_planning_sync"
@@ -123,6 +128,28 @@ async def _list_calendars_outcome(emulate_url: str, preview: dict) -> None:
     assert CALENDAR_ID in json.dumps(preview), preview
 
 
+async def _list_events_outcome(emulate_url: str, preview: dict) -> None:
+    await _seeded_event_baseline(emulate_url)
+    rendered = json.dumps(preview)
+    assert EVENT_ID in rendered, preview
+    assert "Reborn planning sync" in rendered, preview
+
+
+EMPTY_EVENT_QUERY = "REBORN_PROVIDER_CASE_NO_SUCH_EVENT"
+
+
+async def _list_events_empty_outcome(emulate_url: str, preview: dict) -> None:
+    assert await _events(emulate_url, EMPTY_EVENT_QUERY) == []
+    body = provider_http_body(preview)
+    assert body.get("items", []) == [], body
+
+
+async def _free_busy_empty_outcome(emulate_url: str, preview: dict) -> None:
+    await _seeded_event_baseline(emulate_url)
+    body = provider_http_body(preview)
+    assert body["calendars"][CALENDAR_ID]["busy"] == [], body
+
+
 GOOGLE_CALENDAR_PROVIDER_OPERATION_CASES = (
     # Executable evidence for a read capability whose harvested journey was
     # quarantined with the retired activation flow (#6520).
@@ -133,6 +160,50 @@ GOOGLE_CALENDAR_PROVIDER_OPERATION_CASES = (
         arguments={},
         assert_baseline=_calendar_list_baseline,
         assert_outcome=_list_calendars_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_calendar_list_calendars_empty",
+        provider_service="google",
+        capability_id="google-calendar.list_calendars",
+        arguments={},
+        assert_baseline=_calendar_list_baseline,
+        assert_outcome=exact_provider_http_output(
+            {"kind": "calendar#calendarList", "items": []}
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/calendar/v3/users/me/calendarList",
+            payload={"kind": "calendar#calendarList", "items": []},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="google_calendar_list_events",
+        provider_service="google",
+        capability_id="google-calendar.list_events",
+        arguments={
+            "calendar_id": CALENDAR_ID,
+            "time_min": "2026-06-22T12:00:00.000Z",
+            "time_max": "2026-06-22T14:00:00.000Z",
+            "max_results": 25,
+        },
+        assert_baseline=_seeded_event_baseline,
+        assert_outcome=_list_events_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_calendar_list_events_empty",
+        provider_service="google",
+        capability_id="google-calendar.list_events",
+        arguments={
+            "calendar_id": CALENDAR_ID,
+            "query": EMPTY_EVENT_QUERY,
+            "max_results": 25,
+        },
+        assert_baseline=_seeded_event_baseline,
+        assert_outcome=_list_events_empty_outcome,
+        outcome_class="empty",
     ),
     ProviderOperationCase(
         case_id="google_calendar_create_event",
@@ -174,6 +245,28 @@ GOOGLE_CALENDAR_PROVIDER_OPERATION_CASES = (
         assert_outcome=_get_event_outcome,
     ),
     ProviderOperationCase(
+        case_id="google_calendar_get_event_empty",
+        provider_service="google",
+        capability_id="google-calendar.get_event",
+        arguments={
+            "calendar_id": CALENDAR_ID,
+            "event_id": "evt_provider_contract_empty",
+        },
+        assert_baseline=_seeded_event_baseline,
+        assert_outcome=exact_provider_http_output({}),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path=(
+                "/calendar/v3/calendars/primary/events/"
+                "evt_provider_contract_empty"
+            ),
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
         case_id="google_calendar_find_free_slots",
         provider_service="google",
         capability_id="google-calendar.find_free_slots",
@@ -185,6 +278,20 @@ GOOGLE_CALENDAR_PROVIDER_OPERATION_CASES = (
         },
         assert_baseline=_free_busy_baseline,
         assert_outcome=_free_busy_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_calendar_find_free_slots_empty",
+        provider_service="google",
+        capability_id="google-calendar.find_free_slots",
+        arguments={
+            "timeMin": "2026-06-22T15:00:00.000Z",
+            "timeMax": "2026-06-22T15:30:00.000Z",
+            "timeZone": "UTC",
+            "items": [{"id": CALENDAR_ID}],
+        },
+        assert_baseline=_free_busy_baseline,
+        assert_outcome=_free_busy_empty_outcome,
+        outcome_class="empty",
     ),
     ProviderOperationCase(
         case_id="google_calendar_update_event",
@@ -209,6 +316,7 @@ GOOGLE_CALENDAR_PROVIDER_OPERATION_CASES = (
         },
         assert_baseline=_seeded_event_baseline,
         assert_outcome=_add_attendees_outcome,
+        expected_request_count=2,
     ),
     ProviderOperationCase(
         case_id="google_calendar_set_reminder",

--- a/tests/e2e/provider_operation_google_docs_cases.py
+++ b/tests/e2e/provider_operation_google_docs_cases.py
@@ -15,6 +15,8 @@ SEEDED_TEXT = (
     "NEAR AI Strategy: user-owned agents keep credentials and data under user control."
 )
 BATCH_MARKER = " REBORN_PROVIDER_CASE_BATCH"
+CREATE_TITLE = "Reborn Provider Operation Created Document"
+INSERT_MARKER = " REBORN_PROVIDER_CASE_INSERT"
 REPLACEMENT = "customer-owned agents"
 
 
@@ -54,6 +56,35 @@ async def _read_content_outcome(emulate_url: str, preview: dict) -> None:
     assert preview["output_preview"] == SEEDED_TEXT, preview
 
 
+def _output(preview: dict) -> dict:
+    assert preview["truncated"] is False, preview
+    output = json.loads(preview["output_preview"])
+    assert isinstance(output, dict), preview
+    return output
+
+
+async def _create_document_outcome(emulate_url: str, preview: dict) -> None:
+    output = _output(preview)
+    assert set(output) == {"document_id", "title"}, output
+    assert output["document_id"], output
+    assert output["title"] == CREATE_TITLE, output
+    document = await google_json(
+        emulate_url, "GET", f"/v1/documents/{output['document_id']}"
+    )
+    assert document["documentId"] == output["document_id"], document
+    assert document["title"] == CREATE_TITLE, document
+    assert _document_text(document) == "", document
+
+
+async def _insert_text_outcome(emulate_url: str, preview: dict) -> None:
+    output = _output(preview)
+    assert output["document_id"] == DOCUMENT_ID, output
+    assert output["revision_id"] == "2", output
+    document = await _document(emulate_url)
+    assert document["revisionId"] == "2", document
+    assert _document_text(document) == f"{SEEDED_TEXT}{INSERT_MARKER}", document
+
+
 def _revision_outcome(marker: str | None = None):
     async def assert_outcome(emulate_url: str, preview: dict) -> None:
         document = await _document(emulate_url)
@@ -87,6 +118,14 @@ async def _replace_outcome(emulate_url: str, preview: dict) -> None:
 
 
 GOOGLE_DOCS_PROVIDER_OPERATION_CASES = (
+    ProviderOperationCase(
+        case_id="google_docs_create_document",
+        provider_service="google",
+        capability_id="google-docs.create_document",
+        arguments={"title": CREATE_TITLE},
+        assert_baseline=_baseline,
+        assert_outcome=_create_document_outcome,
+    ),
     ProviderOperationCase(
         case_id="google_docs_get_document",
         provider_service="google",
@@ -141,6 +180,18 @@ GOOGLE_DOCS_PROVIDER_OPERATION_CASES = (
         ),
         expect_provider_forward=False,
         expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="google_docs_insert_text",
+        provider_service="google",
+        capability_id="google-docs.insert_text",
+        arguments={
+            "document_id": DOCUMENT_ID,
+            "text": INSERT_MARKER,
+            "index": -1,
+        },
+        assert_baseline=_baseline,
+        assert_outcome=_insert_text_outcome,
     ),
     ProviderOperationCase(
         case_id="google_docs_batch_update",

--- a/tests/e2e/provider_operation_google_docs_cases.py
+++ b/tests/e2e/provider_operation_google_docs_cases.py
@@ -3,7 +3,12 @@
 import json
 
 from emulate_provider import google_json
-from provider_operation_types import ProviderOperationCase
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_output,
+    exact_text_output,
+    static_provider_json_response,
+)
 
 DOCUMENT_ID = "doc_reborn_strategy"
 SEEDED_TEXT = (
@@ -40,6 +45,13 @@ async def _get_outcome(emulate_url: str, preview: dict) -> None:
     rendered = json.dumps(preview)
     assert "NEAR AI Strategy" in rendered, preview
     assert DOCUMENT_ID in rendered, preview
+
+
+async def _read_content_outcome(emulate_url: str, preview: dict) -> None:
+    await _baseline(emulate_url)
+    assert preview["truncated"] is False, preview
+    assert preview["output_kind"] == "text", preview
+    assert preview["output_preview"] == SEEDED_TEXT, preview
 
 
 def _revision_outcome(marker: str | None = None):
@@ -82,6 +94,53 @@ GOOGLE_DOCS_PROVIDER_OPERATION_CASES = (
         arguments={"document_id": DOCUMENT_ID},
         assert_baseline=_baseline,
         assert_outcome=_get_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_docs_get_document_empty",
+        provider_service="google",
+        capability_id="google-docs.get_document",
+        arguments={"document_id": "doc_provider_contract_empty"},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {
+                "document_id": "",
+                "title": "",
+                "revision_id": "",
+                "body_length": 1,
+            }
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/v1/documents/doc_provider_contract_empty",
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="google_docs_read_content",
+        provider_service="google",
+        capability_id="google-docs.read_content",
+        arguments={"document_id": DOCUMENT_ID},
+        assert_baseline=_baseline,
+        assert_outcome=_read_content_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_docs_read_content_empty",
+        provider_service="google",
+        capability_id="google-docs.read_content",
+        arguments={"document_id": "doc_provider_contract_empty"},
+        assert_baseline=_baseline,
+        assert_outcome=exact_text_output(""),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/v1/documents/doc_provider_contract_empty",
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
     ),
     ProviderOperationCase(
         case_id="google_docs_batch_update",

--- a/tests/e2e/provider_operation_google_docs_cases.py
+++ b/tests/e2e/provider_operation_google_docs_cases.py
@@ -51,9 +51,7 @@ async def _get_outcome(emulate_url: str, preview: dict) -> None:
 
 async def _read_content_outcome(emulate_url: str, preview: dict) -> None:
     await _baseline(emulate_url)
-    assert preview["truncated"] is False, preview
-    assert preview["output_kind"] == "text", preview
-    assert preview["output_preview"] == SEEDED_TEXT, preview
+    await exact_text_output(SEEDED_TEXT)(emulate_url, preview)
 
 
 def _output(preview: dict) -> dict:

--- a/tests/e2e/provider_operation_google_drive_cases.py
+++ b/tests/e2e/provider_operation_google_drive_cases.py
@@ -3,6 +3,7 @@
 import json
 
 import httpx
+
 from emulate_provider import google_headers, google_json
 from provider_operation_types import (
     ProviderOperationCase,

--- a/tests/e2e/provider_operation_google_drive_cases.py
+++ b/tests/e2e/provider_operation_google_drive_cases.py
@@ -4,7 +4,6 @@ import json
 
 import httpx
 from emulate_provider import google_headers, google_json
-from provider_fault_proxy import ProviderFaultProfile
 from provider_operation_types import (
     ProviderOperationCase,
     exact_output,
@@ -165,7 +164,8 @@ async def _shared_drives_outcome(emulate_url: str, preview: dict) -> None:
     assert "Reborn Engineering" in rendered, preview
 
 
-EMPTY_FILE_QUERY = "name = 'REBORN_PROVIDER_CASE_NO_SUCH_FILE'"
+EMPTY_FILE_NAME = "REBORN_PROVIDER_CASE_NO_SUCH_FILE"
+EMPTY_FILE_QUERY = f"name = '{EMPTY_FILE_NAME}'"
 EMPTY_DOWNLOAD_ID = "drv_provider_contract_empty"
 
 
@@ -177,9 +177,7 @@ async def _list_files_outcome(emulate_url: str, preview: dict) -> None:
 
 
 async def _list_files_empty_outcome(emulate_url: str, preview: dict) -> None:
-    assert await _files_named(
-        emulate_url, "REBORN_PROVIDER_CASE_NO_SUCH_FILE"
-    ) == []
+    assert await _files_named(emulate_url, EMPTY_FILE_NAME) == []
     assert preview["truncated"] is False, preview
     assert json.loads(preview["output_preview"]) == {"files": []}, preview
 
@@ -194,33 +192,6 @@ async def _download_file_outcome(emulate_url: str, preview: dict) -> None:
         preview["output_preview"]
         == "Drive content seeded by Emulate for Reborn QA."
     ), preview
-
-
-def _setup_empty_download(proxy) -> None:
-    path = f"/drive/v3/files/{EMPTY_DOWNLOAD_ID}"
-    metadata = ProviderFaultProfile(
-        name="provider_contract_empty",
-        action="respond",
-        status=200,
-        body=json.dumps(
-            {
-                "id": EMPTY_DOWNLOAD_ID,
-                "name": "Empty provider file.txt",
-                "mimeType": "text/plain",
-                "size": "0",
-            },
-            separators=(",", ":"),
-        ),
-    )
-    content = ProviderFaultProfile(
-        name="provider_contract_empty",
-        action="respond",
-        status=200,
-        body="",
-        content_type="text/plain",
-    )
-    proxy.arm(metadata, method="GET", path=path)
-    proxy.arm(content, method="GET", path=path)
 
 
 GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
@@ -253,7 +224,7 @@ GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
         case_id="google_drive_get_file_empty",
         provider_service="google",
         capability_id="google-drive.get_file",
-        arguments={"file_id": "drv_provider_contract_empty"},
+        arguments={"file_id": EMPTY_DOWNLOAD_ID},
         assert_baseline=_seeded_file_baseline,
         assert_outcome=exact_output(
             {
@@ -272,7 +243,7 @@ GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
         outcome_class="empty",
         setup_provider_proxy=static_provider_json_response(
             method="GET",
-            path="/drive/v3/files/drv_provider_contract_empty",
+            path=f"/drive/v3/files/{EMPTY_DOWNLOAD_ID}",
             payload={},
         ),
         expect_provider_forward=False,
@@ -296,9 +267,6 @@ GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
         assert_outcome=exact_text_output(""),
         outcome_class="empty",
         expected_request_count=2,
-        setup_provider_proxy=_setup_empty_download,
-        expect_provider_forward=False,
-        expected_proxy_profile="provider_contract_empty",
     ),
     ProviderOperationCase(
         case_id="google_drive_update_file",

--- a/tests/e2e/provider_operation_google_drive_cases.py
+++ b/tests/e2e/provider_operation_google_drive_cases.py
@@ -3,9 +3,14 @@
 import json
 
 import httpx
-
 from emulate_provider import google_headers, google_json
-from provider_operation_types import ProviderOperationCase
+from provider_fault_proxy import ProviderFaultProfile
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_output,
+    exact_text_output,
+    static_provider_json_response,
+)
 
 FILE_ID = "drv_reborn_qa_brief"
 CREATED_FOLDER = "REBORN_PROVIDER_CASE_CREATED_FOLDER"
@@ -160,7 +165,82 @@ async def _shared_drives_outcome(emulate_url: str, preview: dict) -> None:
     assert "Reborn Engineering" in rendered, preview
 
 
+EMPTY_FILE_QUERY = "name = 'REBORN_PROVIDER_CASE_NO_SUCH_FILE'"
+EMPTY_DOWNLOAD_ID = "drv_provider_contract_empty"
+
+
+async def _list_files_outcome(emulate_url: str, preview: dict) -> None:
+    await _seeded_file_baseline(emulate_url)
+    rendered = json.dumps(preview)
+    assert FILE_ID in rendered, preview
+    assert "Reborn QA Brief" in rendered, preview
+
+
+async def _list_files_empty_outcome(emulate_url: str, preview: dict) -> None:
+    assert await _files_named(
+        emulate_url, "REBORN_PROVIDER_CASE_NO_SUCH_FILE"
+    ) == []
+    assert preview["truncated"] is False, preview
+    assert json.loads(preview["output_preview"]) == {"files": []}, preview
+
+
+async def _download_file_outcome(emulate_url: str, preview: dict) -> None:
+    assert await _media(emulate_url, FILE_ID) == (
+        "Drive content seeded by Emulate for Reborn QA."
+    )
+    assert preview["truncated"] is False, preview
+    assert preview["output_kind"] == "text", preview
+    assert (
+        preview["output_preview"]
+        == "Drive content seeded by Emulate for Reborn QA."
+    ), preview
+
+
+def _setup_empty_download(proxy) -> None:
+    path = f"/drive/v3/files/{EMPTY_DOWNLOAD_ID}"
+    metadata = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body=json.dumps(
+            {
+                "id": EMPTY_DOWNLOAD_ID,
+                "name": "Empty provider file.txt",
+                "mimeType": "text/plain",
+                "size": "0",
+            },
+            separators=(",", ":"),
+        ),
+    )
+    content = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body="",
+        content_type="text/plain",
+    )
+    proxy.arm(metadata, method="GET", path=path)
+    proxy.arm(content, method="GET", path=path)
+
+
 GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
+    ProviderOperationCase(
+        case_id="google_drive_list_files",
+        provider_service="google",
+        capability_id="google-drive.list_files",
+        arguments={"page_size": 25},
+        assert_baseline=_seeded_file_baseline,
+        assert_outcome=_list_files_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_drive_list_files_empty",
+        provider_service="google",
+        capability_id="google-drive.list_files",
+        arguments={"query": EMPTY_FILE_QUERY, "page_size": 25},
+        assert_baseline=_seeded_file_baseline,
+        assert_outcome=_list_files_empty_outcome,
+        outcome_class="empty",
+    ),
     ProviderOperationCase(
         case_id="google_drive_get_file",
         provider_service="google",
@@ -168,6 +248,57 @@ GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
         arguments={"file_id": FILE_ID},
         assert_baseline=_seeded_file_baseline,
         assert_outcome=_get_file_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_drive_get_file_empty",
+        provider_service="google",
+        capability_id="google-drive.get_file",
+        arguments={"file_id": "drv_provider_contract_empty"},
+        assert_baseline=_seeded_file_baseline,
+        assert_outcome=exact_output(
+            {
+                "file": {
+                    "id": "",
+                    "name": "",
+                    "is_folder": False,
+                    "mime_type": "",
+                    "shared": False,
+                    "starred": False,
+                    "trashed": False,
+                    "owned_by_me": False,
+                }
+            }
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/drive/v3/files/drv_provider_contract_empty",
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="google_drive_download_file",
+        provider_service="google",
+        capability_id="google-drive.download_file",
+        arguments={"file_id": FILE_ID},
+        assert_baseline=_seeded_file_baseline,
+        assert_outcome=_download_file_outcome,
+        expected_request_count=2,
+    ),
+    ProviderOperationCase(
+        case_id="google_drive_download_file_empty",
+        provider_service="google",
+        capability_id="google-drive.download_file",
+        arguments={"file_id": EMPTY_DOWNLOAD_ID},
+        assert_baseline=_seeded_file_baseline,
+        assert_outcome=exact_text_output(""),
+        outcome_class="empty",
+        expected_request_count=2,
+        setup_provider_proxy=_setup_empty_download,
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
     ),
     ProviderOperationCase(
         case_id="google_drive_update_file",
@@ -226,6 +357,22 @@ GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
         assert_outcome=_list_permissions_outcome,
     ),
     ProviderOperationCase(
+        case_id="google_drive_list_permissions_empty",
+        provider_service="google",
+        capability_id="google-drive.list_permissions",
+        arguments={"file_id": FILE_ID},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output({"permissions": []}),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path=f"/drive/v3/files/{FILE_ID}/permissions",
+            payload={"permissions": []},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
         case_id="google_drive_share_file",
         provider_service="google",
         capability_id="google-drive.share_file",
@@ -256,5 +403,21 @@ GOOGLE_DRIVE_PROVIDER_OPERATION_CASES = (
         arguments={"page_size": 10},
         assert_baseline=_baseline,
         assert_outcome=_shared_drives_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_drive_list_shared_drives_empty",
+        provider_service="google",
+        capability_id="google-drive.list_shared_drives",
+        arguments={"page_size": 10},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output({"drives": []}),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/drive/v3/drives",
+            payload={"drives": []},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
     ),
 )

--- a/tests/e2e/provider_operation_google_sheets_cases.py
+++ b/tests/e2e/provider_operation_google_sheets_cases.py
@@ -3,7 +3,11 @@
 import json
 
 from emulate_provider import google_json
-from provider_operation_types import ProviderOperationCase
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_output,
+    static_provider_json_response,
+)
 
 SPREADSHEET_ID = "sheet_reborn_abc"
 ADDED_SHEET = "ProviderCase"
@@ -50,6 +54,26 @@ async def _batch_read_outcome(emulate_url: str, preview: dict) -> None:
     rendered = json.dumps(preview)
     assert "REBORN_QA_SEEDED" in rendered, preview
     assert "NEAR AI" in rendered, preview
+
+
+async def _batch_read_empty_outcome(emulate_url: str, preview: dict) -> None:
+    assert not await _values(emulate_url, EMPTY_RANGE)
+    assert preview["truncated"] is False, preview
+    assert json.loads(preview["output_preview"]) == {
+        "value_ranges": [{"range": EMPTY_RANGE, "values": []}]
+    }, preview
+
+
+async def _get_spreadsheet_outcome(emulate_url: str, preview: dict) -> None:
+    await _baseline(emulate_url)
+    assert preview["truncated"] is False, preview
+    output = json.loads(preview["output_preview"])
+    assert output["spreadsheet_id"] == SPREADSHEET_ID, output
+    assert output["title"] == "ABC", output
+    assert [(sheet["sheet_id"], sheet["title"]) for sheet in output["sheets"]] == [
+        (0, "Sheet1"),
+        (7, "DeleteMe"),
+    ], output
 
 
 async def _clear_outcome(emulate_url: str, preview: dict) -> None:
@@ -146,6 +170,49 @@ GOOGLE_SHEETS_PROVIDER_OPERATION_CASES = (
         },
         assert_baseline=_baseline,
         assert_outcome=_batch_read_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_sheets_batch_read_values_empty",
+        provider_service="google",
+        capability_id="google-sheets.batch_read_values",
+        arguments={
+            "spreadsheet_id": SPREADSHEET_ID,
+            "ranges": [EMPTY_RANGE],
+        },
+        assert_baseline=_baseline,
+        assert_outcome=_batch_read_empty_outcome,
+        outcome_class="empty",
+    ),
+    ProviderOperationCase(
+        case_id="google_sheets_get_spreadsheet",
+        provider_service="google",
+        capability_id="google-sheets.get_spreadsheet",
+        arguments={"spreadsheet_id": SPREADSHEET_ID},
+        assert_baseline=_baseline,
+        assert_outcome=_get_spreadsheet_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_sheets_get_spreadsheet_empty",
+        provider_service="google",
+        capability_id="google-sheets.get_spreadsheet",
+        arguments={"spreadsheet_id": "sheet_provider_contract_empty"},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {
+                "spreadsheet_id": "",
+                "title": "",
+                "url": "",
+                "sheets": [],
+            }
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/v4/spreadsheets/sheet_provider_contract_empty",
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
     ),
     ProviderOperationCase(
         case_id="google_sheets_clear_values",

--- a/tests/e2e/provider_operation_google_sheets_cases.py
+++ b/tests/e2e/provider_operation_google_sheets_cases.py
@@ -10,6 +10,7 @@ from provider_operation_types import (
 )
 
 SPREADSHEET_ID = "sheet_reborn_abc"
+CREATED_SPREADSHEET_TITLE = "Reborn Provider Operation Spreadsheet"
 ADDED_SHEET = "ProviderCase"
 RENAMED_SHEET = "RenamedByProviderCase"
 # Deliberately below the seeded rows so a write here cannot be confused with an
@@ -18,6 +19,9 @@ RENAMED_SHEET = "RenamedByProviderCase"
 WRITE_RANGE = "Sheet1!A4:C4"
 EMPTY_RANGE = "Sheet1!A50:C60"
 WRITTEN_ROW = ["REBORN_WRITE_VALUES", "isolated", "row"]
+APPENDED_ROW = ["REBORN_APPEND_VALUES", "exactly", "once"]
+APPEND_RANGE = "Sheet1!A:C"
+APPENDED_TARGET_RANGE = "Sheet1!A3:C3"
 
 
 async def _spreadsheet(emulate_url: str) -> dict:
@@ -47,6 +51,36 @@ async def _baseline(emulate_url: str) -> None:
     ] == [(0, "Sheet1"), (7, "DeleteMe")], sheets
     values = await _values(emulate_url, "Sheet1!A1:E2")
     assert values[1][-1] == "REBORN_QA_SEEDED", values
+
+
+def _output(preview: dict) -> dict:
+    assert preview["truncated"] is False, preview
+    output = json.loads(preview["output_preview"])
+    assert isinstance(output, dict), preview
+    return output
+
+
+async def _create_spreadsheet_outcome(
+    emulate_url: str, preview: dict
+) -> None:
+    output = _output(preview)
+    assert output["spreadsheet_id"], output
+    assert output["title"] == CREATED_SPREADSHEET_TITLE, output
+    assert [sheet["title"] for sheet in output["sheets"]] == [
+        "ContractData"
+    ], output
+    spreadsheet = await google_json(
+        emulate_url,
+        "GET",
+        f"/v4/spreadsheets/{output['spreadsheet_id']}",
+    )
+    assert spreadsheet["spreadsheetId"] == output["spreadsheet_id"], spreadsheet
+    assert (
+        spreadsheet["properties"]["title"] == CREATED_SPREADSHEET_TITLE
+    ), spreadsheet
+    assert [
+        sheet["properties"]["title"] for sheet in spreadsheet["sheets"]
+    ] == ["ContractData"], spreadsheet
 
 
 async def _batch_read_outcome(emulate_url: str, preview: dict) -> None:
@@ -124,6 +158,26 @@ async def _write_values_outcome(emulate_url: str, preview: dict) -> None:
     assert "REBORN_WRITE_VALUES" in json.dumps(preview), preview
 
 
+async def _append_values_baseline(emulate_url: str) -> None:
+    await _baseline(emulate_url)
+    assert not await _values(emulate_url, APPENDED_TARGET_RANGE), (
+        "provider world already contains the append-values contract row"
+    )
+
+
+async def _append_values_outcome(emulate_url: str, preview: dict) -> None:
+    assert await _values(emulate_url, APPENDED_TARGET_RANGE) == [APPENDED_ROW], (
+        await _values(emulate_url, APPENDED_TARGET_RANGE)
+    )
+    output = _output(preview)
+    assert output == {
+        "updated_range": APPEND_RANGE,
+        "updated_rows": 1,
+        "updated_columns": 3,
+        "updated_cells": 3,
+    }, output
+
+
 async def _rename_sheet_outcome(emulate_url: str, preview: dict) -> None:
     spreadsheet = await _spreadsheet(emulate_url)
     titles = {
@@ -160,6 +214,17 @@ async def _format_cells_outcome(emulate_url: str, preview: dict) -> None:
 
 
 GOOGLE_SHEETS_PROVIDER_OPERATION_CASES = (
+    ProviderOperationCase(
+        case_id="google_sheets_create_spreadsheet",
+        provider_service="google",
+        capability_id="google-sheets.create_spreadsheet",
+        arguments={
+            "title": CREATED_SPREADSHEET_TITLE,
+            "sheet_names": ["ContractData"],
+        },
+        assert_baseline=_baseline,
+        assert_outcome=_create_spreadsheet_outcome,
+    ),
     ProviderOperationCase(
         case_id="google_sheets_batch_read_values",
         provider_service="google",
@@ -252,6 +317,19 @@ GOOGLE_SHEETS_PROVIDER_OPERATION_CASES = (
         },
         assert_baseline=_write_values_baseline,
         assert_outcome=_write_values_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_sheets_append_values",
+        provider_service="google",
+        capability_id="google-sheets.append_values",
+        arguments={
+            "spreadsheet_id": SPREADSHEET_ID,
+            "range": APPEND_RANGE,
+            "values": [APPENDED_ROW],
+            "value_input_option": "RAW",
+        },
+        assert_baseline=_append_values_baseline,
+        assert_outcome=_append_values_outcome,
     ),
     ProviderOperationCase(
         case_id="google_sheets_rename_sheet",

--- a/tests/e2e/provider_operation_google_slides_cases.py
+++ b/tests/e2e/provider_operation_google_slides_cases.py
@@ -3,7 +3,11 @@
 import json
 
 from emulate_provider import google_json
-from provider_operation_types import ProviderOperationCase
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_output,
+    static_provider_json_response,
+)
 
 PRESENTATION_ID = "slides_reborn_launch"
 PRESENTATION_TITLE = "Reborn Launch Review"
@@ -224,6 +228,30 @@ GOOGLE_SLIDES_PROVIDER_OPERATION_CASES = (
         assert_outcome=_get_presentation_outcome,
     ),
     ProviderOperationCase(
+        case_id="google_slides_get_presentation_empty",
+        provider_service="google",
+        capability_id="google-slides.get_presentation",
+        arguments={"presentation_id": "slides_provider_contract_empty"},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {
+                "presentation_id": "",
+                "title": "",
+                "revision_id": "",
+                "slide_count": 0,
+                "slides": [],
+            }
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/v1/presentations/slides_provider_contract_empty",
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
         case_id="google_slides_get_thumbnail",
         provider_service="google",
         capability_id="google-slides.get_thumbnail",
@@ -233,6 +261,30 @@ GOOGLE_SLIDES_PROVIDER_OPERATION_CASES = (
         },
         assert_baseline=_baseline,
         assert_outcome=_thumbnail_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="google_slides_get_thumbnail_empty",
+        provider_service="google",
+        capability_id="google-slides.get_thumbnail",
+        arguments={
+            "presentation_id": PRESENTATION_ID,
+            "slide_object_id": "slide_provider_contract_empty",
+        },
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {"content_url": "", "width": 0, "height": 0}
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path=(
+                f"/v1/presentations/{PRESENTATION_ID}/pages/"
+                "slide_provider_contract_empty/thumbnail"
+            ),
+            payload={},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
     ),
     ProviderOperationCase(
         case_id="google_slides_create_slide",

--- a/tests/e2e/provider_operation_slack_cases.py
+++ b/tests/e2e/provider_operation_slack_cases.py
@@ -1,4 +1,4 @@
-"""Slack read contracts owned by the Slack provider test module."""
+"""Slack provider operation contracts owned by the Slack test module."""
 
 import json
 
@@ -16,6 +16,7 @@ REVIEWER_NAME = "qa-reviewer"
 SEARCH_MARKER = "ENTITYMSG_1784643032040"
 THREAD_ROOT_MARKER = "QA10 thread root"
 THREAD_REPLY_MARKER = "QA10 visible thread reply"
+SEND_MARKER = "REBORN_PROVIDER_CASE_SLACK_SEND"
 
 
 async def _channel_id(emulate_url: str) -> str:
@@ -153,6 +154,54 @@ async def _whoami_outcome(emulate_url: str, preview: dict) -> None:
         "user_display_name": identity["user"],
         "user_id": identity["user_id"],
     }, output
+
+
+async def _send_arguments(emulate_url: str) -> dict:
+    return {
+        "channel": await _channel_id(emulate_url),
+        "text": SEND_MARKER,
+    }
+
+
+async def _send_baseline(emulate_url: str) -> None:
+    await _baseline(emulate_url)
+    assert not [
+        message
+        for message in await _history(emulate_url)
+        if message["text"] == SEND_MARKER
+    ], "provider world already contains the send-message contract marker"
+
+
+async def _send_outcome(emulate_url: str, preview: dict) -> None:
+    matches = [
+        message
+        for message in await _history(emulate_url)
+        if message["text"] == SEND_MARKER
+    ]
+    assert len(matches) == 1, matches
+    output = _output(preview)
+    assert output == {
+        "ok": True,
+        "channel": await _channel_id(emulate_url),
+        "ts": matches[0]["ts"],
+    }, output
+
+
+async def _cleanup_send(emulate_url: str) -> None:
+    channel = await _channel_id(emulate_url)
+    matches = [
+        message
+        for message in await _history(emulate_url)
+        if message["text"] == SEND_MARKER
+    ]
+    async with httpx.AsyncClient(timeout=15) as client:
+        for message in matches:
+            await slack_post(
+                client,
+                emulate_url,
+                "chat.delete",
+                {"channel": channel, "ts": message["ts"]},
+            )
 
 
 def _setup_empty_slack_history(proxy, endpoint: str) -> None:
@@ -414,5 +463,14 @@ SLACK_PROVIDER_OPERATION_CASES = (
         setup_provider_proxy=_setup_empty_whoami,
         expect_provider_forward=False,
         expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="slack_send_message",
+        provider_service="slack",
+        capability_id="slack.send_message",
+        arguments=_send_arguments,
+        assert_baseline=_send_baseline,
+        assert_outcome=_send_outcome,
+        cleanup_provider=_cleanup_send,
     ),
 )

--- a/tests/e2e/provider_operation_slack_cases.py
+++ b/tests/e2e/provider_operation_slack_cases.py
@@ -1,0 +1,418 @@
+"""Slack read contracts owned by the Slack provider test module."""
+
+import json
+
+import httpx
+from emulate_provider import slack_post
+from provider_fault_proxy import ProviderFaultProfile
+from provider_operation_types import (
+    ProviderOperationCase,
+    exact_output,
+    static_provider_json_response,
+)
+
+CHANNEL_NAME = "reborn-alerts"
+REVIEWER_NAME = "qa-reviewer"
+SEARCH_MARKER = "ENTITYMSG_1784643032040"
+THREAD_ROOT_MARKER = "QA10 thread root"
+THREAD_REPLY_MARKER = "QA10 visible thread reply"
+
+
+async def _channel_id(emulate_url: str) -> str:
+    async with httpx.AsyncClient(timeout=15) as client:
+        result = await slack_post(
+            client,
+            emulate_url,
+            "conversations.list",
+            {"types": "public_channel"},
+        )
+    return next(
+        channel["id"]
+        for channel in result["channels"]
+        if channel["name"] == CHANNEL_NAME
+    )
+
+
+async def _user_id(emulate_url: str) -> str:
+    async with httpx.AsyncClient(timeout=15) as client:
+        result = await slack_post(client, emulate_url, "users.list")
+    return next(
+        user["id"]
+        for user in result["members"]
+        if user["name"] == REVIEWER_NAME
+    )
+
+
+async def _history(emulate_url: str) -> list[dict]:
+    async with httpx.AsyncClient(timeout=15) as client:
+        result = await slack_post(
+            client,
+            emulate_url,
+            "conversations.history",
+            {"channel": await _channel_id(emulate_url), "limit": 200},
+        )
+    return result["messages"]
+
+
+def _output(preview: dict) -> dict:
+    assert preview["truncated"] is False, preview
+    result = json.loads(preview["output_preview"])
+    assert isinstance(result, dict), preview
+    return result
+
+
+async def _baseline(emulate_url: str) -> None:
+    assert await _channel_id(emulate_url)
+    assert await _user_id(emulate_url)
+
+
+async def _conversation_arguments(emulate_url: str) -> dict:
+    return {"channel": await _channel_id(emulate_url)}
+
+
+async def _thread_arguments(emulate_url: str) -> dict:
+    root = next(
+        message
+        for message in await _history(emulate_url)
+        if message["text"] == THREAD_ROOT_MARKER
+    )
+    return {
+        "channel": await _channel_id(emulate_url),
+        "thread_ts": root["ts"],
+        "limit": 50,
+    }
+
+
+async def _user_arguments(emulate_url: str) -> dict:
+    return {"user_id": await _user_id(emulate_url)}
+
+
+async def _search_outcome(_emulate_url: str, preview: dict) -> None:
+    output = _output(preview)
+    matches = [
+        match for match in output["matches"] if SEARCH_MARKER in match["text"]
+    ]
+    assert len(matches) == 1, output
+    assert matches[0]["user_display_name"] == "reborn-user", matches[0]
+
+
+async def _list_conversations_outcome(
+    emulate_url: str, preview: dict
+) -> None:
+    channel_id = await _channel_id(emulate_url)
+    output = _output(preview)
+    matches = [
+        item
+        for item in output["conversations"]
+        if item["id"] == channel_id
+    ]
+    assert len(matches) == 1, output
+    assert matches[0]["name"] == CHANNEL_NAME, matches[0]
+    assert matches[0]["is_member"] is True, matches[0]
+
+
+async def _conversation_info_outcome(
+    emulate_url: str, preview: dict
+) -> None:
+    channel_id = await _channel_id(emulate_url)
+    output = _output(preview)
+    assert output["conversation"]["id"] == channel_id, output
+    assert output["conversation"]["name"] == CHANNEL_NAME, output
+    assert output["conversation"]["is_member"] is True, output
+
+
+async def _history_outcome(_emulate_url: str, preview: dict) -> None:
+    output = _output(preview)
+    by_text = {message["text"]: message for message in output["messages"]}
+    assert THREAD_ROOT_MARKER in by_text, output
+    assert by_text[THREAD_ROOT_MARKER]["is_current_user"] is True, output
+    assert output["current_user_id"], output
+
+
+async def _thread_outcome(_emulate_url: str, preview: dict) -> None:
+    output = _output(preview)
+    by_text = {message["text"]: message for message in output["messages"]}
+    assert {THREAD_ROOT_MARKER, THREAD_REPLY_MARKER} <= set(by_text), output
+    assert by_text[THREAD_REPLY_MARKER]["is_current_user"] is True, output
+
+
+async def _user_outcome(emulate_url: str, preview: dict) -> None:
+    output = _output(preview)
+    assert output["user"]["id"] == await _user_id(emulate_url), output
+    assert output["user"]["real_name"] == "QA Reviewer", output
+    assert output["user"]["title"] == "Release reviewer", output
+
+
+async def _whoami_outcome(emulate_url: str, preview: dict) -> None:
+    async with httpx.AsyncClient() as client:
+        identity = await slack_post(client, emulate_url, "auth.test", {})
+    output = _output(preview)
+    assert output == {
+        "ok": True,
+        "team_id": identity["team_id"],
+        "user_display_name": identity["user"],
+        "user_id": identity["user_id"],
+    }, output
+
+
+def _setup_empty_slack_history(proxy, endpoint: str) -> None:
+    history = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body='{"ok":true,"messages":[],"has_more":false}',
+    )
+    auth = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body='{"ok":true,"user_id":"U_EMPTY","team_id":"T_EMPTY"}',
+    )
+    proxy.arm(history, method="GET", path=f"/api/{endpoint}")
+    proxy.arm(auth, method="GET", path="/api/auth.test")
+
+
+def _setup_empty_history(proxy) -> None:
+    _setup_empty_slack_history(proxy, "conversations.history")
+
+
+def _setup_empty_thread(proxy) -> None:
+    _setup_empty_slack_history(proxy, "conversations.replies")
+
+
+def _setup_empty_whoami(proxy) -> None:
+    auth = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body='{"ok":true,"user_id":"U_EMPTY","team_id":"T_EMPTY"}',
+    )
+    user = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body=(
+            '{"ok":true,"user":{"id":"U_EMPTY","name":"",'
+            '"profile":{"real_name":"","display_name":""},'
+            '"is_bot":false}}'
+        ),
+    )
+    proxy.arm(auth, method="GET", path="/api/auth.test")
+    proxy.arm(user, method="GET", path="/api/users.info")
+
+
+SLACK_PROVIDER_OPERATION_CASES = (
+    ProviderOperationCase(
+        case_id="slack_search_messages",
+        provider_service="slack",
+        capability_id="slack.search_messages",
+        arguments={"query": SEARCH_MARKER, "count": 20},
+        assert_baseline=_baseline,
+        assert_outcome=_search_outcome,
+        expected_request_count=2,
+    ),
+    ProviderOperationCase(
+        case_id="slack_search_messages_empty",
+        provider_service="slack",
+        capability_id="slack.search_messages",
+        arguments={"query": "NO_SUCH_PROVIDER_CONTRACT_MESSAGE", "count": 20},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output({"ok": True, "total": 0, "matches": []}),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/api/search.messages",
+            payload={"ok": True, "messages": {"total": 0, "matches": []}},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="slack_list_conversations",
+        provider_service="slack",
+        capability_id="slack.list_conversations",
+        arguments={"types": "public_channel", "limit": 200},
+        assert_baseline=_baseline,
+        assert_outcome=_list_conversations_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="slack_list_conversations_empty",
+        provider_service="slack",
+        capability_id="slack.list_conversations",
+        arguments={"types": "mpim", "limit": 200},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output({"ok": True, "conversations": []}),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/api/conversations.list",
+            payload={
+                "ok": True,
+                "channels": [],
+                "response_metadata": {"next_cursor": ""},
+            },
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_conversation_info",
+        provider_service="slack",
+        capability_id="slack.get_conversation_info",
+        arguments=_conversation_arguments,
+        assert_baseline=_baseline,
+        assert_outcome=_conversation_info_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_conversation_info_empty",
+        provider_service="slack",
+        capability_id="slack.get_conversation_info",
+        arguments={"channel": "C_EMPTY"},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {
+                "ok": True,
+                "conversation": {
+                    "id": "C_EMPTY",
+                    "is_channel": False,
+                    "is_private": False,
+                    "is_im": False,
+                    "is_mpim": False,
+                },
+            }
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/api/conversations.info",
+            payload={"ok": True, "channel": {"id": "C_EMPTY"}},
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_conversation_history",
+        provider_service="slack",
+        capability_id="slack.get_conversation_history",
+        arguments=_conversation_arguments,
+        assert_baseline=_baseline,
+        assert_outcome=_history_outcome,
+        expected_request_count=3,
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_conversation_history_empty",
+        provider_service="slack",
+        capability_id="slack.get_conversation_history",
+        arguments={"channel": "C_EMPTY", "limit": 50},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {
+                "ok": True,
+                "messages": [],
+                "has_more": False,
+                "current_user_id": "U_EMPTY",
+            }
+        ),
+        outcome_class="empty",
+        expected_request_count=2,
+        setup_provider_proxy=_setup_empty_history,
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_thread_replies",
+        provider_service="slack",
+        capability_id="slack.get_thread_replies",
+        arguments=_thread_arguments,
+        assert_baseline=_baseline,
+        assert_outcome=_thread_outcome,
+        expected_request_count=3,
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_thread_replies_empty",
+        provider_service="slack",
+        capability_id="slack.get_thread_replies",
+        arguments={"channel": "C_EMPTY", "thread_ts": "0.000001", "limit": 50},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {
+                "ok": True,
+                "messages": [],
+                "has_more": False,
+                "current_user_id": "U_EMPTY",
+            }
+        ),
+        outcome_class="empty",
+        expected_request_count=2,
+        setup_provider_proxy=_setup_empty_thread,
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_user_info",
+        provider_service="slack",
+        capability_id="slack.get_user_info",
+        arguments=_user_arguments,
+        assert_baseline=_baseline,
+        assert_outcome=_user_outcome,
+    ),
+    ProviderOperationCase(
+        case_id="slack_get_user_info_empty",
+        provider_service="slack",
+        capability_id="slack.get_user_info",
+        arguments={"user_id": "U_EMPTY"},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {
+                "ok": True,
+                "user": {
+                    "id": "U_EMPTY",
+                    "name": "",
+                    "real_name": "",
+                    "display_name": "",
+                    "is_bot": False,
+                },
+            }
+        ),
+        outcome_class="empty",
+        setup_provider_proxy=static_provider_json_response(
+            method="GET",
+            path="/api/users.info",
+            payload={
+                "ok": True,
+                "user": {
+                    "id": "U_EMPTY",
+                    "name": "",
+                    "profile": {"real_name": "", "display_name": ""},
+                    "is_bot": False,
+                },
+            },
+        ),
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+    ProviderOperationCase(
+        case_id="slack_whoami",
+        provider_service="slack",
+        capability_id="slack.whoami",
+        arguments={},
+        assert_baseline=_baseline,
+        assert_outcome=_whoami_outcome,
+        expected_request_count=2,
+    ),
+    ProviderOperationCase(
+        case_id="slack_whoami_empty",
+        provider_service="slack",
+        capability_id="slack.whoami",
+        arguments={},
+        assert_baseline=_baseline,
+        assert_outcome=exact_output(
+            {"ok": True, "user_id": "U_EMPTY", "team_id": "T_EMPTY"}
+        ),
+        outcome_class="empty",
+        expected_request_count=2,
+        setup_provider_proxy=_setup_empty_whoami,
+        expect_provider_forward=False,
+        expected_proxy_profile="provider_contract_empty",
+    ),
+)

--- a/tests/e2e/provider_operation_slack_cases.py
+++ b/tests/e2e/provider_operation_slack_cases.py
@@ -3,6 +3,7 @@
 import json
 
 import httpx
+
 from emulate_provider import slack_post
 from provider_fault_proxy import ProviderFaultProfile
 from provider_operation_types import (

--- a/tests/e2e/provider_operation_slack_cases.py
+++ b/tests/e2e/provider_operation_slack_cases.py
@@ -17,6 +17,8 @@ SEARCH_MARKER = "ENTITYMSG_1784643032040"
 THREAD_ROOT_MARKER = "QA10 thread root"
 THREAD_REPLY_MARKER = "QA10 visible thread reply"
 SEND_MARKER = "REBORN_PROVIDER_CASE_SLACK_SEND"
+EMPTY_USER_ID = "U_EMPTY"
+EMPTY_TEAM_ID = "T_EMPTY"
 
 
 async def _channel_id(emulate_url: str) -> str:
@@ -145,7 +147,7 @@ async def _user_outcome(emulate_url: str, preview: dict) -> None:
 
 
 async def _whoami_outcome(emulate_url: str, preview: dict) -> None:
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=15) as client:
         identity = await slack_post(client, emulate_url, "auth.test", {})
     output = _output(preview)
     assert output == {
@@ -204,6 +206,22 @@ async def _cleanup_send(emulate_url: str) -> None:
             )
 
 
+def _empty_auth_profile() -> ProviderFaultProfile:
+    return ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body=json.dumps(
+            {
+                "ok": True,
+                "user_id": EMPTY_USER_ID,
+                "team_id": EMPTY_TEAM_ID,
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+
 def _setup_empty_slack_history(proxy, endpoint: str) -> None:
     history = ProviderFaultProfile(
         name="provider_contract_empty",
@@ -211,14 +229,8 @@ def _setup_empty_slack_history(proxy, endpoint: str) -> None:
         status=200,
         body='{"ok":true,"messages":[],"has_more":false}',
     )
-    auth = ProviderFaultProfile(
-        name="provider_contract_empty",
-        action="respond",
-        status=200,
-        body='{"ok":true,"user_id":"U_EMPTY","team_id":"T_EMPTY"}',
-    )
     proxy.arm(history, method="GET", path=f"/api/{endpoint}")
-    proxy.arm(auth, method="GET", path="/api/auth.test")
+    proxy.arm(_empty_auth_profile(), method="GET", path="/api/auth.test")
 
 
 def _setup_empty_history(proxy) -> None:
@@ -230,23 +242,17 @@ def _setup_empty_thread(proxy) -> None:
 
 
 def _setup_empty_whoami(proxy) -> None:
-    auth = ProviderFaultProfile(
-        name="provider_contract_empty",
-        action="respond",
-        status=200,
-        body='{"ok":true,"user_id":"U_EMPTY","team_id":"T_EMPTY"}',
-    )
     user = ProviderFaultProfile(
         name="provider_contract_empty",
         action="respond",
         status=200,
         body=(
-            '{"ok":true,"user":{"id":"U_EMPTY","name":"",'
+            f'{{"ok":true,"user":{{"id":"{EMPTY_USER_ID}","name":"",'
             '"profile":{"real_name":"","display_name":""},'
             '"is_bot":false}}'
         ),
     )
-    proxy.arm(auth, method="GET", path="/api/auth.test")
+    proxy.arm(_empty_auth_profile(), method="GET", path="/api/auth.test")
     proxy.arm(user, method="GET", path="/api/users.info")
 
 
@@ -359,7 +365,7 @@ SLACK_PROVIDER_OPERATION_CASES = (
                 "ok": True,
                 "messages": [],
                 "has_more": False,
-                "current_user_id": "U_EMPTY",
+                "current_user_id": EMPTY_USER_ID,
             }
         ),
         outcome_class="empty",
@@ -388,7 +394,7 @@ SLACK_PROVIDER_OPERATION_CASES = (
                 "ok": True,
                 "messages": [],
                 "has_more": False,
-                "current_user_id": "U_EMPTY",
+                "current_user_id": EMPTY_USER_ID,
             }
         ),
         outcome_class="empty",
@@ -409,13 +415,13 @@ SLACK_PROVIDER_OPERATION_CASES = (
         case_id="slack_get_user_info_empty",
         provider_service="slack",
         capability_id="slack.get_user_info",
-        arguments={"user_id": "U_EMPTY"},
+        arguments={"user_id": EMPTY_USER_ID},
         assert_baseline=_baseline,
         assert_outcome=exact_output(
             {
                 "ok": True,
                 "user": {
-                    "id": "U_EMPTY",
+                    "id": EMPTY_USER_ID,
                     "name": "",
                     "real_name": "",
                     "display_name": "",
@@ -430,7 +436,7 @@ SLACK_PROVIDER_OPERATION_CASES = (
             payload={
                 "ok": True,
                 "user": {
-                    "id": "U_EMPTY",
+                    "id": EMPTY_USER_ID,
                     "name": "",
                     "profile": {"real_name": "", "display_name": ""},
                     "is_bot": False,
@@ -456,7 +462,11 @@ SLACK_PROVIDER_OPERATION_CASES = (
         arguments={},
         assert_baseline=_baseline,
         assert_outcome=exact_output(
-            {"ok": True, "user_id": "U_EMPTY", "team_id": "T_EMPTY"}
+            {
+                "ok": True,
+                "user_id": EMPTY_USER_ID,
+                "team_id": EMPTY_TEAM_ID,
+            }
         ),
         outcome_class="empty",
         expected_request_count=2,

--- a/tests/e2e/provider_operation_types.py
+++ b/tests/e2e/provider_operation_types.py
@@ -135,10 +135,15 @@ def assert_provider_request_evidence(
     operation_case: ProviderOperationCase,
     requests: list[dict],
     *,
-    expected_bearer: str | None,
+    expected_bearer: str | None = None,
+    expected_credential_fingerprint: str | None = None,
     excluded_bearers: tuple[str, ...] = (),
 ) -> None:
     """Require exact, authenticated provider request evidence for a case."""
+    assert not (
+        expected_bearer is not None
+        and expected_credential_fingerprint is not None
+    ), "expected bearer and fingerprint are mutually exclusive"
     excluded_fingerprints = {
         hashlib.sha256(f"Bearer {bearer}".encode()).hexdigest()[:12]
         for bearer in excluded_bearers
@@ -152,7 +157,7 @@ def assert_provider_request_evidence(
         operation_case.case_id,
         requests,
     )
-    expected_fingerprint = (
+    expected_fingerprint = expected_credential_fingerprint or (
         hashlib.sha256(f"Bearer {expected_bearer}".encode()).hexdigest()[:12]
         if expected_bearer is not None
         else None

--- a/tests/e2e/provider_operation_types.py
+++ b/tests/e2e/provider_operation_types.py
@@ -12,6 +12,7 @@ BaselineAssertion = Callable[[str], Awaitable[None]]
 OutcomeAssertion = Callable[[str, dict], Awaitable[None]]
 ArgumentsFactory = Callable[[str], Awaitable[dict]]
 ProviderProxySetup = Callable[[Any], None]
+ProviderCleanup = Callable[[str], Awaitable[None]]
 ProviderService = Literal["google", "github", "slack"]
 
 # Which provider-observable outcome this case pins. A capability covered only
@@ -38,6 +39,7 @@ class ProviderOperationCase:
     expected_proxy_profile: str | None = None
     expected_forwarded_request_count: int | None = None
     expected_profile_request_count: int | None = None
+    cleanup_provider: ProviderCleanup | None = None
 
     async def resolve_arguments(self, emulate_url: str) -> dict:
         """Resolve static arguments or provider-issued values after setup."""

--- a/tests/e2e/provider_operation_types.py
+++ b/tests/e2e/provider_operation_types.py
@@ -1,12 +1,17 @@
 """Shared types for full-path provider operation cases."""
 
+import hashlib
+import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
+
+from provider_fault_proxy import ProviderFaultProfile
 
 BaselineAssertion = Callable[[str], Awaitable[None]]
 OutcomeAssertion = Callable[[str, dict], Awaitable[None]]
 ArgumentsFactory = Callable[[str], Awaitable[dict]]
+ProviderProxySetup = Callable[[Any], None]
 ProviderService = Literal["google", "github", "slack"]
 
 # Which provider-observable outcome this case pins. A capability covered only
@@ -27,9 +32,162 @@ class ProviderOperationCase:
     assert_baseline: BaselineAssertion
     assert_outcome: OutcomeAssertion
     outcome_class: OutcomeClass = "success"
+    expected_request_count: int = 1
+    setup_provider_proxy: ProviderProxySetup | None = None
+    expect_provider_forward: bool = True
+    expected_proxy_profile: str | None = None
+    expected_forwarded_request_count: int | None = None
+    expected_profile_request_count: int | None = None
 
     async def resolve_arguments(self, emulate_url: str) -> dict:
         """Resolve static arguments or provider-issued values after setup."""
         if callable(self.arguments):
             return await self.arguments(emulate_url)
         return self.arguments
+
+
+def static_provider_json_response(
+    *,
+    method: str,
+    path: str,
+    payload: Any,
+) -> ProviderProxySetup:
+    """Return setup for one provider-authentic empty success response."""
+    profile = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body=json.dumps(payload, separators=(",", ":")),
+    )
+
+    def setup(proxy: Any) -> None:
+        proxy.arm(profile, method=method, path=path)
+
+    return setup
+
+
+def static_provider_text_response(
+    *,
+    method: str,
+    path: str,
+    body: str,
+) -> ProviderProxySetup:
+    """Return setup for one provider-authentic plain-text success response."""
+    profile = ProviderFaultProfile(
+        name="provider_contract_empty",
+        action="respond",
+        status=200,
+        body=body,
+        content_type="text/plain",
+    )
+
+    def setup(proxy: Any) -> None:
+        proxy.arm(profile, method=method, path=path)
+
+    return setup
+
+
+def exact_output(expected: Any) -> OutcomeAssertion:
+    """Require a complete, non-truncated capability result with exact JSON."""
+
+    async def assert_outcome(_emulate_url: str, preview: dict) -> None:
+        assert preview["truncated"] is False, preview
+        assert json.loads(preview["output_preview"]) == expected, preview
+
+    return assert_outcome
+
+
+def exact_text_output(expected: str) -> OutcomeAssertion:
+    """Require a complete text result without JSON coercion."""
+
+    async def assert_outcome(_emulate_url: str, preview: dict) -> None:
+        assert preview["truncated"] is False, preview
+        assert preview["output_kind"] == "text", preview
+        assert preview.get("output_preview", "") == expected, preview
+
+    return assert_outcome
+
+
+def exact_provider_http_output(body: Any) -> OutcomeAssertion:
+    """Require the first-party HTTP executor's complete provider response."""
+    return exact_output(
+        {
+            "body": body,
+            "redaction_applied": True,
+            "status": 200,
+        }
+    )
+
+
+def provider_http_body(preview: dict) -> Any:
+    """Return a fully observed first-party HTTP body after pinning its envelope."""
+    assert preview["truncated"] is False, preview
+    output = json.loads(preview["output_preview"])
+    assert set(output) == {"body", "redaction_applied", "status"}, output
+    assert output["redaction_applied"] is True, output
+    assert output["status"] == 200, output
+    return output["body"]
+
+
+def assert_provider_request_evidence(
+    operation_case: ProviderOperationCase,
+    requests: list[dict],
+    *,
+    expected_bearer: str | None,
+    excluded_bearers: tuple[str, ...] = (),
+) -> None:
+    """Require exact, authenticated provider request evidence for a case."""
+    excluded_fingerprints = {
+        hashlib.sha256(f"Bearer {bearer}".encode()).hexdigest()[:12]
+        for bearer in excluded_bearers
+    }
+    requests = [
+        request
+        for request in requests
+        if request["credential_fingerprint"] not in excluded_fingerprints
+    ]
+    assert len(requests) == operation_case.expected_request_count, (
+        operation_case.case_id,
+        requests,
+    )
+    expected_fingerprint = (
+        hashlib.sha256(f"Bearer {expected_bearer}".encode()).hexdigest()[:12]
+        if expected_bearer is not None
+        else None
+    )
+    expected_forwarded_count = operation_case.expected_forwarded_request_count
+    if expected_forwarded_count is None:
+        expected_forwarded_count = (
+            operation_case.expected_request_count
+            if operation_case.expect_provider_forward
+            else 0
+        )
+    assert sum(request["forwarded"] for request in requests) == (
+        expected_forwarded_count
+    ), requests
+    expected_profile_count = operation_case.expected_profile_request_count
+    if expected_profile_count is None:
+        expected_profile_count = (
+            operation_case.expected_request_count
+            if operation_case.expected_proxy_profile is not None
+            else 0
+        )
+    assert all(
+        request["fault"] in {None, operation_case.expected_proxy_profile}
+        for request in requests
+    ), requests
+    assert sum(request["fault"] is not None for request in requests) == (
+        expected_profile_count
+    ), requests
+    observed_fingerprints = {
+        request["credential_fingerprint"] for request in requests
+    }
+    assert None not in observed_fingerprints, requests
+    assert len(observed_fingerprints) == 1, requests
+    if expected_fingerprint is not None:
+        assert observed_fingerprints == {expected_fingerprint}, requests
+    for request in requests:
+        assert request["service"] == operation_case.provider_service, request
+        assert request["responded"] is True, request
+        if request["forwarded"]:
+            assert 200 <= request["upstream_status"] < 300, request

--- a/tests/e2e/scenarios/test_product_surface_coverage.py
+++ b/tests/e2e/scenarios/test_product_surface_coverage.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+
 from journey_cases import ALL_JOURNEY_CASES
 from journey_types import ProviderJourneyCase
 from product_surface_coverage import (
@@ -19,13 +20,13 @@ from provider_capability_inventory import (
 ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_report_uses_production_capability_and_typed_journey_denominators():
+def test_report_uses_complete_production_and_typed_journey_denominators():
     report = build_report()
 
     assert report["summary"]["capabilities"] == len(CAPABILITY_OPERATION_KINDS)
     assert report["summary"]["journeys"] == len(ALL_JOURNEY_CASES)
     assert report["summary"]["missing"] == 0
-    assert report["summary"]["owned_gaps"] > 0
+    assert report["summary"]["owned_gaps"] == 0
     assert {
         row["id"] for row in report["surfaces"] if row["kind"] == "capability"
     } == set(CAPABILITY_OPERATION_KINDS)

--- a/tests/e2e/scenarios/test_provider_capability_inventory.py
+++ b/tests/e2e/scenarios/test_provider_capability_inventory.py
@@ -3,10 +3,11 @@
 import ast
 import json
 import re
+import tomllib
 from pathlib import Path
 
 import pytest
-import tomllib
+
 from provider_capability_inventory import (
     ALL_CLASSIFIED_CAPABILITY_IDS,
     COVERAGE_BACKLOG,

--- a/tests/e2e/scenarios/test_provider_capability_inventory.py
+++ b/tests/e2e/scenarios/test_provider_capability_inventory.py
@@ -2,12 +2,11 @@
 
 import ast
 import json
-from pathlib import Path
 import re
-import tomllib
+from pathlib import Path
 
 import pytest
-
+import tomllib
 from provider_capability_inventory import (
     ALL_CLASSIFIED_CAPABILITY_IDS,
     COVERAGE_BACKLOG,
@@ -95,10 +94,13 @@ def _cargo_test_targets() -> dict[str, str]:
 def _assert_integration_evidence_is_executable(
     evidence: dict, targets: dict[str, str]
 ) -> None:
-    required = {"capability", "target", "source", "test"}
+    required = {"capability", "outcome_class", "target", "source", "test"}
     assert set(evidence) == required, (
         f"integration evidence fields must be exactly {sorted(required)}: "
         f"{evidence}"
+    )
+    assert evidence["outcome_class"] in REQUIRED_READ_OUTCOME_CLASSES, (
+        f"unknown integration outcome class: {evidence}"
     )
 
     assert evidence["target"] in targets, (
@@ -176,13 +178,14 @@ def test_tested_capabilities_have_executable_evidence_at_the_correct_seam():
         capability_id_to_wire_name(case.capability_id)
         for case in PROVIDER_OPERATION_CASES
     }
-    integration_capabilities = [
-        entry["capability"] for entry in INTEGRATION_EVIDENCE
+    integration_outcomes = [
+        (entry["capability"], entry["outcome_class"])
+        for entry in INTEGRATION_EVIDENCE
     ]
     duplicates = sorted(
-        capability
-        for capability in set(integration_capabilities)
-        if integration_capabilities.count(capability) > 1
+        outcome
+        for outcome in set(integration_outcomes)
+        if integration_outcomes.count(outcome) > 1
     )
     assert not duplicates, f"duplicate integration evidence: {duplicates}"
     assert INTEGRATION_EVIDENCE_CAPABILITY_IDS <= TESTED_CAPABILITY_IDS, (
@@ -585,10 +588,14 @@ def test_journey_evidence_accepts_a_genuinely_invoked_helper(call: str):
 
 
 def _covered_capability_outcomes() -> dict[str, set[str]]:
-    """Capability -> outcome classes proven by a typed operation case."""
+    """Capability -> outcome classes proven at an executable provider seam."""
     covered: dict[str, set[str]] = {}
     for case in PROVIDER_OPERATION_CASES:
         covered.setdefault(case.capability_id, set()).add(case.outcome_class)
+    for evidence in INTEGRATION_EVIDENCE:
+        covered.setdefault(evidence["capability"], set()).add(
+            evidence["outcome_class"]
+        )
     return covered
 
 
@@ -619,10 +626,6 @@ def test_read_capabilities_cover_every_required_outcome_class():
     """Epic #6524 workstream 5: seeded success *and* empty-result per read."""
     covered = _covered_capability_outcomes()
     backlogged = backlogged_capabilities("read_requires_outcome_classes")
-    # Integration evidence is not subtracted here. It names one executable test
-    # per capability with no notion of outcome class, so letting it exempt a
-    # read would be a silent exemption of exactly the kind this gate exists to
-    # remove. Those capabilities are carried in the backlog with a reason.
     missing = sorted(
         f"{capability_id}:{outcome_class}"
         for capability_id in READ_CAPABILITY_IDS - backlogged

--- a/tests/e2e/scenarios/test_provider_capability_inventory.py
+++ b/tests/e2e/scenarios/test_provider_capability_inventory.py
@@ -599,25 +599,24 @@ def _covered_capability_outcomes() -> dict[str, set[str]]:
     return covered
 
 
-def test_write_capabilities_are_not_evidenced_by_a_recorded_tool_name():
-    """A recorded tool-call name proves model choice, never a provider mutation.
+def test_write_capabilities_require_typed_provider_operation_contracts():
+    """Every provider mutation requires a typed observed-request contract.
 
-    `_recorded_tool_evidence` only observes that some harvested trace emitted a
-    call with this name. For an `external_write` capability that says nothing
-    about whether the provider committed the effect, so it cannot stand in for
-    a typed case with provider-side readback.
+    Journey evidence remains valuable user-flow coverage, but it cannot assert
+    the exact provider request, credential account, response, and mutation
+    count required by the operation runner.
     """
-    covered = set(_covered_capability_outcomes())
+    typed_capabilities = {
+        case.capability_id for case in PROVIDER_OPERATION_CASES
+    }
     unproven = sorted(
         WRITE_CAPABILITY_IDS
-        - covered
-        - INTEGRATION_EVIDENCE_CAPABILITY_IDS
-        - JOURNEY_EVIDENCE_CAPABILITY_IDS
+        - typed_capabilities
         - backlogged_capabilities("write_requires_operation_case")
     )
     assert not unproven, (
-        "write capabilities whose only evidence is a recorded tool-call name; "
-        "add a ProviderOperationCase with provider readback or an owned "
+        "write capabilities without typed request and readback evidence; "
+        "add a ProviderOperationCase or an owned "
         f"coverage_backlog entry: {unproven}"
     )
 

--- a/tests/e2e/scenarios/test_provider_fault_proxy.py
+++ b/tests/e2e/scenarios/test_provider_fault_proxy.py
@@ -8,6 +8,7 @@ import gzip
 import httpx
 import pytest
 from aiohttp import web
+
 from helpers import AUTH_TOKEN
 from provider_fault_proxy import (
     PROVIDER_FAULT_PROFILES,

--- a/tests/e2e/scenarios/test_provider_fault_proxy.py
+++ b/tests/e2e/scenarios/test_provider_fault_proxy.py
@@ -51,6 +51,19 @@ async def _start_upstream() -> tuple[str, list[dict], web.AppRunner]:
                     "X-Upstream": "emulate",
                 },
             )
+        if request.path == "/oauth/token":
+            return web.json_response(
+                {"access_token": "provider-issued-secret-token"}
+            )
+        if request.path == "/oauth/user-token":
+            return web.json_response(
+                {
+                    "access_token": "provider-issued-bot-token",
+                    "authed_user": {
+                        "access_token": "provider-issued-user-token"
+                    },
+                }
+            )
         return web.json_response(
             response_body,
             status=201 if request.method == "POST" else 200,
@@ -109,6 +122,33 @@ async def test_provider_fault_proxy_is_transparent_and_redacts_credentials(
     assert request["responded"] is True
     assert request["credential_fingerprint"]
     assert "never-record-this-token" not in str(proxy.state)
+
+
+async def test_provider_fault_proxy_fingerprints_issued_token_without_recording_it(
+    fault_proxy,
+):
+    proxy, _ = fault_proxy
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{proxy.url}/oauth/token")
+
+    response.raise_for_status()
+    request = proxy.state["requests"][0]
+    assert request["issued_credential_fingerprint"] == "c3da4738d8e1"
+    assert "provider-issued-secret-token" not in str(proxy.state)
+
+
+async def test_provider_fault_proxy_prefers_issued_user_account_token(
+    fault_proxy,
+):
+    proxy, _ = fault_proxy
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{proxy.url}/oauth/user-token")
+
+    response.raise_for_status()
+    request = proxy.state["requests"][0]
+    assert request["issued_credential_fingerprint"] == "5309d6d55911"
+    assert "provider-issued-user-token" not in str(proxy.state)
+    assert "provider-issued-bot-token" not in str(proxy.state)
 
 
 async def test_provider_fault_proxy_preserves_compressed_responses(fault_proxy):

--- a/tests/e2e/scenarios/test_provider_operation_types.py
+++ b/tests/e2e/scenarios/test_provider_operation_types.py
@@ -39,6 +39,15 @@ def test_provider_request_evidence_accepts_observed_authenticated_success():
     assert_provider_request_evidence(_case(), [_request()], expected_bearer=BEARER)
 
 
+def test_provider_request_evidence_rejects_wrong_bound_account_fingerprint():
+    with pytest.raises(AssertionError):
+        assert_provider_request_evidence(
+            _case(),
+            [_request()],
+            expected_credential_fingerprint="wrong-bound-account",
+        )
+
+
 @pytest.mark.parametrize(
     ("field", "sabotaged"),
     [

--- a/tests/e2e/scenarios/test_provider_operation_types.py
+++ b/tests/e2e/scenarios/test_provider_operation_types.py
@@ -5,6 +5,7 @@ import hashlib
 from types import SimpleNamespace
 
 import pytest
+
 from provider_operation_types import assert_provider_request_evidence
 
 BEARER = "provider-operation-evidence-token"

--- a/tests/e2e/scenarios/test_provider_operation_types.py
+++ b/tests/e2e/scenarios/test_provider_operation_types.py
@@ -1,0 +1,70 @@
+"""Sabotage checks for provider-operation request evidence."""
+
+import copy
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+from provider_operation_types import assert_provider_request_evidence
+
+BEARER = "provider-operation-evidence-token"
+
+
+def _case():
+    return SimpleNamespace(
+        case_id="synthetic-provider-operation",
+        provider_service="github",
+        expected_request_count=1,
+        expected_forwarded_request_count=None,
+        expect_provider_forward=True,
+        expected_profile_request_count=None,
+        expected_proxy_profile=None,
+    )
+
+
+def _request():
+    return {
+        "service": "github",
+        "credential_fingerprint": hashlib.sha256(
+            f"Bearer {BEARER}".encode()
+        ).hexdigest()[:12],
+        "fault": None,
+        "forwarded": True,
+        "upstream_status": 200,
+        "responded": True,
+    }
+
+
+def test_provider_request_evidence_accepts_observed_authenticated_success():
+    assert_provider_request_evidence(_case(), [_request()], expected_bearer=BEARER)
+
+
+@pytest.mark.parametrize(
+    ("field", "sabotaged"),
+    [
+        ("service", "slack"),
+        ("credential_fingerprint", "wrong-account"),
+        ("forwarded", False),
+        ("responded", False),
+        ("upstream_status", 500),
+    ],
+)
+def test_provider_request_evidence_rejects_sabotaged_request(
+    field: str, sabotaged
+):
+    request = copy.deepcopy(_request())
+    request[field] = sabotaged
+    with pytest.raises(AssertionError):
+        assert_provider_request_evidence(
+            _case(), [request], expected_bearer=BEARER
+        )
+
+
+@pytest.mark.parametrize("requests", [[], [_request(), _request()]])
+def test_provider_request_evidence_rejects_missing_or_duplicate_dispatch(
+    requests: list[dict],
+):
+    with pytest.raises(AssertionError):
+        assert_provider_request_evidence(
+            _case(), requests, expected_bearer=BEARER
+        )

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -251,6 +251,11 @@ async def reborn_provider_operation_server(
     try:
         yield reborn_qa_emulate_runtime
     finally:
+        if operation_case.cleanup_provider is not None:
+            emulate_url = reborn_qa_emulate_runtime[
+                f"emulate_{operation_case.provider_service}_url"
+            ]
+            await operation_case.cleanup_provider(emulate_url)
         provider_fault_proxy_world.reset()
         if operation_case.provider_service != "slack":
             await resettable_emulate_provider_world.reset(

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -25,7 +25,6 @@ from emulate_provider import (
 )
 from helpers import (
     EMULATE_GITHUB_BEARER,
-    EMULATE_SLACK_BEARER,
 )
 from journey_cases import (
     PROVIDER_JOURNEY_RUN_IDS,
@@ -61,6 +60,7 @@ from reborn_webui_harness import (
 pytest_plugins = ["reborn_webui_harness"]
 
 GOOGLE_PROVIDER_OPERATION_BEARER = "mock-token-mock_auth_code"
+EMULATE_SLACK_CHANNEL_BEARER = "emulate-slack-channel-token"
 
 ROOT = Path(__file__).resolve().parents[3]
 TRACE_DIR = ROOT / "tests/fixtures/llm_traces/reborn_qa/live_canary"
@@ -204,6 +204,19 @@ async def reborn_qa_emulate_runtime(
     await _seed_github_account(base_url)
     await _seed_slack_account(base_url, emulate_slack_server["url"], slack_state)
     await _assert_extensions_active(base_url, ALL_EXTENSIONS)
+    slack_account_fingerprints = {
+        request["issued_credential_fingerprint"]
+        for request in provider_fault_proxy_world.proxies["slack"].state[
+            "requests"
+        ]
+        if request["path"] == "/api/oauth.v2.access"
+        and request["issued_credential_fingerprint"] is not None
+    }
+    assert len(slack_account_fingerprints) == 1, (
+        "Slack OAuth binding must establish exactly one provider account",
+        provider_fault_proxy_world.proxies["slack"].state["requests"],
+    )
+    slack_account_fingerprint = next(iter(slack_account_fingerprints))
     try:
         yield {
             "base_url": base_url,
@@ -212,6 +225,7 @@ async def reborn_qa_emulate_runtime(
             "emulate_slack_url": emulate_slack_server["url"],
             "provider_fault_proxies": provider_fault_proxy_world.proxies,
             "slack_state": slack_state,
+            "slack_account_fingerprint": slack_account_fingerprint,
         }
     finally:
         await close_reborn_server(proc)
@@ -257,6 +271,9 @@ async def reborn_provider_operation_server(
             ]
             await operation_case.cleanup_provider(emulate_url)
         provider_fault_proxy_world.reset()
+        # Slack's baseline workspace is seeded once after process startup, so
+        # restarting it here would erase the records later cases assert. Its
+        # only mutating operation owns an explicit provider cleanup above.
         if operation_case.provider_service != "slack":
             await resettable_emulate_provider_world.reset(
                 {operation_case.provider_service}
@@ -434,7 +451,10 @@ async def _configure_slack(base_url: str, slack_state: dict[str, str]) -> None:
             f"{base_url}/api/webchat/v2/operator/extension-configuration/extension.slack",
             json={
                 "values": [
-                    {"handle": "slack_bot_token", "value": EMULATE_SLACK_BEARER},
+                    {
+                        "handle": "slack_bot_token",
+                        "value": EMULATE_SLACK_CHANNEL_BEARER,
+                    },
                     {"handle": "slack_signing_secret", "value": "emulate-signing-secret"},
                     {"handle": "slack_team_id", "value": slack_state["team_id"]},
                     {"handle": "slack_api_app_id", "value": client_id},
@@ -1596,12 +1616,17 @@ async def test_provider_operation_case_executes_with_provider_readback(
         operation_case,
         proxy.state["requests"],
         expected_bearer=expected_bearer,
+        expected_credential_fingerprint=(
+            reborn_provider_operation_server["slack_account_fingerprint"]
+            if operation_case.provider_service == "slack"
+            else None
+        ),
         # Product Slack delivery uses the separately configured channel token
         # while extension operations use the caller's OAuth account. Exclude
         # only that known channel credential, then require every observed
         # operation request to share one non-null provider account.
         excluded_bearers=(
-            (EMULATE_SLACK_BEARER,)
+            (EMULATE_SLACK_CHANNEL_BEARER,)
             if operation_case.provider_service == "slack"
             else ()
         ),

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -16,6 +16,7 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
+
 from emulate_provider import (
     github_headers,
     github_json,

--- a/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
+++ b/tests/e2e/scenarios/test_reborn_qa_trace_full_path.py
@@ -16,7 +16,6 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
-
 from emulate_provider import (
     github_headers,
     github_json,
@@ -24,7 +23,10 @@ from emulate_provider import (
     slack_headers,
     slack_post,
 )
-from helpers import EMULATE_GITHUB_BEARER, EMULATE_SLACK_BEARER
+from helpers import (
+    EMULATE_GITHUB_BEARER,
+    EMULATE_SLACK_BEARER,
+)
 from journey_cases import (
     PROVIDER_JOURNEY_RUN_IDS,
     PROVIDER_JOURNEY_RUNS,
@@ -38,7 +40,10 @@ from provider_capability_inventory import (
 from provider_fault_cases import PROVIDER_FAULT_CASES
 from provider_fault_proxy import PROVIDER_FAULT_PROFILES
 from provider_operation_cases import PROVIDER_OPERATION_CASES
-from provider_operation_types import ProviderOperationCase
+from provider_operation_types import (
+    ProviderOperationCase,
+    assert_provider_request_evidence,
+)
 from reborn_webui_harness import (
     YOLO_PROFILE,
     capability_preview_payload,
@@ -54,6 +59,8 @@ from reborn_webui_harness import (
 )
 
 pytest_plugins = ["reborn_webui_harness"]
+
+GOOGLE_PROVIDER_OPERATION_BEARER = "mock-token-mock_auth_code"
 
 ROOT = Path(__file__).resolve().parents[3]
 TRACE_DIR = ROOT / "tests/fixtures/llm_traces/reborn_qa/live_canary"
@@ -236,15 +243,19 @@ async def reborn_qa_emulate_provider_server(
 async def reborn_provider_operation_server(
     reborn_qa_emulate_runtime,
     resettable_emulate_provider_world,
+    provider_fault_proxy_world,
     operation_case,
 ):
-    """Reuse Reborn but restore the case's provider after execution."""
+    """Reuse Reborn while isolating provider state and request evidence."""
+    provider_fault_proxy_world.reset()
     try:
         yield reborn_qa_emulate_runtime
     finally:
-        await resettable_emulate_provider_world.reset(
-            {operation_case.provider_service}
-        )
+        provider_fault_proxy_world.reset()
+        if operation_case.provider_service != "slack":
+            await resettable_emulate_provider_world.reset(
+                {operation_case.provider_service}
+            )
 
 
 @pytest.fixture
@@ -1539,6 +1550,11 @@ async def test_provider_operation_case_executes_with_provider_readback(
     source = f"provider-operation-{operation_case.case_id}.json"
     await operation_case.assert_baseline(emulate_url)
     arguments = await operation_case.resolve_arguments(emulate_url)
+    proxy = reborn_provider_operation_server["provider_fault_proxies"][
+        operation_case.provider_service
+    ]
+    if operation_case.setup_provider_proxy is not None:
+        operation_case.setup_provider_proxy(proxy)
     trace = _provider_operation_trace(operation_case, arguments)
     await _install_inline_trace(mock_llm_server, source, trace)
 
@@ -1565,6 +1581,26 @@ async def test_provider_operation_case_executes_with_provider_readback(
     assert len(matches) == 1, matches
     assert matches[0]["status"] == "completed", matches[0]
     await operation_case.assert_outcome(emulate_url, matches[0])
+    expected_bearer = {
+        # The full-path OAuth exchange deliberately returns this account token;
+        # EMULATE_GOOGLE_BEARER is used only by the test's provider readback.
+        "google": GOOGLE_PROVIDER_OPERATION_BEARER,
+        "github": EMULATE_GITHUB_BEARER,
+    }.get(operation_case.provider_service)
+    assert_provider_request_evidence(
+        operation_case,
+        proxy.state["requests"],
+        expected_bearer=expected_bearer,
+        # Product Slack delivery uses the separately configured channel token
+        # while extension operations use the caller's OAuth account. Exclude
+        # only that known channel credential, then require every observed
+        # operation request to share one non-null provider account.
+        excluded_bearers=(
+            (EMULATE_SLACK_BEARER,)
+            if operation_case.provider_service == "slack"
+            else ()
+        ),
+    )
     assert replay == {
         "source": source,
         "next_response": 3,

--- a/tests/integration/mcp.rs
+++ b/tests/integration/mcp.rs
@@ -135,6 +135,172 @@ async fn nearai_web_search_dispatches_through_bundled_hosted_mcp() {
     );
 }
 
+/// The bundled hosted-MCP path also preserves an authenticated, successful
+/// empty provider result. This separately pins the request and the outcome so
+/// a locally fabricated empty value cannot satisfy the contract.
+#[tokio::test]
+async fn nearai_web_search_empty_result_dispatches_through_bundled_hosted_mcp() {
+    let group = RebornIntegrationGroup::extension_lifecycle()
+        .await
+        .expect("extension-lifecycle group builds");
+    let h = group
+        .thread("nearai-hosted-mcp-empty-result")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                serde_json::json!({"extension_id": "nearai"}),
+            ),
+            RebornScriptedReply::text("NEAR AI search is installed."),
+            RebornScriptedReply::tool_call(
+                "nearai.web_search",
+                serde_json::json!({"query": "NEARAI_EMPTY_PROVIDER_RESULT"}),
+            ),
+            RebornScriptedReply::text("search complete"),
+        ])
+        .build()
+        .await
+        .expect("NEAR AI lifecycle thread builds");
+
+    h.seed_capability_credential_account("nearai", "NEAR AI integration account", &[])
+        .await
+        .expect("NEAR AI account is seeded under the dispatching user");
+    h.submit_turn("install NEAR AI search")
+        .await
+        .expect("install turn completes");
+    h.submit_turn("search for the empty-result sentinel")
+        .await
+        .expect("empty search turn completes");
+    h.assert_tool_invoked("nearai.web_search")
+        .await
+        .expect("canonical NEAR AI capability dispatched");
+
+    let requests = h.captured_network_requests_for_test();
+    let tools_call = requests
+        .iter()
+        .find(|request| {
+            serde_json::from_slice::<serde_json::Value>(&request.body)
+                .ok()
+                .is_some_and(|body| {
+                    body["method"] == "tools/call"
+                        && body["params"]["arguments"]["query"] == "NEARAI_EMPTY_PROVIDER_RESULT"
+                })
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "no empty-result hosted MCP tools/call captured across {} redacted request(s)",
+                requests.len()
+            )
+        });
+    assert!(
+        tools_call.headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("authorization")
+                && value.starts_with("Bearer ")
+                && value.len() > "Bearer ".len()
+        }),
+        "hosted MCP tools/call must carry a mediated bearer credential"
+    );
+
+    let output = h
+        .tool_result_output("nearai.web_search")
+        .await
+        .expect("empty hosted MCP result was recorded");
+    assert_eq!(
+        output["content"],
+        serde_json::json!([{
+            "type": "text",
+            "text": "[]"
+        }])
+    );
+}
+
+/// Provider credentials are selected at the authenticated run-owner boundary:
+/// actor A can dispatch with A's exact account, while actor B cannot install
+/// or call the same hosted extension with A's credential.
+#[tokio::test]
+async fn nearai_hosted_mcp_isolates_provider_accounts_across_actors() {
+    const ACTOR_A_TOKEN: &str = "nearai-provider-account-actor-a";
+    let group = RebornIntegrationGroup::extension_lifecycle_multiuser()
+        .await
+        .expect("multiuser extension-lifecycle group builds");
+    let actor_a = group
+        .thread("nearai-provider-account-actor-a")
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.extension_install",
+                serde_json::json!({"extension_id": "nearai"}),
+            ),
+            RebornScriptedReply::text("NEAR AI search is installed."),
+            RebornScriptedReply::tool_call(
+                "nearai.web_search",
+                serde_json::json!({"query": "actor-a-provider-query"}),
+            ),
+            RebornScriptedReply::text("search complete"),
+        ])
+        .build()
+        .await
+        .expect("actor A lifecycle thread builds");
+    actor_a
+        .seed_capability_credential_account_with_token(
+            "nearai",
+            "actor A NEAR AI account",
+            &[],
+            ACTOR_A_TOKEN,
+        )
+        .await
+        .expect("actor A account is seeded under actor A");
+    actor_a
+        .submit_turn("install NEAR AI search for actor A")
+        .await
+        .expect("actor A install completes");
+    actor_a
+        .submit_turn("search with actor A's account")
+        .await
+        .expect("actor A provider read completes");
+
+    let actor_a_tools_call = actor_a
+        .captured_network_requests_for_test()
+        .into_iter()
+        .find(|request| {
+            serde_json::from_slice::<serde_json::Value>(&request.body)
+                .ok()
+                .is_some_and(|body| {
+                    body["method"] == "tools/call"
+                        && body["params"]["arguments"]["query"] == "actor-a-provider-query"
+                })
+        })
+        .expect("actor A provider request was observed");
+    assert!(
+        actor_a_tools_call.headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("authorization")
+                && value == &format!("Bearer {ACTOR_A_TOKEN}")
+        }),
+        "actor A request must carry actor A's exact provider account"
+    );
+
+    let actor_b = group
+        .thread("nearai-provider-account-actor-b")
+        .with_actor_id("nearai-provider-account-distinct-actor-b")
+        .script([RebornScriptedReply::tool_call(
+            "builtin.extension_install",
+            serde_json::json!({"extension_id": "nearai"}),
+        )])
+        .build()
+        .await
+        .expect("actor B lifecycle thread builds");
+    assert_ne!(
+        actor_a.binding.subject_user_id, actor_b.binding.subject_user_id,
+        "the isolation test requires distinct authenticated actors"
+    );
+    actor_b
+        .submit_turn_until_auth_blocked("install NEAR AI search for actor B")
+        .await
+        .expect("actor B must block on its own missing provider account");
+    assert!(
+        actor_b.captured_network_requests_for_test().is_empty(),
+        "actor B must not reach hosted MCP with actor A's provider account"
+    );
+}
+
 /// Core slice-6 scenario: a scripted MCP tool call round-trips through the real
 /// MCP runtime to the loopback mock server, and the invocation is recorded.
 #[tokio::test]

--- a/tests/integration/mcp.rs
+++ b/tests/integration/mcp.rs
@@ -13,6 +13,7 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
+use ironclaw_network::NetworkHttpRequest;
 use reborn_support::assertions::ToolErrorClass;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::group::RebornIntegrationGroup;
@@ -48,6 +49,38 @@ fn assert_recorded_tools_call(server: &MockMcpServer, expected_tool: &str, expec
             .and_then(|q| q.as_str()),
         Some(expected_query)
     );
+}
+
+fn observed_hosted_mcp_tools_call<'a>(
+    requests: &'a [NetworkHttpRequest],
+    expected_query: &str,
+) -> (&'a NetworkHttpRequest, serde_json::Value) {
+    let (request, body) = requests
+        .iter()
+        .filter_map(|request| {
+            serde_json::from_slice::<serde_json::Value>(&request.body)
+                .ok()
+                .map(|body| (request, body))
+        })
+        .find(|(_, body)| {
+            body["method"] == "tools/call"
+                && body["params"]["arguments"]["query"] == expected_query
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "no hosted MCP tools/call for {expected_query:?} captured across {} redacted request(s)",
+                requests.len()
+            )
+        });
+    assert!(
+        request.headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("authorization")
+                && value.starts_with("Bearer ")
+                && value.len() > "Bearer ".len()
+        }),
+        "hosted MCP tools/call must carry a mediated bearer credential"
+    );
+    (request, body)
 }
 
 /// The bundled `nearai` package is hosted MCP rather than Emulate-backed.
@@ -103,36 +136,8 @@ async fn nearai_web_search_dispatches_through_bundled_hosted_mcp() {
         .expect("hosted MCP response reached the model-facing result");
 
     let requests = h.captured_network_requests_for_test();
-    let tools_call = requests
-        .iter()
-        .find(|request| {
-            serde_json::from_slice::<serde_json::Value>(&request.body)
-                .ok()
-                .and_then(|body| body["method"].as_str().map(str::to_owned))
-                .as_deref()
-                == Some("tools/call")
-        })
-        .unwrap_or_else(|| {
-            panic!(
-                "no hosted MCP tools/call captured across {} redacted request(s)",
-                requests.len()
-            )
-        });
-    let body: serde_json::Value =
-        serde_json::from_slice(&tools_call.body).expect("tools/call body is JSON");
+    let (_, body) = observed_hosted_mcp_tools_call(&requests, "IronClaw capability evidence");
     assert_eq!(body["params"]["name"], "web_search");
-    assert_eq!(
-        body["params"]["arguments"]["query"],
-        "IronClaw capability evidence"
-    );
-    assert!(
-        tools_call.headers.iter().any(|(name, value)| {
-            name.eq_ignore_ascii_case("authorization")
-                && value.starts_with("Bearer ")
-                && value.len() > "Bearer ".len()
-        }),
-        "hosted MCP tools/call must carry a mediated bearer credential"
-    );
 }
 
 /// The bundled hosted-MCP path also preserves an authenticated, successful
@@ -175,30 +180,7 @@ async fn nearai_web_search_empty_result_dispatches_through_bundled_hosted_mcp() 
         .expect("canonical NEAR AI capability dispatched");
 
     let requests = h.captured_network_requests_for_test();
-    let tools_call = requests
-        .iter()
-        .find(|request| {
-            serde_json::from_slice::<serde_json::Value>(&request.body)
-                .ok()
-                .is_some_and(|body| {
-                    body["method"] == "tools/call"
-                        && body["params"]["arguments"]["query"] == "NEARAI_EMPTY_PROVIDER_RESULT"
-                })
-        })
-        .unwrap_or_else(|| {
-            panic!(
-                "no empty-result hosted MCP tools/call captured across {} redacted request(s)",
-                requests.len()
-            )
-        });
-    assert!(
-        tools_call.headers.iter().any(|(name, value)| {
-            name.eq_ignore_ascii_case("authorization")
-                && value.starts_with("Bearer ")
-                && value.len() > "Bearer ".len()
-        }),
-        "hosted MCP tools/call must carry a mediated bearer credential"
-    );
+    observed_hosted_mcp_tools_call(&requests, "NEARAI_EMPTY_PROVIDER_RESULT");
 
     let output = h
         .tool_result_output("nearai.web_search")
@@ -257,18 +239,9 @@ async fn nearai_hosted_mcp_isolates_provider_accounts_across_actors() {
         .await
         .expect("actor A provider read completes");
 
-    let actor_a_tools_call = actor_a
-        .captured_network_requests_for_test()
-        .into_iter()
-        .find(|request| {
-            serde_json::from_slice::<serde_json::Value>(&request.body)
-                .ok()
-                .is_some_and(|body| {
-                    body["method"] == "tools/call"
-                        && body["params"]["arguments"]["query"] == "actor-a-provider-query"
-                })
-        })
-        .expect("actor A provider request was observed");
+    let actor_a_requests = actor_a.captured_network_requests_for_test();
+    let (actor_a_tools_call, _) =
+        observed_hosted_mcp_tools_call(&actor_a_requests, "actor-a-provider-query");
     assert!(
         actor_a_tools_call.headers.iter().any(|(name, value)| {
             name.eq_ignore_ascii_case("authorization")

--- a/tests/integration/support/group_constructors.rs
+++ b/tests/integration/support/group_constructors.rs
@@ -18,6 +18,11 @@ use super::{
     RebornIntegrationGroupBuilder,
 };
 
+enum CapabilityDispatchScope {
+    CanonicalOwner,
+    RunOwner,
+}
+
 /// Shared "align user to the group's canonical binding subject, then build"
 /// step for the preset constructors below whose capability executes under
 /// the group's resolved binding user rather than a fixed constructor test
@@ -332,7 +337,7 @@ impl RebornIntegrationGroupBuilder {
     pub async fn extension_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
         self.extension_lifecycle_with_profile(
             super::super::harness::profiles::extension::extension_lifecycle_tools_profile_for_user,
-            false,
+            CapabilityDispatchScope::CanonicalOwner,
         )
         .await
     }
@@ -342,7 +347,7 @@ impl RebornIntegrationGroupBuilder {
     pub async fn extension_lifecycle_multiuser(self) -> HarnessResult<RebornIntegrationGroup> {
         self.extension_lifecycle_with_profile(
             super::super::harness::profiles::extension::extension_lifecycle_tools_profile_for_user,
-            true,
+            CapabilityDispatchScope::RunOwner,
         )
         .await
     }
@@ -360,7 +365,7 @@ impl RebornIntegrationGroupBuilder {
     ) -> HarnessResult<RebornIntegrationGroup> {
         self.extension_lifecycle_with_profile(
             super::super::harness::profiles::extension::extension_lifecycle_tools_profile_google_oauth_configured_for_user,
-            false,
+            CapabilityDispatchScope::CanonicalOwner,
         )
         .await
     }
@@ -372,7 +377,7 @@ impl RebornIntegrationGroupBuilder {
     async fn extension_lifecycle_with_profile(
         mut self,
         profile_for_user: fn(&str) -> HarnessResult<ToolsProfile>,
-        run_owner_scoped_dispatch: bool,
+        dispatch_scope: CapabilityDispatchScope,
     ) -> HarnessResult<RebornIntegrationGroup> {
         let base = self.build_base().await?;
         // Lifecycle ownership is caller-derived. Build the profile with the
@@ -384,7 +389,7 @@ impl RebornIntegrationGroupBuilder {
         let subject_user = base.canonical_subject_user()?;
         let profile = profile_for_user(subject_user.as_str())?;
         let mut host_runtime = build_group_capability_with_base(profile, &base).await?;
-        if run_owner_scoped_dispatch {
+        if matches!(dispatch_scope, CapabilityDispatchScope::RunOwner) {
             host_runtime = host_runtime.with_run_owner_scoped_capability_dispatch();
         }
         // C-SLACK-LIFECYCLE (issue #6105): wire the REAL generic

--- a/tests/integration/support/group_constructors.rs
+++ b/tests/integration/support/group_constructors.rs
@@ -74,6 +74,13 @@ impl RebornIntegrationGroup {
         Self::builder().extension_lifecycle().await
     }
 
+    /// Extension-lifecycle group whose credential resolution follows each
+    /// run owner. Used to prove one actor cannot dispatch with another
+    /// actor's provider account.
+    pub async fn extension_lifecycle_multiuser() -> HarnessResult<Self> {
+        Self::builder().extension_lifecycle_multiuser().await
+    }
+
     /// Extension-lifecycle group extended with the invented-vendor fixture
     /// (native factory + on-disk assets): drives the full generic runtime
     /// path — install → dispatch-from-snapshot → remove — with
@@ -325,6 +332,17 @@ impl RebornIntegrationGroupBuilder {
     pub async fn extension_lifecycle(self) -> HarnessResult<RebornIntegrationGroup> {
         self.extension_lifecycle_with_profile(
             super::super::harness::profiles::extension::extension_lifecycle_tools_profile_for_user,
+            false,
+        )
+        .await
+    }
+
+    /// Multi-actor extension lifecycle with provider credentials resolved
+    /// from the run owner rather than the group-canonical actor.
+    pub async fn extension_lifecycle_multiuser(self) -> HarnessResult<RebornIntegrationGroup> {
+        self.extension_lifecycle_with_profile(
+            super::super::harness::profiles::extension::extension_lifecycle_tools_profile_for_user,
+            true,
         )
         .await
     }
@@ -342,6 +360,7 @@ impl RebornIntegrationGroupBuilder {
     ) -> HarnessResult<RebornIntegrationGroup> {
         self.extension_lifecycle_with_profile(
             super::super::harness::profiles::extension::extension_lifecycle_tools_profile_google_oauth_configured_for_user,
+            false,
         )
         .await
     }
@@ -353,6 +372,7 @@ impl RebornIntegrationGroupBuilder {
     async fn extension_lifecycle_with_profile(
         mut self,
         profile_for_user: fn(&str) -> HarnessResult<ToolsProfile>,
+        run_owner_scoped_dispatch: bool,
     ) -> HarnessResult<RebornIntegrationGroup> {
         let base = self.build_base().await?;
         // Lifecycle ownership is caller-derived. Build the profile with the
@@ -363,7 +383,10 @@ impl RebornIntegrationGroupBuilder {
         // otherwise credential-ready installs on auth.
         let subject_user = base.canonical_subject_user()?;
         let profile = profile_for_user(subject_user.as_str())?;
-        let host_runtime = build_group_capability_with_base(profile, &base).await?;
+        let mut host_runtime = build_group_capability_with_base(profile, &base).await?;
+        if run_owner_scoped_dispatch {
+            host_runtime = host_runtime.with_run_owner_scoped_capability_dispatch();
+        }
         // C-SLACK-LIFECYCLE (issue #6105): wire the REAL generic
         // channel-connection service over this harness's own `RebornServices`,
         // mirroring the production `build_reborn_runtime` slot fill — so

--- a/tests/integration/support/harness/profiles/extension.rs
+++ b/tests/integration/support/harness/profiles/extension.rs
@@ -98,12 +98,22 @@ fn hosted_mcp_discovery_fixture_response(
                 "annotations": {"readOnlyHint": true}
             }]
         }),
-        "tools/call" if is_nearai => serde_json::json!({
-            "content": [{
-                "type": "text",
-                "text": "REBORN_NEARAI_WEB_SEARCH_RESULT"
-            }]
-        }),
+        "tools/call" if is_nearai => {
+            let is_empty_query = body
+                .pointer("/params/arguments/query")
+                .and_then(serde_json::Value::as_str)
+                == Some("NEARAI_EMPTY_PROVIDER_RESULT");
+            serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": if is_empty_query {
+                        "[]"
+                    } else {
+                        "REBORN_NEARAI_WEB_SEARCH_RESULT"
+                    }
+                }]
+            })
+        }
         _ => return None,
     };
     let response = serde_json::to_vec(&serde_json::json!({

--- a/tests/integration/web_access.rs
+++ b/tests/integration/web_access.rs
@@ -111,6 +111,69 @@ async fn web_search_dispatches_through_scripted_exa_mcp() {
         .expect("scripted MCP search result surfaced back to the model");
 }
 
+/// An empty Exa search is a successful provider outcome, not a transport
+/// failure. The contract observes all three wire requests and the structured
+/// empty result returned through the production executor.
+#[tokio::test]
+async fn web_search_empty_result_dispatches_through_scripted_exa_mcp() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_web_access_tools([
+            MCP_INIT_BODY.to_vec(),
+            MCP_NOTIF_BODY.to_vec(),
+            mcp_tool_call_result_body(""),
+        ])
+        .script([
+            RebornScriptedReply::tool_call(
+                "web-access.search",
+                json!({"query": "provider-empty-search-sentinel"}),
+            ),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness
+        .submit_turn("search for the provider-empty-search-sentinel")
+        .await
+        .expect("empty search turn completes");
+
+    harness
+        .assert_tool_invoked("web-access.search")
+        .await
+        .expect("capability dispatched through the real executor");
+    harness
+        .assert_egress_count(3)
+        .await
+        .expect("initialize, initialized, and tools/call were observed");
+    harness
+        .assert_egress_body_contains_any(
+            ironclaw_first_party_extensions::EXA_MCP_HOST,
+            "web_search_exa",
+        )
+        .await
+        .expect("observed request names the provider operation");
+    harness
+        .assert_egress_body_contains_any(
+            ironclaw_first_party_extensions::EXA_MCP_HOST,
+            "provider-empty-search-sentinel",
+        )
+        .await
+        .expect("observed request carries the exact query");
+
+    let output = harness
+        .tool_result_output("web-access.search")
+        .await
+        .expect("empty provider result was recorded");
+    assert_eq!(output["provider_used"], "exa_mcp");
+    assert_eq!(
+        output["queries"][0]["query"],
+        "provider-empty-search-sentinel"
+    );
+    assert_eq!(output["queries"][0]["answer"], "");
+    assert_eq!(output["queries"][0]["results"], json!([]));
+}
+
 /// `web-access.get_content` dispatches through the real `WebAccessExecutor`
 /// (the `web_fetch_exa` MCP tool) over the same scripted handshake shape.
 #[tokio::test]
@@ -162,6 +225,61 @@ async fn get_content_dispatches_through_scripted_exa_mcp() {
         .assert_tool_result_contains("This domain is for illustrative examples in documents.")
         .await
         .expect("scripted MCP fetch result surfaced back to the model");
+}
+
+/// A fetched document with no body remains a successful, observed provider
+/// response and preserves the requested destination with empty content.
+#[tokio::test]
+async fn get_content_empty_result_dispatches_through_scripted_exa_mcp() {
+    let url = "https://empty.example/provider-contract";
+    let harness = RebornIntegrationHarness::test_default()
+        .with_web_access_tools([
+            MCP_INIT_BODY.to_vec(),
+            MCP_NOTIF_BODY.to_vec(),
+            mcp_tool_call_result_body(&format!("# Empty Provider Document\nURL: {url}\n")),
+        ])
+        .script([
+            RebornScriptedReply::tool_call("web-access.get_content", json!({"url": url})),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness
+        .submit_turn("fetch the empty provider contract document")
+        .await
+        .expect("empty content turn completes");
+
+    harness
+        .assert_tool_invoked("web-access.get_content")
+        .await
+        .expect("capability dispatched through the real executor");
+    harness
+        .assert_egress_count(3)
+        .await
+        .expect("initialize, initialized, and tools/call were observed");
+    harness
+        .assert_egress_body_contains_any(
+            ironclaw_first_party_extensions::EXA_MCP_HOST,
+            "web_fetch_exa",
+        )
+        .await
+        .expect("observed request names the provider operation");
+    harness
+        .assert_egress_body_contains_any(ironclaw_first_party_extensions::EXA_MCP_HOST, url)
+        .await
+        .expect("observed request carries the exact destination");
+
+    let output = harness
+        .tool_result_output("web-access.get_content")
+        .await
+        .expect("empty provider content was recorded");
+    assert_eq!(output["provider_used"], "exa_mcp");
+    assert_eq!(output["title"], "Empty Provider Document");
+    assert_eq!(output["url"], url);
+    assert_eq!(output["content"], "");
+    assert_eq!(output["contents"][0]["content"], "");
 }
 
 /// Format-matrix regression (C-WIREFMT): the Exa MCP server answers


### PR DESCRIPTION
## Summary

- Regenerates the production-derived provider denominator and removes the WS5 backlog: all 52 shipped provider reads have both seeded success and empty-result contracts, with zero unexplained gaps.
- Expands the provider-owned operation registry to 168 cases across Gmail, Google Calendar/Docs/Drive/Sheets/Slides, GitHub, and Slack. All 70 shipped mutations now have typed operation cases with exact destination/content/outcome oracles and provider-side readback.
- Makes every full-path operation require observed authenticated provider requests, exact request/mutation counts, successful provider responses, and the expected provider/account fingerprint; adds fail-loud sabotage tests for missing, duplicate, wrong-provider, wrong-account, non-forwarded, non-responded, and failed requests.
- Adds real extension-boundary empty-result coverage for NearAI and Exa-backed web access, plus authenticated actor/account isolation and tenant-scoped credential regression coverage.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524

Overlap audit: #6831 remains open/conflicted and covers Slack-specific work. This PR reuses the current-main provider contract framework and adds the residual operation matrix without importing or duplicating that PR's product changes.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not selected locally by the testing playbook for test-only changes; scoped touched-target clippy passed with `-D warnings`, and the PR's all-features CI check is required before readiness.
- [x] `cargo build -p ironclaw --bin ironclaw`
- [x] Relevant tests pass: 168 provider operation cases; 60 inventory/proxy/sabotage contracts; 44 touched Rust integration tests; tenant credential isolation unit contract; the current-main architecture regression.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: no database-backed product behavior changed; the specific real-boundary integration targets were run.
- [x] Manual testing: regenerated the live capability matrix (`provider_reads=52 provider_writes=70 typed_operation_cases=168 explained_read_gaps=0 write_gaps=0`) and ran the pinned Emulate provider matrix end to end.
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — `pr-shepherd` workflow plus a maintainer-quality full-diff review completed; the review found six journey-only mutation gaps, which are fixed in the second commit.

## Test Strategy

User behavior:

No shipping behavior changes. This closes the WS5 verification gap so provider operations cannot appear green without a real observed provider request and meaningful provider outcome.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: outcome-aware inventory ratchet and request-evidence sabotage tests.
- Reborn integration: NearAI success/empty and cross-actor account isolation; Exa search/fetch success/empty through real executors.
- Recorded fixture: Not applicable: provider state is seeded hermetically in Emulate/proxy modules; no recorded model/provider fixture changed.
- Browser E2E: Not applicable: provider contracts exercise authenticated API/runtime boundaries without browser behavior.
- Backend or runtime: full Reborn WebUI-to-extension provider matrix for all 168 typed operation cases.
- Live canary: Not applicable: hermetic provider emulation gives deterministic side-effect/readback evidence and avoids external credentials.

What the tests prove:

- Every shipped provider read has both success and empty-result behavior at an executable provider seam. The three non-typed reads (`nearai.web_search`, `web-access.search`, `web-access.get_content`) are explicitly owned by real-boundary integration tests rather than unexplained exceptions.
- Every shipped provider mutation has a typed operation case that observes the expected number of authenticated provider requests and a meaningful exact outcome, including provider-owned readback for actor/account, destination, important content, and mutation count.
- Authenticated actors cannot reuse another actor's provider account, and host-managed NearAI credentials remain tenant-isolated.
- Missing/duplicate dispatch, wrong service/account, bypassed proxy forwarding, missing response, failed upstream response, absent empty outcomes, and incorrect readback/count assertions fail loudly.

Commands run:

- `cargo build -p ironclaw --bin ironclaw`
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_web_access --test reborn_integration_mcp` (44 passed, rerun after final rebase)
- `cargo clippy -p ironclaw_reborn_integration_tests --test reborn_integration_web_access --test reborn_integration_mcp -- -D warnings` (rerun after final rebase)
- `cargo test -p ironclaw_auth resolver_does_not_share_host_managed_nearai_account_across_tenant` (1 passed, rerun after final rebase)
- `cargo test -p ironclaw_turns --lib process_projection::runtime::tests::retry_rejects_checkpoint_rejection_without_creating_a_process -- --exact` (1 passed; current-main architecture gate added during the final rebase)
- `uvx ruff check <all changed Python files>`
- `tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_product_surface_coverage.py tests/e2e/scenarios/test_provider_capability_inventory.py tests/e2e/scenarios/test_journey_coverage.py -q` (66 passed on current main; generated report: 123 capabilities, 23 journeys, 0 missing, 0 owned gaps)
- `cd tests/e2e && .venv/bin/pytest -q scenarios/test_provider_capability_inventory.py scenarios/test_provider_fault_proxy.py scenarios/test_provider_operation_types.py` (60 passed after review fixes)
- `cd tests/e2e && IRONCLAW_EMULATE_CLI=<pinned-emulate>/packages/emulate/dist/index.js .venv/bin/pytest -q scenarios/test_reborn_qa_trace_full_path.py -k provider_operation_case` (168 passed, 33 deselected, final provider-harness run after the WebUI harness rebase: 468.23s)
- `bash scripts/reborn-e2e-rust.sh` selected by the playbook: architecture and runtime groups passed through `process_host_contract`; the local linker then stopped with `errno=28` (disk full), not a test failure. After cleaning generated Cargo output, the remaining process contracts passed (45 assertions; documented Postgres variant skipped without a database URL) and `bash scripts/reborn-e2e-rust.sh substrates` passed in full. The current-main-added exact architecture test was then run separately after the final rebase.
- live matrix report: `provider_reads=52 provider_writes=70 typed_operation_cases=168 explained_read_gaps=0 write_gaps=0`

## Security Impact

Test-only. The new contracts verify mediated provider credentials by purpose-specific SHA-256 fingerprints emitted by the existing fault proxy, require non-null/single-account request evidence, and prove another authenticated actor cannot dispatch with the seeded actor's provider account. No permissions, network policy, secret storage, file access, sandbox policy, or production execution path changed.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? N/A to production; new evidence types live only in the E2E test registry/proxy.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. No prompt construction changed; cases use existing typed extension arguments.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Credential fingerprints are test-only SHA-256 identifiers matching the existing proxy evidence format, not authentication decisions.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. No production variants changed; the final base-to-head diff contains tests only.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. N/A: no serde or durable production fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. N/A: no production queues/maps/buffers/counters changed; request counts are bounded test expectations.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). N/A: no production error semantics changed.
- [x] Sandbox/native/host names accurately describe trust boundary. N/A: no production boundary names changed; integration tests use the existing hosted MCP and mediated network paths.

## Database Impact

None. No migration, schema, PostgreSQL, or libSQL behavior changes.

## Blast Radius

Test infrastructure under `tests/e2e` and `tests/integration`. The principal risk is provider emulator drift or an incorrectly counted multi-request operation causing a deterministic contract failure. No shipping crates are modified.

Compatibility: no production API, manifest, persistence, wire-format, or default changes. Existing provider cases remain registered; the coverage gate becomes stricter and outcome-aware.

## Rollback Plan

Revert `f6fcf57a3`, `ace8a2d6f`, `f5ac8577b`, `638470796`, and `2016aee2c` (newest first). This restores the prior backlog and looser provider-operation assertions without data rollback or production redeployment.

## Review Follow-Through

- Maintainer self-review completed across the full base-to-head diff. It found six writes that still relied on journey-name evidence (`gmail.send_message`, Docs create/insert, Sheets create/append, Slack send); all now have typed provider request/readback/count contracts, and the inventory ratchet forbids future journey-only mutation exemptions. Review follow-up also pins Slack operations to the exact OAuth-bound account fingerprint without storing token material.
- #6831 was inspected for overlap; if it lands first, reconcile Slack case ownership/oracles rather than stacking duplicate product work.
- This PR resolves the proven WS5 residual only. It does not claim the full #6524 epic complete or recreate completed WS3/WS4/WS6 work.

---

**Review track**: A (docs/tests/chore)