### PR TITLE
fix(canary): restore full scheduled Reborn QA matrix

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -900,15 +900,11 @@ jobs:
           - shard_id: qa-8-delivery
             shard_name: QA 8D
             cases: qa_8d_hn_keyword_slack_delivery
-          # Automation delivery probes remain dispatchable as a full shard.
-          # The recurring lane selects only the manifest-declared
-          # representative drift case below.
+          # Automation delivery probes run on the recurring full-matrix lane.
           - shard_id: qa-9
             shard_name: QA 9
             cases: qa_9a_slack_connect,qa_9b_routine_dm_delivery_exactly_once,qa_9c_slack_digest_names_not_ids,qa_9d_routine_per_trigger_delivery_target
-          # Slack tool-correctness probes remain dispatchable as a full shard.
-          # The recurring lane selects only the manifest-declared
-          # representative drift case below.
+          # Slack tool-correctness probes run on the recurring full-matrix lane.
           - shard_id: qa-10
             shard_name: QA 10
             cases: qa_10a_slack_self_attribution,qa_10b_slack_ooo_status,qa_10c_slack_thread_replies,qa_10d_slack_channel_membership,qa_10e_slack_error_honesty,qa_10f_slack_mention_encoding,qa_10g_slack_last_message_sent,qa_10g_slack_last_message_sent_global,qa_10h_slack_email_hallucination_guard,qa_10i_slack_raw_entity_hygiene
@@ -941,10 +937,9 @@ jobs:
         id: resolve_reborn_webui_v2_cases
         shell: bash
         env:
-          # Recurring runs retain only the representative drift suite declared
-          # in the promotion manifest. Explicit dispatches can still select any
-          # known case for attended diagnosis.
-          REQUESTED_CASES: ${{ github.event_name == 'schedule' && 'qa_3b_endpoint_status_live_chat,qa_9b_routine_dm_delivery_exactly_once,qa_10a_slack_self_attribution' || inputs.cases || vars.REBORN_WEBUI_V2_LIVE_QA_CASES || 'all' }}
+          # Recurring runs exercise the complete implemented non-Telegram QA
+          # matrix. Explicit dispatches can still select individual cases.
+          REQUESTED_CASES: ${{ github.event_name == 'schedule' && 'all' || inputs.cases || vars.REBORN_WEBUI_V2_LIVE_QA_CASES || 'all' }}
           DISPATCH_ONLY_SHARD: ${{ matrix.dispatch_only || false }}
           SHARD_CASES: ${{ matrix.cases }}
           ALL_SHARD_CASES: >-

--- a/docs/internal/live-canary.md
+++ b/docs/internal/live-canary.md
@@ -47,6 +47,7 @@ account guide rather than introducing another bespoke runner layout.
 | `auth-channels` | WASM channel auth diagnostic lane | GitHub-hosted | Manual | No |
 | `auth-live-seeded` | Real-provider runtime checks using seeded tokens against a clean DB | GitHub-hosted | Hourly and manual | No |
 | `auth-browser-consent` | Real browser-consent OAuth using Playwright against provider login UIs | GitHub-hosted | Nightly and manual | No |
+| `reborn-webui-v2-live-qa` | Full implemented non-Telegram QA matrix against real model and provider surfaces | GitHub-hosted | Every 3 hours and manual | Opens issue on scheduled failure |
 
 ## Required Repository Configuration
 

