### PR TITLE
fix(libsql): avoid repeated FTS backfills

### DIFF
--- a/crates/substrates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/substrates/ironclaw_filesystem/src/libsql.rs
@@ -140,6 +140,45 @@ impl LibSqlRootFilesystem {
             .await
             .map_err(|error| map_runtime_write_connection_error(path.clone(), operation, error))
     }
+
+    async fn fts_index_spec_is_registered(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+        keys_json: &str,
+        kind: &str,
+    ) -> Result<bool, FilesystemError> {
+        let conn = self.read_connection().await?;
+        let mut rows = conn
+            .query(
+                "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = ?1 AND name = ?2",
+                libsql::params![path.as_str(), spec.name.as_str()],
+            )
+            .await
+            .map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+        let Some(row) = rows.next().await.map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })?
+        else {
+            return Ok(false);
+        };
+        let existing_keys: String = row.get(0).map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })?;
+        let existing_kind: String = row.get(1).map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })?;
+        if existing_keys != keys_json || existing_kind != kind {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: crate::IndexConflictReason::SpecMismatch,
+            });
+        }
+        Ok(true)
+    }
 }
 
 fn map_runtime_connection_error(
@@ -439,6 +478,32 @@ impl RootFilesystem for LibSqlRootFilesystem {
                 };
             }
         }
+        let catalog_prefix = path.as_str();
+        let keys_json = serde_json::to_string(
+            &spec
+                .keys
+                .iter()
+                .map(|k| k.as_str().to_string())
+                .collect::<Vec<_>>(),
+        )
+        .map_err(|_| FilesystemError::SerializeIndexed {
+            path: path.clone(),
+            operation: FilesystemOperation::EnsureIndex,
+        })?;
+
+        // The FTS catalog row and physical table/triggers commit in the same
+        // transaction below. A matching committed row therefore proves FTS
+        // was fully materialized, and repeated declarations can remain on the
+        // read lane instead of contending for libSQL's sole writer. Ordered
+        // projections still enter their versioned installation path below.
+        if matches!(spec.kind, IndexKind::Fts)
+            && self
+                .fts_index_spec_is_registered(path, spec, &keys_json, &kind_str)
+                .await?
+        {
+            return Ok(());
+        }
+
         let _ddl_guard = self.index_ddl_lock.lock().await;
         if shared_projection {
             let cache = self
@@ -461,18 +526,15 @@ impl RootFilesystem for LibSqlRootFilesystem {
                 };
             }
         }
-        let catalog_prefix = path.as_str();
-        let keys_json = serde_json::to_string(
-            &spec
-                .keys
-                .iter()
-                .map(|k| k.as_str().to_string())
-                .collect::<Vec<_>>(),
-        )
-        .map_err(|_| FilesystemError::SerializeIndexed {
-            path: path.clone(),
-            operation: FilesystemOperation::EnsureIndex,
-        })?;
+        // Another FTS declaration in this process may have completed while
+        // this task waited for the DDL guard.
+        if matches!(spec.kind, IndexKind::Fts)
+            && self
+                .fts_index_spec_is_registered(path, spec, &keys_json, &kind_str)
+                .await?
+        {
+            return Ok(());
+        }
 
         let conn = self
             .write_connection(path, FilesystemOperation::EnsureIndex)
@@ -492,7 +554,7 @@ impl RootFilesystem for LibSqlRootFilesystem {
         // then read back the canonical row and compare. If the stored
         // spec matches ours we're idempotent; if it differs we surface
         // IndexConflict.
-        transaction
+        let inserted = transaction
             .execute(
                 "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) \
              VALUES (?1, ?2, ?3, ?4) \
@@ -543,6 +605,16 @@ impl RootFilesystem for LibSqlRootFilesystem {
             });
         }
         drop(rows);
