### PR TITLE
ci: pass the Windows identity variables to the release smoke

### DIFF
--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -53,7 +53,7 @@ PR_STATIC_CONTROL_PATHS = {
     "tests/integration/coverage-floor.toml",
     # Repo-root `scripts/` is deliberately NOT prefix-classified — the
     # `unmapped test or CI path` arm below exists to force a per-file decision.
-    # These two are decided:
+    # These are decided:
     #   * the panic baseline is enforced by Code Style
     #     (`check_no_panics.py --reborn-baseline`), which runs on every PR and
     #     owns the whole check; no Reborn lane reads it.
@@ -61,8 +61,15 @@ PR_STATIC_CONTROL_PATHS = {
     #     its own scope detector (`Detect Reborn E2E scope`). This planner
     #     selects lanes for `Tests (Reborn)` only, and that workflow does not
     #     invoke the script.
+    #   * `tests/test_smoke_release_binary.py` is run by Code Style
+    #     (`python3 -m unittest tests/test_smoke_release_binary.py`), whose
+    #     changed-path filter already names it. It exercises a CI script with
+    #     `unittest`, not Reborn behavior with cargo, so no lane here reads it.
+    #     Its subject, `scripts/ci/smoke-release-binary.py`, is already covered
+    #     by the `scripts/ci/` prefix below.
     "scripts/no_panics_reborn_baseline.txt",
     "scripts/reborn-e2e-rust.sh",
+    "tests/test_smoke_release_binary.py",
 }
 PR_STATIC_CONTROL_PREFIXES = (".github/workflows/", "scripts/ci/")
 BUCKET_WEIGHTS = {

--- a/scripts/ci/smoke-release-binary.py
+++ b/scripts/ci/smoke-release-binary.py
@@ -24,6 +24,12 @@ REQUIRED_EVIDENCE = frozenset(
     }
 )
 REQUIRED_BUNDLED_RUNTIME_KINDS = frozenset({"first_party", "mcp_server", "wasm_tool"})
+# Kept minimal on purpose: the smoke has to prove the packaged binary works
+# from a clean environment, not from whatever the CI job happens to export.
+# USERNAME/USERDOMAIN are here because a real Windows session always sets them
+# and the product reads them when restricting ACLs on the standalone secrets
+# master key — withholding them made the harness less Windows-like than any
+# machine a user would run this on.
 _PASSTHROUGH_ENV = (
     "PATH",
     "SystemRoot",
@@ -32,6 +38,8 @@ _PASSTHROUGH_ENV = (
     "TMP",
     "TEMP",
     "LANG",
+    "USERNAME",
+    "USERDOMAIN",
 )
 
 

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -489,19 +489,26 @@ class RebornPrTestPlanTests(unittest.TestCase):
                 self.assertEqual(plan["integration_lanes"], [])
 
     def test_decided_repo_root_script_paths_are_owned_by_other_workflows(self) -> None:
-        """Repo-root `scripts/` files that another workflow owns.
+        """Repo-root `scripts/` and `tests/` files another workflow owns.
 
         The `unmapped test or CI path` arm deliberately refuses `scripts/**`
-        outside `scripts/ci/` so each file gets a decision rather than a
-        blanket prefix. These two have one, recorded beside the constant: the
-        panic baseline belongs to Code Style, and the E2E selector script
-        belongs to the `Reborn E2E` workflow's own scope detector. Neither
-        selects a lane in *this* planner — but the sibling that has no
-        decision must still refuse, which the second half asserts.
+        outside `scripts/ci/`, and bare `tests/**`, so each file gets a
+        decision rather than a blanket prefix. These have one, recorded beside
+        the constant: the panic baseline belongs to Code Style, the E2E
+        selector script belongs to the `Reborn E2E` workflow's own scope
+        detector, and the release-binary smoke's unit tests are run by Code
+        Style with `unittest`. None selects a lane in *this* planner — but the
+        sibling that has no decision must still refuse, which the second half
+        asserts.
+
+        The smoke entry is a regression: left undecided it aborted the whole
+        planner, failing `Detect Reborn test scope` and `Tests (Reborn)` on
+        any PR that touched the file.
         """
         for path in (
             "scripts/no_panics_reborn_baseline.txt",
             "scripts/reborn-e2e-rust.sh",
+            "tests/test_smoke_release_binary.py",
         ):
             with self.subTest(path=path):
                 plan = self.plan("pull_request", [path])

--- a/tests/test_smoke_release_binary.py
+++ b/tests/test_smoke_release_binary.py
@@ -8,6 +8,7 @@ import subprocess
 import tarfile
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -287,3 +288,47 @@ else:
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class IsolatedEnvironmentTests(unittest.TestCase):
+    """The smoke runs the packaged binary in a scrubbed environment. What that
+    environment does and does not carry is a contract, not an accident."""
+
+    def test_windows_identity_variables_reach_the_binary(self) -> None:
+        # The product resolves the ACL grantee for the standalone secrets
+        # master key from these when the process-token lookup is unavailable.
+        # Dropping them made `extension search --json` abort with "USERNAME is
+        # unset" on Windows, which is what failed release preflight 30955514028.
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            with unittest.mock.patch.dict(
+                os.environ,
+                {"USERNAME": "runneradmin", "USERDOMAIN": "CORP", "PATH": "/usr/bin"},
+                clear=True,
+            ):
+                environment = SMOKE._isolated_environment(root)
+
+        self.assertEqual(environment["USERNAME"], "runneradmin")
+        self.assertEqual(environment["USERDOMAIN"], "CORP")
+
+    def test_ambient_configuration_is_still_scrubbed(self) -> None:
+        # The passthrough list is an allow-list; widening it for Windows
+        # identity must not turn it into "inherit the CI job's environment".
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://leaked",
+                    "ANTHROPIC_API_KEY": "leaked",
+                    "IRONCLAW_REBORN_PROFILE": "production",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ):
+                environment = SMOKE._isolated_environment(root)
+
+        self.assertNotIn("DATABASE_URL", environment)
+        self.assertNotIn("ANTHROPIC_API_KEY", environment)
+        self.assertNotIn("IRONCLAW_REBORN_PROFILE", environment)
+        self.assertEqual(environment["IRONCLAW_DISABLE_OS_KEYCHAIN"], "1")


### PR DESCRIPTION
**Scope reduced.** This PR previously also changed how the product resolves the Windows ACL account. That is now removed — it touches behavior that has shipped since 1.0.0, and a release branch is the wrong place to change it. See "Deliberately not fixed here" below.

## The blocker

Preflight run [30955514028](https://github.com/nearai/ironclaw/actions/runs/30955514028) got past the parent-directory fsync bug fixed in #7182 — 6 of 7 targets green — and Windows failed with:

```
Error: failed to assemble Reborn runtime for extension lifecycle command
Caused by:
  0: reborn runtime build failed: invalid reborn composition configuration:
     standalone secrets master key could not be restricted: USERNAME is unset
```

## Cause

`scripts/ci/smoke-release-binary.py` runs the packaged binary in a scrubbed environment built from an allow-list (`_PASSTHROUGH_ENV`). `USERNAME`/`USERDOMAIN` were not on it. The product reads those to pick the account `icacls` grants sole access to the standalone secrets master key, and fails closed when it cannot.

The GitHub Windows runner does set `USERNAME` (`runneradmin`) — the harness was explicitly withholding it.

## Fix

Add both to the allow-list. Every real Windows session sets them, so withholding them made the harness model a *service account* rather than a machine anyone would actually run this on. The smoke's job is to prove the packaged binary works the way a user runs it, so this makes it more faithful, not less.

No product change. The behavior being satisfied here has shipped since 1.0.0.

The allow-list exists to keep the smoke hermetic, so the widening is pinned by a test: ambient `DATABASE_URL`, `ANTHROPIC_API_KEY`, and `IRONCLAW_REBORN_PROFILE` must still be scrubbed, and `IRONCLAW_DISABLE_OS_KEYCHAIN` still forced. Widening the list must not become "inherit the CI job's environment."

## Verification

- `python3 -m unittest tests.test_smoke_release_binary` — 16 passed (2 new)
- Red-then-green confirmed: re-running `_isolated_environment` against the pre-fix allow-list leaves `USERNAME` absent and the new test fails
- Product code byte-identical to base (`git diff origin/release/1.1.0-rc.1 -- crates/` is empty)

## Deliberately not fixed here

A Windows service, container, or headless run can legitimately have `USERNAME` unset, and standalone boot aborts outright there. That is real, but it **predates 1.0.0, is not a regression, and is not exercised by the release**. The fix is a mechanism change — replacing env-var-derived ACL identity with a proper token lookup — that cannot be verified without a real Windows box; the only loop available is a ~35-minute preflight that tests exactly one identity on one runner configuration.

Tracking separately, off the release branch:

- Replace the env-var account with `GetUserNameExW` (`windows-sys` is already at 0.61.2 in the lock; `ironclaw_resources` sets the `[target.'cfg(windows)'.dependencies]` precedent, so this costs nothing on non-Windows). Evaluate whether `icacls /grant:r "*S-1-3-4:F"` (OWNER RIGHTS, a dynamic reference to the current owner) removes the need for an account name at all — but only behind real evidence, because if the file's owner resolves to the Administrators group, a UAC-filtered token carries that SID as deny-only and the user would lose access to their own key file.
- Move master-key provisioning out of `factory.rs` (1449 lines) into `ironclaw_secrets`, where the keychain code it belongs with already lives.
- On the icacls-failure path, `std::fs::remove_file(path)` runs while the file handle is still open. Windows will not delete a file with an open handle absent `FILE_SHARE_DELETE`, so the cleanup likely fails silently and leaves a zero-byte key file that makes the next boot's `create_new` fail with `AlreadyExists`.

## On the two review findings

Both were against the removed code, so they are moot here — but the reasoning should be on the record, because one of them is wrong and would otherwise propagate.

**ironloopai, 🔴 High, "resolve `whoami` from a trusted system path" — the stated mechanism is incorrect.** The claim is that `Command::new("whoami")` resolves via `CreateProcessW` with `lpApplicationName = NULL`, which searches the current directory before PATH. Current Rust std does not do that: for a bare program name it builds the search list itself and passes a fully-resolved `lpApplicationName`. The order is child PATH (only when set explicitly via `.env`), the directory containing the running exe, `GetSystemDirectoryW` (System32), the Windows directory, and the inherited PATH **last**. The current working directory is never consulted, and System32's real `whoami.exe` always wins ahead of any PATH entry. The only residual is write access to the directory holding `ironclaw.exe` — a strictly stronger compromise than replacing `ironclaw.exe` itself, so no new attack surface.

**chatgpt-codex, P2, "use a Unicode token API" — correct, and the better argument.** `whoami.exe` emits OEM/ANSI code page even when redirected to a pipe, so `String::from_utf8` reliably fails for non-ASCII account names. Impact was narrower than it reads: the fallback chain meant the common case silently degraded to the pre-existing env-var path rather than failing. But it points at the right conclusion for the wrong-severity reason — shelling out to a localized, human-facing diagnostic tool to obtain a value that becomes an ACL grantee is the defect; the encoding bug is just its symptom. That is why the follow-up uses the API rather than patching the decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)