### PR TITLE
ci: merge freeze — every PR requires owner approval (CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Merge freeze: every PR requires an approving review from the repository owner.
+# Added 2026-08-05 with the require_code_owner_review ruleset flag.
+* @BenKurrek


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning every path to @BenKurrek, paired with flipping `require_code_owner_review` on in the Main ruleset (done via the rulesets API alongside this PR). Once this merges, no PR can enter the merge queue without an approving review from the owner — the requested main freeze.

Note: the ruleset flag is inert until this file exists on main, so ordering is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)