### PR TITLE
fix(threads): key tool-result dedup by provider turn + call identity

### DIFF
--- a/crates/ironclaw_loop_host/src/result_read.rs
+++ b/crates/ironclaw_loop_host/src/result_read.rs
@@ -12,6 +12,7 @@ use ironclaw_host_api::{
     ids::{InvocationId, UserId},
     resolution::Resolution,
     result_meta::FailureKind,
+    turn::LoopResultRef,
 };
 use ironclaw_loop_contracts::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityFailureDetail, CapabilityInputIssue,
@@ -234,10 +235,23 @@ impl SyntheticCapabilityHandler for ResultReadHandler {
             "total_bytes": total_bytes,
             "next_offset": next_offset,
         });
+        // `parse_result_read_input` already validated this value against the
+        // durable result-reference grammar. Preserve that pageable identity as
+        // the completed outcome's origin so the transcript and replay surface
+        // exactly the ref the next `result_read` call can use.
+        let continuation_result_ref =
+            LoopResultRef::new(input.result_ref.clone()).map_err(|_| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    "validated result reference could not be represented",
+                )
+            })?;
         // `InlineOnly` (see `DurablePersistence` doc comment): this chunk is
         // already fully delivered to the model inline via
         // `result_read_observation`'s `preview`. The ORIGINAL result this
