### PR TITLE
fix(migration): accept production-encoded rc1 Slack connection paths

### DIFF
--- a/crates/ironclaw_extension_host/src/legacy_channel_state_migration/oauth_channel.rs
+++ b/crates/ironclaw_extension_host/src/legacy_channel_state_migration/oauth_channel.rs
@@ -1,4 +1,5 @@
 use super::*;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 
 pub(super) const SLACK: &str = "slack";
 pub(super) const SLACK_GROUP: &str = "extension.slack";
@@ -6,6 +7,10 @@ const MANAGED_SLACK_SUBJECT_PREFIX: &str = "user:slack-channel:";
 
 pub(super) fn provider_key() -> &'static str {
     SLACK
+}
+
+pub(super) fn rc1_slack_path_segment(value: &str) -> String {
+    URL_SAFE_NO_PAD.encode(value.as_bytes())
 }
 
 pub(super) fn root_migration_spec() -> Rc1ChannelRootMigrationSpec {
@@ -322,7 +327,11 @@ pub(super) async fn inspect_slack_connection_disposition(
         }
         let user = UserId::new(&connection.user_id).map_err(log_malformed)?;
         AdapterInstallationId::new(&connection.installation_id).map_err(log_malformed)?;
-        let expected_suffix = format!("/{}/{}.json", connection.installation_id, user.as_str());
+        let expected_suffix = format!(
+            "/{}/{}.json",
+            rc1_slack_path_segment(&connection.installation_id),
+            rc1_slack_path_segment(user.as_str())
+        );
         if !row.path.as_str().ends_with(&expected_suffix) {
             return Err(Rc1ChannelStateMigrationError::Malformed);
         }

--- a/crates/ironclaw_extension_host/src/legacy_channel_state_migration/tests.rs
+++ b/crates/ironclaw_extension_host/src/legacy_channel_state_migration/tests.rs
@@ -202,6 +202,11 @@ fn identity_prefix_rewrite_is_exact_and_requires_the_target_installation() {
 
 #[tokio::test]
 async fn caller_imports_rc1_slack_setup_and_secrets_idempotently() {
+    assert_eq!(
+        rc1_slack_path_segment("slack-rc1-install"),
+        "c2xhY2stcmMxLWluc3RhbGw"
+    );
+    assert_eq!(rc1_slack_path_segment("operator-a"), "b3BlcmF0b3ItYQ");
     let backend = Arc::new(InMemoryBackend::new());
     let filesystem: Arc<dyn RootFilesystem> = backend.clone();
     let secret_store = Arc::new(SecretStore::ephemeral_over(Arc::clone(&backend)));
@@ -345,7 +350,7 @@ async fn caller_imports_rc1_slack_setup_and_secrets_idempotently() {
             }),
         ),
         (
-            "/tenants/tenant-a/shared/slack-personal-binding/connections/slack-rc1-install/operator-a.json",
+            "/tenants/tenant-a/shared/slack-personal-binding/connections/c2xhY2stcmMxLWluc3RhbGw/b3BlcmF0b3ItYQ.json",
             serde_json::json!({
                 "tenant_id": "tenant-a",
                 "user_id": "operator-a",
@@ -861,7 +866,9 @@ async fn slack_connection_disposition_pages_and_second_run_is_unchanged() {
     for index in 0..total {
         let user = format!("user-{index:04}");
         let path = VirtualPath::new(format!(
-            "{shared}/slack-personal-binding/connections/slack-install/{user}.json"
+            "{shared}/slack-personal-binding/connections/{}/{}.json",
+            rc1_slack_path_segment("slack-install"),
+            rc1_slack_path_segment(&user)
         ))
         .expect("connection path");
         let state = if index + 1 == total {
@@ -923,7 +930,9 @@ async fn interrupted_rc1_slack_disconnect_fails_closed() {
     };
     let shared = "/tenants/tenant-a/shared";
     let path = VirtualPath::new(format!(
-        "{shared}/slack-personal-binding/connections/slack-install/user-a.json"
+        "{shared}/slack-personal-binding/connections/{}/{}.json",
+        rc1_slack_path_segment("slack-install"),
+        rc1_slack_path_segment("user-a")
     ))
     .expect("connection path");
     let connection = serde_json::json!({


### PR DESCRIPTION
## Summary

- Accept Slack connection rows written by `1.0.0-rc.1`, whose installation and user path segments are Base64 URL-safe encoded.
- Keep strict owner/path validation and update the caller-level migration fixtures to use the exact released filesystem grammar.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None — follow-up Railway startup blocker exposed after #7318 made the retained `pending_connection` record readable.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not run workspace-wide; scoped `cargo clippy -p ironclaw_extension_host --all-targets -- -D warnings` passed.
- [ ] `cargo build` — Not run separately; the focused and full crate test builds passed.
- [x] Relevant tests pass: focused caller regression plus the full `ironclaw_extension_host` suite (396 tests across unit and contract targets).
- [ ] `cargo test --features integration` — Not applicable: this changes a backend-neutral filesystem compatibility reader and the production caller is covered with the in-memory `RootFilesystem` implementation.
- [ ] Manual testing — Pending Railway redeploy; the deterministic regression reproduces the exact encoded path from the released rc1 writer.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; final diff, regression gate, scoped Clippy, and repository safety checks were completed locally.

Additional gates: `bash scripts/pre-commit-safety.sh`, repository regression-test checker, and `git diff --check` passed.

## Test Strategy

User behavior: An installation upgrading from v1.0.0-rc.1 to v1.1.0-rc.1 can complete runtime assembly when retained Slack connection records live at the Base64 URL-safe encoded paths written by rc1.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Extended `caller_imports_rc1_slack_setup_and_secrets_idempotently` with exact released path-segment assertions and the production-encoded connection path. Updated paging and interrupted-disconnect fixtures to use the same released grammar.
- Reborn integration: Not applicable: no turn, runner, model, or product workflow behavior changed; the extension-host production migration caller is the meaningful seam.
- Recorded fixture: Not applicable: no model output or provider request behavior changed.
- Browser E2E: Not applicable: the browser was unavailable only because startup aborted; no browser contract changed.
- Backend or runtime: Full `ironclaw_extension_host` unit and contract suite passed over the backend-neutral migration caller.
- Live canary: Recommended after deployment: confirm runtime assembly reaches ready and migrated threads are visible. Slack connection authority remains intentionally expired/superseded and may require reconnection.

What the tests prove:

- The exact rc1 Base64 URL-safe encoding for installation and user path segments is retained.
- The real migration caller accepts a production-shaped Slack connection path instead of returning `Malformed`.
- Strict path-owner validation, paging, restart idempotency, and interrupted-disconnect fail-closed behavior remain intact.

Commands run:

- `cargo test -p ironclaw_extension_host legacy_channel_state_migration::tests::caller_imports_rc1_slack_setup_and_secrets_idempotently -- --exact --nocapture` (failed with `Malformed` before the fix; passed after)
- `cargo test -p ironclaw_extension_host`
- `cargo clippy -p ironclaw_extension_host --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/pre-commit-safety.sh`
- `python3 scripts/ci/regression-test-check.py --repo . --base origin/release/1.1.0-rc.1 --head HEAD --title 'fix(migration): accept production-encoded rc1 Slack connection paths'`
- `git diff --check origin/release/1.1.0-rc.1...HEAD`

## Security Impact

None. The migration still validates that the row path matches its typed installation and user owner. This change computes the expected path with rc1's released Base64 URL-safe encoding; it does not decode untrusted paths, relax JSON validation, restore obsolete connection authority, or change secret handling.

## Reborn Trust-Boundary Checklist

- [ ] Public policy/evidence/trust-bearing types: Not applicable; no public or trust-bearing type changed.
- [ ] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable; no prompt path changed.
- [ ] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable; Base64 here is the released filesystem path encoding, not an authenticity mechanism.
- [ ] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: Not applicable; no variant changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Existing strict rc1 record parsing is unchanged, and the production caller regression covers the exact retained record and path.
- [ ] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Not applicable; no collection or arithmetic behavior changed.
- [ ] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Not applicable; no error class changed.
- [ ] Sandbox/native/host names accurately describe trust boundary. Not applicable; no runtime lane or naming changed.

## Database Impact

None. This changes a frozen filesystem compatibility reader only. It adds no schema migration and is independent of PostgreSQL versus libSQL.

## Blast Radius

Release-pair Slack channel-state migration during startup only. Telegram, current 1.1 channel state, runtime delivery, OAuth flows, and ordinary extension lifecycle behavior are untouched. A wrong encoder would either reject valid rc1 state or weaken path binding; the exact encoded constants and caller-path assertions pin both sides.

## Rollback Plan

Revert commit `08b164fce`. Rc1 source rows are retained and the migration is restartable, so rollback is code-only. Reverting reintroduces the startup blocker for installations with retained Slack connection rows.

## Review Follow-Through

After merge, redeploy the Railway installation that exposed the failure and confirm startup passes channel migration and reaches ready. If another malformed rc1 record is reported, capture the preceding `rc1 channel migration record validation failed` detail before broadening any compatibility reader.

---

**Review track**: C (startup persistence migration)
