### PR TITLE
ci: quote the Windows test filter so the workflow file parses

### DIFF
--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -235,7 +235,11 @@ jobs:
       # test binary.
       - name: Test local filesystem backend behavior on Windows
         if: matrix.name == 'default'
-        run: cargo test -p ironclaw_filesystem --lib local::
+        # Quoted because the `local::` module filter ends in a colon, which an
+        # unquoted YAML scalar reads as a mapping-key separator — that typo
+        # made the whole workflow file unparseable and took every job in it
+        # down, not just this step.
+        run: "cargo test -p ironclaw_filesystem --lib local::"
 
   wasm-wit-compat:
     name: WASM WIT Compatibility


### PR DESCRIPTION
Follow-up to #7182. My fault — that PR broke `.github/workflows/platform-and-compat.yml`.

## What happened

The step I added ended with an unquoted module filter:

```yaml
run: cargo test -p ironclaw_filesystem --lib local::
```

`local::` ends in a colon. A YAML plain scalar treats a trailing colon as a mapping-key separator, so the file stopped parsing at line 238:

```
mapping values are not allowed in this context at line 238 column 60
```

Because the file was unparseable, GitHub could not read the `on:` block either, so it could not apply the trigger filters. That is why run [30954261898](https://github.com/nearai/ironclaw/actions/runs/30954261898) shows up as a `push` run on `release/1.1.0-rc.1` even though this workflow only accepts `push` on `main`, and why it reported **zero jobs** — the whole file was rejected before any job was dispatched.

So the damage was not limited to the new step: **every job in Platform & Compat was down** while this was on the branch.

## Fix

Quote the scalar. Also left a comment on the line so the next person does not re-introduce it.

## Verification

- All 27 files under `.github/workflows/` parse (they did not before this commit)
- `windows-build`'s step list resolves with `run` intact: `run="cargo test -p ironclaw_filesystem --lib local::"`

## Two things worth knowing

**The Windows regression test has still never executed.** The lane was dead for the entire window this was merged, so #7182's fix is not yet proven by CI. And on a *valid* file this workflow does not run on pushes to `release/1.1.0-rc.1` at all — only `push` on `main`, PRs to `main`, `merge_group`, or a `nightly-deep-ci` `workflow_call`. Real verification for the release binary therefore comes from the smoke step in `ironclaw-release.yml` when the tag is re-cut.

**There is no workflow linting in this repo.** `rg -l "actionlint|yamllint" .github/ scripts/` returns nothing, and `scripts/pre-commit-safety.sh` does not parse workflow YAML — which is how an unparseable workflow reached a release branch. A parse check (actionlint, or a plain YAML load over `.github/workflows/*.yml`) would have caught this in seconds. Deliberately not bundled here to keep a release-blocking hotfix minimal; worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)