### PR TITLE
fix(webui): scope chat run bookkeeping to the thread that owns it

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
@@ -33,6 +33,10 @@ import {
   resetToolActivityState,
 } from "../lib/tool-activity-state";
 import {
+  createRunTrackingState,
+  resetRunTrackingState,
+} from "../lib/run-tracking-state";
+import {
   rewriteConnectionLostRunFailures,
   upsertConnectionLostRunFailure,
 } from "../lib/failureMessages";
@@ -224,6 +228,9 @@ export function useChat(threadId) {
   const [busyGateNotice, setBusyGateNotice] = React.useState(null);
   const [stateThreadId, setStateThreadId] = React.useState(threadId);
   const toolActivityStateRef = React.useRef(createToolActivityState());
+  // Owned here rather than inside `useChatEvents` so every piece of
+  // per-thread state is cleared from one place — the effect below.
+  const runTrackingRef = React.useRef(createRunTrackingState());
   const locallyResolvedGatesRef = React.useRef(new Map());
   const authTokenSubmitRef = React.useRef({
     gateKey: null,
@@ -304,6 +311,10 @@ export function useChat(threadId) {
 
   React.useEffect(() => {
     resetToolActivityState(toolActivityStateRef);
+    // Run bookkeeping is per-thread. `latestRunId` is otherwise cleared only
+    // on a TERMINAL run status, so a stuck run would pin it for the life of
+    // the mounted page and bleed into every thread opened afterwards.
+    resetRunTrackingState(runTrackingRef);
     locallyResolvedGatesRef.current.clear();
     connectionInterruptedRunIdsRef.current.clear();
     connectionInterruptedUnknownRef.current = false;
@@ -414,6 +425,7 @@ export function useChat(threadId) {
     activeRunRef,
     locallyResolvedGatesRef,
     toolActivityStateRef,
+    runTrackingRef,
     noteConnectionInterruptedRunId,
     connectionContextForRunFailure,
     onStreamError: handleStreamError,

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/run-tracking-state.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/run-tracking-state.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+
+/* Per-thread run bookkeeping for the chat event handler.
+ *
+ * These three slots are scoped to ONE thread. They used to be private
+ * `React.useRef`s inside `useChatEvents`, which owned them but not their
+ * lifecycle — the thread-switch reset lives in `useChat`, so nothing ever
+ * cleared them. `latestRunId` is only cleared on a TERMINAL run status, so a
+ * run that got stuck pinned it for the life of the mounted chat page and it
+ * followed the user into every thread they opened afterwards, where it was
+ * consumed as the run-id fallback for untagged capability frames and as the
+ * seed for the stale-terminal check (silently dropping the new thread's own
+ * terminal status, so its timeline was never refetched).
+ *
+ * Bundling them behind one owner keeps `useChatEvents` stateless: `useChat`
+ * holds this ref alongside the other per-thread state it already resets, so
+ * "what does a thread switch mean" is answered in exactly one place. The
+ * slots stay ref-shaped (`{ current }`) so the handler's helpers can keep
+ * mutating them directly.
+ */
+export function createRunTrackingState() {
+  return {
+    // Run ids already handed to `onRunSettled`, so SSE replays (reconnect
+    // with last-event-id, repeated snapshots) settle each run exactly once.
+    settledRuns: { current: new Set() },
+    // Most recent run id observed on this thread. Used to reject stale
+    // terminal statuses and to scope capability frames that omit a run id.
+    latestRunId: { current: null },
+    // Run id whose gate prompt is currently displayed.
+    promptRunId: { current: null },
+  };
+}
+
+export function resetRunTrackingState(stateRef) {
+  if (!stateRef) return;
+  stateRef.current = createRunTrackingState();
+}

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -18,6 +18,10 @@ import {
   resetToolActivityState,
 } from "./tool-activity-state";
 import {
+  createRunTrackingState,
+  resetRunTrackingState,
+} from "./run-tracking-state";
+import {
   CONNECTION_LOST_RUN_FAILURE_KEY,
   failureMessageForRequestError,
   rewriteConnectionLostRunFailures,
@@ -116,6 +120,8 @@ function runUseChatSource(context) {
     createToolActivityState,
     failGateToolActivity,
     resetToolActivityState,
+    createRunTrackingState,
+    resetRunTrackingState,
     timelineMessageIdFromAcceptedRef,
     rewriteConnectionLostRunFailures,
     upsertConnectionLostRunFailure,
@@ -6013,4 +6019,91 @@ test("useChat.runCommand: fences the failure notice to the thread it executed ag
   assert.equal(seeded?.length, 1);
   assert.equal(seeded[0].role, CHAT_MESSAGE_ROLES.SYSTEM);
   assert.equal(seeded[0].content, t("chat.commandFailed"));
+});
+
+/* Caller-level cover for the per-thread run bookkeeping.
+ *
+ * `useChatEvents`'s own suite proves the handler behaves correctly GIVEN a
+ * reset. It cannot prove `useChat` performs one — the handler is stubbed
+ * there. This drives the real `useChat` across a thread switch and asserts
+ * the reset actually happens, which is the half that was missing when
+ * `settledRunsRef` / `latestRunIdRef` / `promptRunIdRef` lived inside
+ * `useChatEvents` with no owner clearing them.
+ */
+test("useChat: opening another thread resets the run bookkeeping handed to useChatEvents", () => {
+  const setCalls = [];
+  const react = createReactStub({ setCalls, runEffects: true });
+  let capturedRunTrackingRef = null;
+  let renderedMessages = [];
+  const context = {
+    AbortController,
+    Date,
+    Error,
+    Map,
+    Math,
+    React: react,
+    addPending,
+    toRenderAttachment,
+    toWireAttachment,
+    cancelRunRequest: async () => {},
+    clearInterval,
+    clearTimeout,
+    createThreadRequest: async () => {
+      throw new Error("thread should already exist");
+    },
+    globalThis: {},
+    queryClient: { invalidateQueries: () => {} },
+    recordAcceptedMessageRef,
+    removePending,
+    resolveGateRequest: async () => {},
+    sendMessage: async () => {
+      throw new Error("send should not run");
+    },
+    setInterval,
+    setTimeout,
+    submitManualToken: async () => {},
+    useChatEvents: (props) => {
+      capturedRunTrackingRef = props.runTrackingRef;
+      return () => {};
+    },
+    useHistory: () => ({
+      messages: renderedMessages,
+      hasMore: false,
+      nextCursor: null,
+      isLoading: false,
+      loadError: null,
+      loadHistory: () => {},
+      seedThreadMessages: () => {},
+      setMessages: (updater) => {
+        renderedMessages =
+          typeof updater === "function" ? updater(renderedMessages) : updater;
+      },
+    }),
+    useSSE: () => ({ status: CONNECTION_STATUS.IDLE }),
+  };
+
+  runUseChatSource(context);
+
+  react.__beginRender();
+  context.globalThis.__testExports.useChat("thread-1");
+  const runTrackingRef = capturedRunTrackingRef;
+  assert.ok(runTrackingRef, "useChat must hand a run-tracking ref to useChatEvents");
+
+  // A run that starts and never reaches a terminal status: nothing in the
+  // event handler will clear these on its own.
+  runTrackingRef.current.latestRunId.current = "run-stuck";
+  runTrackingRef.current.promptRunId.current = "run-stuck";
+  runTrackingRef.current.settledRuns.current.add("run-stuck");
+
+  react.__beginRender();
+  context.globalThis.__testExports.useChat("thread-2");
+
+  assert.equal(
+    capturedRunTrackingRef,
+    runTrackingRef,
+    "the ref object stays stable across renders",
+  );
+  assert.equal(runTrackingRef.current.latestRunId.current, null);
+  assert.equal(runTrackingRef.current.promptRunId.current, null);
+  assert.equal(runTrackingRef.current.settledRuns.current.size, 0);
 });

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
@@ -22,6 +22,10 @@ import {
   upsertToolActivityMessage,
 } from "./tool-activity-state";
 import {
+  createRunTrackingState,
+  resetRunTrackingState,
+} from "./run-tracking-state";
+import {
   isFinalAssistantForRun,
   replaceAssistantReplyForRun,
 } from "./stream-order-memory";
@@ -91,21 +95,63 @@ function createUseChatEventsHarness({
   onStreamError = () => {},
   t: selectedTranslator = t,
 } = {}) {
+  let threadId = "thread-1";
   let messages = [];
   let pendingGate = null;
   let isProcessing = false;
   let activeRun = null;
   const activeRunRef = { current: null };
   const toolActivityStateRef = { current: createToolActivityState() };
+  // Owned by `useChat` in production, and reset by it on a thread switch —
+  // `openThread` below mirrors that.
+  const runTrackingRef = { current: createRunTrackingState() };
   // [{ runId, success }] in fire order; one entry per settled run.
   const settledRuns = [];
+  // Real-React semantics for the two primitives `useChatEvents` uses.
+  // `useRef` must hand back the SAME object on every render (call-order
+  // slots) and `useEffect` must re-run only when its dependency array
+  // changes. The previous stub minted a fresh ref per render, which made a
+  // thread switch look like a clean slate when production keeps the refs
+  // alive for the life of the mounted chat page.
+  const refSlots = [];
+  const effectSlots = [];
+  let refCursor = 0;
+  let effectCursor = 0;
+  function beginRender() {
+    refCursor = 0;
+    effectCursor = 0;
+  }
+  function useRefSlot(value) {
+    const slot = refCursor;
+    refCursor += 1;
+    if (!(slot in refSlots)) refSlots[slot] = { current: value };
+    return refSlots[slot];
+  }
+  function useEffectSlot(fn, deps) {
+    const slot = effectCursor;
+    effectCursor += 1;
+    const previous = effectSlots[slot];
+    const unchanged =
+      previous &&
+      deps !== undefined &&
+      previous.deps !== undefined &&
+      deps.length === previous.deps.length &&
+      deps.every((dep, index) => Object.is(dep, previous.deps[index]));
+    if (unchanged) return;
+    if (typeof previous?.cleanup === "function") previous.cleanup();
+    const cleanup = fn();
+    effectSlots[slot] = {
+      deps,
+      cleanup: typeof cleanup === "function" ? cleanup : null,
+    };
+  }
   const context = {
     Date: DateImpl,
     createErrorChatMessage,
     React: {
       useCallback: (fn) => fn,
-      useEffect: (fn) => fn(),
-      useRef: (value) => ({ current: value }),
+      useEffect: useEffectSlot,
+      useRef: useRefSlot,
     },
     failureMessageForRunStatus,
     failureMessageForStreamError,
@@ -128,8 +174,8 @@ function createUseChatEventsHarness({
 
   vm.runInNewContext(useChatEventsSourceForTest(), context);
 
-  const handleEvent = context.globalThis.__testExports.useChatEvents({
-    threadId: "thread-1",
+  const hookProps = () => ({
+    threadId,
     setMessages: (updater) => {
       messages = typeof updater === "function" ? updater(messages) : updater;
     },
@@ -148,6 +194,7 @@ function createUseChatEventsHarness({
     activeRunRef,
     locallyResolvedGatesRef,
     toolActivityStateRef,
+    runTrackingRef,
     noteConnectionInterruptedRunId,
     connectionContextForRunFailure,
     onStreamError,
@@ -155,8 +202,32 @@ function createUseChatEventsHarness({
     t: selectedTranslator,
   });
 
+  function buildHandler() {
+    beginRender();
+    return context.globalThis.__testExports.useChatEvents(hookProps());
+  }
+
+  let currentHandler = buildHandler();
+
   return {
-    handleEvent,
+    handleEvent: (envelope) => currentHandler(envelope),
+    // Model exactly what production does on a thread switch: `useChat` clears
+    // every piece of per-thread state it owns (its render-phase reset plus its
+    // `[threadId]` effect) and `useHistory` swaps in the new thread's timeline.
+    // `useChatEvents` itself holds no state, so there is deliberately nothing
+    // to reset on its side — that is the invariant these tests pin.
+    openThread(nextThreadId) {
+      threadId = nextThreadId;
+      messages = [];
+      pendingGate = null;
+      isProcessing = false;
+      activeRun = null;
+      activeRunRef.current = null;
+      toolActivityStateRef.current = createToolActivityState();
+      resetRunTrackingState(runTrackingRef);
+      locallyResolvedGatesRef.current.clear();
+      currentHandler = buildHandler();
+    },
     get messages() {
       return messages;
     },
@@ -2864,4 +2935,239 @@ test("useChatEvents: stream error ids avoid timestamp collisions", () => {
 
   assert.equal(harness.messages.length, 3);
   assert.equal(harness.messages[2].id, `${baseId}-1788259200000-1`);
+});
+
+/* ---------------------------------------------------------------------------
+ * Cross-thread bleed from a stuck run.
+ *
+ * `useChatEvents` owns three refs — `settledRunsRef`, `latestRunIdRef`,
+ * `promptRunIdRef` — and nothing clears them when `threadId` changes.
+ * `useChat` resets everything IT owns on a switch (useChat.ts:265 and
+ * useChat.ts:305); this hook has no equivalent, and no effect at all.
+ *
+ * `latestRunIdRef` is only cleared on a TERMINAL run status, so a run that
+ * gets stuck (blocked forever, connection dropped mid-run, backend wedged)
+ * pins it for the life of the mounted chat page. It then follows the user
+ * into every thread they open afterwards, where it is consumed as:
+ *
+ *   1. the run-id fallback for capability frames that omit `turn_run_id`
+ *      (`fallbackTurnRunIdForActivity`, line 753), and
+ *   2. the seed for `activeRunId` when classifying a terminal run status as
+ *      stale (lines 459 + 474-480) — which silently drops the new thread's
+ *      own terminal frame, so `onRunSettled` never fires and the timeline is
+ *      never refetched to replace live text with the durable reply.
+ * ------------------------------------------------------------------------- */
+
+// A run that starts and never reaches a terminal status. `latestRunIdRef` is
+// left holding `run-stuck` with no code path that clears it.
+function pinStuckRunInFirstThread(harness) {
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        thread_id: "thread-1",
+        items: [{ run_status: { run_id: "run-stuck", status: "running" } }],
+      },
+    },
+  });
+}
+
+// A capability frame that legitimately omits `turn_run_id` — the shape the
+// run-id fallback exists to serve.
+function untaggedActivity(overrides = {}) {
+  return {
+    invocation_id: "invocation-b",
+    thread_id: "thread-2",
+    capability_id: "builtin.http",
+    status: "started",
+    provider: null,
+    runtime: null,
+    process_id: null,
+    output_bytes: null,
+    error_kind: null,
+    updated_at: "2026-08-05T06:53:00Z",
+    ...overrides,
+  };
+}
+
+test("useChatEvents: an untagged capability_activity in a newly opened thread does not inherit the previous thread's stuck run", () => {
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.openThread("thread-2");
+  harness.handleEvent({
+    type: "capability_activity",
+    frame: { activity: untaggedActivity() },
+  });
+
+  assert.equal(harness.messages.length, 1);
+  assert.equal(harness.messages[0].id, "tool-invocation-b");
+  assert.equal(harness.messages[0].turnRunId, null);
+});
+
+test("useChatEvents: an untagged capability_display_preview in a newly opened thread does not inherit the previous thread's stuck run", () => {
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.openThread("thread-2");
+  harness.handleEvent({
+    type: "capability_display_preview",
+    frame: {
+      preview: untaggedActivity({
+        status: "completed",
+        title: "builtin.http",
+      }),
+    },
+  });
+
+  assert.equal(harness.messages.length, 1);
+  assert.equal(harness.messages[0].turnRunId, null);
+});
+
+test("useChatEvents: an untagged projection capability_activity in a newly opened thread does not inherit the previous thread's stuck run", () => {
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.openThread("thread-2");
+  harness.handleEvent({
+    type: "projection_snapshot",
+    frame: {
+      state: {
+        thread_id: "thread-2",
+        items: [{ capability_activity: untaggedActivity() }],
+      },
+    },
+  });
+
+  assert.equal(harness.messages.length, 1);
+  assert.equal(harness.messages[0].turnRunId, null);
+});
+
+test("useChatEvents: a stuck run does not follow the user across two consecutive thread switches", () => {
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.openThread("thread-2");
+  harness.openThread("thread-3");
+  harness.handleEvent({
+    type: "capability_activity",
+    frame: { activity: untaggedActivity({ thread_id: "thread-3" }) },
+  });
+
+  assert.equal(harness.messages[0].turnRunId, null);
+});
+
+test("useChatEvents: an untagged capability_activity still adopts the active run inside the same thread", () => {
+  // Positive control for the fallback itself — clearing on a thread switch
+  // must not disable run-id inference within one thread.
+  const harness = createUseChatEventsHarness();
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        thread_id: "thread-1",
+        items: [{ run_status: { run_id: "run-1", status: "running" } }],
+      },
+    },
+  });
+
+  harness.handleEvent({
+    type: "capability_activity",
+    frame: { activity: untaggedActivity({ thread_id: "thread-1" }) },
+  });
+
+  assert.equal(harness.messages[0].turnRunId, "run-1");
+});
+
+test("useChatEvents: a completed run in a newly opened thread settles even after a stuck run elsewhere", () => {
+  // Opening an already-finished thread: the first frame the new thread sees
+  // is its own terminal status, which `latestRunIdRef` misclassifies as a
+  // stale status belonging to some other run.
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.openThread("thread-2");
+  harness.handleEvent({
+    type: "projection_snapshot",
+    frame: {
+      state: {
+        thread_id: "thread-2",
+        items: [{ run_status: { run_id: "run-b", status: "completed" } }],
+      },
+    },
+  });
+
+  assert.deepEqual(harness.settledRuns, [{ runId: "run-b", success: true }]);
+  assert.equal(harness.isProcessing, false);
+  assert.equal(harness.activeRun, null);
+});
+
+test("useChatEvents: a failed run in a newly opened thread is not discarded as stale after a stuck run elsewhere", () => {
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.openThread("thread-2");
+  harness.handleEvent({
+    type: "projection_snapshot",
+    frame: {
+      state: {
+        thread_id: "thread-2",
+        items: [{ run_status: { run_id: "run-b", status: "failed" } }],
+      },
+    },
+  });
+
+  assert.deepEqual(harness.settledRuns, [{ runId: "run-b", success: false }]);
+});
+
+test("useChatEvents: leftover streaming assistant text in a newly opened thread still settles its run", () => {
+  // The leftover-assistant-output path. The snapshot for an already-finished
+  // thread carries the run's accumulated text plus its terminal status in one
+  // batch. If the terminal status is dropped, `onRunSettled` never fires, the
+  // durable timeline is never refetched, and this streaming bubble is what the
+  // user keeps looking at instead of the finalized reply.
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.openThread("thread-2");
+  harness.handleEvent({
+    type: "projection_snapshot",
+    frame: {
+      state: {
+        thread_id: "thread-2",
+        items: [
+          { text: { id: "run-b:1", run_id: "run-b", body: "partial answer" } },
+          { run_status: { run_id: "run-b", status: "completed" } },
+        ],
+      },
+    },
+  });
+
+  const assistant = harness.messages.find(
+    (message) => message.role === "assistant",
+  );
+  assert.equal(assistant.content, "partial answer");
+  assert.equal(assistant.isStreaming, true);
+  assert.deepEqual(harness.settledRuns, [{ runId: "run-b", success: true }]);
+});
+
+test("useChatEvents: the stuck run still settles when its own thread finally reports terminal", () => {
+  // Regression guard for the fix: clearing on a thread switch must not break
+  // the normal same-thread lifecycle.
+  const harness = createUseChatEventsHarness();
+  pinStuckRunInFirstThread(harness);
+
+  harness.handleEvent({
+    type: "projection_update",
+    frame: {
+      state: {
+        thread_id: "thread-1",
+        items: [{ run_status: { run_id: "run-stuck", status: "completed" } }],
+      },
+    },
+  });
+
+  assert.deepEqual(harness.settledRuns, [
+    { runId: "run-stuck", success: true },
+  ]);
 });

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
@@ -71,6 +71,7 @@ export function useChatEvents({
   activeRunRef,
   locallyResolvedGatesRef,
   toolActivityStateRef,
+  runTrackingRef,
   noteConnectionInterruptedRunId = noop,
   connectionContextForRunFailure = emptyConnectionContext,
   onStreamError = noop,
@@ -80,23 +81,31 @@ export function useChatEvents({
   if (typeof t !== "function") {
     throw new TypeError("useChatEvents requires a translation function");
   }
-  // Track which runIds we've already settled so that SSE replays
-  // (reconnect with `last-event-id`, repeated snapshots) don't trigger
-  // duplicate timeline refetches. A run settles on ANY terminal status,
-  // not only success — every terminal run reloads the timeline so tool
-  // input/output previews are recovered from the durable record even when
-  // the run failed, was cancelled, or needs recovery.
-  const settledRunsRef = React.useRef(new Set());
-  // Last `run_status.run_id` we've observed, persisted across event frames.
-  // Used to reject stale terminal statuses after a locally resolved gate
-  // resumes a newer active run.
-  const latestRunIdRef = React.useRef(null);
-  const promptRunIdRef = React.useRef(null);
 
   return React.useCallback(
     (envelope) => {
       const { type, frame } = envelope || {};
       if (!type || !frame) return;
+
+      // Per-thread run bookkeeping, owned and reset by `useChat` (see
+      // `lib/run-tracking-state.ts`). Read from the ref on every event rather
+      // than closing over the slots, so a thread switch that swaps in fresh
+      // state cannot be observed through a stale binding:
+      //
+      //   settledRuns — run ids already settled, so SSE replays (reconnect
+      //     with last-event-id, repeated snapshots) settle each run once.
+      //     A run settles on ANY terminal status, not only success; every
+      //     terminal run reloads the timeline so tool input/output previews
+      //     are recovered from the durable record.
+      //   latestRunId — last `run_status.run_id` seen, used to reject stale
+      //     terminal statuses after a locally resolved gate resumed a newer
+      //     run, and to scope capability frames that omit a run id.
+      //   promptRunId — run id whose gate prompt is on screen.
+      const {
+        settledRuns: settledRunsRef,
+        latestRunId: latestRunIdRef,
+        promptRunId: promptRunIdRef,
+      } = runTrackingRef.current;
 
       switch (type) {
         case "accepted": {
@@ -312,6 +321,7 @@ export function useChatEvents({
       activeRunRef,
       locallyResolvedGatesRef,
       toolActivityStateRef,
+      runTrackingRef,
       noteConnectionInterruptedRunId,
       connectionContextForRunFailure,
       onRunSettled,


### PR DESCRIPTION
## Summary

- `useChatEvents` owned three refs (`settledRunsRef`, `latestRunIdRef`, `promptRunIdRef`) while the thread-switch reset lives in `useChat`. Nothing cleared them, so per-thread run bookkeeping leaked across threads.
- `latestRunId` is only cleared on a **terminal** run status, so a run that got stuck pinned it for the life of the mounted chat page and then followed the user into every thread opened afterwards.
- Moved the three slots into `lib/run-tracking-state.ts` behind one ref that `useChat` owns and resets in the `[threadId]` effect it already has, mirroring the existing `createToolActivityState` / `resetToolActivityState` idiom. `useChatEvents` now holds **no state at all**.
- Fixed the test harness, which could not express this bug: its `useRef` stub minted a fresh object per call, so every thread switch looked like a clean slate.

## Observed symptom

Reported from a local run: a chunk of assistant output from the most recently used thread appearing near the top of other threads. Ruled out server-side first — the `/timeline` responses for all 7 threads were correctly scoped, and a live SSE subscription returned 24 frames all carrying the right `thread_id`. It reproduced only in SPA memory and vanished on a hard reload.

## What the stale ref actually breaks

1. **Run-id fallback.** `fallbackTurnRunIdForActivity` stamps `latestRunId` onto capability frames that legitimately omit `turn_run_id`, so another thread's tool cards get attributed to the stuck run.
2. **Stale-terminal suppression.** `activeRunId` is seeded from the same ref, so a newly opened thread's *own* terminal status is classified as stale and dropped. `onRunSettled` never fires, the durable timeline is never refetched, and leftover live assistant text is never replaced by the finalized reply. This is the user-visible half.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

The refactor is not cosmetic: giving the state a single owner *is* the fix. Adding a second reset site inside `useChatEvents` would go green while leaving thread-switch semantics split across two files — the shape that produced this bug.

## Linked Issue

None — reported directly from a local run.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust changed.
- [ ] `cargo clippy ...` — Not applicable: no Rust changed.
- [ ] `cargo build` — Not applicable: no Rust changed.
- [x] Relevant tests pass: `vitest run` — **1088 passed, 0 failed** (baseline + 10 new). The 3 `ERR_MODULE_NOT_FOUND` errors are pre-existing on a clean tree.
- [ ] `cargo test --features integration` — Not applicable: no persistence or backend behavior changed.
- [x] Manual testing: reproduced the reported symptom against the running local instance via the WebChat v2 API (`/timeline` for every thread, plus a live SSE subscription) to establish the leak was client-side before writing any test.
- [ ] `review-pr` / `pr-shepherd --fix` — not run.

Also run: `tsc --noEmit` (clean) and `node --experimental-strip-types scripts/check-source-conventions.ts` (clean).

## Test Strategy

**User behavior:** Opening a thread after leaving one whose run never terminated must not show that run's tool cards or leave the newly opened thread's own reply unfinalized.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: 9 cases in `useChatEvents.test.ts`, 1 caller-level case in `useChat-send.test.ts`.
- Reborn integration: Not applicable: no Rust or cross-crate behavior changed.
- Recorded fixture: Not applicable: no model interaction changed.
- Browser E2E: Not applicable: reachable deterministically at the hook seam; an E2E would need a deliberately wedged run to reproduce.
- Backend or runtime: Not applicable: server-side scoping was verified correct and is unchanged.
- Live canary: Not applicable.

**What the tests prove:**

Seven reproductions, each verified red before the fix and green after — untagged `capability_activity`, untagged `capability_display_preview`, untagged projection items, two consecutive thread switches, completed and failed terminal statuses, and leftover streaming assistant text. Four failed with `'run-stuck'` where `null` is required; three settled nothing where the new thread's own run must settle.

Two controls guard against a fix that is too blunt: untagged activity must *still* adopt the active run within one thread, and the normal same-thread settle path must keep working. Both pass before and after.

The tenth is the one that matters. The other nine run against a harness where the test models `useChat`'s reset, so they prove the handler behaves *given* a reset — not that `useChat` performs one. That gap is exactly what caused this bug. `useChat-send.test.ts` therefore drives the real `useChat` across a thread switch and asserts the reset happens; it was verified red by deleting the `resetRunTrackingState` line and confirming exactly one failure.

**Harness change:** `useChatEvents.test.ts` now uses call-order ref slots and a deps-aware `useEffect`, matching React. All 54 pre-existing tests in that file pass **unchanged**, which is the evidence the old stub was lenient rather than load-bearing. `useChat-send.test.ts` needed the new module injected into its vm context (it strips imports and supplies them as globals).

**Commands run:**

```
vitest run                                                  # 1088 passed
vitest run src/pages/chat/lib/useChatEvents.test.ts         # 63 passed (was 54)
vitest run src/pages/chat/lib/useChat-send.test.ts          # 74 passed (was 73)
tsc --noEmit                                                # clean
node --experimental-strip-types scripts/check-source-conventions.ts   # clean
```

## Security Impact

None. No permissions, network calls, secrets, file access, tool execution, or sandbox policy are touched. Note the leak was never a cross-*user* or cross-tenant exposure: server-side scoping is correct at every layer checked (`ReadScope::matches_event`, the `scope_key`-keyed live update source, the `ProjectionScope`-keyed checkpoint cache). This was one browser tab mixing two of its own threads.

## Reborn Trust-Boundary Checklist

N/A — frontend-only change to SPA hook state. No policy, evidence, trust-bearing types, prompts, hashes, status/exit/error variants, `serde` fields, or sandbox naming involved.

The one adjacent item worth flagging as **not** addressed here: `useChatEvents` ignores the `thread_id` the server already sends on `projection_snapshot`, `capability_activity`, and other frames. That guard would have contained this bug independently and is worth adding, but it is a separate change with its own tests.

## Database Impact

None.

## Blast Radius

WebChat v2 chat surface only — `pages/chat` hooks. `useChatEvents` is consumed by exactly one caller (`useChat`), so the new prop has a single call site. Behavior within a single thread is unchanged by construction: the same ref slots are read and mutated by the same helpers, only their declaration site and reset moved. The two control tests pin that.

The riskiest edge is ordering: the handler destructures the slots inside the callback rather than closing over them, so a thread switch that swaps in fresh state cannot be observed through a stale binding.

## Rollback Plan

Revert the single commit. The change is additive (one new module, one new prop) with no persisted state, no wire-format change, and no migration, so a revert restores previous behavior exactly — including the bug.
