### PR TITLE
fix(ci): pin comm to LC_ALL=C in reborn crate discovery

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -124,6 +124,7 @@ jobs:
         run: |
           scripts/ci/test-check-include-str-paths.sh
           scripts/ci/test-check-hermetic-env.sh
+          scripts/ci/test-ci-comm-locale-pin.sh
           scripts/ci/test-classify-test-scope.sh
           scripts/ci/test-package-feature-flags.sh
           scripts/ci/test-reborn-crate-test-buckets.sh

--- a/scripts/ci/discover-reborn-package-crates.sh
+++ b/scripts/ci/discover-reborn-package-crates.sh
@@ -40,7 +40,7 @@ allowlist="$(
 # Every workspace crate linked by the shipped binary through a normal or build
 # dependency. The union below keeps non-closure allowlist crates covered too.
 closure="$(
-  comm -12 \
+  LC_ALL=C comm -12 \
     <(cargo tree -p ironclaw -e normal,build --prefix none \
       | grep -oE 'ironclaw_[a-z0-9_]+' \
       | LC_ALL=C sort -u) \

--- a/scripts/ci/test-ci-comm-locale-pin.sh
+++ b/scripts/ci/test-ci-comm-locale-pin.sh
@@ -46,17 +46,39 @@ assert_failure() {
 # LC_ALL=C so its collation matches the LC_ALL=C-sorted inputs. Backslash-
 # newline continuations are joined first so multiline invocations — both the
 # offending `comm \` form and a valid `LC_ALL=C \` + `comm` form — are
-# inspected as whole commands; comment lines are then dropped. `find -L`
-# follows the .githooks symlinks to their tracked targets; build caches are
-# pruned. This file is excluded: it deliberately runs unpinned comm to prove
-# the failure mode.
-unpinned=""
-while IFS= read -r -d '' file; do
-    hits="$(sed -e ':a' -e '/\\$/{N; s/\\\n[[:space:]]*/ /; ba' -e '}' "$file" \
+# inspected as whole commands; comment lines are then dropped, and compound
+# commands are split at `;`, `&`, and `|` so each invocation is inspected
+# independently (a pinned comm must not excuse an unpinned one on the same
+# logical line). `find -L` follows the .githooks symlinks to their tracked
+# targets; build caches are pruned. This file is excluded: it deliberately
+# runs unpinned comm to prove the failure mode.
+scan_unpinned_comm() {
+    sed -e ':a' -e '/\\$/{N; s/\\\n[[:space:]]*/ /; ba' -e '}' "$1" \
         | grep -av '^[[:space:]]*#' \
+        | tr ';&|' '\n\n\n' \
         | grep -anE '(^|[^-=[:alnum:]_.])comm([[:space:]]|$)' \
         | grep -avE 'LC_ALL=C[[:space:]]+comm([[:space:]]|$)' \
-        || true)"
+        || true
+}
+
+# Scanner self-checks: each invocation in a compound command is judged on its
+# own, and the pinned forms (single, compound, multiline continuation) stay
+# clean.
+scanner_fixture="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
+printf 'LC_ALL=C comm -12 a b; comm -12 c d\n' > "$scanner_fixture"
+assert_failure "scanner flags an unpinned comm after a pinned one in a compound command" \
+    test -z "$(scan_unpinned_comm "$scanner_fixture")"
+printf 'comm \\\n  -12 a b\n' > "$scanner_fixture"
+assert_failure "scanner flags an unpinned multiline comm continuation" \
+    test -z "$(scan_unpinned_comm "$scanner_fixture")"
+printf 'LC_ALL=C comm -12 a b && LC_ALL=C \\\n  comm -12 c d\n' > "$scanner_fixture"
+assert_success "scanner accepts pinned comm in compound and multiline forms" \
+    test -z "$(scan_unpinned_comm "$scanner_fixture")"
+rm -f "$scanner_fixture"
+
+unpinned=""
+while IFS= read -r -d '' file; do
+    hits="$(scan_unpinned_comm "$file")"
     if [ -n "$hits" ]; then
         unpinned="${unpinned}${file}: ${hits}"$'\n'
     fi
@@ -71,16 +93,17 @@ fi
 
 # Case 2: the fixture pair that broke the ratchet. In C collation
 # "ironclaw_event_streams" < "ironclaw_events" ('_' 0x5f < 's' 0x73). The
