### PR TITLE
fix(extensions): default origin_gate_matrix instead of failing closed

### DIFF
--- a/crates/extensions/ironclaw_extension_registry/src/resolved.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/resolved.rs
@@ -332,7 +332,22 @@ impl ResolvedExtensionManifest {
             descriptor_trust_default: requested_trust_to_descriptor_trust(self.requested_trust),
             runtime: self.runtime.clone(),
             host_apis,
-            capabilities: self.tools.clone(),
+            // Records persisted before #7320 may carry tools whose
+            // `origin_gate_matrix` is `None` (the key was optional at parse
+            // time); re-apply the safe default so an already-installed
+            // extension keeps gating instead of failing closed on upgrade.
+            capabilities: self
+                .tools
+                .iter()
+                .map(|tool| CapabilityDeclV2 {
+                    origin_gate_matrix: Some(
+                        tool.origin_gate_matrix
+                            .clone()
+                            .unwrap_or_else(crate::v2::default_extension_origin_gate_matrix),
+                    ),
+                    ..tool.clone()
+                })
+                .collect(),
             host_api_surfaces,
             hooks: self.hooks.clone(),
         })

--- a/crates/extensions/ironclaw_extension_registry/src/v2.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v2.rs
@@ -43,8 +43,9 @@ use std::sync::Arc;
 use ironclaw_host_api::{
     action::{NetworkScheme, NetworkTargetPattern},
     capability::{
-        EffectKind, OriginGateMatrix, PermissionMode, RuntimeCredentialAccountSetup,
-        RuntimeCredentialRequirement, RuntimeCredentialRequirementSource,
+        EffectKind, OriginGateMatrix, OriginGatePolicy, PermissionMode,
+        RuntimeCredentialAccountSetup, RuntimeCredentialRequirement,
+        RuntimeCredentialRequirementSource,
     },
     capability_profile::CapabilityProfileSchemaRef,
     error::HostApiError,
@@ -576,8 +577,13 @@ pub struct CapabilityDeclV2 {
     #[serde(default)]
     pub max_egress_bytes: Option<u64>,
     pub resource_profile: Option<ResourceProfile>,
-    /// Declared per-origin gate matrix (§5.2.1). `None` = undeclared; a later
-    /// slice populates real matrices and threads this into authorization.
+    /// Declared per-origin gate matrix (§5.2.1). Manifest parsing normalizes
+    /// an omitted declaration to [`default_extension_origin_gate_matrix`]
+    /// (#7320), so a model-visible capability whose manifest omits the key
+    /// gates (`GatedUnlessGranted` for `LoopRun`) instead of failing closed to
+    /// `Forbidden` for every origin. `None` survives only in resolved records
+    /// persisted by an older binary; rehydration re-applies the default
+    /// (`crate::resolved::ResolvedExtensionManifest::to_internal`).
     pub origin_gate_matrix: Option<OriginGateMatrix>,
 }
 
@@ -1170,6 +1176,27 @@ fn validate_hook_entries(
     Ok(entries)
 }
 
+/// The safe default gate matrix for a third-party extension capability whose
+/// manifest omits `origin_gate_matrix` (§5.2.1, #7320).
+///
+/// An omitted declaration must not fail the capability closed for every
+/// origin: extension authors following the guides (which historically did not
+/// mention the key) got an immediate `PolicyDenied` on the first `LoopRun`
+/// invocation in v1.1.0. The default mirrors the host's synthesized manifest
+/// posture for third-party tools (`loop_run = "gated_unless_granted"`, the
+/// same conservative cell `builtin_loop_run_seed` assigns to every
+/// non-allowlisted builtin): the `LoopRun` origin gates behind the ordinary
+/// approval flow instead of denying outright, while `Product`/`Automation`
+/// stay deny-by-default — no reviewed producer exists for them, and a
+/// declaration is required to open them.
+pub(crate) fn default_extension_origin_gate_matrix() -> OriginGateMatrix {
+    OriginGateMatrix {
+        loop_run: OriginGatePolicy::GatedUnlessGranted,
+        product: OriginGatePolicy::Forbidden,
+        automation: OriginGatePolicy::Forbidden,
+    }
+}
+
 impl CapabilityDeclV2 {
     pub(crate) fn from_raw(
         raw: RawCapabilityV2,
@@ -1397,7 +1424,10 @@ impl CapabilityDeclV2 {
             network_targets,
             max_egress_bytes: raw.max_egress_bytes,
             resource_profile: raw.resource_profile,
-            origin_gate_matrix: raw.origin_gate_matrix,
+            origin_gate_matrix: Some(
+                raw.origin_gate_matrix
+                    .unwrap_or_else(default_extension_origin_gate_matrix),
+            ),
         })
     }
 }
