### PR TITLE
feat(slack): native /ironclaw slash commands (PR-3 of command train)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,6 +4844,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
  "uuid",

--- a/crates/ironclaw_extension_host/src/available_extensions.rs
+++ b/crates/ironclaw_extension_host/src/available_extensions.rs
@@ -2125,6 +2125,11 @@ input_schema_ref = "schemas/static-mcp/dynamic/run.input.v1.json"
             Some(40_000),
             "slack declares max_message_chars = 40000"
         );
+        assert_eq!(
+            presentation.command_prefix.as_deref(),
+            Some("/ironclaw "),
+            "slack declares a command_prefix so channel help renders /ironclaw-namespaced"
+        );
         let directions = summary
             .channel_directions
             .expect("unified slack summary carries channel directions");
@@ -2162,6 +2167,17 @@ input_schema_ref = "schemas/static-mcp/dynamic/run.input.v1.json"
                 .commands,
             ["model", "status"],
             "shipping Telegram exposes exactly the model and status commands"
+        );
+        assert_eq!(
+            package
+                .resolved_manifest
+                .channel
+                .as_ref()
+                .expect("telegram channel descriptor")
+                .presentation
+                .command_prefix,
+            None,
+            "telegram stays prefix-free; its channel help renders bare /model, /status"
         );
     }
 

--- a/crates/ironclaw_extension_host/src/channel_host.rs
+++ b/crates/ironclaw_extension_host/src/channel_host.rs
@@ -1031,13 +1031,18 @@ impl GenericChannelHostAssembly {
             .as_ref()
             .map(|channel| channel.commands.as_slice())
             .unwrap_or_default();
+        let command_prefix = source
+            .resolved()
+            .channel
+            .as_ref()
+            .and_then(|channel| channel.presentation.command_prefix.as_deref());
         let observer = Arc::new(
             RunDeliveryObserver::with_settings_and_connection_notices(
                 services,
                 delivery.settings,
                 connection_notices.clone(),
             )
-            .with_enabled_commands(enabled_commands.iter().map(String::as_str)),
+            .with_enabled_commands(enabled_commands.iter().map(String::as_str), command_prefix),
         );
         Ok(Arc::new(RunDeliveryPostAdmissionObserver {
             observer,

--- a/crates/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -4921,9 +4921,9 @@ async fn unknown_dm_slash_command_returns_inventory_help_without_a_turn() {
 
     let feedback =
         wait_for_post_messages_matching(&harness.egress, "command inventory help", |payload| {
-            payload["text"]
-                .as_str()
-                .is_some_and(|text| text == "Available commands:\n/model\n/status")
+            payload["text"].as_str().is_some_and(|text| {
+                text == "Available commands:\n/ironclaw model\n/ironclaw status"
+            })
         })
         .await;
     let text = feedback[0]["text"].as_str().expect("feedback text");
@@ -4959,7 +4959,9 @@ async fn disabled_dm_slash_commands_are_rejected_without_execution() {
     let scoped_help = harness
         .slack_messages()
         .into_iter()
-        .filter(|payload| payload["text"] == "Available commands:\n/model\n/status")
+        .filter(|payload| {
+            payload["text"] == "Available commands:\n/ironclaw model\n/ironclaw status"
+        })
         .count();
     assert_eq!(scoped_help, 2, "one scoped rejection per disabled command");
     assert!(harness.command_executions.invokes().is_empty());

--- a/crates/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -265,6 +265,45 @@ impl Harness {
             .expect("router should respond") // safety: in-process test router should not fail
     }
 
+    /// Identical to [`Self::post_event_with_signature`], but for the native
+    /// slash-command form transport (PR-3): Slack's slash POSTs (and the
+    /// `ssl_check` probe) carry `Content-Type:
+    /// application/x-www-form-urlencoded`, which the Events API JSON helpers
+    /// above never set (axum defaults to no content-type header when none is
+    /// given). The HMAC recipe signs raw body bytes regardless of shape, so
+    /// this signs `form_body` with the exact same [`slack_signature`] recipe
+    /// and sets the content-type explicitly so the adapter's Content-Type
+    /// branch actually dispatches to the form-decoding path under test.
+    async fn post_slash_command_with_signature(
+        &self,
+        form_body: &str,
+        timestamp: u64,
+        signature: String,
+    ) -> axum::response::Response {
+        self.mount
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SLACK_EVENTS_PATH)
+                    .header(SLACK_TIMESTAMP_HEADER, timestamp.to_string())
+                    .header(SLACK_SIGNATURE_HEADER, signature)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(form_body.to_string().into_bytes()))
+                    .expect("request should build"), // safety: static test request fixtures are valid.
+            )
+            .await
+            .expect("router should respond") // safety: in-process test router should not fail
+    }
+
+    async fn post_slash_command(&self, form_body: &str) -> axum::response::Response {
+        let timestamp = current_unix_timestamp();
+        let signature = slack_signature(timestamp, form_body);
+        self.post_slash_command_with_signature(form_body, timestamp, signature)
+            .await
+    }
+
     async fn drain(&self) {
         self.ingress.registry.drain().await;
     }
@@ -5035,6 +5074,190 @@ async fn shared_channel_slash_command_is_denied_with_notice() {
     )
     .await;
     assert_eq!(feedback[0]["channel"], "C123");
+    assert!(harness.command_executions.invokes().is_empty());
+    assert_eq!(harness.coordinator.submitted_turn_count(), 0);
+}
+
+// ── native slash-command dispatcher, signed form bodies (PR-3 Task 3) ──────
+//
+// The JSON-based `dm_slash_command_executes_and_delivers_rendered_result` /
+// `unknown_dm_slash_command_returns_inventory_help_without_a_turn` /
+// `shared_channel_slash_command_is_denied_with_notice` scenarios above pin
+// the SAME production behavior driven through Slack's Events API message
+// shape. These scenarios drive the identical behavior through Slack's real
+// slash-command transport: a signed `application/x-www-form-urlencoded` POST
+// to the SAME ingress route, decoded by `normalize_slack_slash_command`
+// (Task 1) and rendered through the manifest's `/ironclaw `-prefixed help
+// text (Task 2).
+
+/// `/ironclaw status` posted as a signed slash-command form in the bound DM
+/// (`U123`/`D123`) must cross the production channel graph exactly like the
+/// Events-API path: one `product.status.command` invoke as the bound user,
+/// rendered Status feedback delivered to the DM, and no turn submitted.
+#[tokio::test]
+async fn slash_dispatcher_dm_status_executes_and_delivers_result() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "unused".to_string(),
+    })
+    .await;
+
+    let response = harness
+        .post_slash_command(
+            "command=%2Fironclaw&text=status&channel_id=D123&channel_name=directmessage&user_id=U123&team_id=T-A&trigger_id=111.222.slash-status",
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+
+    let feedback = wait_for_post_messages_matching(
+        &harness.egress,
+        "rendered slash command result",
+        |payload| {
+            payload["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("Status"))
+        },
+    )
+    .await;
+    let invokes = harness.command_executions.invokes();
+    assert_eq!(invokes.len(), 1, "exactly one command operation invoke");
+    assert_eq!(invokes[0].0, "product.status.command");
+    assert_eq!(invokes[0].1, USER, "caller is the bound user");
+    assert_eq!(feedback[0]["channel"], CHANNEL);
+    assert_eq!(
+        harness.coordinator.submitted_turn_count(),
+        0,
+        "product commands are not turns"
+    );
+}
+
+/// A bare `/ironclaw` slash invocation (empty `text`) in the DM must render
+/// the SAME manifest-prefixed help text `dm_slash_command`'s sibling JSON
+/// scenario pins (`unknown_dm_slash_command_returns_inventory_help_without_a_turn`),
+/// proving Task 1's dispatcher mapping (`empty text -> "/help"`) and Task 2's
+/// `/ironclaw `-prefixed rendering compose end-to-end over the real form
+/// transport.
+#[tokio::test]
+async fn slash_dispatcher_bare_returns_prefixed_help() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "unused".to_string(),
+    })
+    .await;
+
+    let response = harness
+        .post_slash_command(
+            "command=%2Fironclaw&text=&channel_id=D123&channel_name=directmessage&user_id=U123&trigger_id=111.222.slash-bare",
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+
+    let feedback = wait_for_post_messages_matching(
+        &harness.egress,
+        "prefixed command inventory help",
+        |payload| {
+            payload["text"].as_str().is_some_and(|text| {
+                text == "Available commands:\n/ironclaw model\n/ironclaw status"
+            })
+        },
+    )
+    .await;
+    assert_eq!(feedback[0]["channel"], CHANNEL);
+    assert!(harness.command_executions.invokes().is_empty());
+    assert_eq!(harness.coordinator.submitted_turn_count(), 0);
+}
+
+/// A slash invocation from OUTSIDE the DM (`channel_name=general`, a
+/// `C`-prefixed `channel_id`) must derive a non-`DirectChat` trigger (Task
+/// 1's DM-detection fix) and hit the SAME direct-conversation-only admission
+/// gate the JSON `shared_channel_slash_command_is_denied_with_notice`
+/// scenario pins — `post_command_feedback` addresses the rejection notice at
+/// `envelope.external_conversation_ref()` directly (verified by reading
+/// `crates/ironclaw_product/src/run_delivery/observer.rs`), independent of
+/// any shared-conversation binding/allowlist resolution, so the notice
+/// targets the invoking channel even though `C777` is never configured on
+/// `slack_allowed_channels` (only `C123` is). No command executes and no
+/// turn is submitted.
+#[tokio::test]
+async fn slash_dispatcher_outside_dm_is_rejected_direct_only() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "unused".to_string(),
+    })
+    .await;
+
+    let response = harness
+        .post_slash_command(
+            "command=%2Fironclaw&text=status&channel_id=C777&channel_name=general&user_id=U123&trigger_id=111.222.slash-outside",
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+
+    let feedback = wait_for_post_messages_matching(
+        &harness.egress,
+        "direct-conversation slash command denial",
+        |payload| {
+            payload["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("direct conversation"))
+        },
+    )
+    .await;
+    assert_eq!(
+        feedback[0]["channel"], "C777",
+        "the denial notice targets the invoking (non-DM, non-allowlisted) channel"
+    );
+    assert!(harness.command_executions.invokes().is_empty());
+    assert_eq!(harness.coordinator.submitted_turn_count(), 0);
+}
+
+/// A syntactically valid slash form with a forged `X-Slack-Signature` must be
+/// rejected at the SAME HMAC verification layer the JSON
+/// `slack_events_rejects_forged_hmac_signature` scenario pins — content-type
+/// branching happens strictly after verification (`ingress/router.rs`'s
+/// verify-then-parse order), so a form body never reaches the adapter at
+/// all: nothing is admitted, no notice is posted, no command executes, no
+/// turn is submitted.
+#[tokio::test]
+async fn slash_form_with_forged_signature_is_rejected() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "must not send".to_string(),
+    })
+    .await;
+
+    let response = harness
+        .post_slash_command_with_signature(
+            "command=%2Fironclaw&text=status&channel_id=D123&channel_name=directmessage&user_id=U123&trigger_id=111.222.slash-forged",
+            current_unix_timestamp(),
+            "v0=deadbeef".to_string(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    harness.drain().await;
+    assert!(harness.slack_messages().is_empty());
+    assert!(harness.command_executions.invokes().is_empty());
+    assert_eq!(harness.coordinator.submitted_turn_count(), 0);
+}
+
+/// Slack's endpoint-verification `ssl_check` probe (form-encoded, distinct
+/// from the Events API's JSON `url_verification` challenge) must get an
+/// immediate empty 200 straight from the adapter (Task 1's
+/// `SlackInboundEvent::SslCheck` arm) WITHOUT ever reaching durable
+/// admission: no `chat.postMessage`, no command-surface invoke, no turn.
+#[tokio::test]
+async fn ssl_check_form_gets_empty_200_without_admission() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "unused".to_string(),
+    })
+    .await;
+
+    let response = harness.post_slash_command("ssl_check=1&token=x").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_body(response, "").await;
+    harness.drain().await;
+    assert!(harness.slack_messages().is_empty());
     assert!(harness.command_executions.invokes().is_empty());
     assert_eq!(harness.coordinator.submitted_turn_count(), 0);
 }

