### PR TITLE
fix(filesystem): skip the parent-directory fsync on Windows

### DIFF
--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -225,6 +225,17 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Check compilation
         run: cargo check --all --benches --tests --examples ${{ matrix.flags }}
+      # Compilation alone never caught that DiskFilesystem could not complete a
+      # single write on Windows (the parent-directory fsync opened a directory
+      # as a file, which Windows refuses) — it took a tagged release to surface
+      # it. This is the one lane that actually EXECUTES Rust on Windows, so it
+      # owns the platform-behavior regression. Scoped to the local backend's own
+      # tests on a single matrix leg: `cargo check --tests` above already
+      # compiled them, so the marginal cost is linking and running one small
+      # test binary.
+      - name: Test local filesystem backend behavior on Windows
+        if: matrix.name == 'default'
+        run: cargo test -p ironclaw_filesystem --lib local::
 
   wasm-wit-compat:
     name: WASM WIT Compatibility

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -819,6 +819,20 @@ async fn sync_parent_dir(virtual_path: &VirtualPath, parent: &Path) -> Result<()
     sync_parent_dir_for_operation(virtual_path, parent, FilesystemOperation::WriteFile).await
 }
 
+/// Durability barrier for the rename/hard-link install in
+/// [`atomic_write_file`]: on POSIX the directory entry itself is only durable
+/// once the parent directory's own fsync returns, so the file's fsync is not
+/// sufficient.
+///
+/// Windows has no equivalent, and no way to fake one. `CreateFileW` refuses to
+/// return a handle to a directory unless the caller passes
+/// `FILE_FLAG_BACKUP_SEMANTICS`, which `std::fs::File::open` never sets — so
+/// this open failed with `ERROR_ACCESS_DENIED` on every single write. Adding
+/// the flag would not rescue it either: `FlushFileBuffers` requires write
+/// access, which a directory handle cannot carry, so the `sync_all` would fail
+/// next. NTFS journals the directory-entry metadata as part of the install
+/// operation, so the barrier POSIX needs here does not apply.
+#[cfg(not(windows))]
 async fn sync_parent_dir_for_operation(
     virtual_path: &VirtualPath,
     parent: &Path,
@@ -830,6 +844,15 @@ async fn sync_parent_dir_for_operation(
     dir.sync_all()
         .await
         .map_err(|error| io_error(virtual_path.clone(), operation, error))
+}
+
+#[cfg(windows)]
+async fn sync_parent_dir_for_operation(
+    _virtual_path: &VirtualPath,
+    _parent: &Path,
+    _operation: FilesystemOperation,
+) -> Result<(), FilesystemError> {
+    Ok(())
 }
 
 /// For a [`LocalMount::leaf_scoped`] mount, the shared `host_root` one level
@@ -1193,5 +1216,61 @@ mod tests {
             "expected SymlinkEscape, got: {error:?}"
         );
         assert!(!leaf_b.join("planted.txt").exists());
+    }
+
+    /// Every `atomic_write_file` install is followed by a parent-directory
+    /// fsync, which on Unix means opening the directory as a file. Windows'
+    /// `CreateFileW` refuses a directory handle unless the caller passes
+    /// `FILE_FLAG_BACKUP_SEMANTICS` — which `std` never does — so that open
+    /// returned `ERROR_ACCESS_DENIED`, surfaced as
+    /// `FilesystemError::Backend { reason: "permission denied" }` against the
+    /// *file's* path even though the file had already been written. Effect:
+    /// `DiskFilesystem` could not complete a single write on Windows, which
+    /// took down bundled-skill install and therefore every Reborn runtime
+    /// assembly on that platform (release run 30934516977).
+    ///
+    /// Both CAS shapes are covered because they take different install paths
+    /// (`rename` vs `hard_link`) into the same trailing fsync, and
+    /// `CasExpectation::Absent` is the one the bundled-skill install lock
+    /// uses.
+    #[tokio::test]
+    async fn writes_survive_the_parent_directory_sync_on_every_platform() {
+        let storage = tempdir().unwrap();
+        let mut root = DiskFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let lock = VirtualPath::new("/projects/system/skills/.install.lock").unwrap();
+        root.put(
+            &lock,
+            Entry::bytes(b"held".to_vec()),
+            CasExpectation::Absent,
+        )
+        .await
+        .expect("CAS-absent install must not fail on the parent-directory sync");
+        assert_eq!(root.read_file(&lock).await.unwrap(), b"held");
+
+        let plain = VirtualPath::new("/projects/system/skills/SKILL.md").unwrap();
+        root.write_file(&plain, b"bundled")
+            .await
+            .expect("plain write must not fail on the parent-directory sync");
+        assert_eq!(root.read_file(&plain).await.unwrap(), b"bundled");
+
+        // The lock is still held: a second CAS-absent install must lose.
+        let conflict = root
+            .put(
+                &lock,
+                Entry::bytes(b"stolen".to_vec()),
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(conflict, FilesystemError::VersionMismatch { .. }),
+            "expected VersionMismatch, got: {conflict:?}"
+        );
     }
 }


### PR DESCRIPTION
## What broke

