### PR TITLE
fix(webui): backport SSE reload retry storm fix to RC1

### DIFF
--- a/crates/ironclaw_webui/CLAUDE.md
+++ b/crates/ironclaw_webui/CLAUDE.md
@@ -176,13 +176,15 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
 - The SPA consumes SSE through `event-source-plus`, which owns event framing,
   `Last-Event-ID`, abort, and retry/backoff over `fetch`/`ReadableStream`. The
   bearer is sent in the `Authorization` header rather than the request URL. A
-  bounded, random `connection_id` remains stable for one loaded browser tab and
-  `connection_generation` increments for every package-managed request. A
-  same-caller, same-id stream supersedes its prior generation without consuming
-  another slot; a delayed older generation receives `204` and cannot cancel the
-  current stream. This prevents proxy-reordered closes/opens during thread
-  navigation from stranding the replacement stream behind the cap; distinct
-  tabs still consume distinct slots.
+  bounded, random `connection_id` remains stable for one browser tab across SPA
+  mounts and document reloads, while `connection_generation` increments for
+  every package-managed request. Fresh top-level navigations use a new identity
+  even when a duplicated tab copied `sessionStorage`. A same-caller, same-id
+  stream supersedes its prior generation without consuming another slot; a
+  delayed older generation receives `204` and cannot cancel the current stream.
+  This prevents proxy-reordered closes/opens during thread navigation or reload
+  from stranding the replacement stream behind the cap; distinct tabs still
+  consume distinct slots.
 - A successful facade subscription emits an application-level `keep_alive`
   frame immediately after admission and every 15 seconds while the projection
   is idle. Browser connection state and its activity watchdog use those frames

--- a/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -7,15 +7,71 @@ import {
 } from "../lib/connection-status";
 
 const ACTIVE_STREAM_STALL_DEADLINE_MS = 30_000;
-const SSE_CONNECTION_ID = clientActionId();
-let nextConnectionGeneration = 0;
+const SSE_CONNECTION_STORAGE_KEY = "ironclaw:v2-sse-connection";
 
