### PR TITLE
fix(ci): recapture extension_host coverage floor + run goldens on prompt-surface PRs

### DIFF
--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -233,6 +233,10 @@ PROMPT_SURFACE_PREFIXES = (
     "crates/contracts/ironclaw_host_api/prompts/",
     "crates/loop/ironclaw_agent_loop/prompts/",
     "crates/loop/ironclaw_loop_host/prompts/",
+    # The host-managed ports assemble the exact request the goldens pin:
+    # `prompt.rs` drives the InstructionBundleBuilder into the message list
+    # and `model.rs` shapes the model request around it.
+    "crates/kernel/ironclaw_turns/src/host_managed_ports/",
 )
 PR_STATIC_CONTROL_PATHS = {
     "Cargo.toml",

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -207,6 +207,33 @@ INTEGRATION_SUPPORT_OWNERS = {
 INTEGRATION_SNAPSHOT_PREFIX_OWNERS = {
     "tests/snapshots/golden_payload__": "tests/integration/golden_payload.rs",
 }
+# Production files whose changes alter the model-visible prompt or tool
+# surface that `golden_payload` snapshot-pins — the surface digest, the
+# instruction bundle, the communication-context renderer, and the shipped
+# prompt assets of the crates the golden harness composes. A change here still
+# classifies as a production-package change below (crate buckets, reverse
+# dependents); this mapping ADDITIONALLY schedules the golden integration lane
+# so a prompt-surface PR cannot land green and then bounce the merge queue on
+# stale goldens (#7361's queue failure, 2026-08-07: `surface.rs` changed the
+# surface digest, the PR lane never ran the golden bucket, the exhaustive
+# queue gate caught it first).
+#
+# Curated, not derived — a new prompt-composition site must be added here by
+# hand, and until it is, the merge queue remains the backstop exactly as it
+# was for every path before this mapping existed. Self-tested by
+# `test_reborn_pr_test_plan.py` (positive per entry + a negative control).
+PROMPT_SURFACE_GOLDEN_OWNER = "tests/integration/golden_payload.rs"
+PROMPT_SURFACE_PATHS = (
+    "crates/kernel/ironclaw_host_runtime/src/surface.rs",
+    "crates/contracts/ironclaw_loop_contracts/src/instruction_bundle.rs",
+    "crates/contracts/ironclaw_loop_contracts/src/runtime_context.rs",
+)
+PROMPT_SURFACE_PREFIXES = (
+    "crates/contracts/ironclaw_loop_contracts/prompts/",
+    "crates/contracts/ironclaw_host_api/prompts/",
+    "crates/loop/ironclaw_agent_loop/prompts/",
+    "crates/loop/ironclaw_loop_host/prompts/",
+)
 PR_STATIC_CONTROL_PATHS = {
     "Cargo.toml",
     "rust-toolchain",
@@ -730,6 +757,15 @@ def build_plan(
             # path.
             reasons.append(f"Reborn E2E workflow owns: {path}")
             continue
+        if path in PROMPT_SURFACE_PATHS or path.startswith(PROMPT_SURFACE_PREFIXES):
+            # Deliberately no `continue`: the path still classifies as a
+            # production-package change below. This arm only ADDS the golden
+            # lane so the prompt-surface snapshots run on the PR instead of
+            # first failing in the merge queue.
+            integration_lanes.add(
+                integration_inventory[PROMPT_SURFACE_GOLDEN_OWNER]
+            )
+            reasons.append(f"model-visible prompt surface changed: {path}")
         if path.startswith(CRATE_OR_ASSET_PREFIXES):
             # Family-level prose that belongs to no package: `crates/AGENTS.md`,
             # `crates/README.md`, `crates/Architecture.md`, and the family

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1426,6 +1426,100 @@ class RebornPrTestPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unmapped test or CI path"):
             self.plan("pull_request", ["tests/snapshots/unowned__case.snap"])
 
+    def plan_prompt_surface_owners(self, paths: list[str]) -> dict:
+        """Plan a pull request in a workspace naming the prompt-surface crates.
+
+        Same shape as `real_owner_metadata`: the planner rejects changed
+        packages outside the canonical set, so the crates the
+        `PROMPT_SURFACE_*` tables route from have to exist with their real
+        manifest paths for the paths under test to classify as production
+        changes rather than falling into the exhaustive-plan arm.
+        """
+
+        def package(name: str, manifest: str) -> dict:
+            return {
+                "id": name,
+                "name": name,
+                "manifest_path": str(ROOT / manifest),
+            }
+
+        packages = [
+            package("ironclaw_integration_tests", "Cargo.toml"),
+            package(
+                "ironclaw_host_runtime",
+                "crates/kernel/ironclaw_host_runtime/Cargo.toml",
+            ),
+            package(
+                "ironclaw_loop_contracts",
+                "crates/contracts/ironclaw_loop_contracts/Cargo.toml",
+            ),
+            package(
+                "ironclaw_host_api",
+                "crates/contracts/ironclaw_host_api/Cargo.toml",
+            ),
+            package("ironclaw_memory", "crates/domains/ironclaw_memory/Cargo.toml"),
+        ]
+        metadata = {
+            "workspace_members": [entry["id"] for entry in packages],
+            "packages": packages,
+            "resolve": {
+                "nodes": [{"id": entry["id"], "deps": []} for entry in packages]
+            },
+        }
+        return planner.build_plan(
+            event="pull_request",
+            changed_paths=paths,
+            metadata=metadata,
+            canonical_packages=[
+                entry["name"]
+                for entry in packages
+                if entry["name"] != "ironclaw_integration_tests"
+            ],
+        )
+
+    def test_prompt_surface_change_schedules_golden_lane_and_crate_bucket(self) -> None:
+        golden_lane = planner._integration_test_lanes()[
+            planner.PROMPT_SURFACE_GOLDEN_OWNER
+        ]
+        for path, package in [
+            (
+                "crates/kernel/ironclaw_host_runtime/src/surface.rs",
+                "ironclaw_host_runtime",
+            ),
+            (
+                "crates/contracts/ironclaw_loop_contracts/src/instruction_bundle.rs",
+                "ironclaw_loop_contracts",
+            ),
+            (
+                "crates/contracts/ironclaw_loop_contracts/prompts/delivery.md",
+                "ironclaw_loop_contracts",
+            ),
+            (
+                "crates/contracts/ironclaw_host_api/prompts/messaging/search_messages.core.md",
+                "ironclaw_host_api",
+            ),
+        ]:
+            with self.subTest(path=path):
+                plan = self.plan_prompt_surface_owners([path])
+                self.assertIn(
+                    golden_lane,
+                    plan["integration_lanes"],
+                    "a prompt-surface change must run the golden snapshots on the PR",
+                )
+                self.assertIn(package, plan["changed_packages"])
+
+    def test_non_prompt_production_change_does_not_schedule_golden_lane(self) -> None:
+        plan = self.plan_prompt_surface_owners(
+            ["crates/domains/ironclaw_memory/src/lib.rs"]
+        )
+        self.assertEqual(
+            plan["integration_lanes"],
+            [],
+            "ordinary production changes keep the narrow plan; the merge queue "
+            "remains the exhaustive gate",
+        )
+        self.assertIn("ironclaw_memory", plan["changed_packages"])
+
     def test_workspace_topology_change_defers_exhaustive_matrix_to_queue(self) -> None:
         plan = self.plan("pull_request", ["Cargo.toml"])
         self.assertEqual(plan["mode"], "none")

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1457,6 +1457,15 @@ class RebornPrTestPlanTests(unittest.TestCase):
                 "ironclaw_host_api",
                 "crates/contracts/ironclaw_host_api/Cargo.toml",
             ),
+            package("ironclaw_turns", "crates/kernel/ironclaw_turns/Cargo.toml"),
+            package(
+                "ironclaw_agent_loop",
+                "crates/loop/ironclaw_agent_loop/Cargo.toml",
+            ),
+            package(
+                "ironclaw_loop_host",
+                "crates/loop/ironclaw_loop_host/Cargo.toml",
+            ),
             package("ironclaw_memory", "crates/domains/ironclaw_memory/Cargo.toml"),
         ]
         metadata = {
@@ -1478,28 +1487,45 @@ class RebornPrTestPlanTests(unittest.TestCase):
         )
 
     def test_prompt_surface_change_schedules_golden_lane_and_crate_bucket(self) -> None:
+        """Every configured entry gets a positive case BY CONSTRUCTION.
+
+        The cases are derived from the `PROMPT_SURFACE_*` tables themselves
+        (each exact path, plus one representative file per prefix), so adding
+        an entry whose crate is missing from the fixture fails here instead of
+        shipping untested — the expected package is resolved from the fixture
+        directories, and an unresolvable entry is an explicit failure, not a
+        skip.
+        """
         golden_lane = planner._integration_test_lanes()[
             planner.PROMPT_SURFACE_GOLDEN_OWNER
         ]
-        for path, package in [
-            (
-                "crates/kernel/ironclaw_host_runtime/src/surface.rs",
-                "ironclaw_host_runtime",
-            ),
-            (
-                "crates/contracts/ironclaw_loop_contracts/src/instruction_bundle.rs",
-                "ironclaw_loop_contracts",
-            ),
-            (
-                "crates/contracts/ironclaw_loop_contracts/prompts/delivery.md",
-                "ironclaw_loop_contracts",
-            ),
-            (
-                "crates/contracts/ironclaw_host_api/prompts/messaging/search_messages.core.md",
-                "ironclaw_host_api",
-            ),
-        ]:
+        fixture_directories = {
+            "crates/kernel/ironclaw_host_runtime": "ironclaw_host_runtime",
+            "crates/contracts/ironclaw_loop_contracts": "ironclaw_loop_contracts",
+            "crates/contracts/ironclaw_host_api": "ironclaw_host_api",
+            "crates/kernel/ironclaw_turns": "ironclaw_turns",
+            "crates/loop/ironclaw_agent_loop": "ironclaw_agent_loop",
+            "crates/loop/ironclaw_loop_host": "ironclaw_loop_host",
+        }
+        cases = list(planner.PROMPT_SURFACE_PATHS) + [
+            f"{prefix}golden_probe.md" for prefix in planner.PROMPT_SURFACE_PREFIXES
+        ]
+        for path in cases:
             with self.subTest(path=path):
+                package = next(
+                    (
+                        name
+                        for directory, name in fixture_directories.items()
+                        if path.startswith(f"{directory}/")
+                    ),
+                    None,
+                )
+                self.assertIsNotNone(
+                    package,
+                    f"prompt-surface entry {path} names a crate the fixture does "
+                    "not carry; add it to plan_prompt_surface_owners so the "
+                    "entry is actually tested",
+                )
                 plan = self.plan_prompt_surface_owners([path])
                 self.assertIn(
                     golden_lane,

--- a/tests/integration/coverage-floor.toml
+++ b/tests/integration/coverage-floor.toml
@@ -339,11 +339,33 @@ name = "ironclaw_extension_host"
 # lane produces a coverage verdict (#7036), so these numbers could not be read
 # off this PR's own run; **the next dispatch should recapture this entry and
 # replace this block with a real capture.**
-floor_percent = 87.97
-floor_covered_lines = 21580
-captured_total_lines = 24529
-captured_date = "2026-08-04"
-rationale = "Channel ingress deduplication and outbound delivery routing are production-composed. Recaptured after the WS2.4 extension_manager split moved the product face out, then again on the WS2 closeout as the source side of the NEAR AI embed move; adjusted (not recaptured) for the retired-identity branch deletion in #7143 — see the block above."
+#
+# RECAPTURED 2026-08-07 from run 31208592262 (the `df90072c4e` main-push run,
+# read off this gate's own ratchet output — the same aggregation that enforces
+# this file), discharging the instruction directly above. Two things moved
+# since the 8/04 adjustment:
+#
+# 1. The denominator fell 24,529 -> 24,415 (-114): code left the crate in the
+#    post-8/04 moves, the "source side of a move" shape this entry's own WS2
+#    block documents as the recapture trigger. Covered fell 21,580 -> 21,515
+#    with it while the RATIO — the invariant that survives a move — ROSE
+#    87.98% -> 88.12%. This is a floor that stopped describing its crate, not
+#    a coverage regression.
+# 2. The same commit measured DIFFERENTLY across lanes: the merge-queue run at
+#    18:37Z (green) put covered lines at or above 21,560 while the push run at
+#    18:47Z and its retry both measured 21,515 — a >=45-line same-commit
+#    spread, exactly the "DA: hit counts flipping across the lane+bucket split
+#    under timing" wobble the [global] tolerance comment calls PROVISIONAL.
+#    The default 20-line tolerance sits under this crate's measured wobble, so
+#    it reds on noise; `tolerance_lines` is raised to 60, sized to the
+#    observed spread with the same headroom ratio the 0.5pp percent tolerance
+#    carries. The percent floor (tolerance 0.5pp) stays the tight guard.
+floor_percent = 88.12
+floor_covered_lines = 21515
+tolerance_lines = 60
+captured_total_lines = 24415
+captured_date = "2026-08-07"
+rationale = "Channel ingress deduplication and outbound delivery routing are production-composed. Recaptured after the WS2.4 extension_manager split, the WS2 closeout embed move, the #7143 deletion adjustment, and again 2026-08-07 as the source side of the post-8/04 moves — with tolerance_lines sized to the measured same-commit cross-lane wobble; see the blocks above."
 issue = "https://github.com/nearai/ironclaw/issues/6524"
 
 [[crate]]


### PR DESCRIPTION
## Summary

Two CI fixes from tonight's #7361 merge-queue bounce and the main-push red at `df90072c4e`:

- **Unred main's coverage gate with a real recapture.** The `ironclaw_extension_host` floor was an explicit *adjustment* whose own comment ordered the next real recapture. Since 8/04, code left the crate (denominator 24,529 → 24,415) while the coverage **ratio rose** to 88.12% — the "source side of a move" shape the entry itself documents as the recapture trigger, not a regression. Separately, the **same commit** measured ≥21,560 covered lines in the merge-queue lane but 21,515 twice on the push lane (original run + retry of 31208592262): a ≥45-line same-commit cross-lane spread over a 20-line tolerance, i.e. main redding on measurement noise. Both fields are recaptured from that run's own gate output and `tolerance_lines` is sized to the measured wobble (60); the 0.5pp percent floor stays the tight guard.
- **Close the "green PR, red queue" gap for prompt-surface changes.** #7361 changed `surface.rs` (the surface digest) and its PR lane never ran `golden_payload` — production changes select crate buckets, never integration lanes, so the stale goldens surfaced first in the exhaustive queue gate. A curated `PROMPT_SURFACE_*` owner table now ADDITIONALLY schedules the golden integration lane for the known prompt-composition sites (surface digest, instruction bundle, runtime-context renderer, and the loop-tier `prompts/` assets) without consuming the path's normal package classification. Curated by design: anything not listed keeps today's behavior with the queue as backstop.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #6524 (the coverage-ratchet tracking issue); context: #7361's queue failure and main run 31208592262.

## Validation

- [ ] `cargo fmt --all -- --check` (Not applicable: no Rust changed)
- [ ] `cargo clippy ...` (Not applicable: no Rust changed)
- [ ] `cargo build` (Not applicable: no Rust changed)
- [x] Relevant tests pass: `python3 scripts/ci/test_reborn_pr_test_plan.py` — 68/68 (4 new prompt-surface cases + negative control); `bash scripts/ci/test-reborn-coverage.sh` — 194/194 (validates the ratchet script and floor-file schema incl. `tolerance_lines`)
- [ ] `cargo test -p <owning-crate> --features integration` (Not applicable: CI tooling only)
- [x] Manual testing: floor file re-parsed with tomllib and the extension_host entry verified field-by-field; the recaptured numbers are read directly off run 31208592262's ratchet output; cross-lane wobble established from three same-commit measurements (merge_group 18:37Z green vs push 18:47Z + retry both 21,515)
- [ ] `review-pr` / `pr-shepherd --fix` (Not applicable: repository review automation runs on the ready PR)

## Test Strategy

User behavior: main stops going red on coverage measurement noise, and a PR that changes what the model sees in its prompt runs the golden prompt snapshots before it can reach the merge queue.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: planner self-tests — one positive case per prompt-surface entry class (surface.rs, instruction_bundle.rs, a loop-contracts prompt asset, a host-api prompt asset) asserting the golden lane is ADDED and the crate bucket still selected, plus a negative control asserting an ordinary production change (ironclaw_memory) still selects no integration lane.
- Reborn integration: Not applicable: no runtime behavior changed; the plan is exercised by the planner suite the workflow itself runs before planning.
- Recorded fixture / Browser E2E / Backend or runtime / Live canary: Not applicable: CI planning and gate data only.

What the tests prove: the golden lane is scheduled exactly for the curated prompt-surface set (no over-widening of the narrow-PR design), and the ratchet tooling accepts the recaptured entry.

Commands run:

- `python3 scripts/ci/test_reborn_pr_test_plan.py`
- `bash scripts/ci/test-reborn-coverage.sh`

Rollback: revert either commit independently — the floor recapture and the planner mapping are decoupled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
