### PR TITLE
feat(skills): add railway-test developer skill for Railway preview QA

### DIFF
--- a/.claude/skills/railway-test/SKILL.md
+++ b/.claude/skills/railway-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: railway-test
-description: Verify any pull request on its Railway preview through browser-driven acceptance testing derived from the PR description and diff, then publish exact-head evidence on the pull request. Defaults to nearai/ironclaw and covers deployment freshness, bearer-token login, affected-route discovery, primary user journeys, regression reproduction, forms and state read-back, navigation, permissions, errors, and optional streaming cadence. Use when the user invokes /railway-test or $railway-test, asks to test a PR on Railway, or wants browser-based preview QA with PR evidence before merging.
+description: Triggered when the user invokes /railway-test or $railway-test, asks to test a pull request on Railway, or requests browser-based exact-head preview QA and pull-request evidence before merging.
 ---
 
 # Railway Test
@@ -51,8 +51,35 @@ Identify:
 - dependencies on external services, model behavior, or persisted data.
 
 Write a compact Given/When/Then test matrix before interacting with the
-preview. Use [references/test-recipes.md](references/test-recipes.md) to choose
-only relevant cases. Do not default to chat or streaming tests.
+preview. Give every row an `Acceptance` classification:
+
+- **Required**: directly proves an explicit user request, PR acceptance
+  criterion, or the exact regression claim.
+- **Supplemental**: deployment health, adjacent behavior, or a useful proxy
+  that does not itself prove the changed contract.
+
+Use [references/test-recipes.md](references/test-recipes.md) to choose only
+relevant cases. Do not default to chat or streaming tests. Never reclassify a
+required case as supplemental because the preview lacks its provider, model,
+credentials, role, feature flag, or test data; that makes the run BLOCKED.
+
+#### Mandatory status gate
+
+Compute the overall heading from required cases only:
+
+1. **FAIL** if any required case was executed against the intended contract
+   and the observed behavior contradicted the acceptance claim.
+2. Otherwise **BLOCKED** if any required case was not executed, was
+   inconclusive, or used a substitute provider, model, route, role, tool,
+   state transition, or pre-existing object instead of the intended one.
+3. **PASS** only if every required case was executed against the intended
+   contract and passed.
+
+Passing supplemental cases, a healthy deployment, local tests, recorded
+fixtures, or a nearest-caller check can add evidence but can never upgrade
+FAIL or BLOCKED to PASS. If no required case can run, stop after collecting
+bounded diagnostics and publish BLOCKED; do not invent a proxy journey merely
+to produce a browser PASS.
 
 ### 2. Confirm the intended build is live
 
@@ -111,9 +138,17 @@ For each selected case:
 
 1. Capture the starting URL and a focused DOM snapshot.
 2. Perform the smallest realistic user journey through visible controls.
-3. Assert the promised outcome from rendered state, not click success.
-4. Refresh, revisit, or read back when persistence matters.
-5. Record concise evidence: route, action, observed result, and pass/fail.
+3. Verify that the actual provider, model, route, role, tool, and starting
+   state match the required case before crediting the journey.
+4. Assert the promised outcome from rendered state, not click success.
+5. Refresh, revisit, or read back when persistence matters.
+6. Record concise evidence: acceptance classification, intended contract,
+   actual contract exercised, route, action, observed result, and status.
+
+Treat identity mismatches as **not executed**, not as successful fallbacks.
+For example, if a case requires `tool_search` but the model calls web search,
+or requires deferred-tool promotion but invokes a tool that was already
+advertised, the required case is BLOCKED even when the substitute call works.
 
 Prefer caller-facing verification:
 
@@ -141,7 +176,9 @@ user explicitly requested a fix or broader mutation.
 - Auth/session: verify login, refresh, logout, and denied access only to the
   extent the PR changes those contracts.
 - External provider/model: separate deterministic surface evidence from live
-  canary variability.
+  canary variability. If the PR requires a specific live provider/model and
+  the preview cannot run it, record deterministic tests as supplemental and
+  mark the required live case BLOCKED.
 
 Skip unrelated recipes and state why.
 
@@ -166,7 +203,10 @@ cleanup failure can never lose the PASS/FAIL/BLOCKED result. Include:
 
 - a `Railway preview QA — PASS|FAIL|BLOCKED` heading;
 - the tested head SHA, Railway state, preview URL, and relevant route;
-- the Given/When/Then matrix with concise observed evidence;
+- the Given/When/Then matrix with `Required`/`Supplemental`, intended versus
+  actual contract, and concise observed evidence;
+- a status derivation listing required cases passed, failed, blocked, or not
+  executed; verify the heading follows the mandatory status gate;
 - the exact regression result and any refresh or read-back result;
 - skipped cases with reasons and remaining risks or blockers;
 - cleanup status;

--- a/.claude/skills/railway-test/SKILL.md
+++ b/.claude/skills/railway-test/SKILL.md
@@ -120,12 +120,21 @@ Re-read `headRefOid` and confirm it still equals the `head_sha` recorded in
 step 2 before opening the preview; if it changed, return to step 2 for the new
 head instead of testing a stale build.
 
-Read and follow the `browser:control-in-app-browser` skill. Announce that this
-skill is opening the preview and will use the supplied token only for UI login.
+Select the browser driver available in the current agent harness:
 
-Use the in-app browser, not an external Playwright process. Open the route most
-relevant to the PR; use `/chat` only for chat changes. Wait for session
-initialization and inspect a DOM snapshot before assuming labels or controls.
+- If `browser:control-in-app-browser` is available, read and follow it and use
+  the in-app browser.
+- Otherwise use the harness's supported browser automation capability (for
+  example a browser tool, Playwright integration, or Chrome integration) that
+  can inspect rendered DOM and interact through visible controls.
+- If no browser automation capability is available, mark every required
+  browser case BLOCKED. HTTP requests, local tests, or source inspection may be
+  supplemental evidence, but they do not constitute browser acceptance.
+
+Announce which driver is opening the preview and that the supplied token will
+be used only for UI login. Open the route most relevant to the PR; use `/chat`
+only for chat changes. Wait for session initialization and inspect rendered DOM
+before assuming labels or controls.
 
 - If already authenticated, continue.
 - If a login form appears, fill the bearer into its token/password field and
