### PR TITLE
fix(migration): accept legacy Slack pending connection state

### DIFF
--- a/crates/ironclaw_extension_host/src/legacy_channel_state_migration/oauth_channel.rs
+++ b/crates/ironclaw_extension_host/src/legacy_channel_state_migration/oauth_channel.rs
@@ -461,12 +461,23 @@ pub(super) enum Rc1SlackDisconnectCleanup {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+struct Rc1SlackPendingConnection {
+    epoch: ironclaw_auth::AuthFlowId,
+    expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct Rc1SlackConnection {
     pub(super) tenant_id: String,
     pub(super) user_id: String,
     pub(super) installation_id: String,
     pub(super) epoch: ironclaw_auth::AuthFlowId,
     pub(super) state: Rc1SlackConnectionState,
+    /// Parsed to validate the retired RC1 replacement slot; never restored
+    /// as live connection authority.
+    #[serde(default)]
+    pending_connection: Option<Rc1SlackPendingConnection>,
     #[serde(default)]
     pub(super) disconnect_cleanup: Option<Rc1SlackDisconnectCleanup>,
     pub(super) expires_at: DateTime<Utc>,

--- a/crates/ironclaw_extension_host/src/legacy_channel_state_migration/tests.rs
+++ b/crates/ironclaw_extension_host/src/legacy_channel_state_migration/tests.rs
@@ -296,6 +296,7 @@ async fn caller_imports_rc1_slack_setup_and_secrets_idempotently() {
         )
         .await
         .expect("seed setup");
+    let legacy_connection_epoch = ironclaw_auth::AuthFlowId::new();
     for (path, value) in [
         (
             "/tenants/tenant-a/shared/slack-personal-binding/identities/U-PERSON.json",
@@ -343,6 +344,23 @@ async fn caller_imports_rc1_slack_setup_and_secrets_idempotently() {
                 "updated_at": "2026-07-01T00:00:00Z"
             }),
         ),
+        (
+            "/tenants/tenant-a/shared/slack-personal-binding/connections/slack-rc1-install/operator-a.json",
+            serde_json::json!({
+                "tenant_id": "tenant-a",
+                "user_id": "operator-a",
+                "installation_id": "slack-rc1-install",
+                "epoch": legacy_connection_epoch,
+                "state": "connecting",
+                "pending_connection": {
+                    "epoch": legacy_connection_epoch,
+                    "expires_at": "2026-07-02T00:00:00Z"
+                },
+                "expires_at": "2026-07-02T00:00:00Z",
+                "created_at": "2026-07-01T00:00:00Z",
+                "updated_at": "2026-07-01T00:00:00Z"
+            }),
+        ),
     ] {
         filesystem
             .put(
@@ -380,6 +398,7 @@ async fn caller_imports_rc1_slack_setup_and_secrets_idempotently() {
     assert_eq!(first.identities, 1);
     assert_eq!(first.route_values, 2);
     assert_eq!(first.dm_targets, 1);
+    assert_eq!(first.oauth_channel_stale_connections_expired, 1);
     let state = admin_configuration
         .get(
             &admin_scope,
@@ -488,6 +507,7 @@ async fn caller_imports_rc1_slack_setup_and_secrets_idempotently() {
     assert_eq!(second.identities, 0);
     assert_eq!(second.route_values, 0);
     assert_eq!(second.dm_targets, 0);
+    assert_eq!(second.oauth_channel_connections_unchanged, 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Fix the v1.0.0 to v1.1.0 startup migration crash reported by Railway: `rc1 channel state is malformed`.
- Accept the exact retired Slack `pending_connection` shape that v1.0.0 deliberately tolerated, while retaining strict validation on both the outer and nested records.
- Treat the legacy connecting generation as stale and never restore it as live channel authority.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None — follow-up startup blocker exposed after #7316 restored the preceding RC1 product-adapter migrations.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run workspace-wide; scoped `cargo clippy -p ironclaw_extension_host --all-targets -- -D warnings` passed.
- [ ] `cargo build` — Not run separately; the focused and full crate test builds passed.
- [x] Relevant tests pass: focused caller migration regression and full `ironclaw_extension_host` suite (396 tests across unit and contract targets).
- [ ] `cargo test --features integration` — Not applicable: the migration is filesystem-backed and is covered through the production caller with in-memory filesystem/admin configuration implementations.
- [ ] Manual testing — Not applicable before deployment; the deterministic migration test reproduces the exact persisted JSON shape from the failing startup path.
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — local multi-lens code review and thermo-nuclear quality review completed with no findings.

Additional gates: `bash scripts/pre-commit-safety.sh`, repository regression-test checker, and `git diff --check` all passed.

## Test Strategy

User behavior: An installation upgrading from v1.0.0 to v1.1.0 can finish runtime assembly even if its retained Slack connection record contains the retired `pending_connection` slot. The obsolete connection is expired rather than reactivated, so the WebUI can start and migrated threads can be served.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Extended `caller_imports_rc1_slack_setup_and_secrets_idempotently` with the exact historical connection JSON, first-run stale disposition, and second-run idempotency assertions.
- Reborn integration: Not applicable: no runner, model, capability, or product workflow behavior changed.
- Recorded fixture: Not applicable: no model output or nondeterministic provider behavior changed.
- Browser E2E: Not applicable: the browser was unavailable only because composition aborted before WebUI startup; no browser contract changed.
- Backend or runtime: Full `ironclaw_extension_host` unit and contract suite passed.
- Live canary: Recommended after deployment: confirm runtime assembly reaches ready, WebUI remains available, and the authenticated thread list exposes the migrated threads. Slack is expected to require reconnection; no legacy connection authority is restored.

What the tests prove:

- The real startup migration caller accepts the historically tolerated `pending_connection` record instead of returning `Malformed`.
- The legacy `connecting` generation is classified as stale, not restored as active authority.
- Setup, encrypted secrets, identities, routes, and DM targets continue migrating.
- A second migration run validates the retained source row and reports the connection disposition unchanged.
- The trusted regression gate recognizes the changed test assertion as meaningful.

Commands run:

- `cargo test -p ironclaw_extension_host legacy_channel_state_migration::tests::caller_imports_rc1_slack_setup_and_secrets_idempotently -- --exact --nocapture`
- `cargo test -p ironclaw_extension_host`
- `cargo clippy -p ironclaw_extension_host --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/pre-commit-safety.sh`
- `python3 scripts/ci/regression-test-check.py --repo . --base origin/release/1.1.0-rc.1 --head HEAD ...`
- `git diff --check origin/release/1.1.0-rc.1...HEAD`

## Security Impact

None. The retired field is parsed into bounded typed identifiers/timestamps and is not promoted to live authority. Existing strict unknown-field rejection remains on both record levels; credentials and secrets are unchanged.

## Reborn Trust-Boundary Checklist

- [ ] Public policy/evidence/trust-bearing types: Not applicable; no public or trust-bearing type changed.
- [ ] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable; no prompt path changed.
- [ ] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable; no hash contract changed.
- [ ] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: Not applicable; no variant changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. The optional retired slot retains nested strict validation and has a caller-level migration regression.
- [ ] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable; no queue, map, buffer, or arithmetic changed.
- [ ] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Not applicable; no error type changed.
- [ ] Sandbox/native/host names accurately describe trust boundary. Not applicable; no runtime lane changed.

## Database Impact

None. This adjusts a frozen filesystem reader only. It adds no schema or migration and does not modify PostgreSQL or libSQL behavior.

## Blast Radius

Release-pair Slack channel-state migration during startup only. Existing dispositions remain unchanged: stale/connecting generations expire, active generations are superseded, and interrupted disconnects fail closed. Telegram and ordinary runtime/channel behavior are untouched.

Skipping all channel migration was considered because the reported deployment had unusable Slack and no Telegram setup. The narrower compatibility reader is safer: it avoids discarding otherwise valid setup, secrets, identity, route, and DM-target state while still refusing to restore obsolete connection authority.

## Rollback Plan

Revert commit `73896ef42f`. Source RC1 rows are retained, so rollback is code-only. If deployment remains blocked, channel migration can be operationally omitted for this installation at the cost of losing its legacy channel setup; that broader fallback is not part of this patch.

## Review Follow-Through

Historical schema and sibling readers were audited. The final thermo-nuclear review and the security, bugs, performance, tests, conventions, local-patterns, maintainability, and approach review lanes found no blockers or follow-up changes.

---

**Review track**: C (startup persistence migration)
