### PR TITLE
fix(webui): stop "Reconnecting" badge flashing on every streamed chunk

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -7,6 +7,14 @@ import {
 } from "../lib/connection-status";
 
 const ACTIVE_STREAM_STALL_DEADLINE_MS = 30_000;
+// Per-chunk reconnects (e.g. a proxy closing the SSE body between streamed
+// frames) fire `onRequest` and would otherwise flip the badge to "Reconnecting"
+// for every chunk. A short grace window keeps the status silently CONNECTED
+// for routine in-flight reconnects that settle quickly; a reconnect that
+// actually drags on past the deadline surfaces "Reconnecting" as before.
+// Genuine loss paths (request error, retryable HTTP, watchdog stall, offline,
+// replay rebase) bypass the grace and set RECONNECTING immediately.
+const RECONNECT_GRACE_MS = 1_000;
 const SSE_CONNECTION_ID = clientActionId();
 let nextConnectionGeneration = 0;
 
@@ -53,6 +61,7 @@ export function useSSE({
     }
     let controller = null;
     let activityWatchdog = null;
+    let reconnectGraceTimer = null;
     let disposed = false;
     let terminalErrorReceived = false;
     let connectedOnce = false;
@@ -75,8 +84,36 @@ export function useSSE({
       }
     }
 
+    function clearReconnectGrace() {
+      if (reconnectGraceTimer) {
+        clearTimeout(reconnectGraceTimer);
+        reconnectGraceTimer = null;
+      }
+    }
+
     function activityIsExpected() {
       return activityExpectedRef.current === true;
+    }
+
+    // `graceful: true` is for routine in-flight reconnects (the `onRequest`
+    // hook firing because the previous stream body ended). Those reconnects
+    // are expected and usually settle in well under a second, so we hide the
+    // "Reconnecting" badge behind a grace timer to avoid per-chunk flicker.
+    // Loss paths that already represent a real interruption call this with
+    // `graceful: false` (the default) to set RECONNECTING immediately.
+    function markReconnecting({ graceful = false } = {}) {
+      if (disposed || terminalErrorReceived) return;
+      if (graceful && connectedOnce) {
+        clearReconnectGrace();
+        reconnectGraceTimer = setTimeout(() => {
+          reconnectGraceTimer = null;
+          if (disposed || terminalErrorReceived) return;
+          setStatus(CONNECTION_STATUS.RECONNECTING);
+        }, RECONNECT_GRACE_MS);
+        return;
+      }
+      clearReconnectGrace();
+      setStatus(CONNECTION_STATUS.RECONNECTING);
     }
 
     function scheduleActivityWatchdog() {
@@ -99,13 +136,14 @@ export function useSSE({
         ) {
           return;
         }
-        setStatus(CONNECTION_STATUS.RECONNECTING);
+        markReconnecting();
         controller.reconnect();
       }, ACTIVE_STREAM_STALL_DEADLINE_MS);
     }
 
     function markConnected() {
       if (disposed || terminalErrorReceived) return;
+      clearReconnectGrace();
       connectedOnce = true;
       setStatus(CONNECTION_STATUS.CONNECTED);
     }
