### PR TITLE
fix(composition): stop icacls writing to the CLI's stdout on Windows

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -992,22 +992,37 @@ fn write_standalone_secret_master_key(path: &Path, key: &str) -> Result<(), Rebo
                 reason: "standalone secrets master key could not be restricted: USERNAME is unset"
                     .to_string(),
             })?;
-        let status = std::process::Command::new("icacls")
+        // `output()` rather than `status()` because `status()` lets the child
+        // inherit our stdio, and `icacls` announces itself on success:
+        //
+        //     processed file: C:\...\reborn-local-dev-secrets-master-key
+        //     Successfully processed 1 files; Failed processing 0 files
+        //
+        // Runtime assembly happens before a CLI command prints its own result,
+        // so on Windows that banner landed at the front of `ironclaw.exe`'s
+        // stdout and corrupted every `--json` command that boots a runtime —
+        // `extension search --json` emitted `processed file: ...` ahead of the
+        // JSON document. Capturing the pipes keeps the child's chatter out of
+        // our contract, and gives us its message to report when it fails.
+        let output = std::process::Command::new("icacls")
             .arg(path)
             .arg("/inheritance:r")
             .arg("/grant:r")
             .arg(format!("{account}:F"))
-            .status()
+            .output()
             .map_err(|error| RebornBuildError::InvalidConfig {
                 reason: format!(
                     "standalone secrets master key permissions could not be set: {error}"
                 ),
             })?;
