### PR TITLE
test(extension_support): add bundle.rs test coverage for skill URL install module

### DIFF
--- a/crates/extensions/ironclaw_extension_support/src/skills/url_install/bundle.rs
+++ b/crates/extensions/ironclaw_extension_support/src/skills/url_install/bundle.rs
@@ -1,11 +1,11 @@
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use ironclaw_host_api::dispatch::RuntimeDispatchErrorKind;
 use ironclaw_skills::normalize_safe_relative_path;
 
 use crate::skills::SkillManagementCapabilityError;
 
-use super::{MAX_TOTAL_UNZIPPED_BYTES, MAX_ZIP_ENTRY_BYTES, SkillUrlPayload, SkillUrlPayloadFile};
+use super::{SkillUrlPayload, SkillUrlPayloadFile, MAX_TOTAL_UNZIPPED_BYTES, MAX_ZIP_ENTRY_BYTES};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SkillBundle {
@@ -138,13 +138,19 @@ mod tests {
     #[test]
     fn normalize_archive_path_rejects_absolute() {
         let result = normalize_archive_path(Path::new("/etc/passwd"));
-        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            RuntimeDispatchErrorKind::InputEncode
+        );
     }
 
     #[test]
     fn normalize_archive_path_rejects_upward_traversal() {
         let result = normalize_archive_path(Path::new("../escape"));
-        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            RuntimeDispatchErrorKind::InputEncode
+        );
     }
 
     #[test]
@@ -162,13 +168,19 @@ mod tests {
     #[test]
     fn normalize_archive_path_rejects_windows_backslash() {
         let result = normalize_archive_path(Path::new("my-skill\\SKILL.md"));
-        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            RuntimeDispatchErrorKind::InputEncode
+        );
     }
 
     #[test]
     fn normalize_archive_path_rejects_empty() {
         let result = normalize_archive_path(Path::new(""));
-        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            RuntimeDispatchErrorKind::InputEncode
+        );
     }
 
     #[test]
