### PR TITLE
fix(reborn): preserve result_read continuation authority

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -1473,10 +1473,11 @@ fn child_result_from_outcome(
 /// Rebuild the `ResultReference` model observation from a completed [`Outcome`],
 /// carrying the #5838 first-look inline preview content the model reads without a
 /// follow-up `result_read`. Reconstructed from the channel's real
-/// [`ModelResultPreview`] (`refs.preview`) — the delimiter/JSON-bearing content
-/// that the collapse now preserves (it rode the caption `SafeSummary` before,
-/// which dropped it). `None` when no preview is staged, in which case
-/// `append_capability_result_ref` synthesizes a bare success observation.
+/// [`ModelResultPreview`] (`refs.preview`) and its independent continuation
+/// metadata. Metadata-only observations are reconstructed when preview safety
+/// suppresses the text; `None` is reserved for outcomes with neither preview nor
+/// continuation metadata, where `append_capability_result_ref` synthesizes a bare
+/// success observation.
 fn result_reference_observation_from_outcome(
     outcome: &Outcome,
 ) -> Option<ModelVisibleToolObservation> {

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -1480,8 +1480,11 @@ fn child_result_from_outcome(
 fn result_reference_observation_from_outcome(
     outcome: &Outcome,
 ) -> Option<ModelVisibleToolObservation> {
-    let preview = outcome.refs.preview.as_ref()?;
+    let preview = outcome.refs.preview.as_ref();
     let meta = &outcome.refs.preview_meta;
+    if preview.is_none() && meta.is_empty() {
+        return None;
+    }
     // The observation references the preview's OWN result: `preview_meta`'s
     // referenced ref when it differs (a `result_read` presenting another result),
     // else the outcome's own preserved origin.
@@ -1508,7 +1511,7 @@ fn result_reference_observation_from_outcome(
         detail: ToolObservationDetail::ResultReference {
             result_ref,
             byte_len: outcome.refs.byte_len,
-            preview: Some(preview.as_str().to_string()),
+            preview: preview.map(|preview| preview.as_str().to_string()),
             // Continuation metadata for a truncated first-look preview; falls back
             // to the full inline size for a complete preview.
             total_bytes: meta.total_bytes.or(Some(outcome.refs.byte_len)),

--- a/crates/ironclaw_host_api/src/resolution.rs
+++ b/crates/ironclaw_host_api/src/resolution.rs
@@ -447,8 +447,9 @@ pub struct OutcomeRefs {
     pub preview: Option<ModelResultPreview>,
     /// Continuation metadata for a TRUNCATED first-look preview so the model can
     /// read the full result (`result_read`, large results): the referenced ref,
-    /// full byte size, next offset, and JSON-array element count. Empty (all
-    /// `None`) for a complete inline preview or no preview.
+    /// full byte size, next offset, and JSON-array element count. The metadata
+    /// remains present when an unsafe preview is suppressed, so the durable
+    /// source ref stays authoritative without exposing rejected content.
     #[serde(default, skip_serializing_if = "ResultPreviewMeta::is_empty")]
     pub preview_meta: ResultPreviewMeta,
     /// The preserved originating loop result ref, so output the loop staged under
@@ -464,9 +465,9 @@ pub struct OutcomeRefs {
     pub output_digest: Option<OutputDigest>,
 }
 
-/// Continuation metadata for a truncated first-look result preview (§5838). All
-/// fields default to `None` — an empty value means the preview (if any) is the
-/// complete result and needs no `result_read` follow-up.
+/// Continuation metadata for a first-look result preview (§5838). All fields
+/// default to `None`; metadata can remain non-empty when preview content is
+/// suppressed by model-visible safety validation.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ResultPreviewMeta {
     /// The result ref the preview is OF. A `result_read` reading ANOTHER result

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -857,8 +857,6 @@ fn large_echo_message() -> String {
 #[derive(Debug, Default)]
 struct LargeEchoToolCallingGateway {
     calls: StdMutex<usize>,
-    suppress_result_read_preview: bool,
-    source_result_ref: StdMutex<Option<String>>,
 }
 
 #[async_trait]
@@ -904,22 +902,16 @@ impl HostManagedModelGateway for LargeEchoToolCallingGateway {
                 "tool result replay must stay within the envelope bound, got {} bytes",
                 tool_result.content.len()
             );
-            if !self.suppress_result_read_preview {
-                assert!(
-                    tool_result.content.contains("Secretary of the Treasury"),
-                    "the initial result-reference preview must retain ordinary document text"
-                );
-            }
+            assert!(
+                tool_result.content.contains("Secretary of the Treasury"),
+                "the initial result-reference preview must retain ordinary document text"
+            );
             let result_ref = match tool_result.tool_result_content.as_ref() {
                 Some(HostManagedToolResultContent::Reference { envelope }) => {
                     envelope.result_ref.clone()
                 }
                 other => panic!("expected a result reference, got {other:?}"),
             };
-            *self
-                .source_result_ref
-                .lock()
-                .expect("source result ref lock poisoned") = Some(result_ref.clone());
             let result_read_id = CapabilityId::new("builtin.result_read").expect("reader id");
             let result_read_tool = capabilities
                 .tool_definitions()
@@ -967,43 +959,6 @@ impl HostManagedModelGateway for LargeEchoToolCallingGateway {
                             })
                 })
                 .expect("third model call should include result_read output");
-            if self.suppress_result_read_preview {
-                assert!(
-                    !tool_result.content.contains("\"preview\""),
-                    "the rejected chunk preview must remain suppressed"
-                );
-                let observation: serde_json::Value =
-                    serde_json::from_str(&tool_result.content).expect("result_read observation");
-                let detail = &observation["model_observation"]["detail"];
-                let source_result_ref = self
-                    .source_result_ref
-                    .lock()
-                    .expect("source result ref lock poisoned")
-                    .clone()
-                    .expect("source result ref captured");
-                assert_eq!(
-                    detail["result_ref"].as_str(),
-                    Some(source_result_ref.as_str()),
-                    "suppressed preview replay must retain the durable source result reference"
-                );
-                assert_ne!(
-                    detail["result_ref"], observation["result_ref"],
-                    "the inline result_read invocation ref must never become continuation authority"
-                );
-                assert!(
-                    detail["total_bytes"]
-                        .as_u64()
-                        .is_some_and(|total_bytes| total_bytes > 2048),
-                    "suppressed preview replay must retain total bytes: {}",
-                    tool_result.content
-                );
-                assert_eq!(
-                    detail["next_offset"].as_u64(),
-                    Some(2048),
-                    "suppressed preview replay must retain the next continuation offset"
-                );
-                return Ok(HostManagedModelResponse::assistant_reply("tool ok"));
-            }
             assert!(
                 tool_result.content.contains(LARGE_ECHO_MESSAGE),
                 "result_read must expose its bounded chunk to the model"
@@ -1041,11 +996,7 @@ impl HostManagedModelGateway for LargeEchoToolCallingGateway {
             .find(|definition| definition.capability_id == echo_id)
             .expect("echo provider tool definition");
         // Larger than both the observer preview and model replay preview.
-        let big_message = if self.suppress_result_read_preview {
-            format!("secret {}", large_echo_message())
-        } else {
-            large_echo_message()
-        };
+        let big_message = large_echo_message();
         let candidate = capabilities
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(ProviderToolCall {
                 provider_id: "test-provider".to_string(),
@@ -4211,53 +4162,6 @@ async fn standalone_runtime_safe_preview_observer_receives_bounded_payload() {
         "observer should receive a truncated preview of the large result"
     );
     assert_eq!(results[1].1, "builtin.result_read");
-}
-
-/// Regression: a `result_read` chunk whose inline preview is rejected by the
-/// model-visible credential guard must still replay the durable source ref and
-/// continuation metadata. Its InlineOnly invocation ref is not readable.
-#[tokio::test]
-async fn standalone_runtime_result_read_suppressed_preview_keeps_durable_continuation_ref() {
-    let root = tempfile::tempdir().expect("tempdir");
-    let gateway = Arc::new(LargeEchoToolCallingGateway {
-        calls: StdMutex::new(0),
-        suppress_result_read_preview: true,
-        source_result_ref: StdMutex::new(None),
-    });
-    let gateway_for_runtime: Arc<dyn HostManagedModelGateway> = gateway;
-    let input = RebornRuntimeInput::from_build_input(
-        crate::deployment::local_filesystem_build_input(
-            "runtime-suppressed-preview-owner",
-            root.path().join("standalone"),
-        )
-        .with_runtime_policy(standalone_runtime_policy()),
-    )
-    .with_identity(RebornRuntimeIdentity {
-        tenant_id: "runtime-suppressed-preview-tenant".to_string(),
-        agent_id: "runtime-suppressed-preview-agent".to_string(),
-        source_binding_id: "runtime-suppressed-preview-source".to_string(),
-        reply_target_binding_id: "runtime-suppressed-preview-reply".to_string(),
-    })
-    .with_poll_settings(PollSettings {
-        interval: Duration::from_millis(10),
-        max_total: Duration::from_secs(10),
-    })
-    .with_model_gateway_override(gateway_for_runtime);
-
-    let runtime = build_reborn_runtime(input).await.expect("runtime builds");
-    let conversation = runtime.new_conversation().await.expect("conversation");
-    runtime
-        .enable_global_auto_approve_for_test(&conversation)
-        .await;
-    let reply = tokio::time::timeout(
-        RUNTIME_SEND_TIMEOUT,
-        runtime.send_user_message(&conversation, "echo a sensitive large payload"),
-    )
-    .await
-    .expect("runtime send should finish")
-    .expect("runtime send should succeed");
-    assert_eq!(reply.status, TurnStatus::Completed, "reply: {reply:?}");
-    runtime.shutdown().await.expect("runtime shutdown");
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -857,6 +857,8 @@ fn large_echo_message() -> String {
 #[derive(Debug, Default)]
 struct LargeEchoToolCallingGateway {
     calls: StdMutex<usize>,
+    suppress_result_read_preview: bool,
+    source_result_ref: StdMutex<Option<String>>,
 }
 
 #[async_trait]
@@ -902,16 +904,22 @@ impl HostManagedModelGateway for LargeEchoToolCallingGateway {
                 "tool result replay must stay within the envelope bound, got {} bytes",
                 tool_result.content.len()
             );
-            assert!(
-                tool_result.content.contains("Secretary of the Treasury"),
-                "the initial result-reference preview must retain ordinary document text"
-            );
+            if !self.suppress_result_read_preview {
+                assert!(
+                    tool_result.content.contains("Secretary of the Treasury"),
+                    "the initial result-reference preview must retain ordinary document text"
+                );
+            }
             let result_ref = match tool_result.tool_result_content.as_ref() {
                 Some(HostManagedToolResultContent::Reference { envelope }) => {
                     envelope.result_ref.clone()
                 }
                 other => panic!("expected a result reference, got {other:?}"),
             };
+            *self
+                .source_result_ref
+                .lock()
+                .expect("source result ref lock poisoned") = Some(result_ref.clone());
             let result_read_id = CapabilityId::new("builtin.result_read").expect("reader id");
             let result_read_tool = capabilities
                 .tool_definitions()
@@ -959,6 +967,43 @@ impl HostManagedModelGateway for LargeEchoToolCallingGateway {
                             })
                 })
                 .expect("third model call should include result_read output");
+            if self.suppress_result_read_preview {
+                assert!(
+                    !tool_result.content.contains("\"preview\""),
+                    "the rejected chunk preview must remain suppressed"
+                );
+                let observation: serde_json::Value =
+                    serde_json::from_str(&tool_result.content).expect("result_read observation");
+                let detail = &observation["model_observation"]["detail"];
+                let source_result_ref = self
+                    .source_result_ref
+                    .lock()
+                    .expect("source result ref lock poisoned")
+                    .clone()
+                    .expect("source result ref captured");
+                assert_eq!(
+                    detail["result_ref"].as_str(),
+                    Some(source_result_ref.as_str()),
+                    "suppressed preview replay must retain the durable source result reference"
+                );
+                assert_ne!(
+                    detail["result_ref"], observation["result_ref"],
+                    "the inline result_read invocation ref must never become continuation authority"
+                );
+                assert!(
+                    detail["total_bytes"]
+                        .as_u64()
+                        .is_some_and(|total_bytes| total_bytes > 2048),
+                    "suppressed preview replay must retain total bytes: {}",
+                    tool_result.content
+                );
+                assert_eq!(
+                    detail["next_offset"].as_u64(),
+                    Some(2048),
+                    "suppressed preview replay must retain the next continuation offset"
+                );
+                return Ok(HostManagedModelResponse::assistant_reply("tool ok"));
+            }
             assert!(
                 tool_result.content.contains(LARGE_ECHO_MESSAGE),
                 "result_read must expose its bounded chunk to the model"
@@ -996,7 +1041,11 @@ impl HostManagedModelGateway for LargeEchoToolCallingGateway {
             .find(|definition| definition.capability_id == echo_id)
             .expect("echo provider tool definition");
         // Larger than both the observer preview and model replay preview.
-        let big_message = large_echo_message();
+        let big_message = if self.suppress_result_read_preview {
+            format!("secret {}", large_echo_message())
+        } else {
+            large_echo_message()
+        };
         let candidate = capabilities
             .register_provider_tool_call(RegisterProviderToolCallRequest::new(ProviderToolCall {
                 provider_id: "test-provider".to_string(),
@@ -4162,6 +4211,53 @@ async fn standalone_runtime_safe_preview_observer_receives_bounded_payload() {
         "observer should receive a truncated preview of the large result"
     );
     assert_eq!(results[1].1, "builtin.result_read");
+}
+
+/// Regression: a `result_read` chunk whose inline preview is rejected by the
+/// model-visible credential guard must still replay the durable source ref and
+/// continuation metadata. Its InlineOnly invocation ref is not readable.
+#[tokio::test]
+async fn standalone_runtime_result_read_suppressed_preview_keeps_durable_continuation_ref() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let gateway = Arc::new(LargeEchoToolCallingGateway {
+        calls: StdMutex::new(0),
+        suppress_result_read_preview: true,
+        source_result_ref: StdMutex::new(None),
+    });
+    let gateway_for_runtime: Arc<dyn HostManagedModelGateway> = gateway;
+    let input = RebornRuntimeInput::from_build_input(
+        crate::deployment::local_filesystem_build_input(
+            "runtime-suppressed-preview-owner",
+            root.path().join("standalone"),
+        )
+        .with_runtime_policy(standalone_runtime_policy()),
+    )
+    .with_identity(RebornRuntimeIdentity {
+        tenant_id: "runtime-suppressed-preview-tenant".to_string(),
+        agent_id: "runtime-suppressed-preview-agent".to_string(),
+        source_binding_id: "runtime-suppressed-preview-source".to_string(),
+        reply_target_binding_id: "runtime-suppressed-preview-reply".to_string(),
+    })
+    .with_poll_settings(PollSettings {
+        interval: Duration::from_millis(10),
+        max_total: Duration::from_secs(10),
+    })
+    .with_model_gateway_override(gateway_for_runtime);
+
+    let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+    let conversation = runtime.new_conversation().await.expect("conversation");
+    runtime
+        .enable_global_auto_approve_for_test(&conversation)
+        .await;
+    let reply = tokio::time::timeout(
+        RUNTIME_SEND_TIMEOUT,
+        runtime.send_user_message(&conversation, "echo a sensitive large payload"),
+    )
+    .await
+    .expect("runtime send should finish")
+    .expect("runtime send should succeed");
+    assert_eq!(reply.status, TurnStatus::Completed, "reply: {reply:?}");
+    runtime.shutdown().await.expect("runtime shutdown");
 }
 
 #[tokio::test]

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -895,12 +895,8 @@ fn validate_model_observation_detail(value: &serde_json::Value) -> Result<(), St
                 // untrusted, regardless of the enclosing observation's trust.
                 validate_model_observation_text(preview, ObservationProvenance::Untrusted)?;
             }
-            if object.contains_key("item_count")
-                && (!object.contains_key("preview") || !object.contains_key("next_offset"))
-            {
-                return Err(
-                    "model observation item_count requires preview and next_offset".to_string(),
-                );
+            if object.contains_key("item_count") && !object.contains_key("next_offset") {
+                return Err("model observation item_count requires next_offset".to_string());
             }
             Ok(())
         }
@@ -1995,10 +1991,9 @@ mod tests {
         );
     }
 
-    /// `item_count` is only meaningful alongside a truncated preview -- an
-    /// observation carrying `item_count` without `preview`/`next_offset`
-    /// must drop through the best-effort constructor and fall back to the
-    /// safe summary, mirroring the malformed-type case above.
+    /// `item_count` requires a continuation offset even when an unsafe preview
+    /// was suppressed. Without an offset it must drop through the best-effort
+    /// constructor and fall back to the safe summary.
     #[test]
     fn best_effort_observation_drops_item_count_without_preview() {
         let envelope = ToolResultReferenceEnvelope::new_best_effort_model_observation(
@@ -2021,12 +2016,41 @@ mod tests {
 
         assert!(
             envelope.model_observation.is_none(),
-            "item_count without preview/next_offset must drop the observation, not persist it"
+            "item_count without next_offset must drop the observation, not persist it"
         );
         assert_eq!(
             envelope.model_visible_content_or_safe_summary(),
             "tool completed"
         );
+    }
+
+    #[test]
+    fn best_effort_observation_keeps_item_count_without_preview() {
+        let envelope = ToolResultReferenceEnvelope::new_best_effort_model_observation(
+            "result:item-count-with-suppressed-preview",
+            ToolResultSafeSummary::new("tool completed").expect("summary"),
+            Some(serde_json::json!({
+                "schema_version": 1,
+                "status": "success",
+                "summary": "Tool completed; preview suppressed.",
+                "detail": {
+                    "kind": "result_reference",
+                    "result_ref": "result:item-count-with-suppressed-preview",
+                    "byte_len": 4096,
+                    "total_bytes": 4096,
+                    "next_offset": 2048,
+                    "item_count": 600
+                },
+                "trust": "untrusted_tool_output"
+            })),
+        )
+        .expect("envelope construction succeeds");
+
+        let observation = envelope
+            .model_observation
+            .expect("metadata-only observation is retained");
+        assert_eq!(observation["detail"]["item_count"], 600);
+        assert!(observation["detail"].get("preview").is_none());
     }
 
     fn invalid_input_observation_with_issue(issue: serde_json::Value) -> serde_json::Value {

--- a/crates/ironclaw_turns/src/run_profile/model_observation.rs
+++ b/crates/ironclaw_turns/src/run_profile/model_observation.rs
@@ -134,7 +134,8 @@ pub enum ToolObservationDetail {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         next_offset: Option<u64>,
         /// Element count when the full result is a top-level JSON array.
-        /// Attached only to truncated previews, so the model cannot misread
+        /// Attached only when a continuation offset exists, including when an
+        /// unsafe truncated preview is suppressed, so the model cannot misread
         /// a byte-sliced array as the complete result.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         item_count: Option<u64>,
@@ -163,7 +164,6 @@ impl ToolObservationDetail {
             }
             Self::ResultReference {
                 result_ref,
-                preview,
                 next_offset,
                 item_count,
                 ..
@@ -181,10 +181,8 @@ impl ToolObservationDetail {
                     "model observation result ref",
                     MODEL_OBSERVATION_TEXT_MAX_BYTES,
                 )?;
-                if item_count.is_some() && (preview.is_none() || next_offset.is_none()) {
-                    return Err(
-                        "model observation item_count requires preview and next_offset".to_string(),
-                    );
+                if item_count.is_some() && next_offset.is_none() {
+                    return Err("model observation item_count requires next_offset".to_string());
                 }
                 Ok(())
             }
@@ -485,12 +483,11 @@ mod tests {
         assert_eq!(value["trust"], "untrusted_tool_output");
     }
 
-    /// `item_count` is only meaningful alongside a truncated preview; a
-    /// `ResultReference` carrying `item_count` without both `preview` and
-    /// `next_offset` must fail validation.
+    /// `item_count` is meaningful for a truncated result even when its unsafe
+    /// preview is suppressed, but it must still carry a continuation offset.
     #[test]
-    fn result_reference_rejects_item_count_without_preview_and_next_offset() {
-        let observation = ModelVisibleToolObservation {
+    fn result_reference_allows_item_count_without_preview() {
+        let metadata_only = ModelVisibleToolObservation {
             schema_version: MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
             status: ToolObservationStatus::Success,
             summary: "Tool completed.".to_string(),
@@ -498,8 +495,8 @@ mod tests {
                 result_ref: "result:item-count-without-preview".to_string(),
                 byte_len: 4096,
                 preview: None,
-                total_bytes: None,
-                next_offset: None,
+                total_bytes: Some(4096),
+                next_offset: Some(2048),
                 item_count: Some(600),
             },
             artifacts: Vec::new(),
@@ -507,9 +504,24 @@ mod tests {
             trust: ObservationTrust::UntrustedToolOutput,
         };
 
-        observation
+        metadata_only
             .validate()
-            .expect_err("item_count without preview/next_offset must be rejected");
+            .expect("suppressed preview may retain item_count with next_offset");
+
+        let missing_offset = ModelVisibleToolObservation {
+            detail: ToolObservationDetail::ResultReference {
+                result_ref: "result:item-count-without-offset".to_string(),
+                byte_len: 4096,
+                preview: None,
+                total_bytes: Some(4096),
+                next_offset: None,
+                item_count: Some(600),
+            },
+            ..metadata_only
+        };
+        missing_offset
+            .validate()
+            .expect_err("item_count without next_offset must be rejected");
     }
 
     #[test]

--- a/crates/ironclaw_turns/src/run_profile/resolution.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolution.rs
@@ -1634,5 +1634,35 @@ mod tests {
             refs.preview_meta.summary.as_ref().map(SafeSummary::as_str),
             Some("tool completed")
         );
+
+        let mut suppressed_array = observation("secret");
+        let ToolObservationDetail::ResultReference {
+            total_bytes,
+            next_offset,
+            item_count,
+            ..
+        } = &mut suppressed_array.detail
+        else {
+            panic!("test observation must be a result reference");
+        };
+        *total_bytes = Some(4096);
+        *next_offset = Some(2048);
+        *item_count = Some(600);
+        let refs = match completed(
+            result_ref(),
+            "ok".to_string(),
+            CapabilityProgress::Unknown,
+            false,
+            4096,
+            None,
+            Some(suppressed_array),
+        ) {
+            Resolution::Done(outcome) => outcome.refs,
+            other => panic!("expected Done, got {other:?}"),
+        };
+        assert_eq!(refs.preview, None);
+        assert_eq!(refs.preview_meta.total_bytes, Some(4096));
+        assert_eq!(refs.preview_meta.next_offset, Some(2048));
+        assert_eq!(refs.preview_meta.item_count, Some(600));
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/resolution.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolution.rs
@@ -543,8 +543,10 @@ fn result_progress_of(progress: CapabilityProgress) -> ResultProgress {
 /// at a word boundary, up to 24 KiB. The paired [`ResultPreviewMeta`] carries the
 /// TRUNCATED-preview continuation info (`result_read` / large results): the
 /// referenced result ref, full byte size, next offset, and JSON-array element
-/// count, so the model reads the full result. Detail kinds other than
-/// `ResultReference` have no inline content.
+/// count, so the model reads the full result. This metadata is preserved even
+/// when the preview text is rejected: continuation authority belongs to the
+/// durable source result, not to the ephemeral invocation presenting it. Detail
+/// kinds other than `ResultReference` have no inline content.
 ///
 /// `own_result_ref` is this outcome's own loop result ref: the referenced ref is
 /// carried only when it DIFFERS (a `result_read` presenting another result's ref);
@@ -567,7 +569,7 @@ fn result_preview_parts(
     let summary = SafeSummary::new(summary).ok();
     let ToolObservationDetail::ResultReference {
         result_ref,
-        preview: Some(text),
+        preview,
         total_bytes,
         next_offset,
         item_count,
@@ -577,19 +579,18 @@ fn result_preview_parts(
         return empty;
     };
     // `.ok()` intentionally degrades content that fails the credential redaction
-    // contract to an absent preview (a pure text-to-redacted-content conversion);
-    // the full output stays reachable through the result ref, and without inline
-    // content the continuation metadata is useless, so drop both.
-    let Some(preview) = ModelResultPreview::new(text).ok() else {
-        return empty;
-    };
+    // contract to an absent preview (a pure text-to-redacted-content conversion).
+    // The result ref and paging metadata are independent host-authored authority:
+    // keep them so replay can continue against the durable source without
+    // exposing the rejected content or the current invocation's ephemeral ref.
+    let preview = preview.and_then(|text| ModelResultPreview::new(text).ok());
     let referenced_result_ref = if result_ref == own_result_ref.as_str() {
         None
     } else {
         LoopRef::new(result_ref).ok()
     };
     (
-        Some(preview),
+        preview,
         ResultPreviewMeta {
             referenced_result_ref,
             total_bytes,
@@ -1596,7 +1597,7 @@ mod tests {
 
     #[test]
     fn completed_observation_preview_carries_delimiter_content_and_drops_credentials() {
-        let refs_preview = |content: &str| match completed(
+        let outcome_refs = |content: &str| match completed(
             result_ref(),
             "ok".to_string(),
             CapabilityProgress::Unknown,
@@ -1605,18 +1606,33 @@ mod tests {
             None,
             Some(observation(content)),
         ) {
-            Resolution::Done(outcome) => outcome
-                .refs
-                .preview
-                .as_ref()
-                .map(|p| p.as_str().to_string()),
+            Resolution::Done(outcome) => outcome.refs,
             other => panic!("expected Done, got {other:?}"),
         };
 
         // Structured content with delimiters + "Secretary" retained verbatim.
         let content = "{\"office\": \"Secretary of the Treasury\", \"rows\": [1, 2, 3]}";
-        assert_eq!(refs_preview(content).as_deref(), Some(content));
-        // A genuine credential in the content drops the inline preview to None.
-        assert_eq!(refs_preview("token sk-ant-abc123def456").as_deref(), None);
+        assert_eq!(
+            outcome_refs(content)
+                .preview
+                .as_ref()
+                .map(ModelResultPreview::as_str),
+            Some(content)
+        );
+        // A genuine credential in the content drops only the inline preview.
+        // The referenced durable result remains authoritative for replay.
+        let refs = outcome_refs("token sk-ant-abc123def456");
+        assert_eq!(refs.preview, None);
+        assert_eq!(
+            refs.preview_meta
+                .referenced_result_ref
+                .as_ref()
+                .map(LoopRef::as_str),
+            Some("result:staged")
+        );
+        assert_eq!(
+            refs.preview_meta.summary.as_ref().map(SafeSummary::as_str),
+            Some("tool completed")
+        );
     }
 }

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -519,6 +519,19 @@ fn large_durable_file_content() -> String {
         .join("\n")
 }
 
+fn durable_file_content_with_suppressed_continuation_preview() -> String {
+    (0..1500)
+        .map(|i| {
+            if i == 800 {
+                "line-0800 secret filler filler filler".to_string()
+            } else {
+                format!("line-{i:04} filler filler filler filler")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Durable tool-result projection (issue #5838 / PR #5902): a `read_file`
 /// result routed through the REAL `StagedCapabilityIo`
 /// (`.with_durable_capability_io_file_tools()`, which wires
@@ -592,7 +605,10 @@ async fn durable_large_read_file_result_reaches_model_as_truncated_preview() {
 /// injected with `push_script`. Asserts the returned chunk continues
 /// byte-exactly from the SAME canonical serialization `tool_result_output`
 /// returns for `read_file` — no gap, no overlap — and reports the true
-/// `total_bytes` of the durable record.
+/// `total_bytes` of the durable record. The requested chunk contains a
+/// credential marker, so its inline preview is suppressed; replay must still
+/// retain the original durable ref and continuation metadata rather than the
+/// unreadable `InlineOnly` invocation ref.
 #[tokio::test]
 async fn result_read_continues_a_durable_result_byte_exactly() {
     let h = RebornIntegrationHarness::test_default()
@@ -600,7 +616,10 @@ async fn result_read_continues_a_durable_result_byte_exactly() {
         .script([
             RebornScriptedReply::tool_call(
                 "builtin.write_file",
-                json!({"path": "/workspace/durable.txt", "content": large_durable_file_content()}),
+                json!({
+                    "path": "/workspace/durable.txt",
+                    "content": durable_file_content_with_suppressed_continuation_preview()
+                }),
             ),
             RebornScriptedReply::tool_call(
                 "builtin.read_file",
@@ -664,6 +683,44 @@ async fn result_read_continues_a_durable_result_byte_exactly() {
         chunk["total_bytes"].as_u64(),
         Some(serialized.len() as u64),
         "result_read must report the true total byte length of the durable record"
+    );
+    assert!(
+        chunk_content.contains("secret"),
+        "fixture must put the rejected marker inside the requested chunk"
+    );
+
+    let envelopes = h
+        .persisted_tool_result_envelopes()
+        .await
+        .expect("tool-result envelopes persist");
+    let result_read = envelopes.last().expect("result_read envelope exists");
+    let observation = result_read
+        .model_observation
+        .as_ref()
+        .expect("metadata-only result_read observation survives");
+    let detail = &observation["detail"];
+    assert_ne!(
+        result_read.result_ref, result_ref,
+        "the result_read invocation keeps its own ephemeral envelope ref"
+    );
+    assert_eq!(
+        detail["result_ref"].as_str(),
+        Some(result_ref.as_str()),
+        "continuation authority remains the durable source ref"
+    );
+    assert!(
+        detail.get("preview").is_none(),
+        "credential-bearing preview remains suppressed"
+    );
+    assert_eq!(
+        detail["total_bytes"].as_u64(),
+        Some(serialized.len() as u64)
+    );
+    assert!(
+        detail["next_offset"]
+            .as_u64()
+            .is_some_and(|offset| offset > next_offset),
+        "paging metadata survives independently of preview content"
     );
 }
 
@@ -803,7 +860,8 @@ fn truncated_array_result_persists_item_count_to_model_transcript() {
 }
 
 async fn truncated_array_result_persists_item_count_to_model_transcript_impl() {
-    let items: Vec<String> = (0..4000).map(|i| format!("item-{i:04}")).collect();
+    let mut items: Vec<String> = (0..4000).map(|i| format!("item-{i:04}")).collect();
+    items[0] = "secret".to_string();
     let array_json = serde_json::to_string(&items).expect("array fixture serializes");
     assert!(
         array_json.len() > ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES,
@@ -835,6 +893,19 @@ async fn truncated_array_result_persists_item_count_to_model_transcript_impl() {
     h.assert_conversation_history_role_contains(MessageKind::ToolResultReference, "4000 items")
         .await
         .expect("persisted summary names the array's element count");
+    let envelopes = h
+        .persisted_tool_result_envelopes()
+        .await
+        .expect("tool-result envelopes persist");
+    let observation = envelopes
+        .last()
+        .and_then(|envelope| envelope.model_observation.as_ref())
+        .expect("metadata-only array observation survives");
+    assert_eq!(observation["detail"]["item_count"], 4000);
+    assert!(
+        observation["detail"].get("preview").is_none(),
+        "credential-bearing array preview remains suppressed"
+    );
 }
 
 /// Spawns the async test body on a thread with a larger-than-default OS


### PR DESCRIPTION
## Summary

- Preserve the canonical durable source result ref and paging metadata when a `result_read` chunk's model-visible preview is suppressed.
- Reconstruct a metadata-only result observation instead of exposing the unreadable `InlineOnly` invocation ref as continuation authority.
- Retain top-level JSON-array `item_count` when preview text is suppressed but a valid `next_offset` remains.
- Cover the behavior at the root Reborn caller path and with focused unit/persistence validation tests.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] Full workspace clippy — not run to avoid another broad build after the previously reported disk-pressure incident; the selected integration target already compiled the affected Reborn dependency chain.
- [x] Relevant focused unit tests pass.
- [x] Relevant root Reborn integration tests pass.
- [ ] Manual live-provider testing — not applicable: the behavior is deterministic and the integration harness exercises the production caller path.
- [x] Multi-agent review completed; all three findings were addressed before this update.

## Test Strategy

User behavior: Given a durable tool result, when `result_read` returns a chunk whose untrusted preview is suppressed, the next model replay retains the original readable result ref plus `total_bytes` and `next_offset`, and never offers the ephemeral read invocation ref as continuation authority.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: validates metadata-only `item_count` when `next_offset` is present, rejects `item_count` without an offset, and verifies collapse preserves suppressed-preview metadata.
- Reborn integration: exercises durable file write/read/result_read/replay with the requested chunk intentionally failing preview safety, then asserts the persisted model observation retains the durable source ref and continuation offsets. The existing top-level array caller test now also suppresses its preview and asserts `item_count` persists.
- Recorded fixture: Not applicable: tool choice and provider argument selection are unchanged.
- Browser E2E: Not applicable: no browser-visible surface changed.
- Backend or runtime: Not applicable: no PostgreSQL, libSQL, Docker, WASM, MCP, or runtime-lane contract changed.
- Live canary: Not applicable: no live provider or external integration behavior changed.

What the tests prove: Preview safety remains fail-closed; continuation metadata survives independently of preview content; the durable source ref remains authoritative; metadata-only JSON-array observations survive persistence; and the `InlineOnly` result-read invocation ref is never presented as readable continuation authority.

Commands run:

- `cargo test -p ironclaw_turns result_reference_allows_item_count_without_preview` — passed (1 test).
- `cargo test -p ironclaw_turns completed_observation_preview_carries_delimiter_content_and_drops_credentials` — passed (1 test).
- `cargo test -p ironclaw_threads best_effort_observation_keeps_item_count_without_preview` — passed (1 test).
- `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_tool_call result_read_continues_a_durable_result_byte_exactly` — passed (1 test).
- `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_tool_call truncated_array_result_persists_item_count_to_model_transcript` — passed (1 test).
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Security Impact

No permission, network, file-access, tool-execution, or sandbox policy changes. Untrusted preview content is still rejected and remains absent from replay. Only existing host-authored result-reference and paging metadata is preserved, and `item_count` remains invalid without a continuation offset.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new types; existing `OutcomeRefs` / `ResultPreviewMeta` values remain constructed by the turns resolution boundary.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: preview validation and suppression are unchanged; rejected content is not reconstructed.
- [ ] Hash purpose/authenticity: Not applicable; no hash behavior changed.
- [ ] New/changed status, exit, policy, runtime, or error variants: Not applicable; no variants changed.
- [x] Security/durability serde defaults fail closed: missing historical metadata remains empty and gains no continuation authority.
- [x] Queues/maps/buffers/counters are bounded: no queue, map, buffer, or arithmetic behavior changed.
- [ ] Driver/operator-visible error classes: Not applicable; no error semantics changed.
- [ ] Sandbox/native/host naming: Not applicable; no boundary names changed.

## Database Impact

None. No migrations, schemas, or PostgreSQL/libSQL behavior changed.

## Compatibility and Rollback

Wire compatibility is preserved: all metadata fields already existed and remain optional/defaulted, so historical records continue to deserialize without gaining authority. The behavioral change is limited to retaining already-produced metadata when preview text is absent. Roll back by reverting commits `110ccf510` and `504c356d9`; there is no data migration or cleanup.

## Blast Radius

Touches the turn-resolution collapse, model-observation validation/persistence, and canonical agent-loop reconstruction for successful result-reference observations. Ordinary safe previews and recoverable failures retain their existing behavior.

## Review Follow-Through

The multi-agent review found three actionable items: metadata-only array validation, missing suppressed-array coverage, and caller-test placement. All were addressed in `110ccf510`.

---

**Review track**: C (runtime/trust-boundary behavior)