@@ -129,15 +167,18 @@ export function useSSE({
             ...options.query,
             connection_generation: connectionGeneration(),
           };
-          setStatus(
-            connectedOnce
-              ? CONNECTION_STATUS.RECONNECTING
-              : CONNECTION_STATUS.CONNECTING,
-          );
+          if (!connectedOnce) {
+            setStatus(CONNECTION_STATUS.CONNECTING);
+            return;
+          }
+          // Routine in-flight reconnect (e.g. proxy closed the stream body
+          // between chunks). Stay silently CONNECTED under the grace window
+          // instead of flashing "Reconnecting" for every chunk.
+          markReconnecting({ graceful: true });
         },
         onRequestError() {
           if (disposed || terminalErrorReceived) return;
-          setStatus(CONNECTION_STATUS.RECONNECTING);
+          markReconnecting();
         },
         onResponse({ response }) {
           if (disposed || terminalErrorReceived) return;
@@ -151,12 +192,13 @@ export function useSSE({
         onResponseError({ response }) {
           if (disposed || terminalErrorReceived) return;
           if (isRetryableResponseStatus(response.status)) {
-            setStatus(CONNECTION_STATUS.RECONNECTING);
+            markReconnecting();
             return;
           }
           terminalErrorReceived = true;
           streamOpen = false;
           clearActivityWatchdog();
+          clearReconnectGrace();
           controller?.abort("non-retryable stream response");
           setStatus(CONNECTION_STATUS.DISCONNECTED);
         },
@@ -182,6 +224,7 @@ export function useSSE({
             terminalErrorReceived = true;
             streamOpen = false;
             clearActivityWatchdog();
+            clearReconnectGrace();
             controller?.abort("non-retryable stream event");
             setStatus(CONNECTION_STATUS.DISCONNECTED);
             return;
@@ -192,7 +235,7 @@ export function useSSE({
             frame.retryable === true
           ) {
             stream.lastEventId = undefined;
-            setStatus(CONNECTION_STATUS.RECONNECTING);
+            markReconnecting();
             controller?.reconnect();
           }
         },
@@ -210,6 +253,7 @@ export function useSSE({
       if (disposed || terminalErrorReceived) return;
       streamOpen = false;
       clearActivityWatchdog();
+      clearReconnectGrace();
       controller?.abort("document hidden");
       setStatus(CONNECTION_STATUS.PAUSED);
     }
@@ -230,12 +274,12 @@ export function useSSE({
 
     function handleNetworkOffline() {
       if (disposed || terminalErrorReceived) return;
-      setStatus(CONNECTION_STATUS.RECONNECTING);
+      markReconnecting();
     }
 
     function handleNetworkOnline() {
       if (disposed || terminalErrorReceived) return;
-      setStatus(CONNECTION_STATUS.RECONNECTING);
+      markReconnecting();
       controller?.reconnect();
     }
 
@@ -258,6 +302,7 @@ export function useSSE({
       window.removeEventListener("offline", handleNetworkOffline);
       window.removeEventListener("online", handleNetworkOnline);
       clearActivityWatchdog();
+      clearReconnectGrace();
       syncActivityWatchdogRef.current = () => {};
       controller?.abort("component disposed");
       controller = null;

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -227,6 +227,39 @@ test("useSSE delegates framing, credentials, and retries to EventSourcePlus", ()
   assert.equal(statuses.at(-1), "reconnecting");
 });
 
+test("useSSE hides routine in-flight reconnects behind a grace window (regression for #7071)", () => {
+  // A proxy closing the SSE body between streamed chunks fires `onRequest`
+  // for the next reconnect. That used to flip the badge to "Reconnecting"
+  // for every chunk; the grace window keeps the status silently CONNECTED
+  // until the deadline elapses, while a real loss still surfaces immediately.
+  const { streams, statuses, timers } = createHarness();
+  const stream = streams[0];
+  stream.respond();
+  assert.equal(statuses.at(-1), "connected");
+
+  // Routine reconnect: stays CONNECTED, grace timer armed, no flicker.
+  stream.request();
+  assert.equal(statuses.at(-1), "connected");
+  const grace = timers.find(
+    (timer) => timer.delay === 1_000 && !timer.cleared,
+  );
+  assert.ok(grace, "reconnect grace timer armed");
+
+  // A successful reconnect before the deadline clears the grace and stays CONNECTED.
+  stream.respond();
+  assert.equal(statuses.at(-1), "connected");
+  assert.ok(grace.cleared, "grace timer cleared once the reconnect succeeds");
+
+  // If the reconnect actually drags on past the deadline, "Reconnecting" surfaces.
+  stream.request();
+  const grace2 = timers.find(
+    (timer) => timer.delay === 1_000 && !timer.cleared,
+  );
+  assert.ok(grace2);
+  grace2.handler();
+  assert.equal(statuses.at(-1), "reconnecting");
+});
+
 test("useSSE dispatches typed frames from the packaged parser", () => {
   const events = [];
   const { streams } = createHarness({ onEvent: (event) => events.push(event) });
@@ -292,7 +325,7 @@ test("useSSE rejects a successful response that is not an event stream", () => {
 });
 
 test("useSSE pauses while hidden and reconnects when visible", () => {
-  const { context, documentListeners, statuses, streams } = createHarness();
+  const { context, documentListeners, statuses, streams, timers } = createHarness();
   const stream = streams[0];
   stream.respond();
 
@@ -304,7 +337,16 @@ test("useSSE pauses while hidden and reconnects when visible", () => {
   context.document.visibilityState = "visible";
   documentListeners.get("visibilitychange")();
   assert.equal(stream.controller.reconnectCalls, 1);
-  assert.equal(statuses.at(-2), "connecting");
+  // A routine in-flight reconnect (here triggered by the visibility resume)
+  // stays silently CONNECTED under the reconnect grace window instead of
+  // flashing "Reconnecting"; the badge only surfaces once the grace deadline
+  // elapses without a successful reconnect.
+  assert.equal(statuses.at(-1), "connecting");
+  const grace = timers.find(
+    (timer) => timer.delay === 1_000 && !timer.cleared,
+  );
+  assert.ok(grace, "a reconnect grace timer is armed");
+  grace.handler();
   assert.equal(statuses.at(-1), "reconnecting");
 });
 


### PR DESCRIPTION
## Summary

- The "Reconnecting" connection-status badge was flashing on every streamed chunk because event-source-plus fires `onRequest` whenever the SSE stream body ends (which proxies like Railway do between frames), and `onRequest` set the status to `RECONNECTING` whenever `connectedOnce` was already true. The next `onResponse`/`onMessage` then flipped it back to `CONNECTED`, producing the per-chunk flicker reported in #7071.
- Add a 1s reconnect grace window in `useSSE` for routine in-flight reconnects. `onRequest` reconnects now stay silently `CONNECTED` while the grace timer runs; the badge only surfaces "Reconnecting" if the reconnect genuinely drags past the deadline.
- Genuine loss paths bypass the grace and still set `RECONNECTING` immediately: `onRequestError` (fetch reject / offline), retryable HTTP responses (204/408/425/429/5xx), the 30s active-stream stall watchdog, the `replay_unavailable` cursor rebase, and offline/online network events. `markConnected` (called on every non-error chunk and on a successful event-stream response) clears the grace timer, so steady streaming stays silently `CONNECTED`.
- The i18n keys, the `connection-status` badge component, and the `isConnectionLostStatus` failure-message logic are unchanged — only the `useSSE` status transitions are narrower.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7071

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: frontend `vitest run` (126 files / 1064 tests), `vitest run src/pages/chat` (40 files / 491 tests), `tsc --noEmit` clean
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: not run — change is frontend-only; existing Playwright smoke assertions for offline / `__failLatestV2Sse(0)` / `__failLatestV2Sse(2)` were verified by trace against the grace window and remain satisfied
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: Sending a message that produces a streamed response no longer flashes "Reconnecting" between chunks; the badge only appears on a genuine, sustained connection loss.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: `useSSE.test.ts` — added regression test for the grace window (routine reconnect stays CONNECTED, grace timer armed, cleared on successful reconnect, surfaces RECONNECTING after the deadline) and updated the visibility-resume test to reflect the silent grace path.
- Reborn integration: Not applicable: change is confined to the frontend SSE hook.
- Recorded fixture: Not applicable: no backend/projection wire format changed.
- Browser E2E: Not applicable: existing e2e smoke assertions (`test_reborn_v2_connection_status_*`) verified by trace against the grace window; offline / held-connection / terminal-401 paths still assert the expected statuses within their existing timeouts.
- Backend or runtime: Not applicable: frontend-only change.
- Live canary: Not applicable.

What the tests prove: Routine in-flight SSE reconnects (the `onRequest` hook firing because the previous stream body ended) no longer flip the status to `RECONNECTING` for every chunk; the status stays `CONNECTED` under the grace window, then surfaces `RECONNECTING` only if the reconnect exceeds the 1s deadline. Genuine loss paths still set `RECONNECTING` immediately.

Commands run:
- `pnpm install --frozen-lockfile`
- `node_modules/.bin/vitest run` (126 files, 1064 tests passed)
- `node_modules/.bin/vitest run src/pages/chat` (40 files, 491 tests passed)
- `node_modules/.bin/tsc --noEmit` (clean)

## Security Impact

None. Frontend-only connection-status display change; no permissions, network calls, secrets, file access, tool execution, or sandbox policy affected.

## Reborn Trust-Boundary Checklist

N/A — frontend-only display change; no Reborn runtime, trust-bearing types, persistence, or sandbox boundary touched.

## Database Impact

None.

## Blast Radius

Confined to the WebUI v2 chat SSE status hook (`crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts`). The status it emits feeds the `ConnectionStatus` badge and `isConnectionLostStatus` (used to label run failures as connection-lost). Because genuine loss paths still set `RECONNECTING` immediately and `markConnected` clears the grace on the next successful chunk, the failure-message logic is unaffected. The only observable change is the absence of per-chunk badge flicker during normal streaming.

## Rollback Plan

Revert this single commit. The grace window is additive; removing it restores the prior immediate-`RECONNECTING` behavior with no schema, migration, or persistence consequences.

## Review Follow-Through

No follow-ups known. If reviewers want the grace deadline tuned (e.g. lowered for faster loss surfacing, or raised for slower proxies), it is the single `RECONNECT_GRACE_MS` constant in `useSSE.ts`.

---

**Review track**: B (feature/maintainer-requested refactor)