### PR TITLE
fix(webui): keep failure bubbles with their prompts

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useHistory.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useHistory.ts
@@ -715,9 +715,12 @@ function insertPreservedAtOriginalPositions(fresh, preserved, current) {
   const append = [];
 
   for (const message of anchoredPreserved) {
+    const isClientOnlyError =
+      typeof message?.id === "string" && message.id.startsWith("err-");
     if (
       !isRunActivityMessage(message) &&
-      !isLiveAssistantMessage(message)
+      !isLiveAssistantMessage(message) &&
+      !isClientOnlyError
     ) {
       append.push(message);
       continue;

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useHistory.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useHistory.test.ts
@@ -895,17 +895,18 @@ test("mergeFullRefresh keeps requested client-only bubbles and lets the timeline
   });
 
   // Timeline order is authoritative and the rich tool card replaces the
-  // sparse live one; the client-only err-* bubble is preserved at the end.
+  // sparse live one; the client-only err-* bubble stays at its original
+  // boundary before the later timeline reply.
   assert.equal(
     merged.map((m) => m.id).join(","),
-    "msg-user-1,tool-abc,msg-assistant-1,err-run-1",
+    "msg-user-1,tool-abc,err-run-1,msg-assistant-1",
   );
   const toolCard = merged.find((m) => m.id === "tool-abc");
   assert.equal(toolCard.toolParameters, "{}");
   assert.equal(toolCard.toolResultPreview, "ok");
 });
 
-test("mergeFullRefresh anchors preserved runtime bubbles at their original positions", () => {
+test("mergeFullRefresh keeps client-only failures beside the prompt that failed", () => {
   const context = { globalThis: {}, React: createReactStub() };
   vm.runInNewContext(useHistorySourceForTest(), context);
   const { mergeFullRefresh } = context.globalThis.__testExports;
@@ -915,6 +916,7 @@ test("mergeFullRefresh anchors preserved runtime bubbles at their original posit
       { id: "msg-user-1", role: "user" },
       { id: "msg-assistant-1", role: "assistant" },
       { id: "msg-user-2", role: "user" },
+      { id: "msg-user-3", role: "user" },
     ],
     [
       { id: "msg-user-1", role: "user" },
@@ -922,6 +924,8 @@ test("mergeFullRefresh anchors preserved runtime bubbles at their original posit
       { id: "msg-assistant-1", role: "assistant" },
       { id: "err-run-1", role: "error", content: "run failed" },
       { id: "msg-user-2", role: "user" },
+      { id: "err-run-2", role: "error", content: "run failed again" },
+      { id: "msg-user-3", role: "user" },
     ],
     {
       preserveClientOnly: true,
@@ -930,8 +934,11 @@ test("mergeFullRefresh anchors preserved runtime bubbles at their original posit
 
   assert.equal(
     merged.map((m) => m.id).join(","),
-    "msg-user-1,thinking-live,msg-assistant-1,msg-user-2,err-run-1",
+    "msg-user-1,thinking-live,msg-assistant-1,err-run-1,msg-user-2,err-run-2,msg-user-3",
   );
+  const firstFailure = merged.findIndex((message) => message.id === "err-run-1");
+  const secondPrompt = merged.findIndex((message) => message.id === "msg-user-2");
+  assert.equal(firstFailure + 1, secondPrompt);
 });
 
 test("mergeFullRefresh preserves paginated older timeline messages", () => {


### PR DESCRIPTION
## Summary

- Keep client-only chat failure bubbles beside the prompt or run boundary where they occurred.
- Prevent timeline refreshes from collecting distinct historical failures at the bottom of the conversation.
- Extend the existing history-merge regression coverage across multiple failed prompts.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: TypeScript-only change.
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust changed.
- [ ] `cargo build` — Not applicable: no build or Rust integration changed.
- [x] Relevant tests pass: `corepack pnpm test` (126 files, 1,103 tests).
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database or runtime behavior changed.
- [x] Manual testing: Railway exact-head browser QA was attempted and posted as BLOCKED because no Railway deployment appeared during the bounded polling window.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; the change is a two-file local ordering fix with full frontend tests.

## Test Strategy

User behavior: Given failures attached to earlier prompts, when a terminal-run timeline refresh adds later messages, then each failure remains beside its original prompt instead of moving into a stack at the bottom.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Updated `useHistory.test.ts` to cover one failure before a later reply and multiple failures interleaved with later prompts.
- Reborn integration: Not applicable: the defect is isolated to client-side timeline merging.
- Recorded fixture: Not applicable: no model choice or request shape changed.
- Browser E2E: Not added; exact-head Railway browser QA is run on this PR, while the deterministic regression is owned by the existing frontend history-merge suite.
- Backend or runtime: Not applicable: no backend or runtime behavior changed.
- Live canary: Not applicable: no provider or model behavior changed.

What the tests prove: Client-only `err-*` messages retain their original timeline boundary through full refreshes, including multiple failures separated by later user prompts.

Commands run:
- `corepack pnpm exec vitest run src/pages/chat/lib/useHistory.test.ts`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm lint:conventions`
- `git diff --check`

## Security Impact

None. This changes only in-memory presentation ordering of already-redacted client error messages.

## Reborn Trust-Boundary Checklist

N/A: frontend-only ordering fix; no trust-bearing types, ingress, hashing, status variants, serialization, bounded resources, error classification, or runtime boundaries changed.

## Database Impact

None.

## Blast Radius

WebChat history refresh ordering for client-only `err-*` messages. Durable timeline records, error contents, retry behavior, and server projections are unchanged.

## Rollback Plan

Revert this commit to restore the previous append-at-bottom behavior.

## Review Follow-Through

Railway exact-head browser QA evidence is posted in the PR comments. The required browser case is BLOCKED until Railway publishes this exact head.

---

**Review track**: B
