### PR TITLE
fix(webui): bound SSE reconnect storms

### DIFF
--- a/crates/product/ironclaw_webui/CLAUDE.md
+++ b/crates/product/ironclaw_webui/CLAUDE.md
@@ -238,12 +238,18 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
   — a caller cannot bypass the cap by mixing SSE and WS. Exhaustion returns
   `429` with `retryable: true`.
 - The SPA consumes SSE through `event-source-plus`, which owns event framing,
-  `Last-Event-ID`, abort, and retry/backoff over `fetch`/`ReadableStream`. The
-  bearer is sent in the `Authorization` header rather than the request URL. A
-  bounded, random `connection_id` remains stable for one browser tab across SPA
-  mounts and document reloads, while `connection_generation` increments for
-  every package-managed request. Fresh top-level navigations use a new identity
-  even when a duplicated tab copied `sessionStorage`. A same-caller, same-id
+  `Last-Event-ID`, fetch, and cancellation over `fetch`/`ReadableStream`.
+  IronClaw owns one reconnect coordinator across transport failures, stream
+  endings, activity stalls, visibility recovery, and network recovery. It uses
+  jittered 1/2/4/8/16/30-second backoff, honors `Retry-After`, and resets only
+  after a valid application frame arrives beyond a stable 15-second interval;
+  HTTP headers and the immediate admission keep-alive do not reset it. The
+  bearer is sent in the `Authorization` header rather than
+  the request URL. A bounded, random `connection_id` remains stable for one
+  browser tab across SPA mounts and document reloads, while
+  `connection_generation` increments for every package-managed request. Fresh
+  top-level navigations use a new identity even when a duplicated tab copied
+  `sessionStorage`. A same-caller, same-id
   stream supersedes its prior generation without consuming another slot; a
   delayed older generation receives `204` and cannot cancel the current stream.
   This prevents proxy-reordered closes/opens during thread navigation or reload

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useSSE.ts
@@ -8,6 +8,11 @@ import {
 
 const ACTIVE_STREAM_STALL_DEADLINE_MS = 30_000;
 const SSE_CONNECTION_STORAGE_KEY = "ironclaw:v2-sse-connection";
+const SSE_RETRY_BASE_MS = 1_000;
+const SSE_RETRY_MAX_MS = 30_000;
+const SSE_RETRY_JITTER_RATIO = 0.2;
+const SSE_RETRY_RESET_AFTER_MS = 15_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 function newConnectionState() {
   return { connectionId: clientActionId(), generation: 0 };
@@ -88,6 +93,27 @@ function isRetryableResponseStatus(status) {
   );
 }
 
+function localRetryDelayMs(attempt) {
+  const exponential = Math.min(
+    SSE_RETRY_BASE_MS * 2 ** Math.min(attempt, 30),
+    SSE_RETRY_MAX_MS,
+  );
+  const jitter = 1 - SSE_RETRY_JITTER_RATIO + Math.random() * 2 * SSE_RETRY_JITTER_RATIO;
+  return Math.min(Math.round(exponential * jitter), SSE_RETRY_MAX_MS);
+}
+
+function responseRetryAfterMs(response) {
+  const raw = response?.headers?.get?.("retry-after")?.trim();
+  if (!raw) return 0;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(Math.ceil(seconds * 1_000), MAX_TIMER_DELAY_MS);
+  }
+  const deadline = Date.parse(raw);
+  if (!Number.isFinite(deadline)) return 0;
+  return Math.min(Math.max(0, deadline - Date.now()), MAX_TIMER_DELAY_MS);
+}
+
 export function useSSE({
   threadId,
   onEvent,
@@ -109,10 +135,13 @@ export function useSSE({
     }
     let controller = null;
     let activityWatchdog = null;
+    let retryTimer = null;
+    let retryAttempt = 0;
     let disposed = false;
     let terminalErrorReceived = false;
     let connectedOnce = false;
     let streamOpen = false;
+    let streamOpenedAt = null;
     const request = eventStreamRequest({
       threadId,
     });
@@ -120,7 +149,11 @@ export function useSSE({
       credentials: "same-origin",
       headers: request.headers,
       maxRetryInterval: 30_000,
-      retryStrategy: "always",
+      // IronClaw owns reconnect timing below. `event-source-plus` still owns
+      // fetch, framing, cancellation, and Last-Event-ID, but its 0.1.x retry
+      // clock starts at 2ms and resets on HTTP headers rather than a proven
+      // live SSE frame. Letting both layers retry creates request storms.
+      retryStrategy: "on-error",
     });
 
     function clearActivityWatchdog() {
@@ -132,7 +165,50 @@ export function useSSE({
 
     function markTransportUnavailable() {
       streamOpen = false;
+      streamOpenedAt = null;
       clearActivityWatchdog();
+    }
+
+    function cancelScheduledRetry() {
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+    }
+
+    function resetRetryBackoff() {
+      retryAttempt = 0;
+      cancelScheduledRetry();
+    }
+
+    function scheduleReconnect(reason, response = null) {
+      if (disposed || terminalErrorReceived) return;
+      markTransportUnavailable();
+      setStatus(CONNECTION_STATUS.RECONNECTING);
+      if (retryTimer) return;
+
+      // Abort the package-owned request before its catch path can start an
+      // automatic retry. Every retry source then converges on this one timer.
+      controller?.abort(`retry scheduled: ${reason}`);
+      if (document.visibilityState === "hidden" || isBrowserOffline()) return;
+
+      const delay = Math.max(
+        localRetryDelayMs(retryAttempt),
+        responseRetryAfterMs(response),
+      );
+      retryAttempt = Math.min(retryAttempt + 1, 30);
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        if (
+          disposed ||
+          terminalErrorReceived ||
+          document.visibilityState === "hidden" ||
+          isBrowserOffline()
+        ) {
+          return;
+        }
+        controller?.reconnect();
+      }, delay);
     }
 
     function activityIsExpected() {
@@ -160,12 +236,13 @@ export function useSSE({
           return;
         }
         setStatus(CONNECTION_STATUS.RECONNECTING);
-        controller.reconnect();
+        scheduleReconnect("activity watchdog");
       }, ACTIVE_STREAM_STALL_DEADLINE_MS);
     }
 
     function markConnected() {
       if (disposed || terminalErrorReceived) return;
+      if (!streamOpen) streamOpenedAt = Date.now();
       streamOpen = true;
       connectedOnce = true;
       setStatus(CONNECTION_STATUS.CONNECTED);
@@ -201,8 +278,7 @@ export function useSSE({
         },
         onRequestError() {
           if (disposed || terminalErrorReceived) return;
-          markTransportUnavailable();
-          setStatus(CONNECTION_STATUS.RECONNECTING);
+          scheduleReconnect("request error");
         },
         onResponse({ response }) {
           if (disposed || terminalErrorReceived) return;
@@ -216,12 +292,13 @@ export function useSSE({
         },
         onResponseError({ response }) {
           if (disposed || terminalErrorReceived) return;
-          markTransportUnavailable();
           if (isRetryableResponseStatus(response.status)) {
-            setStatus(CONNECTION_STATUS.RECONNECTING);
+            scheduleReconnect("retryable stream response", response);
             return;
           }
+          markTransportUnavailable();
           terminalErrorReceived = true;
+          cancelScheduledRetry();
           controller?.abort("non-retryable stream response");
           setStatus(CONNECTION_STATUS.DISCONNECTED);
         },
@@ -236,7 +313,18 @@ export function useSSE({
           if (!frame || typeof frame !== "object") return;
           const rawType = frame.type || message.event || "message";
           const type = rawType === "stream_error" ? "error" : rawType;
-          if (type !== "error") markConnected();
+          if (type !== "error") {
+            markConnected();
+            // The server emits one keep_alive immediately after admission.
+            // Require a frame after a stable interval before resetting, or a
+            // stream that opens, pings once, and dies can still loop at 1s.
+            if (
+              streamOpenedAt !== null &&
+              Date.now() - streamOpenedAt >= SSE_RETRY_RESET_AFTER_MS
+            ) {
+              resetRetryBackoff();
+            }
+          }
           onEventRef.current?.({
             type,
             frame,
@@ -245,8 +333,8 @@ export function useSSE({
           scheduleActivityWatchdog();
           if (type === "error" && frame.retryable === false) {
             terminalErrorReceived = true;
-            streamOpen = false;
-            clearActivityWatchdog();
+            markTransportUnavailable();
+            cancelScheduledRetry();
             controller?.abort("non-retryable stream event");
             setStatus(CONNECTION_STATUS.DISCONNECTED);
             return;
@@ -257,11 +345,14 @@ export function useSSE({
             frame.retryable === true
           ) {
             stream.lastEventId = undefined;
-            markTransportUnavailable();
-            setStatus(CONNECTION_STATUS.RECONNECTING);
-            controller?.reconnect();
+            scheduleReconnect("projection replay unavailable");
           }
         },
+      });
+      controller.onAbort?.((event) => {
+        if (event.type === "end-of-stream") {
+          scheduleReconnect("stream ended");
+        }
       });
       if (terminalErrorReceived) {
         streamOpen = false;
@@ -272,8 +363,8 @@ export function useSSE({
 
     function disconnectForHiddenTab() {
       if (disposed || terminalErrorReceived) return;
-      streamOpen = false;
-      clearActivityWatchdog();
+      markTransportUnavailable();
+      cancelScheduledRetry();
       controller?.abort("document hidden");
       setStatus(CONNECTION_STATUS.PAUSED);
     }
@@ -285,22 +376,21 @@ export function useSSE({
       } else if (!controller) {
         connect();
       } else {
-        markTransportUnavailable();
         setStatus(CONNECTION_STATUS.CONNECTING);
-        controller.reconnect();
+        scheduleReconnect("document visible");
       }
     }
 
     function handleNetworkOffline() {
       if (disposed || terminalErrorReceived) return;
+      markTransportUnavailable();
+      cancelScheduledRetry();
       setStatus(CONNECTION_STATUS.RECONNECTING);
     }
 
     function handleNetworkOnline() {
       if (disposed || terminalErrorReceived) return;
-      markTransportUnavailable();
-      setStatus(CONNECTION_STATUS.RECONNECTING);
-      controller?.reconnect();
+      scheduleReconnect("network online");
     }
 
     syncActivityWatchdogRef.current = () => {
@@ -322,6 +412,7 @@ export function useSSE({
       window.removeEventListener("offline", handleNetworkOffline);
       window.removeEventListener("online", handleNetworkOnline);
       clearActivityWatchdog();
+      cancelScheduledRetry();
       syncActivityWatchdogRef.current = () => {};
       controller?.abort("component disposed");
       controller = null;

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useSSE.test.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { test } from "vitest";
+import { EventSourcePlus as PackagedEventSourcePlus } from "event-source-plus";
+import { test, vi } from "vitest";
 import vm from "node:vm";
 
 import { CONNECTION_STATUS } from "./connection-status";
@@ -40,12 +41,14 @@ function createHarness({
   connectionId = "browser-tab-connection",
   navigationType = "navigate",
   sessionStorage = createSessionStorage(),
+  random = () => 0.5,
 } = {}) {
   const statuses = [];
   const streams = [];
   const timers = [];
   const documentListeners = new Map();
   const windowListeners = new Map();
+  let now = 0;
   let refIndex = 0;
   let effectIndex = 0;
   let currentThreadId = "thread-1";
@@ -67,13 +70,18 @@ function createHarness({
       const stream = this;
       this.controller = {
         abortCalls: [],
+        abortHandler: null,
         reconnectCalls: 0,
         abort(reason) {
           this.abortCalls.push(reason);
+          this.abortHandler?.({ type: "manual", reason });
         },
         reconnect() {
           this.reconnectCalls += 1;
           stream.request();
+        },
+        onAbort(handler) {
+          this.abortHandler = handler;
         },
       };
       this.request();
@@ -84,11 +92,11 @@ function createHarness({
       this.hooks.onRequest?.({ options: this.requestOptions });
     }
 
-    respond(status = 200, contentType = "text/event-stream") {
+    respond(status = 200, contentType = "text/event-stream", headers = {}) {
       const response = {
         ok: status >= 200 && status < 300,
         status,
-        headers: new Headers({ "content-type": contentType }),
+        headers: new Headers({ "content-type": contentType, ...headers }),
       };
       if (response.ok) {
         this.hooks.onResponse?.({ response });
@@ -98,6 +106,13 @@ function createHarness({
       } else {
         this.hooks.onResponseError?.({ response });
       }
+    }
+
+    end() {
+      this.controller.abortHandler?.({
+        type: "end-of-stream",
+        reason: "Stream has ended",
+      });
     }
 
     message(frame, { event = frame.type, id = "" } = {}) {
@@ -127,7 +142,12 @@ function createHarness({
     },
     Headers,
     JSON,
-    Math,
+    Math: Object.assign(Object.create(Math), { random }),
+    Date: class extends Date {
+      static now() {
+        return now;
+      }
+    },
     React: {
       useEffect: (effect, dependencies) => {
         const index = effectIndex++;
@@ -167,7 +187,14 @@ function createHarness({
       removeEventListener: (name) => windowListeners.delete(name),
     },
     setTimeout: (handler, delay) => {
-      const timer = { handler, delay };
+      const timer = {
+        cleared: false,
+        delay,
+        handler: () => {
+          timer.cleared = true;
+          handler();
+        },
+      };
       timers.push(timer);
       return timer;
     },
@@ -207,6 +234,9 @@ function createHarness({
   return {
     cleanup: cleanupEffects,
     context,
+    advanceTime: (milliseconds) => {
+      now += milliseconds;
+    },
     documentListeners,
     get result() {
       return result;
@@ -233,7 +263,7 @@ test("useSSE delegates framing, credentials, and retries to EventSourcePlus", ()
   assert.deepEqual(stream.options.headers(), { Authorization: "Bearer token-1" });
   assert.equal(new URL(stream.url).searchParams.has("token"), false);
   assert.equal(stream.options.credentials, "same-origin");
-  assert.equal(stream.options.retryStrategy, "always");
+  assert.equal(stream.options.retryStrategy, "on-error");
   assert.equal(stream.options.maxRetryInterval, 30_000);
   assert.equal(
     stream.requestOptions.query.connection_id,
@@ -291,6 +321,11 @@ test("useSSE reconnects an active run when an open stream stops delivering", () 
   assert.ok(watchdog);
 
   watchdog.handler();
+  const retry = timers.find(
+    (timer) => !timer.cleared && timer.delay >= 800 && timer.delay <= 1_200,
+  );
+  assert.ok(retry);
+  retry.handler();
   assert.equal(stream.controller.reconnectCalls, 1);
   assert.equal(typeof stream.requestOptions.query.connection_generation, "number");
 });
@@ -313,7 +348,7 @@ test("useSSE rejects a successful response that is not an event stream", () => {
 });
 
 test("useSSE pauses while hidden and reconnects when visible", () => {
-  const { context, documentListeners, statuses, streams } = createHarness();
+  const { context, documentListeners, statuses, streams, timers } = createHarness();
   const stream = streams[0];
   stream.respond();
 
@@ -324,8 +359,13 @@ test("useSSE pauses while hidden and reconnects when visible", () => {
 
   context.document.visibilityState = "visible";
   documentListeners.get("visibilitychange")();
+  const retry = timers.find(
+    (timer) => !timer.cleared && timer.delay >= 800 && timer.delay <= 1_200,
+  );
+  assert.ok(retry);
+  retry.handler();
   assert.equal(stream.controller.reconnectCalls, 1);
-  assert.equal(statuses.at(-2), "connecting");
+  assert.ok(statuses.slice(-3).includes("connecting"));
   assert.equal(statuses.at(-1), "reconnecting");
 });
 
@@ -333,7 +373,12 @@ test("useSSE lets retryable responses retry and stops on terminal responses", ()
   const retryable = createHarness();
   retryable.streams[0].respond(204, "");
   assert.equal(retryable.statuses.at(-1), "reconnecting");
-  assert.equal(retryable.streams[0].controller.abortCalls.length, 0);
+  assert.equal(retryable.streams[0].controller.abortCalls.length, 1);
+  assert.ok(
+    retryable.timers.some(
+      (timer) => !timer.cleared && timer.delay >= 800 && timer.delay <= 1_200,
+    ),
+  );
   retryable.cleanup();
 
   const terminal = createHarness();
@@ -366,6 +411,167 @@ test("useSSE does not start a competing watchdog reconnect after a 429", () => {
     stream.controller.reconnectCalls,
     0,
     "a rejected handshake must not race EventSourcePlus's automatic retry",
+  );
+  assert.equal(
+    timers.filter((timer) => !timer.cleared && timer.delay < 30_000).length,
+    1,
+    "one IronClaw retry timer must own recovery from the rejected handshake",
+  );
+});
+
+test("useSSE backs off failed opens and coalesces competing reconnect signals", () => {
+  const { context, streams, timers, windowListeners } = createHarness();
+  const stream = streams[0];
+
+  stream.respond(429, "text/plain");
+  windowListeners.get("online")();
+
+  const firstRetryTimers = timers.filter(
+    (timer) => !timer.cleared && timer.delay >= 800 && timer.delay <= 1_200,
+  );
+  assert.equal(firstRetryTimers.length, 1, "retry signals must share one timer");
+  assert.equal(stream.controller.reconnectCalls, 0);
+
+  firstRetryTimers[0].handler();
+  assert.equal(stream.controller.reconnectCalls, 1);
+  stream.respond(429, "text/plain");
+
+  assert.equal(
+    timers.filter(
+      (timer) => !timer.cleared && timer.delay >= 1_600 && timer.delay <= 2_400,
+    ).length,
+    1,
+    "the second failed open must use the next exponential-backoff step",
+  );
+  assert.equal(context.document.visibilityState, "visible");
+});
+
+test("useSSE honors Retry-After before reopening a rate-limited stream", () => {
+  const { streams, timers } = createHarness();
+  const stream = streams[0];
+
+  stream.respond(429, "text/plain", { "retry-after": "45" });
+
+  const retry = timers.find((timer) => !timer.cleared && timer.delay === 45_000);
+  assert.ok(retry, "the server recovery deadline must override local backoff");
+  assert.equal(stream.controller.reconnectCalls, 0);
+  retry.handler();
+  assert.equal(stream.controller.reconnectCalls, 1);
+});
+
+test("useSSE cannot exhaust the 30-per-minute stream budget by itself", () => {
+  const { streams, timers } = createHarness({ random: () => 0 });
+  const stream = streams[0];
+  let elapsed = 0;
+  let openAttempts = 1;
+
+  while (elapsed < 60_000) {
+    stream.respond(429, "text/plain");
+    const retry = timers.find((timer) => !timer.cleared);
+    assert.ok(retry);
+    if (elapsed + retry.delay >= 60_000) break;
+    elapsed += retry.delay;
+    retry.handler();
+    openAttempts += 1;
+  }
+
+  assert.ok(
+    openAttempts <= 7,
+    `one continuously failing stream opened ${openAttempts} times in one minute`,
+  );
+});
+
+test("the packaged client yields retry ownership when an error hook aborts", async () => {
+  vi.useFakeTimers();
+  const fetch = vi.fn(async () =>
+    new Response("Rate limited", {
+      status: 429,
+      headers: { "content-type": "text/plain" },
+    }),
+  );
+  const stream = new PackagedEventSourcePlus("http://localhost/events", {
+    fetch,
+    retryStrategy: "on-error",
+  });
+  let controller;
+
+  try {
+    controller = stream.listen({
+      onResponseError() {
+        controller.abort("IronClaw retry coordinator owns recovery");
+      },
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    assert.equal(
+      fetch.mock.calls.length,
+      1,
+      "event-source-plus must not start its 2ms retry after IronClaw aborts the failure",
+    );
+  } finally {
+    controller?.abort("test complete");
+    vi.useRealTimers();
+  }
+});
+
+test("useSSE resets reconnect backoff only after a valid SSE frame", () => {
+  const { advanceTime, streams, timers } = createHarness();
+  const stream = streams[0];
+
+  stream.respond(429, "text/plain");
+  const firstRetry = timers.find(
+    (timer) => !timer.cleared && timer.delay >= 800 && timer.delay <= 1_200,
+  );
+  assert.ok(firstRetry);
+  firstRetry.handler();
+
+  stream.respond();
+  stream.end();
+  const unprovenRetry = timers.find(
+    (timer) =>
+      timer !== firstRetry &&
+      !timer.cleared &&
+      timer.delay >= 1_600 &&
+      timer.delay <= 2_400,
+  );
+  assert.ok(
+    unprovenRetry,
+    "HTTP 200 without an SSE frame must not reset the failed-open backoff",
+  );
+  unprovenRetry.handler();
+
+  stream.respond();
+  stream.message({ type: "keep_alive" });
+  stream.end();
+  const unstableRetry = timers.find(
+    (timer) =>
+      timer !== firstRetry &&
+      timer !== unprovenRetry &&
+      !timer.cleared &&
+      timer.delay >= 3_200 &&
+      timer.delay <= 4_800,
+  );
+  assert.ok(
+    unstableRetry,
+    "an immediate keep-alive must not make a rapidly closing stream healthy",
+  );
+  unstableRetry.handler();
+
+  stream.respond();
+  stream.message({ type: "keep_alive" });
+  advanceTime(15_000);
+  stream.message({ type: "keep_alive" });
+  stream.end();
+  assert.ok(
+    timers.some(
+      (timer) =>
+        timer !== firstRetry &&
+        timer !== unprovenRetry &&
+        timer !== unstableRetry &&
+        !timer.cleared &&
+        timer.delay >= 800 &&
+        timer.delay <= 1_200,
+    ),
+    "a valid frame after a stable interval must restore the initial retry delay",
   );
 });
 
@@ -505,7 +711,7 @@ test("useSSE stops after a non-retryable stream event", () => {
 
 test("useSSE clears packaged replay state before rebasing from origin", () => {
   const events = [];
-  const { statuses, streams } = createHarness({
+  const { statuses, streams, timers } = createHarness({
     onEvent: (event) => events.push(event),
   });
   const stream = streams[0];
@@ -522,6 +728,11 @@ test("useSSE clears packaged replay state before rebasing from origin", () => {
   });
 
   assert.equal(stream.lastEventId, undefined);
+  const retry = timers.find(
+    (timer) => !timer.cleared && timer.delay >= 800 && timer.delay <= 1_200,
+  );
+  assert.ok(retry);
+  retry.handler();
   assert.equal(stream.controller.reconnectCalls, 1);
   assert.equal(statuses.at(-1), "reconnecting");
   assert.equal(events.at(-1).type, "error");

--- a/crates/product/ironclaw_webui/src/webui_rate_limit.rs
+++ b/crates/product/ironclaw_webui/src/webui_rate_limit.rs
@@ -56,7 +56,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::extract::{ConnectInfo, Request, State};
-use axum::http::{Method, StatusCode};
+use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use ironclaw_host_api::ingress::{IngressRouteDescriptor, RateLimitPolicy, RateLimitScope};
@@ -407,7 +407,7 @@ pub(crate) async fn enforce_rate_limit(
     let window_seconds = window.as_secs().max(1);
 
     let shard_idx = shard_index(&key.bucket_key);
-    let charged_generation = {
+    let (charged_generation, retry_after_seconds) = {
         let mut guard = match state.shards[shard_idx].lock() {
             Ok(guard) => guard,
             Err(poisoned) => {
@@ -435,21 +435,26 @@ pub(crate) async fn enforce_rate_limit(
             window_entry.window_start = now;
             window_entry.remaining = max_requests.saturating_sub(1);
             window_entry.generation = state.next_generation.fetch_add(1, Ordering::Relaxed);
-            Some(window_entry.generation)
+            (Some(window_entry.generation), 0)
         } else if window_entry.remaining == 0 {
-            None
+            let elapsed = now.saturating_sub(window_entry.window_start);
+            (None, window_seconds.saturating_sub(elapsed).max(1))
         } else {
             window_entry.remaining -= 1;
-            Some(window_entry.generation)
+            (Some(window_entry.generation), 0)
         }
     };
 
     let Some(charged_generation) = charged_generation else {
-        return (
+        let mut response = (
             StatusCode::TOO_MANY_REQUESTS,
             "Rate limit exceeded. Try again shortly.",
         )
             .into_response();
+        if let Ok(value) = HeaderValue::from_str(&retry_after_seconds.to_string()) {
+            response.headers_mut().insert(header::RETRY_AFTER, value);
+        }
+        return response;
     };
 
     let mut response = next.run(request).await;

--- a/crates/product/ironclaw_webui/src/webui_rate_limit_router_contract_test.rs
+++ b/crates/product/ironclaw_webui/src/webui_rate_limit_router_contract_test.rs
@@ -276,6 +276,16 @@ async fn sse_capacity_429_burst_past_refund_limit_drains_budget_to_middleware_42
         StatusCode::TOO_MANY_REQUESTS,
         "attempt 8 must still be a 429"
     );
+    let retry_after = middleware_rejected
+        .headers()
+        .get(axum::http::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .expect("429 must expose a numeric retry delay");
+    assert!(
+        (1..=60).contains(&retry_after),
+        "retry delay must be bounded by the configured 60-second window"
+    );
     let body = to_bytes(middleware_rejected.into_body(), usize::MAX)
         .await
         .expect("read middleware-rejected body");

--- a/crates/product/ironclaw_webui/src/webui_v2/descriptors.rs
+++ b/crates/product/ironclaw_webui/src/webui_v2/descriptors.rs
@@ -1811,18 +1811,15 @@ fn stream_rate_limit() -> RateLimitPolicy {
     // request-rate window here is just for burst protection against
     // reconnect storms.
     //
-    // Set to 30/60s — the SSE route additionally accepts `?token=…`
-    // because `EventSource` can't set headers, which leaks the
-    // bearer into browser history, server access logs, and proxy
-    // logs. Keeping the request rate higher than necessary widens
-    // the replay surface for a logged token, so the budget is capped
-    // at 2x a worst-case exponential-backoff reconnect cycle (≈ 1,
-    // 2, 4, 8, 16, 32s per minute = 6 opens) rather than parity with
-    // the mutation budget. The WS route doesn't carry the same
-    // URL-token risk (headers + `WebSocketOriginPolicy::SameOriginRequired`),
-    // but the lower limit costs it nothing — the same reconnect-storm
-    // math applies, the same concurrency cap is the real load gate,
-    // and using one helper for both keeps the descriptors aligned.
+    // Set to 30/60s. The SPA's one-owner reconnect policy opens at most
+    // seven streams per minute for one continuously failing tab (1, 2, 4,
+    // 8, 16, then 30-second bounded backoff). Three legitimate tabs therefore
+    // stay below this budget with headroom for reload and network transitions.
+    // The route also retains the `?token=…` compatibility escape hatch, so a
+    // materially higher budget would widen the replay surface for a token
+    // captured from browser history or proxy logs. The concurrency cap remains
+    // the primary bound on healthy long-lived streams; this request-rate window
+    // bounds churn from broken or hostile clients.
     rate_limit_per_caller(30, 60)
 }
 

--- a/crates/product/ironclaw_webui/src/webui_v2/handlers.rs
+++ b/crates/product/ironclaw_webui/src/webui_v2/handlers.rs
@@ -1409,7 +1409,10 @@ pub async fn stream_events(
 /// and `sse_capacity::REJECTION_REFUND_LIMIT` for why refunding stops once
 /// a caller hammers a saturated cap.
 fn sse_capacity_rejected(refundable: bool) -> Response {
-    let response = sse_concurrency_exhausted().into_response();
+    let mut response = sse_concurrency_exhausted().into_response();
+    response
+        .headers_mut()
+        .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
     if refundable {
         mark_rate_limit_refundable(response)
     } else {

--- a/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -6761,6 +6761,14 @@ async fn stream_events_caps_concurrent_streams_per_caller() {
         StatusCode::TOO_MANY_REQUESTS,
         "third concurrent open from same caller must be rejected"
     );
+    assert_eq!(
+        third
+            .headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .and_then(|value| value.to_str().ok()),
+        Some("1"),
+        "capacity rejection must tell the stream client when it may retry"
+    );
     let body = read_json(third).await;
     assert_eq!(body["error"], "rate_limited");
     assert_eq!(body["kind"], "busy");


### PR DESCRIPTION
## Summary

- Keep `event-source-plus` for fetch, framing, cancellation, and `Last-Event-ID`, while making one IronClaw coordinator own reconnect timing across HTTP errors, stream endings, activity stalls, visibility changes, and network recovery.
- Apply jittered 1/2/4/8/16/30-second backoff, honor server `Retry-After`, and reset only after the connection remains live for 15 seconds and delivers another valid frame.
- Add `Retry-After` to request-volume and concurrent-stream 429 responses so the browser has an authoritative recovery deadline.
- Correct the stream-budget rationale and lock the real packaged-client behavior, retry budget, coalescing, reload, and server response contracts with regressions.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None — reproduced from the QA Railway deployment report where one caller reached repeated `429 Too Many Requests` responses on the WebChat event stream.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run workspace-wide; scoped owning-crate gate passed: `cargo clippy -p ironclaw_webui --all-targets --all-features -- -D warnings`.
- [ ] `cargo build` — Not run separately; `cargo test -p ironclaw_webui --all-features` compiled the owning crate and `corepack pnpm build` produced the production SPA bundle.
- [x] Relevant tests pass: `cargo test -p ironclaw_webui --all-features`; `corepack pnpm test` (126 files, 1,108 tests).
- [ ] `cargo test --features integration` — Not applicable: no database-backed behavior or Reborn turn/runtime orchestration changed.
- [ ] Manual testing — Not applicable: deterministic hook tests drive all retry clocks and packaged transport callbacks; the production bundle was built and budget-checked.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; final diff, production-file panic patterns, formatting, lint, typecheck, tests, and bundle were reviewed directly.

Additional gates: `corepack pnpm lint`, `corepack pnpm build`, bundle budgets, `git diff --check`.

## Test Strategy

User behavior: During a persistent WebChat stream failure, one tab performs at most seven opens per minute, multiple reconnect signals remain one retry chain, and a server 429 pauses until its advertised recovery deadline instead of feeding a reconnect storm.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Extended `frontend/src/pages/chat/lib/useSSE.test.ts`, the real rate-limit router contract, and the SSE handler caller contract.
- Reborn integration: Not applicable: no turn, runner, agent-loop, capability, or persistence behavior changed.
- Recorded fixture: Not applicable: no model choice or request shape changed.
- Browser E2E: Not applicable: retry timing and competing lifecycle signals are deterministic transport-hook behavior; the source-backed hook harness exercises the mounted hook and the actual `event-source-plus` package without browser/network timing flakiness.
- Backend or runtime: Not applicable: no database or execution-runtime behavior changed.
- Live canary: Not applicable: no provider dependency or model drift risk.

What the tests prove:

- One continuously failing tab cannot exhaust the 30-open-per-minute route budget.
- Watchdog, online, visibility, replay, response-error, and end-of-stream recovery converge on one timer.
- `Retry-After` overrides local backoff.
- HTTP 200 and the immediate admission keep-alive do not reset retry state; a valid frame after 15 stable seconds does.
- Aborting from IronClaw's error hook prevents `event-source-plus@0.1.15` from starting its internal 2ms retry chain.
- Middleware and concurrent-stream 429 responses carry bounded retry hints.

Commands run:

- `corepack pnpm exec vitest run src/pages/chat/lib/useSSE.test.ts`
- `corepack pnpm test`
- `corepack pnpm lint`
- `corepack pnpm build`
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_webui --all-features`
- `cargo clippy -p ironclaw_webui --all-targets --all-features -- -D warnings`
- `git diff --check`

## Security Impact

The existing authenticated per-caller request-volume limit and three-stream concurrency cap remain unchanged. Responses now reveal only the bounded wait until an already-declared limit resets; they expose no caller identity, token, cursor, or internal capacity. The client continues sending the bearer in the `Authorization` header.

## Reborn Trust-Boundary Checklist

N/A: browser transport lifecycle and HTTP recovery metadata only. No public trust-bearing types, prompt inputs, hashes, status/error variants, serialization defaults, runtime lanes, sandbox boundaries, permissions, or authority construction changed. Existing counters remain bounded and use overflow-safe arithmetic.

## Database Impact

None. No schema, migration, persistence format, PostgreSQL, or libSQL behavior changed.

## Blast Radius

WebChat SSE reconnect lifecycle and WebUI rate-limit responses. WebSocket transport behavior is unchanged except that its shared concurrency-cap rejection now also carries `Retry-After: 1`. The numerical rate and concurrency limits are unchanged.

## Rollback Plan

Revert commit `9f72e078f`. There is no schema, persisted-state, configuration, or server/client version migration to reverse; the prior retry behavior returns immediately.

## Review Follow-Through

Reviewer judgment requested on the 15-second stability threshold. It intentionally aligns with the server's keep-alive cadence so the immediate admission frame cannot reset backoff while the next keep-alive proves sustained liveness.

---

**Review track**: B (browser-facing bug fix)