@@ -218,7 +227,8 @@ Then clean up, guarded so failures cannot skip publication:
 
 1. Remove tracked `railway-test-` test data in a `finally`-equivalent step;
    record cleanup status in the evidence regardless of outcome.
-2. Finalize browser tabs best effort:
+2. Finalize browser tabs best effort using the selected driver's close or
+   cleanup operation. With the Codex in-app browser, use:
 
 ```js
 await browser.tabs.finalize({ keep: [] })

--- a/.claude/skills/railway-test/SKILL.md
+++ b/.claude/skills/railway-test/SKILL.md
@@ -62,14 +62,17 @@ Run (resolve the path against this skill's `scripts/` directory):
 scripts/preview_state.sh <PR> [REPO] [PREVIEW_URL]
 ```
 
-Record `head_sha`, `railway_state`, and `asset`. Poll every 30–45 seconds,
-up to 20 attempts (roughly 15 minutes), until the head-specific Railway check
-passes. Send a concise progress update at least once per minute.
+Record `head_sha`, `railway_state` (`success`, `pending`, `failure`, `error`,
+`missing`, or `query_failed`), `railway_details`, and `asset`. The script
+queries the commit-scoped status and check-run endpoints, so the result is
+bound to the tested head SHA — never a stale build. Poll every 30–45 seconds,
+up to 20 attempts (roughly 15 minutes), until `railway_state` reports
+`success`. Send a concise progress update at least once per minute.
 
-If the Railway check is still `missing` or `pending` after the attempt limit,
-stop polling and report BLOCKED with the latest check diagnostics; never test
-a partial build. A failing Railway check is BLOCKED as well until the
-intended build is live.
+If the exact-head Railway status is still `pending`, `missing`, or
+`query_failed` after the attempt limit, stop polling and report BLOCKED with
+the latest diagnostics; never test a partial build. A `failure` or `error`
+status is BLOCKED as well until the intended build is live.
 
 For frontend changes, compare the asset hash with the pre-deploy baseline.
 For backend-only changes, an unchanged asset is acceptable after the
@@ -181,38 +184,53 @@ Then clean up, guarded so failures cannot skip publication:
 await browser.tabs.finalize({ keep: [] })
 ```
 
-3. Re-read `headRefOid` once more. If it differs from the tested head, append
-   a BLOCKED note to the evidence instead of publishing evidence for a stale
-   build.
+3. Re-read `headRefOid` once more. If it differs from the tested head,
+   discard the browser observations: rebuild the evidence as
+   `Railway preview QA — BLOCKED` with the reason (`head changed during
+   testing: tested <old SHA>, head is now <new SHA>`) and no stale PASS/FAIL
+   heading or matrix, then publish that.
 4. Publish the prepared evidence as a comment on the tested pull request.
    Post evidence for PASS, FAIL, and BLOCKED runs; a failed or blocked test is
    still useful PR evidence. Never put the bearer, credentials, sensitive
    browser state, or secrets in the comment.
 
-   Find the existing evidence comment for this exact head — the one whose
-   body contains the hidden marker AND whose author is the current GitHub
-   user:
+   List ALL matching comments — paginated, filtered to the current GitHub
+   user and the exact head marker:
 
    ```bash
    GH_USER="$(gh api user --jq .login)"
-   gh api repos/<REPO>/issues/<PR>/comments \
+   gh api --paginate repos/<REPO>/issues/<PR>/comments \
      --jq ".[] | select(.user.login == \"$GH_USER\") | select(.body | contains(\"railway-test:evidence head=<HEAD_SHA>\")) | .id"
    ```
 
-   - If found, update it instead of adding a duplicate for the same head:
+   Reconcile to exactly one canonical comment before publishing:
 
-     ```bash
-     gh api repos/<REPO>/issues/comments/<COMMENT_ID> -F body=@<evidence-file>
-     ```
-
-   - Otherwise create a new comment:
+   - No match: create a new comment:
 
      ```bash
      gh pr comment <PR> --repo <REPO> --body-file <evidence-file>
      ```
 
-   A new deployed head gets a new evidence comment; the same head is never
-   published twice.
+   - Exactly one match: update it (the API needs PATCH, not the default GET):
+
+     ```bash
+     gh api --method PATCH repos/<REPO>/issues/comments/<COMMENT_ID> \
+       -F body=@<evidence-file>
+     ```
+
+   - Multiple matches (a lost create response or a concurrent run): keep the
+     first as canonical and delete the duplicates:
+
+     ```bash
+     gh api --method DELETE repos/<REPO>/issues/comments/<DUPLICATE_ID>
+     ```
+
+     then update the canonical comment as above.
+
+   Re-list with the same query after creating, updating, or deleting; if the
+   list still does not contain exactly one comment for this user and head,
+   reconcile again before reporting success. A new deployed head gets a new
+   evidence comment; the same head is never published twice.
 5. Capture the resulting comment URL and include it in the final response.
 
 Do not report the Railway test as fully delivered until the comment URL is

--- a/.claude/skills/railway-test/SKILL.md
+++ b/.claude/skills/railway-test/SKILL.md
@@ -13,7 +13,9 @@ Derive the browser plan from the PR instead of running a fixed chat scenario.
 Resolve from the request or current repository:
 
 - PR number or URL. If omitted, use `gh pr view`.
-- Repository. Default to the current `gh` repository.
+- Repository. Default to `nearai/ironclaw`; the preview URL fallback is
+  repo-specific, so an explicit repository must be supplied when testing
+  another repo.
 - Preview URL. Resolve it from the request or Railway status. For
   `nearai/ironclaw`, fall back to
   `https://ironclaw-ironclaw-pr-<PR>.up.railway.app`.
