### PR TITLE
fix(ci): resolve release canary temp path

### DIFF
--- a/.github/workflows/ironclaw-release.yml
+++ b/.github/workflows/ironclaw-release.yml
@@ -267,7 +267,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PREVIOUS_RELEASE_TAG: ironclaw-v1.0.0-rc.1
       CANARY_TARGET: x86_64-unknown-linux-gnu
-      CANARY_ARTIFACT_DIR: ${{ runner.temp }}/release-upgrade-canary
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -277,7 +276,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Prepare upgrade evidence directory
-        run: mkdir -p "$CANARY_ARTIFACT_DIR"
+        id: upgrade-evidence
+        shell: bash
+        run: |
+          evidence_dir="$RUNNER_TEMP/release-upgrade-canary"
+          mkdir -p "$evidence_dir"
+          echo "path=$evidence_dir" >> "$GITHUB_OUTPUT"
       - name: Fetch exact candidate artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -296,6 +300,8 @@ jobs:
             --dir target/previous-release
       - name: Gate publishing on exact release-pair upgrade
         shell: bash
+        env:
+          CANARY_ARTIFACT_DIR: ${{ steps.upgrade-evidence.outputs.path }}
         run: |
           archive="ironclaw-${CANARY_TARGET}.tar.gz"
           candidate_version="${GITHUB_REF_NAME#ironclaw-v}"
@@ -310,13 +316,15 @@ jobs:
             --artifact-dir "$CANARY_ARTIFACT_DIR"
       - name: Scrub upgrade evidence
         if: always()
+        env:
+          CANARY_ARTIFACT_DIR: ${{ steps.upgrade-evidence.outputs.path }}
         run: scripts/live-canary/scrub-artifacts.sh "$CANARY_ARTIFACT_DIR"
       - name: Upload upgrade evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-upgrade-canary-evidence
-          path: ${{ env.CANARY_ARTIFACT_DIR }}
+          path: ${{ steps.upgrade-evidence.outputs.path }}
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -14,6 +14,7 @@ from ws12_workflow_contracts import (
     CODE_STYLE_WORKFLOW,
     CRATE_SCOPE_FILTERS,
     E2E_WORKFLOW,
+    FORBIDDEN_MARKERS,
     PLATFORM_WORKFLOW,
     REQUIRED_MARKERS,
     STRESS_WORKFLOW,
@@ -52,6 +53,18 @@ class WorkflowContractSabotageTests(unittest.TestCase):
         del sabotaged[path]
 
         self.assertIn(f"missing workflow: {path}", validate_workflow_texts(sabotaged))
+
+    def test_reintroducing_each_forbidden_marker_fails_loudly(self) -> None:
+        for path, markers in FORBIDDEN_MARKERS.items():
+            for marker in markers:
+                with self.subTest(path=path, marker=marker):
+                    sabotaged = copy.deepcopy(self.workflows)
+                    sabotaged[path] += f"\n{marker}\n"
+                    errors = validate_workflow_texts(sabotaged)
+                    self.assertTrue(
+                        any(path in error and marker in error for error in errors),
+                        errors,
+                    )
 
     def test_unconditional_skip_fails_loudly(self) -> None:
         path = ".github/workflows/nightly-deep-ci.yml"

--- a/scripts/ci/ws12_workflow_contracts.py
+++ b/scripts/ci/ws12_workflow_contracts.py
@@ -69,8 +69,17 @@ REQUIRED_MARKERS: dict[str, tuple[str, ...]] = {
         "Smoke exact binaries before packaging upload",
         "scripts/ci/smoke-release-binary.py",
         "release-upgrade-canary:",
+        "id: upgrade-evidence",
+        'evidence_dir="$RUNNER_TEMP/release-upgrade-canary"',
+        "CANARY_ARTIFACT_DIR: ${{ steps.upgrade-evidence.outputs.path }}",
         "scripts/ci/release-upgrade-canary.py",
         "needs.release-upgrade-canary.result == 'success'",
+    ),
+}
+
+FORBIDDEN_MARKERS: dict[str, tuple[str, ...]] = {
+    ".github/workflows/ironclaw-release.yml": (
+        "CANARY_ARTIFACT_DIR: ${{ runner.temp }}/release-upgrade-canary",
     ),
 }
 
