### PR TITLE
feat(webui): replace Logs toolbar selects with shared SelectMenu

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/design-system/select-menu.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/design-system/select-menu.test.ts
@@ -268,10 +268,17 @@ test("SelectMenu supports a compact reusable size", () => {
   const harness = createHarness();
   let rendered = harness.render({ size: "sm" });
   let classes = collectScalars(rendered).filter((value) => typeof value === "string");
+  const classTokens = new Set(
+    classes.flatMap((value) => value.split(/\s+/).filter(Boolean))
+  );
 
-  assert.ok(classes.some((value) => value.includes("min-w-[7.5rem] text-xs")));
-  assert.ok(classes.some((value) => value.includes("h-8 px-2")));
-  assert.ok(!classes.some((value) => value.includes("min-w-[9.5rem] text-ui")));
+  assert.ok(classTokens.has("min-w-[7.5rem]"));
+  assert.ok(classTokens.has("text-xs"));
+  assert.ok(classTokens.has("h-8"));
+  assert.ok(classTokens.has("px-2"));
+  assert.ok(!classTokens.has("px-2.5"));
+  assert.ok(!classTokens.has("min-w-[9.5rem]"));
+  assert.ok(!classTokens.has("text-ui"));
 
   firstValueAfter(rendered, "onClick=")();
   rendered = harness.render({ size: "sm" });

--- a/crates/product/ironclaw_webui/frontend/src/design-system/select-menu.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/design-system/select-menu.test.ts
@@ -264,6 +264,21 @@ test("SelectMenu renders a closed custom trigger with the selected label", () =>
   assert.doesNotMatch(collectTemplateText(rendered), /role="listbox"/);
 });
 
+test("SelectMenu supports a compact reusable size", () => {
+  const harness = createHarness();
+  let rendered = harness.render({ size: "sm" });
+  let classes = collectScalars(rendered).filter((value) => typeof value === "string");
+
+  assert.ok(classes.some((value) => value.includes("min-w-[7.5rem] text-xs")));
+  assert.ok(classes.some((value) => value.includes("h-8 px-2")));
+  assert.ok(!classes.some((value) => value.includes("min-w-[9.5rem] text-ui")));
+
+  firstValueAfter(rendered, "onClick=")();
+  rendered = harness.render({ size: "sm" });
+  classes = collectScalars(rendered).filter((value) => typeof value === "string");
+  assert.ok(classes.some((value) => value.includes("px-2 py-1.5 text-xs")));
+});
+
 test("SelectMenu opens, selects an option, and closes after selection", () => {
   const changes = [];
   const harness = createHarness();

--- a/crates/product/ironclaw_webui/frontend/src/design-system/select-menu.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/design-system/select-menu.tsx
@@ -21,6 +21,19 @@ const alignClasses = {
   right: "right-0",
 };
 
+const sizeClasses = {
+  md: {
+    root: "min-w-[9.5rem] text-ui",
+    button: "h-8 px-2.5",
+    option: "px-2.5 py-2",
+  },
+  sm: {
+    root: "min-w-[7.5rem] text-xs",
+    button: "h-8 px-2",
+    option: "px-2 py-1.5 text-xs",
+  },
+};
+
 function createSelectMenuId() {
   nextSelectMenuId += 1;
   return `v2-select-menu-${nextSelectMenuId}`;
@@ -144,6 +157,7 @@ function ToneDot({ tone }) {
 /**
  * @typedef {"neutral" | "positive" | "warning" | "danger" | "info" | "accent"} SelectMenuTone
  * @typedef {"left" | "right"} SelectMenuAlign
+ * @typedef {"md" | "sm"} SelectMenuSize
  * @typedef {{ value: string, label?: string, disabled?: boolean, tone?: SelectMenuTone }} SelectMenuOption
  */
 
@@ -167,6 +181,7 @@ export function SelectMenu({
   menuClassName = "",
   optionClassName = "",
   align = "right",
+  size = "md",
   placeholder = "",
   ...rest
 }) {
@@ -192,6 +207,7 @@ export function SelectMenu({
       : null;
   const effectiveAriaLabel = ariaLabel || ariaLabelProp;
   const effectiveAlign = normalizeAlign(align);
+  const effectiveSize = sizeClasses[size] || sizeClasses.md;
   const hasEnabledOption = firstEnabledIndex(options) >= 0;
   const interactionDisabled = disabled || !hasEnabledOption;
   const optionsKey = optionsIdentity(options);
@@ -289,7 +305,8 @@ export function SelectMenu({
     <div
       ref={rootRef}
       className={cn(
-        "relative inline-block min-w-[9.5rem] text-left font-sans text-ui",
+        "relative inline-block text-left font-sans",
+        effectiveSize.root,
         className
       )}
       {...rootPassthroughProps}
@@ -312,13 +329,14 @@ export function SelectMenu({
           })}
         onKeyDown={handleKeyDown}
         className={cn(
-          "inline-flex h-8 w-full items-center justify-between gap-2 rounded-[8px] border",
-          "border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-2.5",
+          "inline-flex w-full items-center justify-between gap-2 rounded-[8px] border",
+          "border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)]",
           "text-[var(--v2-text-strong)] shadow-none transition-colors",
           "hover:bg-[var(--v2-surface-muted)]",
           "focus-visible:outline-none focus-visible:ring-2",
           "focus-visible:ring-[color-mix(in_srgb,var(--v2-accent)_32%,transparent)]",
           "disabled:cursor-not-allowed disabled:opacity-60",
+          effectiveSize.button,
           buttonClassName
         )}
       >
@@ -364,7 +382,7 @@ export function SelectMenu({
                 onMouseEnter={() => !option.disabled && setActiveIndex(index)}
                 onClick={() => chooseOption(option)}
                 className={cn(
-                  "flex w-full items-center justify-between gap-3 rounded-[7px] px-2.5 py-2",
+                  "flex w-full items-center justify-between gap-3 rounded-[7px]",
                   "text-left text-[var(--v2-text)] transition-colors",
                   "focus-visible:outline-none",
                   "focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--v2-accent)_30%,transparent)]",
@@ -374,6 +392,7 @@ export function SelectMenu({
                     : isSelected
                       ? "bg-[var(--v2-accent-soft)] text-[var(--v2-text-strong)]"
                       : "hover:bg-[var(--v2-surface-soft)]",
+                  effectiveSize.option,
                   optionClassName
                 )}
               >

--- a/crates/product/ironclaw_webui/frontend/src/pages/logs/logs-page.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/logs/logs-page.test.ts
@@ -47,8 +47,10 @@ function createLogsPageHarness(overrides = {}) {
   const hookValues = [];
   let hookCursor = 0;
   function ConfirmDialog() {}
+  function SelectMenu() {}
   const context = {
     ConfirmDialog,
+    SelectMenu,
     globalThis: {},
     React: {
       useRef: (initial) => {
@@ -89,6 +91,7 @@ function createLogsPageHarness(overrides = {}) {
   vm.runInNewContext(logsPageSourceForTest(), context);
   return {
     ConfirmDialog,
+    SelectMenu,
     render() {
       hookCursor = 0;
       return context.globalThis.__testExports.LogsPage();
@@ -320,6 +323,58 @@ test("LogsPage keeps the scrollable log output container", () => {
   const markup = flattenMarkup(renderLogsPage());
   // The inner output region is the actual scroll surface.
   assert.match(markup, /min-h-0 flex-1 overflow-y-auto/);
+});
+
+test("LogsPage changes the log level through the compact shared SelectMenu", () => {
+  const changes = [];
+  const harness = createLogsPageHarness({
+    levelFilter: "all",
+    setLevelFilter: (value) => changes.push(value),
+    targetFilter: "ironclaw::agent",
+    scope: {
+      active: [
+        { param: "thread_id", labelKey: "logs.scope.thread", value: "thread-1" },
+      ],
+    },
+  });
+
+  const rendered = harness.render();
+  const [levelSelect] = componentProps(rendered, harness.SelectMenu);
+  assert.equal(levelSelect.value, "all");
+  assert.equal(levelSelect.size, "sm");
+  assert.equal(levelSelect.align, "left");
+  assert.equal(levelSelect["data-testid"], "logs-level-filter");
+  assert.equal(
+    Array.from(levelSelect.options, (option) => option.value).join(","),
+    "all,trace,debug,info,warn,error",
+  );
+  assert.match(flattenMarkup(rendered), /ironclaw::agent/);
+  assert.match(flattenMarkup(rendered), /thread-1/);
+
+  levelSelect.onChange("warn");
+  assert.deepEqual(changes, ["warn"]);
+});
+
+test("LogsPage changes the server level through the compact shared SelectMenu", () => {
+  const changes = [];
+  const harness = createLogsPageHarness({
+    serverLevel: "info",
+    changeServerLevel: (value) => changes.push(value),
+  });
+
+  const selects = componentProps(harness.render(), harness.SelectMenu);
+  assert.equal(selects.length, 2);
+  const serverSelect = selects[1];
+  assert.equal(serverSelect.value, "info");
+  assert.equal(serverSelect.size, "sm");
+  assert.equal(serverSelect["data-testid"], "logs-server-level");
+  assert.equal(
+    Array.from(serverSelect.options, (option) => option.value).join(","),
+    "trace,debug,info,warn,error",
+  );
+
+  serverSelect.onChange("error");
+  assert.deepEqual(changes, ["error"]);
 });
 
 test("LogsPage renders the load-older action while a cursor is available", () => {

--- a/crates/product/ironclaw_webui/frontend/src/pages/logs/logs-page.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/logs/logs-page.tsx
@@ -2,6 +2,7 @@
 import { useOutletContext } from "react-router";
 import React from "react";
 import { ConfirmDialog } from "../../design-system/confirm-dialog";
+import { SelectMenu } from "../../design-system/select-menu";
 import { useT } from "../../lib/i18n";
 import { useLogs } from "./hooks/useLogs";
 
@@ -102,20 +103,6 @@ function LogEntry({ entry }) {
   );
 }
 
-function ToolbarSelect({ value, onChange, options, labelKey, t }) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.currentTarget.value)}
-      className="v2-select h-8 min-w-0 rounded-[8px] px-2.5 py-0 text-xs"
-    >
-      {options.map(
-        (opt) => (<option key={opt} value={opt}>{t(labelKey(opt))}</option>)
-      )}
-    </select>
-  );
-}
-
 function ScopeChip({ label, value, scopeKey }) {
   return (
     <span
@@ -178,6 +165,14 @@ export function LogsPage() {
 
   const hasEntries = entries.length > 0;
   const activeScope = scope?.active || [];
+  const levelOptions = LEVELS.map((level) => ({
+    value: level,
+    label: t(level === "all" ? "logs.levelAll" : `logs.level.${level}`),
+  }));
+  const serverLevelOptions = SERVER_LEVELS.map((level) => ({
+    value: level,
+    label: t(`logs.level.${level}`),
+  }));
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -186,12 +181,14 @@ export function LogsPage() {
         className="flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--v2-panel-border)] bg-[var(--v2-canvas-strong)] px-4 py-2"
       >
         {/* Level filter */}
-        <ToolbarSelect
+        <SelectMenu
           value={levelFilter}
           onChange={setLevelFilter}
-          options={LEVELS}
-          labelKey={(opt) => (opt === "all" ? "logs.levelAll" : `logs.level.${opt}`)}
-          t={t}
+          options={levelOptions}
+          size="sm"
+          align="left"
+          ariaLabel={t("logs.levelAll")}
+          data-testid="logs-level-filter"
         />
 
         {/* Target filter */}
@@ -266,12 +263,14 @@ export function LogsPage() {
         (
           <div className="flex w-full items-center gap-2 border-t border-[var(--v2-panel-border)] pt-2 text-xs text-[var(--v2-text-muted)]">
             <span>{t("logs.serverLevel")}</span>
-            <ToolbarSelect
+            <SelectMenu
               value={serverLevel}
               onChange={changeServerLevel}
-              options={SERVER_LEVELS}
-              labelKey={(opt) => `logs.level.${opt}`}
-              t={t}
+              options={serverLevelOptions}
+              size="sm"
+              align="left"
+              ariaLabel={t("logs.serverLevel")}
+              data-testid="logs-server-level"
             />
             <span className="ml-auto tabular-nums">
               {t("logs.entryCount", { count: totalCount })}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -389,6 +389,7 @@ entries.
 | Search across settings sections and clear the search | `test_reborn_webui_v2_legacy_settings_search.py` (6), `test_settings_search.py` (5) |
 | Add, test, activate, edit and delete a custom inference provider | `test_reborn_webui_v2_legacy_settings_search.py` |
 | Add/edit/delete skills, with read-only sources locked | `test_reborn_webui_v2_legacy_skills.py` (3), `test_reborn_webui_v2_skills_api.py` (3), `test_portfolio.py` (10) |
+| Filter scoped logs by target and level with the shared SelectMenu while polling and pagination continue | `test_reborn_webui_v2_smoke.py::test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context` |
 | Use plan mode (`/plan`, checklist, approve, status) | `test_plan_mode.py` (5) |
 | As an admin: create users, hand out one-time tokens, page the user list, set roles, suspend/activate, manage write-only secrets, delete users | `test_admin_api.py` (18) |
 | Bootstrap as the single-tenant owner with stable identity | `test_ownership_model.py` (8), `test_multi_tenant_greeting.py` |

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -426,6 +426,7 @@ SEL_V2 = {
     "logs_entry_message": "[data-testid='logs-entry-message']",
     "logs_entry_context": "[data-testid='logs-entry-context']",
     "logs_context_chip": "[data-testid='logs-context-chip'][data-context-key='{key}']",
+    "logs_level_filter": "[data-testid='logs-level-filter']",
     "logs_pagination": "[data-testid='logs-pagination']",
     "logs_load_older": "[data-testid='logs-load-older']",
     "logs_load_older_error": "[data-testid='logs-load-older-error']",

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -427,6 +427,7 @@ SEL_V2 = {
     "logs_entry_context": "[data-testid='logs-entry-context']",
     "logs_context_chip": "[data-testid='logs-context-chip'][data-context-key='{key}']",
     "logs_level_filter": "[data-testid='logs-level-filter']",
+    "logs_target_filter": "input[placeholder='Filter by target…']",
     "logs_pagination": "[data-testid='logs-pagination']",
     "logs_load_older": "[data-testid='logs-load-older']",
     "logs_load_older_error": "[data-testid='logs-load-older-error']",

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -2510,10 +2510,11 @@ async def test_reborn_v2_response_links_open_in_new_tab(reborn_v2_page):
 async def test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context(
     reborn_v2_page, reborn_v2_server
 ):
-    """The browser logs route scopes, paginates, retries, and preserves older entries."""
+    """The logs UI filters with SelectMenu while preserving scope and pagination."""
     requested_queries: list[dict[str, list[str]]] = []
     pagination_cursors: list[str] = []
     logs_requested = asyncio.Event()
+    filtered_logs_requested = asyncio.Event()
     polled_after_pagination = asyncio.Event()
     pagination_attempts = 0
     pagination_loaded = False
@@ -2524,6 +2525,10 @@ async def test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context(
         query = parse_qs(parsed.query)
         requested_queries.append(query)
         logs_requested.set()
+        if query.get("level") == ["warn"] and query.get("target") == [
+            "ironclaw::ui"
+        ]:
+            filtered_logs_requested.set()
         cursor = query.get("cursor", [None])[0]
         if cursor == "older-page-1":
             pagination_cursors.append(cursor)
@@ -2643,6 +2648,29 @@ async def test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context(
     await expect(
         reborn_v2_page.locator(SEL_V2["logs_scope_chip"].format(key="run_id"))
     ).to_contain_text("run-ui")
+
+    level_filter = reborn_v2_page.locator(SEL_V2["logs_level_filter"])
+    level_trigger = level_filter.get_by_role("button")
+    await expect(level_trigger).to_have_attribute("aria-haspopup", "listbox")
+    await expect(level_filter.locator("select")).to_have_count(0)
+    await reborn_v2_page.get_by_placeholder("Filter by target…").fill(
+        "ironclaw::ui"
+    )
+    await level_trigger.click()
+    await expect(reborn_v2_page.get_by_role("listbox")).to_be_visible()
+    await reborn_v2_page.get_by_role("option", name="WARN", exact=True).click()
+    await asyncio.wait_for(filtered_logs_requested.wait(), timeout=10)
+    await expect(level_trigger).to_contain_text("WARN")
+    filtered_query = next(
+        query
+        for query in reversed(requested_queries)
+        if query.get("level") == ["warn"]
+        and query.get("target") == ["ironclaw::ui"]
+    )
+    assert filtered_query.get("thread_id") == ["thread-ui"], filtered_query
+    assert filtered_query.get("run_id") == ["run-ui"], filtered_query
+    assert filtered_query.get("tool_call_id") == ["tool-call-ui"], filtered_query
+    assert filtered_query.get("source") == ["slack"], filtered_query
 
     entry = reborn_v2_page.locator(SEL_V2["logs_entry"]).first
     await expect(entry.locator(SEL_V2["logs_entry_message"])).to_contain_text(

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -2653,9 +2653,7 @@ async def test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context(
     level_trigger = level_filter.get_by_role("button")
     await expect(level_trigger).to_have_attribute("aria-haspopup", "listbox")
     await expect(level_filter.locator("select")).to_have_count(0)
-    await reborn_v2_page.get_by_placeholder("Filter by target…").fill(
-        "ironclaw::ui"
-    )
+    await reborn_v2_page.locator(SEL_V2["logs_target_filter"]).fill("ironclaw::ui")
     await level_trigger.click()
     await expect(reborn_v2_page.get_by_role("listbox")).to_be_visible()
     await reborn_v2_page.get_by_role("option", name="WARN", exact=True).click()


### PR DESCRIPTION
## Summary

- Replaces the Logs page's private native `ToolbarSelect` controls with the shared `SelectMenu`.
- Adds a reusable compact `sm` size variant while preserving the existing default `SelectMenu` appearance.
- Preserves all log-level values, immediate filter updates, target filters, active log scope, polling, and pagination behavior.
- Adds focused frontend coverage and extends the existing Reborn browser E2E scenario to verify the shared listbox and scoped filter requests.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/02caa197-6636-47fc-8e55-0ec5611eae33" />


## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7332

## Validation

- [x] `git diff --check`
- [x] `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend run lint:conventions`
- [x] `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend run typecheck`
- [x] `TZ=UTC corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend test` — 1,122 tests passed
- [x] `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend exec vitest run src/design-system/select-menu.test.ts src/pages/logs/logs-page.test.ts` — 28 tests passed
- [x] `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend exec vite build`
- [x] `node --experimental-strip-types crates/product/ironclaw_webui/frontend/scripts/check-bundle-budgets.ts`
- [x] `tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context -q` — 1 test passed
- [x] Manual browser validation of the Logs page and expanded shared log-level menu
- [ ] `cargo fmt`, `cargo clippy`, and `cargo build` — Not applicable: no Rust source changed
- [ ] Database/runtime integration suite — Not applicable: no database or runtime behavior changed

## Test Strategy

User behavior:

Users can change the Logs page level filter through the shared compact `SelectMenu`. Selecting a level immediately updates the request while retaining target filters and thread, run, tool-call, and source scope. Existing polling and pagination continue to work.

Risk areas:

- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:

- Unit or contract: updated `select-menu.test.ts` and `logs-page.test.ts` to cover the compact size, retained option values, and immediate level-change callbacks.
- Reborn integration: Not applicable: no turn execution or product-surface behavior changed.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: extended `test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context`.
- Backend or runtime: Not applicable: frontend-only change.
- Live canary: Not applicable: the behavior is deterministic and covered hermetically.

What the tests prove:

- The compact shared `SelectMenu` renders without changing its default size behavior.
- The Logs page no longer renders the private native `<select>`.
- All existing filter and server-level values remain available.
- Selecting `WARN` immediately issues a request containing `level=warn`.
- Target, thread, run, tool-call, and source filters remain intact.
- Polling and pagination continue after changing the filter.

Commands run:

- `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend exec vitest run src/design-system/select-menu.test.ts src/pages/logs/logs-page.test.ts`
- `TZ=UTC corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend test`
- `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend run lint:conventions`
- `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend run typecheck`
- `corepack pnpm@11.7.0 --dir crates/product/ironclaw_webui/frontend exec vite build`
- `node --experimental-strip-types crates/product/ironclaw_webui/frontend/scripts/check-bundle-budgets.ts`
- `tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_logs_page_passes_scope_to_api_and_renders_context -q`
- `git diff --check`

## Security Impact

None. This is a frontend-only selection-control change and does not affect authentication, permissions, secrets, network policy, file access, tool execution, or sandbox behavior.

## Reborn Trust-Boundary Checklist

N/A: this change does not modify Reborn trust boundaries, ingress, authorization, runtime behavior, persistence, or trust-bearing types.

## Database Impact

None. No schema, migration, PostgreSQL, or libSQL changes.

## Blast Radius

Limited to the shared frontend `SelectMenu` component, the Logs page toolbar, and their focused frontend and browser tests. Existing `SelectMenu` consumers retain the unchanged default `md` styling; the compact `sm` variant is opt-in.

## Rollback Plan

Revert this PR to restore the private native Logs `ToolbarSelect` controls and remove the opt-in compact `SelectMenu` variant and associated tests.

## Review Follow-Through

The final diff was reviewed after implementation. No blocking findings or additional optimizations were identified. Overall risk is low because the change is frontend-only, preserves default shared-component behavior, and is covered by focused tests plus a real browser E2E scenario.

---

**Review track**: B