### PR TITLE
fix(ci): allow skipped mutation gate on dispatch

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -1037,7 +1037,7 @@ jobs:
             exit 1
           fi
 
-          if ! job_result_ok "critical-mutation" "${{ needs.critical-mutation.result }}" false "allow"; then
+          if ! job_result_ok "critical-mutation" "${{ needs.critical-mutation.result }}" true "allow"; then
             echo "Critical named-function mutation gate failed: ${{ needs.critical-mutation.result }}"
             exit 1
           fi

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -1037,7 +1037,7 @@ jobs:
             exit 1
           fi
 
-          if ! job_result_ok "critical-mutation" "${{ needs.critical-mutation.result }}" true "allow"; then
+          if ! job_result_ok "critical-mutation" "${{ needs.critical-mutation.result }}" "${{ github.event_name == 'workflow_dispatch' }}" "allow"; then
             echo "Critical named-function mutation gate failed: ${{ needs.critical-mutation.result }}"
             exit 1
           fi

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -148,7 +148,8 @@ class WorkflowContractSabotageTests(unittest.TestCase):
 
         self.assertIn(
             'job_result_ok "critical-mutation" '
-            '"${{ needs.critical-mutation.result }}" true "allow"',
+            '"${{ needs.critical-mutation.result }}" '
+            '"${{ github.event_name == \'workflow_dispatch\' }}" "allow"',
             workflow,
         )
 

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -141,6 +141,17 @@ class WorkflowContractSabotageTests(unittest.TestCase):
         self.assertIn("python3 scripts/ci/test_ws12_suite_shards.py", workflow)
         self.assertIn("python3 scripts/ci/test_ws12_workflow_contracts.py", workflow)
 
+    def test_workflow_dispatch_allows_expected_critical_mutation_skip(self) -> None:
+        workflow = (ROOT / ".github/workflows/reborn-tests.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            'job_result_ok "critical-mutation" '
+            '"${{ needs.critical-mutation.result }}" true "allow"',
+            workflow,
+        )
+
     def test_code_style_fast_checks_share_one_runner_without_losing_gates(self) -> None:
         workflow = (ROOT / ".github/workflows/code_style.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

- Allow a skipped `critical-mutation` job during manual `workflow_dispatch` runs, matching the workflow's intentional dispatch-only skip condition.
- Add a workflow contract test that keeps the roll-up behavior aligned with the job condition.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #6978

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (Rust 1.96.0, the workspace MSRV)
- [x] `cargo build`
- [x] Relevant tests pass: `python3 scripts/ci/test_ws12_workflow_contracts.py`; `python3 scripts/ci/test_ws12_suite_shards.py`; `cargo test`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed (not applicable: no database or integration behavior changed)
- [ ] Manual testing (not applicable: this is a workflow contract change)
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: A manually dispatched Reborn workflow can complete its roll-up when the critical-mutation job is intentionally skipped.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added `test_workflow_dispatch_allows_expected_critical_mutation_skip` to the WS12 workflow contracts.
- Reborn integration: Not applicable; the contract test directly exercises the static workflow invariant.
- Recorded fixture: Not applicable; no external response is involved.
- Browser E2E: Not applicable; no browser behavior changes.
- Backend or runtime: Not applicable; no application code changes.
- Live canary: Not applicable; the workflow dispatch itself is the post-merge canary.

What the tests prove: The dispatch condition that skips `critical-mutation` and the roll-up's allowance for that skipped result remain paired. The new contract fails against unmodified `main` and passes with this change.

Commands run:

```text
python3 scripts/ci/test_ws12_workflow_contracts.py
python3 scripts/ci/test_ws12_suite_shards.py
cargo fmt --all -- --check
cargo +1.96.0 clippy --all --benches --tests --examples --all-features -- -D warnings
cargo +1.96.0 build
cargo +1.96.0 test
scripts/pre-commit-safety.sh
git diff --check upstream/main...HEAD
```

## Security Impact

None. The change only alters result aggregation for an already intentional dispatch-only skip.

## Reborn Trust-Boundary Checklist

N/A: no Reborn runtime, policy, security, database, or trust-boundary code changes.

## Database Impact

None.

## Blast Radius

Limited to the `Tests (Reborn)` roll-up on `workflow_dispatch`. Pull request and push runs still require the critical-mutation job to succeed.

## Rollback Plan

Revert this commit to restore the previous roll-up handling. The contract test and workflow line are contained in the same commit.

## Review Follow-Through

The key reviewer judgment is whether a dispatch-only skipped mutation job should remain accepted by the roll-up, as requested in #6978.

---

**Review track**: C (CI)