--- a/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/slack/manifest.toml
@@ -228,6 +228,7 @@ credential_handle = "slack_bot_token"
 supports_markdown = true
 supports_threads = true
 max_message_chars = 40000
+command_prefix = "/ironclaw "
 
 # ---- auth surface: recipe data, zero extension code ------------------------
 

--- a/crates/ironclaw_host_api/src/channel.rs
+++ b/crates/ironclaw_host_api/src/channel.rs
@@ -412,8 +412,9 @@ pub struct ChannelPresentation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_message_chars: Option<u32>,
     /// Optional per-command display prefix a channel adapter renders before
-    /// each declared command name in user-visible help text (e.g. a Slack
-    /// dispatcher's `"/ironclaw "` + `model` -> `/ironclaw model`). `None`
+    /// each declared command name in user-visible help text (e.g. a channel
+    /// whose native command namespace requires an app-scoped dispatcher
+    /// prefix: `"/ironclaw "` + `model` -> `/ironclaw model`). `None`
     /// renders the bare `/{name}` form.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command_prefix: Option<String>,

--- a/crates/ironclaw_host_api/src/channel.rs
+++ b/crates/ironclaw_host_api/src/channel.rs
@@ -14,6 +14,7 @@ use crate::{
 
 const MAX_CHANNEL_COMMANDS: usize = 32;
 const MAX_CHANNEL_COMMAND_NAME_BYTES: usize = 64;
+const MAX_CHANNEL_COMMAND_PREFIX_BYTES: usize = 32;
 
 /// How external conversations map to IronClaw conversations
 /// (`docs/reborn/extension-runtime/overview.md` §3). The host WebUI's
@@ -143,6 +144,14 @@ impl ChannelDescriptor {
                 return Err(ChannelDescriptorError::InvalidCommands);
             }
             seen_commands.push(command);
+        }
+        if let Some(prefix) = &self.presentation.command_prefix
+            && (prefix.is_empty()
+                || !prefix.starts_with('/')
+                || prefix.len() > MAX_CHANNEL_COMMAND_PREFIX_BYTES
+                || prefix.chars().any(char::is_control))
+        {
+            return Err(ChannelDescriptorError::InvalidCommandPrefix);
         }
         if self.inbound && self.ingress.is_none() {
             return Err(ChannelDescriptorError::InboundWithoutIngress);
@@ -402,6 +411,12 @@ pub struct ChannelPresentation {
     pub supports_threads: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_message_chars: Option<u32>,
+    /// Optional per-command display prefix a channel adapter renders before
+    /// each declared command name in user-visible help text (e.g. a Slack
+    /// dispatcher's `"/ironclaw "` + `model` -> `/ironclaw model`). `None`
+    /// renders the bare `/{name}` form.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command_prefix: Option<String>,
 }
 
 /// Structural channel-descriptor failures (path context added by the
@@ -416,6 +431,10 @@ pub enum ChannelDescriptorError {
         "channel commands must contain at most 32 unique tokens of at most 64 bytes using lowercase ASCII letters, digits, '-', or '_'"
     )]
     InvalidCommands,
+    #[error(
+        "channel presentation command_prefix must be non-empty, start with '/', contain no control characters, and be at most 32 bytes"
+    )]
+    InvalidCommandPrefix,
     #[error("an inbound channel must declare [channel.ingress]")]
     InboundWithoutIngress,
     #[error("[channel.connection] requires inbound = true")]
@@ -543,6 +562,60 @@ max_message_chars = 40000
                 channel.validate().unwrap_err(),
                 ChannelDescriptorError::InvalidCommands,
                 "expected invalid commands: {commands}"
+            );
+        }
+    }
+
+    fn channel_toml_with_command_prefix(prefix_toml_value: &str) -> String {
+        documented_channel_toml().replace(
+            "max_message_chars = 40000\n",
+            &format!("max_message_chars = 40000\ncommand_prefix = {prefix_toml_value}\n"),
+        )
+    }
+
+    #[test]
+    fn command_prefix_is_optional_and_round_trips() {
+        let absent: ChannelDescriptor = toml::from_str(documented_channel_toml()).unwrap();
+        assert_eq!(absent.presentation.command_prefix, None);
+        absent.validate().unwrap();
+
+        let declared: ChannelDescriptor =
+            toml::from_str(&channel_toml_with_command_prefix("\"/ironclaw \"")).unwrap();
+        assert_eq!(
+            declared.presentation.command_prefix.as_deref(),
+            Some("/ironclaw ")
+        );
+        declared.validate().unwrap();
+
+        let json = serde_json::to_string(&declared).unwrap();
+        let round_trip: ChannelDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            round_trip.presentation.command_prefix.as_deref(),
+            Some("/ironclaw ")
+        );
+
+        // Unset stays unset on the wire too (skip_serializing_if).
+        let absent_json = serde_json::to_string(&absent).unwrap();
+        assert!(
+            !absent_json.contains("command_prefix"),
+            "unset command_prefix must not appear on the wire: {absent_json}"
+        );
+    }
+
+    #[test]
+    fn command_prefix_validation_rejects_malformed_shapes() {
+        for bad in [
+            "\"\"".to_string(),
+            "\"ironclaw \"".to_string(),
+            "\"/control\t\"".to_string(),
+            format!("\"/{}\"", "a".repeat(32)),
+        ] {
+            let channel: ChannelDescriptor =
+                toml::from_str(&channel_toml_with_command_prefix(&bad)).unwrap();
+            assert_eq!(
+                channel.validate().unwrap_err(),
+                ChannelDescriptorError::InvalidCommandPrefix,
+                "expected invalid command_prefix: {bad}"
             );
         }
     }

--- a/crates/ironclaw_product/src/command_admission.rs
+++ b/crates/ironclaw_product/src/command_admission.rs
@@ -85,6 +85,11 @@ impl ProductCommandAdmissionService for DirectConversationCommandAdmission {
             return Ok(ProductCommandAdmission::Rejected(
                 ProductRejection::permanent(
                     ProductRejectionKind::InvalidRequest,
+                    // Internal-only `ProductRejection.reason`: the observer never
+                    // echoes it (it renders its own role-filtered, prefix-aware
+                    // `command_help_text` instead), so this stays the bare
+                    // `/{name}` form rather than threading the channel's display
+                    // prefix through admission.
                     declared_command_help_text(&self.allowed_commands),
                 ),
             ));

--- a/crates/ironclaw_product/src/commands.rs
+++ b/crates/ironclaw_product/src/commands.rs
@@ -136,6 +136,21 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
+    declared_command_help_text_with_prefix(commands, None)
+}
+
+/// Same rendering as [`declared_command_help_text`], but renders each name
+/// as `{prefix}{name}` instead of the bare `/{name}` form when `prefix` is
+/// set — the manifest-declared `[channel.presentation].command_prefix` a
+/// channel adapter (e.g. Slack's native `/ironclaw` dispatcher) uses to
+/// namespace its commands. `prefix` is rendered exactly as declared,
+/// including any trailing separator (a manifest `command_prefix` of
+/// `"/ironclaw "` plus `model` yields `/ironclaw model`).
+pub fn declared_command_help_text_with_prefix<I, S>(commands: I, prefix: Option<&str>) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
     let names = commands
         .into_iter()
         .map(|command| command.as_ref().to_string())
@@ -145,7 +160,10 @@ where
     }
     let names = names
         .into_iter()
-        .map(|name| format!("/{name}"))
+        .map(|name| match prefix {
+            Some(prefix) => format!("{prefix}{name}"),
+            None => format!("/{name}"),
+        })
         .collect::<Vec<_>>();
     format!("Available commands:\n{}", names.join("\n"))
 }

--- a/crates/ironclaw_product/src/commands.rs
+++ b/crates/ironclaw_product/src/commands.rs
@@ -142,7 +142,8 @@ where
 /// Same rendering as [`declared_command_help_text`], but renders each name
 /// as `{prefix}{name}` instead of the bare `/{name}` form when `prefix` is
 /// set — the manifest-declared `[channel.presentation].command_prefix` a
-/// channel adapter (e.g. Slack's native `/ironclaw` dispatcher) uses to
+/// channel adapter whose native command namespace requires an app-scoped
+/// dispatcher prefix (e.g. a `/ironclaw` slash dispatcher) uses to
 /// namespace its commands. `prefix` is rendered exactly as declared,
 /// including any trailing separator (a manifest `command_prefix` of
 /// `"/ironclaw "` plus `model` yields `/ironclaw model`).

--- a/crates/ironclaw_product/src/communication_context.rs
+++ b/crates/ironclaw_product/src/communication_context.rs
@@ -683,6 +683,7 @@ mod tests {
             supports_markdown: true,
             supports_threads: false,
             max_message_chars: Some(4096),
+            command_prefix: None,
         });
         let provider =
             RuntimeCommunicationContextProvider::new(Arc::new(NoneSetPreferencesService))
@@ -716,6 +717,7 @@ mod tests {
                 supports_markdown: true,
                 supports_threads: false,
                 max_message_chars: Some(4096),
+                command_prefix: None,
             }),
             "the channel's declared presentation reaches the connected-channel summary"
         );

--- a/crates/ironclaw_product/src/run_delivery/observer.rs
+++ b/crates/ironclaw_product/src/run_delivery/observer.rs
@@ -197,8 +197,8 @@ impl RunDeliveryObserver {
     }
 
     /// `prefix` is the channel's manifest-declared
-    /// `[channel.presentation].command_prefix` (e.g. Slack's `"/ironclaw "`);
-    /// `None` renders the bare `/{name}` form.
+    /// `[channel.presentation].command_prefix` (e.g. an app-scoped
+    /// dispatcher's `"/ironclaw "`); `None` renders the bare `/{name}` form.
     pub fn with_enabled_commands<I, S>(mut self, commands: I, prefix: Option<&str>) -> Self
     where
         I: IntoIterator<Item = S>,

--- a/crates/ironclaw_product/src/run_delivery/observer.rs
+++ b/crates/ironclaw_product/src/run_delivery/observer.rs
@@ -7,7 +7,8 @@ use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
 use crate::commands::{
-    CommandAudience, CommandResultView, declared_command_help_text, product_command_descriptors,
+    CommandAudience, CommandResultView, declared_command_help_text,
+    declared_command_help_text_with_prefix, product_command_descriptors,
     render_command_result_text,
 };
 use crate::{
@@ -195,7 +196,10 @@ impl RunDeliveryObserver {
         }
     }
 
