### PR TITLE
chore(release): promote 1.1.0-rc.1 to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0-rc.1] - 2026-08-03
+## [1.1.0] - 2026-08-06
 
-First release candidate since 1.0.0. The headline work is extension reach —
+First stable release since 1.0.0, promoting `1.1.0-rc.1` plus the fixes listed
+under "Fixed since 1.1.0-rc.1". The headline work is extension reach —
 registering arbitrary hosted MCP servers, installing from IronHub deep links,
 durable file attachments that cross channels, and Slack `/ironclaw` slash
 commands — plus a broad pass on making failures legible: to the model, which
@@ -182,6 +183,17 @@ one behavioral removal is the `/webhooks/slack/events` compatibility alias
   `/webhooks/slack/events` forwarding alias. Slack Event Subscriptions must use
   `/webhooks/extensions/slack/events`; generic product-auth OAuth callbacks are
   unchanged.
+
+### Fixed since 1.1.0-rc.1
+
+- **1.0 state is preserved across the 1.1 startup migration:** the release-pair
+  migration keeps existing rc1 workspace, extension, and Railway artifacts
+  intact, recovers across restarts, and bounds extension secret discovery.
+- **Hosted MCP egress target** is preserved for registered MCP servers.
+- **Readable text logs stay writable:** `write_file`'s read-before-edit
+  backstop uses the same lenient binary classification as `read_file`, on both
+  the owning executor and host-runtime caller paths (`apply_patch` stays
+  strict).
 
 ## [1.0.0] - 2026-07-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "1.1.0-rc.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw"
-version = "1.1.0-rc.1"
+version = "1.1.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
Promotes the release branch to the stable `1.1.0` version so the release can be cut as `ironclaw-v1.1.0`.

`scripts/ci/cut_ironclaw_release.py` refuses to create the tag unless the approved commit's `crates/ironclaw_reborn_cli/Cargo.toml` declares the requested version, so the manifest, `Cargo.lock`, and the `CHANGELOG.md` heading move together.

- `crates/ironclaw_reborn_cli/Cargo.toml`: `1.1.0-rc.1` -> `1.1.0`
- `CHANGELOG.md`: heading becomes `[1.1.0] - 2026-08-06`, plus a "Fixed since 1.1.0-rc.1" section for #7256, #7241, and #7227 (the CI-only canary temp-path fix in #7261 is omitted).

Deliberately unchanged: the `rc1_to_1_1` release-pair migration constants (`target_release`, marker paths). They name persisted state that boxes already migrated by the RC depend on — they are not the product version. The release upgrade canary's `PREVIOUS_RELEASE_TAG=ironclaw-v1.0.0-rc.1` also stays valid.

Base is the current `release/1.1.0-rc.1` tip (`6c64ded0e3`); PR #7269 is intentionally excluded from this cut.

After merge: dispatch **Cut Ironclaw Release** from `main` with `version=1.1.0` and the merged commit SHA. That creates the tag, which triggers `ironclaw-release.yml` (cargo-dist build -> upgrade canary -> GitHub Release -> Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)