### PR TITLE
chore(release): forward-port the 1.0.0 release branch and cut 1.1.0-rc.1

### DIFF
--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -33,7 +33,14 @@ on:
   # PRs.
   pull_request:
     branches:
+      # Release branches get the same gate as main: a release-blocker fix
+      # opened against a frozen candidate must clear the E2E lanes before it
+      # can produce a new rc. `release-fix-*` is the 1.0.0-era name;
+      # `release/*` is the weekly cut named in
+      # docs/internal/weekly-release-strategy.md.
       - main
+      - "release-fix-*"
+      - "release/*"
   # The merge queue is the production gate: the deterministic Reborn contract
   # and smoke coverage must pass on the merged state before it reaches main.
   # merge_group does not support `paths:` filters, so scope is resolved by the

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -23,7 +23,14 @@ on:
         type: string
   pull_request:
     branches:
+      # Release branches get the same gate as main: a release-blocker fix
+      # opened against a frozen candidate must clear the deterministic Reborn
+      # suite before it can produce a new rc. `release-fix-*` is the 1.0.0-era
+      # name; `release/*` is the weekly cut named in
+      # docs/internal/weekly-release-strategy.md.
       - main
+      - "release-fix-*"
+      - "release/*"
   merge_group:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0-rc.1] - 2026-08-03
+
+First release candidate since 1.0.0. The headline work is extension reach —
+registering arbitrary hosted MCP servers, installing from IronHub deep links,
+durable file attachments that cross channels, and Slack `/ironclaw` slash
+commands — plus a broad pass on making failures legible: to the model, which
+now gets told what to do next instead of an opaque stop, and to the user, who
+gets localized, actionable errors instead of silent dead ends.
+
+**Upgrading from 1.0.0.** No migration steps. Extension lifecycle state moved
+to a normalized on-disk shape; rows written by 1.0.0 keep deserializing. The
+one behavioral removal is the `/webhooks/slack/events` compatibility alias
+(see Removed).
+
+### Added
+
+- **Custom MCP servers.** Register a hosted MCP server from the WebUI and use
+  its tools like any other extension: discovery accepts bounded
+  OpenAPI-derived tool catalogs within the manifest's declared tool budget,
+  auth is resolved during registration, and the registered tools are exposed
+  to the model.
+- **IronHub install flow.** Install extensions from an IronHub deep link,
+  including private manifest sources, through a register/install gateway.
+- **Attachments.** Durable cross-channel file flows: a file sent on one
+  channel stays retrievable from the others and from the WebUI.
+- **Slack slash commands.** Native `/ironclaw` commands in Slack, backed by a
+  role-filtered command palette in the WebUI and role gating on admin command
+  actions.
+- **Memory as an extension.** The memory provider is modeled as a userland
+  extension with a host-managed lifecycle and a contract built around declared
+  capabilities, so a provider advertises what it can actually do instead of
+  being assumed uniform.
+- **Sandbox lane (opt-in, partly unwired).** A `RuntimeKind::Sandbox` runtime
+  lane with credential reuse, leaf-scoped mount containment, per-user sandbox
+  identity primitives, and a credential placeholder registry. Docker-connect
+  retry, the egress allowlist, and shell limits ship unwired in this release.
+- **Trigger poller on production-shaped runtimes** (opt-in), and the SSO/admin
+  identity resolver wired into those runtimes.
+- **QA run artifacts.** Caller-scoped run and full-thread artifact export,
+  gated off by default, plus a regression promotion loop for the test suite.
+- **`BENCHMARKING_MODE`.** An opt-in system-prompt addendum for unattended
+  evaluation runs.
+
 ### Changed
 
 - **Extension persistence:** normalize filesystem-backed extension lifecycle
@@ -18,6 +61,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   diagnostic health snapshot: it was always `healthy`, never read, and never
   surfaced, while the host's activation record already owns extension failure
   state. Rows written by the previous release keep deserializing.
+- **Model failures now carry a next step.** Every termination path — no
+  progress, iteration limit, disabled capability, denied call, provider error
+  — tells the model what would unlock the call instead of stopping opaquely.
+- **WebUI performance:** route-level code splitting, deferred Markdown and
+  syntax highlighting during chat streaming, optimized embedded static-asset
+  delivery, and pagination for the sidebar thread list, admin users list, and
+  older logs.
+- **Shared WebUI controls:** a common settings `Switch`, a shared
+  `ConfirmDialog` replacing native browser confirmations, and normalized
+  control typography.
 
 ### Fixed
 
@@ -78,6 +131,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Channel removal:** revoke caller-owned OAuth or proof-code pairing state
   through the shared lifecycle before deleting any channel installation, so
   removing Telegram, Slack, or a future channel unpairs it on every surface.
