### PR TITLE
ci: restore the original 90% changed-line coverage floor

### DIFF
--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -360,9 +360,11 @@ The merged Reborn LCOV report enforces three complementary ratchets:
   baseline (which supersedes the historical 80.81% floor);
 - critical production crates have percentage and covered-line floors in
   [`tests/integration/coverage-floor.toml`](../../tests/integration/coverage-floor.toml);
-- added, instrumentable production lines and branch arms must be covered. The
-  denominator comes from the pull-request diff intersected with LLVM `DA` and
-  `BRDA` records, not from a hand-maintained file list.
+- added, instrumentable production code must meet the committed 95% changed-line
+  and 85% changed-branch floors. The denominator comes from the pull-request
+  diff intersected with LLVM `DA` and `BRDA` records, not from a hand-maintained
+  file list. Missing production coverage and changed files with no measured
+  instrumented lines remain hard failures regardless of the percentage floors.
 
 Changed-code exemptions live in
 [`tests/integration/changed-coverage-exemptions.toml`](../../tests/integration/changed-coverage-exemptions.toml).

--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -360,11 +360,12 @@ The merged Reborn LCOV report enforces three complementary ratchets:
   baseline (which supersedes the historical 80.81% floor);
 - critical production crates have percentage and covered-line floors in
   [`tests/integration/coverage-floor.toml`](../../tests/integration/coverage-floor.toml);
-- added, instrumentable production code must meet the committed 95% changed-line
-  and 85% changed-branch floors. The denominator comes from the pull-request
-  diff intersected with LLVM `DA` and `BRDA` records, not from a hand-maintained
-  file list. Missing production coverage and changed files with no measured
-  instrumented lines remain hard failures regardless of the percentage floors.
+- added, instrumentable production code must meet the original committed 90%
+  changed-line floor. Changed-branch coverage is still required in LCOV and
+  reported for review, but has no universal percentage floor. The denominator
+  comes from the pull-request diff intersected with LLVM `DA` and `BRDA`
+  records, not from a hand-maintained file list. Missing production coverage
+  and changed files with no measured instrumented lines remain hard failures.
 
 Changed-code exemptions live in
 [`tests/integration/changed-coverage-exemptions.toml`](../../tests/integration/changed-coverage-exemptions.toml).

--- a/scripts/ci/test-reborn-changed-coverage.sh
+++ b/scripts/ci/test-reborn-changed-coverage.sh
@@ -123,6 +123,67 @@ check_text "line denominator is reported" "Changed line coverage: 100.00% (3/3)"
 check_text "branch denominator is reported" "Changed branch coverage: 100.00% (2/2)"
 check_report_text "machine report preserves the branch denominator" '"instrumented_branches": 2'
 
+echo "▶ committed-style percentage floors"
+cat >"${work}/policy.toml" <<'TOML'
+[policy]
+line_percent = 95.0
+branch_percent = 85.0
+TOML
+threshold_lines=20
+: >"${case_root}/${source_path}"
+: >"${work}/change.diff"
+printf '%s\n' \
+  "diff --git a/${source_path} b/${source_path}" \
+  "--- /dev/null" \
+  "+++ b/${source_path}" \
+  "@@ -0,0 +1,${threshold_lines} @@" >>"${work}/change.diff"
+for line in $(seq 1 "${threshold_lines}"); do
+  printf 'pub fn threshold_line_%s() {}\n' "${line}" >>"${case_root}/${source_path}"
+  printf '+pub fn threshold_line_%s() {}\n' "${line}" >>"${work}/change.diff"
+done
+write_threshold_lcov() {
+  local line_19_hits="$1" line_20_hits="$2" branch_17_hits="$3"
+  printf 'SF:%s\n' "${case_root}/${source_path}" >"${work}/coverage.lcov"
+  for line in $(seq 1 18); do
+    printf 'DA:%s,1\n' "${line}" >>"${work}/coverage.lcov"
+  done
+  printf 'DA:19,%s\nDA:20,%s\n' "${line_19_hits}" "${line_20_hits}" \
+    >>"${work}/coverage.lcov"
+  for line in $(seq 1 16); do
+    printf 'BRDA:%s,0,0,1\n' "${line}" >>"${work}/coverage.lcov"
+  done
+  printf 'BRDA:17,0,0,%s\n' "${branch_17_hits}" >>"${work}/coverage.lcov"
+  for line in 18 19 20; do
+    printf 'BRDA:%s,0,0,0\n' "${line}" >>"${work}/coverage.lcov"
+  done
+  printf 'LF:20\nBRF:20\nend_of_record\n' >>"${work}/coverage.lcov"
+}
+
+write_threshold_lcov 1 0 1
+run_gate
+check_rc "95% changed lines and 85% changed branches pass at the floors" 0
+check_text "line floor denominator is reported" "Changed line coverage: 95.00% (19/20)"
+check_text "branch floor denominator is reported" "Changed branch coverage: 85.00% (17/20)"
+check_report_text "machine report records the 95% line floor" '"threshold_percent": 95.0'
+check_report_text "machine report records the 85% branch floor" '"branch_threshold_percent": 85.0'
+
+write_threshold_lcov 0 0 1
+run_gate
+check_rc "changed-line coverage below 95% fails" 1
+check_text "line-floor failure names the committed threshold" "line coverage 90.00% is below 95.0%"
+
+write_threshold_lcov 1 0 0
+run_gate
+check_rc "changed-branch coverage below 85% fails" 1
+check_text "branch-floor failure names the committed threshold" "branch coverage 80.00% is below 85.0%"
+
+printf '%s\n' 'pub fn classify(value: bool) -> bool {' '    value' '}' >"${case_root}/${source_path}"
+cat >"${work}/policy.toml" <<'TOML'
+[policy]
+line_percent = 100.0
+branch_percent = 100.0
+TOML
+
 echo "▶ diff markers inside hunk content are parsed by their first byte"
 cat >"${work}/change.diff" <<'DIFF'
 diff --git a/crates/ironclaw_demo/src/lib.rs b/crates/ironclaw_demo/src/lib.rs

