### PR TITLE
fix(triggers): notify users when scheduled runs fail

### DIFF
--- a/crates/ironclaw_product/src/run_delivery/triggered.rs
+++ b/crates/ironclaw_product/src/run_delivery/triggered.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use crate::OutboundPart;
 use async_trait::async_trait;
 use chrono::Utc;
+use ironclaw_host_api::failure::summary::reborn_failure_summary_for_category;
 use ironclaw_host_api::ids::{AgentId, UserId};
 use ironclaw_outbound::{
     CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
@@ -322,6 +323,7 @@ async fn deliver_triggered_run(
 
     let mut delivered_blocked_marker: Option<BlockedActionableMarker> = None;
     let mut messages_to_delete_after_final: Vec<DeliveredChannelMessage> = Vec::new();
+    let trigger_label = prompts::triggered_label_from_prompt(&prompt);
 
     loop {
         let state = match wait_for_actionable_state(
@@ -348,6 +350,49 @@ async fn deliver_triggered_run(
                 record_triggered_run_outcome(delivery_store, run_id, outcome).await;
                 return outcome;
             }
+            Err(RunDeliveryError::RunWaitTimedOut { .. }) => {
+                let notification_context = TriggeredNotificationContext {
+                    scope: &scope,
+                    thread_scope: &thread_scope,
+                    actor: &actor,
+                    run_id,
+                    trigger_context: &trigger_context,
+                    delivery_target: delivery_target.as_ref(),
+                    authority: &authority,
+                };
+                let notification = TriggeredNotification {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    intent: DeliveryIntent::TriggeredDelivery,
+                    text: format!(
+                        "{}{}",
+                        prompts::DELIVERY_TIMEOUT_MESSAGE,
+                        prompts::triggered_update_footer(&trigger_label)
+                    ),
+                    attachments: Vec::new(),
+                    gate_ref_for_routing: None,
+                    require_direct_message_target: false,
+                };
+                let outcome = match deliver_triggered_notification(
+                    services,
+                    &notification_context,
+                    notification,
+                )
+                .await
+                {
+                    Ok(_) => TriggeredRunDeliveryOutcomeKind::Delivered,
+                    Err(error) => {
+                        tracing::warn!(
+                            target = "ironclaw::reborn::run_delivery",
+                            %run_id,
+                            error = %error,
+                            "triggered run timeout notification delivery failed"
+                        );
+                        TriggeredRunDeliveryOutcomeKind::Failed
+                    }
+                };
+                record_triggered_run_outcome(delivery_store, run_id, outcome).await;
+                return outcome;
+            }
             Err(err) => {
                 tracing::warn!(
                     target = "ironclaw::reborn::run_delivery",
@@ -361,7 +406,6 @@ async fn deliver_triggered_run(
             }
         };
 
-        let trigger_label = prompts::triggered_label_from_prompt(&prompt);
         let notification = match triggered_notification_for_state(
             services,
             &scope,
@@ -554,15 +598,17 @@ async fn deliver_triggered_run(
 /// ## Triggered channel surface contract
 ///
 /// A triggered run is **output-only over the channel, plus gate-resolution
-/// input** — it is NOT a conversational surface. Only three outputs are
+/// input** — it is NOT a conversational surface. Its outputs are
 /// minted here:
 ///
 /// - `BlockedApproval` → gate prompt (approve/deny)
 /// - `BlockedAuth`     → auth prompt (OAuth link) or, for non-OAuth, a
 ///   cancel + final-reply carrying the auth-unavailable notice
 /// - `Completed`       → final reply
+/// - failed terminals  → sanitized failure summary
+/// - `Cancelled`       → cancellation notice
 ///
-/// Anything else yields `None` — triggered delivery deliberately does not
+/// Non-actionable states yield `None` — triggered delivery deliberately does not
 /// stream progress; that belongs to the live WebUI surface. Preserve that
 /// boundary when extending this function.
 async fn triggered_notification_for_state(
@@ -717,7 +763,39 @@ async fn triggered_notification_for_state(
                 }
             }
         }
-        _ => Ok(None),
+        TurnStatus::Failed | TurnStatus::RecoveryRequired => {
+            let summary = reborn_failure_summary_for_category(
+                state.failure.as_ref().map(|failure| failure.category()),
+            );
+            Ok(Some(TriggeredNotification {
+                event_kind: RunNotificationEventKind::FinalReplyReady,
+                intent: DeliveryIntent::TriggeredDelivery,
+                text: format!(
+                    "{summary}{}",
+                    prompts::triggered_update_footer(trigger_label)
+                ),
+                attachments: Vec::new(),
+                gate_ref_for_routing: None,
+                require_direct_message_target: false,
+            }))
+        }
+        TurnStatus::Cancelled => Ok(Some(TriggeredNotification {
+            event_kind: RunNotificationEventKind::FinalReplyReady,
+            intent: DeliveryIntent::TriggeredDelivery,
+            text: format!(
+                "The run was cancelled before it could finish.{}",
+                prompts::triggered_update_footer(trigger_label)
+            ),
+            attachments: Vec::new(),
+            gate_ref_for_routing: None,
+            require_direct_message_target: false,
+        })),
+        TurnStatus::Queued
+        | TurnStatus::Running
+        | TurnStatus::BlockedResource
+        | TurnStatus::BlockedDependentRun
+        | TurnStatus::BlockedExternalTool
+        | TurnStatus::CancelRequested => Ok(None),
     }
 }
 

--- a/crates/ironclaw_product/tests/run_delivery_contract.rs
+++ b/crates/ironclaw_product/tests/run_delivery_contract.rs
@@ -19,7 +19,7 @@ use ironclaw_extension_contracts::preference_target::{
 };
 use ironclaw_host_api::turn::{
     AcceptedMessageRef, EventCursor, ReplyTargetBindingRef, RunProfileId, RunProfileVersion,
-    SourceBindingRef, TurnGateRef, TurnId, TurnRunId, TurnScope, TurnStatus,
+    SanitizedFailure, SourceBindingRef, TurnGateRef, TurnId, TurnRunId, TurnScope, TurnStatus,
 };
 use ironclaw_host_api::{
     attachment::WorkspaceFile,
@@ -71,12 +71,22 @@ use ironclaw_turns::{
 struct ScriptedRunState {
     status: TurnStatus,
     gate_ref: Option<TurnGateRef>,
+    failure: Option<SanitizedFailure>,
 }
 
 fn scripted_state(status: TurnStatus, gate_ref: Option<&str>) -> ScriptedRunState {
     ScriptedRunState {
         status,
         gate_ref: gate_ref.map(|s| TurnGateRef::new(s).expect("gate ref")),
+        failure: None,
+    }
+}
+
+fn scripted_failed_state(category: &'static str) -> ScriptedRunState {
+    ScriptedRunState {
+        status: TurnStatus::Failed,
+        gate_ref: None,
+        failure: Some(SanitizedFailure::from_trusted_static(category)),
     }
 }
 
@@ -162,7 +172,7 @@ impl TurnCoordinator for ScriptedTurnCoordinator {
             gate_ref: scripted.gate_ref,
             blocked_activity_id: None,
             credential_requirements: Vec::new(),
-            failure: None,
+            failure: scripted.failure,
             event_cursor: EventCursor(1),
             product_context: None,
             resume_disposition: None,
@@ -2002,6 +2012,82 @@ async fn triggered_final_reply_reaches_the_preference_target_with_footer() {
         envelopes[0].target.conversation.conversation_id(),
         "dm-creator",
         "delivered to the decoded preference target"
+    );
+}
+
+#[tokio::test]
+async fn triggered_failed_run_reaches_the_preference_target_with_safe_summary() {
+    let harness = build_triggered_harness(vec![scripted_failed_state("model_error")], None, true);
+    seed_preference(&harness.store).await;
+    let run_id = TurnRunId::new();
+
+    harness
+        .driver
+        .on_trigger_submitted(triggered_request(run_id, false))
+        .await;
+
+    let outcome = wait_for_outcome(&harness.delivery_store, run_id).await;
+    assert_eq!(outcome, TriggeredRunDeliveryOutcomeKind::Delivered);
+    let texts = harness.adapter.texts();
+    assert_eq!(texts.len(), 1, "one failure notification must be delivered");
+    assert!(
+        texts[0].contains("The run failed while calling the model."),
+        "notification must use the sanitized category summary: {}",
+        texts[0]
+    );
+    assert!(
+        texts[0].contains("From a triggered event: “watch the deploys”."),
+        "failure notification must retain trigger context: {}",
+        texts[0]
+    );
+}
+
+#[tokio::test]
+async fn triggered_cancelled_run_reaches_the_preference_target() {
+    let harness = build_triggered_harness(
+        vec![scripted_state(TurnStatus::Cancelled, None)],
+        None,
+        true,
+    );
+    seed_preference(&harness.store).await;
+    let run_id = TurnRunId::new();
+
+    harness
+        .driver
+        .on_trigger_submitted(triggered_request(run_id, false))
+        .await;
+
+    let outcome = wait_for_outcome(&harness.delivery_store, run_id).await;
+    assert_eq!(outcome, TriggeredRunDeliveryOutcomeKind::Delivered);
+    let texts = harness.adapter.texts();
+    assert_eq!(texts.len(), 1, "one cancellation notification");
+    assert!(
+        texts[0].contains("The run was cancelled before it could finish."),
+        "{}",
+        texts[0]
+    );
+}
+
+#[tokio::test]
+async fn triggered_run_wait_timeout_reaches_the_preference_target() {
+    let harness =
+        build_triggered_harness(vec![scripted_state(TurnStatus::Running, None)], None, true);
+    seed_preference(&harness.store).await;
+    let run_id = TurnRunId::new();
+
+    harness
+        .driver
+        .on_trigger_submitted(triggered_request(run_id, false))
+        .await;
+
+    let outcome = wait_for_outcome(&harness.delivery_store, run_id).await;
+    assert_eq!(outcome, TriggeredRunDeliveryOutcomeKind::Delivered);
+    let texts = harness.adapter.texts();
+    assert_eq!(texts.len(), 1, "one timeout notification");
+    assert!(
+        texts[0].contains("This is taking longer than expected"),
+        "{}",
+        texts[0]
     );
 }
 

--- a/crates/ironclaw_reborn_composition/src/automation/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/automation/trigger_poller.rs
@@ -212,6 +212,16 @@ impl TriggerFireSettlementObserver for PostSubmitHookObserver {
         };
         spawn_post_submit_delivery(hook, event);
     }
+
+    async fn on_failed_fire_settled(&self, event: ironclaw_triggers::TriggerFailedFireSettlement) {
+        tracing::warn!(
+            tenant_id = %event.tenant_id,
+            trigger_id = %event.trigger_id,
+            fire_slot = %event.fire_slot,
+            run_id = %event.run_id,
+            "accepted trigger fire settled with a failed run"
+        );
+    }
 }
 
 async fn run_trigger_poller(

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -39,8 +39,8 @@ use ironclaw_loop_contracts::{
 };
 use ironclaw_loop_host::ToolDisclosureMode;
 use ironclaw_loop_host::{
-    HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
-    HostManagedModelResponse,
+    HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
+    HostManagedModelRequest, HostManagedModelResponse,
 };
 use ironclaw_network::{
     NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
@@ -73,6 +73,7 @@ const QA_9B_PROMPT: &str = "QA_9B scheduled health digest";
 const QA_9B_RESULT: &str = "QA_9B scheduled health digest complete";
 const QA_9D_PROMPT: &str = "QA_9D scheduled release digest";
 const QA_9D_RESULT: &str = "QA_9D scheduled release digest complete";
+const FAILED_RUN_PROMPT: &str = "scheduled model failure notification";
 const SLACK_TEAM: &str = "T-TRIGGER-E2E";
 const SLACK_USER: &str = "U-TRIGGER-E2E";
 const SLACK_DEFAULT_DM: &str = "D-TRIGGER-DEFAULT";
@@ -173,6 +174,10 @@ impl HostManagedModelGateway for DeliveryJourneyGateway {
         &self,
         request: HostManagedModelRequest,
     ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        let fails = request
+            .messages
+            .iter()
+            .any(|message| message.content.contains(FAILED_RUN_PROMPT));
         let reply = if request
             .messages
             .iter()
@@ -189,6 +194,12 @@ impl HostManagedModelGateway for DeliveryJourneyGateway {
             "unexpected scheduled-trigger prompt"
         };
         self.requests.lock().await.push(request);
+        if fails {
+            return Err(HostManagedModelError::new(
+                HostManagedModelErrorKind::InvalidRequest,
+                "scripted terminal model failure",
+            ));
+        }
         Ok(HostManagedModelResponse::assistant_reply(reply.to_string()))
     }
 }
@@ -1141,16 +1152,17 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
     );
 }
 
-/// QA-9B + QA-9D whole-path regression:
+/// QA-9B + QA-9D whole-path regression plus #6896 failed-run delivery:
 ///
 /// due trigger -> trusted ingress -> real Reborn run -> persisted final reply
 /// -> generic triggered-delivery hook -> real Slack adapter -> host-mediated
 /// credential injection -> fake Slack HTTP boundary.
 ///
-/// The two arms prove that the creator's default DM is used when the trigger
-/// has no target and that an explicit per-trigger target overrides that
-/// default. Re-polling and rebuilding the runtime over the same durable store
-/// must not repeat either provider mutation.
+/// The success arms prove that the creator's default DM is used when the
+/// trigger has no target and that an explicit per-trigger target overrides
+/// that default. The failure arm proves a terminal model error also reaches
+/// the creator's channel with its safe summary. Re-polling and rebuilding the
+/// runtime over the same durable store must not repeat any provider mutation.
 #[tokio::test]
 async fn scheduled_trigger_results_reach_exact_slack_targets_once_across_restart() {
     let root = tempfile::tempdir().expect("tempdir");
@@ -1174,24 +1186,27 @@ async fn scheduled_trigger_results_reach_exact_slack_targets_once_across_restart
     let default_target_trigger = seed_due_delivery_trigger(&repository, QA_9B_PROMPT, None).await;
     let explicit_target_trigger =
         seed_due_delivery_trigger(&repository, QA_9D_PROMPT, Some(QA_9D_TARGET_ID)).await;
+    let failed_run_trigger = seed_due_delivery_trigger(&repository, FAILED_RUN_PROMPT, None).await;
 
     wait_for_delivered_run(&repository, &delivery_store, default_target_trigger).await;
     wait_for_delivered_run(&repository, &delivery_store, explicit_target_trigger).await;
+    wait_for_delivered_run(&repository, &delivery_store, failed_run_trigger).await;
 
     let provider_messages = slack_provider.provider_messages();
     assert_eq!(
         provider_messages.len(),
-        2,
+        3,
         "one provider-side message per scheduled trigger: {provider_messages:?}"
     );
     assert_slack_dm_delivery_evidence(&provider_messages);
     assert_slack_channel_delivery_evidence(&provider_messages);
+    assert_slack_failed_run_delivery_evidence(&provider_messages);
 
     let wire_messages = slack_provider.wire_messages();
     assert_eq!(
         wire_messages.len(),
-        2,
-        "exactly two Slack wire mutations: {wire_messages:?}"
+        3,
+        "exactly three Slack wire mutations: {wire_messages:?}"
     );
     assert!(
         wire_messages.iter().all(|message| {
@@ -1212,11 +1227,18 @@ async fn scheduled_trigger_results_reach_exact_slack_targets_once_across_restart
         1,
         "QA-9D must execute exactly one model run"
     );
+    assert_eq!(
+        model_gateway
+            .request_count_containing(FAILED_RUN_PROMPT)
+            .await,
+        1,
+        "the failed scheduled run must execute exactly once"
+    );
 
     tokio::time::sleep(Duration::from_millis(250)).await;
     assert_eq!(
         slack_provider.provider_messages().len(),
-        2,
+        3,
         "re-polling completed one-shot triggers must not duplicate delivery"
     );
     runtime.shutdown().await.expect("first runtime shutdown");
@@ -1236,7 +1258,7 @@ async fn scheduled_trigger_results_reach_exact_slack_targets_once_across_restart
 
     assert_eq!(
         slack_provider.provider_messages().len(),
-        2,
+        3,
         "restart over the same durable trigger state must not duplicate provider effects"
     );
     assert_eq!(
@@ -1248,6 +1270,13 @@ async fn scheduled_trigger_results_reach_exact_slack_targets_once_across_restart
         model_gateway.request_count_containing(QA_9D_PROMPT).await,
         1,
         "restart must not rerun QA-9D"
+    );
+    assert_eq!(
+        model_gateway
+            .request_count_containing(FAILED_RUN_PROMPT)
+            .await,
+        1,
+        "restart must not rerun the failed scheduled trigger"
     );
 }
 
@@ -1284,6 +1313,24 @@ fn assert_slack_channel_delivery_evidence(messages: &[Value]) {
         matching.count(),
         expected_count,
         "QA-9D must create exactly one unthreaded message in C-TRIGGER-OVERRIDE: {messages:?}"
+    );
+}
+
+fn assert_slack_failed_run_delivery_evidence(messages: &[Value]) {
+    let expected_summary = ironclaw_host_api::failure::summary::reborn_failure_summary_for_category(
+        Some("driver_failed"),
+    );
+    let matching = messages.iter().filter(|message| {
+        message["channel"] == SLACK_DEFAULT_DM
+            && message.get("thread_ts").is_none()
+            && message["text"]
+                .as_str()
+                .is_some_and(|text| text.contains(expected_summary))
+    });
+    assert_eq!(
+        matching.count(),
+        1,
+        "the failed scheduled run must deliver exactly one safe failure summary: {messages:?}"
     );
 }
 

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1281,11 +1281,12 @@ pub use worker::{
     ACTIVE_HOLD_ELAPSED_OCCURRENCES_CAP, ACTIVE_HOLD_LOOKUP_TIMEOUT, ActiveHoldProjection,
     ActiveHoldReason, BlockedActiveRunKind, MissingTriggerActiveRunLookup,
     NoopTriggerFireSettlementObserver, TriggerAcceptedFireSettlement, TriggerActiveRunLookup,
-    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerFireSettlementObserver,
-    TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerFireReport,
-    TriggerPollerTickReport, TriggerPollerWorker, TriggerPollerWorkerConfig,
-    TriggerPollerWorkerDeps, TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter,
-    TrustedTriggerSubmitRequest, active_hold_projection, active_holds_for_records,
+    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerFailedFireSettlement,
+    TriggerFireSettlementObserver, TriggerPollerFailureReason, TriggerPollerFireOutcome,
+    TriggerPollerFireReport, TriggerPollerTickReport, TriggerPollerWorker,
+    TriggerPollerWorkerConfig, TriggerPollerWorkerDeps, TrustedTriggerFireSubmitOutcome,
+    TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest, active_hold_projection,
+    active_holds_for_records,
 };
 
 #[derive(Clone, Default)]

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -16,9 +16,9 @@ pub use ports::{
     ACTIVE_HOLD_ELAPSED_OCCURRENCES_CAP, ACTIVE_HOLD_LOOKUP_TIMEOUT, ActiveHoldProjection,
     ActiveHoldReason, BlockedActiveRunKind, MissingTriggerActiveRunLookup,
     NoopTriggerFireSettlementObserver, TriggerAcceptedFireSettlement, TriggerActiveRunLookup,
-    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerFireSettlementObserver,
-    TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest,
-    active_hold_projection, active_holds_for_records,
+    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerFailedFireSettlement,
+    TriggerFireSettlementObserver, TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter,
+    TrustedTriggerSubmitRequest, active_hold_projection, active_holds_for_records,
 };
 pub use report::{
     TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerFireReport,

--- a/crates/ironclaw_triggers/src/worker/active_cleanup.rs
+++ b/crates/ironclaw_triggers/src/worker/active_cleanup.rs
@@ -4,9 +4,9 @@ use crate::{
 };
 
 use super::{
-    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerPollerFailureReason,
-    TriggerPollerFireOutcome, TriggerPollerFireReport, TriggerPollerTickReport,
-    TriggerPollerWorker, failure::classify_failure,
+    TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerFailedFireSettlement,
+    TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerFireReport,
+    TriggerPollerTickReport, TriggerPollerWorker, failure::classify_failure,
 };
 
 struct ActiveLookupItem {
@@ -158,6 +158,17 @@ impl TriggerPollerWorker {
                         .await?
                         .is_some()
                     {
+                        if status == TriggerRunHistoryStatus::Error {
+                            self.deps
+                                .fire_settlement_observer
+                                .on_failed_fire_settled(TriggerFailedFireSettlement {
+                                    tenant_id: record.tenant_id.clone(),
+                                    trigger_id: record.trigger_id,
+                                    fire_slot,
+                                    run_id,
+                                })
+                                .await;
+                        }
                         cleared_outcome
                     } else {
                         TriggerPollerFireOutcome::SkippedAlreadyCleared { run_id }

--- a/crates/ironclaw_triggers/src/worker/ports.rs
+++ b/crates/ironclaw_triggers/src/worker/ports.rs
@@ -113,9 +113,20 @@ pub struct TriggerAcceptedFireSettlement {
     pub turn_scope: TurnScope,
 }
 
+/// A previously accepted trigger fire whose run durably settled as an error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerFailedFireSettlement {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub run_id: TurnRunId,
+}
+
 #[async_trait]
 pub trait TriggerFireSettlementObserver: Send + Sync {
     async fn on_accepted_fire_settled(&self, event: TriggerAcceptedFireSettlement);
+
+    async fn on_failed_fire_settled(&self, event: TriggerFailedFireSettlement);
 }
 
 #[derive(Debug, Default)]
@@ -124,6 +135,8 @@ pub struct NoopTriggerFireSettlementObserver;
 #[async_trait]
 impl TriggerFireSettlementObserver for NoopTriggerFireSettlementObserver {
     async fn on_accepted_fire_settled(&self, _event: TriggerAcceptedFireSettlement) {}
+
+    async fn on_failed_fire_settled(&self, _event: TriggerFailedFireSettlement) {}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -689,16 +689,23 @@ async fn tick_records_failed_terminal_active_run_as_error() {
     record.active_fire_slot = Some(fire_slot);
     record.active_run_ref = Some(run_id);
     repo.upsert_trigger(record).await.expect("insert active");
-    let worker = worker(
-        repo.clone(),
-        Arc::new(RecordingMaterializer::success("content:trigger-fire")),
-        Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
-        Arc::new(RecordingActiveRunLookup::with_state(
-            TriggerActiveRunState::Terminal {
-                status: TriggerRunHistoryStatus::Error,
-            },
-        )),
-    );
+    let observer = Arc::new(RecordingSettlementObserver::default());
+    let worker = TriggerPollerWorker::new(
+        TriggerPollerWorkerConfig::default(),
+        TriggerPollerWorkerDeps {
+            repository: repo.clone(),
+            source_provider: Arc::new(crate::ScheduleTriggerSourceProvider),
+            materializer: Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            trusted_submitter: Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            active_run_lookup: Arc::new(RecordingActiveRunLookup::with_state(
+                TriggerActiveRunState::Terminal {
+                    status: TriggerRunHistoryStatus::Error,
+                },
+            )),
+            fire_settlement_observer: observer.clone(),
+        },
+    )
+    .expect("valid worker");
 
     let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
 
@@ -714,6 +721,16 @@ async fn tick_records_failed_terminal_active_run_as_error() {
     assert_eq!(runs[0].run_id, Some(run_id));
     assert_eq!(runs[0].status, TriggerRunHistoryStatus::Error);
     assert!(runs[0].completed_at.is_some());
+    assert_eq!(
+        observer.failed_events(),
+        vec![TriggerFailedFireSettlement {
+            tenant_id: tenant("tenant-a"),
+            trigger_id,
+            fire_slot,
+            run_id,
+        }],
+        "a durably cleared terminal error must emit exactly one failure settlement"
+    );
 }
 
 #[tokio::test]
@@ -2815,6 +2832,7 @@ impl TrustedTriggerFireSubmitter for RecordingSubmitter {
 #[derive(Default)]
 struct RecordingSettlementObserver {
     events: Mutex<Vec<TriggerAcceptedFireSettlement>>,
+    failed_events: Mutex<Vec<TriggerFailedFireSettlement>>,
     visibility_assertion: Option<SettlementVisibilityAssertion>,
 }
 
@@ -2838,6 +2856,7 @@ impl RecordingSettlementObserver {
     ) -> Self {
         Self {
             events: Mutex::new(Vec::new()),
+            failed_events: Mutex::new(Vec::new()),
             visibility_assertion: Some(SettlementVisibilityAssertion {
                 repository,
                 tenant_id,
@@ -2851,6 +2870,13 @@ impl RecordingSettlementObserver {
 
     fn events(&self) -> Vec<TriggerAcceptedFireSettlement> {
         self.events.lock().expect("events lock").clone()
+    }
+
+    fn failed_events(&self) -> Vec<TriggerFailedFireSettlement> {
+        self.failed_events
+            .lock()
+            .expect("failed events lock")
+            .clone()
     }
 }
 
@@ -2881,6 +2907,13 @@ impl TriggerFireSettlementObserver for RecordingSettlementObserver {
             );
         }
         self.events.lock().expect("events lock").push(event);
+    }
+
+    async fn on_failed_fire_settled(&self, event: TriggerFailedFireSettlement) {
+        self.failed_events
+            .lock()
+            .expect("failed events lock")
+            .push(event);
     }
 }
 

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -402,7 +402,13 @@ and submit-result bookkeeping:
 - `ironclaw_triggers::ClearActiveFireRequest` plus
   `TriggerRepository::clear_active_fire` clears only the exact matching
   `(tenant_id, trigger_id, active_fire_slot, active_run_ref)` after the caller
-  has observed a terminal turn outcome.
+  has observed a terminal turn outcome;
+- after an accepted run is durably cleared with `TriggerRunHistoryStatus::Error`,
+  `TriggerFireSettlementObserver::on_failed_fire_settled` receives the exact
+  tenant, trigger, fire-slot, and run identities. Successful terminal runs and
+  clear races do not emit this failure settlement. The observer is an
+  automation-health signal only; it does not mint a replacement turn or bypass
+  the normal triggered-run delivery watcher.
 
 The poller treats per-record due-fire processing and active-run terminal lookup
 errors as structured tick report outcomes so one bad record does not block other


### PR DESCRIPTION
## Summary

- Deliver sanitized terminal notifications for triggered runs that fail, require recovery, are cancelled, or time out.
- Emit an automation-health settlement signal after an accepted failed trigger run is durably cleared.
- Add focused delivery and cleanup contracts plus a scheduled-trigger-to-Slack regression covering exact-target and no-duplicate behavior.
- Document the failed-fire settlement contract without introducing retry or redrive behavior.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #6896

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (repository-wide command not run; scoped changed-package clippy commands passed with warnings denied)
- [ ] `cargo build` (covered by the scoped clippy and test builds below)
- [x] Relevant tests pass: triggered delivery contracts, trigger worker suites, scheduled trigger Slack E2E, and architecture boundary test
- [ ] `cargo test --features integration` if database-backed or integration behavior changed (not applicable: no database schema or backend contract changed; the focused Reborn composition integration test passed)
- [ ] Manual testing: not run; deterministic provider-boundary E2E covers delivery routing and deduplication
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

The broader `cargo test -p ironclaw_product --quiet` run passed all preceding suites but could not complete because `trace_reads_are_available_as_product_views` fails closed when `TRACE_COMMONS_TEST_TOKEN` is unavailable. That test is unrelated to triggered delivery.

## Test Strategy

User behavior:

Scheduled trigger targets now receive a safe terminal notice instead of silence when a run fails, requires recovery, is cancelled, or exceeds its delivery wait. Successful and blocked-action delivery behavior remains unchanged.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `triggered_failed_run_reaches_the_preference_target_with_safe_summary`, `triggered_cancelled_run_reaches_the_preference_target`, `triggered_run_wait_timeout_reaches_the_preference_target`, and failed terminal cleanup observer assertions.
- Reborn integration: extended `scheduled_trigger_results_reach_exact_slack_targets_once_across_restart` with a failed scheduled run.
- Recorded fixture: Not applicable: no external payload parsing or provider response contract changed.
- Browser E2E: Not applicable: no browser or WebUI behavior changed.
- Backend or runtime: full `ironclaw_triggers` suite and the focused composition poller E2E.
- Live canary: Not applicable: deterministic provider-boundary coverage verifies the changed contract without live credentials.

What the tests prove:

- Failed, recovery-required, cancelled, and timed-out triggered runs produce safe outbound notifications.
- A failed scheduled run reaches the exact Slack preference target once.
- Polling and process restart do not duplicate the failure notification.
- Failed-fire settlement is emitted only after the matching active fire is durably cleared.
- Dependency boundaries remain intact.

Commands run:

```text
cargo test -p ironclaw_product --test run_delivery_contract triggered_ -- --nocapture
cargo test -p ironclaw_triggers tick_records_failed_terminal_active_run_as_error -- --nocapture
cargo test -p ironclaw_triggers
cargo test -p ironclaw_reborn_composition --features test-support --test trigger_poller_e2e scheduled_trigger_results_reach_exact_slack_targets_once_across_restart -- --exact --nocapture
cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold
cargo clippy -p ironclaw_product --all-targets -- -D warnings
cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings
cargo clippy -p ironclaw_reborn_composition --all-targets --features test-support -- -D warnings
cargo fmt --all -- --check
git diff --check
```

## Security Impact

None. Failure text uses the central sanitized failure-summary table and does not expose raw model, provider, or runtime error causes. No permissions, credentials, network policy, file access, tool execution, or sandbox behavior changes.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: `TriggerFailedFireSettlement` is constructed by the trigger worker only after the exact active fire is durably cleared; observers consume the identity-only event.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. No new content enters prompts; outbound failure text comes from fixed sanitized summaries.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable: no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. No variant was added; terminal `TurnStatus` handling and all `TriggerFireSettlementObserver` implementations were enumerated with targeted `rg`.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Not applicable: no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable: no queues, maps, buffers, or counters changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). No new driver error class; the observer emits structured health telemetry.
- [x] Sandbox/native/host names accurately describe trust boundary. Not applicable: no sandbox or runtime lane changed.

## Database Impact

None. No migrations, schemas, or backend-specific persistence behavior changed.

## Blast Radius

Touches triggered-run outbound delivery, trigger active-fire cleanup observation, and composition telemetry. The primary regression risk is duplicate or misrouted terminal notifications; exact-target, restart, and delivery-ledger assertions cover those paths.

## Rollback Plan

Revert this commit. Existing successful and blocked-action delivery behavior is isolated from the new terminal branches, and there is no schema or persisted-format migration to undo.

## Review Follow-Through

Retry/redrive policy remains intentionally out of scope. Reviewer judgment is welcome on whether failed-fire health telemetry should later feed a dedicated metric or retry policy; this PR does not mint replacement turns or bypass the canonical delivery watcher.

---

**Review track**: B