-# sentinel second file ("zzz" sorts last in any collation) forces comm to
-# advance through file 1 and check its order — with identical files the lines
-# compare equal and comm never notices the disorder. Select a locale by
-# proving the mismatch — unpinned comm must reject the C-sorted fixture under
-# it (this skips C-compatible collations such as C.UTF-8, where the case would
-# prove nothing) — then assert both sides in that same environment: unpinned
-# comm rejects the fixture and the pinned form accepts it. If no installed
-# locale disagrees with C on the fixture, the
-# mismatch is not reproducible on this machine; say so explicitly instead of
-# silently passing under C.
+# sentinel second file ("zzz") forces comm to advance through file 1 and
+# check its order — with identical files the lines compare equal and comm
+# never notices the disorder. Select a locale by proving the mismatch:
+# the sentinel must still sort after both fixture entries under it (or the
+# fixture-order path is never exercised) and unpinned comm must reject the
+# C-sorted fixture under it (this skips C-compatible collations such as
+# C.UTF-8, where the case would prove nothing). Then assert both sides in
+# that same environment: unpinned comm rejects the fixture and the pinned
+# form accepts it. If no installed locale qualifies, the mismatch is not
+# reproducible on this machine; say so explicitly instead of silently
+# passing under C.
 fixture="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
 sentinel="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
 printf 'ironclaw_event_streams\nironclaw_events\n' > "$fixture"
@@ -88,6 +111,10 @@ printf 'zzz\n' > "$sentinel"
 
 mismatch_locale=""
 while IFS= read -r candidate; do
+    last="$(cat "$fixture" "$sentinel" | LC_ALL="$candidate" sort | tail -n 1)"
+    if [ "$last" != "zzz" ]; then
+        continue
+    fi
     if ! LC_ALL="$candidate" comm -12 "$fixture" "$sentinel" > /dev/null 2>&1; then
         mismatch_locale="$candidate"
         break

--- a/scripts/ci/test-ci-comm-locale-pin.sh
+++ b/scripts/ci/test-ci-comm-locale-pin.sh
@@ -23,12 +23,26 @@ report() {
 }
 
 # Case 1: every comm invocation in CI scripts and tracked hooks must pin
-# LC_ALL=C so its collation matches the LC_ALL=C-sorted inputs.
-unpinned="$(grep -rnE '(^|[^=[:alnum:]_])comm[[:space:]]+-' \
-    "$ROOT_DIR/scripts/ci" "$ROOT_DIR/.githooks" \
-    | grep -v 'LC_ALL=C comm' \
-    | grep -v 'test-ci-comm-locale-pin' \
-    || true)"
+# LC_ALL=C so its collation matches the LC_ALL=C-sorted inputs. Backslash-
+# newline continuations are joined first so multiline invocations — both the
+# offending `comm \` form and a valid `LC_ALL=C \` + `comm` form — are
+# inspected as whole commands; comment lines are then dropped. `find -L`
+# follows the .githooks symlinks to their tracked targets; build caches are
+# pruned. This file is excluded: it deliberately runs unpinned comm to prove
+# the failure mode.
+unpinned=""
+while IFS= read -r -d '' file; do
+    hits="$(sed -e ':a' -e '/\\$/{N; s/\\\n[[:space:]]*/ /; ba' -e '}' "$file" \
+        | grep -av '^[[:space:]]*#' \
+        | grep -anE '(^|[^-=[:alnum:]_.])comm([[:space:]]|$)' \
+        | grep -avE 'LC_ALL=C[[:space:]]+comm([[:space:]]|$)' \
+        || true)"
+    if [ -n "$hits" ]; then
+        unpinned="${unpinned}${file}: ${hits}"$'\n'
+    fi
+done < <(find -L "$ROOT_DIR/scripts/ci" "$ROOT_DIR/.githooks" \
+    -name __pycache__ -prune -o -type f \
+    ! -name "$(basename "${BASH_SOURCE[0]}")" -print0)
 if [ -z "$unpinned" ]; then
     report 1 "all comm invocations are LC_ALL=C-pinned"
 else
@@ -36,26 +50,37 @@ else
 fi
 
 # Case 2: the fixture pair that broke the ratchet. In C collation
