### PR TITLE
fix(ci): restore main coverage across PostgreSQL and workspace E2E

### DIFF
--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -2384,6 +2384,8 @@ const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = concat!(
     include_str!("../../../migrations/V32__root_filesystem_sequences.sql"),
     "\n",
     include_str!("../../../migrations/V33__root_filesystem_ordered_index_rows.sql"),
+    "\n",
+    include_str!("../../../migrations/V34__root_filesystem_ordered_index_path_collation.sql"),
 );
 
 #[cfg(test)]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -2592,10 +2592,7 @@ mod postgres_tests {
         let rows = fs
             .query_ordered(
                 &tenant_prefix,
-                &Filter::Eq {
-                    key: status.clone(),
-                    value: IndexValue::Text("queued".into()),
-                },
+                &Filter::All,
                 &ironclaw_filesystem::OrderedPage::new(
                     index_name,
                     status,

--- a/migrations/V34__root_filesystem_ordered_index_path_collation.sql
+++ b/migrations/V34__root_filesystem_ordered_index_path_collation.sql
@@ -1,0 +1,35 @@
+-- Keep ordered-projection path ranges bytewise, matching the authoritative
+-- root_filesystem_entries.path column.
+--
+-- Ordered queries use half-open descendant ranges. The database-default
+-- collation can order '/' and '0' differently from bytewise ordering, making
+-- an existing projected row invisible on databases initialized with locales
+-- such as en_US.utf8.
+--
+-- Compatibility: this changes only comparison/index ordering. Stored paths and
+-- projection rows are unchanged.
+--
+-- Rollback plan:
+-- 1. Stop writers and ordered readers.
+-- 2. Revert the column to the database-default collation:
+--      ALTER TABLE root_filesystem_ordered_index_rows
+--          ALTER COLUMN path TYPE TEXT COLLATE "default";
+-- 3. Recreate dependent indexes if PostgreSQL reports they were rebuilt or
+--    invalidated by the ALTER COLUMN operation.
+
+DO $$
+BEGIN
+    IF to_regclass('root_filesystem_ordered_index_rows') IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM pg_attribute
+            WHERE attrelid = to_regclass('root_filesystem_ordered_index_rows')
+                AND attname = 'path'
+                AND NOT attisdropped
+                AND attcollation <> 'pg_catalog."C"'::regcollation
+        )
+    THEN
+        ALTER TABLE root_filesystem_ordered_index_rows
+            ALTER COLUMN path TYPE TEXT COLLATE "C";
+    END IF;
+END $$;

--- a/tests/e2e/scenarios/test_reborn_v2_file_download.py
+++ b/tests/e2e/scenarios/test_reborn_v2_file_download.py
@@ -315,7 +315,9 @@ async def test_workspace_tree_keyboard_navigation_and_accessibility(
     await expect(report).to_have_attribute("aria-selected", "true")
     await expect(report).to_have_attribute("tabindex", "0")
     assert await tree.locator('[role="treeitem"][tabindex="0"]').count() == 1
-    await expect(guide).to_have_count(0)
+    await expect(guide).to_be_visible()
+    await expect(guide).to_have_attribute("aria-selected", "false")
+    await expect(guide).to_have_attribute("tabindex", "-1")
 
     # Directory-load errors are live alerts, so they are announced without a
     # separate pointer interaction.


### PR DESCRIPTION
## Summary

- add a forward PostgreSQL migration that gives ordered-projection paths the same bytewise `"C"` collation as authoritative filesystem paths
- repair the long-prefix ordered-query contract case so it uses a valid ordering shape
- update the workspace accessibility scenario to assert preserved branch expansion and a single roving tab stop
- fix the Code Coverage failures observed on main after #6890

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6890

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: full `ironclaw_filesystem` crate suite against PostgreSQL; the exact filesystem suite under LLVM coverage; the failing Playwright scenario
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: applied V34 idempotently to an already-populated `pgvector/pgvector:pg16` database and verified the projection path collation is `C`; also applied the embedded migration chain to a fresh database
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional lint evidence: `cargo clippy -p ironclaw_filesystem --all-targets --all-features -- -D warnings`.

## Test Strategy

User behavior: Ordered filesystem queries return projected descendants consistently regardless of the PostgreSQL database locale. Selecting a workspace file keeps manually expanded sibling branches visible while maintaining one keyboard tab stop.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: updated `postgres_ordered_index_projects_rows_under_long_prefixes`; existing keyset and no-backfill PostgreSQL contracts reproduce the locale regression and pass after V34.
- Reborn integration: Not applicable: no turn, runner, capability, or product-orchestration behavior changed.
- Recorded fixture: Not applicable: no model request or tool-choice behavior changed.
- Browser E2E: updated `test_workspace_tree_keyboard_navigation_and_accessibility` to assert the preserved expanded item remains visible, unselected, and outside the roving tab stop.
- Backend or runtime: ran the full filesystem crate against PostgreSQL and the complete DB contract test binary under LLVM coverage using the same `pgvector/pgvector:pg16` image as CI.
- Live canary: Not applicable: the failure is hermetically reproducible with local PostgreSQL and Playwright fixtures.

What the tests prove: V34 repairs bytewise descendant ranges on both fresh and populated locale-backed databases; ordered projections remain write-maintained without backfill; valid keyset pagination returns rows; the workspace tree preserves expansion without creating a second tab stop.

Commands run:

- `DATABASE_URL=postgres://... IRONCLAW_REQUIRE_POSTGRES=1 cargo llvm-cov test -p ironclaw_filesystem --test db_root_filesystem_contract -- --nocapture`
- `DATABASE_URL=postgres://... IRONCLAW_REQUIRE_POSTGRES=1 cargo test -p ironclaw_filesystem`
- `python3 -m pytest tests/e2e/scenarios/test_reborn_v2_file_download.py::test_workspace_tree_keyboard_navigation_and_accessibility -v --timeout=120`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p ironclaw_filesystem --all-targets --all-features -- -D warnings`

## Security Impact

None. This does not change permissions, network access, secrets, sandboxing, or tool execution.

## Reborn Trust-Boundary Checklist

N/A: this patch changes a PostgreSQL path collation migration and test assertions only. It introduces no trust-bearing types, prompt content, hashes, status/error variants, queues, drivers, or host/sandbox boundaries.

## Database Impact

Adds PostgreSQL migration V34. It changes `root_filesystem_ordered_index_rows.path` from the database-default collation to `"C"`, matching `root_filesystem_entries.path`. Stored values and projection rows are unchanged. PostgreSQL may rebuild the dependent primary-key index and takes the schema lock required by `ALTER COLUMN`; the migration is conditional and idempotent. libSQL is unaffected because its ordered path comparisons are already bytewise.

## Blast Radius

PostgreSQL ordered exact/prefix filesystem projections and the workspace-tree E2E assertion. The migration can briefly block concurrent access while PostgreSQL alters the column and rebuilds dependent indexes. No trait, dependency, serialization, or product contract changes.

## Rollback Plan

Revert the code/test commit after stopping ordered readers and writers, then apply the documented reverse DDL to restore `root_filesystem_ordered_index_rows.path` to `COLLATE "default"`; recreate dependent indexes if PostgreSQL reports them invalidated. Existing rows require no data conversion. Rolling back reintroduces locale-dependent descendant-query failures, so it is operationally safe only where the database default collation has compatible bytewise ordering.

## Review Follow-Through

Reviewer judgment requested on the migration lock window for unusually large ordered-projection tables. No data rewrite or backfill is introduced, and the exact main-coverage failures are reproduced and fixed locally.

---

**Review track**: C (DB/CI)