-    pub fn with_enabled_commands<I, S>(mut self, commands: I) -> Self
+    /// `prefix` is the channel's manifest-declared
+    /// `[channel.presentation].command_prefix` (e.g. Slack's `"/ironclaw "`);
+    /// `None` renders the bare `/{name}` form.
+    pub fn with_enabled_commands<I, S>(mut self, commands: I, prefix: Option<&str>) -> Self
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
@@ -214,7 +218,7 @@ impl RunDeliveryObserver {
             })
             .map(|name| name.as_ref().to_string())
             .collect();
-        self.command_help_text = declared_command_help_text(user_visible);
+        self.command_help_text = declared_command_help_text_with_prefix(user_visible, prefix);
         self
     }
 

--- a/crates/ironclaw_product/tests/run_delivery_contract.rs
+++ b/crates/ironclaw_product/tests/run_delivery_contract.rs
@@ -540,17 +540,19 @@ fn build_harness(
     auth_url: Option<&str>,
     max_wait: Duration,
 ) -> Harness {
-    build_harness_with_commands(states, bind_fails, auth_url, max_wait, &["status"])
+    build_harness_with_commands(states, bind_fails, auth_url, max_wait, &["status"], None)
 }
 
 /// Same as `build_harness`, but with an explicit declared-command set for the
-/// observer's static help text (`build_harness` always enables `["status"]`).
+/// observer's static help text (`build_harness` always enables `["status"]`
+/// with no display prefix).
 fn build_harness_with_commands(
     states: Vec<ScriptedRunState>,
     bind_fails: bool,
     auth_url: Option<&str>,
     max_wait: Duration,
     commands: &[&str],
+    prefix: Option<&str>,
 ) -> Harness {
     build_harness_with_settings(
         states,
@@ -563,6 +565,7 @@ fn build_harness_with_commands(
             max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
         },
         commands,
+        prefix,
     )
 }
 