@@ -510,7 +519,7 @@ def validate_crate_scope_filters(
 def validate_workflow_texts(
     workflows: dict[str, str], root: Path = ROOT
 ) -> list[str]:
-    """Return every missing lane marker; an empty result is the only pass."""
+    """Return every broken lane marker; an empty result is the only pass."""
     errors: list[str] = []
     for path, markers in REQUIRED_MARKERS.items():
         text = workflows.get(path)
@@ -522,6 +531,15 @@ def validate_workflow_texts(
         )
         if UNCONDITIONAL_SKIP.search(text):
             errors.append(f"{path}: contains an unconditionally skipped lane")
+    for path, markers in FORBIDDEN_MARKERS.items():
+        text = workflows.get(path)
+        if text is None:
+            continue
+        errors.extend(
+            f"{path}: contains forbidden {marker!r}"
+            for marker in markers
+            if marker in text
+        )
     e2e = workflows.get(E2E_WORKFLOW)
     if e2e is not None:
         errors.extend(validate_e2e_scope_filters(e2e))


### PR DESCRIPTION
## Summary

- Fix the zero-job failure in the tag-only release workflow introduced by #7256.
- Resolve the canary evidence directory from `$RUNNER_TEMP` inside a runner step, then pass the path explicitly to the gate, scrub, and upload steps.
- Extend the workflow sabotage contract to require the corrected path plumbing and reject the invalid job-level `runner.temp` declaration.

Root cause: `${{ runner.temp }}` was referenced from job-level `env`, where the `runner` context is unavailable. GitHub rejected the workflow before creating any jobs in runs [31049816252](https://github.com/nearai/ironclaw/actions/runs/31049816252) and [31054517315](https://github.com/nearai/ironclaw/actions/runs/31054517315).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Fixes the release-workflow failures linked above.

## Validation

- [ ] `cargo fmt --all -- --check`: Not applicable; no Rust changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`: Not applicable; no Rust changed.
- [ ] `cargo build`: Not applicable; build inputs are unchanged.
- [x] Relevant tests pass: all 26 workflow sabotage tests and the checked-in WS12 workflow contract.
- [ ] `cargo test --features integration`: Not applicable; no database or runtime implementation changed.
- [x] Manual testing: `actionlint` accepts the workflow after filtering unrelated pre-existing ShellCheck diagnostics.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: Pushing the next release tag creates release jobs instead of failing during workflow planning.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: The WS12 workflow contract requires the step-output path and rejects the invalid job-level `runner.temp` declaration; its sabotage test proves reintroduction fails loudly.
- Reborn integration: Not applicable: Reborn runtime behavior is unchanged.
- Recorded fixture: Not applicable: model behavior is unchanged.
- Browser E2E: Not applicable: browser behavior is unchanged.
- Backend or runtime: Not applicable: this changes GitHub workflow planning only.
- Live canary: Not applicable locally: the actual upgrade canary remains gated behind a release tag.

What the tests prove: GitHub expressions are valid, the corrected evidence-path plumbing remains present, and the exact invalid declaration cannot silently return.

Commands run:

```text
actionlint -ignore 'SC[0-9]+' .github/workflows/ironclaw-release.yml
python3 scripts/ci/test_ws12_workflow_contracts.py
python3 scripts/ci/ws12_workflow_contracts.py
git diff --check
```

## Security Impact

None. Workflow token permissions, release permissions, artifact contents, scrubbing, and fail-closed publication gates are unchanged. The evidence directory remains runner-temporary and is not moved into the checkout.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: Not applicable; no product types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable; no prompt behavior changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable; checksum verification is unchanged.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: Not applicable; no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Not applicable; no serialization changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable; no such structures changed.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Not applicable; no runtime errors changed.
- [x] Sandbox/native/host names accurately describe trust boundary. Not applicable; no boundary names changed.

## Database Impact

None.

## Blast Radius

Only `.github/workflows/ironclaw-release.yml` canary evidence-path setup and its existing workflow-contract gate. Runtime binaries and release artifact contents are unchanged. The next real tag remains the final end-to-end verification of the hosted Actions environment.

## Rollback Plan

Revert `db68a9d3f2` only if replacing it with another expression-valid evidence-path mechanism. Reverting it alone restores the zero-job release failure; an emergency rollback must also disable/revert the #7256 upgrade-canary workflow addition before tagging.

## Review Follow-Through

Reviewer judgment is requested on the GitHub Actions step-output plumbing. No unrelated ShellCheck findings in the generated cargo-dist workflow were changed.

---

**Review track**: C (release CI)
