### PR TITLE
fix(loop-host): dedup consumed steering replays

### DIFF
--- a/crates/loop/ironclaw_loop_host/src/durable_input_queue/tests.rs
+++ b/crates/loop/ironclaw_loop_host/src/durable_input_queue/tests.rs
@@ -58,6 +58,27 @@ fn origin() -> LoopInputCursorToken {
     LoopInputCursorToken::origin()
 }
 
+#[test]
+fn legacy_queue_document_without_consumed_ring_still_loads() {
+    let model: RunQueueModel = serde_json::from_value(serde_json::json!({
+        "next_sequence": 1,
+        "entries": [],
+        "acked_watermark": 0,
+        "acked_above": [],
+        "pending_submit_flips": [],
+        "closed": false,
+        "pending_reject_flips": []
+    }))
+    .expect("legacy queue document remains compatible");
+    assert!(
+        model
+            .scan_after(0, 1)
+            .expect("legacy model remains usable")
+            .inputs
+            .is_empty()
+    );
+}
+
 /// The two production backends behind one conformance bound: both shells wrap
 /// the same `RunQueueModel`, and these parameterized tests prove the shells
 /// preserve its behavior identically (the dual-backend parity rule in
@@ -124,6 +145,115 @@ async fn durable_queue_survives_store_reconstruction() {
     assert_eq!(batch.inputs[0].cursor, envelope.cursor);
 }
 
