### PR TITLE
ci(nightly): grant actions: read to the reborn-tests call contract

### DIFF
--- a/.github/workflows/nightly-deep-ci.yml
+++ b/.github/workflows/nightly-deep-ci.yml
@@ -67,12 +67,17 @@ jobs:
     # (65 of 74 retained runs are startup_failures) because of stacked
     # violations of exactly these rules:
     # 1. The called workflow's coverage-report job declares job-level
-    #    `pull-requests: write`; the caller must grant it.
+    #    `pull-requests: write` and `actions: read`; the caller must grant
+    #    both. The `actions: read` scope arrived with #7018's changed-line
+    #    coverage gate (it fetches the base commit's merged-lcov artifact) and
+    #    is the exact omission that turned every nightly run from 2026-08-03
+    #    onward into a zero-job startup_failure.
     # 2. reborn-tests.yml references secrets.SCCACHE_*; the caller must pass
     #    secrets (`secrets: inherit`).
     permissions:
       contents: read
       pull-requests: write
+      actions: read
     secrets: inherit
     with:
       ref: ${{ github.sha }}


### PR DESCRIPTION
## Summary

Fixes the Nightly Deep CI run [31148111585](https://github.com/nearai/ironclaw/actions/runs/31148111585) (and every scheduled run since 2026-08-03), which has been a **zero-job `startup_failure`** five nights running.

## Root cause

`reborn-tests.yml`'s `coverage-report` job declares job-level `actions: read` (added by #7018 — the changed-line coverage gate fetches the base commit's merged-lcov artifact via the Actions API). GitHub validates called-workflow permissions at trigger time: a reusable workflow may not request more than the caller grants, or the entire run fails to start.

`nightly-deep-ci.yml`'s `reborn-tests` job grants only `contents: read` + `pull-requests: write`. The first nightly at the #7018 commit (3be5f056e, 2026-08-03 05:14 UTC) was the first `startup_failure`; the workflow's own comment documents this exact failure mode ("a violation turns the whole nightly run into a startup_failure with ZERO jobs — including nightly-alert, so nothing reports it").

## Fix

Add `actions: read` to the caller's `permissions` for the `reborn-tests` call, and record the full three-scope contract in the comment.

## Verification

- YAML parses; job permissions are now `contents: read`, `pull-requests: write`, `actions: read` with `secrets: inherit`.
- Nightly rerun on this branch will confirm the workflow starts and its jobs run.

## Test Strategy

| Tier | Evidence |
| --- | --- |
| Rust unit | Not applicable: workflow YAML-only change |
| Rust integration | Not applicable: workflow YAML-only change |
| Rust architecture | Not applicable: no crate changes |
| Playwright | Not applicable: no browser-facing change; the nightly rerun exercises the workflow start |
| CI workflows | This change is itself the fix; nightly rerun on the branch verifies startup |
