### PR TITLE
fix(auth): omit empty OAuth scope on RC1

### DIFF
--- a/crates/ironclaw_auth/src/engine/mod.rs
+++ b/crates/ironclaw_auth/src/engine/mod.rs
@@ -713,9 +713,19 @@ fn build_recipe_authorization_url(
         pairs
             .append_pair("client_id", client.client_id.as_str())
             .append_pair("redirect_uri", redirect_uri.as_str())
-            .append_pair("response_type", "code")
-            .append_pair(recipe.scope_param(), &scope_text)
-            .append_pair("state", state.as_str());
+            .append_pair("response_type", "code");
+        // An empty ceiling omits the parameter instead of sending it empty.
+        // RFC 6749 §3.3 makes `scope` optional but requires at least one token
+        // when present, and servers may reject `scope=` while accepting the
+        // same request without it (#7308). A recipe legitimately carries no
+        // scopes when dynamic registration discovers no declared scopes or a
+        // static recipe deliberately defines an empty ceiling —
+        // `OAuth2CodeRecipe::validate` rejects only an empty scope *string*,
+        // not an empty list.
+        if !scopes.is_empty() {
+            pairs.append_pair(recipe.scope_param(), &scope_text);
+        }
+        pairs.append_pair("state", state.as_str());
         if recipe.pkce == PkceMode::S256 {
             let challenge = pkce_s256_challenge(pkce_verifier);
             pairs

--- a/crates/ironclaw_auth/src/product_auth/oauth/oauth_gate.rs
+++ b/crates/ironclaw_auth/src/product_auth/oauth/oauth_gate.rs
@@ -465,6 +465,19 @@ mod tests {
         resolved
     }
 
+    /// The shape a vendor that declares no scopes resolves to: every
+    /// hosted-MCP registration, whose dynamically registered vendor has no
+    /// manifest to declare them, and the bundled `notion-mcp` manifest, which
+    /// ships `scopes = []`.
+    fn acme_empty_ceiling_recipe() -> ResolvedVendorAuthRecipe {
+        let mut resolved = acme_vendor_recipe();
+        let VendorAuthRecipe::Oauth2Code(recipe) = &mut resolved.recipe else {
+            panic!("acme fixture is an oauth2_code recipe");
+        };
+        recipe.scopes.clear();
+        resolved
+    }
+
     fn engine_with_credentials(
         credentials: Arc<dyn crate::EngineClientCredentialsSource>,
     ) -> Arc<AuthEngine> {
@@ -631,6 +644,37 @@ mod tests {
         assert!(
             scopes.contains("msg:write"),
             "the sibling extension's scope must ride the same consent; got {scopes}"
+        );
+    }
+
+    /// A vendor with no declared scopes must produce an authorize URL with no
+    /// scope parameter at all, not one carrying `scope=`. RFC 6749 §3.3 makes
+    /// the parameter optional but requires at least one token when present,
+    /// and servers enforce that — Attio answers `scope=` with
+    /// `400 invalid_scope` (#7308). The gate is the caller that reaches this
+    /// first for a hosted-MCP vendor, since a blocked turn builds the URL
+    /// before any Settings-initiated connect ever runs.
+    #[tokio::test]
+    async fn gate_challenge_omits_scope_param_for_empty_ceiling() {
+        let mut fixture = GateFixture::with_recipe(acme_empty_ceiling_recipe());
+        fixture.requirement.provider_scopes.clear();
+        fixture.requirement.setup =
+            ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
+                scopes: Vec::new(),
+            };
+        let flow = fixture.challenge().await;
+        let AuthChallenge::OAuthUrl {
+            authorization_url: url,
+            ..
+        } = flow.challenge.expect("authorization challenge")
+        else {
+            panic!("expected OAuth URL challenge");
+        };
+        let parsed = url::Url::parse(url.as_str()).expect("authorize URL is a valid URL");
+        assert!(
+            !parsed.query_pairs().any(|(name, _)| name == "scope"),
+            "an empty scope ceiling must omit the scope parameter, not send it \
+             empty; got {parsed}"
         );
     }
 

--- a/crates/ironclaw_webui/src/product_auth/oauth_start_tests.rs
+++ b/crates/ironclaw_webui/src/product_auth/oauth_start_tests.rs
@@ -508,5 +508,32 @@ mod tests {
             "a partial in-ceiling request from Settings must still consent to the \
              shared-vendor ceiling; got {scope}"
         );
+
+        // An EMPTY ceiling must omit the scope parameter entirely rather than
+        // emit it present-but-empty. RFC 6749 §3.3 makes `scope` optional but
+        // requires at least one token when it appears. This is the shape of
+        // hosted-MCP registrations and the bundled `notion-mcp` recipe.
+        let shared = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let state = engine_backed_route_state(
+            shared.clone(),
+            "acme-messenger",
+            Vec::new(),
+            vec![vendor_recipe("acmevendor", &[])],
+        );
+        let app = product_auth_route_mount(state)
+            .protected
+            .layer(axum::Extension(test_caller()));
+        let response = start(app).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("start json");
+        let url = url::Url::parse(json["authorization_url"].as_str().expect("url")).expect("parse");
+        assert!(
+            !url.query_pairs().any(|(key, _)| key == "scope"),
+            "an empty scope ceiling must omit the scope parameter, not send it \
+             empty; got {url}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Port PR #7309 to `release/1.1.0-rc.1`.
- Omit the OAuth `scope` query parameter when the resolved scope ceiling is empty.
- Add regression coverage for the WebUI setup route and turn-blocked OAuth gate.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7308; port of #7309.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_auth --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p ironclaw_webui --all-targets --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo test -p ironclaw_auth --lib` (185 passed); focused WebUI and gate regressions pass.
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; covered by route and gate tests.
- [ ] `review-pr` or `pr-shepherd --fix`: Not run; local diff was reviewed and validated.

## Test Strategy

User behavior: OAuth authorization requests with no declared scopes no longer send a valueless `scope=` parameter; non-empty scope behavior remains unchanged.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added auth gate regression; full `ironclaw_auth` library suite passed.
- Reborn integration: Not applicable: this is covered at the production auth engine callers and no persistence or integration contract changed.
- Recorded fixture: Not applicable: no recorded provider response is involved.
- Browser E2E: Not applicable: the browser only consumes the generated URL; the WebUI route test observes the production URL construction.
- Backend or runtime: Added WebUI OAuth setup regression.
- Live canary: Not applicable: no deployment was requested.

What the tests prove: both production callers omit `scope` when the recipe ceiling is empty, while existing non-empty ceiling assertions continue to require the expected scope values.

Commands run:

```text
cargo fmt --all -- --check
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo test -p ironclaw_auth --lib
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo test -p ironclaw_auth --lib product_auth::oauth::oauth_gate::tests::gate_challenge_omits_scope_param_for_empty_ceiling
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo test -p ironclaw_webui --lib product_auth::oauth_start_tests::tests::extension_oauth_start_enforces_the_recipe_scope_ceiling
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo clippy -p ironclaw_auth --all-targets --all-features -- -D warnings
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo clippy -p ironclaw_webui --all-targets --all-features -- -D warnings
git diff --check
```

## Security Impact

None. This prevents malformed provider authorization requests and does not change credential handling or authorization policy.

## Reborn Trust-Boundary Checklist

N/A: no trust-bearing types, credentials, persistence, runtime lanes, or boundary ownership changed.

## Database Impact

None.

## Blast Radius

`ironclaw_auth` OAuth URL construction and its WebUI/gated callers. Recipes with non-empty scopes retain the existing parameter and ordering; empty-scope recipes omit only the empty parameter.

## Rollback Plan

Revert commit `1ab33e4da7`; this restores the prior URL construction and removes the new regression tests.

## Review Follow-Through

Please verify the RC1 path mapping and confirm that omitting `scope` is acceptable for empty-ceiling OAuth recipes.

---

**Review track**: C