--- a/scripts/ci/test-reborn-changed-coverage.sh
+++ b/scripts/ci/test-reborn-changed-coverage.sh
@@ -123,11 +123,11 @@ check_text "line denominator is reported" "Changed line coverage: 100.00% (3/3)"
 check_text "branch denominator is reported" "Changed branch coverage: 100.00% (2/2)"
 check_report_text "machine report preserves the branch denominator" '"instrumented_branches": 2'
 
-echo "▶ committed-style percentage floors"
+echo "▶ restored original changed-line floor"
 cat >"${work}/policy.toml" <<'TOML'
 [policy]
-line_percent = 95.0
-branch_percent = 85.0
+line_percent = 90.0
+branch_percent = 0.0
 TOML
 threshold_lines=20
 : >"${case_root}/${source_path}"
@@ -142,40 +142,32 @@ for line in $(seq 1 "${threshold_lines}"); do
   printf '+pub fn threshold_line_%s() {}\n' "${line}" >>"${work}/change.diff"
 done
 write_threshold_lcov() {
-  local line_19_hits="$1" line_20_hits="$2" branch_17_hits="$3"
+  local line_18_hits="$1"
   printf 'SF:%s\n' "${case_root}/${source_path}" >"${work}/coverage.lcov"
-  for line in $(seq 1 18); do
+  for line in $(seq 1 17); do
     printf 'DA:%s,1\n' "${line}" >>"${work}/coverage.lcov"
   done
-  printf 'DA:19,%s\nDA:20,%s\n' "${line_19_hits}" "${line_20_hits}" \
+  printf 'DA:18,%s\nDA:19,0\nDA:20,0\n' "${line_18_hits}" \
     >>"${work}/coverage.lcov"
-  for line in $(seq 1 16); do
-    printf 'BRDA:%s,0,0,1\n' "${line}" >>"${work}/coverage.lcov"
-  done
-  printf 'BRDA:17,0,0,%s\n' "${branch_17_hits}" >>"${work}/coverage.lcov"
-  for line in 18 19 20; do
+  for line in $(seq 1 20); do
     printf 'BRDA:%s,0,0,0\n' "${line}" >>"${work}/coverage.lcov"
   done
   printf 'LF:20\nBRF:20\nend_of_record\n' >>"${work}/coverage.lcov"
 }
 
-write_threshold_lcov 1 0 1
+write_threshold_lcov 1
 run_gate