Release run [30934516977](https://github.com/nearai/ironclaw/actions/runs/30934516977) (tag `ironclaw-v1.1.0-rc.1`) failed the `x86_64-pc-windows-msvc` leg of `build-local-artifacts`, blocking the four downstream release jobs (`build-global-artifacts`, `host`, `docker-image`, `announce`). No GitHub release was ever created.

```
ironclaw.exe extension search --json
Error: failed to assemble Reborn runtime for extension lifecycle command
Caused by:
  filesystem backend error during write_file at
    /projects/system/skills/.ironclaw-reborn-bundled.lock: permission denied
```

## Root cause

`atomic_write_file` (`crates/ironclaw_filesystem/src/local.rs:687`) follows every rename/hard-link install with a parent-directory fsync. On POSIX that means opening the directory as a file. Windows' `CreateFileW` refuses to return a directory handle unless the caller passes `FILE_FLAG_BACKUP_SEMANTICS`, which `std::fs::File::open` never sets — so the open returned `ERROR_ACCESS_DENIED`, mapped to `ErrorKind::PermissionDenied`, whose `to_string()` is literally `permission denied`.

The error message misdirects twice: it names the **lock file** and the `write_file` op, but the write had already succeeded — `hard_link` landed the file on disk. The syscall that actually failed targeted the **`system/skills/` directory**.

Adding the flag would not have rescued it: `FlushFileBuffers` requires write access, which a directory handle cannot carry, so the `sync_all` would fail next. Windows has no directory-fsync equivalent; NTFS journals the directory-entry metadata as part of the install operation. So the barrier is `#[cfg(windows)]`-skipped rather than emulated.

## Blast radius

This is a product bug, not just a CI bug — any Windows user running `ironclaw` hits it at runtime assembly.

`sync_parent_dir_for_operation` has two unconditional production callers — `atomic_write_file:687` (every `put`/`write_file`) and `publish_local_atomic_subtree:795` (`create_subtree_atomic`). `ensure_bundled_reborn_skills_installed` reaches them ~20+ times: the install lock, every file of all 19 bundled skills, and every marker. **`DiskFilesystem` has never been able to complete a single write on Windows.** The fix therefore lands in the shared helper, not at a call site — patching only the lock-acquire site would move the same failure to the very next `put`.

## Why nothing caught it

| Lane | Runs on Windows | Executes this code |
|---|---|---|
| `ironclaw-release.yml` | yes | yes — smoke step added in #6881, 2026-07-30 |
| `reborn-release-compile.yml` | yes | `workflow_call`/`workflow_dispatch` only, **no caller**; last run 2026-07-20, predates the smoke |
| `platform-and-compat.yml` → `windows-build` | yes | `cargo check` only — no tests ever executed on Windows |
| `code_style.yml` → `reborn-cli-smoke` | no | ubuntu only |

Tags `ironclaw-v1.0.0` (2026-07-27) and `ironclaw-v1.0.0-rc.1` (2026-07-21) both predate the smoke step. **This run was its first ever execution on Windows** — not a regression, first exposure.

`local.rs` had 3 `#[cfg(unix)]` blocks (all symlink-escape security tests), 0 `#[cfg(windows)]`, and the word "windows" appeared nowhere in the file. The existing test `leaf_scoped_mount_creates_a_brand_new_leaf_on_first_write` is not unix-gated and would have failed on Windows today — it simply never ran there.

## Regression coverage

`windows-build` now also runs the local backend's own tests. It is the only lane that executes Rust on Windows at all, so it owns this class. Cost is close to zero: the job already gates on `push`/deep (never PR or merge_group), and its existing `cargo check --all --tests` already compiles the test code — the marginal cost is linking and running one small test binary, scoped to the `default` matrix leg and the `local::` module.

The new test `writes_survive_the_parent_directory_sync_on_every_platform` drives both CAS shapes — `CasExpectation::Absent` (the `hard_link` path the bundled-skill install lock uses) and a plain `write_file` (the `rename` path) — through the trailing fsync, and asserts the lock still conflicts correctly afterward. It passes on Unix and fails on Windows without this fix.

## Verification

- `cargo test -p ironclaw_filesystem --lib` — 144 passed
- `cargo test -p ironclaw_filesystem --test filesystem_contract --test catalog_contract` — 31 passed
- `cargo clippy -p ironclaw_filesystem --all-targets --all-features -- -D warnings` — clean
- `scripts/pre-commit-safety.sh` — 3 findings, all in `crates/ironclaw_reborn_traces/src/contribution.rs`, untouched by this diff and pre-existing on the base branch

Red/green for this bug is Windows-only by nature; the new CI lane is what proves it.

## Follow-ups (not in this PR)

- **Windows junctions bypass symlink containment.** Every symlink-rejection check on this path (`local.rs:162`, `local.rs:920`, `bundled_skills.rs:44,55,107,152,176,187`) uses Rust's `is_symlink()`, which matches `IO_REPARSE_TAG_SYMLINK` only. NTFS junctions use `IO_REPARSE_TAG_MOUNT_POINT` — they report `is_dir() == true`, `is_symlink() == false`, and pass straight through `resolve_for_write` / `ensure_contained` / `reject_existing_symlink`. This is the Windows analogue of exactly what the three `#[cfg(unix)]` escape tests defend against, with no Windows equivalent. Worth its own issue.
- `hard_link` (`local.rs:649`) fails outright on exFAT/FAT32/SMB, aborting install — only bites if `IRONCLAW_REBORN_HOME` points at a network or USB volume.
- `SkillFilePath` validation (`skill_bundle_source.rs:126-143`) does not reject Windows reserved names (`CON`, `NUL`, `COM1`…) or `< > " | ? *`. None of the 19 embedded skills trip it today.
- Nothing calls `reborn-release-compile.yml`, so a tag can still be pushed with an entirely unverified Windows binary. Wiring it into `cut-ironclaw-release.yml` would close that.

Checked clean: `\\?\` verbatim containment is self-consistent (both sides canonicalized, so `starts_with` holds — and it incidentally makes these writes `MAX_PATH`-immune); path-separator handling is correct; no delete-while-open hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)