### PR TITLE
fix(processes): join legacy checkpoint payloads on the state token

### DIFF
--- a/crates/ironclaw_processes/src/journal_store/migration.rs
+++ b/crates/ironclaw_processes/src/journal_store/migration.rs
@@ -407,14 +407,16 @@ fn legacy_loop_checkpoint(
     checkpoint_states: &HashMap<String, Value>,
 ) -> Result<Option<ProcessCheckpointRecord>, ProcessJournalStoreError> {
     let state_ref = required_string(value, "state_ref")?;
+    let run_id: TurnRunId = required(value, "run_id")?;
     let payload = match value.get("payload").filter(|payload| !payload.is_null()) {
         Some(payload) => serde_json::from_value(payload.clone()).map_err(deserialization)?,
         None => {
-            let stored = checkpoint_states.get(&state_ref).ok_or_else(|| {
-                invalid_legacy(format!(
-                    "legacy loop checkpoint {state_ref} has no checkpoint-state payload"
-                ))
-            })?;
+            let stored = checkpoint_state_record(checkpoint_states, &state_ref, run_id)
+                .ok_or_else(|| {
+                    invalid_legacy(format!(
+                        "legacy loop checkpoint {state_ref} has no checkpoint-state payload"
+                    ))
+                })?;
             validate_checkpoint_state_metadata(value, stored)?;
             let payload_hex = required_string(stored, "payload_hex")?;
             hex::decode(payload_hex).map_err(|error| {
@@ -424,7 +426,6 @@ fn legacy_loop_checkpoint(
             })?
         }
     };
-    let run_id: TurnRunId = required(value, "run_id")?;
     let turn_scope: TurnScope = required(value, "scope")?;
     let mut scope = turn_scope.to_resource_scope();
     scope.invocation_id = InvocationId::from_uuid(run_id.as_uuid());
@@ -446,12 +447,39 @@ fn legacy_loop_checkpoint(
     }))
 }
 
+/// Resolve the checkpoint-state record holding a loop checkpoint's payload.
+///
+/// The two sides of this join do not agree on how a checkpoint state is named:
+///
+/// ```text
+///   loop_checkpoints row   state_ref = "checkpoint:{run_id}:{token}"  (LoopCheckpointStateRef::for_run)
+///   checkpoint-state file  state_ref = "checkpoint:{token}"           (the stored state identity)
+/// ```
+///
+/// Older deployments wrote one opaque ref on both sides, so try the ref
+/// verbatim first and fall back to the stored identity the run-scoped form
+/// wraps. Matching on the whole string alone made every run-scoped row look
+/// like it had lost its payload, which failed the startup migration.
+fn checkpoint_state_record<'a>(
+    checkpoint_states: &'a HashMap<String, Value>,
+    state_ref: &str,
+    run_id: TurnRunId,
+) -> Option<&'a Value> {
+    if let Some(stored) = checkpoint_states.get(state_ref) {
+        return Some(stored);
+    }
+    let token = state_ref.strip_prefix(&format!("checkpoint:{run_id}:"))?;
+    checkpoint_states.get(&format!("checkpoint:{token}"))
+}
+
 fn validate_checkpoint_state_metadata(
     checkpoint: &Value,
     stored: &Value,
 ) -> Result<(), ProcessJournalStoreError> {
+    // `state_ref` is deliberately absent: it is the join key, and the two
+    // sides carry different representations of it (see
+    // `checkpoint_state_record`).
     for field in [
-        "state_ref",
         "scope",
         "turn_id",
         "run_id",

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -809,6 +809,14 @@ async fn deployed_turn_blob_and_run_state_import_before_first_process_request() 
     let turn_id = TurnId::new();
     let checkpoint_id = TurnCheckpointId::new();
     let external_checkpoint_id = TurnCheckpointId::new();
+    let run_scoped_checkpoint_id = TurnCheckpointId::new();
+    // Deployed loop checkpoints carry the run-scoped
+    // `checkpoint:{run_id}:{token}` ref minted by
+    // `LoopCheckpointStateRef::for_run`, while the checkpoint-state authority
+    // record persists the bare `checkpoint:{token}` identity it was stored
+    // under. The migration has to join those two shapes on the token.
+    let run_scoped_state_token = TurnCheckpointId::new().as_uuid().to_string();
+    let run_scoped_state_ref = format!("checkpoint:{}:{run_scoped_state_token}", run_id.as_uuid());
     let root_run_id = TurnRunId::new();
     let capability_invocation_id = InvocationId::new();
     let per_user_capability_invocation_id = InvocationId::new();
@@ -883,6 +891,18 @@ async fn deployed_turn_blob_and_run_state_import_before_first_process_request() 
                 "kind": "Gate",
                 "gate_ref": "gate:migration-approval",
                 "created_at": "2026-01-01T00:00:02Z"
+            },
+            {
+                "checkpoint_id": run_scoped_checkpoint_id,
+                "scope": turn_scope,
+                "turn_id": turn_id,
+                "run_id": run_id,
+                "state_ref": run_scoped_state_ref,
+                "schema_id": "interactive_checkpoint_v1",
+                "schema_version": 1,
+                "kind": "Gate",
+                "gate_ref": "gate:migration-approval",
+                "created_at": "2026-01-01T00:00:03Z"
             }
         ],
         "idempotency_records": [
@@ -942,6 +962,31 @@ async fn deployed_turn_blob_and_run_state_import_before_first_process_request() 
         )
         .await
         .expect("seed deployed per-user checkpoint-state");