@@ -60,9 +62,14 @@ Run (resolve the path against this skill's `scripts/` directory):
 scripts/preview_state.sh <PR> [REPO] [PREVIEW_URL]
 ```
 
-Record `head_sha`, `railway_state`, and `asset`. Poll every 30–45 seconds until
-the head-specific Railway check passes. Send a concise progress update at least
-once per minute.
+Record `head_sha`, `railway_state`, and `asset`. Poll every 30–45 seconds,
+up to 20 attempts (roughly 15 minutes), until the head-specific Railway check
+passes. Send a concise progress update at least once per minute.
+
+If the Railway check is still `missing` or `pending` after the attempt limit,
+stop polling and report BLOCKED with the latest check diagnostics; never test
+a partial build. A failing Railway check is BLOCKED as well until the
+intended build is live.
 
 For frontend changes, compare the asset hash with the pre-deploy baseline.
 For backend-only changes, an unchanged asset is acceptable after the
@@ -71,7 +78,17 @@ head-specific Railway check passes. Do not test a stale build.
 If Railway fails, inspect the linked check/deployment and stop browser testing
 until the intended build is live.
 
+The PR head can move while this skill runs. Re-read `headRefOid` immediately
+before opening the preview (step 3) and again immediately before publishing
+(step 7). If either read differs from `head_sha`, restart build confirmation
+for the new head, or report BLOCKED for the stale build; never run or publish
+browser evidence against a head you did not confirm.
+
 ### 3. Open and authenticate the preview
+
+Re-read `headRefOid` and confirm it still equals the `head_sha` recorded in
+step 2 before opening the preview; if it changed, return to step 2 for the new
+head instead of testing a stale build.
 
 Read and follow the `browser:control-in-app-browser` skill. Announce that this
 skill is opening the preview and will use the supplied token only for UI login.
@@ -139,45 +156,66 @@ When a case fails:
 If the PR claim conflicts with live behavior, report the conflict rather than
 weakening the test.
 
-### 7. Report, clean up, and publish PR evidence
+### 7. Build evidence, clean up, and publish PR evidence
 
-Report:
-
-- PR, tested head SHA, Railway status, and preview URL;
-- test matrix with pass/fail and concise evidence;
-- exact regression result;
-- state read-back or refresh result when applicable;
-- skipped cases with reasons;
-- remaining risks or blockers.
-
-Never include the bearer. Finalize browser tabs with:
-
-```js
-await browser.tabs.finalize({ keep: [] })
-```
-
-After cleanup and browser finalization, always publish the evidence as a
-comment on the tested pull request. Post evidence for PASS, FAIL, and BLOCKED
-runs; a failed or blocked test is still useful PR evidence. Include:
+Build the full evidence body FIRST, before any cleanup, so a browser or
+cleanup failure can never lose the PASS/FAIL/BLOCKED result. Include:
 
 - a `Railway preview QA — PASS|FAIL|BLOCKED` heading;
 - the tested head SHA, Railway state, preview URL, and relevant route;
 - the Given/When/Then matrix with concise observed evidence;
 - the exact regression result and any refresh or read-back result;
-- cleanup status, skipped cases with reasons, and remaining risks;
+- skipped cases with reasons and remaining risks or blockers;
+- cleanup status;
 - `<!-- railway-test:evidence head=<HEAD_SHA> -->` as a hidden marker.
 
-Use `gh pr comment <PR> --repo <REPO> --body-file -` or the equivalent GitHub
-API. Never put the bearer, credentials, sensitive browser state, or secrets in
-the comment. Capture the created comment URL and include it in the final
-response.
+Never include the bearer, credentials, sensitive browser state, or secrets.
 
-Before creating a comment, check for an evidence comment with the same hidden
-head marker authored by the current GitHub user. Update that comment instead
-of adding a duplicate for the same head. A new deployed head gets a new
-evidence comment.
+Then clean up, guarded so failures cannot skip publication:
 
-Do not report the Railway test as fully delivered until the PR comment URL is
+1. Remove tracked `railway-test-` test data in a `finally`-equivalent step;
+   record cleanup status in the evidence regardless of outcome.
+2. Finalize browser tabs best effort:
+
+```js
+await browser.tabs.finalize({ keep: [] })
+```
+
+3. Re-read `headRefOid` once more. If it differs from the tested head, append
+   a BLOCKED note to the evidence instead of publishing evidence for a stale
+   build.
+4. Publish the prepared evidence as a comment on the tested pull request.
+   Post evidence for PASS, FAIL, and BLOCKED runs; a failed or blocked test is
+   still useful PR evidence. Never put the bearer, credentials, sensitive
+   browser state, or secrets in the comment.
+
+   Find the existing evidence comment for this exact head — the one whose
+   body contains the hidden marker AND whose author is the current GitHub
+   user:
+
+   ```bash
+   GH_USER="$(gh api user --jq .login)"
+   gh api repos/<REPO>/issues/<PR>/comments \
+     --jq ".[] | select(.user.login == \"$GH_USER\") | select(.body | contains(\"railway-test:evidence head=<HEAD_SHA>\")) | .id"
+   ```
+
+   - If found, update it instead of adding a duplicate for the same head:
+
+     ```bash
+     gh api repos/<REPO>/issues/comments/<COMMENT_ID> -F body=@<evidence-file>
+     ```
+
+   - Otherwise create a new comment:
+
+     ```bash
+     gh pr comment <PR> --repo <REPO> --body-file <evidence-file>
+     ```
+
+   A new deployed head gets a new evidence comment; the same head is never
+   published twice.
+5. Capture the resulting comment URL and include it in the final response.
+
+Do not report the Railway test as fully delivered until the comment URL is
 available. If GitHub authentication, permissions, or connectivity prevents
 posting, retry once, then report the publication failure explicitly and return
 the complete copy-ready Markdown evidence. Never claim PR evidence was posted

--- a/.claude/skills/railway-test/SKILL.md
+++ b/.claude/skills/railway-test/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: railway-test
+description: Verify any pull request on its Railway preview through browser-driven acceptance testing derived from the PR description and diff, then publish exact-head evidence on the pull request. Defaults to nearai/ironclaw and covers deployment freshness, bearer-token login, affected-route discovery, primary user journeys, regression reproduction, forms and state read-back, navigation, permissions, errors, and optional streaming cadence. Use when the user invokes /railway-test or $railway-test, asks to test a PR on Railway, or wants browser-based preview QA with PR evidence before merging.
+---
+
+# Railway Test
+
+Test the behavior the PR claims to change against the exact deployed PR head.
+Derive the browser plan from the PR instead of running a fixed chat scenario.
+
+## Inputs and secrets
+
+Resolve from the request or current repository:
+
+- PR number or URL. If omitted, use `gh pr view`.
+- Repository. Default to the current `gh` repository.
+- Preview URL. Resolve it from the request or Railway status. For
+  `nearai/ironclaw`, fall back to
+  `https://ironclaw-ironclaw-pr-<PR>.up.railway.app`.
+- Preview bearer token. Reuse an authenticated browser session when possible;
+  otherwise request it from the user.
+
+Never persist the bearer in the skill, repository, scripts, shell history,
+URLs, PR text, logs, screenshots, or final response. Never print or repeat it.
+Type it only into the preview login UI. Do not inspect or return browser
+storage values containing it.
+
+## Workflow
+
+### 1. Understand the PR before opening Railway
+
+Read repository guidance relevant to testing. For Ironclaw, read
+`docs/internal/testing-playbook.md` before selecting tests.
+
+Inspect:
+
+```bash
+gh pr view <PR> --repo <REPO> \
+  --json number,title,body,url,baseRefName,headRefName,headRefOid,files
+gh pr diff <PR> --repo <REPO>
+```
+
+Identify:
+
+- the user-visible behavior promised by the PR;
+- affected routes, screens, roles, and state;
+- the exact regression or before/after claim;
+- important success, validation, permission, and error paths;
+- dependencies on external services, model behavior, or persisted data.
+
+Write a compact Given/When/Then test matrix before interacting with the
+preview. Use [references/test-recipes.md](references/test-recipes.md) to choose
+only relevant cases. Do not default to chat or streaming tests.
+
+### 2. Confirm the intended build is live
+
+Run (resolve the path against this skill's `scripts/` directory):
+
+```bash
+scripts/preview_state.sh <PR> [REPO] [PREVIEW_URL]
+```
+
+Record `head_sha`, `railway_state`, and `asset`. Poll every 30–45 seconds until
+the head-specific Railway check passes. Send a concise progress update at least
+once per minute.
+
+For frontend changes, compare the asset hash with the pre-deploy baseline.
+For backend-only changes, an unchanged asset is acceptable after the
+head-specific Railway check passes. Do not test a stale build.
+
+If Railway fails, inspect the linked check/deployment and stop browser testing
+until the intended build is live.
+
+### 3. Open and authenticate the preview
+
+Read and follow the `browser:control-in-app-browser` skill. Announce that this
+skill is opening the preview and will use the supplied token only for UI login.
+
+Use the in-app browser, not an external Playwright process. Open the route most
+relevant to the PR; use `/chat` only for chat changes. Wait for session
+initialization and inspect a DOM snapshot before assuming labels or controls.
+
+- If already authenticated, continue.
+- If a login form appears, fill the bearer into its token/password field and
+  submit without exposing it in tool titles or output.
+- If authentication fails, report only that the credential was rejected.
+
+### 4. Execute the PR-specific browser matrix
+
+For each selected case:
+
+1. Capture the starting URL and a focused DOM snapshot.
+2. Perform the smallest realistic user journey through visible controls.
+3. Assert the promised outcome from rendered state, not click success.
+4. Refresh, revisit, or read back when persistence matters.
+5. Record concise evidence: route, action, observed result, and pass/fail.
+
+Prefer caller-facing verification:
+
+- For saved settings or CRUD, read back after refresh or navigation.
+- For permissions, test both the intended role and a safe denied path when
+  credentials are available.
+- For navigation, test deep links and refresh behavior.
+- For errors, use bounded invalid input; do not damage shared data.
+- For backend-only changes, drive the nearest real UI caller when one exists.
+- For side effects, create clearly named temporary test data and clean it up
+  only when cleanup is safe and authorized.
+
+Do not modify code or production state beyond reversible test data unless the
+user explicitly requested a fix or broader mutation.
+
+### 5. Run specialized checks only when relevant
+
+- Streaming or incremental UI: read
+  [references/streaming-cadence.md](references/streaming-cadence.md) and measure
+  visible DOM growth. Raw wire delivery alone is insufficient.
+- Upload/download: use a small non-sensitive fixture and verify content
+  read-back, not only a success toast.
+- Responsive/layout: inspect at the viewport sizes named in the PR or the
+  nearest product-supported breakpoints.
+- Auth/session: verify login, refresh, logout, and denied access only to the
+  extent the PR changes those contracts.
+- External provider/model: separate deterministic surface evidence from live
+  canary variability.
+
+Skip unrelated recipes and state why.
+
+### 6. Diagnose failures without silently expanding scope
+
+When a case fails:
+
+- reproduce once;
+- capture the smallest useful DOM, route, status, and timing evidence;
+- distinguish stale deployment, authentication, frontend presentation,
+  backend response, persistence, and external-service failures;
+- inspect read-only logs or network evidence when available;
+- do not implement a fix unless requested.
+
+If the PR claim conflicts with live behavior, report the conflict rather than
+weakening the test.
+
+### 7. Report, clean up, and publish PR evidence
+
+Report:
+
+- PR, tested head SHA, Railway status, and preview URL;
+- test matrix with pass/fail and concise evidence;
+- exact regression result;
+- state read-back or refresh result when applicable;
+- skipped cases with reasons;
+- remaining risks or blockers.
+
+Never include the bearer. Finalize browser tabs with:
+
+```js
+await browser.tabs.finalize({ keep: [] })
+```
+
+After cleanup and browser finalization, always publish the evidence as a
+comment on the tested pull request. Post evidence for PASS, FAIL, and BLOCKED
+runs; a failed or blocked test is still useful PR evidence. Include:
+
+- a `Railway preview QA — PASS|FAIL|BLOCKED` heading;
+- the tested head SHA, Railway state, preview URL, and relevant route;
+- the Given/When/Then matrix with concise observed evidence;
+- the exact regression result and any refresh or read-back result;
+- cleanup status, skipped cases with reasons, and remaining risks;
+- `<!-- railway-test:evidence head=<HEAD_SHA> -->` as a hidden marker.
+
+Use `gh pr comment <PR> --repo <REPO> --body-file -` or the equivalent GitHub
+API. Never put the bearer, credentials, sensitive browser state, or secrets in
+the comment. Capture the created comment URL and include it in the final
+response.
+
+Before creating a comment, check for an evidence comment with the same hidden
+head marker authored by the current GitHub user. Update that comment instead
+of adding a duplicate for the same head. A new deployed head gets a new
+evidence comment.
+
+Do not report the Railway test as fully delivered until the PR comment URL is
+available. If GitHub authentication, permissions, or connectivity prevents
+posting, retry once, then report the publication failure explicitly and return
+the complete copy-ready Markdown evidence. Never claim PR evidence was posted
+without verifying the resulting comment URL.

--- a/.claude/skills/railway-test/openai.yaml
+++ b/.claude/skills/railway-test/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Railway Test"
+  short_description: "Test Railway PR previews and post evidence"
+  default_prompt: "Use $railway-test to run exact-head browser acceptance tests on this Railway preview and publish the evidence on the pull request."

--- a/.claude/skills/railway-test/references/streaming-cadence.md
+++ b/.claude/skills/railway-test/references/streaming-cadence.md
@@ -17,7 +17,12 @@ streaming, so stream naturally and do not make the answer terse.
 
 ## Fresh-thread sampler
 
-Assume the browser skill produced a tab binding named `railwayTab`.
+Sample rendered text at roughly 100 ms intervals with the selected browser
+driver. Record a baseline immediately after submission, then count only later
+DOM changes; the submitted user message and static post-submit markup are not
+streaming evidence. The following implementation is for the Codex in-app
+browser when it produced a tab binding named `railwayTab`. With another driver,
+translate the same baseline, polling, and completion assertions to its DOM API.
 
 ```js
 var railwayPrompt = "Compare and contrast NEAR Protocol with Ethereum using current web research. Briefly tell me what you will research before using at least three tools, include another short progress update between tool phases, then write a detailed final answer of at least ten short paragraphs. I am testing smooth streaming, so stream naturally and do not make the answer terse.";

--- a/.claude/skills/railway-test/references/streaming-cadence.md
+++ b/.claude/skills/railway-test/references/streaming-cadence.md
@@ -29,7 +29,12 @@ await railwayTab.playwright.getByRole("button", {
   name: "Send message",
 }).click();
 var railwayStarted = Date.now();
-var railwayPrevious = "";
+// Baseline AFTER submission: the user message and static post-submit DOM
+// markup are not streaming evidence. Only growth after this signature counts
+// as assistant response streaming.
+var railwayPrevious = (
+  await railwayTab.playwright.locator("main p").allTextContents()
+).join("\n");
 var railwayChanges = [];
 while (Date.now() - railwayStarted < 55_000) {
   var railwayParts = await railwayTab.playwright

--- a/.claude/skills/railway-test/references/streaming-cadence.md
+++ b/.claude/skills/railway-test/references/streaming-cadence.md
@@ -1,0 +1,123 @@
+# Optional streaming cadence canary
+
+Use this recipe only when the PR changes chat, SSE/WebSocket delivery,
+incremental rendering, or live-update reconciliation. Use fresh `var` names
+when the Node REPL already contains these bindings. Adapt role names after
+inspecting the live DOM snapshot.
+
+## Fresh-thread prompt
+
+```text
+Compare and contrast NEAR Protocol with Ethereum using current web research.
+Briefly tell me what you will research before using at least three tools,
+include another short progress update between tool phases, then write a
+detailed final answer of at least ten short paragraphs. I am testing smooth
+streaming, so stream naturally and do not make the answer terse.
+```
+
+## Fresh-thread sampler
+
+Assume the browser skill produced a tab binding named `railwayTab`.
+
+```js
+var railwayPrompt = "Compare and contrast NEAR Protocol with Ethereum using current web research. Briefly tell me what you will research before using at least three tools, include another short progress update between tool phases, then write a detailed final answer of at least ten short paragraphs. I am testing smooth streaming, so stream naturally and do not make the answer terse.";
+var railwayBox = railwayTab.playwright.getByRole("textbox", {
+  name: "Ask IronClaw anything.",
+});
+await railwayBox.fill(railwayPrompt);
+await railwayTab.playwright.getByRole("button", {
+  name: "Send message",
+}).click();
+var railwayStarted = Date.now();
+var railwayPrevious = "";
+var railwayChanges = [];
+while (Date.now() - railwayStarted < 55_000) {
+  var railwayParts = await railwayTab.playwright
+    .locator("main p")
+    .allTextContents();
+  var railwaySignature = railwayParts.join("\n");
+  if (railwaySignature !== railwayPrevious) {
+    railwayChanges.push({
+      t: Date.now() - railwayStarted,
+      len: railwaySignature.length,
+      parts: railwayParts.length,
+      tail: railwaySignature.slice(-140),
+    });
+    railwayPrevious = railwaySignature;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+nodeRepl.write(JSON.stringify({
+  count: railwayChanges.length,
+  first: railwayChanges.slice(0, 12),
+  last: railwayChanges.slice(-20),
+}));
+```
+
+## Existing-thread follow-up prompt
+
+```text
+Follow up by using at least two web searches to verify the newest roadmap
+milestones for both protocols. Give one short progress sentence before the
+tools, then a fresh final answer of at least eight short paragraphs. Keep the
+final answer flowing naturally so I can observe streaming.
+```
+
+## Existing-thread sampler
+
+```js
+var railwayFollowup = "Follow up by using at least two web searches to verify the newest roadmap milestones for both protocols. Give one short progress sentence before the tools, then a fresh final answer of at least eight short paragraphs. Keep the final answer flowing naturally so I can observe streaming.";
+var railwayFollowupBox = railwayTab.playwright.getByRole("textbox", {
+  name: "Ask for follow-up changes",
+});
+await railwayFollowupBox.fill(railwayFollowup);
+await railwayTab.playwright.getByRole("button", {
+  name: "Send message",
+}).click();
+var railwayFollowupStarted = Date.now();
+var railwayFollowupPrevious = (
+  await railwayTab.playwright.locator("main p").allTextContents()
+).join("\n");
+var railwayFollowupChanges = [];
+while (Date.now() - railwayFollowupStarted < 55_000) {
+  var railwayFollowupParts = await railwayTab.playwright
+    .locator("main p")
+    .allTextContents();
+  var railwayFollowupSignature = railwayFollowupParts.join("\n");
+  if (railwayFollowupSignature !== railwayFollowupPrevious) {
+    railwayFollowupChanges.push({
+      t: Date.now() - railwayFollowupStarted,
+      len: railwayFollowupSignature.length,
+      parts: railwayFollowupParts.length,
+      tail: railwayFollowupSignature.slice(-140),
+    });
+    railwayFollowupPrevious = railwayFollowupSignature;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+nodeRepl.write(JSON.stringify({
+  count: railwayFollowupChanges.length,
+  first: railwayFollowupChanges.slice(0, 12),
+  last: railwayFollowupChanges.slice(-20),
+}));
+```
+
+## Completion inspection
+
+```js
+var railwaySnapshot = await railwayTab.playwright.domSnapshot();
+var railwayButtons = await railwayTab.playwright
+  .getByRole("button")
+  .allTextContents();
+var railwayParagraphs = await railwayTab.playwright
+  .locator("main p")
+  .allTextContents();
+nodeRepl.write(JSON.stringify({
+  terminalComposer: railwaySnapshot.includes("Ask for follow-up changes"),
+  activityButtons: railwayButtons.filter((text) =>
+    text.includes("Activity -")
+  ),
+  paragraphCount: railwayParagraphs.length,
+  tail: railwayParagraphs.slice(-10),
+}));
+```

--- a/.claude/skills/railway-test/references/test-recipes.md
+++ b/.claude/skills/railway-test/references/test-recipes.md
@@ -30,6 +30,17 @@ user-visible or durable outcome. Prefer:
 - downloaded or persisted content identity;
 - visible incremental changes for streaming.
 
+Before crediting a result, verify the journey exercised the intended contract,
+not merely a nearby successful behavior. Record the actual provider/model,
+route, role, tool or operation, and relevant starting state when any of those
+are part of the acceptance claim. A fallback provider, similarly named tool,
+different route, broader role, or already-existing state is supplemental
+evidence only. If it replaced a required journey, that journey was not
+executed and the overall Railway QA status is BLOCKED.
+
+Local tests and fixtures may prove deterministic protocol details, but they do
+not turn an unavailable required live canary into a browser PASS.
+
 ## Test-data discipline
 
 - Use names prefixed with `railway-test-` when creating temporary records.
@@ -37,4 +48,3 @@ user-visible or durable outcome. Prefer:
 - Resolve exact targets before deletion.
 - Clean up only records created by the current test.
 - State explicitly when cleanup was not authorized or could not be verified.
-

--- a/.claude/skills/railway-test/references/test-recipes.md
+++ b/.claude/skills/railway-test/references/test-recipes.md
@@ -1,0 +1,40 @@
+# PR-derived browser test recipes
+
+Choose the smallest set that reaches the changed contract.
+
+| PR change | Primary browser evidence | Important second case |
+|---|---|---|
+| New page or component | Navigate through the intended entrypoint and verify rendered content/actions | Deep-link and refresh |
+| Form or settings | Submit realistic valid input and verify the resulting state | Invalid/boundary input; refresh read-back |
+| CRUD | Create clearly named temporary data and verify it appears | Edit/read-back; delete only when safe |
+| Navigation/routing | Click through and verify URL plus target content | Browser back/forward or direct URL |
+| Auth/session | Login and verify protected content | Refresh, logout, or denied route as relevant |
+| Permissions | Verify the allowed role can act | Verify a lower role is denied without side effects |
+| Backend behavior exposed in UI | Trigger through the nearest production caller and verify rendered result | Error/retry path |
+| Upload/download | Upload a small non-sensitive fixture and verify it is usable | Download/read-back and content identity |
+| Async job/automation | Start the action and verify status transition | Refresh/poll to terminal state |
+| Streaming/live updates | Measure visible DOM/state changes over time | Existing-page follow-up or reconnect case |
+| Visual/layout | Inspect the changed viewport and interaction | One adjacent supported breakpoint |
+| Error handling | Trigger bounded safe failure and verify actionable UI | Recovery/retry succeeds |
+
+## Evidence standard
+
+A click, HTTP 200, toast, or raw event is not enough when the PR promises a
+user-visible or durable outcome. Prefer:
+
+- rendered state after the action;
+- read-back after refresh/navigation;
+- exact URL and route state;
+- role-specific allowed/denied behavior;
+- terminal job status;
+- downloaded or persisted content identity;
+- visible incremental changes for streaming.
+
+## Test-data discipline
+
+- Use names prefixed with `railway-test-` when creating temporary records.
+- Do not use secrets, PII, or user-owned content.
+- Resolve exact targets before deletion.
+- Clean up only records created by the current test.
+- State explicitly when cleanup was not authorized or could not be verified.
+

--- a/.claude/skills/railway-test/scripts/preview_state.sh
+++ b/.claude/skills/railway-test/scripts/preview_state.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  echo "usage: preview_state.sh <pr> [repo] [preview_url]" >&2
+  exit 2
+fi
+
+pr="$1"
+repo="${2:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+preview_url="${3:-}"
+
+head_sha="$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)"
+check_line="$(
+  gh pr checks "$pr" --repo "$repo" 2>/dev/null \
+    | awk -F '\t' '
+        tolower($1) ~ /railway/ ||
+        $1 ~ /^ironclaw-ci-preview/ ||
+        tolower($5) ~ /railway/ {
+          print
+          exit
+        }
+      ' \
+    || true
+)"
+
+railway_state="missing"
+railway_description=""
+if [[ -n "$check_line" ]]; then
+  IFS=$'\t' read -r _ railway_state _ _ railway_description <<<"$check_line"
+fi
+
+if [[ -z "$preview_url" && "$repo" == "nearai/ironclaw" ]]; then
+  preview_url="https://ironclaw-ironclaw-pr-${pr}.up.railway.app"
+fi
+if [[ -z "$preview_url" && "$railway_description" =~ ([A-Za-z0-9.-]+\.up\.railway\.app) ]]; then
+  preview_url="https://${BASH_REMATCH[1]}"
+fi
+
+asset=""
+if [[ -n "$preview_url" ]]; then
+  asset="$(
+    curl -fsSL --max-time 15 "$preview_url/" 2>/dev/null \
+      | rg -o 'assets/app-[A-Za-z0-9_-]+\.js' \
+      | head -1 \
+      || true
+  )"
+fi
+
+printf 'pr=%s\n' "$pr"
+printf 'repo=%s\n' "$repo"
+printf 'head_sha=%s\n' "$head_sha"
+printf 'preview_url=%s\n' "${preview_url:-unresolved}"
+printf 'railway_state=%s\n' "$railway_state"
+printf 'railway_description=%s\n' "$railway_description"
+printf 'asset=%s\n' "${asset:-unavailable}"

--- a/.claude/skills/railway-test/scripts/preview_state.sh
+++ b/.claude/skills/railway-test/scripts/preview_state.sh
@@ -21,30 +21,59 @@ fi
 
 head_sha="$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)"
 
-# Match the Railway check by name or description through the structured
-# --json interface instead of parsing the human-readable check table.
-railway_check="$(
-  gh pr checks "$pr" --repo "$repo" --json name,state,description 2>/dev/null \
-    --jq '.[] |
+# Query the commit-scoped statuses (and check-runs as a fallback) so the
+# Railway result is bound to the tested head SHA. Query failures are captured
+# separately: an empty successful result means "no Railway status for this
+# head", a failed query is reported as query_failed — never as `missing` — so
+# the skill does not waste polling budget without diagnostics.
+railway_query="ok"
+railway_line=""
+if status_line="$(
+  gh api "repos/$repo/commits/$head_sha/status" 2>/dev/null \
+    --jq '.statuses[] |
       select(
-        (.name | ascii_downcase | contains("railway")) or
-        (.description // "" | ascii_downcase | contains("railway"))
+        (.context | ascii_downcase | contains("railway")) or
+        (.context | ascii_downcase | contains("ci-preview")) or
+        ((.description // "") | ascii_downcase | contains("railway"))
       ) |
-      "\(.state)\t\(.description)"' \
-    | head -1 \
-    || true
-)"
+      "\(.state)\t\(.description // "")\t\(.target_url // "")"' \
+    | head -1
+)"; then
+  railway_line="$status_line"
+else
+  railway_query="failed"
+fi
+if [[ -z "$railway_line" && "$railway_query" == "ok" ]]; then
+  # Some providers post check-runs instead of statuses; still commit-scoped.
+  if check_line="$(
+    gh api --paginate "repos/$repo/commits/$head_sha/check-runs" 2>/dev/null \
+      --jq '.check_runs[] |
+        select(
+          (.name | ascii_downcase | contains("railway")) or
+          (.name | ascii_downcase | startswith("ironclaw-ci-preview")) or
+          ((.app.name // "") | ascii_downcase | contains("railway"))
+        ) |
+        "\(.status):\(.conclusion // "unknown")\t\(.name)\t\(.details_url // "")"' \
+      | head -1
+  )"; then
+    railway_line="$check_line"
+  else
+    railway_query="failed"
+  fi
+fi
 
 railway_state="missing"
-railway_description=""
-if [[ -n "$railway_check" ]]; then
-  IFS=$'\t' read -r railway_state railway_description <<<"$railway_check"
+railway_details=""
+if [[ "$railway_query" == "ok" && -n "$railway_line" ]]; then
+  IFS=$'\t' read -r railway_state railway_details _ <<<"$railway_line"
+elif [[ "$railway_query" == "failed" ]]; then
+  railway_state="query_failed"
 fi
 
 if [[ -z "$preview_url" && "$repo" == "nearai/ironclaw" && "$pr_num" =~ ^[0-9]+$ ]]; then
   preview_url="https://ironclaw-ironclaw-pr-${pr_num}.up.railway.app"
 fi
-if [[ -z "$preview_url" && "$railway_description" =~ ([A-Za-z0-9.-]+\.up\.railway\.app) ]]; then
+if [[ -z "$preview_url" && "$railway_details" =~ ([A-Za-z0-9.-]+\.up\.railway\.app) ]]; then
   preview_url="https://${BASH_REMATCH[1]}"
 fi
 
@@ -63,5 +92,5 @@ printf 'repo=%s\n' "$repo"
 printf 'head_sha=%s\n' "$head_sha"
 printf 'preview_url=%s\n' "${preview_url:-unresolved}"
 printf 'railway_state=%s\n' "$railway_state"
-printf 'railway_description=%s\n' "$railway_description"
+printf 'railway_details=%s\n' "$railway_details"
 printf 'asset=%s\n' "${asset:-unavailable}"

--- a/.claude/skills/railway-test/scripts/preview_state.sh
+++ b/.claude/skills/railway-test/scripts/preview_state.sh
@@ -6,32 +6,43 @@ if [[ $# -lt 1 || $# -gt 3 ]]; then
   exit 2
 fi
 
-pr="$1"
-repo="${2:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+pr="${1%/}"
+repo="${2:-nearai/ironclaw}"
 preview_url="${3:-}"
 
+# Accept a PR number or a PR URL. The preview hostname fallback needs the
+# numeric PR number, so extract it before building any hostname.
+pr_num=""
+if [[ "$pr" =~ ^[0-9]+$ ]]; then
+  pr_num="$pr"
+elif command -v gh >/dev/null 2>&1; then
+  pr_num="$(gh pr view "$pr" --repo "$repo" --json number --jq .number 2>/dev/null || true)"
+fi
+
 head_sha="$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)"
-check_line="$(
-  gh pr checks "$pr" --repo "$repo" 2>/dev/null \
-    | awk -F '\t' '
-        tolower($1) ~ /railway/ ||
-        $1 ~ /^ironclaw-ci-preview/ ||
-        tolower($5) ~ /railway/ {
-          print
-          exit
-        }
-      ' \
+
+# Match the Railway check by name or description through the structured
+# --json interface instead of parsing the human-readable check table.
+railway_check="$(
+  gh pr checks "$pr" --repo "$repo" --json name,state,description 2>/dev/null \
+    --jq '.[] |
+      select(
+        (.name | ascii_downcase | contains("railway")) or
+        (.description // "" | ascii_downcase | contains("railway"))
+      ) |
+      "\(.state)\t\(.description)"' \
+    | head -1 \
     || true
 )"
 
 railway_state="missing"
 railway_description=""
-if [[ -n "$check_line" ]]; then
-  IFS=$'\t' read -r _ railway_state _ _ railway_description <<<"$check_line"
+if [[ -n "$railway_check" ]]; then
+  IFS=$'\t' read -r railway_state railway_description <<<"$railway_check"
 fi
 
-if [[ -z "$preview_url" && "$repo" == "nearai/ironclaw" ]]; then
-  preview_url="https://ironclaw-ironclaw-pr-${pr}.up.railway.app"
+if [[ -z "$preview_url" && "$repo" == "nearai/ironclaw" && "$pr_num" =~ ^[0-9]+$ ]]; then
+  preview_url="https://ironclaw-ironclaw-pr-${pr_num}.up.railway.app"
 fi
 if [[ -z "$preview_url" && "$railway_description" =~ ([A-Za-z0-9.-]+\.up\.railway\.app) ]]; then
   preview_url="https://${BASH_REMATCH[1]}"


### PR DESCRIPTION
## Summary

- Adds the `railway-test` developer skill under `.claude/skills/railway-test/` (SKILL.md, openai.yaml interface metadata, `scripts/preview_state.sh`, `references/streaming-cadence.md`, `references/test-recipes.md`).
- The skill derives a browser test matrix from a PR's description and diff, confirms the exact head build is live on Railway, drives the preview through the in-app browser, and publishes PASS/FAIL/BLOCKED evidence as a PR comment keyed to the tested head SHA (`<!-- railway-test:evidence head=... -->` marker, deduplicated per head).
- Script invocation changed from the gist's machine-local `~/.codex/skills/...` path to a skill-relative path so it works from any install location (repo `.claude/skills/`, or a symlinked `~/.codex/skills/railway-test`).
- Adds a mandatory Required/Supplemental status gate: unavailable, inconclusive, or substituted acceptance paths force BLOCKED; deployment health, nearest-caller checks, and local tests cannot upgrade the run to PASS.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: `Not applicable: no Rust code changed`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — `Not applicable: no Rust code changed`
- [x] Manual testing: `bash -n` passes on `preview_state.sh`; live smoke run against PR 7232 resolved head SHA, Railway check state (pass), preview URL, and asset hash:
  `head_sha=c7e4852eb... railway_state=pass preview_url=https://ironclaw-ironclaw-pr-7232.up.railway.app asset=assets/app-_4yTj8D1.js`
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — `Not applicable: agent did not support it`

### Skill regression validation

- Pre-change fresh-agent trap, using the exact escaped-QA shape (required provider-specific discovery and promotion journey unavailable; alternate tool and local tests available): returned BLOCKED. This did not reproduce the observed false PASS on the newer PR draft, but confirms the intended classification.
- Post-change fresh-agent adversarial trap with renamed providers/tools: returned BLOCKED; all four unexecuted required cases remained blocking while deployment, auth, navigation, console, and local checks remained Supplemental/PASS.
- Mechanical validation: `quick_validate.py`, `bash -n .claude/skills/railway-test/scripts/preview_state.sh`, reference/executable checks, and `git diff --check` passed.

## Test Strategy

User behavior: A developer (or agent) invokes the skill to QA a PR on its Railway preview; the skill confirms the deployed head matches the PR head before testing and leaves a verifiable, deduplicated evidence comment on the PR.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: `Not applicable: no code changed; bash syntax checked`
- Reborn integration: `Not applicable`
- Recorded fixture: `Not applicable`
- Browser E2E: `Not applicable: browser driving happens at skill runtime against live previews`
- Backend or runtime: `Not applicable`
- Live canary: `Not applicable`

What the tests prove: `preview_state.sh` resolves the PR head SHA, matches the Railway check from `gh pr checks`, falls back to the deterministic `ironclaw-ironclaw-pr-<PR>.up.railway.app` URL for nearai/ironclaw, and fingerprints the deployed frontend asset (verified live against PR 7232).

Commands run:

```bash
bash -n .claude/skills/railway-test/scripts/preview_state.sh
.claude/skills/railway-test/scripts/preview_state.sh 7232 nearai/ironclaw
```

## Security Impact

The skill instructs agents to handle the preview bearer token as a secret: never persist it in the skill, repository, scripts, shell history, URLs, PR text, logs, screenshots, or responses; type it only into the login UI; and never include it in the evidence comment. `preview_state.sh` only reads public `gh`/`curl` data (PR head SHA, check state, rendered HTML asset name).

## Reborn Trust-Boundary Checklist

N/A: guidance-layer addition only; no trust-bearing types, runtime variants, queues, serialization, or production boundaries changed.

## Database Impact

None.

## Blast Radius

Guidance layer only (`.claude/skills/`). No runtime, CI, or product behavior changes. The skill is inert until invoked by a developer or agent.

## Rollback Plan

Delete `.claude/skills/railway-test/`.

## Review Follow-Through

- Step 3 prefers the Codex in-app browser when available and otherwise uses supported DOM-capable browser automation in the current harness (for example Playwright or Chrome integration). A harness without browser automation must report required browser cases BLOCKED; HTTP or local-test evidence remains supplemental.
- The `openai.yaml` file carries Codex interface metadata (`$railway-test`). Codex does not load `.claude/skills/`; users who want it under Codex should symlink `~/.codex/skills/railway-test` to the repo directory. Flagging per the skill-maintainer Codex-parity rule; an AGENTS.md pointer was intentionally not added because this is an operational tool, not a rule Codex must follow.
- The `railway-test-` data-creation prefix and evidence-comment deduplication marker are conventions enforced by the skill itself, not by CI.

---

**Review track**: A (docs/tests/chore)