@@ -573,6 +576,7 @@ fn build_harness_with_settings(
     auth_url: Option<&str>,
     settings: RunDeliverySettings,
     commands: &[&str],
+    prefix: Option<&str>,
 ) -> Harness {
     let adapter = Arc::new(RecordingChannelAdapter::new());
     let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
@@ -619,7 +623,7 @@ fn build_harness_with_settings(
             settings,
             connection_notices.clone(),
         )
-        .with_enabled_commands(commands.iter().copied()),
+        .with_enabled_commands(commands.iter().copied(), prefix),
     );
     Harness {
         observer,
@@ -822,6 +826,7 @@ async fn static_command_help_excludes_admin_audience_commands() {
         None,
         Duration::from_secs(5),
         &["model", "status", "extension_configure"],
+        None,
     );
     let command = InboundCommandPayload::new("notacommand", "", ProductTriggerReason::DirectChat)
         .expect("command");
@@ -844,6 +849,40 @@ async fn static_command_help_excludes_admin_audience_commands() {
     assert_eq!(
         harness.adapter.texts(),
         vec!["Available commands:\n/model\n/status".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn static_command_help_renders_with_manifest_declared_prefix() {
+    let harness = build_harness_with_commands(
+        vec![scripted_state(TurnStatus::Completed, None)],
+        false,
+        None,
+        Duration::from_secs(5),
+        &["model", "status"],
+        Some("/ironclaw "),
+    );
+    let command = InboundCommandPayload::new("notacommand", "", ProductTriggerReason::DirectChat)
+        .expect("command");
+    let command_envelope = envelope(
+        ProductInboundPayload::Command(command),
+        "evt-command-invalid-prefixed-help",
+    );
+
+    harness
+        .observer
+        .observe_ack(
+            command_envelope,
+            ProductInboundAck::Rejected(ProductRejection::permanent(
+                ProductRejectionKind::InvalidRequest,
+                "opaque parser or admission detail",
+            )),
+        )
+        .await;
+
+    assert_eq!(
+        harness.adapter.texts(),
+        vec!["Available commands:\n/ironclaw model\n/ironclaw status".to_string()]
     );
 }
 
@@ -974,7 +1013,7 @@ async fn observer_keeps_watching_a_healthy_run_past_the_previous_two_minute_cuto
     let mut states = vec![scripted_state(TurnStatus::Running, None)];
     states.extend(std::iter::repeat_with(|| scripted_state(TurnStatus::Running, None)).take(32));
     states.push(scripted_state(TurnStatus::Completed, None));
-    let harness = build_harness_with_settings(states, false, None, settings, &["status"]);
+    let harness = build_harness_with_settings(states, false, None, settings, &["status"], None);
     let run_id = TurnRunId::new();
     seed_final_message(&harness.threads, run_id, "slow run finished").await;
 

--- a/crates/ironclaw_slack_extension/Cargo.toml
+++ b/crates/ironclaw_slack_extension/Cargo.toml
@@ -19,6 +19,11 @@ chrono = { version = "0.4", features = ["serde"] }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Form-encoded Slack slash-command / ssl_check payloads (PR-3 native
+# dispatcher). Already resolved workspace-wide via axum's `Form` extractor
+# (used in ironclaw_webui's OAuth callbacks), so this adds zero new compiled
+# crates to the dependency graph.
+serde_urlencoded = "0.7"
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 

--- a/crates/ironclaw_slack_extension/src/channel.rs
+++ b/crates/ironclaw_slack_extension/src/channel.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 use crate::delivery::{SlackDeliveryFailureKind, slack_error_kind};
 use crate::mrkdwn::{render_slack_mrkdwn, slack_text_chunks};
 use crate::payload::{
-    SLACK_API_HOST, SlackInboundEvent, SlackPayloadParseError, normalize_slack_event,
+    SLACK_API_HOST, SlackInboundEvent, SlackPayloadParseError, normalize_slack_inbound,
 };
 
 /// The administrator-configuration handle carrying the bot token (manifest data; the
@@ -45,7 +45,9 @@ impl ChannelAdapter for SlackChannelAdapter {
                     reason: format!("invalid installation id: {error}"),
                 }
             })?;
-        match normalize_slack_event(request.body, &installation_id).map_err(parse_error)? {
+        match normalize_slack_inbound(request.body, request.headers, &installation_id)
+            .map_err(parse_error)?
+        {
             SlackInboundEvent::UrlVerification { challenge } => {
                 Ok(InboundOutcome::Respond(ImmediateResponse {
                     status: 200,
@@ -53,6 +55,11 @@ impl ChannelAdapter for SlackChannelAdapter {
                     body: challenge.into_bytes(),
                 }))
             }
+            SlackInboundEvent::SslCheck => Ok(InboundOutcome::Respond(ImmediateResponse {
+                status: 200,
+                content_type: None,
+                body: Vec::new(),
+            })),
             SlackInboundEvent::Ignore => Ok(InboundOutcome::Ignore),
             SlackInboundEvent::Message(message) => Ok(InboundOutcome::Messages(vec![*message])),
         }
@@ -403,12 +410,23 @@ mod tests {
     use super::*;
 
     fn inbound(body: &[u8]) -> Result<InboundOutcome, ChannelError> {
+        inbound_with_headers(body, &[])
+    }
+
+    fn inbound_with_headers(
+        body: &[u8],
+        headers: &[(&str, &str)],
+    ) -> Result<InboundOutcome, ChannelError> {
+        let owned_headers: Vec<(String, String)> = headers
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect();
         SlackChannelAdapter.inbound(VerifiedInbound {
             extension_id: "slack",
             installation_id: "install_alpha",
             config: &[],
             body,
-            headers: &[],
+            headers: &owned_headers,
         })
     }
 
@@ -561,6 +579,164 @@ mod tests {
             inbound(br#"{"type":"event_callback","event":{"type":"message"}}"#),
             Err(ChannelError::Parse { .. })
         ));
+    }
+
+    // ── native slash-command form transport (PR-3) ──────────────────────────
+
+    const SLASH_FORM_HEADERS: &[(&str, &str)] =
+        &[("content-type", "application/x-www-form-urlencoded")];
+
+    #[test]
+    fn slash_dm_command_normalizes_with_status_text_and_direct_chat_trigger() {
+        let outcome = inbound_with_headers(
+            b"command=%2Fironclaw&text=status&channel_id=D123&channel_name=directmessage&user_id=U123&team_id=T1&trigger_id=111.222.abc",
+            SLASH_FORM_HEADERS,
+        )
+        .expect("slash command parses");
+        let InboundOutcome::Messages(messages) = outcome else {
+            panic!("expected Messages");
+        };
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.text, "/status");
+        assert_eq!(message.trigger, ProductTriggerReason::DirectChat);
+        assert_eq!(message.actor.id(), "U123");
+        assert_eq!(
+            message.event_id.as_str(),
+            "slack-install_alpha-slash-111.222.abc"
+        );
+    }
+
+    #[test]
+    fn slash_dispatcher_args_join_with_spaces() {
+        let outcome = inbound_with_headers(
+            b"command=%2Fironclaw&text=model+set-provider+openai&channel_id=D123&channel_name=directmessage&user_id=U123&trigger_id=111.222.arg",
+            SLASH_FORM_HEADERS,
+        )
+        .expect("slash command parses");
+        let InboundOutcome::Messages(messages) = outcome else {
+            panic!("expected Messages");
+        };
+        assert_eq!(messages[0].text, "/model set-provider openai");
+    }
+
+    #[test]
+    fn slash_defensive_strip_avoids_double_slash() {
+        let outcome = inbound_with_headers(
+            b"command=%2Fironclaw&text=%2Fstatus&channel_id=D123&channel_name=directmessage&user_id=U123&trigger_id=111.222.strip",
+            SLASH_FORM_HEADERS,
+        )
+        .expect("slash command parses");
+        let InboundOutcome::Messages(messages) = outcome else {
+            panic!("expected Messages");
+        };
+        assert_eq!(
+            messages[0].text, "/status",
+            "must not double the leading slash"
+        );
+    }
+
+    #[test]
+    fn slash_bare_and_help_map_to_help() {
+        for body in [
+            b"command=%2Fironclaw&text=&channel_id=D123&channel_name=directmessage&user_id=U123&trigger_id=111.222.bare".as_slice(),
+            b"command=%2Fironclaw&text=help&channel_id=D123&channel_name=directmessage&user_id=U123&trigger_id=111.222.help".as_slice(),
+        ] {
+            let outcome =
+                inbound_with_headers(body, SLASH_FORM_HEADERS).expect("slash command parses");
+            let InboundOutcome::Messages(messages) = outcome else {
+                panic!("expected Messages");
+            };
+            assert_eq!(messages[0].text, "/help");
+        }
+    }
+
+    #[test]
+    fn slash_non_dm_channel_maps_to_bot_command_trigger() {
+        let outcome = inbound_with_headers(
+            b"command=%2Fironclaw&text=status&channel_id=C777&channel_name=general&user_id=U123&trigger_id=111.222.pub",
+            SLASH_FORM_HEADERS,
+        )
+        .expect("slash command parses");
+        let InboundOutcome::Messages(messages) = outcome else {
+            panic!("expected Messages");
+        };
+        assert_eq!(messages[0].trigger, ProductTriggerReason::BotCommand);
+    }
+
+    #[test]
+    fn slash_foreign_command_name_is_passed_through_verbatim() {
+        let outcome = inbound_with_headers(
+            b"command=%2Fsomethingelse&text=hi&channel_id=D123&channel_name=directmessage&user_id=U123&trigger_id=111.222.foreign",
+            SLASH_FORM_HEADERS,
+        )
+        .expect("slash command parses");
+        let InboundOutcome::Messages(messages) = outcome else {
+            panic!("expected Messages");
+        };
+        assert_eq!(messages[0].text, "/somethingelse hi");
+    }
+
+    #[test]
+    fn slash_ssl_check_probe_gets_immediate_empty_200() {
+        let outcome = inbound_with_headers(
+            b"ssl_check=1&token=deprecated-verification-token",
+            SLASH_FORM_HEADERS,
+        )
+        .expect("ssl_check probe parses");
+        let InboundOutcome::Respond(response) = outcome else {
+            panic!("expected Respond");
+        };
+        assert_eq!(response.status, 200);
+        assert!(response.body.is_empty());
+    }
+
+    #[test]
+    fn slash_malformed_form_missing_user_id_is_typed_parse_error() {
+        let result = inbound_with_headers(
+            b"command=%2Fironclaw&text=status&channel_id=D123&channel_name=directmessage&trigger_id=111.222.bad",
+            SLASH_FORM_HEADERS,
+        );
+        assert!(matches!(result, Err(ChannelError::Parse { .. })));
+    }
+
+    #[test]
+    fn json_body_still_normalizes_through_the_header_aware_helper() {
+        // Same two existing JSON scenarios, driven through the new
+        // header-aware entry point — byte-identical outcomes.
+        let challenge = inbound_with_headers(
+            br#"{"type":"url_verification","challenge":"challenge-token"}"#,
+            &[("content-type", "application/json")],
+        )
+        .expect("challenge parses");
+        let InboundOutcome::Respond(response) = challenge else {
+            panic!("expected Respond");
+        };
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, b"challenge-token");
+
+        let dm = inbound_with_headers(
+            br#"{
+                "type": "event_callback",
+                "event_id": "Ev123",
+                "team_id": "T-A",
+                "event": {
+                    "type": "message",
+                    "user": "U123",
+                    "channel": "D123",
+                    "channel_type": "im",
+                    "text": "hello there",
+                    "ts": "1710000000.000100"
+                }
+            }"#,
+            &[],
+        )
+        .expect("dm parses with no content-type header");
+        let InboundOutcome::Messages(messages) = dm else {
+            panic!("expected Messages");
+        };
+        assert_eq!(messages[0].text, "hello there");
+        assert_eq!(messages[0].trigger, ProductTriggerReason::DirectChat);
     }
 
     // ── deliver() (delivery coordinator cutover, extension-runtime P5) ──────

--- a/crates/ironclaw_slack_extension/src/payload.rs
+++ b/crates/ironclaw_slack_extension/src/payload.rs
@@ -61,6 +61,8 @@ pub fn parse_slack_url_verification_challenge(
 pub enum SlackPayloadParseError {
     #[error("invalid Slack event JSON: {reason}")]
     InvalidJson { reason: String },
+    #[error("invalid Slack slash-command form: {reason}")]
+    InvalidForm { reason: String },
     #[error("invalid external reference: {kind}: {reason}")]
     InvalidExternalRef { kind: &'static str, reason: String },
     #[error(
@@ -117,7 +119,13 @@ pub fn parse_slack_event(
 /// the shared host sink applies the channel-neutral interaction grammar.
 #[derive(Debug)]
 pub enum SlackInboundEvent {
-    UrlVerification { challenge: String },
+    UrlVerification {
+        challenge: String,
+    },
+    /// Slack's one-time endpoint-verification probe for a native slash
+    /// command (distinct from the Events API's `UrlVerification` challenge).
+    /// Any 200 response satisfies it; the body is ignored.
+    SslCheck,
     Ignore,
     Message(Box<NormalizedInboundMessage>),
 }
@@ -214,6 +222,134 @@ pub fn normalize_slack_event(
         // NoOp — authenticated no-ops for the channel contract.
         _ => Ok(SlackInboundEvent::Ignore),
     }
+}
+
+/// Parse one host-verified Slack inbound request that may be EITHER the
+/// Events API's JSON envelope or a native slash-command form POST — Slack
+/// registers both against the identical Request URL (one ingress route per
+/// extension), distinguished only by the (host-forwarded, verification-
+/// exempt) Content-Type header. The JSON branch delegates verbatim to
+/// [`normalize_slack_event`] so the two entry points share exactly one JSON
+/// parsing implementation; this function adds no new behavior to that path.
+pub(crate) fn normalize_slack_inbound(
+    raw_payload: &[u8],
+    headers: &[(String, String)],
+    installation_id: &AdapterInstallationId,
+) -> Result<SlackInboundEvent, SlackPayloadParseError> {
+    if is_form_urlencoded_content_type(headers) {
+        return normalize_slack_slash_command(raw_payload, installation_id);
+    }
+    normalize_slack_event(raw_payload, installation_id)
+}
+
+/// Case-insensitive Content-Type match for Slack's slash-command / ssl_check
+/// form encoding. Absent or non-matching headers fall through to the JSON
+/// path — the pre-existing default behavior.
+fn is_form_urlencoded_content_type(headers: &[(String, String)]) -> bool {
+    headers.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("content-type")
+            && value
+                .to_ascii_lowercase()
+                .contains("application/x-www-form-urlencoded")
+    })
+}
+
+/// Parse one native Slack slash-command form POST (`ssl_check` handshake or
+/// a real `/ironclaw ...` invocation) into its normalized channel form.
+fn normalize_slack_slash_command(
+    raw_payload: &[u8],
+    installation_id: &AdapterInstallationId,
+) -> Result<SlackInboundEvent, SlackPayloadParseError> {
+    if raw_payload.len() > MAX_SLACK_PAYLOAD_BYTES {
+        return Err(SlackPayloadParseError::InvalidForm {
+            reason: "payload exceeds size limit".into(),
+        });
+    }
+
+    // Slack's ssl_check verification probe carries ONLY `ssl_check` +
+    // `token` — never the slash command's mandatory fields. Check for it
+    // via a minimal, all-Option probe BEFORE parsing the full form (which
+    // requires channel_id/user_id/command/trigger_id), or the probe would
+    // always fail mandatory-field validation.
+    let probe: SlackSlashCommandProbe =
+        serde_urlencoded::from_bytes(raw_payload).map_err(|err| {
+            SlackPayloadParseError::InvalidForm {
+                reason: err.to_string(),
+            }
+        })?;
+    if probe.ssl_check.is_some() {
+        return Ok(SlackInboundEvent::SslCheck);
+    }
+
+    let form: SlackSlashCommandForm = serde_urlencoded::from_bytes(raw_payload).map_err(|err| {
+        SlackPayloadParseError::InvalidForm {
+            reason: err.to_string(),
+        }
+    })?;
+
+    let event_id = build_slash_event_id(installation_id, &form.trigger_id)?;
+    let actor = build_actor_ref(Some(&form.user_id))?;
+    let conversation =
+        build_conversation_ref(form.team_id.as_deref(), Some(&form.channel_id), None, None)?;
+    let is_dm = form.channel_name.as_deref() == Some("directmessage")
+        || is_dm_channel(&form.channel_id, None);
+    let trigger = if is_dm {
+        ProductTriggerReason::DirectChat
+    } else {
+        ProductTriggerReason::BotCommand
+    };
+    let text = slash_command_dispatch_text(&form.command, form.text.as_deref());
+
+    Ok(SlackInboundEvent::Message(Box::new(
+        NormalizedInboundMessage {
+            actor,
+            conversation,
+            event_id,
+            text,
+            trigger,
+            attachments: Vec::new(),
+            reply_context: None,
+        },
+    )))
+}
+
+/// Map a slash command's `command` + `text` fields to the dispatcher's
+/// invocation text. `/ironclaw` is this extension's own registered command:
+/// empty or `help` text becomes `/help`; otherwise the text becomes the
+/// dispatched command, defensively stripped of a leading `/` first so a
+/// user typing `/ironclaw /status` does not double it to `//status`. A
+/// DIFFERENT registered command name (an app-config mistake pointing a
+/// second slash command at this same URL) is passed through verbatim as
+/// `"{command} {text}"` — the generic classifier/admission layer rejects it
+/// as undeclared, with help, rather than this adapter guessing intent.
+fn slash_command_dispatch_text(command: &str, text: Option<&str>) -> String {
+    let text = text.unwrap_or_default().trim();
+    if command != "/ironclaw" {
+        return format!("{command} {text}").trim().to_string();
+    }
+    if text.is_empty() || text.eq_ignore_ascii_case("help") {
+        return "/help".to_string();
+    }
+    let stripped = text.strip_prefix('/').unwrap_or(text);
+    format!("/{stripped}")
+}
+
+fn build_slash_event_id(
+    installation_id: &AdapterInstallationId,
+    trigger_id: &str,
+) -> Result<ExternalEventId, SlackPayloadParseError> {
+    // Namespaced separately from the Events API's `event_callback` id space
+    // (same defensive rationale as build_event_id's own `-noop-` namespace):
+    // a slash invocation and an Events API callback must never collide on
+    // dedup key even if some future id happened to coincide.
+    ExternalEventId::new(format!(
+        "slack-{}-slash-{trigger_id}",
+        installation_id.as_str()
+    ))
+    .map_err(|err| SlackPayloadParseError::InvalidExternalRef {
+        kind: "external_event_id",
+        reason: err.to_string(),
+    })
 }
 
 /// Classify a normalized message's text as a gate-resolution interaction
@@ -715,6 +851,36 @@ struct SlackFile {
     mimetype: Option<String>,
     name: Option<String>,
     size: Option<u64>,
+}
+
+/// Minimal probe for Slack's `ssl_check` endpoint-verification POST, which
+/// carries only `ssl_check` + `token` — never a slash command's mandatory
+/// fields. Parsed before [`SlackSlashCommandForm`] so the probe never trips
+/// that struct's required-field validation.
+#[derive(Debug, Clone, Deserialize)]
+struct SlackSlashCommandProbe {
+    ssl_check: Option<String>,
+}
+
+/// One native Slack slash-command form POST
+/// (`application/x-www-form-urlencoded`). Liberal on purpose — Slack adds
+/// fields across API versions and this is a public untrusted-ingress
+/// boundary — so only the fields the dispatcher mapping cannot proceed
+/// without are mandatory; everything else is `Option`. There is no
+/// `deny_unknown_fields`, so fields this crate does not yet consume
+/// (`response_url` — future out-of-DM delivery; `ssl_check` — already
+/// resolved by [`SlackSlashCommandProbe`] before this struct is parsed;
+/// `token` — Slack's legacy verification field, superseded here by HMAC
+/// signing) arrive and are silently dropped rather than declared dead.
+#[derive(Debug, Clone, Deserialize)]
+struct SlackSlashCommandForm {
+    channel_id: String,
+    user_id: String,
+    command: String,
+    trigger_id: String,
+    text: Option<String>,
+    channel_name: Option<String>,
+    team_id: Option<String>,
 }
 
 #[cfg(test)]
@@ -1281,6 +1447,138 @@ mod tests {
                 assert_eq!(payload.trigger, ProductTriggerReason::BotMention);
             }
             other => panic!("expected user message, got {other:?}"),
+        }
+    }
+
+    // ── native slash-command form transport (PR-3) ──────────────────────────
+
+    fn form_headers() -> Vec<(String, String)> {
+        vec![(
+            "content-type".to_string(),
+            "application/x-www-form-urlencoded".to_string(),
+        )]
+    }
+
+    #[test]
+    fn normalize_slack_inbound_maps_dm_slash_command_to_direct_chat_message() {
+        let body = b"command=%2Fironclaw&text=status&channel_id=D123&channel_name=directmessage&user_id=U123&team_id=T1&trigger_id=111.222.abc";
+        let event = normalize_slack_inbound(body, &form_headers(), &installation_id())
+            .expect("slash command form parses");
+        let SlackInboundEvent::Message(message) = event else {
+            panic!("expected Message, got {event:?}");
+        };
+        assert_eq!(message.text, "/status");
+        assert_eq!(message.trigger, ProductTriggerReason::DirectChat);
+        assert_eq!(message.actor.id(), "U123");
+        assert_eq!(
+            message.event_id.as_str(),
+            "slack-slack_install_beta-slash-111.222.abc"
+        );
+        assert_eq!(message.conversation.conversation_id(), "D123");
+        assert_eq!(message.conversation.space_id(), Some("T1"));
+    }
+
+    #[test]
+    fn normalize_slack_inbound_non_dm_channel_maps_to_bot_command_trigger() {
+        let body = b"command=%2Fironclaw&text=status&channel_id=C777&channel_name=general&user_id=U123&team_id=T1&trigger_id=111.222.def";
+        let event = normalize_slack_inbound(body, &form_headers(), &installation_id())
+            .expect("slash command form parses");
+        let SlackInboundEvent::Message(message) = event else {
+            panic!("expected Message, got {event:?}");
+        };
+        assert_eq!(message.trigger, ProductTriggerReason::BotCommand);
+    }
+
+    #[test]
+    fn normalize_slack_inbound_ssl_check_short_circuits_before_mandatory_field_validation() {
+        // Slack's ssl_check probe carries ONLY ssl_check + token — none of the
+        // slash command's mandatory fields (channel_id/user_id/command/trigger_id).
+        // This must succeed anyway: the ssl_check test has to run before the
+        // mandatory-field validation, not after it.
+        let body = b"ssl_check=1&token=deprecated-verification-token";
+        let event = normalize_slack_inbound(body, &form_headers(), &installation_id())
+            .expect("ssl_check probe parses even without mandatory slash fields");
+        assert!(matches!(event, SlackInboundEvent::SslCheck));
+    }
+
+    #[test]
+    fn normalize_slack_inbound_malformed_form_missing_user_id_is_typed_parse_error() {
+        let body = b"command=%2Fironclaw&text=status&channel_id=D123&channel_name=directmessage&team_id=T1&trigger_id=111.222.ghi";
+        let err = normalize_slack_inbound(body, &form_headers(), &installation_id())
+            .expect_err("missing user_id must fail");
+        assert!(matches!(err, SlackPayloadParseError::InvalidForm { .. }));
+    }
+
+    #[test]
+    fn normalize_slack_inbound_oversized_slash_form_is_rejected() {
+        let mut oversized = Vec::with_capacity(MAX_SLACK_PAYLOAD_BYTES + 32);
+        oversized.extend_from_slice(b"command=%2Fironclaw&text=");
+        oversized.resize(MAX_SLACK_PAYLOAD_BYTES + 16, b'a');
+        let err = normalize_slack_inbound(&oversized, &form_headers(), &installation_id())
+            .expect_err("an over-limit slash form must be rejected");
+        assert!(matches!(err, SlackPayloadParseError::InvalidForm { .. }));
+    }
+
+    #[test]
+    fn normalize_slack_inbound_json_content_type_is_byte_identical_to_normalize_slack_event() {
+        let body = br#"{
+            "type": "event_callback",
+            "event_id": "Ev123",
+            "team_id": "T-A",
+            "event": {
+                "type": "message",
+                "user": "U123",
+                "channel": "D123",
+                "channel_type": "im",
+                "text": "hello there",
+                "ts": "1710000000.000100"
+            }
+        }"#;
+        let json_headers = vec![("content-type".to_string(), "application/json".to_string())];
+        let via_inbound = normalize_slack_inbound(body, &json_headers, &installation_id())
+            .expect("json parses through the header-aware helper");
+        let via_event =
+            normalize_slack_event(body, &installation_id()).expect("json parses directly");
+        let (SlackInboundEvent::Message(a), SlackInboundEvent::Message(b)) =
+            (via_inbound, via_event)
+        else {
+            panic!("expected both paths to normalize to Message");
+        };
+        assert_eq!(a, b);
+
+        // No Content-Type header at all must also fall through to the JSON
+        // path (the default when the header is absent, not just when it's
+        // explicitly "application/json").
+        let via_no_headers = normalize_slack_inbound(body, &[], &installation_id())
+            .expect("json parses with no content-type header");
+        let SlackInboundEvent::Message(c) = via_no_headers else {
+            panic!("expected Message");
+        };
+        assert_eq!(c, a);
+    }
+
+    #[test]
+    fn slash_command_dispatch_text_mapping() {
+        let cases: &[(&str, Option<&str>, &str)] = &[
+            (
+                "/ironclaw",
+                Some("model set-provider openai"),
+                "/model set-provider openai",
+            ),
+            ("/ironclaw", Some("/status"), "/status"),
+            ("/ironclaw", Some(""), "/help"),
+            ("/ironclaw", None, "/help"),
+            ("/ironclaw", Some("help"), "/help"),
+            ("/ironclaw", Some("HELP"), "/help"),
+            ("/ironclaw", Some("  "), "/help"),
+            ("/somethingelse", Some("hi"), "/somethingelse hi"),
+        ];
+        for (command, text, expected) in cases {
+            assert_eq!(
+                &slash_command_dispatch_text(command, *text),
+                expected,
+                "command={command:?} text={text:?}"
+            );
         }
     }
 }