+    filesystem
+        .put(
+            &ResourceScope::system(),
+            &ScopedPath::new(format!(
+                "/legacy-tenants/tenant-process-test/users/user-process-test/checkpoint-state/agents/agent-process-test/threads/thread-process-test/states/checkpoint/{run_scoped_state_token}.json"
+            ))
+            .expect("run-scoped legacy checkpoint-state path"),
+            Entry::bytes(
+                serde_json::to_vec(&json!({
+                    "state_ref": format!("checkpoint:{run_scoped_state_token}"),
+                    "scope": turn_scope,
+                    "turn_id": turn_id,
+                    "run_id": run_id,
+                    "schema_id": "interactive_checkpoint_v1",
+                    "schema_version": 1,
+                    "kind": "Gate",
+                    "payload_hex": "72756e2d73636f706564",
+                    "created_at": "2026-01-01T00:00:03Z"
+                }))
+                .expect("serialize run-scoped checkpoint-state record"),
+            ),
+            CasExpectation::Absent,
+        )
+        .await
+        .expect("seed deployed run-scoped checkpoint-state");
     let capability_scope = scope();
     filesystem
         .put(
@@ -1053,6 +1098,23 @@ async fn deployed_turn_blob_and_run_state_import_before_first_process_request() 
         .expect("read externally stored checkpoint")
         .expect("external checkpoint exists");
     assert_eq!(external_checkpoint.payload.as_bytes(), b"external");
+    let run_scoped_checkpoint = store
+        .get_process_checkpoint(GetProcessCheckpointRequest {
+            checkpoint_id: ProcessCheckpointId::from_trusted(
+                run_scoped_checkpoint_id.as_uuid().to_string(),
+            ),
+            process_id: turn_process_id,
+            scope: imported_scope.clone(),
+        })
+        .await
+        .expect("read run-scoped externally stored checkpoint")
+        .expect("run-scoped checkpoint exists");
+    assert_eq!(run_scoped_checkpoint.payload.as_bytes(), b"run-scoped");
+    assert_eq!(
+        run_scoped_checkpoint.state_ref.as_str(),
+        run_scoped_state_ref,
+        "the imported record keeps the deployed run-scoped ref"
+    );
 
     let replay = store
         .submit_process(SubmitProcessRequest {


### PR DESCRIPTION
## Summary

- `ironclaw serve` failed at startup on any store holding legacy loop checkpoints: `process journal startup migration failed: ... legacy loop checkpoint checkpoint:{run_id}:{token} has no checkpoint-state payload`. The payload was never missing — the migration joined the two sides on mismatched keys.
- A `loop_checkpoints` row carries the run-scoped ref `checkpoint:{run_id}:{token}` (minted by `LoopCheckpointStateRef::for_run`, `ironclaw_loop_contracts/src/host/refs.rs:101`); the `checkpoint-state` record that holds the payload carries the bare stored identity `checkpoint:{token}`. `legacy_loop_checkpoint` looked the payload up by the whole ref string, so **every** run-scoped row looked like it had lost its payload.
- The migration hard-fails, which fails composition, which bricks `serve` with no way past it. On a real deployed store: **0/36** rows matched by full string, **36/36** match on the token, with zero metadata disagreement on scope/turn/run/schema/kind.
- Fix: resolve through the stored identity the run-scoped ref wraps, keeping the verbatim lookup first for older deployments that wrote one opaque ref on both sides.
- `validate_checkpoint_state_metadata` no longer compares `state_ref`. It is the join key, and the check was already tautological (the map is keyed by the record's own `state_ref`, so the exact-match path could never disagree); retained on the run-scoped path it would reject every legitimate join. The other six fields still catch a wrong record.

## Change Type

- [x] Bug fix

## Linked Issue

None — found while debugging a local `serve` failure; no existing issue covers it.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_processes --all-targets --all-features -- -D warnings` (workspace-wide lane left to CI)
- [x] `cargo build --release -p ironclaw`
- [x] Relevant tests pass: `cargo test -p ironclaw_processes` (91 tests / 6 binaries), `cargo test -p ironclaw_architecture` (116 tests)
- [ ] `cargo test --features integration` — not run; no schema or backend behavior changed, and this path is exercised by the crate contract suite against both the in-memory and libSQL backends
- [x] Manual testing: rebuilt the release binary and ran it against a real deployed libSQL store that reproduced the failure. Migration now completes, imports 100 materialized rows, and `serve` comes up (401 unauthenticated / 200 with bearer / SPA served).
- [x] `bash scripts/pre-commit-safety.sh`

## Test Strategy

User behavior: a user upgrading with legacy loop checkpoints in their store can start `ironclaw serve` instead of hitting a permanent startup failure.

Risk areas:
- [x] Persistence
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `crates/ironclaw_processes/tests/process_journal_store_contract.rs::deployed_turn_blob_and_run_state_import_before_first_process_request` — extended with a third loop checkpoint in the real deployed shape (run-scoped `state_ref` on the row, bare stored identity on the `checkpoint-state` record) and an assertion that its payload imports and the record keeps the deployed ref.
- Reborn integration: Not applicable — the failure is entirely inside the process-journal migration, and the crate contract suite reaches it through the public `migrate_legacy_journal` caller.
- Recorded fixture: Not applicable: no model behavior.
- Browser E2E: Not applicable: no user-visible surface change.
- Backend or runtime: Not applicable: no schema change; the contract suite already runs against libSQL.
- Live canary: Not applicable: no external provider.

What the tests prove: the extended test fails before the fix with the exact production error string and passes after. Coverage was extended rather than duplicated because the existing test already owns this seam — its fixture was the reason the bug shipped, since it seeded a synthetic `state_ref` (`"state:external"`) identical on both sides, a shape production never writes.

Commands run:

```
cargo test -p ironclaw_processes
cargo test -p ironclaw_architecture
cargo fmt --all -- --check
cargo clippy -p ironclaw_processes --all-targets --all-features -- -D warnings
bash scripts/pre-commit-safety.sh
```

## Security Impact

None. No change to permissions, network calls, secrets, file access, tool execution, or sandbox policy. The migration still runs only under `ResourceScope::system()` through the same process-journal-specific `/legacy-tenants` read-only alias; no mount, scope, or authority changed.

## Reborn Trust-Boundary Checklist

- Public policy/evidence/trust-bearing types: none added. `checkpoint_state_record` is a private module-level helper.
- Untrusted content enters prompts only through an envelope: N/A — no prompt path.
- Hashes declare purpose: N/A — no hashing.
- New/changed status/exit/policy/runtime/error variants: none. No new error variant; the existing `invalid_legacy` message is unchanged.
- Security/durability `serde(default)` fields: N/A — no serde shape changed.
- Queues/maps/buffers/counters bounded: N/A — lookup is a `HashMap::get` on an already-built map; no new allocation growth.
- Driver/operator-visible error class semantics: unchanged; a genuinely missing payload still fails the migration loudly with the same message.
- Sandbox/native/host names: N/A.

## Database Impact

No schema change, no migration file. This changes how the **existing** one-time legacy-journal import reads already-persisted records. Behavior is backend-neutral (the code path is `RootFilesystem`-level and runs identically on libSQL, PostgreSQL, and in-memory). Records that previously failed the import now import correctly; nothing that imported before changes.

## Blast Radius

`ironclaw_processes` legacy journal migration only, reached from `ironclaw_reborn_composition::factory::production_backend_assembly` at startup. It runs once per store and is a no-op afterwards (the rerun-is-idempotent assertion in the same test still holds). Worst realistic case is a wrong join importing the wrong payload — guarded by `validate_checkpoint_state_metadata` on scope/turn_id/run_id/schema_id/schema_version/kind, which was verified to agree on all 36 real rows.

## Rollback Plan

Revert the commit. The change only affects a one-time import; stores already migrated by this build keep their imported rows, which are the same records the pre-fix code would have produced had it matched. No data is deleted or rewritten by reverting.

## Review Follow-Through

One judgement call worth a reviewer's eye: I kept the fail-loud behavior. A genuinely missing payload still hard-fails startup with no recovery path or opt-out. That is defensible for a one-time import, but a bricked `serve` with no way past it is a rough edge that deserves its own issue. I deliberately did not widen the fallback to skip missing payloads, since that would mask the next real bug in exactly the way this one was masked.

---

**Review track**: C (persistence / startup path)
