### PR TITLE
ci(gate): run the pre-push test suite with nextest when available

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -158,6 +158,7 @@ jobs:
           scripts/ci/test-build-wasm-extensions.sh
           scripts/ci/test-check-wasm-artifact-freshness.sh
           scripts/ci/test-package-feature-flags.sh
+          scripts/ci/test-quality-gate-runner.sh
           python3 scripts/ci/test_changed_workspace_packages.py
           scripts/ci/test-reborn-crate-test-buckets.sh
           scripts/ci/test-main-ci-slack-alerts.sh

--- a/scripts/ci/quality_gate.sh
+++ b/scripts/ci/quality_gate.sh
@@ -48,7 +48,14 @@ run_cargo_ci cargo clippy --locked --all --tests --examples --all-features -- -D
 select_test_runner() {
     case "${IRONCLAW_GATE_TEST_RUNNER:-auto}" in
         cargo) echo "cargo" ;;
-        nextest) echo "nextest" ;;
+        nextest)
+            if command -v cargo-nextest >/dev/null 2>&1; then
+                echo "nextest"
+            else
+                echo "IRONCLAW_GATE_TEST_RUNNER=nextest requires cargo-nextest" >&2
+                return 1
+            fi
+            ;;
         auto)
             if command -v cargo-nextest >/dev/null 2>&1; then
                 echo "nextest"

--- a/scripts/ci/quality_gate.sh
+++ b/scripts/ci/quality_gate.sh
@@ -24,7 +24,53 @@ run_cargo_ci() {
 echo "==> clippy (CI parity: all features, all warnings)"
 run_cargo_ci cargo clippy --locked --all --tests --examples --all-features -- -D warnings
 
+# Which runner executes the workspace tests.
+#
+# `cargo test` runs each test binary strictly sequentially — it parallelises
+# *within* a binary but never across them. This workspace builds well over 400
+# test binaries, the large majority finishing in under a second, so the gate
+# spends most of its wall clock starting and tearing down processes one at a
+# time. `cargo nextest` runs them in a single parallel pool instead.
+#
+# Coverage is equivalent: `--all-targets` expands to
+# `--lib --bins --tests --benches --examples` and so has never included
+# doctests, which nextest also does not run. This swap therefore changes
+# scheduling only, not what is executed.
+#
+# nextest stays OPTIONAL. `tests/fixtures/llm_traces/README.md` documents that
+# local development must keep working without it, so an absent binary falls
+# back rather than failing. `.config/nextest.toml` already carries the
+# repository's profiles and per-test slow-timeouts; CI's insta gate uses them.
+#
+#   auto (default) — nextest when installed, otherwise cargo test
+#   nextest        — require nextest, fail if missing
+#   cargo          — force the sequential runner
+select_test_runner() {
+    case "${IRONCLAW_GATE_TEST_RUNNER:-auto}" in
+        cargo) echo "cargo" ;;
+        nextest) echo "nextest" ;;
+        auto)
+            if command -v cargo-nextest >/dev/null 2>&1; then
+                echo "nextest"
+            else
+                echo "cargo"
+            fi
+            ;;
+        *)
+            echo "unknown IRONCLAW_GATE_TEST_RUNNER: ${IRONCLAW_GATE_TEST_RUNNER}" >&2
+            return 1
+            ;;
+    esac
+}
+
 if [ "${IRONCLAW_PREPUSH_TEST:-1}" = "1" ]; then
-    echo "==> tests (CI parity: workspace, all targets, all features; skip with IRONCLAW_PREPUSH_TEST=0)"
-    run_cargo_ci cargo test --locked --workspace --all-targets --all-features --no-fail-fast
+    runner="$(select_test_runner)"
+    if [ "$runner" = "nextest" ]; then
+        echo "==> tests (nextest: workspace, all targets, all features; skip with IRONCLAW_PREPUSH_TEST=0)"
+        run_cargo_ci cargo nextest run --locked --workspace --all-targets --all-features --no-fail-fast
+    else
+        echo "==> tests (cargo test: workspace, all targets, all features; skip with IRONCLAW_PREPUSH_TEST=0)"
+        echo "    install cargo-nextest for a parallel run: https://nexte.st/docs/installation/"
+        run_cargo_ci cargo test --locked --workspace --all-targets --all-features --no-fail-fast
+    fi
 fi

