### PR TITLE
Fix Windows clippy for legacy skill backfill imports

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -49,11 +49,11 @@ use crate::runtime_mounts::{
     ambient_workspace_mount_view, memory_mount_view, scoped_skill_context_mount_view,
     skill_management_mount_view, workspace_mount_view,
 };
-use crate::standalone_bootstrap_assembly::bootstrap_standalone_host;
+#[cfg(all(test, unix))]
+use crate::standalone_bootstrap_assembly::LEGACY_SKILLS_BACKFILL_MARKER;
 #[cfg(test)]
-use crate::standalone_bootstrap_assembly::{
-    LEGACY_SKILLS_BACKFILL_MARKER, backfill_legacy_user_skills,
-};
+use crate::standalone_bootstrap_assembly::backfill_legacy_user_skills;
+use crate::standalone_bootstrap_assembly::bootstrap_standalone_host;
 use crate::{
     RebornBuildError, RebornCompositionProfile, RebornHostBindings, RebornReadiness,
     RebornServiceReadiness, RebornWorkerReadiness,

--- a/crates/ironclaw_reborn_composition/src/standalone_bootstrap_assembly.rs
+++ b/crates/ironclaw_reborn_composition/src/standalone_bootstrap_assembly.rs
@@ -6,7 +6,7 @@ use crate::RebornBuildError;
 use crate::root::default_system_prompt::seed_default_system_prompt;
 
 const DEFAULT_SYSTEM_PROMPT_PATH: &str = "system/prompts/default-system.md";
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(crate) use ironclaw_extension_host::bundled_skills::LEGACY_SKILLS_BACKFILL_MARKER;
 const STANDALONE_LEGACY_SKILL_TENANTS: [&str; 2] = ["default", "reborn-cli"];
 


### PR DESCRIPTION
## Summary

- Gate the legacy skill backfill marker re-export and factory import with `cfg(all(test, unix))`.
- Keep the cross-platform backfill helper available under `cfg(test)`.
- Fix the deterministic Windows clippy failure introduced by #6691 without changing runtime behavior.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6691.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run workspace-wide; targeted composition lint commands below cover the changed crate and failing target.
- [ ] `cargo build` — not run separately; targeted clippy compiled the changed crate for Linux and Windows targets.
- [x] Relevant tests pass: `standalone_legacy_skill_backfill_marker_preserves_deletions` and Unix symlink coverage.
- [x] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: no database-backed or runtime behavior changed.
- [x] Manual testing: reproduced the Windows-target unused import chain and verified both default and all-feature Windows-target clippy after the fix.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; PR remains draft.

## Test Strategy

User behavior:

No user-visible behavior changes. Windows CI can compile the composition crate's tests without treating Unix-only marker imports as errors.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: No new test; the existing Unix-only backfill test is the compile-time contract that owns the marker import.
- Reborn integration: Not applicable: no runtime or cross-crate behavior changed.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Windows-target clippy was run with default and all features; Linux all-target/all-feature clippy also passed.
- Live canary: Not applicable: no provider or live-model behavior changed.

What the tests prove:

The legacy marker remains available to the Unix-only symlink regression test, while non-Unix test builds no longer compile unused marker imports or re-exports.

Commands run:

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_composition standalone_legacy_skill_backfill --all-features`
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --lib --tests --target x86_64-pc-windows-gnu -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --lib --tests --all-features --target x86_64-pc-windows-gnu -- -D warnings`
- `git diff --check`

## Security Impact

None. This changes only conditional compilation for test imports.

## Reborn Trust-Boundary Checklist

N/A: the diff only narrows test-only imports by operating system and changes no public types, policies, serialization, queues, errors, runtime lanes, or trust boundaries.

## Database Impact

None. No migration, schema, query, or backend behavior changed.

## Blast Radius

Limited to test compilation in `ironclaw_reborn_composition`. Production builds already excluded both imports through `cfg(test)`, and the backfill implementation is unchanged.

Compatibility: no runtime, wire, schema, configuration, or platform behavior changes.

Known unrelated CI state: the post-merge coverage workflow also reported pre-existing PostgreSQL ordered-index failures and an untouched browser coverage assertion; those are intentionally excluded from this deterministic Windows clippy fix.

## Rollback Plan

Revert commit `82843b21e`. No data or configuration cleanup is required.

## Review Follow-Through

Review should confirm that both ends of the test-only marker re-export are Unix-gated while `backfill_legacy_user_skills` remains cross-platform for its non-Unix test coverage.

---

**Review track**: C (CI/platform compatibility)