### PR TITLE
fix(webui): let a failed run's error bubble capture a trace

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -374,7 +374,7 @@ async function renderExpandedActivity(activity, activeRunId: string | null = nul
   }
 }
 
-test("artifact downloads require the deployment gate and a final assistant reply", async () => {
+test("artifact downloads require the deployment gate, and either a final assistant reply or a failed run", async () => {
   const { MessageBubble } = await import("./message-bubble");
   const render = (isFinalReply: boolean, enabled = false) =>
     renderToStaticMarkup(
@@ -391,6 +391,21 @@ test("artifact downloads require the deployment gate and a final assistant reply
         regressionArtifactExportEnabled: enabled,
       }),
     );
+  const renderError = (enabled: boolean, turnRunId?: string) =>
+    renderToStaticMarkup(
+      React.createElement(MessageBubble, {
+        message: {
+          id: "err-run-1",
+          role: CHAT_MESSAGE_ROLES.ERROR,
+          content:
+            "The run failed because its runner lease expired. Retry the run.",
+          timestamp: "2026-06-02T00:00:00.000Z",
+          turnRunId,
+        },
+        threadId: "thread-1",
+        regressionArtifactExportEnabled: enabled,
+      }),
+    );
 
   assert.doesNotMatch(render(true), /data-testid="download-run-artifact"/);
   assert.doesNotMatch(render(true), /data-testid="download-thread-artifact"/);
@@ -398,6 +413,31 @@ test("artifact downloads require the deployment gate and a final assistant reply
   assert.match(render(true, true), /data-testid="download-thread-artifact"/);
   assert.doesNotMatch(render(false, true), /data-testid="download-run-artifact"/);
   assert.doesNotMatch(render(false, true), /data-testid="download-thread-artifact"/);
+
+  // #7369 — a failed run's error bubble must offer the same run-artifact
+  // download so a user can capture a trace when the agent errors, without
+  // needing a completed assistant reply.
+  assert.match(
+    renderError(true, "run-1"),
+    /data-testid="download-run-artifact"/,
+    "a failed run with a known run id should expose the trace-capture download button",
+  );
+  assert.doesNotMatch(
+    renderError(true, "run-1"),
+    /data-testid="download-thread-artifact"/,
+    "error bubbles should not gain the whole-thread download action",
+  );
+  assert.doesNotMatch(
+    renderError(false, "run-1"),
+    /data-testid="download-run-artifact"/,
+    "the deployment gate must still apply to error bubbles",
+  );
+  assert.doesNotMatch(
+    renderError(true, undefined),
+    /data-testid="download-run-artifact"/,
+    "an error bubble with no known run id yet must not render a button with nothing to fetch",
+  );
+
   assert.match(messageBubbleSource, /fetchRunArtifact\(\{/);
   assert.match(messageBubbleSource, /fetchThreadArtifact\(\{/);
   assert.match(messageBubbleSource, /ironclaw-run-\$\{filenameRunId\}\.json/);

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
@@ -310,10 +310,18 @@ function MessageBubbleImpl({
     (role === CHAT_MESSAGE_ROLES.ASSISTANT &&
       !isOptimistic &&
       !isIntermediateAssistantPhase);
+  const isNotice = role === CHAT_MESSAGE_ROLES.SYSTEM;
+  const isError = role === CHAT_MESSAGE_ROLES.ERROR;
+  // A failed run's terminal error bubble carries its own `turnRunId` (see
+  // `appendRunFailureMessage` in useChatEvents.ts) so the same run-artifact
+  // export used for a completed assistant reply is also reachable from the
+  // error message itself — otherwise a failed run has no trace-capture path
+  // at all (#7369).
   const showArtifactAction = Boolean(
-    role === CHAT_MESSAGE_ROLES.ASSISTANT &&
-    message.isFinalReply === true &&
-    !isOptimistic &&
+    (isError ||
+      (role === CHAT_MESSAGE_ROLES.ASSISTANT &&
+        message.isFinalReply === true &&
+        !isOptimistic)) &&
     threadId &&
     turnRunId &&
     regressionArtifactExportEnabled,
@@ -325,8 +333,6 @@ function MessageBubbleImpl({
     threadId &&
     regressionArtifactExportEnabled,
   );
-  const isNotice = role === CHAT_MESSAGE_ROLES.SYSTEM;
-  const isError = role === CHAT_MESSAGE_ROLES.ERROR;
   const bubbleWidthClass = isUser
     ? "v2-chat-readable-width"
     : isNotice
@@ -430,7 +436,10 @@ function MessageBubbleImpl({
           ].join(" ")}
         >
           {timeLabel && (<time dateTime={timestamp} className="shrink-0 font-mono text-[11px] text-[var(--v2-text-muted)]">{timeLabel}</time>)}
-          {(showActions || showRetryAction) && (
+          {(showActions ||
+            showRetryAction ||
+            showArtifactAction ||
+            showThreadArtifactAction) && (
             <div className="flex shrink-0 items-center gap-1">
             {showActions && (
               <button

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
@@ -63,6 +63,10 @@ export type ErrorChatMessage = {
   failureStatus?: string | null;
   failureCategory?: string | null;
   failureSummary?: string | null;
+  // The failed run's id, when known — lets a terminal run-failure bubble
+  // offer the same run-artifact/trace download action as a completed
+  // assistant reply (#7369).
+  turnRunId?: string | null;
   [key: string]: unknown;
 };
 
@@ -73,6 +77,7 @@ export type ErrorChatMessageInput = {
   failureStatus?: string | null;
   failureCategory?: string | null;
   failureSummary?: string | null;
+  turnRunId?: string | null;
   [key: string]: unknown;
 };
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
@@ -1687,6 +1687,10 @@ test("useChatEvents: failed terminal projection appends visible error", () => {
     harness.messages[0].content,
     "The run failed because the execution driver rejected the request.",
   );
+  // #7369 — the failed run's id must land on the error message itself so the
+  // WebUI can offer the same run-artifact/trace download a completed reply
+  // gets; without it there is no way to capture a trace for a failed run.
+  assert.equal(harness.messages[0].turnRunId, "run-failed-1");
 });
 
 test("useChatEvents: restored run and stream failures use the selected language", () => {
@@ -1825,6 +1829,7 @@ test("useChatEvents: repeated failed projection updates existing error content",
   assert.equal(harness.messages.length, 1);
   assert.equal(harness.messages[0].id, "err-run-failed-update");
   assert.equal(harness.messages[0].content, "driver_protocol_violation");
+  assert.equal(harness.messages[0].turnRunId, "run-failed-update");
 });
 
 test("useChatEvents: typed failed event appends visible error", () => {
@@ -1935,6 +1940,11 @@ test("useChatEvents: adjacent duplicate run failures collapse across unknown and
   assert.equal(harness.messages.length, 1);
   assert.equal(harness.messages[0].id, "err-run-known-failure");
   assert.equal(harness.messages[0].content, failureCategory);
+  // #7369 — promoting an unknown-run failure bubble to its now-known run id
+  // must also backfill `turnRunId`, or the trace-download action stays
+  // permanently unavailable for a run that only resolved its id after the
+  // bubble was first created.
+  assert.equal(harness.messages[0].turnRunId, "run-known-failure");
 
   harness.replaceMessages([
     ...harness.messages,
@@ -1960,6 +1970,7 @@ test("useChatEvents: adjacent duplicate run failures collapse across unknown and
   assert.equal(harness.messages.length, 3);
   assert.equal(harness.messages[2].id, "err-run-next-failure");
   assert.equal(harness.messages[2].content, failureCategory);
+  assert.equal(harness.messages[2].turnRunId, "run-next-failure");
 });
 
 test("useChatEvents: locally resolved approval gate is not restored by stale projection", () => {

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
@@ -865,12 +865,17 @@ function appendRunFailureMessage(
         failureStatus: status,
         failureCategory,
         failureSummary,
+        turnRunId: runId,
       };
       return next;
     }
     const lastMessage = prev[prev.length - 1];
     if (isAdjacentDuplicateRunFailure(lastMessage, content)) {
-      const replacement = promotedRunFailureMessage(lastMessage, messageId);
+      const replacement = promotedRunFailureMessage(
+        lastMessage,
+        messageId,
+        runId,
+      );
       if (replacement === lastMessage) return prev;
       const next = [...prev];
       next[next.length - 1] = replacement;
@@ -885,6 +890,11 @@ function appendRunFailureMessage(
         failureStatus: status,
         failureCategory,
         failureSummary,
+        // Lets the failed-run bubble reuse the same run-artifact/trace
+        // export as a completed assistant reply (#7369) — without this the
+        // error message has no run id and the download action never has
+        // anything to fetch.
+        turnRunId: runId,
       }),
     ];
   });
@@ -901,10 +911,10 @@ function isAdjacentDuplicateRunFailure(message, content) {
   );
 }
 
-function promotedRunFailureMessage(message, messageId) {
+function promotedRunFailureMessage(message, messageId, runId) {
   return message?.id === UNKNOWN_RUN_FAILURE_ID &&
     messageId !== UNKNOWN_RUN_FAILURE_ID
-    ? { ...message, id: messageId }
+    ? { ...message, id: messageId, turnRunId: runId }
     : message;
 }
 


### PR DESCRIPTION
## Summary
- A terminal run failure renders as a `role: "error"` chat message. That message never carried a `turnRunId`, and the existing "download run artifact" action was gated on `role === assistant && isFinalReply`, so it never appeared for a failed run — matching the report: no button to capture a trace when the agent errors.
- The action-button row itself was also gated on `showActions || showRetryAction`, both false for an error bubble, so relaxing the role check alone would still have been a no-op.
- Threaded `turnRunId` onto the run-failure message at creation, at in-place update, and through the unknown→known-run-id promotion path (`err-unknown` → `err-<runId>`), and let `showArtifactAction`/the button row fire for error messages that carry a `turnRunId`. The existing `downloadArtifact` handler needed no changes — it was already keyed only on `threadId`/`turnRunId`, never role.

Fixes #7369.

## Test plan
- [x] Added regression coverage in `message-bubble.test.ts` (button renders for a failed-run error bubble with a known run id, respects the deployment gate, and stays hidden with no run id yet) and `useChatEvents.test.ts` (three mutation paths: fresh creation, in-place update, and unknown→known-run-id promotion all set `turnRunId`).
- [x] Verified all 4 new/extended assertions fail red against the pre-fix code, and pass green with the fix restored.
- [x] `npx vitest run` — full frontend suite: 1139 passed, 1 pre-existing unrelated failure (`theme.test.tsx`, a `localStorage` mocking issue, confirmed to fail identically on `main` before this change).
- [x] `pnpm lint` (conventions + `tsc --noEmit`) — clean.
- [x] `pnpm build` — production build succeeds, bundle budgets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)