-        if !status.success() {
+        if !output.status.success() {
             let _ = std::fs::remove_file(path);
+            let detail = String::from_utf8_lossy(&output.stderr);
+            let detail = detail.trim();
             return Err(RebornBuildError::InvalidConfig {
                 reason: format!(
-                    "standalone secrets master key permissions could not be set: icacls exited with {status}"
+                    "standalone secrets master key permissions could not be set: icacls exited with {}: {detail}",
+                    output.status
                 ),
             });
         }

--- a/scripts/ci/smoke-release-binary.py
+++ b/scripts/ci/smoke-release-binary.py
@@ -63,6 +63,15 @@ def _run_command(
             check=False,
             capture_output=True,
             text=True,
+            # The binary emits UTF-8 on every platform. Without an explicit
+            # encoding, `text=True` decodes with Python's locale encoding —
+            # the ANSI code page on Windows — which mangles any non-ASCII
+            # character in a JSON payload we are about to parse. `replace`
+            # keeps a decode problem visible as replacement characters in the
+            # failure message instead of raising an opaque UnicodeDecodeError
+            # from inside the runner.
+            encoding="utf-8",
+            errors="replace",
             env=environment,
             timeout=120,
         )
@@ -86,6 +95,17 @@ def _checked_output(
             f"{binary.name} {' '.join(args)} exited {result.returncode}\n"
             f"stdout:\n{stdout}\nstderr:\n{stderr}"
         )
+    # Every command this smoke runs is asserted on its stdout, so a silent
+    # success is always a failure. Catching it here — while stderr is still in
+    # hand — turns "exited 0 and printed nothing" into a report that says so,
+    # rather than a downstream decoder error that has already discarded the
+    # only evidence of what the binary did.
+    if not result.stdout.strip():
+        stderr = result.stderr[-4000:]
+        raise SmokeFailure(
+            f"{binary.name} {' '.join(args)} exited 0 but wrote nothing to stdout\n"
+            f"stderr:\n{stderr}"
+        )
     return result.stdout
 
 
@@ -93,7 +113,14 @@ def _parse_json_object(output: str, label: str) -> dict[str, object]:
     try:
         value = json.loads(output)
     except json.JSONDecodeError as error:
-        raise SmokeFailure(f"{label} did not emit valid JSON: {error}") from error
+        # Show what actually arrived. A bare decoder message cannot distinguish
+        # a leading BOM from a log line ahead of the payload from truncated
+        # output, and on a platform that only reproduces in CI that ambiguity
+        # costs a full release-preflight cycle to resolve.
+        raise SmokeFailure(
+            f"{label} did not emit valid JSON: {error}\n"
+            f"received {len(output)} characters: {output[:2000]!r}"
+        ) from error
     if not isinstance(value, dict):
         raise SmokeFailure(f"{label} must emit a JSON object")
     return value

--- a/tests/test_smoke_release_binary.py
+++ b/tests/test_smoke_release_binary.py
@@ -332,3 +332,69 @@ class IsolatedEnvironmentTests(unittest.TestCase):
         self.assertNotIn("ANTHROPIC_API_KEY", environment)
         self.assertNotIn("IRONCLAW_REBORN_PROFILE", environment)
         self.assertEqual(environment["IRONCLAW_DISABLE_OS_KEYCHAIN"], "1")
+
+
+class SmokeDiagnosticsTests(unittest.TestCase):
+    """When the binary misbehaves, the failure must carry the evidence.
+
+    These paths only ever reproduce on a platform we cannot run locally, so a
+    failure message that discards the binary's actual output costs a full
+    ~35-minute release-preflight cycle to re-learn what it already knew.
+    """
+
+    def setUp(self) -> None:
+        self.runner = FakeRunner()
+        self.temp = tempfile.TemporaryDirectory()
+        self.binary = Path(self.temp.name) / "ironclaw"
+        self.binary.write_text("#!/bin/sh\n")
+        self.binary.chmod(0o755)
+        self.addCleanup(self.temp.cleanup)
+
+    def test_silent_success_names_the_command_and_shows_stderr(self) -> None:
+        # Exit 0 with empty stdout is always a contract violation here: every
+        # command the smoke runs is asserted on its output.
+        self.runner.responses[("extension", "search", "--json")] = (
+            subprocess.CompletedProcess([], 0, stdout="   \n", stderr="runtime warning: catalog empty")
+        )
+
+        with self.assertRaises(SMOKE.SmokeFailure) as caught:
+            SMOKE.smoke_release_binary(self.binary, self.runner)
+
+        message = str(caught.exception)
+        self.assertIn("wrote nothing to stdout", message)
+        self.assertIn("extension search --json", message)
+        self.assertIn("runtime warning: catalog empty", message)
+
+    def test_unparseable_json_reports_what_was_actually_received(self) -> None:
+        # A leading BOM and a log line ahead of the payload produce the same
+        # bare decoder message; only the echoed output tells them apart.
+        self.runner.responses[("extension", "search", "--json")] = completed(
+            '﻿{"extensions": []}'
+        )
+
+        with self.assertRaises(SMOKE.SmokeFailure) as caught:
+            SMOKE.smoke_release_binary(self.binary, self.runner)
+
+        message = str(caught.exception)
+        self.assertIn("did not emit valid JSON", message)
+        self.assertIn("\\ufeff", message)
+        self.assertIn("characters", message)
+
+    def test_subprocess_banner_before_the_payload_is_shown_verbatim(self) -> None:
+        # The real Windows failure: `icacls`, spawned during runtime assembly,
+        # inherited the process's stdout and printed its success banner ahead
+        # of the JSON document. The old message said only "Expecting value:
+        # line 1 column 1 (char 0)", which named neither the intruder nor the
+        # fact that valid JSON followed it.
+        self.runner.responses[("extension", "search", "--json")] = completed(
+            "processed file: C:\\Users\\runneradmin\\key\n"
+            "Successfully processed 1 files; Failed processing 0 files\n"
+            '{"extensions": []}'
+        )
+
+        with self.assertRaises(SMOKE.SmokeFailure) as caught:
+            SMOKE.smoke_release_binary(self.binary, self.runner)
+
+        message = str(caught.exception)
+        self.assertIn("did not emit valid JSON", message)
+        self.assertIn("processed file", message)


### PR DESCRIPTION
Fourth Windows defect blocking `ironclaw-v1.1.0-rc.1`. Preflight [30962170467](https://github.com/nearai/ironclaw/actions/runs/30962170467) cleared the `USERNAME is unset` failure from #7197 and got further than any prior run — compile, `--version`, `--help`, `profile list --json` all pass — then:

```
SmokeFailure: extension search --json did not emit valid JSON:
  Expecting value: line 1 column 1 (char 0)
```

6 of 7 targets green. Windows the only failure.

## Cause

`write_standalone_secret_master_key` (`factory.rs:995`) restricts the key file by shelling out to `icacls` with `.status()`, which lets the child **inherit our stdio**. On success `icacls` prints its own banner:

```
processed file: C:\...\reborn-local-dev-secrets-master-key
Successfully processed 1 files; Failed processing 0 files
```

Runtime assembly happens before a CLI command prints its result, so that banner landed at the front of `ironclaw.exe`'s stdout. Character 0 was the `p` of `processed`. The command exited 0 and its JSON was intact — it just was no longer the only thing on stdout.

This corrupts **every `--json` command that builds a runtime**, not only the one the smoke happens to run.

Why `profile list --json` passed in the same run: it is pure in-process (`RebornProfile::all()` plus a `println!`) and never assembles a runtime. The Unix branch is unaffected — it sets `mode(0o600)` at open and spawns nothing. This is the only subprocess anywhere in the boot path.

It fires on essentially every fresh run: no cached key file, no `IRONCLAW_SECRETS_MASTER_KEY` override, and `IRONCLAW_DISABLE_OS_KEYCHAIN` makes the keychain miss deterministic, so the generate-fresh-key branch is always taken.

## Fix

`output()` instead of `status()` — captures both pipes. Keeps the child's chatter out of our stdout contract, and lets the failure path report what `icacls` actually said rather than only its exit status.

Deliberately minimal: this does not touch how the account is resolved, which is pre-existing behavior shipped since 1.0.0 and explicitly out of scope on a release branch (see #7197).

## Harness hardening

The smoke found this but **discarded the evidence** — it reported the decoder message with no sight of the output, which cost a full ~35-minute preflight cycle to diagnose. Fixed:

- a JSON parse failure now echoes the length and `repr` of what actually arrived, so a BOM, a banner, and truncation are distinguishable
- exit-0-with-empty-stdout is now called out by name, with stderr attached — every command here is asserted on its output, so silent success is always a contract violation
- subprocess output is decoded as UTF-8 explicitly. `text=True` alone uses Python's **locale** encoding — the ANSI code page on Windows — which would mangle any non-ASCII byte in a payload we are about to parse. Latent bug independent of this failure.

## Verification

- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings` — clean
- `cargo test -p ironclaw_reborn_composition --lib` — 552 passed
- `python3 -m unittest tests.test_smoke_release_binary` — 19 passed (3 new)
- Changed expressions type-checked standalone on the host, since `#[cfg(windows)]` hides them from every local build and cross-compiling the crate fails in `ring`'s C build

## Coverage gap, stated plainly

Regression coverage is at the smoke tier, which is where this class is actually reachable — the new harness tests pin that a leading banner, a BOM, and a silent success each name themselves. There is **no Windows Rust test lane that reaches this code**; #7182 added the only Windows test execution in CI and it is scoped to `ironclaw_filesystem`. The product fix itself is verified only by the next preflight run.

Four Windows defects have now been found one at a time, each by a tagged release or a manual preflight, because nothing automatic executes Windows. Wiring `reborn-release-compile.yml` into `cut-ironclaw-release.yml` remains the change that would stop this class from reaching a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)