### PR TITLE
fix(release): backport MCP egress and readable log fixes

### DIFF
--- a/crates/extensions/ironclaw_extension_support/src/coding/file.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/file.rs
@@ -492,7 +492,10 @@ async fn verify_read_before_edit(
     if content_fingerprint(&bytes) != recorded.fingerprint {
         return Err(stale_read_error(operation, resolved.scoped_path.as_str()));
     }
-    reject_binary_probe(&bytes)
+    // Match the read path's classification: text logs with a few stray NULs
+    // are readable and must remain writable. apply_patch performs its own
+    // strict probe below because patching requires byte-fidelity.
+    reject_binary_probe_lenient(&bytes)
         .map_err(|_| binary_document_write_error(operation, resolved.scoped_path.as_str()))?;
     Ok(bytes)
 }

--- a/crates/extensions/ironclaw_extension_support/src/coding/mod.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/mod.rs
@@ -816,6 +816,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn readable_text_log_with_a_stray_nul_remains_writable() {
+        let fixture = CodingFixture::new("stray-nul-log-user");
+        let file = fixture.workspace_dir.join("syslog.log");
+        let mut original = b"Jan  1 00:00:00 host sshd[1]: Failed password for root\n".to_vec();
+        original.push(0u8);
+        original.extend_from_slice(b"Jan  1 00:00:01 host sshd[1]: more log line\n");
+        tokio::fs::write(&file, original)
+            .await
+            .expect("seed text log");
+
+        fixture
+            .dispatch(
+                super::CodingCapabilityKind::ReadFile,
+                json!({"path": "/workspace/syslog.log"}),
+            )
+            .await
+            .expect("text log with a stray NUL must be readable");
+
+        fixture
+            .dispatch(
+                super::CodingCapabilityKind::WriteFile,
+                json!({"path": "/workspace/syslog.log", "content": "redacted log\n"}),
+            )
+            .await
+            .expect("a text log accepted by read_file must remain writable");
+
+        assert_eq!(
+            tokio::fs::read(file)
+                .await
+                .expect("text log after overwrite"),
+            b"redacted log\n"
+        );
+    }
+
+    #[tokio::test]
     async fn write_file_rejects_existing_pdf_but_allows_new_pdf() {
         let fixture = CodingFixture::new("pdf-write-user");
         let existing = fixture.workspace_dir.join("existing.pdf");

--- a/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
+++ b/crates/ironclaw_extensions/src/hosted_mcp_discovery.rs
@@ -1,4 +1,5 @@
 use ironclaw_host_api::{
+    action::{NetworkScheme, NetworkTargetPattern},
     capability::{CapabilityDescriptor, EffectKind, PermissionMode},
     capability_profile::CapabilityProfileSchemaRef,
     ids::CapabilityId,
@@ -134,6 +135,12 @@ fn valid_hosted_mcp_url(url: &str) -> bool {
 fn hosted_mcp_capability_template(
     package: &ExtensionPackage,
 ) -> Result<HostedMcpCapabilityTemplate, ExtensionError> {
+    let network_target = hosted_mcp_network_target(package).ok_or_else(|| {
+        invalid_hosted_mcp_manifest(format!(
+            "hosted MCP provider {} has no valid network target",
+            package.id
+        ))
+    })?;
     let first = package.manifest.capabilities.first().ok_or_else(|| {
         invalid_hosted_mcp_manifest(format!(
             "hosted MCP provider {} has no capability template",
@@ -159,6 +166,7 @@ fn hosted_mcp_capability_template(
             .any(|capability| capability.effects.contains(&EffectKind::ExternalWrite)),
         required_host_ports: first.required_host_ports.clone(),
         runtime_credentials: first.runtime_credentials.clone(),
+        network_target,
         resource_profile: first.resource_profile.clone(),
         origin_gate_matrix: first.origin_gate_matrix.clone(),
     })
@@ -168,6 +176,7 @@ struct HostedMcpCapabilityTemplate {
     provider_declares_external_write: bool,
     required_host_ports: Vec<ironclaw_host_api::host_port::HostPortId>,
     runtime_credentials: Vec<ironclaw_host_api::capability::RuntimeCredentialRequirement>,
+    network_target: NetworkTargetPattern,
     resource_profile: Option<ironclaw_host_api::resource::ResourceProfile>,
     origin_gate_matrix: Option<ironclaw_host_api::capability::OriginGateMatrix>,
 }
@@ -222,14 +231,24 @@ fn discovered_capability_manifest(
         prompt_doc_ref: None,
         required_host_ports: template.required_host_ports.clone(),
         runtime_credentials: template.runtime_credentials.clone(),
-        // MCP discovered tools derive egress from their credential audiences,
-        // not a manifest-declared allowlist.
-        network_targets: Vec::new(),
+        // Credential-free providers have no credential audience from which to
+        // derive egress, so every discovered tool retains the registered MCP
+        // endpoint as its explicit allowlist target.
+        network_targets: vec![template.network_target.clone()],
         // MCP discovered tools take no manifest egress cap; their egress is
         // bounded by credential audiences and the runtime resource profile.
         max_egress_bytes: None,
         resource_profile: template.resource_profile.clone(),
         origin_gate_matrix: template.origin_gate_matrix.clone(),
+    })
+}
+
+fn hosted_mcp_network_target(package: &ExtensionPackage) -> Option<NetworkTargetPattern> {
+    let endpoint = url::Url::parse(hosted_http_mcp_url(package)?).ok()?;
+    Some(NetworkTargetPattern {
+        scheme: Some(NetworkScheme::Https),
+        host_pattern: endpoint.host_str()?.to_ascii_lowercase(),
+        port: endpoint.port(),
     })
 }
 
@@ -356,6 +375,41 @@ runtime_credentials = [
             .expect("discovered create-pages capability");
         assert!(create_pages.effects.contains(&EffectKind::ExternalWrite));
         assert_eq!(discovered.manifest.capabilities.len(), 2);
+    }
+
+    /// Regression: credential-free hosted MCP tools still need the registered
+    /// server in their egress allowlist. Without it, authorization emits an
+    /// empty network-policy obligation and dispatch fails before any request.
+    #[test]
+    fn discovered_public_mcp_tool_keeps_endpoint_as_network_target() {
+        let mut package = notion_package();
+        package.manifest.capabilities[0].runtime_credentials.clear();
+        package.capabilities[0].runtime_credentials.clear();
+        let tools = vec![HostedMcpDiscoveredTool {
+            name: "read_wiki".to_string(),
+            description: "Read a repository wiki".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: HostedMcpDiscoveredToolAnnotations {
+                read_only_hint: true,
+                ..Default::default()
+            },
+        }];
+
+        let discovered = package_with_discovered_hosted_mcp_tools(&package, &tools)
+            .expect("build discovered public MCP package");
+        let capability = discovered
+            .capabilities
+            .first()
+            .expect("discovered capability");
+
+        assert_eq!(
+            capability.network_targets,
+            vec![ironclaw_host_api::action::NetworkTargetPattern {
+                scheme: Some(ironclaw_host_api::action::NetworkScheme::Https),
+                host_pattern: "mcp.notion.com".to_string(),
+                port: None,
+            }]
+        );
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -7257,6 +7257,40 @@ async fn read_file_tolerates_stray_nul_and_invalid_utf8_in_text_logs() {
 }
 
 #[tokio::test]
+async fn write_file_overwrites_a_readable_text_log_with_a_stray_nul() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut original = b"Jan  1 00:00:00 host sshd[1]: Failed password for root\n".to_vec();
+    original.push(0u8);
+    original.extend_from_slice(b"Jan  1 00:00:01 host sshd[1]: more log line\n");
+    let log_path = temp.path().join("syslog.log");
+    tokio::fs::write(&log_path, original).await.unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(all_builtin_capability_ids(), mounts);
+
+    invoke_with_context(
+        &runtime,
+        READ_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/syslog.log"}),
+        context.clone(),
+    )
+    .await
+    .expect("text log with a stray NUL must be readable");
+
+    invoke_with_context(
+        &runtime,
+        WRITE_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/syslog.log", "content": "redacted log\n"}),
+        context,
+    )
+    .await
+    .expect("a text log accepted by read_file must remain writable");
+
+    assert_eq!(tokio::fs::read(log_path).await.unwrap(), b"redacted log\n");
+}
+
+#[tokio::test]
 async fn read_file_still_rejects_nul_dense_binary() {
     // Genuine binary (NUL-dense): must still be kept out of context rather than
     // dumped as U+FFFD soup. 25% NUL bytes clears both the floor and the ratio.


### PR DESCRIPTION
## Summary

- Backport #7241 so dynamically discovered hosted MCP tools retain the registered HTTPS endpoint as an explicit network target, including credential-free providers.
- Backport #7227 so a text log accepted by `read_file` remains writable after the required read-before-edit check when it contains only a stray NUL; strict `apply_patch` binary handling is unchanged.
- Add the upstream owning-crate and host-runtime regression coverage to the 1.1 RC branch.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Release backport of #7227 and #7241.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: hosted MCP network-target unit regression, coding executor stray-NUL write regression, and host-runtime caller regression
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; deterministic regressions exercise both fixes.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional lint evidence: `cargo clippy -p ironclaw_extensions -p ironclaw_extension_support -p ironclaw_host_runtime --all-targets --all-features -- -D warnings`.

## Test Strategy

User behavior: Credential-free hosted MCP tools can reach their registered server, and readable text logs containing an isolated NUL can be overwritten after a successful read.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Hosted MCP discovery retains the endpoint network target; coding executor preserves read/write classification parity for stray-NUL text logs.
- Reborn integration: Not applicable: no turn-orchestration behavior changed; the production host-runtime caller path is covered directly.
- Recorded fixture: Not applicable: model selection and arguments are unchanged.
- Browser E2E: Not applicable: no browser-visible workflow changed.
- Backend or runtime: Host-runtime built-in tool integration test verifies the write behavior through the production wrapper boundary.
- Live canary: Not applicable: both regressions are deterministic and do not require live provider credentials.

What the tests prove: The MCP endpoint survives dynamic capability projection, the owning coding executor accepts a write after the same file was readable, and the host-runtime integration exposes that behavior to callers.

Commands run:

```text
cargo fmt --all -- --check
cargo test -p ironclaw_extensions discovered_public_mcp_tool_keeps_endpoint_as_network_target
cargo test -p ironclaw_extension_support readable_text_log_with_a_stray_nul_remains_writable
cargo test -p ironclaw_host_runtime --test first_party_builtin_tools write_file_overwrites_a_readable_text_log_with_a_stray_nul
cargo clippy -p ironclaw_extensions -p ironclaw_extension_support -p ironclaw_host_runtime --all-targets --all-features -- -D warnings
git diff --check origin/release/1.1.0-rc.1..HEAD
```

## Security Impact

This changes two mediated boundaries. Hosted MCP discovery now preserves only the already-registered validated HTTPS endpoint as the capability's explicit egress target; it does not broaden discovery to another host. `write_file` now uses the same lenient binary classification as `read_file` during read-before-edit verification, while dense binary documents, opaque office/PDF inputs, stale reads, and strict `apply_patch` probing remain protected.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: No new constructors or trust-bearing types; the existing validated hosted MCP URL is projected into the existing `NetworkTargetPattern`.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable: prompt construction is unchanged.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable: hashing behavior is unchanged.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: Not applicable; no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Not applicable: serialization and persistence schemas are unchanged.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable: no queue, map, buffer, or counter behavior changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Not applicable: error variants and classification are unchanged.
- [x] Sandbox/native/host names accurately describe trust boundary. No boundary names changed.

## Database Impact

None.

## Blast Radius

Dynamic hosted-MCP capability manifests, the first-party coding executor's read-before-edit guard, and the host-runtime built-in tool wrapper. No persistence schema, credential injection, transport, or UI code changes.

## Rollback Plan

Revert commits `6a997c4818` and `af7e968bd1` from the release branch. This restores the prior behavior without a data migration.

## Review Follow-Through

Reviewers should confirm the backports remain identical to the merged upstream fixes after Git rename detection mapped the pre-rename release paths. No manual conflict resolution was required.

---

**Review track**: C (network-policy and host-runtime behavior)