@@ -1950,9 +1980,11 @@ pub(crate) struct RawCapabilityV2 {
     #[serde(default)]
     pub(crate) resource_profile: Option<ResourceProfile>,
     /// Per-origin gate matrix (§5.2.1). `#[serde(default)]` so existing
-    /// manifests without the key parse to `None`. `OriginGateMatrix`
-    /// deserializes directly from TOML (snake_case fields, each defaulting to
-    /// `Forbidden` when omitted), so no raw mirror is needed.
+    /// manifests without the key parse to `None`, which [`CapabilityDeclV2::from_raw`]
+    /// normalizes to [`default_extension_origin_gate_matrix`] (#7320).
+    /// `OriginGateMatrix` deserializes directly from TOML (snake_case fields,
+    /// each defaulting to `Forbidden` when omitted), so no raw mirror is
+    /// needed.
     #[serde(default)]
     pub(crate) origin_gate_matrix: Option<OriginGateMatrix>,
 }

--- a/crates/extensions/ironclaw_extension_registry/tests/manifest_v2_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/manifest_v2_contract.rs
@@ -102,9 +102,17 @@ fn parses_minimum_valid_v2_manifest_for_installed_third_party_extension() {
     assert_eq!(cap.visibility, CapabilityVisibility::Model);
     assert_eq!(cap.default_permission, PermissionMode::Allow);
     assert!(cap.prompt_doc_ref.is_none());
-    // A manifest that omits the §5.2.1 origin→gate key parses to `None`
-    // (undeclared), preserving compatibility with existing manifests.
-    assert!(cap.origin_gate_matrix.is_none());
+    // A manifest that omits the §5.2.1 origin→gate key is compatibility-
+    // normalized to the safe default (#7320): `LoopRun` gates behind the
+    // ordinary approval flow (`GatedUnlessGranted`) instead of failing closed
+    // to `Forbidden`, while `Product`/`Automation` stay deny-by-default.
+    let matrix = cap
+        .origin_gate_matrix
+        .as_ref()
+        .expect("omitted origin_gate_matrix normalizes to Some");
+    assert_eq!(matrix.loop_run, OriginGatePolicy::GatedUnlessGranted);
+    assert_eq!(matrix.product, OriginGatePolicy::Forbidden);
+    assert_eq!(matrix.automation, OriginGatePolicy::Forbidden);
 }
 
 /// The `standard:` schema-ref namespace is reserved to host-synthesized

--- a/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
@@ -645,6 +645,24 @@ fn mcp_manifest_parses_and_synthesizes_a_host_internal_template() {
     assert_eq!(mcp.max_tools, 64);
 }
 
