### PR TITLE
test(event_projections): restore manager-suite contracts at the projection-service seam (post-#6943)

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_struct_test_support_ratchet.rs
+++ b/crates/ironclaw_architecture/tests/reborn_struct_test_support_ratchet.rs
@@ -34,10 +34,11 @@ struct FrozenPathCount {
 /// Measured 2026-07-30 against `origin/main` @ `ae0989c37` from
 /// `FROZEN_PATH_COUNTS` below — 82 frozen `(category, kind, path)` entries
 /// totalling 283 suppressed members (both printed by the assertion at the end
-/// of the gate below on failure). Lowered to 81/282 by the WS0 dead-module
-/// deletion, which removed
+/// of the gate below on failure). Lowered to 81/282 by the **WS8** dead-module
+/// deletion (#6943), which removed
 /// `event_projections/src/pending_gate_projection.rs` and its one
-/// test-support method.
+/// test-support method. (The `WS0_` prefix records when the baseline was
+/// *captured*, by #6936; deletions that lower it come from WS8.)
 ///
 /// The per-path checks already refuse growth *within* a listed file and refuse
 /// staleness. These two totals close the remaining door: adding a **new** path

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -3,10 +3,11 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_event_projections::{
-    AuditProjectionEntry, AuditProjectionRequest, AuditProjectionService, CapabilityActivityStatus,
-    EventProjectionService, MAX_PROJECTION_PAGE_LIMIT, ProjectionCursor, ProjectionError,
-    ProjectionReplay, ProjectionRequest, ProjectionScope, ReplayAuditProjectionService,
-    ReplayEventProjectionService, RunProjectionStatus, TimelineEntryKind,
+    AuditProjectionCursor, AuditProjectionEntry, AuditProjectionError, AuditProjectionRequest,
+    AuditProjectionService, CapabilityActivityStatus, EventProjectionService,
+    MAX_PROJECTION_PAGE_LIMIT, ProjectionCursor, ProjectionError, ProjectionReplay,
+    ProjectionRequest, ProjectionScope, ReplayAuditProjectionService, ReplayEventProjectionService,
+    RunProjectionStatus, TimelineEntryKind,
 };
 use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventReplay,
@@ -91,6 +92,127 @@ async fn replay_audit_projection_preserves_valid_capability_targets() {
         snapshot.entries[0].action_target.as_deref(),
         Some("1234567890123456789012345-cap.echo")
     );
+}
+
+/// Audit-side counterpart to
+/// `replay_projection_rejects_cursor_minted_under_a_different_scope` and
+/// `replay_projection_updates_return_rebase_signal_for_foreign_or_stale_cursor`.
+///
+/// `ReplayAuditProjectionService` enforces two cursor contracts of its own —
+/// `read_audit` rejects a cursor minted under a different scope, and
+/// `map_audit_projection_error` turns a durable `ReplayGap` into
+/// `AuditProjectionError::RebaseRequired`. Both were only ever asserted
+/// through the duplicate `EventStreamManager` deleted in #6943, whose own
+/// `audit_resume` re-implemented the scope check; when it went, these two live
+/// service behaviors lost their only coverage (CodeRabbit review on that PR).
+/// Restored here at the seam that actually owns them, so the audit half is
+/// pinned symmetrically with the runtime half.
+#[tokio::test]
+async fn replay_audit_projection_rejects_foreign_and_stale_cursors() {
+    let log = Arc::new(InMemoryDurableAuditLog::new());
+    let service = ReplayAuditProjectionService::new(Arc::clone(&log));
+    let ctx_a = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-a").unwrap()));
+    let ctx_b = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-b").unwrap()));
+    let action = Action::ReadFile {
+        path: ScopedPath::new("/workspace/notes.md").unwrap(),
+    };
+
+    let entry_a = log
+        .append(AuditEnvelope::denied(
+            &ctx_a,
+            AuditStage::Denied,
+            ActionSummary::from_action(&action),
+            DenyReason::PolicyDenied,
+        ))
+        .await
+        .unwrap();
+    let entry_b = log
+        .append(AuditEnvelope::denied(
+            &ctx_b,
+            AuditStage::Denied,
+            ActionSummary::from_action(&action),
+            DenyReason::PolicyDenied,
+        ))
+        .await
+        .unwrap();
+    assert!(entry_b.cursor > entry_a.cursor);
+
+    let scope_a = ProjectionScope::from_resource_scope(&ctx_a.resource_scope);
+    let scope_b = ProjectionScope::from_resource_scope(&ctx_b.resource_scope);
+
+    // (1) A cursor minted under thread B's scope must not be consumed as a
+    // resume cursor for thread A: the durable stream is partitioned by
+    // (tenant, user, agent), so the sibling cursor would silently skip
+    // records thread A had not yet seen.
+    let foreign_cursor = AuditProjectionCursor::for_scope(scope_b, entry_b.cursor);
+    let error = service
+        .snapshot(AuditProjectionRequest {
+            scope: scope_a.clone(),
+            after: Some(foreign_cursor.clone()),
+            limit: 16,
+        })
+        .await
+        .expect_err("cross-scope audit cursor must be rejected, not silently consumed");
+    match error {
+        AuditProjectionError::RebaseRequired {
+            requested,
+            earliest,
+        } => {
+            assert_eq!(*requested, foreign_cursor);
+            assert_eq!(earliest.scope, scope_a);
+        }
+        other => panic!("expected RebaseRequired for cross-scope audit cursor, got {other:?}"),
+    }
+
+    // The same foreign cursor must be rejected by `updates()` too — both
+    // entry points share `read_audit`, and a divergence there would let one
+    // surface a partial replay.
+    let updates_error = service
+        .updates(AuditProjectionRequest {
+            scope: scope_a.clone(),
+            after: Some(foreign_cursor),
+            limit: 16,
+        })
+        .await
+        .expect_err("updates() must enforce the same audit scope binding as snapshot()");
+    assert!(matches!(
+        updates_error,
+        AuditProjectionError::RebaseRequired { .. }
+    ));
+
+    // (2) A same-scope cursor beyond the stream head is a stale/foreign
+    // cursor the log reports as a replay gap; the projection must surface
+    // RebaseRequired rather than echoing it back as an empty page.
+    let stale_error = service
+        .updates(AuditProjectionRequest {
+            scope: scope_a.clone(),
+            after: Some(AuditProjectionCursor::for_scope(
+                scope_a.clone(),
+                EventCursor::new(99),
+            )),
+            limit: 16,
+        })
+        .await
+        .expect_err("a cursor beyond the audit head must surface a rebase, not an empty replay");
+    match stale_error {
+        AuditProjectionError::RebaseRequired { requested, .. } => {
+            assert_eq!(requested.audit, EventCursor::new(99));
+        }
+        other => panic!("expected RebaseRequired for stale audit cursor, got {other:?}"),
+    }
+
+    // Positive control: resuming from the legitimate origin still sees thread
+    // A's entry, proving the rejections above did not paper over a read
+    // failure.
+    let snapshot = service
+        .snapshot(AuditProjectionRequest {
+            scope: scope_a,
+            after: None,
+            limit: 16,
+        })
+        .await
+        .unwrap();
+    assert_eq!(snapshot.entries.len(), 1);
 }
 
 fn audit_projection_entry_for_stage(stage: AuditStage) -> AuditProjectionEntry {

--- a/crates/ironclaw_memory_native/src/service.rs
+++ b/crates/ironclaw_memory_native/src/service.rs
@@ -33,10 +33,11 @@ use ironclaw_memory::{
 };
 use serde_json::{Map, Value, json};
 
-// The host-facing operation shapes + the `MemoryService` trait moved to
-// `ironclaw_memory`; re-exported so `crate::service::*` and the crate's
-// public API stay unchanged while `NativeMemoryService` (below) keeps the native
-// adapter behavior here.
+// The host-facing operation shapes and the `MemoryService` trait are owned by
+// `ironclaw_memory`; consumers import them from there. The imports above are
+// private to this module — #6943 deleted the re-export shim that used to
+// republish them under `ironclaw_memory_native::` — and this module exports
+// only `NativeMemoryService`, the native adapter implemented below.
 
 const MEMORY_PATH: &str = "MEMORY.md";
 const HEARTBEAT_PATH: &str = "HEARTBEAT.md";


### PR DESCRIPTION
Follow-up to #6943 (merged as `c70c1b9ae`), triaging CodeRabbit's review of it. One real coverage gap, two comment corrections, no behavior change.

## The investigation

#6943 deleted `event_projections`' duplicate `EventStreamManager` — the one that name-collided with the live `ironclaw_event_streams` manager — along with the 13 tests that drove it. CodeRabbit flagged that four contracts those tests asserted (scope-mismatch rejection, stale-cursor rebase, replay-gap handling, metadata-only serialization) are *projection-layer* contracts that may have lost coverage. Correct question. Checking each against the surviving seam:

**Runtime half — no gap.** `ReplayEventProjectionService` owns and still asserts both cursor contracts:

| contract | enforced at | still asserted by |
|---|---|---|
| cross-scope cursor rejected | `read_runtime`, `lib.rs:694` | `replay_projection_rejects_cursor_minted_under_a_different_scope` (covers `snapshot()` *and* `updates()`) |
| `ReplayGap` → `RebaseRequired` | `map_projection_error`, `lib.rs:1222` | `replay_projection_updates_return_rebase_signal_for_foreign_or_stale_cursor` |

**Metadata-only serialization — no gap.** Pinned on the live DTOs in the same file: `AuditProjectionSnapshot` at lines 148 and 222, `ProjectionSnapshot`/`ProjectionReplay` at 820, 854, 1320, 1603, 2311. The deleted manager only wrapped these in `RuntimeStreamResume`/`AuditStreamResume`, DTOs that no longer exist — there is no live type left to serialize there.

**Audit half — a real gap.** `ReplayAuditProjectionService` enforces the same two contracts:

- `read_audit` (`lib.rs:553`) rejects a cursor minted under a different scope
- `map_audit_projection_error` (`lib.rs:1199`) maps a durable `ReplayGap` to `AuditProjectionError::RebaseRequired`

…and after #6943 **nothing asserted either one**. Every surviving audit test called the service with `after: None`, and `AuditProjectionError::RebaseRequired` had zero occurrences anywhere under `tests/`. Live behavior, no coverage — the case the un-masking rule says to restore rather than document.

## The restoration

`replay_audit_projection_rejects_foreign_and_stale_cursors` mirrors the runtime pair at the audit seam:

1. a cursor minted under a sibling scope is rejected by `snapshot()` **and** `updates()` — they share `read_audit`, so a divergence there would let one return a partial replay;
2. a same-scope cursor beyond the head surfaces `RebaseRequired` rather than an empty page;
3. a positive control proves the rejections did not paper over a read failure.

**It passed on the first run.** The behavior was correct all along and merely uncovered, so this is a coverage restoration, not a bug fix — no regression on main.

Deliberately one consolidated test rather than four, per the repo's "consolidate, don't proliferate" rule; and added to `replay_projection_contract.rs` rather than duplicated into `nested_dispatch_projection_contract.rs`, whose `updates` call is already covered by the runtime cases above.

## Two comment corrections (same review)

- `reborn_struct_test_support_ratchet.rs` — the baseline note said "WS0 dead-module deletion"; the deletion is WS8 work. The `WS0_` constant prefix is correct and unchanged (it records when the baseline was *captured*, by #6936), so the note now says that explicitly.
- `memory_native/src/service.rs` — still claimed it "re-exported" the shared service contracts "so `crate::service::*` and the crate's public API stay unchanged". #6943 deleted that shim; the imports are private and the module exports only `NativeMemoryService`.

## Gauntlet

- `cargo test -p ironclaw_event_projections -p ironclaw_memory_native` — green (`replay_projection_contract` 44 → **45**)
- `cargo test -p ironclaw_architecture` — all suites green
- `cargo fmt --all` — clean

Tests and comments only; no production code changed.

Refs #6920, epic #3773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)