### PR TITLE
fix(product): accept model set command syntax

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -225,7 +225,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `config` | ✅ | ✅ | - | Read/write config plus validate/path helpers |
 | `backup` | ✅ | ❌ | P3 | Create/verify local backup archives |
 | `channels` | ✅ | 🚧 | P2 | Reborn `channels list` stays visible in `--help`/completions but exits nonzero as unimplemented (stub disabled); `enable`/`disable`/`status` deferred pending config source unification |
-| `models` | ✅ | 🚧 | P1 | Reborn now uses a shared composition provider-admin facade for CLI `models list [<provider>]` (`--verbose`, `--json`), `models status`, `models set <model>`, `models set-provider <provider> [--model model]`, plus Product Workflow typed `model set-provider ...` parsing without touching v1 state. Remaining: live model fetching, OAuth/API-key login flows, and wiring the provider-admin ProductCommandService into product surfaces. |
+| `models` | ✅ | 🚧 | P1 | Reborn now uses a shared composition provider-admin facade for CLI `models list [<provider>]` (`--verbose`, `--json`), `models status`, `models set <model>`, `models set-provider <provider> [--model model]`, plus Product Workflow typed `model <name>`, `model set <name>`, and `model set-provider ...` parsing without touching v1 state. Remaining: live model fetching, OAuth/API-key login flows, and wiring the provider-admin ProductCommandService into product surfaces. |
 | `status` | ✅ | ✅ | - | System status (enriched session details) |
 | `agents` | ✅ | ❌ | P3 | Multi-agent management |
 | `sessions` | ✅ | ❌ | P3 | Session listing (shows subagent models) |

--- a/crates/product/ironclaw_assistant/src/commands.rs
+++ b/crates/product/ironclaw_assistant/src/commands.rs
@@ -368,6 +368,16 @@ fn parse_model_command(payload: &InboundCommandPayload) -> ProductCommandParseRe
             action: ProductModelCommand::Default,
         });
     }
