### PR TITLE
Fix grep filesystem diagnostics

### DIFF
--- a/crates/extensions/ironclaw_extension_support/src/coding/file.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/file.rs
@@ -21,9 +21,9 @@ use super::{
     patch::{parse_apply_patch_input, replacement_error},
     paths::{
         create_parent_dir_unless_sensitive, deny_sensitive_existing_path, filesystem_error,
-        is_excluded_name, is_sensitive_scoped_path, is_workspace_path, operation_allowed,
-        resolve_optional_path, resolve_required_path, scoped_child_path, stat_optional,
-        virtual_to_relative,
+        filesystem_error_with_summary, is_excluded_name, is_sensitive_scoped_path,
+        is_workspace_path, operation_allowed, resolve_optional_path, resolve_required_path,
+        safe_summary_path, scoped_child_path, stat_optional, virtual_to_relative,
     },
     state::{
         CodingReadScopeKey, SharedCodingEditLocks, SharedCodingReadStates, content_fingerprint,
@@ -682,46 +682,6 @@ pub(super) async fn apply_patch(
         result,
         Some(display_preview),
     ))
-}
-
-fn filesystem_error_with_summary(
-    operation: &str,
-    scoped_path: &str,
-    error: ironclaw_filesystem::FilesystemError,
-) -> CodingCapabilityError {
-    let scoped_path = safe_summary_path(scoped_path);
-    let summary = match &error {
-        ironclaw_filesystem::FilesystemError::NotFound { .. } => {
-            format!("{operation} failed for {scoped_path}: file not found")
-        }
-        ironclaw_filesystem::FilesystemError::PermissionDenied { .. }
-        | ironclaw_filesystem::FilesystemError::MountNotFound { .. }
-        | ironclaw_filesystem::FilesystemError::PathOutsideMount { .. }
-        | ironclaw_filesystem::FilesystemError::SymlinkEscape { .. }
-        | ironclaw_filesystem::FilesystemError::MountConflict { .. }
-        | ironclaw_filesystem::FilesystemError::VersionMismatch { .. }
-        | ironclaw_filesystem::FilesystemError::Unsupported { .. }
-        | ironclaw_filesystem::FilesystemError::IndexConflict { .. } => {
-            format!("{operation} failed for {scoped_path}: permission denied or unsupported path")
-        }
-        ironclaw_filesystem::FilesystemError::Backend { .. }
-        | ironclaw_filesystem::FilesystemError::BackendInfrastructure { .. } => {
-            format!("{operation} failed for {scoped_path}: filesystem backend error")
-        }
-        ironclaw_filesystem::FilesystemError::Contract(_) => {
-            format!("{operation} failed for {scoped_path}: invalid path")
-        }
-        _ => format!("{operation} failed for {scoped_path}: filesystem error"),
-    };
-    let kind = filesystem_error(error).kind();
-    CodingCapabilityError::with_safe_summary(kind, summary)
-}
-
-fn safe_summary_path(scoped_path: &str) -> String {
-    let path_hint = scoped_path
-        .trim_start_matches('/')
-        .replace(['/', '\\'], " ");
-    format!("path {path_hint}")
 }
 
 fn existing_text_for_preview(stat: &ironclaw_filesystem::FileStat, bytes: &[u8]) -> Option<String> {

--- a/crates/extensions/ironclaw_extension_support/src/coding/grep_tool.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/grep_tool.rs
@@ -25,9 +25,9 @@ use super::{
     input_error,
     inputs::{optional_usize, optional_usize_allow_zero, required_str},
     paths::{
-        filesystem_error, is_excluded_name, is_sensitive_scoped_path, operation_allowed,
-        resolve_optional_path, scoped_child_path, type_filter_matches, validate_relative_pattern,
-        virtual_to_relative,
+        filesystem_error, filesystem_error_with_summary, is_excluded_name,
+        is_sensitive_scoped_path, operation_allowed, resolve_optional_path, scoped_child_path,
+        type_filter_matches, validate_relative_pattern, virtual_to_relative,
     },
     text::{decode_text, previous_char_boundary, reject_binary_probe},
     types::{GrepFileResult, GrepLine, ResolvedPath},
@@ -46,7 +46,9 @@ pub(super) async fn grep(
         .filesystem
         .stat(&resolved.virtual_path)
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            filesystem_error_with_summary("grep", resolved.scoped_path.as_str(), error)
+        })?;
     if root_stat.sensitive {
         return Err(CodingCapabilityError::new(
             RuntimeDispatchErrorKind::FilesystemDenied,
@@ -175,10 +177,32 @@ pub(super) async fn grep(
     ))
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+const MAX_REPORTED_SKIPPED_FILES: usize = 20;
+
+#[derive(Debug, Default)]
 struct WalkFilesResult {
     scan_limit: Option<ScanLimit>,
     bytes_scanned: u64,
+    skipped_file_count: usize,
+    skipped_files: Vec<SkippedFile>,
+}
+
+impl WalkFilesResult {
+    fn record_skipped_file(&mut self, relative: &str, operation: FilesystemOperation) {
+        self.skipped_file_count = self.skipped_file_count.saturating_add(1);
+        if self.skipped_files.len() < MAX_REPORTED_SKIPPED_FILES {
+            self.skipped_files.push(SkippedFile {
+                relative: relative.to_string(),
+                operation,
+            });
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SkippedFile {
+    relative: String,
+    operation: FilesystemOperation,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -200,12 +224,16 @@ async fn walk_files(
         if include(&relative)
             && !visit_file(
                 request,
-                &root.virtual_path,
-                &relative,
-                root_stat,
+                FileVisit {
+                    path: &root.virtual_path,
+                    relative: &relative,
+                    stat: root_stat,
+                },
                 &mut walk_result,
                 &mut visit,
-                false,
+                FileVisitMode::ExplicitFile {
+                    scoped_path: root.scoped_path.as_str(),
+                },
             )
             .await?
         {
@@ -246,12 +274,12 @@ async fn walk_files(
                     if !include(&relative) {
                         continue;
                     }
-                    // silent-ok: grep directory search skips entries that disappear or fail stat.
                     let Ok(stat) = request.filesystem.stat(&entry.path).await else {
                         tracing::debug!(
                             path = entry.path.as_str(),
                             "skipping grep file after stat failed"
                         );
+                        walk_result.record_skipped_file(&relative, FilesystemOperation::Stat);
                         continue;
                     };
                     if stat.sensitive {
@@ -259,12 +287,14 @@ async fn walk_files(
                     }
                     if !visit_file(
                         request,
-                        &entry.path,
-                        &relative,
-                        stat,
+                        FileVisit {
+                            path: &entry.path,
+                            relative: &relative,
+                            stat,
+                        },
                         &mut walk_result,
                         &mut visit,
-                        true,
+                        FileVisitMode::DirectoryScan,
                     )
                     .await?
                     {
@@ -281,36 +311,46 @@ async fn walk_files(
     Ok(walk_result)
 }
 
+struct FileVisit<'a> {
+    path: &'a VirtualPath,
+    relative: &'a str,
+    stat: FileStat,
+}
+
+#[derive(Clone, Copy)]
+enum FileVisitMode<'a> {
+    ExplicitFile { scoped_path: &'a str },
+    DirectoryScan,
+}
+
 async fn visit_file(
     request: &CodingCapabilityRequest<'_>,
-    path: &VirtualPath,
-    relative: &str,
-    stat: FileStat,
+    target: FileVisit<'_>,
     walk_result: &mut WalkFilesResult,
     visit: &mut impl FnMut(&str, &[u8], Option<SystemTime>) -> Result<bool, CodingCapabilityError>,
-    skip_read_errors: bool,
+    mode: FileVisitMode<'_>,
 ) -> Result<bool, CodingCapabilityError> {
-    if stat.len > MAX_READ_SIZE {
+    if target.stat.len > MAX_READ_SIZE {
         tracing::debug!(
-            path = path.as_str(),
-            len = stat.len,
+            path = target.path.as_str(),
+            len = target.stat.len,
             max_read_size = MAX_READ_SIZE,
             "skipping oversized grep file"
         );
-        if !skip_read_errors {
+        if matches!(mode, FileVisitMode::ExplicitFile { .. }) {
             walk_result.scan_limit = Some(ScanLimit::FileBytes {
-                file_bytes: stat.len,
+                file_bytes: target.stat.len,
             });
             return Ok(false);
         }
         return Ok(true);
     }
-    let next_total = walk_result.bytes_scanned.saturating_add(stat.len);
+    let next_total = walk_result.bytes_scanned.saturating_add(target.stat.len);
     if next_total > GREP_MAX_TOTAL_BYTES {
         tracing::debug!(
-            path = path.as_str(),
+            path = target.path.as_str(),
             total_bytes = walk_result.bytes_scanned,
-            next_file_bytes = stat.len,
+            next_file_bytes = target.stat.len,
             max_total_bytes = GREP_MAX_TOTAL_BYTES,
             "stopping grep after aggregate scan budget"
         );
@@ -318,16 +358,23 @@ async fn visit_file(
         return Ok(false);
     }
     walk_result.bytes_scanned = next_total;
-    let bytes = match request.filesystem.read_file(path).await {
+    let bytes = match request.filesystem.read_file(target.path).await {
         Ok(bytes) => bytes,
-        Err(_error) if skip_read_errors => {
-            // silent-ok: grep directory search skips files that disappear or fail read.
-            tracing::debug!(path = path.as_str(), "skipping grep file after read failed");
-            return Ok(true);
-        }
-        Err(error) => return Err(filesystem_error(error)),
+        Err(error) => match mode {
+            FileVisitMode::ExplicitFile { scoped_path } => {
+                return Err(filesystem_error_with_summary("grep", scoped_path, error));
+            }
+            FileVisitMode::DirectoryScan => {
+                tracing::debug!(
+                    path = target.path.as_str(),
+                    "skipping grep file after read failed"
+                );
+                walk_result.record_skipped_file(target.relative, FilesystemOperation::ReadFile);
+                return Ok(true);
+            }
+        },
     };
-    visit(relative, &bytes, stat.modified)
+    visit(target.relative, &bytes, target.stat.modified)
 }
 
 fn root_file_relative(path: &ScopedPath) -> String {
@@ -367,7 +414,7 @@ fn build_grep_output(
                 "truncated": walk_result.scan_limit.is_some()
                     || total > offset.saturating_add(effective_limit)
             });
-            add_scan_limit_metadata(&mut output, walk_result);
+            add_walk_metadata(&mut output, walk_result);
             output
         }
         "count" => {
@@ -387,7 +434,7 @@ fn build_grep_output(
                 "truncated": walk_result.scan_limit.is_some()
                     || total_count > offset.saturating_add(effective_limit)
             });
-            add_scan_limit_metadata(&mut output, walk_result);
+            add_walk_metadata(&mut output, walk_result);
             output
         }
         _ => {
@@ -421,13 +468,27 @@ fn build_grep_output(
                 truncated = true;
             }
             let mut output = json!({ "content": content, "truncated": truncated });
-            add_scan_limit_metadata(&mut output, walk_result);
+            add_walk_metadata(&mut output, walk_result);
             output
         }
     }
 }
 
-fn add_scan_limit_metadata(output: &mut Value, walk_result: WalkFilesResult) {
+fn add_walk_metadata(output: &mut Value, walk_result: WalkFilesResult) {
+    if walk_result.skipped_file_count > 0 {
+        output["incomplete"] = json!(true);
+        output["skipped_file_count"] = json!(walk_result.skipped_file_count);
+        output["skipped_files"] = json!(
+            walk_result
+                .skipped_files
+                .into_iter()
+                .map(|skipped| json!({
+                    "file": skipped.relative,
+                    "operation": skipped.operation.to_string(),
+                }))
+                .collect::<Vec<_>>()
+        );
+    }
     match walk_result.scan_limit {
         Some(ScanLimit::AggregateBytes) => {
             output["limit_reason"] = json!("aggregate_scan_bytes");

--- a/crates/extensions/ironclaw_extension_support/src/coding/paths.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/paths.rs
@@ -64,7 +64,7 @@ fn resolve_path(
                 RuntimeDispatchErrorKind::InputEncode,
                 format!(
                     "{} is not under an available scoped root (available roots: {})",
-                    summary_path_hint(path),
+                    safe_summary_path(path),
                     available_roots(mounts)
                 ),
             )
@@ -80,7 +80,7 @@ fn resolve_path(
             RuntimeDispatchErrorKind::FilesystemDenied,
             format!(
                 "{} does not resolve inside an available scoped root (available roots: {})",
-                summary_path_hint(path),
+                safe_summary_path(path),
                 available_roots(mounts)
             ),
         )
@@ -95,7 +95,7 @@ fn resolve_path(
             RuntimeDispatchErrorKind::FilesystemDenied,
             format!(
                 "the mount for {} does not permit this operation",
-                summary_path_hint(path)
+                safe_summary_path(path)
             ),
         ));
     }
@@ -106,27 +106,13 @@ fn resolve_path(
     })
 }
 
-/// Delimiter-free path rendering for loop-safe failure summaries, mirroring
-/// `file.rs::safe_summary_path`: "/testbed/replacer.go" → "path testbed
-/// replacer.go". The strict summary validator bans `/` and `\`.
-fn summary_path_hint(path: &str) -> String {
-    let hint = path.trim_start_matches('/').replace(['/', '\\'], " ");
-    format!("path {hint}")
-}
-
 fn available_roots(mounts: &ironclaw_host_api::mount::MountView) -> String {
     let mut roots: Vec<String> = mounts
         .mounts
         .iter()
         // Aliases are absolute ("/workspace"); render them without the
         // leading delimiter so the summary stays loop-safe.
-        .map(|mount| {
-            mount
-                .alias
-                .as_str()
-                .trim_start_matches('/')
-                .replace(['/', '\\'], " ")
-        })
+        .map(|mount| safe_summary_path_text(mount.alias.as_str()))
         .collect();
     roots.sort_unstable();
     roots.join(", ")
@@ -390,4 +376,47 @@ pub(super) fn filesystem_error(error: FilesystemError) -> CodingCapabilityError 
         // denial here until coding-tool semantics for it are designed.
         _ => CodingCapabilityError::new(RuntimeDispatchErrorKind::FilesystemDenied),
     }
+}
+
+pub(super) fn filesystem_error_with_summary(
+    operation: &str,
+    scoped_path: &str,
+    error: FilesystemError,
+) -> CodingCapabilityError {
+    let scoped_path = safe_summary_path(scoped_path);
+    let summary = match &error {
+        FilesystemError::NotFound { .. } => {
+            format!("{operation} failed for {scoped_path}: file not found")
+        }
+        FilesystemError::PermissionDenied { .. }
+        | FilesystemError::MountNotFound { .. }
+        | FilesystemError::PathOutsideMount { .. }
+        | FilesystemError::SymlinkEscape { .. }
+        | FilesystemError::MountConflict { .. }
+        | FilesystemError::VersionMismatch { .. }
+        | FilesystemError::Unsupported { .. }
+        | FilesystemError::IndexConflict { .. } => {
+            format!("{operation} failed for {scoped_path}: permission denied or unsupported path")
+        }
+        FilesystemError::Backend { .. } | FilesystemError::BackendInfrastructure { .. } => {
+            format!("{operation} failed for {scoped_path}: filesystem backend error")
+        }
+        FilesystemError::Contract(_) => {
+            format!("{operation} failed for {scoped_path}: invalid path")
+        }
+        _ => format!("{operation} failed for {scoped_path}: filesystem error"),
+    };
+    let kind = filesystem_error(error).kind();
+    CodingCapabilityError::with_safe_summary(kind, summary)
+}
+
+pub(super) fn safe_summary_path(scoped_path: &str) -> String {
+    // The strict loop summary validator bans path delimiters. Keep all coding
+    // tool path hints on this single renderer so resolution and filesystem
+    // failures cannot drift into different redaction behavior.
+    format!("path {}", safe_summary_path_text(scoped_path))
+}
+
+fn safe_summary_path_text(path: &str) -> String {
+    path.trim_start_matches('/').replace(['/', '\\'], " ")
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::{
-    DirEntry, DiskFilesystem, Fault, FaultInjecting, FileStat, FileType, FilesystemError,
-    FilesystemOperation, RootFilesystem,
+    DirEntry, DiskFilesystem, Fault, FaultInjecting, FaultKind, FileStat, FileType,
+    FilesystemError, FilesystemOperation, RootFilesystem,
 };
 use ironclaw_host_api::result_meta::FailureKind;
 use ironclaw_host_api::runtime_policy::{
@@ -180,6 +180,48 @@ async fn builtin_coding_list_and_grep_skip_entries_when_stat_fails() {
     .await
     .unwrap();
     assert_eq!(grepped["files"], json!(["ok.rs"]));
+    assert_eq!(grepped["incomplete"], json!(true));
+    assert_eq!(grepped["skipped_file_count"], json!(1));
+    assert_eq!(
+        grepped["skipped_files"],
+        json!([{"file": "skip.rs", "operation": "stat"}])
+    );
+}
+
+#[tokio::test]
+async fn builtin_coding_grep_bounds_skipped_file_diagnostics() {
+    let temp = tempfile::tempdir().unwrap();
+    for index in 0..25 {
+        std::fs::write(temp.path().join(format!("file-{index:02}.rs")), "needle\n").unwrap();
+    }
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::Stat)
+                .path("/file-")
+                .backend("injected host path /private/secret and backend details"),
+        ),
+    );
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let grepped = invoke_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({"path": "/workspace", "pattern": "needle"}),
+        context,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(grepped["incomplete"], json!(true));
+    assert_eq!(grepped["skipped_file_count"], json!(25));
+    assert_eq!(grepped["skipped_files"].as_array().unwrap().len(), 20);
+    assert!(
+        !grepped.to_string().contains("private")
+            && !grepped.to_string().contains("backend details"),
+        "grep output must not expose injected host paths or backend reasons: {grepped}"
+    );
 }
 
 #[tokio::test]
@@ -208,6 +250,64 @@ async fn builtin_coding_grep_skips_entries_when_read_fails_during_directory_sear
     .unwrap();
 
     assert_eq!(grepped["files"], json!(["ok.rs"]));
+    assert_eq!(grepped["incomplete"], json!(true));
+    assert_eq!(grepped["skipped_file_count"], json!(1));
+    assert_eq!(
+        grepped["skipped_files"],
+        json!([{"file": "skip.rs", "operation": "read_file"}])
+    );
+}
+
+#[tokio::test]
+async fn builtin_coding_grep_failure_reports_missing_root_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let failure = invoke_failure_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({"path": "/workspace/missing.py", "pattern": "needle"}),
+        context,
+    )
+    .await;
+
+    assert_eq!(failure.kind, FailureKind::OperationFailed);
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("grep failed for path workspace missing.py: file not found")
+    );
+}
+
+#[tokio::test]
+async fn builtin_coding_grep_failure_reports_file_disappeared_before_read() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("gone.rs"), "needle\n").unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
+    let runtime = runtime_with_filesystem(
+        FaultInjecting::new(filesystem).with_fault(
+            Fault::on(FilesystemOperation::ReadFile)
+                .path("/gone.rs")
+                .returning(FaultKind::NotFound),
+        ),
+    );
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let failure = invoke_failure_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({"path": "/workspace/gone.rs", "pattern": "needle"}),
+        context,
+    )
+    .await;
+
+    assert_eq!(failure.kind, FailureKind::OperationFailed);
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("grep failed for path workspace gone.rs: file not found")
+    );
 }
 
 #[tokio::test]
@@ -225,16 +325,19 @@ async fn builtin_coding_grep_fails_on_explicit_file_read_error() {
     );
     let context = execution_context_with_mounts(coding_capability_ids(), mounts);
 
-    let error = invoke_with_context(
+    let failure = invoke_failure_with_context(
         &runtime,
         GREP_CAPABILITY_ID,
         json!({"path": "/workspace/fail.rs", "pattern": "needle"}),
         context,
     )
-    .await
-    .unwrap_err();
+    .await;
 
-    assert_eq!(error, FailureKind::Backend);
+    assert_eq!(failure.kind, FailureKind::Backend);
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("grep failed for path workspace fail.rs: filesystem backend error")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Make builtin grep root stat/read failures model-visible and actionable, including a specific redacted `file not found` reason.
- Report bounded directory-scan incompleteness with relative skipped-file names and canonical filesystem operation labels instead of silently hiding stat/read failures.
- Reuse one delimiter-free coding-tool path renderer so summaries cannot expose host paths or backend details.
- Add host-runtime caller-path regression coverage for missing/disappearing files, backend redaction, partial scans, and the 20-entry diagnostic cap.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run workspace-wide; focused owning/caller targets passed with `-D warnings`.
- [ ] `cargo build` — Not run separately; focused tests and clippy compiled the changed crates and caller test.
- [x] Relevant tests pass: `cargo test -p ironclaw_extension_support`; focused `first_party_coding_tools` grep tests.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — Not applicable: no database or persistence behavior changed.
- [ ] Manual testing — Not applicable: deterministic caller-path tests cover the capability result contract.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; an explicit thermo-nuclear maintainability review was completed and all findings were fixed.

## Test Strategy

User behavior:

Given a grep request whose scoped root is missing or disappears before reading, the model receives a stable actionable failure naming only the scoped path. Given a directory scan with per-file stat/read failures, successful matches are returned together with bounded structured incompleteness metadata.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Updated `crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs` through the production host-runtime capability caller.
- Reborn integration: Not applicable: behavior is local to the first-party capability result boundary and does not change turn scheduling, loop execution, or product workflow.
- Recorded fixture: Not applicable: model tool choice and request shape are unchanged.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: Not applicable: no database, Docker, WASM, MCP, or external runtime behavior changed; filesystem faults are injected beneath the real production caller.
- Live canary: Not applicable: deterministic error/result mapping does not depend on a live model or provider.

What the tests prove:

- Missing root stat and explicit-file read failures retain their failure class and expose delimiter-free actionable summaries.
- Backend reasons and injected host paths do not enter model-visible output.
- Directory stat/read failures set `incomplete`, preserve the total skipped count, and report at most 20 relative entries with canonical operation names.
- Existing scan-budget and oversized-file behavior remains intact.

Commands run:

- `cargo fmt --all -- --check`
- `cargo check -p ironclaw_extension_support --all-targets`
- `cargo test -p ironclaw_extension_support`
- `cargo test -p ironclaw_host_runtime --test first_party_coding_tools builtin_coding_grep_ -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test first_party_coding_tools builtin_coding_list_and_grep_skip_entries_when_stat_fails -- --exact --nocapture`
- `cargo test -p ironclaw_extension_support coding::tests::out_of_scope_path_rejection_names_the_path_and_available_roots -- --exact`
- `cargo clippy -p ironclaw_extension_support --all-targets --all-features -- -D warnings`
- `cargo clippy -p ironclaw_host_runtime --test first_party_coding_tools -- -D warnings`
- `git diff --check`

## Security Impact

Improves filesystem diagnostic confidentiality. Model-visible failures use scoped delimiter-free path hints and closed reason text; host paths and backend reasons remain excluded. Directory diagnostics expose only bounded paths relative to the requested scoped root.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new public trust-bearing type; new visit/diagnostic types are private to the coding grep implementation.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: no prompt construction changed; path hints continue through bounded safe-summary validation.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: Not applicable; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: no variants changed. Existing filesystem-to-dispatch failure classes are preserved and caller-tested.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: Not applicable; no persisted or serde-defaulted fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: skipped diagnostics are capped at 20 and the total count uses saturating arithmetic.
- [x] Driver/operator-visible errors have stable class semantics: NotFound remains OperationFailed; backend and infrastructure errors remain Backend; only safe summaries are added.
- [x] Sandbox/native/host names accurately describe trust boundary: Not applicable; no runtime lane or sandbox naming changed.

## Database Impact

None. No migrations, schemas, persistence, PostgreSQL, or libSQL behavior changed.

## Blast Radius

Limited to builtin coding grep diagnostics and the shared safe filesystem-summary renderer used by coding file tools. The read_file mapping is moved without semantic change. Existing grep matching, sorting, filtering, scan budgets, permissions, and loop logic are unchanged.

## Rollback Plan

Revert commit `ae3bda185`. There is no data migration or persisted compatibility concern; rollback restores the previous category-only/silent-skip diagnostics.

## Review Follow-Through

An aggressive maintainability review identified implicit boolean policy coupling, raw operation strings, and duplicate path renderers. All three were replaced with a typed explicit-file/directory-scan mode, canonical `FilesystemOperation`, and one shared safe renderer. Reviewer attention should focus on the additive grep result metadata contract.

---

**Review track**: C (runtime-facing tool diagnostics and filesystem redaction)
