### PR TITLE
fix(libsql): recover cancelled transactions and history migration

### DIFF
--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -1487,13 +1487,14 @@ impl StorageTxn for LibSqlStorageTxn {
 
 impl Drop for LibSqlStorageTxn {
     fn drop(&mut self) {
-        if !self.active {
-            return;
-        }
-        if let Some(conn) = self.conn.take() {
-            tokio::spawn(async move {
-                let _ = conn.execute("ROLLBACK", ()).await;
-            });
+        if self.active
+            && let Some(conn) = self.conn.take()
+        {
+            // A destructor cannot await ROLLBACK. Discard the connection so
+            // SQLite rolls back while closing it and the pool can create a
+            // clean replacement without a detached task retaining its only
+            // writer lease.
+            conn.discard();
         }
     }
 }
@@ -3699,5 +3700,74 @@ mod tests {
         .await
         .expect("independent writer must not hang behind a cancelled pooled transaction")
         .expect("independent writer must acquire the SQLite writer lock");
+    }
+
+    /// Break caught: dropping the filesystem transaction must release the
+    /// size-one writer lane before the same task performs its next write.
+    #[tokio::test]
+    async fn dropping_storage_transaction_releases_writer_lane_synchronously() {
+        let (fs, _dir) = fresh_backend().await;
+        let fs = Arc::new(fs);
+        let prefix = VirtualPath::new("/resources").unwrap();
+        let abandoned_path = VirtualPath::new("/resources/abandoned").unwrap();
+        let next_path = VirtualPath::new("/resources/next").unwrap();
+        let task_fs = Arc::clone(&fs);
+        let task_prefix = prefix.clone();
+        let task_abandoned_path = abandoned_path.clone();
+        let task_next_path = next_path.clone();
+        tokio::spawn(async move {
+            let mut transaction = task_fs.begin(&task_prefix).await.unwrap();
+            transaction
+                .put(
+                    &task_abandoned_path,
+                    Entry::bytes(b"uncommitted".to_vec()),
+                    CasExpectation::Absent,
+                )
+                .await
+                .unwrap();
+            drop(transaction);
+
+            let mut writer_checkout = Box::pin(task_fs.runtime.write());
+            let first_poll = std::future::poll_fn(|context| {
+                std::task::Poll::Ready(std::future::Future::poll(writer_checkout.as_mut(), context))
+            })
+            .await;
+            match first_poll {
+                std::task::Poll::Ready(Ok(writer)) => drop(writer),
+                std::task::Poll::Ready(Err(error)) => {
+                    panic!("dropping the transaction must clear writer ownership: {error}")
+                }
+                std::task::Poll::Pending => {
+                    drop(
+                        writer_checkout
+                            .await
+                            .expect("a recycled writer connection must become available"),
+                    );
+                }
+            }
+
+            tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                task_fs.put(
+                    &task_next_path,
+                    Entry::bytes(b"committed".to_vec()),
+                    CasExpectation::Absent,
+                ),
+            )
+            .await
+            .expect("the next write must not wait behind a detached rollback")
+            .expect("the same task must reacquire the writer lane after dropping a transaction");
+        })
+        .await
+        .expect("writer task");
+
+        assert!(
+            fs.get(&abandoned_path).await.unwrap().is_none(),
+            "dropping an active transaction must roll back its staged write"
+        );
+        assert!(
+            fs.get(&next_path).await.unwrap().is_some(),
+            "the writer lane must remain usable after cancellation cleanup"
+        );
     }
 }

