### PR TITLE
fix(docker): install curl so orchestrator healthchecks can run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bb
 RUN apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         ca-certificates \
+        curl \
         postgresql-client \
         sqlite3 \
     && rm -rf /var/lib/apt/lists/*

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -226,19 +226,18 @@ def _bound_pr_buckets(
     return bounded
 
 
+DOCKERFILE_ROOT_TEST = "tests/dockerfile_runtime_home.rs"
+
+
 def _root_test_partitions() -> dict[str, int]:
-    support_tests = (
-        ["support_unit_tests"]
-        if (ROOT / "tests/support_unit_tests.rs").is_file()
-        else []
-    )
+    # Every root test target, not just the `reborn_*` ones. Cargo
+    # auto-discovers `tests/*.rs` for the root package, so a narrower glob
+    # left the remainder (`dockerfile_runtime_home`, `trace_format`,
+    # `trace_llm_tests`, the `e2e_trace_runtime_policy_*` pair) outside the
+    # inventory — and the planner fails closed, so touching one of them in a
+    # PR aborted planning with `unmapped test or CI path`.
     names = sorted(
-        [
-            path.stem
-            for path in (ROOT / "tests").glob("reborn_*.rs")
-            if path.is_file()
-        ]
-        + support_tests
+        {path.stem for path in (ROOT / "tests").glob("*.rs") if path.is_file()}
     )
     return {f"tests/{name}.rs": index % 4 for index, name in enumerate(names)}
 
@@ -431,6 +430,19 @@ def build_plan(
         }:
             qa_evidence_changed = True
             reasons.append("recorded QA evidence changed")
+            continue
+        if (
+            path == "Dockerfile"
+            or path.startswith("Dockerfile.")
+            or path == ".dockerignore"
+            or path.startswith("docker/")
+        ):
+            # The shipped container image is asserted by
+            # `tests/dockerfile_runtime_home.rs` (runtime packages, entrypoint
+            # behavior, seed configs), so schedule that test's partition
+            # instead of failing closed on an unclassified path.
+            root_partitions.add(root_inventory.get(DOCKERFILE_ROOT_TEST, 0))
+            reasons.append(f"container image definition changed: {path}")
             continue
         if path.startswith(("tests/reborn_", "tests/e2e/reborn_", "scripts/ci/reborn-")):
             raise ValueError(f"unmapped Reborn test path: {path}")

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -453,8 +453,11 @@ class RebornPrTestPlanTests(unittest.TestCase):
             self.plan("pull_request", ["crates/deleted/src/lib.rs"])
 
     def test_unclassified_build_input_fails_fast(self) -> None:
+        # `Dockerfile` used to be the example here; it now has a decision (see
+        # `test_container_image_paths_select_the_dockerfile_root_test`). The
+        # fail-closed arm still has to reject build inputs nobody has ruled on.
         with self.assertRaisesRegex(ValueError, "unclassified pull-request path"):
-            self.plan("pull_request", ["Dockerfile"])
+            self.plan("pull_request", ["Makefile"])
 
     def test_agent_guidance_is_classified_and_selects_no_rust_lane(self) -> None:
         """`.claude/**` is prose, like `docs/**`.
@@ -552,6 +555,42 @@ class RebornPrTestPlanTests(unittest.TestCase):
         )
         self.assertEqual(root_plan["root_partitions"], [0])
         self.assertEqual(integration_plan["integration_lanes"], [0])
+
+    def test_non_reborn_root_tests_are_classified(self) -> None:
+        # The root inventory used to glob only `tests/reborn_*.rs`, so every
+        # other root test (`dockerfile_runtime_home.rs`, `trace_format.rs`,
+        # the `e2e_trace_runtime_policy_*` pair, ...) fell through to the
+        # fail-closed `unmapped test or CI path` error. Touching one of them
+        # in a PR failed the planner outright.
+        inventory = planner._root_test_partitions()
+        for name in (
+            "tests/dockerfile_runtime_home.rs",
+            "tests/trace_format.rs",
+            "tests/trace_llm_tests.rs",
+        ):
+            with self.subTest(path=name):
+                self.assertIn(name, inventory)
+                plan = self.plan("pull_request", [name])
+                self.assertEqual(plan["root_partitions"], [inventory[name]])
+
+    def test_container_image_paths_select_the_dockerfile_root_test(self) -> None:
+        # `Dockerfile` and friends are covered by
+        # `tests/dockerfile_runtime_home.rs`, so a change to the image
+        # definition must schedule that test's partition rather than being
+        # rejected as an unclassified path.
+        expected = planner._root_test_partitions()["tests/dockerfile_runtime_home.rs"]
+        for path in (
+            "Dockerfile",
+            "Dockerfile.process-sandbox",
+            ".dockerignore",
+            # Seed configs are asserted by the same root test. Note
+            # `docker/reborn/entrypoint.sh` is deliberately excluded — it has a
+            # pre-existing explicit decision in PR_STATIC_CONTROL_PATHS.
+            "docker/reborn/config.hosted-single-tenant.toml",
+        ):
+            with self.subTest(path=path):
+                plan = self.plan("pull_request", [path])
+                self.assertEqual(plan["root_partitions"], [expected])
 
     def test_hosted_mcp_support_selects_its_owning_integration_lane(self) -> None:
         owner = planner.INTEGRATION_SUPPORT_OWNERS[

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -204,6 +204,26 @@ fn reborn_runtime_image_includes_sql_debug_clients() {
 }
 
 #[test]
+fn reborn_runtime_image_can_run_the_orchestrator_healthcheck() {
+    // Container orchestrators probe this image with an in-container HTTP
+    // healthcheck, so the probe client has to exist inside the image. The
+    // hosted CrabShack template runs
+    //   test: ["CMD-SHELL", "curl -fsS http://localhost:3000/ || exit 1"]
+    // against the worker container. `debian:bookworm-slim` ships no HTTP
+    // client, so without this package the check can never pass — the
+    // container is marked unhealthy, the deploy times out, and the instance
+    // lands in `error` while the listener itself is serving 200s. That is
+    // precisely how 1.1.0 failed on staging: the server was healthy the whole
+    // time and only the probe was impossible to run.
+    let dockerfile = read_repo_file("Dockerfile");
+
+    assert!(
+        dockerfile.contains("curl"),
+        "runtime image must include an HTTP client for orchestrator healthchecks"
+    );
+}
+
+#[test]
 fn reborn_hosted_single_tenant_seed_config_contains_postgres_storage() {
     let config = read_repo_file("docker/reborn/config.hosted-single-tenant.toml");
 


### PR DESCRIPTION
## Problem

Hosted staging nodes running `docker.io/nearaidev/ironclaw:1.1.0` sit in status `error` even though the server is completely healthy.

The app is fine. From outside the node, the gateway port answers:

```
GET /            -> 200, 2104 bytes
GET /api/health  -> 200 {"status":"healthy","channel":"reborn"}
```

The failure is that the orchestrator's healthcheck **cannot run inside the image**. The hosted worker template probes the container with:

```yaml
healthcheck:
  test: ["CMD-SHELL", "curl -fsS http://localhost:3000/ || exit 1"]
  interval: 5s   timeout: 5s   retries: 10   start_period: 10s
```

The runtime stage installs only `ca-certificates`, `postgresql-client`, `sqlite3` on top of `debian:bookworm-slim`, which ships no HTTP client. So the probe always fails, the container is never marked healthy, the deploy times out after 10 minutes, and the instance is moved to `error`.

## Fix

Add `curl` to the runtime stage.

## Verification: A/B on the published image

Two containers, same server, same healthcheck, one variable — the second is the published image with nothing changed but `curl` layered on:

| container | image | health | probe output |
|---|---|---|---|
| `hc-base` | `nearaidev/ironclaw:1.1.0` | **unhealthy** | `/bin/sh: 1: curl: not found` |
| `hc-curl` | same + `curl` | **healthy** | `<meta charset=...` |

Both containers were `state=running` — the listener was up and serving in both cases. The only thing separating healthy from unhealthy is the presence of `curl`.

Also confirmed directly against the published image:

```
$ docker run --rm --entrypoint sh nearaidev/ironclaw:1.1.0 -c 'command -v curl || echo NO_CURL; command -v wget || echo NO_WGET'
NO_CURL
NO_WGET
```

and that the package resolves on the pinned base digest, after which the exact healthcheck command succeeds:

```
installed: curl 7.88.1 (x86_64-pc-linux-gnu) ...
HEALTHCHECK COMMAND: PASS
```

## Why this is a 1.1.0 regression

The 1.0.0 line shipped `curl`, but only by accident. Its Dockerfile had an extra `runtime-release-tools` stage carrying a dev toolchain, whose apt list included `curl`. The image that ran on staging was built from that stage:

```
$ docker run --rm --entrypoint sh sakethare/ironclaw-reborn:1.0.0-rc.9 -c '...'
curl: /usr/bin/curl        sshd: /usr/sbin/sshd
gh:   /usr/bin/gh          bun:  /usr/local/bin/bun
```

1.1.0 builds the minimal `runtime` target, which never had `curl` — so a dependency that was always implicit became load-bearing and silently vanished. This PR makes it explicit.

## Regression test

`tests/dockerfile_runtime_home.rs` asserts the runtime stage installs an HTTP client. Confirmed RED before the change:

```
runtime image must include an HTTP client for orchestrator healthchecks
test result: FAILED. 19 passed; 1 failed
```

and GREEN after:

```
test result: ok. 20 passed; 0 failed
```

## Notes

Two things deliberately **not** changed here, both surfaced while diagnosing this:

1. **No sshd in this image.** For hosted service type `ironclaw`, SSH is provided by a separate `linuxserver/openssh-server` sidecar container sharing the workspace volume, mapped to container port `2222`. A closed SSH port on a failing instance is a consequence of the deploy failing, not a missing image feature.
2. **Profile selection.** Hosted containers launch without `IRONCLAW_REBORN_PROFILE`, so `docker/reborn/entrypoint.sh` falls through to the dev seed `config.toml` and readiness reports `profile: Standalone, state: DevOnly, blocks_production: true`. Real gap, but deployment-side configuration rather than an image defect, and not the cause of the `error` status. Worth a separate issue.

Separately worth checking before the next deploy: the hosted worker template pins `command: ["run", "--no-onboard"]`, but 1.1.0's `run` rejects `--no-onboard` (removed with the v1 monolith in `b6da0272a8`) and is documented as "Initialize the minimal Reborn runtime shell and exit". A container launched that way exits 2 immediately:

```
error: unexpected argument '--no-onboard' found
```

Staging logs show a persistent WebChat listener, so those nodes were not started via that command path — but a corrected deploy could hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)