### PR TITLE
fix(webui): stop "Reconnecting" badge flashing on every streamed chunk

### DIFF
--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/connection-status.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/connection-status.test.ts
@@ -165,3 +165,43 @@ test("ConnectionStatus falls back safely for an unknown interruption", () => {
   assert.ok(floatingLabel.props.className.includes("--v2-surface-soft"));
   assert.equal(floatingLabel.children[0], "blocked");
 });
+
+test("ConnectionStatus does not render a Reconnecting badge during streaming (#7071)", () => {
+  // Regression for #7071: a proxy that closes the SSE body between streamed
+  // frames makes the transport retry on every chunk, flipping the status to
+  // RECONNECTING for each retry. The badge must not surface that routine
+  // in-flight reconnect — only a sustained loss that escalates to
+  // DISCONNECTED is user-visible.
+  const ConnectionStatus = loadConnectionStatusForTest();
+
+  const reconnecting = ConnectionStatus({ status: CONNECTION_STATUS.RECONNECTING });
+  assert(
+    nodeByTestId(reconnecting, "connection-status") === null,
+    "RECONNECTING must not render the desktop status badge",
+  );
+  assert(
+    nodeByTestId(reconnecting, "connection-status-toggle") === null,
+    "RECONNECTING must not render the mobile status toggle",
+  );
+  assert(
+    nodeByTestId(reconnecting, "connection-status-label") === null,
+    "RECONNECTING must not render the mobile status label",
+  );
+
+  const liveStatus = findNode(
+    reconnecting,
+    (node) => node.props?.role === "status",
+  );
+  assert(liveStatus !== null, "the live region stays mounted for RECONNECTING");
+  assert.equal(liveStatus.children[0], "", "RECONNECTING keeps the live region empty");
+
+  const disconnected = ConnectionStatus({ status: CONNECTION_STATUS.DISCONNECTED });
+  assert(
+    nodeByTestId(disconnected, "connection-status") !== null,
+    "DISCONNECTED still renders the desktop status badge",
+  );
+  assert(
+    nodeByTestId(disconnected, "connection-status-label").children[0] === "disconnected",
+    "DISCONNECTED still labels the badge",
+  );
+});

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/connection-status.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/connection-status.test.ts
@@ -73,6 +73,11 @@ test("ConnectionStatus keeps an empty live region mounted for routine states", (
     CONNECTION_STATUS.IDLE,
     CONNECTION_STATUS.CONNECTING,
     CONNECTION_STATUS.CONNECTED,
+    // RECONNECTING is an internal state only: a proxy that closes the SSE
+    // body between streamed frames makes the transport retry on every chunk,
+    // so rendering it would only blink. It stays surfaced for run-failure
+    // attribution via `isConnectionLostStatus` but is not rendered.
+    CONNECTION_STATUS.RECONNECTING,
   ]) {
     const rendered = ConnectionStatus({ status });
     assert.notEqual(rendered, null, status);
@@ -99,7 +104,6 @@ test("ConnectionStatus renders static desktop status and mobile disclosure", () 
   const ConnectionStatus = loadConnectionStatusForTest();
 
   for (const [status, style] of [
-    [CONNECTION_STATUS.RECONNECTING, "--v2-warning-soft"],
     [CONNECTION_STATUS.DISCONNECTED, "--v2-danger-soft"],
     [CONNECTION_STATUS.PAUSED, "--v2-surface-soft"],
   ]) {
@@ -143,7 +147,7 @@ test("ConnectionStatus renders static desktop status and mobile disclosure", () 
 
 test("ConnectionStatus exposes the expanded mobile label state", () => {
   const ConnectionStatus = loadConnectionStatusForTest({ expanded: true });
-  const rendered = ConnectionStatus({ status: CONNECTION_STATUS.RECONNECTING });
+  const rendered = ConnectionStatus({ status: CONNECTION_STATUS.DISCONNECTED });
   const toggle = nodeByTestId(rendered, "connection-status-toggle");
   const floatingLabel = nodeByTestId(rendered, "connection-status-label");
 

--- a/crates/ironclaw_webui/frontend/src/pages/chat/components/connection-status.tsx
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/components/connection-status.tsx
@@ -26,10 +26,17 @@ const STATUS_DOT_STYLES: Partial<Record<ConnectionStatus, string>> = {
 
 const DEFAULT_DOT_STYLE = "text-[var(--v2-text-muted)]";
 
+// `RECONNECTING` is kept as an internal connection state (it still feeds
+// run-failure attribution via `isConnectionLostStatus`) but is intentionally
+// not rendered: a proxy that closes the SSE body between streamed frames
+// makes the transport retry on every chunk, and surfacing "Reconnecting" for
+// those routine in-flight reconnects only produces a misleading blinking
+// badge. Sustained loss still escalates to `DISCONNECTED`, which is shown.
 const HIDDEN_STATUSES: ReadonlySet<ConnectionStatus> = new Set([
   CONNECTION_STATUS.IDLE,
   CONNECTION_STATUS.CONNECTING,
   CONNECTION_STATUS.CONNECTED,
+  CONNECTION_STATUS.RECONNECTING,
 ]);
 
 export function ConnectionStatus({ status }: ConnectionStatusProps) {

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -220,6 +220,14 @@ async def _install_fake_v2_event_stream(page) -> None:
             return activeStream;
           };
 
+          // Readiness probes so tests do not race forced failures against the
+          // fake stream lifecycle. A hidden RECONNECTING badge can no longer
+          // double as a wait for reconnect readiness.
+          window.__v2SseHasOpenStream = () =>
+            Boolean(activeStream && !activeStream.closed && activeStream.controller);
+          window.__v2SseHasHeldConnection = () =>
+            Boolean(activeStream && !activeStream.closed && activeStream.resolve);
+
           const closeStream = (stream, error = null) => {
             if (!stream || stream.closed) return;
             stream.closed = true;
@@ -1680,6 +1688,7 @@ async def test_reborn_v2_disconnected_run_shows_status_and_stops_typing(
 
         await page.set_viewport_size({"width": 1280, "height": 720})
         await context.set_offline(False)
+        await page.wait_for_function("() => window.__v2SseHasOpenStream?.() === true")
         await expect(connection_status).to_have_count(0, timeout=5000)
 
         await composer.fill("summarize 3 X/Twitter posts")
@@ -1687,8 +1696,13 @@ async def test_reborn_v2_disconnected_run_shows_status_and_stops_typing(
         await expect(page.locator(SEL_V2["typing_indicator"])).to_be_visible(timeout=5000)
 
         # A retryable stream interruption (readyState 0) stays RECONNECTING
-        # internally and is not rendered; the badge remains absent.
+        # internally and is not rendered; the badge remains absent. Wait for
+        # an open stream first so the forced failure does not race the fake
+        # stream lifecycle, then wait for the held pending connection so the
+        # terminal failure below targets the held promise.
+        await page.wait_for_function("() => window.__v2SseHasOpenStream?.() === true")
         await page.evaluate("() => window.__failLatestV2Sse(0)")
+        await page.wait_for_function("() => window.__v2SseHasHeldConnection?.() === true")
         await expect(connection_status).to_have_count(0, timeout=5000)
 
         # A terminal (non-retryable) failure escalates to DISCONNECTED, which

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -1663,30 +1663,18 @@ async def test_reborn_v2_disconnected_run_shows_status_and_stops_typing(
         connection_status = page.locator(SEL_V2["connection_status"])
 
         await context.set_offline(True)
-        await expect(connection_status).to_have_text("Reconnecting...", timeout=5000)
-        await expect(connection_status).to_have_css("position", "static")
-        assert await connection_status.evaluate("node => Boolean(node.closest('header'))")
-        await expect(connection_status).to_be_in_viewport()
-
+        # RECONNECTING is no longer rendered (internal state only): a proxy
+        # that closes the SSE body between streamed frames would otherwise
+        # blink the badge on every chunk. The badge stays absent during a
+        # transient/retryable reconnect and only reappears on a terminal
+        # DISCONNECTED state.
+        await expect(connection_status).to_have_count(0, timeout=5000)
         await page.set_viewport_size({"width": 390, "height": 844})
         connection_status_toggle = page.locator(SEL_V2["connection_status_toggle"])
         connection_status_label = page.locator(SEL_V2["connection_status_label"])
-        disclosure_id = await connection_status_label.get_attribute("id")
-        assert disclosure_id
-        await expect(connection_status_label).to_be_hidden()
-        await expect(connection_status_label).to_have_attribute("aria-hidden", "true")
-        await expect(connection_status_toggle).to_have_attribute("aria-expanded", "false")
-        await expect(connection_status_toggle).to_have_attribute("aria-controls", disclosure_id)
-        await expect(connection_status_toggle).to_be_in_viewport()
-
-        await connection_status_toggle.click()
-        await expect(connection_status_toggle).to_have_attribute("aria-expanded", "true")
-        await expect(connection_status_label).to_have_attribute("aria-hidden", "false")
-        await expect(connection_status_label).to_be_visible()
-        await expect(connection_status_label).to_have_text("Reconnecting...")
-        await expect(connection_status_label).to_have_css("position", "absolute")
-        await expect(connection_status_toggle).to_be_in_viewport()
-        await expect(connection_status_label).to_be_in_viewport()
+        # No visible status affordance while RECONNECTING is hidden.
+        await expect(connection_status_toggle).to_have_count(0, timeout=5000)
+        await expect(connection_status_label).to_have_count(0, timeout=5000)
         await expect(page.locator(SEL_V2["header_logs_link"])).to_be_visible()
         await expect(page.locator(SEL_V2["header_docs_link"])).to_be_visible()
 
@@ -1698,9 +1686,13 @@ async def test_reborn_v2_disconnected_run_shows_status_and_stops_typing(
         await composer.press("Enter")
         await expect(page.locator(SEL_V2["typing_indicator"])).to_be_visible(timeout=5000)
 
+        # A retryable stream interruption (readyState 0) stays RECONNECTING
+        # internally and is not rendered; the badge remains absent.
         await page.evaluate("() => window.__failLatestV2Sse(0)")
-        await expect(connection_status).to_have_text("Reconnecting...", timeout=5000)
+        await expect(connection_status).to_have_count(0, timeout=5000)
 
+        # A terminal (non-retryable) failure escalates to DISCONNECTED, which
+        # is still rendered.
         await page.evaluate("() => window.__failLatestV2Sse(2)")
         await expect(connection_status).to_have_text("Disconnected", timeout=5000)
 


### PR DESCRIPTION
## Summary

- The "Reconnecting" connection-status badge blinked on every streamed chunk: a proxy (e.g. Railway) that closes the SSE stream body between frames makes event-source-plus retry the transport on every chunk, flipping the status to `RECONNECTING` and back to `CONNECTED` for each retry. While the response was being delivered successfully, the badge repeatedly flashed "Reconnecting", creating a misleading impression of instability (#7071).
- `RECONNECTING` remains an internal connection state — it still feeds run-failure attribution via `isConnectionLostStatus` and the transport retry loop in `useSSE` is untouched. Only the header badge stops rendering it. Sustained loss still escalates to `DISCONNECTED`, which is rendered as before, so genuine connection failures remain visible.
- Add `CONNECTION_STATUS.RECONNECTING` to `HIDDEN_STATUSES` in `connection-status.tsx`. The i18n keys, the dot/breathing styles, and the `sseStatus` plumbing are unchanged; `useSSE.ts` is untouched. This intentionally does not change EventSourcePlus retry behavior; actual transport reconnects are separate from the misleading status badge.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7071

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: frontend `vitest run` (126 files / 1063 tests), `vitest run src/pages/chat` (40 files / 490 tests), `tsc --noEmit` clean
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: not run — change is frontend-only; existing Playwright smoke assertions for offline / `__failLatestV2Sse(0)` / `__failLatestV2Sse(2)` were updated to assert the badge stays absent during transient/retryable reconnects and still renders "Disconnected" on the terminal failure
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: Sending a message that produces a streamed response no longer flashes "Reconnecting" between chunks. The badge only appears on a genuine, sustained connection loss that escalates to `DISCONNECTED`.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: `connection-status.test.ts` — `RECONNECTING` is now covered as a hidden routine state (empty live region, no badge/toggle), and the expanded mobile-label test asserts via `DISCONNECTED` instead. `useSSE.test.ts` is unchanged.
- Reborn integration: Not applicable: change is confined to the frontend status badge component.
- Recorded fixture: Not applicable: no backend/projection wire format changed.
- Browser E2E: `test_reborn_webui_v2_smoke.py` connection-status test — the offline path and the retryable stream-interruption path (`__failLatestV2Sse(0)`) now assert the badge stays absent (`count == 0`); the terminal non-retryable path (`__failLatestV2Sse(2)`) still asserts "Disconnected" is rendered.
- Backend or runtime: Not applicable: frontend-only change.
- Live canary: Not applicable.

What the tests prove: `RECONNECTING` is no longer rendered in the header UI, while `DISCONNECTED` still is. The internal `RECONNECTING` state is preserved for run-failure attribution. Routine per-chunk transport reconnects no longer surface a blinking badge.

Commands run:
- `pnpm install --frozen-lockfile`
- `node_modules/.bin/vitest run` (126 files, 1063 tests passed)
- `node_modules/.bin/vitest run src/pages/chat` (40 files, 490 tests passed)
- `node_modules/.bin/tsc --noEmit` (clean)

## Security Impact

None. Frontend-only connection-status display change; no permissions, network calls, secrets, file access, tool execution, or sandbox policy affected.

## Reborn Trust-Boundary Checklist

N/A — frontend-only display change; no Reborn runtime, trust-bearing types, persistence, or sandbox boundary touched.

## Database Impact

None.

## Blast Radius

Confined to the WebUI v2 chat connection-status badge (`crates/ironclaw_webui/frontend/src/pages/chat/components/connection-status.tsx`). The `RECONNECTING` status still propagates internally to `isConnectionLostStatus` (used to label run failures as connection-lost), so failure-message logic is unaffected. The only observable change is the absence of the "Reconnecting" badge during transient reconnects; `DISCONNECTED` still renders on sustained loss.

## Rollback Plan

Revert this single commit. Removing `RECONNECTING` from `HIDDEN_STATUSES` restores the prior rendered badge with no schema, migration, or persistence consequences.

## Review Follow-Through

No follow-ups known. The `connection.reconnecting` i18n keys are intentionally retained: the `RECONNECTING` status value still exists internally and may be surfaced again if a future change distinguishes a sustained reconnect from a per-chunk transport retry.

---

**Review track**: B (feature/maintainer-requested refactor)