### PR TITLE
Fix hosted MCP egress target propagation

### DIFF
--- a/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
+++ b/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
@@ -1,6 +1,7 @@
 use ironclaw_extension_contracts::hosted_mcp::HostedMcpDiscoveredTool;
 use ironclaw_extension_contracts::runtime::ExtensionRuntime;
 use ironclaw_host_api::{
+    action::{NetworkScheme, NetworkTargetPattern},
     capability::{CapabilityDescriptor, EffectKind, PermissionMode},
     capability_profile::CapabilityProfileSchemaRef,
     ids::CapabilityId,
@@ -113,6 +114,12 @@ fn valid_hosted_mcp_url(url: &str) -> bool {
 fn hosted_mcp_capability_template(
     package: &ExtensionPackage,
 ) -> Result<HostedMcpCapabilityTemplate, ExtensionError> {
+    let network_target = hosted_mcp_network_target(package).ok_or_else(|| {
+        invalid_hosted_mcp_manifest(format!(
+            "hosted MCP provider {} has no valid network target",
+            package.id
+        ))
+    })?;
     let first = package.manifest.capabilities.first().ok_or_else(|| {
         invalid_hosted_mcp_manifest(format!(
             "hosted MCP provider {} has no capability template",
@@ -138,6 +145,7 @@ fn hosted_mcp_capability_template(
             .any(|capability| capability.effects.contains(&EffectKind::ExternalWrite)),
         required_host_ports: first.required_host_ports.clone(),
         runtime_credentials: first.runtime_credentials.clone(),
+        network_target,
         resource_profile: first.resource_profile.clone(),
         origin_gate_matrix: first.origin_gate_matrix.clone(),
     })
@@ -147,6 +155,7 @@ struct HostedMcpCapabilityTemplate {
     provider_declares_external_write: bool,
     required_host_ports: Vec<ironclaw_host_api::host_port::HostPortId>,
     runtime_credentials: Vec<ironclaw_host_api::capability::RuntimeCredentialRequirement>,
+    network_target: NetworkTargetPattern,
     resource_profile: Option<ironclaw_host_api::resource::ResourceProfile>,
     origin_gate_matrix: Option<ironclaw_host_api::capability::OriginGateMatrix>,
 }
@@ -201,14 +210,24 @@ fn discovered_capability_manifest(
         prompt_doc_ref: None,
         required_host_ports: template.required_host_ports.clone(),
         runtime_credentials: template.runtime_credentials.clone(),
-        // MCP discovered tools derive egress from their credential audiences,
-        // not a manifest-declared allowlist.
-        network_targets: Vec::new(),
+        // Credential-free providers have no credential audience from which to
+        // derive egress, so every discovered tool retains the registered MCP
+        // endpoint as its explicit allowlist target.
+        network_targets: vec![template.network_target.clone()],
         // MCP discovered tools take no manifest egress cap; their egress is
         // bounded by credential audiences and the runtime resource profile.
         max_egress_bytes: None,
         resource_profile: template.resource_profile.clone(),
         origin_gate_matrix: template.origin_gate_matrix.clone(),
+    })
+}
+
+fn hosted_mcp_network_target(package: &ExtensionPackage) -> Option<NetworkTargetPattern> {
+    let endpoint = url::Url::parse(hosted_http_mcp_url(package)?).ok()?;
+    Some(NetworkTargetPattern {
+        scheme: Some(NetworkScheme::Https),
+        host_pattern: endpoint.host_str()?.to_ascii_lowercase(),
+        port: endpoint.port(),
     })
 }
 
@@ -336,6 +355,41 @@ runtime_credentials = [
             .expect("discovered create-pages capability");
         assert!(create_pages.effects.contains(&EffectKind::ExternalWrite));
         assert_eq!(discovered.manifest.capabilities.len(), 2);
+    }
+
+    /// Regression: credential-free hosted MCP tools still need the registered
+    /// server in their egress allowlist. Without it, authorization emits an
+    /// empty network-policy obligation and dispatch fails before any request.
+    #[test]
+    fn discovered_public_mcp_tool_keeps_endpoint_as_network_target() {
+        let mut package = notion_package();
+        package.manifest.capabilities[0].runtime_credentials.clear();
+        package.capabilities[0].runtime_credentials.clear();
+        let tools = vec![HostedMcpDiscoveredTool {
+            name: "read_wiki".to_string(),
+            description: "Read a repository wiki".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: HostedMcpDiscoveredToolAnnotations {
+                read_only_hint: true,
+                ..Default::default()
+            },
+        }];
+
+        let discovered = package_with_discovered_hosted_mcp_tools(&package, &tools)
+            .expect("build discovered public MCP package");
+        let capability = discovered
+            .capabilities
+            .first()
+            .expect("discovered capability");
+
+        assert_eq!(
+            capability.network_targets,
+            vec![ironclaw_host_api::action::NetworkTargetPattern {
+                scheme: Some(ironclaw_host_api::action::NetworkScheme::Https),
+                host_pattern: "mcp.notion.com".to_string(),
+                port: None,
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve the validated hosted-MCP endpoint as an explicit network target on every discovered tool.
- Prevent credential-free hosted-MCP calls from producing an empty `ApplyNetworkPolicy` obligation and failing before dispatch.
- Add a regression test for the credential-free discovery path.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — scoped owning-crate clippy was run instead.
- [ ] `cargo build` — covered by the owning-crate and integration test builds.
- [x] Relevant tests pass: `cargo test -p ironclaw_extensions`; credential-free hosted-MCP lifecycle integration test.
- [ ] `cargo test --features integration` — no database-backed behavior changed.
- [ ] Manual testing — deterministic production-path integration coverage was used instead.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — final diff was audited locally; no automated PR review was run.

## Test Strategy

User behavior: A registered credential-free hosted MCP tool can reach its registered server instead of failing locally with `network_denied` during obligation preparation.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added `discovered_public_mcp_tool_keeps_endpoint_as_network_target` in `ironclaw_extensions`.
- Reborn integration: Reused the existing `no_auth_registration_story_replays_streamable_http_mrc_trace_through_real_lifecycle` production-path test.
- Recorded fixture: Not applicable: model selection and request arguments are unchanged.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: The existing hermetic hosted-MCP lifecycle integration test exercises registration, discovery, activation, authorization, mediated HTTP, and completion.
- Live canary: Not applicable: the behavior is deterministic and covered without a real provider.

What the tests prove: Credential-free discovered tools retain the exact HTTPS host and optional port from the validated registration endpoint, authorization receives a non-empty egress allowlist, and the real hosted-MCP runtime path completes against a hermetic server.

Commands run:

```text
cargo test -p ironclaw_extensions discovered_public_mcp_tool_keeps_endpoint_as_network_target
cargo test -p ironclaw_extensions
cargo clippy -p ironclaw_extensions --all-targets --all-features -- -D warnings
cargo test -p ironclaw_reborn_integration_tests --test reborn_integration_hosted_mcp_registration no_auth_registration_story_replays_streamable_http_mrc_trace_through_real_lifecycle -- --exact
cargo fmt --all -- --check
git diff --check
```

## Security Impact

Corrects fail-closed hosted-MCP egress authorization. The change does not introduce wildcard access: each discovered tool receives only the HTTPS host and optional port from the already validated registered MCP endpoint. Paths, queries, private-IP denial, and host-runtime mediation remain unchanged.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: construction remains inside validated hosted-MCP package discovery; extensions cannot supply arbitrary discovered-tool targets.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not affected.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not affected.
- [x] New/changed status, exit, policy, runtime, or error variants: none added; downstream policy construction was audited through `extension_network_policy` and obligation validation.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Not affected.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not affected.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). No error taxonomy changed.
- [x] Sandbox/native/host names accurately describe trust boundary. Not affected.

## Database Impact

None. No migrations, schemas, or persistence behavior changed.

## Blast Radius

Hosted HTTP MCP capability metadata generated after tool discovery. Credentialed providers may now carry the endpoint both explicitly and through credential audiences; the existing policy projection deduplicates identical targets. Other extension runtimes and network policies are unchanged.

## Rollback Plan

Revert this commit. That restores the previous fail-closed behavior where credential-free hosted-MCP invocations are rejected during network-obligation preparation.

## Review Follow-Through

Please verify that retaining the registered endpoint on discovered capabilities is the preferred ownership boundary. No known follow-up is required.

---

**Review track**: C (network authorization)