@@ -179,10 +191,7 @@ mod tests {
 
     #[test]
     fn strip_common_root_two_flat_files_no_strip() {
-        let paths = vec![
-            PathBuf::from("SKILL.md"),
-            PathBuf::from("config.json"),
-        ];
+        let paths = vec![PathBuf::from("SKILL.md"), PathBuf::from("config.json")];
         assert_eq!(strip_common_archive_root(&paths), None);
     }
 
@@ -255,12 +264,16 @@ mod tests {
             .push_file(
                 PathBuf::from("skill/SKILL.md"),
                 b"# Test Skill\n
-## Description\nA test.".to_vec(),
+## Description\nA test."
+                    .to_vec(),
             )
             .unwrap();
         let payload = collector.finish().unwrap();
-        assert_eq!(payload.content, "# Test Skill\n
-## Description\nA test.");
+        assert_eq!(
+            payload.content,
+            "# Test Skill\n
+## Description\nA test."
+        );
         assert!(payload.files.is_empty());
     }
 
@@ -268,16 +281,10 @@ mod tests {
     fn bundle_collector_push_extra_files() {
         let mut collector = BundleCollector::new(PathBuf::from("skill"));
         collector
-            .push_file(
-                PathBuf::from("skill/SKILL.md"),
-                b"content".to_vec(),
-            )
+            .push_file(PathBuf::from("skill/SKILL.md"), b"content".to_vec())
             .unwrap();
         collector
-            .push_file(
-                PathBuf::from("skill/config.json"),
-                b"{}".to_vec(),
-            )
+            .push_file(PathBuf::from("skill/config.json"), b"{}".to_vec())
             .unwrap();
         collector
             .push_file(
@@ -287,8 +294,14 @@ mod tests {
             .unwrap();
         let payload = collector.finish().unwrap();
         assert_eq!(payload.files.len(), 2);
-        assert!(payload.files.iter().any(|f| f.path == PathBuf::from("config.json")));
-        assert!(payload.files.iter().any(|f| f.path == PathBuf::from("scripts/setup.sh")));
+        assert!(payload
+            .files
+            .iter()
+            .any(|f| f.path == PathBuf::from("config.json")));
+        assert!(payload
+            .files
+            .iter()
+            .any(|f| f.path == PathBuf::from("scripts/setup.sh")));
     }
 
     #[test]
@@ -313,10 +326,7 @@ mod tests {
         let mut collector = BundleCollector::new(PathBuf::from("skill"));
         // Push SKILL.md first to avoid finish() error
         collector
-            .push_file(
-                PathBuf::from("skill/SKILL.md"),
-                b"valid".to_vec(),
-            )
+            .push_file(PathBuf::from("skill/SKILL.md"), b"valid".to_vec())
             .unwrap();
         // Push a file that would exceed total
         let big = vec![0u8; (MAX_TOTAL_UNZIPPED_BYTES + 1) as usize];
@@ -342,10 +352,7 @@ mod tests {
     fn bundle_collector_ignore_files_outside_root() {
         let mut collector = BundleCollector::new(PathBuf::from("subdir"));
         collector
-            .push_file(
-                PathBuf::from("subdir/SKILL.md"),
-                b"content".to_vec(),
-            )
+            .push_file(PathBuf::from("subdir/SKILL.md"), b"content".to_vec())
             .unwrap();
         let payload = collector.finish().unwrap();
         assert_eq!(payload.content, "content");

--- a/crates/extensions/ironclaw_extension_support/src/skills/url_install/bundle.rs
+++ b/crates/extensions/ironclaw_extension_support/src/skills/url_install/bundle.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 use ironclaw_host_api::dispatch::RuntimeDispatchErrorKind;
 use ironclaw_skills::normalize_safe_relative_path;
@@ -129,4 +129,242 @@ pub(super) fn strip_common_archive_root(paths: &[PathBuf]) -> Option<PathBuf> {
         return None;
     }
     root.map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_archive_path_rejects_absolute() {
+        let result = normalize_archive_path(Path::new("/etc/passwd"));
+        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn normalize_archive_path_rejects_upward_traversal() {
+        let result = normalize_archive_path(Path::new("../escape"));
+        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn normalize_archive_path_normalizes_dot_segments() {
+        let path = normalize_archive_path(Path::new("foo/./bar/./baz")).unwrap();
+        assert_eq!(path, PathBuf::from("foo/bar/baz"));
+    }
+
+    #[test]
+    fn normalize_archive_path_accepts_simple_relative() {
+        let path = normalize_archive_path(Path::new("my-skill/SKILL.md")).unwrap();
+        assert_eq!(path, PathBuf::from("my-skill/SKILL.md"));
+    }
+
+    #[test]
+    fn normalize_archive_path_rejects_windows_backslash() {
+        let result = normalize_archive_path(Path::new("my-skill\\SKILL.md"));
+        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn normalize_archive_path_rejects_empty() {
+        let result = normalize_archive_path(Path::new(""));
+        assert_eq!(result.unwrap_err().kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn strip_common_root_single_file_no_strip() {
+        let paths = vec![PathBuf::from("SKILL.md")];
+        assert_eq!(strip_common_archive_root(&paths), None);
+    }
+
+    #[test]
+    fn strip_common_root_two_flat_files_no_strip() {
+        let paths = vec![
+            PathBuf::from("SKILL.md"),
+            PathBuf::from("config.json"),
+        ];
+        assert_eq!(strip_common_archive_root(&paths), None);
+    }
+
+    #[test]
+    fn strip_common_root_nested_with_common_prefix() {
+        let paths = vec![
+            PathBuf::from("my-skill-repo/SKILL.md"),
+            PathBuf::from("my-skill-repo/tools/helper.rs"),
+        ];
+        assert_eq!(
+            strip_common_archive_root(&paths).as_deref(),
+            Some(Path::new("my-skill-repo"))
+        );
+    }
+
+    #[test]
+    fn strip_common_root_no_common_prefix() {
+        let paths = vec![
+            PathBuf::from("repo-a/SKILL.md"),
+            PathBuf::from("repo-b/SKILL.md"),
+        ];
+        assert_eq!(strip_common_archive_root(&paths), None);
+    }
+
+    #[test]
+    fn strip_common_root_absolute_components_return_none() {
+        let paths = vec![PathBuf::from("/absolute/SKILL.md")];
+        assert_eq!(strip_common_archive_root(&paths), None);
+    }
+
+    #[test]
+    fn bundle_collector_new_accepts_root_path() {
+        let collector = BundleCollector::new(PathBuf::from("my-skill"));
+        assert_eq!(collector.root, PathBuf::from("my-skill"));
+        assert_eq!(collector.skill_md, None);
+        assert!(collector.files.is_empty());
+        assert_eq!(collector.total_bytes, 0);
+    }
+
+    #[test]
+    fn bundle_collector_relative_path_returns_relative() {
+        let collector = BundleCollector::new(PathBuf::from("root"));
+        let rel = collector
+            .relative_path(Path::new("root/sub/file.txt"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(rel, PathBuf::from("sub/file.txt"));
+    }
+
+    #[test]
+    fn bundle_collector_relative_path_returns_none_for_root_itself() {
+        let collector = BundleCollector::new(PathBuf::from("root"));
+        let rel = collector.relative_path(Path::new("root")).unwrap();
+        assert_eq!(rel, None);
+    }
+
+    #[test]
+    fn bundle_collector_relative_path_errors_on_mismatch() {
+        let collector = BundleCollector::new(PathBuf::from("root"));
+        let err = collector
+            .relative_path(Path::new("other/file.txt"))
+            .unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[test]
+    fn bundle_collector_push_skill_md_then_finish() {
+        let mut collector = BundleCollector::new(PathBuf::from("skill"));
+        collector
+            .push_file(
+                PathBuf::from("skill/SKILL.md"),
+                b"# Test Skill\n
+## Description\nA test.".to_vec(),
+            )
+            .unwrap();
+        let payload = collector.finish().unwrap();
+        assert_eq!(payload.content, "# Test Skill\n
+## Description\nA test.");
+        assert!(payload.files.is_empty());
+    }
+
+    #[test]
+    fn bundle_collector_push_extra_files() {
+        let mut collector = BundleCollector::new(PathBuf::from("skill"));
+        collector
+            .push_file(
+                PathBuf::from("skill/SKILL.md"),
+                b"content".to_vec(),
+            )
+            .unwrap();
+        collector
+            .push_file(
+                PathBuf::from("skill/config.json"),
+                b"{}".to_vec(),
+            )
+            .unwrap();
+        collector
+            .push_file(
+                PathBuf::from("skill/scripts/setup.sh"),
+                b"#!/bin/sh".to_vec(),
+            )
+            .unwrap();
+        let payload = collector.finish().unwrap();
+        assert_eq!(payload.files.len(), 2);
+        assert!(payload.files.iter().any(|f| f.path == PathBuf::from("config.json")));
+        assert!(payload.files.iter().any(|f| f.path == PathBuf::from("scripts/setup.sh")));
+    }
+
+    #[test]
+    fn bundle_collector_finish_errors_without_skill_md() {
+        let collector = BundleCollector::new(PathBuf::from("skill"));
+        let err = collector.finish().unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[test]
+    fn bundle_collector_rejects_entry_over_limit() {
+        let mut collector = BundleCollector::new(PathBuf::from("skill"));
+        let oversized = vec![0u8; (MAX_ZIP_ENTRY_BYTES + 1) as usize];
+        let err = collector
+            .push_file(PathBuf::from("skill/big.bin"), oversized)
+            .unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+
+    #[test]
+    fn bundle_collector_rejects_total_over_limit() {
+        let mut collector = BundleCollector::new(PathBuf::from("skill"));
+        // Push SKILL.md first to avoid finish() error
+        collector
+            .push_file(
+                PathBuf::from("skill/SKILL.md"),
+                b"valid".to_vec(),
+            )
+            .unwrap();
+        // Push a file that would exceed total
+        let big = vec![0u8; (MAX_TOTAL_UNZIPPED_BYTES + 1) as usize];
+        let err = collector
+            .push_file(PathBuf::from("skill/big.bin"), big)
+            .unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+
+    #[test]
+    fn bundle_collector_rejects_invalid_utf8_in_skill_md() {
+        let mut collector = BundleCollector::new(PathBuf::from("skill"));
+        let err = collector
+            .push_file(
+                PathBuf::from("skill/SKILL.md"),
+                vec![0xff, 0xfe, 0x00, 0x01],
+            )
+            .unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[test]
+    fn bundle_collector_ignore_files_outside_root() {
+        let mut collector = BundleCollector::new(PathBuf::from("subdir"));
+        collector
+            .push_file(
+                PathBuf::from("subdir/SKILL.md"),
+                b"content".to_vec(),
+            )
+            .unwrap();
+        let payload = collector.finish().unwrap();
+        assert_eq!(payload.content, "content");
+    }
+
+    #[test]
+    fn strip_common_root_single_nested_file_no_strip() {
+        // One deeply nested file: the root is the parent, but has_nested is false
+        let paths = vec![PathBuf::from("my-skill-repo/SKILL.md")];
+        assert_eq!(strip_common_archive_root(&paths), None);
+    }
+
+    #[test]
+    fn strip_common_root_mixed_prefixes_return_none() {
+        let paths = vec![
+            PathBuf::from("v1-skill/SKILL.md"),
+            PathBuf::from("v1-skill/helper.txt"),
+            PathBuf::from("v2-skill/README.md"),
+        ];
+        assert_eq!(strip_common_archive_root(&paths), None);
+    }
 }

--- a/crates/extensions/ironclaw_extension_support/src/skills/url_install/bundle.rs
+++ b/crates/extensions/ironclaw_extension_support/src/skills/url_install/bundle.rs
@@ -5,7 +5,7 @@ use ironclaw_skills::normalize_safe_relative_path;
 
 use crate::skills::SkillManagementCapabilityError;
 
-use super::{SkillUrlPayload, SkillUrlPayloadFile, MAX_TOTAL_UNZIPPED_BYTES, MAX_ZIP_ENTRY_BYTES};
+use super::{MAX_TOTAL_UNZIPPED_BYTES, MAX_ZIP_ENTRY_BYTES, SkillUrlPayload, SkillUrlPayloadFile};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SkillBundle {
@@ -166,12 +166,13 @@ mod tests {
     }
 
     #[test]
-    fn normalize_archive_path_rejects_windows_backslash() {
-        let result = normalize_archive_path(Path::new("my-skill\\SKILL.md"));
-        assert_eq!(
-            result.unwrap_err().kind(),
-            RuntimeDispatchErrorKind::InputEncode
-        );
+    fn normalize_archive_path_keeps_backslash_as_plain_segment() {
+        // On unix hosts `\` is an ordinary filename byte, not a separator, so a
+        // zip entry named `my-skill\SKILL.md` normalizes to a single in-root
+        // segment rather than escaping the bundle directory. The security
+        // property is containment: no segment may traverse or be absolute.
+        let path = normalize_archive_path(Path::new("my-skill\\SKILL.md")).unwrap();
+        assert_eq!(path, PathBuf::from("my-skill\\SKILL.md"));
     }
 
     #[test]
@@ -294,14 +295,18 @@ mod tests {
             .unwrap();
         let payload = collector.finish().unwrap();
         assert_eq!(payload.files.len(), 2);
-        assert!(payload
-            .files
-            .iter()
-            .any(|f| f.path == PathBuf::from("config.json")));
-        assert!(payload
-            .files
-            .iter()
-            .any(|f| f.path == PathBuf::from("scripts/setup.sh")));
+        assert!(
+            payload
+                .files
+                .iter()
+                .any(|f| f.path == Path::new("config.json"))
+        );
+        assert!(
+            payload
+                .files
+                .iter()
+                .any(|f| f.path == Path::new("scripts/setup.sh"))
+        );
     }
 
     #[test]
@@ -324,14 +329,23 @@ mod tests {
     #[test]
     fn bundle_collector_rejects_total_over_limit() {
         let mut collector = BundleCollector::new(PathBuf::from("skill"));
-        // Push SKILL.md first to avoid finish() error
-        collector
-            .push_file(PathBuf::from("skill/SKILL.md"), b"valid".to_vec())
-            .unwrap();
-        // Push a file that would exceed total
-        let big = vec![0u8; (MAX_TOTAL_UNZIPPED_BYTES + 1) as usize];
+        // Every push stays under the per-entry limit; only the cumulative total
+        // crosses MAX_TOTAL_UNZIPPED_BYTES (10 full-size entries fit, the 11th
+        // pushes the running total past the cap).
+        let full_entries = MAX_TOTAL_UNZIPPED_BYTES / MAX_ZIP_ENTRY_BYTES;
+        for index in 0..full_entries {
+            collector
+                .push_file(
+                    PathBuf::from(format!("skill/fragment-{index}.bin")),
+                    vec![0u8; MAX_ZIP_ENTRY_BYTES as usize],
+                )
+                .unwrap();
+        }
         let err = collector
-            .push_file(PathBuf::from("skill/big.bin"), big)
+            .push_file(
+                PathBuf::from("skill/fragment-overflow.bin"),
+                vec![0u8; MAX_ZIP_ENTRY_BYTES as usize],
+            )
             .unwrap_err();
         assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
     }
@@ -349,20 +363,76 @@ mod tests {
     }
 
     #[test]
-    fn bundle_collector_ignore_files_outside_root() {
+    fn bundle_collector_push_file_outside_root_errors() {
         let mut collector = BundleCollector::new(PathBuf::from("subdir"));
         collector
             .push_file(PathBuf::from("subdir/SKILL.md"), b"content".to_vec())
             .unwrap();
-        let payload = collector.finish().unwrap();
-        assert_eq!(payload.content, "content");
+        // A path that does not share the collector root is rejected, not
+        // silently ignored: it cannot be relativized into the bundle.
+        let err = collector
+            .push_file(PathBuf::from("other/file.txt"), b"x".to_vec())
+            .unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OperationFailed);
     }
 
     #[test]
-    fn strip_common_root_single_nested_file_no_strip() {
-        // One deeply nested file: the root is the parent, but has_nested is false
+    fn bundle_collector_push_root_itself_is_skipped() {
+        let mut collector = BundleCollector::new(PathBuf::from("subdir"));
+        // The root path relativizes to nothing, so pushing it is a no-op
+        // rather than an error; finish() still fails without a SKILL.md.
+        collector
+            .push_file(PathBuf::from("subdir"), b"content".to_vec())
+            .unwrap();
+        assert_eq!(
+            collector.finish().unwrap_err().kind(),
+            RuntimeDispatchErrorKind::OperationFailed
+        );
+    }
+
+    #[test]
+    fn bundle_collector_rejects_skill_md_over_prompt_size() {
+        let mut collector = BundleCollector::new(PathBuf::from("skill"));
+        // Under the per-entry limit and the running total, but SKILL.md itself
+        // may not exceed MAX_PROMPT_FILE_SIZE.
+        let err = collector
+            .push_file(
+                PathBuf::from("skill/SKILL.md"),
+                vec![0u8; ironclaw_skills::MAX_PROMPT_FILE_SIZE as usize + 1],
+            )
+            .unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+
+    #[test]
+    fn bundle_collector_rejects_over_max_bundle_files() {
+        let mut collector = BundleCollector::new(PathBuf::from("skill"));
+        collector
+            .push_file(PathBuf::from("skill/SKILL.md"), b"content".to_vec())
+            .unwrap();
+        for index in 0..ironclaw_skills::MAX_INSTALL_BUNDLE_FILES {
+            collector
+                .push_file(
+                    PathBuf::from(format!("skill/auxiliary-{index}.bin")),
+                    b"x".to_vec(),
+                )
+                .unwrap();
+        }
+        let err = collector
+            .push_file(PathBuf::from("skill/overflow.bin"), b"x".to_vec())
+            .unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+
+    #[test]
+    fn strip_common_root_single_nested_file_strips_parent() {
+        // A single nested file still has a nested component, so its parent
+        // directory is treated as the common archive root and stripped.
         let paths = vec![PathBuf::from("my-skill-repo/SKILL.md")];
-        assert_eq!(strip_common_archive_root(&paths), None);
+        assert_eq!(
+            strip_common_archive_root(&paths).as_deref(),
+            Some(Path::new("my-skill-repo"))
+        );
     }
 
     #[test]

--- a/crates/extensions/ironclaw_extension_support/src/skills/url_install/github.rs
+++ b/crates/extensions/ironclaw_extension_support/src/skills/url_install/github.rs
@@ -713,3 +713,223 @@ fn normalized_archive_path_to_string(
     }
     Ok(segments.join("/"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_blob_ref_extracts_segments() {
+        let parsed = url::Url::parse(
+            "https://github.com/Pika-Labs/Pika-Skills/blob/main/fetched-helper/SKILL.md",
+        )
+        .unwrap();
+        let blob = parse_github_blob_ref(&parsed).unwrap();
+        assert_eq!(blob.owner, "Pika-Labs");
+        assert_eq!(blob.repo, "Pika-Skills");
+        assert_eq!(
+            blob.blob_segments,
+            vec!["main", "fetched-helper", "SKILL.md"]
+        );
+    }
+
+    #[test]
+    fn parse_blob_ref_trims_git_suffix() {
+        let parsed =
+            url::Url::parse("https://github.com/Pika-Labs/Pika-Skills.git/blob/main/SKILL.md")
+                .unwrap();
+        let blob = parse_github_blob_ref(&parsed).unwrap();
+        assert_eq!(blob.repo, "Pika-Skills");
+    }
+
+    #[test]
+    fn parse_blob_ref_rejects_non_github_hosts() {
+        let parsed =
+            url::Url::parse("https://example.com/Pika-Labs/Pika-Skills/blob/main/SKILL.md")
+                .unwrap();
+        assert_eq!(parse_github_blob_ref(&parsed), None);
+    }
+
+    #[test]
+    fn parse_blob_ref_rejects_short_paths() {
+        let parsed = url::Url::parse("https://github.com/Pika-Labs/Pika-Skills/blob").unwrap();
+        assert_eq!(parse_github_blob_ref(&parsed), None);
+    }
+
+    #[test]
+    fn parse_blob_ref_rejects_non_blob_verbs() {
+        let parsed =
+            url::Url::parse("https://github.com/Pika-Labs/Pika-Skills/raw/main/SKILL.md").unwrap();
+        assert_eq!(parse_github_blob_ref(&parsed), None);
+    }
+
+    #[test]
+    fn parse_blob_ref_rejects_empty_repo_after_trim() {
+        let parsed =
+            url::Url::parse("https://github.com/Pika-Labs/.git/blob/main/SKILL.md").unwrap();
+        assert_eq!(parse_github_blob_ref(&parsed), None);
+    }
+
+    #[test]
+    fn parse_repo_ref_plain_repo() {
+        let parsed = url::Url::parse("https://github.com/Pika-Labs/Pika-Skills").unwrap();
+        let repo = parse_github_repo_ref(&parsed).unwrap();
+        assert_eq!(repo.owner, "Pika-Labs");
+        assert_eq!(repo.repo, "Pika-Skills");
+        assert_eq!(repo.tree_segments, None);
+    }
+
+    #[test]
+    fn parse_repo_ref_trims_git_suffix() {
+        let parsed = url::Url::parse("https://github.com/Pika-Labs/Pika-Skills.git").unwrap();
+        let repo = parse_github_repo_ref(&parsed).unwrap();
+        assert_eq!(repo.repo, "Pika-Skills");
+    }
+
+    #[test]
+    fn parse_repo_ref_tree_segments() {
+        let parsed =
+            url::Url::parse("https://github.com/Pika-Labs/Pika-Skills/tree/main/sub/dir").unwrap();
+        let repo = parse_github_repo_ref(&parsed).unwrap();
+        assert_eq!(
+            repo.tree_segments,
+            Some(vec![
+                "main".to_string(),
+                "sub".to_string(),
+                "dir".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_repo_ref_rejects_single_segment() {
+        let parsed = url::Url::parse("https://github.com/Pika-Labs").unwrap();
+        assert_eq!(parse_github_repo_ref(&parsed), None);
+    }
+
+    #[test]
+    fn parse_repo_ref_rejects_tree_without_segments() {
+        let parsed = url::Url::parse("https://github.com/Pika-Labs/Pika-Skills/tree").unwrap();
+        assert_eq!(parse_github_repo_ref(&parsed), None);
+    }
+
+    #[test]
+    fn parse_repo_ref_rejects_blob_paths() {
+        let parsed =
+            url::Url::parse("https://github.com/Pika-Labs/Pika-Skills/blob/main/SKILL.md").unwrap();
+        assert_eq!(parse_github_repo_ref(&parsed), None);
+    }
+
+    #[test]
+    fn parse_repo_ref_rejects_empty_repo() {
+        let parsed = url::Url::parse("https://github.com/Pika-Labs/.git").unwrap();
+        assert_eq!(parse_github_repo_ref(&parsed), None);
+    }
+
+    #[test]
+    fn safe_component_accepts_plain_names() {
+        assert!(is_safe_github_component("main"));
+        assert!(is_safe_github_component("Pika-Skills_v1.2"));
+    }
+
+    #[test]
+    fn safe_component_rejects_unsafe_names() {
+        assert!(!is_safe_github_component(""));
+        assert!(!is_safe_github_component("a/b"));
+        assert!(!is_safe_github_component("a b"));
+        assert!(!is_safe_github_component("a;b"));
+        assert!(!is_safe_github_component("ünïcode"));
+    }
+
+    #[test]
+    fn validate_repo_components_accepts_safe_pairs() {
+        validate_github_repo_components("Pika-Labs", "Pika-Skills").unwrap();
+    }
+
+    #[test]
+    fn validate_repo_components_rejects_unsafe_pairs() {
+        let err = validate_github_repo_components("bad/owner", "repo").unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+        let err = validate_github_repo_components("owner", "").unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn build_api_base_url_produces_repos_endpoint() {
+        let url = build_github_api_base_url("Pika-Labs", "Pika-Skills").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://api.github.com/repos/Pika-Labs/Pika-Skills"
+        );
+    }
+
+    #[test]
+    fn build_api_base_url_rejects_unsafe_components() {
+        let err = build_github_api_base_url("bad/owner", "repo").unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn build_contents_url_appends_path_and_ref() {
+        let url = build_github_contents_url("o", "r", Some("src/lib"), "main").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://api.github.com/repos/o/r/contents/src/lib?ref=main"
+        );
+    }
+
+    #[test]
+    fn build_raw_url_appends_owner_repo_ref_path() {
+        let url = build_github_raw_url("o", "r", "main", Path::new("a/b/c.rs")).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://raw.githubusercontent.com/o/r/main/a/b/c.rs"
+        );
+    }
+
+    #[test]
+    fn build_matching_refs_url_accepts_heads_and_tags() {
+        let heads = build_github_matching_refs_url("o", "r", "heads", "main").unwrap();
+        assert_eq!(
+            heads.as_str(),
+            "https://api.github.com/repos/o/r/git/matching-refs/heads/main"
+        );
+        let tags = build_github_matching_refs_url("o", "r", "tags", "v1.2").unwrap();
+        assert_eq!(
+            tags.as_str(),
+            "https://api.github.com/repos/o/r/git/matching-refs/tags/v1.2"
+        );
+    }
+
+    #[test]
+    fn build_matching_refs_url_rejects_other_namespaces_and_prefixes() {
+        let err = build_github_matching_refs_url("o", "r", "release", "main").unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+        let err = build_github_matching_refs_url("o", "r", "heads", "bad/prefix").unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn normalized_path_to_string_joins_segments() {
+        assert_eq!(
+            normalized_archive_path_to_string(Path::new("a/b/c.txt")).unwrap(),
+            "a/b/c.txt"
+        );
+    }
+
+    #[test]
+    fn normalized_path_to_string_rejects_empty_path() {
+        let err = normalized_archive_path_to_string(Path::new("")).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn api_budget_exhausts_after_cap() {
+        let mut budget = GitHubApiBudget::default();
+        for _ in 0..MAX_GITHUB_API_REQUESTS {
+            budget.consume().unwrap();
+        }
+        let err = budget.consume().unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+}

--- a/crates/extensions/ironclaw_extension_support/src/skills/url_install/zip_bundle.rs
+++ b/crates/extensions/ironclaw_extension_support/src/skills/url_install/zip_bundle.rs
@@ -178,3 +178,185 @@ pub(super) fn extract_skill_bundle(
             .then(|| requested_dir.display().to_string()),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn skill_bundle_zip(files: &[(&str, &[u8])]) -> Vec<u8> {
+        skill_bundle_zip_owned(
+            files
+                .iter()
+                .map(|(path, content)| ((*path).to_string(), (*content).to_vec())),
+        )
+    }
+
+    fn skill_bundle_zip_owned(files: impl IntoIterator<Item = (String, Vec<u8>)>) -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        for (path, content) in files {
+            writer.start_file(path, options).unwrap();
+            writer.write_all(&content).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn extract_flat_single_skill_md() {
+        let data = skill_bundle_zip(&[("SKILL.md", b"# One\n")]);
+        let bundle = extract_skill_bundle(&data, None).unwrap();
+        assert_eq!(bundle.skill_md, "# One\n");
+        assert!(bundle.files.is_empty());
+        assert_eq!(bundle.bundle_subdir, None);
+    }
+
+    #[test]
+    fn extract_common_root_skill_with_supporting_files() {
+        let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        writer.add_directory("my-skill-repo/", options).unwrap();
+        writer
+            .start_file("my-skill-repo/SKILL.md", options)
+            .unwrap();
+        writer.write_all(b"# Root\n").unwrap();
+        writer
+            .start_file("my-skill-repo/tools/helper.rs", options)
+            .unwrap();
+        writer.write_all(b"fn help() {}").unwrap();
+        let data = writer.finish().unwrap().into_inner();
+
+        let bundle = extract_skill_bundle(&data, None).unwrap();
+        assert_eq!(bundle.skill_md, "# Root\n");
+        // The common archive root is stripped, leaving the skill at bundle
+        // root, so no subdir is recorded.
+        assert_eq!(bundle.bundle_subdir, None);
+        assert_eq!(bundle.files.len(), 1);
+        assert_eq!(bundle.files[0].path, PathBuf::from("tools/helper.rs"));
+    }
+
+    #[test]
+    fn extract_records_subdir_after_stripping_archive_root() {
+        let data = skill_bundle_zip(&[
+            ("repo/pack/SKILL.md", b"# Packed\n"),
+            ("repo/pack/run.sh", b"#!/bin/sh"),
+        ]);
+        let bundle = extract_skill_bundle(&data, None).unwrap();
+        assert_eq!(bundle.skill_md, "# Packed\n");
+        assert_eq!(bundle.bundle_subdir.as_deref(), Some("pack"));
+        assert_eq!(bundle.files.len(), 1);
+        assert_eq!(bundle.files[0].path, PathBuf::from("run.sh"));
+    }
+
+    #[test]
+    fn extract_rejects_traversal_entries() {
+        let data = skill_bundle_zip(&[("SKILL.md", b"# ok\n"), ("../escape.txt", b"evil")]);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn extract_rejects_absolute_entries() {
+        let data = skill_bundle_zip(&[("/etc/passwd", b"root:x")]);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn extract_rejects_duplicate_normalized_paths() {
+        // Distinct raw entry names that normalize to the same path are
+        // ambiguous and rejected rather than silently overwriting.
+        let data = skill_bundle_zip(&[
+            ("repo/SKILL.md", b"# One\n"),
+            ("repo/./SKILL.md", b"# Two\n"),
+        ]);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn extract_errors_without_skill_md() {
+        let data = skill_bundle_zip(&[("readme.txt", b"no skill here")]);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[test]
+    fn extract_rejects_multiple_skill_dirs_without_subdir() {
+        let data = skill_bundle_zip(&[("alpha/SKILL.md", b"# A\n"), ("beta/SKILL.md", b"# B\n")]);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::InputEncode);
+    }
+
+    #[test]
+    fn extract_selects_requested_subdir() {
+        let data = skill_bundle_zip(&[
+            ("alpha/SKILL.md", b"# A\n"),
+            ("beta/SKILL.md", b"# B\n"),
+            ("beta/tool.sh", b"#!/bin/sh"),
+        ]);
+        let bundle = extract_skill_bundle(&data, Some("beta")).unwrap();
+        assert_eq!(bundle.skill_md, "# B\n");
+        assert_eq!(bundle.bundle_subdir.as_deref(), Some("beta"));
+        assert_eq!(bundle.files.len(), 1);
+        assert_eq!(bundle.files[0].path, PathBuf::from("tool.sh"));
+    }
+
+    #[test]
+    fn extract_rejects_missing_requested_subdir() {
+        let data = skill_bundle_zip(&[("alpha/SKILL.md", b"# A\n")]);
+        let err = extract_skill_bundle(&data, Some("nope")).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[test]
+    fn extract_rejects_invalid_zip_bytes() {
+        let err = extract_skill_bundle(b"not a zip at all", None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OperationFailed);
+    }
+
+    #[test]
+    fn extract_rejects_skill_md_over_prompt_size() {
+        let oversized = vec![b'x'; ironclaw_skills::MAX_PROMPT_FILE_SIZE as usize + 1];
+        let data = skill_bundle_zip(&[("SKILL.md", &oversized)]);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+
+    #[test]
+    fn extract_rejects_entry_over_zip_entry_limit() {
+        let oversized = vec![0u8; MAX_ZIP_ENTRY_BYTES as usize + 1];
+        let data = skill_bundle_zip(&[("big.bin", &oversized)]);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+
+    #[test]
+    fn extract_rejects_total_unzipped_over_limit() {
+        // Each entry sits exactly at the per-entry limit, so only the running
+        // total crosses MAX_TOTAL_UNZIPPED_BYTES (10 full-size entries fit).
+        let chunks = MAX_TOTAL_UNZIPPED_BYTES / MAX_ZIP_ENTRY_BYTES;
+        let files = (0..(chunks + 2)).map(|index| {
+            (
+                format!("chunk-{index}.bin"),
+                vec![0u8; MAX_ZIP_ENTRY_BYTES as usize],
+            )
+        });
+        let data = skill_bundle_zip_owned(files);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+
+    #[test]
+    fn extract_rejects_too_many_zip_entries() {
+        let files = (0..(MAX_ZIP_FILE_ENTRIES + 1))
+            .map(|index| (format!("entry-{index}.txt"), b"x".to_vec()));
+        let data = skill_bundle_zip_owned(files);
+        let err = extract_skill_bundle(&data, None).unwrap_err();
+        assert_eq!(err.kind(), RuntimeDispatchErrorKind::OutputTooLarge);
+    }
+}


### PR DESCRIPTION
## What

Adds unit-test coverage for the skill URL install executor that arrived in `ironclaw_extension_support` via WS3 (`crates/extensions/ironclaw_extension_support/src/skills/url_install/`), and repairs defects found in the first revision of the suite.

## Why

The coverage ratchet floor for `ironclaw_extension_support` dropped when the skill-install URL executor moved in with low coverage. The floor recapture documented an explicit follow-up: *"raise the executor's own coverage in its new home."* This PR performs that follow-up.

Measured before (branch-aware, full suite incl. host_runtime integration): bundle.rs 72.3% lines / 63.6% branches, github.rs 82.3% / 80.3%, zip_bundle.rs 75.0% / 57.1%. After: **bundle.rs 99.0% / 97.5%, github.rs 87.4% / 86.2%, zip_bundle.rs 91.9% / 82.4%**.

## Fixes to the original suite

- `normalize_archive_path_rejects_windows_backslash` asserted behavior that does not exist on unix (a backslash is an ordinary filename byte, so `my-skill\SKILL.md` is a single in-root segment). Replaced with a test pinning the actual containment behavior.
- `strip_common_root_single_nested_file_no_strip` had the expectation backwards: a single nested file does carry a nested component, so its parent is stripped.
- `bundle_collector_rejects_total_over_limit` was vacuous: a single 20 MiB+1 push trips the per-entry limit (2 MiB) first. It now crosses only the cumulative `MAX_TOTAL_UNZIPPED_BYTES` cap with full-size entries.
- `bundle_collector_ignore_files_outside_root` tested nothing (only pushed an in-root file) and the PR description's "silently ignored" claim was wrong: outside-root paths are rejected with `OperationFailed`; only the root path itself is a silent no-op. Both behaviors are now tested.
- Missing error paths added: SKILL.md over `MAX_PROMPT_FILE_SIZE`, `MAX_INSTALL_BUNDLE_FILES` exhaustion.

## Tests added (69 in the module)

### bundle.rs (27)
`normalize_archive_path` (6), `strip_common_archive_root` (7), `BundleCollector` (14) — including the corrected cumulative-total, outside-root rejection, root-path no-op, SKILL.md prompt-size, and bundle-file-count limits.

### zip_bundle.rs (15, new)
`extract_skill_bundle` end-to-end with generated zip fixtures: common-root stripping, subdir selection and recording, traversal and absolute entry rejection, duplicate-normalized-path rejection, invalid zip bytes, missing SKILL.md, multiple skill dirs without a requested subdir, per-entry and cumulative size caps, entry-count cap, SKILL.md prompt-size cap.

### github.rs (26, new)
Pure parsing/validation layer: blob and repo ref parsing (incl. `.git` trimming and rejection cases), component safety checks, contents/raw/matching-refs URL builders, ref namespace validation, API budget exhaustion.

## Verification

```bash
cargo test -p ironclaw_extension_support -- url_install   # 70 pass
cargo test -p ironclaw_host_runtime --test first_party_builtin_tools skill_install  # 29 pass
cargo clippy -p ironclaw_extension_support --all-targets  # clean
cargo fmt --check                                          # clean
```

The `checked_add` overflow guard and the `MAX_INSTALL_BUNDLE_FILES` push-path guard in `zip_bundle.rs` remain covered only via the shared bounded-CAS semantics; overflow needs u64::MAX total bytes and is unreachable behind the per-entry cap. The remaining uncovered github.rs lines are the async fetch/resolve network paths, exercised end-to-end by the host_runtime integration tests.