--- a/scripts/ci/test-quality-gate-runner.sh
+++ b/scripts/ci/test-quality-gate-runner.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Regression tests for the quality gate's test-runner selection.
+#
+# The gate must keep working on a machine without cargo-nextest
+# (`tests/fixtures/llm_traces/README.md` documents that local development does
+# not require it), must use nextest when it is available, and must honour an
+# explicit override. Every cargo invocation here is stubbed, so this runs in
+# milliseconds and compiles nothing.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$SCRIPT_DIR/quality_gate.sh"
+failures=0
+
+# Run the gate with a stubbed `cargo` (and optionally a stubbed
+# `cargo-nextest`) on PATH, echoing each invocation to a log.
+run_gate() {
+    local with_nextest="$1"
+    shift
+    local sandbox
+    sandbox="$(mktemp -d)"
+    cat >"$sandbox/cargo" <<'STUB'
+#!/usr/bin/env bash
+echo "cargo $*" >>"$GATE_TEST_LOG"
+STUB
+    chmod +x "$sandbox/cargo"
+    if [ "$with_nextest" = "with-nextest" ]; then
+        cat >"$sandbox/cargo-nextest" <<'STUB'
+#!/usr/bin/env bash
+echo "cargo-nextest $*" >>"$GATE_TEST_LOG"
+STUB
+        chmod +x "$sandbox/cargo-nextest"
+    fi
+    # PATH is REPLACED, not prepended: a real cargo-nextest installed in the
+    # developer's ~/.cargo/bin would otherwise satisfy `command -v` and make
+    # the "nextest absent" case silently test the wrong branch.
+    GATE_TEST_LOG="$sandbox/log" \
+        PATH="$sandbox:/usr/bin:/bin" \
+        "$@" bash "$GATE" >/dev/null 2>&1 || true
+    cat "$sandbox/log" 2>/dev/null || true
+    rm -rf "$sandbox"
+}
+
+expect_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "ok   — $label"
+    else
+        echo "FAIL — $label"
+        echo "       expected to find: $needle"
+        echo "       in: $haystack"
+        failures=$((failures + 1))
+    fi
+}
+
+expect_not_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "ok   — $label"
+    else
+        echo "FAIL — $label"
+        echo "       expected NOT to find: $needle"
+        failures=$((failures + 1))
+    fi
+}
+
+log="$(run_gate with-nextest)"
+expect_contains "nextest present: runs the parallel runner" "$log" "cargo nextest run"
+expect_not_contains "nextest present: does not also run cargo test" "$log" "cargo test"
+
+log="$(run_gate without-nextest)"
+expect_contains "nextest absent: falls back to cargo test" "$log" "cargo test --locked --workspace"
+expect_not_contains "nextest absent: does not invoke nextest" "$log" "nextest run"
+
+log="$(run_gate with-nextest env IRONCLAW_GATE_TEST_RUNNER=cargo)"
+expect_contains "override=cargo: forces the sequential runner" "$log" "cargo test --locked --workspace"
+expect_not_contains "override=cargo: skips nextest even when installed" "$log" "nextest run"
+
+log="$(run_gate without-nextest env IRONCLAW_PREPUSH_TEST=0)"
+expect_not_contains "IRONCLAW_PREPUSH_TEST=0: runs no tests at all" "$log" "--workspace"
+expect_contains "IRONCLAW_PREPUSH_TEST=0: still runs clippy" "$log" "clippy"
+
+# Coverage parity is the reason this swap is safe: `--all-targets` never
+# included doctests, so neither runner loses them.
+log="$(run_gate with-nextest)"
+expect_contains "nextest run keeps --all-targets --all-features" "$log" "--all-targets --all-features"
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures check(s) failed"
+    exit 1
+fi
+echo "all quality-gate runner checks passed"