-# "ironclaw_event_streams" < "ironclaw_events" ('_' 0x5f < 's' 0x73); UTF-8
-# collations disagree, so an unpinned comm rejects the C-sorted file. The
-# pinned form must accept it regardless of the ambient locale.
-utf8_locale=""
-for candidate in C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8; do
-    if locale -a 2>/dev/null | grep -qx "$candidate"; then
-        utf8_locale="$candidate"
+# "ironclaw_event_streams" < "ironclaw_events" ('_' 0x5f < 's' 0x73). The
+# sentinel second file ("zzz" sorts last in any collation) forces comm to
+# advance through file 1 and check its order — with identical files the lines
+# compare equal and comm never notices the disorder. Select a locale by
+# proving the mismatch — unpinned comm must reject the C-sorted fixture under
+# it (this skips C-compatible collations such as C.UTF-8, where the case would
+# prove nothing) — then assert the pinned form succeeds in that same
+# environment. If no installed locale disagrees with C on the fixture, the
+# mismatch is not reproducible on this machine; say so explicitly instead of
+# silently passing under C.
+fixture="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
+sentinel="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
+printf 'ironclaw_event_streams\nironclaw_events\n' > "$fixture"
+printf 'zzz\n' > "$sentinel"
+
+mismatch_locale=""
+while IFS= read -r candidate; do
+    if ! LC_ALL="$candidate" comm -12 "$fixture" "$sentinel" > /dev/null 2>&1; then
+        mismatch_locale="$candidate"
         break
     fi
-done
+done < <(locale -a 2>/dev/null | grep -aiE 'utf-?8$')
 
-fixture="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
-printf 'ironclaw_event_streams\nironclaw_events\n' > "$fixture"
-
-if LC_ALL="${utf8_locale:-C}" sh -c 'LC_ALL=C comm -12 "$1" "$1"' _ "$fixture" > /dev/null 2>&1; then
-    report 1 "LC_ALL=C comm accepts C-sorted input under ${utf8_locale:-C} locale"
+if [ -z "$mismatch_locale" ]; then
+    echo "SKIP: no installed UTF-8 locale rejects the C-sorted fixture; collation mismatch not reproducible here"
+elif LC_ALL="$mismatch_locale" sh -c 'LC_ALL=C comm -12 "$1" "$2"' _ "$fixture" "$sentinel" > /dev/null 2>&1; then
+    report 1 "LC_ALL=C comm accepts C-sorted input under mismatching locale $mismatch_locale"
 else
-    report 0 "LC_ALL=C comm accepts C-sorted input under ${utf8_locale:-C} locale"
+    report 0 "LC_ALL=C comm accepts C-sorted input under mismatching locale $mismatch_locale"
 fi
-rm -f "$fixture"
+rm -f "$fixture" "$sentinel"
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts/ci/test-ci-comm-locale-pin.sh
+++ b/scripts/ci/test-ci-comm-locale-pin.sh
@@ -22,6 +22,26 @@ report() {
     fi
 }
 
+assert_success() {
+    local label="$1"
+    shift
+    if "$@" > /dev/null 2>&1; then
+        report 1 "$label"
+    else
+        report 0 "$label"
+    fi
+}
+
+assert_failure() {
+    local label="$1"
+    shift
+    if "$@" > /dev/null 2>&1; then
+        report 0 "$label"
+    else
+        report 1 "$label"
+    fi
+}
+
 # Case 1: every comm invocation in CI scripts and tracked hooks must pin
 # LC_ALL=C so its collation matches the LC_ALL=C-sorted inputs. Backslash-
 # newline continuations are joined first so multiline invocations — both the
@@ -56,8 +76,9 @@ fi
 # compare equal and comm never notices the disorder. Select a locale by
 # proving the mismatch — unpinned comm must reject the C-sorted fixture under
 # it (this skips C-compatible collations such as C.UTF-8, where the case would
-# prove nothing) — then assert the pinned form succeeds in that same
-# environment. If no installed locale disagrees with C on the fixture, the
+# prove nothing) — then assert both sides in that same environment: unpinned
+# comm rejects the fixture and the pinned form accepts it. If no installed
+# locale disagrees with C on the fixture, the
 # mismatch is not reproducible on this machine; say so explicitly instead of
 # silently passing under C.
 fixture="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
@@ -75,10 +96,11 @@ done < <(locale -a 2>/dev/null | grep -aiE 'utf-?8$')
 
 if [ -z "$mismatch_locale" ]; then
     echo "SKIP: no installed UTF-8 locale rejects the C-sorted fixture; collation mismatch not reproducible here"
-elif LC_ALL="$mismatch_locale" sh -c 'LC_ALL=C comm -12 "$1" "$2"' _ "$fixture" "$sentinel" > /dev/null 2>&1; then
-    report 1 "LC_ALL=C comm accepts C-sorted input under mismatching locale $mismatch_locale"
 else