-check_rc "95% changed lines and 85% changed branches pass at the floors" 0
-check_text "line floor denominator is reported" "Changed line coverage: 95.00% (19/20)"
-check_text "branch floor denominator is reported" "Changed branch coverage: 85.00% (17/20)"
-check_report_text "machine report records the 95% line floor" '"threshold_percent": 95.0'
-check_report_text "machine report records the 85% branch floor" '"branch_threshold_percent": 85.0'
+check_rc "90% changed lines pass at the original floor" 0
+check_text "line floor denominator is reported" "Changed line coverage: 90.00% (18/20)"
+check_text "ungated branch coverage remains visible" "Changed branch coverage: 0.00% (0/20)"
+check_text "uncovered branch detail remains visible" "${source_path}:1 branch 0/0"
+check_report_text "machine report records the 90% line floor" '"threshold_percent": 90.0'
+check_report_text "machine report records the zero branch floor" '"branch_threshold_percent": 0.0'
 
-write_threshold_lcov 0 0 1
+write_threshold_lcov 0
 run_gate
-check_rc "changed-line coverage below 95% fails" 1
-check_text "line-floor failure names the committed threshold" "line coverage 90.00% is below 95.0%"
-
-write_threshold_lcov 1 0 0
-run_gate
-check_rc "changed-branch coverage below 85% fails" 1
-check_text "branch-floor failure names the committed threshold" "branch coverage 80.00% is below 85.0%"
+check_rc "changed-line coverage below 90% fails" 1
+check_text "line-floor failure names the original threshold" "line coverage 85.00% is below 90.0%"
 
 printf '%s\n' 'pub fn classify(value: bool) -> bool {' '    value' '}' >"${case_root}/${source_path}"
 cat >"${work}/policy.toml" <<'TOML'

--- a/scripts/ci/test_reborn_changed_coverage.py
+++ b/scripts/ci/test_reborn_changed_coverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Workflow-contract tests for strict changed-line and branch coverage."""
+"""Workflow-contract tests for thresholded changed-line and branch coverage."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import ast
 import re
 import subprocess
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -16,7 +17,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class ChangedCoverageWorkflowTests(unittest.TestCase):
-    def test_strict_gate_sabotage_harness_passes(self):
+    def test_gate_sabotage_harness_passes(self):
         result = subprocess.run(
             ["bash", "scripts/ci/test-reborn-changed-coverage.sh"],
             cwd=ROOT,
@@ -32,7 +33,16 @@ class ChangedCoverageWorkflowTests(unittest.TestCase):
         )
         self.assertIsNotNone(success, result.stdout)
 
-    def test_reborn_workflow_runs_strict_gate_and_preserves_machine_report(self):
+    def test_committed_policy_keeps_high_non_absolute_floors(self):
+        with (ROOT / "tests/integration/changed-coverage-exemptions.toml").open(
+            "rb"
+        ) as handle:
+            policy = tomllib.load(handle)["policy"]
+
+        self.assertEqual(policy["line_percent"], 95.0)
+        self.assertEqual(policy["branch_percent"], 85.0)
+
+    def test_reborn_workflow_runs_gate_and_preserves_machine_report(self):
         workflow = (ROOT / ".github/workflows/reborn-tests.yml").read_text(
             encoding="utf-8"
         )
@@ -53,7 +63,7 @@ class ChangedCoverageWorkflowTests(unittest.TestCase):
         self.assertNotIn(
             "--threshold",
             gate_step,
-            "the strict line/branch gate has no threshold CLI and must gate every denominator",
+            "thresholds come from the reviewed manifest, not a workflow override",
         )
         self.assertRegex(
             workflow,

--- a/scripts/ci/test_reborn_changed_coverage.py
+++ b/scripts/ci/test_reborn_changed_coverage.py
@@ -33,14 +33,14 @@ class ChangedCoverageWorkflowTests(unittest.TestCase):
         )
         self.assertIsNotNone(success, result.stdout)
 
-    def test_committed_policy_keeps_high_non_absolute_floors(self):
+    def test_committed_policy_restores_original_line_floor(self):
         with (ROOT / "tests/integration/changed-coverage-exemptions.toml").open(
             "rb"
         ) as handle:
             policy = tomllib.load(handle)["policy"]
 
