### PR TITLE
fix(telegram): accept /pair as a pairing-code alias

### DIFF
--- a/crates/extensions/ironclaw_extension_host/src/channel_pairing/tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_pairing/tests.rs
@@ -401,11 +401,13 @@ fn fixture_with(
     deep_link_template: Option<&str>,
     template_values: BTreeMap<String, String>,
 ) -> Fixture {
+    // Mirrors the bundled Telegram manifest: `/start` (vendor deep-link
+    // convention, the only suggested wording) plus the `/pair` alias.
     fixture_with_prefixes(
         installation,
         deep_link_template,
         template_values,
-        &["/start"],
+        &["/start", "/pair"],
     )
 }
 
@@ -1161,7 +1163,7 @@ fn direct_message(text: &str, actor_id: &str) -> NormalizedInboundMessage {
 }
 
 #[tokio::test]
-async fn interceptor_services_manifest_declared_start_messages_only() {
+async fn interceptor_services_manifest_declared_code_prefixes_only() {
     let fixture = fixture();
     let issue = fixture
         .service
@@ -1184,10 +1186,10 @@ async fn interceptor_services_manifest_declared_start_messages_only() {
         fixture.service.intercept(&install(), &group).await,
         ChannelPairingInterception::NotHandled
     );
-    // `/pair` remains ordinary text because Telegram declares only `/start`.
-    let pair = direct_message(&format!("/pair {}", issue.code.as_str()), "u-1");
+    // An undeclared command remains ordinary text.
+    let link = direct_message(&format!("/link {}", issue.code.as_str()), "u-1");
     assert_eq!(
-        fixture.service.intercept(&install(), &pair).await,
+        fixture.service.intercept(&install(), &link).await,
         ChannelPairingInterception::NotHandled
     );
 
@@ -1207,6 +1209,21 @@ async fn interceptor_services_manifest_declared_start_messages_only() {
             .await
             .expect("lookup"),
         Some(user("alice"))
+    );
+
+    // The `/pair` alias is equally declared: a bound sender re-sending a
+    // fresh code through it is serviced as the idempotent repair path.
+    let repair = fixture
+        .service
+        .issue_or_rotate(&user("alice"))
+        .await
+        .expect("re-mint");
+    let pair = direct_message(&format!("/pair {}", repair.code.as_str()), "u-1");
+    assert_eq!(
+        fixture.service.intercept(&install(), &pair).await,
+        ChannelPairingInterception::Consumed(ChannelPairingConsumeOutcome::AlreadyPairedSameUser {
+            user_id: user("alice"),
+        })
     );
 }
 

--- a/crates/extensions/packages/telegram/manifest.toml
+++ b/crates/extensions/packages/telegram/manifest.toml
@@ -43,7 +43,10 @@ submit_label = "Open pairing"
 error_message = "Telegram pairing failed. Get a fresh code and try again."
 connection_success_message = "Telegram is installed as an inbound entrypoint. If WebChat shows a Telegram pairing panel, tell the user to pair via the link, the QR code, or by sending the shown code to the bot in Telegram — nothing is pasted into normal chat. Once paired the user can DM the bot directly. Telegram exposes no tools and cannot read messages or send on the user's behalf."
 deep_link_template = "https://t.me/{bot_username}?start={code}"
-inbound_code_prefixes = ["/start"]
+# `/start` is the vendor deep-link convention and stays the only prefix any
+# instruction wording suggests; `/pair` is an accepted alias for users who
+# type it from habit and must never appear in suggested wording.
+inbound_code_prefixes = ["/start", "/pair"]
 
 [channel.connection.notices]
 connect_required = "👋 Pair your Telegram account in the IronClaw web app, then message me here again."

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -2645,7 +2645,11 @@ async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_t
 
     // 6. Mint through the web-side pairing service and consume through the
     // real verified webhook again. No direct store/service mutation repairs
-    // the actor binding in this journey.
+    // the actor binding in this journey. This leg pairs via the plain
+    // `/pair CODE` alias (the manifest's second declared prefix — kept for
+    // muscle-memory compatibility while all suggested wording stays
+    // `/start`), so both declared prefixes and the untargeted command shape
+    // stay pinned through the real bundled manifest.
     let repaired_code = services
         .pairing_mint_for_test("telegram", &paired_user)
         .await
@@ -2653,7 +2657,7 @@ async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_t
     let status = ingress
         .post(
             TELEGRAM_ROUTE,
-            &targeted_start_body(606, 515151, &repaired_code),
+            &dm_body(606, 515151, &format!("/pair {repaired_code}")),
             vec![(
                 "X-Telegram-Bot-Api-Secret-Token",
                 TELEGRAM_WEBHOOK_SECRET.to_string(),


### PR DESCRIPTION
## Summary

- Accept `/pair <CODE>` as a Telegram pairing-code alias alongside `/start <CODE>` — users trained on the earlier flow keep typing `/pair`, and today that leaves them at the connect nudge instead of paired (follow-up to #6475's redesign; per the team decision: suggest `/start`, allow both).
- Every suggested wording (manifest `instructions`, deep link, notices) still names only `/start`; the alias is deliberately absent from all guidance and documented as such in the manifest comment.
- Pinned through the real bundled manifest: the pairing journey's re-pair leg now pairs via plain `/pair CODE` over the production verified webhook, so both declared prefixes and the untargeted command shape stay covered.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6475

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_extension_host --all-targets --all-features -- -D warnings` (scoped to the only Rust owner in the diff; the other two changed files are manifest data and the root integration suite)
- [x] `cargo build` (covered by the test/clippy builds)
- [x] Relevant tests pass: `cargo test -p ironclaw_extension_host` (388 across suites, incl. the reworked `interceptor_services_manifest_declared_code_prefixes_only`), `cargo test -p ironclaw_integration_tests --test reborn_integration_extension_delivery unbound_telegram_actor_pairs`
- [ ] `cargo test -p <owning-crate> --features integration` (Not applicable: no database-backed or runtime-integration behavior changed; the touched integration journey runs in the default lanes)
- [x] Manual testing: red/green cycle — the integration leg fails on the pre-change manifest at "verified webhook re-pair must restore the durable connection" (`Some(false) != Some(true)`), passes after
- [ ] `review-pr` / `pr-shepherd --fix` (Not applicable: repository review automation runs on the ready PR)

## Test Strategy

User behavior: a paired-or-unpaired Telegram user who types `/pair <CODE>` (plain or bot-targeted) pairs exactly as if they had used `/start <CODE>`; all instructions keep suggesting `/start` only.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `channel_pairing::tests::interceptor_services_manifest_declared_code_prefixes_only` reworked — fixture now mirrors the bundled manifest (`/start` + `/pair`), asserts undeclared commands stay ordinary text, `/start` pairs, and a bound sender re-sending a fresh code via `/pair` is serviced as the idempotent repair path (`AlreadyPairedSameUser`).
- Reborn integration: the existing `unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_to_the_paired_user` journey's re-pair leg (step 6) now consumes plain `/pair CODE` through the production verified webhook against the real bundled manifest — fails before the manifest change, passes after.
- Recorded fixture: Not applicable: no model behavior involved; pairing interception is deterministic host code.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: Not applicable: no backend or runtime lane behavior changed; the interceptor is prefix-generic and only manifest data changed.
- Live canary: Not applicable: covered deterministically at the integration tier; the journey drives the production ingress route with verified-webhook evidence.

What the tests prove: the alias is declared manifest data flowing through the generic interceptor (no Telegram-specific host code), `/pair CODE` durably pairs via the production webhook path, undeclared commands still fall through to the connect nudge, and suggested wording remains `/start`-only.

Commands run:

- `cargo test -p ironclaw_extension_host`
- `cargo test -p ironclaw_integration_tests --test reborn_integration_extension_delivery unbound_telegram_actor_pairs`
- `cargo clippy -p ironclaw_extension_host --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