--- a/crates/ironclaw_libsql_runtime/src/lib.rs
+++ b/crates/ironclaw_libsql_runtime/src/lib.rs
@@ -127,8 +127,27 @@ impl LibSqlReadConnectionLease {
 /// Exclusive checkout from the single-slot writer pool.
 pub struct LibSqlWriteConnectionLease {
     connection: Object<LibSqlConnectionManager>,
+    _holder: LibSqlWriterHolderGuard,
+}
+
+struct LibSqlWriterHolderGuard {
     writer_holder: Arc<Mutex<Option<tokio::task::Id>>>,
     holder_task_id: Option<tokio::task::Id>,
+}
+
+impl LibSqlWriteConnectionLease {
+    /// Permanently remove this connection from the pool.
+    ///
+    /// Cancellation cleanup uses this when the connection may still own an
+    /// open transaction. Physically dropping it releases SQLite's writer lock
+    /// immediately; a later checkout creates a clean replacement.
+    pub fn discard(self) {
+        let Self {
+            connection,
+            _holder,
+        } = self;
+        drop(Object::take(connection));
+    }
 }
 
 impl Deref for LibSqlWriteConnectionLease {
@@ -139,7 +158,7 @@ impl Deref for LibSqlWriteConnectionLease {
     }
 }
 
-impl Drop for LibSqlWriteConnectionLease {
+impl Drop for LibSqlWriterHolderGuard {
     fn drop(&mut self) {
         let Some(holder_task_id) = self.holder_task_id else {
             return;
@@ -247,8 +266,10 @@ impl LibSqlRuntime {
         }
         Ok(LibSqlWriteConnectionLease {
             connection,
-            writer_holder: Arc::clone(&self.writer_holder),
-            holder_task_id,
+            _holder: LibSqlWriterHolderGuard {
+                writer_holder: Arc::clone(&self.writer_holder),
+                holder_task_id,
+            },
         })
     }
 }
@@ -336,13 +357,28 @@ async fn checkout(
     let started = Instant::now();
     let result = pool.get().await;
     let wait_ms = started.elapsed().as_millis();
-    tracing::debug!(
-        lane = %lane,
-        wait_ms,
-        queued,
-        "libSQL connection checkout completed"
-    );
-    result.map_err(|error| map_pool_error(error, lane))
+    match result {
+        Ok(connection) => {
+            tracing::trace!(
+                lane = %lane,
+                wait_ms,
+                queued,
+                "libSQL connection checkout completed"
+            );
+            Ok(connection)
+        }
+        Err(error) => {
+            let error = map_pool_error(error, lane);
+            tracing::debug!(
+                lane = %lane,
+                wait_ms,
+                queued,
+                reason = %error,
+                "libSQL connection checkout failed"
+            );
+            Err(error)
+        }
+    }
 }
 
 fn map_pool_error(error: PoolError<LibSqlRuntimeError>, lane: LibSqlLane) -> LibSqlRuntimeError {

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -564,7 +564,14 @@ where
                             &scoped_path(crate::filesystem_service::THREADS_PREFIX)?,
                         )
                         .await?;
-                    for row in rows {
+                    for listed_row in rows {
+                        // The listing runs before BEGIN IMMEDIATE owns the
+                        // writer lock. Re-read inside the transaction so a
+                        // current-code message update in that window cannot
+                        // make this one-time migration fail with a stale CAS.
+                        let Some(row) = txn.get(&listed_row.path).await? else {
+                            continue;
+                        };
                         let expected_kind = if messages {
                             crate::filesystem_service::THREAD_MESSAGE_KIND
                         } else {

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -12,7 +12,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -2159,6 +2159,71 @@ async fn filesystem_explicit_migration_rebuilds_missing_thread_index_rows() {
     );
 }
 
+/// Break caught: a message updated after the migration query but before the
+/// migration transaction starts must not make conversation history unavailable.
+#[tokio::test]
+async fn filesystem_history_survives_transcript_migration_racing_a_message_update() {
+    let backend = Arc::new(MigrationRaceBackend::new());
+    let scoped = scoped_threads_fs_at(
+        Arc::clone(&backend),
+        "tenant-transcript-migration-race",
+        "alice",
+    );
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("transcript-migration-race");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-transcript-migration-race").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: Some("event-transcript-migration-race".into()),
+            content: MessageContent::text("hello from the migration race"),
+        })
+        .await
+        .unwrap();
+
+    let migration_marker = transcript_index_migration_marker_path_for_test(&scope);
+    if scoped
+        .get(&scope.to_resource_scope(), &migration_marker)
+        .await
+        .expect("test setup reads the migration marker")
+        .is_some()
+    {
+        scoped
+            .delete(&scope.to_resource_scope(), &migration_marker)
+            .await
+            .expect("test setup removes the completed migration marker");
+    }
+    backend.arm();
+
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .expect("a concurrent current-code update must not fail history migration");
+
+    assert_eq!(backend.race_count(), 1, "the test must inject one race");
+    assert_eq!(history.messages.len(), 1);
+    assert_eq!(
+        history.messages[0].content.as_deref(),
+        Some("hello from the migration race")
+    );
+}
+
 #[tokio::test]
 async fn optional_index_write_cache_does_not_skip_required_migration_marker() {
     use ironclaw_threads::ListThreadsForScopeRequest;
@@ -3126,6 +3191,24 @@ fn thread_index_migration_marker_path_for_test(scope: &ThreadScope) -> ScopedPat
     .unwrap()
 }
 
+fn transcript_index_migration_marker_path_for_test(scope: &ThreadScope) -> ScopedPath {
+    ScopedPath::new(format!(
+        "/threads/agents/{}/projects/{}/owners/{}/index-migrations/transcript-index-v1.complete",
+        scope.agent_id.as_str(),
+        scope
+            .project_id
+            .as_ref()
+            .expect("test scope has project")
+            .as_str(),
+        scope
+            .owner_user_id
+            .as_ref()
+            .expect("test scope has owner")
+            .as_str()
+    ))
+    .unwrap()
+}
+
 fn thread_root_path_for_test(scope: &ThreadScope, thread_id: &str) -> ScopedPath {
     ScopedPath::new(format!(
         "/threads/agents/{}/projects/{}/owners/{}/threads/{thread_id}",
@@ -3233,6 +3316,32 @@ struct QueryCountingBackend {
     inner: InMemoryBackend,
     query_count: AtomicUsize,
     get_count: AtomicUsize,
+}
+
+struct MigrationRaceBackend {
+    inner: InMemoryBackend,
+    armed: AtomicBool,
+    pending_message_path: Mutex<Option<VirtualPath>>,
+    race_count: AtomicUsize,
+}
+
+impl MigrationRaceBackend {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            armed: AtomicBool::new(false),
+            pending_message_path: Mutex::new(None),
+            race_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+
+    fn race_count(&self) -> usize {
+        self.race_count.load(Ordering::SeqCst)
+    }
 }
 
 impl QueryCountingBackend {
@@ -3415,6 +3524,95 @@ impl RootFilesystem for QueryCountingBackend {
     }
 
     async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        self.inner.begin(path).await
+    }
+
+    async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
+        self.inner.reserve_sequence(path).await
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for MigrationRaceBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let rows = self.inner.query(path, filter, page).await?;
+        if self.armed.load(Ordering::SeqCst)
+            && self.race_count.load(Ordering::SeqCst) == 0
+            && let Some(message) = rows
+                .iter()
+                .find(|row| row.path.as_str().contains("/messages/"))
+        {
+            *self.pending_message_path.lock().await = Some(message.path.clone());
+        }
+        Ok(rows)
+    }
+
+    async fn query_ordered(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: &OrderedPage,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        self.inner.query_ordered(path, filter, page).await
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        self.inner.ensure_index(path, spec).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        if let Some(message_path) = self.pending_message_path.lock().await.take() {
+            let versioned =
+                self.inner
+                    .get(&message_path)
+                    .await?
+                    .ok_or_else(|| FilesystemError::NotFound {
+                        path: message_path.clone(),
+                        operation: FilesystemOperation::ReadFile,
+                    })?;
+            self.inner
+                .put(&message_path, versioned.entry, CasExpectation::Any)
+                .await?;
+            self.race_count.fetch_add(1, Ordering::SeqCst);
+        }
         self.inner.begin(path).await
     }
 


### PR DESCRIPTION
## Summary

- Fix conversation-history and timeline 503s caused by transcript-index migration racing a current message update.
- Prevent cancelled filesystem transactions from retaining the single libSQL writer lease in a detached rollback task.
- Move successful connection-checkout telemetry from `DEBUG` to `TRACE`, and emit accurate `DEBUG` diagnostics only for failed checkouts.
- QA evidence: deployment `047e9307-25b8-41fb-b943-795bfce08d2b` first showed `TimelineUnavailable` alongside `expected version 1, found version 2`, then entered repeated 10-second writer checkout timeouts with `queued=2`. PR #6696 introduced both failing paths after PR #6863 established the shared one-writer runtime.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6871. Regression follow-up to #6696 and #6863.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run workspace-wide; affected crates passed `cargo clippy -p ironclaw_libsql_runtime -p ironclaw_filesystem -p ironclaw_threads --all-targets --all-features -- -D warnings`.
- [ ] `cargo build` — Not run separately; affected crates were compiled by tests and clippy.
- [x] Relevant tests pass: full `ironclaw_libsql_runtime`, `ironclaw_filesystem`, and `ironclaw_threads` suites; focused storage architecture gate.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: the changed libSQL contract is covered against a real temporary libSQL database in the owning crate; no PostgreSQL or composition behavior changed.
- [ ] Manual testing — Live QA logs were used to reproduce and correlate the failure; this branch has not been deployed.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: Loading conversation history and timelines remains available while the one-time transcript migration overlaps an active message update; a cancelled storage transaction no longer leaves QA's writer lane unavailable until restart.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `filesystem_history_survives_transcript_migration_racing_a_message_update` deterministically injects the observed CAS race through the real filesystem thread service.
- Reborn integration: Not applicable: both failures are owned by local thread-storage/runtime contracts and do not require turn orchestration.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: no frontend behavior changed; the 503 source is covered below the HTTP presentation layer.
- Backend or runtime: `dropping_storage_transaction_releases_writer_lane_synchronously` uses a real local libSQL database and the production size-one writer runtime.
- Live canary: Not run; the branch is not deployed to QA.

What the tests prove:

- A message version change between the migration query and `BEGIN IMMEDIATE` no longer escapes as a history/timeline backend error.
- Dropping an active transaction rolls back uncommitted state, releases writer ownership synchronously, and permits the next write without a detached rollback retaining the only lease.
- Existing libSQL runtime, filesystem backend, transcript, and storage projection contracts remain green.

Commands run:

- `cargo test -p ironclaw_libsql_runtime`
- `cargo test -p ironclaw_filesystem`
- `cargo test -p ironclaw_threads`
- `cargo fmt --all -- --check`
- `cargo clippy -p ironclaw_libsql_runtime -p ironclaw_filesystem -p ironclaw_threads --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture --test reborn_process_storage_scan_gate`
- `cargo test -p ironclaw_architecture` — partially passed, then hit the pre-existing generated-WebUI ratchet failure for `builtin.profile_set` in committed `crates/ironclaw_webui/frontend/dist` assets; none of those files are changed here.

## Security Impact

None. No permissions, network calls, secrets, file-access authority, tool execution, or sandbox policy changed. Runtime error displays remain redacted.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: Not applicable; no trust-bearing types were added or changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable; no prompt path changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: no variants changed; existing typed checkout errors are preserved.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Not applicable; no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. No queue or pool bounds changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Existing checkout and filesystem error classification is unchanged.
- [x] Sandbox/native/host names accurately describe trust boundary. Not applicable; no sandbox or host surface changed.

## Database Impact

No schema or data migration. libSQL cancellation cleanup now discards an open transaction's connection so SQLite rolls it back on close and the pool creates a clean replacement. Transcript index migration re-reads each listed row inside its existing transaction; PostgreSQL behavior is otherwise unchanged.

## Blast Radius

The changes touch the shared libSQL writer lease, libSQL filesystem transaction cancellation, and one-time transcript index migration. Main risks are connection-pool capacity recovery after discard and migration atomicity under concurrent writes; both have regression coverage plus the full owning-crate suites.

## Rollback Plan

Revert commit `55033b0de` and redeploy. There is no schema or persisted-format rollback. Reverting restores the known risk that a cancelled transaction can retain the sole writer lease and that a first-read migration race can surface a 503.

## Review Follow-Through

Please focus review on deadpool's permanent object removal during cancellation and the transaction-local re-read in transcript migration. The broad architecture suite's unrelated generated-asset failure is documented above; the storage-specific architecture gate passes.

---

**Review track**: C
