### PR TITLE
fix(webui): keep message actions visible

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -548,7 +548,7 @@ test("error bubbles expose structural provider failure metadata", async () => {
   assert.match(html, /data-failure-status="failed"/);
 });
 
-test("message timestamp and actions share a hover-only meta row", () => {
+test("message timestamp and actions share an always-visible meta row", () => {
   assert.match(
     messageBubbleSource,
     /const showActions =[\s\S]*CHAT_MESSAGE_ROLES\.USER[\s\S]*CHAT_MESSAGE_ROLES\.ASSISTANT/,
@@ -561,8 +561,13 @@ test("message timestamp and actions share a hover-only meta row", () => {
   );
   assert.match(
     messageBubbleSource,
-    /mt-1 flex min-h-7 w-max v2-chat-readable-width flex-nowrap items-center gap-3 px-1 text-iron-400 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100/,
-    "timestamp and controls should stay hidden until message hover or focus without being constrained to the bubble width",
+    /mt-1 flex min-h-7 w-max v2-chat-readable-width flex-nowrap items-center gap-3 px-1 text-iron-400/,
+    "timestamp and controls should remain visible without being constrained to the bubble width",
+  );
+  assert.doesNotMatch(
+    messageBubbleSource,
+    /text-iron-400[^"\n]*(?:opacity-0|group-hover:opacity-100|focus-within:opacity-100)/,
+    "message actions should not depend on hover or keyboard focus for visibility",
   );
   assert.match(
     messageBubbleSource,
@@ -577,7 +582,7 @@ test("message timestamp and actions share a hover-only meta row", () => {
   assert.doesNotMatch(
     actionRow,
     />\s*\$\{copied \? "Copied" : "Copy"\}\s*<|>Retry</,
-    "hover controls should use fixed-size icons instead of text that competes with the timestamp",
+    "message controls should use fixed-size icons instead of text that competes with the timestamp",
   );
 });
 

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
@@ -378,7 +378,7 @@ function MessageBubbleImpl({
       {showMetaRow && (
         <div
           className={[
-            "mt-1 flex min-h-7 w-max v2-chat-readable-width flex-nowrap items-center gap-3 px-1 text-iron-400 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100",
+            "mt-1 flex min-h-7 w-max v2-chat-readable-width flex-nowrap items-center gap-3 px-1 text-iron-400",
             isUser
               ? "self-end justify-end"
               : isNotice


### PR DESCRIPTION
## Summary

- Keeps each message timestamp and action row visible without requiring pointer hover or keyboard focus.
- Preserves the existing muted default color, per-icon hover feedback, action gating, disabled states, and tooltips.
- Adds a regression assertion that prevents the hover-only opacity classes from returning.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None — requested as a focused WebUI visibility correction.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust changed.
- [x] `pnpm lint` (`lint:conventions` + `tsc --noEmit`)
- [x] `pnpm test` — 117 files / 986 tests
- [x] `pnpm build` — includes enforced bundle budgets
- [ ] `cargo test --features integration` — Not applicable: no database or integration behavior changed.
- [ ] Manual testing — Not performed; the component-level class contract covers this presentation-only change.
- [ ] `review-pr` / `pr-shepherd --fix` — Not run for this two-file presentation fix.

## Test Strategy

User behavior: Given a rendered user or final assistant message, when the pointer is not hovering the message and no action has focus, then its timestamp and permitted message action icons remain visible.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Updated `message-bubble.test.ts` to require the always-visible meta-row classes and reject `opacity-0`, `group-hover:opacity-100`, or `focus-within:opacity-100` visibility gating.
- Reborn integration: Not applicable: no turn, runner, product workflow, or backend behavior changed.
- Recorded fixture: Not applicable: no model choice or request shape changed.
- Browser E2E: Not added: the existing component contract directly covers the rendered class behavior; no interaction flow changed.
- Backend or runtime: Not applicable: no backend or runtime behavior changed.
- Live canary: Not applicable: no model or provider behavior changed.

What the tests prove: message timestamps and permitted action icons remain in the rendered meta row without hover/focus opacity gating, while the existing action layout and icon-only controls remain intact.

Commands run:
- `pnpm exec vitest run src/pages/chat/components/message-bubble.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Security Impact

None. Existing action availability and export feature gates are unchanged.

## Reborn Trust-Boundary Checklist

N/A — presentation-only frontend class change; no trust, ingress, runtime, persistence, or policy boundary changed.

## Database Impact

None.

## Blast Radius

Limited to the timestamp/action meta row for user and final assistant message bubbles. A regression could affect visual density, but not whether an action is authorized or executable.

## Rollback Plan

Revert the single commit to restore hover/focus-only visibility.

## Review Follow-Through

No known follow-up. Reviewer judgment is limited to the always-visible visual density.

---

**Review track**: A (presentational WebUI bug fix with focused regression coverage)