-        self.assertEqual(policy["line_percent"], 95.0)
-        self.assertEqual(policy["branch_percent"], 85.0)
+        self.assertEqual(policy["line_percent"], 90.0)
+        self.assertEqual(policy["branch_percent"], 0.0)
 
     def test_reborn_workflow_runs_gate_and_preserves_machine_report(self):
         workflow = (ROOT / ".github/workflows/reborn-tests.yml").read_text(

--- a/tests/integration/changed-coverage-exemptions.toml
+++ b/tests/integration/changed-coverage-exemptions.toml
@@ -1,12 +1,14 @@
-# Changed-code coverage keeps a high floor without requiring every defensive
-# line and branch arm to execute in every PR. Missing production coverage and
-# changed files with an empty instrumented denominator still fail closed. An
-# exemption remains exact-line only and requires an owner, reason, tracking
-# issue, and review date; whole-file and glob exemptions are not supported.
+# Changed-code coverage retains the original 90% changed-line floor. Branch
+# coverage remains required in LCOV and reported for review, but it has no
+# universal percentage floor: defensive async/backend arms made a blanket
+# branch threshold incentive-incompatible with meaningful tests. Missing
+# production coverage and changed files with an empty instrumented denominator
+# still fail closed. Exemptions remain exact-line only; whole-file and glob
+# exemptions are not supported.
 
 [policy]
-line_percent = 95.0
-branch_percent = 85.0
+line_percent = 90.0
+branch_percent = 0.0
 
 # Example (remove the comment markers only after reviewer approval):
 #

--- a/tests/integration/changed-coverage-exemptions.toml
+++ b/tests/integration/changed-coverage-exemptions.toml
@@ -1,11 +1,12 @@
-# Changed-code coverage is intentionally strict: every LLVM-instrumentable
-# production line and branch arm added by a PR must execute. An exemption is
-# exact-line only and requires an owner, reason, tracking issue, and review
-# date. Whole-file and glob exemptions are not supported.
+# Changed-code coverage keeps a high floor without requiring every defensive
+# line and branch arm to execute in every PR. Missing production coverage and
+# changed files with an empty instrumented denominator still fail closed. An
+# exemption remains exact-line only and requires an owner, reason, tracking
+# issue, and review date; whole-file and glob exemptions are not supported.
 
 [policy]
-line_percent = 100.0
-branch_percent = 100.0
+line_percent = 95.0
+branch_percent = 85.0
 
 # Example (remove the comment markers only after reviewer approval):
 #


### PR DESCRIPTION
## Summary

- restore the changed-code gate's original 90% changed-line threshold
- keep changed-branch LCOV mandatory and visible without imposing a universal branch-percentage gate
- preserve fail-closed behavior for missing coverage and changed production files with an empty measured denominator
- add boundary regression tests and document the restored policy

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6973, #6881, and #6889.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: changed-coverage Python contract tests and shell sabotage suite
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: exercised exact-floor and below-floor LCOV fixtures
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: contributors return to the original 90% changed-line requirement. Defensive async/backend branches remain measured and review-visible without forcing artificial tests or large exemption manifests solely to satisfy a universal branch threshold.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: policy assertions pin the restored 90% line floor and zero universal branch floor.
- Reborn integration: Not applicable: this changes coverage post-processing policy, not runtime behavior.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: no UI behavior changed.
- Backend or runtime: Not applicable: no backend or runtime behavior changed.
- Live canary: Not applicable: no deployed product behavior changed.

What the tests prove: exactly 90% changed-line coverage passes; 85% fails; 0% branch coverage is still reported with exact uncovered branch details; missing branch instrumentation, missing production LCOV files, empty per-file denominators, stale exemptions, renamed files, and unattributable crate paths continue to fail closed.

Commands run: `python3 scripts/ci/test_reborn_changed_coverage.py`; `bash scripts/ci/test-reborn-changed-coverage.sh`; `python3 -m py_compile scripts/ci/reborn_changed_coverage.py scripts/ci/test_reborn_changed_coverage.py`; `bash -n scripts/ci/test-reborn-changed-coverage.sh`; `shellcheck scripts/ci/test-reborn-changed-coverage.sh`; `scripts/pre-commit-safety.sh`; `git diff --check`.

## Security Impact

None. The change affects CI coverage policy only and does not modify permissions, networking, secrets, file access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

N/A: no Reborn runtime, authority, persistence, or trust-bearing contract changes.

## Database Impact

None.

## Blast Radius

The Reborn changed-code coverage step in pull-request and merge-group CI. Missing coverage remains a hard failure. Measured changed lines return to the original 90% floor; branch coverage remains mandatory in LCOV and review-visible but does not gate on a universal percentage.

## Rollback Plan

Revert this PR to restore the later 100% line and branch policy.

## Review Follow-Through

This restores the policy shape introduced by #6881 while retaining the fail-closed LCOV discovery and reporting improvements added later. Reviewer judgment is requested on whether any explicitly critical functions should continue to rely on the separate mutation gate instead of a universal branch threshold.

---

**Review track**: C (CI policy)
