### PR TITLE
ci: move coverage to main CI — PR and merge-queue lanes run uninstrumented (Ben+Firat decision)

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -806,9 +806,21 @@ jobs:
         run: python3 scripts/ci/test_reborn_changed_coverage.py
 
       - name: Gate changed Reborn lines and branches
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
+        # Owner decision 2026-08-04 (Ben + Firat, reversing the "leave CI
+        # policy as-is" note recorded on #7036): the changed-line verdict no
+        # longer blocks PRs or the merge queue. For move-heavy refactors it
+        # re-attributes relocated code as new-and-uncovered, and because this
+        # job runs last its verdict lands after the full hour of test lanes —
+        # the worst feedback shape the program has. It still RUNS on both
+        # lanes for visibility (step summary, sticky comment, and this step's
+        # red annotation), and it ENFORCES on pushes to main, where
+        # main-ci-slack-alerts.yml surfaces a breach. The aggregate and
+        # per-crate coverage floors are untouched and still gate everywhere
+        # they always did.
+        continue-on-error: ${{ github.event_name != 'push' }}
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           # `gh` resolves the base commit's merged-lcov artifact. The checkout
           # runs with persist-credentials: false, so the token is passed here

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -164,7 +164,17 @@ jobs:
           echo "run_group_tests=$(jq -r '.run_group_tests' <<< "${plan}")" >> "$GITHUB_OUTPUT"
           echo "run_integration_tests=$(jq -r '.integration_lanes | length > 0' <<< "${plan}")" >> "$GITHUB_OUTPUT"
           echo "integration_lanes=$(jq -c '.integration_lanes' <<< "${plan}")" >> "$GITHUB_OUTPUT"
-          echo "run_coverage=$(jq -r '.coverage_mode == "full"' <<< "${plan}")" >> "$GITHUB_OUTPUT"
+          # Owner decision 2026-08-04 (Ben + Firat): coverage collection,
+          # the report job, the floors, and the changed-line gate all run on
+          # pushes to main ONLY. PR and merge-queue lanes run plain
+          # (uninstrumented) tests — llvm-cov overhead was a large share of
+          # the ~hour cycle — and a post-merge coverage breach lands as a red
+          # main run that main-ci-slack-alerts.yml announces, fixed forward.
+          run_coverage="$(jq -r '.coverage_mode == "full"' <<< "${plan}")"
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            run_coverage=false
+          fi
+          echo "run_coverage=${run_coverage}" >> "$GITHUB_OUTPUT"
           echo "run_qa_replay=$(jq -r '.run_qa_replay' <<< "${plan}")" >> "$GITHUB_OUTPUT"
 
           scripts/ci/check-test-suite-boundaries.sh
@@ -1070,13 +1080,21 @@ jobs:
               "${{ needs.changes.outputs.run_root_tests }}" \
               "${{ needs.changes.outputs.run_group_tests }}" \
               "${{ needs.changes.outputs.run_integration_tests }}" \
-              "${{ needs.changes.outputs.run_coverage }}" \
               "${{ needs.changes.outputs.run_qa_replay }}"; do
               if [[ "${flag}" != "true" ]]; then
                 echo "Full Reborn plan omitted a required lane"
                 exit 1
               fi
             done
+            # Coverage is push-only by owner decision (2026-08-04, Ben +
+            # Firat): full-mode merge_group runs plain tests, so run_coverage
+            # must be true exactly when the event is a push and false
+            # otherwise — either mismatch is a wiring bug worth failing on.
+            expected_coverage=${{ github.event_name == 'push' }}
+            if [[ "${{ needs.changes.outputs.run_coverage }}" != "${expected_coverage}" ]]; then
+              echo "run_coverage=${{ needs.changes.outputs.run_coverage }} but expected ${expected_coverage} for ${{ github.event_name }}"
+              exit 1
+            fi
           fi
 
           check_planned_job() {


### PR DESCRIPTION
Implements the full team decision from today (Ben + Firat; reverses the "leave CI policy as-is" note recorded on #7036), in two commits:

**Commit 1 — the changed-line verdict stops blocking.** `continue-on-error` on PR/queue lanes (still runs, still annotates, still posts the sticky comment); enforces on pushes to main.

**Commit 2 — the whole coverage apparatus moves to main.** `run_coverage` is gated to `push` events only, and every consumer keys off that one output: PR and merge-queue lanes now run **plain uninstrumented `cargo test`** — no llvm-cov overhead (a large share of the ~hour cycle), no coverage-report join at the end, no floors, no changed-line gate. On pushes to main the full apparatus runs and **enforces** exactly as before, with `main-ci-slack-alerts.yml` surfacing any breach for fix-forward.

**The deliberate trade, stated plainly:** a coverage-losing PR can now land before the alarm rings — the protection is post-merge (red main + Slack alert) instead of pre-merge blocking. That is exactly what was chosen, because the pre-merge shape was costing hour-long cycles that failed at the very end, always on move-heavy refactors where the changed-line gate re-attributes relocated code as new.

**Wiring safety:** the `Tests (Reborn)` rollup's full-mode completeness check now asserts `run_coverage == (event == push)` and fails on either mismatch, so the gating cannot silently drift; `coverage-report` skipping on PR/queue is expected-skipped by the existing `check_planned_job` logic.

Verified: YAML parses, `ws12_workflow_contracts.py` green, planner suite OK, every `run_coverage` consumer keys off the gated output (grep audit in the PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)