--- a/crates/ironclaw_slack_extension/src/payload.rs
+++ b/crates/ironclaw_slack_extension/src/payload.rs
@@ -1,4 +1,5 @@
 //! Slack Events API payload normalization.
+// arch-exempt: large_file, split into Events-API vs slash-form parsing vs shared normalization modules, plan #6894
 //!
 //! Inputs are raw Slack webhook event bytes. Event callbacks become
 //! [`ParsedProductInbound`] values; URL-verification payloads are exposed for

--- a/crates/ironclaw_turns/src/run_profile/runtime_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/runtime_context.rs
@@ -709,6 +709,7 @@ mod tests {
         );
     }
 
+    // arch-exempt: large_file, mechanical command_prefix ripple from ChannelPresentation gaining a field (PR-3 Task 2), plan #4875
     #[test]
     fn renders_channel_presentation_hint() {
         // OUT-11: a channel's declared `[channel.presentation]` renders as a
@@ -725,6 +726,7 @@ mod tests {
                             supports_markdown: false,
                             supports_threads: false,
                             max_message_chars: Some(4000),
+                            command_prefix: None,
                         }),
                     },
                     ConnectedChannelSummary {
@@ -735,6 +737,7 @@ mod tests {
                             supports_markdown: true,
                             supports_threads: true,
                             max_message_chars: None,
+                            command_prefix: None,
                         }),
                     },
                 ]),

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -22,11 +22,11 @@ channels and DMs.
 
 Create an app at [api.slack.com/apps](https://api.slack.com/apps). The fastest route is
 **From an app manifest** — paste the [manifest below](#app-manifest), which sets the
-scopes, events, and redirect URL in one step. Replace `example.com` with your own host
-first.
+scopes, events, the `/ironclaw` slash command, and redirect URL in one step. Replace
+`example.com` with your own host first.
 
 If you build the app from scratch instead, configure **OAuth & Permissions**, **Event
-Subscriptions**, and the redirect URL to match that manifest.
+Subscriptions**, **Slash Commands**, and the redirect URL to match that manifest.
 
 Once created, install the app to your workspace and copy the bot token from **OAuth &
 Permissions**, and the signing secret from **Basic Information**. IronClaw uses the signing
@@ -68,11 +68,16 @@ in the web interface. The agent may reply that it can't help.
 Back in your Slack app, confirm **Event Subscriptions** points at your instance:
 
 ```
-https://your-host/webhooks/slack/events
+https://your-host/webhooks/extensions/slack/events
 ```
 
 Slack sends a verification challenge to that URL, so IronClaw must already be running and
 reachable when you save it. Reinstall the app if Slack asks you to.
+
+Also register the `/ironclaw` slash command under **Slash Commands**, pointed at the
+identical Request URL — Slack allows a slash command's endpoint to be any URL, so one
+signed address answers both surfaces. Registering a slash command adds the `commands` bot
+scope, which also needs a reinstall.
 
 </Step>
 
@@ -94,21 +99,28 @@ or self-signed endpoint.
 
 | Slack setting | URL |
 | --- | --- |
-| Event Subscriptions → Request URL | `https://your-host/webhooks/slack/events` |
-| OAuth & Permissions → Redirect URL | `https://your-host/api/reborn/product-auth/oauth/slack_personal/callback` |
+| Event Subscriptions → Request URL | `https://your-host/webhooks/extensions/slack/events` |
+| Slash Commands → Request URL | `https://your-host/webhooks/extensions/slack/events` |
+| OAuth & Permissions → Redirect URL | `https://your-host/api/reborn/product-auth/oauth/slack/callback` |
+
+<Note>
+Event Subscriptions and the `/ironclaw` slash command point at the identical Request
+URL — one signed endpoint answers both surfaces, so there is no second address to stand
+up.
+</Note>
 
 The redirect URL is used for per-user ("personal") Slack authorization. Tell IronClaw the
 same value so the two agree:
 
 ```bash
-export IRONCLAW_REBORN_SLACK_PERSONAL_OAUTH_REDIRECT_URI=https://your-host/api/reborn/product-auth/oauth/slack_personal/callback
+export IRONCLAW_REBORN_SLACK_PERSONAL_OAUTH_REDIRECT_URI=https://your-host/api/reborn/product-auth/oauth/slack/callback
 ```
 
 <Warning>
 The redirect URL must match **exactly** on both sides, including scheme, host, port, and
 path. Slack rejects the authorization with a redirect-URI mismatch if it differs by even a
-trailing slash. The path is `/api/reborn/product-auth/oauth/slack_personal/callback` — a
-shortened form like `/oauth/slack_personal/callback` is not served and will 404.
+trailing slash. The path is `/api/reborn/product-auth/oauth/slack/callback` — a shortened
+form like `/oauth/slack/callback` is not served and will 404.
 </Warning>
 
 For a local instance the values are `http://127.0.0.1:3000/...`, but Slack cannot reach
@@ -119,7 +131,8 @@ loopback, so events only work once the instance is reachable from the internet.
 ## App Manifest
 
 Create the app with **From an app manifest** and paste this, replacing `example.com` with
-your host. It sets the scopes, bot events, and redirect URL that the steps above describe.
+your host. It sets the scopes, bot events, the `/ironclaw` slash command, and redirect URL
+that the steps above describe.
 
 ```json
 {
@@ -135,11 +148,20 @@ your host. It sets the scopes, bot events, and redirect URL that the steps above
     "bot_user": {
       "display_name": "IronClaw",
       "always_online": true
-    }
+    },
+    "slash_commands": [
+      {
+        "command": "/ironclaw",
+        "url": "https://example.com/webhooks/extensions/slack/events",
+        "description": "Run IronClaw commands",
+        "usage_hint": "status | model <name> | help",
+        "should_escape": false
+      }
+    ]
   },
   "oauth_config": {
     "redirect_urls": [
-      "https://example.com/api/reborn/product-auth/oauth/slack_personal/callback"
+      "https://example.com/api/reborn/product-auth/oauth/slack/callback"
     ],
     "scopes": {
       "user": [
@@ -163,14 +185,15 @@ your host. It sets the scopes, bot events, and redirect URL that the steps above
         "im:write",
         "files:read",
         "groups:history",
-        "mpim:history"
+        "mpim:history",
+        "commands"
       ]
     },
     "pkce_enabled": false
   },
   "settings": {
     "event_subscriptions": {
-      "request_url": "https://example.com/webhooks/slack/events",
+      "request_url": "https://example.com/webhooks/extensions/slack/events",
       "bot_events": [
         "app_mention",
         "message.channels",
@@ -234,13 +257,13 @@ ironclaw config list | grep slack
 <Accordion title="Slack can't verify the request URL">
 IronClaw has to be running and publicly reachable over HTTPS before you save the URL.
 Confirm the instance answers from outside your network, and that you used the exact
-`/webhooks/slack/events` path.
+`/webhooks/extensions/slack/events` path.
 </Accordion>
 
 <Accordion title="Slack rejects authorization with a redirect-URI mismatch">
 The redirect URL in the Slack app and `IRONCLAW_REBORN_SLACK_PERSONAL_OAUTH_REDIRECT_URI`
 must match character for character. Check the scheme, the port, and that the path is the
-full `/api/reborn/product-auth/oauth/slack_personal/callback`.
+full `/api/reborn/product-auth/oauth/slack/callback`.
 </Accordion>
 
 <Accordion title="The bot doesn't respond in a channel">

--- a/docs/reborn/setup-slack-for-reborn-binary.md
+++ b/docs/reborn/setup-slack-for-reborn-binary.md
@@ -165,6 +165,8 @@ https://<public-host>/api/reborn/product-auth/oauth/slack/callback
   - `groups:history` if the bot should receive private-channel message events.
   - `mpim:history` if the bot should receive group-DM message events.
   - `files:read` if Slack file attachments should be downloaded and processed.
+  - `commands` to register the `/ironclaw` slash command (see Slash Command
+    below).
 - Add user token scopes:
   - `users:read` for binding the authenticated Slack user to the Reborn user.
 - Install or reinstall the app to the workspace after changing scopes.
@@ -186,6 +188,26 @@ https://<public-host>/webhooks/extensions/slack/events
   - Optional: `message.groups`
   - Optional: `message.mpim`
 
+Slash Command:
+
+- Slack allows a slash command's Request URL to be any URL, so it can point
+  at the exact same signed endpoint as Event Subscriptions above — there is
+  no second route to register, and the events ingress already accepts the
+  slash command's form payload, answers its `ssl_check` verification probe,
+  and rejects non-DM invocations by design (see Troubleshooting).
+- Create a command:
+  - Command: `/ironclaw`
+  - Request URL:
+
+```text
+https://<public-host>/webhooks/extensions/slack/events
+```
+
+  - Short Description: `Run IronClaw commands`
+  - Usage Hint: `status | model <name> | help`
+- Save. Registering a slash command adds the `commands` bot token scope;
+  install or reinstall the app after saving.
+
 App Home:
 
 - Enable messages so users can DM the app.
@@ -204,6 +226,12 @@ features:
   bot_user:
     display_name: IronClaw Reborn
     always_online: false
+  slash_commands:
+    - command: /ironclaw
+      description: Run IronClaw commands
+      usage_hint: "status | model <name> | help"
+      url: https://<public-host>/webhooks/extensions/slack/events
+      should_escape: false
 oauth_config:
   redirect_urls:
     - https://<public-host>/api/reborn/product-auth/oauth/slack/callback
@@ -217,6 +245,7 @@ oauth_config:
       - groups:history
       - mpim:history
       - files:read
+      - commands
     user:
       - users:read
 settings:
@@ -266,6 +295,7 @@ Verification checklist:
   connects the Slack extension, the OAuth callback
   binds that Slack user to the authenticated Reborn user.
 - A DM to the app routes through the OAuth-connected Reborn user.
+- `/ironclaw status` sent in the bot DM replies with the rendered status result.
 - A channel `@app` mention replies in the same channel thread.
 - Bot-originated and subtyped Slack messages are ignored.
 
@@ -278,6 +308,14 @@ Confirm the Reborn config sets [slack].enabled = true, or that the deployment en
 ### Slack route never receives events
 
 Confirm the Slack Request URL is exactly https://<public-host>/webhooks/extensions/slack/events, the public URL reaches the Reborn listener, and Socket Mode is disabled for this host path.
+
+### Slash command shows dispatch_failed
+
+The `/ironclaw` command is not registered on this Slack app, or its Request URL does not exactly match https://<public-host>/webhooks/extensions/slack/events. Add or fix the command under Slack App Configuration, Slash Command, then reinstall the app.
+
+### Slash command reply is slow or times out
+
+The ingress only answers 200 once the request is durably admitted, so a healthy deployment replies well inside Slack's short response budget, but a degraded backend can occasionally push that past Slack's client-side timeout even though the bot still posts the reply moments later in the DM. This is a rare, pre-existing exposure and is not unique to slash commands.
 
 ### Slack URL verification fails
 
@@ -299,10 +337,15 @@ Confirm the app is invited to the channel, app_mention is subscribed, and the Te
 
 Configure Shared subject or use the WebUI Slack channel picker to allow the channel.
 
+### Slash command outside the bot DM is denied
+
+This is by design: `/ironclaw` requires a direct conversation, so an invocation from any other channel is rejected with a denial notice posted back into that same channel, and no command executes. Message the app directly instead.
+
 ## Slack References
 
 - Events API: https://docs.slack.dev/apis/events-api/
 - Message events: https://docs.slack.dev/reference/events/message/
 - `app_mention`: https://api.slack.com/events/app_mention
 - Sending messages: https://docs.slack.dev/messaging/sending-and-scheduling-messages/
+- Slash commands: https://docs.slack.dev/interactivity/implementing-slash-commands/
 - Request signing: https://docs.slack.dev/authentication/verifying-requests-from-slack/

--- a/docs/superpowers/plans/2026-07-29-pr3-slack-native-dispatcher.md
+++ b/docs/superpowers/plans/2026-07-29-pr3-slack-native-dispatcher.md
@@ -1,0 +1,120 @@
+# PR-3: Slack-Native /ironclaw Dispatcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Typing `/ironclaw status` (or `model …`, or nothing) in Slack invokes the command pipeline natively — no leading-space trick — with help text rendered as `/ironclaw <cmd>` on Slack, and the app-registration snippet documented for all deployments.
+
+**Architecture:** The Slack extension's inbound path branches on `Content-Type`: JSON keeps today's Events-API flow; `application/x-www-form-urlencoded` parses the slash form (`serde_urlencoded`, already in the workspace lock — zero new compiled crates), answering `ssl_check` with an immediate empty 200 and mapping `/ironclaw <text>` to a normalized message whose text is `/<text>` — trigger DERIVED via DM detection (`DirectChat` for DMs, `BotCommand` otherwise, which the direct-conversation admission rejects). Everything downstream is the existing pipeline. `ChannelPresentation` gains `command_prefix: Option<String>`; the observer's help renders `/ironclaw model` on Slack; the WebUI and admission internals stay bare. Spec: `docs/superpowers/specs/2026-07-29-product-command-train-design.md` PR-3 section (as corrected in d80bb29c9). Branch: `pr3-slack-native-dispatcher` (stacks on `pr2-webui-command-palette`; PR base = that branch until PR-2 merges).
+
+**Tech Stack:** Rust 2024 (`ironclaw_slack_extension`, `ironclaw_host_api`, `ironclaw_product`, `ironclaw_extension_host`), serde_urlencoded 0.7, Mintlify docs.
+
+## Global Constraints
+
+- No `.unwrap()` / `.expect()` in production code. The slack extension stays transport-light (no network clients).
+- One new direct dependency only: `serde_urlencoded = "0.7"` in `ironclaw_slack_extension` (already resolved workspace-wide via axum — state this in the manifest comment).
+- The slash form struct is liberal: every field `Option<String>` EXCEPT the four the mapping cannot proceed without (`channel_id`, `user_id`, `command`, `trigger_id`); NO `deny_unknown_fields`.
+- Trigger derivation is mandatory: `DirectChat` only for genuine DMs (reuse `is_dm_channel` semantics — slash forms have no `channel_type`, so the `D`-prefix fallback carries it; also treat `channel_name == "directmessage"` as DM); otherwise `ProductTriggerReason::BotCommand`. Never hardcode.
+- The existing ingress proptest gate (`payload.rs` `ingress_properties`, "never panics over arbitrary bytes") must stay green UNMODIFIED — the form branch may not introduce any panic path.
+- Prefix rendering: ONLY the observer's user-visible help text gets the prefix. `command_admission.rs`'s internal rejection reason stays bare (never user-visible — proven in the transport map). WebUI rendering stays bare `/name`.
+- Red-green per behavior change; suites with `--no-fail-fast`; never pipe test output through `head`/`tail`; `cargo fmt -- --check` clean per touched crate BEFORE committing.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+## File Structure
+
+- `crates/ironclaw_slack_extension/src/payload.rs` — form parse + dispatcher mapping; `src/channel.rs` — SslCheck arm + test helper; `Cargo.toml` — dep.
+- `crates/ironclaw_host_api/src/channel.rs` — `ChannelPresentation.command_prefix` + validation.
+- `crates/ironclaw_product/src/commands.rs` — prefix-aware help; `run_delivery/observer.rs` — prefix threading.
+- `crates/ironclaw_extension_host/src/channel_host.rs` — assembly read (~1030); `channel_host/e2e_tests.rs` — journeys.
+- `crates/ironclaw_first_party_extensions/assets/slack/manifest.toml` — `command_prefix`.
+- `docs/reborn/setup-slack-for-reborn-binary.md`, `docs/channels/slack.mdx` — registration.
+
+---
+
+### Task 1: Slash-form transport + dispatcher mapping in the Slack extension
+
+**Files:**
+- Modify: `crates/ironclaw_slack_extension/Cargo.toml`, `src/payload.rs`, `src/channel.rs`
+- Test: `src/payload.rs` + `src/channel.rs` `#[cfg(test)]` modules (extend existing; the proptest module is a regression gate, don't touch it)
+
+**Interfaces:**
+- Consumes: `VerifiedInbound { body, headers, installation_id, .. }` (headers include Content-Type — verified plumbed); `SlackInboundEvent { UrlVerification, Ignore, Message }` (`payload.rs:118-123`); `NormalizedInboundMessage` fields actor/conversation/event_id/text/trigger; helpers `build_actor_ref`, `build_conversation_ref`, `is_dm_channel` (`payload.rs:571-661`); `InboundOutcome::Respond(ImmediateResponse)` precedent (`channel.rs:105-111`).
+- Produces: `SlackInboundEvent::SslCheck` variant; `normalize_slack_event(body, headers, installation_id)` signature change (gains headers — update the existing callers/tests) OR a sibling entry `normalize_slack_inbound(request: &VerifiedInbound)` — pick whichever keeps `payload.rs` pure and say why; event ids shaped `slack-{installation}-slash-{trigger_id}`.
+
+- [ ] **Step 1: Failing unit tests** (in `channel.rs` tests via an `inbound_with_headers(body, headers)` sibling of the existing `inbound()` helper, and in `payload.rs` tests for the pure mapping):
+  - DM slash: form body `command=%2Fironclaw&text=status&channel_id=D123&channel_name=directmessage&user_id=U123&team_id=T1&trigger_id=111.222.abc` with header `("content-type","application/x-www-form-urlencoded")` → one normalized message: `text == "/status"`, `trigger == ProductTriggerReason::DirectChat`, `actor.id() == "U123"`, `event_id == "slack-install_alpha-slash-111.222.abc"`.
+  - Dispatcher args: `text=model+set-provider+openai` → `"/model set-provider openai"`. Defensive strip: `text=%2Fstatus` → `"/status"` (not `"//status"`).
+  - Bare and help: empty `text` → `"/help"`; `text=help` → `"/help"`.
+  - Non-DM: `channel_id=C777&channel_name=general` → `trigger == ProductTriggerReason::BotCommand`.
+  - Foreign command name (an app-config mistake registers a second command at this URL): `command=%2Fsomethingelse&text=hi` → normalized text is the raw invocation `"{command} {text}"` = `"/somethingelse hi"`; the generic classifier/admission then rejects it as undeclared with help. Pin exactly that.
+  - `ssl_check=1` form → `InboundOutcome::Respond` with status 200 and EMPTY body.
+  - Malformed form (missing `user_id`) → typed `SlackPayloadParseError` (no panic).
+  - JSON body with JSON content-type → existing behavior byte-identical (rerun two existing cases through the new header-aware helper).
+- [ ] **Step 2: Red.** `cargo test -p ironclaw_slack_extension --no-fail-fast` — new tests fail to compile/fail.
+- [ ] **Step 3: Implement.**
+  - `Cargo.toml`: `serde_urlencoded = "0.7" # form-encoded Slack slash payloads; already resolved workspace-wide (axum), zero new crates`.
+  - `payload.rs`: `#[derive(Deserialize)] struct SlackSlashCommandForm { channel_id: String, user_id: String, command: String, trigger_id: String, text: Option<String>, channel_name: Option<String>, team_id: Option<String>, response_url: Option<String>, ssl_check: Option<String>, token: Option<String> }` (liberal; no deny_unknown_fields). Content-type detection: case-insensitive header lookup; form branch when it contains `application/x-www-form-urlencoded`. `ssl_check` present (any value) → `SlackInboundEvent::SslCheck` (check BEFORE requiring the four mandatory fields — Slack's ssl_check probe carries only `ssl_check` + `token`, so parse a minimal probe struct first or make all fields Option and validate after the ssl_check test). Dispatcher mapping: trim `text`; empty or `help` (case-insensitive) → `"/help"`; else strip leading `/` if present, then `format!("/{trimmed}")`. If `command != "/ironclaw"`, use `format!("{command} {text}")` trimmed as the message text verbatim. Trigger: DM iff `channel_name.as_deref() == Some("directmessage")` or `is_dm_channel(&channel_id, None)`; DM → DirectChat else BotCommand. Event id: `slack-{installation}-slash-{trigger_id}` via the `build_event_id`-adjacent pattern. Conversation: `build_conversation_ref(team_id, channel_id, None, None)`.
+  - `channel.rs`: `SlackInboundEvent::SslCheck => Ok(InboundOutcome::Respond(ImmediateResponse { status: 200, content_type: None, body: Vec::new() }))`.
+- [ ] **Step 4: Green + gates.** Full crate suite (proptest module must pass unmodified); `cargo fmt -p ironclaw_slack_extension -- --check`; `cargo clippy -p ironclaw_slack_extension --all-targets --all-features -- -D warnings`.
+- [ ] **Step 5: Commit** `feat(slack): accept native slash-command payloads through the events ingress`.
+
+---
+
+### Task 2: Command display prefix (manifest → observer help)
+
+**Files:**
+- Modify: `crates/ironclaw_host_api/src/channel.rs` (~396-405 + validate), `crates/ironclaw_product/src/commands.rs` (`declared_command_help_text`), `crates/ironclaw_product/src/run_delivery/observer.rs` (`with_enabled_commands` ~198), `crates/ironclaw_extension_host/src/channel_host.rs` (`build_observer` ~1030), `crates/ironclaw_first_party_extensions/assets/slack/manifest.toml` (`[channel.presentation]` ~227)
+- Test: host_api channel tests, `crates/ironclaw_product/tests/run_delivery_contract.rs`, extension_host `available_extensions` manifest pins
+
+**Interfaces:**
+- Produces: `ChannelPresentation { …, pub command_prefix: Option<String> }` (serde default + skip-if-none; validation: non-empty, starts with `/`, ≤ 32 bytes, no control chars); `declared_command_help_text_with_prefix<I, S>(commands: I, prefix: Option<&str>) -> String` (existing `declared_command_help_text` delegates with `None`; prefixed rendering replaces the leading `/` formatting: `Some("/ironclaw ")` + `model` → `/ironclaw model`); `RunDeliveryObserver::with_enabled_commands` gains the prefix (new signature `with_enabled_commands<I, S>(self, commands: I, prefix: Option<&str>)` — update ALL call sites/tests).
+
+- [ ] **Step 1: Failing tests.** host_api: presentation deserializes `command_prefix = "/ironclaw "`; validation rejects empty / non-slash-leading / control chars; absent field stays None (existing manifests unaffected). run_delivery_contract: observer built with `(["model","status"], Some("/ironclaw "))` delivers help exactly `"Available commands:\n/ironclaw model\n/ironclaw status"`; with `None` exactly the current text (existing pin stays). Manifest pin: bundled slack presentation carries the prefix; telegram carries none.
+- [ ] **Step 2: Red.** Product + host_api + extension_host focused suites.
+- [ ] **Step 3: Implement** per the interfaces; assembly reads `source.resolved().channel.as_ref().and_then(|c| c.presentation.command_prefix.as_deref())` beside the existing `enabled_commands` extraction and threads it. Slack manifest: `command_prefix = "/ironclaw "` in `[channel.presentation]`. Admission's internal `declared_command_help_text(&self.allowed_commands)` call stays bare (add a one-line comment: internal reason, never user-rendered).
+- [ ] **Step 4: Green + suites** for the four touched crates; fmt/clippy per crate.
+- [ ] **Step 5: Commit** `feat(channels): render channel help with the manifest command prefix`.
+
+---
+
+### Task 3: Channel-host e2e journeys (signed form bodies)
+
+**Files:**
+- Modify: `crates/ironclaw_extension_host/src/channel_host/e2e_tests.rs`
+
+**Interfaces:**
+- Consumes: harness `post_event_with_signature` (~216-266) + `slack_signature(timestamp, body)` (~199-213); `SLACK_EVENTS_PATH`; `HarnessOptions.actor_role`; the recording egress + `command_executions`.
+- Produces: `Harness::post_slash_command(form_body: &str)` — identical to `post_event_with_signature` but sets `content-type: application/x-www-form-urlencoded` explicitly (axum sets none by default — verified) and signs the raw form bytes with the SAME recipe.
+
+- [ ] **Step 1: Failing tests** (form bodies urlencoded; paired DM uses the harness's bound `U123`/`D123` identities):
+  - `slash_dispatcher_dm_status_executes_and_delivers_result`: `command=/ironclaw&text=status` in the DM → exactly one `product.status.command` invoke as the bound user, rendered Status feedback delivered, zero turns.
+  - `slash_dispatcher_bare_returns_prefixed_help`: empty text → delivered notice exactly `"Available commands:\n/ironclaw model\n/ironclaw status"` (proves Task 2 end-to-end), zero invokes.
+  - `slash_dispatcher_outside_dm_is_rejected_direct_only`: `channel_id=C777&channel_name=general` → direct-conversation denial copy delivered (or, if the bot cannot post there in the harness, assert zero invokes + zero turns + the denial notice attempt recorded — match what the recording egress captures), zero invokes.
+  - `slash_form_with_forged_signature_is_rejected`: valid form body, bad signature → 401/403 per the existing forged-HMAC pin, nothing admitted.
+  - `ssl_check_form_gets_empty_200_without_admission`: `ssl_check=1&token=x` signed → 200 empty body, zero admissions/invokes.
+- [ ] **Step 2: Red** (`cargo test -p ironclaw_extension_host --no-fail-fast -- channel_host`).
+- [ ] **Step 3:** implement the helper; adjust only if the red reveals harness gaps (report, don't fudge).
+- [ ] **Step 4: Green** full extension_host suite.
+- [ ] **Step 5: Commit** `test(slack): pin the native slash dispatcher end to end`.
+
+---
+
+### Task 4: Registration docs (+ fix the stale mdx paths while touching)
+
+**Files:**
+- Modify: `docs/reborn/setup-slack-for-reborn-binary.md`, `docs/channels/slack.mdx`
+
+- [ ] **Step 1:** `setup-slack-for-reborn-binary.md`: new "Slash Command" subsection beside "Event Subscriptions" (register ONE command `/ironclaw`, description `Run IronClaw commands`, usage hint `status | model <name> | help`, Request URL = the SAME events URL — one URL serves both surfaces); add `slash_commands:` to the YAML manifest sketch after `event_subscriptions`; verification-checklist line (`/ironclaw status` replies in the bot DM); troubleshooting entry (slash outside the DM is rejected by design; `dispatch_failed` = missing registration/URL); references link `https://docs.slack.dev/interactivity/implementing-slash-commands/`.
+- [ ] **Step 2:** `slack.mdx`: `features.slash_commands` array in the JSON manifest; a note in the URLs table that the events URL now serves Events API + slash commands; a step note about registering `/ironclaw`; FIX the pre-existing stale paths in this file while touching it (`/webhooks/slack/events` → `/webhooks/extensions/slack/events`; `oauth/slack_personal/callback` → `oauth/slack/callback`) and say so in the commit body.
+- [ ] **Step 3: Commit** `docs(slack): register the /ironclaw slash command and fix stale ingress paths`.
+
+---
+
+### Task 5: Gauntlet + PR
+
+- [ ] `cargo fmt`; three clippy lanes (default / `--all-features` / `--workspace --all-targets --all-features`), all `-D warnings`.
+- [ ] `cargo test -p ironclaw_slack_extension -p ironclaw_host_api -p ironclaw_product -p ironclaw_extension_host -p ironclaw_architecture --no-fail-fast`; `scripts/pre-commit-safety.sh`; `RUST_MIN_STACK=67108864 bash scripts/reborn-e2e-rust.sh`.
+- [ ] Spec sync: re-read the PR-3 section against the diff; fix drift in the spec.
+- [ ] Controller pushes and opens the PR (base `pr2-webui-command-palette` until PR-2 merges; retarget to `main` after). Body notes: the 20s-deadline nuance, slash-retry citation, the four Slack apps' one-time registration steps, follow-ups (`response_url` delivery for out-of-DM rejections; Telegram `setMyCommands`).
+
+## Self-review checklist
+- Trigger derivation pinned in unit + e2e (non-DM rejection real). Prefix renders ONLY via observer. Proptest gate untouched and green. ssl_check before mandatory-field validation. No deny_unknown_fields on the form. Foreign-command passthrough pinned.

--- a/docs/superpowers/specs/2026-07-29-product-command-train-design.md
+++ b/docs/superpowers/specs/2026-07-29-product-command-train-design.md
@@ -277,10 +277,20 @@ to bind the real translator, so the key is now actually reachable.
 
 Reuse the single signed `[channel.ingress]` `events` route — Slack lets every
 slash command point at any Request URL, and the HMAC recipe signs the raw
-body regardless of content type. No manifest-schema or host changes.
-`crates/ironclaw_slack_extension/src/{payload,channel}.rs` learn the payload
-shapes: JSON → existing event path; form-encoded with `command` → slash
-invocation; form-encoded `ssl_check=1` → immediate empty 200.
+body regardless of content type; verification happens before content-type
+branching, so a forged signature on a form body is rejected at the same
+ingress layer as a forged JSON body. No manifest-schema or host changes.
+`crates/ironclaw_slack_extension/src/payload.rs` gains `normalize_slack_inbound`,
+a sibling entry point that branches on the (host-forwarded) Content-Type
+header: `application/x-www-form-urlencoded` → the new slash-command form
+parser; anything else, including an absent header, → delegates verbatim to
+the existing `normalize_slack_event`, so the two entry points share exactly
+one JSON parsing implementation. Inside the form branch, a minimal
+all-`Option` probe for `ssl_check` is parsed BEFORE the full slash-command
+form: Slack's `ssl_check` endpoint-verification POST carries only
+`ssl_check` + `token`, never the mandatory `channel_id`/`user_id`/`command`/
+`trigger_id` fields a real invocation requires, so the probe must run first
+or the handshake would always fail mandatory-field validation.
 
 ### Normalization (dispatcher mapping)
 
@@ -296,6 +306,12 @@ message events produce:
   unknown-command rejection path, which delivers the role-filtered
   "Available commands" help. (If a real `help` command ever joins the
   registry, this mapping upgrades gracefully into executing it.)
+- A registered command **other than** `/ironclaw` pointed at this same
+  Request URL (an app-config mistake — a second Slack slash command
+  aimed at the identical signed endpoint) is passed through raw as
+  `"{command} {text}"` rather than mapped — the adapter does not guess
+  intent; the generic classifier/admission layer rejects the unrecognized
+  text as an undeclared command, with role-filtered help.
 - Actor from `user_id`, conversation from `channel_id`; event id
   `slack-{installation}-slash-{trigger_id}` (namespaced beside the
   event_callback id space; unique per invocation — Slack does not redeliver
@@ -319,18 +335,30 @@ risk. The visible result is the bot's DM message.
 ### Help rendering: per-channel invocation prefix
 
 Neutral help renders `/model`, but typing `/model` bare in Slack fails
-(client-intercepted). `ChannelDescriptor` presentation gains an optional
-command display prefix; Slack's manifest sets `/ironclaw ` so help and
-rejection notices render `/ironclaw model` there. Other channels keep the
-plain `/name` rendering. The space-typed ` /model` path keeps working as an
-undocumented fallback.
+(client-intercepted). `ChannelPresentation`
+(`crates/ironclaw_host_api/src/channel.rs`) gains an optional
+`command_prefix: Option<String>` field, declared under the manifest's
+`[channel.presentation]` section beside `supports_markdown` /
+`max_message_chars`; Slack's manifest sets `command_prefix = "/ironclaw "` so
+help and rejection notices render `/ironclaw model` there. Other channels
+leave it `None` and keep the plain `/name` rendering.
+`ChannelDescriptor::validate` rejects a declared prefix that is empty, does
+not start with `/`, contains a control character, or exceeds 32 bytes
+(`ChannelDescriptorError::InvalidCommandPrefix`). The space-typed ` /model`
+path keeps working as an undocumented fallback.
 
 ### Behavioral edges
 
 - Slash invoked outside the bot DM: flows through the same pipeline; the
-  direct-conversation admission rejects; if the bot cannot post into that
-  conversation the user sees nothing — accepted MVP limitation, noted in the
-  PR. `response_url` support is the future fix.
+  direct-conversation admission rejects, and the observer's command-feedback
+  path posts the denial notice straight to the invoking channel
+  (`envelope.external_conversation_ref()`) — independent of any
+  shared-conversation binding or `slack_allowed_channels` allowlist
+  resolution, so it is delivered even to a channel never configured there.
+  The user sees nothing only if Slack itself refuses the post (the bot is
+  not a member of that specific channel) — accepted MVP limitation, noted in
+  the PR. `response_url` delivery would remove even that dependency and is
+  the future fix.
 - Unpaired user: existing connect-nudge path.
 - Natively registered but manifest-undeclared command: rejects with
   role-filtered help. Declaration is the single source of truth; Slack

--- a/docs/superpowers/specs/2026-07-29-product-command-train-design.md
+++ b/docs/superpowers/specs/2026-07-29-product-command-train-design.md
@@ -296,14 +296,25 @@ message events produce:
   unknown-command rejection path, which delivers the role-filtered
   "Available commands" help. (If a real `help` command ever joins the
   registry, this mapping upgrades gracefully into executing it.)
-- Actor from `user_id`, conversation from `channel_id`, `DirectChat`
-  trigger, event id derived from `trigger_id` (unique per invocation; Slack
-  does not redeliver slash commands).
+- Actor from `user_id`, conversation from `channel_id`; event id
+  `slack-{installation}-slash-{trigger_id}` (namespaced beside the
+  event_callback id space; unique per invocation — Slack does not redeliver
+  slash commands, unlike the Events API; cite Slack's docs in the PR).
+- **Trigger is derived, never hardcoded**: `DirectChat` only when the slash
+  form indicates a genuine DM (`channel_name == "directmessage"` /
+  `D`-prefixed `channel_id` — the adapter's existing `is_dm_channel`
+  semantics), else `BotCommand` (maps to the Shared route, which the
+  direct-conversation admission rejects). Hardcoding `DirectChat` would
+  silently defeat both the non-DM rejection edge and the connect-nudge
+  gate, which key off the same trigger classification.
 
 Downstream — classification, pairing, PR-1 admission, dispatch, observer
-bot-DM delivery — is identical to the space-prefixed path. Ingress ACK is
-the immediate empty 200 (Slack's ≤3s rule); the visible result is the bot's
-DM message.
+bot-DM delivery — is identical to the space-prefixed path. The ingress 200
+is ack-after-durable-admission (command execution itself is synchronous
+within the ingress request; only the reply posting is async), normally well
+inside Slack's ≤3s rule — the router's 20s deadline ceiling is a
+pre-existing degraded-backend exposure worth one line in the PR, not new
+risk. The visible result is the bot's DM message.
 
 ### Help rendering: per-channel invocation prefix
 


### PR DESCRIPTION
Final PR of the command train (after #6873 role gating and #6891 the WebUI palette). Spec: `docs/superpowers/specs/2026-07-29-product-command-train-design.md` (PR-3 section); plan: `docs/superpowers/plans/2026-07-29-pr3-slack-native-dispatcher.md`.

## What this fixes

Slash commands in Slack only worked with a leading space (` /status`), because Slack's client intercepts bare `/text` for its own slash-command system and never delivers it to the app. Now `/ironclaw status` works natively.

## How

- **Same signed ingress, no new route.** The Slack extension branches on `Content-Type`: JSON keeps the existing Events-API path; `application/x-www-form-urlencoded` parses a slash invocation; Slack's `ssl_check` probe gets an immediate empty 200. The HMAC layer is content-type agnostic, so verification is unchanged and still runs *before* any parsing — a forged signature on a form body is rejected exactly like a forged JSON one. `serde_urlencoded` was already in the workspace lock (via axum), so this adds zero new compiled crates.
- **Dispatcher mapping.** `/ironclaw status …` normalizes to the text `/status …` — the identical shape the typed path produces — so classification, pairing, admission, dispatch and delivery downstream are byte-for-byte the same code. Bare `/ironclaw` (or `/ironclaw help`) maps to `/help`, which rides the existing unknown-command path and returns role-filtered help. A foreign command pointed at the same URL passes through raw and is rejected as undeclared.
- **Trigger derived, never hardcoded.** The spec originally said to stamp `DirectChat` on every slash invocation. Research against Slack's payload contract showed that would silently defeat the promised non-DM rejection: `route_kind_for_trigger` maps `DirectChat` to the Direct route, so a public-channel `/ironclaw model set …` would have executed as though it were a DM. The trigger is now derived from Slack's DM signals (`channel_name == "directmessage"` / `D`-prefixed id), falling back to `BotCommand` (Shared route → admission rejects). The spec was corrected in-branch; an e2e test pins the denial.
- **Per-channel help prefix.** `ChannelPresentation` gains an optional `command_prefix`; Slack's manifest sets `/ironclaw ` so help renders `/ironclaw model` there, while every other channel and the WebUI keep plain `/model`. Validation bounds the value (non-empty, leading `/`, ≤32 bytes, no control chars).
- **Registration docs.** Both Slack setup docs gain the one-command app-manifest snippet, the `commands` scope + reinstall note, verification checklist line, and troubleshooting entries. Nine pre-existing stale ingress paths in `slack.mdx` were corrected while touching it.

## Testing

- Adapter unit tests for the dispatcher mapping (arg passthrough, defensive leading-slash strip, bare/`help`, foreign command), DM-vs-non-DM trigger derivation, `ssl_check` short-circuit ordering, malformed-form rejection, and JSON path unchanged. The pre-existing arbitrary-bytes proptest gate passes unmodified — the form branch introduces no panic path.
- Channel-host e2e over signed form bodies: `/ironclaw status` in a paired DM executes end to end with zero turns; bare `/ironclaw` returns the prefixed help; a non-DM invocation is denied; a forged signature is still rejected; `ssl_check` returns an empty 200 with nothing admitted. Each was proven by breaking its production line and observing the failure before restoring.
- Full gauntlet: three clippy lanes, five crate suites, the complete integration harness, fmt, and the safety/architecture gates (which surfaced two branch-level gaps — a missing large-file annotation, tracked as #6894, and three vendor-name mentions in generic crates — both fixed here).

## After merge: one-time Slack app setup

Each deployment's Slack app needs a single slash command registered — `/ironclaw`, Request URL identical to the existing Events API URL, plus the `commands` scope and a reinstall. Applies to the local, QA, canary, and prod apps. Manifest snippets are in `docs/reborn/setup-slack-for-reborn-binary.md` and `docs/channels/slack.mdx`.

## Follow-ups

- `response_url` delivery so an out-of-DM rejection is visible when the bot can't post in that conversation.
- Telegram `setMyCommands` for the native command menu there.
- #6894 (split the now-large `payload.rs`), #6877 (operator-fallback activation guard), #6875 (`/model set <name>` trailing-arg parse wart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)