--- a/scripts/ci/test-quality-gate-runner.sh
+++ b/scripts/ci/test-quality-gate-runner.sh
@@ -111,15 +111,22 @@ capture_gate without-nextest
 expect_status "nextest absent: gate succeeds" "$gate_status" 0
 expect_contains "nextest absent: falls back to cargo test" "$gate_log" "cargo test --locked --workspace"
 expect_not_contains "nextest absent: does not invoke nextest" "$gate_log" "nextest run"
+expect_contains "nextest absent: keeps --all-targets --all-features" "$gate_log" "--all-targets --all-features"
 
 capture_gate with-nextest IRONCLAW_GATE_TEST_RUNNER=cargo
 expect_status "override=cargo: gate succeeds" "$gate_status" 0
 expect_contains "override=cargo: forces the sequential runner" "$gate_log" "cargo test --locked --workspace"
 expect_not_contains "override=cargo: skips nextest even when installed" "$gate_log" "nextest run"
 
+capture_gate with-nextest IRONCLAW_GATE_TEST_RUNNER=nextest
+expect_status "override=nextest: gate succeeds" "$gate_status" 0
+expect_contains "override=nextest: runs the parallel runner" "$gate_log" "cargo nextest run"
+expect_not_contains "override=nextest: does not also run cargo test" "$gate_log" "cargo test"
+
 capture_gate without-nextest IRONCLAW_PREPUSH_TEST=0
 expect_status "IRONCLAW_PREPUSH_TEST=0: gate succeeds" "$gate_status" 0
-expect_not_contains "IRONCLAW_PREPUSH_TEST=0: runs no tests at all" "$gate_log" "--workspace"
+expect_not_contains "IRONCLAW_PREPUSH_TEST=0: skips cargo test" "$gate_log" "cargo test"
+expect_not_contains "IRONCLAW_PREPUSH_TEST=0: skips nextest" "$gate_log" "cargo nextest run"
 expect_contains "IRONCLAW_PREPUSH_TEST=0: still runs clippy" "$gate_log" "clippy"
 
 capture_gate without-nextest IRONCLAW_GATE_TEST_RUNNER=nextest

--- a/scripts/ci/test-quality-gate-runner.sh
+++ b/scripts/ci/test-quality-gate-runner.sh
@@ -34,11 +34,26 @@ STUB
     # PATH is REPLACED, not prepended: a real cargo-nextest installed in the
     # developer's ~/.cargo/bin would otherwise satisfy `command -v` and make
     # the "nextest absent" case silently test the wrong branch.
-    GATE_TEST_LOG="$sandbox/log" \
+    local status
+    set +e
+    env \
+        GATE_TEST_LOG="$sandbox/log" \
         PATH="$sandbox:/usr/bin:/bin" \
-        "$@" bash "$GATE" >/dev/null 2>&1 || true
+        IRONCLAW_GATE_TEST_RUNNER=auto \
+        IRONCLAW_PREPUSH_TEST=1 \
+        "$@" bash "$GATE" >/dev/null 2>&1
+    status=$?
+    set -e
     cat "$sandbox/log" 2>/dev/null || true
     rm -rf "$sandbox"