+/// An `[mcp]` declaration omitting `origin_gate_matrix` must not fail every
+/// discovered tool closed (#7320): the host-internal connection template
+/// normalizes to the safe interactive default, and tools discovered later
+/// inherit the template's matrix (`hosted_mcp_discovery`).
+#[test]
+fn mcp_template_omitting_origin_gate_matrix_defaults_to_interactive_gating() {
+    let record = parse_v3(&mcp_manifest()).expect("mcp manifest without origin_gate_matrix parses");
+    let template = &record.manifest().capabilities[0];
+    assert_eq!(template.id.as_str(), "zeta.mcp_server");
+    let matrix = template
+        .origin_gate_matrix
+        .as_ref()
+        .expect("omitted origin_gate_matrix normalizes to Some");
+    assert_eq!(matrix.loop_run, OriginGatePolicy::GatedUnlessGranted);
+    assert_eq!(matrix.product, OriginGatePolicy::Forbidden);
+    assert_eq!(matrix.automation, OriginGatePolicy::Forbidden);
+}
+
 #[test]
 fn mcp_is_mutually_exclusive_with_runtime_and_channel() {
     let with_runtime = mcp_manifest().replace(
@@ -1198,6 +1216,45 @@ fn allowlisted_memory_read_tool_keeps_ungated_loop_run() {
     assert_eq!(matrix.loop_run, OriginGatePolicy::Ungated);
 }
 
+/// A v3 `[[tools]]` declaration omitting `origin_gate_matrix` must not fail
+/// the capability closed for every origin (#7320): parsing normalizes the
+/// omission to the safe interactive default — `LoopRun` gates behind the
+/// ordinary approval flow (`GatedUnlessGranted`) instead of denying outright,
+/// while `Product`/`Automation` stay deny-by-default.
+#[test]
+fn v3_tool_omitting_origin_gate_matrix_defaults_to_interactive_gating() {
+    let toml = format!(
+        r#"
+schema_version = "{MANIFEST_SCHEMA_VERSION_V3}"
+id = "iota"
+name = "Iota"
+version = "0.1.0"
+description = "Omission fixture"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/iota.wasm"
+
+[[tools]]
+id = "iota.echo"
+description = "Echo records."
+effects = ["network", "use_secret"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/iota/echo.input.v1.json"
+"#
+    );
+    let record = parse_v3(&toml).expect("v3 manifest without origin_gate_matrix parses");
+    let matrix = record.manifest().capabilities[0]
+        .origin_gate_matrix
+        .as_ref()
+        .expect("omitted origin_gate_matrix normalizes to Some");
+    assert_eq!(matrix.loop_run, OriginGatePolicy::GatedUnlessGranted);
+    assert_eq!(matrix.product, OriginGatePolicy::Forbidden);
+    assert_eq!(matrix.automation, OriginGatePolicy::Forbidden);
+}
+
 // ---------------------------------------------------------------------------
 // standard_op binding (standardized messaging framework, task 2)
 // ---------------------------------------------------------------------------
@@ -1670,4 +1727,58 @@ fn legacy_resolved_record_without_standard_op_rehydrates_to_none() {
         .expect("a descriptor without a standard_op key must still deserialize");
     assert_eq!(rehydrated_descriptor.standard_op, None);
     assert_eq!(rehydrated_descriptor.id, descriptor.id);
+}
+
+/// Remove the `origin_gate_matrix` key from every tool object in a serialized
+/// [`ironclaw_extension_registry::ResolvedExtensionManifest`], simulating a
+/// record persisted before #7320 made the key meaningful (when an omitted
+/// declaration parsed to `None`). Operates on the live serialized shape of a
+/// *current* record, so the fixture cannot silently drift out of sync as the
+/// struct evolves.
+fn strip_origin_gate_matrix_from_tools(resolved_json: &mut serde_json::Value) {
+    let tools = resolved_json
+        .get_mut("tools")
+        .and_then(serde_json::Value::as_array_mut)
+        .expect("resolved manifest JSON carries a tools array");
+    assert!(!tools.is_empty(), "fixture must declare at least one tool");
+    for tool in tools {
+        let removed = tool
+            .as_object_mut()
+            .expect("each tool serializes as a JSON object")
+            .remove("origin_gate_matrix");
+        assert!(
+            removed.is_some(),
+            "tool must currently serialize an origin_gate_matrix key for this pin to be meaningful"
+        );
+    }
+}
+
+/// Records persisted before #7320 may carry tools whose `origin_gate_matrix`
+/// is absent (the key was optional at parse time). Rehydration through
+/// `ResolvedExtensionManifest::to_internal` must re-apply the safe interactive
+/// default, so an already-installed extension keeps gating instead of failing
+/// closed to `PolicyDenied` for every `LoopRun` invocation after upgrade.
+#[test]
+fn legacy_resolved_record_without_origin_gate_matrix_rehydrates_to_default_gating() {
+    let record = parse_v3(&zeta_standard_op_manifest()).expect("zeta fixture parses");
+    let mut legacy_manifest =
+        serde_json::to_value(record.resolved()).expect("serialize current resolved manifest");
+    strip_origin_gate_matrix_from_tools(&mut legacy_manifest);
+    let rehydrated: ironclaw_extension_registry::ResolvedExtensionManifest =
+        serde_json::from_value(legacy_manifest)
+            .expect("a resolved manifest without origin_gate_matrix keys must still deserialize");
+
+    let internal = rehydrated
+        .to_internal(ManifestSource::UserRegistered)
+        .expect("legacy record rehydrates to an internal manifest");
+    assert_eq!(internal.capabilities.len(), rehydrated.tools.len());
+    for tool in &internal.capabilities {
+        let matrix = tool
+            .origin_gate_matrix
+            .as_ref()
+            .expect("rehydrated tools carry a normalized matrix");
+        assert_eq!(matrix.loop_run, OriginGatePolicy::GatedUnlessGranted);
+        assert_eq!(matrix.product, OriginGatePolicy::Forbidden);
+        assert_eq!(matrix.automation, OriginGatePolicy::Forbidden);
+    }
 }

--- a/docs/extensions/building-a-tool.md
+++ b/docs/extensions/building-a-tool.md
@@ -232,6 +232,7 @@ description = "Search Example records."
 effects = ["dispatch_capability", "network", "use_secret"]
 default_permission = "ask"
 visibility = "model"
+origin_gate_matrix = { loop_run = "gated_unless_granted", product = "forbidden", automation = "forbidden" }
 input_schema_ref = "schemas/example/search.input.v1.json"
 output_schema_ref = "schemas/example/search.output.v1.json"
 prompt_doc_ref = "prompts/example/search.md"
@@ -257,6 +258,15 @@ Required per model-visible capability:
 - `default_permission`: use `ask` for writes and high-risk reads; use `allow`
   only for low-risk read capabilities that policy deliberately permits.
 - `visibility`: usually `model`.
+- `origin_gate_matrix`: per-origin invocation gating (§5.2.1). The standard
+  interactive posture is
+  `{ loop_run = "gated_unless_granted", product = "forbidden", automation = "forbidden" }`
+  — the `LoopRun` origin gates behind the ordinary approval flow, and
+  `Product`/`Automation` origins are deny-by-default until you deliberately
+  open them. A manifest that omits the key is compatibility-normalized to
+  exactly this posture at parse time, so a tool never fails closed to
+  `PolicyDenied` for every origin; declaring it explicitly is still
+  recommended because it makes the tool's gating auditable.
 - `input_schema_ref`: relative path to JSON schema.
 - `output_schema_ref`: relative path to JSON schema.
 - `prompt_doc_ref`: relative path to concise operation guidance.


### PR DESCRIPTION
## Summary

- `ironclaw_extension_registry` now normalizes an omitted `origin_gate_matrix` on a capability declaration to the safe interactive default (`{ loop_run = "gated_unless_granted", product = "forbidden", automation = "forbidden" }`) instead of leaving it `None`, which the origin gate resolved to `Forbidden` for every origin — an immediate `PolicyDenied` on the first `LoopRun` invocation for any extension written per the docs.
- Applies at `CapabilityDeclV2::from_raw` (single chokepoint covering v2 host-api capabilities, v3 `[[tools]]`, and v3 `[mcp]` connection templates, whose matrix is inherited by discovered tools) and re-applies in `ResolvedExtensionManifest::to_internal`, so records persisted before the fix recover on upgrade without reinstall.
- `LoopRun` now gates behind the ordinary approval flow (soft `GatedUnlessGranted` gate, same conservative cell `builtin_loop_run_seed` assigns to non-allowlisted builtins); `Product`/`Automation` stay deny-by-default — no reviewed producer exists for them and a declaration is required to open them. Explicitly declared matrices are untouched.
- `docs/extensions/building-a-tool.md`: `origin_gate_matrix` added to the manifest example and the required per-model-visible-capability field list, with the omission default spelled out.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Fixes #7320

## Validation

- [x] `cargo fmt --all -- --check` — `cargo fmt -p ironclaw_extension_registry` applied; no diff remains
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — `cargo clippy -p ironclaw_extension_registry --all-targets` clean (targeted crate; full-workspace clippy not run)
- [ ] `cargo build` — `cargo check -p ironclaw_extension_registry` + dependent test builds pass
- [x] Relevant tests pass: `cargo test -p ironclaw_extension_registry`, `cargo test -p ironclaw_extension_host`, `cargo test -p ironclaw_approvals` — all suites green
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed/runtime-integration path changed; manifest parsing and rehydration are pure
- [ ] Manual testing: Not run
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run

## Test Strategy

User behavior: A WASM or MCP extension whose manifest omits `origin_gate_matrix` is invocable again: the first `LoopRun` call now goes through the normal approval gate instead of failing closed with `PolicyDenied`. Already-installed extensions recover after upgrade (rehydration re-applies the default). Manifests that declare a matrix are unchanged.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence — legacy resolved records with `None` matrices rehydrate to the default
- [x] Security or permissions — gating default, deny-by-default Product/Automation preserved
- [ ] External provider
- [x] Cross-component behavior — v2/v3/MCP-template parse paths, rehydration path, descriptor composition

Tests added or updated:
- Unit or contract: updated `manifest_v2_contract.rs` (`parses_minimum_valid_v2_manifest_for_installed_third_party_extension` now asserts the normalized default cells); added `manifest_v3_contract.rs` `v3_tool_omitting_origin_gate_matrix_defaults_to_interactive_gating`, `mcp_template_omitting_origin_gate_matrix_defaults_to_interactive_gating`, and `legacy_resolved_record_without_origin_gate_matrix_rehydrates_to_default_gating` (strips the key from a live-serialized record, deserializes, rehydrates via `to_internal`, asserts the default).
- Reborn integration: Not applicable — no cross-crate integration tier exercised; affected consumer crates (`ironclaw_extension_host`, `ironclaw_approvals`) run their full test suites.
- Recorded fixture: Not applicable — no fixture additions; tests operate on live-serialized current records so fixtures cannot drift.
- Browser E2E: Not applicable — no frontend change.
- Backend or runtime: Not applicable — no runtime/daemon change; policy evaluation for `GatedUnlessGranted`/`Forbidden` cells was already covered by `ironclaw_approvals` suites.
- Live canary: Not applicable — no live service change.

What the tests prove: omission of `origin_gate_matrix` at parse time (v2 capability, v3 tool, v3 MCP template) normalizes to `{ loop_run = gated_unless_granted, product = forbidden, automation = forbidden }`; explicitly declared matrices (including partial ones) still parse unchanged; resolved records persisted by an older binary without the key rehydrate to the same default through `to_internal`.

Commands run: `cargo test -p ironclaw_extension_registry`, `cargo test -p ironclaw_extension_host`, `cargo test -p ironclaw_approvals`, `cargo clippy -p ironclaw_extension_registry --all-targets`, `python3 scripts/ci/docs_publication_boundary.py`

## Security Impact

Permits what v1.1.0 hard-denied for undeclared manifests only: `LoopRun` invocations of such capabilities now reach the ordinary approval gate (soft gate, satisfied by grants/always-allow/bypass exactly like the effects gate). This restores pre-1.1.0 behavior for effect-bearing tools and mirrors the posture the host already synthesizes for third-party manifests (`available_extension_import`, `hosted_mcp_manifest`). No privilege is granted: `Product`/`Automation` origins remain `Forbidden` without an explicit declaration, `Ungated` remains unreachable from a manifest (memory-tool clamp and allowlist unchanged), and the approvals kernel's `None`-matrix fail-closed arm is untouched as defense in depth.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? — The new default lives in the registry crate (`pub(crate)` helper); descriptor-level semantics of `OriginGateMatrix` unchanged.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. — N/A: no prompt construction touched.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. — N/A: no hashing touched.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. — No new variants; only a normalization default. Downstream consumers (package descriptor build, hosted-MCP discovery, extension host) thread the matrix through unchanged.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. — The rehydration normalization has a dedicated migration test; omitted cells of a declared matrix still deserialize to `Forbidden` (existing test).
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. — N/A: no such structures touched.
- [x] Driver/operator-visible errors have stable class semantics. — N/A: no error paths added.
- [x] Sandbox/native/host names accurately describe trust boundary. — N/A: no naming touched.

## Database Impact

None. Resolved records are re-normalized in memory at rehydration; no schema change.
