### PR TITLE
fix hosted HTTP response saving

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
@@ -613,11 +613,20 @@ pub(super) async fn build_backend_production(
     .with_turn_run_wake_notifier_dyn(production_wiring.turn_run_wake_notifier);
     #[cfg(any(test, feature = "test-support"))]
     let services = match network_http_egress_for_test {
-        Some(test_egress) => services.try_with_host_http_egress(test_egress)?,
-        None => services.try_with_host_http_egress(default_host_http_egress()?)?,
+        Some(test_egress) => services.try_with_host_http_egress_with_body_store(
+            test_egress,
+            Arc::clone(&stores.scoped_filesystem),
+        )?,
+        None => services.try_with_host_http_egress_with_body_store(
+            default_host_http_egress()?,
+            Arc::clone(&stores.scoped_filesystem),
+        )?,
     };
     #[cfg(not(any(test, feature = "test-support")))]
-    let services = services.try_with_host_http_egress(default_host_http_egress()?)?;
+    let services = services.try_with_host_http_egress_with_body_store(
+        default_host_http_egress()?,
+        Arc::clone(&stores.scoped_filesystem),
+    )?;
     let product_auth_runtime_ports = require_product_auth_runtime_ports(&services)?;
     let services = attach_hosted_mcp_runtime(services)?;
     let admin_configuration_credential_slot = AdminConfigurationCredentialSlot::default();

--- a/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
@@ -612,19 +612,15 @@ pub(super) async fn build_backend_production(
     .with_production_reborn_event_stores(event_stores)
     .with_turn_run_wake_notifier_dyn(production_wiring.turn_run_wake_notifier);
     #[cfg(any(test, feature = "test-support"))]
-    let services = match network_http_egress_for_test {
-        Some(test_egress) => services.try_with_host_http_egress_with_body_store(
-            test_egress,
-            Arc::clone(&stores.scoped_filesystem),
-        )?,
-        None => services.try_with_host_http_egress_with_body_store(
-            default_host_http_egress()?,
-            Arc::clone(&stores.scoped_filesystem),
-        )?,
+    let network_http_egress = match network_http_egress_for_test {
+        Some(test_egress) => test_egress,
+        None => Arc::new(default_host_http_egress()?),
     };
     #[cfg(not(any(test, feature = "test-support")))]
+    let network_http_egress: Arc<dyn ironclaw_network::NetworkHttpEgress> =
+        Arc::new(default_host_http_egress()?);
     let services = services.try_with_host_http_egress_with_body_store(
-        default_host_http_egress()?,
+        network_http_egress,
         Arc::clone(&stores.scoped_filesystem),
     )?;
     let product_auth_runtime_ports = require_product_auth_runtime_ports(&services)?;

--- a/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
@@ -619,10 +619,9 @@ pub(super) async fn build_backend_production(
     #[cfg(not(any(test, feature = "test-support")))]
     let network_http_egress: Arc<dyn ironclaw_network::NetworkHttpEgress> =
         Arc::new(default_host_http_egress()?);
-    let services = services.try_with_host_http_egress_with_body_store(
-        network_http_egress,
-        Arc::clone(&stores.scoped_filesystem),
-    )?;
+    let http_body_store = Arc::clone(&stores.scoped_filesystem);
+    let services =
+        services.try_with_host_http_egress_with_body_store(network_http_egress, http_body_store)?;
     let product_auth_runtime_ports = require_product_auth_runtime_ports(&services)?;
     let services = attach_hosted_mcp_runtime(services)?;
     let admin_configuration_credential_slot = AdminConfigurationCredentialSlot::default();

--- a/tests/integration/support/harness/assembly.rs
+++ b/tests/integration/support/harness/assembly.rs
@@ -391,10 +391,13 @@ pub(crate) fn standalone_host_runtime_with_real_egress_pipeline(
 ) -> HarnessResult<Arc<dyn HostRuntime>> {
     let mut registry = ExtensionRegistry::new();
     registry.insert(builtin_first_party_package()?)?;
+    let filesystem =
+        standalone_root_filesystem(storage_root, StandaloneRootMounts::core_builtins())?;
+    let scoped_filesystem = ironclaw_reborn_composition::wrap_scoped(Arc::clone(&filesystem));
 
     let mut services = HostRuntimeServices::new(
         Arc::new(registry),
-        standalone_root_filesystem(storage_root, StandaloneRootMounts::core_builtins())?,
+        filesystem,
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
@@ -404,10 +407,10 @@ pub(crate) fn standalone_host_runtime_with_real_egress_pipeline(
     .with_first_party_capabilities(Arc::new(builtin_first_party_handlers(Arc::new(
         ironclaw_triggers::InMemoryTriggerRepository::default(),
     ))?))
-    .try_with_host_http_egress(PolicyNetworkHttpEgress::new_with_resolver(
-        network_transport,
-        StaticNetworkResolver,
-    ))
+    .try_with_host_http_egress_with_body_store(
+        PolicyNetworkHttpEgress::new_with_resolver(network_transport, StaticNetworkResolver),
+        scoped_filesystem,
+    )
     .map_err(|report| {
         std::io::Error::other(format!(
             "real egress pipeline production wiring failed: {report:?}"

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -321,9 +321,9 @@ async fn assertions_fail_when_tool_present_but_requested_tool_or_url_does_not_ma
 /// encoding to `builtin__http__save` at the provider seam) resolves end-to-end,
 /// writing to the `/workspace` mount `core_builtin_tools` provides read-write.
 #[tokio::test]
-async fn runs_http_save_tool_call_through_recorded_egress() {
+async fn runs_http_save_tool_call_through_real_egress_and_persists_body() {
     let h = RebornIntegrationHarness::test_default()
-        .with_builtin_http_tools()
+        .with_real_egress_pipeline()
         .script([
             RebornScriptedReply::tool_call(
                 "builtin.http.save",
@@ -340,10 +340,9 @@ async fn runs_http_save_tool_call_through_recorded_egress() {
     h.assert_tool_invoked("builtin.http.save")
         .await
         .expect("http.save tool ran");
-    // The save path must reach the real `RuntimeHttpEgress`.
-    h.assert_egress_request_matching("api.example.test")
+    h.assert_workspace_file_contains("response.json", r#"{"ok":true}"#)
         .await
-        .expect("http.save egress captured");
+        .expect("http.save persisted the response body");
     h.assert_reply_contains("saved")
         .await
         .expect("final reply finalized");


### PR DESCRIPTION
## Summary

- Wire the scoped filesystem into hosted Reborn HTTP egress so `builtin.http.save` can persist sanitized response bodies.
- Preserve the existing network-policy, mount-authorization, and response-limit pipeline.
- Strengthen the whole-turn regression to assert the downloaded bytes actually exist in `/workspace`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Reproduced from an exported hosted single-tenant run.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run workspace-wide; scoped all-target/all-feature clippy passed for `ironclaw_reborn_composition`.
- [ ] `cargo build` — Not run separately; targeted integration and clippy builds completed.
- [x] Relevant tests pass: focused saved-body regression after rebasing onto current `main`; complete 30-test `reborn_integration_tool_call` suite before rebase.
- [ ] `cargo test --features integration` — Not applicable: no database schema or backend-specific persistence behavior changed.
- [ ] Manual testing — Not applicable: the supplied run artifact was historical; deterministic caller-path coverage reproduces the failure.
- [ ] Agent review workflow — Not run; PR remains draft.

A broad `cargo test -p ironclaw_reborn_composition` run compiled and started 535 tests, but was stopped after unrelated OAuth/extension lifecycle tests exceeded their 60-second warnings. It is not counted as passing evidence.

## Test Strategy

User behavior:

Given a hosted single-tenant user invokes `builtin.http.save`, when the mediated HTTP request succeeds, the sanitized response body is written to the requested scoped `/workspace` path instead of returning `response body store is unavailable`.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable: this defect is production composition wiring, not isolated logic.
- Reborn integration: Updated `runs_http_save_tool_call_through_real_egress_and_persists_body`.
- Recorded fixture: Not applicable: model tool selection and arguments are not changing.
- Browser E2E: Not applicable: no browser surface changes.
- Backend or runtime: The Reborn integration uses the real host egress pipeline with a hermetic wire transport and real scoped filesystem.
- Live canary: Not applicable: deterministic behavior does not depend on a live provider.

What the tests prove:

The test drives a whole scripted turn through the real capability and host egress path, then reads the actual workspace file and verifies the response bytes. Before the fix, the file was absent; after the fix, it contains the expected response body.

Commands run:

- `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_tool_call runs_http_save_tool_call_through_real_egress_and_persists_body`
- `cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_tool_call`
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Security Impact

Restores the declared scoped-filesystem write path for `builtin.http.save`. The change does not grant new authority or bypass approval, network policy, mount resolution, sanitization, or response-size enforcement.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no public types changed.
- [x] Untrusted content enters prompts only through an envelope: N/A; no prompt handling changed.
- [x] Hashes declare purpose: N/A; no hashing changed.
- [x] New/changed status, policy, runtime, or error variants: N/A; no variants changed.
- [x] Security/durability `serde(default)` fields: N/A; no serialization changed.
- [x] Queues/maps/buffers/counters: N/A; no collection or accounting changes.
- [x] Driver/operator-visible errors retain stable class semantics.
- [x] The host-owned scoped filesystem remains behind the existing body-store port.

## Database Impact

None. No migrations, schemas, queries, or PostgreSQL/libSQL-specific behavior changed.

## Blast Radius

Hosted and production-shaped Reborn runtime composition for `builtin.http.save`, including `hosted-single-tenant` and `hosted-single-tenant-volume`. Inline `builtin.http`, network policy, secrets, approvals, and other filesystem capabilities are unchanged.

## Rollback Plan

Revert commit `2e1ffa279`. This restores the prior fail-closed behavior where saved-body HTTP requests return the body-store-unavailable error and write no file.

## Review Follow-Through

Reviewer judgment requested on whether a production-profile-specific composition test is desirable beyond the whole-turn real-egress regression. No known compatibility or migration risk.

---

**Review track**: C (runtime wiring)