-    report 0 "LC_ALL=C comm accepts C-sorted input under mismatching locale $mismatch_locale"
+    assert_failure "unpinned comm rejects C-sorted input under mismatching locale $mismatch_locale" \
+        env LC_ALL="$mismatch_locale" comm -12 "$fixture" "$sentinel"
+    assert_success "LC_ALL=C comm accepts C-sorted input under mismatching locale $mismatch_locale" \
+        env LC_ALL="$mismatch_locale" sh -c 'LC_ALL=C comm -12 "$1" "$2"' _ "$fixture" "$sentinel"
 fi
 rm -f "$fixture" "$sentinel"
 

--- a/scripts/ci/test-ci-comm-locale-pin.sh
+++ b/scripts/ci/test-ci-comm-locale-pin.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression tests for the comm/sort collation mismatch fixed in
+# discover-reborn-package-crates.sh: inputs were sorted with LC_ALL=C but comm
+# ran in the ambient locale, so under a UTF-8 collation (which orders
+# "ironclaw_events" before "ironclaw_event_streams", unlike C) the pre-push
+# coverage ratchet died with "comm: input is not in sorted order".
+
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+report() {
+    local ok="$1" label="$2" detail="${3:-}"
+    if [ "$ok" -eq 1 ]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label${detail:+ — $detail}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Case 1: every comm invocation in CI scripts and tracked hooks must pin
+# LC_ALL=C so its collation matches the LC_ALL=C-sorted inputs.
+unpinned="$(grep -rnE '(^|[^=[:alnum:]_])comm[[:space:]]+-' \
+    "$ROOT_DIR/scripts/ci" "$ROOT_DIR/.githooks" \
+    | grep -v 'LC_ALL=C comm' \
+    | grep -v 'test-ci-comm-locale-pin' \
+    || true)"
+if [ -z "$unpinned" ]; then
+    report 1 "all comm invocations are LC_ALL=C-pinned"
+else
+    report 0 "all comm invocations are LC_ALL=C-pinned" "$unpinned"
+fi
+
+# Case 2: the fixture pair that broke the ratchet. In C collation
+# "ironclaw_event_streams" < "ironclaw_events" ('_' 0x5f < 's' 0x73); UTF-8
+# collations disagree, so an unpinned comm rejects the C-sorted file. The
+# pinned form must accept it regardless of the ambient locale.
+utf8_locale=""
+for candidate in C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8; do
+    if locale -a 2>/dev/null | grep -qx "$candidate"; then
+        utf8_locale="$candidate"
+        break
+    fi
+done
+
+fixture="$(mktemp "${TMPDIR:-/tmp}/comm-locale.XXXXXX")"
+printf 'ironclaw_event_streams\nironclaw_events\n' > "$fixture"
+
+if LC_ALL="${utf8_locale:-C}" sh -c 'LC_ALL=C comm -12 "$1" "$1"' _ "$fixture" > /dev/null 2>&1; then
+    report 1 "LC_ALL=C comm accepts C-sorted input under ${utf8_locale:-C} locale"
+else
+    report 0 "LC_ALL=C comm accepts C-sorted input under ${utf8_locale:-C} locale"
+fi
+rm -f "$fixture"
+
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

`scripts/ci/discover-reborn-package-crates.sh` sorts both `comm` inputs with `LC_ALL=C` but ran `comm` itself in the ambient locale. Under a UTF-8 collation — which orders `ironclaw_events` before `ironclaw_event_streams`, the opposite of C order (`_` 0x5f < `s` 0x73) — `comm` rejects the C-sorted input with `comm: input is not in sorted order`, killing the pre-push coverage ratchet for any contributor whose shell has a UTF-8 locale. Hit in practice while pushing #6991 (noted in that PR's body).

**Fix:** one line — `LC_ALL=C comm -12` so comm's collation matches its inputs.

## Regression test

`scripts/ci/test-ci-comm-locale-pin.sh` (wired into the code_style static-check self-tests):
1. Asserts every `comm` invocation in `scripts/ci/` and `.githooks/` is `LC_ALL=C`-pinned — fails on the pre-fix tree pointing at the exact line.
2. Exercises the real-world fixture pair (`ironclaw_event_streams` / `ironclaw_events`) under an available UTF-8 locale with the pinned form.

Verified red-then-green: test fails with the fix stashed, passes with it applied; `discover-reborn-package-crates.sh` now runs end-to-end under `en_US.UTF-8` and emits the crate closure (previously exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)