-        // chunk was paged from stays durable and untouched.
+        // chunk was paged from stays durable and untouched. The writer still
+        // mints an internal staging/display ref for byte accounting and output
+        // evidence, but that inline-only ref is not continuation authority.
         let mut write = invocation
             .result_writer
             .write_capability_result(CapabilityResultWrite {
@@ -258,7 +272,7 @@ impl SyntheticCapabilityHandler for ResultReadHandler {
             sanitize_model_visible_text(content),
         ));
         Ok(resolution::completed(
-            write.result_ref,
+            continuation_result_ref,
             "result chunk returned".to_string(),
             CapabilityProgress::MadeProgress,
             false,

--- a/crates/ironclaw_loop_host/src/result_read.rs
+++ b/crates/ironclaw_loop_host/src/result_read.rs
@@ -240,11 +240,12 @@ impl SyntheticCapabilityHandler for ResultReadHandler {
         // the completed outcome's origin so the transcript and replay surface
         // exactly the ref the next `result_read` call can use.
         let continuation_result_ref =
-            LoopResultRef::new(input.result_ref.clone()).map_err(|_| {
+            LoopResultRef::new(input.result_ref.clone()).map_err(|error| {
                 AgentLoopHostError::new(
                     AgentLoopHostErrorKind::Internal,
                     "validated result reference could not be represented",
                 )
+                .with_detail(format!("loop result reference validation failed: {error}"))
             })?;
         // `InlineOnly` (see `DurablePersistence` doc comment): this chunk is
         // already fully delivered to the model inline via

--- a/crates/ironclaw_loop_host/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_host/src/subagent_spawn_port.rs
@@ -271,6 +271,10 @@ pub struct AwaitedChildSetRecord {
     pub reply_target_binding_ref: ReplyTargetBindingRef,
     pub subagent_kind: SubagentKindId,
     pub spawn_capability_id: CapabilityId,
+    /// Pins the eventual summary update to the spawn transcript row even when
+    /// paged reads reuse `result_ref`. Missing only on legacy durable edges.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawn_provider_call_id: Option<String>,
     pub result_ref: LoopResultRef,
     pub mode: SpawnSubagentMode,
 }
@@ -295,6 +299,10 @@ pub struct SubagentThreadMetadata {
     pub subagent_kind: SubagentKindId,
     pub mode: SpawnSubagentMode,
     pub result_ref: LoopResultRef,
+    /// Provider-call identity of the spawn result placeholder. Recovery
+    /// copies this into the reconstructed await edge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawn_provider_call_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub handoff: Option<String>,
     /// The spawning parent's `LoopRunContext`, cached verbatim at spawn time
@@ -383,8 +391,14 @@ pub struct SubagentSpawnCapabilityPort {
     limits: SubagentSpawnLimits,
     deps: Arc<SubagentSpawnDeps>,
     parameters_schema: Arc<serde_json::Value>,
-    spawn_authorizations: Mutex<HashMap<CapabilityInputRef, CapabilityActivityId>>,
+    spawn_authorizations: Mutex<HashMap<CapabilityInputRef, SpawnAuthorization>>,
     spawned_this_turn: AtomicU32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SpawnAuthorization {
+    activity_id: CapabilityActivityId,
+    provider_call_id: String,
 }
 
 struct SpawnContext {
@@ -599,6 +613,7 @@ impl SubagentSpawnCapabilityPort {
             .spawn_input_codec
             .register_provider_tool_call_input(&self.run_context, &tool_call)
             .await?;
+        let provider_call_id = tool_call.id.clone();
         let activity_id = {
             let mut spawn_authorizations = self.spawn_authorizations.lock().map_err(|_| {
                 AgentLoopHostError::new(
@@ -608,20 +623,29 @@ impl SubagentSpawnCapabilityPort {
             })?;
             match spawn_authorizations.entry(input_ref.clone()) {
                 Entry::Occupied(entry) => {
-                    let registered_activity_id = *entry.get();
+                    let registered = entry.get();
                     if let Some(activity_id) = activity_id
-                        && registered_activity_id != activity_id
+                        && registered.activity_id != activity_id
                     {
                         return Err(AgentLoopHostError::new(
                             AgentLoopHostErrorKind::InvalidInvocation,
                             "provider tool-call activity identity changed",
                         ));
                     }
-                    registered_activity_id
+                    if registered.provider_call_id != provider_call_id {
+                        return Err(AgentLoopHostError::new(
+                            AgentLoopHostErrorKind::InvalidInvocation,
+                            "provider tool-call identity changed",
+                        ));
+                    }
+                    registered.activity_id
                 }
                 Entry::Vacant(entry) => {
                     let activity_id = activity_id.unwrap_or_default();
-                    entry.insert(activity_id);
+                    entry.insert(SpawnAuthorization {
+                        activity_id,
+                        provider_call_id,
+                    });
                     activity_id
                 }
             }
@@ -685,10 +709,17 @@ impl SubagentSpawnCapabilityPort {
         invocation: &LoopRequest,
         args: SpawnSubagentArgs,
         gate_override: Option<TurnGateRef>,
+        provider_call_id: String,
     ) -> Result<Resolution, AgentLoopHostError> {
         let mut compensation = SpawnCompensationState::default();
-        self.handle_spawn_with_gate_recording(invocation, args, gate_override, &mut compensation)
-            .await
+        self.handle_spawn_with_gate_recording(
+            invocation,
+            args,
+            gate_override,
+            provider_call_id,
+            &mut compensation,
+        )
+        .await
     }
 
     async fn handle_spawn_with_gate_recording(
@@ -696,6 +727,7 @@ impl SubagentSpawnCapabilityPort {
         invocation: &LoopRequest,
         args: SpawnSubagentArgs,
         gate_override: Option<TurnGateRef>,
+        provider_call_id: String,
         compensation: &mut SpawnCompensationState,
     ) -> Result<Resolution, AgentLoopHostError> {
         let Some(spawn_slot) = self.reserve_spawn_slot() else {
@@ -769,7 +801,14 @@ impl SubagentSpawnCapabilityPort {
         };
 
         let result = self
-            .finish_spawn(args, spawn_ctx, actor, invocation, compensation)
+            .finish_spawn(
+                args,
+                spawn_ctx,
+                actor,
+                invocation,
+                provider_call_id,
+                compensation,
+            )
             .await;
         match result {
             Ok(outcome) => {
@@ -789,25 +828,31 @@ impl SubagentSpawnCapabilityPort {
     async fn authorize_spawn(
         &self,
         invocation: &LoopRequest,
-    ) -> Result<Option<Resolution>, AgentLoopHostError> {
+    ) -> Result<Result<String, Resolution>, AgentLoopHostError> {
         let mut spawn_authorizations = self.spawn_authorizations.lock().map_err(|_| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Unavailable,
                 "subagent spawn authorization store is unavailable",
             )
         })?;
-        let Some(registered_activity_id) = spawn_authorizations.get(&invocation.input_ref).copied()
-        else {
-            return Ok(Some(spawn_rejected("spawn_requires_provider_registration")));
+        let Some(registered_authorization) = spawn_authorizations.get(&invocation.input_ref) else {
+            return Ok(Err(spawn_rejected("spawn_requires_provider_registration")));
         };
-        if registered_activity_id != invocation.activity_id {
+        if registered_authorization.activity_id != invocation.activity_id {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::InvalidInvocation,
                 "registered provider tool-call activity identity does not match the requested activity",
             ));
         }
-        spawn_authorizations.remove(&invocation.input_ref);
-        Ok(None)
+        let authorization = spawn_authorizations
+            .remove(&invocation.input_ref)
+            .ok_or_else(|| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    "subagent spawn authorization disappeared before dispatch",
+                )
+            })?;
+        Ok(Ok(authorization.provider_call_id))
     }
 
     #[cfg(test)]
@@ -819,7 +864,13 @@ impl SubagentSpawnCapabilityPort {
         self.spawn_authorizations
             .lock()
             .expect("spawn authorization lock")
-            .insert(input_ref, activity_id);
+            .insert(
+                input_ref,
+                SpawnAuthorization {
+                    activity_id,
+                    provider_call_id: "test-provider-call".to_string(),
+                },
+            );
     }
 
     #[cfg(test)]
@@ -831,7 +882,7 @@ impl SubagentSpawnCapabilityPort {
             .lock()
             .expect("spawn authorization lock")
             .get(input_ref)
-            .copied()
+            .map(|authorization| authorization.activity_id)
     }
 
     #[cfg(test)]
@@ -848,6 +899,7 @@ impl SubagentSpawnCapabilityPort {
         ctx: SpawnContext,
         actor: TurnActor,
         invocation: &LoopRequest,
+        provider_call_id: String,
         compensation: &mut SpawnCompensationState,
     ) -> Result<Resolution, AgentLoopHostError> {
         let SpawnContext {
@@ -909,6 +961,7 @@ impl SubagentSpawnCapabilityPort {
                     subagent_kind: definition.subagent_kind.clone(),
                     mode,
                     result_ref: result_ref.clone(),
+                    spawn_provider_call_id: Some(provider_call_id.clone()),
                     handoff: args.handoff.clone(),
                     parent_run_context: self.run_context.clone(),
                     gate_ref: gate_ref.clone(),
@@ -993,6 +1046,7 @@ impl SubagentSpawnCapabilityPort {
             )?,
             subagent_kind: definition.subagent_kind.clone(),
             spawn_capability_id: self.spawn_id.clone(),
+            spawn_provider_call_id: Some(provider_call_id),
             result_ref: result_ref.clone(),
             mode,
         };
@@ -1186,10 +1240,13 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 Ok(args) => args,
                 Err(error) => return spawn_input_decode_outcome(error),
             };
-            if let Some(resolution) = self.authorize_spawn(&request).await? {
-                return Ok(resolution);
-            }
-            return self.handle_spawn_with_gate(&request, args, None).await;
+            let provider_call_id = match self.authorize_spawn(&request).await? {
+                Ok(provider_call_id) => provider_call_id,
+                Err(resolution) => return Ok(resolution),
+            };
+            return self
+                .handle_spawn_with_gate(&request, args, None, provider_call_id)
+                .await;
         }
         self.inner.invoke_capability(request).await
     }
@@ -1246,8 +1303,8 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                     continue;
                 }
                 let outcome = match self.authorize_spawn(invocation).await {
-                    Ok(Some(outcome)) => outcome,
-                    Ok(None) => {
+                    Ok(Err(outcome)) => outcome,
+                    Ok(Ok(provider_call_id)) => {
                         let args = match spawn_args.remove(&index) {
                             Some(args) => args,
                             None => {
@@ -1267,6 +1324,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                                 invocation,
                                 args,
                                 gate_override,
+                                provider_call_id,
                                 &mut compensation,
                             )
                             .await

--- a/crates/ironclaw_loop_host/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_host/src/subagent_spawn_port.rs
@@ -32,7 +32,7 @@ use ironclaw_loop_contracts::{
 use ironclaw_processes::{ProcessInputPayload, ProcessInputRef, ProcessInputSubmission};
 use ironclaw_threads::{
     AcceptInboundMessageRequest, EnsureThreadRequest, MessageContent, SessionThreadService,
-    ThreadMessageId, ThreadScope,
+    ThreadMessageId, ThreadScope, ToolResultProviderCallKey,
 };
 use ironclaw_turns::{
     AgentTurnSpawnTreeRuntimePort, CancelRunRequest, SubmitChildRunRequest, SubmitTurnResponse,
@@ -274,7 +274,7 @@ pub struct AwaitedChildSetRecord {
     /// Pins the eventual summary update to the spawn transcript row even when
     /// paged reads reuse `result_ref`. Missing only on legacy durable edges.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub spawn_provider_call_id: Option<String>,
+    pub spawn_provider_call: Option<ToolResultProviderCallKey>,
     pub result_ref: LoopResultRef,
     pub mode: SpawnSubagentMode,
 }
@@ -302,7 +302,7 @@ pub struct SubagentThreadMetadata {
     /// Provider-call identity of the spawn result placeholder. Recovery
     /// copies this into the reconstructed await edge.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub spawn_provider_call_id: Option<String>,
+    pub spawn_provider_call: Option<ToolResultProviderCallKey>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub handoff: Option<String>,
     /// The spawning parent's `LoopRunContext`, cached verbatim at spawn time
@@ -398,7 +398,9 @@ pub struct SubagentSpawnCapabilityPort {
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct SpawnAuthorization {
     activity_id: CapabilityActivityId,
-    provider_call_id: String,
+    /// Provider turn *and* call id: OpenAI-compatible backends mint call ids
+    /// per response, so the call id alone repeats across turns in one run.
+    provider_call: ToolResultProviderCallKey,
 }
 
 struct SpawnContext {
@@ -613,7 +615,8 @@ impl SubagentSpawnCapabilityPort {
             .spawn_input_codec
             .register_provider_tool_call_input(&self.run_context, &tool_call)
             .await?;
-        let provider_call_id = tool_call.id.clone();
+        let provider_call =
+            ToolResultProviderCallKey::new(provider_turn_id.clone(), tool_call.id.clone());
         let activity_id = {
             let mut spawn_authorizations = self.spawn_authorizations.lock().map_err(|_| {
                 AgentLoopHostError::new(
@@ -632,7 +635,7 @@ impl SubagentSpawnCapabilityPort {
                             "provider tool-call activity identity changed",
                         ));
                     }
-                    if registered.provider_call_id != provider_call_id {
+                    if registered.provider_call != provider_call {
                         return Err(AgentLoopHostError::new(
                             AgentLoopHostErrorKind::InvalidInvocation,
                             "provider tool-call identity changed",
@@ -644,7 +647,7 @@ impl SubagentSpawnCapabilityPort {
                     let activity_id = activity_id.unwrap_or_default();
                     entry.insert(SpawnAuthorization {
                         activity_id,
-                        provider_call_id,
+                        provider_call,
                     });
                     activity_id
                 }
@@ -709,14 +712,14 @@ impl SubagentSpawnCapabilityPort {
         invocation: &LoopRequest,
         args: SpawnSubagentArgs,
         gate_override: Option<TurnGateRef>,
-        provider_call_id: String,
+        provider_call: ToolResultProviderCallKey,
     ) -> Result<Resolution, AgentLoopHostError> {
         let mut compensation = SpawnCompensationState::default();
         self.handle_spawn_with_gate_recording(
             invocation,
             args,
             gate_override,
-            provider_call_id,
+            provider_call,
             &mut compensation,
         )
         .await
@@ -727,7 +730,7 @@ impl SubagentSpawnCapabilityPort {
         invocation: &LoopRequest,
         args: SpawnSubagentArgs,
         gate_override: Option<TurnGateRef>,
-        provider_call_id: String,
+        provider_call: ToolResultProviderCallKey,
         compensation: &mut SpawnCompensationState,
     ) -> Result<Resolution, AgentLoopHostError> {
         let Some(spawn_slot) = self.reserve_spawn_slot() else {
@@ -806,7 +809,7 @@ impl SubagentSpawnCapabilityPort {
                 spawn_ctx,
                 actor,
                 invocation,
-                provider_call_id,
+                provider_call,
                 compensation,
             )
             .await;
@@ -828,7 +831,7 @@ impl SubagentSpawnCapabilityPort {
     async fn authorize_spawn(
         &self,
         invocation: &LoopRequest,
-    ) -> Result<Result<String, Resolution>, AgentLoopHostError> {
+    ) -> Result<Result<ToolResultProviderCallKey, Resolution>, AgentLoopHostError> {
         let mut spawn_authorizations = self.spawn_authorizations.lock().map_err(|_| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Unavailable,
@@ -852,7 +855,7 @@ impl SubagentSpawnCapabilityPort {
                     "subagent spawn authorization disappeared before dispatch",
                 )
             })?;
-        Ok(Ok(authorization.provider_call_id))
+        Ok(Ok(authorization.provider_call))
     }
 
     #[cfg(test)]
@@ -868,7 +871,10 @@ impl SubagentSpawnCapabilityPort {
                 input_ref,
                 SpawnAuthorization {
                     activity_id,
-                    provider_call_id: "test-provider-call".to_string(),
+                    provider_call: ToolResultProviderCallKey::new(
+                        "test-provider-turn",
+                        "test-provider-call",
+                    ),
                 },
             );
     }
@@ -899,7 +905,7 @@ impl SubagentSpawnCapabilityPort {
         ctx: SpawnContext,
         actor: TurnActor,
         invocation: &LoopRequest,
-        provider_call_id: String,
+        provider_call: ToolResultProviderCallKey,
         compensation: &mut SpawnCompensationState,
     ) -> Result<Resolution, AgentLoopHostError> {
         let SpawnContext {
@@ -961,7 +967,7 @@ impl SubagentSpawnCapabilityPort {
                     subagent_kind: definition.subagent_kind.clone(),
                     mode,
                     result_ref: result_ref.clone(),
-                    spawn_provider_call_id: Some(provider_call_id.clone()),
+                    spawn_provider_call: Some(provider_call.clone()),
                     handoff: args.handoff.clone(),
                     parent_run_context: self.run_context.clone(),
                     gate_ref: gate_ref.clone(),
@@ -1046,7 +1052,7 @@ impl SubagentSpawnCapabilityPort {
             )?,
             subagent_kind: definition.subagent_kind.clone(),
             spawn_capability_id: self.spawn_id.clone(),
-            spawn_provider_call_id: Some(provider_call_id),
+            spawn_provider_call: Some(provider_call),
             result_ref: result_ref.clone(),
             mode,
         };
@@ -1240,12 +1246,12 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 Ok(args) => args,
                 Err(error) => return spawn_input_decode_outcome(error),
             };
-            let provider_call_id = match self.authorize_spawn(&request).await? {
-                Ok(provider_call_id) => provider_call_id,
+            let provider_call = match self.authorize_spawn(&request).await? {
+                Ok(provider_call) => provider_call,
                 Err(resolution) => return Ok(resolution),
             };
             return self
-                .handle_spawn_with_gate(&request, args, None, provider_call_id)
+                .handle_spawn_with_gate(&request, args, None, provider_call)
                 .await;
         }
         self.inner.invoke_capability(request).await
@@ -1304,7 +1310,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 }
                 let outcome = match self.authorize_spawn(invocation).await {
                     Ok(Err(outcome)) => outcome,
-                    Ok(Ok(provider_call_id)) => {
+                    Ok(Ok(provider_call)) => {
                         let args = match spawn_args.remove(&index) {
                             Some(args) => args,
                             None => {
@@ -1324,7 +1330,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                                 invocation,
                                 args,
                                 gate_override,
-                                provider_call_id,
+                                provider_call,
                                 &mut compensation,
                             )
                             .await

--- a/crates/ironclaw_loop_host/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_host/src/subagent_spawn_port/tests.rs
@@ -2106,6 +2106,10 @@ async fn invoke_spawn_submits_child_run_through_spawn_tree_port() {
     assert_eq!(awaited[0].parent_run_context.run_id, context.run_id);
     assert_eq!(awaited[0].child_scope, request.child_scope);
     assert_eq!(awaited[0].result_ref.as_str(), "result:spawn");
+    assert_eq!(
+        awaited[0].spawn_provider_call_id.as_deref(),
+        Some("test-provider-call")
+    );
     assert_eq!(awaited[0].mode, SpawnSubagentMode::Blocking);
 }
 

--- a/crates/ironclaw_loop_host/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_host/src/subagent_spawn_port/tests.rs
@@ -2107,8 +2107,11 @@ async fn invoke_spawn_submits_child_run_through_spawn_tree_port() {
     assert_eq!(awaited[0].child_scope, request.child_scope);
     assert_eq!(awaited[0].result_ref.as_str(), "result:spawn");
     assert_eq!(
-        awaited[0].spawn_provider_call_id.as_deref(),
-        Some("test-provider-call")
+        awaited[0].spawn_provider_call,
+        Some(ironclaw_threads::ToolResultProviderCallKey::new(
+            "test-provider-turn",
+            "test-provider-call",
+        ))
     );
     assert_eq!(awaited[0].mode, SpawnSubagentMode::Blocking);
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/capability_host.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/capability_host.rs
@@ -373,6 +373,23 @@ impl StagedCapabilityIo {
             .map(|results| results.get(result_ref).cloned())
     }
 
+    #[cfg(test)]
+    fn latest_result_output(
+        &self,
+    ) -> Result<Option<(String, serde_json::Value)>, AgentLoopHostError> {
+        self.results
+            .lock()
+            .map_err(|_| capability_io_error())
+            .map(|results| {
+                results.oldest_refs.back().and_then(|result_ref| {
+                    results
+                        .get(result_ref)
+                        .cloned()
+                        .map(|output| (result_ref.clone(), output))
+                })
+            })
+    }
+
     async fn persist_tool_result(
         &self,
         run_context: &LoopRunContext,

--- a/crates/ironclaw_reborn_composition/src/runtime/capability_host/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/capability_host/tests.rs
@@ -1618,8 +1618,13 @@ mod tests {
             Resolution::Done(done) => done,
             other => panic!("result_read should complete, got {other:?}"),
         };
-        let continuation_output = capability_io
-            .result_output(&completed_loop_result_ref(&done))
+        assert_eq!(
+            completed_loop_result_ref(&done),
+            write_result.result_ref.as_str(),
+            "result_read must surface the original pageable result reference"
+        );
+        let (_, continuation_output) = capability_io
+            .latest_result_output()
             .expect("continuation result output lookup succeeds")
             .expect("continuation result output exists");
         let continuation_content = continuation_output["content"]
@@ -1930,6 +1935,21 @@ mod tests {
             other => panic!("result_read should complete, got {other:?}"),
         };
 
+        assert_eq!(
+            completed_loop_result_ref(&done),
+            write_result.result_ref.as_str(),
+            "result_read must surface the original pageable result reference"
+        );
+        let (inline_result_ref, _) = capability_io
+            .latest_result_output()
+            .expect("inline result lookup succeeds")
+            .expect("result_read stages inline output evidence");
+        assert_ne!(
+            inline_result_ref,
+            write_result.result_ref.as_str(),
+            "the inline write reference remains distinct from continuation authority"
+        );
+
         // RED before the fix: `result_read`'s chunk write went through the
         // same durable path as every other capability result, so this read
         // would find a durable record for the chunk's own (freshly minted)
@@ -1939,7 +1959,7 @@ mod tests {
             .read_tool_result_record(ironclaw_threads::ReadToolResultRecordRequest {
                 scope: thread_scope.clone(),
                 thread_id: run_context.thread_id.clone(),
-                result_ref: completed_loop_result_ref(&done),
+                result_ref: inline_result_ref,
                 offset: 0,
                 max_bytes: 64,
             })
@@ -3075,8 +3095,9 @@ mod tests {
         // structured fields are dropped from the loop-visible channel and can no
         // longer be asserted here. Re-express against the durable observation or
         // the preview summary.
-        let output = capability_io
-            .result_output(&completed_loop_result_ref(&done))
+        assert_eq!(completed_loop_result_ref(&done), original_result_ref);
+        let (_, output) = capability_io
+            .latest_result_output()
             .expect("result output lookup succeeds")
             .expect("result_read output exists");
         assert_eq!(output["content"], "abcdefgh");
@@ -3108,8 +3129,9 @@ mod tests {
             Resolution::Done(done) => done,
             other => panic!("adjacent result_read should complete, got {other:?}"),
         };
-        let adjacent_output = capability_io
-            .result_output(&completed_loop_result_ref(&adjacent))
+        assert_eq!(completed_loop_result_ref(&adjacent), original_result_ref);
+        let (_, adjacent_output) = capability_io
+            .latest_result_output()
             .expect("adjacent result output lookup succeeds")
             .expect("adjacent result_read output exists");
         assert_eq!(adjacent_output["content"], "ijklmnop");
@@ -3140,8 +3162,9 @@ mod tests {
             Resolution::Done(done) => done,
             other => panic!("final result_read should complete, got {other:?}"),
         };
-        let final_output = capability_io
-            .result_output(&completed_loop_result_ref(&final_chunk))
+        assert_eq!(completed_loop_result_ref(&final_chunk), original_result_ref);
+        let (_, final_output) = capability_io
+            .latest_result_output()
             .expect("final result output lookup succeeds")
             .expect("final result_read output exists");
         assert_eq!(final_output["content"], "qrstuvwxyz");

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -3819,7 +3819,7 @@ async fn cancel_run_propagates_to_subagent_children() {
                     subagent_kind: SubagentKindId::new("general").unwrap(),
                     mode: SpawnSubagentMode::Blocking,
                     result_ref,
-                    spawn_provider_call_id: None,
+                    spawn_provider_call: None,
                     handoff: None,
                     parent_run_context: parent_run_context.clone(),
                     gate_ref: ironclaw_host_api::turn::TurnGateRef::new(

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -3819,6 +3819,7 @@ async fn cancel_run_propagates_to_subagent_children() {
                     subagent_kind: SubagentKindId::new("general").unwrap(),
                     mode: SpawnSubagentMode::Blocking,
                     result_ref,
+                    spawn_provider_call_id: None,
                     handoff: None,
                     parent_run_context: parent_run_context.clone(),
                     gate_ref: ironclaw_host_api::turn::TurnGateRef::new(

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/core.rs
@@ -1035,9 +1035,9 @@ impl HostManagedModelGateway for LargeEchoToolCallingGateway {
             let observation: serde_json::Value =
                 serde_json::from_str(&tool_result.content).expect("result_read observation");
             let detail = &observation["model_observation"]["detail"];
-            assert_ne!(
+            assert_eq!(
                 detail["result_ref"], observation["result_ref"],
-                "result_read replay must retain the original result reference, not its own output ref"
+                "result_read replay must expose only the original pageable result reference"
             );
             assert!(
                 detail["total_bytes"]

--- a/crates/ironclaw_runner/src/subagent/await_edge/mod.rs
+++ b/crates/ironclaw_runner/src/subagent/await_edge/mod.rs
@@ -69,9 +69,10 @@ impl EdgeTerminalKind {
 }
 
 /// One await-edge: parent-awaits-child bookkeeping, §5.6 assembled — plus
-/// four additive fields beyond the design doc's exact list (`gate_ref`, the
+/// five additive fields beyond the design doc's exact list (`gate_ref`, the
 /// `source_binding_ref`/`reply_target_binding_ref` pair, `parent_run_context`,
-/// and `terminal_reason`), each named as a spec deviation in the PR:
+/// `spawn_provider_call_id`, and `terminal_reason`), each named as a spec
+/// deviation in the PR:
 ///
 /// - `gate_ref` (D3): the pre-existing shared-batch-gate mechanism (one
 ///   `TurnGateRef` covering N children spawned in one call, parent resumes once
@@ -88,6 +89,8 @@ impl EdgeTerminalKind {
 ///   recomputed, to avoid duplicating that private format-string logic
 ///   across the crate boundary and the drift risk of two copies going stale
 ///   independently.
+/// - `spawn_provider_call_id`: pins settlement updates to the original spawn
+///   transcript row when later `result_read` calls share its result reference.
 ///
 /// Identity (`parent_run_id`, `child_run_id`) lives in the path (§4.2), not
 /// here.
@@ -116,6 +119,8 @@ pub struct AwaitEdge {
     pub reply_target_binding_ref: ReplyTargetBindingRef,
     pub subagent_kind: SubagentKindId,
     pub spawn_capability_id: CapabilityId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawn_provider_call_id: Option<String>,
     pub result_ref: LoopResultRef,
     pub mode: SpawnSubagentMode,
     pub state: AwaitEdgeState,

--- a/crates/ironclaw_runner/src/subagent/await_edge/mod.rs
+++ b/crates/ironclaw_runner/src/subagent/await_edge/mod.rs
@@ -10,6 +10,7 @@ use ironclaw_host_api::turn::{
     LoopResultRef, ReplyTargetBindingRef, SourceBindingRef, TurnGateRef, TurnRunId, TurnScope,
 };
 use ironclaw_loop_host::{SpawnSubagentMode, SubagentKindId};
+use ironclaw_threads::ToolResultProviderCallKey;
 use serde::{Deserialize, Serialize};
 
 /// CAS state machine (§2): `Open -> Settled -> Drained`, `Open -> Abandoned`.
@@ -71,7 +72,7 @@ impl EdgeTerminalKind {
 /// One await-edge: parent-awaits-child bookkeeping, §5.6 assembled — plus
 /// five additive fields beyond the design doc's exact list (`gate_ref`, the
 /// `source_binding_ref`/`reply_target_binding_ref` pair, `parent_run_context`,
-/// `spawn_provider_call_id`, and `terminal_reason`), each named as a spec
+/// `spawn_provider_call`, and `terminal_reason`), each named as a spec
 /// deviation in the PR:
 ///
 /// - `gate_ref` (D3): the pre-existing shared-batch-gate mechanism (one
@@ -89,8 +90,10 @@ impl EdgeTerminalKind {
 ///   recomputed, to avoid duplicating that private format-string logic
 ///   across the crate boundary and the drift risk of two copies going stale
 ///   independently.
-/// - `spawn_provider_call_id`: pins settlement updates to the original spawn
+/// - `spawn_provider_call`: pins settlement updates to the original spawn
 ///   transcript row when later `result_read` calls share its result reference.
+///   Both halves are load-bearing — providers that mint tool-call ids per
+///   response reuse the same call id across turns of one run.
 ///
 /// Identity (`parent_run_id`, `child_run_id`) lives in the path (§4.2), not
 /// here.
@@ -120,7 +123,7 @@ pub struct AwaitEdge {
     pub subagent_kind: SubagentKindId,
     pub spawn_capability_id: CapabilityId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub spawn_provider_call_id: Option<String>,
+    pub spawn_provider_call: Option<ToolResultProviderCallKey>,
     pub result_ref: LoopResultRef,
     pub mode: SpawnSubagentMode,
     pub state: AwaitEdgeState,

--- a/crates/ironclaw_runner/src/subagent/await_edge/resolver.rs
+++ b/crates/ironclaw_runner/src/subagent/await_edge/resolver.rs
@@ -376,6 +376,7 @@ where
                     reason: reason.to_string(),
                 },
             )?,
+            spawn_provider_call_id: metadata.spawn_provider_call_id,
             result_ref: metadata.result_ref,
             mode: metadata.mode,
             state: AwaitEdgeState::Open,
@@ -480,6 +481,7 @@ where
                 thread_id: edge.parent_thread_id.clone(),
                 turn_run_id: parent_run_id.to_string(),
                 result_ref: edge.result_ref.as_str().to_string(),
+                provider_call_id: edge.spawn_provider_call_id.clone(),
                 safe_summary,
             })
             .await
@@ -1057,6 +1059,7 @@ mod tests {
             mode: ironclaw_loop_host::SpawnSubagentMode::Blocking,
             result_ref: ironclaw_host_api::turn::LoopResultRef::new("result:subagent.recon-t1")
                 .unwrap(),
+            spawn_provider_call_id: Some("spawn-call-recon-t1".to_string()),
             handoff: None,
             parent_run_context: parent_context.clone(),
             gate_ref: metadata_gate_ref.clone(),
@@ -1137,6 +1140,7 @@ mod tests {
             mode: ironclaw_loop_host::SpawnSubagentMode::Blocking,
             result_ref: ironclaw_host_api::turn::LoopResultRef::new("result:subagent.recon-t2")
                 .unwrap(),
+            spawn_provider_call_id: None,
             handoff: None,
             parent_run_context: parent_context,
             gate_ref: TurnGateRef::new("gate:subagent-t2").unwrap(),
@@ -1283,6 +1287,7 @@ mod tests {
             mode: ironclaw_loop_host::SpawnSubagentMode::Blocking,
             result_ref: ironclaw_host_api::turn::LoopResultRef::new("result:subagent.recon-t4")
                 .unwrap(),
+            spawn_provider_call_id: None,
             handoff: None,
             parent_run_context: tampered_context,
             gate_ref: TurnGateRef::new("gate:subagent-t4").unwrap(),
@@ -1441,7 +1446,7 @@ mod tests {
     #[tokio::test]
     async fn mixed_status_group_updates_each_result_resumes_once_and_consumes_every_edge() {
         use chrono::Utc;
-        use ironclaw_host_api::ids::ProcessId;
+        use ironclaw_host_api::ids::{ProcessId, ProviderToolName};
         use ironclaw_loop_host::{AwaitedChildSetRecord, SpawnSubagentMode, SubagentKindId};
         use ironclaw_processes::{
             ProcessDependencyPort, ProcessDependencySubmission, ProcessJournalStore, ProcessKind,
@@ -1449,8 +1454,9 @@ mod tests {
         };
         use ironclaw_threads::{
             AppendFinalizedAssistantMessageRequest, AppendToolResultReferenceRequest,
-            EnsureThreadRequest, MessageContent, SessionThreadService, ThreadHistoryRequest,
-            ThreadScope, ToolResultReferenceEnvelope, ToolResultSafeSummary,
+            EnsureThreadRequest, MessageContent, ProviderToolCallReferenceEnvelope,
+            SessionThreadService, ThreadHistoryRequest, ThreadScope, ToolResultReferenceEnvelope,
+            ToolResultSafeSummary,
         };
 
         let process_store = Arc::new(ProcessJournalStore::new(recon_scoped_fs()));
@@ -1566,6 +1572,7 @@ mod tests {
             let result_ref =
                 ironclaw_host_api::turn::LoopResultRef::new(format!("result:drain-{label}"))
                     .expect("result ref");
+            let spawn_provider_call_id = format!("spawn-call-{label}");
             thread_service
                 .ensure_thread(EnsureThreadRequest {
                     scope: parent_thread_scope.clone(),
@@ -1593,7 +1600,20 @@ mod tests {
                     result_ref: result_ref.as_str().to_string(),
                     safe_summary: ToolResultSafeSummary::new("subagent still running")
                         .expect("initial summary"),
-                    provider_call: None,
+                    provider_call: Some(ProviderToolCallReferenceEnvelope {
+                        provider_id: "test-provider".to_string(),
+                        provider_model_id: "test-model".to_string(),
+                        provider_turn_id: "test-turn".to_string(),
+                        provider_call_id: spawn_provider_call_id.clone(),
+                        provider_tool_name: ProviderToolName::new("spawn_subagent")
+                            .expect("provider tool name"),
+                        capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
+                            .expect("capability"),
+                        arguments: serde_json::json!({"task": label}),
+                        response_reasoning: None,
+                        reasoning: None,
+                        signature: None,
+                    }),
                     model_observation: None,
                 })
                 .await
@@ -1617,6 +1637,7 @@ mod tests {
                 subagent_kind: SubagentKindId::new("general").expect("kind"),
                 spawn_capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
                     .expect("capability"),
+                spawn_provider_call_id: Some(spawn_provider_call_id),
                 result_ref: result_ref.clone(),
                 mode: SpawnSubagentMode::Blocking,
             };

--- a/crates/ironclaw_runner/src/subagent/await_edge/resolver.rs
+++ b/crates/ironclaw_runner/src/subagent/await_edge/resolver.rs
@@ -376,7 +376,7 @@ where
                     reason: reason.to_string(),
                 },
             )?,
-            spawn_provider_call_id: metadata.spawn_provider_call_id,
+            spawn_provider_call: metadata.spawn_provider_call,
             result_ref: metadata.result_ref,
             mode: metadata.mode,
             state: AwaitEdgeState::Open,
@@ -481,7 +481,7 @@ where
                 thread_id: edge.parent_thread_id.clone(),
                 turn_run_id: parent_run_id.to_string(),
                 result_ref: edge.result_ref.as_str().to_string(),
-                provider_call_id: edge.spawn_provider_call_id.clone(),
+                provider_call: edge.spawn_provider_call.clone(),
                 safe_summary,
             })
             .await
@@ -1059,7 +1059,10 @@ mod tests {
             mode: ironclaw_loop_host::SpawnSubagentMode::Blocking,
             result_ref: ironclaw_host_api::turn::LoopResultRef::new("result:subagent.recon-t1")
                 .unwrap(),
-            spawn_provider_call_id: Some("spawn-call-recon-t1".to_string()),
+            spawn_provider_call: Some(ironclaw_threads::ToolResultProviderCallKey::new(
+                "spawn-turn-recon-t1",
+                "spawn-call-recon-t1",
+            )),
             handoff: None,
             parent_run_context: parent_context.clone(),
             gate_ref: metadata_gate_ref.clone(),
@@ -1140,7 +1143,7 @@ mod tests {
             mode: ironclaw_loop_host::SpawnSubagentMode::Blocking,
             result_ref: ironclaw_host_api::turn::LoopResultRef::new("result:subagent.recon-t2")
                 .unwrap(),
-            spawn_provider_call_id: None,
+            spawn_provider_call: None,
             handoff: None,
             parent_run_context: parent_context,
             gate_ref: TurnGateRef::new("gate:subagent-t2").unwrap(),
@@ -1287,7 +1290,7 @@ mod tests {
             mode: ironclaw_loop_host::SpawnSubagentMode::Blocking,
             result_ref: ironclaw_host_api::turn::LoopResultRef::new("result:subagent.recon-t4")
                 .unwrap(),
-            spawn_provider_call_id: None,
+            spawn_provider_call: None,
             handoff: None,
             parent_run_context: tampered_context,
             gate_ref: TurnGateRef::new("gate:subagent-t4").unwrap(),
@@ -1572,7 +1575,10 @@ mod tests {
             let result_ref =
                 ironclaw_host_api::turn::LoopResultRef::new(format!("result:drain-{label}"))
                     .expect("result ref");
-            let spawn_provider_call_id = format!("spawn-call-{label}");
+            let spawn_provider_call = ironclaw_threads::ToolResultProviderCallKey::new(
+                "test-turn",
+                format!("spawn-call-{label}"),
+            );
             thread_service
                 .ensure_thread(EnsureThreadRequest {
                     scope: parent_thread_scope.clone(),
@@ -1603,8 +1609,8 @@ mod tests {
                     provider_call: Some(ProviderToolCallReferenceEnvelope {
                         provider_id: "test-provider".to_string(),
                         provider_model_id: "test-model".to_string(),
-                        provider_turn_id: "test-turn".to_string(),
-                        provider_call_id: spawn_provider_call_id.clone(),
+                        provider_turn_id: spawn_provider_call.provider_turn_id.clone(),
+                        provider_call_id: spawn_provider_call.provider_call_id.clone(),
                         provider_tool_name: ProviderToolName::new("spawn_subagent")
                             .expect("provider tool name"),
                         capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
@@ -1637,7 +1643,7 @@ mod tests {
                 subagent_kind: SubagentKindId::new("general").expect("kind"),
                 spawn_capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
                     .expect("capability"),
-                spawn_provider_call_id: Some(spawn_provider_call_id),
+                spawn_provider_call: Some(spawn_provider_call),
                 result_ref: result_ref.clone(),
                 mode: SpawnSubagentMode::Blocking,
             };

--- a/crates/ironclaw_runner/src/subagent/await_edge/store.rs
+++ b/crates/ironclaw_runner/src/subagent/await_edge/store.rs
@@ -10,6 +10,8 @@ use ironclaw_processes::{
     ProcessDependencyRecord, ProcessDependencyState, ProcessJournalStoreError,
     ProcessLifecycleStatus, ProcessTerminalEvidence, SettleProcessDependencyRequest,
 };
+#[cfg(test)]
+use ironclaw_threads::ToolResultProviderCallKey;
 
 use super::{
     AwaitEdge, AwaitEdgeState, AwaitEdgeStoreError, EdgeTerminalKind, ReservationReleaseState,
@@ -71,7 +73,7 @@ impl AwaitEdgeStore {
                     reply_target_binding_ref: submitted.reply_target_binding_ref,
                     subagent_kind: submitted.subagent_kind,
                     spawn_capability_id: submitted.spawn_capability_id,
-                    spawn_provider_call_id: submitted.spawn_provider_call_id,
+                    spawn_provider_call: submitted.spawn_provider_call,
                     result_ref: submitted.result_ref,
                     mode: submitted.mode,
                     state: AwaitEdgeState::Open,
@@ -371,7 +373,10 @@ mod tests {
                     ironclaw_loop_host::DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID,
                 )
                 .expect("capability"),
-                spawn_provider_call_id: Some("spawn-call-store-transition".to_string()),
+                spawn_provider_call: Some(ToolResultProviderCallKey::new(
+                    "spawn-turn-store-transition",
+                    "spawn-call-store-transition",
+                )),
                 result_ref: LoopResultRef::new("result:store-transition").expect("result"),
                 mode: SpawnSubagentMode::Blocking,
                 state: AwaitEdgeState::Open,
@@ -486,7 +491,7 @@ mod tests {
             reply_target_binding_ref: edge.reply_target_binding_ref.clone(),
             subagent_kind: edge.subagent_kind.clone(),
             spawn_capability_id: edge.spawn_capability_id.clone(),
-            spawn_provider_call_id: edge.spawn_provider_call_id.clone(),
+            spawn_provider_call: edge.spawn_provider_call.clone(),
             result_ref: edge.result_ref.clone(),
             mode: edge.mode,
         };

--- a/crates/ironclaw_runner/src/subagent/await_edge/store.rs
+++ b/crates/ironclaw_runner/src/subagent/await_edge/store.rs
@@ -71,6 +71,7 @@ impl AwaitEdgeStore {
                     reply_target_binding_ref: submitted.reply_target_binding_ref,
                     subagent_kind: submitted.subagent_kind,
                     spawn_capability_id: submitted.spawn_capability_id,
+                    spawn_provider_call_id: submitted.spawn_provider_call_id,
                     result_ref: submitted.result_ref,
                     mode: submitted.mode,
                     state: AwaitEdgeState::Open,
@@ -370,6 +371,7 @@ mod tests {
                     ironclaw_loop_host::DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID,
                 )
                 .expect("capability"),
+                spawn_provider_call_id: Some("spawn-call-store-transition".to_string()),
                 result_ref: LoopResultRef::new("result:store-transition").expect("result"),
                 mode: SpawnSubagentMode::Blocking,
                 state: AwaitEdgeState::Open,
@@ -484,6 +486,7 @@ mod tests {
             reply_target_binding_ref: edge.reply_target_binding_ref.clone(),
             subagent_kind: edge.subagent_kind.clone(),
             spawn_capability_id: edge.spawn_capability_id.clone(),
+            spawn_provider_call_id: edge.spawn_provider_call_id.clone(),
             result_ref: edge.result_ref.clone(),
             mode: edge.mode,
         };

--- a/crates/ironclaw_runner/src/subagent/prompt_material.rs
+++ b/crates/ironclaw_runner/src/subagent/prompt_material.rs
@@ -494,6 +494,7 @@ mod tests {
                 subagent_kind,
                 mode: SpawnSubagentMode::Blocking,
                 result_ref: LoopResultRef::new("result:subagent.prompt").unwrap(),
+                spawn_provider_call_id: None,
                 handoff: None,
                 parent_run_context: context.clone(),
                 gate_ref: TurnGateRef::new("gate:subagent-prompt-test").unwrap(),

--- a/crates/ironclaw_runner/src/subagent/prompt_material.rs
+++ b/crates/ironclaw_runner/src/subagent/prompt_material.rs
@@ -494,7 +494,7 @@ mod tests {
                 subagent_kind,
                 mode: SpawnSubagentMode::Blocking,
                 result_ref: LoopResultRef::new("result:subagent.prompt").unwrap(),
-                spawn_provider_call_id: None,
+                spawn_provider_call: None,
                 handoff: None,
                 parent_run_context: context.clone(),
                 gate_ref: TurnGateRef::new("gate:subagent-prompt-test").unwrap(),

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::capability_display_preview::CapabilityDisplayPreviewEnvelope;
 use crate::identifiers::{SummaryArtifactId, ThreadMessageId};
-use crate::tool_result_reference::{ProviderToolCallReferenceEnvelope, ToolResultSafeSummary};
+use crate::tool_result_reference::{
+    ProviderToolCallReferenceEnvelope, ToolResultProviderCallKey, ToolResultSafeSummary,
+};
 
 pub const GOAL_STATEMENT_MAX_CHARS: usize = 4000;
 
@@ -446,9 +448,11 @@ pub struct UpdateToolResultReferenceRequest {
     pub thread_id: ThreadId,
     pub turn_run_id: String,
     pub result_ref: String,
-    /// Exact provider-call row to update. `None` is reserved for legacy
-    /// callers whose durable edge predates provider-call identity.
-    pub provider_call_id: Option<String>,
+    /// Exact provider-call row to update, identified by provider turn *and*
+    /// call id — the call id alone repeats across turns on providers that mint
+    /// it per response. `None` is reserved for legacy callers whose durable
+    /// edge predates provider-call identity.
+    pub provider_call: Option<ToolResultProviderCallKey>,
     pub safe_summary: ToolResultSafeSummary,
 }
 

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -446,6 +446,9 @@ pub struct UpdateToolResultReferenceRequest {
     pub thread_id: ThreadId,
     pub turn_run_id: String,
     pub result_ref: String,
+    /// Exact provider-call row to update. `None` is reserved for legacy
+    /// callers whose durable edge predates provider-call identity.
+    pub provider_call_id: Option<String>,
     pub safe_summary: ToolResultSafeSummary,
 }
 

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -78,11 +78,12 @@ use crate::{
     CreateSummaryArtifactRequest, DeleteToolResultRecordRequest, EnsureThreadRequest,
     LatestThreadMessageRequest, ListThreadsForScopeRequest, ListThreadsForScopeResponse,
     LoadContextMessagesRequest, LoadContextWindowRequest, MessageContent, MessageKind,
-    MessageStatus, PutToolResultRecordRequest, ReadToolResultRecordRequest, RedactMessageRequest,
-    ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadRecord,
-    SessionThreadService, SummaryArtifact, SummaryModelContextPolicy, ThreadHistory,
-    ThreadHistoryRequest, ThreadMessageId, ThreadMessageRange, ThreadMessageRangeRequest,
-    ThreadMessageRecord, ThreadScope, ToolResultRecordChunk, ToolResultReferenceEnvelope,
+    MessageStatus, ProviderToolCallReferenceEnvelope, PutToolResultRecordRequest,
+    ReadToolResultRecordRequest, RedactMessageRequest, ReplayAcceptedInboundMessageRequest,
+    SessionThreadError, SessionThreadRecord, SessionThreadService, SummaryArtifact,
+    SummaryModelContextPolicy, ThreadHistory, ThreadHistoryRequest, ThreadMessageId,
+    ThreadMessageRange, ThreadMessageRangeRequest, ThreadMessageRecord, ThreadScope,
+    ToolResultProviderCallKey, ToolResultRecordChunk, ToolResultReferenceEnvelope,
     UpdateAssistantDraftRequest, UpdateToolResultRecordRequest, UpdateToolResultReferenceRequest,
 };
 use message_lookup_index::MessageLookupIndexStore;
@@ -710,19 +711,19 @@ where
         thread_id: &ThreadId,
         turn_run_id: &str,
         result_ref: &str,
-        provider_call_id: Option<&str>,
+        provider_call: Option<&ToolResultProviderCallKey>,
     ) -> Result<Option<ThreadMessageRecord>, SessionThreadError> {
         self.ensure_transcript_indexes_migrated(scope).await?;
         let index_store = MessageLookupIndexStore::new(self.filesystem.as_ref());
-        let indexed_message_id = match provider_call_id {
-            Some(provider_call_id) => {
+        let indexed_message_id = match provider_call {
+            Some(provider_call) => {
                 index_store
                     .read_tool_result_provider_call(
                         scope,
                         thread_id,
                         turn_run_id,
                         result_ref,
-                        provider_call_id,
+                        provider_call,
                     )
                     .await?
             }
@@ -740,7 +741,7 @@ where
                 &message,
                 turn_run_id,
                 result_ref,
-                provider_call_id,
+                provider_call,
             )
         {
             return Ok(Some(message));
@@ -750,7 +751,7 @@ where
         // provider-call-specific result indexes. Before provider calls were
         // part of this key there could be at most one row per (run, result), so
         // only a row with no provider metadata is an unambiguous legacy match.
-        if provider_call_id.is_some() {
+        if provider_call.is_some() {
             let indexed_message_id = index_store
                 .read_tool_result(scope, thread_id, turn_run_id, result_ref)
                 .await?;
@@ -1986,15 +1987,16 @@ where
             request.model_observation,
         )
         .map_err(SessionThreadError::Serialization)?;
+        let provider_call_key = provider_call
+            .as_ref()
+            .map(ProviderToolCallReferenceEnvelope::call_key);
         if let Some(existing) = self
             .find_tool_result_reference_message(
                 &request.scope,
                 &request.thread_id,
                 &request.turn_run_id,
                 &envelope.result_ref,
-                provider_call
-                    .as_ref()
-                    .map(|provider_call| provider_call.provider_call_id.as_str()),
+                provider_call_key.as_ref(),
             )
             .await?
         {
@@ -2195,7 +2197,7 @@ where
                 &request.thread_id,
                 &request.turn_run_id,
                 &request.result_ref,
-                request.provider_call_id.as_deref(),
+                request.provider_call.as_ref(),
             )
             .await?
             .ok_or_else(|| {
@@ -2212,7 +2214,7 @@ where
         // the initial lookup path.
         let turn_run_id = request.turn_run_id.clone();
         let result_ref = request.result_ref.clone();
-        let provider_call_id = request.provider_call_id.clone();
+        let provider_call = request.provider_call.clone();
         let thread_id_for_error = request.thread_id.clone();
         let safe_summary = request.safe_summary;
         let now = Utc::now();
@@ -2226,7 +2228,7 @@ where
                     message,
                     &turn_run_id,
                     &result_ref,
-                    provider_call_id.as_deref(),
+                    provider_call.as_ref(),
                 ) {
                     return Err(SessionThreadError::Backend(format!(
                         "tool result reference {result_ref} was not found in thread {thread_id_for_error}",
@@ -3297,14 +3299,14 @@ fn matches_tool_result_reference_invocation(
     message: &ThreadMessageRecord,
     turn_run_id: &str,
     result_ref: &str,
-    provider_call_id: Option<&str>,
+    provider_call: Option<&ToolResultProviderCallKey>,
 ) -> bool {
     matches_tool_result_reference(message, turn_run_id, result_ref)
-        && provider_call_id.is_none_or(|requested| {
+        && provider_call.is_none_or(|requested| {
             message
                 .tool_result_provider_call
                 .as_ref()
-                .is_none_or(|existing| existing.provider_call_id == requested)
+                .is_none_or(|existing| existing.matches_call_key(requested))
         })
 }
 

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -710,19 +710,63 @@ where
         thread_id: &ThreadId,
         turn_run_id: &str,
         result_ref: &str,
+        provider_call_id: Option<&str>,
     ) -> Result<Option<ThreadMessageRecord>, SessionThreadError> {
         self.ensure_transcript_indexes_migrated(scope).await?;
         let index_store = MessageLookupIndexStore::new(self.filesystem.as_ref());
-        let indexed_message_id = index_store
-            .read_tool_result(scope, thread_id, turn_run_id, result_ref)
-            .await?;
+        let indexed_message_id = match provider_call_id {
+            Some(provider_call_id) => {
+                index_store
+                    .read_tool_result_provider_call(
+                        scope,
+                        thread_id,
+                        turn_run_id,
+                        result_ref,
+                        provider_call_id,
+                    )
+                    .await?
+            }
+            None => {
+                index_store
+                    .read_tool_result(scope, thread_id, turn_run_id, result_ref)
+                    .await?
+            }
+        };
         if let Some(message_id) = indexed_message_id
             && let Some((message, _)) = self
                 .read_message_versioned(scope, thread_id, message_id)
                 .await?
-            && matches_tool_result_reference(&message, turn_run_id, result_ref)
+            && matches_tool_result_reference_invocation(
+                &message,
+                turn_run_id,
+                result_ref,
+                provider_call_id,
+            )
         {
             return Ok(Some(message));
+        }
+
+        // Compatibility/backfill path for rows whose generic v1 index predates
+        // provider-call-specific result indexes. Before provider calls were
+        // part of this key there could be at most one row per (run, result), so
+        // accepting only a missing or matching call id is unambiguous.
+        if provider_call_id.is_some() {
+            let indexed_message_id = index_store
+                .read_tool_result(scope, thread_id, turn_run_id, result_ref)
+                .await?;
+            if let Some(message_id) = indexed_message_id
+                && let Some((message, _)) = self
+                    .read_message_versioned(scope, thread_id, message_id)
+                    .await?
+                && matches_tool_result_reference_invocation(
+                    &message,
+                    turn_run_id,
+                    result_ref,
+                    provider_call_id,
+                )
+            {
+                return Ok(Some(message));
+            }
         }
 
         Ok(None)
@@ -1935,6 +1979,11 @@ where
         request: AppendToolResultReferenceRequest,
     ) -> Result<ThreadMessageRecord, SessionThreadError> {
         let provider_call = request.provider_call;
+        if let Some(provider_call) = &provider_call {
+            provider_call
+                .validate()
+                .map_err(SessionThreadError::Serialization)?;
+        }
         let envelope = ToolResultReferenceEnvelope::new_best_effort_model_observation(
             request.result_ref,
             request.safe_summary,
@@ -1947,6 +1996,9 @@ where
                 &request.thread_id,
                 &request.turn_run_id,
                 &envelope.result_ref,
+                provider_call
+                    .as_ref()
+                    .map(|provider_call| provider_call.provider_call_id.as_str()),
             )
             .await?
         {
@@ -1954,9 +2006,6 @@ where
             // and attach it (or reject on conflict) — matching the in-memory
             // contract semantics.
             let provider_call_update = if let Some(provider_call) = provider_call.as_ref() {
-                provider_call
-                    .validate()
-                    .map_err(SessionThreadError::Serialization)?;
                 match existing.tool_result_provider_call.as_ref() {
                     Some(existing_call) if existing_call == provider_call => None,
                     Some(_) => {
@@ -2018,11 +2067,6 @@ where
                 return Ok(updated);
             }
             return Ok(existing);
-        }
-        if let Some(provider_call) = &provider_call {
-            provider_call
-                .validate()
-                .map_err(SessionThreadError::Serialization)?;
         }
         let content = serde_json::to_string(&envelope)
             .map_err(|error| SessionThreadError::Serialization(error.to_string()))?;
@@ -2155,6 +2199,7 @@ where
                 &request.thread_id,
                 &request.turn_run_id,
                 &request.result_ref,
+                None,
             )
             .await?
             .ok_or_else(|| {
@@ -3244,6 +3289,21 @@ fn matches_tool_result_reference(
         && message.status == MessageStatus::Finalized
         && message.turn_run_id.as_deref() == Some(turn_run_id)
         && message.tool_result_ref.as_deref() == Some(result_ref)
+}
+
+fn matches_tool_result_reference_invocation(
+    message: &ThreadMessageRecord,
+    turn_run_id: &str,
+    result_ref: &str,
+    provider_call_id: Option<&str>,
+) -> bool {
+    matches_tool_result_reference(message, turn_run_id, result_ref)
+        && provider_call_id.is_none_or(|requested| {
+            message
+                .tool_result_provider_call
+                .as_ref()
+                .is_none_or(|existing| existing.provider_call_id == requested)
+        })
 }
 
 fn assistant_message_matches_run(

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -749,7 +749,7 @@ where
         // Compatibility/backfill path for rows whose generic v1 index predates
         // provider-call-specific result indexes. Before provider calls were
         // part of this key there could be at most one row per (run, result), so
-        // accepting only a missing or matching call id is unambiguous.
+        // only a row with no provider metadata is an unambiguous legacy match.
         if provider_call_id.is_some() {
             let indexed_message_id = index_store
                 .read_tool_result(scope, thread_id, turn_run_id, result_ref)
@@ -758,12 +758,8 @@ where
                 && let Some((message, _)) = self
                     .read_message_versioned(scope, thread_id, message_id)
                     .await?
-                && matches_tool_result_reference_invocation(
-                    &message,
-                    turn_run_id,
-                    result_ref,
-                    provider_call_id,
-                )
+                && matches_tool_result_reference(&message, turn_run_id, result_ref)
+                && message.tool_result_provider_call.is_none()
             {
                 return Ok(Some(message));
             }
@@ -2199,7 +2195,7 @@ where
                 &request.thread_id,
                 &request.turn_run_id,
                 &request.result_ref,
-                None,
+                request.provider_call_id.as_deref(),
             )
             .await?
             .ok_or_else(|| {
@@ -2216,6 +2212,7 @@ where
         // the initial lookup path.
         let turn_run_id = request.turn_run_id.clone();
         let result_ref = request.result_ref.clone();
+        let provider_call_id = request.provider_call_id.clone();
         let thread_id_for_error = request.thread_id.clone();
         let safe_summary = request.safe_summary;
         let now = Utc::now();
@@ -2225,7 +2222,12 @@ where
             &request.thread_id,
             message.message_id,
             |message| {
-                if !matches_tool_result_reference(message, &turn_run_id, &result_ref) {
+                if !matches_tool_result_reference_invocation(
+                    message,
+                    &turn_run_id,
+                    &result_ref,
+                    provider_call_id.as_deref(),
+                ) {
                     return Err(SessionThreadError::Backend(format!(
                         "tool result reference {result_ref} was not found in thread {thread_id_for_error}",
                     )));

--- a/crates/ironclaw_threads/src/filesystem_service/message_lookup_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/message_lookup_index.rs
@@ -66,6 +66,25 @@ where
                 message.message_id,
             )
             .await?;
+            if let Some(provider_call_id) = message
+                .tool_result_provider_call
+                .as_ref()
+                .map(|provider_call| provider_call.provider_call_id.as_str())
+            {
+                self.write(
+                    scope,
+                    &tool_result_provider_call_index_path(
+                        scope,
+                        thread_id,
+                        turn_run_id,
+                        result_ref,
+                        provider_call_id,
+                    )?,
+                    thread_id,
+                    message.message_id,
+                )
+                .await?;
+            }
         }
         if message.kind == MessageKind::User {
             self.write_if_absent(
@@ -133,6 +152,22 @@ where
                 tool_result_index_path(scope, thread_id, turn_run_id, result_ref)?,
                 CasExpectation::Any,
             )?;
+            if let Some(provider_call_id) = message
+                .tool_result_provider_call
+                .as_ref()
+                .map(|provider_call| provider_call.provider_call_id.as_str())
+            {
+                push(
+                    tool_result_provider_call_index_path(
+                        scope,
+                        thread_id,
+                        turn_run_id,
+                        result_ref,
+                        provider_call_id,
+                    )?,
+                    CasExpectation::Any,
+                )?;
+            }
         }
         if message.kind == MessageKind::User {
             push(
@@ -199,6 +234,24 @@ where
         result_ref: &str,
     ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
         let path = tool_result_index_path(scope, thread_id, turn_run_id, result_ref)?;
+        self.read(scope, thread_id, &path).await
+    }
+
+    pub(super) async fn read_tool_result_provider_call(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        turn_run_id: &str,
+        result_ref: &str,
+        provider_call_id: &str,
+    ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
+        let path = tool_result_provider_call_index_path(
+            scope,
+            thread_id,
+            turn_run_id,
+            result_ref,
+            provider_call_id,
+        )?;
         self.read(scope, thread_id, &path).await
     }
 
@@ -346,6 +399,33 @@ fn tool_result_index_path(
         &ToolResultIndexKey {
             turn_run_id,
             result_ref,
+        },
+    )?;
+    scoped_path(&format!(
+        "{}/indexes/tool-results/{key}.json",
+        thread_root_string(scope, thread_id)
+    ))
+}
+
+fn tool_result_provider_call_index_path(
+    scope: &ThreadScope,
+    thread_id: &ThreadId,
+    turn_run_id: &str,
+    result_ref: &str,
+    provider_call_id: &str,
+) -> Result<ScopedPath, SessionThreadError> {
+    #[derive(Serialize)]
+    struct ToolResultProviderCallIndexKey<'a> {
+        turn_run_id: &'a str,
+        result_ref: &'a str,
+        provider_call_id: &'a str,
+    }
+    let key = lookup_index_key(
+        "tool-result-provider-call",
+        &ToolResultProviderCallIndexKey {
+            turn_run_id,
+            result_ref,
+            provider_call_id,
         },
     )?;
     scoped_path(&format!(

--- a/crates/ironclaw_threads/src/filesystem_service/message_lookup_index.rs
+++ b/crates/ironclaw_threads/src/filesystem_service/message_lookup_index.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     CapabilityDisplayPreviewEnvelope, MessageKind, SessionThreadError, ThreadMessageId,
-    ThreadMessageRecord, ThreadScope,
+    ThreadMessageRecord, ThreadScope, ToolResultProviderCallKey,
 };
 
 use super::{
@@ -66,11 +66,7 @@ where
                 message.message_id,
             )
             .await?;
-            if let Some(provider_call_id) = message
-                .tool_result_provider_call
-                .as_ref()
-                .map(|provider_call| provider_call.provider_call_id.as_str())
-            {
+            if let Some(provider_call) = message.tool_result_provider_call.as_ref() {
                 self.write(
                     scope,
                     &tool_result_provider_call_index_path(
@@ -78,7 +74,7 @@ where
                         thread_id,
                         turn_run_id,
                         result_ref,
-                        provider_call_id,
+                        &provider_call.call_key(),
                     )?,
                     thread_id,
                     message.message_id,
@@ -152,18 +148,14 @@ where
                 tool_result_index_path(scope, thread_id, turn_run_id, result_ref)?,
                 CasExpectation::Any,
             )?;
-            if let Some(provider_call_id) = message
-                .tool_result_provider_call
-                .as_ref()
-                .map(|provider_call| provider_call.provider_call_id.as_str())
-            {
+            if let Some(provider_call) = message.tool_result_provider_call.as_ref() {
                 push(
                     tool_result_provider_call_index_path(
                         scope,
                         thread_id,
                         turn_run_id,
                         result_ref,
-                        provider_call_id,
+                        &provider_call.call_key(),
                     )?,
                     CasExpectation::Any,
                 )?;
@@ -243,14 +235,14 @@ where
         thread_id: &ThreadId,
         turn_run_id: &str,
         result_ref: &str,
-        provider_call_id: &str,
+        provider_call: &ToolResultProviderCallKey,
     ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
         let path = tool_result_provider_call_index_path(
             scope,
             thread_id,
             turn_run_id,
             result_ref,
-            provider_call_id,
+            provider_call,
         )?;
         self.read(scope, thread_id, &path).await
     }
@@ -412,12 +404,13 @@ fn tool_result_provider_call_index_path(
     thread_id: &ThreadId,
     turn_run_id: &str,
     result_ref: &str,
-    provider_call_id: &str,
+    provider_call: &ToolResultProviderCallKey,
 ) -> Result<ScopedPath, SessionThreadError> {
     #[derive(Serialize)]
     struct ToolResultProviderCallIndexKey<'a> {
         turn_run_id: &'a str,
         result_ref: &'a str,
+        provider_turn_id: &'a str,
         provider_call_id: &'a str,
     }
     let key = lookup_index_key(
@@ -425,7 +418,8 @@ fn tool_result_provider_call_index_path(
         &ToolResultProviderCallIndexKey {
             turn_run_id,
             result_ref,
-            provider_call_id,
+            provider_turn_id: provider_call.provider_turn_id.as_str(),
+            provider_call_id: provider_call.provider_call_id.as_str(),
         },
     )?;
     scoped_path(&format!(

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -530,7 +530,8 @@ impl SessionThreadService for InMemorySessionThreadService {
                         .tool_result_provider_call
                         .as_ref()
                         .is_none_or(|existing| {
-                            existing.provider_call_id == requested.provider_call_id
+                            existing.provider_turn_id == requested.provider_turn_id
+                                && existing.provider_call_id == requested.provider_call_id
                         })
                 })
         }) {
@@ -687,7 +688,7 @@ impl SessionThreadService for InMemorySessionThreadService {
                     && message.turn_run_id.as_deref() == Some(request.turn_run_id.as_str())
                     && message.tool_result_ref.as_deref() == Some(request.result_ref.as_str())
             };
-            let message_index = match request.provider_call_id.as_deref() {
+            let message_index = match request.provider_call.as_ref() {
                 Some(requested) => thread
                     .messages
                     .iter()
@@ -696,7 +697,7 @@ impl SessionThreadService for InMemorySessionThreadService {
                             && message
                                 .tool_result_provider_call
                                 .as_ref()
-                                .is_some_and(|existing| existing.provider_call_id == requested)
+                                .is_some_and(|existing| existing.matches_call_key(requested))
                     })
                     .or_else(|| {
                         thread.messages.iter().position(|message| {

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -509,6 +509,11 @@ impl SessionThreadService for InMemorySessionThreadService {
         let mut state = self.state.lock().await;
         let thread = get_thread_mut(&mut state, &request.scope, &request.thread_id)?;
         let provider_call = request.provider_call;
+        if let Some(provider_call) = &provider_call {
+            provider_call
+                .validate()
+                .map_err(SessionThreadError::Serialization)?;
+        }
         let envelope = ToolResultReferenceEnvelope::new_best_effort_model_observation(
             request.result_ref,
             request.safe_summary,
@@ -520,15 +525,20 @@ impl SessionThreadService for InMemorySessionThreadService {
                 && message.status == MessageStatus::Finalized
                 && message.turn_run_id.as_deref() == Some(request.turn_run_id.as_str())
                 && message.tool_result_ref.as_deref() == Some(envelope.result_ref.as_str())
+                && provider_call.as_ref().is_none_or(|requested| {
+                    message
+                        .tool_result_provider_call
+                        .as_ref()
+                        .is_none_or(|existing| {
+                            existing.provider_call_id == requested.provider_call_id
+                        })
+                })
         }) {
             let now = Utc::now();
             let before_created_at = existing.created_at;
             let before_updated_at = existing.updated_at;
             let mut changed = false;
             if let Some(provider_call) = provider_call.as_ref() {
-                provider_call
-                    .validate()
-                    .map_err(SessionThreadError::Serialization)?;
                 match existing.tool_result_provider_call.as_ref() {
                     None => {
                         existing.tool_result_provider_call = Some(provider_call.clone());
@@ -576,11 +586,6 @@ impl SessionThreadService for InMemorySessionThreadService {
                 thread.record.updated_at = Some(now);
             }
             return Ok(updated);
-        }
-        if let Some(provider_call) = &provider_call {
-            provider_call
-                .validate()
-                .map_err(SessionThreadError::Serialization)?;
         }
         let content = serde_json::to_string(&envelope)
             .map_err(|error| SessionThreadError::Serialization(error.to_string()))?;

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -681,21 +681,40 @@ impl SessionThreadService for InMemorySessionThreadService {
         let mut state = self.state.lock().await;
         let thread = get_thread_mut(&mut state, &request.scope, &request.thread_id)?;
         let updated = {
+            let matches_request = |message: &ThreadMessageRecord| {
+                message.kind == MessageKind::ToolResultReference
+                    && message.status == MessageStatus::Finalized
+                    && message.turn_run_id.as_deref() == Some(request.turn_run_id.as_str())
+                    && message.tool_result_ref.as_deref() == Some(request.result_ref.as_str())
+            };
+            let message_index = match request.provider_call_id.as_deref() {
+                Some(requested) => thread
+                    .messages
+                    .iter()
+                    .position(|message| {
+                        matches_request(message)
+                            && message
+                                .tool_result_provider_call
+                                .as_ref()
+                                .is_some_and(|existing| existing.provider_call_id == requested)
+                    })
+                    .or_else(|| {
+                        thread.messages.iter().position(|message| {
+                            matches_request(message) && message.tool_result_provider_call.is_none()
+                        })
+                    }),
+                None => thread.messages.iter().position(matches_request),
+            }
+            .ok_or_else(|| {
+                SessionThreadError::Backend(format!(
+                    "tool result reference {} was not found in thread {}",
+                    request.result_ref, request.thread_id
+                ))
+            })?;
             let message = thread
                 .messages
-                .iter_mut()
-                .find(|message| {
-                    message.kind == MessageKind::ToolResultReference
-                        && message.status == MessageStatus::Finalized
-                        && message.turn_run_id.as_deref() == Some(request.turn_run_id.as_str())
-                        && message.tool_result_ref.as_deref() == Some(request.result_ref.as_str())
-                })
-                .ok_or_else(|| {
-                    SessionThreadError::Backend(format!(
-                        "tool result reference {} was not found in thread {}",
-                        request.result_ref, request.thread_id
-                    ))
-                })?;
+                .get_mut(message_index)
+                .ok_or_else(|| SessionThreadError::Backend("tool result index vanished".into()))?;
             let before_created_at = message.created_at;
             let before_updated_at = message.updated_at;
             let content = message.content.as_deref().ok_or_else(|| {

--- a/crates/ironclaw_threads/src/lib.rs
+++ b/crates/ironclaw_threads/src/lib.rs
@@ -62,5 +62,6 @@ pub use in_memory::InMemorySessionThreadService;
 pub use ironclaw_common::{AttachmentKind, AttachmentRef};
 pub use service::SessionThreadService;
 pub use tool_result_reference::{
-    ProviderToolCallReferenceEnvelope, ToolResultReferenceEnvelope, ToolResultSafeSummary,
+    ProviderToolCallReferenceEnvelope, ToolResultProviderCallKey, ToolResultReferenceEnvelope,
+    ToolResultSafeSummary,
 };

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -154,7 +154,39 @@ pub struct ProviderToolCallReferenceEnvelope {
     pub signature: Option<String>,
 }
 
+/// Identity of one provider tool call inside a run: the provider's turn id
+/// paired with its call id.
+///
+/// The call id alone is not unique. OpenAI-compatible backends (ollama, vllm,
+/// llama.cpp gateways) mint call ids per response, so two model turns in the
+/// same run routinely both emit `call_0`. Keying transcript rows on the pair
+/// keeps those calls distinct.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ToolResultProviderCallKey {
+    pub provider_turn_id: String,
+    pub provider_call_id: String,
+}
+
+impl ToolResultProviderCallKey {
+    pub fn new(provider_turn_id: impl Into<String>, provider_call_id: impl Into<String>) -> Self {
+        Self {
+            provider_turn_id: provider_turn_id.into(),
+            provider_call_id: provider_call_id.into(),
+        }
+    }
+}
+
 impl ProviderToolCallReferenceEnvelope {
+    /// The dedup identity of this call, dropping the payload fields.
+    pub fn call_key(&self) -> ToolResultProviderCallKey {
+        ToolResultProviderCallKey::new(self.provider_turn_id.clone(), self.provider_call_id.clone())
+    }
+
+    pub fn matches_call_key(&self, key: &ToolResultProviderCallKey) -> bool {
+        self.provider_turn_id == key.provider_turn_id
+            && self.provider_call_id == key.provider_call_id
+    }
+
     pub fn validate(&self) -> Result<(), String> {
         validate_provider_identity(&self.provider_id, "provider id", 512)
             .map_err(|error| error.to_string())?;

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -44,8 +44,8 @@ use ironclaw_threads::{
     PutToolResultRecordRequest, ReadToolResultRecordRequest, RedactMessageRequest,
     ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
     SummaryModelContextPolicy, ThreadHistoryRequest, ThreadMessageId, ThreadScope,
-    ToolResultReferenceEnvelope, ToolResultSafeSummary, UpdateAssistantDraftRequest,
-    UpdateToolResultReferenceRequest,
+    ToolResultProviderCallKey, ToolResultReferenceEnvelope, ToolResultSafeSummary,
+    UpdateAssistantDraftRequest, UpdateToolResultReferenceRequest,
 };
 use tokio::sync::{Barrier, Mutex, OwnedMutexGuard};
 
@@ -105,6 +105,22 @@ async fn filesystem_tool_result_update_targets_the_exact_provider_call_row() {
         })
         .await
         .unwrap();
+    // A later provider turn recycling the spawn row's call id must not become
+    // the update target.
+    let mut recycled_call = provider_call_reference("spawn-call");
+    recycled_call.provider_turn_id = "turn_2".to_string();
+    let recycled = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-update".into(),
+            safe_summary: ToolResultSafeSummary::new("recycled call id page").unwrap(),
+            provider_call: Some(recycled_call),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
 
     let updated = service
         .update_tool_result_reference(UpdateToolResultReferenceRequest {
@@ -112,7 +128,7 @@ async fn filesystem_tool_result_update_targets_the_exact_provider_call_row() {
             thread_id: thread.thread_id.clone(),
             turn_run_id: "run-1".into(),
             result_ref: "result:shared-update".into(),
-            provider_call_id: Some("spawn-call".to_string()),
+            provider_call: Some(ToolResultProviderCallKey::new("turn_1", "spawn-call")),
             safe_summary: ToolResultSafeSummary::new("subagent completed").unwrap(),
         })
         .await
@@ -120,6 +136,7 @@ async fn filesystem_tool_result_update_targets_the_exact_provider_call_row() {
 
     assert_eq!(updated.message_id, spawn.message_id);
     assert_ne!(updated.message_id, page.message_id);
+    assert_ne!(updated.message_id, recycled.message_id);
     let updated_envelope =
         ToolResultReferenceEnvelope::from_json_str(updated.content.as_deref().unwrap()).unwrap();
     assert_eq!(updated_envelope.safe_summary.as_str(), "subagent completed");
@@ -190,9 +207,31 @@ async fn filesystem_tool_result_dedup_keys_distinct_provider_calls_sharing_a_res
         })
         .await
         .unwrap();
+    // OpenAI-compatible backends mint call ids per response, so a later model
+    // turn in the same run can page this result under a call id it already
+    // used. Only the provider turn id keeps the rows apart.
+    let mut next_turn_call = provider_call_reference("call_1");
+    next_turn_call.provider_turn_id = "turn_2".to_string();
+    let next_turn = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("next turn page").unwrap(),
+            provider_call: Some(next_turn_call),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
 
     assert_eq!(duplicate.message_id, first.message_id);
     assert_ne!(second.message_id, first.message_id);
+    assert_ne!(
+        next_turn.message_id, first.message_id,
+        "a recycled provider call id in a later provider turn must not collide \
+         with the earlier turn's row"
+    );
     assert_eq!(
         first
             .tool_result_provider_call
@@ -222,7 +261,7 @@ async fn filesystem_tool_result_dedup_keys_distinct_provider_calls_sharing_a_res
             .iter()
             .filter(|message| message.kind == MessageKind::ToolResultReference)
             .count(),
-        2
+        3
     );
 }
 

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -44,7 +44,8 @@ use ironclaw_threads::{
     PutToolResultRecordRequest, ReadToolResultRecordRequest, RedactMessageRequest,
     ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
     SummaryModelContextPolicy, ThreadHistoryRequest, ThreadMessageId, ThreadScope,
-    ToolResultSafeSummary, UpdateAssistantDraftRequest,
+    ToolResultReferenceEnvelope, ToolResultSafeSummary, UpdateAssistantDraftRequest,
+    UpdateToolResultReferenceRequest,
 };
 use tokio::sync::{Barrier, Mutex, OwnedMutexGuard};
 
@@ -62,6 +63,77 @@ fn provider_call_reference(call_id: &str) -> ProviderToolCallReferenceEnvelope {
         reasoning: None,
         signature: None,
     }
+}
+
+#[tokio::test]
+async fn filesystem_tool_result_update_targets_the_exact_provider_call_row() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-exact-result-update", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("fs-exact-result-update");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-fs-exact-result-update").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    let spawn = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-update".into(),
+            safe_summary: ToolResultSafeSummary::new("subagent still running").unwrap(),
+            provider_call: Some(provider_call_reference("spawn-call")),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+    let page = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-update".into(),
+            safe_summary: ToolResultSafeSummary::new("result page returned").unwrap(),
+            provider_call: Some(provider_call_reference("result-read-call")),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+
+    let updated = service
+        .update_tool_result_reference(UpdateToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-update".into(),
+            provider_call_id: Some("spawn-call".to_string()),
+            safe_summary: ToolResultSafeSummary::new("subagent completed").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(updated.message_id, spawn.message_id);
+    assert_ne!(updated.message_id, page.message_id);
+    let updated_envelope =
+        ToolResultReferenceEnvelope::from_json_str(updated.content.as_deref().unwrap()).unwrap();
+    assert_eq!(updated_envelope.safe_summary.as_str(), "subagent completed");
+    let context = service
+        .load_context_messages(LoadContextMessagesRequest {
+            scope,
+            thread_id: thread.thread_id,
+            message_ids: vec![page.message_id],
+        })
+        .await
+        .unwrap();
+    let page_envelope =
+        ToolResultReferenceEnvelope::from_json_str(context.messages[0].content.as_str()).unwrap();
+    assert_eq!(page_envelope.safe_summary.as_str(), "result page returned");
 }
 
 #[tokio::test]
@@ -121,6 +193,22 @@ async fn filesystem_tool_result_dedup_keys_distinct_provider_calls_sharing_a_res
 
     assert_eq!(duplicate.message_id, first.message_id);
     assert_ne!(second.message_id, first.message_id);
+    assert_eq!(
+        first
+            .tool_result_provider_call
+            .as_ref()
+            .expect("first provider call persists")
+            .provider_call_id,
+        "call_1"
+    );
+    assert_eq!(
+        second
+            .tool_result_provider_call
+            .as_ref()
+            .expect("second provider call persists")
+            .provider_call_id,
+        "call_2"
+    );
     let history = service
         .list_thread_history(ThreadHistoryRequest {
             scope,

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -25,7 +25,10 @@ use ironclaw_filesystem::{
     TxnCapability, VersionedEntry,
 };
 use ironclaw_host_api::{
-    ids::{AgentId, CapabilityId, InvocationId, ProjectId, TenantId, ThreadId, UserId},
+    ids::{
+        AgentId, CapabilityId, InvocationId, ProjectId, ProviderToolName, TenantId, ThreadId,
+        UserId,
+    },
     mount::{MountGrant, MountPermissions, MountView},
     path::{HostPath, MountAlias, ScopedPath, VirtualPath},
 };
@@ -37,13 +40,103 @@ use ironclaw_threads::{
     CapabilityDisplayPreviewStatus, CreateSummaryArtifactRequest, EnsureThreadRequest,
     FilesystemSessionThreadService, FinalizedAssistantMessageByRunRequest,
     ListThreadsForScopeRequest, LoadContextMessagesRequest, LoadContextWindowRequest,
-    MessageContent, MessageKind, MessageStatus, PutToolResultRecordRequest,
-    ReadToolResultRecordRequest, RedactMessageRequest, ReplayAcceptedInboundMessageRequest,
-    SessionThreadError, SessionThreadService, SummaryKind, SummaryModelContextPolicy,
-    ThreadHistoryRequest, ThreadMessageId, ThreadScope, ToolResultSafeSummary,
-    UpdateAssistantDraftRequest,
+    MessageContent, MessageKind, MessageStatus, ProviderToolCallReferenceEnvelope,
+    PutToolResultRecordRequest, ReadToolResultRecordRequest, RedactMessageRequest,
+    ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
+    SummaryModelContextPolicy, ThreadHistoryRequest, ThreadMessageId, ThreadScope,
+    ToolResultSafeSummary, UpdateAssistantDraftRequest,
 };
 use tokio::sync::{Barrier, Mutex, OwnedMutexGuard};
+
+fn provider_call_reference(call_id: &str) -> ProviderToolCallReferenceEnvelope {
+    ProviderToolCallReferenceEnvelope {
+        provider_id: "test-provider".to_string(),
+        provider_model_id: "test-model".to_string(),
+        provider_turn_id: "turn_1".to_string(),
+        provider_call_id: call_id.to_string(),
+        provider_tool_name: ProviderToolName::new("builtin__result_read")
+            .expect("provider tool name"),
+        capability_id: CapabilityId::new("builtin.result_read").unwrap(),
+        arguments: serde_json::json!({"offset": 0}),
+        response_reasoning: None,
+        reasoning: None,
+        signature: None,
+    }
+}
+
+#[tokio::test]
+async fn filesystem_tool_result_dedup_keys_distinct_provider_calls_sharing_a_result_ref() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-shared-continuation", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("fs-shared-continuation");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-fs-shared-continuation").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    let first_call = provider_call_reference("call_1");
+
+    let first = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("first page").unwrap(),
+            provider_call: Some(first_call.clone()),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+    let duplicate = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("first page replay").unwrap(),
+            provider_call: Some(first_call),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+    let second = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("second page").unwrap(),
+            provider_call: Some(provider_call_reference("call_2")),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(duplicate.message_id, first.message_id);
+    assert_ne!(second.message_id, first.message_id);
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        history
+            .messages
+            .iter()
+            .filter(|message| message.kind == MessageKind::ToolResultReference)
+            .count(),
+        2
+    );
+}
 
 #[tokio::test]
 async fn filesystem_delete_thread_removes_owned_thread_and_hides_missing_or_wrong_scope() {

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -15,8 +15,9 @@ use ironclaw_threads::{
     PutToolResultRecordRequest, ReadToolResultRecordRequest, RedactMessageRequest,
     SessionThreadError, SessionThreadService, SummaryKind, SummaryModelContextPolicy,
     TOOL_RESULT_RECORD_READ_MAX_BYTES, ThreadHistoryRequest, ThreadMessageId,
-    ThreadMessageRangeRequest, ThreadScope, ToolResultReferenceEnvelope, ToolResultSafeSummary,
-    UpdateAssistantDraftRequest, UpdateToolResultRecordRequest, UpdateToolResultReferenceRequest,
+    ThreadMessageRangeRequest, ThreadScope, ToolResultProviderCallKey, ToolResultReferenceEnvelope,
+    ToolResultSafeSummary, UpdateAssistantDraftRequest, UpdateToolResultRecordRequest,
+    UpdateToolResultReferenceRequest,
 };
 
 fn scope(label: &str) -> ThreadScope {
@@ -880,6 +881,12 @@ async fn append_tool_result_reference_keeps_distinct_provider_calls_with_the_sam
     let first_call = provider_call_reference();
     let mut second_call = provider_call_reference();
     second_call.provider_call_id = "call_2".to_string();
+    // OpenAI-compatible backends (ollama, vllm, llama.cpp gateways) mint
+    // per-response call ids, so a later model turn in the SAME run can page the
+    // same durable result under a call id it already used. Only the provider
+    // turn id separates the two.
+    let mut next_turn_call = provider_call_reference();
+    next_turn_call.provider_turn_id = "turn_2".to_string();
 
     let first = service
         .append_tool_result_reference(AppendToolResultReferenceRequest {
@@ -917,22 +924,45 @@ async fn append_tool_result_reference_keeps_distinct_provider_calls_with_the_sam
         })
         .await
         .unwrap();
+    let next_turn = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("next turn page").unwrap(),
+            provider_call: Some(next_turn_call),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
 
     assert_eq!(duplicate.message_id, first.message_id);
     assert_ne!(second.message_id, first.message_id);
+    assert_ne!(
+        next_turn.message_id, first.message_id,
+        "a recycled provider call id in a later provider turn must not collide \
+         with the earlier turn's row"
+    );
+    assert_ne!(next_turn.message_id, second.message_id);
     let updated = service
         .update_tool_result_reference(UpdateToolResultReferenceRequest {
             scope: scope.clone(),
             thread_id: thread.thread_id.clone(),
             turn_run_id: "run-1".into(),
             result_ref: "result:shared-continuation".into(),
-            provider_call_id: Some("call_1".to_string()),
+            provider_call: Some(ToolResultProviderCallKey::new("turn_1", "call_1")),
             safe_summary: ToolResultSafeSummary::new("first page settled").unwrap(),
         })
         .await
         .unwrap();
     assert_eq!(updated.message_id, first.message_id);
     assert_ne!(updated.message_id, second.message_id);
+    assert_ne!(
+        updated.message_id, next_turn.message_id,
+        "an update keyed by provider turn must not land on the recycled call id \
+         from another turn"
+    );
     assert_eq!(
         first
             .tool_result_provider_call
@@ -949,6 +979,14 @@ async fn append_tool_result_reference_keeps_distinct_provider_calls_with_the_sam
             .provider_call_id,
         "call_2"
     );
+    assert_eq!(
+        next_turn
+            .tool_result_provider_call
+            .as_ref()
+            .expect("next-turn provider call persists")
+            .provider_turn_id,
+        "turn_2"
+    );
     let history = service
         .list_thread_history(ThreadHistoryRequest {
             scope,
@@ -961,7 +999,7 @@ async fn append_tool_result_reference_keeps_distinct_provider_calls_with_the_sam
         .iter()
         .filter(|message| message.kind == MessageKind::ToolResultReference)
         .collect::<Vec<_>>();
-    assert_eq!(result_messages.len(), 2);
+    assert_eq!(result_messages.len(), 3);
 }
 
 #[tokio::test]
@@ -2265,7 +2303,7 @@ async fn append_tool_result_reference_persists_model_observation_in_envelope() {
             thread_id: thread.thread_id.clone(),
             turn_run_id: "run-1".into(),
             result_ref: "result:model-observation-tool".into(),
-            provider_call_id: None,
+            provider_call: None,
             safe_summary: ToolResultSafeSummary::new("tool failed after child completion").unwrap(),
         })
         .await

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -920,6 +920,19 @@ async fn append_tool_result_reference_keeps_distinct_provider_calls_with_the_sam
 
     assert_eq!(duplicate.message_id, first.message_id);
     assert_ne!(second.message_id, first.message_id);
+    let updated = service
+        .update_tool_result_reference(UpdateToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            provider_call_id: Some("call_1".to_string()),
+            safe_summary: ToolResultSafeSummary::new("first page settled").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(updated.message_id, first.message_id);
+    assert_ne!(updated.message_id, second.message_id);
     assert_eq!(
         first
             .tool_result_provider_call
@@ -2252,6 +2265,7 @@ async fn append_tool_result_reference_persists_model_observation_in_envelope() {
             thread_id: thread.thread_id.clone(),
             turn_run_id: "run-1".into(),
             result_ref: "result:model-observation-tool".into(),
+            provider_call_id: None,
             safe_summary: ToolResultSafeSummary::new("tool failed after child completion").unwrap(),
         })
         .await

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -843,7 +843,9 @@ async fn append_tool_result_reference_rejects_conflicting_provider_metadata_on_r
         .await
         .unwrap();
     let mut conflicting_provider_call = provider_call_reference();
-    conflicting_provider_call.provider_call_id = "call_2".to_string();
+    conflicting_provider_call.provider_tool_name =
+        ProviderToolName::new("demo__other").expect("provider tool name");
+    conflicting_provider_call.capability_id = CapabilityId::new("demo.other").unwrap();
 
     let error = service
         .append_tool_result_reference(AppendToolResultReferenceRequest {
@@ -859,6 +861,94 @@ async fn append_tool_result_reference_rejects_conflicting_provider_metadata_on_r
         .expect_err("conflicting provider metadata rejected");
 
     assert!(error.to_string().contains("provider metadata conflicts"));
+}
+
+#[tokio::test]
+async fn append_tool_result_reference_keeps_distinct_provider_calls_with_the_same_result_ref() {
+    let service = InMemorySessionThreadService::default();
+    let scope = scope("tool-result-shared-continuation");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-tool-result-shared-continuation").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    let first_call = provider_call_reference();
+    let mut second_call = provider_call_reference();
+    second_call.provider_call_id = "call_2".to_string();
+
+    let first = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("first page").unwrap(),
+            provider_call: Some(first_call.clone()),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+    let duplicate = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("first page replay").unwrap(),
+            provider_call: Some(first_call),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+    let second = service
+        .append_tool_result_reference(AppendToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            turn_run_id: "run-1".into(),
+            result_ref: "result:shared-continuation".into(),
+            safe_summary: ToolResultSafeSummary::new("second page").unwrap(),
+            provider_call: Some(second_call),
+            model_observation: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(duplicate.message_id, first.message_id);
+    assert_ne!(second.message_id, first.message_id);
+    assert_eq!(
+        first
+            .tool_result_provider_call
+            .as_ref()
+            .expect("first provider call persists")
+            .provider_call_id,
+        "call_1"
+    );
+    assert_eq!(
+        second
+            .tool_result_provider_call
+            .as_ref()
+            .expect("second provider call persists")
+            .provider_call_id,
+        "call_2"
+    );
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .unwrap();
+    let result_messages = history
+        .messages
+        .iter()
+        .filter(|message| message.kind == MessageKind::ToolResultReference)
+        .collect::<Vec<_>>();
+    assert_eq!(result_messages.len(), 2);
 }
 
 #[tokio::test]

--- a/tests/integration/subagent_await_edge.rs
+++ b/tests/integration/subagent_await_edge.rs
@@ -53,6 +53,7 @@ async fn runner_await_edge_is_a_projection_over_process_dependencies() {
         reply_target_binding_ref: ReplyTargetBindingRef::new("reply:child").expect("reply target"),
         subagent_kind: SubagentKindId::new("general").expect("subagent kind"),
         spawn_capability_id: CapabilityId::new("builtin.subagent.spawn").expect("capability"),
+        spawn_provider_call: None,
         result_ref: LoopResultRef::new("result:child").expect("result ref"),
         mode: SpawnSubagentMode::Blocking,
     })

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -595,19 +595,16 @@ async fn durable_large_read_file_result_reaches_model_as_truncated_preview() {
     );
 }
 
-/// `result_read` continuation (issue #5838): a second scripted turn on the
-/// SAME thread calls `builtin.result_read` (`RESULT_READ_CAPABILITY_ID`,
-/// `runtime/standalone/result_read.rs`) with the durable `result_ref` and
-/// `next_offset` the first turn's `read_file` observation reported —
-/// discovered via `latest_tool_result_ref`/`latest_tool_result_next_offset`
-/// (a static script cannot know a server-minted ref ahead of time) and
-/// injected with `push_script`. Asserts the returned chunk continues
-/// byte-exactly from the SAME canonical serialization `tool_result_output`
-/// returns for `read_file` — no gap, no overlap — and reports the true
-/// `total_bytes` of the durable record. The requested chunk contains a
-/// credential marker, so its inline preview is suppressed; replay must still
-/// retain the original durable ref and continuation metadata rather than the
-/// unreadable `InlineOnly` invocation ref.
+/// `result_read` continuation (issue #5838): two subsequent scripted turns on
+/// the SAME thread page the durable `read_file` result. Page two is invoked
+/// exclusively with the `result_ref` and `next_offset` surfaced by page one,
+/// proving that model-visible continuation metadata retains the original
+/// pageable identity instead of exposing the fresh `InlineOnly` write ref.
+/// Both chunks continue byte-exactly through the SAME canonical serialization
+/// `tool_result_output` returns for `read_file` — no gap, no overlap — and
+/// report the durable record's true `total_bytes`. Page one's chunk contains a
+/// credential marker, so its inline preview is suppressed; the continuation
+/// identity and offset must survive independently of preview content.
 #[tokio::test]
 async fn result_read_continues_a_durable_result_byte_exactly() {
     let h = RebornIntegrationHarness::test_default()
@@ -688,38 +685,114 @@ async fn result_read_continues_a_durable_result_byte_exactly() {
         "fixture must put the rejected marker inside the requested chunk"
     );
 
+    let surfaced_result_ref = h
+        .latest_tool_result_ref()
+        .await
+        .expect("page one surfaces a continuation result_ref");
+    let page_two_offset = h
+        .latest_tool_result_next_offset()
+        .await
+        .expect("page one surfaces a continuation offset");
+    assert_eq!(
+        surfaced_result_ref, result_ref,
+        "page one must surface the original durable result ref, not its inline-only write ref"
+    );
+
+    h.push_script([
+        RebornScriptedReply::tool_call(
+            "builtin.result_read",
+            json!({
+                "result_ref": surfaced_result_ref,
+                "offset": page_two_offset,
+                "max_bytes": ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES,
+            }),
+        ),
+        RebornScriptedReply::text("continued again"),
+    ]);
+    h.submit_turn("continue reading the next page")
+        .await
+        .expect("third turn completes");
+
+    let page_two = h
+        .tool_result_output("builtin.result_read")
+        .await
+        .expect("second result_read result recorded");
+    let page_two_content = page_two["content"]
+        .as_str()
+        .expect("second chunk content is text");
+    let page_two_start = page_two_offset as usize;
+    let page_two_expected = &serialized[page_two_start..page_two_start + page_two_content.len()];
+    assert_eq!(
+        page_two_content.as_bytes(),
+        page_two_expected,
+        "second result_read chunk must continue from page one's surfaced next_offset"
+    );
+    assert_eq!(
+        page_two["total_bytes"].as_u64(),
+        Some(serialized.len() as u64),
+        "every page must report the same durable total byte length"
+    );
+
     let envelopes = h
         .persisted_tool_result_envelopes()
         .await
         .expect("tool-result envelopes persist");
-    let result_read = envelopes.last().expect("result_read envelope exists");
-    let observation = result_read
+    let mut result_read_envelopes = envelopes.iter().rev();
+    let page_two_envelope = result_read_envelopes
+        .next()
+        .expect("second result_read envelope exists");
+    let page_one_envelope = result_read_envelopes
+        .next()
+        .expect("first result_read envelope exists");
+    let page_one_observation = page_one_envelope
         .model_observation
         .as_ref()
-        .expect("metadata-only result_read observation survives");
-    let detail = &observation["detail"];
-    assert_ne!(
-        result_read.result_ref, result_ref,
-        "the result_read invocation keeps its own ephemeral envelope ref"
+        .expect("metadata-only first-page observation survives");
+    let page_one_detail = &page_one_observation["detail"];
+    assert_eq!(
+        page_one_envelope.result_ref, result_ref,
+        "first-page replay must retain the original pageable result ref"
     );
     assert_eq!(
-        detail["result_ref"].as_str(),
+        page_one_detail["result_ref"].as_str(),
         Some(result_ref.as_str()),
         "continuation authority remains the durable source ref"
     );
     assert!(
-        detail.get("preview").is_none(),
+        page_one_detail.get("preview").is_none(),
         "credential-bearing preview remains suppressed"
     );
     assert_eq!(
-        detail["total_bytes"].as_u64(),
+        page_one_detail["total_bytes"].as_u64(),
         Some(serialized.len() as u64)
     );
-    assert!(
-        detail["next_offset"]
-            .as_u64()
-            .is_some_and(|offset| offset > next_offset),
-        "paging metadata survives independently of preview content"
+    assert_eq!(
+        page_one_detail["next_offset"].as_u64(),
+        Some(page_two_offset),
+        "first-page replay must retain the offset fed into page two"
+    );
+
+    let page_two_observation = page_two_envelope
+        .model_observation
+        .as_ref()
+        .expect("second-page observation survives");
+    let page_two_detail = &page_two_observation["detail"];
+    assert_eq!(
+        page_two_envelope.result_ref, result_ref,
+        "second-page replay must retain the original pageable result ref"
+    );
+    assert_eq!(
+        page_two_detail["result_ref"].as_str(),
+        Some(result_ref.as_str())
+    );
+    assert_eq!(
+        page_two_detail["total_bytes"].as_u64(),
+        Some(serialized.len() as u64)
+    );
+    assert_eq!(
+        page_two_detail["next_offset"].as_u64(),
+        page_two["next_offset"].as_u64(),
+        "second-page replay metadata must match the second page output"
     );
 }
 

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -737,13 +737,24 @@ async fn result_read_continues_a_durable_result_byte_exactly() {
         .persisted_tool_result_envelopes()
         .await
         .expect("tool-result envelopes persist");
-    let mut result_read_envelopes = envelopes.iter().rev();
-    let page_two_envelope = result_read_envelopes
-        .next()
-        .expect("second result_read envelope exists");
-    let page_one_envelope = result_read_envelopes
-        .next()
-        .expect("first result_read envelope exists");
+    let result_read_envelopes = envelopes
+        .iter()
+        .filter(|envelope| {
+            envelope.result_ref == result_ref
+                && envelope
+                    .model_observation
+                    .as_ref()
+                    .and_then(|observation| observation["summary"].as_str())
+                    == Some("Requested tool-result chunk returned.")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        result_read_envelopes.len(),
+        2,
+        "exactly the two ordered result_read envelopes must be selected"
+    );
+    let page_one_envelope = result_read_envelopes[0];
+    let page_two_envelope = result_read_envelopes[1];
     let page_one_observation = page_one_envelope
         .model_observation
         .as_ref()


### PR DESCRIPTION
## Summary

- Widen the tool-result transcript dedup discriminator from `provider_call_id` alone to the composite `(provider_turn_id, provider_call_id)`, carried as a new `ToolResultProviderCallKey` strong type.
- Include `provider_turn_id` in the filesystem provider-call lookup index key.
- Pin subagent settlement updates by the composite key (`AwaitEdge.spawn_provider_call`), so a later provider turn recycling a call id can never become the update target.
- Extend the #7135 dedup/settlement contract tests with the recycled-call-id collision scenario (in-memory + filesystem).

**Stacked on #7135** (base: `codex/fix-result-read-continuation-ref`) — it hardens the provider-call dedup key that PR introduces; merge after #7135.

## Change Type

- [x] Bug fix

## Linked Issue

Related #5838 (follow-up hardening to #7135)

## Motivation

#7135 keys durable tool-result dedup by provider call identity. Anthropic/OpenAI mint globally unique call ids, but OpenAI-compatible backends (ollama, vllm, llama.cpp gateways) mint call ids **per response** — the first call of every model turn can be `call_0`. Adapters pass provider ids through verbatim (Gemini synthesizes a UUID only when the id is absent). Within one run, two model turns paging the same durable result under a recycled call id would collide on `(turn_run_id, result_ref, provider_call_id)`; the append replay path then fails full-envelope equality and hard-errors with `provider metadata conflicts` — a run-borking persistence failure on a successful tool call. `provider_turn_id` is already mandatory in `ProviderToolCallReferenceEnvelope` and already validated at the spawn port, so the composite key closes the collision with data every row already carries.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_loop_host -p ironclaw_threads -p ironclaw_runner --all-targets --all-features -- -D warnings`
- [x] Relevant tests pass: in-memory session thread contract (62), filesystem session thread contract (61), `ironclaw_loop_host --lib` (550), `ironclaw_runner await_edge --lib` (10), focused composition cancellation test (1).
- [ ] Workspace-wide build/tests and Reborn integration buckets — left to CI.
- [ ] Railway preview — not run; #7135's exact-head evidence (048c4c348) remains valid for its branch, and this PR is deterministic-contract-level hardening.

## Test Strategy

User behavior: on providers that recycle tool-call ids per response, a second model turn paging the same durable result persists as its own transcript row instead of failing the run with `provider metadata conflicts`; subagent settlement still lands on the exact spawn placeholder row.

Tests added or updated (test-first — the collision cases fail on #7135's head, pass here):
- `session_thread_contract.rs` / `filesystem_session_thread_contract.rs`: same `turn_run_id`, same `result_ref`, same `provider_call_id`, different `provider_turn_id` → distinct rows; exact replay of the same (turn, call) still dedups; settlement keyed `("turn_1", "spawn-call")` must not land on the `turn_2` row recycling the same call id.
- Field-shape updates across spawn-port, await-edge resolver/store, prompt-material, and integration fixtures.

## Security Impact

None. No permission, redaction, or trust-boundary change; the dedup key gains a field that is already persisted and validated.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: `ToolResultProviderCallKey` is a plain identity pair; no trust semantics change.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: `spawn_provider_call` remains additive-optional vs `main`; absent ⇒ the same legacy generic-index fallback #7135 ships.
- [x] No new/changed status, error, or runtime variants; no hash-purpose, bounds, or sandbox-naming changes.

## Database Impact

None. Filesystem provider-call index keys now include `provider_turn_id`; the index is a derived additive lookup (the generic index remains written), and no rows exist on any deployed environment since #7135 is unmerged.

## Blast Radius

Tool-result transcript dedup/settlement identity, only for rows carrying provider-call metadata — the surface #7135 introduces. Legacy rows and edges keep #7135's fallback behavior byte-for-byte.

## Rollback Plan

Revert this single commit; #7135 stands alone without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