+- **One authorization per vendor account:** authorizing a vendor now covers
+  every installed extension sharing that account, instead of re-prompting per
+  extension. Token response scopes are trusted over the OAuth redirect echo.
+- **Extension package roots** are persisted rather than fabricated on load, so
+  a stale or partial catalog entry no longer takes down startup.
+- **Tool disclosure** is narrowed by the caller's allow-set, closing three
+  paths that leaked tool definitions the caller was not granted.
+- **Provider errors are classified correctly:** rate limits are no longer read
+  as auth failures, a missing model is not retried, adapters report the
+  provider's real finish reason, and the runner stops silently retrying
+  model-stage failures that cannot succeed.
+- **Context overflow and compaction:** secret matches are redacted during
+  compaction and a run recovers from context overflow instead of terminating.
+- **libSQL durability:** writers are serialized, cancelled transactions and
+  interrupted history migrations recover, and transient writer contention no
+  longer surfaces as a failed run.
+- **Panic and cancellation safety** on the run path, plus bounded
+  deterministic gateway failures so a wedged model stage cannot hang a turn.
+- **WebUI streaming and navigation:** smooth streaming with preserved model
+  phases, route state and workspace-tree state preserved across SPA
+  navigation, viewport preserved while loading older messages, message actions
+  kept visible, and active run state preserved when cancellation fails.
+- **WebUI correctness and a11y:** localized chat/extension/OAuth failure
+  messages, surfaced admin user-management failures, recovery from transient
+  session checks, focus trapping in the extension configuration modal, no
+  crash on admin configuration paste, pairing prompts rendered without a text
+  input, tool-permission selection retained while saving, always-allow reset
+  when the approval gate changes, and authenticated previews for workspace
+  file links.
+- **Automations** inherit the implicit source channel target, and the
+  outbound delivery-target registry is caller-scoped structurally rather than
+  by convention.
+- **Skills:** the model is told to review the available skills before
+  answering.
+- **`ironclaw service`:** the generated systemd unit no longer quotes
+  `WorkingDirectory=`.
+- **Projects** show only API-backed data instead of placeholder rows.
+
+### Performance
+
+- **Hosted Postgres API capacity** regressed by the row-native process journal
+  is recovered.
+- **Durable turn-event reads** are served by an indexed scope+cursor query
+  instead of a scan.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,15 +86,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/webhooks/extensions/slack/events`; generic product-auth OAuth callbacks are
   unchanged.
 
+## [1.0.0] - 2026-07-27
+
+First stable release of a rearchitected IronClaw. This is not an increment on
+the 0.29.x line — it is a ground-up rebuild of the agent runtime, storage,
+extension host, and web UI.
+
+**The `ironclaw` binary is the rearchitected CLI.** The v1 monolith builds as
+the `ironclaw-legacy` binary and is not published; 1.0.0 publishes the new
+`ironclaw` binary only.
+
+### This is not an in-place upgrade from 0.29.x
+
+There is no migration for v1 config, databases, settings, or secrets, and
+installing 1.0.0 does not touch your existing v1 data. Treat it as a fresh
+install: point `IRONCLAW_REBORN_HOME` at a new directory, run
+`ironclaw onboard`, and reconnect your providers and channels. Do not point it
+at a v1 data directory.
+
+### What ships
+
+- **Platforms.** Seven targets — macOS (Apple Silicon, Intel), Linux
+  (`x86_64`/`aarch64`, gnu and static musl), and Windows (`x86_64`), with shell,
+  PowerShell, and MSI installers.
+- **Guided setup.** `ironclaw onboard` provisions the config, the encrypted
+  credential store, an LLM provider (interactive key entry with a live probe),
+  a WebUI login token, and — on macOS and Linux — the background service. The
+  credential store's master key is provisioned in the OS keychain when one is
+  available, falling back to a locally cached key file otherwise.
+- **Model providers.** 26 providers in the built-in catalog, including NEAR AI,
+  OpenAI, Anthropic, Gemini, Bedrock, Ollama, OpenRouter, Groq, DeepSeek, and
+  any OpenAI-compatible endpoint. Manage routes with `ironclaw models`.
+- **Web UI.** `ironclaw serve` starts the WebChat v2 interface with the frontend
+  embedded in the binary — no separate asset deploy. Chat, extensions,
+  automations, settings, and admin surfaces are served from root-level routes.
+- **Extensions.** Twelve first-party extensions ship embedded and install
+  without a network fetch: GitHub, Gmail, Google Calendar, Docs, Drive, Sheets,
+  Slides, Notion, NEAR AI MCP, Slack, Telegram, and web access. Manage them with
+  `ironclaw extension` or the WebUI registry.
+- **Channels.** Slack and Telegram, both configured from the WebUI; Slack
+  connects per user through OAuth, Telegram through a per-user pairing code.
+- **Runtime.** Skills, scheduled and triggered automations, subagents, workspace
+  memory, and trace capture.
+- **Storage.** File-backed libSQL by default, so a stock install needs no
+  external database; PostgreSQL is opt-in via `[storage]`.
+- **Service management.** `ironclaw service install|start|stop|restart|status|uninstall`
+  runs the binary as a launchd user agent (macOS) or systemd user unit (Linux).
+
+### Known limitations
+
+- `ironclaw channels list`, `hooks list`, and `logs` appear in `--help` but
+  return an explicit "not implemented yet" error.
+- `mcp`, `memory`, `pairing`, `import`, and `login` subcommands from v1 have no
+  equivalent in this release; MCP servers and memory are reached through
+  extensions and the WebUI instead.
+- `onboard --import-history` parses but does nothing.
+- `skills` is list-only from the CLI.
+- `extension` and `skills` work out of the box: `ironclaw onboard` defaults to
+  the `local-dev` profile, where both are fully supported (as under
+  `local-dev-yolo`, `hosted-single-tenant`, and `hosted-single-tenant-volume`).
+  Only operators who explicitly choose `production` or `migration-dry-run`
+  hit a clear error instead.
+
+Please report problems at https://github.com/nearai/ironclaw/issues — include
+`ironclaw status --json` output.
+
+The itemized changes since 1.0.0-rc.1 follow; see the 1.0.0-rc.1 entry below for
+everything that landed between 0.29.1 and the release candidate.
+
+### Fixed
+
+- *(webui)* restore SSE streams across navigation, so chat keeps streaming when
+  the user moves between WebUI routes mid-turn ([#6425](https://github.com/nearai/ironclaw/pull/6425)).
+- *(webui)* stop the WebChat "Disconnected" lockout caused by rate-limit budget
+  exhaustion and navigation-race SSE thrash ([#6592](https://github.com/nearai/ironclaw/pull/6592)).
+
+### CI / Release
+
+- *(release)* update the Reborn Dockerfile and make the Reborn Docker image
+  buildable ([#6612](https://github.com/nearai/ironclaw/pull/6612)).
+- *(ci)* run the full Reborn test and E2E gates on `release-fix-*` pull-request
+  branches ([#6537](https://github.com/nearai/ironclaw/pull/6537)).
+
 ## [1.0.0-rc.1] - 2026-07-20
 
-First release candidate of the rearchitected IronClaw, internally called
-**Reborn**. This is not an increment on the 0.29.x line — it is a ground-up
-rebuild of the agent runtime, storage, extension host, and web UI.
+First release candidate of a rearchitected IronClaw. This is not an increment
+on the 0.29.x line — it is a ground-up rebuild of the agent runtime, storage,
+extension host, and web UI.
 
-**The `ironclaw` binary is now the Reborn CLI.** The v1 monolith now builds as
-the `ironclaw-legacy` binary and is no longer published; 1.0.0-rc.1 publishes
-the Reborn `ironclaw` binary only.
+**The `ironclaw` binary is now the rearchitected CLI.** The v1 monolith now
+builds as the `ironclaw-legacy` binary and is no longer published; 1.0.0-rc.1
+publishes the new `ironclaw` binary only.
 
 ### This is not an in-place upgrade from 0.29.x
 
@@ -138,8 +220,8 @@ it at a v1 data directory.
 - `ironclaw channels list`, `hooks list`, and `logs` appear in `--help` but
   return an explicit "not implemented yet" error.
 - `mcp`, `memory`, `pairing`, `import`, and `login` subcommands from v1 have no
-  Reborn equivalent; MCP servers and memory are reached through extensions and
-  the WebUI instead.
+  equivalent in this release; MCP servers and memory are reached through
+  extensions and the WebUI instead.
 - `onboard --import-history` parses but does nothing.
 - `skills` is list-only from the CLI.
 - `extension` and `skills` work out of the box: `ironclaw onboard` defaults to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "1.0.0-rc.1"
+version = "1.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw"
-version = "1.0.0-rc.1"
+version = "1.1.0-rc.1"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/chat.tsx
@@ -175,6 +175,24 @@ export function Chat({
     cooldownSeconds > 0;
   const composerSendBlockedRef = React.useRef(composerSendDisabled);
   composerSendBlockedRef.current = composerSendDisabled;
+  // Identifies which "empty-thread cycle" may navigate away from the
+  // landing view. It's bumped on every truthy->falsy transition of
+  // activeThreadId (a genuine new cycle, e.g. "+ New") and by whichever
+  // send wins the navigation for the current cycle -- so a captured id
+  // only matches while its cycle is still current and unclaimed. That one
+  // comparison is enough to stop every stale closure from a batch of
+  // concurrent landing-composer sends from re-navigating, whether its
+  // cycle was already claimed by an earlier winner or superseded by a
+  // "+ New" before it settled. Each redundant navigation tears down and
+  // reopens the app's single SSE stream, and those reconnects are
+  // genuinely accepted, so they burn the caller's server-side rate-limit
+  // budget and strand WebChat on the "Disconnected" badge.
+  const previousActiveThreadIdRef = React.useRef(activeThreadId);
+  const emptyThreadCycleIdRef = React.useRef(0);
+  if (previousActiveThreadIdRef.current && !activeThreadId) {
+    emptyThreadCycleIdRef.current += 1;
+  }
+  previousActiveThreadIdRef.current = activeThreadId;
   const composerStatusText =
     approvalSubmitWarning ||
     (cooldownSeconds > 0 ? t("chat.retryIn", { seconds: cooldownSeconds }) : undefined);
@@ -199,13 +217,22 @@ export function Chat({
         throw new Error(approvalSubmitWarning);
       }
       if (composerSendBlockedRef.current) return null;
+      const sendCycleId = emptyThreadCycleIdRef.current;
       // A newly created thread (from either path below) is not yet the
       // selected/active one — route the browser to it, exactly as the send
       // path already did, so the result (a system notice for a command, the
-      // first reply for a message) renders somewhere visible.
+      // first reply for a message) renders somewhere visible. Only the send
+      // that still owns the current empty-thread cycle may navigate; see
+      // `emptyThreadCycleIdRef`.
       const selectResponseThread = (response) => {
         const responseThreadId = response?.thread_id || activeThreadId;
-        if (!activeThreadId && responseThreadId && onSelectThread) {
+        if (
+          !activeThreadId &&
+          responseThreadId &&
+          onSelectThread &&
+          emptyThreadCycleIdRef.current === sendCycleId
+        ) {
+          emptyThreadCycleIdRef.current += 1;
           onSelectThread(responseThreadId, { replace: true });
         }
       };

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
@@ -77,7 +77,15 @@ function renderChat({
   showChatLogsShortcut = true,
   onSelectThread = () => {},
   contextOverrides = {},
+  // Positional ref slots, shared by reference across repeated renderChat()
+  // calls that pass the same array -- lets a test simulate the same
+  // component "instance" re-rendering (e.g. a navigation-triggered
+  // rerender) with useRef state persisted across renders, the way real
+  // React would. Left undefined by default: each call gets fresh refs,
+  // matching every existing single-render test.
+  refs = [],
 }) {
+  let refSlot = 0;
   const components = {
     ApprovalCard() {},
     AuthGenericCard() {},
@@ -102,7 +110,12 @@ function renderChat({
         if (runEffects) effect();
       },
       useMemo: (fn) => fn(),
-      useRef: (initial) => ({ current: initial }),
+      useRef: (initial) => {
+        const slot = refSlot;
+        refSlot += 1;
+        if (!(slot in refs)) refs[slot] = { current: initial };
+        return refs[slot];
+      },
       useState: (initial) => [
         typeof initial === "function" ? initial() : initial,
         () => {},
@@ -1113,4 +1126,248 @@ test("Chat landing view submits unknown slash text as an ordinary message", asyn
   await props.onSend("/unknown-text", {});
   assert.deepEqual(commandRuns, [], "unrecognized slash text is not a command");
   assert.deepEqual(sends, ["/unknown-text"], "unknown slash text still sends as an ordinary message");
+});
+
+
+test("Chat does not double-navigate when multiple sends resolve before either can navigate away from the empty-thread view", async () => {
+  // Regression test for issue #6581's frontend half: firing several
+  // "new chat" sends before the first one's response has navigated the
+  // view away from the empty-thread state used to make every one of
+  // those sends independently navigate, each tearing down and reopening
+  // the single app-wide SSE stream -- exhausting the rate-limit budget
+  // through genuinely-accepted reconnects even with the backend fix in
+  // place.
+  const selections = [];
+  const { tree, components } = renderChat({
+    activeThreadId: null,
+    onSelectThread: (threadId, options) => selections.push({ threadId, options }),
+    hookState: {
+      messages: [],
+      isProcessing: false,
+      pendingGate: null,
+      suggestions: [],
+      sseStatus: "closed",
+      historyLoading: false,
+      hasMore: false,
+      cooldownSeconds: 0,
+      recoveryNotice: null,
+      activeRun: null,
+      send: async (content) => ({ thread_id: `thread-for-${content}` }),
+      cancelRun: async () => {},
+      retryMessage: () => {},
+      approve: () => {},
+      recoverHistory: () => {},
+      loadMore: () => {},
+      setSuggestions: () => {},
+      submitAuthToken: async () => {},
+    },
+  });
+
+  // No messages yet -> the landing composer (EmptyState), not the
+  // in-thread ChatInput, is what's rendered and wired to handleSend.
+  const emptyState = findComponent(tree, components.EmptyState);
+  const { onSend } = componentProps(emptyState, components.EmptyState);
+
+  const [first, second] = await Promise.all([
+    onSend("weather in NY"),
+    onSend("weather in LA"),
+  ]);
+
+  assert.equal(first.thread_id, "thread-for-weather in NY");
+  assert.equal(second.thread_id, "thread-for-weather in LA");
+  assert.equal(
+    selections.length,
+    1,
+    "only the first concurrent send should navigate the empty-thread view"
+  );
+  assert.equal(selections[0].threadId, "thread-for-weather in NY");
+  // Not deepEqual: the options object is constructed inside the vm-sandboxed
+  // chat.tsx source, so it's a cross-realm object relative to this test file
+  // and fails Node's strict deep-equality identity checks despite matching
+  // structurally.
+  assert.equal(selections[0].options.replace, true);
+});
+
+test("Chat does not double-navigate when a stale send resolves after the first navigation's rerender", async () => {
+  // Regression test for PR #6592 review comment: the previous reset rule
+  // ("clear the claim whenever activeThreadId is truthy") fires on the very
+  // rerender the first navigation itself causes, re-opening the window for
+  // a second, still-in-flight send -- one whose closure captured the old
+  // null activeThreadId, same as the first -- to navigate again and
+  // reproduce the SSE thrash. This is a genuinely distinct race from
+  // "Chat does not double-navigate when multiple sends resolve before
+  // either can navigate away from the empty-thread view" above: that test
+  // resolves both sends within a single render and never exercises the
+  // rerender in between, so it can't see this bug. Reproducing it needs
+  // controllable send resolution order plus a real second render sharing
+  // ref state, which is why it's a separate test rather than an extra
+  // assertion on the existing one.
+  const selections = [];
+  let resolveFirst;
+  let resolveSecond;
+  const hookState = {
+    messages: [],
+    isProcessing: false,
+    pendingGate: null,
+    suggestions: [],
+    sseStatus: "closed",
+    historyLoading: false,
+    hasMore: false,
+    cooldownSeconds: 0,
+    recoveryNotice: null,
+    activeRun: null,
+    send: async (content) =>
+      content === "weather in NY"
+        ? new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+        : new Promise((resolve) => {
+            resolveSecond = resolve;
+          }),
+    cancelRun: async () => {},
+    retryMessage: () => {},
+    approve: () => {},
+    recoverHistory: () => {},
+    loadMore: () => {},
+    setSuggestions: () => {},
+    submitAuthToken: async () => {},
+  };
+  const refs = [];
+
+  // Render 1: the empty-thread landing view (activeThreadId = null). Both
+  // sends are fired from this render, so both handleSend closures capture
+  // activeThreadId = null -- exactly like two concurrent "new chat" sends.
+  const render1 = renderChat({
+    activeThreadId: null,
+    onSelectThread: (threadId, options) => selections.push({ threadId, options }),
+    hookState,
+    refs,
+  });
+  const emptyState1 = findComponent(render1.tree, render1.components.EmptyState);
+  const { onSend } = componentProps(emptyState1, render1.components.EmptyState);
+
+  const firstSend = onSend("weather in NY");
+  const secondSend = onSend("weather in LA");
+
+  // The first send resolves and claims the navigation.
+  resolveFirst({ thread_id: "thread-for-weather in NY" });
+  await firstSend;
+  assert.equal(selections.length, 1, "first send should navigate");
+  assert.equal(selections[0].threadId, "thread-for-weather in NY");
+
+  // Render 2: simulates the rerender `onSelectThread` triggers once the
+  // parent adopts the new thread id -- activeThreadId is now truthy. Shares
+  // `refs` with render 1 so the navigation-claim ref persists across
+  // renders the way a real mounted component would.
+  renderChat({
+    activeThreadId: "thread-for-weather in NY",
+    onSelectThread: (threadId, options) => selections.push({ threadId, options }),
+    hookState,
+    refs,
+  });
+
+  // The second send -- still holding its stale render-1 closure with
+  // activeThreadId = null -- resolves after the rerender.
+  resolveSecond({ thread_id: "thread-for-weather in LA" });
+  await secondSend;
+
+  assert.equal(
+    selections.length,
+    1,
+    "a stale send resolving after the first navigation's rerender must not navigate again"
+  );
+});
+
+test("Chat does not let a stale send from an earlier empty-thread cycle hijack a new cycle started by \"+ New\"", async () => {
+  // Regression test for PR #6592 review comment (chat.tsx:201, Medium):
+  // the previous reset rule cleared the navigation claim on *any*
+  // truthy->falsy transition of activeThreadId without regard to which
+  // batch of sends the transition belonged to. Sequence: A and B are both
+  // fired from the landing composer (both closures capture
+  // activeThreadId = null). A resolves first and claims/navigates to
+  // threadA. The user clicks "+ New" -- a genuine new empty-thread cycle
+  // begins, and the old code reset the claim unconditionally. B, a stale
+  // closure from the *original* batch, then resolves and -- because the
+  // claim was reset and its captured activeThreadId is still null --
+  // hijacks the brand-new empty cycle by navigating to threadB.
+  const selections = [];
+  let resolveFirst;
+  let resolveSecond;
+  const hookState = {
+    messages: [],
+    isProcessing: false,
+    pendingGate: null,
+    suggestions: [],
+    sseStatus: "closed",
+    historyLoading: false,
+    hasMore: false,
+    cooldownSeconds: 0,
+    recoveryNotice: null,
+    activeRun: null,
+    send: async (content) =>
+      content === "weather in NY"
+        ? new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+        : new Promise((resolve) => {
+            resolveSecond = resolve;
+          }),
+    cancelRun: async () => {},
+    retryMessage: () => {},
+    approve: () => {},
+    recoverHistory: () => {},
+    loadMore: () => {},
+    setSuggestions: () => {},
+    submitAuthToken: async () => {},
+  };
+  const refs = [];
+
+  // Render 1: the empty-thread landing view (activeThreadId = null). Both
+  // sends are fired from this render, so both handleSend closures capture
+  // activeThreadId = null.
+  const render1 = renderChat({
+    activeThreadId: null,
+    onSelectThread: (threadId, options) => selections.push({ threadId, options }),
+    hookState,
+    refs,
+  });
+  const emptyState1 = findComponent(render1.tree, render1.components.EmptyState);
+  const { onSend } = componentProps(emptyState1, render1.components.EmptyState);
+
+  const firstSend = onSend("weather in NY");
+  const secondSend = onSend("weather in LA");
+
+  // A resolves and claims the navigation.
+  resolveFirst({ thread_id: "thread-for-weather in NY" });
+  await firstSend;
+  assert.equal(selections.length, 1, "first send should navigate");
+  assert.equal(selections[0].threadId, "thread-for-weather in NY");
+
+  // Render 2: the post-navigation rerender, activeThreadId is now truthy.
+  renderChat({
+    activeThreadId: "thread-for-weather in NY",
+    onSelectThread: (threadId, options) => selections.push({ threadId, options }),
+    hookState,
+    refs,
+  });
+
+  // Render 3: the user clicks "+ New" -- activeThreadId goes back to null,
+  // a genuinely new empty-thread cycle begins.
+  renderChat({
+    activeThreadId: null,
+    onSelectThread: (threadId, options) => selections.push({ threadId, options }),
+    hookState,
+    refs,
+  });
+
+  // B -- still holding its stale render-1 closure with activeThreadId =
+  // null from the *original* batch -- resolves after the "+ New" reset.
+  resolveSecond({ thread_id: "thread-for-weather in LA" });
+  await secondSend;
+
+  assert.equal(
+    selections.length,
+    1,
+    "a stale send from the original batch must not hijack the new empty-thread cycle started by \"+ New\""
+  );
 });

--- a/crates/ironclaw_webui/src/webui_rate_limit.rs
+++ b/crates/ironclaw_webui/src/webui_rate_limit.rs
@@ -32,10 +32,26 @@
 //! - **Disabled routes pass through.** A descriptor with
 //!   `RateLimitPolicy::Disabled` (the v2 beta does not have any, but
 //!   the type allows it) records no counters and never returns 429.
+//! - **Explicitly-marked downstream 429s are refunded.** A handler can
+//!   opt a specific rejection out of this middleware's charge by calling
+//!   [`mark_rate_limit_refundable`] on its response — used today by the
+//!   SSE per-caller concurrency cap in `webui_v2::sse_capacity`, which
+//!   reflects a resource limit unrelated to request-volume abuse. The
+//!   marker is a response *extension* (server-side-only metadata, never
+//!   serialized onto the wire) that this middleware consumes and removes
+//!   before returning — it never reaches the client either way.
+//!   Refunding is opt-in and keyed off this explicit marker, **not**
+//!   the bare `429` status code: this protected surface also carries
+//!   system-wide admission-control 429s (`TurnErrorCategory::
+//!   AdmissionRejected` / `CapacityExceeded`) that must keep draining the
+//!   caller's budget precisely during the overload they exist to signal —
+//!   refunding those would let a caller flooding the system during an
+//!   outage dodge the very limit meant to contain it.
 
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -119,6 +135,17 @@ enum ResolvedPolicy {
 pub(crate) struct RateLimitState {
     routes: Arc<Vec<RouteLimit>>,
     shards: Arc<Vec<Mutex<LruCache<CounterKey, Window>>>>,
+    /// Mints a unique, monotonically increasing id every time a [`Window`]
+    /// entry is (re)created — a fresh key insert or a window-expiry reset.
+    /// [`refund_charge`] validates this instead of `window_start` alone: an
+    /// entry evicted from the shard's LRU under load and then reinserted
+    /// for the same key within the same wall-clock second would otherwise
+    /// coincidentally match on `window_start`, letting a delayed refund for
+    /// the evicted charge credit the unrelated replacement entry (PR #6592
+    /// review). A single counter shared across shards is simplest and the
+    /// contention is negligible next to the shard mutex each charge/refund
+    /// already takes.
+    next_generation: Arc<AtomicU64>,
 }
 
 impl std::fmt::Debug for RateLimitState {
@@ -145,6 +172,11 @@ struct Window {
     remaining: u32,
     /// Epoch second at which the current window started.
     window_start: u64,
+    /// Unique id minted by [`RateLimitState::next_generation`] when this
+    /// window instance was (re)created. Refunds validate this — see the
+    /// field doc on `next_generation` for why `window_start` alone isn't
+    /// sufficient.
+    generation: u64,
 }
 
 #[derive(Debug)]
@@ -179,6 +211,7 @@ pub(crate) fn build_rate_limit_state(
     Ok(RateLimitState {
         routes: Arc::new(routes),
         shards: Arc::new(shards),
+        next_generation: Arc::new(AtomicU64::new(0)),
     })
 }
 
@@ -299,6 +332,27 @@ fn caller_key(caller: &ProductSurfaceCaller) -> String {
     )
 }
 
+/// Marker a handler attaches to its own `429` response (via
+/// [`mark_rate_limit_refundable`]) to opt that specific rejection out of
+/// [`enforce_rate_limit`]'s charge — see the "Explicitly-marked downstream
+/// 429s are refunded" module doc. Carried as a response *extension*, not a
+/// header: extensions are server-side-only metadata that never serialize
+/// onto the wire, so there is no risk of this internal signal leaking to
+/// the actual HTTP client.
+#[derive(Clone)]
+struct RateLimitRefundable;
+
+/// Marks a handler's own `429` response as refundable against the caller's
+/// [`enforce_rate_limit`] budget — use for a rejection that reflects a
+/// resource limit unrelated to request-volume abuse (e.g. the SSE
+/// per-caller concurrency cap in `webui_v2::sse_capacity`). Do **not** use
+/// for a system-wide capacity/admission-control signal: those must keep
+/// draining the caller's budget during the overload they exist to contain.
+pub(crate) fn mark_rate_limit_refundable(mut response: Response) -> Response {
+    response.extensions_mut().insert(RateLimitRefundable);
+    response
+}
+
 fn now_epoch_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -352,9 +406,9 @@ pub(crate) async fn enforce_rate_limit(
     let now = now_epoch_secs();
     let window_seconds = window.as_secs().max(1);
 
-    let shard = &state.shards[shard_index(&key.bucket_key)];
-    let allowed = {
-        let mut guard = match shard.lock() {
+    let shard_idx = shard_index(&key.bucket_key);
+    let charged_generation = {
+        let mut guard = match state.shards[shard_idx].lock() {
             Ok(guard) => guard,
             Err(poisoned) => {
                 tracing::debug!(
@@ -365,34 +419,94 @@ pub(crate) async fn enforce_rate_limit(
             }
         };
 
-        let window_entry = guard.get_or_insert_mut(key, || Window {
+        let window_entry = guard.get_or_insert_mut(key.clone(), || Window {
             remaining: max_requests,
             window_start: now,
+            generation: state.next_generation.fetch_add(1, Ordering::Relaxed),
         });
 
         if now.saturating_sub(window_entry.window_start) >= window_seconds {
             // Window expired — start a new one. Charge the current
-            // request against the fresh budget.
+            // request against the fresh budget. This is logically a new
+            // window instance, so it gets a fresh generation too — a
+            // refund arriving after a legitimate rollover for the same
+            // caller must not credit the new window any more than one
+            // arriving after an LRU eviction should.
             window_entry.window_start = now;
             window_entry.remaining = max_requests.saturating_sub(1);
-            true
+            window_entry.generation = state.next_generation.fetch_add(1, Ordering::Relaxed);
+            Some(window_entry.generation)
         } else if window_entry.remaining == 0 {
-            false
+            None
         } else {
             window_entry.remaining -= 1;
-            true
+            Some(window_entry.generation)
         }
     };
 
-    if !allowed {
+    let Some(charged_generation) = charged_generation else {
         return (
             StatusCode::TOO_MANY_REQUESTS,
             "Rate limit exceeded. Try again shortly.",
         )
             .into_response();
+    };
+
+    let mut response = next.run(request).await;
+
+    if response
+        .extensions_mut()
+        .remove::<RateLimitRefundable>()
+        .is_some()
+    {
+        refund_charge(
+            &state.shards[shard_idx],
+            &key,
+            charged_generation,
+            max_requests,
+        );
     }
 
-    next.run(request).await
+    response
+}
+
+/// Credits back a charge made by [`enforce_rate_limit`] when the downstream
+/// handler marked its own `429` response refundable (see
+/// [`mark_rate_limit_refundable`]). Only refunds into the exact window
+/// instance it charged — validated by `generation`, a per-entry token minted
+/// by [`RateLimitState::next_generation`] whenever a [`Window`] is (re)created
+/// (fresh insert or window-expiry reset). A plain `window_start` comparison
+/// is only second-resolution: if the charged entry is evicted from the
+/// shard's LRU under load and the same caller then makes a brand-new,
+/// unrelated request within the same wall-clock second, the replacement
+/// entry's `window_start` can coincidentally match the original charge's.
+/// `generation` is unique per (re)creation regardless of timing, so it
+/// can't be fooled by that coincidence — it subsumes the `window_start`
+/// check rather than complementing it. If the entry is missing (evicted and
+/// never reinserted) or its generation has moved on (rolled over or
+/// replaced), this is a no-op rather than mis-crediting the wrong window.
+fn refund_charge(
+    shard: &Mutex<LruCache<CounterKey, Window>>,
+    key: &CounterKey,
+    charged_generation: u64,
+    max_requests: u32,
+) {
+    let mut guard = match shard.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            tracing::debug!(
+                target = "ironclaw::reborn::webui_rate_limit",
+                "rate-limit LRU mutex poisoned during refund — recovering",
+            );
+            poisoned.into_inner()
+        }
+    };
+    if let Some(window_entry) = guard.get_mut(key)
+        && window_entry.generation == charged_generation
+        && window_entry.remaining < max_requests
+    {
+        window_entry.remaining += 1;
+    }
 }
 
 #[cfg(test)]
@@ -400,7 +514,8 @@ mod tests {
     use super::*;
     use ironclaw_host_api::ids::{TenantId, UserId};
 
-    fn caller(tenant: &str, user: &str) -> ProductSurfaceCaller {
+    /// `pub(super)`: reused by the sibling `webui_rate_limit_router_contract_test` module.
+    pub(super) fn caller(tenant: &str, user: &str) -> ProductSurfaceCaller {
         ProductSurfaceCaller::new(
             TenantId::new(tenant).expect("tenant"),
             UserId::new(user).expect("user"),
@@ -409,7 +524,8 @@ mod tests {
         )
     }
 
-    fn limited_state(max: u32, window_secs: u32) -> RateLimitState {
+    /// `pub(super)`: reused by the sibling `webui_rate_limit_refund_test` module.
+    pub(super) fn limited_state(max: u32, window_secs: u32) -> RateLimitState {
         let route = RouteLimit {
             route_id: "test.route".into(),
             method: Method::POST,
@@ -426,6 +542,7 @@ mod tests {
         RateLimitState {
             routes: Arc::new(vec![route]),
             shards: Arc::new(shards),
+            next_generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -464,10 +581,12 @@ mod tests {
         let window_entry = guard.get_or_insert_mut(key, || Window {
             remaining: max,
             window_start: now,
+            generation: state.next_generation.fetch_add(1, Ordering::Relaxed),
         });
         if now.saturating_sub(window_entry.window_start) >= window_seconds {
             window_entry.window_start = now;
             window_entry.remaining = max.saturating_sub(1);
+            window_entry.generation = state.next_generation.fetch_add(1, Ordering::Relaxed);
             true
         } else if window_entry.remaining == 0 {
             false
@@ -603,3 +722,15 @@ mod tests {
         ));
     }
 }
+
+#[cfg(test)]
+#[path = "webui_rate_limit_router_contract_test.rs"]
+mod webui_rate_limit_router_contract_test;
+
+// Finding C6 (PR #6592 review, decompose >1000-line file): the
+// refund-specific `mod tests` helpers/tests moved to this sibling
+// module — see its module doc for why it stays under `src/` rather
+// than `tests/`.
+#[cfg(test)]
+#[path = "webui_rate_limit_refund_test.rs"]
+mod webui_rate_limit_refund_test;

--- a/crates/ironclaw_webui/src/webui_rate_limit_refund_test.rs
+++ b/crates/ironclaw_webui/src/webui_rate_limit_refund_test.rs
@@ -1,0 +1,316 @@
+//! Refund-specific regression tests for PR #6592's `mark_rate_limit_refundable`
+//! / `refund_charge` mechanism, split out of `webui_rate_limit.rs`'s
+//! `mod tests` (Finding C6) to keep that file under the repo's 1000-line
+//! decomposition threshold. Intentionally NOT under `tests/` — like
+//! `webui_rate_limit_router_contract_test.rs` (see that file's module doc
+//! for the full rationale), this is a unit-level test module that exercises
+//! `pub(crate)`-only middleware internals (`RateLimitState`, `RouteLimit`,
+//! `ResolvedPolicy`, `refund_charge`, `enforce_rate_limit`); moving it to
+//! `tests/` would force exporting those internals just for this suite.
+
+use super::tests::{caller, limited_state};
+use super::*;
+
+/// Shared harness for the two `enforce_rate_limit` + downstream-429
+/// regression tests below: a real axum app with the middleware wired
+/// exactly as production does (`middleware::from_fn_with_state`, per
+/// `webui_serve.rs`), fronting a handler that always 429s — marking the
+/// response refundable or not depending on `mark_refundable`.
+fn refund_test_app(
+    max_requests: u32,
+    succeed: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    mark_refundable: bool,
+) -> axum::Router {
+    use axum::Router;
+    use axum::extract::State as AxumState;
+    use axum::middleware;
+    use axum::response::IntoResponse;
+    use axum::routing::post;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(Clone)]
+    struct HandlerState {
+        succeed: Arc<AtomicBool>,
+        mark_refundable: bool,
+    }
+
+    async fn handler(AxumState(state): AxumState<HandlerState>) -> Response {
+        if state.succeed.load(Ordering::SeqCst) {
+            StatusCode::OK.into_response()
+        } else if state.mark_refundable {
+            mark_rate_limit_refundable(StatusCode::TOO_MANY_REQUESTS.into_response())
+        } else {
+            StatusCode::TOO_MANY_REQUESTS.into_response()
+        }
+    }
+
+    // `limited_state` registers its route as POST — match it here, or
+    // `match_route` silently no-ops the limiter for the whole test
+    // (mismatched method looks like an unrelated route to the matcher).
+    Router::new()
+        .route("/api/test", post(handler))
+        .with_state(HandlerState {
+            succeed,
+            mark_refundable,
+        })
+        .route_layer(middleware::from_fn_with_state(
+            limited_state(max_requests, 60),
+            enforce_rate_limit,
+        ))
+}
+
+fn refund_test_request(alice: &ProductSurfaceCaller) -> Request<axum::body::Body> {
+    use axum::body::Body;
+    use axum::http::{Method as HttpMethod, Request};
+
+    let mut request = Request::builder()
+        .method(HttpMethod::POST)
+        .uri("/api/test")
+        .body(Body::empty())
+        .expect("request"); // safety: test-only helper in a #[cfg(test)] sibling module
+    request.extensions_mut().insert(alice.clone());
+    request
+}
+
+/// Regression test for issue #6581: a downstream handler rejecting a
+/// request with its own 429 marked refundable (e.g. the SSE per-caller
+/// concurrency cap in `webui_v2::sse_capacity`, via
+/// `mark_rate_limit_refundable`) must not also drain the caller's
+/// per-route rate-limit budget.
+#[tokio::test]
+async fn refundable_downstream_429_does_not_consume_rate_limit_budget() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tower::ServiceExt;
+
+    let succeed = Arc::new(AtomicBool::new(false));
+    let app = refund_test_app(2, succeed.clone(), true);
+    let alice = caller("tenant-alpha", "alice");
+
+    // max_requests is 2, but fire 5 requests against the always-429
+    // handler. If the budget were spent on these, the middleware itself
+    // would start rejecting before the handler is even reached.
+    for attempt in 0..5 {
+        let response = app
+            .clone()
+            .oneshot(refund_test_request(&alice))
+            .await
+            .expect("oneshot");
+        assert_eq!(
+            response.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "attempt {attempt} should reach the handler and get its 429"
+        );
+    }
+
+    // Now let the handler succeed. This proves the budget was never
+    // actually spent by the downstream refundable 429s above.
+    succeed.store(true, Ordering::SeqCst);
+    let response = app
+        .clone()
+        .oneshot(refund_test_request(&alice))
+        .await
+        .expect("oneshot");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "refundable downstream 429s must not have consumed the rate-limit budget"
+    );
+}
+
+/// Security regression: a downstream 429 that is NOT marked refundable —
+/// e.g. the turn-submission admission-control rejections
+/// (`TurnErrorCategory::AdmissionRejected` / `CapacityExceeded`) — must
+/// keep draining the caller's budget. Refunding these would let a
+/// caller flooding the system during an overload dodge the very limit
+/// meant to contain it.
+#[tokio::test]
+async fn unmarked_downstream_429_still_consumes_rate_limit_budget() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tower::ServiceExt;
+
+    let succeed = Arc::new(AtomicBool::new(false));
+    let app = refund_test_app(2, succeed.clone(), false);
+    let alice = caller("tenant-alpha", "alice");
+
+    // Two unmarked 429s spend the whole (max_requests = 2) budget.
+    for _ in 0..2 {
+        let response = app
+            .clone()
+            .oneshot(refund_test_request(&alice))
+            .await
+            .expect("oneshot");
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    // Even once the handler would succeed, the middleware itself now
+    // rejects because the budget was genuinely spent.
+    succeed.store(true, Ordering::SeqCst);
+    let response = app
+        .clone()
+        .oneshot(refund_test_request(&alice))
+        .await
+        .expect("oneshot");
+    assert_eq!(
+        response.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "unmarked downstream 429s must still consume the rate-limit budget"
+    );
+}
+
+#[test]
+fn refund_charge_noops_when_window_rolled_over_since_charge() {
+    let state = limited_state(3, 60);
+    let alice = caller("tenant-alpha", "alice");
+    let key = CounterKey {
+        route_idx: 0,
+        bucket_key: caller_key(&alice),
+    };
+    let shard = &state.shards[shard_index(&key.bucket_key)];
+
+    // Simulate a charge made against a now-stale window: insert an
+    // entry whose generation differs from what the (stale) caller
+    // believes it charged — e.g. the window rolled over since, minting
+    // a fresh generation for the new window instance.
+    {
+        let mut guard = shard.lock().expect("lock");
+        guard.get_or_insert_mut(key.clone(), || Window {
+            remaining: 1,
+            window_start: 1_000,
+            generation: 7,
+        });
+    }
+    let stale_charged_generation = 3; // does not match the live entry's generation (7)
+
+    refund_charge(shard, &key, stale_charged_generation, 3);
+
+    let guard = shard.lock().expect("lock");
+    let entry = guard.peek(&key).expect("entry still present");
+    assert_eq!(
+        entry.remaining, 1,
+        "refund into a rolled-over window must be a no-op"
+    );
+}
+
+#[test]
+fn refund_charge_noops_when_key_missing_from_cache() {
+    let state = limited_state(3, 60);
+    let alice = caller("tenant-alpha", "alice");
+    let key = CounterKey {
+        route_idx: 0,
+        bucket_key: caller_key(&alice),
+    };
+    let shard = &state.shards[shard_index(&key.bucket_key)];
+
+    // No entry was ever inserted for this key (never charged, or
+    // evicted under LRU pressure) — refund must not fabricate one.
+    refund_charge(shard, &key, 0, 3);
+
+    let guard = shard.lock().expect("lock");
+    assert!(
+        guard.peek(&key).is_none(),
+        "refund must not create an entry for an uncharged/evicted key"
+    );
+}
+
+/// Regression for PR #6592 review comment ("Refund can credit a
+/// replacement entry after LRU eviction"): a plain `window_start`
+/// equality check is only second-resolution. If the original charge's
+/// entry is evicted from the shard's LRU (other callers on the same
+/// shard churning it out under load) and the SAME caller then makes a
+/// brand-new, unrelated request within the same wall-clock second, the
+/// replacement entry's `window_start` can coincidentally match the
+/// original charge's `window_start` — so a `window_start`-only guard
+/// would let a delayed refund for the evicted charge incorrectly credit
+/// the unrelated replacement entry. The per-entry `generation` token
+/// is unique per (re)creation regardless of any `window_start`
+/// coincidence, so it must not be fooled by this.
+#[test]
+fn refund_charge_does_not_credit_replacement_entry_after_eviction_same_second() {
+    let state = limited_state(3, 60);
+    let alice = caller("tenant-alpha", "alice");
+    let key = CounterKey {
+        route_idx: 0,
+        bucket_key: caller_key(&alice),
+    };
+    let shard = &state.shards[shard_index(&key.bucket_key)];
+    let window_start = 1_000;
+
+    // Original charge: insert alice's entry at generation 1, remember
+    // that generation as `refund_charge` would (this is exactly
+    // `charged_generation` in `enforce_rate_limit`).
+    {
+        let mut guard = shard.lock().expect("lock");
+        guard.get_or_insert_mut(key.clone(), || Window {
+            remaining: 2,
+            window_start,
+            generation: 1,
+        });
+    }
+    let charged_generation = 1;
+
+    // Simulate LRU eviction of alice's entry (other callers on the same
+    // shard churning through their 512-entry cap under load), then a
+    // brand-new, unrelated request from alice within the same second
+    // reinserting a fresh entry — same `window_start` by coincidence,
+    // but a new, distinct `generation` (2).
+    {
+        let mut guard = shard.lock().expect("lock");
+        guard.pop(&key);
+        guard.get_or_insert_mut(key.clone(), || Window {
+            remaining: 1,
+            window_start,
+            generation: 2,
+        });
+    }
+
+    // The delayed refund for the ORIGINAL (now-evicted, generation 1)
+    // charge arrives late and must not credit the unrelated
+    // replacement entry (generation 2) it happens to collide with on
+    // `window_start`.
+    refund_charge(shard, &key, charged_generation, 3);
+
+    let guard = shard.lock().expect("lock");
+    let entry = guard.peek(&key).expect("replacement entry still present");
+    assert_eq!(
+        entry.remaining, 1,
+        "refund for an evicted charge must not credit an unrelated \
+         replacement entry that coincidentally shares window_start"
+    );
+}
+
+#[test]
+fn refund_charge_does_not_credit_past_max_requests() {
+    let state = limited_state(3, 60);
+    let alice = caller("tenant-alpha", "alice");
+    let key = CounterKey {
+        route_idx: 0,
+        bucket_key: caller_key(&alice),
+    };
+    let shard = &state.shards[shard_index(&key.bucket_key)];
+    let window_start = now_epoch_secs();
+    let generation = 42;
+
+    {
+        let mut guard = shard.lock().expect("lock");
+        guard.get_or_insert_mut(key.clone(), || Window {
+            remaining: 3,
+            window_start,
+            generation,
+        });
+    }
+
+    // Two refunds for the same charge (a duplicate/racing refund)
+    // must not push `remaining` past `max_requests`.
+    refund_charge(shard, &key, generation, 3);
+    refund_charge(shard, &key, generation, 3);
+
+    let guard = shard.lock().expect("lock");
+    let entry = guard.peek(&key).expect("entry still present");
+    assert_eq!(
+        entry.remaining, 3,
+        "refund must not credit a window past max_requests"
+    );
+}

--- a/crates/ironclaw_webui/src/webui_rate_limit_router_contract_test.rs
+++ b/crates/ironclaw_webui/src/webui_rate_limit_router_contract_test.rs
@@ -1,0 +1,396 @@
+//! Caller-level contract tests for PR #6592 review comments about
+//! `enforce_rate_limit` ↔ `SseCapacity` refund behavior driven through the
+//! real, fully-wired v2 router (real `stream_events` / `stream_events_ws`
+//! handlers, real `SseCapacity`) rather than a synthetic always-429
+//! handler.
+//!
+//! Intentionally NOT under `crates/ironclaw_webui/tests/`: every test
+//! here builds `RateLimitState` / `RouteLimit` / `ResolvedPolicy` literals
+//! and calls `enforce_rate_limit` directly, all `pub(crate)`-only
+//! internals of this module. Moving this file to `tests/` (an external,
+//! separately-compiled crate) would force widening those internals to
+//! `pub` just to serve this suite — the wrong tradeoff for middleware
+//! plumbing nothing outside the crate needs to see. It stays a
+//! caller-level contract test in an internal sibling module instead,
+//! exercised via `cargo test -p ironclaw_webui --lib`.
+use super::tests::caller;
+use super::*;
+
+use crate::webui_v2::{WebUiV2State, webui_v2_router};
+use async_trait::async_trait;
+use axum::body::{Body, to_bytes};
+use axum::http::Request as HttpRequest;
+use axum::middleware;
+use ironclaw_product_contracts::surface::{
+    ProductSurface, ProductSurfaceError, ProductSurfaceInvokeRequest, ProductSurfaceInvokeResponse,
+    ProductSurfaceQueryPage, ProductSurfaceQueryRequest, ProductSurfaceStreamRequest,
+    ProductSurfaceStreamResponse,
+};
+use tower::ServiceExt;
+
+/// Minimal `ProductSurface` fake shared by the tests in this file. Only
+/// `stream_events` needs a real body: the SSE/WS capacity slot is reserved
+/// synchronously at the top of the `stream_events` / `stream_events_ws`
+/// handlers before the surface is ever touched, so the other operations are
+/// unreachable for these tests and panic loudly if that ever changes.
+#[derive(Default)]
+struct FakeServices;
+
+#[async_trait]
+impl ProductSurface for FakeServices {
+    async fn invoke(
+        &self,
+        _caller: ProductSurfaceCaller,
+        _request: ProductSurfaceInvokeRequest,
+    ) -> Result<ProductSurfaceInvokeResponse, ProductSurfaceError> {
+        unreachable!("test does not drive invoke")
+    }
+
+    async fn query(
+        &self,
+        _caller: ProductSurfaceCaller,
+        _request: ProductSurfaceQueryRequest,
+    ) -> Result<ProductSurfaceQueryPage, ProductSurfaceError> {
+        unreachable!("test does not drive query")
+    }
+
+    async fn stream_events(
+        &self,
+        _caller: ProductSurfaceCaller,
+        _request: ProductSurfaceStreamRequest,
+    ) -> Result<ProductSurfaceStreamResponse, ProductSurfaceError> {
+        // Returns instantly with an empty page — no backing projection
+        // store is needed because these tests never drain the SSE/WS body,
+        // only the handshake status.
+        Ok(ProductSurfaceStreamResponse {
+            events: Vec::new(),
+            next_cursor: None,
+            subscription: None,
+        })
+    }
+}
+
+/// Build the real `webui_v2_router` (real handlers, real `SseCapacity`)
+/// with `enforce_rate_limit` wired in front of it for the given `routes`,
+/// exactly as `webui_serve::webui_v2_app_with_lifecycle` wires production
+/// for the routes under test (`enforce_rate_limit` closest to the route
+/// set). `sse_capacity_cap` bounds concurrent `SseCapacity` streams per
+/// caller. Paths with no entry in `routes` simply fall through unrated —
+/// `match_route` no-ops for them, same as an unknown path in production.
+fn test_router(sse_capacity_cap: usize, routes: Vec<RouteLimit>) -> axum::Router {
+    let shards = (0..SHARD_COUNT)
+        .map(|_| Mutex::new(LruCache::new(RATE_LIMIT_PER_SHARD_CAPACITY)))
+        .collect::<Vec<_>>();
+    let rate_limit_state = RateLimitState {
+        routes: Arc::new(routes),
+        shards: Arc::new(shards),
+        next_generation: Arc::new(AtomicU64::new(0)),
+    };
+
+    let services: Arc<dyn ProductSurface> = Arc::new(FakeServices);
+    webui_v2_router(WebUiV2State::new(services, sse_capacity_cap)).route_layer(
+        middleware::from_fn_with_state(rate_limit_state, enforce_rate_limit),
+    )
+}
+
+fn stream_events_route(max_requests: u32) -> RouteLimit {
+    RouteLimit {
+        route_id: "webui_v2.stream_events".into(),
+        method: Method::GET,
+        segments: parse_pattern("/api/webchat/v2/threads/{thread_id}/events"),
+        policy: ResolvedPolicy::Limited {
+            scope: RateLimitScope::PerCaller,
+            max_requests,
+            window: Duration::from_secs(60),
+        },
+    }
+}
+
+fn stream_events_ws_route(max_requests: u32) -> RouteLimit {
+    RouteLimit {
+        route_id: "webui_v2.stream_events_ws".into(),
+        method: Method::GET,
+        segments: parse_pattern("/api/webchat/v2/threads/{thread_id}/ws"),
+        policy: ResolvedPolicy::Limited {
+            scope: RateLimitScope::PerCaller,
+            max_requests,
+            window: Duration::from_secs(60),
+        },
+    }
+}
+
+/// Caller-level contract test for the PR #6592 review comment "Missing
+/// production test for refundable SSE capacity 429s". The two
+/// `refund_test_app` tests in `webui_rate_limit_refund_test.rs` front
+/// `enforce_rate_limit` with a synthetic handler that always 429s, and the
+/// `SseCapacity` cap tests (`webui_v2::handlers` contract suite) inject the
+/// caller `Extension` directly, bypassing this middleware entirely. Neither
+/// proves that exhausting the SSE per-caller concurrency cap through the
+/// real, fully-wired route — `enforce_rate_limit` in front of the real
+/// `stream_events` handler and a real `SseCapacity` — actually refunds the
+/// caller's rate-limit budget end to end. This test drives that exact
+/// combination.
+#[tokio::test]
+async fn sse_capacity_429_through_real_stream_events_handler_is_refunded() {
+    // Rate-limit budget deliberately smaller than the number of
+    // SseCapacity rejections fired below: if those refundable 429s were
+    // NOT actually refunded, `enforce_rate_limit` itself would start
+    // rejecting before this test's final request, which would mask the
+    // real assertion.
+    let app = test_router(1, vec![stream_events_route(2)]);
+
+    let alice = caller("tenant-alpha", "alice");
+    let open_request = || {
+        let mut request = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("/api/webchat/v2/threads/thread-x/events")
+            .body(Body::empty())
+            .expect("request"); // safety: test-only helper in a #[cfg(test)] sibling module
+        request.extensions_mut().insert(alice.clone());
+        request
+    };
+
+    // First open succeeds and reserves the caller's only SseCapacity
+    // slot. Hold the response alive so the slot stays reserved for the
+    // rest of the test — the slot guard lives inside the SSE body.
+    let held = app.clone().oneshot(open_request()).await.expect("oneshot");
+    assert_eq!(held.status(), StatusCode::OK);
+
+    // Fire more capacity-rejected opens than the rate-limit budget (2)
+    // allows. Each must be `SseCapacity`'s own refundable 429 — a JSON
+    // body `{"error":"rate_limited","kind":"busy",...}` from
+    // `sse_capacity_rejected()` — not the middleware's own plain-text
+    // "Rate limit exceeded" 429, which would mean the limiter itself
+    // short-circuited before the real handler ran.
+    for attempt in 0..5 {
+        let rejected = app.clone().oneshot(open_request()).await.expect("oneshot");
+        assert_eq!(
+            rejected.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "attempt {attempt} must hit the real SseCapacity cap"
+        );
+        let body = to_bytes(rejected.into_body(), usize::MAX)
+            .await
+            .expect("read rejected body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(
+            json["error"], "rate_limited",
+            "attempt {attempt} must be SseCapacity's own 429 body, not the rate limiter's"
+        );
+        assert_eq!(json["kind"], "busy");
+    }
+
+    // Release the held slot; the `SseSlot` guard's Drop runs
+    // synchronously, but yield once so any pending wakers settle.
+    drop(held);
+    tokio::task::yield_now().await;
+
+    // A fresh open must succeed. If the five refundable SseCapacity
+    // 429s above had actually drained the (max_requests = 2)
+    // rate-limit budget, `enforce_rate_limit` would reject this
+    // request itself before it ever reached the handler.
+    let recovered = app.clone().oneshot(open_request()).await.expect("oneshot");
+    assert_eq!(
+        recovered.status(),
+        StatusCode::OK,
+        "refundable SseCapacity 429s through the real router must not have \
+             consumed the caller's rate-limit budget"
+    );
+}
+
+/// Finding C4 (PR #6592 review): the test above only ever fires exactly
+/// `sse_capacity::REJECTION_REFUND_LIMIT` (5) rejections, so nothing
+/// end-to-end proves what happens *past* that burst — that further
+/// capacity rejections genuinely drain `enforce_rate_limit`'s budget and
+/// that, once the budget is gone, the caller gets the middleware's own
+/// 429 rather than `SseCapacity`'s. This test saturates the cap and fires
+/// past the refund burst, asserting all three phases: (1) refundable
+/// capacity 429s that leave the budget untouched, (2) non-refundable
+/// capacity 429s that drain it, (3) the middleware's own plain-text 429
+/// once the budget is gone — proving the burst cutoff is not a free
+/// 429 generator forever.
+#[tokio::test]
+async fn sse_capacity_429_burst_past_refund_limit_drains_budget_to_middleware_429() {
+    // max_requests = 3: the initial successful open charges 1 (2 left).
+    // The first 5 rejections (within REJECTION_REFUND_LIMIT) are
+    // refundable and must not touch that remaining 2. Rejections 6 and 7
+    // are past the burst limit and must each charge one unit, exhausting
+    // the budget; rejection 8 must then be the middleware's own 429.
+    let app = test_router(1, vec![stream_events_route(3)]);
+
+    let alice = caller("tenant-alpha", "alice");
+    let open_request = || {
+        let mut request = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("/api/webchat/v2/threads/thread-x/events")
+            .body(Body::empty())
+            .expect("request"); // safety: test-only helper in a #[cfg(test)] sibling module
+        request.extensions_mut().insert(alice.clone());
+        request
+    };
+
+    let held = app.clone().oneshot(open_request()).await.expect("oneshot");
+    assert_eq!(held.status(), StatusCode::OK);
+
+    async fn assert_sse_capacity_json_429(response: Response, attempt: u32) {
+        assert_eq!(
+            response.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "attempt {attempt} must be a 429"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read rejected body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(
+            json["error"], "rate_limited",
+            "attempt {attempt} must be SseCapacity's own body, not the rate limiter's"
+        );
+        assert_eq!(json["kind"], "busy");
+    }
+
+    // Phase 1: attempts 1-5 are within REJECTION_REFUND_LIMIT — refundable,
+    // budget stays at 2.
+    for attempt in 1..=5 {
+        let rejected = app.clone().oneshot(open_request()).await.expect("oneshot");
+        assert_sse_capacity_json_429(rejected, attempt).await;
+    }
+
+    // Phase 2: attempts 6-7 are past the burst limit — still SseCapacity's
+    // own JSON 429 (the handler still runs and still rejects on capacity),
+    // but no longer marked refundable, so each drains one unit of the
+    // (now down to 2) rate-limit budget.
+    for attempt in 6..=7 {
+        let rejected = app.clone().oneshot(open_request()).await.expect("oneshot");
+        assert_sse_capacity_json_429(rejected, attempt).await;
+    }
+
+    // Phase 3: the budget is now fully spent (2 units drained by phase 2).
+    // `enforce_rate_limit` must reject this request itself, before the
+    // handler — and therefore SseCapacity — ever runs. That means the
+    // exact plain-text body `enforce_rate_limit` returns on its own
+    // rejection, not SseCapacity's JSON shape.
+    let middleware_rejected = app.clone().oneshot(open_request()).await.expect("oneshot");
+    assert_eq!(
+        middleware_rejected.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "attempt 8 must still be a 429"
+    );
+    let body = to_bytes(middleware_rejected.into_body(), usize::MAX)
+        .await
+        .expect("read middleware-rejected body");
+    assert_eq!(
+        body.as_ref(),
+        b"Rate limit exceeded. Try again shortly.",
+        "once the budget is exhausted, the response must be enforce_rate_limit's own \
+         plain-text 429 body, not SseCapacity's JSON body — proving the handler (and \
+         therefore SseCapacity) was never reached for this attempt"
+    );
+
+    drop(held);
+}
+
+/// Finding C3 (PR #6592 review): `stream_events_ws` also marks capacity
+/// 429s refundable (`handlers.rs`, mirroring `stream_events`), but no test
+/// drove the WebSocket route through `enforce_rate_limit` — a bare
+/// `tower::oneshot` request cannot reach a WS handler because axum's
+/// `WebSocketUpgrade` extractor requires a real `hyper::upgrade::OnUpgrade`
+/// extension, which only a real connection provides. This mirrors the raw
+/// TCP + real WS handshake pattern in
+/// `webui_v2_handlers_contract::stream_events_ws_shares_capacity_with_sse_streams`,
+/// adding the real `enforce_rate_limit` middleware in front and asserting
+/// the same budget-untouched refund property the SSE test above asserts,
+/// but through a real WebSocket upgrade over a real socket.
+#[tokio::test]
+async fn stream_events_ws_429_through_real_socket_is_refunded() {
+    // max_requests = 2: the initial successful WS upgrade charges 1 (1
+    // left). If the refundable capacity 429s fired below drained that
+    // last unit, the final reconnect attempt would get the middleware's
+    // own 429 instead of completing the upgrade.
+    let app = test_router(1, vec![stream_events_ws_route(2)])
+        // Caller identity injected the same way as the other raw-TCP WS
+        // test in `webui_v2_handlers_contract.rs`: a router-wide
+        // `Extension` layer standing in for the bearer-auth middleware,
+        // which is out of scope for this rate-limit ↔ SseCapacity
+        // regression.
+        .layer(axum::Extension(caller("tenant-alpha", "alice")));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let serve_handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let ws_url = format!("ws://{addr}/api/webchat/v2/threads/thread-x/ws");
+
+    // First upgrade succeeds and reserves the caller's only SseCapacity
+    // slot (shared between the SSE and WS transports). Keep the socket
+    // open so the slot stays reserved for the rest of the test.
+    let (held_ws, held_response) = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tokio_tungstenite::connect_async(ws_url.clone()),
+    )
+    .await
+    .expect("initial ws connect within 5s")
+    .expect("initial ws upgrade must succeed");
+    assert_eq!(held_response.status().as_u16(), 101);
+
+    // Fire more capacity-rejected upgrade attempts than the rate-limit
+    // budget (2) allows, all within REJECTION_REFUND_LIMIT (5) so every
+    // one must be refundable — over the real socket, the 429 comes back
+    // as the HTTP response to the failed upgrade handshake.
+    for attempt in 0..5 {
+        let rejected = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            tokio_tungstenite::connect_async(ws_url.clone()),
+        )
+        .await
+        .expect("rejected ws connect attempt within 5s");
+        match rejected {
+            Ok((_ws, response)) => panic!(
+                "attempt {attempt} must be rejected by the SseCapacity cap; instead the \
+                 server completed the upgrade with status {}",
+                response.status().as_u16(),
+            ),
+            Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+                assert_eq!(
+                    response.status().as_u16(),
+                    429,
+                    "attempt {attempt} must be a 429 over the socket"
+                );
+            }
+            Err(other) => panic!("attempt {attempt} failed with unexpected error: {other:?}"),
+        }
+    }
+
+    // Release the held slot and wait for the server to observe the
+    // socket close and drop the `SseSlot` guard.
+    drop(held_ws);
+
+    // A fresh upgrade must succeed. If the five refundable capacity 429s
+    // above had actually drained the (max_requests = 2) rate-limit
+    // budget, `enforce_rate_limit` would reject this upgrade itself
+    // (before `stream_events_ws` — and therefore `SseCapacity` — ever
+    // ran) instead of completing it.
+    let recovered = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            match tokio_tungstenite::connect_async(ws_url.clone()).await {
+                Ok((ws, response)) => return Ok::<_, ()>((ws, response)),
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(25)).await,
+            }
+        }
+    })
+    .await
+    .expect("recovered ws upgrade must complete within 5s after the slot is released")
+    .expect("recovered ws upgrade");
+    let (mut recovered_ws, recovered_response) = recovered;
+    assert_eq!(
+        recovered_response.status().as_u16(),
+        101,
+        "refundable SseCapacity 429s through the real WS route must not have \
+         consumed the caller's rate-limit budget"
+    );
+    let _ = recovered_ws.close(None).await;
+    serve_handle.abort();
+}

--- a/crates/ironclaw_webui/src/webui_v2/handlers.rs
+++ b/crates/ironclaw_webui/src/webui_v2/handlers.rs
@@ -143,10 +143,11 @@ use ironclaw_product_contracts::surface::{
 };
 use uuid::Uuid;
 
+use crate::webui_rate_limit::mark_rate_limit_refundable;
 use crate::webui_v2::error::WebUiV2HttpError;
 use crate::webui_v2::router::{WebUiV2Capabilities, WebUiV2State};
 use crate::webui_v2::schema::{WebChatV2Event, WebChatV2EventFrame};
-use crate::webui_v2::sse_capacity::{SSE_MAX_LIFETIME, SseSlot};
+use crate::webui_v2::sse_capacity::{SSE_MAX_LIFETIME, SseAcquireResult, SseSlot};
 use ironclaw_product_contracts::admin_users::AdminUserSecretMeta;
 
 // Session bootstrap must stay cheap and non-blocking: this flag only tunes
@@ -1216,8 +1217,8 @@ pub async fn stream_events(
         connection_id.and(query.connection_generation),
     ) {
         crate::webui_v2::sse_capacity::SseAcquireResult::Acquired(slot) => slot,
-        crate::webui_v2::sse_capacity::SseAcquireResult::AtCapacity => {
-            return Err(sse_concurrency_exhausted());
+        crate::webui_v2::sse_capacity::SseAcquireResult::AtCapacity { refundable } => {
+            return Ok(sse_capacity_rejected(refundable));
         }
         crate::webui_v2::sse_capacity::SseAcquireResult::StaleGeneration => {
             return Ok(StatusCode::NO_CONTENT.into_response());
@@ -1247,7 +1248,26 @@ pub async fn stream_events(
     Ok(response)
 }
 
-/// Build the 429 response for SSE openings that exceed the per-caller
+/// Build the 429 response for SSE openings (both [`stream_events`] and
+/// [`stream_events_ws`]) that exceed the per-caller concurrency cap.
+///
+/// `refundable` — decided by `SseCapacity::try_acquire_ordered`'s per-caller
+/// rejection streak — marks the response so it doesn't also drain
+/// `enforce_rate_limit`'s separate request-volume budget, *up to* a short
+/// burst of consecutive rejections; see that middleware's module doc for
+/// why refunding differs from e.g. turn-submission admission-control 429s,
+/// and `sse_capacity::REJECTION_REFUND_LIMIT` for why refunding stops once
+/// a caller hammers a saturated cap.
+fn sse_capacity_rejected(refundable: bool) -> Response {
+    let response = sse_concurrency_exhausted().into_response();
+    if refundable {
+        mark_rate_limit_refundable(response)
+    } else {
+        response
+    }
+}
+
+/// Build the 429 error for SSE openings that exceed the per-caller
 /// concurrency cap. `retryable: true` because the slot will free as soon
 /// as one of the caller's existing streams closes.
 fn sse_concurrency_exhausted() -> WebUiV2HttpError {
@@ -4045,14 +4065,24 @@ pub async fn stream_events_ws(
     Query(query): Query<StreamEventsQuery>,
     upgrade: axum::extract::ws::WebSocketUpgrade,
 ) -> Result<axum::response::Response, WebUiV2HttpError> {
-    let slot = state
-        .sse_capacity()
-        .try_acquire(
-            &caller.tenant_id,
-            &caller.user_id,
-            stream_connection_id(query.connection_id.as_deref()),
-        )
-        .ok_or_else(sse_concurrency_exhausted)?;
+    let slot = match state.sse_capacity().try_acquire(
+        &caller.tenant_id,
+        &caller.user_id,
+        stream_connection_id(query.connection_id.as_deref()),
+    ) {
+        SseAcquireResult::Acquired(slot) => slot,
+        SseAcquireResult::AtCapacity { refundable } => {
+            return Ok(sse_capacity_rejected(refundable));
+        }
+        // A stale generation on the upgrade path means a newer stream for
+        // the same connection id already holds the slot. Treat it as the
+        // ordinary capacity rejection this handler has always returned, but
+        // never refund it: it is not the saturation signal the refund
+        // budget exists to absorb.
+        SseAcquireResult::StaleGeneration => {
+            return Ok(sse_capacity_rejected(false));
+        }
+    };
     let services = state.services().clone();
     let initial_cursor = headers
         .get(LAST_EVENT_ID_HEADER)

--- a/crates/ironclaw_webui/src/webui_v2/sse_capacity.rs
+++ b/crates/ironclaw_webui/src/webui_v2/sse_capacity.rs
@@ -26,6 +26,25 @@ use tokio::sync::watch;
 /// the cap and gets 429.
 pub const DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER: usize = 3;
 
+/// Number of consecutive capacity-rejected SSE open attempts (while a
+/// caller sits at the concurrency cap) that stay marked refundable against
+/// `webui_rate_limit::enforce_rate_limit`'s request-volume budget, before
+/// this module stops refunding and lets further attempts drain that budget
+/// like any other request.
+///
+/// Without this bound, a caller who is already saturated could send
+/// unlimited capacity-rejected opens and every single one would be
+/// refunded — the per-caller request-volume limiter (whose whole job is
+/// bounding request *volume*) would provide zero throttling for the rest
+/// of the saturation episode (PR #6592 review). The cap is generous enough
+/// to absorb ordinary reconnect racing (a browser `EventSource` retrying
+/// while an old stream hasn't yet closed) without penalizing it, while
+/// still bounding a saturated caller's free-429 hammer: once a streak
+/// crosses this limit, further rejections are ordinary (non-refunded)
+/// charges against the route's configured request-volume budget, same as
+/// any other request.
+const REJECTION_REFUND_LIMIT: u32 = 5;
+
 /// Maximum lifetime of a single SSE stream before the handler closes it
 /// cleanly so the browser can reconnect with `Last-Event-ID`. Bounds
 /// drift between the projection cursor and any stale handler state, and
@@ -48,8 +67,19 @@ pub(crate) struct SseCapacity {
 
 #[derive(Debug, Default)]
 struct CapacityState {
-    open_by_caller: HashMap<CallerKey, usize>,
+    open_by_caller: HashMap<CallerKey, CallerState>,
     named_slots: HashMap<(CallerKey, String), NamedSlot>,
+}
+
+#[derive(Debug, Default)]
+struct CallerState {
+    /// Number of currently held slots.
+    open: usize,
+    /// Consecutive capacity-rejected attempts since this caller last
+    /// successfully acquired a slot. Reset to 0 on every successful
+    /// acquire; bounds how many rejections in a row are reported as
+    /// refundable — see [`REJECTION_REFUND_LIMIT`].
+    rejected_streak: u32,
 }
 
 #[derive(Debug)]
@@ -62,7 +92,13 @@ struct NamedSlot {
 #[derive(Debug)]
 pub(crate) enum SseAcquireResult {
     Acquired(SseSlot),
-    AtCapacity,
+    /// The caller is at or above the concurrency cap. `refundable` says
+    /// whether this specific rejection should be exempted from
+    /// `webui_rate_limit::enforce_rate_limit`'s request-volume charge —
+    /// see [`REJECTION_REFUND_LIMIT`].
+    AtCapacity {
+        refundable: bool,
+    },
     StaleGeneration,
 }
 
@@ -75,19 +111,18 @@ impl SseCapacity {
         }
     }
 
-    /// Reserve one slot for the given caller. Returns `None` if the
-    /// caller is at or above [`Self::max_per_caller`]. Drop the returned
-    /// guard to release the slot.
+    /// Reserve one slot for the given caller, or report a capacity
+    /// rejection (with whether it should be refunded — see
+    /// [`REJECTION_REFUND_LIMIT`]) if the caller is at or above
+    /// [`Self::max_per_caller`]. Drop the returned guard to release the
+    /// slot.
     pub(crate) fn try_acquire(
         self: &Arc<Self>,
         tenant_id: &TenantId,
         user_id: &UserId,
         connection_id: Option<&str>,
-    ) -> Option<SseSlot> {
-        match self.try_acquire_ordered(tenant_id, user_id, connection_id, None) {
-            SseAcquireResult::Acquired(slot) => Some(slot),
-            SseAcquireResult::AtCapacity | SseAcquireResult::StaleGeneration => None,
-        }
+    ) -> SseAcquireResult {
+        self.try_acquire_ordered(tenant_id, user_id, connection_id, None)
     }
 
     /// Reserve a slot using the browser tab's monotonically increasing stream
@@ -100,14 +135,22 @@ impl SseCapacity {
         connection_id: Option<&str>,
         client_generation: Option<u64>,
     ) -> SseAcquireResult {
-        // Reject before touching the HashMap so a configured cap of 0
-        // (SSE disabled) does not leak a zero-count entry per rejected
-        // open. With the insert-before-check order we used to use, every
-        // 429 under a configured cap of 0 would
-        // store the caller's `(tenant, user)` key indefinitely.
-        if self.max_per_caller == 0 {
-            return SseAcquireResult::AtCapacity;
-        }
+        // A configured cap of 0 (SSE disabled) is not special-cased: with
+        // `open` starting at 0, `entry.open >= self.max_per_caller` is
+        // immediately true, so cap-zero callers fall straight into the
+        // same saturated-rejection branch below and get the same
+        // `rejected_streak` / `REJECTION_REFUND_LIMIT` bookkeeping as any
+        // other saturated caller. An earlier version special-cased
+        // `max_per_caller == 0` with an early return before this
+        // bookkeeping ran, which meant every cap-zero rejection was
+        // reported refundable forever — see [`REJECTION_REFUND_LIMIT`]'s
+        // doc comment. Cap-zero callers can never successfully acquire
+        // (the `open >= max_per_caller` check never lets them through), so
+        // their per-caller entry is never released and its
+        // `rejected_streak` accumulates for the life of the process; that
+        // is the intended trade-off to keep this rejection path free of
+        // free 429s, and no production profile configures a cap of 0
+        // today.
         let key = CallerKey {
             tenant_id: tenant_id.clone(),
             user_id: user_id.clone(),
@@ -134,6 +177,12 @@ impl SseCapacity {
                         cancel,
                     },
                 );
+                // A named-slot replacement is a successful acquire (it
+                // reuses the caller's existing reservation rather than
+                // taking a new one), so it ends any rejection streak.
+                if let Some(entry) = state.open_by_caller.get_mut(&key) {
+                    entry.rejected_streak = 0;
+                }
                 return SseAcquireResult::Acquired(SseSlot {
                     capacity: Arc::clone(self),
                     key,
@@ -143,11 +192,14 @@ impl SseCapacity {
                 });
             }
         }
-        let entry = state.open_by_caller.entry(key.clone()).or_insert(0);
-        if *entry >= self.max_per_caller {
-            return SseAcquireResult::AtCapacity;
+        let entry = state.open_by_caller.entry(key.clone()).or_default();
+        if entry.open >= self.max_per_caller {
+            entry.rejected_streak = entry.rejected_streak.saturating_add(1);
+            let refundable = entry.rejected_streak <= REJECTION_REFUND_LIMIT;
+            return SseAcquireResult::AtCapacity { refundable };
         }
-        *entry += 1;
+        entry.open += 1;
+        entry.rejected_streak = 0;
         let (connection_id, cancellation) = if let Some(connection_id) = connection_id {
             let (cancel, cancellation) = watch::channel(false);
             state.named_slots.insert(
@@ -184,9 +236,13 @@ impl SseCapacity {
             }
             state.named_slots.remove(&named_key);
         }
-        if let Some(count) = state.open_by_caller.get_mut(key) {
-            *count = count.saturating_sub(1);
-            if *count == 0 {
+        if let Some(entry) = state.open_by_caller.get_mut(key) {
+            entry.open = entry.open.saturating_sub(1);
+            if entry.open == 0 {
+                // No slots left — drop the whole entry (including any
+                // stale `rejected_streak`) rather than let it linger
+                // unbounded. The caller is no longer saturated, so the
+                // next attempt succeeds and starts a fresh streak anyway.
                 state.open_by_caller.remove(key);
             }
         }
@@ -199,7 +255,11 @@ impl SseCapacity {
             user_id: user_id.clone(),
         };
         let state = lock_state(&self.state);
-        state.open_by_caller.get(&key).copied().unwrap_or(0)
+        state
+            .open_by_caller
+            .get(&key)
+            .map(|entry| entry.open)
+            .unwrap_or(0)
     }
 }
 
@@ -214,7 +274,7 @@ impl SseCapacity {
 /// per-connection cleanup hook.
 ///
 /// Recovering with `into_inner()` is safe here because the only data
-/// behind the lock is a `HashMap<CallerKey, usize>` and every critical
+/// behind the lock is a `HashMap<CallerKey, CallerState>` and every critical
 /// section is a few lines of straight-line code that mutates a single
 /// counter — there is no compound invariant for a mid-mutation panic to
 /// break. The worst case is a single caller's count being off by one,
@@ -273,6 +333,23 @@ impl Drop for SseSlot {
 }
 
 #[cfg(test)]
+impl SseAcquireResult {
+    fn acquired(self) -> Option<SseSlot> {
+        match self {
+            SseAcquireResult::Acquired(slot) => Some(slot),
+            SseAcquireResult::AtCapacity { .. } | SseAcquireResult::StaleGeneration => None,
+        }
+    }
+
+    fn rejected_refundable(&self) -> Option<bool> {
+        match self {
+            SseAcquireResult::AtCapacity { refundable } => Some(*refundable),
+            SseAcquireResult::Acquired(_) | SseAcquireResult::StaleGeneration => None,
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -290,12 +367,16 @@ mod tests {
         let alice = user("alice");
         let s1 = cap
             .try_acquire(&tenant(), &alice, None)
+            .acquired()
             .expect("first slot");
         let s2 = cap
             .try_acquire(&tenant(), &alice, None)
+            .acquired()
             .expect("second slot");
         assert!(
-            cap.try_acquire(&tenant(), &alice, None).is_none(),
+            cap.try_acquire(&tenant(), &alice, None)
+                .acquired()
+                .is_none(),
             "third slot must be refused"
         );
         assert_eq!(cap.open_count(&tenant(), &alice), 2);
@@ -303,6 +384,7 @@ mod tests {
         // After release, a new slot is available again.
         let s3 = cap
             .try_acquire(&tenant(), &alice, None)
+            .acquired()
             .expect("slot after release");
         drop(s2);
         drop(s3);
@@ -310,19 +392,93 @@ mod tests {
     }
 
     #[test]
-    fn zero_capacity_rejects_without_creating_caller_entry() {
-        // Regression for the review point that `try_acquire` used to call
-        // `state.entry(...).or_insert(0)` *before* the cap check. With
-        // max_per_caller=0 every rejected open would leave a zero-count
-        // entry in the HashMap that nothing ever cleared. With the early
-        // return the rejected open touches no state.
+    fn zero_capacity_rejects_and_stops_refunding_after_the_streak_limit() {
+        // PR #6592 review round 2: `max_per_caller == 0` used to short-circuit
+        // *before* the rejection bookkeeping, so every cap-zero rejection was
+        // reported refundable forever — a caller could hammer a disabled SSE
+        // route at zero cost to the request-volume budget. Cap-zero now falls
+        // through the same `rejected_streak` accounting as any other saturated
+        // caller.
         let cap = Arc::new(SseCapacity::new(0));
         let alice = user("alice");
-        assert!(cap.try_acquire(&tenant(), &alice, None).is_none());
+        for attempt in 1..=REJECTION_REFUND_LIMIT {
+            let outcome = cap.try_acquire(&tenant(), &alice, None);
+            assert!(
+                matches!(outcome, SseAcquireResult::AtCapacity { .. }),
+                "cap 0 never acquires"
+            );
+            assert_eq!(
+                outcome.rejected_refundable(),
+                Some(true),
+                "attempt {attempt} is within the refundable streak"
+            );
+        }
+        assert_eq!(
+            cap.try_acquire(&tenant(), &alice, None)
+                .rejected_refundable(),
+            Some(false),
+            "past the streak limit, rejections drain the request-volume budget"
+        );
         assert_eq!(
             cap.open_count(&tenant(), &alice),
             0,
-            "rejected open must not store a HashMap entry"
+            "a rejected open never holds a slot"
+        );
+    }
+
+    #[test]
+    fn saturated_caller_stops_being_refunded_after_the_streak_limit() {
+        // The same bound applies to an ordinary (non-zero) cap: a caller
+        // pinned at the concurrency cap gets a short refundable burst — enough
+        // to absorb normal `EventSource` reconnect racing — and then pays for
+        // further attempts out of the route's request-volume budget.
+        let cap = Arc::new(SseCapacity::new(1));
+        let alice = user("alice");
+        let _held = cap
+            .try_acquire(&tenant(), &alice, None)
+            .acquired()
+            .expect("first slot");
+        for attempt in 1..=REJECTION_REFUND_LIMIT {
+            assert_eq!(
+                cap.try_acquire(&tenant(), &alice, None)
+                    .rejected_refundable(),
+                Some(true),
+                "attempt {attempt} is within the refundable streak"
+            );
+        }
+        assert_eq!(
+            cap.try_acquire(&tenant(), &alice, None)
+                .rejected_refundable(),
+            Some(false),
+            "past the streak limit the rejection is charged like any request"
+        );
+    }
+
+    #[test]
+    fn successful_acquire_resets_the_rejection_streak() {
+        let cap = Arc::new(SseCapacity::new(1));
+        let alice = user("alice");
+        let held = cap
+            .try_acquire(&tenant(), &alice, None)
+            .acquired()
+            .expect("first slot");
+        for _ in 0..=REJECTION_REFUND_LIMIT {
+            let _ = cap.try_acquire(&tenant(), &alice, None);
+        }
+        drop(held);
+
+        // Releasing the slot drops the caller entry entirely, so the next
+        // acquire starts from a clean streak and the burst budget is whole
+        // again — a caller that recovers is not punished for the episode.
+        let _reacquired = cap
+            .try_acquire(&tenant(), &alice, None)
+            .acquired()
+            .expect("slot after release");
+        assert_eq!(
+            cap.try_acquire(&tenant(), &alice, None)
+                .rejected_refundable(),
+            Some(true),
+            "the first rejection after a successful acquire is refundable again"
         );
     }
 
@@ -339,6 +495,7 @@ mod tests {
         let alice = user("alice");
         let slot = cap
             .try_acquire(&tenant(), &alice, None)
+            .acquired()
             .expect("first slot");
 
         // Poison the mutex by panicking while holding the guard. We
@@ -371,6 +528,7 @@ mod tests {
         // new SSE open.
         let recovered = cap
             .try_acquire(&tenant(), &alice, None)
+            .acquired()
             .expect("try_acquire must recover from a poisoned lock");
         drop(recovered);
     }
@@ -380,10 +538,20 @@ mod tests {
         let cap = Arc::new(SseCapacity::new(1));
         let alice = user("alice");
         let bob = user("bob");
-        let _alice_slot = cap.try_acquire(&tenant(), &alice, None).expect("alice");
-        let _bob_slot = cap.try_acquire(&tenant(), &bob, None).expect("bob");
-        assert!(cap.try_acquire(&tenant(), &alice, None).is_none());
-        assert!(cap.try_acquire(&tenant(), &bob, None).is_none());
+        let _alice_slot = cap
+            .try_acquire(&tenant(), &alice, None)
+            .acquired()
+            .expect("alice");
+        let _bob_slot = cap
+            .try_acquire(&tenant(), &bob, None)
+            .acquired()
+            .expect("bob");
+        assert!(
+            cap.try_acquire(&tenant(), &alice, None)
+                .acquired()
+                .is_none()
+        );
+        assert!(cap.try_acquire(&tenant(), &bob, None).acquired().is_none());
     }
 
     #[test]
@@ -392,9 +560,11 @@ mod tests {
         let alice = user("alice");
         let first = cap
             .try_acquire(&tenant(), &alice, Some("browser-tab"))
+            .acquired()
             .expect("first named slot");
         let replacement = cap
             .try_acquire(&tenant(), &alice, Some("browser-tab"))
+            .acquired()
             .expect("same browser tab replaces its stale stream");
 
         assert!(first.is_cancelled(), "the prior stream must be cancelled");
@@ -402,6 +572,7 @@ mod tests {
         assert_eq!(cap.open_count(&tenant(), &alice), 1);
         assert!(
             cap.try_acquire(&tenant(), &alice, Some("different-tab"))
+                .acquired()
                 .is_none(),
             "a different browser tab still respects the per-caller cap"
         );


### PR DESCRIPTION
## Why

`main` and `release-fix-1.0.0-rc.1` diverged and were never reconciled. `main` forked at `40ae72000`; **both** release tags point at commits that live only on the release branch. So today:

- `crates/ironclaw_reborn_cli/Cargo.toml` on `main` still says `1.0.0-rc.1`.
- `CHANGELOG.md` has no `[1.0.0]` section at all — the shipped release is unrecorded on the trunk.
- A real user-facing WebChat fix that shipped in 1.0.0 never came back.
- 280 commits have landed since the fork with only a partial `[Unreleased]` section describing them.

This PR reconciles the trunk with what actually shipped, records 1.0.0, and cuts the next candidate.

## What's in it

| Commit | |
|---|---|
| `fix(webui)` | Forward-port of #6592 — the WebChat "Disconnected" lockout |
| `ci` | Forward-port of #6537 — full Reborn gates on release-branch PRs |
| `docs(changelog)` | The `[1.0.0]` record + #6383's "Reborn" codename scrub |
| `chore(release)` | Bump to `1.1.0-rc.1` + the release notes |

### #6592 — WebChat "Disconnected" lockout

Reconciled by hand, **not** cherry-picked: `main`'s `SseCapacity` has since grown `try_acquire_ordered` / `SseAcquireResult` for browser-tab stream generations, which the release branch never had.

Two independent causes, both fixed:

1. `enforce_rate_limit` charged the caller's per-route budget for SSE opens the handler itself immediately rejected on the per-caller concurrency cap. Ordinary reconnect churn could exhaust the budget on capacity contention alone, after which the middleware rejected everything for the rest of the window — surviving a page reload, because the budget is server-side and keyed to the caller. Handlers now opt a *specific* 429 into a refund via `mark_rate_limit_refundable`. Deliberately **not** keyed off bare HTTP 429: turn-submission admission-control 429s on the same routes must keep draining budget during the overload they exist to signal.
2. `handleSend` closed over `activeThreadId` at creation time, so concurrent landing-composer sends each navigated their own thread, flipping the URL repeatedly. Each flip tears down and reopens the single SSE stream — genuinely-accepted reconnects, which burn the budget fixed above all on their own.

Hardening carried over from that PR's review: `Window` gets a generation token so a delayed refund can't credit a replacement entry after an LRU eviction inside the same wall-clock second; `SseCapacity` bounds how many consecutive rejections stay refundable so a saturated caller can't hammer free 429s; cap-zero flows through the same accounting instead of short-circuiting.

### #6383, #6736 — changelog history

`#6383`'s Cargo.toml half (the package description) is **already** on `main` and already matches `wix/main.wxs`, so only the prose is ported. The `[1.0.0]` section is inserted verbatim from the commit tagged `ironclaw-v1.0.0`.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy --all --benches --tests --examples --all-features` | zero warnings |
| `cargo test -p ironclaw_webui` | 221 lib + all integration targets green |
| `pnpm test` (frontend) | 1063 / 126 files green |
| `cargo test -p ironclaw --test smoke release_ci_` | 2 passed |
| `scripts/check_no_panics.py` | OK |
| `dist plan` (pinned 0.31.0) | `1.1.0-rc.1`, `announcement_is_prerelease: true`, 7 targets, shell/PowerShell/MSI, release notes extracted from the new section |

**The new tests were confirmed to fail without the fix.** With `mark_rate_limit_refundable` disabled, all three router-contract tests fail; with the cycle guard disabled, all three `chat.test.ts` navigation tests fail. The router-contract tests drive the real `stream_events` and `stream_events_ws` handlers behind the real `enforce_rate_limit` and a real `SseCapacity` — including a real-socket WebSocket upgrade, since `tower::oneshot` cannot reach a WS handler.

## Merging this fires the release

`release-plz` on push to `main` creates `ironclaw-v1.1.0-rc.1`, which matches `ironclaw-release.yml`'s tag trigger and runs cargo-dist: 7 targets, installers, a GitHub **prerelease**, then the `nearaidev/ironclaw` Docker image.

⚠️ **One caveat worth watching.** Both existing tags were pushed by hand from the release branch. `release-plz-release` has run green on every `main` push but has never actually minted a tag, because `main`'s version hasn't changed since that config landed — the `publish = false` → still-tag path is configured and documented in `release-plz.toml` but unexercised. If no tag appears within ~10 minutes of merge, push `ironclaw-v1.1.0-rc.1` by hand from the merge commit, which is exactly how 1.0.0-rc.1 and 1.0.0 shipped.

## Deliberately out of scope

- **#6612 (Docker sshd).** Drops `USER ironclaw` from the runtime stage, adds `openssh-server` + `gosu` + a passwordless `agent` account, and adds a `runtime-release-tools` stage. `main` has since renamed `Dockerfile.reborn` → `Dockerfile` and grown Railway host detection in the entrypoint. That surface deserves its own PR and its own security review.
- **Two release-pipeline defects found while mapping this**, to be filed separately:
  1. `rebuild-release-image.yml:32` extracts the version with `grep '^version' Cargo.toml | head -1` — that reads the **workspace root** package (`0.1.0`), not the CLI's. Every manual rebuild is tagged `0.1.0`.
  2. The release tag glob `ironclaw**[0-9]+.[0-9]+.[0-9]+*` also matches library tags like `ironclaw_common-v0.4.3`, which release-plz pushes whenever those crates bump — cargo-dist would then run against a non-dist-able package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)