--- a/scripts/ci/check-regression-promotions.py
+++ b/scripts/ci/check-regression-promotions.py
@@ -167,36 +167,48 @@ def validate(
         elif fixture and not (repo_root / fixture).is_file():
             errors.append(f"{field}.deterministic_fixture does not exist")
 
-    replayable = selected - no_model - quarantined
-    accounted = drift_set | retired_set
-    missing = sorted(replayable - accounted)
-    unexpected = sorted(accounted - replayable)
-    if missing:
-        errors.append(
-            "replayable cases must be representative drift or retired: "
-            + ", ".join(missing)
-        )
-    if unexpected:
-        errors.append(
-            "live/retired cases must have active deterministic replay: "
-            + ", ".join(unexpected)
-        )
-
-    workflow = (repo_root / ".github/workflows/live-canary.yml").read_text(encoding="utf-8")
+    workflow = (repo_root / ".github/workflows/live-canary.yml").read_text(
+        encoding="utf-8"
+    )
     scheduled_match = re.search(
         r"REQUESTED_CASES:\s*\$\{\{\s*github\.event_name == 'schedule'\s*&&\s*'([^']+)'",
         workflow,
     )
+    scheduled: set[str] = set()
     if not scheduled_match:
-        errors.append("live-canary workflow has no mechanical scheduled drift selection")
+        errors.append("live-canary workflow has no mechanical scheduled case selection")
     else:
-        scheduled = {
-            case.strip() for case in scheduled_match.group(1).split(",") if case.strip()
-        }
-        if scheduled != drift_set:
-            errors.append(
-                "scheduled live cases must exactly match representative_drift_cases"
-            )
+        scheduled_selector = scheduled_match.group(1).strip()
+        if scheduled_selector.lower() == "all" or scheduled_selector == "*":
+            scheduled = set(selected)
+        else:
+            scheduled = {
+                case.strip()
+                for case in scheduled_selector.split(",")
+                if case.strip()
+            }
+
+    for case in sorted(scheduled - selected):
+        errors.append(f"scheduled case is not in the harvested inventory: {case}")
+    for case in sorted(drift_set - scheduled):
+        errors.append(f"representative drift case is not scheduled: {case}")
+    for case in sorted(retired_set & scheduled):
+        errors.append(f"retired case is still scheduled: {case}")
+
+    replayable = selected - no_model - quarantined
+    accounted = scheduled | retired_set
+    missing = sorted(replayable - accounted)
+    if missing:
+        errors.append(
+            "replayable cases must be scheduled or retired: "
+            + ", ".join(missing)
+        )
+    unscheduled_without_replay = sorted((no_model | quarantined) - scheduled)
+    if unscheduled_without_replay:
+        errors.append(
+            "cases without active deterministic replay must remain scheduled: "
+            + ", ".join(unscheduled_without_replay)
+        )
     return errors
 
 

--- a/scripts/ci/check-regression-promotions.py
+++ b/scripts/ci/check-regression-promotions.py
@@ -23,6 +23,23 @@ def current_date(override: dt.date | None) -> dt.date:
     return override if override is not None else dt.date.today()
 
 
+def live_qa_matrix_cases(workflow: str, errors: list[str]) -> set[str]:
+    job_match = re.search(
+        r"(?ms)^  reborn-webui-v2-live-qa:\n(?P<job>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if not job_match:
+        errors.append("live-canary workflow has no reborn-webui-v2-live-qa job")
+        return set()
+
+    cases: set[str] = set()
+    for value in re.findall(r"(?m)^ {12}cases:\s*([^#\n]+)$", job_match.group("job")):
+        cases.update(case.strip() for case in value.split(",") if case.strip())
+    if not cases:
+        errors.append("reborn-webui-v2-live-qa matrix has no cases")
+    return cases
+
+
 def validate(
     manifest_path: pathlib.Path, today: dt.date, repo_root: pathlib.Path
 ) -> list[str]:
@@ -170,6 +187,12 @@ def validate(
     workflow = (repo_root / ".github/workflows/live-canary.yml").read_text(
         encoding="utf-8"
     )
+    matrix_cases = live_qa_matrix_cases(workflow, errors)
+    for case in sorted(matrix_cases - selected):
+        errors.append(f"matrix case is not in the harvested inventory: {case}")
+    for case in sorted(selected - matrix_cases):
+        errors.append(f"harvested case is missing from live-canary matrix: {case}")
+
     scheduled_match = re.search(
         r"REQUESTED_CASES:\s*\$\{\{\s*github\.event_name == 'schedule'\s*&&\s*'([^']+)'",
         workflow,
@@ -180,7 +203,7 @@ def validate(
     else:
         scheduled_selector = scheduled_match.group(1).strip()
         if scheduled_selector.lower() == "all" or scheduled_selector == "*":
-            scheduled = set(selected)
+            scheduled = set(matrix_cases)
         else:
             scheduled = {
                 case.strip()
@@ -190,6 +213,8 @@ def validate(
 
     for case in sorted(scheduled - selected):
         errors.append(f"scheduled case is not in the harvested inventory: {case}")
+    for case in sorted(scheduled - matrix_cases):
+        errors.append(f"scheduled case is not in the live-canary matrix: {case}")
     for case in sorted(drift_set - scheduled):
         errors.append(f"representative drift case is not scheduled: {case}")
     for case in sorted(retired_set & scheduled):

--- a/scripts/ci/test-check-regression-promotions.py
+++ b/scripts/ci/test-check-regression-promotions.py
@@ -29,6 +29,7 @@ class RegressionPromotionMetadataTest(unittest.TestCase):
         manifest: dict[str, object],
         today: dt.date = dt.date(2026, 7, 30),
         scheduled_cases: str = "all",
+        removed_matrix_case: str | None = None,
     ) -> list[str]:
         with tempfile.TemporaryDirectory() as directory:
             root = pathlib.Path(directory)
@@ -46,6 +47,20 @@ class RegressionPromotionMetadataTest(unittest.TestCase):
                 f"github.event_name == 'schedule' && '{scheduled_cases}'",
                 1,
             )
+            if removed_matrix_case is not None:
+                lines = workflow.splitlines()
+                for index, line in enumerate(lines):
+                    if not line.startswith("            cases: "):
+                        continue
+                    matrix_cases = line.removeprefix("            cases: ").split(",")
+                    if removed_matrix_case not in matrix_cases:
+                        continue
+                    matrix_cases.remove(removed_matrix_case)
+                    lines[index] = "            cases: " + ",".join(matrix_cases)
+                    break
+                else:
+                    self.fail(f"matrix case not found: {removed_matrix_case}")
+                workflow = "\n".join(lines) + "\n"
             workflow_path.write_text(workflow, encoding="utf-8")
             lifecycle = manifest.get("promotion_metadata", {}).get("live_retirement", {})
             for entry in lifecycle.get("retired_cases", []):
@@ -123,6 +138,16 @@ class RegressionPromotionMetadataTest(unittest.TestCase):
                 in error
                 for error in errors
             ),
+            errors,
+        )
+
+    def test_all_selector_fails_when_matrix_omits_harvested_case(self) -> None:
+        removed = "qa_10i_slack_raw_entity_hygiene"
+
+        errors = self.validate(self.manifest, removed_matrix_case=removed)
+
+        self.assertIn(
+            f"harvested case is missing from live-canary matrix: {removed}",
             errors,
         )
 

--- a/scripts/ci/test-check-regression-promotions.py
+++ b/scripts/ci/test-check-regression-promotions.py
@@ -28,6 +28,7 @@ class RegressionPromotionMetadataTest(unittest.TestCase):
         self,
         manifest: dict[str, object],
         today: dt.date = dt.date(2026, 7, 30),
+        scheduled_cases: str = "all",
     ) -> list[str]:
         with tempfile.TemporaryDirectory() as directory:
             root = pathlib.Path(directory)
@@ -39,9 +40,13 @@ class RegressionPromotionMetadataTest(unittest.TestCase):
             )
             workflow_path = root / ".github/workflows/live-canary.yml"
             workflow_path.parent.mkdir(parents=True)
-            workflow_path.write_text(
-                workflow_source.read_text(encoding="utf-8"), encoding="utf-8"
+            workflow = workflow_source.read_text(encoding="utf-8")
+            workflow = workflow.replace(
+                "github.event_name == 'schedule' && 'all'",
+                f"github.event_name == 'schedule' && '{scheduled_cases}'",
+                1,
             )
+            workflow_path.write_text(workflow, encoding="utf-8")
             lifecycle = manifest.get("promotion_metadata", {}).get("live_retirement", {})
             for entry in lifecycle.get("retired_cases", []):
                 fixture = entry.get("deterministic_fixture")
@@ -83,13 +88,39 @@ class RegressionPromotionMetadataTest(unittest.TestCase):
         self.assertIn("missing retirement_evidence", errors)
         self.assertTrue(any("deterministic_test" in error for error in errors), errors)
 
-    def test_every_replayable_case_is_live_or_retired_with_evidence(self) -> None:
+    def test_every_replayable_case_is_scheduled_or_retired_with_evidence(self) -> None:
         broken = copy.deepcopy(self.manifest)
         broken["promotion_metadata"]["live_retirement"]["retired_cases"] = []
-        errors = self.validate(broken)
+        errors = self.validate(
+            broken,
+            scheduled_cases=(
+                "qa_3b_endpoint_status_live_chat,"
+                "qa_9b_routine_dm_delivery_exactly_once,"
+                "qa_10a_slack_self_attribution"
+            ),
+        )
         self.assertTrue(
             any(
-                "replayable cases must be representative drift or retired" in error
+                "replayable cases must be scheduled or retired" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_cases_without_active_replay_must_remain_scheduled(self) -> None:
+        errors = self.validate(
+            self.manifest,
+            scheduled_cases=(
+                "qa_3b_endpoint_status_live_chat,"
+                "qa_9b_routine_dm_delivery_exactly_once,"
+                "qa_10a_slack_self_attribution"
+            ),
+        )
+
+        self.assertTrue(
+            any(
+                "cases without active deterministic replay must remain scheduled"
+                in error
                 for error in errors
             ),
             errors,

--- a/tests/fixtures/llm_traces/reborn_qa/README.md
+++ b/tests/fixtures/llm_traces/reborn_qa/README.md
@@ -73,12 +73,12 @@ fixture schema, journey ownership, last successful replay, and the retained
 representative drift set. `scripts/ci/check-regression-promotions.py` fails on
 missing metadata, stale replay, too few drift cases, or a retirement without an
 existing deterministic fixture, exact replay command, reviewed reason, and
-date. Every replayable harvested case must be accounted for as either retained
-drift or retired; no-model and quarantined cases remain explicitly excluded
-until active deterministic replay evidence exists.
+date. Every replayable harvested case must be accounted for as either scheduled
+or retired. No-model and quarantined cases must remain scheduled until active
+deterministic replay evidence exists.
 
-During the 30-day review, retire a scheduled live case once its permanent
-purpose is covered deterministically. Keep only the manifest's representative
-model/provider/drift cases on the recurring lane; retired cases remain
-available for explicit attended runs and historical diagnosis. A case cannot
-be both retired and representative drift.
+During the 30-day review, a scheduled live case may be retired once its
+permanent purpose is covered deterministically. Retired cases remain available
+for explicit attended runs and historical diagnosis. The recurring lane may
+retain more than the minimum representative drift set, but a case cannot be
+both scheduled and retired.

--- a/tests/fixtures/llm_traces/reborn_qa/live_canary/case-manifest.json
+++ b/tests/fixtures/llm_traces/reborn_qa/live_canary/case-manifest.json
@@ -109,10 +109,10 @@
       ],
       "retirement_evidence": {
         "deterministic_test": "uv run --project tests/e2e --python 3.12 pytest tests/e2e/scenarios/test_reborn_qa_trace_replay.py::test_every_harvested_trace_replays -q",
-        "reason": "Retired from recurring live coverage after deterministic harvested-trace replay passed; representative drift remains scheduled.",
+        "reason": "Eligible for retirement after deterministic harvested-trace replay passed; retained on the recurring full-matrix schedule.",
         "retired_at": "2026-07-29"
       },
-      "retired_cases": [
+      "retirement_candidates": [
         {
           "case": "qa_2d_calendar_prep_live_chat",
           "deterministic_fixture": "tests/fixtures/llm_traces/reborn_qa/live_canary/qa_2d_calendar_prep_live_chat.json"
@@ -209,7 +209,8 @@
           "case": "qa_10i_slack_raw_entity_hygiene",
           "deterministic_fixture": "tests/fixtures/llm_traces/reborn_qa/live_canary/qa_10i_slack_raw_entity_hygiene.json"
         }
-      ]
+      ],
+      "retired_cases": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- Restore every implemented non-Telegram Reborn live-QA case to the three-hour scheduled run: 47 cases across 11 shards.
- Keep the three representative drift cases as the minimum signal while preventing no-model and quarantined cases from being silently unscheduled without deterministic replay evidence.
- Align promotion metadata and live-canary documentation with the restored full-matrix schedule.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust files changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust files changed.
- [ ] `cargo build` — Not applicable: workflow, Python validation, fixture metadata, and documentation only.
- [x] Relevant tests pass: promotion metadata unit tests, fixture scrub/checker self-tests, live-canary dispatch tests, Python compilation, YAML parsing, and matrix-to-manifest inventory comparison.
- [ ] `cargo test --features integration` — Not applicable: no database-backed or runtime behavior changed.
- [ ] Manual testing — Not applicable: executing the live lane requires repository credentials and provider side effects; workflow selection and inventory were validated locally.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; focused diff review and relevant validation completed locally.

## Test Strategy

User behavior: The scheduled Reborn live-canary run executes the full implemented non-Telegram QA matrix every three hours instead of only three representative cases.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Updated `test-check-regression-promotions.py` to prove replayable cases remain scheduled or explicitly retired and cases without active replay cannot be unscheduled.
- Reborn integration: Not applicable: no Reborn runtime behavior changed.
- Recorded fixture: No fixture payload changed; the committed fixture inventory and promotion metadata pass scrub and consistency checks.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Not applicable: no backend, database, WASM, or runtime implementation changed.
- Live canary: Not run locally because it requires live repository credentials and performs provider side effects. This PR restores the scheduled lane that supplies that evidence after merge.

What the tests prove: The workflow selects `all`; all 47 matrix cases exactly match the harvested manifest inventory; representative drift remains scheduled; and no-model or quarantined cases cannot be removed from recurring coverage before deterministic replay exists.

Commands run:
- `bash scripts/ci/check-reborn-qa-fixtures.sh`
- `bash scripts/ci/test-check-reborn-qa-fixtures.sh`
- `python3 -m unittest scripts/ci/test-check-regression-promotions.py`
- `python3 scripts/live-canary/test_run_dispatch.py`
- `python3 -m py_compile scripts/ci/check-regression-promotions.py scripts/ci/test-check-regression-promotions.py`
- `ruby -e "require YAML; YAML.load_file workflow"` equivalent local YAML parse
- Matrix-to-manifest Python inventory assertion: 47 workflow cases equals 47 manifest cases
- `git diff --check`

## Security Impact

No trust boundary, permission, or secret-handling changes. The restored schedule increases how often existing credentialed provider cases run; existing secret materialization, authorization, artifact scrubbing, and no-retry protections remain unchanged.

## Reborn Trust-Boundary Checklist

N/A: CI scheduling and validation metadata only; no Reborn trust-bearing types, ingress, serialization, queues, runtime errors, or sandbox boundaries changed.

## Database Impact

None.

## Blast Radius

Touches the Reborn live-QA cron selector, promotion-retirement validation, harvested manifest metadata, and documentation. After merge, scheduled runs again fan out across all 11 shards, increasing model/provider API use and restoring provider side-effect coverage. Release-only and upgrade jobs remain manual. Retired v1 wrapper jobs were not re-enabled because their test binaries no longer exist.

## Rollback Plan

Revert commit `d41d2e464` to return the scheduled selector and promotion guard to the three-case representative drift suite. No persisted product data or schema rollback is required.

## Review Follow-Through

Reviewer judgment requested on scheduled provider load and whether the full three-hour cadence remains the desired operating cost. No known code follow-up.

---

**Review track**: C (CI scheduling and credentialed live-provider execution)