### PR TITLE
test(disclosure): pin wide-catalog schema-token reduction floor and make drift visible

### DIFF
--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -1948,6 +1948,31 @@ mod tests {
         );
     }
 
+    /// Hard schema-token reduction floor for the representative wide catalog,
+    /// as defined by the default-on rollout outcome (#6810). Dropping below
+    /// this means bridged disclosure no longer pays for its round trip.
+    const REPRESENTATIVE_REDUCTION_FLOOR_PCT: f64 = 50.0;
+
+    /// Recorded reduction for the representative catalog on `main`. Drift
+    /// history, so a future move is explained rather than rediscovered:
+    ///
+    /// - 93.3% (21,240 -> 1,427): first one-off measurement, when a deferred
+    ///   surface advertised only the bridge meta-tools.
+    /// - 83.7%: after the bridge grew (`tool_search`'s description became the
+    ///   always-on catalog index, plus `tool_describe`/`tool_call`) and the
+    ///   always-advertised Core tier was introduced.
+    /// - 82.9% (21,130 -> 3,618, 20 advertised): current, with 17 Core-tier
+    ///   loop primitives in this fixture always advertised alongside the three
+    ///   bridge tools.
+    ///
+    /// Moving this constant is allowed, but the PR that moves it must say which
+    /// of core-set width, bridge-schema growth, or fixture change caused it.
+    const REPRESENTATIVE_REDUCTION_BASELINE_PCT: f64 = 82.9;
+
+    /// Band around the recorded baseline that counts as noise rather than
+    /// material drift.
+    const REPRESENTATIVE_REDUCTION_DRIFT_TOLERANCE_PCT: f64 = 2.0;
+
     #[test]
     fn benchmark_tool_disclosure_token_reduction() {
         let definitions = representative_tool_fixture();
@@ -1972,15 +1997,43 @@ mod tests {
             (reduction_abs as f64 / full_tokens as f64) * 100.0
         };
 
+        // Attribute the advertised cost so drift points at its cause instead of
+        // just moving a number.
+        let (bridge_definitions, core_definitions): (Vec<_>, Vec<_>) = disclosed
+            .definitions
+            .iter()
+            .partition(|definition| is_bridge_name(definition.name.as_str()));
+        let bridge_tokens = bridge_definitions.iter().fold(0_u32, |total, definition| {
+            total.saturating_add(estimate_definition_tokens(definition))
+        });
+        let core_tokens = core_definitions.iter().fold(0_u32, |total, definition| {
+            total.saturating_add(estimate_definition_tokens(definition))
+        });
+        let breakdown = format!(
+            "measured={reduction_pct:.1}% (full={full_count} tools/{full_tokens} tokens, \
+             advertised={disclosed_count} tools/{disclosed_tokens} tokens; \
+             bridge={} tools/{bridge_tokens} tokens, core={} tools/{core_tokens} tokens)",
+            bridge_definitions.len(),
+            core_definitions.len(),
+        );
+
         println!(
-            "\n| full_count | full_tokens | disclosed_count | disclosed_tokens | reduction_abs | reduction_pct |\n| ---: | ---: | ---: | ---: | ---: | ---: |\n| {full_count} | {full_tokens} | {disclosed_count} | {disclosed_tokens} | {reduction_abs} | {reduction_pct:.1}% |"
+            "\n| full_count | full_tokens | disclosed_count | disclosed_tokens | reduction_abs | reduction_pct |\n| ---: | ---: | ---: | ---: | ---: | ---: |\n| {full_count} | {full_tokens} | {disclosed_count} | {disclosed_tokens} | {reduction_abs} | {reduction_pct:.1}% |\n{breakdown}"
         );
 
         assert_eq!(full_count, 91);
         assert!(disclosed.deferred);
         assert!(
-            disclosed_tokens as f64 <= full_tokens as f64 * 0.5,
-            "disclosed={disclosed_tokens}, full={full_tokens}"
+            reduction_pct >= REPRESENTATIVE_REDUCTION_FLOOR_PCT,
+            "wide-catalog schema-token reduction fell below the {REPRESENTATIVE_REDUCTION_FLOOR_PCT}% floor (#6810): {breakdown}"
+        );
+        assert!(
+            (reduction_pct - REPRESENTATIVE_REDUCTION_BASELINE_PCT).abs()
+                <= REPRESENTATIVE_REDUCTION_DRIFT_TOLERANCE_PCT,
+            "wide-catalog schema-token reduction drifted more than \
+             {REPRESENTATIVE_REDUCTION_DRIFT_TOLERANCE_PCT} points from the recorded \
+             {REPRESENTATIVE_REDUCTION_BASELINE_PCT}% baseline: {breakdown}. Update \
+             REPRESENTATIVE_REDUCTION_BASELINE_PCT and explain the cause in the PR body."
         );
     }
 

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -1999,22 +1999,38 @@ mod tests {
 
         // Attribute the advertised cost so drift points at its cause instead of
         // just moving a number.
-        let (bridge_definitions, core_definitions): (Vec<_>, Vec<_>) = disclosed
-            .definitions
-            .iter()
-            .partition(|definition| is_bridge_name(definition.name.as_str()));
-        let bridge_tokens = bridge_definitions.iter().fold(0_u32, |total, definition| {
-            total.saturating_add(estimate_definition_tokens(definition))
-        });
-        let core_tokens = core_definitions.iter().fold(0_u32, |total, definition| {
-            total.saturating_add(estimate_definition_tokens(definition))
-        });
+        // Classify by the catalog's own `ToolTier`, never by "not a bridge
+        // name": a promoted Discoverable definition also reaches the advertised
+        // surface, and charging it to Core would misdiagnose the drift it
+        // caused.
+        let mut bridge = (0_usize, 0_u32);
+        let mut core = (0_usize, 0_u32);
+        let mut discoverable = (0_usize, 0_u32);
+        for definition in &disclosed.definitions {
+            let tokens = estimate_definition_tokens(definition);
+            let bucket = if is_bridge_name(definition.name.as_str()) {
+                &mut bridge
+            } else {
+                match catalog
+                    .entry_by_name(definition.name.as_str())
+                    .map(|entry| entry.tier)
+                {
+                    Some(ToolTier::Core) => &mut core,
+                    Some(ToolTier::Discoverable) => &mut discoverable,
+                    None => panic!(
+                        "advertised definition {} is neither a bridge tool nor a catalog entry",
+                        definition.name
+                    ),
+                }
+            };
+            bucket.0 = bucket.0.saturating_add(1);
+            bucket.1 = bucket.1.saturating_add(tokens);
+        }
         let breakdown = format!(
             "measured={reduction_pct:.1}% (full={full_count} tools/{full_tokens} tokens, \
              advertised={disclosed_count} tools/{disclosed_tokens} tokens; \
-             bridge={} tools/{bridge_tokens} tokens, core={} tools/{core_tokens} tokens)",
-            bridge_definitions.len(),
-            core_definitions.len(),
+             bridge={}/{} tokens, core={}/{} tokens, promoted_discoverable={}/{} tokens)",
+            bridge.0, bridge.1, core.0, core.1, discoverable.0, discoverable.1,
         );
 
         println!(
@@ -2023,6 +2039,11 @@ mod tests {
 
         assert_eq!(full_count, 91);
         assert!(disclosed.deferred);
+        assert_eq!(
+            discoverable.0, 0,
+            "the benchmark promotes nothing, so a Discoverable tool on the advertised \
+             surface means the selection path changed: {breakdown}"
+        );
         assert!(
             reduction_pct >= REPRESENTATIVE_REDUCTION_FLOOR_PCT,
             "wide-catalog schema-token reduction fell below the {REPRESENTATIVE_REDUCTION_FLOOR_PCT}% floor (#6810): {breakdown}"


### PR DESCRIPTION
## Summary

- The representative wide-catalog disclosure benchmark (91 tools) asserted only the 50% schema-token floor from #6810 and printed a table. A slow slide in advertised cost — a widening Core tier, a growing bridge schema — could eat almost all the headroom without any test noticing.
- Extends the existing benchmark test (no second test) to pin the currently measured **82.9%** reduction with a ±2 point drift band, so material movement fails loudly and forces an explanation, while the 50% floor stays as a separate, message-carrying assertion.
- Records the drift history next to the baseline constant and attributes advertised tokens to bridge vs Core tier in the emitted line, so a failure names its own cause.
- Test-only. No production behavior changes.

## Measured result

```
| full_count | full_tokens | disclosed_count | disclosed_tokens | reduction_abs | reduction_pct |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 91 | 21130 | 20 | 3618 | 17512 | 82.9% |
measured=82.9% (full=91 tools/21130 tokens, advertised=20 tools/3618 tokens; bridge=3 tools/798 tokens, core=17 tools/2820 tokens)
```

**82.9%**, well above the 50% floor.

### Drift vs the earlier numbers

- **93.3% (21,240 → 1,427)** — the first one-off measurement, taken when a deferred surface advertised *only* the bridge meta-tools.
- **83.7%** — after two changes: the bridge grew (`tool_search`'s description became the always-on catalog index, plus `tool_describe` and `tool_call`), and the always-advertised Core tier was introduced.
- **82.9% (21,130 → 3,618)** — current. The 0.8-point move from 83.7% is not a new mechanism; it is the same two causes continuing, and the breakdown now makes the split explicit: of the 3,618 advertised tokens, **2,820 (78%) are the 17 Core-tier loop primitives** that are always advertised, and only **798 are the three bridge tools**. The gap from the original 93.3% is therefore almost entirely core-set widening, not bridge growth — and it is a deliberate trade: the Core tier keeps everyday tools direct (no discovery round trip) and `tool_search`'s catalog index keeps the model structurally aware of what it cannot see.

The `full_tokens` figure also moved 21,240 → 21,130 because the fixture's tier mix was adjusted when the Core names were added; the fixture is still 91 tools and deterministic.

## Change Type

- [x] CI/Infrastructure (test coverage)

## Linked Issue

Refs #7166 — section 5 acceptance item: "The representative wide-catalog benchmark retains at least the 50% schema-token reduction floor defined by #6810; material drift from the previous 83.7% result is explained." (Not closing: section 5 has other open items.)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_loop_host --benches --tests --examples --all-features -- -D warnings` (clean; change is confined to this crate's unit tests)
- [x] `cargo build` (via the test/clippy builds)
- [x] Relevant tests pass: `cargo test -p ironclaw_loop_host` — 630 lib + 54 + 4 + 85 + 16 + 101 passed, 0 failed
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed or runtime-integration behavior changed.
- [x] Manual testing: ran `cargo test -p ironclaw_loop_host --lib benchmark_tool_disclosure -- --nocapture` to read the emitted measurement, and hand-perturbed the baseline constant to confirm the drift assertion fires with the full breakdown in the message.

## Test Strategy

User behavior: a user on a wide capability surface (dozens of installed extensions/tools) pays for every advertised tool schema in every model call. Progressive disclosure is what keeps that bill small. This PR does not change what the user sees; it makes sure a future change cannot quietly make that bill large again.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

(No risk boxes checked: the diff is a single `#[cfg(test)]` function plus three test-only constants.)

Tests added or updated:
- Unit or contract: `crates/loop/ironclaw_loop_host/src/tool_disclosure.rs::tests::benchmark_tool_disclosure_token_reduction` — extended.
- Reborn integration: Not applicable: the measurement is a pure function of `CapabilityCatalog::new` + `select_active_set` + the production `estimate_definition_tokens` path; there is no wiring, transport, or persistence to drive through the harness, and `tests/integration/tool_disclosure.rs` already covers the wired disclosure behavior this PR does not touch.
- Recorded fixture: Not applicable: the 91-tool catalog is a committed, deterministic in-code fixture (`representative_tool_fixture`) — no live calls, no trace replay.
- Browser E2E: Not applicable: no UI surface.
- Backend or runtime: Not applicable: no runtime lane, store, or worker involved.
- Live canary: Not applicable: the assertion is deterministic and provider-independent; live token evidence belongs to the separate canary item in #7166 section 5.

What the tests prove: that the representative wide catalog still advertises at most half its full schema-token cost (the #6810 floor), that the current figure is 82.9%, and that any future change moving it more than 2 points fails the build with the measured number and its bridge/Core attribution in the failure message — which is exactly the "material drift is explained" obligation, enforced instead of remembered.

Commands run:

```
cargo fmt
cargo clippy -p ironclaw_loop_host --benches --tests --examples --all-features -- -D warnings
cargo test -p ironclaw_loop_host
cargo test -p ironclaw_loop_host --lib benchmark_tool_disclosure -- --nocapture
```

## Security Impact

None. Test-only change; no permissions, network, secrets, file access, tool execution, or sandbox policy touched.

## Reborn Trust-Boundary Checklist

N/A — test-only change; introduces no types, variants, fields, queues, or error classes.

## Database Impact

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