+
+        // A different process can win the FTS declaration race after both
+        // read checks. Its committed catalog row also proves its DDL/backfill
+        // committed atomically, so do not repeat that work under this writer.
+        if inserted == 0 && matches!(spec.kind, IndexKind::Fts) {
+            transaction.commit().await.map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+            return Ok(());
+        }
 
         let index_name = sql_index_name(path.as_str(), spec.name.as_str());
         match &spec.kind {
@@ -3527,14 +3599,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_index_rolls_back_the_catalog_when_ddl_fails() {
+    async fn ensure_index_rolls_back_the_catalog_when_materialization_fails() {
         let (fs, _dir) = fresh_backend().await;
         let path = VirtualPath::new("/resources/index-atomicity").unwrap();
-        let spec = IndexSpec::new(
-            IndexName::new("by_status").unwrap(),
-            vec![IndexKey::new("status").unwrap()],
-            IndexKind::Exact,
-        );
         let writer = fs.migration_write_connection().await.unwrap();
         writer
             .execute("DROP TABLE root_filesystem_entries", ())
@@ -3542,26 +3609,36 @@ mod tests {
             .unwrap();
         drop(writer);
 
-        let error = fs
-            .ensure_index(&path, &spec)
-            .await
-            .expect_err("the conflicting table must make index DDL fail");
-        assert!(matches!(error, FilesystemError::Backend { .. }));
+        for (name, key, kind) in [
+            ("by_status", "status", IndexKind::Exact),
+            ("by_content", "content", IndexKind::Fts),
+        ] {
+            let spec = IndexSpec::new(
+                IndexName::new(name).unwrap(),
+                vec![IndexKey::new(key).unwrap()],
+                kind,
+            );
+            let error = fs
+                .ensure_index(&path, &spec)
+                .await
+                .expect_err("the missing entries table must make index materialization fail");
+            assert!(matches!(error, FilesystemError::Backend { .. }));
 
-        let reader = fs.read_connection().await.unwrap();
-        let mut rows = reader
-            .query(
-                "SELECT COUNT(*) FROM root_filesystem_index_specs \
-                 WHERE prefix = ?1 AND name = ?2",
-                libsql::params![path.as_str(), spec.name.as_str()],
-            )
-            .await
-            .unwrap();
-        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
-        assert_eq!(
-            count, 0,
-            "failed index DDL must roll back the preceding catalog upsert"
-        );
+            let reader = fs.read_connection().await.unwrap();
+            let mut rows = reader
+                .query(
+                    "SELECT COUNT(*) FROM root_filesystem_index_specs \
+                     WHERE prefix = ?1 AND name = ?2",
+                    libsql::params![path.as_str(), spec.name.as_str()],
+                )
+                .await
+                .unwrap();
+            let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+            assert_eq!(
+                count, 0,
+                "failed index materialization must roll back the preceding catalog upsert"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/substrates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/substrates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1,4 +1,6 @@
 // arch-exempt: large_file, backend parity contracts stay in one shared behavioral suite, plan #5274
+use std::time::Duration;
+
 use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_filesystem::{
@@ -778,6 +780,37 @@ async fn libsql_ensure_index_accepts_fts_kind_and_filter_matches_text() {
         .unwrap();
     assert_eq!(results.len(), 2);
 }
+
+#[tokio::test]
+async fn libsql_repeated_fts_declaration_does_not_wait_for_the_writer() {
+    // Regression for #7283: memory search re-declares its FTS index on the
+    // query hot path. Once the cataloged declaration has committed, checking
+    // it must remain available while an unrelated durable write owns libSQL's
+    // single writer lease.
+    let filesystem = libsql_root().await;
+    let prefix = VirtualPath::new("/memory/repeated-fts").unwrap();
+    let content = IndexKey::new("content").unwrap();
+    let spec = IndexSpec::new(
+        IndexName::new("by_content_repeated").unwrap(),
+        vec![content],
+        IndexKind::Fts,
+    );
+    filesystem.ensure_index(&prefix, &spec).await.unwrap();
+
+    let writer = filesystem.begin(&prefix).await.unwrap();
+    let redeclaration = tokio::time::timeout(
+        Duration::from_secs(1),
+        filesystem.ensure_index(&prefix, &spec),
+    )
+    .await;
+    writer.rollback().await;
+
+    assert!(
+        matches!(redeclaration, Ok(Ok(()))),
+        "an existing FTS declaration must not require the writer: {redeclaration:?}"
+    );
+}
+
 #[tokio::test]
 async fn libsql_fts_filter_picks_up_inserts_through_triggers() {
     // After ensure_index, inserting a new row through put() updates the


### PR DESCRIPTION
## Summary

- Treat a matching committed libSQL FTS catalog row as proof that its table, triggers, and initial backfill were atomically materialized.
- Resolve repeated FTS declarations through the read lane, avoiding DDL/backfill work and contention for the sole writer.
- Add liveness and rollback coverage for the production failure described in #7283.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7283

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run workspace-wide; the owning crate passed `cargo clippy -p ironclaw_filesystem --all-targets -- -D warnings`.
- [ ] `cargo build` — covered by the owning-crate test and clippy builds.
- [x] Relevant tests pass: `cargo test -p ironclaw_filesystem` (143 unit, 9 catalog contract, 7 CAS/runtime concurrency, 107 DB backend contract, 31 filesystem contract, and 1 Postgres race test).
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed — not applicable: `ironclaw_filesystem` has no crate-local `integration` feature; its standard suite exercises a real local libSQL database and shared runtime.
- [ ] Manual testing: not applicable; the production symptom is promoted to a deterministic backend liveness contract.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run; the scoped diff, full owning-crate suite, and warnings-denied clippy were reviewed locally.

## Test Strategy

User behavior: Repeated memory searches no longer re-enter FTS DDL/backfill or wait for libSQL's writer, leaving the writer available for runner heartbeat and journal writes.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Added `libsql_repeated_fts_declaration_does_not_wait_for_the_writer`; expanded index-materialization rollback coverage to include FTS.
- Reborn integration: Not applicable: the lowest deterministic seam is the shared libSQL writer plus filesystem index contract; runner-level timing would be slower and less precise.
- Recorded fixture: Not applicable: no provider/model interaction or replayable external payload.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Full `ironclaw_filesystem` suite, including libSQL runtime contention and DB backend contracts.
- Live canary: Not run locally; after deployment, Railway traces should show no repeated FTS DDL/backfill for an existing memory index.

What the tests prove: The regression test holds the sole writer lease and proves that re-declaring an existing FTS index still completes within one second through the read lane. Before the fix it deterministically times out. The rollback test proves failed FTS materialization leaves no catalog row that could falsely trigger the fast path. Existing FTS search, trigger-sync, conflict, vector, ordered-projection, and PostgreSQL parity contracts remain green.

Commands run:

```text
cargo fmt --all -- --check
cargo test -p ironclaw_filesystem
cargo clippy -p ironclaw_filesystem --all-targets -- -D warnings
```

## Security Impact

None. No permissions, network calls, secrets, file authority, tool execution, or sandbox policy changed.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: not applicable; no public types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: not applicable; no prompt path changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: not applicable; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: not applicable; no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: not applicable; no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: not applicable; no such state added.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent): unchanged; existing `IndexConflict` and backend errors are preserved.
- [x] Sandbox/native/host names accurately describe trust boundary: not applicable; no boundary names changed.

## Database Impact

No migration or schema change. libSQL only: repeated matching FTS declarations become catalog reads instead of writer transactions. First-time catalog insertion, FTS table/trigger creation, and backfill remain one atomic transaction. PostgreSQL behavior is unchanged.

## Blast Radius

Limited to libSQL `RootFilesystem::ensure_index` for `IndexKind::Fts`. Ordered indexes retain their versioned installation path, vector behavior is unchanged, and mismatched specs still fail closed.

## Rollback Plan

Revert this commit to restore the prior ensure-on-every-call behavior. No data or schema rollback is required. The operational regression on rollback would be renewed writer monopolization during repeated memory searches.

## Review Follow-Through

Reviewer judgment is requested on the committed-catalog atomicity invariant and the read-lane liveness test. Follow-up after deployment is to verify Railway traces show FTS backfill only at first materialization and no heartbeat checkout timeouts under repeated memory search.

---

**Review track**: C (runtime/DB)