-function connectionGeneration() {
-  nextConnectionGeneration =
-    nextConnectionGeneration >= Number.MAX_SAFE_INTEGER
-      ? 1
-      : nextConnectionGeneration + 1;
-  return nextConnectionGeneration;
+function newConnectionState() {
+  return { connectionId: clientActionId(), generation: 0 };
+}
+
+function isDocumentReload() {
+  try {
+    const navigation =
+      globalThis.performance?.getEntriesByType?.("navigation")[0];
+    return Boolean(
+      navigation && "type" in navigation && navigation.type === "reload",
+    );
+  } catch (_) {
+    return false;
+  }
+}
+
+function loadConnectionState() {
+  // sessionStorage can be copied into a newly opened or duplicated tab. Only
+  // an actual reload may reuse the predecessor document's stream identity;
+  // every fresh top-level navigation must get an independent server slot.
+  if (!isDocumentReload()) return newConnectionState();
+  try {
+    const raw = globalThis.sessionStorage?.getItem(SSE_CONNECTION_STORAGE_KEY);
+    if (!raw) return newConnectionState();
+    const candidate = JSON.parse(raw);
+    const validConnectionId =
+      typeof candidate?.connectionId === "string" &&
+      /^[A-Za-z0-9_-]{1,64}$/.test(candidate.connectionId);
+    const validGeneration =
+      typeof candidate?.generation === "number" &&
+      Number.isSafeInteger(candidate.generation) &&
+      candidate.generation >= 0;
+    if (validConnectionId && validGeneration) {
+      return {
+        connectionId: candidate.connectionId,
+        generation: candidate.generation,
+      };
+    }
+  } catch (_) {
+    // Storage may be unavailable or contain stale data. A fresh identity still
+    // gives this document a usable stream; the server's max lifetime bounds
+    // any proxy-held stream that cannot be superseded.
+  }
+  return newConnectionState();
+}
+
+const sseConnectionState = loadConnectionState();
+
+function nextConnectionState() {
+  if (sseConnectionState.generation >= Number.MAX_SAFE_INTEGER) {
+    sseConnectionState.connectionId = clientActionId();
+    sseConnectionState.generation = 0;
+  }
+  sseConnectionState.generation += 1;
+  try {
+    globalThis.sessionStorage?.setItem(
+      SSE_CONNECTION_STORAGE_KEY,
+      JSON.stringify(sseConnectionState),
+    );
+  } catch (_) {
+    // Best effort. In-memory state still orders this document's reconnects.
+  }
+  return { ...sseConnectionState };
 }
 
 function isBrowserOffline() {
@@ -59,7 +115,6 @@ export function useSSE({
     let streamOpen = false;
     const request = eventStreamRequest({
       threadId,
-      connectionId: SSE_CONNECTION_ID,
     });
     const stream = new EventSourcePlus(request.url, {
       credentials: "same-origin",
@@ -73,6 +128,11 @@ export function useSSE({
         clearTimeout(activityWatchdog);
         activityWatchdog = null;
       }
+    }
+
+    function markTransportUnavailable() {
+      streamOpen = false;
+      clearActivityWatchdog();
     }
 
     function activityIsExpected() {
@@ -106,6 +166,7 @@ export function useSSE({
 
     function markConnected() {
       if (disposed || terminalErrorReceived) return;
+      streamOpen = true;
       connectedOnce = true;
       setStatus(CONNECTION_STATUS.CONNECTED);
     }
@@ -125,9 +186,12 @@ export function useSSE({
       controller = stream.listen({
         onRequest({ options }) {
           if (disposed || terminalErrorReceived) return;
+          markTransportUnavailable();
+          const connectionState = nextConnectionState();
           options.query = {
             ...options.query,
-            connection_generation: connectionGeneration(),
+            connection_id: connectionState.connectionId,
+            connection_generation: connectionState.generation,
           };
           setStatus(
             connectedOnce
@@ -137,6 +201,7 @@ export function useSSE({
         },
         onRequestError() {
           if (disposed || terminalErrorReceived) return;
+          markTransportUnavailable();
           setStatus(CONNECTION_STATUS.RECONNECTING);
         },
         onResponse({ response }) {
@@ -146,17 +211,17 @@ export function useSSE({
             response.headers.get("content-type")?.includes("text/event-stream")
           ) {
             markConnected();
+            scheduleActivityWatchdog();
           }
         },
         onResponseError({ response }) {
           if (disposed || terminalErrorReceived) return;
+          markTransportUnavailable();
           if (isRetryableResponseStatus(response.status)) {
             setStatus(CONNECTION_STATUS.RECONNECTING);
             return;
           }
           terminalErrorReceived = true;
-          streamOpen = false;
-          clearActivityWatchdog();
           controller?.abort("non-retryable stream response");
           setStatus(CONNECTION_STATUS.DISCONNECTED);
         },
@@ -192,6 +257,7 @@ export function useSSE({
             frame.retryable === true
           ) {
             stream.lastEventId = undefined;
+            markTransportUnavailable();
             setStatus(CONNECTION_STATUS.RECONNECTING);
             controller?.reconnect();
           }
@@ -202,8 +268,6 @@ export function useSSE({
         controller?.abort("non-retryable stream response");
         return;
       }
-      streamOpen = true;
-      scheduleActivityWatchdog();
     }
 
     function disconnectForHiddenTab() {
@@ -221,10 +285,9 @@ export function useSSE({
       } else if (!controller) {
         connect();
       } else {
-        streamOpen = true;
+        markTransportUnavailable();
         setStatus(CONNECTION_STATUS.CONNECTING);
         controller.reconnect();
-        scheduleActivityWatchdog();
       }
     }
 
@@ -235,6 +298,7 @@ export function useSSE({
 
     function handleNetworkOnline() {
       if (disposed || terminalErrorReceived) return;
+      markTransportUnavailable();
       setStatus(CONNECTION_STATUS.RECONNECTING);
       controller?.reconnect();
     }

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -24,11 +24,22 @@ function useSSESourceForTest() {
   return `${lines.join("\n")}\nglobalThis.__testExports = { useSSE };`;
 }
 
+function createSessionStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+  };
+}
+
 function createHarness({
   online = true,
   visibilityState = "visible",
   onEvent = () => {},
   activityExpected = false,
+  connectionId = "browser-tab-connection",
+  navigationType = "navigate",
+  sessionStorage = createSessionStorage(),
 } = {}) {
   const statuses = [];
   const streams = [];
@@ -101,13 +112,19 @@ function createHarness({
 
   const context = {
     CONNECTION_STATUS,
-    clientActionId: () => "browser-tab-connection",
+    clientActionId: () => connectionId,
     EventSourcePlus,
-    eventStreamRequest: ({ threadId, connectionId }) => ({
-      url: `http://localhost/events/${threadId}?connection_id=${connectionId}`,
+    eventStreamRequest: ({ threadId }) => ({
+      url: `http://localhost/events/${threadId}`,
       headers: () => ({ Authorization: "Bearer token-1" }),
     }),
-    globalThis: {},
+    globalThis: {
+      performance: {
+        getEntriesByType: (type) =>
+          type === "navigation" ? [{ type: navigationType }] : [],
+      },
+      sessionStorage,
+    },
     Headers,
     JSON,
     Math,
@@ -211,13 +228,17 @@ test("useSSE delegates framing, credentials, and retries to EventSourcePlus", ()
 
   assert.equal(
     stream.url,
-    "http://localhost/events/thread-1?connection_id=browser-tab-connection",
+    "http://localhost/events/thread-1",
   );
   assert.deepEqual(stream.options.headers(), { Authorization: "Bearer token-1" });
   assert.equal(new URL(stream.url).searchParams.has("token"), false);
   assert.equal(stream.options.credentials, "same-origin");
   assert.equal(stream.options.retryStrategy, "always");
   assert.equal(stream.options.maxRetryInterval, 30_000);
+  assert.equal(
+    stream.requestOptions.query.connection_id,
+    "browser-tab-connection",
+  );
   assert.equal(typeof stream.requestOptions.query.connection_generation, "number");
 
   stream.respond();
@@ -324,6 +345,144 @@ test("useSSE lets retryable responses retry and stops on terminal responses", ()
   terminal.cleanup();
 });
 
+test("useSSE does not start a competing watchdog reconnect after a 429", () => {
+  const { streams, timers } = createHarness({ activityExpected: true });
+  const stream = streams[0];
+  stream.respond();
+  const watchdog = timers.find(
+    (timer) => timer.delay === 30_000 && !timer.cleared,
+  );
+  assert.ok(watchdog);
+
+  // EventSourcePlus schedules its own retry when onResponseError returns.
+  // Once the handshake has failed, the activity watchdog must no longer
+  // behave as though an established stream stalled and launch a second retry.
+  stream.request();
+  stream.respond(429, "application/json");
+  assert.equal(watchdog.cleared, true);
+  watchdog.handler();
+
+  assert.equal(
+    stream.controller.reconnectCalls,
+    0,
+    "a rejected handshake must not race EventSourcePlus's automatic retry",
+  );
+});
+
+test("useSSE preserves connection identity and generation across a document reload", () => {
+  const sessionStorage = createSessionStorage();
+  const firstDocument = createHarness({
+    connectionId: "first-document-id",
+    sessionStorage,
+  });
+
+  assert.equal(
+    firstDocument.streams[0].requestOptions.query.connection_id,
+    "first-document-id",
+  );
+  assert.equal(
+    firstDocument.streams[0].requestOptions.query.connection_generation,
+    1,
+  );
+  firstDocument.cleanup();
+
+  const reloadedDocument = createHarness({
+    connectionId: "new-id-must-not-be-used",
+    navigationType: "reload",
+    sessionStorage,
+  });
+
+  assert.equal(
+    reloadedDocument.streams[0].requestOptions.query.connection_id,
+    "first-document-id",
+    "a reload must address the same server slot as the proxy-held predecessor",
+  );
+  assert.equal(
+    reloadedDocument.streams[0].requestOptions.query.connection_generation,
+    2,
+    "a reload must supersede rather than be rejected as a stale generation",
+  );
+  reloadedDocument.cleanup();
+});
+
+test("useSSE gives a duplicated tab a fresh connection identity", () => {
+  const copiedSessionStorage = createSessionStorage({
+    "ironclaw:v2-sse-connection": JSON.stringify({
+      connectionId: "original-tab-id",
+      generation: 7,
+    }),
+  });
+
+  const duplicatedTab = createHarness({
+    connectionId: "duplicated-tab-id",
+    navigationType: "navigate",
+    sessionStorage: copiedSessionStorage,
+  });
+
+  assert.equal(
+    duplicatedTab.streams[0].requestOptions.query.connection_id,
+    "duplicated-tab-id",
+  );
+  assert.equal(
+    duplicatedTab.streams[0].requestOptions.query.connection_generation,
+    1,
+  );
+  duplicatedTab.cleanup();
+});
+
+test("useSSE rejects malformed persisted connection state", () => {
+  const invalidValues = [
+    "{not-json",
+    JSON.stringify({ connectionId: "x".repeat(65), generation: 3 }),
+    JSON.stringify({ connectionId: "invalid/id", generation: 3 }),
+    JSON.stringify({ connectionId: "stored-id", generation: -1 }),
+  ];
+
+  invalidValues.forEach((value, index) => {
+    const harness = createHarness({
+      connectionId: `fallback-id-${index}`,
+      navigationType: "reload",
+      sessionStorage: createSessionStorage({
+        "ironclaw:v2-sse-connection": value,
+      }),
+    });
+    assert.equal(
+      harness.streams[0].requestOptions.query.connection_id,
+      `fallback-id-${index}`,
+    );
+    assert.equal(
+      harness.streams[0].requestOptions.query.connection_generation,
+      1,
+    );
+    harness.cleanup();
+  });
+});
+
+test("useSSE rotates connection identity before generation exceeds the safe integer limit", () => {
+  const harness = createHarness({
+    connectionId: "rotated-id",
+    navigationType: "reload",
+    sessionStorage: createSessionStorage({
+      "ironclaw:v2-sse-connection": JSON.stringify({
+        connectionId: "stored-id",
+        generation: Number.MAX_SAFE_INTEGER - 1,
+      }),
+    }),
+  });
+  const stream = harness.streams[0];
+
+  assert.equal(stream.requestOptions.query.connection_id, "stored-id");
+  assert.equal(
+    stream.requestOptions.query.connection_generation,
+    Number.MAX_SAFE_INTEGER,
+  );
+
+  stream.request();
+  assert.equal(stream.requestOptions.query.connection_id, "rotated-id");
+  assert.equal(stream.requestOptions.query.connection_generation, 1);
+  harness.cleanup();
+});
+
 test("useSSE stops after a non-retryable stream event", () => {
   const events = [];
   const { statuses, streams } = createHarness({
@@ -385,8 +544,8 @@ test("useSSE starts each route from a fresh stream and ignores disposed callback
   assert.equal(second.lastEventId, undefined);
   assert.match(second.url, /thread-2/);
   assert.equal(
-    new URL(first.url).searchParams.get("connection_id"),
-    new URL(second.url).searchParams.get("connection_id"),
+    first.requestOptions.query.connection_id,
+    second.requestOptions.query.connection_id,
   );
   assert.ok(
     second.requestOptions.query.connection_generation >

--- a/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -362,7 +362,7 @@ test("useSSE does not start a competing watchdog reconnect after a 429", () => {
   assert.equal(watchdog.cleared, true);
   watchdog.handler();
 
-  assert.equal(
+  assert.strictEqual(
     stream.controller.reconnectCalls,
     0,
     "a rejected handshake must not race EventSourcePlus's automatic retry",


### PR DESCRIPTION
## Summary

- Backport #7268 onto `release/1.1.0-rc.1`.
- Preserve the WebChat SSE connection identity and generation across genuine document reloads so a proxy-held predecessor is superseded instead of consuming another per-user slot.
- Keep fresh and duplicated tabs on independent identities, validate persisted state, and rotate identity before generation exceeds JavaScript's safe integer range.
- Mark failed or retrying handshakes unavailable so the activity watchdog cannot race `event-source-plus` retry ownership.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None — backport of #7268 following an RC deployment report.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust files changed.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust files changed.
- [ ] `cargo build` — Not applicable: frontend-only change; the production Vite build ran directly.
- [x] Relevant tests pass: focused `useSSE` suite (15 tests) and full frontend suite (126 files, 1,084 tests).
- [ ] `cargo test --features integration` — Not applicable: no database-backed or cross-runtime behavior changed.
- [ ] Manual testing — Not applicable: deterministic hook regressions drive navigation timing, storage state, transport callbacks, and request query shape.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run for this mechanical backport; source PR #7268 records its review passes.

Additional gates: frontend lint/typecheck, production Vite build with bundle budgets, and `git diff --check`.

## Test Strategy

User behavior: Repeatedly refreshing WebChat no longer consumes independent per-user SSE slots, and a 429 handshake no longer leaves a competing activity-watchdog reconnect armed.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `crates/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts`
- Reborn integration: Not applicable: no product/runtime orchestration changed.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: the source-backed hook harness deterministically drives packaged transport callbacks, navigation timing, storage state, and request query shape.
- Backend or runtime: Not applicable: server capacity and rate-limit behavior are unchanged and already covered by WebUI contracts.
- Live canary: Not applicable: no live provider dependency.

What the tests prove:

- A true document reload reuses the predecessor `connection_id` and increments its generation.
- A fresh or duplicated tab gets an independent identity.
- Malformed persisted state fails safely to a fresh identity.
- Generation rollover rotates identity atomically before exceeding the safe integer limit.
- A retrying 429 handshake clears the active-stream watchdog and does not launch a second reconnect owner.

Commands run:

- `corepack pnpm exec vitest run src/pages/chat/lib/useSSE.test.ts`
- `corepack pnpm test`
- `corepack pnpm lint`
- `corepack pnpm build`
- `git diff --check origin/release/1.1.0-rc.1...HEAD`

## Security Impact

None. Persisted values are a bounded opaque connection ID and monotonic generation only; bearer credentials remain in the `Authorization` header.

## Reborn Trust-Boundary Checklist

N/A: frontend transport lifecycle only; no trust-bearing types, prompts, hashes, permissions, runtime variants, serialization contracts, or sandbox boundaries changed. Persisted reload state is shape-validated and bounded before use.

## Database Impact

None.

## Blast Radius

WebChat SSE connection lifecycle only. Fresh tabs remain independent; SPA thread changes retain one loaded-document identity; server concurrency and request-rate policies are unchanged.

## Rollback Plan

Revert commit `4c114dadf5`. No schema, migration, or server compatibility rollback is required.

## Review Follow-Through

This is a mechanical backport of #7268 with paths adapted to the release branch's pre-move crate layout. The patch applied cleanly and retained the source regression coverage.

---

**Review track**: B (browser-facing bug fix)
