### PR TITLE
perf: recover hosted Postgres API capacity regressed by the row-native process journal (#6696)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3904,6 +3904,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "testcontainers-modules",
  "thiserror 2.0.19",
  "tokio",
  "tokio-postgres",

--- a/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
@@ -16,24 +16,25 @@ fn process_and_thread_request_storage_paths_do_not_enumerate_collections() {
     ));
     // The transcript rebuild moved out of `thread_index` into its own module;
     // the enumeration it performs is still migration-only and is gated below.
-    let transcript_migration =
-        read(&root.join("crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs"));
+    let transcript_migration = scannable(&read(
+        &root.join("crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs"),
+    ));
 
     assert_calls_are_confined_to(
         &process_store,
-        ".query(",
+        "query",
         "pub async fn migrate_row_native_indexes",
         "async fn initialize_materialized",
     );
     assert_calls_are_confined_to(
         &process_store,
-        ".tail_bounded(",
+        "tail_bounded",
         "async fn initialize_materialized",
         "\n}\n\n#[async_trait]",
     );
     assert_calls_are_confined_to(
         &thread_index,
-        ".list_dir(",
+        "list_dir",
         "pub async fn migrate_thread_index_for_scope",
         "pub(super) async fn thread_record_with_index_overlay",
     );
@@ -41,18 +42,18 @@ fn process_and_thread_request_storage_paths_do_not_enumerate_collections() {
     // `.query(` it had belonged to the transcript rebuild, which now lives in
     // its own module. Assert the absence directly rather than bounding it.
     assert!(
-        !thread_index.contains(".query("),
+        call_offsets(&thread_index, "query").is_empty(),
         "thread_index must not enumerate collections; the transcript rebuild owns that call"
     );
     assert_calls_are_confined_to(
         &transcript_migration,
-        ".query(",
+        "query",
         "pub async fn migrate_transcript_indexes_for_scope",
         "async fn migrate_transcript_page",
     );
     assert_calls_are_confined_to(
         &transcript_migration,
-        ".list_dir(",
+        "list_dir",
         "pub async fn migrate_transcript_indexes_for_scope",
         "async fn migrate_transcript_page",
     );
@@ -67,7 +68,32 @@ fn scannable(source: &str) -> String {
     ratchet_support::strip_comments_and_strings(source)
 }
 
-fn assert_calls_are_confined_to(source: &str, call: &str, start: &str, end: &str) {
+/// Offsets of `.<method>` calls, tolerating whitespace before the paren.
+///
+/// `.query(`, `.query (` and `.query\n(` are the same call to rustc, so a
+/// literal-substring scan lets a reformat walk straight through the gate. The
+/// trailing check also keeps `.query_ordered(` from matching `query`.
+fn call_offsets(source: &str, method: &str) -> Vec<usize> {
+    let needle = format!(".{method}");
+    let mut offsets = Vec::new();
+    let mut from = 0;
+    while let Some(relative) = source[from..].find(&needle) {
+        let start = from + relative;
+        let after = start + needle.len();
+        let rest = &source[after..];
+        let continues_identifier = rest
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if !continues_identifier && rest.trim_start().starts_with('(') {
+            offsets.push(start);
+        }
+        from = after;
+    }
+    offsets
+}
+
+fn assert_calls_are_confined_to(source: &str, method: &str, start: &str, end: &str) {
     let start_offset = source
         .find(start)
         .unwrap_or_else(|| panic!("migration boundary `{start}` must exist"));
@@ -76,14 +102,14 @@ fn assert_calls_are_confined_to(source: &str, call: &str, start: &str, end: &str
         .map(|offset| start_offset + offset)
         .unwrap_or_else(|| panic!("migration boundary `{end}` must exist after `{start}`"));
 
-    let violations = source
-        .match_indices(call)
-        .filter(|(offset, _)| *offset < start_offset || *offset >= end_offset)
-        .map(|(offset, _)| line_number(source, offset))
+    let violations = call_offsets(source, method)
+        .into_iter()
+        .filter(|offset| *offset < start_offset || *offset >= end_offset)
+        .map(|offset| line_number(source, offset))
         .collect::<Vec<_>>();
     assert!(
         violations.is_empty(),
-        "`{call}` may only appear in the explicit offline migration boundary \
+        "`.{method}(` may only appear in the explicit offline migration boundary \
          `{start}`..`{end}`; found request/startup uses on lines {violations:?}"
     );
 }
@@ -115,7 +141,7 @@ mod self_tests {
         let source = scannable(&format!("{MIGRATION}{BOUNDARY}"));
         assert_calls_are_confined_to(
             &source,
-            ".query(",
+            "query",
             "pub async fn migrate_x",
             "async fn after_migration",
         );
@@ -129,7 +155,37 @@ mod self_tests {
         ));
         assert_calls_are_confined_to(
             &source,
-            ".query(",
+            "query",
+            "pub async fn migrate_x",
+            "async fn after_migration",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "may only appear in the explicit offline migration")]
+    fn a_multiline_call_outside_the_migration_range_is_rejected() {
+        // Legal Rust that a literal-substring scan walks straight past.
+        let source = scannable(&format!(
+            "async fn request_path() {{\n    self.fs.query\n        ();\n}}\n{MIGRATION}{BOUNDARY}"
+        ));
+        assert_calls_are_confined_to(
+            &source,
+            "query",
+            "pub async fn migrate_x",
+            "async fn after_migration",
+        );
+    }
+
+    #[test]
+    fn a_longer_method_name_is_not_the_scanned_call() {
+        // `.query_ordered(` is a different, bounded call and must not trip the
+        // gate for `query`.
+        let source = scannable(&format!(
+            "async fn request_path() {{\n    self.fs.query_ordered();\n}}\n{MIGRATION}{BOUNDARY}"
+        ));
+        assert_calls_are_confined_to(
+            &source,
+            "query",
             "pub async fn migrate_x",
             "async fn after_migration",
         );
@@ -145,7 +201,7 @@ mod self_tests {
         ));
         assert_calls_are_confined_to(
             &source,
-            ".query(",
+            "query",
             "pub async fn migrate_x",
             "async fn after_migration",
         );

--- a/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
@@ -11,6 +11,10 @@ fn process_and_thread_request_storage_paths_do_not_enumerate_collections() {
     let process_store = read(&root.join("crates/ironclaw_processes/src/journal_store.rs"));
     let thread_index =
         read(&root.join("crates/ironclaw_threads/src/filesystem_service/thread_index.rs"));
+    // The transcript rebuild moved out of `thread_index` into its own module;
+    // the enumeration it performs is still migration-only and is gated below.
+    let transcript_migration =
+        read(&root.join("crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs"));
 
     assert_calls_are_confined_to(
         &process_store,
@@ -30,11 +34,24 @@ fn process_and_thread_request_storage_paths_do_not_enumerate_collections() {
         "pub async fn migrate_thread_index_for_scope",
         "pub(super) async fn thread_record_with_index_overlay",
     );
+    // The listing projection module no longer enumerates at all: the only
+    // `.query(` it had belonged to the transcript rebuild, which now lives in
+    // its own module. Assert the absence directly rather than bounding it.
+    assert!(
+        !thread_index.contains(".query("),
+        "thread_index must not enumerate collections; the transcript rebuild owns that call"
+    );
     assert_calls_are_confined_to(
-        &thread_index,
+        &transcript_migration,
         ".query(",
         "pub async fn migrate_transcript_indexes_for_scope",
-        "pub(super) async fn thread_record_with_index_overlay",
+        "async fn migrate_transcript_page",
+    );
+    assert_calls_are_confined_to(
+        &transcript_migration,
+        ".list_dir(",
+        "pub async fn migrate_transcript_indexes_for_scope",
+        "async fn migrate_transcript_page",
     );
 }
 

--- a/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
@@ -8,9 +8,12 @@ use ratchet_support::workspace_root;
 #[test]
 fn process_and_thread_request_storage_paths_do_not_enumerate_collections() {
     let root = workspace_root();
-    let process_store = read(&root.join("crates/ironclaw_processes/src/journal_store.rs"));
-    let thread_index =
-        read(&root.join("crates/ironclaw_threads/src/filesystem_service/thread_index.rs"));
+    let process_store = scannable(&read(
+        &root.join("crates/ironclaw_processes/src/journal_store.rs"),
+    ));
+    let thread_index = scannable(&read(
+        &root.join("crates/ironclaw_threads/src/filesystem_service/thread_index.rs"),
+    ));
     // The transcript rebuild moved out of `thread_index` into its own module;
     // the enumeration it performs is still migration-only and is gated below.
     let transcript_migration =
@@ -55,6 +58,15 @@ fn process_and_thread_request_storage_paths_do_not_enumerate_collections() {
     );
 }
 
+/// Scan a source with comments and string literals removed.
+///
+/// The gate matches call text, so prose that names `.query(` — a doc comment
+/// explaining why enumeration is confined, for instance — would otherwise read
+/// as a violation, and a call hidden inside a string would read as compliant.
+fn scannable(source: &str) -> String {
+    ratchet_support::strip_comments_and_strings(source)
+}
+
 fn assert_calls_are_confined_to(source: &str, call: &str, start: &str, end: &str) {
     let start_offset = source
         .find(start)
@@ -87,4 +99,55 @@ fn line_number(source: &str, offset: usize) -> usize {
 fn read(path: &Path) -> String {
     std::fs::read_to_string(path)
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+/// Guardrails are code: the confinement scan needs its own coverage, or a
+/// change to it can silently stop catching the thing it exists for.
+#[cfg(test)]
+mod self_tests {
+    use super::*;
+
+    const MIGRATION: &str = "pub async fn migrate_x() {\n    self.fs.query();\n}\n";
+    const BOUNDARY: &str = "async fn after_migration() {}\n";
+
+    #[test]
+    fn a_call_inside_the_migration_range_is_allowed() {
+        let source = scannable(&format!("{MIGRATION}{BOUNDARY}"));
+        assert_calls_are_confined_to(
+            &source,
+            ".query(",
+            "pub async fn migrate_x",
+            "async fn after_migration",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "may only appear in the explicit offline migration")]
+    fn a_call_outside_the_migration_range_is_rejected() {
+        let source = scannable(&format!(
+            "async fn request_path() {{\n    self.fs.query();\n}}\n{MIGRATION}{BOUNDARY}"
+        ));
+        assert_calls_are_confined_to(
+            &source,
+            ".query(",
+            "pub async fn migrate_x",
+            "async fn after_migration",
+        );
+    }
+
+    #[test]
+    fn prose_naming_the_call_is_not_a_call_site() {
+        // The doc comment and the string both name `.query(` without calling
+        // it; only stripping them keeps this from reading as a violation.
+        let source = scannable(&format!(
+            "/// Enumeration via .query( belongs to the migration.\n\
+             async fn request_path() {{\n    let _ = \".query(\";\n}}\n{MIGRATION}{BOUNDARY}"
+        ));
+        assert_calls_are_confined_to(
+            &source,
+            ".query(",
+            "pub async fn migrate_x",
+            "async fn after_migration",
+        );
+    }
 }

--- a/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
+++ b/crates/ironclaw_architecture/tests/reborn_process_storage_scan_gate.rs
@@ -68,27 +68,35 @@ fn scannable(source: &str) -> String {
     ratchet_support::strip_comments_and_strings(source)
 }
 
-/// Offsets of `.<method>` calls, tolerating whitespace before the paren.
+/// Offsets of `.<method>(` calls, tolerating whitespace anywhere rustc does.
 ///
-/// `.query(`, `.query (` and `.query\n(` are the same call to rustc, so a
-/// literal-substring scan lets a reformat walk straight through the gate. The
-/// trailing check also keeps `.query_ordered(` from matching `query`.
+/// `.query(`, `.query (`, `.query\n(` and `.\nquery()` are all the same call,
+/// so the scan walks from each `.`, skips whitespace on both sides of the
+/// method name, and requires a call paren. Matching literal text instead lets
+/// a reformat carry an unbounded call straight through the gate. The
+/// identifier-boundary check keeps `.query_ordered(` from matching `query`.
 fn call_offsets(source: &str, method: &str) -> Vec<usize> {
-    let needle = format!(".{method}");
+    let bytes = source.as_bytes();
     let mut offsets = Vec::new();
-    let mut from = 0;
-    while let Some(relative) = source[from..].find(&needle) {
-        let start = from + relative;
-        let after = start + needle.len();
-        let rest = &source[after..];
-        let continues_identifier = rest
+    for (dot, _) in source.match_indices('.') {
+        let mut cursor = dot + 1;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if !source[cursor..].starts_with(method) {
+            continue;
+        }
+        let after_name = cursor + method.len();
+        if source[after_name..]
             .chars()
             .next()
-            .is_some_and(|c| c.is_alphanumeric() || c == '_');
-        if !continues_identifier && rest.trim_start().starts_with('(') {
-            offsets.push(start);
+            .is_some_and(|c| c.is_alphanumeric() || c == '_')
+        {
+            continue;
         }
-        from = after;
+        if source[after_name..].trim_start().starts_with('(') {
+            offsets.push(dot);
+        }
     }
     offsets
 }
@@ -167,6 +175,22 @@ mod self_tests {
         // Legal Rust that a literal-substring scan walks straight past.
         let source = scannable(&format!(
             "async fn request_path() {{\n    self.fs.query\n        ();\n}}\n{MIGRATION}{BOUNDARY}"
+        ));
+        assert_calls_are_confined_to(
+            &source,
+            "query",
+            "pub async fn migrate_x",
+            "async fn after_migration",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "may only appear in the explicit offline migration")]
+    fn a_call_split_after_the_dot_is_rejected() {
+        // `self.fs.\nquery()` is legal Rust that a scan anchored on `.query`
+        // never sees.
+        let source = scannable(&format!(
+            "async fn request_path() {{\n    self.fs.\n        query();\n}}\n{MIGRATION}{BOUNDARY}"
         ));
         assert_calls_are_confined_to(
             &source,

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -41,6 +41,10 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
+# The Postgres contract tests provision their own container when no database
+# URL is supplied, so they run in any Docker-enabled lane instead of silently
+# skipping. Same image the CI lanes pre-pull.
+testcontainers-modules = { version = "0.12", features = ["postgres"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/ironclaw_filesystem/src/fault.rs
+++ b/crates/ironclaw_filesystem/src/fault.rs
@@ -65,6 +65,12 @@ pub enum FaultKind {
     NotFound,
     /// [`FilesystemError::Unsupported`] for the op's path.
     Unsupported,
+    /// [`FilesystemError::VersionMismatch`] for the op's path, with
+    /// `expected`/`found` unset — the shape of a lost CAS race whose winner is
+    /// unknown. This is the only way to exercise CAS-conflict retry paths
+    /// deterministically over the in-memory backend: its transactions hold the
+    /// whole-state lock, so a real concurrent writer cannot interleave.
+    VersionMismatch,
 }
 
 impl FaultKind {
@@ -79,6 +85,11 @@ impl FaultKind {
             FaultKind::BackendBusy => FilesystemError::BackendBusy { path, operation },
             FaultKind::NotFound => FilesystemError::NotFound { path, operation },
             FaultKind::Unsupported => FilesystemError::Unsupported { path, operation },
+            FaultKind::VersionMismatch => FilesystemError::VersionMismatch {
+                path,
+                expected: None,
+                found: None,
+            },
         }
     }
 }
@@ -148,6 +159,12 @@ impl Fault {
     /// Return the given [`FaultKind`].
     pub fn returning(mut self, kind: FaultKind) -> Self {
         self.kind = kind;
+        self
+    }
+
+    /// Return a [`FilesystemError::VersionMismatch`] — a lost CAS race.
+    pub fn version_mismatch(mut self) -> Self {
+        self.kind = FaultKind::VersionMismatch;
         self
     }
 

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -1365,6 +1365,69 @@ mod tests {
         );
     }
 
+    /// The ascending and descending ordered-query loops carry separate subtree
+    /// guards. Only ascending is exercised by the ancestor-declaration
+    /// contract, so a missing descending guard would leak sibling-subtree rows
+    /// without failing anything.
+    #[tokio::test]
+    async fn descending_query_from_an_ancestor_declared_index_excludes_siblings() {
+        let backend = InMemoryBackend::new();
+        let rank = IndexKey::new("rank").unwrap();
+        let id = IndexKey::new("id").unwrap();
+        backend
+            .ensure_index(
+                &VirtualPath::new("/engine/scoped").unwrap(),
+                &IndexSpec::new(
+                    IndexName::new("scoped_items_v1").unwrap(),
+                    vec![rank.clone(), id.clone()],
+                    IndexKind::Exact,
+                ),
+            )
+            .await
+            .unwrap();
+        for (path, leaf) in [
+            ("/engine/scoped/alpha/a-1", "a-1"),
+            ("/engine/scoped/beta/b-1", "b-1"),
+        ] {
+            backend
+                .put(
+                    &VirtualPath::new(path).unwrap(),
+                    Entry::record(RecordKind::new("scoped").unwrap(), &serde_json::json!({}))
+                        .unwrap()
+                        .with_indexed(rank.clone(), IndexValue::Text(leaf.to_string()))
+                        .with_indexed(id.clone(), IndexValue::Text(leaf.to_string())),
+                    CasExpectation::Absent,
+                )
+                .await
+                .unwrap();
+        }
+
+        let rows = backend
+            .query_ordered(
+                &VirtualPath::new("/engine/scoped/alpha").unwrap(),
+                &Filter::All,
+                &crate::OrderedPage::new(
+                    IndexName::new("scoped_items_v1").unwrap(),
+                    rank.clone(),
+                    id.clone(),
+                    crate::SortDirection::Descending,
+                    16,
+                ),
+            )
+            .await
+            .unwrap();
+        let paths = rows
+            .iter()
+            .map(|row| row.path.as_str().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paths,
+            vec!["/engine/scoped/alpha/a-1".to_string()],
+            "a descending child query resolved from an ancestor spec must not \
+             return a sibling subtree"
+        );
+    }
+
     #[tokio::test]
     async fn ordered_index_declaration_never_backfills_existing_rows() {
         let fs = InMemoryBackend::new();

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -345,10 +345,18 @@ impl RootFilesystem for InMemoryBackend {
         page: &crate::OrderedPage,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let state = self.state.lock().await;
-        let Some(materialized) = state
-            .ordered_indexes
-            .get(path.as_str())
-            .and_then(|indexes| indexes.get(&page.index))
+        // Resolve against `path` and every ancestor prefix, most specific
+        // first, so a caller may declare the index once on a higher prefix and
+        // query a child path. Bounded by path depth, not a scan over declared
+        // prefixes.
+        let Some(materialized) = crate::index::ancestor_prefixes(path.as_str())
+            .into_iter()
+            .find_map(|prefix| {
+                state
+                    .ordered_indexes
+                    .get(prefix)
+                    .and_then(|indexes| indexes.get(&page.index))
+            })
         else {
             return Err(FilesystemError::Unsupported {
                 path: path.clone(),
@@ -388,6 +396,14 @@ impl RootFilesystem for InMemoryBackend {
                     {
                         continue;
                     }
+                    // A spec resolved from an ancestor covers a wider subtree
+                    // than the caller asked for; its rows carry no record of
+                    // the declaring prefix. Without this check a query would
+                    // return sibling subtrees' rows. The SQL backends apply the
+                    // equivalent predicate in their row SELECT.
+                    if !crate::index::path_within_prefix(matched_path.as_str(), path.as_str()) {
+                        continue;
+                    }
                     push_ordered_result(&state, matched_path, &mut results);
                     if results.len() >= page.limit as usize {
                         break;
@@ -413,6 +429,11 @@ impl RootFilesystem for InMemoryBackend {
                         && (values.get(sort_position), values.get(sort_position + 1))
                             >= (Some(&cursor.value), Some(&cursor.tie_breaker))
                     {
+                        continue;
+                    }
+                    // See the ascending branch: ancestor-resolved specs cover a
+                    // wider subtree than the caller asked for.
+                    if !crate::index::path_within_prefix(matched_path.as_str(), path.as_str()) {
                         continue;
                     }
                     push_ordered_result(&state, matched_path, &mut results);
@@ -677,7 +698,9 @@ fn update_materialized_indexes(
     old_entry: Option<&Entry>,
     new_entry: Option<&Entry>,
 ) {
-    for prefix in ancestor_paths(path.as_str()) {
+    // Projects into every matching ancestor declaration, so a root-declared
+    // spec and a narrower one declared under it both stay current.
+    for prefix in crate::index::ancestor_prefixes(path.as_str()) {
         let Some(indexes) = state.ordered_indexes.get_mut(prefix) else {
             continue;
         };
@@ -694,19 +717,6 @@ fn update_materialized_indexes(
             }
         }
     }
-}
-
-fn ancestor_paths(path: &str) -> Vec<&str> {
-    let mut prefixes = vec!["/"];
-    prefixes.extend(
-        path.char_indices()
-            .filter(|(index, character)| *index > 0 && *character == '/')
-            .filter_map(|(index, _)| path.get(..index)),
-    );
-    if path != "/" {
-        prefixes.push(path);
-    }
-    prefixes
 }
 
 fn state_append(state: &mut State, path: &VirtualPath, payload: Vec<u8>) -> SeqNo {

--- a/crates/ironclaw_filesystem/src/index.rs
+++ b/crates/ironclaw_filesystem/src/index.rs
@@ -398,6 +398,13 @@ impl OrderedPage {
     }
 }
 
+/// Number of projected key columns (`k0`..`k7`) an ordered index carries.
+///
+/// One definition for both SQL backends' projection DDL and the query-side
+/// tie-breaker guard: a second copy that drifts silently stops projecting the
+/// extra key.
+pub(crate) const MAX_ORDERED_INDEX_KEYS: usize = 8;
+
 /// All ancestor prefixes of `path`, **most specific first**, ending at `/`.
 ///
 /// Index-spec resolution walks this chain so a caller may declare an index on

--- a/crates/ironclaw_filesystem/src/index.rs
+++ b/crates/ironclaw_filesystem/src/index.rs
@@ -398,6 +398,57 @@ impl OrderedPage {
     }
 }
 
+/// All ancestor prefixes of `path`, **most specific first**, ending at `/`.
+///
+/// Index-spec resolution walks this chain so a caller may declare an index on
+/// a higher prefix and query a child path (the "declare high, query low"
+/// contract the FTS path already documented). The walk is bounded by path
+/// depth — never a catalog scan — and "most specific first" is what gives
+/// callers most-specific-spec-wins when several ancestors declare the same
+/// index name.
+pub(crate) fn ancestor_prefixes(path: &str) -> Vec<&str> {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return vec!["/"];
+    }
+    let mut out = vec![trimmed];
+    let mut end = trimmed.len();
+    // `rfind('/')` can only return the offset of an ASCII '/', so every index
+    // here is already a char boundary and neither `get` can yield `None`.
+    // Going through `get` keeps this a total function — a path segment holding
+    // multi-byte characters can never be split into a panic.
+    while let Some(index) = trimmed.get(..end).and_then(|head| head.rfind('/')) {
+        if index == 0 {
+            out.push("/");
+            break;
+        }
+        let Some(parent) = trimmed.get(..index) else {
+            break;
+        };
+        out.push(parent);
+        end = index;
+    }
+    out
+}
+
+/// Whether `candidate` is `prefix` itself or lies in its subtree.
+///
+/// Ordered-index rows are keyed by spec name and path only, with no record of
+/// which declaration prefix projected them. Once resolution can match an
+/// ancestor spec, every backend must re-apply this containment check to the
+/// matched rows, or a query would return rows from sibling subtrees that the
+/// caller's scope does not cover.
+pub(crate) fn path_within_prefix(candidate: &str, prefix: &str) -> bool {
+    let prefix = prefix.trim_end_matches('/');
+    if prefix.is_empty() {
+        return true;
+    }
+    candidate == prefix
+        || (candidate.len() > prefix.len()
+            && candidate.starts_with(prefix)
+            && candidate.as_bytes()[prefix.len()] == b'/')
+}
+
 pub(crate) fn ordered_query_prefix_values(
     spec: &IndexSpec,
     filter: &Filter,
@@ -454,6 +505,41 @@ fn collect_equality_values<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ancestor_prefixes_walk_from_most_to_least_specific() {
+        // Order is the precedence rule: spec resolution takes the first match,
+        // so the most specific declaration must come first.
+        assert_eq!(
+            ancestor_prefixes("/threads/agents/a/owners/u/threads/t-1/messages"),
+            vec![
+                "/threads/agents/a/owners/u/threads/t-1/messages",
+                "/threads/agents/a/owners/u/threads/t-1",
+                "/threads/agents/a/owners/u/threads",
+                "/threads/agents/a/owners/u",
+                "/threads/agents/a/owners",
+                "/threads/agents/a",
+                "/threads/agents",
+                "/threads",
+                "/",
+            ]
+        );
+        assert_eq!(ancestor_prefixes("/threads"), vec!["/threads", "/"]);
+        assert_eq!(ancestor_prefixes("/"), vec!["/"]);
+        // A trailing separator must not produce a distinct candidate.
+        assert_eq!(ancestor_prefixes("/threads/"), vec!["/threads", "/"]);
+    }
+
+    #[test]
+    fn path_within_prefix_requires_a_segment_boundary() {
+        assert!(path_within_prefix("/a/b", "/a/b"));
+        assert!(path_within_prefix("/a/b/c", "/a/b"));
+        // The classic prefix-matching bug: a sibling sharing a textual prefix
+        // is not in the subtree, and must not be returned by a scoped query.
+        assert!(!path_within_prefix("/a/bc", "/a/b"));
+        assert!(!path_within_prefix("/a", "/a/b"));
+        assert!(path_within_prefix("/anything", "/"));
+    }
 
     #[test]
     fn index_name_rejects_empty_and_separators() {

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2488,8 +2488,7 @@ async fn ensure_libsql_ordered_projection(
     path: &VirtualPath,
     spec: &IndexSpec,
 ) -> Result<(), FilesystemError> {
-    const MAX_ORDERED_INDEX_KEYS: usize = 8;
-    if spec.keys.len() > MAX_ORDERED_INDEX_KEYS {
+    if spec.keys.len() > crate::index::MAX_ORDERED_INDEX_KEYS {
         return Err(FilesystemError::Unsupported {
             path: path.clone(),
             operation: FilesystemOperation::EnsureIndex,
@@ -2574,7 +2573,7 @@ async fn ensure_libsql_static_ordered_projection(
          OR (new.path >= s.prefix || '/' AND new.path < s.prefix || '0'))";
     let mut key_values = Vec::new();
     let mut key_presence = Vec::new();
-    for i in 0..8 {
+    for i in 0..crate::index::MAX_ORDERED_INDEX_KEYS {
         key_values.push(format!(
             "CASE WHEN json_array_length(s.keys) > {i} \
              THEN json_extract(new.indexed, '$.' || json_extract(s.keys, '$[{i}]')) END"

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2251,26 +2251,30 @@ impl LibSqlRootFilesystem {
         // Scan the spec catalog for FTS specs whose prefix is path or any
         // ancestor (so callers may declare the index on a higher prefix
         // and query a child path).
-        let candidate_prefixes = crate::index::ancestor_prefixes(path.as_str());
-        let placeholders: Vec<String> = (1..=candidate_prefixes.len())
-            .map(|i| format!("?{i}"))
+        // Same candidate set and same precedence as `query_ordered` over this
+        // table: every ancestor prefix plus `/shared`, with `/shared` ranking
+        // ahead of every path-derived candidate. Omitting it left a shared FTS
+        // declaration undiscoverable from any query outside `/shared`.
+        //
+        // Ordered in SQL rather than by hoping the driver returns insertion
+        // order: the caller keeps the first row it sees per key, so "most
+        // specific wins" only holds if the most specific prefix arrives first.
+        // Without ORDER BY, two declarations at different ancestor prefixes
+        // resolve by rowid.
+        let mut params: Vec<libsql::Value> = crate::index::ancestor_prefixes(path.as_str())
+            .iter()
+            .map(|prefix| libsql::Value::Text((*prefix).to_string()))
             .collect();
-        // Order in SQL, not by hoping the driver returns insertion order. The
-        // caller keeps the first row it sees per key, so "most specific wins"
-        // is only true if the most specific prefix arrives first; without an
-        // explicit ORDER BY, two FTS declarations at different ancestor
-        // prefixes resolve by rowid instead of by specificity. `query_ordered`
-        // in this file already orders the same table this way.
+        params.push(libsql::Value::Text("/shared".to_string()));
+        let placeholders: Vec<String> = (1..=params.len())
+            .map(|position| format!("?{position}"))
+            .collect();
         let sql = format!(
             "SELECT prefix, name, keys FROM root_filesystem_index_specs \
              WHERE kind = 'fts' AND prefix IN ({}) \
-             ORDER BY LENGTH(prefix) DESC",
+             ORDER BY CASE WHEN prefix = '/shared' THEN 0 ELSE 1 END, LENGTH(prefix) DESC",
             placeholders.join(", ")
         );
-        let params: Vec<libsql::Value> = candidate_prefixes
-            .iter()
-            .map(|p| libsql::Value::Text((*p).to_string()))
-            .collect();
         let mut rows = conn
             .query(&sql, params)
             .await

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2535,7 +2535,9 @@ async fn ensure_libsql_static_ordered_projection(
         .query(
             "SELECT name FROM sqlite_master \
              WHERE type = 'trigger' \
-               AND name LIKE 'idx_rfs_%' \
+               AND (name LIKE 'idx_rfs_%' \
+                    OR (name LIKE 'rfs_ordered_projection_%' \
+                        AND name NOT LIKE 'rfs_ordered_projection_v3_%')) \
                AND sql LIKE '%root_filesystem_ordered_index_rows%'",
             (),
         )
@@ -2594,21 +2596,22 @@ async fn ensure_libsql_static_ordered_projection(
            AND {containment} \
            AND new.is_dir = 0 \
            AND new.indexed IS NOT NULL \
-           AND {key_presence};"
+           AND {key_presence} \
+         ORDER BY LENGTH(s.prefix) ASC;"
     );
     let statements = format!(
         "CREATE INDEX IF NOT EXISTS idx_root_filesystem_ordered_rows_path \
            ON root_filesystem_ordered_index_rows(path);\
-         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v2_ai \
+         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v3_ai \
            AFTER INSERT ON root_filesystem_entries \
            BEGIN {project} END;\
-         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v2_au \
+         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v3_au \
            AFTER UPDATE ON root_filesystem_entries \
            BEGIN \
              DELETE FROM root_filesystem_ordered_index_rows WHERE path = old.path; \
              {project} \
            END;\
-         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v2_ad \
+         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v3_ad \
            AFTER DELETE ON root_filesystem_entries \
            BEGIN \
              DELETE FROM root_filesystem_ordered_index_rows WHERE path = old.path; \
@@ -3481,9 +3484,9 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "rfs_ordered_projection_v2_ad".to_string(),
-                "rfs_ordered_projection_v2_ai".to_string(),
-                "rfs_ordered_projection_v2_au".to_string(),
+                "rfs_ordered_projection_v3_ad".to_string(),
+                "rfs_ordered_projection_v3_ai".to_string(),
+                "rfs_ordered_projection_v3_au".to_string(),
             ],
             "five declarations leave exactly the static trigger set and the \
              legacy per-declaration trigger is swept"

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2251,28 +2251,32 @@ impl LibSqlRootFilesystem {
         // Scan the spec catalog for FTS specs whose prefix is path or any
         // ancestor (so callers may declare the index on a higher prefix
         // and query a child path).
-        // Same candidate set and same precedence as `query_ordered` over this
-        // table: every ancestor prefix plus `/shared`, with `/shared` ranking
-        // ahead of every path-derived candidate. Omitting it left a shared FTS
-        // declaration undiscoverable from any query outside `/shared`.
+        // Ancestors only, deliberately unlike `query_ordered`, which also
+        // considers `/shared`. The two resolve different things: an ordered
+        // index is a projection row keyed by `(index_name, path)` and readable
+        // from anywhere, whereas an FTS declaration owns a table whose triggers
+        // and backfill populate rows for the declaring prefix's subtree alone.
+        // Selecting `/shared` for a path outside it therefore points the
+        // `path IN (SELECT path FROM <fts> MATCH …)` clause at a table with no
+        // rows for that path — a silent empty result rather than a miss the
+        // caller can see.
         //
         // Ordered in SQL rather than by hoping the driver returns insertion
         // order: the caller keeps the first row it sees per key, so "most
         // specific wins" only holds if the most specific prefix arrives first.
         // Without ORDER BY, two declarations at different ancestor prefixes
         // resolve by rowid.
-        let mut params: Vec<libsql::Value> = crate::index::ancestor_prefixes(path.as_str())
+        let params: Vec<libsql::Value> = crate::index::ancestor_prefixes(path.as_str())
             .iter()
             .map(|prefix| libsql::Value::Text((*prefix).to_string()))
             .collect();
-        params.push(libsql::Value::Text("/shared".to_string()));
         let placeholders: Vec<String> = (1..=params.len())
             .map(|position| format!("?{position}"))
             .collect();
         let sql = format!(
             "SELECT prefix, name, keys FROM root_filesystem_index_specs \
              WHERE kind = 'fts' AND prefix IN ({}) \
-             ORDER BY CASE WHEN prefix = '/shared' THEN 0 ELSE 1 END, LENGTH(prefix) DESC",
+             ORDER BY LENGTH(prefix) DESC",
             placeholders.join(", ")
         );
         let mut rows = conn

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -805,14 +805,31 @@ impl RootFilesystem for LibSqlRootFilesystem {
         page: &crate::OrderedPage,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let conn = self.read_connection().await?;
+        // Resolve the spec against `path` and every ancestor prefix, most
+        // specific first, so a caller may declare the index once on a higher
+        // prefix and query a child path. `/shared` keeps its existing
+        // precedence over every path-derived candidate. The candidate list is
+        // bounded by path depth, so this stays a keyed lookup, not a scan.
+        let candidate_prefixes = crate::index::ancestor_prefixes(path.as_str());
+        let mut spec_params: Vec<libsql::Value> = candidate_prefixes
+            .iter()
+            .map(|prefix| libsql::Value::Text((*prefix).to_string()))
+            .collect();
+        spec_params.push(libsql::Value::Text("/shared".to_string()));
+        let spec_placeholders: Vec<String> = (1..=spec_params.len())
+            .map(|position| format!("?{position}"))
+            .collect();
+        let name_placeholder = format!("?{}", spec_params.len() + 1);
+        spec_params.push(libsql::Value::Text(page.index.as_str().to_string()));
+        let spec_sql = format!(
+            "SELECT keys, kind FROM root_filesystem_index_specs \
+             WHERE prefix IN ({}) AND name = {name_placeholder} \
+             ORDER BY CASE WHEN prefix = '/shared' THEN 0 ELSE 1 END, LENGTH(prefix) DESC \
+             LIMIT 1",
+            spec_placeholders.join(", ")
+        );
         let mut spec_rows = conn
-            .query(
-                "SELECT keys, kind FROM root_filesystem_index_specs \
-                 WHERE prefix IN (?1, '/shared') AND name = ?2 \
-                 ORDER BY CASE WHEN prefix = '/shared' THEN 0 ELSE 1 END \
-                 LIMIT 1",
-                libsql::params![path.as_str(), page.index.as_str()],
-            )
+            .query(&spec_sql, spec_params)
             .await
             .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Query, error))?;
         let spec = if let Some(row) = spec_rows
@@ -2234,7 +2251,7 @@ impl LibSqlRootFilesystem {
         // Scan the spec catalog for FTS specs whose prefix is path or any
         // ancestor (so callers may declare the index on a higher prefix
         // and query a child path).
-        let candidate_prefixes = ancestor_prefixes(path.as_str());
+        let candidate_prefixes = crate::index::ancestor_prefixes(path.as_str());
         let placeholders: Vec<String> = (1..=candidate_prefixes.len())
             .map(|i| format!("?{i}"))
             .collect();
@@ -2245,7 +2262,7 @@ impl LibSqlRootFilesystem {
         );
         let params: Vec<libsql::Value> = candidate_prefixes
             .iter()
-            .map(|p| libsql::Value::Text(p.clone()))
+            .map(|p| libsql::Value::Text((*p).to_string()))
             .collect();
         let mut rows = conn
             .query(&sql, params)
@@ -2730,22 +2747,6 @@ fn collect_fts_keys(filter: &Filter, out: &mut Vec<String>) {
     }
 }
 
-/// All ancestor paths of `path`, **most specific first**, ending at `/`.
-/// Used to find an FTS index declared on a higher prefix that should still
-/// cover descendant queries.
-fn ancestor_prefixes(path: &str) -> Vec<String> {
-    let mut out = vec![path.trim_end_matches('/').to_string()];
-    let mut cur = path.trim_end_matches('/').to_string();
-    while let Some(idx) = cur.rfind('/') {
-        if idx == 0 {
-            out.push("/".to_string());
-            break;
-        }
-        cur.truncate(idx);
-        out.push(cur.clone());
-    }
-    out
-}
 fn bind_index_value(
     path: &VirtualPath,
     value: &IndexValue,

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2568,9 +2568,26 @@ async fn ensure_libsql_static_ordered_projection(
     // half-open band `(prefix || '/', prefix || '0')` is the range form of
     // `LIKE prefix || '/%'` without wildcard-injection from stored prefixes;
     // '/' needs its own arm because '//' breaks the band trick.
-    let containment = "(s.prefix = '/' \
-         OR new.path = s.prefix \
-         OR (new.path >= s.prefix || '/' AND new.path < s.prefix || '0'))";
+    // Ancestors of the written path, walked by string surgery: rtrim with the
+    // path's own non-slash characters strips the trailing segment, leaving
+    // ".../" to trim. Joining the catalog by equality on these turns the
+    // projection into an index seek on the `(prefix, name)` key. Comparing
+    // every catalog row against the path instead — which is what a
+    // containment predicate does — scans every declaration ever made, and an
+    // upgraded database keeps its per-thread declaration rows forever.
+    let ancestors = "WITH RECURSIVE rfs_ancestors(prefix) AS ( \
+           SELECT new.path \
+           UNION ALL \
+           SELECT CASE \
+             WHEN length(rtrim(prefix, replace(prefix, '/', ''))) <= 1 THEN '/' \
+             ELSE substr( \
+               rtrim(prefix, replace(prefix, '/', '')), \
+               1, \
+               length(rtrim(prefix, replace(prefix, '/', ''))) - 1 \
+             ) \
+           END \
+           FROM rfs_ancestors WHERE prefix <> '/' \
+         )";
     let mut key_values = Vec::new();
     let mut key_presence = Vec::new();
     for i in 0..crate::index::MAX_ORDERED_INDEX_KEYS {
@@ -2589,10 +2606,11 @@ async fn ensure_libsql_static_ordered_projection(
         "INSERT OR REPLACE INTO root_filesystem_ordered_index_rows(\
            index_name, path, k0, k1, k2, k3, k4, k5, k6, k7\
          ) \
+         {ancestors} \
          SELECT s.name, new.path, {key_values} \
-         FROM root_filesystem_index_specs s \
+         FROM rfs_ancestors a \
+         JOIN root_filesystem_index_specs s ON s.prefix = a.prefix \
          WHERE s.kind IN ('exact', 'prefix') \
-           AND {containment} \
            AND new.is_dir = 0 \
            AND new.indexed IS NOT NULL \
            AND {key_presence} \

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2551,8 +2551,9 @@ async fn ensure_libsql_static_ordered_projection(
         let name: String = row.get(0).map_err(|error| {
             infrastructure_libsql_error(FilesystemOperation::EnsureIndex, error)
         })?;
-        // Trigger names come from sql_index_name (ASCII alphanumerics and
-        // underscores only), but quote defensively anyway.
+        // The name is interpolated into DDL unquoted, so the ASCII
+        // alphanumeric/underscore check below is the whole safeguard, not a
+        // belt-and-braces extra: relaxing it would admit injection.
         if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
             drops.push_str(&format!("DROP TRIGGER IF EXISTS {name};"));
         }

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2495,80 +2495,129 @@ async fn ensure_libsql_ordered_projection(
             operation: FilesystemOperation::EnsureIndex,
         });
     }
-    let trigger_base = sql_index_name(path.as_str(), spec.name.as_str());
-    let legacy_trigger_base = sql_index_name("/ordered_projection", spec.name.as_str());
-    let index_name = spec.name.as_str();
-    let escaped_prefix = path.as_str().replace('\'', "''");
-    let descendant_pattern = if path.as_str() == "/" {
-        "/%".to_string()
-    } else {
-        format!("{}/%", path.as_str().trim_end_matches('/'))
-    }
-    .replace('\'', "''");
-    let new_path_matches =
-        format!("(new.path = '{escaped_prefix}' OR new.path LIKE '{descendant_pattern}')");
-    let old_path_matches =
-        format!("(old.path = '{escaped_prefix}' OR old.path LIKE '{descendant_pattern}')");
-    let projected_values = spec
-        .keys
-        .iter()
-        .map(|key| format!("json_extract(new.indexed, '$.{}')", key.as_str()))
-        .chain(
-            std::iter::repeat_with(|| "NULL".to_string())
-                .take(MAX_ORDERED_INDEX_KEYS.saturating_sub(spec.keys.len())),
+    ensure_libsql_static_ordered_projection(conn)
+        .await
+        .map_err(|error| match error {
+            // The static ensure reports path-less infrastructure errors; the
+            // declaration seam's contract is a path-carrying backend error.
+            FilesystemError::Backend {
+                operation, reason, ..
+            }
+            | FilesystemError::BackendInfrastructure { operation, reason } => {
+                FilesystemError::Backend {
+                    path: path.clone(),
+                    operation,
+                    reason,
+                }
+            }
+            other => other,
+        })
+}
+
+/// Projection triggers are static: three triggers total, whose bodies project
+/// by joining the spec catalog on prefix containment. The previous design
+/// installed three triggers per (declaration prefix, spec); every entry write
+/// then evaluated every trigger ever declared — O(total declarations) per
+/// statement (measured 3,750 triggers and ~38ms/statement after a 50-user
+/// run). The catalog join is O(catalog rows) with a tiny constant, and
+/// declaration becomes a pure catalog insert.
+///
+/// Semantics are unchanged, including "declaration never backfills": triggers
+/// only fire on writes after the fact, and a spec projects exactly the
+/// subtree of its declared prefix.
+async fn ensure_libsql_static_ordered_projection(
+    conn: &libsql::Connection,
+) -> Result<(), FilesystemError> {
+    // Drop the legacy per-declaration triggers exactly once per database.
+    // SQLite has no dynamic DDL in plain SQL, so the sweep is done here; it
+    // is cheap when nothing matches (single catalog scan).
+    let mut legacy = conn
+        .query(
+            "SELECT name FROM sqlite_master \
+             WHERE type = 'trigger' \
+               AND name LIKE 'idx_rfs_%' \
+               AND sql LIKE '%root_filesystem_ordered_index_rows%'",
+            (),
         )
-        .collect::<Vec<_>>()
-        .join(", ");
-    let predicate = spec
-        .keys
-        .iter()
-        .map(|key| format!("json_type(new.indexed, '$.{}') IS NOT NULL", key.as_str()))
-        .collect::<Vec<_>>()
-        .join(" AND ");
-    let insert = format!(
-        "CREATE TRIGGER IF NOT EXISTS {trigger_base}_ai \
-         AFTER INSERT ON root_filesystem_entries \
-         WHEN {new_path_matches} \
-         BEGIN \
-           INSERT OR REPLACE INTO root_filesystem_ordered_index_rows(\
-             index_name, path, k0, k1, k2, k3, k4, k5, k6, k7\
-           ) \
-           SELECT '{index_name}', new.path, {projected_values} \
-           WHERE {new_path_matches} AND new.is_dir = 0 AND {predicate}; \
-         END;"
+        .await
+        .map_err(|error| infrastructure_libsql_error(FilesystemOperation::EnsureIndex, error))?;
+    let mut drops = String::new();
+    while let Some(row) = legacy
+        .next()
+        .await
+        .map_err(|error| infrastructure_libsql_error(FilesystemOperation::EnsureIndex, error))?
+    {
+        let name: String = row.get(0).map_err(|error| {
+            infrastructure_libsql_error(FilesystemOperation::EnsureIndex, error)
+        })?;
+        // Trigger names come from sql_index_name (ASCII alphanumerics and
+        // underscores only), but quote defensively anyway.
+        if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            drops.push_str(&format!("DROP TRIGGER IF EXISTS {name};"));
+        }
+    }
+    drop(legacy);
+    if !drops.is_empty() {
+        conn.execute_batch(&drops).await.map_err(|error| {
+            infrastructure_libsql_error(FilesystemOperation::EnsureIndex, error)
+        })?;
+    }
+
+    // Containment: spec.prefix is the path itself or a proper ancestor. The
+    // half-open band `(prefix || '/', prefix || '0')` is the range form of
+    // `LIKE prefix || '/%'` without wildcard-injection from stored prefixes;
+    // '/' needs its own arm because '//' breaks the band trick.
+    let containment = "(s.prefix = '/' \
+         OR new.path = s.prefix \
+         OR (new.path >= s.prefix || '/' AND new.path < s.prefix || '0'))";
+    let mut key_values = Vec::new();
+    let mut key_presence = Vec::new();
+    for i in 0..8 {
+        key_values.push(format!(
+            "CASE WHEN json_array_length(s.keys) > {i} \
+             THEN json_extract(new.indexed, '$.' || json_extract(s.keys, '$[{i}]')) END"
+        ));
+        key_presence.push(format!(
+            "(json_array_length(s.keys) <= {i} \
+             OR json_type(new.indexed, '$.' || json_extract(s.keys, '$[{i}]')) IS NOT NULL)"
+        ));
+    }
+    let key_values = key_values.join(", ");
+    let key_presence = key_presence.join(" AND ");
+    let project = format!(
+        "INSERT OR REPLACE INTO root_filesystem_ordered_index_rows(\
+           index_name, path, k0, k1, k2, k3, k4, k5, k6, k7\
+         ) \
+         SELECT s.name, new.path, {key_values} \
+         FROM root_filesystem_index_specs s \
+         WHERE s.kind IN ('exact', 'prefix') \
+           AND {containment} \
+           AND new.is_dir = 0 \
+           AND new.indexed IS NOT NULL \
+           AND {key_presence};"
     );
-    let update = format!(
-        "CREATE TRIGGER IF NOT EXISTS {trigger_base}_au \
-         AFTER UPDATE ON root_filesystem_entries \
-         WHEN {old_path_matches} OR {new_path_matches} \
-         BEGIN \
-           DELETE FROM root_filesystem_ordered_index_rows \
-             WHERE index_name = '{index_name}' AND path = old.path; \
-           INSERT OR REPLACE INTO root_filesystem_ordered_index_rows(\
-             index_name, path, k0, k1, k2, k3, k4, k5, k6, k7\
-           ) \
-           SELECT '{index_name}', new.path, {projected_values} \
-           WHERE {new_path_matches} AND new.is_dir = 0 AND {predicate}; \
-         END;"
+    let statements = format!(
+        "CREATE INDEX IF NOT EXISTS idx_root_filesystem_ordered_rows_path \
+           ON root_filesystem_ordered_index_rows(path);\
+         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v2_ai \
+           AFTER INSERT ON root_filesystem_entries \
+           BEGIN {project} END;\
+         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v2_au \
+           AFTER UPDATE ON root_filesystem_entries \
+           BEGIN \
+             DELETE FROM root_filesystem_ordered_index_rows WHERE path = old.path; \
+             {project} \
+           END;\
+         CREATE TRIGGER IF NOT EXISTS rfs_ordered_projection_v2_ad \
+           AFTER DELETE ON root_filesystem_entries \
+           BEGIN \
+             DELETE FROM root_filesystem_ordered_index_rows WHERE path = old.path; \
+           END;"
     );
-    let delete = format!(
-        "CREATE TRIGGER IF NOT EXISTS {trigger_base}_ad \
-         AFTER DELETE ON root_filesystem_entries \
-         WHEN {old_path_matches} \
-         BEGIN \
-           DELETE FROM root_filesystem_ordered_index_rows \
-             WHERE index_name = '{index_name}' AND path = old.path; \
-         END;"
-    );
-    let remove_legacy = format!(
-        "DROP TRIGGER IF EXISTS {legacy_trigger_base}_ai;\
-         DROP TRIGGER IF EXISTS {legacy_trigger_base}_au;\
-         DROP TRIGGER IF EXISTS {legacy_trigger_base}_ad;"
-    );
-    conn.execute_batch(&format!("{remove_legacy}{insert}{update}{delete}"))
+    conn.execute_batch(&statements)
         .await
         .map(|_| ())
-        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error))
+        .map_err(|error| infrastructure_libsql_error(FilesystemOperation::EnsureIndex, error))
 }
 async fn ensure_libsql_events_table(conn: &libsql::Connection) -> Result<(), FilesystemError> {
     conn.execute_batch(LIBSQL_EVENTS_SCHEMA)
@@ -3382,6 +3431,63 @@ mod tests {
                 operation: FilesystemOperation::Append,
             } if error_path == path
         ));
+    }
+
+    /// The projection trigger set is static: declaring many specs at many
+    /// prefixes must leave exactly three triggers on the entries table, and a
+    /// surviving legacy per-declaration trigger must be swept on the next
+    /// declaration. The per-declaration design accumulated 3 triggers per
+    /// (prefix, spec) — O(total declarations) evaluated on every write.
+    #[tokio::test]
+    async fn ordered_projection_triggers_stay_constant_across_declarations() {
+        let (fs, _dir) = fresh_backend().await;
+        let writer = fs.migration_write_connection().await.unwrap();
+        // A survivor from the per-declaration era, shaped like sql_index_name
+        // output and touching the projection table so the sweep matches it.
+        writer
+            .execute_batch(
+                "CREATE TRIGGER idx_rfs_legacy_by_status_ai \
+                 AFTER INSERT ON root_filesystem_entries BEGIN \
+                   DELETE FROM root_filesystem_ordered_index_rows WHERE path = new.path; \
+                 END;",
+            )
+            .await
+            .unwrap();
+        drop(writer);
+
+        for i in 0..5 {
+            let path = VirtualPath::new(format!("/resources/trigger-count/{i}")).unwrap();
+            let spec = IndexSpec::new(
+                IndexName::new(format!("by_status_{i}")).unwrap(),
+                vec![IndexKey::new("status").unwrap()],
+                IndexKind::Exact,
+            );
+            fs.ensure_index(&path, &spec).await.unwrap();
+        }
+
+        let reader = fs.read_connection().await.unwrap();
+        let mut rows = reader
+            .query(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger' \
+                 AND sql LIKE '%root_filesystem_ordered_index_rows%' ORDER BY name",
+                (),
+            )
+            .await
+            .unwrap();
+        let mut names = Vec::new();
+        while let Some(row) = rows.next().await.unwrap() {
+            names.push(row.get::<String>(0).unwrap());
+        }
+        assert_eq!(
+            names,
+            vec![
+                "rfs_ordered_projection_v2_ad".to_string(),
+                "rfs_ordered_projection_v2_ai".to_string(),
+                "rfs_ordered_projection_v2_au".to_string(),
+            ],
+            "five declarations leave exactly the static trigger set and the \
+             legacy per-declaration trigger is swept"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -2255,9 +2255,16 @@ impl LibSqlRootFilesystem {
         let placeholders: Vec<String> = (1..=candidate_prefixes.len())
             .map(|i| format!("?{i}"))
             .collect();
+        // Order in SQL, not by hoping the driver returns insertion order. The
+        // caller keeps the first row it sees per key, so "most specific wins"
+        // is only true if the most specific prefix arrives first; without an
+        // explicit ORDER BY, two FTS declarations at different ancestor
+        // prefixes resolve by rowid instead of by specificity. `query_ordered`
+        // in this file already orders the same table this way.
         let sql = format!(
             "SELECT prefix, name, keys FROM root_filesystem_index_specs \
-             WHERE kind = 'fts' AND prefix IN ({})",
+             WHERE kind = 'fts' AND prefix IN ({}) \
+             ORDER BY LENGTH(prefix) DESC",
             placeholders.join(", ")
         );
         let params: Vec<libsql::Value> = candidate_prefixes

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -881,7 +881,7 @@ impl RootFilesystem for LibSqlRootFilesystem {
         };
         let sort_position = prefix_values.len();
         let tie_position = sort_position.saturating_add(1);
-        if tie_position >= 8 {
+        if tie_position >= crate::index::MAX_ORDERED_INDEX_KEYS {
             return Err(FilesystemError::Unsupported {
                 path: path.clone(),
                 operation: FilesystemOperation::Query,

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -2130,130 +2130,173 @@ async fn ensure_postgres_ordered_projection(
             operation: FilesystemOperation::EnsureIndex,
         });
     }
-    let trigger_base = sql_index_name(path.as_str(), spec.name.as_str());
-    let legacy_trigger_name = format!(
-        "{}_sync",
-        sql_index_name("/ordered_projection", spec.name.as_str())
-    );
-    // Hash each final identifier independently. Appending suffixes to an
-    // already-capped 62-byte base lets PostgreSQL truncate every trigger name
-    // to the same identifier on long tenant paths.
-    let function_name = sql_index_name(
-        path.as_str(),
-        &format!("{}_ordered_sync_fn", spec.name.as_str()),
-    );
-    let insert_trigger_name = sql_index_name(
-        path.as_str(),
-        &format!("{}_ordered_insert", spec.name.as_str()),
-    );
-    let update_trigger_name = sql_index_name(
-        path.as_str(),
-        &format!("{}_ordered_update", spec.name.as_str()),
-    );
-    let delete_trigger_name = sql_index_name(
-        path.as_str(),
-        &format!("{}_ordered_delete", spec.name.as_str()),
-    );
-    let legacy_scoped_trigger_name = format!("{trigger_base}_sync");
-    let index_name = spec.name.as_str().replace('\'', "''");
-    let escaped_prefix = path.as_str().replace('\'', "''");
-    let (prefix_lower, prefix_upper) = descendant_path_range(path);
-    let prefix_lower = prefix_lower.replace('\'', "''");
-    let prefix_upper = prefix_upper.replace('\'', "''");
-    let new_path_matches = format!(
-        "(NEW.path = '{escaped_prefix}' OR (NEW.path >= '{prefix_lower}' AND NEW.path < '{prefix_upper}'))"
-    );
-    let old_path_matches = format!(
-        "(OLD.path = '{escaped_prefix}' OR (OLD.path >= '{prefix_lower}' AND OLD.path < '{prefix_upper}'))"
-    );
-    let projected_values = spec
-        .keys
-        .iter()
-        .map(|key| format!("NEW.indexed->'{}'", key.as_str()))
-        .chain(
-            std::iter::repeat_with(|| "NULL".to_string())
-                .take(MAX_ORDERED_INDEX_KEYS.saturating_sub(spec.keys.len())),
+    ensure_postgres_static_ordered_projection(client, path).await
+}
+
+/// Projection triggers are static: three triggers sharing one function, whose
+/// body projects by joining the spec catalog on prefix containment. The
+/// previous design installed a plpgsql function plus three row triggers per
+/// (declaration prefix, spec); every entries write then evaluated every
+/// trigger ever declared — O(total declarations) per statement, the same
+/// accumulation pathology measured on libSQL (3,750 triggers after a 50-user
+/// run). The catalog join is O(catalog rows); declaration becomes a pure
+/// catalog insert.
+///
+/// Semantics are unchanged, including "declaration never backfills": triggers
+/// only fire on writes after the fact, and a spec projects exactly the
+/// subtree of its declared prefix.
+async fn ensure_postgres_static_ordered_projection(
+    client: &mut deadpool_postgres::Object,
+    path: &VirtualPath,
+) -> Result<(), FilesystemError> {
+    let map_err = |error: tokio_postgres::Error| {
+        db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+    };
+    // Fast path: the static trigger set is installed and no legacy
+    // per-declaration triggers remain. Re-running the DDL would take
+    // ShareRowExclusive locks on the entries table on every declaration and
+    // convoy concurrent writers.
+    let ensured = client
+        .query_opt(
+            "SELECT 1              FROM pg_trigger t              JOIN pg_class c ON c.oid = t.tgrelid              WHERE c.relname = 'root_filesystem_entries'                AND t.tgname = 'rfs_ordered_projection_v3_ai'                AND NOT EXISTS (                 SELECT 1 FROM pg_trigger l                  JOIN pg_class lc ON lc.oid = l.tgrelid                  WHERE lc.relname = 'root_filesystem_entries'                    AND NOT l.tgisinternal                    AND (l.tgname LIKE 'idx\\_rfs\\_%' \
+                        OR (l.tgname LIKE 'rfs\\_ordered\\_projection\\_%' \
+                            AND l.tgname NOT LIKE 'rfs\\_ordered\\_projection\\_v3\\_%')))",
+            &[],
         )
-        .collect::<Vec<_>>()
-        .join(", ");
-    let predicate = spec
-        .keys
-        .iter()
-        .map(|key| {
-            format!(
-                "(NEW.indexed->'{}') IS NOT NULL AND (NEW.indexed->'{}') <> 'null'::jsonb",
-                key.as_str(),
-                key.as_str()
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(" AND ");
-    let updates = (0..MAX_ORDERED_INDEX_KEYS)
+        .await
+        .map_err(map_err)?;
+    if ensured.is_some() {
+        return Ok(());
+    }
+    let transaction = client.transaction().await.map_err(map_err)?;
+    // One writer at a time for projection DDL, matching the per-declaration
+    // design's advisory lock.
+    transaction
+        .execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            &[&"rfs_ordered_projection_v3"],
+        )
+        .await
+        .map_err(map_err)?;
+
+    // Sweep the legacy per-declaration generation: every trigger this crate
+    // ever installed on the entries table is `idx_rfs_`-prefixed (FTS and
+    // vector never used triggers on PostgreSQL), and its function is resolved
+    // through the trigger row rather than by name pattern because
+    // sql_index_name hash-truncates long identifiers.
+    let legacy = transaction
+        .query(
+            "SELECT t.tgname, p.proname \
+             FROM pg_trigger t \
+             JOIN pg_class c ON c.oid = t.tgrelid \
+             JOIN pg_proc p ON p.oid = t.tgfoid \
+             WHERE c.relname = 'root_filesystem_entries' \
+               AND NOT t.tgisinternal \
+               AND (t.tgname LIKE 'idx\\_rfs\\_%' \
+                    OR (t.tgname LIKE 'rfs\\_ordered\\_projection\\_%' \
+                        AND t.tgname NOT LIKE 'rfs\\_ordered\\_projection\\_v3\\_%'))",
+            &[],
+        )
+        .await
+        .map_err(map_err)?;
+    let mut drops = String::new();
+    let mut functions = std::collections::BTreeSet::new();
+    for row in &legacy {
+        let trigger: String = row.get(0);
+        let function: String = row.get(1);
+        if trigger
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            drops.push_str(&format!(
+                "DROP TRIGGER IF EXISTS {trigger} ON root_filesystem_entries;"
+            ));
+        }
+        if (function.starts_with("idx_rfs_")
+            || (function.starts_with("rfs_ordered_projection_")
+                && function != "rfs_ordered_projection_v3"))
+            && function
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            functions.insert(function);
+        }
+    }
+    for function in functions {
+        drops.push_str(&format!("DROP FUNCTION IF EXISTS {function}();"));
+    }
+    if !drops.is_empty() {
+        transaction.batch_execute(&drops).await.map_err(map_err)?;
+    }
+
+    // Containment: spec.prefix is the path itself or a proper ancestor. The
+    // half-open band `(prefix || '/', prefix || '0')` matches
+    // descendant_path_range; '/' needs its own arm because '//' breaks the
+    // band trick.
+    let containment = "(s.prefix = '/' \
+         OR NEW.path = s.prefix \
+         OR (NEW.path >= s.prefix || '/' AND NEW.path < s.prefix || '0'))";
+    let mut key_values = Vec::new();
+    let mut key_presence = Vec::new();
+    for i in 0..MAX_ORDERED_INDEX_KEYS_STATIC {
+        key_values.push(format!(
+            "CASE WHEN jsonb_array_length(s.keys) > {i} \
+             THEN NEW.indexed -> (s.keys ->> {i}) END"
+        ));
+        key_presence.push(format!(
+            "(jsonb_array_length(s.keys) <= {i} \
+             OR ((NEW.indexed -> (s.keys ->> {i})) IS NOT NULL \
+                 AND (NEW.indexed -> (s.keys ->> {i})) <> 'null'::jsonb))"
+        ));
+    }
+    let key_values = key_values.join(", ");
+    let key_presence = key_presence.join(" AND ");
+    let updates = (0..MAX_ORDERED_INDEX_KEYS_STATIC)
         .map(|position| format!("k{position} = EXCLUDED.k{position}"))
         .collect::<Vec<_>>()
         .join(", ");
     let ddl = format!(
-        "CREATE OR REPLACE FUNCTION {function_name}() RETURNS trigger \
+        "CREATE INDEX IF NOT EXISTS idx_root_filesystem_ordered_rows_path \
+           ON root_filesystem_ordered_index_rows(path); \
+         CREATE OR REPLACE FUNCTION rfs_ordered_projection_v3() RETURNS trigger \
          LANGUAGE plpgsql AS $projection$ \
          BEGIN \
+           IF TG_OP IN ('UPDATE', 'DELETE') THEN \
+             DELETE FROM root_filesystem_ordered_index_rows WHERE path = OLD.path; \
+           END IF; \
            IF TG_OP = 'DELETE' THEN \
-             IF {old_path_matches} THEN \
-               DELETE FROM root_filesystem_ordered_index_rows \
-                WHERE index_name = '{index_name}' AND path = OLD.path; \
-             END IF; \
              RETURN OLD; \
            END IF; \
-           IF TG_OP = 'UPDATE' AND {old_path_matches} THEN \
-             DELETE FROM root_filesystem_ordered_index_rows \
-              WHERE index_name = '{index_name}' AND path = OLD.path; \
-           END IF; \
-           IF {new_path_matches} AND NEW.is_dir = FALSE AND {predicate} THEN \
+           IF NEW.is_dir = FALSE AND NEW.indexed IS NOT NULL THEN \
              INSERT INTO root_filesystem_ordered_index_rows(\
                index_name, path, k0, k1, k2, k3, k4, k5, k6, k7\
-             ) VALUES ('{index_name}', NEW.path, {projected_values}) \
+             ) \
+             SELECT DISTINCT ON (s.name) s.name, NEW.path, {key_values} \
+             FROM root_filesystem_index_specs s \
+             WHERE s.kind IN ('exact', 'prefix') \
+               AND {containment} \
+               AND {key_presence} \
+             ORDER BY s.name, length(s.prefix) DESC \
              ON CONFLICT (index_name, path) DO UPDATE SET {updates}; \
            END IF; \
            RETURN NEW; \
          END; \
          $projection$; \
-         DROP TRIGGER IF EXISTS {legacy_trigger_name} ON root_filesystem_entries; \
-         DROP TRIGGER IF EXISTS {legacy_scoped_trigger_name} ON root_filesystem_entries; \
-         DROP TRIGGER IF EXISTS {insert_trigger_name} ON root_filesystem_entries; \
-         DROP TRIGGER IF EXISTS {update_trigger_name} ON root_filesystem_entries; \
-         DROP TRIGGER IF EXISTS {delete_trigger_name} ON root_filesystem_entries; \
-         CREATE TRIGGER {insert_trigger_name} \
+         CREATE OR REPLACE TRIGGER rfs_ordered_projection_v3_ai \
            AFTER INSERT ON root_filesystem_entries \
-           FOR EACH ROW WHEN ({new_path_matches}) \
-           EXECUTE FUNCTION {function_name}(); \
-         CREATE TRIGGER {update_trigger_name} \
+           FOR EACH ROW EXECUTE FUNCTION rfs_ordered_projection_v3(); \
+         CREATE OR REPLACE TRIGGER rfs_ordered_projection_v3_au \
            AFTER UPDATE ON root_filesystem_entries \
-           FOR EACH ROW WHEN ({old_path_matches} OR {new_path_matches}) \
-           EXECUTE FUNCTION {function_name}(); \
-         CREATE TRIGGER {delete_trigger_name} \
+           FOR EACH ROW EXECUTE FUNCTION rfs_ordered_projection_v3(); \
+         CREATE OR REPLACE TRIGGER rfs_ordered_projection_v3_ad \
            AFTER DELETE ON root_filesystem_entries \
-           FOR EACH ROW WHEN ({old_path_matches}) \
-           EXECUTE FUNCTION {function_name}();"
+           FOR EACH ROW EXECUTE FUNCTION rfs_ordered_projection_v3();"
     );
-    let transaction = client
-        .transaction()
-        .await
-        .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
-    transaction
-        .execute(
-            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
-            &[&spec.name.as_str()],
-        )
-        .await
-        .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
-    transaction
-        .batch_execute(&ddl)
-        .await
-        .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
-    transaction
-        .commit()
-        .await
-        .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))
+    transaction.batch_execute(&ddl).await.map_err(map_err)?;
+    transaction.commit().await.map_err(map_err)
 }
+
+const MAX_ORDERED_INDEX_KEYS_STATIC: usize = 8;
 
 /// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
 /// Bound parameters use `$N` placeholders sized from `params.len() + 1`.

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -556,13 +556,24 @@ impl RootFilesystem for PostgresRootFilesystem {
         page: &crate::OrderedPage,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let client = self.client().await?;
+        // Resolve the spec against `path` and every ancestor prefix, most
+        // specific first, so a caller may declare the index once on a higher
+        // prefix and query a child path. `/shared` keeps its existing
+        // precedence over every path-derived candidate. Binding the candidates
+        // as one array keeps this a single prepared statement regardless of
+        // path depth, and the lookup stays keyed rather than a catalog scan.
+        let mut candidate_prefixes: Vec<String> = crate::index::ancestor_prefixes(path.as_str())
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        candidate_prefixes.push("/shared".to_string());
         let spec_row = cached_query_opt(
             &client,
             "SELECT keys, kind FROM root_filesystem_index_specs \
-             WHERE prefix IN ($1, '/shared') AND name = $2 \
-             ORDER BY CASE WHEN prefix = '/shared' THEN 0 ELSE 1 END \
+             WHERE prefix = ANY($1) AND name = $2 \
+             ORDER BY CASE WHEN prefix = '/shared' THEN 0 ELSE 1 END, length(prefix) DESC \
              LIMIT 1",
-            &[&path.as_str(), &page.index.as_str()],
+            &[&candidate_prefixes, &page.index.as_str()],
         )
         .await
         .map_err(|error| db_error(path.clone(), FilesystemOperation::Query, error))?;

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -134,6 +134,30 @@ impl PostgresRootFilesystem {
         }
     }
 
+    /// Run raw SQL against the backend. Test-only: the projection's trigger
+    /// sweep is only observable through the catalog it manipulates, and a
+    /// contract test cannot seed a legacy trigger any other way.
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn execute_raw_for_test(&self, sql: &str) -> Result<(), FilesystemError> {
+        let client = self.client().await?;
+        client.batch_execute(sql).await.map_err(|error| {
+            crate::db::infrastructure_error(FilesystemOperation::EnsureIndex, error.to_string())
+        })
+    }
+
+    /// Collect the first text column of `sql`. Test-only, same rationale.
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn query_raw_names_for_test(
+        &self,
+        sql: &str,
+    ) -> Result<Vec<String>, FilesystemError> {
+        let client = self.client().await?;
+        let rows = client.query(sql, &[]).await.map_err(|error| {
+            crate::db::infrastructure_error(FilesystemOperation::Query, error.to_string())
+        })?;
+        Ok(rows.iter().map(|row| row.get::<_, String>(0)).collect())
+    }
+
     async fn client(&self) -> Result<deadpool_postgres::Object, FilesystemError> {
         self.pool.get().await.map_err(|error| {
             let reason = format!(
@@ -2232,9 +2256,19 @@ async fn ensure_postgres_static_ordered_projection(
     // half-open band `(prefix || '/', prefix || '0')` matches
     // descendant_path_range; '/' needs its own arm because '//' breaks the
     // band trick.
-    let containment = "(s.prefix = '/' \
-         OR NEW.path = s.prefix \
-         OR (NEW.path >= s.prefix || '/' AND NEW.path < s.prefix || '0'))";
+    // Ancestors of the written path, so the catalog is joined by equality on
+    // its `(prefix, name)` key rather than compared row by row. A containment
+    // predicate scans every declaration ever made, and an upgraded database
+    // keeps its per-thread declaration rows forever.
+    let ancestors = "WITH RECURSIVE rfs_ancestors(prefix) AS ( \
+           SELECT NEW.path \
+           UNION ALL \
+           SELECT CASE \
+             WHEN strpos(reverse(prefix), '/') <= 1 THEN '/' \
+             ELSE left(prefix, length(prefix) - strpos(reverse(prefix), '/')) \
+           END \
+           FROM rfs_ancestors WHERE prefix <> '/' \
+         )";
     let mut key_values = Vec::new();
     let mut key_presence = Vec::new();
     for i in 0..crate::index::MAX_ORDERED_INDEX_KEYS {
@@ -2273,10 +2307,11 @@ async fn ensure_postgres_static_ordered_projection(
              INSERT INTO root_filesystem_ordered_index_rows(\
                index_name, path, k0, k1, k2, k3, k4, k5, k6, k7\
              ) \
+             {ancestors} \
              SELECT DISTINCT ON (s.name) s.name, NEW.path, {key_values} \
-             FROM root_filesystem_index_specs s \
+             FROM rfs_ancestors a \
+             JOIN root_filesystem_index_specs s ON s.prefix = a.prefix \
              WHERE s.kind IN ('exact', 'prefix') \
-               AND {containment} \
                AND {key_presence} \
              ORDER BY s.name, length(s.prefix) DESC \
              ON CONFLICT (index_name, path) DO UPDATE SET {updates}; \

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -134,30 +134,6 @@ impl PostgresRootFilesystem {
         }
     }
 
-    /// Run raw SQL against the backend. Test-only: the projection's trigger
-    /// sweep is only observable through the catalog it manipulates, and a
-    /// contract test cannot seed a legacy trigger any other way.
-    #[cfg(any(test, feature = "test-support"))]
-    pub async fn execute_raw_for_test(&self, sql: &str) -> Result<(), FilesystemError> {
-        let client = self.client().await?;
-        client.batch_execute(sql).await.map_err(|error| {
-            crate::db::infrastructure_error(FilesystemOperation::EnsureIndex, error.to_string())
-        })
-    }
-
-    /// Collect the first text column of `sql`. Test-only, same rationale.
-    #[cfg(any(test, feature = "test-support"))]
-    pub async fn query_raw_names_for_test(
-        &self,
-        sql: &str,
-    ) -> Result<Vec<String>, FilesystemError> {
-        let client = self.client().await?;
-        let rows = client.query(sql, &[]).await.map_err(|error| {
-            crate::db::infrastructure_error(FilesystemOperation::Query, error.to_string())
-        })?;
-        Ok(rows.iter().map(|row| row.get::<_, String>(0)).collect())
-    }
-
     async fn client(&self) -> Result<deadpool_postgres::Object, FilesystemError> {
         self.pool.get().await.map_err(|error| {
             let reason = format!(

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -2123,8 +2123,7 @@ async fn ensure_postgres_ordered_projection(
     path: &VirtualPath,
     spec: &IndexSpec,
 ) -> Result<(), FilesystemError> {
-    const MAX_ORDERED_INDEX_KEYS: usize = 8;
-    if spec.keys.len() > MAX_ORDERED_INDEX_KEYS {
+    if spec.keys.len() > crate::index::MAX_ORDERED_INDEX_KEYS {
         return Err(FilesystemError::Unsupported {
             path: path.clone(),
             operation: FilesystemOperation::EnsureIndex,
@@ -2238,7 +2237,7 @@ async fn ensure_postgres_static_ordered_projection(
          OR (NEW.path >= s.prefix || '/' AND NEW.path < s.prefix || '0'))";
     let mut key_values = Vec::new();
     let mut key_presence = Vec::new();
-    for i in 0..MAX_ORDERED_INDEX_KEYS_STATIC {
+    for i in 0..crate::index::MAX_ORDERED_INDEX_KEYS {
         key_values.push(format!(
             "CASE WHEN jsonb_array_length(s.keys) > {i} \
              THEN NEW.indexed -> (s.keys ->> {i}) END"
@@ -2251,10 +2250,13 @@ async fn ensure_postgres_static_ordered_projection(
     }
     let key_values = key_values.join(", ");
     let key_presence = key_presence.join(" AND ");
-    let updates = (0..MAX_ORDERED_INDEX_KEYS_STATIC)
+    let updates = (0..crate::index::MAX_ORDERED_INDEX_KEYS)
         .map(|position| format!("k{position} = EXCLUDED.k{position}"))
         .collect::<Vec<_>>()
         .join(", ");
+    // DROP + CREATE rather than CREATE OR REPLACE TRIGGER: the latter needs
+    // PostgreSQL 14+, and this whole block runs in one advisory-locked
+    // transaction, so the drop is never observable to another writer.
     let ddl = format!(
         "CREATE INDEX IF NOT EXISTS idx_root_filesystem_ordered_rows_path \
            ON root_filesystem_ordered_index_rows(path); \
@@ -2282,21 +2284,22 @@ async fn ensure_postgres_static_ordered_projection(
            RETURN NEW; \
          END; \
          $projection$; \
-         CREATE OR REPLACE TRIGGER rfs_ordered_projection_v3_ai \
+         DROP TRIGGER IF EXISTS rfs_ordered_projection_v3_ai ON root_filesystem_entries; \
+         DROP TRIGGER IF EXISTS rfs_ordered_projection_v3_au ON root_filesystem_entries; \
+         DROP TRIGGER IF EXISTS rfs_ordered_projection_v3_ad ON root_filesystem_entries; \
+         CREATE TRIGGER rfs_ordered_projection_v3_ai \
            AFTER INSERT ON root_filesystem_entries \
            FOR EACH ROW EXECUTE FUNCTION rfs_ordered_projection_v3(); \
-         CREATE OR REPLACE TRIGGER rfs_ordered_projection_v3_au \
+         CREATE TRIGGER rfs_ordered_projection_v3_au \
            AFTER UPDATE ON root_filesystem_entries \
            FOR EACH ROW EXECUTE FUNCTION rfs_ordered_projection_v3(); \
-         CREATE OR REPLACE TRIGGER rfs_ordered_projection_v3_ad \
+         CREATE TRIGGER rfs_ordered_projection_v3_ad \
            AFTER DELETE ON root_filesystem_entries \
            FOR EACH ROW EXECUTE FUNCTION rfs_ordered_projection_v3();"
     );
     transaction.batch_execute(&ddl).await.map_err(map_err)?;
     transaction.commit().await.map_err(map_err)
 }
-
-const MAX_ORDERED_INDEX_KEYS_STATIC: usize = 8;
 
 /// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
 /// Bound parameters use `$N` placeholders sized from `params.len() + 1`.

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -617,7 +617,7 @@ impl RootFilesystem for PostgresRootFilesystem {
         };
         let sort_position = prefix_values.len();
         let tie_position = sort_position.saturating_add(1);
-        if tie_position >= 8 {
+        if tie_position >= crate::index::MAX_ORDERED_INDEX_KEYS {
             return Err(FilesystemError::Unsupported {
                 path: path.clone(),
                 operation: FilesystemOperation::Query,
@@ -2240,7 +2240,7 @@ async fn ensure_postgres_static_ordered_projection(
            SELECT NEW.path \
            UNION ALL \
            SELECT CASE \
-             WHEN strpos(reverse(prefix), '/') <= 1 THEN '/' \
+             WHEN length(prefix) - strpos(reverse(prefix), '/') <= 0 THEN '/' \
              ELSE left(prefix, length(prefix) - strpos(reverse(prefix), '/')) \
            END \
            FROM rfs_ancestors WHERE prefix <> '/' \

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -2272,9 +2272,17 @@ mod postgres_tests {
     }
 
     impl IsolatedDatabase {
-        /// Drop the database, so a run against a developer's own server does
-        /// not leak one per execution. `FORCE` closes the pool's connections,
-        /// which are not guaranteed to have gone away when the handles drop.
+        /// Drop the database on the way out of a passing test.
+        ///
+        /// This is the tidy path, not a guarantee: a failing assertion unwinds
+        /// straight past it, so a red run can leave its database behind. That
+        /// is what the sweep in `postgres_isolated_root` collects, rather than
+        /// wrapping the test body in `catch_unwind` — the cleanup is a courtesy
+        /// to whoever points these tests at their own server, and it is not
+        /// worth contorting the test to make it absolute.
+        ///
+        /// `FORCE` closes the pool's connections, which are not guaranteed to
+        /// have gone away by the time the handles drop.
         async fn cleanup(self) {
             let Self {
                 filesystem,
@@ -2292,6 +2300,12 @@ mod postgres_tests {
     }
 
     async fn postgres_isolated_root() -> Option<IsolatedDatabase> {
+        // Same opt-out every other PostgreSQL case honours through
+        // `postgres_pool`, checked before anything provisions a container or
+        // issues DDL.
+        if std::env::var("IRONCLAW_SKIP_POSTGRES_TESTS").is_ok() {
+            return None;
+        }
         let config = postgres_url()
             .await?
             .parse::<tokio_postgres::Config>()
@@ -2300,7 +2314,28 @@ mod postgres_tests {
         tokio::spawn(async move {
             let _ = connection.await;
         });
-        // `uuid::simple` is hex, so the identifier needs no quoting.
+
+        // Collect databases a previously failed run unwound past. No `FORCE`:
+        // a database another run still holds open refuses to drop, which is
+        // exactly the outcome we want when two binaries share a server.
+        if let Ok(stale) = admin
+            .query(
+                "SELECT datname FROM pg_database WHERE datname LIKE 'rfs_isolated_%'",
+                &[],
+            )
+            .await
+        {
+            for row in stale {
+                let name = row.get::<_, String>(0);
+                let _ = admin
+                    .execute(&format!("DROP DATABASE IF EXISTS {name}"), &[])
+                    .await;
+            }
+        }
+
+        // Identifiers cannot be bind parameters in DDL. `uuid::simple` is hex
+        // and the swept names come from `pg_database`, so both interpolations
+        // are server-supplied or generated, never caller input.
         let name = format!("rfs_isolated_{}", uuid::Uuid::new_v4().simple());
         admin
             .execute(&format!("CREATE DATABASE {name}"), &[])

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -2211,31 +2211,135 @@ mod postgres_tests {
             .ok()
     }
 
+    /// Installs the projection triggers once per binary, before tests race.
+    ///
+    /// Declaring an ordered index installs those triggers, and that takes an
+    /// ACCESS EXCLUSIVE lock on `root_filesystem_entries`. Against a *fresh*
+    /// database every test would otherwise race the install while its
+    /// neighbours write the same table, and a writer already holding a row lock
+    /// there while it waits on the installer's advisory lock is a deadlock —
+    /// PostgreSQL breaks it by killing one side, which surfaces as `BackendBusy`
+    /// in whichever test lost rather than in the one doing the DDL. Running it
+    /// once leaves every later declaration on the no-DDL fast path. A warm
+    /// database hides this completely, so it reproduces only against a fresh
+    /// one, which is what CI provisions and a repeat local run does not.
+    ///
+    /// The work borrows the first caller's filesystem instead of caching a pool:
+    /// every `#[tokio::test]` has its own runtime, and `tokio_postgres` drives
+    /// each connection from a task on the runtime that created it, so a pool
+    /// shared across tests dies as `connection closed` the moment its origin
+    /// test finishes.
+    static PROJECTION_INSTALLED: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+    async fn install_projection_once(filesystem: &PostgresRootFilesystem) {
+        PROJECTION_INSTALLED
+            .get_or_init(|| async {
+                // A unique prefix that is an ancestor of nothing any test
+                // writes, so the declaration projects no rows for them.
+                let Ok(path) = VirtualPath::new(format!(
+                    "/secrets/leases/pgwarmup_{}",
+                    uuid::Uuid::new_v4().simple()
+                )) else {
+                    return;
+                };
+                let (Ok(name), Ok(key)) = (IndexName::new("warmup_probe"), IndexKey::new("rank"))
+                else {
+                    return;
+                };
+                let _ = filesystem
+                    .ensure_index(&path, &IndexSpec::new(name, vec![key], IndexKind::Exact))
+                    .await;
+            })
+            .await;
+    }
+
+    /// A private database for a test that mutates or asserts global schema.
+    ///
+    /// The projection triggers live on `root_filesystem_entries`, so installing
+    /// or sweeping them takes an ACCESS EXCLUSIVE lock on that whole table, and
+    /// the `pg_trigger` assertions read state every other test shares. Sharing
+    /// one database, such a test blocks unrelated concurrent writers — which
+    /// surfaces as a `BackendBusy` failure in whichever test happens to be
+    /// mid-write, far from the cause — and races its own assertions against
+    /// their declarations. Path prefixes isolate rows; they cannot isolate
+    /// schema, so a schema-level test gets a schema-level scope.
+    struct IsolatedDatabase {
+        filesystem: PostgresRootFilesystem,
+        prefix: String,
+        client: tokio_postgres::Client,
+        admin: tokio_postgres::Client,
+        name: String,
+    }
+
+    impl IsolatedDatabase {
+        /// Drop the database, so a run against a developer's own server does
+        /// not leak one per execution. `FORCE` closes the pool's connections,
+        /// which are not guaranteed to have gone away when the handles drop.
+        async fn cleanup(self) {
+            let Self {
+                filesystem,
+                client,
+                admin,
+                name,
+                ..
+            } = self;
+            drop(filesystem);
+            drop(client);
+            let _ = admin
+                .execute(&format!("DROP DATABASE IF EXISTS {name} WITH (FORCE)"), &[])
+                .await;
+        }
+    }
+
+    async fn postgres_isolated_root() -> Option<IsolatedDatabase> {
+        let config = postgres_url()
+            .await?
+            .parse::<tokio_postgres::Config>()
+            .ok()?;
+        let (admin, connection) = config.connect(tokio_postgres::NoTls).await.ok()?;
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        // `uuid::simple` is hex, so the identifier needs no quoting.
+        let name = format!("rfs_isolated_{}", uuid::Uuid::new_v4().simple());
+        admin
+            .execute(&format!("CREATE DATABASE {name}"), &[])
+            .await
+            .ok()?;
+
+        let mut isolated = config.clone();
+        isolated.dbname(&name);
+        let manager = deadpool_postgres::Manager::new(isolated.clone(), tokio_postgres::NoTls);
+        let pool = deadpool_postgres::Pool::builder(manager)
+            .max_size(4)
+            .build()
+            .ok()?;
+        let filesystem = PostgresRootFilesystem::new(pool);
+        filesystem.run_migrations().await.ok()?;
+        let (client, connection) = isolated.connect(tokio_postgres::NoTls).await.ok()?;
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        Some(IsolatedDatabase {
+            filesystem,
+            prefix: format!("/secrets/leases/pgtest_{}", uuid::Uuid::new_v4().simple()),
+            client,
+            admin,
+            name,
+        })
+    }
+
     /// Build a fresh Postgres-backed filesystem with migrations applied.
     /// Returns `None` if no Postgres is reachable — caller must early-return
     /// so the test passes in environments without a DB. Each test uses a
     /// unique path prefix so concurrent runs against a shared DB don't
     /// interfere.
-    /// A direct connection to the same database `postgres_root` uses. Seeding
-    /// a legacy trigger needs raw SQL, which belongs in the test rather than
-    /// as a test-only method on the production filesystem type.
-    async fn raw_postgres_client() -> tokio_postgres::Client {
-        let url = postgres_url()
-            .await
-            .expect("postgres url present when postgres_root yielded a filesystem");
-        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
-            .await
-            .expect("connect to postgres");
-        tokio::spawn(async move {
-            let _ = connection.await;
-        });
-        client
-    }
-
     async fn postgres_root() -> Option<(PostgresRootFilesystem, String)> {
         let pool = postgres_pool().await?;
         let fs = PostgresRootFilesystem::new(pool);
         fs.run_migrations().await.ok()?;
+        install_projection_once(&fs).await;
         // Unique per-test prefix under /secrets/leases (a known VirtualPath
         // root). Concurrent test runs against the same Postgres get
         // isolation via the prefix; cleanup happens by the next test's
@@ -3210,12 +3314,19 @@ mod postgres_tests {
     /// tests still pass.
     #[tokio::test]
     async fn postgres_static_projection_sweeps_legacy_triggers() {
-        let Some((filesystem, prefix)) = postgres_root().await else {
+        // Its own database: this case rewrites and then asserts the trigger set
+        // of a shared table, which no path prefix can isolate.
+        let Some(isolated) = postgres_isolated_root().await else {
             return;
         };
+        let IsolatedDatabase {
+            ref filesystem,
+            ref prefix,
+            ref client,
+            ..
+        } = isolated;
         // Seed a survivor shaped like the per-declaration generation, over the
         // test's own connection: production types must not carry test seams.
-        let client = raw_postgres_client().await;
         client
             .batch_execute(
                 "CREATE OR REPLACE FUNCTION idx_rfs_legacy_probe_fn() RETURNS trigger                  LANGUAGE plpgsql AS $legacy$ BEGIN                    DELETE FROM root_filesystem_ordered_index_rows WHERE path = NEW.path;                    RETURN NEW; END; $legacy$;                  DROP TRIGGER IF EXISTS idx_rfs_legacy_probe ON root_filesystem_entries;                  CREATE TRIGGER idx_rfs_legacy_probe AFTER INSERT ON root_filesystem_entries                    FOR EACH ROW EXECUTE FUNCTION idx_rfs_legacy_probe_fn();",
@@ -3225,7 +3336,7 @@ mod postgres_tests {
 
         filesystem
             .ensure_index(
-                &vpath(&prefix, "sweep"),
+                &vpath(prefix, "sweep"),
                 &IndexSpec::new(
                     IndexName::new("sweep_probe_v1").unwrap(),
                     vec![IndexKey::new("rank").unwrap()],
@@ -3265,7 +3376,8 @@ mod postgres_tests {
             );
         }
         // And the behavior those triggers exist for, end to end.
-        super::static_projection_update_and_delete_contract(&filesystem, &prefix).await;
+        super::static_projection_update_and_delete_contract(filesystem, prefix).await;
+        isolated.cleanup().await;
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -2160,6 +2160,22 @@ mod postgres_tests {
     /// so the test passes in environments without a DB. Each test uses a
     /// unique path prefix so concurrent runs against a shared DB don't
     /// interfere.
+    /// A direct connection to the same database `postgres_root` uses. Seeding
+    /// a legacy trigger needs raw SQL, which belongs in the test rather than
+    /// as a test-only method on the production filesystem type.
+    async fn raw_postgres_client() -> tokio_postgres::Client {
+        let url = std::env::var("IRONCLAW_FILESYSTEM_POSTGRES_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .expect("postgres url present when postgres_root yielded a filesystem");
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .expect("connect to postgres");
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client
+    }
+
     async fn postgres_root() -> Option<(PostgresRootFilesystem, String)> {
         let pool = postgres_pool().await?;
         let fs = PostgresRootFilesystem::new(pool);
@@ -3141,9 +3157,11 @@ mod postgres_tests {
         let Some((filesystem, prefix)) = postgres_root().await else {
             return;
         };
-        // Seed a survivor shaped like the per-declaration generation.
-        filesystem
-            .execute_raw_for_test(
+        // Seed a survivor shaped like the per-declaration generation, over the
+        // test's own connection: production types must not carry test seams.
+        let client = raw_postgres_client().await;
+        client
+            .batch_execute(
                 "CREATE OR REPLACE FUNCTION idx_rfs_legacy_probe_fn() RETURNS trigger                  LANGUAGE plpgsql AS $legacy$ BEGIN                    DELETE FROM root_filesystem_ordered_index_rows WHERE path = NEW.path;                    RETURN NEW; END; $legacy$;                  DROP TRIGGER IF EXISTS idx_rfs_legacy_probe ON root_filesystem_entries;                  CREATE TRIGGER idx_rfs_legacy_probe AFTER INSERT ON root_filesystem_entries                    FOR EACH ROW EXECUTE FUNCTION idx_rfs_legacy_probe_fn();",
             )
             .await
@@ -3161,12 +3179,18 @@ mod postgres_tests {
             .await
             .expect("declaration installs the static set and sweeps legacy triggers");
 
-        let remaining = filesystem
-            .query_raw_names_for_test(
-                "SELECT t.tgname FROM pg_trigger t                  JOIN pg_class c ON c.oid = t.tgrelid                  WHERE c.relname = 'root_filesystem_entries' AND NOT t.tgisinternal                  ORDER BY t.tgname",
+        let remaining = client
+            .query(
+                "SELECT t.tgname FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid \
+                 WHERE c.relname = 'root_filesystem_entries' AND NOT t.tgisinternal \
+                 ORDER BY t.tgname",
+                &[],
             )
             .await
-            .expect("list triggers");
+            .expect("list triggers")
+            .iter()
+            .map(|row| row.get::<_, String>(0))
+            .collect::<Vec<_>>();
         assert!(
             !remaining.iter().any(|name| name.starts_with("idx_rfs_")),
             "legacy per-declaration triggers must be swept, saw {remaining:?}"

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -3,8 +3,8 @@ use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_filesystem::{
     AtomicSubtreeEntry, Capability, CasExpectation, Entry, FileType, FilesystemError,
-    FilesystemOperation, Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue,
-    LibSqlRootFilesystem, Page, RecordKind, SeqNo, SortDirection,
+    FilesystemOperation, Filter, InMemoryBackend, IndexKey, IndexKind, IndexName, IndexSpec,
+    IndexValue, LibSqlRootFilesystem, OrderedPage, Page, RecordKind, SeqNo, SortDirection,
 };
 use ironclaw_host_api::path::VirtualPath;
 
@@ -1105,6 +1105,91 @@ async fn libsql_scopes_ordered_index_names_by_prefix() {
         )
         .await
         .expect("same index name with a different prefix is independent");
+}
+
+/// The projection's UPDATE and DELETE branches were replaced wholesale
+/// with the static trigger set, but the ordered-index contracts only insert and
+/// query. A stale row left behind after an indexed key changes, or after the
+/// source row is deleted, would go unnoticed.
+async fn static_projection_update_and_delete_contract<F: RootFilesystem>(
+    filesystem: &F,
+    base: &str,
+) {
+    let rank = IndexKey::new("rank").unwrap();
+    let item_id = IndexKey::new("item_id").unwrap();
+    let spec = IndexSpec::new(
+        IndexName::new("mutating_items_v1").unwrap(),
+        vec![rank.clone(), item_id.clone()],
+        IndexKind::Exact,
+    );
+    filesystem
+        .ensure_index(&VirtualPath::new(base.to_string()).unwrap(), &spec)
+        .await
+        .unwrap();
+    let path = VirtualPath::new(format!("{base}/item")).unwrap();
+    let write = async |rank_value: &str, expectation: CasExpectation| {
+        filesystem
+            .put(
+                &path,
+                Entry::record(
+                    RecordKind::new("mutating_item").unwrap(),
+                    &serde_json::json!({}),
+                )
+                .unwrap()
+                .with_indexed(rank.clone(), IndexValue::Text(rank_value.to_string()))
+                .with_indexed(item_id.clone(), IndexValue::Text("item".to_string())),
+                expectation,
+            )
+            .await
+            .unwrap()
+    };
+    let query = async || {
+        filesystem
+            .query_ordered(
+                &VirtualPath::new(base.to_string()).unwrap(),
+                &Filter::All,
+                &OrderedPage::new(
+                    IndexName::new("mutating_items_v1").unwrap(),
+                    rank.clone(),
+                    item_id.clone(),
+                    SortDirection::Ascending,
+                    16,
+                ),
+            )
+            .await
+            .unwrap()
+            .len()
+    };
+
+    let version = write("a", CasExpectation::Absent).await;
+    assert_eq!(query().await, 1, "the insert projects one row");
+
+    // Replacing the indexed key must leave exactly one row, not two.
+    write("b", CasExpectation::Version(version)).await;
+    assert_eq!(
+        query().await,
+        1,
+        "an indexed-key update must replace the projection row, not add one"
+    );
+
+    filesystem.delete(&path).await.unwrap();
+    assert_eq!(
+        query().await,
+        0,
+        "deleting the source row must remove its projection row"
+    );
+}
+
+#[tokio::test]
+async fn libsql_static_projection_update_and_delete_remove_stale_rows() {
+    let filesystem = libsql_root().await;
+    static_projection_update_and_delete_contract(&*filesystem, "/engine/mutating").await;
+}
+
+#[tokio::test]
+async fn in_memory_static_projection_update_and_delete_remove_stale_rows() {
+    let filesystem = InMemoryBackend::new();
+    static_projection_update_and_delete_contract(&filesystem, "/engine/mutating").await;
 }
 
 #[tokio::test]
@@ -3044,6 +3129,54 @@ mod postgres_tests {
             .await
             .expect("same index name with a different prefix is independent");
         }
+    }
+
+    /// libSQL pins the legacy-trigger sweep, PostgreSQL did not. Its
+    /// discovery, identifier validation, and drop path are distinct code, so a
+    /// sweep that silently misses would leave the per-declaration trigger
+    /// growth in place on every upgraded database while all other projection
+    /// tests still pass.
+    #[tokio::test]
+    async fn postgres_static_projection_sweeps_legacy_triggers() {
+        let Some((filesystem, prefix)) = postgres_root().await else {
+            return;
+        };
+        // Seed a survivor shaped like the per-declaration generation.
+        filesystem
+            .execute_raw_for_test(
+                "CREATE OR REPLACE FUNCTION idx_rfs_legacy_probe_fn() RETURNS trigger                  LANGUAGE plpgsql AS $legacy$ BEGIN                    DELETE FROM root_filesystem_ordered_index_rows WHERE path = NEW.path;                    RETURN NEW; END; $legacy$;                  DROP TRIGGER IF EXISTS idx_rfs_legacy_probe ON root_filesystem_entries;                  CREATE TRIGGER idx_rfs_legacy_probe AFTER INSERT ON root_filesystem_entries                    FOR EACH ROW EXECUTE FUNCTION idx_rfs_legacy_probe_fn();",
+            )
+            .await
+            .expect("seed legacy trigger");
+
+        filesystem
+            .ensure_index(
+                &vpath(&prefix, "sweep"),
+                &IndexSpec::new(
+                    IndexName::new("sweep_probe_v1").unwrap(),
+                    vec![IndexKey::new("rank").unwrap()],
+                    IndexKind::Exact,
+                ),
+            )
+            .await
+            .expect("declaration installs the static set and sweeps legacy triggers");
+
+        let remaining = filesystem
+            .query_raw_names_for_test(
+                "SELECT t.tgname FROM pg_trigger t                  JOIN pg_class c ON c.oid = t.tgrelid                  WHERE c.relname = 'root_filesystem_entries' AND NOT t.tgisinternal                  ORDER BY t.tgname",
+            )
+            .await
+            .expect("list triggers");
+        assert!(
+            !remaining.iter().any(|name| name.starts_with("idx_rfs_")),
+            "legacy per-declaration triggers must be swept, saw {remaining:?}"
+        );
+        assert!(
+            remaining
+                .iter()
+                .any(|name| name == "rfs_ordered_projection_v3_ai"),
+            "the static set must be installed, saw {remaining:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -3251,12 +3251,21 @@ mod postgres_tests {
             !remaining.iter().any(|name| name.starts_with("idx_rfs_")),
             "legacy per-declaration triggers must be swept, saw {remaining:?}"
         );
-        assert!(
-            remaining
-                .iter()
-                .any(|name| name == "rfs_ordered_projection_v3_ai"),
-            "the static set must be installed, saw {remaining:?}"
-        );
+        // The whole set, not just the insert trigger: an install that dropped
+        // the update or delete trigger would still project new rows while
+        // silently leaving stale ones behind on replacement and deletion.
+        for required in [
+            "rfs_ordered_projection_v3_ai",
+            "rfs_ordered_projection_v3_au",
+            "rfs_ordered_projection_v3_ad",
+        ] {
+            assert!(
+                remaining.iter().any(|name| name == required),
+                "the static set must install {required}, saw {remaining:?}"
+            );
+        }
+        // And the behavior those triggers exist for, end to end.
+        super::static_projection_update_and_delete_contract(&filesystem, &prefix).await;
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1172,6 +1172,192 @@ async fn libsql_ordered_index_declaration_never_backfills_existing_rows() {
     );
 }
 
+/// Shared cross-backend body: an ordered-index spec declared on an ancestor
+/// prefix serves queries at child paths, and those queries stay scoped to the
+/// queried child subtree.
+///
+/// Projection rows are keyed by spec name and path only, with no record of the
+/// prefix that declared them, so a backend resolving an ancestor spec must
+/// still constrain results to the queried subtree. Without that constraint a
+/// child query returns a sibling's rows — a scope leak, not just a parity
+/// difference.
+async fn ancestor_declared_ordered_index_contract<F: RootFilesystem>(filesystem: &F, base: &str) {
+    let rank = IndexKey::new("rank").unwrap();
+    let item_id = IndexKey::new("item_id").unwrap();
+    let spec = IndexSpec::new(
+        IndexName::new("ancestor_declared_items_v1").unwrap(),
+        vec![rank.clone(), item_id.clone()],
+        IndexKind::Exact,
+    );
+    let root = VirtualPath::new(base.to_string()).unwrap();
+    filesystem.ensure_index(&root, &spec).await.unwrap();
+
+    for (child, leaf) in [("alpha", "a-1"), ("alpha", "a-2"), ("beta", "b-1")] {
+        filesystem
+            .put(
+                &VirtualPath::new(format!("{base}/{child}/{leaf}")).unwrap(),
+                Entry::record(
+                    RecordKind::new("ancestor_item").unwrap(),
+                    &serde_json::json!({}),
+                )
+                .unwrap()
+                .with_indexed(rank.clone(), IndexValue::Text(leaf.to_string()))
+                .with_indexed(item_id.clone(), IndexValue::Text(leaf.to_string())),
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+
+    let page = || {
+        ironclaw_filesystem::OrderedPage::new(
+            spec.name.clone(),
+            rank.clone(),
+            item_id.clone(),
+            SortDirection::Ascending,
+            10,
+        )
+    };
+    let paths_at = async |prefix: String| -> Vec<String> {
+        filesystem
+            .query_ordered(&VirtualPath::new(prefix).unwrap(), &Filter::All, &page())
+            .await
+            .unwrap()
+            .iter()
+            .map(|row| row.path.as_str().to_string())
+            .collect()
+    };
+
+    // Declared on the ancestor, queried on a child: the write path projected
+    // into the ancestor declaration, and resolution found it from below.
+    assert_eq!(
+        paths_at(format!("{base}/alpha")).await,
+        vec![format!("{base}/alpha/a-1"), format!("{base}/alpha/a-2")],
+        "a child query must see the rows in its own subtree"
+    );
+    assert_eq!(
+        paths_at(format!("{base}/beta")).await,
+        vec![format!("{base}/beta/b-1")],
+        "a sibling subtree must not leak into a child query resolved from an ancestor spec"
+    );
+    // The declaring prefix itself still spans the whole subtree.
+    assert_eq!(paths_at(base.to_string()).await.len(), 3);
+}
+
+/// Shared cross-backend body for the existing-deployment path: a narrower spec
+/// declared before the root one keeps serving its own subtree once the root
+/// declaration is added, and a subtree that never had its own declaration is
+/// served by the root spec.
+///
+/// Declarations never backfill, so resolution must prefer the more specific
+/// spec — its projection is the one already holding rows written before the
+/// root declaration existed.
+async fn narrow_then_root_ordered_index_contract<F: RootFilesystem>(filesystem: &F, base: &str) {
+    let rank = IndexKey::new("rank").unwrap();
+    let item_id = IndexKey::new("item_id").unwrap();
+    let spec = || {
+        IndexSpec::new(
+            IndexName::new("migrating_items_v1").unwrap(),
+            vec![rank.clone(), item_id.clone()],
+            IndexKind::Exact,
+        )
+    };
+    let write = async |path: String, leaf: &str| {
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                Entry::record(
+                    RecordKind::new("migrating_item").unwrap(),
+                    &serde_json::json!({}),
+                )
+                .unwrap()
+                .with_indexed(rank.clone(), IndexValue::Text(leaf.to_string()))
+                .with_indexed(item_id.clone(), IndexValue::Text(leaf.to_string())),
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    };
+
+    // The deployment as it stands before the fix: a per-thread declaration,
+    // and a row written under it.
+    filesystem
+        .ensure_index(
+            &VirtualPath::new(format!("{base}/threads/t-1")).unwrap(),
+            &spec(),
+        )
+        .await
+        .unwrap();
+    write(format!("{base}/threads/t-1/m-1"), "m-1").await;
+
+    // The upgrade: the root declaration lands while the narrow one remains.
+    filesystem
+        .ensure_index(&VirtualPath::new(base.to_string()).unwrap(), &spec())
+        .await
+        .unwrap();
+    write(format!("{base}/threads/t-1/m-2"), "m-2").await;
+    // A thread created after the upgrade never gets its own declaration.
+    write(format!("{base}/threads/t-2/m-1"), "m-1").await;
+
+    let paths_at = async |prefix: String| -> Vec<String> {
+        filesystem
+            .query_ordered(
+                &VirtualPath::new(prefix).unwrap(),
+                &Filter::All,
+                &ironclaw_filesystem::OrderedPage::new(
+                    IndexName::new("migrating_items_v1").unwrap(),
+                    rank.clone(),
+                    item_id.clone(),
+                    SortDirection::Ascending,
+                    10,
+                ),
+            )
+            .await
+            .unwrap()
+            .iter()
+            .map(|row| row.path.as_str().to_string())
+            .collect()
+    };
+
+    assert_eq!(
+        paths_at(format!("{base}/threads/t-1")).await,
+        vec![
+            format!("{base}/threads/t-1/m-1"),
+            format!("{base}/threads/t-1/m-2"),
+        ],
+        "rows written before the root declaration must stay queryable after it"
+    );
+    assert_eq!(
+        paths_at(format!("{base}/threads/t-2")).await,
+        vec![format!("{base}/threads/t-2/m-1")],
+        "a subtree with no declaration of its own is served by the root spec"
+    );
+}
+
+#[tokio::test]
+async fn libsql_ordered_index_declared_at_ancestor_serves_scoped_descendant_queries() {
+    let filesystem = libsql_root().await;
+    ancestor_declared_ordered_index_contract(&*filesystem, "/engine/ancestor-declared").await;
+}
+
+#[tokio::test]
+async fn libsql_ordered_index_narrow_declaration_survives_root_declaration() {
+    let filesystem = libsql_root().await;
+    narrow_then_root_ordered_index_contract(&*filesystem, "/engine/narrow-then-root").await;
+}
+
+#[tokio::test]
+async fn in_memory_ordered_index_declared_at_ancestor_serves_scoped_descendant_queries() {
+    let filesystem = ironclaw_filesystem::InMemoryBackend::new();
+    ancestor_declared_ordered_index_contract(&filesystem, "/engine/ancestor-declared").await;
+}
+
+#[tokio::test]
+async fn in_memory_ordered_index_narrow_declaration_survives_root_declaration() {
+    let filesystem = ironclaw_filesystem::InMemoryBackend::new();
+    narrow_then_root_ordered_index_contract(&filesystem, "/engine/narrow-then-root").await;
+}
+
 #[tokio::test]
 async fn libsql_query_filters_on_indexed_projection() {
     let filesystem = libsql_root().await;
@@ -1904,6 +2090,22 @@ mod postgres_tests {
 
     fn vpath(prefix: &str, leaf: &str) -> VirtualPath {
         VirtualPath::new(format!("{prefix}/{leaf}")).unwrap()
+    }
+
+    #[tokio::test]
+    async fn postgres_ordered_index_declared_at_ancestor_serves_scoped_descendant_queries() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        super::ancestor_declared_ordered_index_contract(&fs, &prefix).await;
+    }
+
+    #[tokio::test]
+    async fn postgres_ordered_index_narrow_declaration_survives_root_declaration() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        super::narrow_then_root_ordered_index_contract(&fs, &prefix).await;
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -2140,13 +2140,69 @@ mod postgres_tests {
     };
     use ironclaw_host_api::path::VirtualPath;
 
+    /// One container per test binary, started on first use.
+    ///
+    /// Kept alive for the process: dropping the handle stops the database out
+    /// from under every later test. Each test still namespaces by a unique
+    /// path prefix, so sharing one instance is safe.
+    static POSTGRES_CONTAINER: tokio::sync::OnceCell<Option<ContainerUrl>> =
+        tokio::sync::OnceCell::const_new();
+
+    struct ContainerUrl {
+        url: String,
+        _container: testcontainers_modules::testcontainers::ContainerAsync<
+            testcontainers_modules::postgres::Postgres,
+        >,
+    }
+
+    /// The database these tests run against.
+    ///
+    /// An explicit URL wins, so a local run can point at an existing server.
+    /// Otherwise a container is provisioned, which is what lets these tests
+    /// actually run in CI lanes that have Docker but set no database URL —
+    /// previously every case here skipped there, leaving the PostgreSQL
+    /// projection code untested and uncovered.
+    async fn postgres_url() -> Option<String> {
+        if let Ok(url) = std::env::var("IRONCLAW_FILESYSTEM_POSTGRES_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+        {
+            return Some(url);
+        }
+        POSTGRES_CONTAINER
+            .get_or_init(|| async {
+                use testcontainers_modules::testcontainers::{ImageExt, runners::AsyncRunner};
+                let image = testcontainers_modules::postgres::Postgres::default()
+                    .with_db_name("ironclaw_test")
+                    .with_user("postgres")
+                    .with_password("postgres")
+                    .with_tag("16-alpine");
+                let container = match image.start().await {
+                    Ok(container) => container,
+                    Err(error) => {
+                        eprintln!(
+                            "skipping Postgres filesystem contract tests: \
+                             docker/testcontainers unavailable ({error})"
+                        );
+                        return None;
+                    }
+                };
+                let host = container.get_host().await.ok()?;
+                let port = container.get_host_port_ipv4(5432).await.ok()?;
+                Some(ContainerUrl {
+                    url: format!("postgres://postgres:postgres@{host}:{port}/ironclaw_test"),
+                    _container: container,
+                })
+            })
+            .await
+            .as_ref()
+            .map(|container| container.url.clone())
+    }
+
     async fn postgres_pool() -> Option<deadpool_postgres::Pool> {
         if std::env::var("IRONCLAW_SKIP_POSTGRES_TESTS").is_ok() {
             return None;
         }
-        let url = std::env::var("IRONCLAW_FILESYSTEM_POSTGRES_URL")
-            .or_else(|_| std::env::var("DATABASE_URL"))
-            .ok()?;
+        let url = postgres_url().await?;
         let config = url.parse::<tokio_postgres::Config>().ok()?;
         let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
         deadpool_postgres::Pool::builder(manager)
@@ -2164,8 +2220,8 @@ mod postgres_tests {
     /// a legacy trigger needs raw SQL, which belongs in the test rather than
     /// as a test-only method on the production filesystem type.
     async fn raw_postgres_client() -> tokio_postgres::Client {
-        let url = std::env::var("IRONCLAW_FILESYSTEM_POSTGRES_URL")
-            .or_else(|_| std::env::var("DATABASE_URL"))
+        let url = postgres_url()
+            .await
             .expect("postgres url present when postgres_root yielded a filesystem");
         let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
             .await

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -2236,19 +2236,25 @@ mod postgres_tests {
             .get_or_init(|| async {
                 // A unique prefix that is an ancestor of nothing any test
                 // writes, so the declaration projects no rows for them.
-                let Ok(path) = VirtualPath::new(format!(
+                //
+                // Every step panics rather than returning: reaching here means
+                // a database was resolved, so a failure is a broken setup, not
+                // an unconfigured one. Completing the `OnceCell` quietly with no
+                // triggers installed would let the whole PostgreSQL projection
+                // suite pass while testing nothing -- and the changed-coverage
+                // exemptions for those residual lines are justified by these
+                // tests running.
+                let path = VirtualPath::new(format!(
                     "/secrets/leases/pgwarmup_{}",
                     uuid::Uuid::new_v4().simple()
-                )) else {
-                    return;
-                };
-                let (Ok(name), Ok(key)) = (IndexName::new("warmup_probe"), IndexKey::new("rank"))
-                else {
-                    return;
-                };
-                let _ = filesystem
+                ))
+                .expect("warm-up prefix is a valid virtual path");
+                let name = IndexName::new("warmup_probe").expect("warm-up index name");
+                let key = IndexKey::new("rank").expect("warm-up index key");
+                filesystem
                     .ensure_index(&path, &IndexSpec::new(name, vec![key], IndexKind::Exact))
-                    .await;
+                    .await
+                    .expect("warm-up declaration installs the static projection triggers");
             })
             .await;
     }
@@ -2306,11 +2312,21 @@ mod postgres_tests {
         if std::env::var("IRONCLAW_SKIP_POSTGRES_TESTS").is_ok() {
             return None;
         }
+        // Past the skip flag and a resolvable URL, every failure below is a
+        // broken environment rather than an unconfigured one, so it panics.
+        // Returning `None` instead would make the legacy-trigger sweep -- the
+        // only coverage for that path, and the basis for waiving its residual
+        // lines in the changed-coverage exemptions -- report success while
+        // never running. A role that cannot CREATE DATABASE would silence the
+        // test and the gate together.
         let config = postgres_url()
             .await?
             .parse::<tokio_postgres::Config>()
-            .ok()?;
-        let (admin, connection) = config.connect(tokio_postgres::NoTls).await.ok()?;
+            .expect("resolved postgres url parses as a connection config");
+        let (admin, connection) = config
+            .connect(tokio_postgres::NoTls)
+            .await
+            .expect("connect to the resolved postgres server");
         tokio::spawn(async move {
             let _ = connection.await;
         });
@@ -2340,7 +2356,7 @@ mod postgres_tests {
         admin
             .execute(&format!("CREATE DATABASE {name}"), &[])
             .await
-            .ok()?;
+            .expect("create the isolated database (the role needs CREATEDB)");
 
         let mut isolated = config.clone();
         isolated.dbname(&name);
@@ -2348,10 +2364,16 @@ mod postgres_tests {
         let pool = deadpool_postgres::Pool::builder(manager)
             .max_size(4)
             .build()
-            .ok()?;
+            .expect("build a pool against the isolated database");
         let filesystem = PostgresRootFilesystem::new(pool);
-        filesystem.run_migrations().await.ok()?;
-        let (client, connection) = isolated.connect(tokio_postgres::NoTls).await.ok()?;
+        filesystem
+            .run_migrations()
+            .await
+            .expect("migrate the isolated database");
+        let (client, connection) = isolated
+            .connect(tokio_postgres::NoTls)
+            .await
+            .expect("connect to the isolated database");
         tokio::spawn(async move {
             let _ = connection.await;
         });

--- a/crates/ironclaw_processes/src/journal.rs
+++ b/crates/ironclaw_processes/src/journal.rs
@@ -447,6 +447,23 @@ pub trait ProcessJournalCommitObserver: Send + Sync {
     }
 
     async fn observe_process_commit(&self, commit: ProcessJournalCommit) -> Result<(), String>;
+
+    /// Deliver one committed batch in a single call, in cursor order.
+    ///
+    /// The journal commits many lifecycle commands per transaction, so an
+    /// observer that persists per commit can group a whole batch into one
+    /// round trip by overriding this. The default applies the per-commit
+    /// method in order, which is what an observer with no groupable work
+    /// wants.
+    async fn observe_process_commits(
+        &self,
+        commits: Vec<ProcessJournalCommit>,
+    ) -> Result<(), String> {
+        for commit in commits {
+            self.observe_process_commit(commit).await?;
+        }
+        Ok(())
+    }
 }
 
 pub trait ProcessJournalObserverRegistry: Send + Sync {

--- a/crates/ironclaw_processes/src/journal_store.rs
+++ b/crates/ironclaw_processes/src/journal_store.rs
@@ -16,7 +16,7 @@ use ironclaw_host_api::{ids::ProcessId, path::ScopedPath, resource::ResourceScop
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, OnceCell};
 
 use crate::ProcessRuntimePort;
 use crate::journal::{
@@ -39,6 +39,7 @@ use crate::journal::{
 use crate::types::{invalid_path, same_scope_owner};
 
 mod command;
+mod flusher;
 mod migration;
 mod observer;
 mod rows;
@@ -168,6 +169,8 @@ where
     migration: Arc<Mutex<()>>,
     materialized_ready: Arc<AtomicBool>,
     observers: Arc<StdMutex<Vec<RegisteredProcessObserver>>>,
+    /// Group-commit funnel, started on the first write so `new` stays sync.
+    flusher: Arc<OnceCell<flusher::FlusherHandle>>,
     lease_duration: Duration,
     concurrency_limits: ProcessConcurrencyLimits,
 }
@@ -182,6 +185,7 @@ where
             migration: Arc::clone(&self.migration),
             materialized_ready: Arc::clone(&self.materialized_ready),
             observers: Arc::clone(&self.observers),
+            flusher: Arc::clone(&self.flusher),
             lease_duration: self.lease_duration,
             concurrency_limits: self.concurrency_limits.clone(),
         }
@@ -198,8 +202,23 @@ where
             migration: Arc::new(Mutex::new(())),
             materialized_ready: Arc::new(AtomicBool::new(false)),
             observers: Arc::new(StdMutex::new(Vec::new())),
+            flusher: Arc::new(OnceCell::new()),
             lease_duration: DEFAULT_PROCESS_LEASE_DURATION,
             concurrency_limits: ProcessConcurrencyLimits::default(),
+        }
+    }
+
+    /// A handle whose funnel slot is empty.
+    ///
+    /// The flusher and delivery tasks own a store handle. Sharing the funnel's
+    /// `OnceCell` with them would make the command sender reachable from the
+    /// task that reads it, so the channel would never close and the tasks would
+    /// outlive every real store handle. Detached handles are used only for
+    /// reads and observer replay, never to submit commands.
+    fn detached(&self) -> Self {
+        Self {
+            flusher: Arc::new(OnceCell::new()),
+            ..self.clone()
         }
     }
 
@@ -216,7 +235,10 @@ where
     async fn submit_process_inner(
         &self,
         request: SubmitProcessRequest,
-    ) -> Result<(JournaledProcessSnapshot, bool), ProcessJournalStoreError> {
+    ) -> Result<(JournaledProcessSnapshot, bool), ProcessJournalStoreError>
+    where
+        F: Send + Sync + 'static,
+    {
         match self
             .execute(StoredProcessCommand::Submit(Box::new(request)))
             .await?
@@ -226,115 +248,41 @@ where
         }
     }
 
+    /// Submit one lifecycle command to the group-commit funnel and wait for its
+    /// durable outcome.
+    ///
+    /// The funnel batches concurrent commands into one transaction; see
+    /// [`flusher`] for why the write path and observer delivery run on separate
+    /// tasks.
     async fn execute(
         &self,
         command: StoredProcessCommand,
-    ) -> Result<StoredCommandOutcome, ProcessJournalStoreError> {
+    ) -> Result<StoredCommandOutcome, ProcessJournalStoreError>
+    where
+        F: Send + Sync + 'static,
+    {
         self.ensure_materialized().await?;
-        let references = command.load_references()?;
-        'transaction: for attempt in 0..MAX_TRANSACTION_RETRIES {
-            let mut loaded = match rows::load(self.filesystem.as_ref(), &references).await {
-                Ok(loaded) => loaded,
-                Err(ProcessJournalStoreError::Filesystem(error))
-                    if rows::retryable_transaction_error(&error) =>
-                {
-                    rows::retry_transaction(attempt).await;
-                    continue;
-                }
-                Err(error) => return Err(error),
-            };
-            let mut state = std::mem::take(&mut loaded.state);
-            let prefix = processes_prefix()?;
-            // Determine the exact number of journal entries before touching the
-            // global cursor allocator. Polling an empty queue used to reserve
-            // `max_processes` cursors despite producing no entries, so idle
-            // supervisors continuously contended with real submissions.
-            let mut preview = state.clone();
-            preview.apply_command(command.clone())?;
-            let reservation_count = command.cursor_reservation_count(preview.journal.len());
-            let sequence_path = self
-                .filesystem
-                .resolve(&ResourceScope::system(), &process_journal_sequence_path()?)?;
-            let mut txn = match self
-                .filesystem
-                .begin(&ResourceScope::system(), &prefix)
-                .await
-            {
-                Ok(txn) => txn,
-                Err(error) if rows::retryable_transaction_error(&error) => {
-                    rows::retry_transaction(attempt).await;
-                    continue;
-                }
-                Err(error) => return Err(error.into()),
-            };
-            let mut first_cursor = None;
-            if reservation_count > 0 {
-                for _ in 0..reservation_count {
-                    let reserved = match txn.reserve_sequence(&sequence_path).await {
-                        Ok(reserved) => reserved,
-                        Err(error) if rows::retryable_transaction_error(&error) => {
-                            txn.rollback().await;
-                            rows::retry_transaction(attempt).await;
-                            continue 'transaction;
-                        }
-                        Err(error) => {
-                            txn.rollback().await;
-                            return Err(error.into());
-                        }
-                    };
-                    first_cursor.get_or_insert(reserved.get());
-                }
-            }
-            if let Some(first_cursor) = first_cursor {
-                state.next_cursor = first_cursor;
-            }
-            // Reserve cursors and persist their journal/materialized rows in
-            // one transaction. The sequence row therefore serializes commit
-            // order: an observer can never advance past a lower cursor that
-            // was reserved by a writer which has not committed yet.
-            let outcome = match state.apply_command(command.clone()) {
-                Ok(outcome) => outcome,
-                Err(error) => {
-                    txn.rollback().await;
-                    return Err(error);
-                }
-            };
-            let entries = std::mem::take(&mut state.journal);
-            let result = async {
-                rows::persist(self.filesystem.as_ref(), txn.as_mut(), &loaded, &state).await?;
-                rows::persist_journal(self.filesystem.as_ref(), txn.as_mut(), entries.as_slice())
-                    .await?;
-                Ok::<(), ProcessJournalStoreError>(())
-            }
-            .await;
-            match result {
-                Ok(()) => match txn.commit().await {
-                    Ok(()) => return Ok(outcome),
-                    Err(error) if rows::retryable_transaction_error(&error) => {
-                        rows::retry_transaction(attempt).await;
-                    }
-                    Err(error) => return Err(error.into()),
-                },
-                Err(ProcessJournalStoreError::Filesystem(error))
-                    if rows::retryable_transaction_error(&error) =>
-                {
-                    txn.rollback().await;
-                    rows::retry_transaction(attempt).await;
-                }
-                Err(error) => {
-                    txn.rollback().await;
-                    return Err(error);
-                }
-            }
+        let (responder, response) = tokio::sync::oneshot::channel();
+        let queued = flusher::QueuedCommand {
+            command,
+            responder,
+            awaits_observer_delivery: !observer::inside_observer_delivery(),
+        };
+        if self.flusher().await.submit(queued).is_err() {
+            return Err(flusher::backend_busy(self));
         }
-        Err(ProcessJournalStoreError::Filesystem(
-            FilesystemError::BackendBusy {
-                path: self
-                    .filesystem
-                    .resolve(&ResourceScope::system(), &processes_prefix()?)?,
-                operation: ironclaw_filesystem::FilesystemOperation::BeginTxn,
-            },
-        ))
+        response
+            .await
+            .unwrap_or_else(|_| Err(flusher::backend_busy(self)))
+    }
+
+    async fn flusher(&self) -> &flusher::FlusherHandle
+    where
+        F: Send + Sync + 'static,
+    {
+        self.flusher
+            .get_or_init(|| async { flusher::spawn(self.detached()) })
+            .await
     }
 
     async fn load_process(
@@ -697,11 +645,10 @@ where
         &self,
         request: SubmitProcessRequest,
     ) -> Result<JournaledProcessSnapshot, Self::Error> {
-        let (snapshot, changed) = self.submit_process_inner(request).await?;
-        if changed {
-            self.notify_process_commit(snapshot.clone(), ProcessJournalKind::Submitted, None)
-                .await;
-        }
+        // Observer delivery is driven from the journal by the group-commit
+        // funnel, so it happens before this call returns without the wrapper
+        // replaying each outcome.
+        let (snapshot, _changed) = self.submit_process_inner(request).await?;
         Ok(snapshot)
     }
 
@@ -719,16 +666,12 @@ where
             self.execute(StoredProcessCommand::Submit(Box::new(request.submission)))
                 .await?
         };
-        let StoredCommandOutcome::Submitted(snapshot, changed) = outcome else {
+        let StoredCommandOutcome::Submitted(snapshot, _changed) = outcome else {
             return Err(unexpected_outcome(
                 "submit_process_with_checkpoint",
                 outcome,
             ));
         };
-        if changed {
-            self.notify_process_commit(snapshot.clone(), ProcessJournalKind::Submitted, None)
-                .await;
-        }
         Ok(snapshot)
     }
 }
@@ -787,10 +730,6 @@ where
             StoredCommandOutcome::Claimed(claimed) => claimed,
             outcome => return Err(unexpected_outcome("claim", outcome)),
         };
-        for process in &claimed {
-            self.notify_process_commit(process.state.clone(), ProcessJournalKind::Claimed, None)
-                .await;
-        }
         Ok(claimed)
     }
 
@@ -815,8 +754,6 @@ where
             StoredCommandOutcome::Heartbeat(snapshot) => snapshot,
             outcome => return Err(unexpected_outcome("heartbeat", outcome)),
         };
-        self.notify_process_commit(snapshot.clone(), ProcessJournalKind::Heartbeat, None)
-            .await;
         Ok(snapshot.journal_cursor)
     }
 
@@ -831,16 +768,6 @@ where
             StoredCommandOutcome::Recovered(response) => response,
             outcome => return Err(unexpected_outcome("recover_expired", outcome)),
         };
-        for snapshot in &response.recovered {
-            let kind = match snapshot.status {
-                ProcessLifecycleStatus::Queued => ProcessJournalKind::Resumed,
-                ProcessLifecycleStatus::Cancelled => ProcessJournalKind::Cancelled,
-                ProcessLifecycleStatus::Failed => ProcessJournalKind::Failed,
-                _ => ProcessJournalKind::RecoveryRequired,
-            };
-            self.notify_process_commit(snapshot.clone(), kind, None)
-                .await;
-        }
         Ok(response)
     }
 
@@ -1024,18 +951,13 @@ where
         &self,
         mutation: ProcessControlMutation,
     ) -> Result<ProcessControlResult, ProcessJournalStoreError> {
-        let reason = mutation.reason.clone();
-        let (result, committed_kind) = match self
+        let (result, _committed_kind) = match self
             .execute(StoredProcessCommand::Control(mutation))
             .await?
         {
             StoredCommandOutcome::Controlled(result, kind) => (result, kind),
             outcome => return Err(unexpected_outcome("control", outcome)),
         };
-        if let Some(kind) = committed_kind {
-            self.notify_process_commit(result.state.clone(), kind, reason)
-                .await;
-        }
         Ok(result)
     }
 
@@ -1044,7 +966,6 @@ where
         request: ProcessLeaseRequest,
         mutation: ProcessTransitionMutation,
     ) -> Result<JournaledProcessSnapshot, ProcessJournalStoreError> {
-        let kind = mutation.kind;
         let snapshot = match self
             .execute(StoredProcessCommand::LeasedTransition { request, mutation })
             .await?
@@ -1052,8 +973,6 @@ where
             StoredCommandOutcome::Transitioned(snapshot) => snapshot,
             outcome => return Err(unexpected_outcome("leased_transition", outcome)),
         };
-        self.notify_process_commit(snapshot.clone(), kind, None)
-            .await;
         Ok(snapshot)
     }
 }

--- a/crates/ironclaw_processes/src/journal_store.rs
+++ b/crates/ironclaw_processes/src/journal_store.rs
@@ -268,7 +268,7 @@ where
             responder,
             awaits_observer_delivery: !observer::inside_observer_delivery(),
         };
-        if self.flusher().await.submit(queued).is_err() {
+        if self.flusher().await.submit(queued).await.is_err() {
             return Err(flusher::backend_busy(self));
         }
         response

--- a/crates/ironclaw_processes/src/journal_store.rs
+++ b/crates/ironclaw_processes/src/journal_store.rs
@@ -110,6 +110,13 @@ pub enum ProcessJournalStoreError {
     Deserialization(String),
     #[error("process journal observer error: {0}")]
     Observer(String),
+    /// A group commit failed as a whole and was deliberately not replayed.
+    ///
+    /// Nothing in the batch committed. Replaying to attribute the failure
+    /// would let a command whose write was meant to fail succeed on the second
+    /// attempt, so every command in the batch observes this instead.
+    #[error("process journal group commit failed and was not replayed: {reason}")]
+    GroupCommitFailed { reason: String },
     #[error("legacy process lifecycle data requires migration before row-native initialization")]
     MigrationRequired,
 }

--- a/crates/ironclaw_processes/src/journal_store.rs
+++ b/crates/ironclaw_processes/src/journal_store.rs
@@ -135,7 +135,7 @@ enum StoredCommandOutcome {
     Heartbeat(JournaledProcessSnapshot),
     Recovered(RecoverExpiredProcessLeasesResponse),
     Transitioned(JournaledProcessSnapshot),
-    Controlled(ProcessControlResult, Option<ProcessJournalKind>),
+    Controlled(ProcessControlResult),
     TreeReserved(ProcessTreeReservation),
     TreeReleased,
     TreePruned,
@@ -958,14 +958,15 @@ where
         &self,
         mutation: ProcessControlMutation,
     ) -> Result<ProcessControlResult, ProcessJournalStoreError> {
-        let (result, _committed_kind) = match self
+        match self
             .execute(StoredProcessCommand::Control(mutation))
             .await?
         {
-            StoredCommandOutcome::Controlled(result, kind) => (result, kind),
-            outcome => return Err(unexpected_outcome("control", outcome)),
-        };
-        Ok(result)
+            // Observer delivery derives kinds from the committed journal
+            // entries, so the control outcome carries only its result.
+            StoredCommandOutcome::Controlled(result) => Ok(result),
+            outcome => Err(unexpected_outcome("control", outcome)),
+        }
     }
 
     async fn leased_transition(

--- a/crates/ironclaw_processes/src/journal_store/command.rs
+++ b/crates/ironclaw_processes/src/journal_store/command.rs
@@ -59,6 +59,13 @@ impl StoredProcessCommand {
         }
     }
 
+    /// Legacy import rewrites the cursor allocator wholesale and reserves a
+    /// range the batch preview cannot account for, so it never shares a
+    /// group-commit transaction with ordinary lifecycle commands.
+    pub(super) fn requires_solo_transaction(&self) -> bool {
+        matches!(self, Self::ImportLegacyState(_))
+    }
+
     pub(super) fn load_references(
         &self,
     ) -> Result<rows::LoadReferences, super::ProcessJournalStoreError> {
@@ -70,10 +77,14 @@ impl StoredProcessCommand {
                 references.process_ids.extend(request.parent_process_id);
                 references.process_ids.extend(request.root_process_id);
                 references.tree_roots.extend(request.root_process_id);
-                references.submission_idempotency_key = submission_replay_key(request)?;
-                references.active_conflict = request
-                    .exclusive_within_scope
-                    .then(|| (request.scope.clone(), request.process_kind.clone()));
+                references
+                    .submission_idempotency_keys
+                    .extend(submission_replay_key(request)?);
+                references.active_conflicts.extend(
+                    request
+                        .exclusive_within_scope
+                        .then(|| (request.scope.clone(), request.process_kind.clone())),
+                );
                 if let Some(dependency) = &request.dependency {
                     references.process_ids.push(dependency.dependent_process_id);
                     references.process_ids.push(dependency.root_process_id);
@@ -92,17 +103,19 @@ impl StoredProcessCommand {
                 request, limits, ..
             } => {
                 references.process_ids.extend(request.process_id_filter);
-                references.claim = Some((request.clone(), limits.clone()));
+                references.claims.push((request.clone(), limits.clone()));
             }
             Self::RecoverExpired(request) => {
-                references.recover_expired = Some(request.clone());
+                references.recover_expired.push(request.clone());
             }
             Self::Heartbeat { request, .. } | Self::LeasedTransition { request, .. } => {
                 references.process_ids.push(request.process_id);
             }
             Self::Control(mutation) => {
                 references.process_ids.push(mutation.process_id);
-                references.control_idempotency_key = control_replay_key(mutation);
+                references
+                    .control_idempotency_keys
+                    .extend(control_replay_key(mutation));
             }
             Self::ReserveTree(request) => {
                 references.process_ids.push(request.root_process_id);
@@ -146,16 +159,7 @@ impl StoredProcessCommand {
                 references.checkpoints.push(request.checkpoint_id.clone());
             }
         }
-        references
-            .process_ids
-            .sort_by_key(|process_id| process_id.as_uuid());
-        references.process_ids.dedup();
-        references.tree_roots.sort_by_key(ProcessId::as_uuid);
-        references.tree_roots.dedup();
-        references
-            .dependencies
-            .sort_by_key(|(dependent, dependency)| (dependent.as_uuid(), dependency.as_uuid()));
-        references.dependencies.dedup();
+        references.normalize();
         Ok(references)
     }
 }

--- a/crates/ironclaw_processes/src/journal_store/flusher.rs
+++ b/crates/ironclaw_processes/src/journal_store/flusher.rs
@@ -325,11 +325,47 @@ fn clone_transaction_error(error: &ProcessJournalStoreError) -> ProcessJournalSt
     // server and return a stable category; the classification callers act on is
     // "transient, re-issue", which needs no detail.
     //
+    // The log gets the category, not the error. Logging `%error` would put the
+    // same resolved path into the log that this function exists to keep out of
+    // the response — sanitizing only the returned value moves the leak rather
+    // than closing it. The variant name still says which class of failure
+    // rolled the batch back, which is what a diagnosis starts from.
+    //
     // `debug!` rather than `warn!`: this runs on a background task, and higher
     // levels corrupt the REPL/TUI display (see CLAUDE.md logging guidance).
-    tracing::debug!(cause = %error, "process journal group commit rolled back");
+    tracing::debug!(
+        category = group_commit_failure_category(error),
+        "process journal group commit rolled back"
+    );
     ProcessJournalStoreError::GroupCommitFailed {
         reason: "group commit rolled back".to_string(),
+    }
+}
+
+/// A closed set of failure categories safe to log.
+///
+/// Deliberately the variant name only: several variants Display a resolved
+/// `VirtualPath` or backend error text, and none of that may reach a log.
+fn group_commit_failure_category(error: &ProcessJournalStoreError) -> &'static str {
+    match error {
+        ProcessJournalStoreError::UnknownProcess { .. } => "unknown_process",
+        ProcessJournalStoreError::ProcessAlreadyExists { .. } => "process_already_exists",
+        ProcessJournalStoreError::ActiveProcessConflict { .. } => "active_process_conflict",
+        ProcessJournalStoreError::InvalidTransition { .. } => "invalid_transition",
+        ProcessJournalStoreError::InvalidLease { .. } => "invalid_lease",
+        ProcessJournalStoreError::UnauthorizedScope => "unauthorized_scope",
+        ProcessJournalStoreError::InvalidRequest(_) => "invalid_request",
+        ProcessJournalStoreError::ProcessTreeCapacityExceeded { .. } => {
+            "process_tree_capacity_exceeded"
+        }
+        ProcessJournalStoreError::StaleSnapshot { .. } => "stale_snapshot",
+        ProcessJournalStoreError::InvalidPath(_) => "invalid_path",
+        ProcessJournalStoreError::Filesystem(_) => "filesystem",
+        ProcessJournalStoreError::Serialization(_) => "serialization",
+        ProcessJournalStoreError::Deserialization(_) => "deserialization",
+        ProcessJournalStoreError::Observer(_) => "observer",
+        ProcessJournalStoreError::GroupCommitFailed { .. } => "group_commit_failed",
+        ProcessJournalStoreError::MigrationRequired => "migration_required",
     }
 }
 

--- a/crates/ironclaw_processes/src/journal_store/flusher.rs
+++ b/crates/ironclaw_processes/src/journal_store/flusher.rs
@@ -1,0 +1,450 @@
+//! Group-commit funnel for the process journal write path.
+//!
+//! Every lifecycle command used to own a backend transaction and reserve its
+//! journal cursors one at a time from the single global sequence row. On
+//! PostgreSQL that row's lock is held until commit, so unrelated commands
+//! system-wide serialized behind one full transaction round trip each.
+//!
+//! A single writer task now drains the command queue and commits many commands
+//! in one transaction: global metadata and the shared idempotency-order row are
+//! read once per batch, and the whole cursor range is reserved with one call.
+//! This is a single-writer funnel, not a lock around I/O — no process-local
+//! mutex is held across a backend call (see `.claude/rules/database.md`).
+//!
+//! Observer delivery runs on its own task rather than inline in the flusher.
+//! Observer callbacks legitimately re-enter the store (the sub-agent await-edge
+//! resolver settles dependencies and resumes the parent process from inside
+//! `observe_process_commit`), so a flusher that blocked on delivery could never
+//! commit the command delivery is waiting on.
+
+use std::mem;
+
+use ironclaw_filesystem::{FilesystemError, FilesystemOperation, RootFilesystem};
+use ironclaw_host_api::resource::ResourceScope;
+use tokio::sync::{mpsc, oneshot};
+
+use super::{
+    MAX_TRANSACTION_RETRIES, ProcessJournalStore, ProcessJournalStoreError, StoredCommandOutcome,
+    StoredProcessCommand, process_journal_sequence_path, processes_prefix, rows,
+};
+use crate::ProcessJournalCursor;
+
+/// Upper bound on how many commands share one transaction. The flusher never
+/// waits to fill a batch: it commits whatever is already queued, so a single
+/// caller pays no added latency and batches only form under real contention.
+const MAX_BATCH_COMMANDS: usize = 64;
+
+type CommandResult = Result<StoredCommandOutcome, ProcessJournalStoreError>;
+type CommandResponder = oneshot::Sender<CommandResult>;
+
+pub(super) struct QueuedCommand {
+    pub(super) command: StoredProcessCommand,
+    pub(super) responder: CommandResponder,
+    /// `false` for commands issued from inside an observer callback, which must
+    /// not wait on the delivery their own caller is blocking.
+    pub(super) awaits_observer_delivery: bool,
+}
+
+pub(super) struct FlusherHandle {
+    commands: mpsc::UnboundedSender<QueuedCommand>,
+}
+
+/// The funnel is gone because every store handle that owned it was dropped.
+pub(super) struct FunnelClosed;
+
+impl FlusherHandle {
+    pub(super) fn submit(&self, queued: QueuedCommand) -> Result<(), FunnelClosed> {
+        match self.commands.send(queued) {
+            Ok(()) => Ok(()),
+            // The channel closes only when the flusher task is gone. The
+            // command was never queued and its responder is dropped with it.
+            Err(_never_queued) => Err(FunnelClosed),
+        }
+    }
+}
+
+/// The error every caller of a batch that could not reach a durable commit
+/// observes, matching the per-command retry-exhaustion error.
+pub(super) fn backend_busy<F>(store: &ProcessJournalStore<F>) -> ProcessJournalStoreError
+where
+    F: RootFilesystem,
+{
+    let resolved = processes_prefix().and_then(|prefix| {
+        store
+            .filesystem
+            .resolve(&ResourceScope::system(), &prefix)
+            .map_err(ProcessJournalStoreError::from)
+    });
+    match resolved {
+        Ok(path) => ProcessJournalStoreError::Filesystem(FilesystemError::BackendBusy {
+            path,
+            operation: FilesystemOperation::BeginTxn,
+        }),
+        Err(error) => error,
+    }
+}
+
+/// Start the funnel. `store` must be a detached handle so the tasks below do
+/// not keep the command channel alive after every real store handle is dropped.
+pub(super) fn spawn<F>(store: ProcessJournalStore<F>) -> FlusherHandle
+where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    let (commands, command_receiver) = mpsc::unbounded_channel();
+    let (deliveries, delivery_receiver) = mpsc::unbounded_channel();
+    tokio::spawn(run_delivery(store.clone(), delivery_receiver));
+    tokio::spawn(run_flusher(store, command_receiver, deliveries));
+    FlusherHandle { commands }
+}
+
+struct DeliveryBatch {
+    target: ProcessJournalCursor,
+    waiters: Vec<(CommandResponder, CommandResult)>,
+}
+
+impl DeliveryBatch {
+    fn release(self) {
+        for (responder, result) in self.waiters {
+            let _ = responder.send(result);
+        }
+    }
+}
+
+async fn run_flusher<F>(
+    store: ProcessJournalStore<F>,
+    mut receiver: mpsc::UnboundedReceiver<QueuedCommand>,
+    deliveries: mpsc::UnboundedSender<DeliveryBatch>,
+) where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    let mut carried: Option<QueuedCommand> = None;
+    loop {
+        let first = match carried.take() {
+            Some(queued) => queued,
+            None => match receiver.recv().await {
+                Some(queued) => queued,
+                None => break,
+            },
+        };
+        let mut batch = Vec::with_capacity(1);
+        let solo = first.command.requires_solo_transaction();
+        batch.push(first);
+        if !solo {
+            while batch.len() < MAX_BATCH_COMMANDS {
+                let Ok(queued) = receiver.try_recv() else {
+                    break;
+                };
+                if queued.command.requires_solo_transaction() {
+                    carried = Some(queued);
+                    break;
+                }
+                batch.push(queued);
+            }
+        }
+        flush_batch(&store, batch, &deliveries).await;
+    }
+}
+
+async fn run_delivery<F>(
+    store: ProcessJournalStore<F>,
+    mut receiver: mpsc::UnboundedReceiver<DeliveryBatch>,
+) where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    while let Some(first) = receiver.recv().await {
+        let mut target = first.target;
+        let mut waiters = first.waiters;
+        while let Ok(next) = receiver.try_recv() {
+            if next.target.0 > target.0 {
+                target = next.target;
+            }
+            waiters.extend(next.waiters);
+        }
+        for observer in store.registered_observers() {
+            if let Err(error) = store
+                .replay_durable_observer_once(&observer, Some(target))
+                .await
+            {
+                tracing::warn!(
+                    observer_id = %observer.id,
+                    cursor = target.0,
+                    %error,
+                    "process journal observer delivery failed after durable commit"
+                );
+                // Commit durability is the caller's contract; delivery retries
+                // in the background exactly as it did per commit.
+                store.spawn_observer_replay(observer);
+            }
+        }
+        DeliveryBatch { target, waiters }.release();
+    }
+}
+
+struct PendingCommand {
+    command: StoredProcessCommand,
+    references: rows::LoadReferences,
+    responder: Option<CommandResponder>,
+    awaits_observer_delivery: bool,
+    outcome: Option<StoredCommandOutcome>,
+}
+
+impl PendingCommand {
+    fn is_live(&self) -> bool {
+        self.responder.is_some()
+    }
+
+    fn respond(&mut self, result: CommandResult) {
+        if let Some(responder) = self.responder.take() {
+            let _ = responder.send(result);
+        }
+    }
+}
+
+async fn flush_batch<F>(
+    store: &ProcessJournalStore<F>,
+    batch: Vec<QueuedCommand>,
+    deliveries: &mpsc::UnboundedSender<DeliveryBatch>,
+) where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    let mut pending = Vec::with_capacity(batch.len());
+    for queued in batch {
+        match queued.command.load_references() {
+            Ok(references) => pending.push(PendingCommand {
+                command: queued.command,
+                references,
+                responder: Some(queued.responder),
+                awaits_observer_delivery: queued.awaits_observer_delivery,
+                outcome: None,
+            }),
+            Err(error) => {
+                let _ = queued.responder.send(Err(error));
+            }
+        }
+    }
+    let Err(error) = commit_pending(store, &mut pending, deliveries).await else {
+        return;
+    };
+    let mut live = pending
+        .into_iter()
+        .filter(PendingCommand::is_live)
+        .collect::<Vec<_>>();
+    if live.len() <= 1 {
+        respond_first_live(&mut live, error);
+        return;
+    }
+    // The transaction failed for the batch as a whole. Retry each command in
+    // its own transaction so every caller observes the error its own command
+    // produced instead of a neighbour's.
+    tracing::warn!(
+        %error,
+        commands = live.len(),
+        "process journal group commit failed; retrying commands individually"
+    );
+    for command in live {
+        let mut single = vec![command];
+        if let Err(error) = commit_pending(store, &mut single, deliveries).await {
+            respond_first_live(&mut single, error);
+        }
+    }
+}
+
+fn respond_first_live(pending: &mut [PendingCommand], error: ProcessJournalStoreError) {
+    if let Some(command) = pending.iter_mut().find(|command| command.is_live()) {
+        command.respond(Err(error));
+    }
+}
+
+/// Commit every live command in `pending` in one transaction.
+///
+/// Per-command validation failures are answered here and are final, matching
+/// the previous one-transaction-per-command semantics. `Err` means the
+/// transaction itself failed non-retryably and the batch is still unanswered.
+async fn commit_pending<F>(
+    store: &ProcessJournalStore<F>,
+    pending: &mut [PendingCommand],
+    deliveries: &mpsc::UnboundedSender<DeliveryBatch>,
+) -> Result<(), ProcessJournalStoreError>
+where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    let prefix = processes_prefix()?;
+    let sequence_path = store
+        .filesystem
+        .resolve(&ResourceScope::system(), &process_journal_sequence_path()?)?;
+    'transaction: for attempt in 0..MAX_TRANSACTION_RETRIES {
+        if !pending.iter().any(PendingCommand::is_live) {
+            return Ok(());
+        }
+        let mut references = rows::LoadReferences::default();
+        for command in pending.iter().filter(|command| command.is_live()) {
+            references.merge_from(&command.references);
+        }
+        let mut loaded = match rows::load(store.filesystem.as_ref(), &references).await {
+            Ok(loaded) => loaded,
+            Err(ProcessJournalStoreError::Filesystem(error))
+                if rows::retryable_transaction_error(&error) =>
+            {
+                rows::retry_transaction(attempt).await;
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        let mut state = mem::take(&mut loaded.state);
+
+        // Determine the exact number of journal entries before touching the
+        // global cursor allocator. Polling an empty queue used to reserve
+        // `max_processes` cursors despite producing no entries, so idle
+        // supervisors continuously contended with real submissions.
+        let mut preview = state.clone();
+        let mut reservations = 0_usize;
+        for command in pending.iter_mut().filter(|command| command.is_live()) {
+            let mut candidate = preview.clone();
+            match candidate.apply_command(command.command.clone()) {
+                Ok(_) => {
+                    let generated = candidate.journal.len();
+                    candidate.journal.clear();
+                    reservations = reservations
+                        .saturating_add(command.command.cursor_reservation_count(generated));
+                    preview = candidate;
+                }
+                Err(error) => command.respond(Err(error)),
+            }
+        }
+        drop(preview);
+        if !pending.iter().any(PendingCommand::is_live) {
+            return Ok(());
+        }
+
+        let mut txn = match store
+            .filesystem
+            .begin(&ResourceScope::system(), &prefix)
+            .await
+        {
+            Ok(txn) => txn,
+            Err(error) if rows::retryable_transaction_error(&error) => {
+                rows::retry_transaction(attempt).await;
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
+        // Reserving the cursor range must stay inside the transaction: the
+        // sequence row's lock is what orders commits, so an observer can never
+        // advance past a lower cursor reserved by a writer that has not
+        // committed yet.
+        if reservations > 0 {
+            let count = reservations as u64;
+            let last = match txn.reserve_sequence_range(&sequence_path, count).await {
+                Ok(last) => last,
+                Err(error) if rows::retryable_transaction_error(&error) => {
+                    txn.rollback().await;
+                    rows::retry_transaction(attempt).await;
+                    continue 'transaction;
+                }
+                Err(error) => {
+                    txn.rollback().await;
+                    return Err(error.into());
+                }
+            };
+            state.next_cursor = last.get().saturating_sub(count).saturating_add(1);
+        }
+
+        let mut entries = Vec::new();
+        for command in pending.iter_mut().filter(|command| command.is_live()) {
+            // Apply against a clone so one command failing validation drops
+            // only its own mutations and leaves the rest of the batch intact.
+            // Its share of the reserved cursor range is then simply unused;
+            // journal readers page by cursor order and tolerate gaps.
+            let mut candidate = state.clone();
+            match candidate.apply_command(command.command.clone()) {
+                Ok(outcome) => {
+                    entries.append(&mut candidate.journal);
+                    state = candidate;
+                    command.outcome = Some(outcome);
+                }
+                Err(error) => command.respond(Err(error)),
+            }
+        }
+        let committed_cursor = entries.last().map(|entry| entry.cursor);
+        let result = async {
+            rows::persist(store.filesystem.as_ref(), txn.as_mut(), &loaded, &state).await?;
+            rows::persist_journal(store.filesystem.as_ref(), txn.as_mut(), entries.as_slice())
+                .await?;
+            Ok::<(), ProcessJournalStoreError>(())
+        }
+        .await;
+        match result {
+            Ok(()) => match txn.commit().await {
+                Ok(()) => {
+                    release_committed_batch(store, pending, committed_cursor, deliveries);
+                    return Ok(());
+                }
+                Err(error) if rows::retryable_transaction_error(&error) => {
+                    discard_outcomes(pending);
+                    rows::retry_transaction(attempt).await;
+                }
+                Err(error) => return Err(error.into()),
+            },
+            Err(ProcessJournalStoreError::Filesystem(error))
+                if rows::retryable_transaction_error(&error) =>
+            {
+                txn.rollback().await;
+                discard_outcomes(pending);
+                rows::retry_transaction(attempt).await;
+            }
+            Err(error) => {
+                txn.rollback().await;
+                return Err(error);
+            }
+        }
+    }
+    for command in pending.iter_mut() {
+        let error = backend_busy(store);
+        command.respond(Err(error));
+    }
+    Ok(())
+}
+
+fn discard_outcomes(pending: &mut [PendingCommand]) {
+    for command in pending.iter_mut() {
+        command.outcome = None;
+    }
+}
+
+/// Answer a committed batch, holding back callers that require read-your-writes
+/// until this batch has been delivered to every registered observer.
+fn release_committed_batch<F>(
+    store: &ProcessJournalStore<F>,
+    pending: &mut [PendingCommand],
+    committed_cursor: Option<ProcessJournalCursor>,
+    deliveries: &mpsc::UnboundedSender<DeliveryBatch>,
+) where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    let deliver = committed_cursor.is_some() && !store.registered_observers().is_empty();
+    let mut waiters = Vec::new();
+    for command in pending.iter_mut() {
+        let Some(outcome) = command.outcome.take() else {
+            continue;
+        };
+        let Some(responder) = command.responder.take() else {
+            continue;
+        };
+        if deliver && command.awaits_observer_delivery {
+            waiters.push((responder, Ok(outcome)));
+        } else {
+            let _ = responder.send(Ok(outcome));
+        }
+    }
+    let Some(target) = committed_cursor.filter(|_| deliver) else {
+        return;
+    };
+    let batch = DeliveryBatch { target, waiters };
+    if let Err(undeliverable) = deliveries.send(batch) {
+        tracing::warn!(
+            cursor = target.0,
+            "process journal delivery task is gone; committed batch will not be delivered"
+        );
+        undeliverable.0.release();
+    }
+}

--- a/crates/ironclaw_processes/src/journal_store/flusher.rs
+++ b/crates/ironclaw_processes/src/journal_store/flusher.rs
@@ -25,9 +25,10 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::{
     MAX_TRANSACTION_RETRIES, ProcessJournalStore, ProcessJournalStoreError, StoredCommandOutcome,
-    StoredProcessCommand, process_journal_sequence_path, processes_prefix, rows,
+    StoredProcessCommand, observer::CommittedBatch, process_journal_sequence_path,
+    processes_prefix, rows,
 };
-use crate::ProcessJournalCursor;
+use crate::{ProcessJournalCommit, ProcessJournalEntry};
 
 /// Upper bound on how many commands share one transaction. The flusher never
 /// waits to fill a batch: it commits whatever is already queued, so a single
@@ -98,11 +99,28 @@ where
 }
 
 struct DeliveryBatch {
-    target: ProcessJournalCursor,
+    committed: CommittedBatch,
     waiters: Vec<(CommandResponder, CommandResult)>,
 }
 
 impl DeliveryBatch {
+    /// Whether `next` starts exactly where this batch ends.
+    ///
+    /// Only then may the two be delivered as one range: a gap could hold
+    /// another writer's committed entries, and folding over it would advance
+    /// the observer cursor past entries that were never delivered.
+    fn precedes(&self, next: &DeliveryBatch) -> bool {
+        self.committed.last.0.saturating_add(1) == next.committed.first.0
+    }
+
+    /// Fold a directly following batch into this one so a run of commits is
+    /// delivered in a single pass, in cursor order.
+    fn absorb(&mut self, next: DeliveryBatch) {
+        self.committed.last = next.committed.last;
+        self.committed.commits.extend(next.committed.commits);
+        self.waiters.extend(next.waiters);
+    }
+
     fn release(self) {
         for (responder, result) in self.waiters {
             let _ = responder.send(result);
@@ -151,33 +169,52 @@ async fn run_delivery<F>(
 ) where
     F: RootFilesystem + Send + Sync + 'static,
 {
-    while let Some(first) = receiver.recv().await {
-        let mut target = first.target;
-        let mut waiters = first.waiters;
+    let mut carried: Option<DeliveryBatch> = None;
+    loop {
+        let mut batch = match carried.take() {
+            Some(batch) => batch,
+            None => match receiver.recv().await {
+                Some(batch) => batch,
+                None => break,
+            },
+        };
         while let Ok(next) = receiver.try_recv() {
-            if next.target.0 > target.0 {
-                target = next.target;
-            }
-            waiters.extend(next.waiters);
-        }
-        for observer in store.registered_observers() {
-            if let Err(error) = store
-                .replay_durable_observer_once(&observer, Some(target))
-                .await
-            {
-                tracing::warn!(
-                    observer_id = %observer.id,
-                    cursor = target.0,
-                    %error,
-                    "process journal observer delivery failed after durable commit"
-                );
-                // Commit durability is the caller's contract; delivery retries
-                // in the background exactly as it did per commit.
-                store.spawn_observer_replay(observer);
+            if batch.precedes(&next) {
+                batch.absorb(next);
+            } else {
+                carried = Some(next);
+                break;
             }
         }
-        DeliveryBatch { target, waiters }.release();
+        deliver_batch(&store, &batch.committed).await;
+        batch.release();
     }
+}
+
+/// Deliver one committed range to every observer.
+///
+/// Observers own independent cursors and stores, so they run concurrently:
+/// delivery sits between a commit and the release of its foreground waiters,
+/// and serializing independent observers there adds their latencies together.
+async fn deliver_batch<F>(store: &ProcessJournalStore<F>, committed: &CommittedBatch)
+where
+    F: RootFilesystem + Send + Sync + 'static,
+{
+    let observers = store.registered_observers();
+    futures::future::join_all(observers.into_iter().map(|observer| async move {
+        if let Err(error) = store.deliver_committed_batch(&observer, committed).await {
+            tracing::warn!(
+                observer_id = %observer.id,
+                cursor = committed.last.0,
+                %error,
+                "process journal observer delivery failed after durable commit"
+            );
+            // Commit durability is the caller's contract; delivery retries in
+            // the background exactly as it did per commit.
+            store.spawn_observer_replay(observer);
+        }
+    }))
+    .await;
 }
 
 struct PendingCommand {
@@ -365,7 +402,6 @@ where
                 Err(error) => command.respond(Err(error)),
             }
         }
-        let committed_cursor = entries.last().map(|entry| entry.cursor);
         let result = async {
             rows::persist(store.filesystem.as_ref(), txn.as_mut(), &loaded, &state).await?;
             rows::persist_journal(store.filesystem.as_ref(), txn.as_mut(), entries.as_slice())
@@ -376,7 +412,10 @@ where
         match result {
             Ok(()) => match txn.commit().await {
                 Ok(()) => {
-                    release_committed_batch(store, pending, committed_cursor, deliveries);
+                    // The committed entries are the delivery payload: observers
+                    // are fed from memory instead of paging the journal back
+                    // out of the backend.
+                    release_committed_batch(store, pending, committed_batch(entries), deliveries);
                     return Ok(());
                 }
                 Err(error) if rows::retryable_transaction_error(&error) => {
@@ -411,17 +450,41 @@ fn discard_outcomes(pending: &mut [PendingCommand]) {
     }
 }
 
+/// Turn the entries this transaction committed into the delivery payload.
+///
+/// Entries without committed state advance the observer cursor but carry
+/// nothing to deliver, so they bound the range without joining `commits`.
+fn committed_batch(entries: Vec<ProcessJournalEntry>) -> Option<CommittedBatch> {
+    let first = entries.first()?.cursor;
+    let last = entries.last()?.cursor;
+    let commits = entries
+        .into_iter()
+        .filter_map(|entry| {
+            entry.committed_state.map(|state| ProcessJournalCommit {
+                state: *state,
+                kind: entry.kind,
+                sanitized_reason: entry.sanitized_reason,
+            })
+        })
+        .collect();
+    Some(CommittedBatch {
+        first,
+        last,
+        commits,
+    })
+}
+
 /// Answer a committed batch, holding back callers that require read-your-writes
 /// until this batch has been delivered to every registered observer.
 fn release_committed_batch<F>(
     store: &ProcessJournalStore<F>,
     pending: &mut [PendingCommand],
-    committed_cursor: Option<ProcessJournalCursor>,
+    committed: Option<CommittedBatch>,
     deliveries: &mpsc::UnboundedSender<DeliveryBatch>,
 ) where
     F: RootFilesystem + Send + Sync + 'static,
 {
-    let deliver = committed_cursor.is_some() && !store.registered_observers().is_empty();
+    let deliver = committed.is_some() && !store.registered_observers().is_empty();
     let mut waiters = Vec::new();
     for command in pending.iter_mut() {
         let Some(outcome) = command.outcome.take() else {
@@ -436,13 +499,14 @@ fn release_committed_batch<F>(
             let _ = responder.send(Ok(outcome));
         }
     }
-    let Some(target) = committed_cursor.filter(|_| deliver) else {
+    let Some(committed) = committed.filter(|_| deliver) else {
         return;
     };
-    let batch = DeliveryBatch { target, waiters };
+    let cursor = committed.last.0;
+    let batch = DeliveryBatch { committed, waiters };
     if let Err(undeliverable) = deliveries.send(batch) {
         tracing::warn!(
-            cursor = target.0,
+            cursor,
             "process journal delivery task is gone; committed batch will not be delivered"
         );
         undeliverable.0.release();

--- a/crates/ironclaw_processes/src/journal_store/flusher.rs
+++ b/crates/ironclaw_processes/src/journal_store/flusher.rs
@@ -289,19 +289,35 @@ async fn flush_batch<F>(
         respond_first_live(&mut live, error);
         return;
     }
-    // The transaction failed for the batch as a whole. Retry each command in
-    // its own transaction so every caller observes the error its own command
-    // produced instead of a neighbour's.
-    tracing::warn!(
+    // The transaction failed as a whole and nothing in it committed. Every
+    // live command observes that failure.
+    //
+    // Re-executing them individually to attribute the error would be wrong:
+    // the batch already consumed whatever externally observable effect the
+    // backend applied before failing, so a command whose write was supposed
+    // to fail can succeed on the replay and report a durable state it never
+    // reached (a one-shot store fault reaching its retry, observed as
+    // Completed/Failed where the contract requires Running). Reporting the
+    // rollback to all of them is truthful — none of them committed — and a
+    // caller that wants another attempt re-issues its own command.
+    tracing::debug!(
         %error,
         commands = live.len(),
-        "process journal group commit failed; retrying commands individually"
+        "process journal group commit failed; failing the batch without replay"
     );
-    for command in live {
-        let mut single = vec![command];
-        if let Err(error) = commit_pending(store, &mut single, deliveries).await {
-            respond_first_live(&mut single, error);
-        }
+    for command in live.iter_mut() {
+        command.respond(Err(clone_transaction_error(&error)));
+    }
+}
+
+/// Reproduce a batch-wide transaction failure for each caller.
+///
+/// `ProcessJournalStoreError` is not `Clone` (it carries backend error types),
+/// so the batch failure is re-expressed per command with its cause preserved
+/// in the message.
+fn clone_transaction_error(error: &ProcessJournalStoreError) -> ProcessJournalStoreError {
+    ProcessJournalStoreError::GroupCommitFailed {
+        reason: error.to_string(),
     }
 }
 

--- a/crates/ironclaw_processes/src/journal_store/flusher.rs
+++ b/crates/ironclaw_processes/src/journal_store/flusher.rs
@@ -318,8 +318,18 @@ async fn flush_batch<F>(
 /// so the batch failure is re-expressed per command with its cause preserved
 /// in the message.
 fn clone_transaction_error(error: &ProcessJournalStoreError) -> ProcessJournalStoreError {
+    // The batch's own error text is not safe to hand back. A `FilesystemError`
+    // Displays the resolved `VirtualPath` it failed on, and this value reaches
+    // callers as a product-facing `TurnError::Unavailable`, so the raw string
+    // would carry a backend path across a public surface. Keep the cause on the
+    // server and return a stable category; the classification callers act on is
+    // "transient, re-issue", which needs no detail.
+    //
+    // `debug!` rather than `warn!`: this runs on a background task, and higher
+    // levels corrupt the REPL/TUI display (see CLAUDE.md logging guidance).
+    tracing::debug!(cause = %error, "process journal group commit rolled back");
     ProcessJournalStoreError::GroupCommitFailed {
-        reason: error.to_string(),
+        reason: "group commit rolled back".to_string(),
     }
 }
 

--- a/crates/ironclaw_processes/src/journal_store/flusher.rs
+++ b/crates/ironclaw_processes/src/journal_store/flusher.rs
@@ -46,16 +46,30 @@ pub(super) struct QueuedCommand {
     pub(super) awaits_observer_delivery: bool,
 }
 
+/// Queue depth for lifecycle commands awaiting a batch.
+///
+/// The funnel is the one writer, so an unbounded queue would let a stalled
+/// backend accumulate one boxed request per in-flight caller with no ceiling.
+/// A bounded queue turns that into backpressure at `execute`. It also bounds
+/// the delivery queue transitively: every delivery batch comes from commands
+/// that passed through here.
+const COMMAND_QUEUE_CAPACITY: usize = 1_024;
+
 pub(super) struct FlusherHandle {
-    commands: mpsc::UnboundedSender<QueuedCommand>,
+    commands: mpsc::Sender<QueuedCommand>,
 }
 
 /// The funnel is gone because every store handle that owned it was dropped.
 pub(super) struct FunnelClosed;
 
 impl FlusherHandle {
-    pub(super) fn submit(&self, queued: QueuedCommand) -> Result<(), FunnelClosed> {
-        match self.commands.send(queued) {
+    /// Enqueue a command, waiting for room when the funnel is saturated.
+    ///
+    /// Waiting here is the backpressure: the flusher drains continuously and
+    /// never blocks on a caller, so a queued caller cannot stall the drain
+    /// (including the re-entrant commands observer callbacks issue).
+    pub(super) async fn submit(&self, queued: QueuedCommand) -> Result<(), FunnelClosed> {
+        match self.commands.send(queued).await {
             Ok(()) => Ok(()),
             // The channel closes only when the flusher task is gone. The
             // command was never queued and its responder is dropped with it.
@@ -91,7 +105,12 @@ pub(super) fn spawn<F>(store: ProcessJournalStore<F>) -> FlusherHandle
 where
     F: RootFilesystem + Send + Sync + 'static,
 {
-    let (commands, command_receiver) = mpsc::unbounded_channel();
+    let (commands, command_receiver) = mpsc::channel(COMMAND_QUEUE_CAPACITY);
+    // Deliveries stay unbounded deliberately. Observer callbacks re-enter the
+    // store (the await-edge resolver settles dependencies from inside one), so
+    // a full delivery queue would block the flusher while the delivery task
+    // waits on a command the flusher can no longer accept. Its depth is
+    // already bounded by the command queue that feeds it.
     let (deliveries, delivery_receiver) = mpsc::unbounded_channel();
     tokio::spawn(run_delivery(store.clone(), delivery_receiver));
     tokio::spawn(run_flusher(store, command_receiver, deliveries));
@@ -130,7 +149,7 @@ impl DeliveryBatch {
 
 async fn run_flusher<F>(
     store: ProcessJournalStore<F>,
-    mut receiver: mpsc::UnboundedReceiver<QueuedCommand>,
+    mut receiver: mpsc::Receiver<QueuedCommand>,
     deliveries: mpsc::UnboundedSender<DeliveryBatch>,
 ) where
     F: RootFilesystem + Send + Sync + 'static,
@@ -317,6 +336,8 @@ where
         for command in pending.iter().filter(|command| command.is_live()) {
             references.merge_from(&command.references);
         }
+        // One pass over the fully merged batch, so a row is read once.
+        references.normalize();
         let mut loaded = match rows::load(store.filesystem.as_ref(), &references).await {
             Ok(loaded) => loaded,
             Err(ProcessJournalStoreError::Filesystem(error))

--- a/crates/ironclaw_processes/src/journal_store/flusher.rs
+++ b/crates/ironclaw_processes/src/journal_store/flusher.rs
@@ -222,7 +222,9 @@ where
     let observers = store.registered_observers();
     futures::future::join_all(observers.into_iter().map(|observer| async move {
         if let Err(error) = store.deliver_committed_batch(&observer, committed).await {
-            tracing::warn!(
+            // debug!, not warn!: this is a background-task diagnostic, and
+            // warn-level output is rendered by the REPL/TUI.
+            tracing::debug!(
                 observer_id = %observer.id,
                 cursor = committed.last.0,
                 %error,
@@ -542,7 +544,7 @@ fn release_committed_batch<F>(
     let cursor = committed.last.0;
     let batch = DeliveryBatch { committed, waiters };
     if let Err(undeliverable) = deliveries.send(batch) {
-        tracing::warn!(
+        tracing::debug!(
             cursor,
             "process journal delivery task is gone; committed batch will not be delivered"
         );

--- a/crates/ironclaw_processes/src/journal_store/observer.rs
+++ b/crates/ironclaw_processes/src/journal_store/observer.rs
@@ -24,6 +24,27 @@ pub(super) struct RegisteredProcessObserver {
     pub(super) replay_running: Arc<AtomicBool>,
 }
 
+tokio::task_local! {
+    /// Set while an observer callback runs on this task.
+    ///
+    /// Observer callbacks legitimately re-enter the journal store (the
+    /// sub-agent await-edge resolver settles dependencies and resumes the
+    /// parent process from inside `observe_process_commit`). Such a nested
+    /// commit must not wait for observer delivery, because delivery is exactly
+    /// what is blocked on the callback that issued it.
+    static OBSERVER_DELIVERY: ();
+}
+
+/// Run an observer callback with the re-entrancy marker set.
+pub(super) async fn observer_delivery_scope<T>(future: impl Future<Output = T>) -> T {
+    OBSERVER_DELIVERY.scope((), future).await
+}
+
+/// Whether the current task is inside an observer callback.
+pub(super) fn inside_observer_delivery() -> bool {
+    OBSERVER_DELIVERY.try_with(|()| ()).is_ok()
+}
+
 struct ObserverReplayGuard(Arc<AtomicBool>);
 
 impl Drop for ObserverReplayGuard {
@@ -36,15 +57,9 @@ impl<F> ProcessJournalStore<F>
 where
     F: RootFilesystem,
 {
-    pub(super) async fn notify_process_commit(
-        &self,
-        state: crate::JournaledProcessSnapshot,
-        kind: crate::ProcessJournalKind,
-        sanitized_reason: Option<String>,
-    ) where
-        F: Send + Sync + 'static,
-    {
-        let observers = match self.observers.lock() {
+    /// Snapshot of the currently registered observers.
+    pub(super) fn registered_observers(&self) -> Vec<RegisteredProcessObserver> {
+        match self.observers.lock() {
             Ok(observers) => observers.clone(),
             Err(poisoned) => {
                 tracing::error!(
@@ -52,28 +67,10 @@ where
                 );
                 poisoned.into_inner().clone()
             }
-        };
-        let target_cursor = state.journal_cursor;
-        for observer in observers {
-            if let Err(error) = self
-                .replay_durable_observer_once(&observer, Some(target_cursor))
-                .await
-            {
-                tracing::warn!(
-                    process_id = %state.process_id,
-                    cursor = target_cursor.0,
-                    observer_id = %observer.id,
-                    kind = ?kind,
-                    reason = ?sanitized_reason,
-                    %error,
-                    "process journal observer delivery failed after durable commit"
-                );
-                self.spawn_observer_replay(observer);
-            }
         }
     }
 
-    async fn replay_durable_observer_once(
+    pub(super) async fn replay_durable_observer_once(
         &self,
         observer: &RegisteredProcessObserver,
         target: Option<ProcessJournalCursor>,
@@ -93,23 +90,45 @@ where
             })
             .transpose()?;
         loop {
+            // A concurrent replay may already have delivered past this target
+            // while this call waited for the delivery lock.
+            if let (Some(after), Some(target)) = (after, target)
+                && after.0 >= target.0
+            {
+                return Ok(());
+            }
             let page = self
                 .read_journal_page(None, None, after, JOURNAL_READ_BATCH - 1)
                 .await
                 .map_err(|error| error.to_string())?;
+            let mut delivered = None;
+            let mut reached_target = false;
             for entry in &page.entries {
                 if let Some(state) = entry.committed_state.as_deref() {
-                    observer
-                        .observer
-                        .observe_process_commit(ProcessJournalCommit {
+                    // Callbacks may re-enter the journal store; the marker lets
+                    // those nested commits skip the delivery wait that this
+                    // very call is holding (see `flusher`).
+                    observer_delivery_scope(observer.observer.observe_process_commit(
+                        ProcessJournalCommit {
                             state: state.clone(),
                             kind: entry.kind,
                             sanitized_reason: entry.sanitized_reason.clone(),
-                        })
-                        .await?;
+                        },
+                    ))
+                    .await?;
                 }
+                delivered = Some(entry.cursor);
+                if target.is_some_and(|target| entry.cursor.0 >= target.0) {
+                    reached_target = true;
+                    break;
+                }
+            }
+            // One cursor write per delivered page rather than per entry. A
+            // crash between pages redelivers the page; observers already
+            // tolerate redelivery because every retry path replays.
+            if let Some(cursor) = delivered {
                 let cursor_body =
-                    serde_json::to_vec(&entry.cursor.0).map_err(|error| error.to_string())?;
+                    serde_json::to_vec(&cursor.0).map_err(|error| error.to_string())?;
                 self.filesystem
                     .put(
                         &ResourceScope::system(),
@@ -119,18 +138,15 @@ where
                     )
                     .await
                     .map_err(|error| error.to_string())?;
-                if target.is_some_and(|target| entry.cursor.0 >= target.0) {
-                    return Ok(());
-                }
             }
-            if !page.truncated {
+            if reached_target || !page.truncated {
                 return Ok(());
             }
             after = Some(page.next_cursor);
         }
     }
 
-    fn spawn_observer_replay(&self, observer: RegisteredProcessObserver)
+    pub(super) fn spawn_observer_replay(&self, observer: RegisteredProcessObserver)
     where
         F: Send + Sync + 'static,
     {

--- a/crates/ironclaw_processes/src/journal_store/observer.rs
+++ b/crates/ironclaw_processes/src/journal_store/observer.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use ironclaw_filesystem::{CasExpectation, Entry, RootFilesystem};
+use ironclaw_filesystem::{CasExpectation, Entry, FilesystemError, RecordVersion, RootFilesystem};
 use ironclaw_host_api::{path::ScopedPath, resource::ResourceScope};
 use tokio::sync::Mutex;
 
@@ -35,6 +35,24 @@ pub(super) struct ObserverDeliveryState {
     /// the cursor row and page the journal back out of the backend just to
     /// rediscover what it had in memory.
     acknowledged: Option<ProcessJournalCursor>,
+    /// Version of the cursor row observed alongside `acknowledged`, or `None`
+    /// when the row was absent at that observation.
+    ///
+    /// Every cursor write is conditional on it. Two store instances can share
+    /// one observer id across a rolling restart; without the condition, an
+    /// instance holding a stale cache would overwrite a newer durable cursor
+    /// with a lower one and silently rewind acknowledged progress, redelivering
+    /// the difference after the next restart.
+    version: Option<RecordVersion>,
+}
+
+/// Why a cursor acknowledgement did not land.
+enum AcknowledgeError {
+    /// The durable row moved under us: another store instance advanced this
+    /// observer. The cached view is dropped and the caller must fall back to
+    /// the authoritative durable replay rather than retry the stale write.
+    Conflict,
+    Backend(String),
 }
 
 /// One or more committed transactions' deliverable entries, carried in memory
@@ -131,8 +149,22 @@ where
             )
             .await?;
         }
-        self.acknowledge_observer_cursor(observer, &mut delivery, batch.last)
+        match self
+            .acknowledge_observer_cursor(observer, &mut delivery, batch.last)
             .await
+        {
+            Ok(()) => Ok(()),
+            Err(AcknowledgeError::Backend(error)) => Err(error),
+            Err(AcknowledgeError::Conflict) => {
+                // Another instance owns newer progress. Re-derive from the
+                // durable row instead of forcing our cursor onto it; the
+                // entries above may be delivered twice, which every replay
+                // path already permits.
+                drop(delivery);
+                self.replay_durable_observer_once(observer, Some(batch.last))
+                    .await
+            }
+        }
     }
 
     /// Persist an observer's delivery cursor and refresh the cached value.
@@ -141,21 +173,39 @@ where
         observer: &RegisteredProcessObserver,
         delivery: &mut ObserverDeliveryState,
         cursor: ProcessJournalCursor,
-    ) -> Result<(), String> {
-        let cursor_path =
-            process_observer_cursor_path(&observer.id).map_err(|error| error.to_string())?;
-        let cursor_body = serde_json::to_vec(&cursor.0).map_err(|error| error.to_string())?;
-        self.filesystem
+    ) -> Result<(), AcknowledgeError> {
+        let cursor_path = process_observer_cursor_path(&observer.id)
+            .map_err(|error| AcknowledgeError::Backend(error.to_string()))?;
+        let cursor_body = serde_json::to_vec(&cursor.0)
+            .map_err(|error| AcknowledgeError::Backend(error.to_string()))?;
+        // Conditional on the version this process last observed, so the write
+        // can only advance the row it actually read.
+        let expectation = match delivery.version {
+            Some(version) => CasExpectation::Version(version),
+            None => CasExpectation::Absent,
+        };
+        match self
+            .filesystem
             .put(
                 &ResourceScope::system(),
                 &cursor_path,
                 Entry::bytes(cursor_body),
-                CasExpectation::Any,
+                expectation,
             )
             .await
-            .map_err(|error| error.to_string())?;
-        delivery.acknowledged = Some(cursor);
-        Ok(())
+        {
+            Ok(version) => {
+                delivery.acknowledged = Some(cursor);
+                delivery.version = Some(version);
+                Ok(())
+            }
+            Err(FilesystemError::VersionMismatch { .. }) => {
+                delivery.acknowledged = None;
+                delivery.version = None;
+                Err(AcknowledgeError::Conflict)
+            }
+            Err(error) => Err(AcknowledgeError::Backend(error.to_string())),
+        }
     }
 
     pub(super) async fn replay_durable_observer_once(
@@ -166,11 +216,13 @@ where
         let mut delivery = observer.delivery.lock().await;
         let cursor_path =
             process_observer_cursor_path(&observer.id).map_err(|error| error.to_string())?;
-        let mut after = self
+        let read_cursor = self
             .filesystem
             .get(&ResourceScope::system(), &cursor_path)
             .await
-            .map_err(|error| error.to_string())?
+            .map_err(|error| error.to_string())?;
+        let version = read_cursor.as_ref().map(|versioned| versioned.version);
+        let mut after = read_cursor
             .map(|versioned| {
                 serde_json::from_slice::<u64>(&versioned.entry.body)
                     .map(ProcessJournalCursor)
@@ -182,6 +234,7 @@ where
         // "unknown") lets a journal that starts empty take the in-memory
         // delivery path from its very first batch.
         delivery.acknowledged = Some(after.unwrap_or(ProcessJournalCursor(0)));
+        delivery.version = version;
         loop {
             // A concurrent replay may already have delivered past this target
             // while this call waited for the delivery lock.
@@ -218,8 +271,34 @@ where
             // crash mid-page redelivers the page; observers already tolerate
             // redelivery because every retry path replays.
             if let Some(cursor) = delivered {
-                self.acknowledge_observer_cursor(observer, &mut delivery, cursor)
-                    .await?;
+                match self
+                    .acknowledge_observer_cursor(observer, &mut delivery, cursor)
+                    .await
+                {
+                    Ok(()) => {}
+                    Err(AcknowledgeError::Backend(error)) => return Err(error),
+                    Err(AcknowledgeError::Conflict) => {
+                        // Another instance advanced this observer while the
+                        // page was in flight. Re-read the durable row and
+                        // resume from wherever it now stands; its cursor is
+                        // authoritative and may already cover the target.
+                        let read_cursor = self
+                            .filesystem
+                            .get(&ResourceScope::system(), &cursor_path)
+                            .await
+                            .map_err(|error| error.to_string())?;
+                        delivery.version = read_cursor.as_ref().map(|versioned| versioned.version);
+                        after = read_cursor
+                            .map(|versioned| {
+                                serde_json::from_slice::<u64>(&versioned.entry.body)
+                                    .map(ProcessJournalCursor)
+                                    .map_err(|error| error.to_string())
+                            })
+                            .transpose()?;
+                        delivery.acknowledged = Some(after.unwrap_or(ProcessJournalCursor(0)));
+                        continue;
+                    }
+                }
             }
             if reached_target || !page.truncated {
                 return Ok(());

--- a/crates/ironclaw_processes/src/journal_store/observer.rs
+++ b/crates/ironclaw_processes/src/journal_store/observer.rs
@@ -235,6 +235,17 @@ where
         // delivery path from its very first batch.
         delivery.acknowledged = Some(after.unwrap_or(ProcessJournalCursor(0)));
         delivery.version = version;
+        // Bound on losing the cursor CAS, not on pages: a page that makes
+        // progress resets it. Two instances sharing an observer id can each
+        // hold a valid version and win in turn, and if the re-read cursor does
+        // not advance past the page just delivered, `after` is unchanged and
+        // the same page is re-read, re-delivered, and conflicts again. Every
+        // iteration costs a journal read plus a full observer callback, so
+        // unbounded retries live-lock while redelivering. Giving up returns an
+        // error, which hands the retry to `spawn_observer_replay` and its
+        // backoff instead of spinning here.
+        const MAX_CURSOR_CONFLICT_RETRIES: u32 = 8;
+        let mut cursor_conflicts = 0_u32;
         loop {
             // A concurrent replay may already have delivered past this target
             // while this call waited for the delivery lock.
@@ -275,9 +286,20 @@ where
                     .acknowledge_observer_cursor(observer, &mut delivery, cursor)
                     .await
                 {
-                    Ok(()) => {}
+                    // A page that lands is progress, so a long healthy replay is
+                    // never killed by conflicts accumulated across pages.
+                    Ok(()) => cursor_conflicts = 0,
                     Err(AcknowledgeError::Backend(error)) => return Err(error),
                     Err(AcknowledgeError::Conflict) => {
+                        cursor_conflicts += 1;
+                        if cursor_conflicts > MAX_CURSOR_CONFLICT_RETRIES {
+                            return Err(format!(
+                                "process journal observer {} lost the cursor CAS \
+                                 {MAX_CURSOR_CONFLICT_RETRIES} times without \
+                                 advancing; deferring to backoff",
+                                observer.id
+                            ));
+                        }
                         // Another instance advanced this observer while the
                         // page was in flight. Re-read the durable row and
                         // resume from wherever it now stands; its cursor is

--- a/crates/ironclaw_processes/src/journal_store/observer.rs
+++ b/crates/ironclaw_processes/src/journal_store/observer.rs
@@ -322,7 +322,7 @@ where
                 match store.replay_durable_observer_once(&observer, None).await {
                     Ok(()) => break,
                     Err(error) => {
-                        tracing::warn!(
+                        tracing::debug!(
                             observer_id = %observer.id,
                             %error,
                             "durable process observer delivery will retry"
@@ -369,7 +369,7 @@ where
         let store = self.clone();
         runtime.spawn(async move {
             if let Err(error) = store.replay_durable_observer_once(&registered, None).await {
-                tracing::warn!(
+                tracing::debug!(
                     observer_id = %registered.id,
                     %error,
                     "initial durable process observer replay failed"

--- a/crates/ironclaw_processes/src/journal_store/observer.rs
+++ b/crates/ironclaw_processes/src/journal_store/observer.rs
@@ -20,8 +20,34 @@ use crate::{
 pub(super) struct RegisteredProcessObserver {
     pub(super) id: String,
     pub(super) observer: Arc<dyn ProcessJournalCommitObserver>,
-    pub(super) delivery: Arc<Mutex<()>>,
+    pub(super) delivery: Arc<Mutex<ObserverDeliveryState>>,
     pub(super) replay_running: Arc<AtomicBool>,
+}
+
+/// Delivery progress for one observer, guarded by its delivery lock.
+#[derive(Default)]
+pub(super) struct ObserverDeliveryState {
+    /// Last cursor known to be durably acknowledged, when this process has
+    /// already read or written the observer's cursor row.
+    ///
+    /// Caching it is what lets a committed batch be delivered straight from the
+    /// entries the flusher already holds: without it every batch would re-read
+    /// the cursor row and page the journal back out of the backend just to
+    /// rediscover what it had in memory.
+    acknowledged: Option<ProcessJournalCursor>,
+}
+
+/// One or more committed transactions' deliverable entries, carried in memory
+/// from the flusher to observer delivery so the common path never reads the
+/// journal back out of the backend.
+pub(super) struct CommittedBatch {
+    /// Cursor of the first journal entry the batch committed.
+    pub(super) first: ProcessJournalCursor,
+    /// Cursor of the last journal entry the batch committed.
+    pub(super) last: ProcessJournalCursor,
+    /// Entries that carry committed state, in cursor order. Entries without
+    /// committed state advance the cursor but are not delivered.
+    pub(super) commits: Vec<ProcessJournalCommit>,
 }
 
 tokio::task_local! {
@@ -70,12 +96,74 @@ where
         }
     }
 
+    /// Deliver one committed batch straight from the entries the flusher holds.
+    ///
+    /// This is the hot path: it costs one cursor write per observer and reads
+    /// nothing back out of the backend. It is only valid when the observer's
+    /// acknowledged cursor sits immediately before the batch, which is the
+    /// normal case because the flusher delivers batches in commit order. Any
+    /// gap — a cold cache, another writer's entries, or a cursor range this
+    /// process reserved but did not use — falls back to the paged replay, which
+    /// is authoritative.
+    pub(super) async fn deliver_committed_batch(
+        &self,
+        observer: &RegisteredProcessObserver,
+        batch: &CommittedBatch,
+    ) -> Result<(), String> {
+        let mut delivery = observer.delivery.lock().await;
+        let contiguous = delivery
+            .acknowledged
+            .is_some_and(|acknowledged| acknowledged.0.saturating_add(1) == batch.first.0);
+        if !contiguous {
+            drop(delivery);
+            return self
+                .replay_durable_observer_once(observer, Some(batch.last))
+                .await;
+        }
+        if !batch.commits.is_empty() {
+            // Callbacks may re-enter the journal store; the marker lets those
+            // nested commits skip the delivery wait that this very call holds
+            // (see `flusher`).
+            observer_delivery_scope(
+                observer
+                    .observer
+                    .observe_process_commits(batch.commits.clone()),
+            )
+            .await?;
+        }
+        self.acknowledge_observer_cursor(observer, &mut delivery, batch.last)
+            .await
+    }
+
+    /// Persist an observer's delivery cursor and refresh the cached value.
+    async fn acknowledge_observer_cursor(
+        &self,
+        observer: &RegisteredProcessObserver,
+        delivery: &mut ObserverDeliveryState,
+        cursor: ProcessJournalCursor,
+    ) -> Result<(), String> {
+        let cursor_path =
+            process_observer_cursor_path(&observer.id).map_err(|error| error.to_string())?;
+        let cursor_body = serde_json::to_vec(&cursor.0).map_err(|error| error.to_string())?;
+        self.filesystem
+            .put(
+                &ResourceScope::system(),
+                &cursor_path,
+                Entry::bytes(cursor_body),
+                CasExpectation::Any,
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        delivery.acknowledged = Some(cursor);
+        Ok(())
+    }
+
     pub(super) async fn replay_durable_observer_once(
         &self,
         observer: &RegisteredProcessObserver,
         target: Option<ProcessJournalCursor>,
     ) -> Result<(), String> {
-        let _delivery = observer.delivery.lock().await;
+        let mut delivery = observer.delivery.lock().await;
         let cursor_path =
             process_observer_cursor_path(&observer.id).map_err(|error| error.to_string())?;
         let mut after = self
@@ -89,6 +177,11 @@ where
                     .map_err(|error| error.to_string())
             })
             .transpose()?;
+        // Cursor 0 precedes every real entry, so an observer with no cursor row
+        // has provably acknowledged nothing. Recording that (rather than
+        // "unknown") lets a journal that starts empty take the in-memory
+        // delivery path from its very first batch.
+        delivery.acknowledged = Some(after.unwrap_or(ProcessJournalCursor(0)));
         loop {
             // A concurrent replay may already have delivered past this target
             // while this call waited for the delivery lock.
@@ -103,19 +196,14 @@ where
                 .map_err(|error| error.to_string())?;
             let mut delivered = None;
             let mut reached_target = false;
+            let mut commits = Vec::new();
             for entry in &page.entries {
                 if let Some(state) = entry.committed_state.as_deref() {
-                    // Callbacks may re-enter the journal store; the marker lets
-                    // those nested commits skip the delivery wait that this
-                    // very call is holding (see `flusher`).
-                    observer_delivery_scope(observer.observer.observe_process_commit(
-                        ProcessJournalCommit {
-                            state: state.clone(),
-                            kind: entry.kind,
-                            sanitized_reason: entry.sanitized_reason.clone(),
-                        },
-                    ))
-                    .await?;
+                    commits.push(ProcessJournalCommit {
+                        state: state.clone(),
+                        kind: entry.kind,
+                        sanitized_reason: entry.sanitized_reason.clone(),
+                    });
                 }
                 delivered = Some(entry.cursor);
                 if target.is_some_and(|target| entry.cursor.0 >= target.0) {
@@ -123,21 +211,15 @@ where
                     break;
                 }
             }
+            if !commits.is_empty() {
+                observer_delivery_scope(observer.observer.observe_process_commits(commits)).await?;
+            }
             // One cursor write per delivered page rather than per entry. A
-            // crash between pages redelivers the page; observers already
-            // tolerate redelivery because every retry path replays.
+            // crash mid-page redelivers the page; observers already tolerate
+            // redelivery because every retry path replays.
             if let Some(cursor) = delivered {
-                let cursor_body =
-                    serde_json::to_vec(&cursor.0).map_err(|error| error.to_string())?;
-                self.filesystem
-                    .put(
-                        &ResourceScope::system(),
-                        &cursor_path,
-                        Entry::bytes(cursor_body),
-                        CasExpectation::Any,
-                    )
-                    .await
-                    .map_err(|error| error.to_string())?;
+                self.acknowledge_observer_cursor(observer, &mut delivery, cursor)
+                    .await?;
             }
             if reached_target || !page.truncated {
                 return Ok(());
@@ -190,7 +272,7 @@ where
         let registered = RegisteredProcessObserver {
             id: observer.process_observer_id().to_string(),
             observer,
-            delivery: Arc::new(Mutex::new(())),
+            delivery: Arc::new(Mutex::new(ObserverDeliveryState::default())),
             replay_running: Arc::new(AtomicBool::new(false)),
         };
         if observers

--- a/crates/ironclaw_processes/src/journal_store/rows.rs
+++ b/crates/ironclaw_processes/src/journal_store/rows.rs
@@ -259,6 +259,16 @@ where
     Ok(())
 }
 
+/// The `count` oldest keys of an idempotency order deque.
+///
+/// A group commit inserting N new keys can evict N old ones once the deque is
+/// at its cap. Loading only the single oldest row left the rest of the evicted
+/// keys untombstoned in storage, where a later retry could still read one and
+/// replay its stale outcome.
+fn oldest_keys(order: &std::collections::VecDeque<String>, count: usize) -> Vec<String> {
+    order.iter().take(count).cloned().collect()
+}
+
 pub(super) async fn load<F>(
     filesystem: &ScopedFilesystem<F>,
     references: &LoadReferences,
@@ -276,7 +286,7 @@ where
         .collect::<Vec<_>>();
     let order_path = scoped_path(&format!("{MATERIALIZED_PREFIX}/idempotency-order"))?;
     push_if_present(filesystem, &mut records, &order_path).await?;
-    let (oldest_control_key, oldest_submission_key) = records
+    let (oldest_control_keys, oldest_submission_keys) = records
         .iter()
         .map(decode)
         .collect::<Result<Vec<_>, _>>()?
@@ -286,8 +296,11 @@ where
                 control_order,
                 submission_order,
             } => Some((
-                control_order.front().cloned(),
-                submission_order.front().cloned(),
+                oldest_keys(&control_order, references.control_idempotency_keys.len()),
+                oldest_keys(
+                    &submission_order,
+                    references.submission_idempotency_keys.len(),
+                ),
             )),
             _ => None,
         })
@@ -301,8 +314,11 @@ where
                         submission_order,
                         ..
                     } => Some((
-                        control_order.front().cloned(),
-                        submission_order.front().cloned(),
+                        oldest_keys(&control_order, references.control_idempotency_keys.len()),
+                        oldest_keys(
+                            &submission_order,
+                            references.submission_idempotency_keys.len(),
+                        ),
                     )),
                     _ => None,
                 })
@@ -312,14 +328,14 @@ where
         .control_idempotency_keys
         .iter()
         .map(|key| ("control", key))
-        .chain(oldest_control_key.iter().map(|key| ("control", key)))
+        .chain(oldest_control_keys.iter().map(|key| ("control", key)))
         .chain(
             references
                 .submission_idempotency_keys
                 .iter()
                 .map(|key| ("submission", key)),
         )
-        .chain(oldest_submission_key.iter().map(|key| ("submission", key)))
+        .chain(oldest_submission_keys.iter().map(|key| ("submission", key)))
         .collect::<Vec<_>>();
     for (collection, key) in idempotency_keys {
         let path = hashed_scoped_path(collection, key)?;

--- a/crates/ironclaw_processes/src/journal_store/rows.rs
+++ b/crates/ironclaw_processes/src/journal_store/rows.rs
@@ -23,10 +23,12 @@ use crate::{
 };
 
 mod keys;
+mod references;
 use keys::{
     index_key, index_name, lineage_scope_key, ordered_index, owner_scope_key, process_kind_key,
     process_status_key, scope_owner_key, scoped_path,
 };
+pub(super) use references::LoadReferences;
 
 const MATERIALIZED_PREFIX: &str = "/processes/materialized";
 const MATERIALIZED_KIND: &str = "process_materialized";
@@ -72,19 +74,6 @@ pub(super) struct LoadedRows {
     rows: HashMap<VirtualPath, MaterializedRow>,
     versions: HashMap<VirtualPath, RecordVersion>,
     pub(super) initialized: bool,
-}
-
-#[derive(Default)]
-pub(super) struct LoadReferences {
-    pub(super) process_ids: Vec<ProcessId>,
-    pub(super) tree_roots: Vec<ProcessId>,
-    pub(super) dependencies: Vec<(ProcessId, ProcessId)>,
-    pub(super) checkpoints: Vec<ProcessCheckpointId>,
-    pub(super) submission_idempotency_key: Option<String>,
-    pub(super) control_idempotency_key: Option<String>,
-    pub(super) active_conflict: Option<(ResourceScope, ProcessKind)>,
-    pub(super) claim: Option<(ClaimProcessesRequest, ProcessConcurrencyLimits)>,
-    pub(super) recover_expired: Option<RecoverExpiredProcessLeasesRequest>,
 }
 
 pub(super) fn retryable_transaction_error(error: &ironclaw_filesystem::FilesystemError) -> bool {
@@ -319,27 +308,34 @@ where
                 })
         })
         .unwrap_or_default();
-    for (collection, key) in [
-        ("control", references.control_idempotency_key.as_ref()),
-        ("control", oldest_control_key.as_ref()),
-        ("submission", references.submission_idempotency_key.as_ref()),
-        ("submission", oldest_submission_key.as_ref()),
-    ] {
-        if let Some(key) = key {
-            let path = hashed_scoped_path(collection, key)?;
-            push_if_present(filesystem, &mut records, &path).await?;
-        }
+    let idempotency_keys = references
+        .control_idempotency_keys
+        .iter()
+        .map(|key| ("control", key))
+        .chain(oldest_control_key.iter().map(|key| ("control", key)))
+        .chain(
+            references
+                .submission_idempotency_keys
+                .iter()
+                .map(|key| ("submission", key)),
+        )
+        .chain(oldest_submission_key.iter().map(|key| ("submission", key)))
+        .collect::<Vec<_>>();
+    for (collection, key) in idempotency_keys {
+        let path = hashed_scoped_path(collection, key)?;
+        push_if_present(filesystem, &mut records, &path).await?;
     }
     for process_id in &references.process_ids {
         let path = process_scoped_path(*process_id)?;
         push_if_present(filesystem, &mut records, &path).await?;
     }
-    if let Some((scope, process_kind)) = &references.active_conflict {
+    for (scope, process_kind) in &references.active_conflicts {
         records.extend(query_active_conflict(filesystem, scope, process_kind, 1).await?);
     }
-    if let Some((request, limits)) = &references.claim
-        && request.process_id_filter.is_none()
-    {
+    for (request, limits) in &references.claims {
+        if request.process_id_filter.is_some() {
+            continue;
+        }
         let candidates = query_claim_candidates(filesystem, request).await?;
         records.extend(candidates.clone());
         let snapshots = candidates
@@ -368,7 +364,7 @@ where
             );
         }
     }
-    if let Some(request) = &references.recover_expired {
+    for request in &references.recover_expired {
         records.extend(query_expired_processes(filesystem, request).await?);
     }
     for root_process_id in &references.tree_roots {

--- a/crates/ironclaw_processes/src/journal_store/rows.rs
+++ b/crates/ironclaw_processes/src/journal_store/rows.rs
@@ -348,11 +348,38 @@ where
     for (scope, process_kind) in &references.active_conflicts {
         records.extend(query_active_conflict(filesystem, scope, process_kind, 1).await?);
     }
+    // Sum the demand of equivalent unfiltered claims before querying any of
+    // them. Two claims are equivalent when they drive the same query, which is
+    // the scope and kind filters; `process_id_filter` claims are skipped
+    // entirely and named rows are loaded elsewhere. Linear scan because a group
+    // commit holds at most `MAX_BATCH_COMMANDS` claims, so this is a handful of
+    // comparisons, not a data structure.
+    let mut batched_demand: Vec<(&ClaimProcessesRequest, usize)> = Vec::new();
+    for (request, _) in &references.claims {
+        if request.process_id_filter.is_some() {
+            continue;
+        }
+        match batched_demand.iter_mut().find(|(equivalent, _)| {
+            equivalent.scope_filter == request.scope_filter
+                && equivalent.process_kind_filter == request.process_kind_filter
+        }) {
+            Some((_, total)) => *total = total.saturating_add(request.max_processes),
+            None => batched_demand.push((request, request.max_processes)),
+        }
+    }
+
     for (request, limits) in &references.claims {
         if request.process_id_filter.is_some() {
             continue;
         }
-        let candidates = query_claim_candidates(filesystem, request).await?;
+        let demand = batched_demand
+            .iter()
+            .find(|(equivalent, _)| {
+                equivalent.scope_filter == request.scope_filter
+                    && equivalent.process_kind_filter == request.process_kind_filter
+            })
+            .map_or(request.max_processes, |(_, total)| *total);
+        let candidates = query_claim_candidates(filesystem, request, demand).await?;
         records.extend(candidates.clone());
         let snapshots = candidates
             .iter()
@@ -891,9 +918,19 @@ where
 const RECOVERY_BATCH_LIMIT: u32 = Page::MAX_LIMIT;
 const CLAIM_QUOTA_SKIP_ALLOWANCE: usize = 64;
 
+/// Load queued candidates for one claim shape.
+///
+/// `batched_demand` is the summed `max_processes` of every equivalent claim in
+/// the group commit, not just this request's. A batch materializes one shared
+/// state, so a window sized for a single request leaves later claims in the
+/// same batch reading an already-exhausted candidate set and returning empty
+/// while eligible work is still queued. Before group commit each claim ran its
+/// own transaction and re-queried after the previous one advanced state, so the
+/// window was always fresh; batching removed that and this replaces it.
 async fn query_claim_candidates<F>(
     filesystem: &ScopedFilesystem<F>,
     request: &ClaimProcessesRequest,
+    batched_demand: usize,
 ) -> Result<Vec<VersionedEntry>, ProcessJournalStoreError>
 where
     F: RootFilesystem,
@@ -924,8 +961,8 @@ where
         }
         (None, None) => index_name("process_queue_v4")?,
     };
-    let candidate_limit = request
-        .max_processes
+    let candidate_limit = batched_demand
+        .max(request.max_processes)
         .saturating_add(CLAIM_QUOTA_SKIP_ALLOWANCE)
         .min(Page::MAX_LIMIT as usize);
     let candidate_limit = u32::try_from(candidate_limit).unwrap_or(Page::MAX_LIMIT);

--- a/crates/ironclaw_processes/src/journal_store/rows/references.rs
+++ b/crates/ironclaw_processes/src/journal_store/rows/references.rs
@@ -1,0 +1,66 @@
+//! Row references a batch of journal commands needs loaded.
+
+use ironclaw_host_api::{ids::ProcessId, resource::ResourceScope};
+
+use crate::{
+    ClaimProcessesRequest, ProcessCheckpointId, ProcessConcurrencyLimits, ProcessKind,
+    RecoverExpiredProcessLeasesRequest,
+};
+
+/// Rows one or more commands need loaded before they can be applied.
+///
+/// Every field is plural because the group-commit funnel merges the references
+/// of a whole batch and loads their union once: global metadata and the shared
+/// idempotency-order row are then read once per transaction rather than once
+/// per command.
+#[derive(Default, Clone)]
+pub(in crate::journal_store) struct LoadReferences {
+    pub(in crate::journal_store) process_ids: Vec<ProcessId>,
+    pub(in crate::journal_store) tree_roots: Vec<ProcessId>,
+    pub(in crate::journal_store) dependencies: Vec<(ProcessId, ProcessId)>,
+    pub(in crate::journal_store) checkpoints: Vec<ProcessCheckpointId>,
+    pub(in crate::journal_store) submission_idempotency_keys: Vec<String>,
+    pub(in crate::journal_store) control_idempotency_keys: Vec<String>,
+    pub(in crate::journal_store) active_conflicts: Vec<(ResourceScope, ProcessKind)>,
+    pub(in crate::journal_store) claims: Vec<(ClaimProcessesRequest, ProcessConcurrencyLimits)>,
+    pub(in crate::journal_store) recover_expired: Vec<RecoverExpiredProcessLeasesRequest>,
+}
+
+impl LoadReferences {
+    /// Fold another command's references into this batch-wide set.
+    pub(in crate::journal_store) fn merge_from(&mut self, other: &Self) {
+        self.process_ids.extend(other.process_ids.iter().copied());
+        self.tree_roots.extend(other.tree_roots.iter().copied());
+        self.dependencies.extend(other.dependencies.iter().copied());
+        self.checkpoints.extend(other.checkpoints.iter().cloned());
+        self.submission_idempotency_keys
+            .extend(other.submission_idempotency_keys.iter().cloned());
+        self.control_idempotency_keys
+            .extend(other.control_idempotency_keys.iter().cloned());
+        self.active_conflicts
+            .extend(other.active_conflicts.iter().cloned());
+        self.claims.extend(other.claims.iter().cloned());
+        self.recover_expired
+            .extend(other.recover_expired.iter().cloned());
+        self.normalize();
+    }
+
+    /// Sort and dedupe the reference sets that address individual rows so a
+    /// merged batch never reads the same row twice.
+    pub(in crate::journal_store) fn normalize(&mut self) {
+        self.process_ids.sort_by_key(ProcessId::as_uuid);
+        self.process_ids.dedup();
+        self.tree_roots.sort_by_key(ProcessId::as_uuid);
+        self.tree_roots.dedup();
+        self.dependencies
+            .sort_by_key(|(dependent, dependency)| (dependent.as_uuid(), dependency.as_uuid()));
+        self.dependencies.dedup();
+        self.checkpoints
+            .sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        self.checkpoints.dedup();
+        self.submission_idempotency_keys.sort();
+        self.submission_idempotency_keys.dedup();
+        self.control_idempotency_keys.sort();
+        self.control_idempotency_keys.dedup();
+    }
+}

--- a/crates/ironclaw_processes/src/journal_store/rows/references.rs
+++ b/crates/ironclaw_processes/src/journal_store/rows/references.rs
@@ -28,6 +28,9 @@ pub(in crate::journal_store) struct LoadReferences {
 
 impl LoadReferences {
     /// Fold another command's references into this batch-wide set.
+    /// Append `other`'s references. The caller normalizes once after folding
+    /// the whole batch — normalizing per merge would re-sort collections that
+    /// the previous fold already sorted.
     pub(in crate::journal_store) fn merge_from(&mut self, other: &Self) {
         self.process_ids.extend(other.process_ids.iter().copied());
         self.tree_roots.extend(other.tree_roots.iter().copied());
@@ -42,7 +45,6 @@ impl LoadReferences {
         self.claims.extend(other.claims.iter().cloned());
         self.recover_expired
             .extend(other.recover_expired.iter().cloned());
-        self.normalize();
     }
 
     /// Sort and dedupe the reference sets that address individual rows so a

--- a/crates/ironclaw_processes/src/journal_store/state.rs
+++ b/crates/ironclaw_processes/src/journal_store/state.rs
@@ -620,7 +620,7 @@ impl ProcessJournalMaterializedState {
                     process_id: mutation.process_id,
                 });
             }
-            return Ok(StoredCommandOutcome::Controlled(result.clone(), None));
+            return Ok(StoredCommandOutcome::Controlled(result.clone()));
         }
         let snapshot = self.process_mut(mutation.process_id)?;
         if !process_scope_visible(&snapshot.scope, &mutation.scope) {
@@ -668,7 +668,7 @@ impl ProcessJournalMaterializedState {
                 already_terminal,
             };
             self.remember_control_result(replay_key, result.clone());
-            return Ok(StoredCommandOutcome::Controlled(result, None));
+            return Ok(StoredCommandOutcome::Controlled(result));
         };
         if status == snapshot.status {
             let result = ProcessControlResult {
@@ -677,7 +677,7 @@ impl ProcessJournalMaterializedState {
                 already_terminal,
             };
             self.remember_control_result(replay_key, result.clone());
-            return Ok(StoredCommandOutcome::Controlled(result, None));
+            return Ok(StoredCommandOutcome::Controlled(result));
         }
         let cursor = self.next_cursor();
         let snapshot = self.process_mut(mutation.process_id)?;
@@ -707,7 +707,7 @@ impl ProcessJournalMaterializedState {
             already_terminal,
         };
         self.remember_control_result(replay_key, result.clone());
-        Ok(StoredCommandOutcome::Controlled(result, Some(kind)))
+        Ok(StoredCommandOutcome::Controlled(result))
     }
 
     fn apply_reserve_tree(

--- a/crates/ironclaw_processes/src/journal_store/state_tests.rs
+++ b/crates/ironclaw_processes/src/journal_store/state_tests.rs
@@ -275,7 +275,7 @@ fn control_transition_table_covers_every_action_class() {
             })
             .map_err(error_class)?;
         match outcome {
-            StoredCommandOutcome::Controlled(result, _) => {
+            StoredCommandOutcome::Controlled(result) => {
                 Ok((result.state.status, result.changed, result.already_terminal))
             }
             _ => panic!("control command returned a non-control outcome"),

--- a/crates/ironclaw_processes/src/journal_store/state_tests.rs
+++ b/crates/ironclaw_processes/src/journal_store/state_tests.rs
@@ -94,6 +94,7 @@ fn error_class(error: ProcessJournalStoreError) -> &'static str {
         ProcessJournalStoreError::Deserialization(_) => "deserialization",
         ProcessJournalStoreError::Observer(_) => "observer",
         ProcessJournalStoreError::MigrationRequired => "migration",
+        ProcessJournalStoreError::GroupCommitFailed { .. } => "group_commit",
     }
 }
 

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -1974,6 +1974,94 @@ async fn observer_cursor_never_rewinds_from_a_stale_cache() {
     );
 }
 
+/// Another writer's entries push this observer onto the authoritative replay.
+///
+/// The in-memory delivery path may only hand a batch straight to an observer
+/// when the batch starts exactly one past what this process acknowledged.
+/// A second instance committing in between leaves a gap, and delivering across
+/// it would skip that instance's entries entirely — the observer would never
+/// see them, because the fast path carries only what this process committed.
+///
+/// This case exists to pin that fallback deterministically. Registration primes
+/// the cursor from a *spawned* task, so a freshly subscribed observer reaches
+/// the gap branch only when the first commit beats that task — a race that
+/// silently stops covering the branch whenever the scheduler goes the other
+/// way. Driving the gap through a real second writer does not depend on
+/// scheduling at all.
+#[tokio::test]
+async fn observer_replays_when_a_second_writer_leaves_a_cursor_gap() {
+    let filesystem = in_memory_backed_processes_filesystem();
+    let store = ProcessJournalStore::new(Arc::clone(&filesystem));
+    let other_writer = ProcessJournalStore::new(Arc::clone(&filesystem));
+    let scope = scope();
+    let submit = async |store: &ProcessJournalStore<_>| {
+        let process_id = ProcessId::new();
+        store
+            .submit_process(SubmitProcessRequest {
+                process_id,
+                process_kind: ProcessKind::Internal,
+                scope: scope.clone(),
+                exclusive_within_scope: false,
+                operation_id: None,
+                owner_user_id: Some(scope.user_id.clone()),
+                concurrency_class: None,
+                parent_process_id: None,
+                root_process_id: None,
+                spawn_tree_descendant_cap: None,
+                dependency: None,
+                checkpoint_ref: None,
+                input: None,
+                created_at: Utc::now(),
+                metadata: serde_json::Value::Null,
+            })
+            .await
+            .expect("submit");
+        process_id
+    };
+
+    let observer = Arc::new(RecordingProcessObserver::default());
+    store
+        .subscribe_process_observer(observer.clone())
+        .expect("subscribe observer");
+
+    // Let this instance acknowledge a cursor of its own first, so the gap below
+    // is a genuine discontinuity rather than the cold-cache case.
+    submit(&store).await;
+    let cursor_path = observer_cursor_path();
+    await_observer_cursor(&filesystem, &cursor_path).await;
+
+    // The gap: entries this observer's instance never committed and so can
+    // never deliver from memory.
+    let unseen_by_the_fast_path = submit(&other_writer).await;
+
+    // Committing again now starts past the gap, forcing the replay.
+    submit(&store).await;
+
+    let observed = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let seen = observer
+                .commits
+                .lock()
+                .expect("observer mutex")
+                .iter()
+                .any(|commit| commit.state.process_id == unseen_by_the_fast_path);
+            if seen {
+                return true;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or(false);
+
+    assert!(
+        observed,
+        "the other writer's commit must reach the observer through the durable \
+         replay; the in-memory path carries only this instance's own batches, \
+         so delivering across the gap would drop it"
+    );
+}
+
 fn observer_cursor_path() -> ScopedPath {
     let digest = blake3::hash(b"recording-process-observer").to_hex();
     ScopedPath::new(format!("/processes/materialized/observer-cursor/{digest}"))

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -2248,10 +2248,7 @@ async fn group_committed_submissions_deliver_every_entry_once_before_returning()
         .iter()
         .map(|commit| commit.state.process_id)
         .collect::<Vec<_>>();
-    for process_id in process_ids
-        .iter()
-        .chain(std::iter::once(&warmup.process_id))
-    {
+    for process_id in process_ids.iter() {
         assert_eq!(
             delivered
                 .iter()
@@ -2261,6 +2258,20 @@ async fn group_committed_submissions_deliver_every_entry_once_before_returning()
             "{process_id} must be delivered exactly once"
         );
     }
+    // The warm-up is held to at-least-once, not exactly-once. Registration
+    // primes the cursor from a spawned task, so if this entry commits before
+    // that task runs, `deliver_committed_batch` sees no acknowledged cursor,
+    // takes the non-contiguous fallback, and the registration replay can then
+    // deliver the same entry again. That redelivery is permitted -- the fast
+    // path documents that entries above a gap "may be delivered twice, which
+    // every replay path already permits" -- so asserting a count of one here
+    // would pin scheduling rather than the contract. The 32 submissions above
+    // are strict: by then the cursor is primed and they arrive through the
+    // funnel in order.
+    assert!(
+        delivered.contains(&warmup.process_id),
+        "the warm-up commit must reach the observer at least once"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -1613,6 +1613,120 @@ async fn observer_registration_replays_commits_durably_after_restart() {
     .expect("durable observer replay");
 }
 
+/// Two store instances can share one observer id across a rolling restart, and
+/// each caches its own view of the shared cursor row. The instance holding the
+/// older view must never overwrite the newer durable cursor: rewinding it
+/// silently redelivers the difference after the next restart, and the persisted
+/// acknowledgement stops representing real progress.
+///
+/// The newer position is written directly here so the stale-cache window is
+/// deterministic — the contiguity check hides it whenever the other instance's
+/// entries also land in this instance's journal view.
+#[tokio::test]
+async fn observer_cursor_never_rewinds_from_a_stale_cache() {
+    let filesystem = in_memory_backed_processes_filesystem();
+    let store = ProcessJournalStore::new(Arc::clone(&filesystem));
+    let scope = scope();
+    let submit = async |store: &ProcessJournalStore<_>| {
+        store
+            .submit_process(SubmitProcessRequest {
+                process_id: ProcessId::new(),
+                process_kind: ProcessKind::Internal,
+                scope: scope.clone(),
+                exclusive_within_scope: false,
+                operation_id: None,
+                owner_user_id: Some(scope.user_id.clone()),
+                concurrency_class: None,
+                parent_process_id: None,
+                root_process_id: None,
+                spawn_tree_descendant_cap: None,
+                dependency: None,
+                checkpoint_ref: None,
+                input: None,
+                created_at: Utc::now(),
+                metadata: serde_json::Value::Null,
+            })
+            .await
+            .expect("submit");
+    };
+    let observer = Arc::new(RecordingProcessObserver::default());
+    store
+        .subscribe_process_observer(observer.clone())
+        .expect("subscribe observer");
+
+    // Deliver once so this instance caches the cursor row it just wrote.
+    submit(&store).await;
+    let cursor_path = observer_cursor_path();
+    await_observer_cursor(&filesystem, &cursor_path).await;
+
+    // A second instance races ahead of this one's cached view.
+    const AHEAD: u64 = 9_999;
+    filesystem
+        .put(
+            &ResourceScope::system(),
+            &cursor_path,
+            Entry::bytes(serde_json::to_vec(&AHEAD).expect("cursor body")),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("simulate a second instance advancing the shared cursor");
+
+    // This instance commits again on its stale cache. Its next entry is
+    // contiguous with what it cached, so it takes the in-memory delivery path.
+    submit(&store).await;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if read_observer_cursor(&filesystem, &cursor_path).await != Some(AHEAD) {
+                tokio::task::yield_now().await;
+                continue;
+            }
+            // Give a rewind a chance to appear before declaring success.
+            tokio::task::yield_now().await;
+            if read_observer_cursor(&filesystem, &cursor_path).await == Some(AHEAD) {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap_or(());
+    let observed = read_observer_cursor(&filesystem, &cursor_path).await;
+    assert_eq!(
+        observed,
+        Some(AHEAD),
+        "a stale cache must never rewind the durable observer cursor"
+    );
+}
+
+fn observer_cursor_path() -> ScopedPath {
+    let digest = blake3::hash(b"recording-process-observer").to_hex();
+    ScopedPath::new(format!("/processes/materialized/observer-cursor/{digest}"))
+        .expect("cursor path")
+}
+
+async fn read_observer_cursor(
+    filesystem: &Arc<ScopedFilesystem<InMemoryBackend>>,
+    path: &ScopedPath,
+) -> Option<u64> {
+    filesystem
+        .get(&ResourceScope::system(), path)
+        .await
+        .expect("read cursor")
+        .map(|versioned| serde_json::from_slice::<u64>(&versioned.entry.body).expect("cursor body"))
+}
+
+async fn await_observer_cursor(
+    filesystem: &Arc<ScopedFilesystem<InMemoryBackend>>,
+    path: &ScopedPath,
+) -> u64 {
+    for _ in 0..2_000 {
+        if let Some(cursor) = read_observer_cursor(filesystem, path).await {
+            return cursor;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("observer cursor row was never written");
+}
+
 #[tokio::test]
 async fn observer_failure_retries_until_durable_cursor_is_acknowledged() {
     let filesystem = in_memory_backed_processes_filesystem();
@@ -1708,14 +1822,20 @@ async fn group_committed_submissions_deliver_every_entry_once_before_returning()
     let snapshots = futures::future::join_all(submissions).await;
     assert_eq!(snapshots.len(), process_ids.len());
 
-    // The 32 group-committed submissions reach the observer as one batched
-    // call, not 32: delivery sits between the commit and the caller's response,
-    // so a per-entry hand-off there costs a round trip per entry.
+    // The group-committed submissions reach the observer batched, not one call
+    // per entry: delivery sits between the commit and the caller's response, so
+    // a per-entry hand-off there costs a round trip per entry. Asserted as a
+    // property rather than an exact batch size, which depends on how far the
+    // runtime lets submissions queue before the flusher drains them.
     let batch_sizes = observer.batch_sizes.lock().expect("observer batch sizes");
+    let largest = batch_sizes.iter().copied().max().unwrap_or_default();
     assert!(
-        batch_sizes.contains(&process_ids.len()),
-        "expected one delivery of {} commits, saw batches {batch_sizes:?}",
-        process_ids.len()
+        largest > 1,
+        "expected batched delivery, saw only per-entry calls {batch_sizes:?}"
+    );
+    assert!(
+        batch_sizes.len() < process_ids.len(),
+        "expected fewer deliveries than commits, saw batches {batch_sizes:?}"
     );
     drop(batch_sizes);
 

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -1702,6 +1702,55 @@ async fn observer_registration_replays_commits_durably_after_restart() {
 /// The newer position is written directly here so the stale-cache window is
 /// deterministic — the contiguity check hides it whenever the other instance's
 /// entries also land in this instance's journal view.
+/// Delivery fans out across observers so one slow observer does not add its
+/// latency to every other observer's foreground response. Every other contract
+/// test registers a single observer, so a regression back to sequential
+/// delivery would stay correct and pass the suite while restoring the
+/// write-amplified latency this change targets. Two observers rendezvous on a
+/// barrier: if delivery were sequential, neither could pass it.
+#[tokio::test]
+async fn observer_delivery_runs_registered_observers_concurrently() {
+    struct BarrierObserver {
+        id: &'static str,
+        barrier: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait]
+    impl ProcessJournalCommitObserver for BarrierObserver {
+        fn process_observer_id(&self) -> &'static str {
+            self.id
+        }
+
+        async fn observe_process_commit(
+            &self,
+            _commit: ProcessJournalCommit,
+        ) -> Result<(), String> {
+            self.barrier.wait().await;
+            Ok(())
+        }
+    }
+
+    let filesystem = in_memory_backed_processes_filesystem();
+    let store = ProcessJournalStore::new(filesystem);
+    let resource_scope = scope();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    for id in ["barrier-observer-a", "barrier-observer-b"] {
+        store
+            .subscribe_process_observer(Arc::new(BarrierObserver {
+                id,
+                barrier: Arc::clone(&barrier),
+            }))
+            .expect("subscribe barrier observer");
+    }
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        submit_internal_process(&store, &resource_scope, ProcessId::new()),
+    )
+    .await
+    .expect("observers must be delivered concurrently; serial delivery cannot clear the barrier");
+}
+
 /// Observer callbacks legitimately re-enter the store: the sub-agent
 /// await-edge resolver settles dependencies and resumes the parent from inside
 /// `observe_process_commit`. The task-local marker is the only thing stopping

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -254,6 +254,86 @@ async fn process_journal_rows_serialize_concurrent_store_handles() {
     assert_ne!(first_result.is_ok(), second_result.is_ok());
 }
 
+/// A one-shot backend write fault must be observed by a caller.
+///
+/// Group commit made this a durability question: when the batch transaction
+/// fails non-retryably, replaying its commands individually re-runs their
+/// externally observable semantics against a backend whose fault the aborted
+/// batch already consumed. The command whose write was supposed to fail then
+/// succeeds on the replay, and its caller is told a durable state was reached
+/// that never was. The batch therefore fails as a whole instead of replaying.
+#[tokio::test]
+async fn group_commit_does_not_replay_a_consumed_one_shot_write_fault() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::clone(&backend),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/processes").expect("process alias"),
+            VirtualPath::new("/engine/processes").expect("process target"),
+            MountPermissions::read_write_list_delete(),
+        )])
+        .expect("process mount"),
+    ));
+    let store = ProcessJournalStore::new(filesystem);
+    let resource_scope = scope();
+    // Materialize the store and its funnel before arming, so the fault lands
+    // on a batch of real submissions rather than on startup bookkeeping.
+    submit_internal_process(&store, &resource_scope, ProcessId::new()).await;
+
+    // A non-retryable write failure somewhere inside the next batch.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .nth(1)
+            .backend("one-shot journal write failure"),
+    );
+
+    let process_ids = (0..16).map(|_| ProcessId::new()).collect::<Vec<_>>();
+    let submissions = process_ids.iter().map(|process_id| {
+        let store = &store;
+        let scope = resource_scope.clone();
+        let process_id = *process_id;
+        async move {
+            store
+                .submit_process(SubmitProcessRequest {
+                    process_id,
+                    process_kind: ProcessKind::Internal,
+                    scope,
+                    exclusive_within_scope: false,
+                    operation_id: None,
+                    owner_user_id: None,
+                    concurrency_class: None,
+                    parent_process_id: None,
+                    root_process_id: None,
+                    spawn_tree_descendant_cap: None,
+                    dependency: None,
+                    checkpoint_ref: None,
+                    input: None,
+                    created_at: Utc::now(),
+                    metadata: serde_json::Value::Null,
+                })
+                .await
+        }
+    });
+    let outcomes = futures::future::join_all(submissions).await;
+
+    assert!(
+        outcomes.iter().any(|outcome| outcome.is_err()),
+        "an armed one-shot write fault must surface to a caller; replaying the \
+         batch would consume it silently and report durable state that was \
+         never committed"
+    );
+    // Re-submitting a failed command is the caller's own decision and must
+    // still work: the batch rolled back, so nothing conflicts.
+    let failed = process_ids
+        .iter()
+        .zip(outcomes.iter())
+        .filter_map(|(process_id, outcome)| outcome.as_ref().err().map(|_| *process_id))
+        .collect::<Vec<_>>();
+    for process_id in failed {
+        submit_internal_process(&store, &resource_scope, process_id).await;
+    }
+}
+
 #[tokio::test]
 async fn process_journal_retries_transient_transaction_setup_contention() {
     let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -2274,6 +2274,68 @@ async fn group_committed_submissions_deliver_every_entry_once_before_returning()
     );
 }
 
+/// Concurrent claims in one group commit each get work.
+///
+/// A group commit materializes one shared state for the whole batch, so the
+/// candidate window has to cover the batch's total demand. Sized for a single
+/// request it does not: the first claim consumes the window and the rest come
+/// back empty while eligible work is still queued. Before batching each claim
+/// ran its own transaction and re-queried after the previous one advanced
+/// state, so the window was always fresh.
+///
+/// Deliberately more queued work than any one claim asks for, and enough
+/// concurrent claimants that they batch.
+#[tokio::test]
+async fn concurrent_claims_in_one_batch_each_receive_queued_work() {
+    // Demand must exceed one request's window, which is `max_processes` plus
+    // the 64-row quota-skip allowance; below that the allowance already covers
+    // the batch and the defect is invisible.
+    const CLAIMANTS: usize = 40;
+    const PER_CLAIM: usize = 4;
+
+    let store = Arc::new(ProcessJournalStore::new(
+        in_memory_backed_processes_filesystem(),
+    ));
+    let scope = scope();
+    for _ in 0..(CLAIMANTS * PER_CLAIM) {
+        submit_internal_process(store.as_ref(), &scope, ProcessId::new()).await;
+    }
+
+    let claims = (0..CLAIMANTS).map(|worker| {
+        let store = Arc::clone(&store);
+        async move {
+            store
+                .claim_next_processes(ClaimProcessesRequest {
+                    worker_id: ProcessWorkerId::from_trusted(format!("worker-{worker}")),
+                    scope_filter: None,
+                    process_id_filter: None,
+                    process_kind_filter: None,
+                    max_processes: PER_CLAIM,
+                })
+                .await
+                .expect("claim")
+        }
+    });
+    let claimed = futures::future::join_all(claims).await;
+
+    let empty = claimed.iter().filter(|batch| batch.is_empty()).count();
+    let total = claimed.iter().map(Vec::len).sum::<usize>();
+    assert_eq!(
+        empty,
+        0,
+        "every claimant must receive work when the queue holds \
+         {} processes and the batch asks for {}; got per-claimant counts {:?}",
+        CLAIMANTS * PER_CLAIM,
+        CLAIMANTS * PER_CLAIM,
+        claimed.iter().map(Vec::len).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        total,
+        CLAIMANTS * PER_CLAIM,
+        "claims must not overlap or drop work"
+    );
+}
+
 #[tokio::test]
 async fn group_commit_isolates_a_rejected_command_from_its_batch() {
     let store = Arc::new(ProcessJournalStore::new(

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -2026,7 +2026,7 @@ async fn observer_replays_when_a_second_writer_leaves_a_cursor_gap() {
 
     // Let this instance acknowledge a cursor of its own first, so the gap below
     // is a genuine discontinuity rather than the cold-cache case.
-    submit(&store).await;
+    let before_the_gap = submit(&store).await;
     let cursor_path = observer_cursor_path();
     await_observer_cursor(&filesystem, &cursor_path).await;
 
@@ -2035,7 +2035,7 @@ async fn observer_replays_when_a_second_writer_leaves_a_cursor_gap() {
     let unseen_by_the_fast_path = submit(&other_writer).await;
 
     // Committing again now starts past the gap, forcing the replay.
-    submit(&store).await;
+    let after_the_gap = submit(&store).await;
 
     let observed = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
@@ -2060,6 +2060,36 @@ async fn observer_replays_when_a_second_writer_leaves_a_cursor_gap() {
          replay; the in-memory path carries only this instance's own batches, \
          so delivering across the gap would drop it"
     );
+
+    // Nothing either side of the gap may be lost: the entry before it arrived
+    // on the fast path, the entry after it through the replay, and the replay
+    // must not skip past what it was catching up on.
+    //
+    // Deliberately a subset check rather than an exact count. Redelivery is
+    // permitted here by design -- `deliver_committed_batch` says the entries
+    // above a gap "may be delivered twice, which every replay path already
+    // permits" -- and registration primes the cursor from a spawned task, so a
+    // slow enough runner can legitimately replay the first entry on top of its
+    // live delivery. Asserting an exact count would pin scheduling, not the
+    // contract.
+    let delivered = observer
+        .commits
+        .lock()
+        .expect("observer commits")
+        .iter()
+        .map(|commit| commit.state.process_id)
+        .collect::<std::collections::HashSet<_>>();
+    for (label, process_id) in [
+        ("before the gap", before_the_gap),
+        ("the other writer's", unseen_by_the_fast_path),
+        ("after the gap", after_the_gap),
+    ] {
+        assert!(
+            delivered.contains(&process_id),
+            "{label} commit never reached the observer; crossing the fast path \
+             and the durable replay must lose nothing"
+        );
+    }
 }
 
 fn observer_cursor_path() -> ScopedPath {

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -66,6 +66,32 @@ impl ProcessJournalCommitObserver for RecordingProcessObserver {
     }
 }
 
+/// Recording observer whose callback suspends before it records.
+///
+/// Delivery therefore cannot complete within the flusher's own scheduling slot,
+/// so a store that answered its callers before delivery finished would let them
+/// observe a commit the observer has not seen yet.
+#[derive(Default)]
+struct SuspendingProcessObserver {
+    commits: Mutex<Vec<ProcessJournalCommit>>,
+}
+
+#[async_trait]
+impl ProcessJournalCommitObserver for SuspendingProcessObserver {
+    fn process_observer_id(&self) -> &'static str {
+        "suspending-process-observer"
+    }
+
+    async fn observe_process_commit(&self, commit: ProcessJournalCommit) -> Result<(), String> {
+        tokio::task::yield_now().await;
+        self.commits
+            .lock()
+            .map_err(|_| "observer mutex poisoned".to_string())?
+            .push(commit);
+        Ok(())
+    }
+}
+
 struct FailingProcessObserver;
 
 #[async_trait]
@@ -1625,6 +1651,147 @@ async fn observer_failure_retries_until_durable_cursor_is_acknowledged() {
         .expect("subscribe after acknowledged replay");
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert_eq!(after_restart.attempts.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn group_committed_submissions_deliver_every_entry_once_before_returning() {
+    let store = Arc::new(ProcessJournalStore::new(
+        in_memory_backed_processes_filesystem(),
+    ));
+    let observer = Arc::new(SuspendingProcessObserver::default());
+    store
+        .subscribe_process_observer(observer.clone())
+        .expect("subscribe observer");
+    let scope = scope();
+    // Materialize the store and start the group-commit funnel so the
+    // submissions below are all queued before the flusher drains them.
+    let warmup = submit_internal_process(store.as_ref(), &scope, ProcessId::new()).await;
+
+    let process_ids = (0..32).map(|_| ProcessId::new()).collect::<Vec<_>>();
+    let submissions = process_ids.iter().copied().map(|process_id| {
+        let store = Arc::clone(&store);
+        let observer = Arc::clone(&observer);
+        let scope = scope.clone();
+        async move {
+            let snapshot = submit_internal_process(store.as_ref(), &scope, process_id).await;
+            // Read-your-writes: a caller that reads projections right after
+            // this call returns must never miss its own commit.
+            let delivered = observer
+                .commits
+                .lock()
+                .expect("observer commits")
+                .iter()
+                .any(|commit| commit.state.process_id == process_id);
+            assert!(
+                delivered,
+                "observer must have seen {process_id} before its submission returned"
+            );
+            snapshot
+        }
+    });
+    let snapshots = futures::future::join_all(submissions).await;
+    assert_eq!(snapshots.len(), process_ids.len());
+
+    let commits = observer.commits.lock().expect("observer commits");
+    assert_eq!(
+        commits.len(),
+        process_ids.len() + 1,
+        "every committed entry is delivered exactly once"
+    );
+    let mut previous = 0;
+    for commit in commits.iter() {
+        assert!(
+            commit.state.journal_cursor.0 > previous,
+            "observer deliveries must be strictly ordered by cursor"
+        );
+        previous = commit.state.journal_cursor.0;
+    }
+    let delivered = commits
+        .iter()
+        .map(|commit| commit.state.process_id)
+        .collect::<Vec<_>>();
+    for process_id in process_ids
+        .iter()
+        .chain(std::iter::once(&warmup.process_id))
+    {
+        assert_eq!(
+            delivered
+                .iter()
+                .filter(|delivered| *delivered == process_id)
+                .count(),
+            1,
+            "{process_id} must be delivered exactly once"
+        );
+    }
+}
+
+#[tokio::test]
+async fn group_commit_isolates_a_rejected_command_from_its_batch() {
+    let store = Arc::new(ProcessJournalStore::new(
+        in_memory_backed_processes_filesystem(),
+    ));
+    let scope = scope();
+    let leased_process_id = ProcessId::new();
+    submit_internal_process(store.as_ref(), &scope, leased_process_id).await;
+    let claim = store
+        .claim_next_processes(ClaimProcessesRequest {
+            worker_id: ProcessWorkerId::from_trusted(ProcessId::new().as_uuid().to_string()),
+            scope_filter: Some(scope.clone()),
+            process_id_filter: None,
+            process_kind_filter: None,
+            max_processes: 1,
+        })
+        .await
+        .expect("claim process")
+        .pop()
+        .expect("claimed process");
+
+    let rejected = {
+        let store = Arc::clone(&store);
+        async move {
+            store
+                .complete_process(ProcessStateTransitionRequest {
+                    lease: ProcessLeaseRequest {
+                        process_id: leased_process_id,
+                        worker_id: claim.worker_id,
+                        lease_token: ProcessLeaseToken::from_trusted(
+                            ProcessId::new().as_uuid().to_string(),
+                        ),
+                    },
+                    metadata: None,
+                })
+                .await
+        }
+    };
+    let accepted_ids = (0..8).map(|_| ProcessId::new()).collect::<Vec<_>>();
+    let accepted = futures::future::join_all(accepted_ids.iter().copied().map(|process_id| {
+        let store = Arc::clone(&store);
+        let scope = scope.clone();
+        async move { submit_internal_process(store.as_ref(), &scope, process_id).await }
+    }));
+    // Both futures are queued before the flusher runs, so the rejected command
+    // and the valid submissions share one group-commit transaction.
+    let (rejected, accepted) = tokio::join!(rejected, accepted);
+
+    let error = rejected.expect_err("wrong lease must fail");
+    assert!(error.to_string().contains("lease is invalid"));
+    for (process_id, snapshot) in accepted_ids.iter().zip(accepted.iter()) {
+        assert_eq!(&snapshot.process_id, process_id);
+        assert_eq!(snapshot.status, ProcessLifecycleStatus::Queued);
+    }
+    let persisted = store
+        .process_snapshots(&scope)
+        .await
+        .expect("read persisted process snapshots")
+        .into_iter()
+        .map(|snapshot| snapshot.process_id)
+        .collect::<Vec<_>>();
+    for process_id in &accepted_ids {
+        assert!(
+            persisted.contains(process_id),
+            "a batch member rejected for an invalid lease must not drop {process_id}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -334,6 +334,69 @@ async fn group_commit_does_not_replay_a_consumed_one_shot_write_fault() {
     }
 }
 
+/// Contention is retried, but not forever. When the backend stays busy past
+/// the retry bound the batch has to give the caller a definite answer rather
+/// than hang or claim success — every command in it observes the exhaustion.
+#[tokio::test]
+async fn group_commit_surfaces_retry_exhaustion_to_every_caller() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::clone(&backend),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/processes").expect("process alias"),
+            VirtualPath::new("/engine/processes").expect("process target"),
+            MountPermissions::read_write_list_delete(),
+        )])
+        .expect("process mount"),
+    ));
+    let store = ProcessJournalStore::new(filesystem);
+    let resource_scope = scope();
+    // Materialize the store first so the fault lands on real submissions.
+    submit_internal_process(&store, &resource_scope, ProcessId::new()).await;
+
+    // The writer never becomes available again.
+    backend.add_fault(Fault::on(FilesystemOperation::BeginTxn).returning(FaultKind::BackendBusy));
+
+    let process_ids = (0..4).map(|_| ProcessId::new()).collect::<Vec<_>>();
+    let submissions = process_ids.iter().map(|process_id| {
+        let store = &store;
+        let scope = resource_scope.clone();
+        let process_id = *process_id;
+        async move {
+            store
+                .submit_process(SubmitProcessRequest {
+                    process_id,
+                    process_kind: ProcessKind::Internal,
+                    scope,
+                    exclusive_within_scope: false,
+                    operation_id: None,
+                    owner_user_id: None,
+                    concurrency_class: None,
+                    parent_process_id: None,
+                    root_process_id: None,
+                    spawn_tree_descendant_cap: None,
+                    dependency: None,
+                    checkpoint_ref: None,
+                    input: None,
+                    created_at: Utc::now(),
+                    metadata: serde_json::Value::Null,
+                })
+                .await
+        }
+    });
+    let outcomes = tokio::time::timeout(
+        Duration::from_secs(30),
+        futures::future::join_all(submissions),
+    )
+    .await
+    .expect("retry exhaustion must terminate rather than hang");
+
+    assert!(
+        outcomes.iter().all(|outcome| outcome.is_err()),
+        "a permanently busy backend must fail every command in the batch"
+    );
+}
+
 #[tokio::test]
 async fn process_journal_retries_transient_transaction_setup_contention() {
     let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -1702,6 +1702,91 @@ async fn observer_registration_replays_commits_durably_after_restart() {
 /// The newer position is written directly here so the stale-cache window is
 /// deterministic — the contiguity check hides it whenever the other instance's
 /// entries also land in this instance's journal view.
+/// Observer callbacks legitimately re-enter the store: the sub-agent
+/// await-edge resolver settles dependencies and resumes the parent from inside
+/// `observe_process_commit`. The task-local marker is the only thing stopping
+/// such a nested command from waiting on the very delivery it is running
+/// inside, and nothing else in the suite invokes the store from a callback —
+/// so removing or mis-scoping the marker would restore the documented
+/// self-deadlock silently.
+#[tokio::test]
+async fn observer_callback_can_reenter_store_without_deadlock() {
+    struct ReenteringObserver {
+        store: Mutex<Option<Arc<ProcessJournalStore<InMemoryBackend>>>>,
+        scope: ResourceScope,
+        nested: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ProcessJournalCommitObserver for ReenteringObserver {
+        fn process_observer_id(&self) -> &'static str {
+            "reentering-process-observer"
+        }
+
+        async fn observe_process_commit(
+            &self,
+            _commit: ProcessJournalCommit,
+        ) -> Result<(), String> {
+            // Only the first delivery re-enters; the nested command's own
+            // delivery must not recurse forever.
+            if self.nested.fetch_add(1, Ordering::SeqCst) > 0 {
+                return Ok(());
+            }
+            let store = self
+                .store
+                .lock()
+                .map_err(|_| "observer store mutex poisoned".to_string())?
+                .clone()
+                .ok_or_else(|| "observer store not wired".to_string())?;
+            store
+                .submit_process(SubmitProcessRequest {
+                    process_id: ProcessId::new(),
+                    process_kind: ProcessKind::Internal,
+                    scope: self.scope.clone(),
+                    exclusive_within_scope: false,
+                    operation_id: None,
+                    owner_user_id: None,
+                    concurrency_class: None,
+                    parent_process_id: None,
+                    root_process_id: None,
+                    spawn_tree_descendant_cap: None,
+                    dependency: None,
+                    checkpoint_ref: None,
+                    input: None,
+                    created_at: Utc::now(),
+                    metadata: serde_json::Value::Null,
+                })
+                .await
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        }
+    }
+
+    let filesystem = in_memory_backed_processes_filesystem();
+    let store = Arc::new(ProcessJournalStore::new(filesystem));
+    let resource_scope = scope();
+    let observer = Arc::new(ReenteringObserver {
+        store: Mutex::new(Some(Arc::clone(&store))),
+        scope: resource_scope.clone(),
+        nested: Arc::new(AtomicUsize::new(0)),
+    });
+    store
+        .subscribe_process_observer(observer.clone())
+        .expect("subscribe re-entering observer");
+
+    // Both the outer command and the one its delivery issues must complete.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        submit_internal_process(&store, &resource_scope, ProcessId::new()),
+    )
+    .await
+    .expect("a command whose delivery re-enters the store must not deadlock");
+    assert!(
+        observer.nested.load(Ordering::SeqCst) >= 1,
+        "the observer callback must actually have re-entered the store"
+    );
+}
+
 #[tokio::test]
 async fn observer_cursor_never_rewinds_from_a_stale_cache() {
     let filesystem = in_memory_backed_processes_filesystem();

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -2037,48 +2037,42 @@ async fn observer_replays_when_a_second_writer_leaves_a_cursor_gap() {
     // Committing again now starts past the gap, forcing the replay.
     let after_the_gap = submit(&store).await;
 
-    let observed = tokio::time::timeout(Duration::from_secs(5), async {
+    // Nothing either side of the gap may be lost: the entry before it arrived
+    // on the fast path, the entry after it through the replay, and the replay
+    // must not skip past what it was catching up on.
+    //
+    // Waiting for all three rather than just the other writer's, because the
+    // replay records the entries it catches up on one at a time -- seeing that
+    // one has landed says nothing about the next.
+    //
+    // Deliberately a subset rather than an exact count. Redelivery is permitted
+    // here by design -- `deliver_committed_batch` says the entries above a gap
+    // "may be delivered twice, which every replay path already permits" -- and
+    // registration primes the cursor from a spawned task, so a slow enough
+    // runner can legitimately replay the first entry on top of its live
+    // delivery. Asserting an exact count would pin scheduling, not the contract.
+    let expected = [before_the_gap, unseen_by_the_fast_path, after_the_gap];
+    let delivered = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            let seen = observer
+            let delivered = observer
                 .commits
                 .lock()
                 .expect("observer mutex")
                 .iter()
-                .any(|commit| commit.state.process_id == unseen_by_the_fast_path);
-            if seen {
-                return true;
+                .map(|commit| commit.state.process_id)
+                .collect::<std::collections::HashSet<_>>();
+            if expected
+                .iter()
+                .all(|process_id| delivered.contains(process_id))
+            {
+                return delivered;
             }
             tokio::task::yield_now().await;
         }
     })
     .await
-    .unwrap_or(false);
+    .unwrap_or_default();
 
-    assert!(
-        observed,
-        "the other writer's commit must reach the observer through the durable \
-         replay; the in-memory path carries only this instance's own batches, \
-         so delivering across the gap would drop it"
-    );
-
-    // Nothing either side of the gap may be lost: the entry before it arrived
-    // on the fast path, the entry after it through the replay, and the replay
-    // must not skip past what it was catching up on.
-    //
-    // Deliberately a subset check rather than an exact count. Redelivery is
-    // permitted here by design -- `deliver_committed_batch` says the entries
-    // above a gap "may be delivered twice, which every replay path already
-    // permits" -- and registration primes the cursor from a spawned task, so a
-    // slow enough runner can legitimately replay the first entry on top of its
-    // live delivery. Asserting an exact count would pin scheduling, not the
-    // contract.
-    let delivered = observer
-        .commits
-        .lock()
-        .expect("observer commits")
-        .iter()
-        .map(|commit| commit.state.process_id)
-        .collect::<std::collections::HashSet<_>>();
     for (label, process_id) in [
         ("before the gap", before_the_gap),
         ("the other writer's", unseen_by_the_fast_path),
@@ -2087,7 +2081,9 @@ async fn observer_replays_when_a_second_writer_leaves_a_cursor_gap() {
         assert!(
             delivered.contains(&process_id),
             "{label} commit never reached the observer; crossing the fast path \
-             and the durable replay must lose nothing"
+             and the durable replay must lose nothing. The other writer's entry \
+             is the one the in-memory path cannot carry, so a delivery that \
+             skipped the gap drops it"
         );
     }
 }

--- a/crates/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -74,6 +74,8 @@ impl ProcessJournalCommitObserver for RecordingProcessObserver {
 #[derive(Default)]
 struct SuspendingProcessObserver {
     commits: Mutex<Vec<ProcessJournalCommit>>,
+    /// Size of every batch this observer was handed, in delivery order.
+    batch_sizes: Mutex<Vec<usize>>,
 }
 
 #[async_trait]
@@ -88,6 +90,20 @@ impl ProcessJournalCommitObserver for SuspendingProcessObserver {
             .lock()
             .map_err(|_| "observer mutex poisoned".to_string())?
             .push(commit);
+        Ok(())
+    }
+
+    async fn observe_process_commits(
+        &self,
+        commits: Vec<ProcessJournalCommit>,
+    ) -> Result<(), String> {
+        self.batch_sizes
+            .lock()
+            .map_err(|_| "observer mutex poisoned".to_string())?
+            .push(commits.len());
+        for commit in commits {
+            self.observe_process_commit(commit).await?;
+        }
         Ok(())
     }
 }
@@ -1691,6 +1707,17 @@ async fn group_committed_submissions_deliver_every_entry_once_before_returning()
     });
     let snapshots = futures::future::join_all(submissions).await;
     assert_eq!(snapshots.len(), process_ids.len());
+
+    // The 32 group-committed submissions reach the observer as one batched
+    // call, not 32: delivery sits between the commit and the caller's response,
+    // so a per-entry hand-off there costs a round trip per entry.
+    let batch_sizes = observer.batch_sizes.lock().expect("observer batch sizes");
+    assert!(
+        batch_sizes.contains(&process_ids.len()),
+        "expected one delivery of {} commits, saw batches {batch_sizes:?}",
+        process_ids.len()
+    );
+    drop(batch_sizes);
 
     let commits = observer.commits.lock().expect("observer commits");
     assert_eq!(

--- a/crates/ironclaw_product/src/reborn_services.rs
+++ b/crates/ironclaw_product/src/reborn_services.rs
@@ -6644,9 +6644,14 @@ fn map_timeline_probe_error(error: SessionThreadError) -> ProductSurfaceError {
         | SessionThreadError::Deserialization(_)
         | SessionThreadError::InvalidMessageTimestamp { .. }
         | SessionThreadError::Backend(_) => {
-            // The boundary error is sanitized to a retryable 503; the cause
-            // must stay visible server-side or these become undiagnosable.
-            tracing::warn!(%error, "timeline probe failed; returning retryable TimelineUnavailable");
+            // The boundary error is sanitized to a retryable 503; the failure
+            // still has to be visible server-side or it is undiagnosable. Log
+            // the detail-free kind rather than the Display, whose Backend
+            // variant carries virtual tenant/user paths and raw backend text.
+            tracing::warn!(
+                error_kind = error.kind_name(),
+                "timeline probe failed; returning retryable TimelineUnavailable"
+            );
             ProductSurfaceError::from_status_kind(
                 ProductSurfaceErrorCode::Unavailable,
                 ProductSurfaceErrorKind::TimelineUnavailable,

--- a/crates/ironclaw_product/src/reborn_services.rs
+++ b/crates/ironclaw_product/src/reborn_services.rs
@@ -6643,12 +6643,17 @@ fn map_timeline_probe_error(error: SessionThreadError) -> ProductSurfaceError {
         SessionThreadError::Serialization(_)
         | SessionThreadError::Deserialization(_)
         | SessionThreadError::InvalidMessageTimestamp { .. }
-        | SessionThreadError::Backend(_) => ProductSurfaceError::from_status_kind(
-            ProductSurfaceErrorCode::Unavailable,
-            ProductSurfaceErrorKind::TimelineUnavailable,
-            503,
-            true,
-        ),
+        | SessionThreadError::Backend(_) => {
+            // The boundary error is sanitized to a retryable 503; the cause
+            // must stay visible server-side or these become undiagnosable.
+            tracing::warn!(%error, "timeline probe failed; returning retryable TimelineUnavailable");
+            ProductSurfaceError::from_status_kind(
+                ProductSurfaceErrorCode::Unavailable,
+                ProductSurfaceErrorKind::TimelineUnavailable,
+                503,
+                true,
+            )
+        }
         _ => map_ownership_probe_error(error),
     }
 }

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -35,6 +35,7 @@
 mod message_lookup_index;
 mod message_read;
 mod thread_index;
+mod transcript_migration;
 
 use std::{
     collections::{HashMap, HashSet},

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -2665,8 +2665,8 @@ where
                     // The write path seeded the label into the index row; the
                     // sidebar entry costs no extra reads.
                     Some(derived) => record.title = Some(derived.clone()),
-                    // Row predates write-time derivation: probe once below and
-                    // heal the index row so this thread never probes again.
+                    // Row predates write-time derivation: probe for this
+                    // response; the migration backfills the label durably.
                     None => needs_title.push((idx, record.thread_id.clone(), index.next_sequence)),
                 }
             }
@@ -2707,11 +2707,11 @@ where
                             .and_then(|message| message.content.as_deref())
                             .and_then(derive_title_from_message)
                         {
-                            page[idx].title = Some(title.clone());
-                            // One-time heal: persist the label so this row
-                            // stops paying the probe on every list request.
-                            self.store_derived_title_best_effort(&request.scope, &thread_id, title)
-                                .await;
+                            // Read-only: the label serves this response but is
+                            // not persisted here. Backfilling it durably is the
+                            // thread-index migration's job (threads guardrail —
+                            // a list request must not repair the projection).
+                            page[idx].title = Some(title);
                         }
                     }
                     Err(error) => {

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -1532,6 +1532,11 @@ where
         // lands when the thread has no title yet). Best-effort: the message is
         // already durable, so a touch failure must not fail (and retry) the
         // accept.
+        // Only the first user message may seed the label. A pre-upgrade thread
+        // has messages but no cached label, and seeding from whatever arrives
+        // next would show the newest message where the sidebar contract
+        // promises the first — the probe-and-heal path derives those correctly.
+        let derived_title_candidate = (sequence == 1).then_some(derived_title_candidate).flatten();
         if let Err(error) = self
             .touch_thread_index_updated_at_with_derived_title(
                 &scope,
@@ -2283,6 +2288,11 @@ where
                     Ok(())
                 },
             )
+            .await?;
+        // The cached sidebar label may be a copy of the text just redacted.
+        // Propagating the removal is a redaction obligation, not best-effort:
+        // failing here is correct if the copy cannot be cleared.
+        self.clear_derived_title(&request.scope, &request.thread_id)
             .await?;
         self.touch_thread_updated_at_best_effort_at(&request.scope, &request.thread_id, now)
             .await;

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -160,6 +160,10 @@ where
     filesystem: Arc<ScopedFilesystem<F>>,
     known_thread_index_rows: Mutex<HashSet<String>>,
     ready_thread_index_scopes: Mutex<HashSet<String>>,
+    /// Mounts whose `/threads`-root index specs are already declared, keyed by
+    /// `tenant:user` — the pair the alias resolves through. Keeps thread create
+    /// off the index-DDL path after a mount's first thread.
+    ready_index_mounts: Mutex<HashSet<String>>,
     thread_index_declaration_lock: tokio::sync::Mutex<()>,
     one_shot_context_windows: Mutex<HashMap<String, ContextWindow>>,
 }
@@ -173,6 +177,7 @@ where
             filesystem,
             known_thread_index_rows: Mutex::new(HashSet::new()),
             ready_thread_index_scopes: Mutex::new(HashSet::new()),
+            ready_index_mounts: Mutex::new(HashSet::new()),
             thread_index_declaration_lock: tokio::sync::Mutex::new(()),
             one_shot_context_windows: Mutex::new(HashMap::new()),
         }
@@ -293,28 +298,66 @@ where
             ))
     }
 
-    async fn ensure_thread_record_indexes(
+    /// Declare every ordered-index spec this crate queries, once per mount.
+    ///
+    /// These are declared at the `/threads` alias root rather than under each
+    /// thread. An ordered-index declaration installs write-maintained
+    /// projection triggers whose match clause embeds the declared prefix, so
+    /// declaring per thread both cost a DDL transaction on every thread create
+    /// and accumulated triggers without bound (three per spec per thread) on
+    /// the shared entries table. Every spec leads with its partition key
+    /// (`thread_id`, or `scope_key` for the listing projection), so a single
+    /// declaration above the per-thread paths serves every thread under this
+    /// mount; `query_ordered` resolves it by walking ancestor prefixes.
+    ///
+    /// The alias root resolves to a per-(tenant, user) backend path, so the
+    /// memo is keyed by that pair. Racing callers may each declare once more
+    /// than strictly needed — declarations are idempotent by contract, and the
+    /// backend keeps its own cache on the same resolved path — which is why
+    /// this deliberately takes no lock.
+    ///
+    /// `fail_soft_unsupported` lets a caller that only needs the projection for
+    /// an optional listing tolerate a mount without ordered-index support;
+    /// callers that require it propagate. The mount is memoized as declared
+    /// only on full success, so a fail-soft skip does not suppress a later
+    /// required declaration.
+    pub(super) async fn declare_root_indexes(
         &self,
         scope: &ThreadScope,
-        thread_id: &ThreadId,
+        fail_soft_unsupported: bool,
     ) -> Result<(), SessionThreadError> {
-        let messages = messages_root(scope, thread_id)?;
-        for index in [
-            message_sequence_index_spec()?,
-            message_kind_status_index_spec()?,
-        ] {
-            self.filesystem
-                .ensure_index(&scope.to_resource_scope(), &messages, &index)
-                .await?;
+        let resource_scope = scope.to_resource_scope();
+        let mount_key = format!(
+            "{}:{}",
+            resource_scope.tenant_id.as_str(),
+            resource_scope.user_id.as_str()
+        );
+        if self
+            .ready_index_mounts
+            .lock()
+            .map(|ready| ready.contains(&mount_key))
+            .unwrap_or(false)
+        {
+            return Ok(());
         }
-        let summaries = summaries_root(scope, thread_id)?;
-        self.filesystem
-            .ensure_index(
-                &scope.to_resource_scope(),
-                &summaries,
-                &summary_index_spec()?,
-            )
-            .await?;
+        let root = scoped_path(THREADS_PREFIX)?;
+        for index in root_index_specs()? {
+            match self
+                .filesystem
+                .ensure_index(&resource_scope, &root, &index)
+                .await
+            {
+                Ok(()) => {}
+                Err(FilesystemError::Unsupported { .. }) if fail_soft_unsupported => {
+                    return Ok(());
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        if let Ok(mut ready) = self.ready_index_mounts.lock() {
+            ready.insert(mount_key.clone());
+            thread_index::evict_hash_set_entry_over_limit(&mut ready, 512, &mount_key);
+        }
         Ok(())
     }
 
@@ -1328,8 +1371,7 @@ where
         .await
         .map_err(map_cas_error)?;
         if created {
-            self.ensure_thread_record_indexes(&record.scope, &record.thread_id)
-                .await?;
+            self.declare_root_indexes(&record.scope, false).await?;
         }
         if created || !self.is_thread_index_known(&record.scope, &record.thread_id) {
             self.refresh_thread_index_from_source(&record.scope, &record.thread_id)
@@ -2841,6 +2883,18 @@ fn fs_index_key(raw: &str) -> Result<IndexKey, SessionThreadError> {
 fn fs_index_name(raw: &str) -> Result<IndexName, SessionThreadError> {
     IndexName::new(raw)
         .map_err(|error| SessionThreadError::Backend(format!("invalid index name: {error}")))
+}
+
+/// Every ordered-index spec this crate queries, all declared together at the
+/// `/threads` alias root. Each leads with its partition key, so one
+/// declaration above the per-thread paths serves every thread on the mount.
+fn root_index_specs() -> Result<[IndexSpec; 4], SessionThreadError> {
+    Ok([
+        message_sequence_index_spec()?,
+        message_kind_status_index_spec()?,
+        summary_index_spec()?,
+        thread_index::thread_activity_index_spec()?,
+    ])
 }
 
 fn summary_index_spec() -> Result<IndexSpec, SessionThreadError> {

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -333,9 +333,10 @@ where
     /// backend keeps its own cache on the same resolved path — which is why
     /// this deliberately takes no lock.
     ///
-    /// `fail_soft_unsupported` lets a caller that only needs the projection for
-    /// an optional listing tolerate a mount without ordered-index support;
-    /// callers that require it propagate. The mount is memoized as declared
+    /// `IndexDeclarationPolicy::Optional` lets a caller that only needs the
+    /// projection for an optional listing tolerate a mount without
+    /// ordered-index support; `Required` propagates. The mount is memoized as
+    /// declared
     /// only on full success, so a fail-soft skip does not suppress a later
     /// required declaration.
     pub(super) async fn declare_root_indexes(

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -852,13 +852,15 @@ where
             .transpose()
     }
 
+    /// Caller must have run `ensure_transcript_indexes_migrated` for the
+    /// scope; hoisted out so a list page pays the marker check once, not once
+    /// per untitled thread.
     async fn first_user_message_for_title(
         &self,
         scope: &ThreadScope,
         thread_id: &ThreadId,
         _next_sequence: u64,
     ) -> Result<Option<ThreadMessageRecord>, SessionThreadError> {
-        self.ensure_transcript_indexes_migrated(scope).await?;
         let Some(message_id) = MessageLookupIndexStore::new(self.filesystem.as_ref())
             .read_first_user(scope, thread_id)
             .await?
@@ -1423,6 +1425,9 @@ where
 
         let message_id = ThreadMessageId::new();
         let (content_text, attachments) = content.into_parts();
+        // Derived before `content_text` moves into the message record; seeds
+        // the sidebar label in the post-accept activity touch below.
+        let derived_title_candidate = derive_title_from_message(&content_text);
         crate::contract::validate_attachment_refs(&attachments)?;
         // Sequence assignment happens only after payload validation. On
         // transactional backends the thread counter, message, sequence index,
@@ -1522,11 +1527,26 @@ where
         }
 
         // Inbound user message is thread activity — stamp recency so the
-        // sidebar surfaces this thread first. Best-effort: the message is
+        // sidebar surfaces this thread first, and seed the derived sidebar
+        // label from this message in the same index-row write (the label only
+        // lands when the thread has no title yet). Best-effort: the message is
         // already durable, so a touch failure must not fail (and retry) the
         // accept.
-        self.touch_thread_updated_at_best_effort_at(&scope, &thread_id, now)
-            .await;
+        if let Err(error) = self
+            .touch_thread_index_updated_at_with_derived_title(
+                &scope,
+                &thread_id,
+                now,
+                derived_title_candidate,
+            )
+            .await
+        {
+            tracing::debug!(
+                thread_id = %thread_id.as_str(),
+                ?error,
+                "skipping thread recency/title touch after inbound accept"
+            );
+        }
 
         Ok(AcceptedInboundMessage {
             thread_id,
@@ -2605,9 +2625,16 @@ where
         let mut needs_title: Vec<(usize, ThreadId, u64)> = Vec::new();
         for index in &listed {
             let idx = page.len();
-            let record = index.record.clone();
+            let mut record = index.record.clone();
             if record.title.is_none() {
-                needs_title.push((idx, record.thread_id.clone(), index.next_sequence));
+                match &index.derived_title {
+                    // The write path seeded the label into the index row; the
+                    // sidebar entry costs no extra reads.
+                    Some(derived) => record.title = Some(derived.clone()),
+                    // Row predates write-time derivation: probe once below and
+                    // heal the index row so this thread never probes again.
+                    None => needs_title.push((idx, record.thread_id.clone(), index.next_sequence)),
+                }
             }
             page.push(record);
         }
@@ -2619,6 +2646,8 @@ where
         // are silent-ok — the sidebar entry simply falls back to its
         // thread-id label, matching the WebUI fallback path.
         if !needs_title.is_empty() {
+            self.ensure_transcript_indexes_migrated(&request.scope)
+                .await?;
             let title_results: Vec<(
                 usize,
                 ThreadId,
@@ -2644,7 +2673,11 @@ where
                             .and_then(|message| message.content.as_deref())
                             .and_then(derive_title_from_message)
                         {
-                            page[idx].title = Some(title);
+                            page[idx].title = Some(title.clone());
+                            // One-time heal: persist the label so this row
+                            // stops paying the probe on every list request.
+                            self.store_derived_title_best_effort(&request.scope, &thread_id, title)
+                                .await;
                         }
                     }
                     Err(error) => {

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -52,7 +52,7 @@ use ironclaw_filesystem::{
 };
 use ironclaw_host_api::{
     error::HostApiError,
-    ids::{InvocationId, ThreadId},
+    ids::{InvocationId, TenantId, ThreadId, UserId},
     path::ScopedPath,
     resource::ResourceScope,
 };
@@ -163,9 +163,23 @@ where
     /// Mounts whose `/threads`-root index specs are already declared, keyed by
     /// `tenant:user` — the pair the alias resolves through. Keeps thread create
     /// off the index-DDL path after a mount's first thread.
-    ready_index_mounts: Mutex<HashSet<String>>,
+    ready_index_mounts: Mutex<HashSet<(TenantId, UserId)>>,
     thread_index_declaration_lock: tokio::sync::Mutex<()>,
     one_shot_context_windows: Mutex<HashMap<String, ContextWindow>>,
+}
+
+/// Whether a mount that cannot serve ordered indexes is a hard failure.
+///
+/// A named mode rather than a boolean: one caller derives it from `!required`,
+/// and an inverted argument there would silently downgrade a required
+/// declaration to a skipped one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IndexDeclarationPolicy {
+    /// Propagate `Unsupported` — the caller needs the projection.
+    Required,
+    /// Tolerate `Unsupported` — the caller only wants the projection if the
+    /// mount can serve it.
+    Optional,
 }
 
 impl<F> FilesystemSessionThreadService<F>
@@ -301,11 +315,13 @@ where
     /// Declare every ordered-index spec this crate queries, once per mount.
     ///
     /// These are declared at the `/threads` alias root rather than under each
-    /// thread. An ordered-index declaration installs write-maintained
-    /// projection triggers whose match clause embeds the declared prefix, so
-    /// declaring per thread both cost a DDL transaction on every thread create
-    /// and accumulated triggers without bound (three per spec per thread) on
-    /// the shared entries table. Every spec leads with its partition key
+    /// thread. A declaration is catalog work — a spec row, and on first use the
+    /// static projection trigger set — so declaring per thread paid that cost
+    /// on every thread create and left a catalog row per thread behind
+    /// forever, which the projection then has to consider on each write.
+    /// (Under the per-declaration trigger design this branch replaced, it also
+    /// accumulated three triggers per spec per thread.) Every spec leads with
+    /// its partition key
     /// (`thread_id`, or `scope_key` for the listing projection), so a single
     /// declaration above the per-thread paths serves every thread under this
     /// mount; `query_ordered` resolves it by walking ancestor prefixes.
@@ -324,13 +340,15 @@ where
     pub(super) async fn declare_root_indexes(
         &self,
         scope: &ThreadScope,
-        fail_soft_unsupported: bool,
+        policy: IndexDeclarationPolicy,
     ) -> Result<(), SessionThreadError> {
         let resource_scope = scope.to_resource_scope();
-        let mount_key = format!(
-            "{}:{}",
-            resource_scope.tenant_id.as_str(),
-            resource_scope.user_id.as_str()
+        // The `/threads` alias resolves through tenant and user, so the mount
+        // identity is that pair. Kept typed rather than flattened into a
+        // delimited string (typed-internals rule).
+        let mount_key = (
+            resource_scope.tenant_id.clone(),
+            resource_scope.user_id.clone(),
         );
         if self
             .ready_index_mounts
@@ -348,7 +366,9 @@ where
                 .await
             {
                 Ok(()) => {}
-                Err(FilesystemError::Unsupported { .. }) if fail_soft_unsupported => {
+                Err(FilesystemError::Unsupported { .. })
+                    if policy == IndexDeclarationPolicy::Optional =>
+                {
                     return Ok(());
                 }
                 Err(error) => return Err(error.into()),
@@ -356,7 +376,7 @@ where
         }
         if let Ok(mut ready) = self.ready_index_mounts.lock() {
             ready.insert(mount_key.clone());
-            thread_index::evict_hash_set_entry_over_limit(&mut ready, 512, &mount_key);
+            thread_index::evict_entry_over_limit(&mut ready, 512, &mount_key);
         }
         Ok(())
     }
@@ -1373,7 +1393,8 @@ where
         .await
         .map_err(map_cas_error)?;
         if created {
-            self.declare_root_indexes(&record.scope, false).await?;
+            self.declare_root_indexes(&record.scope, IndexDeclarationPolicy::Required)
+                .await?;
         }
         if created || !self.is_thread_index_known(&record.scope, &record.thread_id) {
             self.refresh_thread_index_from_source(&record.scope, &record.thread_id)

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -1541,6 +1541,9 @@ where
             )
             .await
         {
+            // silent-ok: the message is already durable; the recency stamp and
+            // derived label are advisory, and failing the accept here could
+            // make an un-idempotent caller retry and duplicate the message.
             tracing::debug!(
                 thread_id = %thread_id.as_str(),
                 ?error,

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -409,6 +409,46 @@ where
         Ok(())
     }
 
+    /// Drop the cached sidebar label for a thread.
+    ///
+    /// The label is a copy of user message text, so whatever removes that text
+    /// must remove the copy: redaction clears the message content but the
+    /// listing serves the index row, which would otherwise keep showing the
+    /// redacted words. Clearing (rather than re-deriving here) keeps redaction
+    /// off the transcript-read path; the next list falls back to the probe,
+    /// which now sees the redacted message.
+    pub(super) async fn clear_derived_title(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        let path = thread_index_record_path(scope, thread_id)?;
+        let resource_scope = scope.to_resource_scope();
+        cas_update(
+            self.filesystem.as_ref(),
+            &resource_scope,
+            &path,
+            |bytes: &[u8]| deserialize::<ThreadIndexRecord>(bytes),
+            |record: &ThreadIndexRecord| Self::thread_index_entry(record),
+            |current: Option<ThreadIndexRecord>| async move {
+                let Some(mut index) = current else {
+                    return Ok(CasApply::no_op(
+                        no_op_thread_index_record(scope.clone(), thread_id.clone()),
+                        (),
+                    ));
+                };
+                if index.derived_title.is_none() {
+                    return Ok(CasApply::no_op(index, ()));
+                }
+                index.derived_title = None;
+                Ok(CasApply::new(index, ()))
+            },
+        )
+        .await
+        .map_err(map_cas_error)?;
+        Ok(())
+    }
+
     /// One-time heal for index rows that predate write-time title derivation:
     /// persist the probed label (never bumping activity) so the thread stops
     /// paying a transcript probe on every list request. Best-effort — listing
@@ -696,13 +736,24 @@ where
         messages: bool,
         rows: Vec<ironclaw_filesystem::VersionedEntry>,
     ) -> Result<TranscriptPageOutcome, SessionThreadError> {
-        let mut txn = self
+        // Writer admission is exactly where the observed QA failure happens:
+        // acquiring the sole libSQL writer can time out as `BackendBusy`, and
+        // propagating it here would escape as the retryable timeline 503 this
+        // retry loop exists to absorb.
+        let mut txn = match self
             .filesystem
             .begin(
                 &scope.to_resource_scope(),
                 &scoped_path(crate::filesystem_service::THREADS_PREFIX)?,
             )
-            .await?;
+            .await
+        {
+            Ok(txn) => txn,
+            Err(error) if transcript_migration_conflict(&error) => {
+                return Ok(TranscriptPageOutcome::Conflict(error));
+            }
+            Err(error) => return Err(error.into()),
+        };
         for listed_row in rows {
             // The listing runs before BEGIN IMMEDIATE owns the
             // writer lock. Re-read inside the transaction so a

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -545,6 +545,13 @@ where
             .filter(|entry| entry.file_type == FileType::Directory)
             .map(|entry| ThreadId::new(entry.name).map_err(invalid_path))
             .collect::<Result<Vec<_>, _>>()?;
+        // The title backfill below reads the transcript lookup projection, and
+        // on a scope upgraded from before that projection existed the rows are
+        // not there yet. Migrating first is what makes the backfill see legacy
+        // messages: skip it and every untitled thread derives `None`, the
+        // completion marker still lands, and each later sidebar request pays
+        // the per-thread transcript probe this migration exists to retire.
+        self.ensure_transcript_indexes_migrated(scope).await?;
         for thread_id in &thread_ids {
             if let Some((stored, _)) = self.read_thread_versioned(scope, thread_id).await? {
                 let mut index = Self::thread_index_record(&stored);
@@ -553,11 +560,12 @@ where
                 // listing projection must stay read-only (threads guardrail —
                 // projection backfill is explicit migration work).
                 if index.record.title.is_none() {
+                    // Propagate rather than `.ok()`: this migration writes a
+                    // completion marker, so swallowing a read failure records a
+                    // backfill that never happened and no later pass retries it.
                     index.derived_title = self
                         .first_user_message_for_title(scope, thread_id, stored.next_sequence)
-                        .await
-                        .ok()
-                        .flatten()
+                        .await?
                         .and_then(|message| message.content.as_deref().map(str::to_string))
                         .and_then(|content| crate::title::derive_title_from_message(&content));
                 }

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 
 use super::{
-    StoredThreadRecord, deserialize, invalid_path, is_not_found, map_cas_error, messages_root,
-    scope_axes_string, scoped_path, serialize_pretty, summaries_root,
+    IndexDeclarationPolicy, StoredThreadRecord, deserialize, invalid_path, is_not_found,
+    map_cas_error, messages_root, scope_axes_string, scoped_path, serialize_pretty, summaries_root,
 };
 
 const THREAD_INDEX_KIND: &str = "thread_index";
@@ -144,10 +144,18 @@ where
         // The listing projection is declared once per mount at the `/threads`
         // alias root, not per scope. Ancestor-prefix resolution lets the
         // per-scope `thread_index_root` query below still find it.
-        self.declare_root_indexes(scope, !required).await?;
+        self.declare_root_indexes(
+            scope,
+            if required {
+                IndexDeclarationPolicy::Required
+            } else {
+                IndexDeclarationPolicy::Optional
+            },
+        )
+        .await?;
         if let Ok(mut ready) = self.ready_thread_index_scopes.lock() {
             ready.insert(scope_key.clone());
-            evict_hash_set_entry_over_limit(&mut ready, 128, &scope_key);
+            evict_entry_over_limit(&mut ready, 128, &scope_key);
         }
         if required {
             let marker = thread_index_migration_marker_path(scope)?;
@@ -231,7 +239,7 @@ where
         if let Ok(mut known) = self.known_thread_index_rows.lock() {
             let key = thread_index_record_cache_key(scope, thread_id);
             known.insert(key.clone());
-            evict_hash_set_entry_over_limit(&mut known, THREAD_INDEX_KNOWN_ROW_MAX, &key);
+            evict_entry_over_limit(&mut known, THREAD_INDEX_KNOWN_ROW_MAX, &key);
         }
     }
 
@@ -665,7 +673,8 @@ where
             .map(|entry| ThreadId::new(entry.name).map_err(invalid_path))
             .collect::<Result<Vec<_>, _>>()?;
         let mut migrated = 0usize;
-        self.declare_root_indexes(scope, false).await?;
+        self.declare_root_indexes(scope, IndexDeclarationPolicy::Required)
+            .await?;
         for thread_id in thread_ids {
             for (prefix, messages) in [
                 (messages_root(scope, &thread_id)?, true),
@@ -988,17 +997,18 @@ fn thread_activity_sort_key(record: &SessionThreadRecord) -> String {
     format!("{descending_rank:020}")
 }
 
-pub(super) fn evict_hash_set_entry_over_limit(
-    set: &mut HashSet<String>,
-    max_entries: usize,
-    keep: &str,
-) {
+/// Generic over the key so typed cache keys (a `(TenantId, UserId)` mount
+/// pair) do not have to be flattened into a string to be evicted.
+pub(super) fn evict_entry_over_limit<K>(set: &mut HashSet<K>, max_entries: usize, keep: &K)
+where
+    K: std::hash::Hash + Eq + Clone,
+{
     if set.len() <= max_entries {
         return;
     }
     let mut keys = set.iter();
     let victim = match keys.next() {
-        Some(first) if first.as_str() == keep => keys.next().cloned(),
+        Some(first) if first == keep => keys.next().cloned(),
         Some(first) => Some(first.clone()),
         None => None,
     };

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -449,6 +449,8 @@ where
         )
         .await;
         if let Err(error) = result {
+            // silent-ok: opportunistic heal; listing already holds the label
+            // for this response and the next request simply probes again.
             tracing::debug!(
                 thread_id = %thread_id.as_str(),
                 ?error,
@@ -735,10 +737,20 @@ where
                     let virtual_path = self
                         .filesystem
                         .resolve(&scope.to_resource_scope(), &lookup_path)?;
-                    if matches!(expectation, CasExpectation::Absent)
-                        && txn.get(&virtual_path).await?.is_some()
-                    {
-                        continue;
+                    if matches!(expectation, CasExpectation::Absent) {
+                        // This read can lose the same writer race as the
+                        // writes below (BackendBusy under contention on both
+                        // SQL backends); classify it the same way or the
+                        // bounded-retry contract has a hole.
+                        match txn.get(&virtual_path).await {
+                            Ok(Some(_)) => continue,
+                            Ok(None) => {}
+                            Err(error) if transcript_migration_conflict(&error) => {
+                                txn.rollback().await;
+                                return Ok(TranscriptPageOutcome::Conflict(error));
+                            }
+                            Err(error) => return Err(error.into()),
+                        }
                     }
                     match txn.put(&virtual_path, lookup_entry, expectation).await {
                         Ok(_) => {}

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -457,56 +457,6 @@ where
         Ok(())
     }
 
-    /// One-time heal for index rows that predate write-time title derivation:
-    /// persist the probed label (never bumping activity) so the thread stops
-    /// paying a transcript probe on every list request. Best-effort — listing
-    /// already has the label in hand for this response.
-    pub(super) async fn store_derived_title_best_effort(
-        &self,
-        scope: &ThreadScope,
-        thread_id: &ThreadId,
-        derived_title: String,
-    ) {
-        let path = match thread_index_record_path(scope, thread_id) {
-            Ok(path) => path,
-            Err(error) => {
-                tracing::debug!(?error, "derived-title heal skipped: bad index path");
-                return;
-            }
-        };
-        let resource_scope = scope.to_resource_scope();
-        let derived_title = &derived_title;
-        let result = cas_update(
-            self.filesystem.as_ref(),
-            &resource_scope,
-            &path,
-            |bytes: &[u8]| deserialize::<ThreadIndexRecord>(bytes),
-            |record: &ThreadIndexRecord| Self::thread_index_entry(record),
-            |current: Option<ThreadIndexRecord>| async move {
-                let Some(mut index) = current else {
-                    return Err(SessionThreadError::UnknownThread {
-                        thread_id: thread_id.clone(),
-                    });
-                };
-                if index.record.title.is_some() || index.derived_title.is_some() {
-                    return Ok(CasApply::no_op(index, ()));
-                }
-                index.derived_title = Some(derived_title.clone());
-                Ok(CasApply::new(index, ()))
-            },
-        )
-        .await;
-        if let Err(error) = result {
-            // silent-ok: opportunistic heal; listing already holds the label
-            // for this response and the next request simply probes again.
-            tracing::debug!(
-                thread_id = %thread_id.as_str(),
-                ?error,
-                "derived-title heal failed; the next list request will probe again"
-            );
-        }
-    }
-
     async fn read_thread_index_record(
         &self,
         scope: &ThreadScope,
@@ -622,8 +572,21 @@ where
             .collect::<Result<Vec<_>, _>>()?;
         for thread_id in &thread_ids {
             if let Some((stored, _)) = self.read_thread_versioned(scope, thread_id).await? {
-                self.merge_thread_index_record_declared(Self::thread_index_record(&stored))
-                    .await?;
+                let mut index = Self::thread_index_record(&stored);
+                // Backfill the sidebar label here rather than from a list
+                // request: deriving it costs a transcript probe, and the
+                // listing projection must stay read-only (threads guardrail —
+                // projection backfill is explicit migration work).
+                if index.record.title.is_none() {
+                    index.derived_title = self
+                        .first_user_message_for_title(scope, thread_id, stored.next_sequence)
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|message| message.content.as_deref().map(str::to_string))
+                        .and_then(|content| crate::title::derive_title_from_message(&content));
+                }
+                self.merge_thread_index_record_declared(index).await?;
             }
         }
         let source_ids = thread_ids

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -54,6 +54,13 @@ pub(super) struct ThreadIndexRecord {
     pub(super) record: SessionThreadRecord,
     pub(super) next_sequence: u64,
     flags: ThreadIndexFlags,
+    /// Sidebar label derived from the thread's first user message, written at
+    /// message-accept time (and healed lazily for rows that predate it).
+    /// Without it every list request re-derived titles with per-thread
+    /// transcript probes — an N+1 that dominates listing once a user has many
+    /// threads. `record.title` (user-set) always wins over this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) derived_title: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -183,6 +190,7 @@ where
         ThreadIndexRecord {
             record: stored.record.clone(),
             next_sequence: stored.next_sequence,
+            derived_title: None,
             flags: ThreadIndexFlags {
                 title_present: stored.record.title.is_some(),
                 metadata_present: stored.record.metadata_json.is_some(),
@@ -320,6 +328,11 @@ where
             source.record.goal = existing.record.goal;
             source.flags.goal_present = true;
         }
+        // The derived sidebar label lives only on the index row; a rebuild
+        // from the source record must not erase it.
+        if same_source_generation && source.derived_title.is_none() {
+            source.derived_title = existing.derived_title;
+        }
         Ok(source)
     }
 
@@ -329,11 +342,27 @@ where
         thread_id: &ThreadId,
         updated_at: DateTime<Utc>,
     ) -> Result<(), SessionThreadError> {
+        self.touch_thread_index_updated_at_with_derived_title(scope, thread_id, updated_at, None)
+            .await
+    }
+
+    /// Activity touch that can also seed the derived sidebar label in the
+    /// same index-row CAS — zero extra round trips on the message-accept
+    /// path. The candidate only lands when the thread has neither a user-set
+    /// title nor a previously derived one.
+    pub(super) async fn touch_thread_index_updated_at_with_derived_title(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        updated_at: DateTime<Utc>,
+        derived_title: Option<String>,
+    ) -> Result<(), SessionThreadError> {
         self.ensure_thread_index_query(scope, false).await?;
         let path = thread_index_record_path(scope, thread_id)?;
         let resource_scope = scope.to_resource_scope();
         let scope_for_retry = scope.clone();
         let thread_id_for_retry = thread_id.clone();
+        let derived_title = &derived_title;
         let row_known = cas_update(
             self.filesystem.as_ref(),
             &resource_scope,
@@ -365,6 +394,9 @@ where
                         }
                     };
                     index.record.updated_at = Some(updated_at);
+                    if index.record.title.is_none() && index.derived_title.is_none() {
+                        index.derived_title = derived_title.as_ref().cloned();
+                    }
                     Ok(CasApply::new(index, true))
                 }
             },
@@ -375,6 +407,54 @@ where
             self.mark_thread_index_known(scope, thread_id);
         }
         Ok(())
+    }
+
+    /// One-time heal for index rows that predate write-time title derivation:
+    /// persist the probed label (never bumping activity) so the thread stops
+    /// paying a transcript probe on every list request. Best-effort — listing
+    /// already has the label in hand for this response.
+    pub(super) async fn store_derived_title_best_effort(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        derived_title: String,
+    ) {
+        let path = match thread_index_record_path(scope, thread_id) {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::debug!(?error, "derived-title heal skipped: bad index path");
+                return;
+            }
+        };
+        let resource_scope = scope.to_resource_scope();
+        let derived_title = &derived_title;
+        let result = cas_update(
+            self.filesystem.as_ref(),
+            &resource_scope,
+            &path,
+            |bytes: &[u8]| deserialize::<ThreadIndexRecord>(bytes),
+            |record: &ThreadIndexRecord| Self::thread_index_entry(record),
+            |current: Option<ThreadIndexRecord>| async move {
+                let Some(mut index) = current else {
+                    return Err(SessionThreadError::UnknownThread {
+                        thread_id: thread_id.clone(),
+                    });
+                };
+                if index.record.title.is_some() || index.derived_title.is_some() {
+                    return Ok(CasApply::no_op(index, ()));
+                }
+                index.derived_title = Some(derived_title.clone());
+                Ok(CasApply::new(index, ()))
+            },
+        )
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(
+                thread_id = %thread_id.as_str(),
+                ?error,
+                "derived-title heal failed; the next list request will probe again"
+            );
+        }
     }
 
     async fn read_thread_index_record(
@@ -866,6 +946,7 @@ pub(super) fn evict_hash_set_entry_over_limit(
 
 fn no_op_thread_index_record(scope: ThreadScope, thread_id: ThreadId) -> ThreadIndexRecord {
     ThreadIndexRecord {
+        derived_title: None,
         record: SessionThreadRecord {
             scope,
             thread_id,
@@ -917,6 +998,7 @@ mod tests {
                 updated_at: Some(created_at),
             },
             next_sequence: 3,
+            derived_title: None,
             flags: ThreadIndexFlags {
                 title_present: true,
                 metadata_present: true,
@@ -935,6 +1017,7 @@ mod tests {
                 updated_at: Some(created_at),
             },
             next_sequence: 7,
+            derived_title: None,
             flags: ThreadIndexFlags {
                 title_present: true,
                 metadata_present: true,

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -20,6 +20,29 @@ use super::{
 };
 
 const THREAD_INDEX_KIND: &str = "thread_index";
+
+/// Bounded retries for a transcript-migration page that lost a CAS or
+/// writer-contention race against live turn writes.
+const TRANSCRIPT_PAGE_CONFLICT_RETRIES: u32 = 5;
+
+/// Outcome of one transactional transcript-migration page.
+enum TranscriptPageOutcome {
+    Committed,
+    /// The page lost a concurrency race and should be re-read and retried;
+    /// carries the underlying error so retry exhaustion can fail loud with
+    /// the real cause.
+    Conflict(ironclaw_filesystem::FilesystemError),
+}
+
+/// Whether a transcript-migration transaction error is a concurrency race
+/// (safe to retry with fresh reads) rather than a real backend failure.
+fn transcript_migration_conflict(error: &ironclaw_filesystem::FilesystemError) -> bool {
+    matches!(
+        error,
+        ironclaw_filesystem::FilesystemError::VersionMismatch { .. }
+            | ironclaw_filesystem::FilesystemError::BackendBusy { .. }
+    )
+}
 const THREAD_SCOPE_INDEX_KEY: &str = "scope_key";
 const THREAD_ACTIVITY_SORT_KEY: &str = "activity_sort";
 const THREAD_ID_INDEX_KEY: &str = "thread_id";
@@ -527,6 +550,7 @@ where
                 (summaries_root(scope, &thread_id)?, false),
             ] {
                 let mut offset = 0u64;
+                let mut conflict_attempts = 0u32;
                 loop {
                     let rows = self
                         .filesystem
@@ -541,66 +565,134 @@ where
                         break;
                     }
                     let received = rows.len();
-                    let mut txn = self
-                        .filesystem
-                        .begin(
-                            &scope.to_resource_scope(),
-                            &scoped_path(crate::filesystem_service::THREADS_PREFIX)?,
-                        )
-                        .await?;
-                    for listed_row in rows {
-                        // The listing runs before BEGIN IMMEDIATE owns the
-                        // writer lock. Re-read inside the transaction so a
-                        // current-code message update in that window cannot
-                        // make this one-time migration fail with a stale CAS.
-                        let Some(row) = txn.get(&listed_row.path).await? else {
-                            continue;
-                        };
-                        let expected_kind = if messages {
-                            crate::filesystem_service::THREAD_MESSAGE_KIND
-                        } else {
-                            crate::filesystem_service::THREAD_SUMMARY_KIND
-                        };
-                        if row.entry.kind.as_ref().map(RecordKind::as_str) != Some(expected_kind) {
-                            continue;
-                        }
-                        let entry = if messages {
-                            let record = deserialize::<ThreadMessageRecord>(&row.entry.body)?;
-                            for (lookup_path, lookup_entry, expectation) in
-                                crate::filesystem_service::message_lookup_index::MessageLookupIndexStore::<F>::entries_for_message(
-                                    scope,
-                                    &thread_id,
-                                    &record,
-                                )?
-                            {
-                                let virtual_path = self
-                                    .filesystem
-                                    .resolve(&scope.to_resource_scope(), &lookup_path)?;
-                                if matches!(expectation, CasExpectation::Absent)
-                                    && txn.get(&virtual_path).await?.is_some()
-                                {
-                                    continue;
-                                }
-                                txn.put(&virtual_path, lookup_entry, expectation).await?;
+                    match self
+                        .migrate_transcript_page(scope, &thread_id, messages, rows)
+                        .await?
+                    {
+                        TranscriptPageOutcome::Committed => {
+                            conflict_attempts = 0;
+                            migrated = migrated.saturating_add(received);
+                            if received < Page::MAX_LIMIT as usize {
+                                break;
                             }
-                            Self::message_entry(&record)?
-                        } else {
-                            let record = deserialize::<SummaryArtifact>(&row.entry.body)?;
-                            Self::summary_entry(&record)?
-                        };
-                        txn.put(&row.path, entry, CasExpectation::Version(row.version))
-                            .await?;
+                            offset = offset.saturating_add(received as u64);
+                        }
+                        TranscriptPageOutcome::Conflict(error) => {
+                            // A live writer (turn finalization, preview append)
+                            // landed between this page's in-transaction reads
+                            // and its commit. Re-reading the page picks up the
+                            // committed versions, so the retry converges; the
+                            // bound keeps a pathological writer from pinning
+                            // the migration forever.
+                            conflict_attempts += 1;
+                            if conflict_attempts > TRANSCRIPT_PAGE_CONFLICT_RETRIES {
+                                return Err(error.into());
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(
+                                10u64.saturating_mul(conflict_attempts.into()),
+                            ))
+                            .await;
+                        }
                     }
-                    txn.commit().await?;
-                    migrated = migrated.saturating_add(received);
-                    if received < Page::MAX_LIMIT as usize {
-                        break;
-                    }
-                    offset = offset.saturating_add(received as u64);
                 }
             }
         }
         Ok(migrated)
+    }
+
+    /// One transactional page of [`Self::migrate_transcript_indexes_for_scope`].
+    ///
+    /// Returns `Conflict` instead of an error when the transaction lost a CAS
+    /// or writer-contention race, so the caller can re-read and retry the page
+    /// bounded — an escaped `VersionMismatch` here surfaced to WebUI timeline
+    /// reads as a retryable 503 whenever the scope's first transcript read
+    /// overlapped a running turn.
+    async fn migrate_transcript_page(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        messages: bool,
+        rows: Vec<ironclaw_filesystem::VersionedEntry>,
+    ) -> Result<TranscriptPageOutcome, SessionThreadError> {
+        let mut txn = self
+            .filesystem
+            .begin(
+                &scope.to_resource_scope(),
+                &scoped_path(crate::filesystem_service::THREADS_PREFIX)?,
+            )
+            .await?;
+        for listed_row in rows {
+            // The listing runs before BEGIN IMMEDIATE owns the
+            // writer lock. Re-read inside the transaction so a
+            // current-code message update in that window cannot
+            // make this one-time migration fail with a stale CAS.
+            let row = match txn.get(&listed_row.path).await {
+                Ok(Some(row)) => row,
+                Ok(None) => continue,
+                Err(error) if transcript_migration_conflict(&error) => {
+                    txn.rollback().await;
+                    return Ok(TranscriptPageOutcome::Conflict(error));
+                }
+                Err(error) => return Err(error.into()),
+            };
+            let expected_kind = if messages {
+                crate::filesystem_service::THREAD_MESSAGE_KIND
+            } else {
+                crate::filesystem_service::THREAD_SUMMARY_KIND
+            };
+            if row.entry.kind.as_ref().map(RecordKind::as_str) != Some(expected_kind) {
+                continue;
+            }
+            let entry = if messages {
+                let record = deserialize::<ThreadMessageRecord>(&row.entry.body)?;
+                for (lookup_path, lookup_entry, expectation) in
+                    crate::filesystem_service::message_lookup_index::MessageLookupIndexStore::<F>::entries_for_message(
+                        scope,
+                        thread_id,
+                        &record,
+                    )?
+                {
+                    let virtual_path = self
+                        .filesystem
+                        .resolve(&scope.to_resource_scope(), &lookup_path)?;
+                    if matches!(expectation, CasExpectation::Absent)
+                        && txn.get(&virtual_path).await?.is_some()
+                    {
+                        continue;
+                    }
+                    match txn.put(&virtual_path, lookup_entry, expectation).await {
+                        Ok(_) => {}
+                        Err(error) if transcript_migration_conflict(&error) => {
+                            txn.rollback().await;
+                            return Ok(TranscriptPageOutcome::Conflict(error));
+                        }
+                        Err(error) => return Err(error.into()),
+                    }
+                }
+                Self::message_entry(&record)?
+            } else {
+                let record = deserialize::<SummaryArtifact>(&row.entry.body)?;
+                Self::summary_entry(&record)?
+            };
+            match txn
+                .put(&row.path, entry, CasExpectation::Version(row.version))
+                .await
+            {
+                Ok(_) => {}
+                Err(error) if transcript_migration_conflict(&error) => {
+                    txn.rollback().await;
+                    return Ok(TranscriptPageOutcome::Conflict(error));
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        match txn.commit().await {
+            Ok(()) => Ok(TranscriptPageOutcome::Committed),
+            Err(error) if transcript_migration_conflict(&error) => {
+                Ok(TranscriptPageOutcome::Conflict(error))
+            }
+            Err(error) => Err(error.into()),
+        }
     }
 
     pub(super) async fn ensure_transcript_indexes_migrated(

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -111,26 +111,10 @@ where
                 return Ok(());
             }
         }
-        let root = thread_index_root(scope)?;
-        let spec = IndexSpec::new(
-            thread_index_name()?,
-            vec![
-                thread_index_key(THREAD_SCOPE_INDEX_KEY)?,
-                thread_index_key(THREAD_ACTIVITY_SORT_KEY)?,
-                thread_index_key(THREAD_ID_INDEX_KEY)?,
-            ],
-            IndexKind::Exact,
-        );
-        let result = self
-            .filesystem
-            .ensure_index(&scope.to_resource_scope(), &root, &spec)
-            .await;
-        if let Err(ironclaw_filesystem::FilesystemError::Unsupported { .. }) = result
-            && !required
-        {
-            return Ok(());
-        }
-        result.map_err(SessionThreadError::from)?;
+        // The listing projection is declared once per mount at the `/threads`
+        // alias root, not per scope. Ancestor-prefix resolution lets the
+        // per-scope `thread_index_root` query below still find it.
+        self.declare_root_indexes(scope, !required).await?;
         if let Ok(mut ready) = self.ready_thread_index_scopes.lock() {
             ready.insert(scope_key.clone());
             evict_hash_set_entry_over_limit(&mut ready, 128, &scope_key);
@@ -536,8 +520,8 @@ where
             .map(|entry| ThreadId::new(entry.name).map_err(invalid_path))
             .collect::<Result<Vec<_>, _>>()?;
         let mut migrated = 0usize;
+        self.declare_root_indexes(scope, false).await?;
         for thread_id in thread_ids {
-            self.ensure_thread_record_indexes(scope, &thread_id).await?;
             for (prefix, messages) in [
                 (messages_root(scope, &thread_id)?, true),
                 (summaries_root(scope, &thread_id)?, false),
@@ -686,6 +670,20 @@ fn thread_index_name() -> Result<IndexName, SessionThreadError> {
         .map_err(|error| SessionThreadError::Backend(error.to_string()))
 }
 
+/// The thread-listing projection, declared once per mount at the `/threads`
+/// alias root alongside the transcript projections.
+pub(super) fn thread_activity_index_spec() -> Result<IndexSpec, SessionThreadError> {
+    Ok(IndexSpec::new(
+        thread_index_name()?,
+        vec![
+            thread_index_key(THREAD_SCOPE_INDEX_KEY)?,
+            thread_index_key(THREAD_ACTIVITY_SORT_KEY)?,
+            thread_index_key(THREAD_ID_INDEX_KEY)?,
+        ],
+        IndexKind::Exact,
+    ))
+}
+
 #[derive(Serialize, Deserialize)]
 struct ThreadIndexCursor {
     activity_sort: String,
@@ -755,7 +753,11 @@ fn thread_activity_sort_key(record: &SessionThreadRecord) -> String {
     format!("{descending_rank:020}")
 }
 
-fn evict_hash_set_entry_over_limit(set: &mut HashSet<String>, max_entries: usize, keep: &str) {
+pub(super) fn evict_hash_set_entry_over_limit(
+    set: &mut HashSet<String>,
+    max_entries: usize,
+    keep: &str,
+) {
     if set.len() <= max_entries {
         return;
     }

--- a/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -9,40 +9,15 @@ use ironclaw_filesystem::{
 use ironclaw_host_api::{ids::ThreadId, path::ScopedPath};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    FilesystemSessionThreadService, SessionThreadError, SessionThreadRecord, SummaryArtifact,
-    ThreadMessageRecord, ThreadScope,
-};
+use crate::{FilesystemSessionThreadService, SessionThreadError, SessionThreadRecord, ThreadScope};
 
 use super::{
     IndexDeclarationPolicy, StoredThreadRecord, deserialize, invalid_path, is_not_found,
-    map_cas_error, messages_root, scope_axes_string, scoped_path, serialize_pretty, summaries_root,
+    map_cas_error, scope_axes_string, scoped_path, serialize_pretty,
 };
 
 const THREAD_INDEX_KIND: &str = "thread_index";
 
-/// Bounded retries for a transcript-migration page that lost a CAS or
-/// writer-contention race against live turn writes.
-const TRANSCRIPT_PAGE_CONFLICT_RETRIES: u32 = 5;
-
-/// Outcome of one transactional transcript-migration page.
-enum TranscriptPageOutcome {
-    Committed,
-    /// The page lost a concurrency race and should be re-read and retried;
-    /// carries the underlying error so retry exhaustion can fail loud with
-    /// the real cause.
-    Conflict(ironclaw_filesystem::FilesystemError),
-}
-
-/// Whether a transcript-migration transaction error is a concurrency race
-/// (safe to retry with fresh reads) rather than a real backend failure.
-fn transcript_migration_conflict(error: &ironclaw_filesystem::FilesystemError) -> bool {
-    matches!(
-        error,
-        ironclaw_filesystem::FilesystemError::VersionMismatch { .. }
-            | ironclaw_filesystem::FilesystemError::BackendBusy { .. }
-    )
-}
 const THREAD_SCOPE_INDEX_KEY: &str = "scope_key";
 const THREAD_ACTIVITY_SORT_KEY: &str = "activity_sort";
 const THREAD_ID_INDEX_KEY: &str = "thread_id";
@@ -615,236 +590,6 @@ where
         Ok(thread_ids.len())
     }
 
-    /// Idempotent rebuild for message, summary, and exact-lookup projections.
-    pub async fn migrate_transcript_indexes_for_scope(
-        &self,
-        scope: &ThreadScope,
-    ) -> Result<usize, SessionThreadError> {
-        let root = scoped_path(&format!("{}/threads", scope_axes_string(scope)))?;
-        let entries = match self
-            .filesystem
-            .list_dir(&scope.to_resource_scope(), &root)
-            .await
-        {
-            Ok(entries) => entries,
-            Err(error) if is_not_found(&error) => Vec::new(),
-            Err(error) => return Err(error.into()),
-        };
-        let thread_ids = entries
-            .into_iter()
-            .filter(|entry| entry.file_type == FileType::Directory)
-            .map(|entry| ThreadId::new(entry.name).map_err(invalid_path))
-            .collect::<Result<Vec<_>, _>>()?;
-        let mut migrated = 0usize;
-        self.declare_root_indexes(scope, IndexDeclarationPolicy::Required)
-            .await?;
-        for thread_id in thread_ids {
-            for (prefix, messages) in [
-                (messages_root(scope, &thread_id)?, true),
-                (summaries_root(scope, &thread_id)?, false),
-            ] {
-                let mut offset = 0u64;
-                let mut conflict_attempts = 0u32;
-                loop {
-                    let rows = self
-                        .filesystem
-                        .query(
-                            &scope.to_resource_scope(),
-                            &prefix,
-                            &Filter::All,
-                            Page::new(offset, Page::MAX_LIMIT),
-                        )
-                        .await?;
-                    if rows.is_empty() {
-                        break;
-                    }
-                    let received = rows.len();
-                    match self
-                        .migrate_transcript_page(scope, &thread_id, messages, rows)
-                        .await?
-                    {
-                        TranscriptPageOutcome::Committed => {
-                            conflict_attempts = 0;
-                            migrated = migrated.saturating_add(received);
-                            if received < Page::MAX_LIMIT as usize {
-                                break;
-                            }
-                            offset = offset.saturating_add(received as u64);
-                        }
-                        TranscriptPageOutcome::Conflict(error) => {
-                            // A live writer (turn finalization, preview append)
-                            // landed between this page's in-transaction reads
-                            // and its commit. Re-reading the page picks up the
-                            // committed versions, so the retry converges; the
-                            // bound keeps a pathological writer from pinning
-                            // the migration forever.
-                            conflict_attempts += 1;
-                            if conflict_attempts > TRANSCRIPT_PAGE_CONFLICT_RETRIES {
-                                return Err(error.into());
-                            }
-                            tokio::time::sleep(std::time::Duration::from_millis(
-                                10u64.saturating_mul(conflict_attempts.into()),
-                            ))
-                            .await;
-                        }
-                    }
-                }
-            }
-        }
-        Ok(migrated)
-    }
-
-    /// One transactional page of [`Self::migrate_transcript_indexes_for_scope`].
-    ///
-    /// Returns `Conflict` instead of an error when the transaction lost a CAS
-    /// or writer-contention race, so the caller can re-read and retry the page
-    /// bounded — an escaped `VersionMismatch` here surfaced to WebUI timeline
-    /// reads as a retryable 503 whenever the scope's first transcript read
-    /// overlapped a running turn.
-    async fn migrate_transcript_page(
-        &self,
-        scope: &ThreadScope,
-        thread_id: &ThreadId,
-        messages: bool,
-        rows: Vec<ironclaw_filesystem::VersionedEntry>,
-    ) -> Result<TranscriptPageOutcome, SessionThreadError> {
-        // Writer admission is exactly where the observed QA failure happens:
-        // acquiring the sole libSQL writer can time out as `BackendBusy`, and
-        // propagating it here would escape as the retryable timeline 503 this
-        // retry loop exists to absorb.
-        let mut txn = match self
-            .filesystem
-            .begin(
-                &scope.to_resource_scope(),
-                &scoped_path(crate::filesystem_service::THREADS_PREFIX)?,
-            )
-            .await
-        {
-            Ok(txn) => txn,
-            Err(error) if transcript_migration_conflict(&error) => {
-                return Ok(TranscriptPageOutcome::Conflict(error));
-            }
-            Err(error) => return Err(error.into()),
-        };
-        for listed_row in rows {
-            // The listing runs before BEGIN IMMEDIATE owns the
-            // writer lock. Re-read inside the transaction so a
-            // current-code message update in that window cannot
-            // make this one-time migration fail with a stale CAS.
-            let row = match txn.get(&listed_row.path).await {
-                Ok(Some(row)) => row,
-                Ok(None) => continue,
-                Err(error) if transcript_migration_conflict(&error) => {
-                    txn.rollback().await;
-                    return Ok(TranscriptPageOutcome::Conflict(error));
-                }
-                Err(error) => return Err(error.into()),
-            };
-            let expected_kind = if messages {
-                crate::filesystem_service::THREAD_MESSAGE_KIND
-            } else {
-                crate::filesystem_service::THREAD_SUMMARY_KIND
-            };
-            if row.entry.kind.as_ref().map(RecordKind::as_str) != Some(expected_kind) {
-                continue;
-            }
-            let entry = if messages {
-                let record = deserialize::<ThreadMessageRecord>(&row.entry.body)?;
-                for (lookup_path, lookup_entry, expectation) in
-                    crate::filesystem_service::message_lookup_index::MessageLookupIndexStore::<F>::entries_for_message(
-                        scope,
-                        thread_id,
-                        &record,
-                    )?
-                {
-                    let virtual_path = self
-                        .filesystem
-                        .resolve(&scope.to_resource_scope(), &lookup_path)?;
-                    if matches!(expectation, CasExpectation::Absent) {
-                        // This read can lose the same writer race as the
-                        // writes below (BackendBusy under contention on both
-                        // SQL backends); classify it the same way or the
-                        // bounded-retry contract has a hole.
-                        match txn.get(&virtual_path).await {
-                            Ok(Some(_)) => continue,
-                            Ok(None) => {}
-                            Err(error) if transcript_migration_conflict(&error) => {
-                                txn.rollback().await;
-                                return Ok(TranscriptPageOutcome::Conflict(error));
-                            }
-                            Err(error) => return Err(error.into()),
-                        }
-                    }
-                    match txn.put(&virtual_path, lookup_entry, expectation).await {
-                        Ok(_) => {}
-                        Err(error) if transcript_migration_conflict(&error) => {
-                            txn.rollback().await;
-                            return Ok(TranscriptPageOutcome::Conflict(error));
-                        }
-                        Err(error) => return Err(error.into()),
-                    }
-                }
-                Self::message_entry(&record)?
-            } else {
-                let record = deserialize::<SummaryArtifact>(&row.entry.body)?;
-                Self::summary_entry(&record)?
-            };
-            match txn
-                .put(&row.path, entry, CasExpectation::Version(row.version))
-                .await
-            {
-                Ok(_) => {}
-                Err(error) if transcript_migration_conflict(&error) => {
-                    txn.rollback().await;
-                    return Ok(TranscriptPageOutcome::Conflict(error));
-                }
-                Err(error) => return Err(error.into()),
-            }
-        }
-        match txn.commit().await {
-            Ok(()) => Ok(TranscriptPageOutcome::Committed),
-            Err(error) if transcript_migration_conflict(&error) => {
-                Ok(TranscriptPageOutcome::Conflict(error))
-            }
-            Err(error) => Err(error.into()),
-        }
-    }
-
-    pub(super) async fn ensure_transcript_indexes_migrated(
-        &self,
-        scope: &ThreadScope,
-    ) -> Result<(), SessionThreadError> {
-        let marker = transcript_index_migration_marker_path(scope)?;
-        if self
-            .filesystem
-            .get(&scope.to_resource_scope(), &marker)
-            .await?
-            .is_some()
-        {
-            return Ok(());
-        }
-        self.migrate_transcript_indexes_for_scope(scope).await?;
-        self.filesystem
-            .put(
-                &scope.to_resource_scope(),
-                &marker,
-                Entry::bytes(b"transcript-index-v1".to_vec()),
-                CasExpectation::Any,
-            )
-            .await?;
-        if self
-            .filesystem
-            .get(&scope.to_resource_scope(), &marker)
-            .await?
-            .is_none()
-        {
-            return Err(SessionThreadError::Backend(
-                "transcript index migration marker was not durable after write".to_string(),
-            ));
-        }
-        Ok(())
-    }
-
     pub(super) async fn thread_record_with_index_overlay(
         &self,
         mut stored: StoredThreadRecord,
@@ -915,15 +660,6 @@ fn thread_index_migration_marker_path(
 ) -> Result<ScopedPath, SessionThreadError> {
     scoped_path(&format!(
         "{}/index-migrations/thread-index-v1.complete",
-        scope_axes_string(scope)
-    ))
-}
-
-fn transcript_index_migration_marker_path(
-    scope: &ThreadScope,
-) -> Result<ScopedPath, SessionThreadError> {
-    scoped_path(&format!(
-        "{}/index-migrations/transcript-index-v1.complete",
         scope_axes_string(scope)
     ))
 }

--- a/crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs
@@ -216,10 +216,21 @@ where
                         Err(error) => return Err(error.into()),
                     }
                 }
-                Self::message_entry(&record)?
+                // Refresh the projection, keep the stored body. Rebuilding the
+                // entry from `record` would round-trip the row through the
+                // current struct, so any field a newer binary wrote and this
+                // one does not know is dropped permanently -- a one-way rewrite
+                // of durable transcript data. It also rewrites every body in
+                // the scope, which is the write amplification this change is
+                // trying to remove. The rebuild is only needed for `indexed`.
+                let mut entry = row.entry.clone();
+                entry.indexed = Self::message_entry(&record)?.indexed;
+                entry
             } else {
                 let record = deserialize::<SummaryArtifact>(&row.entry.body)?;
-                Self::summary_entry(&record)?
+                let mut entry = row.entry.clone();
+                entry.indexed = Self::summary_entry(&record)?.indexed;
+                entry
             };
             match txn
                 .put(&row.path, entry, CasExpectation::Version(row.version))

--- a/crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs
@@ -1,0 +1,288 @@
+//! One-time rebuild of the message, summary, and exact-lookup projections.
+//!
+//! Split out of `thread_index` (which owns the thread-listing projection):
+//! this is a separate transactional state machine with its own retry outcome,
+//! backoff loop, page transaction, and completion marker, and a reader of the
+//! listing projection does not need to understand any of it.
+
+use ironclaw_filesystem::{
+    CasExpectation, Entry, FileType, Filter, Page, RecordKind, RootFilesystem,
+};
+use ironclaw_host_api::{ids::ThreadId, path::ScopedPath};
+
+use crate::{
+    FilesystemSessionThreadService, SessionThreadError, SummaryArtifact, ThreadMessageRecord,
+    ThreadScope,
+};
+
+use super::{
+    IndexDeclarationPolicy, deserialize, invalid_path, is_not_found, messages_root,
+    scope_axes_string, scoped_path, summaries_root,
+};
+
+/// Bounded retries for a transcript-migration page that lost a CAS or
+/// writer-contention race against live turn writes.
+const TRANSCRIPT_PAGE_CONFLICT_RETRIES: u32 = 5;
+
+/// Outcome of one transactional transcript-migration page.
+enum TranscriptPageOutcome {
+    Committed,
+    /// The page lost a concurrency race and should be re-read and retried;
+    /// carries the underlying error so retry exhaustion can fail loud with
+    /// the real cause.
+    Conflict(ironclaw_filesystem::FilesystemError),
+}
+
+/// Whether a transcript-migration transaction error is a concurrency race
+/// (safe to retry with fresh reads) rather than a real backend failure.
+fn transcript_migration_conflict(error: &ironclaw_filesystem::FilesystemError) -> bool {
+    matches!(
+        error,
+        ironclaw_filesystem::FilesystemError::VersionMismatch { .. }
+            | ironclaw_filesystem::FilesystemError::BackendBusy { .. }
+    )
+}
+
+impl<F> FilesystemSessionThreadService<F>
+where
+    F: RootFilesystem,
+{
+    /// Idempotent rebuild for message, summary, and exact-lookup projections.
+    pub async fn migrate_transcript_indexes_for_scope(
+        &self,
+        scope: &ThreadScope,
+    ) -> Result<usize, SessionThreadError> {
+        let root = scoped_path(&format!("{}/threads", scope_axes_string(scope)))?;
+        let entries = match self
+            .filesystem
+            .list_dir(&scope.to_resource_scope(), &root)
+            .await
+        {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => Vec::new(),
+            Err(error) => return Err(error.into()),
+        };
+        let thread_ids = entries
+            .into_iter()
+            .filter(|entry| entry.file_type == FileType::Directory)
+            .map(|entry| ThreadId::new(entry.name).map_err(invalid_path))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut migrated = 0usize;
+        self.declare_root_indexes(scope, IndexDeclarationPolicy::Required)
+            .await?;
+        for thread_id in thread_ids {
+            for (prefix, messages) in [
+                (messages_root(scope, &thread_id)?, true),
+                (summaries_root(scope, &thread_id)?, false),
+            ] {
+                let mut offset = 0u64;
+                let mut conflict_attempts = 0u32;
+                loop {
+                    let rows = self
+                        .filesystem
+                        .query(
+                            &scope.to_resource_scope(),
+                            &prefix,
+                            &Filter::All,
+                            Page::new(offset, Page::MAX_LIMIT),
+                        )
+                        .await?;
+                    if rows.is_empty() {
+                        break;
+                    }
+                    let received = rows.len();
+                    match self
+                        .migrate_transcript_page(scope, &thread_id, messages, rows)
+                        .await?
+                    {
+                        TranscriptPageOutcome::Committed => {
+                            conflict_attempts = 0;
+                            migrated = migrated.saturating_add(received);
+                            if received < Page::MAX_LIMIT as usize {
+                                break;
+                            }
+                            offset = offset.saturating_add(received as u64);
+                        }
+                        TranscriptPageOutcome::Conflict(error) => {
+                            // A live writer (turn finalization, preview append)
+                            // landed between this page's in-transaction reads
+                            // and its commit. Re-reading the page picks up the
+                            // committed versions, so the retry converges; the
+                            // bound keeps a pathological writer from pinning
+                            // the migration forever.
+                            conflict_attempts += 1;
+                            if conflict_attempts > TRANSCRIPT_PAGE_CONFLICT_RETRIES {
+                                return Err(error.into());
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(
+                                10u64.saturating_mul(conflict_attempts.into()),
+                            ))
+                            .await;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(migrated)
+    }
+
+    /// One transactional page of [`Self::migrate_transcript_indexes_for_scope`].
+    ///
+    /// Returns `Conflict` instead of an error when the transaction lost a CAS
+    /// or writer-contention race, so the caller can re-read and retry the page
+    /// bounded — an escaped `VersionMismatch` here surfaced to WebUI timeline
+    /// reads as a retryable 503 whenever the scope's first transcript read
+    /// overlapped a running turn.
+    async fn migrate_transcript_page(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        messages: bool,
+        rows: Vec<ironclaw_filesystem::VersionedEntry>,
+    ) -> Result<TranscriptPageOutcome, SessionThreadError> {
+        // Writer admission is exactly where the observed QA failure happens:
+        // acquiring the sole libSQL writer can time out as `BackendBusy`, and
+        // propagating it here would escape as the retryable timeline 503 this
+        // retry loop exists to absorb.
+        let mut txn = match self
+            .filesystem
+            .begin(
+                &scope.to_resource_scope(),
+                &scoped_path(crate::filesystem_service::THREADS_PREFIX)?,
+            )
+            .await
+        {
+            Ok(txn) => txn,
+            Err(error) if transcript_migration_conflict(&error) => {
+                return Ok(TranscriptPageOutcome::Conflict(error));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        for listed_row in rows {
+            // The listing runs before BEGIN IMMEDIATE owns the
+            // writer lock. Re-read inside the transaction so a
+            // current-code message update in that window cannot
+            // make this one-time migration fail with a stale CAS.
+            let row = match txn.get(&listed_row.path).await {
+                Ok(Some(row)) => row,
+                Ok(None) => continue,
+                Err(error) if transcript_migration_conflict(&error) => {
+                    txn.rollback().await;
+                    return Ok(TranscriptPageOutcome::Conflict(error));
+                }
+                Err(error) => return Err(error.into()),
+            };
+            let expected_kind = if messages {
+                crate::filesystem_service::THREAD_MESSAGE_KIND
+            } else {
+                crate::filesystem_service::THREAD_SUMMARY_KIND
+            };
+            if row.entry.kind.as_ref().map(RecordKind::as_str) != Some(expected_kind) {
+                continue;
+            }
+            let entry = if messages {
+                let record = deserialize::<ThreadMessageRecord>(&row.entry.body)?;
+                for (lookup_path, lookup_entry, expectation) in
+                    crate::filesystem_service::message_lookup_index::MessageLookupIndexStore::<F>::entries_for_message(
+                        scope,
+                        thread_id,
+                        &record,
+                    )?
+                {
+                    let virtual_path = self
+                        .filesystem
+                        .resolve(&scope.to_resource_scope(), &lookup_path)?;
+                    if matches!(expectation, CasExpectation::Absent) {
+                        // This read can lose the same writer race as the
+                        // writes below (BackendBusy under contention on both
+                        // SQL backends); classify it the same way or the
+                        // bounded-retry contract has a hole.
+                        match txn.get(&virtual_path).await {
+                            Ok(Some(_)) => continue,
+                            Ok(None) => {}
+                            Err(error) if transcript_migration_conflict(&error) => {
+                                txn.rollback().await;
+                                return Ok(TranscriptPageOutcome::Conflict(error));
+                            }
+                            Err(error) => return Err(error.into()),
+                        }
+                    }
+                    match txn.put(&virtual_path, lookup_entry, expectation).await {
+                        Ok(_) => {}
+                        Err(error) if transcript_migration_conflict(&error) => {
+                            txn.rollback().await;
+                            return Ok(TranscriptPageOutcome::Conflict(error));
+                        }
+                        Err(error) => return Err(error.into()),
+                    }
+                }
+                Self::message_entry(&record)?
+            } else {
+                let record = deserialize::<SummaryArtifact>(&row.entry.body)?;
+                Self::summary_entry(&record)?
+            };
+            match txn
+                .put(&row.path, entry, CasExpectation::Version(row.version))
+                .await
+            {
+                Ok(_) => {}
+                Err(error) if transcript_migration_conflict(&error) => {
+                    txn.rollback().await;
+                    return Ok(TranscriptPageOutcome::Conflict(error));
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        match txn.commit().await {
+            Ok(()) => Ok(TranscriptPageOutcome::Committed),
+            Err(error) if transcript_migration_conflict(&error) => {
+                Ok(TranscriptPageOutcome::Conflict(error))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) async fn ensure_transcript_indexes_migrated(
+        &self,
+        scope: &ThreadScope,
+    ) -> Result<(), SessionThreadError> {
+        let marker = transcript_index_migration_marker_path(scope)?;
+        if self
+            .filesystem
+            .get(&scope.to_resource_scope(), &marker)
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+        self.migrate_transcript_indexes_for_scope(scope).await?;
+        self.filesystem
+            .put(
+                &scope.to_resource_scope(),
+                &marker,
+                Entry::bytes(b"transcript-index-v1".to_vec()),
+                CasExpectation::Any,
+            )
+            .await?;
+        if self
+            .filesystem
+            .get(&scope.to_resource_scope(), &marker)
+            .await?
+            .is_none()
+        {
+            return Err(SessionThreadError::Backend(
+                "transcript index migration marker was not durable after write".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn transcript_index_migration_marker_path(
+    scope: &ThreadScope,
+) -> Result<ScopedPath, SessionThreadError> {
+    scoped_path(&format!(
+        "{}/index-migrations/transcript-index-v1.complete",
+        scope_axes_string(scope)
+    ))
+}

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -2206,6 +2206,80 @@ async fn filesystem_list_threads_derives_titles_without_transcript_probes() {
     );
 }
 
+/// The sidebar label is a copy of user message text, so redaction has to
+/// remove the copy too. Serving listings from the index row made this a real
+/// exposure: redaction clears the message body, but a cached label kept the
+/// redacted words visible in every thread list.
+#[tokio::test]
+async fn filesystem_redaction_clears_the_cached_sidebar_title() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-title-redact", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("title-redact");
+    let thread_id = ThreadId::new("thread-title-redact").unwrap();
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    let accepted = service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: Some("binding-title-redact".into()),
+            reply_target_binding_id: None,
+            external_event_id: Some("event-title-redact".into()),
+            content: MessageContent::text("my social security number is 000-00-0000"),
+        })
+        .await
+        .unwrap();
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        listed.threads[0]
+            .title
+            .as_deref()
+            .is_some_and(|title| title.contains("000-00-0000")),
+        "precondition: the label was seeded from the message text"
+    );
+
+    service
+        .redact_message(RedactMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            message_id: accepted.message_id,
+            redaction_ref: "redaction/audit/title".into(),
+        })
+        .await
+        .expect("redaction succeeds");
+
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let title = listed.threads[0].title.as_deref().unwrap_or_default();
+    assert!(
+        !title.contains("000-00-0000"),
+        "redacted text must not survive in the sidebar label, got {title:?}"
+    );
+}
+
 /// Rows written before write-time seeding existed carry no derived label:
 /// the first list probes the transcript once and persists the label; the
 /// second list must be probe-free.

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -2175,6 +2175,18 @@ async fn filesystem_list_threads_derives_titles_without_transcript_probes() {
             .unwrap();
     }
 
+    // The first list for a scope also runs the one-time thread-index
+    // migration, which backfills labels for pre-seeding rows and does probe.
+    // Steady state is what write-time seeding is for, so measure the list
+    // after that migration has run.
+    service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
     let reads_before = backend
         .recorded_paths(FilesystemOperation::ReadFile)
         .into_iter()
@@ -2203,7 +2215,8 @@ async fn filesystem_list_threads_derives_titles_without_transcript_probes() {
         .count();
     assert_eq!(
         reads_after, reads_before,
-        "listing must not probe transcripts when titles are seeded at accept time"
+        "steady-state listing must not probe transcripts when titles are seeded \
+         at accept time"
     );
 }
 
@@ -2281,11 +2294,13 @@ async fn filesystem_redaction_clears_the_cached_sidebar_title() {
     );
 }
 
-/// Rows written before write-time seeding existed carry no derived label:
-/// the first list probes the transcript once and persists the label; the
-/// second list must be probe-free.
+/// Rows written before write-time seeding existed carry no derived label, so
+/// listing derives one per request (read-only — repairing the projection from
+/// a list request is what the threads guardrail forbids). The durable backfill
+/// belongs to the explicit thread-index migration, after which listing is
+/// probe-free.
 #[tokio::test]
-async fn filesystem_list_threads_heals_legacy_rows_after_one_probe() {
+async fn filesystem_migration_backfills_legacy_derived_titles() {
     let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
     let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-title-heal", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
@@ -2364,6 +2379,12 @@ async fn filesystem_list_threads_heals_legacy_rows_after_one_probe() {
         "the first list after the strip must probe the transcript"
     );
 
+    // The explicit migration is what makes the label durable.
+    service
+        .migrate_thread_index_for_scope(&scope)
+        .await
+        .expect("thread index migration backfills derived titles");
+
     let before_second = probes(&backend);
     let listed = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
@@ -2376,12 +2397,12 @@ async fn filesystem_list_threads_heals_legacy_rows_after_one_probe() {
     assert_eq!(
         listed.threads[0].title.as_deref(),
         Some("legacy row message"),
-        "healed label serves from the index row"
+        "the backfilled label serves from the index row"
     );
     assert_eq!(
         probes(&backend),
         before_second,
-        "the heal must make subsequent lists probe-free"
+        "after the migration, listing must be probe-free"
     );
 }
 

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -2137,6 +2137,179 @@ async fn filesystem_thread_create_declares_indexes_once_per_mount() {
     );
 }
 
+/// Sidebar titles for untitled threads used to be derived on EVERY list
+/// request with per-thread transcript probes — an N+1 that dominates listing
+/// once a user has many threads. The label is now seeded into the index row
+/// at message-accept time, so listing reads no transcripts at all; rows that
+/// predate the seeding probe once and heal.
+#[tokio::test]
+async fn filesystem_list_threads_derives_titles_without_transcript_probes() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-title-seed", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("title-seed");
+    for i in 0..3 {
+        let thread_id = ThreadId::new(format!("thread-title-{i}")).unwrap();
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: "actor-a".into(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        service
+            .accept_inbound_message(AcceptInboundMessageRequest {
+                scope: scope.clone(),
+                thread_id: thread_id.clone(),
+                actor_id: "actor-a".into(),
+                source_binding_id: Some("binding-title-seed".into()),
+                reply_target_binding_id: None,
+                external_event_id: Some(format!("event-title-seed-{i}")),
+                content: MessageContent::text(format!("hello sidebar label {i}")),
+            })
+            .await
+            .unwrap();
+    }
+
+    let reads_before = backend
+        .recorded_paths(FilesystemOperation::ReadFile)
+        .into_iter()
+        .filter(|path| path.as_str().contains("/messages/"))
+        .count();
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(listed.threads.len(), 3);
+    for thread in &listed.threads {
+        let title = thread.title.as_deref().expect("derived title present");
+        assert!(
+            title.starts_with("hello sidebar label"),
+            "derived from the first user message: {title}"
+        );
+    }
+    let reads_after = backend
+        .recorded_paths(FilesystemOperation::ReadFile)
+        .into_iter()
+        .filter(|path| path.as_str().contains("/messages/"))
+        .count();
+    assert_eq!(
+        reads_after, reads_before,
+        "listing must not probe transcripts when titles are seeded at accept time"
+    );
+}
+
+/// Rows written before write-time seeding existed carry no derived label:
+/// the first list probes the transcript once and persists the label; the
+/// second list must be probe-free.
+#[tokio::test]
+async fn filesystem_list_threads_heals_legacy_rows_after_one_probe() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-title-heal", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("title-heal");
+    let thread_id = ThreadId::new("thread-title-heal").unwrap();
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: Some("binding-title-heal".into()),
+            reply_target_binding_id: None,
+            external_event_id: Some("event-title-heal".into()),
+            content: MessageContent::text("legacy row message"),
+        })
+        .await
+        .unwrap();
+
+    // Simulate a row written before write-time seeding: strip the derived
+    // label out of the index row through the raw backend.
+    let index_path = backend
+        .recorded_paths(FilesystemOperation::WriteFile)
+        .into_iter()
+        .rev()
+        .find(|path| path.as_str().contains("/thread_index/"))
+        .expect("index row written during accept");
+    let versioned = backend.get(&index_path).await.unwrap().unwrap();
+    let mut row: serde_json::Value = serde_json::from_slice(&versioned.entry.body).unwrap();
+    assert!(
+        row.as_object_mut()
+            .unwrap()
+            .remove("derived_title")
+            .is_some(),
+        "accept seeded the derived title"
+    );
+    let mut entry = versioned.entry.clone();
+    entry.body = serde_json::to_vec(&row).unwrap();
+    backend
+        .put(&index_path, entry, CasExpectation::Any)
+        .await
+        .unwrap();
+
+    let probes = |backend: &FaultInjecting<InMemoryBackend>| {
+        backend
+            .recorded_paths(FilesystemOperation::ReadFile)
+            .into_iter()
+            .filter(|path| path.as_str().contains("/messages/"))
+            .count()
+    };
+    let before_first = probes(&backend);
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        listed.threads[0].title.as_deref(),
+        Some("legacy row message"),
+        "legacy row derives via the one-time probe"
+    );
+    assert!(
+        probes(&backend) > before_first,
+        "the first list after the strip must probe the transcript"
+    );
+
+    let before_second = probes(&backend);
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        listed.threads[0].title.as_deref(),
+        Some("legacy row message"),
+        "healed label serves from the index row"
+    );
+    assert_eq!(
+        probes(&backend),
+        before_second,
+        "the heal must make subsequent lists probe-free"
+    );
+}
+
 /// The one-time transcript-index migration runs on a scope's first transcript
 /// read and rewrites message rows under CAS expectations. When that first read
 /// overlaps a live turn's message writes, the migration can lose the race; the

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_filesystem::{
     BackendCapabilities, CasExpectation, DirEntry, DiskFilesystem, Entry, Fault, FaultInjecting,
-    FileStat, FilesystemError, FilesystemOperation, Filter, InMemoryBackend, IndexSpec,
+    FaultKind, FileStat, FilesystemError, FilesystemOperation, Filter, InMemoryBackend, IndexSpec,
     OrderedPage, Page, RecordVersion, RootFilesystem, ScopedFilesystem, SeqNo, StorageTxn,
     TxnCapability, VersionedEntry,
 };
@@ -2404,6 +2404,61 @@ async fn filesystem_migration_backfills_legacy_derived_titles() {
         before_second,
         "after the migration, listing must be probe-free"
     );
+}
+
+/// Writer admission is where the observed QA failure happens: acquiring the
+/// sole libSQL writer can time out as `BackendBusy`, and the migration runs
+/// from the first transcript read. Classifying only the in-transaction calls
+/// left that arm escaping to the caller as the retryable timeline 503 the
+/// bounded retry exists to absorb.
+#[tokio::test]
+async fn filesystem_transcript_migration_retries_writer_admission_contention() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-migrate-admit", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("migrate-admit");
+    let thread_id = ThreadId::new("thread-migrate-admit").unwrap();
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    service
+        .append_finalized_assistant_message(AppendFinalizedAssistantMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            turn_run_id: "run-migrate-admit".into(),
+            content: MessageContent::text("assistant reply"),
+        })
+        .await
+        .unwrap();
+    let marker = backend
+        .recorded_paths(FilesystemOperation::WriteFile)
+        .into_iter()
+        .find(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .expect("seeding wrote the transcript migration marker");
+    backend.delete(&marker).await.unwrap();
+
+    // The migration's first attempt to take the writer times out.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::BeginTxn)
+            .nth(1)
+            .returning(FaultKind::BackendBusy),
+    );
+
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+        })
+        .await
+        .expect("writer-admission contention must be retried, not surfaced as a 503");
+    assert_eq!(history.messages.len(), 1);
 }
 
 /// The one-time transcript-index migration runs on a scope's first transcript

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -2137,6 +2137,142 @@ async fn filesystem_thread_create_declares_indexes_once_per_mount() {
     );
 }
 
+/// The one-time transcript-index migration runs on a scope's first transcript
+/// read and rewrites message rows under CAS expectations. When that first read
+/// overlaps a live turn's message writes, the migration can lose the race; the
+/// resulting `VersionMismatch` used to escape to WebUI timeline reads as a
+/// retryable 503 (`TimelineUnavailable`, observed under the api-user-capacity
+/// stress workload). The migration must re-read and retry the page instead.
+#[tokio::test]
+async fn filesystem_transcript_migration_retries_a_lost_cas_race() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-migrate-race", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("migrate-race");
+    let thread_id = ThreadId::new("thread-migrate-race").unwrap();
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    service
+        .append_finalized_assistant_message(AppendFinalizedAssistantMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            turn_run_id: "run-migrate-race".into(),
+            content: MessageContent::text("assistant reply"),
+        })
+        .await
+        .unwrap();
+
+    // Reset the one-time marker so the next transcript read re-runs the
+    // migration with a message row present.
+    let marker = backend
+        .recorded_paths(FilesystemOperation::WriteFile)
+        .into_iter()
+        .find(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .expect("seeding wrote the transcript migration marker");
+    backend.delete(&marker).await.unwrap();
+
+    // Lose the CAS race exactly once: the first migration-transaction write to
+    // a message row fails the way a concurrent turn write makes it fail.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path("/messages/")
+            .nth(1)
+            .version_mismatch(),
+    );
+
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+        })
+        .await
+        .expect("a single lost CAS race must be retried, not surfaced");
+    assert_eq!(history.messages.len(), 1);
+    let marker_writes = backend
+        .recorded_paths(FilesystemOperation::WriteFile)
+        .into_iter()
+        .filter(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .count();
+    assert_eq!(
+        marker_writes, 2,
+        "the retried migration completes and re-writes the one-time marker"
+    );
+}
+
+/// Retry exhaustion must stay bounded and fail loud with the real cause —
+/// a writer that conflicts forever must not pin the migration in a loop.
+#[tokio::test]
+async fn filesystem_transcript_migration_conflict_retries_are_bounded() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-migrate-bound", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("migrate-bound");
+    let thread_id = ThreadId::new("thread-migrate-bound").unwrap();
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    service
+        .append_finalized_assistant_message(AppendFinalizedAssistantMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            turn_run_id: "run-migrate-bound".into(),
+            content: MessageContent::text("assistant reply"),
+        })
+        .await
+        .unwrap();
+    let marker = backend
+        .recorded_paths(FilesystemOperation::WriteFile)
+        .into_iter()
+        .find(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .expect("seeding wrote the transcript migration marker");
+    backend.delete(&marker).await.unwrap();
+
+    let writes_before = backend.count(FilesystemOperation::WriteFile);
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path("/messages/")
+            .version_mismatch(),
+    );
+
+    let error = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+        })
+        .await
+        .expect_err("a permanently conflicting migration must fail, not loop");
+    assert!(
+        matches!(error, SessionThreadError::Backend(_)),
+        "retry exhaustion surfaces the underlying conflict: {error:?}"
+    );
+    let message_row_attempts = backend
+        .recorded_paths(FilesystemOperation::WriteFile)
+        .into_iter()
+        .skip(writes_before)
+        .filter(|path| path.as_str().contains("/messages/"))
+        .count();
+    // Initial attempt + TRANSCRIPT_PAGE_CONFLICT_RETRIES (5) retries.
+    assert_eq!(
+        message_row_attempts, 6,
+        "conflict retries are bounded, not unbounded"
+    );
+}
+
 #[tokio::test]
 async fn filesystem_list_threads_page_does_not_scan_scope_or_source_directory() {
     let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -2068,12 +2068,13 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
 }
 
 /// PR #6696 declared the transcript and listing projections under each thread,
-/// so every thread create paid an index-DDL transaction and — on the SQL
-/// backends, where a declaration installs projection triggers whose match
-/// clause embeds the declared prefix — permanently added three more triggers
-/// per spec to the shared entries table. The specs are now declared once per
-/// mount at the `/threads` alias root, so only a mount's first thread create
-/// issues DDL and listing still resolves the spec from a deeper path.
+/// so every thread create paid redundant index-declaration work and left a
+/// catalog row per thread behind forever — rows the SQL projection then has to
+/// consider on every entry write. (Under the per-declaration trigger design
+/// that PR shipped, each also added three triggers per spec to the shared
+/// entries table.) The specs are now declared once per mount at the `/threads`
+/// alias root, so only a mount's first thread create declares anything and
+/// listing still resolves the spec from a deeper path.
 #[tokio::test]
 async fn filesystem_thread_create_declares_indexes_once_per_mount() {
     let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -2067,6 +2067,76 @@ async fn filesystem_list_threads_for_scope_is_scope_filtered_and_paginated() {
     assert_eq!(ids_b, ["t-b-001"]);
 }
 
+/// PR #6696 declared the transcript and listing projections under each thread,
+/// so every thread create paid an index-DDL transaction and — on the SQL
+/// backends, where a declaration installs projection triggers whose match
+/// clause embeds the declared prefix — permanently added three more triggers
+/// per spec to the shared entries table. The specs are now declared once per
+/// mount at the `/threads` alias root, so only a mount's first thread create
+/// issues DDL and listing still resolves the spec from a deeper path.
+#[tokio::test]
+async fn filesystem_thread_create_declares_indexes_once_per_mount() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-index-ddl", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("index-ddl");
+    let create = async |id: &str| {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id.to_string()).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    };
+
+    create("ddl-000").await;
+    let after_first = backend.count(FilesystemOperation::EnsureIndex);
+    assert_eq!(
+        after_first, 4,
+        "a mount's first thread declares exactly the four root specs \
+         (message sequence, message kind/status, summary, thread activity)"
+    );
+
+    for index in 1..5 {
+        create(&format!("ddl-{index:03}")).await;
+    }
+    assert_eq!(
+        backend.count(FilesystemOperation::EnsureIndex),
+        after_first,
+        "thread create must issue no index DDL after a mount's first thread"
+    );
+
+    // Every declaration lands on the mount root, never a per-thread path.
+    for path in backend.recorded_paths(FilesystemOperation::EnsureIndex) {
+        assert_eq!(
+            path.as_str(),
+            "/tenants/tenant-index-ddl/users/alice/threads",
+            "projections are declared at the mount root, above the per-thread paths"
+        );
+    }
+
+    // Listing resolves the root-declared spec from the deeper per-scope path,
+    // and needs no further declaration to do it.
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(listed.threads.len(), 5);
+    assert_eq!(
+        backend.count(FilesystemOperation::EnsureIndex),
+        after_first,
+        "listing resolves the ancestor-declared spec without redeclaring it"
+    );
+}
+
 #[tokio::test]
 async fn filesystem_list_threads_page_does_not_scan_scope_or_source_directory() {
     let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));

--- a/crates/ironclaw_turns/src/process_projection/store_adapter.rs
+++ b/crates/ironclaw_turns/src/process_projection/store_adapter.rs
@@ -390,7 +390,11 @@ pub fn turn_error_from_process_journal_store_error(error: ProcessJournalStoreErr
                 cap.into(),
             )
         }
-        ProcessJournalStoreError::InvalidLease { .. }
+        // A group commit that rolled back is a transient storage-side failure
+        // from the caller's perspective: nothing committed, and re-issuing the
+        // command is the correct response.
+        ProcessJournalStoreError::GroupCommitFailed { .. }
+        | ProcessJournalStoreError::InvalidLease { .. }
         | ProcessJournalStoreError::InvalidPath(_)
         | ProcessJournalStoreError::Filesystem(_)
         | ProcessJournalStoreError::Serialization(_)

--- a/docs/reborn/contracts/filesystem.md
+++ b/docs/reborn/contracts/filesystem.md
@@ -396,6 +396,45 @@ Memory-specific backend adapters are owned outside this crate. The first Reborn 
 
 ---
 
+## 12a. Ordered-index declaration and resolution
+
+Ordered (`Exact` / `Prefix`) indexes are declared on a path prefix and queried
+on a path. The two need not be the same path.
+
+**Resolution walks ancestors, most specific first.** A query at `/a/b/c` for
+index `N` resolves the declaration of `N` at `/a/b/c`, else `/a/b`, else `/a`,
+else `/`. This is the "declare high, query low" contract the FTS path already
+followed; a caller may declare once at a mount root and query any descendant.
+A spec declared at the sentinel prefix `/shared` takes precedence over every
+path-derived candidate (SQL backends only — the in-memory backend does not
+implement the sentinel).
+
+**Nested same-name declarations resolve most-specific-wins.** Where several
+ancestors declare the same index name, the deepest one wins on both the read
+and the write side. Declaring one name at overlapping prefixes with *different*
+key layouts is therefore not supported: projection rows are identified by
+`(index_name, path)`, so the two declarations share a row and the broader
+query reads the narrower declaration's values. Same name at *disjoint*
+prefixes is fully independent and supported.
+
+**Queries are scoped to their own subtree.** A spec resolved from an ancestor
+covers a wider subtree than the caller asked for, so every backend re-applies
+subtree containment to the matched rows. A query never returns rows outside
+the path it was issued on.
+
+**Declaration never backfills.** Projection is write-maintained: rows already
+present when a spec is declared are not projected. Populating them is explicit
+migration work.
+
+**Projection machinery is static and versioned.** Each SQL backend installs one
+generation of projection triggers for the whole database (currently `v3`), not
+one per declaration; declaring an index writes a catalog row. Installing a
+generation sweeps older generations, including the pre-`v3` per-declaration
+triggers. The sweep is one-way: an older binary re-installs its own generation
+on next declaration, but rows written while the newer generation was active are
+not re-projected — a downgrade should be followed by the explicit migration for
+any scope written in between.
+
 ## 13. Error contract
 
 Use a filesystem-specific service error that can wrap `HostApiError` but does not expose raw host internals.

--- a/tests/integration/changed-coverage-exemptions.toml
+++ b/tests/integration/changed-coverage-exemptions.toml
@@ -677,6 +677,151 @@ issue = "https://github.com/nearai/ironclaw/issues/6963"
 review_after = "2026-10-31"
 
 # ---------------------------------------------------------------------------
+# PR #6973 recovers the process-journal and ordered-index capacity regression
+# tracked in #6974. The branch adds deterministic contract coverage for the
+# successful paths and the faults that can be injected through the public test
+# seam. The residual lines below are the exact output of run 30719767929's
+# merged integration LCOV, replayed locally with reborn_changed_coverage.py.
+#
+# They fall into three narrow classes:
+#   * generic/test-support counter attribution (the calling contract tests run,
+#     but LLVM assigns the monomorphized body to another crate or test binary);
+#   * defensive infrastructure-error arms that require corrupt driver rows,
+#     failed rollback/oneshot channels, or a scheduler race unavailable through
+#     the typed contract seam;
+#   * retry/fallback arms whose externally observable boundary is already
+#     covered by deterministic BackendBusy/VersionMismatch and retry-exhaustion
+#     tests, while each internal failure site cannot be independently injected.
+# No file or glob is waived and the 100% policy remains unchanged.
+
+[[exemption]]
+path = "crates/ironclaw_filesystem/src/fault.rs"
+lines = [88, 89, 90, 91, 92, 166, 167, 168, 169]
+owner = "@nearai/reborn"
+reason = "FaultInjecting::version_mismatch is exercised by the transcript-migration CAS retry and exhaustion contract tests, but LLVM attributes this generic test-support body to the consuming ironclaw_threads test binary instead of ironclaw_filesystem. These are the constructor and conversion lines only."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_filesystem/src/index.rs"
+lines = [433]
+branch_lines = [427, 432]
+owner = "@nearai/reborn"
+reason = "ancestor_prefixes is covered by direct root, trailing-slash, and deep-path tests plus three backend conformance suites. The residual arms are total-function defenses after rfind returns an ASCII slash offset; get(..index) cannot fail for that offset, and the loop termination variants are counter-attributed across backend monomorphizations."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_filesystem/src/libsql.rs"
+lines = [2503, 2512, 2552, 2553, 2564, 2565]
+branch_lines = [2491, 2557]
+owner = "@nearai/reborn"
+reason = "The libSQL ordered-index conformance and legacy-trigger sweep execute the static projection install and validate insert/update/delete behavior. Residual arms require an over-arity typed IndexSpec, corrupt sqlite_master trigger metadata, invalid legacy trigger names, or an infrastructure failure during cleanup DDL; those cannot be produced through the validated contract seam."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_filesystem/src/postgres.rs"
+lines = [2152, 2153, 2215, 2216]
+branch_lines = [2126, 2206, 2214, 2215, 2216, 2217]
+owner = "@nearai/reborn"
+reason = "The PostgreSQL contract suite provisions a real PG16 instance, validates the full static trigger set and update/delete projection behavior, and exercises the isolated legacy sweep. Residual arms are driver-error mapping, over-arity input rejected by the typed API, and defensive identifier filtering over catalog names created only by trusted DDL."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_processes/src/journal_store.rs"
+lines = [279, 968]
+branch_lines = [278]
+owner = "@nearai/reborn"
+reason = "Process-journal contract tests cover grouped submission, mixed-command isolation, retry exhaustion, observer re-entry, and read-your-writes. These residual lines require the lazily owned flusher receiver or a oneshot responder to disappear while the store still owns the corresponding sender, an internal task-lifetime failure with no typed injection seam."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_processes/src/journal_store/flusher.rs"
+lines = [
+  76, 98, 160, 175, 176, 180, 194, 204, 205, 231,
+  278, 279, 280, 307, 308, 351, 405, 420, 421, 422,
+  441, 460, 461, 462, 464, 466, 469, 470, 471, 486,
+  487, 488, 489, 490, 533, 547, 549, 551,
+]
+branch_lines = [
+  169, 170, 174, 201, 255, 327, 350, 401, 415, 460, 467, 532, 546,
+]
+owner = "@nearai/reborn"
+reason = "The production funnel is covered through batching, per-command rejection, retry exhaustion, one-shot write-fault, observer ordering, and re-entrant commit contracts. The exact residuals are task shutdown, rollback failure, sender disappearance, impossible post-preview shape mismatch, and scheduler-dependent fallback branches that are not independently injectable without production-only seams."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_processes/src/journal_store/observer.rs"
+lines = [
+  151, 157, 207, 263, 264, 279, 285, 286, 287, 288,
+  289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299,
+]
+branch_lines = [141, 242, 303]
+owner = "@nearai/reborn"
+reason = "Observer contracts cover in-memory batch delivery, cursor monotonicity under a stale cache, replay fallback, concurrent observers, and callback re-entry. Residuals require poisoned registration state, task/channel teardown, or every observer/replay recovery path failing together; the public seam exposes observer failures but not these internal task-lifetime combinations."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_processes/src/journal_store/rows.rs"
+lines = [317, 318, 319, 320, 321]
+owner = "@nearai/reborn"
+reason = "Batch row loading is exercised by every process-journal contract test. This residual is the defensive conversion of a supposedly loaded idempotency-order singleton being absent after its reference was requested; producing it would require violating the private References/load invariant rather than a backend behavior."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_product/src/reborn_services.rs"
+lines = [6746, 6747]
+owner = "@nearai/reborn"
+reason = "TimelineUnavailable mapping is exercised at the product boundary; these lines only emit the server-side tracing event for a backend/serialization cause while preserving the sanitized response. The integration lane does not install a tracing collector that can force and attribute this detail-only side effect."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_threads/src/filesystem_service.rs"
+lines = [371, 373, 375]
+branch_lines = [371, 378]
+owner = "@nearai/reborn"
+reason = "Thread contracts cover required and optional root-index declaration and the once-per-mount cache. Residuals are the optional Unsupported downgrade, a backend error while declaring a validated built-in spec, and poisoned cache-lock recovery; none is independently injectable through the filesystem contract without broadening production seams."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_threads/src/filesystem_service/thread_index.rs"
+lines = [418, 419, 420, 421, 710]
+branch_lines = [417, 710]
+owner = "@nearai/reborn"
+reason = "Thread-index contracts cover title seeding, redaction clearing, migration backfill, and bounded cache eviction. The residual title arm is the idempotent no-op for a missing projection row; the eviction arm depends on HashSet iteration choosing the protected key first and is scheduler/hash-seed dependent while both externally visible outcomes preserve the bound."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_threads/src/filesystem_service/transcript_migration.rs"
+lines = [
+  39, 62, 63, 103, 104, 159, 168, 169, 170, 171,
+  173, 178, 190, 202, 203, 204, 205, 207, 212, 213,
+  214, 216, 221, 222, 233, 238, 239, 241, 273, 274, 275,
+]
+branch_lines = [62, 101, 156, 169, 175, 183, 203, 212, 229, 238, 267]
+owner = "@nearai/reborn"
+reason = "Contract tests deterministically cover writer-admission BackendBusy, VersionMismatch page retry, bounded exhaustion, successful message/summary rebuild, and durable marker read-back. Residuals are alternate failure sites inside the same bounded state machine, malformed legacy records, disappearing rows, and non-durable marker/backend failures not separately selectable through FaultInjecting."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+[[exemption]]
+path = "crates/ironclaw_turns/src/process_projection/store_adapter.rs"
+lines = [393, 394, 395, 396, 397]
+owner = "@nearai/reborn"
+reason = "The only executable semantic change is adding GroupCommitFailed to the existing retryable Unavailable match arm. The variant-pattern line has no LLVM DA record of its own, so this otherwise changed production file contributes a zero denominator; process contracts cover the variant and state_tests classify it explicitly."
+issue = "https://github.com/nearai/ironclaw/issues/6974"
+review_after = "2026-11-02"
+
+# ---------------------------------------------------------------------------
 # WS2.1, second tranche: the type-position residue.
 #
 # Deleting `ironclaw_product`'s re-exports forced every signature that named a

--- a/tools/ironclaw_stress/src/api_capacity.rs
+++ b/tools/ironclaw_stress/src/api_capacity.rs
@@ -1224,23 +1224,36 @@ async fn setup_users(
             let identity = identities[next_index % identities.len()].clone();
             let thread_id = format!("stress-{run_id}-{thread_label}-{next_index}");
             let user_index = next_index;
+            let threads_per_user = args.api_threads_per_user.max(1);
             join_set.spawn(async move {
                 let create = harness.create_thread(&identity, &thread_id).await;
-                match create.value {
-                    Ok(value) => {
-                        let thread_id = extract_thread_id(&value).unwrap_or(thread_id);
-                        Ok(ApiUser {
-                            index: user_index,
-                            label: identity.label,
-                            bearer_token: identity.bearer_token,
-                            thread_id,
-                        })
+                let primary = match create.value {
+                    Ok(value) => extract_thread_id(&value).unwrap_or(thread_id),
+                    Err(failure) => {
+                        return Err(format!(
+                            "create thread for api user {user_index}: {}: {}",
+                            failure.bucket, failure.detail
+                        ));
                     }
-                    Err(failure) => Err(format!(
-                        "create thread for api user {user_index}: {}: {}",
-                        failure.bucket, failure.detail
-                    )),
+                };
+                // Extra threads exist purely to grow the user's sidebar; sends
+                // keep targeting the primary thread.
+                for extra in 1..threads_per_user {
+                    let extra_id = format!("{primary}-extra-{extra}");
+                    let create = harness.create_thread(&identity, &extra_id).await;
+                    if let Err(failure) = create.value {
+                        return Err(format!(
+                            "create extra thread {extra} for api user {user_index}: {}: {}",
+                            failure.bucket, failure.detail
+                        ));
+                    }
                 }
+                Ok(ApiUser {
+                    index: user_index,
+                    label: identity.label,
+                    bearer_token: identity.bearer_token,
+                    thread_id: primary,
+                })
             });
             next_index += 1;
         }

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -432,6 +432,11 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = 1)]
     pub(crate) thread_list_users: usize,
 
+    /// Seed thread-list threads without titles, each carrying one accepted
+    /// user message — the shape that exercises sidebar title derivation.
+    #[arg(long, default_value_t = false)]
+    pub(crate) thread_list_untitled: bool,
+
     /// Page size used while walking the thread-list workload.
     #[arg(long, default_value_t = 50)]
     pub(crate) thread_list_page_size: usize,

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -2327,11 +2327,21 @@ pub(crate) fn default_libsql_path() -> PathBuf {
 }
 
 pub(crate) async fn cleanup_generated_libsql_path(path: &Path) {
-    for candidate in [
-        path.to_path_buf(),
-        path.with_extension("db-wal"),
-        path.with_extension("db-shm"),
-    ] {
+    // SQLite appends `-wal`/`-shm` to the whole file name; it does not replace
+    // the extension. `with_extension("db-wal")` only lined up when the path
+    // ended in `.db`, so an explicit `--libsql-path bench.sqlite` left
+    // `bench-<case>.sqlite-wal` and `-shm` behind on every run.
+    let sidecars = path
+        .file_name()
+        .map(|name| {
+            let name = name.to_string_lossy().into_owned();
+            [
+                path.with_file_name(format!("{name}-wal")),
+                path.with_file_name(format!("{name}-shm")),
+            ]
+        })
+        .unwrap_or_else(|| [path.to_path_buf(), path.to_path_buf()]);
+    for candidate in [path.to_path_buf(), sidecars[0].clone(), sidecars[1].clone()] {
         match tokio::fs::remove_file(&candidate).await {
             Ok(()) => {}
             Err(error) if error.kind() == ErrorKind::NotFound => {}

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -2315,7 +2315,7 @@ pub(crate) fn default_libsql_path() -> PathBuf {
     ))
 }
 
-async fn cleanup_generated_libsql_path(path: &Path) {
+pub(crate) async fn cleanup_generated_libsql_path(path: &Path) {
     for candidate in [
         path.to_path_buf(),
         path.with_extension("db-wal"),

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -2331,16 +2331,15 @@ pub(crate) async fn cleanup_generated_libsql_path(path: &Path) {
     // the extension. `with_extension("db-wal")` only lined up when the path
     // ended in `.db`, so an explicit `--libsql-path bench.sqlite` left
     // `bench-<case>.sqlite-wal` and `-shm` behind on every run.
-    let sidecars = path
-        .file_name()
-        .map(|name| {
-            let name = name.to_string_lossy().into_owned();
-            [
-                path.with_file_name(format!("{name}-wal")),
-                path.with_file_name(format!("{name}-shm")),
-            ]
-        })
-        .unwrap_or_else(|| [path.to_path_buf(), path.to_path_buf()]);
+    // Appended as `OsString`, not through `to_string_lossy`: a lossy round trip
+    // substitutes replacement characters for a valid non-UTF-8 filename, so the
+    // derived paths would not name the files SQLite actually created and the
+    // sidecars would survive the cleanup meant to remove them.
+    let sidecars = ["-wal", "-shm"].map(|suffix| {
+        let mut sidecar = path.as_os_str().to_os_string();
+        sidecar.push(suffix);
+        PathBuf::from(sidecar)
+    });
     for candidate in [path.to_path_buf(), sidecars[0].clone(), sidecars[1].clone()] {
         match tokio::fs::remove_file(&candidate).await {
             Ok(()) => {}

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -226,6 +226,12 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = 16)]
     pub(crate) api_setup_concurrency: usize,
 
+    /// Threads created per API user during setup. Values above 1 exercise
+    /// listing/read paths against large sidebars; sends still target each
+    /// user's first thread.
+    #[arg(long, default_value_t = 1)]
+    pub(crate) api_threads_per_user: usize,
+
     /// Background long-running API users to run alongside foreground api-user-capacity sends.
     #[arg(long, default_value_t = 0)]
     pub(crate) api_background_users: usize,

--- a/tools/ironclaw_stress/src/suite.rs
+++ b/tools/ironclaw_stress/src/suite.rs
@@ -262,7 +262,7 @@ pub(crate) fn build_cases(suite: StressSuite) -> Vec<SuiteCase> {
     }
 }
 
-fn apply_case(base_args: &Args, case: &SuiteCase, case_args: &mut Args, run_id: &str) {
+pub(crate) fn apply_case(base_args: &Args, case: &SuiteCase, case_args: &mut Args, run_id: &str) {
     case_args.run_id = Some(run_id.to_string());
     case_args.suite = None;
     case_args.preset = case.preset;

--- a/tools/ironclaw_stress/src/suite.rs
+++ b/tools/ironclaw_stress/src/suite.rs
@@ -83,6 +83,8 @@ pub(crate) async fn run(args: &Args, suite_run_id: &str) -> Result<(), String> {
         crate::trace::prepare_trace_outputs(&case_args).await?;
         let started = Instant::now();
         let case_result = run_once(&case_args, &run_id).await;
+        // Measure the workload, not the teardown that follows it.
+        let duration_ms = started.elapsed().as_millis();
         if let Some(path) = case_args
             .libsql_path
             .as_ref()
@@ -93,7 +95,6 @@ pub(crate) async fn run(args: &Args, suite_run_id: &str) -> Result<(), String> {
         let captured = case_result?;
         let metrics = captured.metrics();
         let summary = captured.summary_value();
-        let duration_ms = started.elapsed().as_millis();
         let top_failure_bucket = top_failure_bucket(&summary);
         let top_operation_group = top_operation_group(&summary);
         let record = json!({

--- a/tools/ironclaw_stress/src/suite.rs
+++ b/tools/ironclaw_stress/src/suite.rs
@@ -309,8 +309,13 @@ pub(crate) fn apply_case(base_args: &Args, case: &SuiteCase, case_args: &mut Arg
                     .extension()
                     .map(|extension| format!(".{}", extension.to_string_lossy()))
                     .unwrap_or_default();
-                per_case
-                    .set_file_name(format!("{stem}-{}{extension}", case_args.scenario.as_str()));
+                // Keyed on the case label, not the scenario: several cases
+                // share a scenario (`tool-heavy`, `tool-wait`, and
+                // `tool-failure` are all `ToolSession`), so a scenario suffix
+                // hands them one file and reintroduces the cross-case lock
+                // contention this split exists to remove. Labels are internal
+                // constants, never user input.
+                per_case.set_file_name(format!("{stem}-{}{extension}", case.label));
                 per_case
             }
             None => crate::default_libsql_path(),

--- a/tools/ironclaw_stress/src/suite.rs
+++ b/tools/ironclaw_stress/src/suite.rs
@@ -82,7 +82,15 @@ pub(crate) async fn run(args: &Args, suite_run_id: &str) -> Result<(), String> {
         );
         crate::trace::prepare_trace_outputs(&case_args).await?;
         let started = Instant::now();
-        let captured = run_once(&case_args, &run_id).await?;
+        let case_result = run_once(&case_args, &run_id).await;
+        if let Some(path) = case_args
+            .libsql_path
+            .as_ref()
+            .filter(|path| Some(*path) != args.libsql_path.as_ref())
+        {
+            crate::cleanup_generated_libsql_path(path).await;
+        }
+        let captured = case_result?;
         let metrics = captured.metrics();
         let summary = captured.summary_value();
         let duration_ms = started.elapsed().as_millis();
@@ -276,6 +284,15 @@ fn apply_case(base_args: &Args, case: &SuiteCase, case_args: &mut Args, run_id: 
     case_args.compare_json = None;
     case_args.human_read = false;
     case_args.bottleneck_report = false;
+    // Every case gets its own database file. Sharing the parent's generated
+    // path let each case's runtime contend on the same SQLite file with the
+    // previous cases' still-running background pollers, drowning later cases
+    // (tool-*) in cross-runtime write-lock waits that no production deployment
+    // shape has — one libSQL file is owned by one process runtime.
+    if matches!(case_args.backend, crate::Backend::Libsql) && !case_args.scenario.is_api_capacity()
+    {
+        case_args.libsql_path = Some(crate::default_libsql_path());
+    }
     case_args.prefill_threads = 0;
     case_args.prefill_turns_per_thread = 0;
 

--- a/tools/ironclaw_stress/src/suite.rs
+++ b/tools/ironclaw_stress/src/suite.rs
@@ -290,9 +290,31 @@ pub(crate) fn apply_case(base_args: &Args, case: &SuiteCase, case_args: &mut Arg
     // previous cases' still-running background pollers, drowning later cases
     // (tool-*) in cross-runtime write-lock waits that no production deployment
     // shape has — one libSQL file is owned by one process runtime.
+    //
+    // Only when the caller did not name a path. Overwriting an explicit
+    // `--libsql-path` would silently run the suite against temporary files
+    // instead of the database the operator selected; derive a per-case sibling
+    // of their path instead, which keeps the one-file-per-runtime property
+    // without discarding the choice.
     if matches!(case_args.backend, crate::Backend::Libsql) && !case_args.scenario.is_api_capacity()
     {
-        case_args.libsql_path = Some(crate::default_libsql_path());
+        case_args.libsql_path = Some(match &base_args.libsql_path {
+            Some(explicit) => {
+                let mut per_case = explicit.clone();
+                let stem = explicit
+                    .file_stem()
+                    .map(|stem| stem.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "ironclaw-stress".to_string());
+                let extension = explicit
+                    .extension()
+                    .map(|extension| format!(".{}", extension.to_string_lossy()))
+                    .unwrap_or_default();
+                per_case
+                    .set_file_name(format!("{stem}-{}{extension}", case_args.scenario.as_str()));
+                per_case
+            }
+            None => crate::default_libsql_path(),
+        });
     }
     case_args.prefill_threads = 0;
     case_args.prefill_turns_per_thread = 0;

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -283,6 +283,63 @@ fn libsql_cases_use_distinct_generated_database_paths() {
     );
 }
 
+/// An explicit `--libsql-path` is honoured and still isolates every case.
+///
+/// Two properties at once, because they trade off against each other: the
+/// operator's directory and extension survive (the path is not silently
+/// replaced with a temporary file), and no two cases land on the same file.
+/// Keying the suffix on the scenario satisfies only the first — `tool-heavy`,
+/// `tool-wait`, and `tool-failure` are all `ToolSession` and would share one
+/// database, which is the cross-runtime lock contention the split exists to
+/// prevent.
+#[test]
+fn explicit_libsql_path_is_preserved_and_still_isolates_each_case() {
+    let mut base = test_args();
+    base.backend = crate::Backend::Libsql;
+    base.libsql_path = Some(std::path::PathBuf::from(
+        "/tmp/operator-choice/bench.sqlite",
+    ));
+    let cases = suite::build_cases(StressSuite::BottleneckFinder);
+    let mut seen = std::collections::BTreeSet::new();
+    let mut checked = 0;
+    for case in &cases {
+        let mut case_args = base.clone();
+        suite::apply_case(&base, case, &mut case_args, "run-id");
+        if case_args.scenario.is_api_capacity() {
+            continue;
+        }
+        let path = case_args
+            .libsql_path
+            .clone()
+            .expect("every non-API libSQL case gets a database path");
+        assert_eq!(
+            path.parent(),
+            Some(std::path::Path::new("/tmp/operator-choice")),
+            "case {} moved off the operator's directory to {}",
+            case.label,
+            path.display()
+        );
+        assert_eq!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some("sqlite"),
+            "case {} dropped the operator's extension: {}",
+            case.label,
+            path.display()
+        );
+        assert!(
+            seen.insert(path.clone()),
+            "case {} reused database path {}",
+            case.label,
+            path.display()
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 1,
+        "the suite must exercise more than one explicit-path libSQL case"
+    );
+}
+
 #[test]
 fn postgres_pool_pressure_suite_includes_remote_pool_cases() {
     let cases = suite::build_cases(StressSuite::PostgresPoolPressure);

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -248,6 +248,41 @@ fn bottleneck_finder_suite_includes_core_pressure_cases() {
     assert!(labels.contains("memory-churn"));
 }
 
+/// The suite regression fix depends on every non-API libSQL case getting its
+/// own database path: sharing the parent's path is what let earlier cases'
+/// still-running pollers contend on the file and invalidate the benchmark.
+/// Existing suite tests only assert case labels, so a regression here would be
+/// silent.
+#[test]
+fn libsql_cases_use_distinct_generated_database_paths() {
+    let mut base = test_args();
+    base.backend = crate::Backend::Libsql;
+    base.libsql_path = None;
+    let cases = suite::build_cases(StressSuite::BottleneckFinder);
+    let mut seen = std::collections::BTreeSet::new();
+    for case in &cases {
+        let mut case_args = base.clone();
+        suite::apply_case(&base, case, &mut case_args, "run-id");
+        if case_args.scenario.is_api_capacity() {
+            continue;
+        }
+        let path = case_args
+            .libsql_path
+            .clone()
+            .expect("every non-API libSQL case gets a generated database path");
+        assert!(
+            seen.insert(path.clone()),
+            "case {} reused database path {}",
+            case.label,
+            path.display()
+        );
+    }
+    assert!(
+        seen.len() > 1,
+        "the suite must exercise more than one isolated libSQL case"
+    );
+}
+
 #[test]
 fn postgres_pool_pressure_suite_includes_remote_pool_cases() {
     let cases = suite::build_cases(StressSuite::PostgresPoolPressure);

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -353,6 +353,23 @@ async fn cleanup_removes_the_database_and_its_sqlite_sidecars() {
     tokio::fs::create_dir_all(&dir)
         .await
         .expect("create temp dir");
+    // A non-UTF-8 byte in the name is what pins the `OsString` derivation: an
+    // ASCII name survives a `to_string_lossy` round trip unchanged, so on the
+    // ASCII path this case still only covers the extension half of the defect.
+    //
+    // Linux only. macOS rejects a non-UTF-8 filename at creation with EILSEQ
+    // ("Illegal byte sequence"), so seeding the file is impossible there —
+    // gating keeps the byte-preservation pin on the CI runners while leaving
+    // the case runnable for developers on macOS.
+    #[cfg(target_os = "linux")]
+    let database = {
+        use std::os::unix::ffi::OsStringExt;
+        let mut name = b"bench-tool-heavy-".to_vec();
+        name.push(0xff);
+        name.extend_from_slice(b".sqlite");
+        dir.join(std::ffi::OsString::from_vec(name))
+    };
+    #[cfg(not(target_os = "linux"))]
     let database = dir.join("bench-tool-heavy.sqlite");
     let mut created = vec![database.clone()];
     for suffix in ["-wal", "-shm"] {
@@ -374,7 +391,9 @@ async fn cleanup_removes_the_database_and_its_sqlite_sidecars() {
             path.display()
         );
     }
-    let _ = tokio::fs::remove_dir_all(&dir).await;
+    tokio::fs::remove_dir_all(&dir)
+        .await
+        .expect("remove temp dir");
 }
 
 #[test]

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -1222,6 +1222,7 @@ fn test_args() -> Args {
         api_poll_interval_ms: 250,
         api_request_timeout_ms: 10_000,
         api_setup_concurrency: 16,
+        api_threads_per_user: 1,
         api_background_users: 0,
         api_background_concurrency: 0,
         api_background_operations: 1,

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -340,6 +340,43 @@ fn explicit_libsql_path_is_preserved_and_still_isolates_each_case() {
     );
 }
 
+/// Teardown removes the database and both SQLite sidecars it created.
+///
+/// Drives the real side effect against real files rather than asserting on a
+/// derived string: the previous derivation used `Path::with_extension`, which
+/// only lined up for `.db`, and a string-shaped assertion would have agreed
+/// with it. The path here carries a non-`.db` extension for that reason, which
+/// is also the shape an explicit `--libsql-path` now produces.
+#[tokio::test]
+async fn cleanup_removes_the_database_and_its_sqlite_sidecars() {
+    let dir = std::env::temp_dir().join(format!("ironclaw-stress-cleanup-{}", std::process::id()));
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .expect("create temp dir");
+    let database = dir.join("bench-tool-heavy.sqlite");
+    let mut created = vec![database.clone()];
+    for suffix in ["-wal", "-shm"] {
+        let mut sidecar = database.clone().into_os_string();
+        sidecar.push(suffix);
+        created.push(std::path::PathBuf::from(sidecar));
+    }
+    for path in &created {
+        tokio::fs::write(path, b"x").await.expect("seed file");
+    }
+
+    crate::cleanup_generated_libsql_path(&database).await;
+
+    for path in &created {
+        assert!(
+            !path.exists(),
+            "{} survived cleanup; SQLite appends -wal/-shm to the whole file \
+             name, so deriving them by extension misses any non-.db path",
+            path.display()
+        );
+    }
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
 #[test]
 fn postgres_pool_pressure_suite_includes_remote_pool_cases() {
     let cases = suite::build_cases(StressSuite::PostgresPoolPressure);

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -1223,6 +1223,7 @@ fn test_args() -> Args {
         api_request_timeout_ms: 10_000,
         api_setup_concurrency: 16,
         api_threads_per_user: 1,
+        thread_list_untitled: false,
         api_background_users: 0,
         api_background_concurrency: 0,
         api_background_operations: 1,

--- a/tools/ironclaw_stress/src/user_turn.rs
+++ b/tools/ironclaw_stress/src/user_turn.rs
@@ -967,19 +967,44 @@ where
             .user_turn_context_for_user_index(owner_index)
             .map_err(|error| OperationFailure::invalid_request("thread_list_context", error))?;
         let thread_id = thread_list_thread_id(thread_index)?;
+        let title = if args.thread_list_untitled {
+            None
+        } else {
+            Some(format!("Thread list seed {thread_index:06}"))
+        };
         time_stage(
             &mut stages.ensure_thread,
             self.thread_service.ensure_thread(EnsureThreadRequest {
-                scope: context.thread_scope,
-                thread_id: Some(thread_id),
+                scope: context.thread_scope.clone(),
+                thread_id: Some(thread_id.clone()),
                 created_by_actor_id: context.user_id.as_str().to_string(),
-                title: Some(format!("Thread list seed {thread_index:06}")),
+                title,
                 metadata_json: None,
             }),
         )
         .await
         .map(|_| ())
-        .map_err(|error| thread_failure("thread_list_prefill_ensure_thread", error))
+        .map_err(|error| thread_failure("thread_list_prefill_ensure_thread", error))?;
+        if args.thread_list_untitled {
+            // One accepted user message gives the sidebar something to derive
+            // a label from — the untitled-thread listing shape.
+            self.thread_service
+                .accept_inbound_message(ironclaw_threads::AcceptInboundMessageRequest {
+                    scope: context.thread_scope,
+                    thread_id,
+                    actor_id: context.user_id.as_str().to_string(),
+                    source_binding_id: None,
+                    reply_target_binding_id: None,
+                    external_event_id: None,
+                    content: ironclaw_threads::MessageContent::text(format!(
+                        "thread list seed message {thread_index:06}"
+                    )),
+                })
+                .await
+                .map(|_| ())
+                .map_err(|error| thread_failure("thread_list_prefill_seed_message", error))?;
+        }
+        Ok(())
     }
 
     async fn run_operation(


### PR DESCRIPTION
> **Reopened from #6973** to get a fresh review — same changes, rebased onto current `main` (no content change, no conflicts). The original PR was fully reviewed and green; it is closed only because its reviewer is out of office.
>
> Carried over from #6973: CodeRabbit's final review had no actionable comments, and all checks were green — including `Test Reborn crate bucket (llm-mcp)`, the `Reborn integration-tier coverage report` changed-lines gate, and all 16 enforced ratchet floors.

## Problem

The scheduled `hosted-single-tenant Postgres API capacity` gate regressed from p95 **3.74s / 6.86 ops/sec** (last passing nightly, `b60038b`) to p95 **12.0s / 2.57 ops/sec** (`4c075913`, run 30604660405) — `send_message` p95 went 275ms → 4.78s while mock-LLM latency stayed flat at 3.0s. The libSQL bottleneck/soak nightlies also began timing out. Bisection attributes the regression to #6696 (*Collapse lifecycle state into the row-native process journal*); a revert is infeasible (92 conflicting files, the replaced stores were deleted), so this recovers forward.

## Root causes (verified by instrumented benchmarks)

1. **Globally serialized commits.** Every lifecycle command (submit/claim/heartbeat/transition) ran its own transaction that locked the single `/processes/materialized/journal-sequence` row until commit — one commit at a time, system-wide, plus a global metadata + idempotency-order read per command.
2. **Write-amplified synchronous observer delivery.** After every commit, each observer re-read the journal from the backend and CAS-wrote its cursor once **per delivered entry**, serialized behind a per-observer mutex.
3. **Per-thread index DDL.** #6696 added ~4 ordered-index declarations per thread create — a DDL transaction each behind a global lock and, on both SQL backends, three projection **triggers per spec per thread** accumulating forever on the shared entries table (~18k triggers over the libSQL soak's prefill — why those jobs time out).
4. **(Exposed, pre-existing) transcript-migration CAS race.** The one-time transcript-index migration runs on a scope's first transcript read and rewrites message rows under CAS; once the pipeline got fast enough to overlap live turn writes, lost races escaped as retryable `TimelineUnavailable` 503s.

## Fixes (one commit each)

- `perf(processes): group-commit funnel` — single-writer flusher batches commands into one transaction: one merged row load, one `reserve_sequence_range`, one commit per batch; per-command failure isolation; read-your-writes preserved (waiters release only after their batch's observer delivery). Also removes a documented pre-existing observer re-entrancy self-deadlock.
- `perf(processes): deliver committed batches from memory` — delivery uses the batch's in-memory entries (no journal re-read), one cursor CAS per observer per batch, observers delivered concurrently; paged replay remains the catch-up/startup path.
- `perf(threads): declare thread indexes once per mount` — the four specs (all leading with their partition key) are declared once per (tenant, user) at the `/threads` alias root; ordered-index spec resolution learns the ancestor-prefix walk the FTS path already documented, on all three backends, with a subtree containment filter added to the in-memory query (it had none — ancestor resolution without it would leak sibling subtrees). Existing per-thread specs keep working via most-specific-wins; on SQL backends both generations share physical rows, so no backfill.
- `fix(product): log the discarded cause behind TimelineUnavailable` — the sanitized 503 previously destroyed the server-side cause entirely.
- `fix(threads): retry transcript-migration pages that lose a CAS race` — bounded re-read-and-retry (converges; exhaustion fails loud). `FaultInjecting` gains a `VersionMismatch` fault kind to make CAS-conflict paths deterministically testable over the in-memory backend.

## Evidence (local, CI-shaped workload: 100 users, c25, 3s mock LLM, 7s p95 gate)

Same machine, native Postgres 16 + pgvector, identical harness — three-way against the actual pre-#6696 last-good commit (`b60038b`):

| | pre-#6696 `b60038b` | regressed `main` | after first 5 commits | **branch head** (incl. trigger redesign) |
|---|---|---|---|---|
| full-flow p95 | 4.19s (p99 4.53s) | 6.90s (p99 8.03s) | 5.45s / 5.52s | **4.15s (p99 4.15s)** |
| `send_message` p95 | 0.57s | 2.96s | 0.62s | **0.38s** |
| `wait_for_assistant` p95 | 4.10s | 5.01s | 5.09s | **3.85s** |
| setup/first-LLM offset | 0.36s | 4.85s | 3.04s | 0.95s |
| throughput | 6.6 ops/sec | 4.3 ops/sec | 5.0 ops/sec | **6.6 ops/sec** |
| failures | 0 | 0 | 0 | **0** |

At branch head every runtime metric matches or beats the pre-#6696 last-good; the only residual is the setup/first-LLM offset (0.95s vs 0.36s), which is provisioning-phase cost paid once per run before any measured operation and off every latency gate. Local last-good throughput (6.6 ops/sec) matches CI's last-good (6.86) almost exactly, so pre-#6696 code is round-trip-insensitive; the regressed code is what collapses on slow CI storage.

On slower storage the delta is much larger because the regression's cost scales with round-trip latency: against the CI-identical Docker pgvector image, clean `main` measures **p95 9.80s / 3.19 ops/sec (gate FAIL)** locally vs the funnel's first iteration already at 7.41s — and CI's nightly measured 12.0s. The fixes cut round-trip count, so the CI-side improvement should exceed the local native-PG delta. The deciding verdict is the next scheduled nightly.

libSQL nightly-shape suite (ops 20 / c4 / u50): the suite now **completes** (`main` cannot get past the `large-context` prefill inside CI's 20-minute timeout); `large-context` p95 3.67s, `chat-baseline` 8.18s vs 10.46s failing on `main`. The tool-heavy cases remain far over the 2.5s gate (p95 37–135s, dominated by `thread_store_writes` on the single libSQL writer) — a distinct #6696 pathology that predates this branch's fixes and needs its own investigation; filing as a follow-up issue.

## Testing

- `cargo test -p ironclaw_processes` (93), `-p ironclaw_filesystem` (149+), `-p ironclaw_threads` (all suites) — green, unfiltered.
- Full workspace suite: green except 20 pre-existing environment-dependent CLI tests requiring `ANTHROPIC_API_KEY` (untouched crates; fail identically on `main` in a keyless shell).
- New regression tests: concurrent-submit batching + read-your-writes delivery ordering; batch failure isolation; thread create issues **zero** index DDL after a mount's first thread; declare-at-ancestor/query-at-descendant conformance incl. the subtree-leak guard, across backends; transcript-migration CAS-race retry + bounded exhaustion.
- `cargo clippy` default and `--all-features` lanes: zero warnings. `cargo fmt` clean. Per-commit `scripts/pre-commit-safety.sh` clean.



## Follow-up commits in this branch (post-open)

The libSQL suite investigation (#6974) landed four more commits here:

- **`fix(stress)`: per-case database isolation** — the bottleneck-finder suite ran every case against one shared libSQL file while earlier cases' still-running pollers held its write locks; tool-* cases measured contention no deployment has (tool-failure 135.6s → 10.7s p95 from isolation alone).
- **`perf(filesystem)`: catalog-driven ordered-index projection triggers, libSQL + Postgres** — declarations used to install 3 triggers per (prefix, spec); every entries write evaluated every trigger ever declared (3,750 measured after a 50-user run ≈ 38ms/statement). Now 3 static triggers per backend project via an indexed spec-catalog join; declaration is a pure catalog insert. Same-name nested declarations become deterministically most-specific-wins; the static set is versioned with a stale-generation sweep.
- **`perf(threads)`: sidebar titles seeded at message accept** — listing derived titles for untitled threads with up to 50 transcript probes per page, on every request; the label now rides the existing accept-time index-row CAS, with one-time healing for pre-existing rows.

**Result: both backends now at or better than the pre-#6696 last-good on this rig, fully durable:**

| | pre-#6696 `b60038b` | this branch |
|---|---|---|
| Postgres capacity p95 / throughput | 4.19s / 6.6 ops/s | **4.15s / 6.6 ops/s** |
| libSQL nightly suite | PASS | **PASS** (chat turn-store 31.5ms vs 19.4ms; thread writes beat last-good) |
| `list_threads`, 200-thread untitled sidebar | — | **1.6ms p50 / 2.1ms p95** (was 11.9ms / 12.7ms with a 1.25s p99 tail before the title fix)


---

## Change Type

- [x] Bug fix (performance regression recovery)
- [ ] New feature
- [x] Refactor (module split, typed modes — incidental to the fixes)
- [x] Documentation (ordered-index declaration/resolution contract)
- [x] CI/Infrastructure (stress-harness isolation + levers)
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6696 (the regressing PR). Resolves the root causes tracked in #6974.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `ironclaw_processes`, `ironclaw_filesystem`, `ironclaw_threads`, `ironclaw_host_runtime`, `ironclaw_architecture` — full suites, unfiltered
- [x] Postgres-backed conformance run against a live PostgreSQL 16 + pgvector (47 tests), including the projection DDL change and the upgrade path
- [x] Manual testing: CI-shaped capacity workload (100 users, c25, 3s mock LLM) and the libSQL nightly bottleneck suite, before/after, on identical local infrastructure

## Test Strategy

User behavior: sending a message and opening a thread stay responsive under concurrent load, and the thread sidebar stays fast as a user's thread count grows.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect (observer delivery, one-shot fault semantics)
- [x] Persistence (journal commits, index projections, transcript migration)
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior (processes → turns → threads → product)

Tests added or updated:
- Unit or contract: group-commit batching and read-your-writes ordering; batch failure isolation; one-shot write fault must reach a caller; observer cursor monotonicity under a stale cache; observer callback re-entrancy; concurrent observer delivery; ancestor-declared index resolution and subtree scoping across three backends; projection UPDATE/DELETE staleness; PostgreSQL legacy-trigger sweep; thread-create declares indexes once per mount; sidebar title seeding, redaction clearing, and migration backfill; transcript-migration CAS retry and bounded exhaustion; stress-suite per-case database isolation
- Reborn integration: covered through the existing integration tier; no new integration wiring was required
- Recorded fixture: Not applicable: no model interaction changed
- Browser E2E: Not applicable: no user-visible WebUI surface changed
- Backend or runtime: PostgreSQL conformance suite run against live PG16
- Live canary: Not applicable

What the tests prove: that a rolled-back batch never reports durable state it did not reach; that a stale in-process cache cannot rewind durable observer progress; that redacted message text cannot survive in a thread listing; that index declarations no longer accumulate per thread; and that ordered-index queries resolved from an ancestor never return another subtree's rows.

Commands run: `cargo test -p ironclaw_processes -p ironclaw_filesystem -p ironclaw_threads -p ironclaw_host_runtime -p ironclaw_architecture --no-fail-fast`, `cargo clippy --all --tests --examples [--all-features] -- -D warnings`, `scripts/pre-commit-safety.sh`, `IRONCLAW_FILESYSTEM_POSTGRES_URL=... cargo test -p ironclaw_filesystem --test db_root_filesystem_contract postgres`

## Security Impact

One security-relevant fix: the cached sidebar label was a copy of user message text that redaction did not clear, so redacted content stayed visible in thread listings. Redaction now clears it as an obligation, with a regression test. Timeline probe logging was also narrowed to a detail-free error kind so virtual tenant/user paths and raw backend text no longer reach ordinary tracing fields. No change to permissions, network egress, secrets handling, file access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: unchanged; no prompt path touched.
- [x] Hashes declare purpose: unchanged (existing BLAKE3 observer-id digest reused).
- [x] New/changed error variants: `ProcessJournalStoreError::GroupCommitFailed` added; all match sites audited (`cargo check --workspace` surfaced the two exhaustive matches, both updated — `store_adapter.rs` maps it to the retryable `Unavailable` class, `state_tests.rs` classifies it).
- [x] Security/durability `serde(default)` fields fail closed: `derived_title` is `#[serde(default)]` and its absence means "no cached label", which falls back to the probe — the safe direction.
- [x] Queues/maps/buffers/counters bounded: the command funnel is bounded with backpressure; the delivery queue is deliberately unbounded (re-entrant observers would deadlock behind it) and is transitively bounded by the command queue.
- [x] Errors have stable class semantics: `GroupCommitFailed` maps to the same retryable class as other storage faults.
- [x] Sandbox/native/host names: unchanged.

## Database Impact

No migration files added. Both SQL backends change **how the ordered-index projection is maintained**, not what it stores:

- The per-declaration trigger generation is replaced by one static, versioned generation (`v3`) per database. Installing it sweeps the older generations. Row shape and identity (`index_name`, `path`) are unchanged, so no data migration is needed and existing rows stay readable.
- PostgreSQL DDL uses `DROP` + `CREATE` rather than `CREATE OR REPLACE TRIGGER`, so no PostgreSQL 14 floor is introduced.
- Thread index specs are declared once per (tenant, user) mount instead of per thread; pre-existing per-thread catalog rows keep working through most-specific-wins resolution.
- The transcript-index migration is unchanged in what it writes; it now retries pages that lose a CAS or writer-admission race instead of surfacing them.

## Blast Radius

`ironclaw_processes` (journal commit path — every lifecycle transition), `ironclaw_filesystem` (ordered-index projection on all three backends), `ironclaw_threads` (listing, titles, transcript migration), plus the error-mapping seam in `ironclaw_turns` and the timeline log in `ironclaw_product`. The highest-risk surface is the process journal: it is on every turn. The failure mode to watch after deploy is a rise in retryable `Unavailable`/`GroupCommitFailed` responses, which would indicate group commits rolling back more often than expected.

## Rollback Plan

Revert the branch. The projection change is forward-and-back safe with one caveat now documented in the filesystem contract: an older binary reinstalls its own trigger generation on the next declaration, but rows written while `v3` was active are not re-projected, so a downgrade should be followed by the explicit transcript/thread-index migration for any scope written in between. No schema or data migration has to be undone.

## Review Follow-Through

Fixed from the consolidated review: f-01 through f-04, f-06, f-11 through f-16, f-18 through f-26, f-29, f-30, f-31. Two High findings are deliberately deferred to a follow-up PR rather than landed here — **f-05** (the lazy transcript migration still runs from the request path and can stampede the sole libSQL writer) and **f-07** (overlapping same-name index declarations share a projection row, so a broader query can read a narrower declaration's values — a schema change with a compatibility story). **f-08/f-09/f-10** (delivery in-flight permit, O(B²) batch state cloning, serial batch reads) and **f-17/f-27/f-28** remain open and are contained but invasive.

Reviewer judgment still wanted on: whether the Reborn integration-tier coverage lane should be given a PostgreSQL URL. It currently sets none, so every PostgreSQL conformance test — including the sweep test added here — skips in that lane, which is why the changed-lines coverage gate counts `postgres.rs` lines as uncovered.

---

**Review track**: C (runtime/DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
