### PR TITLE
fix(ci): create nested mutation audit output directory

### DIFF
--- a/scripts/mutation-audit.sh
+++ b/scripts/mutation-audit.sh
@@ -103,6 +103,10 @@ for file in "${files[@]:-}"; do
 done
 [ "$MUT_ITERATE" = "1" ] && args+=(--iterate)
 
+# cargo-mutants creates --output with a single-level mkdir, which fails when
+# an intermediate parent (such as target/) does not exist on a fresh runner.
+mkdir -p -- "$MUT_OUT"
+
 echo "▶ mutation audit: package=$package files=${files[*]:-<all>}"
 set +e
 cargo mutants "${args[@]}"

--- a/scripts/test-mutation-audit.sh
+++ b/scripts/test-mutation-audit.sh
@@ -127,7 +127,8 @@ echo "▶ G. the audit hands the generator the directory cargo-mutants wrote to"
 # itself. Testing the helper proved nothing about the caller wiring it — the
 # gap .claude/rules/testing.md calls "test through the caller".
 #
-# A stub cargo reproduces that layout without compiling anything.
+# A stub cargo reproduces that layout and cargo-mutants' non-recursive creation
+# of --output without compiling anything.
 stub_bin="$work/stub-bin"
 mkdir -p "$stub_bin"
 for tool in bash sed grep python3 mktemp rm dirname cat mkdir; do
@@ -138,7 +139,10 @@ done
 chmod +x "$stub_bin/cargo-mutants"
 cat >"$stub_bin/cargo" <<'STUB'
 #!/usr/bin/env bash
-# Mimic the one behaviour under test: `--output DIR` yields DIR/mutants.out.
+set -euo pipefail
+
+# Mimic the behaviours under test: cargo-mutants creates --output with a
+# single-level mkdir, then creates mutants.out inside it.
 out="."
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -146,13 +150,14 @@ while [ $# -gt 0 ]; do
     *) shift ;;
   esac
 done
-mkdir -p "$out/mutants.out"
+[ -d "$out" ] || mkdir "$out"
+mkdir "$out/mutants.out"
 echo 'crates/demo/src/lib.rs:12:5: replace add with ()' >"$out/mutants.out/missed.txt"
 : >"$out/mutants.out/caught.txt"
 STUB
 chmod +x "$stub_bin/cargo"
 
-audit_out="$work/audit-out"
+audit_out="$work/missing-parent/audit-out"
 check "audit completes and writes the queue where cargo-mutants wrote results" \
   bash -c "PATH='$stub_bin' MUT_OUT='$audit_out' '$audit' -p demo >/dev/null 2>&1 \
     && [ -f '$audit_out/mutants.out/triage-queue.md' ]"


### PR DESCRIPTION
## Summary

- Create the configured mutation-audit output directory recursively before invoking cargo-mutants.
- Make the mutation harness self-test reproduce cargo-mutants single-level output-directory creation.
- Prevent the nightly mutation frontier from failing before any mutants run on a fresh runner.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Fixes the failure in https://github.com/nearai/ironclaw/actions/runs/30606102176/job/91078540152.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust files changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust code changed.
- [ ] `cargo build` — Not applicable: shell-only CI harness change.
- [x] Relevant tests pass: `scripts/test-mutation-audit.sh`
- [ ] `cargo test --features integration` — Not applicable: no database-backed or integration behavior changed.
- [x] Manual testing: confirmed the regression test fails before the fix and passes after it; `bash -n` and `git diff --check` pass.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run: focused two-file shell change with direct regression coverage.

## Test Strategy

User behavior: Scheduled mutation audits using a nested `MUT_OUT` path complete setup and start cargo-mutants on a fresh runner.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Updated `scripts/test-mutation-audit.sh` to use a missing intermediate output parent and to mirror cargo-mutants non-recursive directory creation.
- Reborn integration: Not applicable: no Reborn product behavior changed.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Not applicable: no backend or runtime behavior changed.
- Live canary: Not applicable: no provider or model drift behavior changed.

What the tests prove: The caller prepares all missing output-directory ancestors before invoking cargo-mutants, and still generates the triage queue from the expected report location.

Commands run:

- `scripts/test-mutation-audit.sh` (failed before the fix, passed after it)
- `bash -n scripts/mutation-audit.sh scripts/test-mutation-audit.sh`
- `git diff --check`
- `shellcheck` was unavailable locally and was explicitly skipped.

## Security Impact

None. The script already accepted `MUT_OUT` and wrote mutation reports beneath it; this change only prepares that configured directory recursively before the existing write.

## Reborn Trust-Boundary Checklist

N/A: this is a shell-only scheduled CI harness fix and does not change Reborn types, prompts, runtime status, serialization, queues, errors, or trust boundaries.

## Database Impact

None.

## Blast Radius

Limited to `scripts/mutation-audit.sh` callers that provide a missing nested `MUT_OUT`. Existing output rotation and report paths remain owned by cargo-mutants and are unchanged.

## Rollback Plan

Revert this commit. As an emergency workflow-only workaround, create `target/nightly-mutation` before invoking the audit script.

## Review Follow-Through

No known follow-up. Reviewer attention should focus on whether output-directory ownership belongs in the reusable harness; its documented `MUT_OUT` contract indicates that it does.

---

**Review track**: C (scheduled CI behavior)