+#[tokio::test]
+async fn durable_consumed_dedup_survives_store_reconstruction() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let scope = ghost_scope();
+    let thread = thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: None,
+            created_by_actor_id: "actor-iq".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    let accepted = thread_service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-iq".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: None,
+            content: MessageContent::text("consumed before restart"),
+        })
+        .await
+        .unwrap();
+    let run_id = TurnRunId::new();
+    let turn_id = TurnId::new();
+    let input = steering(&format!("msg:{}", accepted.message_id));
+    thread_service
+        .mark_message_queued(
+            &scope,
+            &thread.thread_id,
+            accepted.message_id,
+            run_id.to_string(),
+        )
+        .await
+        .unwrap();
+
+    let first = {
+        let queue = FilesystemHostInputQueue::new(
+            make_fs(Arc::clone(&backend)),
+            owner_scope(),
+            Arc::clone(&thread_service) as Arc<dyn SessionThreadService>,
+        );
+        let envelope = queue
+            .enqueue_queued_message(EnqueueQueuedMessageRequest {
+                run_id,
+                turn_id,
+                scope: scope.clone(),
+                thread_id: thread.thread_id.clone(),
+                message_id: accepted.message_id,
+                input: input.clone(),
+            })
+            .await
+            .expect("enqueue before restart");
+        queue
+            .ack_consumed(run_id, vec![envelope.ack_token.clone()])
+            .await
+            .expect("consume before restart");
+        envelope
+    };
+
+    // A reconstructed queue must load the consumed-message tombstone from the
+    // durable document rather than treating the replay as a fresh input.
+    let queue = FilesystemHostInputQueue::new(
+        make_fs(Arc::clone(&backend)),
+        owner_scope(),
+        Arc::clone(&thread_service) as Arc<dyn SessionThreadService>,
+    );
+    let replay = queue
+        .enqueue_queued_message(EnqueueQueuedMessageRequest {
+            run_id,
+            turn_id,
+            scope,
+            thread_id: thread.thread_id,
+            message_id: accepted.message_id,
+            input,
+        })
+        .await
+        .expect("replay after restart dedups");
+    assert_eq!(replay.ack_token, first.ack_token);
+    assert!(
+        queue
+            .next_after(run_id, origin(), 8)
+            .await
+            .expect("poll after replay")
+            .inputs
+            .is_empty(),
+        "a consumed replay must not become deliverable after reconstruction"
+    );
+    assert!(
+        queue
+            .reject_unconsumed(run_id)
+            .await
+            .expect("terminal reconciliation")
+            .is_empty()
+    );
+    assert!(
+        make_fs(backend)
+            .get(&owner_scope(), &queue_path(run_id).expect("queue path"))
+            .await
+            .expect("read queue document after reconciliation")
+            .is_none(),
+        "terminal reconciliation must reclaim a document containing only consumed tombstones"
+    );
+}
+
 async fn conformance_enqueue_poll_ack<Q: ConformanceQueue>(
     queue: Q,
     thread_service: Arc<InMemorySessionThreadService>,
@@ -162,15 +292,17 @@ async fn conformance_enqueue_poll_ack<Q: ConformanceQueue>(
         .await
         .unwrap();
 
-    queue
-        .enqueue_queued_message(EnqueueQueuedMessageRequest {
-            run_id,
-            turn_id: TurnId::new(),
-            scope: scope.clone(),
-            thread_id: thread.thread_id.clone(),
-            message_id: accepted.message_id,
-            input: steering(&format!("msg:{}", accepted.message_id)),
-        })
+    let input = steering(&format!("msg:{}", accepted.message_id));
+    let enqueue_request = || EnqueueQueuedMessageRequest {
+        run_id,
+        turn_id: TurnId::new(),
+        scope: scope.clone(),
+        thread_id: thread.thread_id.clone(),
+        message_id: accepted.message_id,
+        input: input.clone(),
+    };
+    let first = queue
+        .enqueue_queued_message(enqueue_request())
         .await
         .expect("enqueue");
 
@@ -185,15 +317,27 @@ async fn conformance_enqueue_poll_ack<Q: ConformanceQueue>(
     // Status durably flipped to Submitted...
     let history = thread_service
         .list_thread_history(ThreadHistoryRequest {
-            scope,
-            thread_id: thread.thread_id,
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
         })
         .await
         .unwrap();
     assert_eq!(history.messages[0].status, MessageStatus::Submitted);
+    // A retry can race with the successful Queued -> Submitted flip after it
+    // has already classified the row as Queued. The queue remains the final
+    // idempotency boundary: replaying the same message after consumption must
+    // return its original identity without minting a deliverable entry.
+    let replay = queue
+        .enqueue_queued_message(enqueue_request())
+        .await
+        .expect("consumed replay dedups");
+    assert_eq!(
+        replay.ack_token, first.ack_token,
+        "a consumed replay must retain the original queue identity"
+    );
     // ...and the consumed input is not redelivered.
     let after = queue
-        .next_after(run_id, batch.next_cursor, 8)
+        .next_after(run_id, origin(), 8)
         .await
         .expect("poll after ack");
     assert!(after.inputs.is_empty());
@@ -714,6 +858,91 @@ async fn conformance_enqueue_bounds_per_run_capacity<Q: ConformanceQueue>(queue:
     assert_eq!(retry.ack_token, batch.inputs[0].ack_token);
 }
 
+/// Successful consumption uses a separate bounded replay window rather than
+/// occupying live capacity. Drive more successful messages than the live
+/// ceiling, then verify the newest consumed identity still dedups.
+async fn conformance_consumed_dedup_does_not_exhaust_capacity<Q: ConformanceQueue>(
+    queue: Q,
+    thread_service: Arc<InMemorySessionThreadService>,
+) {
+    let scope = ghost_scope();
+    let thread = thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: None,
+            created_by_actor_id: "actor-iq".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    let run_id = TurnRunId::new();
+    let mut newest = None;
+
+    for index in 0..=crate::input_queue::MAX_QUEUED_INPUTS_PER_RUN {
+        let accepted = thread_service
+            .accept_inbound_message(AcceptInboundMessageRequest {
+                scope: scope.clone(),
+                thread_id: thread.thread_id.clone(),
+                actor_id: "actor-iq".into(),
+                source_binding_id: None,
+                reply_target_binding_id: None,
+                external_event_id: None,
+                content: MessageContent::text(format!("successful steering {index}")),
+            })
+            .await
+            .unwrap();
+        thread_service
+            .mark_message_queued(
+                &scope,
+                &thread.thread_id,
+                accepted.message_id,
+                run_id.to_string(),
+            )
+            .await
+            .unwrap();
+        let input = steering(&format!("msg:{}", accepted.message_id));
+        let envelope = queue
+            .enqueue_queued_message(EnqueueQueuedMessageRequest {
+                run_id,
+                turn_id: TurnId::new(),
+                scope: scope.clone(),
+                thread_id: thread.thread_id.clone(),
+                message_id: accepted.message_id,
+                input: input.clone(),
+            })
+            .await
+            .expect("successful consumptions must not exhaust live capacity");
+        queue
+            .ack_consumed(run_id, vec![envelope.ack_token.clone()])
+            .await
+            .expect("consume queued input");
+        newest = Some((accepted.message_id, input, envelope.ack_token));
+    }
+
+    let (message_id, input, original_ack) = newest.expect("at least one input consumed");
+    let replay = queue
+        .enqueue_queued_message(EnqueueQueuedMessageRequest {
+            run_id,
+            turn_id: TurnId::new(),
+            scope,
+            thread_id: thread.thread_id,
+            message_id,
+            input,
+        })
+        .await
+        .expect("newest consumed input remains deduplicated");
+    assert_eq!(replay.ack_token, original_ack);
+    assert!(
+        queue
+            .next_after(run_id, origin(), 1)
+            .await
+            .expect("poll after consumed replay")
+            .inputs
+            .is_empty()
+    );
+}
+
 #[tokio::test]
 async fn durable_enqueue_bounds_per_run_capacity() {
     conformance_enqueue_bounds_per_run_capacity(durable_queue(Arc::new(
@@ -728,6 +957,20 @@ async fn in_memory_enqueue_bounds_per_run_capacity() {
         InMemorySessionThreadService::default(),
     )))
     .await;
+}
+
+#[tokio::test]
+async fn durable_consumed_dedup_does_not_exhaust_capacity() {
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let queue = durable_queue(Arc::clone(&thread_service));
+    conformance_consumed_dedup_does_not_exhaust_capacity(queue, thread_service).await;
+}
+
+#[tokio::test]
+async fn in_memory_consumed_dedup_does_not_exhaust_capacity() {
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let queue = in_memory_queue(Arc::clone(&thread_service));
+    conformance_consumed_dedup_does_not_exhaust_capacity(queue, thread_service).await;
 }
 
 /// Terminal reconciliation settles and STAYS settled: the rows flip to

--- a/crates/loop/ironclaw_loop_host/src/input_queue.rs
+++ b/crates/loop/ironclaw_loop_host/src/input_queue.rs
@@ -919,3 +919,65 @@ pub(crate) fn ack_sequence(token: &LoopInputAckToken) -> Result<u64, HostInputQu
             reason: "input ack token is malformed".to_string(),
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::ids::{AgentId, TenantId};
+    use ironclaw_turns::LoopMessageRef;
+
+    #[test]
+    fn recently_consumed_dedup_window_stays_bounded() {
+        let mut model = RunQueueModel::default();
+        let scope = ThreadScope {
+            tenant_id: TenantId::new("tenant-iq").unwrap(),
+            agent_id: AgentId::new("agent-iq").unwrap(),
+            project_id: None,
+            owner_user_id: None,
+            mission_id: None,
+        };
+        let thread_id = ThreadId::new("thread-iq").unwrap();
+        let mut oldest_message_id = None;
+
+        for index in 0..=RECENTLY_CONSUMED_DEDUP_LIMIT {
+            let message_id = ThreadMessageId::new();
+            if index == 0 {
+                oldest_message_id = Some(message_id);
+            }
+            let message_ref = format!("msg:{message_id}");
+            let disposition = model
+                .enqueue_dedup(
+                    LoopInput::Steering {
+                        message_ref: LoopMessageRef::new(&message_ref).unwrap(),
+                    },
+                    QueuedMessageStatusUpdate {
+                        turn_id: TurnId::new(),
+                        scope: scope.clone(),
+                        thread_id: thread_id.clone(),
+                        message_id,
+                    },
+                )
+                .expect("enqueue distinct input");
+            let EnqueueDisposition::Inserted { sequence } = disposition else {
+                panic!("distinct input must insert");
+            };
+            model
+                .validate_and_ack(&[ack_token(sequence).unwrap()])
+                .expect("ack inserted input");
+            model.confirm_submit_flips(&[sequence]);
+        }
+
+        assert_eq!(
+            model.recently_consumed.len(),
+            RECENTLY_CONSUMED_DEDUP_LIMIT,
+            "consumed replay identities must not grow durable state without bound"
+        );
+        assert!(
+            !model
+                .recently_consumed
+                .iter()
+                .any(|consumed| Some(consumed.message_id) == oldest_message_id),
+            "the oldest consumed identity must be evicted when the window is full"
+        );
+    }
+}

--- a/crates/loop/ironclaw_loop_host/src/input_queue.rs
+++ b/crates/loop/ironclaw_loop_host/src/input_queue.rs
@@ -135,6 +135,10 @@ pub enum HostInputQueueError {
 /// serialized size; 32 is far beyond any interactive use while keeping the
 /// durable document's rewrite-per-enqueue cost trivial.
 pub const MAX_QUEUED_INPUTS_PER_RUN: usize = 32;
+/// Independent replay-dedup window for inputs already consumed successfully.
+/// Keeping this separate from live capacity avoids exhausting a long-running
+/// run merely because it has processed inputs over time.
+const RECENTLY_CONSUMED_DEDUP_LIMIT: usize = MAX_QUEUED_INPUTS_PER_RUN;
 
 #[async_trait]
 pub trait HostInputEnqueuePort: Send + Sync {
@@ -222,6 +226,18 @@ pub(crate) struct PendingSubmitFlip {
     pub(crate) status: QueuedMessageStatusUpdate,
 }
 
+/// Bounded dedup identity for an input the loop already consumed. Successful
+/// transcript flips remove [`PendingSubmitFlip`], so they cannot double as the
+/// replay tombstone: a request that classified the row as `Queued` before the
+/// flip may reach enqueue afterward. Retaining the message id with its original
+/// sequence lets that racing replay return the same envelope without becoming
+/// deliverable again.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ConsumedMessage {
+    pub(crate) sequence: u64,
+    pub(crate) message_id: ThreadMessageId,
+}
+
 fn first_sequence() -> u64 {
     1
 }
@@ -240,9 +256,8 @@ pub(crate) struct RunQueueModel {
     entries: Vec<QueueEntry>,
     /// Compact ack state: every sequence `<= acked_watermark` is acked, plus
     /// the sparse out-of-order set above it. Keeps duplicate/redelivered acks
-    /// idempotent without a tombstone per input, so the state does not grow
-    /// (or, durably, get reparsed and rewritten) without bound over a
-    /// long-lived run. `BTreeSet` serializes as a sorted array.
+    /// idempotent without an unbounded tombstone per input. `BTreeSet`
+    /// serializes as a sorted array.
     #[serde(default)]
     acked_watermark: u64,
     #[serde(default)]
@@ -252,6 +267,12 @@ pub(crate) struct RunQueueModel {
     /// every later ack, re-enqueue, and the terminal reconciliation.
     #[serde(default)]
     pending_submit_flips: Vec<PendingSubmitFlip>,
+    /// Recent successful or pending consumptions, retained independently from
+    /// live queue capacity. The ring is bounded to cover concurrent/retried
+    /// admissions without making a long-lived run permanently full after the
+    /// same number of successful inputs.
+    #[serde(default)]
+    recently_consumed: Vec<ConsumedMessage>,
     /// Terminal tombstone: set by [`Self::close_and_claim`]. A closed queue
     /// rejects enqueues ([`HostInputQueueError::RunClosed`]) and treats late
     /// acks as no-ops — terminal reconciliation owns settlement from then on.
@@ -274,6 +295,7 @@ impl Default for RunQueueModel {
             acked_watermark: 0,
             acked_above: BTreeSet::new(),
             pending_submit_flips: Vec::new(),
+            recently_consumed: Vec::new(),
             closed: false,
             pending_reject_flips: Vec::new(),
         }
@@ -348,11 +370,18 @@ impl RunQueueModel {
                 flip: pending.clone(),
             });
         }
-        // The ceiling bounds the WHOLE persisted state, not only the live
-        // segment: a consumed entry whose `Submitted` flip keeps failing
-        // moves to `pending_submit_flips` rather than vanishing, so counting
-        // live entries alone would let the document grow past the bound one
-        // failed flip at a time.
+        if let Some(consumed) = self
+            .recently_consumed
+            .iter()
+            .find(|consumed| consumed.message_id == status.message_id)
+        {
+            return Ok(EnqueueDisposition::Duplicate {
+                sequence: consumed.sequence,
+            });
+        }
+        // The ceiling bounds the live + failed-flip segment. The independently
+        // bounded recent-consumption ring does not consume live capacity: a
+        // successful run must remain able to accept later distinct inputs.
         if self.entries.len() + self.pending_submit_flips.len() >= MAX_QUEUED_INPUTS_PER_RUN {
             return Err(HostInputQueueError::CapacityExhausted);
         }
@@ -453,6 +482,13 @@ impl RunQueueModel {
                 sequence,
                 status: entry.status.clone(),
             });
+            self.recently_consumed.push(ConsumedMessage {
+                sequence,
+                message_id: entry.status.message_id,
+            });
+            if self.recently_consumed.len() > RECENTLY_CONSUMED_DEDUP_LIMIT {
+                self.recently_consumed.remove(0);
+            }
             newly_acked.push(sequence);
         }
         for sequence in &newly_acked {
@@ -487,6 +523,9 @@ impl RunQueueModel {
             .collect();
         self.pending_reject_flips.extend(claimed);
         self.entries.clear();
+        // `closed` is now the authoritative tombstone, so replay identities
+        // are unnecessary while a terminal document awaits flip settlement.
+        self.recently_consumed.clear();
     }
 
     /// Drop the pending `RejectedBusy` flips whose transcript writes


### PR DESCRIPTION
## Summary

- Preserve a bounded durable identity window for successfully consumed steering messages.
- Deduplicate delayed queued-message replays against their original queue sequence so they cannot trigger another model iteration and duplicate assistant reply.
- Keep consumed identities separate from live queue capacity, clear them on terminal reconciliation, and retain compatibility with legacy queue documents.
- Add dual-backend, durable-restart, bounded-capacity, legacy-serde, and terminal-reclamation regression coverage.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Related context: #5981.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — scoped owning-crate clippy passed: `cargo clippy -p ironclaw_loop_host --all-targets --all-features -- -D warnings`
- [ ] `cargo build` — covered by the owning-crate test and clippy builds below
- [x] Relevant tests pass: `cargo test -p ironclaw_loop_host`; `cargo test -p ironclaw_integration_tests --test reborn_integration_steering`
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed — no database feature applies; the dedicated Reborn steering integration suite passed
- [ ] Manual testing: Not applicable; this is a deterministic queue replay race covered at its durable and caller-facing seams
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — an independent agent design review was performed instead

## Test Strategy

User behavior:

A retried or delayed copy of an already-consumed steering message is consumed exactly once and does not cause the agent to send another assistant reply.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Extended shared durable/in-memory conformance coverage to replay an input after successful acknowledgement; added bounded-capacity and legacy-document tests.
- Reborn integration: Existing `reborn_integration_steering` suite passes all 15 tests, including mid-run steering and restart behavior.
- Recorded fixture: Not applicable: provider request/response translation is unchanged.
- Browser E2E: Not applicable: no browser or WebUI behavior changed.
- Backend or runtime: Durable filesystem reconstruction proves the consumed identity survives queue recreation; terminal reconciliation proves consumed-only documents are reclaimed.
- Live canary: Not applicable: no external provider or deployment-specific behavior is involved.

What the tests prove:

The regression failed on both queue backends before the production change because replay minted `input-ack:2` and became deliverable. It now returns the original `input-ack:1`, remains absent from polling, survives durable reconstruction, does not consume live capacity after more than 32 successful inputs, loads pre-change documents, and cleans up at run termination.

Commands run:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ironclaw_loop_host`
- `cargo clippy -p ironclaw_loop_host --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_integration_tests --test reborn_integration_steering`

## Security Impact

None. Authorization, ingress validation, prompt construction, network access, credentials, and sandbox policy are unchanged. The persisted replay record contains only an existing typed message ID and queue sequence.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no public trust-bearing type changed; the consumed identity is private to the queue model.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Unchanged; replay matching stores no message content.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. Not applicable: no hashing changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: Not applicable; no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. The additive consumed ring defaults empty, and a legacy-document deserialization regression was added.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Live/pending capacity remains 32; the independent recent-consumption ring is also bounded to 32.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Unchanged.
- [x] Sandbox/native/host names accurately describe trust boundary. Unchanged.

## Database Impact

None. This adds an optional, defaulted field to the filesystem-backed queue JSON document; there is no database schema or migration.

## Blast Radius

This touches active-run host input queue replay/idempotency behavior for both in-memory and durable backends. The recent-consumption window is deliberately bounded to 32 entries, so a replay delayed beyond 32 later successful consumptions is outside the protected race window. Worst-case persisted state remains bounded at 32 live/pending entries plus 32 recent identities.

## Rollback Plan

Revert commit `c95199fb7`. Existing queue data remains readable because the new field is additive and defaulted; an older binary will ignore/drop it on a later rewrite, after which the duplicate-reply race may recur. No migration rollback is required.

## Review Follow-Through

Reviewer judgment is requested on the 32-entry replay window, chosen to match the existing per-run live input bound while preventing unbounded durable tombstones. No other follow-up is known.

---

**Review track**: C (runtime/persistence queue behavior)
