### PR TITLE
Fix PostgreSQL sequence range binding in coverage CI

### DIFF
--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1371,9 +1371,9 @@ async fn postgres_reserve_sequence_range_with_client(
         client,
         r#"
             INSERT INTO root_filesystem_sequences (path, next_seq, updated_at)
-            VALUES ($1, $2 + 1, NOW())
+            VALUES ($1, CAST($2 AS BIGINT) + 1, NOW())
             ON CONFLICT (path) DO UPDATE SET
-                next_seq = root_filesystem_sequences.next_seq + $2,
+                next_seq = root_filesystem_sequences.next_seq + CAST($2 AS BIGINT),
                 updated_at = NOW()
             RETURNING next_seq - 1 AS reserved
             "#,

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -2369,6 +2369,33 @@ mod postgres_tests {
     }
 
     #[tokio::test]
+    async fn postgres_transaction_reserves_i64_sequence_ranges_atomically() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let prefix_path = VirtualPath::new(&prefix).unwrap();
+        let sequence_path = vpath(&prefix, "sequence-range");
+        let mut transaction = fs.begin(&prefix_path).await.unwrap();
+
+        let first = transaction
+            .reserve_sequence_range(&sequence_path, 3)
+            .await
+            .unwrap();
+        let second = transaction
+            .reserve_sequence_range(&sequence_path, 2)
+            .await
+            .unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(first, SeqNo::from_backend(3));
+        assert_eq!(second, SeqNo::from_backend(5));
+        assert_eq!(
+            fs.reserve_sequence(&sequence_path).await.unwrap(),
+            SeqNo::from_backend(6)
+        );
+    }
+
+    #[tokio::test]
     async fn postgres_get_returns_none_for_missing_path() {
         let Some((fs, prefix)) = postgres_root().await else {
             return;


### PR DESCRIPTION
## Summary

- Cast PostgreSQL sequence-range parameters to `BIGINT` so the driver accepts the existing Rust `i64` binding.
- Add a PostgreSQL transaction regression test that reserves multiple ranges, commits, and verifies the next sequence.
- Fix the remaining default and all-features Code Coverage failures on `main` after #6893.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6893

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — focused equivalent passed: `cargo clippy -p ironclaw_filesystem --all-targets --all-features -- -D warnings`
- [ ] `cargo build` — covered by both complete workspace LLVM coverage builds below.
- [x] Relevant tests pass: `deployed_legacy_layouts_import_on_postgres` and `postgres_transaction_reserves_i64_sequence_ranges_atomically`
- [x] `cargo test --features integration` if database-backed or integration behavior changed — the all-features workspace coverage lane includes the integration feature and passed.
- [x] Manual testing: reproduced the original `error serializing parameter 1` against `pgvector/pgvector:pg16` before the patch, then reran both complete Code Coverage matrix commands successfully.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — draft PR; not requested yet.

## Test Strategy

User behavior: The Code Coverage workflow can import deployed legacy process layouts on PostgreSQL without failing while reserving a sequence range.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added `postgres_transaction_reserves_i64_sequence_ranges_atomically` to the filesystem PostgreSQL backend contract.
- Reborn integration: Existing `deployed_legacy_layouts_import_on_postgres` passed under LLVM coverage after reproducing its pre-fix failure.
- Recorded fixture: Not applicable: no model/provider fixture behavior changed.
- Browser E2E: Not applicable: no browser or frontend behavior changed.
- Backend or runtime: Ran both exact Code Coverage workspace matrix lanes against PostgreSQL 16, default features and all features.
- Live canary: Not applicable: the defect is deterministic PostgreSQL parameter typing and needs no live provider.

What the tests prove: PostgreSQL now accepts the `i64` range count, sequence reservations remain contiguous and atomic across a committed transaction, the legacy process migration succeeds, and both complete main coverage matrices reach LCOV report generation.

Commands run:

- `cargo llvm-cov test -p ironclaw_processes --test legacy_migration_backend_contract -- --nocapture`
- `cargo llvm-cov test -p ironclaw_filesystem --test db_root_filesystem_contract postgres_transaction_reserves_i64_sequence_ranges_atomically -- --nocapture`
- `cargo llvm-cov --workspace --lcov --output-path /tmp/ironclaw-default-lcov.info`
- `cargo llvm-cov --all-features --workspace --lcov --output-path /tmp/ironclaw-all-features-lcov.info`
- `cargo fmt --all -- --check`
- `cargo clippy -p ironclaw_filesystem --all-targets --all-features -- -D warnings`
- `git diff --check`

The PostgreSQL commands used `DATABASE_URL` against `pgvector/pgvector:pg16`, `IRONCLAW_DISABLE_OS_KEYCHAIN=1`, `CARGO_PROFILE_DEV_DEBUG=0`, `CARGO_PROFILE_TEST_DEBUG=0`, and `RUST_MIN_STACK=67108864`, matching the workflow environment.

## Security Impact

None. This does not change permissions, network calls, secrets, file access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no public or trust-bearing types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A; no prompt path changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: N/A; no hashing changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: N/A; no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: N/A; no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: the existing checked `u64` to `i64` conversion remains in place before SQL binding.
- [x] Driver/operator-visible errors have stable class semantics: no error classification changed.
- [x] Sandbox/native/host names accurately describe trust boundary: N/A; no runtime boundary names changed.

## Database Impact

No migration, schema, or stored-data change. The SQL now explicitly declares `$2` as PostgreSQL `BIGINT`, matching the existing `BIGINT` sequence column and Rust `i64` driver binding. libSQL behavior is unchanged.

## Blast Radius

Limited to PostgreSQL transactional sequence-range reservation. Direct single-sequence reservation and all non-PostgreSQL backends are unchanged. A regression here could affect event/process migrations that allocate ranges, which is why both complete workspace coverage matrices and a backend contract test were run.

## Rollback Plan

Revert commit `b6fb7661c`. This restores the prior implicit PostgreSQL parameter inference and therefore also restores the known coverage failure; there is no schema or data rollback.

## Review Follow-Through

Reviewer judgment is requested on the explicit `CAST($2 AS BIGINT)` placement in both insert and conflict-update expressions. No follow-up work is known.

---

**Review track**: C (DB/CI)