### PR TITLE
fix(migration): add explicit rc1 channel-state bypass

### DIFF
--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -724,6 +724,13 @@ pub(crate) fn build_services_input_with_options(
     {
         services_input = services_input.with_legacy_workspace_snapshot(snapshot);
     }
+    if caller == RuntimeInputCaller::Serve
+        && parse_rc1_channel_state_migration_override(std::env::var(
+            "IRONCLAW_REBORN_SKIP_RC1_CHANNEL_STATE_MIGRATION",
+        ))?
+    {
+        services_input = services_input.with_rc1_channel_state_migration_skipped_by_operator();
+    }
     if let Some(ResolvedGoogleOAuthConfig {
         client,
         hosted_domain_hint: _hosted_domain_hint,
@@ -1174,6 +1181,23 @@ fn optional_path_env(name: &str) -> anyhow::Result<Option<PathBuf>> {
     }
 }
 
+fn parse_rc1_channel_state_migration_override(
+    raw: Result<String, std::env::VarError>,
+) -> anyhow::Result<bool> {
+    const NAME: &str = "IRONCLAW_REBORN_SKIP_RC1_CHANNEL_STATE_MIGRATION";
+    match raw {
+        Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" => Ok(true),
+            "0" | "false" => Ok(false),
+            _ => anyhow::bail!("{NAME} must be one of 1, true, 0, false"),
+        },
+        Err(std::env::VarError::NotPresent) => Ok(false),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("{NAME} contains non-UTF-8 bytes")
+        }
+    }
+}
+
 fn local_runtime_workspace_root(profile: RebornProfile) -> anyhow::Result<PathBuf> {
     optional_path_env("IRONCLAW_REBORN_WORKSPACE_ROOT")?
         .map(Ok)
@@ -1570,8 +1594,9 @@ mod tests {
         GoogleOAuthConfigState, GoogleOAuthEnvInputs, GoogleOAuthResolution, RuntimeInputCaller,
         RuntimeInputOptions, apply_credential_refresh_override, block_on_cli, build_runtime_input,
         build_runtime_input_with_options, initialize_local_runtime_storage_root,
-        no_assistant_text_message, protect_reborn_log_filter, resolve_google_oauth_config,
-        resolve_google_oauth_config_state, resolve_google_oauth_config_state_merged,
+        no_assistant_text_message, parse_rc1_channel_state_migration_override,
+        protect_reborn_log_filter, resolve_google_oauth_config, resolve_google_oauth_config_state,
+        resolve_google_oauth_config_state_merged,
         resolve_google_oauth_config_state_with_store_loader, runner_settings,
         with_binary_host_extension_bindings_from_bundles,
     };
@@ -1622,6 +1647,30 @@ mod tests {
                 .to_string()
                 .contains("must inject the first-party package inventory"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn rc1_channel_state_migration_override_is_explicit_and_fail_loud() {
+        assert!(
+            !parse_rc1_channel_state_migration_override(Err(std::env::VarError::NotPresent))
+                .expect("unset override keeps fail-closed migration enabled")
+        );
+        assert!(
+            parse_rc1_channel_state_migration_override(Ok(" TRUE ".to_string()))
+                .expect("explicit true enables the emergency override")
+        );
+        assert!(
+            !parse_rc1_channel_state_migration_override(Ok("0".to_string()))
+                .expect("explicit false keeps migration enabled")
+        );
+
+        let error = parse_rc1_channel_state_migration_override(Ok("".to_string()))
+            .expect_err("blank override must not silently skip or run migration");
+        assert!(
+            error
+                .to_string()
+                .contains("IRONCLAW_REBORN_SKIP_RC1_CHANNEL_STATE_MIGRATION must be one of")
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/production_backend_assembly.rs
@@ -361,6 +361,7 @@ pub(super) async fn build_backend_production(
         default_system_prompt_path,
         workspace_root,
         legacy_workspace_snapshot,
+        skip_rc1_channel_state_migration,
         #[cfg(any(test, feature = "test-support"))]
         network_http_egress_for_test,
         #[cfg(any(test, feature = "test-support"))]
@@ -960,23 +961,33 @@ pub(super) async fn build_backend_production(
             reason: format!("admin configuration service could not be built: {error}"),
         })?,
     );
-    let legacy_channel_filesystem: Arc<dyn RootFilesystem> = stores.filesystem.clone();
-    let extension_state_migration = match ironclaw_extension_host::migrate_all_rc1_channel_state(
-        legacy_channel_filesystem,
-        Arc::clone(&extension_installation_store),
-        Arc::clone(&secret_store),
-        Arc::clone(&admin_configuration),
-    )
-    .await
-    {
-        Ok(report) => report,
-        Err(error) => {
-            release_migration.fail_and_log().await;
-            return Err(crate::RebornCompositionError::InvalidConfig {
-                reason: format!("channel extension-state startup migration failed: {error}"),
+    let extension_state_migration = if skip_rc1_channel_state_migration {
+        tracing::warn!(
+            override_env = "IRONCLAW_REBORN_SKIP_RC1_CHANNEL_STATE_MIGRATION",
+            source_rows_retained = true,
+            "skipping rc1 Slack/Telegram extension-state startup migration by explicit operator override; channel credentials, setup, identities, routes, and DM targets must be reconfigured"
+        );
+        ironclaw_release_migration::Rc1To11ChannelStateMigrationOutcome::SkippedByOperator
+    } else {
+        let legacy_channel_filesystem: Arc<dyn RootFilesystem> = stores.filesystem.clone();
+        let report = match ironclaw_extension_host::migrate_all_rc1_channel_state(
+            legacy_channel_filesystem,
+            Arc::clone(&extension_installation_store),
+            Arc::clone(&secret_store),
+            Arc::clone(&admin_configuration),
+        )
+        .await
+        {
+            Ok(report) => report,
+            Err(error) => {
+                release_migration.fail_and_log().await;
+                return Err(crate::RebornCompositionError::InvalidConfig {
+                    reason: format!("channel extension-state startup migration failed: {error}"),
+                }
+                .into());
             }
-            .into());
-        }
+        };
+        ironclaw_release_migration::Rc1To11ChannelStateMigrationOutcome::Completed(report)
     };
     release_migration
         .complete(ironclaw_release_migration::Rc1To11ExtensionReports {

--- a/crates/ironclaw_reborn_composition/src/factory/production_build_assembly.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/production_build_assembly.rs
@@ -24,6 +24,7 @@ pub(super) async fn build_production_shaped(
         memory_binding_policy,
         memory_provider_connection,
         legacy_workspace_snapshot,
+        skip_rc1_channel_state_migration,
         ..
     } = input;
     let owner_id = deployment.owner_id.clone();
@@ -93,6 +94,7 @@ pub(super) async fn build_production_shaped(
         default_system_prompt_path: None,
         workspace_root: None,
         legacy_workspace_snapshot,
+        skip_rc1_channel_state_migration,
         #[cfg(any(test, feature = "test-support"))]
         network_http_egress_for_test,
         #[cfg(any(test, feature = "test-support"))]
@@ -369,6 +371,7 @@ pub(super) struct RebornProductionBuildContext {
     pub(super) default_system_prompt_path: Option<PathBuf>,
     pub(super) workspace_root: Option<PathBuf>,
     pub(super) legacy_workspace_snapshot: Option<PathBuf>,
+    pub(super) skip_rc1_channel_state_migration: bool,
     #[cfg(any(test, feature = "test-support"))]
     pub(super) network_http_egress_for_test: Option<Arc<dyn ironclaw_network::NetworkHttpEgress>>,
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -229,6 +229,10 @@ pub struct RebornHostBindings {
     /// release-pair barrier. `None` is the normal path; discovery is never
     /// guessed because rc1 shared ownership can be ambiguous.
     pub(crate) legacy_workspace_snapshot: Option<PathBuf>,
+    /// Explicit emergency override for an unrecoverably malformed rc1
+    /// Slack/Telegram extension-state authority. Core, installation, OAuth,
+    /// thread, routine, and workspace migrations remain enabled.
+    pub(crate) skip_rc1_channel_state_migration: bool,
 }
 
 /// One channel extension's binary-assembled vendor binding
@@ -540,6 +544,15 @@ impl RebornHostBindings {
 
     pub fn with_legacy_workspace_snapshot(mut self, source: PathBuf) -> Self {
         self.legacy_workspace_snapshot = Some(source);
+        self
+    }
+
+    /// Omit only the rc1 Slack/Telegram extension-state import.
+    ///
+    /// This is a data-loss-accepting operator action: the old rows remain
+    /// available for recovery, but 1.1 channel setup must be reconfigured.
+    pub fn with_rc1_channel_state_migration_skipped_by_operator(mut self) -> Self {
+        self.skip_rc1_channel_state_migration = true;
         self
     }
 
@@ -941,6 +954,7 @@ impl RebornHostBindings {
             memory_binding_policy: None,
             memory_provider_connection: Mem0ConnectionConfig::default(),
             legacy_workspace_snapshot: None,
+            skip_rc1_channel_state_migration: false,
         }
     }
 
@@ -1298,5 +1312,14 @@ mod tests {
             .with_product_auth_ports(product_auth.clone());
 
         assert!(input.product_auth_ports.is_some());
+    }
+
+    #[test]
+    fn rc1_channel_state_migration_skip_requires_explicit_builder() {
+        let default_input = RebornHostBindings::disabled("test-owner");
+        assert!(!default_input.skip_rc1_channel_state_migration);
+
+        let skipped_input = default_input.with_rc1_channel_state_migration_skipped_by_operator();
+        assert!(skipped_input.skip_rc1_channel_state_migration);
     }
 }

--- a/crates/ironclaw_reborn_composition/tests/release_pair_migration_barrier.rs
+++ b/crates/ironclaw_reborn_composition/tests/release_pair_migration_barrier.rs
@@ -12,6 +12,9 @@ fn production_writer_workers_remain_behind_the_completed_migration_barrier() {
     let channel_migration = flattened
         .find("migrate_all_rc1_channel_state")
         .expect("channel state migration remains in production startup");
+    let operator_skip = flattened
+        .find("Rc1To11ChannelStateMigrationOutcome::SkippedByOperator")
+        .expect("the explicit operator skip remains typed and visible");
     let completion = flattened
         .find("release_migration .complete(")
         .expect("release-pair completion barrier remains in production startup");
@@ -21,6 +24,14 @@ fn production_writer_workers_remain_behind_the_completed_migration_barrier() {
     assert!(
         migration_begin < channel_migration && channel_migration < completion,
         "the typed migration session must cover channel-state migration through completion"
+    );
+    assert!(
+        migration_begin < operator_skip && operator_skip < completion,
+        "the operator skip decision must be recorded inside the typed migration session"
+    );
+    assert!(
+        flattened[..completion].contains("skip_rc1_channel_state_migration"),
+        "startup must make the channel-state decision before publishing completion"
     );
     assert!(
         completion < first_worker,

--- a/crates/ironclaw_release_migration/src/lib.rs
+++ b/crates/ironclaw_release_migration/src/lib.rs
@@ -14,8 +14,8 @@ mod workspace;
 pub use error::ReleasePairMigrationError;
 pub use rc1_to_1_1::{
     ChannelRootMigrationReport, ChannelScopeMigrationReport, ExtensionInstallationMigrationReport,
-    Rc1To11ExtensionReports, Rc1To11Migration, Rc1To11MigrationInput,
-    discover_rc1_hosted_extension_snapshots, migrate_channel_roots,
+    Rc1To11ChannelStateMigrationOutcome, Rc1To11ExtensionReports, Rc1To11Migration,
+    Rc1To11MigrationInput, discover_rc1_hosted_extension_snapshots, migrate_channel_roots,
     migrate_rc1_hosted_extension_snapshots, validate_channel_thread_references,
 };
 pub use workspace::{

--- a/crates/ironclaw_release_migration/src/rc1_to_1_1.rs
+++ b/crates/ironclaw_release_migration/src/rc1_to_1_1.rs
@@ -179,7 +179,17 @@ where
 #[derive(Default)]
 pub struct Rc1To11ExtensionReports {
     pub installations: Option<ExtensionInstallationMigrationReport>,
-    pub channel_state: Option<ironclaw_extension_host::Rc1ChannelStateMigrationReport>,
+    pub channel_state: Option<Rc1To11ChannelStateMigrationOutcome>,
+}
+
+/// Verified result of the rc1 Slack/Telegram extension-state migration.
+///
+/// The operator skip is deliberately distinct from an absent report: it lets
+/// the release-pair marker state that this domain was omitted without
+/// fabricating success counts or deleting the retained rc1 authority.
+pub enum Rc1To11ChannelStateMigrationOutcome {
+    Completed(ironclaw_extension_host::Rc1ChannelStateMigrationReport),
+    SkippedByOperator,
 }
 
 /// In-progress rc1 -> 1.1 migration barrier.
@@ -622,7 +632,7 @@ fn redacted_core_report(
     channels: &ChannelRootMigrationReport,
     oauth: &ironclaw_auth::OAuthProviderAliasMigrationReport,
     installations: Option<&ExtensionInstallationMigrationReport>,
-    extension_state: Option<&ironclaw_extension_host::Rc1ChannelStateMigrationReport>,
+    extension_state: Option<&Rc1To11ChannelStateMigrationOutcome>,
     workspace: Option<&LegacyWorkspaceMigrationReport>,
 ) -> Value {
     let thread_scopes = threads
@@ -741,7 +751,11 @@ fn redacted_core_report(
             }),
         );
     }
-    if let (Value::Object(domains), Some(extension_state)) = (&mut report, extension_state) {
+    if let (
+        Value::Object(domains),
+        Some(Rc1To11ChannelStateMigrationOutcome::Completed(extension_state)),
+    ) = (&mut report, extension_state)
+    {
         let extension_state_scopes = extension_state
             .scopes
             .iter()
@@ -790,6 +804,18 @@ fn redacted_core_report(
                 .proof_code_pairing_rows_unchanged,
             "scopes": extension_state_scopes,
         }));
+    }
+    if let (Value::Object(domains), Some(Rc1To11ChannelStateMigrationOutcome::SkippedByOperator)) =
+        (&mut report, extension_state)
+    {
+        domains.insert(
+            "channel_extension_state".to_string(),
+            json!({
+                "status": "skipped_by_operator",
+                "counts_available": false,
+                "source_retained": true,
+            }),
+        );
     }
     report
 }

--- a/crates/ironclaw_release_migration/src/rc1_to_1_1/tests.rs
+++ b/crates/ironclaw_release_migration/src/rc1_to_1_1/tests.rs
@@ -23,6 +23,62 @@ fn absent_extension_domains_are_not_reported_as_completed() {
     assert!(report.get("workspace_artifacts").is_none());
 }
 
+#[test]
+fn operator_skipped_channel_state_is_recorded_without_false_success_counts() {
+    let channel_state = Rc1To11ChannelStateMigrationOutcome::SkippedByOperator;
+    let report = redacted_core_report(
+        &ironclaw_processes::LegacyProcessMigrationReport::default(),
+        &ironclaw_threads::ThreadStartupMigrationReport::default(),
+        &ChannelRootMigrationReport::default(),
+        &ironclaw_auth::OAuthProviderAliasMigrationReport::default(),
+        None,
+        Some(&channel_state),
+        None,
+    );
+    let channel_state = report
+        .get("channel_extension_state")
+        .expect("operator skip must remain visible in release completion evidence");
+
+    assert_eq!(
+        channel_state.get("status"),
+        Some(&json!("skipped_by_operator"))
+    );
+    assert_eq!(channel_state.get("counts_available"), Some(&json!(false)));
+    assert_eq!(channel_state.get("source_retained"), Some(&json!(true)));
+    assert!(
+        channel_state.get("migrated").is_none(),
+        "an omitted migration must not publish fabricated success counts"
+    );
+}
+
+#[test]
+fn completed_channel_state_keeps_verified_count_evidence() {
+    let channel_state = Rc1To11ChannelStateMigrationOutcome::Completed(
+        ironclaw_extension_host::Rc1ChannelStateMigrationReport {
+            configuration_values: 2,
+            identities: 3,
+            ..Default::default()
+        },
+    );
+    let report = redacted_core_report(
+        &ironclaw_processes::LegacyProcessMigrationReport::default(),
+        &ironclaw_threads::ThreadStartupMigrationReport::default(),
+        &ChannelRootMigrationReport::default(),
+        &ironclaw_auth::OAuthProviderAliasMigrationReport::default(),
+        None,
+        Some(&channel_state),
+        None,
+    );
+    let channel_state = report
+        .get("channel_extension_state")
+        .expect("completed channel migration remains reported");
+
+    assert_eq!(channel_state.get("migrated"), Some(&json!(5)));
+    assert_eq!(channel_state.get("configuration_values"), Some(&json!(2)));
+    assert_eq!(channel_state.get("identities"), Some(&json!(3)));
+    assert!(channel_state.get("status").is_none());
+}
+
 #[tokio::test]
 async fn release_lifecycle_accepts_another_pair_without_rc1_branching() {
     const TEST_PAIR: ReleasePair = ReleasePair {

--- a/docs/internal/rc1-to-1.1-startup-migration.md
+++ b/docs/internal/rc1-to-1.1-startup-migration.md
@@ -63,6 +63,30 @@ identifiers, message contents, credentials, or secret handles.
   configured 1.1 tenant/default owner is its intended recipient. A conflicting
   destination or unsupported special file fails startup without overwrite.
 
+### Emergency Slack/Telegram state bypass
+
+If the retained rc1 Slack/Telegram extension-state rows are malformed and the
+operator accepts reconfiguring those channels in 1.1, set:
+
+```bash
+IRONCLAW_REBORN_SKIP_RC1_CHANNEL_STATE_MIGRATION=true
+```
+
+This is an explicit, narrow override. It skips only Slack/Telegram setup,
+channel-admin secret bindings, identities, routes, DM targets, connection
+rows, and pairing state. Thread messages, routines/triggers, channel conversations and
+idempotency, extension installations, OAuth provider aliases, processes, and
+the optional workspace snapshot still migrate normally. The source channel
+rows are retained, startup emits a warning, and the release completion report
+records `channel_extension_state.status=skipped_by_operator` without fabricated
+counts.
+
+Keep the variable configured while this release-pair migration remains in the
+binary: completed migrations are reverified on every startup. Remove it only
+to retry the normal channel-state migration after repairing the rc1 source.
+Invalid or blank values fail startup; unset, `0`, or `false` preserve the
+default fail-closed migration.
+
 ## Release artifact gate
 
 The tag publisher must pass `scripts/ci/release-upgrade-canary.py` before its

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -159,6 +159,12 @@ verifies file hashes, retains the source, and fails rather than guessing on
 conflicts or shared-workspace ownership. See
 `docs/internal/rc1-to-1.1-startup-migration.md` for the exact handoff.
 
+If malformed rc1 Slack/Telegram extension state blocks the upgrade and the
+operator accepts reconfiguring those channels, the same runbook documents the
+narrow `IRONCLAW_REBORN_SKIP_RC1_CHANNEL_STATE_MIGRATION=true` emergency
+override. It does not skip threads, routines, artifacts, extension
+installations, or other release-pair domains.
+
 The image includes `sqlite3` and `psql` for terminal inspection from Railway
 shells. Use `sqlite3` for mounted-volume libSQL/SQLite state and `psql` for
 `IRONCLAW_REBORN_POSTGRES_URL` deployments.


### PR DESCRIPTION
## Summary

- Add an explicit `IRONCLAW_REBORN_SKIP_RC1_CHANNEL_STATE_MIGRATION=true` emergency override for rc1 Slack/Telegram state that cannot be decoded.
- Keep every other rc1 → 1.1 migration enabled, including threads/messages, routines/triggers, workspace artifacts, channel conversations, installations, OAuth aliases, and processes.
- Preserve the fail-closed default, retain rc1 source rows, emit a prominent warning, and record `channel_extension_state.status=skipped_by_operator` without fabricated migration counts.
- Document the Railway/operator consequences: Slack/Telegram setup may need reconfiguration, and the override must remain configured while this release-pair migration is reverified on startup.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7178

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — broad scoped clippy was stopped at operator request; CI is the remaining lint gate.
- [ ] `cargo build` — covered by the test builds below.
- [x] Relevant tests pass: `cargo test -p ironclaw_release_migration`; `cargo test -p ironclaw_reborn_composition --test release_pair_migration_barrier`; `cargo test -p ironclaw`; targeted CLI/parser and composition input tests.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — not applicable: no schema/store implementation changes; this is a typed startup decision over the existing backend-neutral migration path.
- [ ] Manual testing: not run; CI will provide the remaining branch-wide validation before Railway deployment.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run; expedited at operator request.

Composition full-suite note: 551/553 library tests passed. `capture_skips_when_policy_missing_or_disabled` fails unchanged on the release base because the untouched trace code creates its queue directory; `multi_tool_call_response_survives_surface_change_mid_register` timed out in the full parallel run and passed immediately in isolation. Neither failure touches this diff.

## Test Strategy

User behavior: An operator with malformed rc1 Slack/Telegram extension state can explicitly accept channel reconfiguration and let 1.1 start without losing threads, routines, artifacts, installations, or other migrated domains.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: release report distinguishes verified completion, explicit operator skip, and absent domain; CLI parser accepts only explicit booleans; composition input defaults to migration enabled.
- Reborn integration: Not applicable: the changed behavior is startup composition before the turn/runtime path exists; the existing migration-barrier caller contract was extended instead.
- Recorded fixture: Not applicable: no model choice or request shape changes.
- Browser E2E: Not applicable: no browser-visible surface changes.
- Backend or runtime: Existing production startup barrier contract now proves both normal channel migration and the typed skip decision complete before writer workers start. No database schema/backend implementation changed.
- Live canary: Not applicable: no external-provider call is needed to prove the startup decision.

What the tests prove: The default remains fail closed; only an explicit valid override selects the skip; the skip is represented durably without false counts; normal completed reports retain their count evidence; and no production writer starts before the selected migration outcome is committed.

Commands run:
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_release_migration`
- `cargo test -p ironclaw_reborn_composition --test release_pair_migration_barrier`
- `cargo test -p ironclaw rc1_channel_state_migration_override_is_explicit_and_fail_loud`
- `cargo test -p ironclaw`
- `cargo test -p ironclaw_reborn_composition` (551 passed, two unrelated base failures described above)
- Targeted rerun of `multi_tool_call_response_survives_surface_change_mid_register` (passed)

## Security Impact

The override intentionally omits migration of Slack/Telegram channel-admin secret bindings and routing identity state. It is opt-in, serve-only, rejects blank/invalid values, emits a warning, retains source rows, and does not expose secret material. Normal behavior remains fail closed. Operators choosing it must reconfigure affected channels in 1.1.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: only the binary reads the env; composition receives an explicit typed builder choice; release evidence uses a closed enum.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. N/A: no prompt content changes.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. N/A: no hashing changes.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: `rg -n "Rc1To11ExtensionReports|redacted_core_report|migrate_all_rc1_channel_state|RebornHostBindings" crates/ironclaw_release_migration crates/ironclaw_reborn_composition crates/ironclaw_reborn_cli`.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. N/A: no serde field; the in-memory input defaults to `false` and is tested.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. N/A: none added.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Invalid env values remain startup misconfiguration errors; the selected skip is a warning plus durable evidence.
- [x] Sandbox/native/host names accurately describe trust boundary. The API and env name explicitly scope the action to rc1 channel-state migration.

## Database Impact

No DDL or record schema changes. Existing libSQL/PostgreSQL-backed `RootFilesystem` migration behavior is unchanged except that an explicit operator choice can omit only the Slack/Telegram channel-state importer. The release/domain completion marker records the omission; retained rc1 source rows remain the recovery authority.

## Blast Radius

Startup configuration in the CLI, production composition, and rc1 → 1.1 release completion evidence. With the env unset/false, behavior is unchanged. With it true, Slack/Telegram channel setup, admin credentials, identities, routes, DM targets, connection rows, and pairing state may require reconfiguration; threads, messages, routines, artifacts, installations, and other migration domains continue normally.

## Rollback Plan

Unset the environment variable to restore the normal fail-closed channel migration and retry after repairing the rc1 source. Revert this commit to remove the override entirely. Source channel rows are never deleted, so rollback/recovery remains possible; keep the platform database/volume snapshot as documented in the migration runbook.

## Review Follow-Through

CI is intentionally the remaining broad lint/test gate. Reviewer judgment requested on the operator-facing warning wording and whether the environment variable should be removed alongside the rc1 release-pair migration after the upgrade window closes.

---

**Review track**: C (runtime/persistence startup behavior)