+    return "$status"
+}
+
+capture_gate() {
+    set +e
+    gate_log="$(run_gate "$@")"
+    gate_status=$?
+    set -e
 }
 
 expect_contains() {
@@ -64,26 +79,60 @@ expect_not_contains() {
     fi
 }
 
-log="$(run_gate with-nextest)"
-expect_contains "nextest present: runs the parallel runner" "$log" "cargo nextest run"
-expect_not_contains "nextest present: does not also run cargo test" "$log" "cargo test"
+expect_status() {
+    local label="$1" actual="$2" expected="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        echo "ok   — $label"
+    else
+        echo "FAIL — $label"
+        echo "       expected status: $expected"
+        echo "       actual status: $actual"
+        failures=$((failures + 1))
+    fi
+}
 
-log="$(run_gate without-nextest)"
-expect_contains "nextest absent: falls back to cargo test" "$log" "cargo test --locked --workspace"
-expect_not_contains "nextest absent: does not invoke nextest" "$log" "nextest run"
+expect_failure() {
+    local label="$1" actual="$2"
+    if [ "$actual" -ne 0 ]; then
+        echo "ok   — $label"
+    else
+        echo "FAIL — $label"
+        echo "       expected a non-zero status"
+        failures=$((failures + 1))
+    fi
+}
 
-log="$(run_gate with-nextest env IRONCLAW_GATE_TEST_RUNNER=cargo)"
-expect_contains "override=cargo: forces the sequential runner" "$log" "cargo test --locked --workspace"
-expect_not_contains "override=cargo: skips nextest even when installed" "$log" "nextest run"
+capture_gate with-nextest
+expect_status "nextest present: gate succeeds" "$gate_status" 0
+expect_contains "nextest present: runs the parallel runner" "$gate_log" "cargo nextest run"
+expect_not_contains "nextest present: does not also run cargo test" "$gate_log" "cargo test"
 
-log="$(run_gate without-nextest env IRONCLAW_PREPUSH_TEST=0)"
-expect_not_contains "IRONCLAW_PREPUSH_TEST=0: runs no tests at all" "$log" "--workspace"
-expect_contains "IRONCLAW_PREPUSH_TEST=0: still runs clippy" "$log" "clippy"
+capture_gate without-nextest
+expect_status "nextest absent: gate succeeds" "$gate_status" 0
+expect_contains "nextest absent: falls back to cargo test" "$gate_log" "cargo test --locked --workspace"
+expect_not_contains "nextest absent: does not invoke nextest" "$gate_log" "nextest run"
+
+capture_gate with-nextest IRONCLAW_GATE_TEST_RUNNER=cargo
+expect_status "override=cargo: gate succeeds" "$gate_status" 0
+expect_contains "override=cargo: forces the sequential runner" "$gate_log" "cargo test --locked --workspace"
+expect_not_contains "override=cargo: skips nextest even when installed" "$gate_log" "nextest run"
+
+capture_gate without-nextest IRONCLAW_PREPUSH_TEST=0
+expect_status "IRONCLAW_PREPUSH_TEST=0: gate succeeds" "$gate_status" 0
+expect_not_contains "IRONCLAW_PREPUSH_TEST=0: runs no tests at all" "$gate_log" "--workspace"
+expect_contains "IRONCLAW_PREPUSH_TEST=0: still runs clippy" "$gate_log" "clippy"
+
+capture_gate without-nextest IRONCLAW_GATE_TEST_RUNNER=nextest
+expect_failure "override=nextest: fails when cargo-nextest is absent" "$gate_status"
+
+capture_gate with-nextest IRONCLAW_GATE_TEST_RUNNER=invalid
+expect_failure "invalid runner: gate fails" "$gate_status"
 
 # Coverage parity is the reason this swap is safe: `--all-targets` never
 # included doctests, so neither runner loses them.
-log="$(run_gate with-nextest)"
-expect_contains "nextest run keeps --all-targets --all-features" "$log" "--all-targets --all-features"
+capture_gate with-nextest
+expect_status "coverage parity: gate succeeds" "$gate_status" 0
+expect_contains "nextest run keeps --all-targets --all-features" "$gate_log" "--all-targets --all-features"
 
 if [ "$failures" -ne 0 ]; then
     echo "$failures check(s) failed"


### PR DESCRIPTION
## Summary

- Run the local pre-push workspace test suite with `cargo nextest` when available, falling back to `cargo test` without changing target coverage.
- Support deterministic `auto`, `nextest`, and `cargo` selection; explicit `nextest` now fails clearly when cargo-nextest is unavailable.
- Make runner-selection regressions blocking by asserting gate exit statuses, covering the complete success/failure/disabled matrix, and registering the shell suite in Code Style CI.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — attempted locally in an isolated target, then interrupted when another concurrent workspace build reduced free disk below 2 GiB. The post-push Code Style roll-up passed; CI correctly skipped its full workspace clippy matrix for this CI/test-only diff.
- [ ] `cargo build` — Not applicable: no Rust source or dependency changes.
- [x] Relevant tests pass: `TMPDIR=/tmp bash scripts/ci/test-quality-gate-runner.sh`; `python3 scripts/ci/test_ws12_workflow_contracts.py`; `bash scripts/pre-commit-safety.sh`; `git diff --check`; post-push Fast deterministic checks.
- [ ] `cargo test --features integration` — Not applicable: no database-backed or product integration behavior changed.
- [x] Manual testing: reran the harness with hostile exported `IRONCLAW_GATE_TEST_RUNNER` and `IRONCLAW_PREPUSH_TEST` values; deterministic defaults and per-case overrides still passed.
- [x] Review feedback workflow completed; all CodeRabbit and IronLoop findings were verified, addressed, replied to, and resolved.

## Test Strategy

User behavior: A developer running the pre-push gate gets the parallel nextest runner when installed, a cargo-test fallback otherwise, and a clear failure for an explicitly required but unavailable runner.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Updated `scripts/ci/test-quality-gate-runner.sh` to assert zero/non-zero statuses, deterministic environment defaults, automatic and explicit runner selection, disabled tests, missing nextest, invalid values, and coverage flags for both runners. Added it to Code Style's static-check self-tests.
- Reborn integration: Not applicable: this changes only a local/CI shell gate.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: no user interface changed.
- Backend or runtime: Not applicable: no backend/runtime behavior changed.
- Live canary: Not applicable: no provider behavior changed.

What the tests prove: The selected runner and arguments are correct, successful branches return zero, error branches return non-zero, ambient environment cannot corrupt default cases, disabled workspace tests invoke neither runner while retaining clippy, both runners preserve target/feature coverage flags, and CI executes the regression harness.

Commands run:
- `TMPDIR=/tmp bash scripts/ci/test-quality-gate-runner.sh`
- `IRONCLAW_GATE_TEST_RUNNER=invalid IRONCLAW_PREPUSH_TEST=0 TMPDIR=/tmp bash scripts/ci/test-quality-gate-runner.sh`
- `python3 scripts/ci/test_ws12_workflow_contracts.py`
- `bash scripts/pre-commit-safety.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- GitHub: Code Style, Fast deterministic checks, Tests (Reborn), Reborn E2E, Platform & Compat, hook parity, recorded fixtures, Regression test enforcement, and CodeRabbit all passed.

## Security Impact

None. Runner selection stays local to the pre-push quality gate and does not change permissions, networking, secrets, file access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

N/A: no Reborn, security, runtime, persistence, status-contract, or trust-boundary behavior changed.

## Database Impact

None.

## Blast Radius

Limited to the local pre-push quality gate and the Code Style static-check self-test lane. A regression can block pushes/CI; it cannot change shipped runtime behavior.

## Rollback Plan

Revert `92998fe37` and `1622f0dbe` to remove the review follow-ups, or also revert the original runner-selection commit to restore the prior sequential `cargo test` gate.

## Review Follow-Through

All three actionable threads across two review rounds are addressed and resolved. The final post-push CI run is green with no failing or pending checks.

---

**Review track**: C (CI)