+    if first == "set" {
+        let Some(model) = args.next() else {
+            return invalid_lifecycle_command("model set requires a model name");
+        };
+        return Ok(ProductCommand::Model {
+            action: ProductModelCommand::Set {
+                model: model.to_string(),
+            },
+        });
+    }
     match ModelCommandHead::parse(first)? {
         ModelCommandHead::SetProvider => {
             let Some(provider) = args.next() else {

--- a/crates/product/ironclaw_assistant/src/commands.rs
+++ b/crates/product/ironclaw_assistant/src/commands.rs
@@ -372,6 +372,14 @@ fn parse_model_command(payload: &InboundCommandPayload) -> ProductCommandParseRe
         let Some(model) = args.next() else {
             return invalid_lifecycle_command("model set requires a model name");
         };
+        if model.starts_with('-') {
+            return invalid_lifecycle_command(
+                "model set requires a model name; flags are only valid after `set-provider`",
+            );
+        }
+        if args.next().is_some() {
+            return invalid_lifecycle_command("model set accepts only a model name");
+        }
         return Ok(ProductCommand::Model {
             action: ProductModelCommand::Set {
                 model: model.to_string(),

--- a/crates/product/ironclaw_assistant/tests/product_commands_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/product_commands_contract.rs
@@ -62,6 +62,32 @@ fn model_preference_commands_reject_missing_or_extra_arguments() {
 }
 
 #[test]
+fn model_command_accepts_optional_set_keyword() {
+    let payload =
+        InboundCommandPayload::new("model", "set gpt-5-mini", ProductTriggerReason::BotCommand)
+            .expect("valid command");
+
+    assert_eq!(
+        ProductCommand::from_payload(&payload).expect("parse model command"),
+        ProductCommand::Model {
+            action: ProductModelCommand::Set {
+                model: "gpt-5-mini".to_string(),
+            }
+        }
+    );
+}
+
+#[test]
+fn model_command_rejects_set_without_model_name() {
+    let payload = InboundCommandPayload::new("model", "set", ProductTriggerReason::BotCommand)
+        .expect("valid command");
+
+    let rejection = ProductCommand::from_payload(&payload).expect_err("missing model");
+
+    assert_eq!(rejection.kind, ProductRejectionKind::InvalidRequest);
+}
+
+#[test]
 fn model_command_maps_provider_selection_without_cli_shelling_contract() {
     let payload = InboundCommandPayload::new(
         "model",

--- a/crates/product/ironclaw_assistant/tests/product_commands_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/product_commands_contract.rs
@@ -88,6 +88,19 @@ fn model_command_rejects_set_without_model_name() {
 }
 
 #[test]
+fn model_command_rejects_malformed_set_arguments() {
+    for arguments in ["set gpt-5-mini extra", "set --model gpt-5-mini"] {
+        let payload =
+            InboundCommandPayload::new("model", arguments, ProductTriggerReason::BotCommand)
+                .expect("valid command");
+
+        let rejection = ProductCommand::from_payload(&payload).expect_err("malformed model set");
+
+        assert_eq!(rejection.kind, ProductRejectionKind::InvalidRequest);
+    }
+}
+
+#[test]
 fn model_command_maps_provider_selection_without_cli_shelling_contract() {
     let payload = InboundCommandPayload::new(
         "model",


### PR DESCRIPTION
## Summary

- accept `/model set <name>` as the documented equivalent of `/model <name>`
- keep `/model set-provider ...` behavior unchanged
- reject `/model set` without a model name instead of silently selecting `set`
- update the feature parity matrix to describe the accepted model selection forms

## Change type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Maintenance

## Linked issue

Closes #6875

## Validation

- [x] `cargo +1.96.0 fmt --all -- --check`
- [x] `cargo +1.96.0 clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo +1.96.0 build`
- [x] `cargo +1.96.0 test`
- [x] Relevant focused test: `cargo +1.96.0 test -p ironclaw_product --test product_commands_contract model_command_`
- [ ] Integration tests (N/A: this is a pure local command-parser change)
- [ ] Manual end-to-end verification (N/A: public parser contract tests cover both accepted and rejected forms)

## Test Strategy

### User-visible behavior or state transition being changed

Typing `/model set gpt-5-mini` now selects `gpt-5-mini`. Typing `/model set` returns the existing invalid-command response instead of selecting a model literally named `set`.

### User-visible success and failure scenarios

- Success: `model set gpt-5-mini` produces `ModelCommand::Set { model: "gpt-5-mini" }`.
- Failure: `model set` is rejected because the required model name is absent.
- Regression guard: `model gpt-5`, `model`, and `model set-provider openai` retain their prior behavior.

### Unit or public API contract coverage

`crates/ironclaw_product/tests/product_commands_contract.rs` exercises the public `ProductCommand::parse` contract. The two new tests failed on the unmodified code and pass with this change.

### Property or invariant coverage

N/A: the parser branch has two finite invariants (a required argument and exact preservation of its value), covered directly by contract tests.

### Stateful or model-based coverage

N/A: parsing is pure and stateless.

### Protocol, schema, compatibility, or migration coverage

N/A: no protocol, persisted schema, or migration changes.

### Stress, soak, fuzz, or chaos coverage

N/A: no concurrency, unbounded input transformation, or stateful resource behavior is introduced.

### Manual end-to-end coverage

N/A: no runtime integration boundary changes; the command handler already consumes the same `ModelCommand::Set` variant.

### What proves the intended behavior

The focused public contract test proves the documented alias and the missing-name error. The full workspace build, clippy, and test suite prove unchanged command variants and downstream consumers still compile and pass.

### Exact commands run

```text
cargo +1.96.0 test -p ironclaw_product --test product_commands_contract model_command_
cargo +1.96.0 fmt --all -- --check
cargo +1.96.0 clippy --all --benches --tests --examples --all-features -- -D warnings
cargo +1.96.0 build
cargo +1.96.0 test
```

## Security Impact

None. This only normalizes a local slash-command syntax before it reaches the existing model-selection action. It does not change permissions, credentials, network access, tool admission, or trust boundaries.

## Trust-Bearing Types Checklist

N/A. The change creates no new trust-bearing type and does not alter an existing one.

## Effect Admission / Audience

Unchanged. The parser returns the same existing `ModelCommand::Set` action, so no new effect is admitted and no audience is broadened.

## Database Impact

None.

## Blast Radius and Rollback

Blast radius is limited to the `model` command parser and its feature-parity documentation. Existing short form and provider configuration parsing are contract-tested. Rollback is a straight revert of the two commits in this PR.

## Review Track

Track B: small behavior fix with public contract coverage.