### PR TITLE
feat(stress): scripted tool-call workload with durable write read-back (#7360)

### DIFF
--- a/.github/workflows/ironclaw-stress.yml
+++ b/.github/workflows/ironclaw-stress.yml
@@ -377,28 +377,14 @@ jobs:
             > target/ironclaw-stress/postgres-api-capacity-summary.json \
             2> target/ironclaw-stress/postgres-api-capacity-report.txt
 
-      - name: Upload Postgres API capacity artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ironclaw-stress-postgres-api-capacity
-          path: |
-            target/ironclaw-stress/postgres-api-server.log
-            target/ironclaw-stress/postgres-api-capacity.jsonl
-            target/ironclaw-stress/postgres-api-capacity-summary.json
-            target/ironclaw-stress/postgres-api-capacity-report.txt
-          if-no-files-found: ignore
-
-      - name: Run hosted-single-tenant Postgres scripted tool writes
-        run: |
-          set -euo pipefail
-          mkdir -p target/ironclaw-stress
-          # The first stress invocation exited, releasing the mock sidecar
-          # port; the server keeps running and this leg rebinds the sidecar
-          # at the same address the server's LLM base_url points at. Each
-          # operation is a scripted memory write/read-back through the real
-          # capability host (issue #7360 Phase 1); the scripted summary
-          # reports read-back verdicts and stage latencies per document size.
+          # Scripted tool-write leg: the first stress invocation exited,
+          # releasing the mock sidecar port; the server keeps running and
+          # this leg rebinds the sidecar at the same address the server's
+          # LLM base_url points at. Each operation is a scripted memory
+          # write/read-back through the real capability host (issue #7360
+          # Phase 1); the scripted summary reports read-back verdicts and
+          # stage latencies per document size. Runs inside this block so
+          # the server stays alive until both workloads complete.
           target/release/ironclaw_stress \
             --backend libsql \
             --scenario api-user-capacity \
@@ -421,12 +407,16 @@ jobs:
             > target/ironclaw-stress/postgres-api-scripted-summary.json \
             2> target/ironclaw-stress/postgres-api-scripted-report.txt
 
-      - name: Upload Postgres scripted tool write artifacts
+      - name: Upload Postgres API capacity artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ironclaw-stress-postgres-api-scripted
+          name: ironclaw-stress-postgres-api-capacity
           path: |
+            target/ironclaw-stress/postgres-api-server.log
+            target/ironclaw-stress/postgres-api-capacity.jsonl
+            target/ironclaw-stress/postgres-api-capacity-summary.json
+            target/ironclaw-stress/postgres-api-capacity-report.txt
             target/ironclaw-stress/postgres-api-scripted.jsonl
             target/ironclaw-stress/postgres-api-scripted-summary.json
             target/ironclaw-stress/postgres-api-scripted-report.txt

--- a/.github/workflows/ironclaw-stress.yml
+++ b/.github/workflows/ironclaw-stress.yml
@@ -388,3 +388,46 @@ jobs:
             target/ironclaw-stress/postgres-api-capacity-summary.json
             target/ironclaw-stress/postgres-api-capacity-report.txt
           if-no-files-found: ignore
+
+      - name: Run hosted-single-tenant Postgres scripted tool writes
+        run: |
+          set -euo pipefail
+          mkdir -p target/ironclaw-stress
+          # The first stress invocation exited, releasing the mock sidecar
+          # port; the server keeps running and this leg rebinds the sidecar
+          # at the same address the server's LLM base_url points at. Each
+          # operation is a scripted memory write/read-back through the real
+          # capability host (issue #7360 Phase 1); the scripted summary
+          # reports read-back verdicts and stage latencies per document size.
+          target/release/ironclaw_stress \
+            --backend libsql \
+            --scenario api-user-capacity \
+            --api-base-url http://127.0.0.1:18080 \
+            --api-admin-bearer-token "$IRONCLAW_REBORN_WEBUI_TOKEN" \
+            --users 6 \
+            --concurrency 3 \
+            --operations 2 \
+            --api-scripted-tool memory_roundtrip \
+            --api-scripted-doc-sizes 4096,32768,131072,1048576 \
+            --api-hot-writers 2 \
+            --mock-llm-bind 127.0.0.1:19090 \
+            --mock-llm-latency-ms 250 \
+            --progress-interval-seconds 0 \
+            --human-read \
+            --bottleneck-report \
+            --output-jsonl target/ironclaw-stress/postgres-api-scripted.jsonl \
+            --max-failure-rate 0.05 \
+            --max-p95-ms 30000 \
+            > target/ironclaw-stress/postgres-api-scripted-summary.json \
+            2> target/ironclaw-stress/postgres-api-scripted-report.txt
+
+      - name: Upload Postgres scripted tool write artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ironclaw-stress-postgres-api-scripted
+          path: |
+            target/ironclaw-stress/postgres-api-scripted.jsonl
+            target/ironclaw-stress/postgres-api-scripted-summary.json
+            target/ironclaw-stress/postgres-api-scripted-report.txt
+          if-no-files-found: ignore

--- a/tools/ironclaw_stress/README.md
+++ b/tools/ironclaw_stress/README.md
@@ -184,10 +184,11 @@ Scripts:
 
 All memory scripts target the same relative path for every user, so each run
 also exercises same-relative-path isolation. `--api-scripted-doc-sizes` cycles
-document sizes per operation (default `4096,32768,131072,1048576`); results are
-bucketed per size with submit-to-tool-visible and submit-to-finalize stage
-latencies. `--api-hot-writers N` spawns N extra concurrent writers sharing the
-first user's thread to contend on the same memory document.
+document sizes per operation (default `4096,32768,131072,1048576`, minimum
+4096); results are bucketed per size with submit-to-tool-visible and
+submit-to-finalize stage latencies. `--api-hot-writers N` spawns N extra
+concurrent writers on distinct threads of the first user so they contend on
+the same per-user memory document without per-thread turn serialization.
 
 Scripted mode requires `--mock-llm-bind` (the sidecar serves the tool calls)
 and `--api-wait-for-assistant`. Gated tools (`builtin.write_file`, memory

--- a/tools/ironclaw_stress/README.md
+++ b/tools/ironclaw_stress/README.md
@@ -137,7 +137,6 @@ Use `--scenario` for a single workload.
 | `api-user-capacity` | End-to-end WebUI API send/read pressure against a running Reborn server. |
 | `cpu-burn` | Process-local CPU pressure control. |
 | `memory-churn` | Process-local allocation/RSS pressure control. |
-
 `api-user-capacity` can use either pre-minted users from `--api-users-jsonl`,
 a shared bearer via `--api-bearer-token`, or real per-user provisioning through
 the WebUI admin surface:
@@ -153,6 +152,61 @@ cargo run -p ironclaw_stress -- \
   --concurrency 100 \
   --operations 1 \
   --api-read-qps-per-user 2 \
+  --mock-llm-bind 127.0.0.1:3911
+```
+
+### Scripted tool writes (issue #7360)
+
+Scripted mode drives each API operation through a real builtin/memory tool
+sequence: the driver embeds a marker in the user message, the mock LLM sidecar
+emits the scripted tool calls, the server executes them through the production
+capability host, and the driver verifies the read-back verdict in the final
+assistant message. Verdicts:
+
+- `confirmed`: the read-back returned exactly this operation's content marker.
+- `contended`: a concurrent same-user write won the document between write and
+  read (expected under `--api-hot-writers`, counted not failed).
+- `leak`: another user's content marker appeared in the read-back (cross-user
+  isolation violation, hard failure).
+- `missing`: the read-back lost the content (durable write failure, hard
+  failure).
+- `undisclosed`: the required tool was never advertised to the model
+  (disclosure/agent-surface regression, hard failure).
+
+Scripts:
+
+| `--api-scripted-tool` | Tool sequence |
+| --- | --- |
+| `write_file_roundtrip` | `builtin.write_file` then `builtin.read_file` of a unique workspace path. |
+| `memory_roundtrip` | `ironclaw.memory.write` (replace) then `ironclaw.memory.read` of `stress/shared.md`. |
+| `memory_grow` | Write a quarter, append three quarters, then read — growing-append slope. |
+| `memory_mixed` | Write half, read, append half, read — mixed read/write. |
+
+All memory scripts target the same relative path for every user, so each run
+also exercises same-relative-path isolation. `--api-scripted-doc-sizes` cycles
+document sizes per operation (default `4096,32768,131072,1048576`); results are
+bucketed per size with submit-to-tool-visible and submit-to-finalize stage
+latencies. `--api-hot-writers N` spawns N extra concurrent writers sharing the
+first user's thread to contend on the same memory document.
+
+Scripted mode requires `--mock-llm-bind` (the sidecar serves the tool calls)
+and `--api-wait-for-assistant`. Gated tools (`builtin.write_file`, memory
+writes) are exercised through the per-user Tools auto-approve setting, which
+the driver enables during user setup through the same settings API a real
+user would use.
+
+```bash
+cargo run -p ironclaw_stress -- \
+  --backend libsql \
+  --scenario api-user-capacity \
+  --api-base-url http://127.0.0.1:3900 \
+  --api-admin-bearer-token "$IRONCLAW_REBORN_WEBUI_BEARER_TOKEN" \
+  --users 6 \
+  --concurrency 3 \
+  --operations 2 \
+  --api-scripted-tool memory_roundtrip \
+  --api-scripted-doc-sizes 4096,32768,131072,1048576 \
+  --api-hot-writers 2 \
   --mock-llm-bind 127.0.0.1:3911
 ```
 

--- a/tools/ironclaw_stress/src/api_capacity.rs
+++ b/tools/ironclaw_stress/src/api_capacity.rs
@@ -174,6 +174,11 @@ struct ApiUser {
     label: String,
     bearer_token: Option<String>,
     thread_id: String,
+    /// Additional threads of the same user. Scripted hot writers use these
+    /// so concurrent operations run on distinct threads (no per-thread turn
+    /// serialization) while still contending on the same per-user durable
+    /// memory document.
+    extra_thread_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -725,9 +730,9 @@ async fn run_window(
         });
     }
 
-    // Scripted hot writers: extra concurrent writers sharing the first
-    // user's thread so several operations contend on the same durable
-    // document at once (CAS contention on one memory document).
+    // Scripted hot writers: extra concurrent writers on distinct threads of
+    // the first user so several operations contend on the same per-user
+    // durable memory document at once (CAS contention on one document).
     if args.api_scripted_tool.is_some()
         && args.api_hot_writers > 0
         && let Some(hot_user) = users.first().cloned()
@@ -904,8 +909,10 @@ async fn run_virtual_user(
     run_virtual_user_with_identity(args, operation_namespace, harness, user, progress, None).await
 }
 
-/// A hot writer task: a scripted writer sharing the first user's thread so
-/// several operations contend on the same durable document at once.
+/// A hot writer task: a scripted writer on its own thread of the first user
+/// so several operations run concurrently (no per-thread turn
+/// serialization) while contending on the same per-user durable memory
+/// document.
 async fn run_hot_writer(
     args: &Args,
     operation_namespace: &str,
@@ -914,6 +921,12 @@ async fn run_hot_writer(
     progress: Arc<ProgressCounters>,
     hot_index: usize,
 ) -> Result<TaskResult, String> {
+    let thread_id = user
+        .extra_thread_ids
+        .get(hot_index)
+        .cloned()
+        .unwrap_or_else(|| user.thread_id.clone());
+    let user = ApiUser { thread_id, ..user };
     let identity = ScriptedTaskIdentity {
         op_prefix: format!("h{hot_index}-"),
         marker_user: format!("u{}", user.index),
@@ -1564,6 +1577,7 @@ impl ApiHarness {
             label: identity.label.clone(),
             bearer_token: identity.bearer_token.clone(),
             thread_id: requested_thread_id.to_string(),
+            extra_thread_ids: Vec::new(),
         };
         self.request_json(
             &user,
@@ -1770,6 +1784,14 @@ async fn setup_users(
             let user_index = next_index;
             let threads_per_user = args.api_threads_per_user.max(1);
             let enable_auto_approve = args.api_scripted_tool.is_some();
+            // The first user hosts the scripted hot writers: one thread per
+            // hot writer in addition to the primary thread.
+            let hot_extra_count = if enable_auto_approve && user_index == 0 {
+                args.api_hot_writers
+            } else {
+                0
+            };
+            let extra_count = threads_per_user.saturating_sub(1).max(hot_extra_count);
             join_set.spawn(async move {
                 let create = harness.create_thread(&identity, &thread_id).await;
                 let primary = match create.value {
@@ -1791,6 +1813,7 @@ async fn setup_users(
                         label: identity.label.clone(),
                         bearer_token: identity.bearer_token.clone(),
                         thread_id: primary.clone(),
+                        extra_thread_ids: Vec::new(),
                     };
                     let approve = harness.enable_tools_auto_approve(&user).await;
                     if let Err(failure) = approve.value {
@@ -1800,16 +1823,23 @@ async fn setup_users(
                         ));
                     }
                 }
-                // Extra threads exist purely to grow the user's sidebar; sends
+                // Extra threads grow the user's sidebar; scripted hot writers
+                // additionally use them as distinct contention lanes. Sends
                 // keep targeting the primary thread.
-                for extra in 1..threads_per_user {
+                let mut extra_thread_ids = Vec::with_capacity(extra_count);
+                for extra in 1..=extra_count {
                     let extra_id = format!("{primary}-extra-{extra}");
                     let create = harness.create_thread(&identity, &extra_id).await;
-                    if let Err(failure) = create.value {
-                        return Err(format!(
-                            "create extra thread {extra} for api user {user_index}: {}: {}",
-                            failure.bucket, failure.detail
-                        ));
+                    match create.value {
+                        Ok(value) => {
+                            extra_thread_ids.push(extract_thread_id(&value).unwrap_or(extra_id));
+                        }
+                        Err(failure) => {
+                            return Err(format!(
+                                "create extra thread {extra} for api user {user_index}: {}: {}",
+                                failure.bucket, failure.detail
+                            ));
+                        }
                     }
                 }
                 Ok(ApiUser {
@@ -1817,6 +1847,7 @@ async fn setup_users(
                     label: identity.label,
                     bearer_token: identity.bearer_token,
                     thread_id: primary,
+                    extra_thread_ids,
                 })
             });
             next_index += 1;
@@ -2999,6 +3030,62 @@ mod tests {
 
         serde_json::from_value::<rig::providers::openai::completion::CompletionResponse>(response)
             .expect("stress mock should deserialize as rig-core OpenAI completion response");
+    }
+
+    #[test]
+    fn mock_tool_call_response_matches_rig_openai_shape() {
+        let call = scripted::ToolCallSpec {
+            wire_name: "ironclaw__memory__write".to_string(),
+            arguments: json!({
+                "target": "stress/shared.md",
+                "content": "IRONCLAW_STRESS_READBACK_u0__1 payload",
+                "append": false,
+            }),
+        };
+        let response = mock_tool_call_response("stress-mock", 7, &call);
+
+        assert_eq!(response["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(response["choices"][0]["message"]["content"], Value::Null);
+        let parsed: rig::providers::openai::completion::CompletionResponse =
+            serde_json::from_value(response)
+                .expect("stress mock tool call should deserialize as rig-core OpenAI completion");
+        let message = &parsed.choices[0].message;
+        let tool_calls = match message {
+            rig::providers::openai::Message::Assistant { tool_calls, .. } => tool_calls,
+            other => panic!("expected assistant message, got {other:?}"),
+        };
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "ironclaw__memory__write");
+        assert_eq!(
+            tool_calls[0].function.arguments,
+            json!({
+                "target": "stress/shared.md",
+                "content": "IRONCLAW_STRESS_READBACK_u0__1 payload",
+                "append": false,
+            })
+        );
+    }
+
+    #[test]
+    fn mock_streaming_tool_call_chunks_carry_indexed_delta_tool_calls() {
+        let call = scripted::ToolCallSpec {
+            wire_name: "builtin__write_file".to_string(),
+            arguments: json!({"path": "stress/u0__1.txt", "content": "payload"}),
+        };
+        let (header, body, done) = mock_streaming_tool_call_chunks("stress-mock", 7, &call);
+
+        let header_call = &header["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(header_call["index"], 0);
+        assert_eq!(header_call["function"]["name"], "builtin__write_file");
+        assert_eq!(header["choices"][0]["delta"]["role"], "assistant");
+
+        let body_call = &body["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(body_call["index"], 0);
+        let arguments: Value =
+            serde_json::from_str(body_call["function"]["arguments"].as_str().expect("string"))
+                .expect("arguments json");
+        assert_eq!(arguments["path"], "stress/u0__1.txt");
+        assert_eq!(done["choices"][0]["finish_reason"], "tool_calls");
     }
 
     #[test]

--- a/tools/ironclaw_stress/src/api_capacity.rs
+++ b/tools/ironclaw_stress/src/api_capacity.rs
@@ -970,8 +970,15 @@ async fn run_virtual_user_with_identity(
     let mut scripted_samples = Vec::new();
 
     while crate::should_run_operation(target, started, operation_index) {
+        // The op prefix (hot writers: `h{k}-`) is part of the client action
+        // id so concurrent writers never collide on a duplicate-action
+        // conflict even when they share the same user.
+        let op_prefix = identity
+            .as_ref()
+            .map(|identity| identity.op_prefix.as_str())
+            .unwrap_or("");
         let operation_ref = format!(
-            "{operation_namespace}:{}:{}:{}",
+            "{operation_namespace}:{}:{}:{op_prefix}{}",
             user.label, user.index, operation_index
         );
         let (
@@ -1058,8 +1065,12 @@ async fn run_background_user(
     let mut scripted_samples = Vec::new();
 
     for operation_index in 0..args.api_background_operations {
+        let op_prefix = identity
+            .as_ref()
+            .map(|identity| identity.op_prefix.as_str())
+            .unwrap_or("");
         let operation_ref = format!(
-            "{operation_namespace}:background:{}:{}:{}",
+            "{operation_namespace}:background:{}:{}:{op_prefix}{}",
             user.label, user.index, operation_index
         );
         let (

--- a/tools/ironclaw_stress/src/api_capacity.rs
+++ b/tools/ironclaw_stress/src/api_capacity.rs
@@ -116,7 +116,11 @@ struct ScriptedFlowContext {
     key: scripted::ScriptKey,
     identity: ScriptedTaskIdentity,
     expected_tool_results: usize,
-    previous_tool_result_count: usize,
+    /// Highest message sequence observed in the timeline before this
+    /// operation's marker was submitted. Tool results with a sequence above
+    /// the baseline belong to this operation, so per-op tool evidence stays
+    /// correct even once the thread outgrows one timeline page.
+    baseline_sequence: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -338,8 +342,8 @@ impl MockLlmState {
         let scripted = self
             .scripted_counters
             .lock()
-            .map(|counters| counters.clone())
-            .unwrap_or_default();
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
         MockLlmSummary {
             base_url,
             model: self.model.clone(),
@@ -584,7 +588,7 @@ pub(crate) async fn run(
 
 /// Aggregate scripted operation samples into per-document-size buckets.
 fn summarize_scripted(samples: &[ScriptedOpSample], args: &Args) -> Option<ApiScriptedSummary> {
-    let script = args.api_scripted_tool.as_deref()?;
+    let script = args.api_scripted_tool?;
     if samples.is_empty() {
         return None;
     }
@@ -594,6 +598,7 @@ fn summarize_scripted(samples: &[ScriptedOpSample], args: &Args) -> Option<ApiSc
         let size_key = sample.size_bytes.to_string();
         let bucket = size_buckets.entry(size_key.clone()).or_default();
         bucket.attempted += 1;
+        bucket.tool_results += sample.tools_executed as u64;
         match &sample.failure {
             Some(failure) => {
                 bucket.failed += 1;
@@ -625,24 +630,23 @@ fn summarize_scripted(samples: &[ScriptedOpSample], args: &Args) -> Option<ApiSc
                 .or_default()
                 .push(latency.as_micros());
         }
-        let bucket = size_buckets.get_mut(&sample.size_bytes.to_string());
-        if let Some(bucket) = bucket {
-            bucket.tool_results += sample.tools_executed as u64;
-        }
     }
     for (size_key, stages) in stage_latencies {
         let bucket = size_buckets.get_mut(&size_key);
         let Some(bucket) = bucket else {
             continue;
         };
-        for (stage, values) in stages {
+        for (stage, mut values) in stages {
+            // `latency_summary` reads percentiles and min/max by index, so
+            // values must be sorted before aggregation.
+            values.sort_unstable();
             bucket
                 .stage_latency_us
                 .insert(stage, latency_summary(&values));
         }
     }
     Some(ApiScriptedSummary {
-        script: script.to_string(),
+        script: script.as_str().to_string(),
         doc_sizes: args.api_scripted_doc_sizes.clone(),
         hot_writers: args.api_hot_writers,
         size_buckets,
@@ -694,6 +698,7 @@ async fn run_window(
 ) -> Result<WindowResult, String> {
     let mut background_tasks = JoinSet::new();
     let mut writer_tasks = JoinSet::new();
+    let mut hot_writer_tasks = JoinSet::new();
     let mut read_tasks = JoinSet::new();
     let stop_reads = Arc::new(ReadShutdown::new());
 
@@ -733,6 +738,10 @@ async fn run_window(
     // Scripted hot writers: extra concurrent writers on distinct threads of
     // the first user so several operations contend on the same per-user
     // durable memory document at once (CAS contention on one document).
+    // They drain in their own JoinSet after the regular writer loop so a hot
+    // writer finishing never triggers a `run_virtual_user` refill — hot
+    // writers are deliberately extra concurrency beyond `--concurrency`,
+    // not part of the writer accounting.
     if args.api_scripted_tool.is_some()
         && args.api_hot_writers > 0
         && let Some(hot_user) = users.first().cloned()
@@ -743,7 +752,7 @@ async fn run_window(
             let args = args.clone();
             let operation_namespace = operation_namespace.to_string();
             let user = hot_user.clone();
-            writer_tasks.spawn(async move {
+            hot_writer_tasks.spawn(async move {
                 run_hot_writer(
                     &args,
                     &operation_namespace,
@@ -793,6 +802,15 @@ async fn run_window(
                 run_virtual_user(&args, &operation_namespace, harness, user, progress).await
             });
         }
+    }
+
+    while let Some(joined) = hot_writer_tasks.join_next().await {
+        let result =
+            joined.map_err(|error| format!("api hot-writer task join failed: {error}"))??;
+        flow_samples.extend(result.flow_samples);
+        background_flow_samples.extend(result.background_flow_samples);
+        api_samples.extend(result.api_samples);
+        scripted_samples.extend(result.scripted_samples);
     }
 
     stop_reads.stop();
@@ -950,10 +968,7 @@ async fn run_virtual_user_with_identity(
     progress: Arc<ProgressCounters>,
     scripted_identity: Option<ScriptedTaskIdentity>,
 ) -> Result<TaskResult, String> {
-    let script_key = args
-        .api_scripted_tool
-        .as_deref()
-        .and_then(scripted::ScriptKey::parse);
+    let script_key = args.api_scripted_tool;
     let identity = scripted_identity.or_else(|| {
         script_key.map(|_| ScriptedTaskIdentity {
             op_prefix: String::new(),
@@ -964,7 +979,7 @@ async fn run_virtual_user_with_identity(
     let started = Instant::now();
     let mut operation_index = 0;
     let mut expected_finalized_assistant_count = 0usize;
-    let mut expected_tool_result_count = 0usize;
+    let mut max_sequence_seen = 0u64;
     let mut flow_samples = Vec::with_capacity(args.initial_worker_sample_capacity());
     let mut api_samples = Vec::new();
     let mut scripted_samples = Vec::new();
@@ -981,50 +996,44 @@ async fn run_virtual_user_with_identity(
             "{operation_namespace}:{}:{}:{op_prefix}{}",
             user.label, user.index, operation_index
         );
-        let (
-            flow,
-            mut operation_api_samples,
-            updated_finalized_assistant_count,
-            tool_result_count,
-            scripted_op,
-        ) = match (script_key, identity.as_ref()) {
-            (Some(key), Some(identity)) => {
-                let flow_context = ScriptedFlowContext {
-                    key,
-                    identity: identity.clone(),
-                    expected_tool_results: key.expected_tool_results(),
-                    previous_tool_result_count: expected_tool_result_count,
-                };
-                let (flow, api, finalized, tools, op_sample) = run_scripted_full_flow(
-                    args,
-                    &harness,
-                    &user,
-                    operation_index,
-                    &operation_ref,
-                    ApiFlowKind::Foreground,
-                    &flow_context,
-                )
-                .await;
-                scripted_samples.push(op_sample);
-                (flow, api, finalized, tools, Some(()))
-            }
-            _ => {
-                let (flow, api, finalized) = run_full_flow(
-                    args,
-                    &harness,
-                    &user,
-                    operation_index,
-                    &operation_ref,
-                    expected_finalized_assistant_count,
-                    ApiFlowKind::Foreground,
-                )
-                .await;
-                (flow, api, finalized, expected_tool_result_count, None)
-            }
-        };
+        let (flow, mut operation_api_samples, updated_finalized_assistant_count, max_sequence) =
+            match (script_key, identity.as_ref()) {
+                (Some(key), Some(identity)) => {
+                    let flow_context = ScriptedFlowContext {
+                        key,
+                        identity: identity.clone(),
+                        expected_tool_results: key.expected_tool_results(),
+                        baseline_sequence: max_sequence_seen,
+                    };
+                    let (flow, api, finalized, sequence, op_sample) = run_scripted_full_flow(
+                        args,
+                        &harness,
+                        &user,
+                        operation_index,
+                        &operation_ref,
+                        ApiFlowKind::Foreground,
+                        &flow_context,
+                    )
+                    .await;
+                    scripted_samples.push(op_sample);
+                    (flow, api, finalized, sequence)
+                }
+                _ => {
+                    let (flow, api, finalized) = run_full_flow(
+                        args,
+                        &harness,
+                        &user,
+                        operation_index,
+                        &operation_ref,
+                        expected_finalized_assistant_count,
+                        ApiFlowKind::Foreground,
+                    )
+                    .await;
+                    (flow, api, finalized, max_sequence_seen)
+                }
+            };
         expected_finalized_assistant_count = updated_finalized_assistant_count;
-        expected_tool_result_count = tool_result_count;
-        let _ = scripted_op;
+        max_sequence_seen = max_sequence;
         progress.record(flow.error.is_some(), flow.latency);
         api_samples.append(&mut operation_api_samples);
         flow_samples.push(flow);
@@ -1050,16 +1059,17 @@ async fn run_background_user(
     harness: ApiHarness,
     user: ApiUser,
 ) -> Result<TaskResult, String> {
-    let script_key = args
-        .api_scripted_tool
-        .as_deref()
-        .and_then(scripted::ScriptKey::parse);
+    let script_key = args.api_scripted_tool;
+    // Background users are namespaced `b{index}` so their marker identities
+    // cannot collide with foreground user `u{index}` operations: a real
+    // cross-cohort isolation violation would otherwise read back as its own
+    // token and be reported `confirmed`.
     let identity = script_key.map(|_| ScriptedTaskIdentity {
         op_prefix: String::new(),
-        marker_user: format!("u{}", user.index),
+        marker_user: format!("b{}", user.index),
     });
     let mut expected_finalized_assistant_count = 0usize;
-    let mut expected_tool_result_count = 0usize;
+    let mut max_sequence_seen = 0u64;
     let mut background_flow_samples = Vec::with_capacity(args.api_background_operations);
     let mut api_samples = Vec::new();
     let mut scripted_samples = Vec::new();
@@ -1073,50 +1083,44 @@ async fn run_background_user(
             "{operation_namespace}:background:{}:{}:{op_prefix}{}",
             user.label, user.index, operation_index
         );
-        let (
-            flow,
-            mut operation_api_samples,
-            updated_finalized_assistant_count,
-            tool_result_count,
-            scripted_op,
-        ) = match (script_key, identity.as_ref()) {
-            (Some(key), Some(identity)) => {
-                let flow_context = ScriptedFlowContext {
-                    key,
-                    identity: identity.clone(),
-                    expected_tool_results: key.expected_tool_results(),
-                    previous_tool_result_count: expected_tool_result_count,
-                };
-                let (flow, api, finalized, tools, op_sample) = run_scripted_full_flow(
-                    args,
-                    &harness,
-                    &user,
-                    operation_index,
-                    &operation_ref,
-                    ApiFlowKind::Background,
-                    &flow_context,
-                )
-                .await;
-                scripted_samples.push(op_sample);
-                (flow, api, finalized, tools, Some(()))
-            }
-            _ => {
-                let (flow, api, finalized) = run_full_flow(
-                    args,
-                    &harness,
-                    &user,
-                    operation_index,
-                    &operation_ref,
-                    expected_finalized_assistant_count,
-                    ApiFlowKind::Background,
-                )
-                .await;
-                (flow, api, finalized, expected_tool_result_count, None)
-            }
-        };
+        let (flow, mut operation_api_samples, updated_finalized_assistant_count, max_sequence) =
+            match (script_key, identity.as_ref()) {
+                (Some(key), Some(identity)) => {
+                    let flow_context = ScriptedFlowContext {
+                        key,
+                        identity: identity.clone(),
+                        expected_tool_results: key.expected_tool_results(),
+                        baseline_sequence: max_sequence_seen,
+                    };
+                    let (flow, api, finalized, sequence, op_sample) = run_scripted_full_flow(
+                        args,
+                        &harness,
+                        &user,
+                        operation_index,
+                        &operation_ref,
+                        ApiFlowKind::Background,
+                        &flow_context,
+                    )
+                    .await;
+                    scripted_samples.push(op_sample);
+                    (flow, api, finalized, sequence)
+                }
+                _ => {
+                    let (flow, api, finalized) = run_full_flow(
+                        args,
+                        &harness,
+                        &user,
+                        operation_index,
+                        &operation_ref,
+                        expected_finalized_assistant_count,
+                        ApiFlowKind::Background,
+                    )
+                    .await;
+                    (flow, api, finalized, max_sequence_seen)
+                }
+            };
         expected_finalized_assistant_count = updated_finalized_assistant_count;
-        expected_tool_result_count = tool_result_count;
-        let _ = scripted_op;
+        max_sequence_seen = max_sequence;
         api_samples.append(&mut operation_api_samples);
         background_flow_samples.push(flow);
     }
@@ -1260,13 +1264,7 @@ async fn run_scripted_full_flow(
     operation_ref: &str,
     flow_kind: ApiFlowKind,
     flow: &ScriptedFlowContext,
-) -> (
-    Sample,
-    Vec<ApiRequestSample>,
-    usize,
-    usize,
-    ScriptedOpSample,
-) {
+) -> (Sample, Vec<ApiRequestSample>, usize, u64, ScriptedOpSample) {
     let started = Instant::now();
     let mut api_samples = Vec::new();
     let key = flow.key;
@@ -1297,13 +1295,13 @@ async fn run_scripted_full_flow(
     // count at completion.
     let mut verdict: Option<scripted::Verdict> = None;
     let mut failure: Option<FailureCause> = None;
-    let mut tools_seen = flow.previous_tool_result_count;
+    let mut tools_seen = 0usize;
+    let mut latest_sequence = flow.baseline_sequence;
     let mut tool_visible_latency: Option<Duration> = None;
     let mut finalize_latency: Option<Duration> = None;
 
     match send_value {
         Ok(value) if submitted_or_already_submitted(&value) => {
-            let target_tool_visible = flow.previous_tool_result_count + 1;
             let verdict_prefix = format!("{} {}", scripted::RESULT_PREFIX, op.identity());
             let deadline = Instant::now() + Duration::from_millis(args.api_terminal_timeout_ms);
             let mut placeholder_seen = false;
@@ -1319,9 +1317,13 @@ async fn run_scripted_full_flow(
                 api_samples.push(timeline.sample);
                 match value {
                     Ok(value) => {
-                        let tools = timeline_tool_result_count(&value);
-                        tools_seen = tools;
-                        if tool_visible_latency.is_none() && tools >= target_tool_visible {
+                        // Count only tool results that landed after this
+                        // operation's baseline: subtracting page-limited
+                        // absolute counts would under-count once the thread
+                        // outgrows a single timeline page.
+                        tools_seen = timeline_tool_results_after(&value, flow.baseline_sequence);
+                        latest_sequence = timeline_max_sequence(&value).max(latest_sequence);
+                        if tool_visible_latency.is_none() && tools_seen >= 1 {
                             tool_visible_latency = Some(started.elapsed());
                         }
                         placeholder_seen |= timeline_has_placeholder(&value);
@@ -1341,11 +1343,12 @@ async fn run_scripted_full_flow(
                 tokio::time::sleep(Duration::from_millis(args.api_poll_interval_ms)).await;
             }
 
-            verdict = my_final_content
+            let final_verdict = my_final_content
                 .as_ref()
                 .and_then(|content| scripted::parse_result_verdict(content, &op));
+            verdict = final_verdict;
             failure = failure.or_else(|| match &my_final_content {
-                Some(content) => match scripted::parse_result_verdict(content, &op) {
+                Some(_) => match final_verdict {
                     Some(parsed) if !parsed.is_failure() => None,
                     Some(parsed) => Some(FailureCause::new(
                         format!("scripted_verdict_{}", parsed.as_str()),
@@ -1379,13 +1382,12 @@ async fn run_scripted_full_flow(
                     ),
                 )),
             });
-            let tools_executed = tools_seen.saturating_sub(flow.previous_tool_result_count);
-            if failure.is_none() && tools_executed < flow.expected_tool_results {
+            if failure.is_none() && tools_seen < flow.expected_tool_results {
                 failure = Some(FailureCause::new(
                     "scripted_tools_not_executed",
                     flow_kind.wait_sample_name(),
                     format!(
-                        "operation {} finalized with {tools_executed}/{} tool results",
+                        "operation {} finalized with {tools_seen}/{} tool results",
                         op.identity(),
                         flow.expected_tool_results
                     ),
@@ -1406,7 +1408,6 @@ async fn run_scripted_full_flow(
 
     let latency = started.elapsed();
     let error = failure.as_ref().map(|cause| cause.bucket.clone());
-    let tools_executed = tools_seen.saturating_sub(flow.previous_tool_result_count);
     (
         Sample {
             latency,
@@ -1416,11 +1417,11 @@ async fn run_scripted_full_flow(
         },
         api_samples,
         operation_index + 1,
-        tools_seen,
+        latest_sequence,
         ScriptedOpSample {
             size_bytes: op.size_bytes,
             verdict,
-            tools_executed,
+            tools_executed: tools_seen,
             tool_visible_latency,
             finalize_latency,
             failure,
@@ -1428,7 +1429,7 @@ async fn run_scripted_full_flow(
     )
 }
 
-fn timeline_tool_result_count(value: &Value) -> usize {
+fn timeline_tool_results_after(value: &Value, baseline_sequence: u64) -> usize {
     value
         .get("messages")
         .and_then(Value::as_array)
@@ -1436,8 +1437,23 @@ fn timeline_tool_result_count(value: &Value) -> usize {
         .flatten()
         .filter(|message| {
             message.get("kind").and_then(Value::as_str) == Some("tool_result_reference")
+                && message
+                    .get("sequence")
+                    .and_then(Value::as_u64)
+                    .is_some_and(|sequence| sequence > baseline_sequence)
         })
         .count()
+}
+
+fn timeline_max_sequence(value: &Value) -> u64 {
+    value
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|message| message.get("sequence").and_then(Value::as_u64))
+        .max()
+        .unwrap_or(0)
 }
 
 fn timeline_has_placeholder(value: &Value) -> bool {
@@ -1455,6 +1471,10 @@ fn timeline_has_placeholder(value: &Value) -> bool {
 }
 
 fn timeline_finalized_verdict_content(value: &Value, verdict_prefix: &str) -> Option<String> {
+    // Match the prefix followed by a space so operation `1` cannot
+    // terminate on operation `10`'s finalized message (`u0__1 ` is not a
+    // substring of `...u0__10 confirmed`).
+    let delimited = format!("{verdict_prefix} ");
     value
         .get("messages")
         .and_then(Value::as_array)
@@ -1465,7 +1485,7 @@ fn timeline_finalized_verdict_content(value: &Value, verdict_prefix: &str) -> Op
                 && message.get("status").and_then(Value::as_str) == Some("finalized")
         })
         .filter_map(|message| message.get("content").and_then(Value::as_str))
-        .find(|content| content.contains(verdict_prefix))
+        .find(|content| content.contains(&delimited))
         .map(str::to_string)
 }
 
@@ -2393,10 +2413,7 @@ async fn start_mock_llm(args: &Args) -> Result<Option<MockLlmHandle>, String> {
         jitter_ms: args.mock_llm_jitter_ms,
         output_bytes: args.mock_llm_output_bytes,
         failure_rate: args.mock_llm_failure_rate,
-        scripted: args
-            .api_scripted_tool
-            .clone()
-            .and_then(|key| ScriptKey::parse(&key)),
+        scripted: args.api_scripted_tool,
     };
     let listener = TcpListener::bind(config.bind)
         .await
@@ -2655,11 +2672,11 @@ fn scripted_decision_for(state: &MockLlmState, request: &Value) -> ScriptedDecis
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
-    let Some(op) = scripted::latest_op(&messages) else {
+    let available = available_tool_names(request);
+    let (decision, op) = scripted::decide_with_op(&messages, &available);
+    let Some(op) = op else {
         return ScriptedDecision::None;
     };
-    let available = available_tool_names(request);
-    let decision = scripted::decide(&messages, &available);
     let mut counters = state
         .scripted_counters
         .lock()
@@ -3170,17 +3187,21 @@ mod tests {
     }
 
     #[test]
-    fn timeline_counts_tool_result_references() {
+    fn timeline_counts_tool_results_after_baseline_sequence() {
         let value = json!({
             "messages": [
-                {"kind": "user", "status": "finalized"},
-                {"kind": "assistant", "status": "finalized", "content": "ok"},
-                {"kind": "tool_result_reference", "tool_result_ref": "r1"},
-                {"kind": "tool_result_reference", "tool_result_ref": "r2"}
+                {"kind": "user", "status": "finalized", "sequence": 1},
+                {"kind": "assistant", "status": "finalized", "content": "ok", "sequence": 2},
+                {"kind": "tool_result_reference", "tool_result_ref": "r1", "sequence": 3},
+                {"kind": "tool_result_reference", "tool_result_ref": "r2", "sequence": 4},
+                {"kind": "tool_result_reference", "tool_result_ref": "r3", "sequence": 7}
             ]
         });
-        assert_eq!(timeline_tool_result_count(&value), 2);
-        assert_eq!(timeline_tool_result_count(&json!({"messages": []})), 0);
+        assert_eq!(timeline_tool_results_after(&value, 2), 3);
+        assert_eq!(timeline_tool_results_after(&value, 4), 1);
+        assert_eq!(timeline_tool_results_after(&value, 7), 0);
+        assert_eq!(timeline_max_sequence(&value), 7);
+        assert_eq!(timeline_tool_results_after(&json!({"messages": []}), 0), 0);
     }
 
     #[test]
@@ -3200,6 +3221,23 @@ mod tests {
         assert_eq!(
             timeline_finalized_verdict_content(&value, "ironclaw-stress-tool result u0__2"),
             None
+        );
+        // `u0__1` must not match `u0__10`: the prefix is delimited by the
+        // following space so op 1 cannot terminate on op 10's message.
+        let longer_op = json!({
+            "messages": [
+                {"kind": "assistant", "status": "finalized",
+                 "content": "ironclaw-stress-tool result u0__10 confirmed"}
+            ]
+        });
+        assert_eq!(
+            timeline_finalized_verdict_content(&longer_op, "ironclaw-stress-tool result u0__1"),
+            None
+        );
+        assert_eq!(
+            timeline_finalized_verdict_content(&longer_op, "ironclaw-stress-tool result u0__10")
+                .as_deref(),
+            Some("ironclaw-stress-tool result u0__10 confirmed")
         );
     }
 
@@ -3223,7 +3261,7 @@ mod tests {
     #[test]
     fn scripted_summary_buckets_by_size_and_verdict() {
         let mut args = parsed_api_args(&[]);
-        args.api_scripted_tool = Some("memory_roundtrip".to_string());
+        args.api_scripted_tool = Some(scripted::ScriptKey::MemoryRoundtrip);
         args.api_scripted_doc_sizes = vec![4096, 32768];
         let samples = vec![
             ScriptedOpSample {
@@ -3276,7 +3314,7 @@ mod tests {
         let args = parsed_api_args(&[]);
         assert!(summarize_scripted(&[], &args).is_none());
         let mut scripted = parsed_api_args(&[]);
-        scripted.api_scripted_tool = Some("memory_roundtrip".to_string());
+        scripted.api_scripted_tool = Some(scripted::ScriptKey::MemoryRoundtrip);
         assert!(summarize_scripted(&[], &scripted).is_none());
     }
 }

--- a/tools/ironclaw_stress/src/api_capacity.rs
+++ b/tools/ironclaw_stress/src/api_capacity.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     net::SocketAddr,
     path::Path,
     sync::{
@@ -22,6 +22,7 @@ use tokio::{
 use crate::{
     Args, Sample,
     progress::ProgressCounters,
+    scripted::{self, ScriptKey, ScriptedDecision, ScriptedMockCounters},
     summary::{FailureCause, LatencySummary, latency_summary, summarize_failure_causes},
 };
 
@@ -51,6 +52,71 @@ pub(crate) struct ApiCapacitySummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mock_llm: Option<MockLlmSummary>,
     pub(crate) endpoints: BTreeMap<String, ApiEndpointSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scripted: Option<ApiScriptedSummary>,
+}
+
+/// Driver-side summary of scripted tool-call workloads, bucketed by
+/// document size.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ApiScriptedSummary {
+    pub(crate) script: String,
+    pub(crate) doc_sizes: Vec<usize>,
+    pub(crate) hot_writers: usize,
+    pub(crate) size_buckets: BTreeMap<String, ApiScriptedSizeSummary>,
+}
+
+/// Per-document-size scripted workload results.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub(crate) struct ApiScriptedSizeSummary {
+    pub(crate) attempted: u64,
+    pub(crate) succeeded: u64,
+    pub(crate) failed: u64,
+    #[serde(default)]
+    pub(crate) verdicts: BTreeMap<String, u64>,
+    #[serde(default)]
+    pub(crate) failure_buckets: BTreeMap<String, u64>,
+    /// Tool-result messages observed for this bucket's operations (read-back
+    /// correlation evidence).
+    #[serde(default)]
+    pub(crate) tool_results: u64,
+    /// Submit-to-first-tool-visible and submit-to-finalize latencies in
+    /// microseconds, per stage.
+    #[serde(default)]
+    pub(crate) stage_latency_us: BTreeMap<String, LatencySummary>,
+}
+
+/// One scripted operation sample, carried from the writer tasks to the
+/// summary.
+#[derive(Debug, Clone)]
+pub(crate) struct ScriptedOpSample {
+    pub(crate) size_bytes: usize,
+    pub(crate) verdict: Option<scripted::Verdict>,
+    /// Tool-result messages observed for this operation, relative to the
+    /// previous operation on the same thread.
+    pub(crate) tools_executed: usize,
+    /// Submit to first tool result visible in the timeline.
+    pub(crate) tool_visible_latency: Option<Duration>,
+    /// Submit to finalized assistant.
+    pub(crate) finalize_latency: Option<Duration>,
+    pub(crate) failure: Option<FailureCause>,
+}
+
+/// Scripted-mode task identity: the operation id prefix (empty for regular
+/// users, `h{k}-` for hot writers) and the user identity part of markers.
+#[derive(Debug, Clone)]
+struct ScriptedTaskIdentity {
+    op_prefix: String,
+    marker_user: String,
+}
+
+/// Everything a scripted operation needs besides the harness and user.
+#[derive(Debug, Clone)]
+struct ScriptedFlowContext {
+    key: scripted::ScriptKey,
+    identity: ScriptedTaskIdentity,
+    expected_tool_results: usize,
+    previous_tool_result_count: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -78,6 +144,8 @@ pub(crate) struct MockLlmSummary {
     pub(crate) last_request_offset_ms: Option<u128>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) request_start_spread_ms: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scripted: Option<ScriptedMockCounters>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -213,6 +281,7 @@ struct MockLlmConfig {
     jitter_ms: u64,
     output_bytes: usize,
     failure_rate: f64,
+    scripted: Option<ScriptKey>,
 }
 
 #[derive(Debug)]
@@ -223,6 +292,8 @@ struct MockLlmState {
     jitter_ms: u64,
     output_bytes: usize,
     failure_rate: f64,
+    scripted: Option<ScriptKey>,
+    scripted_counters: Mutex<ScriptedMockCounters>,
     counter: AtomicU64,
     foreground_counter: AtomicU64,
     background_counter: AtomicU64,
@@ -259,6 +330,11 @@ impl MockLlmState {
             .unwrap_or_default();
         let first_request_offset = request_start_offsets.iter().min().copied();
         let last_request_offset = request_start_offsets.iter().max().copied();
+        let scripted = self
+            .scripted_counters
+            .lock()
+            .map(|counters| counters.clone())
+            .unwrap_or_default();
         MockLlmSummary {
             base_url,
             model: self.model.clone(),
@@ -279,6 +355,7 @@ impl MockLlmState {
             request_start_spread_ms: first_request_offset
                 .zip(last_request_offset)
                 .map(|(first, last)| last.saturating_sub(first).as_millis()),
+            scripted: self.scripted.map(|_| scripted),
         }
     }
 
@@ -489,6 +566,7 @@ pub(crate) async fn run(
         poll_interval_ms: args.api_poll_interval_ms,
         mock_llm: mock_summary,
         endpoints,
+        scripted: summarize_scripted(&window.scripted_samples, args),
     };
 
     Ok(ApiCapacityRun {
@@ -499,10 +577,78 @@ pub(crate) async fn run(
     })
 }
 
+/// Aggregate scripted operation samples into per-document-size buckets.
+fn summarize_scripted(samples: &[ScriptedOpSample], args: &Args) -> Option<ApiScriptedSummary> {
+    let script = args.api_scripted_tool.as_deref()?;
+    if samples.is_empty() {
+        return None;
+    }
+    let mut size_buckets: BTreeMap<String, ApiScriptedSizeSummary> = BTreeMap::new();
+    let mut stage_latencies: BTreeMap<String, BTreeMap<String, Vec<u128>>> = BTreeMap::new();
+    for sample in samples {
+        let size_key = sample.size_bytes.to_string();
+        let bucket = size_buckets.entry(size_key.clone()).or_default();
+        bucket.attempted += 1;
+        match &sample.failure {
+            Some(failure) => {
+                bucket.failed += 1;
+                *bucket
+                    .failure_buckets
+                    .entry(failure.bucket.clone())
+                    .or_insert(0) += 1;
+            }
+            None => {
+                bucket.succeeded += 1;
+                if let Some(verdict) = sample.verdict {
+                    *bucket
+                        .verdicts
+                        .entry(verdict.as_str().to_string())
+                        .or_insert(0) += 1;
+                }
+            }
+        }
+        let stages = stage_latencies.entry(size_key).or_default();
+        if let Some(latency) = sample.tool_visible_latency {
+            stages
+                .entry("tool_visible".to_string())
+                .or_default()
+                .push(latency.as_micros());
+        }
+        if let Some(latency) = sample.finalize_latency {
+            stages
+                .entry("finalize".to_string())
+                .or_default()
+                .push(latency.as_micros());
+        }
+        let bucket = size_buckets.get_mut(&sample.size_bytes.to_string());
+        if let Some(bucket) = bucket {
+            bucket.tool_results += sample.tools_executed as u64;
+        }
+    }
+    for (size_key, stages) in stage_latencies {
+        let bucket = size_buckets.get_mut(&size_key);
+        let Some(bucket) = bucket else {
+            continue;
+        };
+        for (stage, values) in stages {
+            bucket
+                .stage_latency_us
+                .insert(stage, latency_summary(&values));
+        }
+    }
+    Some(ApiScriptedSummary {
+        script: script.to_string(),
+        doc_sizes: args.api_scripted_doc_sizes.clone(),
+        hot_writers: args.api_hot_writers,
+        size_buckets,
+    })
+}
+
 struct WindowResult {
     flow_samples: Vec<Sample>,
     background_flow_samples: Vec<Sample>,
     api_samples: Vec<ApiRequestSample>,
+    scripted_samples: Vec<ScriptedOpSample>,
 }
 
 struct ReadShutdown {
@@ -579,6 +725,33 @@ async fn run_window(
         });
     }
 
+    // Scripted hot writers: extra concurrent writers sharing the first
+    // user's thread so several operations contend on the same durable
+    // document at once (CAS contention on one memory document).
+    if args.api_scripted_tool.is_some()
+        && args.api_hot_writers > 0
+        && let Some(hot_user) = users.first().cloned()
+    {
+        for hot_index in 0..args.api_hot_writers {
+            let harness = harness.clone();
+            let progress = Arc::clone(&progress);
+            let args = args.clone();
+            let operation_namespace = operation_namespace.to_string();
+            let user = hot_user.clone();
+            writer_tasks.spawn(async move {
+                run_hot_writer(
+                    &args,
+                    &operation_namespace,
+                    harness,
+                    user,
+                    progress,
+                    hot_index,
+                )
+                .await
+            });
+        }
+    }
+
     if args.api_read_qps_per_user > 0.0 {
         let read_workers = read_worker_count(args);
         for worker_index in 0..read_workers {
@@ -596,11 +769,13 @@ async fn run_window(
     let mut flow_samples = Vec::new();
     let mut background_flow_samples = Vec::new();
     let mut api_samples = Vec::new();
+    let mut scripted_samples = Vec::new();
     while let Some(joined) = writer_tasks.join_next().await {
         let result = joined.map_err(|error| format!("api task join failed: {error}"))??;
         flow_samples.extend(result.flow_samples);
         background_flow_samples.extend(result.background_flow_samples);
         api_samples.extend(result.api_samples);
+        scripted_samples.extend(result.scripted_samples);
 
         if next_writer_index < writer_user_count {
             let user = users[next_writer_index].clone();
@@ -628,6 +803,7 @@ async fn run_window(
             joined.map_err(|error| format!("api background task join failed: {error}"))??;
         background_flow_samples.extend(result.background_flow_samples);
         api_samples.extend(result.api_samples);
+        scripted_samples.extend(result.scripted_samples);
 
         if next_background_index < background_users.len() {
             let user = background_users[next_background_index].clone();
@@ -645,6 +821,7 @@ async fn run_window(
         flow_samples,
         background_flow_samples,
         api_samples,
+        scripted_samples,
     })
 }
 
@@ -676,6 +853,7 @@ struct TaskResult {
     flow_samples: Vec<Sample>,
     background_flow_samples: Vec<Sample>,
     api_samples: Vec<ApiRequestSample>,
+    scripted_samples: Vec<ScriptedOpSample>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -723,29 +901,110 @@ async fn run_virtual_user(
     user: ApiUser,
     progress: Arc<ProgressCounters>,
 ) -> Result<TaskResult, String> {
+    run_virtual_user_with_identity(args, operation_namespace, harness, user, progress, None).await
+}
+
+/// A hot writer task: a scripted writer sharing the first user's thread so
+/// several operations contend on the same durable document at once.
+async fn run_hot_writer(
+    args: &Args,
+    operation_namespace: &str,
+    harness: ApiHarness,
+    user: ApiUser,
+    progress: Arc<ProgressCounters>,
+    hot_index: usize,
+) -> Result<TaskResult, String> {
+    let identity = ScriptedTaskIdentity {
+        op_prefix: format!("h{hot_index}-"),
+        marker_user: format!("u{}", user.index),
+    };
+    run_virtual_user_with_identity(
+        args,
+        operation_namespace,
+        harness,
+        user,
+        progress,
+        Some(identity),
+    )
+    .await
+}
+
+async fn run_virtual_user_with_identity(
+    args: &Args,
+    operation_namespace: &str,
+    harness: ApiHarness,
+    user: ApiUser,
+    progress: Arc<ProgressCounters>,
+    scripted_identity: Option<ScriptedTaskIdentity>,
+) -> Result<TaskResult, String> {
+    let script_key = args
+        .api_scripted_tool
+        .as_deref()
+        .and_then(scripted::ScriptKey::parse);
+    let identity = scripted_identity.or_else(|| {
+        script_key.map(|_| ScriptedTaskIdentity {
+            op_prefix: String::new(),
+            marker_user: format!("u{}", user.index),
+        })
+    });
     let target = args.operation_target();
     let started = Instant::now();
     let mut operation_index = 0;
     let mut expected_finalized_assistant_count = 0usize;
+    let mut expected_tool_result_count = 0usize;
     let mut flow_samples = Vec::with_capacity(args.initial_worker_sample_capacity());
     let mut api_samples = Vec::new();
+    let mut scripted_samples = Vec::new();
 
     while crate::should_run_operation(target, started, operation_index) {
         let operation_ref = format!(
             "{operation_namespace}:{}:{}:{}",
             user.label, user.index, operation_index
         );
-        let (flow, mut operation_api_samples, updated_finalized_assistant_count) = run_full_flow(
-            args,
-            &harness,
-            &user,
-            operation_index,
-            &operation_ref,
-            expected_finalized_assistant_count,
-            ApiFlowKind::Foreground,
-        )
-        .await;
+        let (
+            flow,
+            mut operation_api_samples,
+            updated_finalized_assistant_count,
+            tool_result_count,
+            scripted_op,
+        ) = match (script_key, identity.as_ref()) {
+            (Some(key), Some(identity)) => {
+                let flow_context = ScriptedFlowContext {
+                    key,
+                    identity: identity.clone(),
+                    expected_tool_results: key.expected_tool_results(),
+                    previous_tool_result_count: expected_tool_result_count,
+                };
+                let (flow, api, finalized, tools, op_sample) = run_scripted_full_flow(
+                    args,
+                    &harness,
+                    &user,
+                    operation_index,
+                    &operation_ref,
+                    ApiFlowKind::Foreground,
+                    &flow_context,
+                )
+                .await;
+                scripted_samples.push(op_sample);
+                (flow, api, finalized, tools, Some(()))
+            }
+            _ => {
+                let (flow, api, finalized) = run_full_flow(
+                    args,
+                    &harness,
+                    &user,
+                    operation_index,
+                    &operation_ref,
+                    expected_finalized_assistant_count,
+                    ApiFlowKind::Foreground,
+                )
+                .await;
+                (flow, api, finalized, expected_tool_result_count, None)
+            }
+        };
         expected_finalized_assistant_count = updated_finalized_assistant_count;
+        expected_tool_result_count = tool_result_count;
+        let _ = scripted_op;
         progress.record(flow.error.is_some(), flow.latency);
         api_samples.append(&mut operation_api_samples);
         flow_samples.push(flow);
@@ -761,6 +1020,7 @@ async fn run_virtual_user(
         flow_samples,
         background_flow_samples: Vec::new(),
         api_samples,
+        scripted_samples,
     })
 }
 
@@ -770,26 +1030,69 @@ async fn run_background_user(
     harness: ApiHarness,
     user: ApiUser,
 ) -> Result<TaskResult, String> {
+    let script_key = args
+        .api_scripted_tool
+        .as_deref()
+        .and_then(scripted::ScriptKey::parse);
+    let identity = script_key.map(|_| ScriptedTaskIdentity {
+        op_prefix: String::new(),
+        marker_user: format!("u{}", user.index),
+    });
     let mut expected_finalized_assistant_count = 0usize;
+    let mut expected_tool_result_count = 0usize;
     let mut background_flow_samples = Vec::with_capacity(args.api_background_operations);
     let mut api_samples = Vec::new();
+    let mut scripted_samples = Vec::new();
 
     for operation_index in 0..args.api_background_operations {
         let operation_ref = format!(
             "{operation_namespace}:background:{}:{}:{}",
             user.label, user.index, operation_index
         );
-        let (flow, mut operation_api_samples, updated_finalized_assistant_count) = run_full_flow(
-            args,
-            &harness,
-            &user,
-            operation_index,
-            &operation_ref,
-            expected_finalized_assistant_count,
-            ApiFlowKind::Background,
-        )
-        .await;
+        let (
+            flow,
+            mut operation_api_samples,
+            updated_finalized_assistant_count,
+            tool_result_count,
+            scripted_op,
+        ) = match (script_key, identity.as_ref()) {
+            (Some(key), Some(identity)) => {
+                let flow_context = ScriptedFlowContext {
+                    key,
+                    identity: identity.clone(),
+                    expected_tool_results: key.expected_tool_results(),
+                    previous_tool_result_count: expected_tool_result_count,
+                };
+                let (flow, api, finalized, tools, op_sample) = run_scripted_full_flow(
+                    args,
+                    &harness,
+                    &user,
+                    operation_index,
+                    &operation_ref,
+                    ApiFlowKind::Background,
+                    &flow_context,
+                )
+                .await;
+                scripted_samples.push(op_sample);
+                (flow, api, finalized, tools, Some(()))
+            }
+            _ => {
+                let (flow, api, finalized) = run_full_flow(
+                    args,
+                    &harness,
+                    &user,
+                    operation_index,
+                    &operation_ref,
+                    expected_finalized_assistant_count,
+                    ApiFlowKind::Background,
+                )
+                .await;
+                (flow, api, finalized, expected_tool_result_count, None)
+            }
+        };
         expected_finalized_assistant_count = updated_finalized_assistant_count;
+        expected_tool_result_count = tool_result_count;
+        let _ = scripted_op;
         api_samples.append(&mut operation_api_samples);
         background_flow_samples.push(flow);
     }
@@ -798,6 +1101,7 @@ async fn run_background_user(
         flow_samples: Vec::new(),
         background_flow_samples,
         api_samples,
+        scripted_samples,
     })
 }
 
@@ -916,6 +1220,231 @@ async fn run_full_flow(
     )
 }
 
+/// Drive one scripted operation: submit the marker message, then poll the
+/// timeline until the operation's verdict text is visible, recording the
+/// submit-to-first-tool and submit-to-finalize stages and the read-back
+/// verdict.
+///
+/// Completion is detected by verdict-text presence rather than assistant
+/// counts because hot writers share one thread: several operations race on
+/// the same timeline and counts cannot be attributed to a single op.
+async fn run_scripted_full_flow(
+    args: &Args,
+    harness: &ApiHarness,
+    user: &ApiUser,
+    operation_index: usize,
+    operation_ref: &str,
+    flow_kind: ApiFlowKind,
+    flow: &ScriptedFlowContext,
+) -> (
+    Sample,
+    Vec<ApiRequestSample>,
+    usize,
+    usize,
+    ScriptedOpSample,
+) {
+    let started = Instant::now();
+    let mut api_samples = Vec::new();
+    let key = flow.key;
+    let op = scripted::ScriptedOp {
+        key,
+        user: flow.identity.marker_user.clone(),
+        op: format!("{}{}", flow.identity.op_prefix, operation_index),
+        size_bytes: scripted::doc_size_for(&args.api_scripted_doc_sizes, operation_index),
+    };
+    let marker = scripted::marker_message(key, &op.user, &op.op, op.size_bytes);
+    let body = json!({
+        "client_action_id": format!("ironclaw-stress-api:{operation_ref}"),
+        "content": stress_payload(marker, args.user_message_bytes),
+    });
+    let send = harness
+        .request_json(
+            user,
+            flow_kind.send_sample_name(),
+            Method::POST,
+            &format!("/api/webchat/v2/threads/{}/messages", user.thread_id),
+            Some(body),
+        )
+        .await;
+    let send_value = send.value.clone();
+    api_samples.push(send.sample);
+
+    // Outcome of the submit step: verdict, failure, and the observed tool
+    // count at completion.
+    let mut verdict: Option<scripted::Verdict> = None;
+    let mut failure: Option<FailureCause> = None;
+    let mut tools_seen = flow.previous_tool_result_count;
+    let mut tool_visible_latency: Option<Duration> = None;
+    let mut finalize_latency: Option<Duration> = None;
+
+    match send_value {
+        Ok(value) if submitted_or_already_submitted(&value) => {
+            let target_tool_visible = flow.previous_tool_result_count + 1;
+            let verdict_prefix = format!("{} {}", scripted::RESULT_PREFIX, op.identity());
+            let deadline = Instant::now() + Duration::from_millis(args.api_terminal_timeout_ms);
+            let mut placeholder_seen = false;
+            let mut my_final_content: Option<String> = None;
+            loop {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                let timeline = harness
+                    .timeline_with_name(user, flow_kind.timeline_sample_name())
+                    .await;
+                let value = timeline.value.clone();
+                api_samples.push(timeline.sample);
+                match value {
+                    Ok(value) => {
+                        let tools = timeline_tool_result_count(&value);
+                        tools_seen = tools;
+                        if tool_visible_latency.is_none() && tools >= target_tool_visible {
+                            tool_visible_latency = Some(started.elapsed());
+                        }
+                        placeholder_seen |= timeline_has_placeholder(&value);
+                        if let Some(content) =
+                            timeline_finalized_verdict_content(&value, &verdict_prefix)
+                        {
+                            finalize_latency = Some(started.elapsed());
+                            my_final_content = Some(content);
+                            break;
+                        }
+                    }
+                    Err(timeline_failure) => {
+                        failure = Some(timeline_failure);
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(args.api_poll_interval_ms)).await;
+            }
+
+            verdict = my_final_content
+                .as_ref()
+                .and_then(|content| scripted::parse_result_verdict(content, &op));
+            failure = failure.or_else(|| match &my_final_content {
+                Some(content) => match scripted::parse_result_verdict(content, &op) {
+                    Some(parsed) if !parsed.is_failure() => None,
+                    Some(parsed) => Some(FailureCause::new(
+                        format!("scripted_verdict_{}", parsed.as_str()),
+                        flow_kind.wait_sample_name(),
+                        format!(
+                            "operation {} finalized with failing verdict {}",
+                            op.identity(),
+                            parsed.as_str()
+                        ),
+                    )),
+                    None => Some(FailureCause::new(
+                        "scripted_no_verdict",
+                        flow_kind.wait_sample_name(),
+                        format!(
+                            "operation {} finalized without a verdict text",
+                            op.identity()
+                        ),
+                    )),
+                },
+                None => Some(FailureCause::new(
+                    if placeholder_seen {
+                        "scripted_tool_undisclosed"
+                    } else {
+                        "api_full_flow_timeout"
+                    },
+                    flow_kind.wait_sample_name(),
+                    format!(
+                        "operation {} verdict not visible after {}ms",
+                        op.identity(),
+                        args.api_terminal_timeout_ms
+                    ),
+                )),
+            });
+            let tools_executed = tools_seen.saturating_sub(flow.previous_tool_result_count);
+            if failure.is_none() && tools_executed < flow.expected_tool_results {
+                failure = Some(FailureCause::new(
+                    "scripted_tools_not_executed",
+                    flow_kind.wait_sample_name(),
+                    format!(
+                        "operation {} finalized with {tools_executed}/{} tool results",
+                        op.identity(),
+                        flow.expected_tool_results
+                    ),
+                ));
+            }
+        }
+        Ok(value) => {
+            failure = Some(FailureCause::new(
+                "api_submit_not_accepted",
+                flow_kind.send_sample_name(),
+                compact_json(&value),
+            ));
+        }
+        Err(send_failure) => {
+            failure = Some(send_failure);
+        }
+    }
+
+    let latency = started.elapsed();
+    let error = failure.as_ref().map(|cause| cause.bucket.clone());
+    let tools_executed = tools_seen.saturating_sub(flow.previous_tool_result_count);
+    (
+        Sample {
+            latency,
+            error,
+            failure: failure.clone(),
+            stages: None,
+        },
+        api_samples,
+        operation_index + 1,
+        tools_seen,
+        ScriptedOpSample {
+            size_bytes: op.size_bytes,
+            verdict,
+            tools_executed,
+            tool_visible_latency,
+            finalize_latency,
+            failure,
+        },
+    )
+}
+
+fn timeline_tool_result_count(value: &Value) -> usize {
+    value
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|message| {
+            message.get("kind").and_then(Value::as_str) == Some("tool_result_reference")
+        })
+        .count()
+}
+
+fn timeline_has_placeholder(value: &Value) -> bool {
+    value
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|message| {
+            message.get("kind").and_then(Value::as_str) == Some("assistant")
+                && message.get("status").and_then(Value::as_str) == Some("finalized")
+        })
+        .filter_map(|message| message.get("content").and_then(Value::as_str))
+        .any(|content| content.contains(scripted::PLACEHOLDER_TEXT))
+}
+
+fn timeline_finalized_verdict_content(value: &Value, verdict_prefix: &str) -> Option<String> {
+    value
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|message| {
+            message.get("kind").and_then(Value::as_str) == Some("assistant")
+                && message.get("status").and_then(Value::as_str) == Some("finalized")
+        })
+        .filter_map(|message| message.get("content").and_then(Value::as_str))
+        .find(|content| content.contains(verdict_prefix))
+        .map(str::to_string)
+}
+
 async fn wait_for_assistant(
     args: &Args,
     harness: &ApiHarness,
@@ -998,6 +1527,7 @@ async fn run_read_worker(
         flow_samples: Vec::new(),
         background_flow_samples: Vec::new(),
         api_samples,
+        scripted_samples: Vec::new(),
     })
 }
 
@@ -1126,6 +1656,20 @@ impl ApiHarness {
         .await
     }
 
+    /// Enable the per-user Tools global auto-approve setting so scripted
+    /// gated tool calls (`builtin.write_file`, memory writes) can execute
+    /// without an interactive approver.
+    async fn enable_tools_auto_approve(&self, user: &ApiUser) -> ApiCallResult {
+        self.request_json(
+            user,
+            "enable_auto_approve",
+            Method::POST,
+            "/api/webchat/v2/settings/tools",
+            Some(json!({ "enabled": true })),
+        )
+        .await
+    }
+
     async fn request_json(
         &self,
         user: &ApiUser,
@@ -1225,6 +1769,7 @@ async fn setup_users(
             let thread_id = format!("stress-{run_id}-{thread_label}-{next_index}");
             let user_index = next_index;
             let threads_per_user = args.api_threads_per_user.max(1);
+            let enable_auto_approve = args.api_scripted_tool.is_some();
             join_set.spawn(async move {
                 let create = harness.create_thread(&identity, &thread_id).await;
                 let primary = match create.value {
@@ -1236,6 +1781,25 @@ async fn setup_users(
                         ));
                     }
                 };
+                if enable_auto_approve {
+                    // Scripted tools (`builtin.write_file`, memory writes) are
+                    // gated_unless_granted for loop-run origins; enable the
+                    // per-user Tools auto-approve setting through the same
+                    // settings API a real user would use.
+                    let user = ApiUser {
+                        index: user_index,
+                        label: identity.label.clone(),
+                        bearer_token: identity.bearer_token.clone(),
+                        thread_id: primary.clone(),
+                    };
+                    let approve = harness.enable_tools_auto_approve(&user).await;
+                    if let Err(failure) = approve.value {
+                        return Err(format!(
+                            "enable auto-approve for api user {user_index}: {}: {}",
+                            failure.bucket, failure.detail
+                        ));
+                    }
+                }
                 // Extra threads exist purely to grow the user's sidebar; sends
                 // keep targeting the primary thread.
                 for extra in 1..threads_per_user {
@@ -1787,6 +2351,10 @@ async fn start_mock_llm(args: &Args) -> Result<Option<MockLlmHandle>, String> {
         jitter_ms: args.mock_llm_jitter_ms,
         output_bytes: args.mock_llm_output_bytes,
         failure_rate: args.mock_llm_failure_rate,
+        scripted: args
+            .api_scripted_tool
+            .clone()
+            .and_then(|key| ScriptKey::parse(&key)),
     };
     let listener = TcpListener::bind(config.bind)
         .await
@@ -1801,6 +2369,8 @@ async fn start_mock_llm(args: &Args) -> Result<Option<MockLlmHandle>, String> {
         jitter_ms: config.jitter_ms,
         output_bytes: config.output_bytes,
         failure_rate: config.failure_rate,
+        scripted: config.scripted,
+        scripted_counters: Mutex::new(ScriptedMockCounters::default()),
         counter: AtomicU64::new(0),
         foreground_counter: AtomicU64::new(0),
         background_counter: AtomicU64::new(0),
@@ -1959,15 +2529,124 @@ async fn handle_mock_completion(
         .get("stream")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let content = stress_payload("mock assistant response".to_string(), state.output_bytes);
-    if stream_response {
-        let (chunk, done) = mock_streaming_completion_chunks(&state.model, request_index, content);
-        let payload = format!("data: {chunk}\n\ndata: {done}\n\ndata: [DONE]\n\n");
-        write_mock_response(stream, 200, "text/event-stream", payload.as_bytes()).await
-    } else {
-        let response = mock_completion_response(&state.model, request_index, content);
-        write_json_response(stream, 200, &response).await
+
+    let decision = scripted_decision_for(&state, &request);
+    match &decision {
+        ScriptedDecision::ToolCall(call) => {
+            if stream_response {
+                let (header, body, done) =
+                    mock_streaming_tool_call_chunks(&state.model, request_index, call);
+                let payload =
+                    format!("data: {header}\n\ndata: {body}\n\ndata: {done}\n\ndata: [DONE]\n\n");
+                write_mock_response(stream, 200, "text/event-stream", payload.as_bytes()).await
+            } else {
+                let response = mock_tool_call_response(&state.model, request_index, call);
+                write_json_response(stream, 200, &response).await
+            }
+        }
+        ScriptedDecision::FinalText(text) => {
+            if stream_response {
+                let (chunk, done) =
+                    mock_streaming_completion_chunks(&state.model, request_index, text.clone());
+                let payload = format!("data: {chunk}\n\ndata: {done}\n\ndata: [DONE]\n\n");
+                write_mock_response(stream, 200, "text/event-stream", payload.as_bytes()).await
+            } else {
+                let response = mock_completion_response(&state.model, request_index, text.clone());
+                write_json_response(stream, 200, &response).await
+            }
+        }
+        ScriptedDecision::Placeholder => {
+            let text = scripted::PLACEHOLDER_TEXT.to_string();
+            if stream_response {
+                let (chunk, done) =
+                    mock_streaming_completion_chunks(&state.model, request_index, text);
+                let payload = format!("data: {chunk}\n\ndata: {done}\n\ndata: [DONE]\n\n");
+                write_mock_response(stream, 200, "text/event-stream", payload.as_bytes()).await
+            } else {
+                let response = mock_completion_response(&state.model, request_index, text);
+                write_json_response(stream, 200, &response).await
+            }
+        }
+        ScriptedDecision::None => {
+            let content = stress_payload("mock assistant response".to_string(), state.output_bytes);
+            if stream_response {
+                let (chunk, done) =
+                    mock_streaming_completion_chunks(&state.model, request_index, content);
+                let payload = format!("data: {chunk}\n\ndata: {done}\n\ndata: [DONE]\n\n");
+                write_mock_response(stream, 200, "text/event-stream", payload.as_bytes()).await
+            } else {
+                let response = mock_completion_response(&state.model, request_index, content);
+                write_json_response(stream, 200, &response).await
+            }
+        }
     }
+}
+
+/// Advertised tool names in a chat completion request (`tools[].function.name`).
+fn available_tool_names(request: &Value) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let Some(tools) = request.get("tools").and_then(Value::as_array) else {
+        return names;
+    };
+    for tool in tools {
+        let function = tool
+            .get("function")
+            .filter(|function| function.is_object())
+            .or_else(|| (tool.is_object()).then_some(tool));
+        let Some(function) = function else {
+            continue;
+        };
+        if let Some(name) = function.get("name").and_then(Value::as_str) {
+            names.insert(name.to_string());
+        }
+    }
+    names
+}
+
+/// Decide the scripted response for a request and record sidecar counters.
+fn scripted_decision_for(state: &MockLlmState, request: &Value) -> ScriptedDecision {
+    if state.scripted.is_none() {
+        return ScriptedDecision::None;
+    }
+    let messages = request
+        .get("messages")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let Some(op) = scripted::latest_op(&messages) else {
+        return ScriptedDecision::None;
+    };
+    let available = available_tool_names(request);
+    let decision = scripted::decide(&messages, &available);
+    let mut counters = state
+        .scripted_counters
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *counters
+        .requests_seen
+        .entry(op.key.as_str().to_string())
+        .or_insert(0) += 1;
+    match &decision {
+        ScriptedDecision::ToolCall(_) => {
+            *counters
+                .tool_calls_emitted
+                .entry(op.key.as_str().to_string())
+                .or_insert(0) += 1;
+        }
+        ScriptedDecision::Placeholder => {
+            counters.placeholder_responses += 1;
+        }
+        ScriptedDecision::FinalText(text) => {
+            if let Some(verdict) = scripted::parse_result_verdict(text, &op) {
+                *counters
+                    .final_verdicts
+                    .entry(verdict.as_str().to_string())
+                    .or_insert(0) += 1;
+            }
+        }
+        ScriptedDecision::None => {}
+    }
+    decision
 }
 
 fn classify_mock_request(body: &[u8]) -> MockRequestKind {
@@ -2003,6 +2682,116 @@ fn mock_completion_response(model: &str, request_index: u64, content: String) ->
             "prompt_tokens_details": null
         }
     })
+}
+
+/// Non-streaming chat completion carrying one tool call. The `arguments`
+/// field is a JSON string, matching the rig OpenAI wire shape the server
+/// parses (`Function::arguments` uses `stringified_json`).
+fn mock_tool_call_response(
+    model: &str,
+    request_index: u64,
+    call: &scripted::ToolCallSpec,
+) -> Value {
+    let arguments = match serde_json::to_string(&call.arguments) {
+        Ok(arguments) => arguments,
+        Err(_) => "{}".to_string(),
+    };
+    json!({
+        "id": format!("chatcmpl-stress-{request_index}"),
+        "object": "chat.completion",
+        "created": MOCK_COMPLETION_CREATED_AT,
+        "model": model,
+        "system_fingerprint": null,
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": format!("call-stress-{request_index}"),
+                    "type": "function",
+                    "function": {
+                        "name": call.wire_name,
+                        "arguments": arguments
+                    }
+                }],
+                "refusal": null
+            },
+            "logprobs": null,
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {
+            "prompt_tokens": 16,
+            "completion_tokens": 5,
+            "total_tokens": 21,
+            "prompt_tokens_details": null
+        }
+    })
+}
+
+/// Streaming chat-completion chunks carrying one tool call: a header chunk
+/// with the call id and name, an arguments chunk, and a finish chunk.
+fn mock_streaming_tool_call_chunks(
+    model: &str,
+    request_index: u64,
+    call: &scripted::ToolCallSpec,
+) -> (Value, Value, Value) {
+    let base = json!({
+        "id": format!("chatcmpl-stress-{request_index}"),
+        "object": "chat.completion.chunk",
+        "created": MOCK_COMPLETION_CREATED_AT,
+        "model": model,
+        "system_fingerprint": null,
+    });
+    let call_id = format!("call-stress-{request_index}");
+    let mut header = base.clone();
+    header["choices"] = json!([{
+        "index": 0,
+        "delta": {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "index": 0,
+                "id": call_id,
+                "type": "function",
+                "function": {"name": call.wire_name, "arguments": ""}
+            }]
+        },
+        "logprobs": null,
+        "finish_reason": null
+    }]);
+
+    let arguments = match serde_json::to_string(&call.arguments) {
+        Ok(arguments) => arguments,
+        Err(_) => "{}".to_string(),
+    };
+    let mut body = base.clone();
+    body["choices"] = json!([{
+        "index": 0,
+        "delta": {
+            "tool_calls": [{
+                "index": 0,
+                "function": {"arguments": arguments}
+            }]
+        },
+        "logprobs": null,
+        "finish_reason": null
+    }]);
+
+    let mut done = base;
+    done["choices"] = json!([{
+        "index": 0,
+        "delta": {},
+        "logprobs": null,
+        "finish_reason": "tool_calls"
+    }]);
+    done["usage"] = json!({
+        "prompt_tokens": 16,
+        "completion_tokens": 5,
+        "total_tokens": 21,
+        "prompt_tokens_details": null
+    });
+    (header, body, done)
 }
 
 fn mock_streaming_completion_chunks(
@@ -2280,5 +3069,116 @@ mod tests {
             ),
             MockRequestKind::Background
         );
+    }
+
+    #[test]
+    fn timeline_counts_tool_result_references() {
+        let value = json!({
+            "messages": [
+                {"kind": "user", "status": "finalized"},
+                {"kind": "assistant", "status": "finalized", "content": "ok"},
+                {"kind": "tool_result_reference", "tool_result_ref": "r1"},
+                {"kind": "tool_result_reference", "tool_result_ref": "r2"}
+            ]
+        });
+        assert_eq!(timeline_tool_result_count(&value), 2);
+        assert_eq!(timeline_tool_result_count(&json!({"messages": []})), 0);
+    }
+
+    #[test]
+    fn timeline_finds_finalized_verdict_content() {
+        let value = json!({
+            "messages": [
+                {"kind": "assistant", "status": "submitted", "content": "working"},
+                {"kind": "assistant", "status": "finalized",
+                 "content": "ironclaw-stress-tool result u0__1 confirmed"}
+            ]
+        });
+        assert_eq!(
+            timeline_finalized_verdict_content(&value, "ironclaw-stress-tool result u0__1")
+                .as_deref(),
+            Some("ironclaw-stress-tool result u0__1 confirmed")
+        );
+        assert_eq!(
+            timeline_finalized_verdict_content(&value, "ironclaw-stress-tool result u0__2"),
+            None
+        );
+    }
+
+    #[test]
+    fn timeline_detects_placeholder_text() {
+        let value = json!({
+            "messages": [
+                {"kind": "assistant", "status": "finalized",
+                 "content": "ironclaw-stress-tool pending \u{2014} I'll perform the stress tool action next."}
+            ]
+        });
+        assert!(timeline_has_placeholder(&value));
+        let normal = json!({
+            "messages": [
+                {"kind": "assistant", "status": "finalized", "content": "hello"}
+            ]
+        });
+        assert!(!timeline_has_placeholder(&normal));
+    }
+
+    #[test]
+    fn scripted_summary_buckets_by_size_and_verdict() {
+        let mut args = parsed_api_args(&[]);
+        args.api_scripted_tool = Some("memory_roundtrip".to_string());
+        args.api_scripted_doc_sizes = vec![4096, 32768];
+        let samples = vec![
+            ScriptedOpSample {
+                size_bytes: 4096,
+                verdict: Some(scripted::Verdict::Confirmed),
+                tools_executed: 2,
+                tool_visible_latency: Some(Duration::from_millis(100)),
+                finalize_latency: Some(Duration::from_millis(500)),
+                failure: None,
+            },
+            ScriptedOpSample {
+                size_bytes: 4096,
+                verdict: None,
+                tools_executed: 0,
+                tool_visible_latency: None,
+                finalize_latency: None,
+                failure: Some(FailureCause::new(
+                    "scripted_verdict_leak",
+                    "wait_for_assistant",
+                    "leak detected",
+                )),
+            },
+            ScriptedOpSample {
+                size_bytes: 32768,
+                verdict: Some(scripted::Verdict::Contended),
+                tools_executed: 2,
+                tool_visible_latency: Some(Duration::from_millis(90)),
+                finalize_latency: Some(Duration::from_millis(450)),
+                failure: None,
+            },
+        ];
+        let summary = summarize_scripted(&samples, &args).expect("scripted summary present");
+
+        assert_eq!(summary.script, "memory_roundtrip");
+        assert_eq!(summary.doc_sizes, vec![4096, 32768]);
+        let four_kb = &summary.size_buckets["4096"];
+        assert_eq!(four_kb.attempted, 2);
+        assert_eq!(four_kb.succeeded, 1);
+        assert_eq!(four_kb.failed, 1);
+        assert_eq!(four_kb.verdicts["confirmed"], 1);
+        assert_eq!(four_kb.failure_buckets["scripted_verdict_leak"], 1);
+        assert_eq!(four_kb.tool_results, 2);
+        assert_eq!(four_kb.stage_latency_us["finalize"].p50_us, 500_000);
+        let thirty_two_kb = &summary.size_buckets["32768"];
+        assert_eq!(thirty_two_kb.verdicts["contended"], 1);
+    }
+
+    #[test]
+    fn scripted_summary_absent_without_script() {
+        let args = parsed_api_args(&[]);
+        assert!(summarize_scripted(&[], &args).is_none());
+        let mut scripted = parsed_api_args(&[]);
+        scripted.api_scripted_tool = Some("memory_roundtrip".to_string());
+        assert!(summarize_scripted(&[], &scripted).is_none());
     }
 }

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -1150,9 +1150,12 @@ fn validate_args(args: &Args) -> Result<(), String> {
             return Err("--api-scripted-doc-sizes must not be empty".to_string());
         }
         for size in &args.api_scripted_doc_sizes {
-            if *size == 0 || *size > scripted::MAX_SCRIPTED_DOC_SIZE_BYTES {
+            if *size < scripted::MIN_SCRIPTED_DOC_SIZE_BYTES
+                || *size > scripted::MAX_SCRIPTED_DOC_SIZE_BYTES
+            {
                 return Err(format!(
-                    "--api-scripted-doc-sizes values must be between 1 and {} bytes",
+                    "--api-scripted-doc-sizes values must be between {} and {} bytes",
+                    scripted::MIN_SCRIPTED_DOC_SIZE_BYTES,
                     scripted::MAX_SCRIPTED_DOC_SIZE_BYTES
                 ));
             }

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -230,8 +230,8 @@ pub(crate) struct Args {
     /// Scripted tool-call workload for api-user-capacity: each operation is
     /// driven through a configured builtin/memory tool sequence and verified
     /// by its read-back verdict (issue #7360 Phase 1).
-    #[arg(long)]
-    pub(crate) api_scripted_tool: Option<String>,
+    #[arg(long, value_enum)]
+    pub(crate) api_scripted_tool: Option<scripted::ScriptKey>,
 
     /// Document sizes in bytes to cycle through for scripted operations.
     #[arg(
@@ -1134,11 +1134,13 @@ fn validate_args(args: &Args) -> Result<(), String> {
         if !args.scenario.is_api_capacity() {
             return Err("--api-scripted-tool requires --scenario api-user-capacity".to_string());
         }
-        if scripted::ScriptKey::parse(key).is_none() {
-            return Err(format!(
-                "unknown --api-scripted-tool {key:?}; expected one of {}",
-                scripted::ScriptKey::known_keys().join(", ")
-            ));
+        if *key == scripted::ScriptKey::WriteFileRoundtrip && args.api_hot_writers > 0 {
+            return Err(
+                "--api-hot-writers requires a memory script (memory_roundtrip, memory_grow, \
+                 or memory_mixed); write_file_roundtrip targets a per-operation path and \
+                 cannot exercise shared-document contention"
+                    .to_string(),
+            );
         }
         if args.mock_llm_bind.is_none() {
             return Err("--api-scripted-tool requires --mock-llm-bind".to_string());

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -12,6 +12,7 @@ mod ramp;
 mod redaction;
 mod report;
 mod resource_ops;
+mod scripted;
 mod secret_ops;
 mod suite;
 mod summary;
@@ -225,6 +226,26 @@ pub(crate) struct Args {
     /// Concurrent setup creates for API scenario user threads.
     #[arg(long, default_value_t = 16)]
     pub(crate) api_setup_concurrency: usize,
+
+    /// Scripted tool-call workload for api-user-capacity: each operation is
+    /// driven through a configured builtin/memory tool sequence and verified
+    /// by its read-back verdict (issue #7360 Phase 1).
+    #[arg(long)]
+    pub(crate) api_scripted_tool: Option<String>,
+
+    /// Document sizes in bytes to cycle through for scripted operations.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_value = "4096,32768,131072,1048576"
+    )]
+    pub(crate) api_scripted_doc_sizes: Vec<usize>,
+
+    /// Concurrent scripted writers sharing the first user's thread so they
+    /// contend on the same durable document. 0 disables hot-writer
+    /// contention.
+    #[arg(long, default_value_t = 0)]
+    pub(crate) api_hot_writers: usize,
 
     /// Threads created per API user during setup. Values above 1 exercise
     /// listing/read paths against large sidebars; sends still target each
@@ -1109,6 +1130,36 @@ fn validate_args(args: &Args) -> Result<(), String> {
         );
     }
     api_capacity::validate_read_mix(&args.api_read_mix)?;
+    if let Some(key) = &args.api_scripted_tool {
+        if !args.scenario.is_api_capacity() {
+            return Err("--api-scripted-tool requires --scenario api-user-capacity".to_string());
+        }
+        if scripted::ScriptKey::parse(key).is_none() {
+            return Err(format!(
+                "unknown --api-scripted-tool {key:?}; expected one of {}",
+                scripted::ScriptKey::known_keys().join(", ")
+            ));
+        }
+        if args.mock_llm_bind.is_none() {
+            return Err("--api-scripted-tool requires --mock-llm-bind".to_string());
+        }
+        if !args.api_wait_for_assistant {
+            return Err("--api-scripted-tool requires --api-wait-for-assistant".to_string());
+        }
+        if args.api_scripted_doc_sizes.is_empty() {
+            return Err("--api-scripted-doc-sizes must not be empty".to_string());
+        }
+        for size in &args.api_scripted_doc_sizes {
+            if *size == 0 || *size > scripted::MAX_SCRIPTED_DOC_SIZE_BYTES {
+                return Err(format!(
+                    "--api-scripted-doc-sizes values must be between 1 and {} bytes",
+                    scripted::MAX_SCRIPTED_DOC_SIZE_BYTES
+                ));
+            }
+        }
+    } else if args.api_hot_writers > 0 {
+        return Err("--api-hot-writers requires --api-scripted-tool".to_string());
+    }
     if !(0.0..=1.0).contains(&args.mock_llm_failure_rate) {
         return Err("--mock-llm-failure-rate must be between 0.0 and 1.0".to_string());
     }

--- a/tools/ironclaw_stress/src/scripted.rs
+++ b/tools/ironclaw_stress/src/scripted.rs
@@ -37,6 +37,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -63,6 +64,10 @@ pub(crate) const UNDISCLOSED_ATTEMPTS: usize = 2;
 /// Separator between the user part and the op part of a marker identity.
 /// `-` and `.` can appear in user labels, so `__` is the split token.
 const IDENTITY_SEPARATOR: &str = "__";
+/// Upper bound for one marker identity part (`user` or `op`), in bytes. Keeps
+/// read-back tokens and tool arguments bounded regardless of the configured
+/// document size.
+const MAX_IDENTITY_PART_LEN: usize = 64;
 /// Interim text the sidecar emits while a scripted tool is not yet
 /// advertised. The driver detects it in the timeline and classifies the op
 /// as `undisclosed` instead of a plain timeout.
@@ -70,33 +75,35 @@ pub(crate) const PLACEHOLDER_TEXT: &str =
     "ironclaw-stress-tool pending \u{2014} I'll perform the stress tool action next.";
 
 /// Scripted workload keys. The wire key is what the driver puts in the
-/// marker and the sidecar switches on.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// marker and the sidecar switches on. The string mapping lives in the clap
+/// value names so the CLI flag, the marker wire format, and any parsing
+/// share one source of truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum ScriptKey {
     /// `builtin.write_file` then `builtin.read_file` of the same unique
     /// workspace path.
+    #[value(name = "write_file_roundtrip")]
     WriteFileRoundtrip,
     /// `ironclaw.memory.write` (replace) then `ironclaw.memory.read` of the
     /// shared relative memory target.
+    #[value(name = "memory_roundtrip")]
     MemoryRoundtrip,
     /// `ironclaw.memory.write` (quarter) then append (three quarters) then
     /// read of the shared target — growing-append slope workload.
+    #[value(name = "memory_grow")]
     MemoryGrow,
     /// `ironclaw.memory.write` (half), read, append (half), read of the
     /// shared target — mixed read/write workload.
+    #[value(name = "memory_mixed")]
     MemoryMixed,
 }
 
 impl ScriptKey {
+    /// Parse a wire-format key from a marker message. Delegates to clap's
+    /// value mapping so the CLI and the marker format cannot drift apart.
     pub(crate) fn parse(key: &str) -> Option<Self> {
-        match key {
-            "write_file_roundtrip" => Some(Self::WriteFileRoundtrip),
-            "memory_roundtrip" => Some(Self::MemoryRoundtrip),
-            "memory_grow" => Some(Self::MemoryGrow),
-            "memory_mixed" => Some(Self::MemoryMixed),
-            _ => None,
-        }
+        Self::from_str(key, false).ok()
     }
 
     pub(crate) fn as_str(self) -> &'static str {
@@ -106,15 +113,6 @@ impl ScriptKey {
             Self::MemoryGrow => "memory_grow",
             Self::MemoryMixed => "memory_mixed",
         }
-    }
-
-    pub(crate) fn known_keys() -> &'static [&'static str] {
-        &[
-            "write_file_roundtrip",
-            "memory_roundtrip",
-            "memory_grow",
-            "memory_mixed",
-        ]
     }
 
     /// Number of tool-result messages the driver must observe in the
@@ -325,7 +323,13 @@ pub(crate) fn parse_marker(content: &str) -> Option<ScriptedOp> {
         return None;
     }
     let (user, op) = identity.split_once(IDENTITY_SEPARATOR)?;
-    if user.is_empty() || op.is_empty() {
+    if user.is_empty()
+        || op.is_empty()
+        || user.len() > MAX_IDENTITY_PART_LEN
+        || op.len() > MAX_IDENTITY_PART_LEN
+        || !is_readback_compatible(user)
+        || !is_readback_compatible(op)
+    {
         return None;
     }
     Some(ScriptedOp {
@@ -334,6 +338,15 @@ pub(crate) fn parse_marker(content: &str) -> Option<ScriptedOp> {
         op: op.to_string(),
         size_bytes,
     })
+}
+
+/// Whether an identity part survives `readback_tokens` scanning: ASCII
+/// alphanumerics plus `-`, `_`, and `.`. Any other character truncates the
+/// read-back token at that character, so the scripted call could never
+/// produce a matching verdict.
+fn is_readback_compatible(part: &str) -> bool {
+    part.chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
 }
 
 /// Pick the document size for an operation index from a size list, cycling.
@@ -394,18 +407,20 @@ impl Conversation {
 }
 
 /// Decide what the mock LLM sidecar should answer for a chat completion
-/// request. Pure function of the conversation and the advertised tools.
-pub(crate) fn decide(
+/// request, together with the scripted operation the decision applies to.
+/// Pure function of the conversation and the advertised tools; the message
+/// array is walked exactly once.
+pub(crate) fn decide_with_op(
     messages: &[Value],
     available_tool_names: &HashSet<String>,
-) -> ScriptedDecision {
+) -> (ScriptedDecision, Option<ScriptedOp>) {
     let conversation = Conversation::from_messages(messages);
     let Some((marker_position, op)) = find_latest_op(&conversation) else {
-        return ScriptedDecision::None;
+        return (ScriptedDecision::None, None);
     };
 
     if conversation_has_result(&conversation, marker_position, &op) {
-        return ScriptedDecision::None;
+        return (ScriptedDecision::None, Some(op));
     }
 
     let tool_results_after = conversation
@@ -419,11 +434,14 @@ pub(crate) fn decide(
     if step_index < steps.len() {
         let step = &steps[step_index];
         if let Some(wire_name) = resolve_wire_name(available_tool_names, step.capability_id) {
-            let arguments = build_arguments(&op, step);
-            return ScriptedDecision::ToolCall(ToolCallSpec {
-                wire_name,
-                arguments,
-            });
+            let arguments = build_arguments(&op, step, step_index);
+            return (
+                ScriptedDecision::ToolCall(ToolCallSpec {
+                    wire_name,
+                    arguments,
+                }),
+                Some(op),
+            );
         }
         let assistant_turns_after = conversation
             .assistant_messages
@@ -432,13 +450,36 @@ pub(crate) fn decide(
             .count();
         if assistant_turns_after >= UNDISCLOSED_ATTEMPTS {
             let verdict = result_text(&op, Verdict::Undisclosed);
-            return ScriptedDecision::FinalText(verdict);
+            return (ScriptedDecision::FinalText(verdict), Some(op));
         }
-        return ScriptedDecision::Placeholder;
+        return (ScriptedDecision::Placeholder, Some(op));
     }
 
-    let verdict = compute_verdict(&op, &tool_results_after);
-    ScriptedDecision::FinalText(result_text(&op, verdict))
+    // The verdict must come from what the read steps returned: write tool
+    // results may echo the written content, which embeds this operation's
+    // read-back token, and would mask `missing`/`contended` verdicts.
+    let read_results = steps
+        .iter()
+        .zip(&tool_results_after)
+        .filter(|(step, _)| matches!(step.kind, StepKind::ReadFile | StepKind::MemoryRead))
+        .map(|(_, text)| *text)
+        .collect::<Vec<_>>();
+    let verdict = compute_verdict(&op, &read_results);
+    (
+        ScriptedDecision::FinalText(result_text(&op, verdict)),
+        Some(op),
+    )
+}
+
+/// Convenience wrapper returning only the decision; the mock sidecar uses
+/// [`decide_with_op`] so the conversation is parsed once. Test-only in the
+/// current crate.
+#[cfg(test)]
+pub(crate) fn decide(
+    messages: &[Value],
+    available_tool_names: &HashSet<String>,
+) -> ScriptedDecision {
+    decide_with_op(messages, available_tool_names).0
 }
 
 /// Sidecar-side counters for scripted workloads, reported in the run
@@ -457,12 +498,6 @@ pub(crate) struct ScriptedMockCounters {
     /// Final verdict texts emitted, per verdict.
     #[serde(default)]
     pub(crate) final_verdicts: BTreeMap<String, u64>,
-}
-
-/// Find the latest scripted marker among the user messages of a
-/// conversation.
-pub(crate) fn latest_op(messages: &[Value]) -> Option<ScriptedOp> {
-    find_latest_op(&Conversation::from_messages(messages)).map(|(_, op)| op)
 }
 
 /// Find the latest scripted marker among the user messages.
@@ -540,14 +575,15 @@ fn result_text(op: &ScriptedOp, verdict: Verdict) -> String {
 }
 
 /// Resolve the advertised wire name for a capability id, accepting the
-/// `__`-encoded form, the dotted capability id, and the bare tool name.
+/// `__`-encoded form or the dotted capability id. The bare tool name is
+/// deliberately not a candidate: an extension could export a same-named
+/// tool and the script would silently drive a different capability.
 pub(crate) fn resolve_wire_name(
     available_tool_names: &HashSet<String>,
     capability_id: &str,
 ) -> Option<String> {
     let encoded = capability_id.replace('.', "__");
-    let bare = capability_id.rsplit('.').next().unwrap_or(capability_id);
-    for candidate in [encoded.as_str(), capability_id, bare] {
+    for candidate in [encoded.as_str(), capability_id] {
         if let Some(name) = available_tool_names.get(candidate) {
             return Some(name.clone());
         }
@@ -556,7 +592,9 @@ pub(crate) fn resolve_wire_name(
 }
 
 /// Build the arguments for a script step from the operation marker.
-pub(crate) fn build_arguments(op: &ScriptedOp, step: &ScriptStep) -> Value {
+/// `step_index` locates the step in `op.key.steps()` so split writes can
+/// derive their chunk from cumulative fraction boundaries.
+pub(crate) fn build_arguments(op: &ScriptedOp, step: &ScriptStep, step_index: usize) -> Value {
     match step.kind {
         StepKind::WriteFile => {
             let path = format!("stress/{}.txt", sanitize_path_segment(&op.identity()));
@@ -568,7 +606,17 @@ pub(crate) fn build_arguments(op: &ScriptedOp, step: &ScriptStep) -> Value {
             serde_json::json!({ "path": path })
         }
         StepKind::MemoryWrite { append, fraction } => {
-            let size = fraction_size(op.size_bytes, fraction);
+            let cumulative_after = op
+                .key
+                .steps()
+                .iter()
+                .take(step_index + 1)
+                .filter_map(|candidate| match candidate.kind {
+                    StepKind::MemoryWrite { fraction, .. } => Some(fraction),
+                    _ => None,
+                })
+                .sum::<u8>();
+            let size = fraction_chunk(op.size_bytes, fraction, cumulative_after);
             serde_json::json!({
                 "target": SHARED_MEMORY_TARGET,
                 "content": scripted_content(op, size),
@@ -581,9 +629,15 @@ pub(crate) fn build_arguments(op: &ScriptedOp, step: &ScriptStep) -> Value {
     }
 }
 
-/// Content share of the operation's total size: fraction out of 4.
-fn fraction_size(size_bytes: usize, fraction: u8) -> usize {
-    (size_bytes * fraction as usize) / 4
+/// Size of the `fraction`/4 chunk of `size_bytes` ending at the cumulative
+/// fraction boundary `cumulative_after` (the sum of write fractions up to
+/// and including this step). Deriving each chunk from cumulative boundaries
+/// assigns any size remainder exactly once, so a split write persists
+/// exactly `size_bytes` in total.
+fn fraction_chunk(size_bytes: usize, fraction: u8, cumulative_after: u8) -> usize {
+    let after = (size_bytes * cumulative_after as usize) / 4;
+    let before = (size_bytes * (cumulative_after - fraction) as usize) / 4;
+    after - before
 }
 
 /// Build deterministic write content of exactly `size_bytes` carrying the
@@ -613,9 +667,13 @@ pub(crate) fn sanitize_path_segment(identity: &str) -> String {
 }
 
 /// Parse the verdict out of a finalized assistant message for this operation.
+/// The marker is located with substring matching (like
+/// `conversation_has_result`) so a host wrapper around the content does not
+/// make the operation unparseable.
 pub(crate) fn parse_result_verdict(content: &str, op: &ScriptedOp) -> Option<Verdict> {
     let prefix = format!("{RESULT_PREFIX} {}", op.identity());
-    let rest = content.strip_prefix(&prefix)?.trim_start();
+    let start = content.find(&prefix)?;
+    let rest = content[start + prefix.len()..].trim_start();
     let verdict = rest.split_whitespace().next()?;
     Verdict::parse(verdict)
 }
@@ -701,6 +759,32 @@ mod tests {
         );
         assert_eq!(
             parse_marker("ironclaw-stress-tool memory_roundtrip __1 4096"),
+            None
+        );
+        // A `/` truncates the read-back token and can never produce a
+        // verdict, so the identity is rejected up front.
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool memory_roundtrip u0/x__1 4096"),
+            None
+        );
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool memory_roundtrip u0__1/x 4096"),
+            None
+        );
+        // Oversized identity parts are bounded to keep read-back tokens and
+        // tool arguments small.
+        let oversized_user = "u".repeat(MAX_IDENTITY_PART_LEN + 1);
+        assert_eq!(
+            parse_marker(&format!(
+                "ironclaw-stress-tool memory_roundtrip {oversized_user}__1 4096"
+            )),
+            None
+        );
+        let oversized_op = "o".repeat(MAX_IDENTITY_PART_LEN + 1);
+        assert_eq!(
+            parse_marker(&format!(
+                "ironclaw-stress-tool memory_roundtrip u0__{oversized_op} 4096"
+            )),
             None
         );
     }
@@ -810,6 +894,30 @@ mod tests {
     }
 
     #[test]
+    fn write_result_echo_does_not_mask_missing_read() {
+        // The write tool result echoes the written content (which embeds the
+        // operation's own read-back token); the read returns nothing. The
+        // verdict must come from the read step alone: Missing, not Confirmed.
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let token = parsed.readback_token();
+        let marker = marker_message(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let messages = vec![
+            user(&marker),
+            tool_result(&format!("Tool write returned: wrote {token}")),
+            tool_result("Tool read returned: (empty)"),
+        ];
+        match decide(
+            &messages,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::FinalText(text) => {
+                assert_eq!(text, "ironclaw-stress-tool result u0__1 missing");
+            }
+            other => panic!("expected missing verdict, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn verdict_leak_takes_precedence_over_own_token() {
         let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
         let own = parsed.readback_token();
@@ -899,7 +1007,7 @@ mod tests {
     }
 
     #[test]
-    fn wire_name_resolution_accepts_encoded_dotted_and_bare() {
+    fn wire_name_resolution_accepts_encoded_and_dotted_only() {
         let encoded = tools(&["builtin__write_file"]);
         assert_eq!(
             resolve_wire_name(&encoded, "builtin.write_file").as_deref(),
@@ -910,11 +1018,10 @@ mod tests {
             resolve_wire_name(&dotted, "builtin.write_file").as_deref(),
             Some("builtin.write_file")
         );
+        // The bare name is not a candidate: an extension could export a
+        // same-named tool and the script would silently bind to it.
         let bare = tools(&["write_file"]);
-        assert_eq!(
-            resolve_wire_name(&bare, "builtin.write_file").as_deref(),
-            Some("write_file")
-        );
+        assert_eq!(resolve_wire_name(&bare, "builtin.write_file"), None);
         assert_eq!(resolve_wire_name(&tools(&[]), "builtin.write_file"), None);
     }
 
@@ -973,6 +1080,28 @@ mod tests {
                 assert_eq!(spec.arguments["content"].as_str().unwrap().len(), 16384);
             }
             other => panic!("expected first write, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn split_writes_preserve_exact_configured_size() {
+        // 4097 is not divisible by 4. Chunks derived from cumulative
+        // fraction boundaries must still persist exactly the configured
+        // size across the split writes.
+        for (key, expected_chunks) in [
+            (ScriptKey::MemoryGrow, vec![1024, 3073]),
+            (ScriptKey::MemoryMixed, vec![2048, 2049]),
+        ] {
+            let parsed = op(key, "u0", "1", 4097);
+            let mut chunks = Vec::new();
+            for (index, step) in key.steps().iter().enumerate() {
+                if matches!(step.kind, StepKind::MemoryWrite { .. }) {
+                    let arguments = build_arguments(&parsed, step, index);
+                    chunks.push(arguments["content"].as_str().expect("string").len());
+                }
+            }
+            assert_eq!(chunks, expected_chunks, "chunks for {key:?}");
+            assert_eq!(chunks.iter().sum::<usize>(), 4097, "total for {key:?}");
         }
     }
 

--- a/tools/ironclaw_stress/src/scripted.rs
+++ b/tools/ironclaw_stress/src/scripted.rs
@@ -50,6 +50,11 @@ pub(crate) const READBACK_MARKER: &str = "IRONCLAW_STRESS_READBACK";
 /// share the same logical relative path, so each operation doubles as a
 /// same-relative-path isolation check.
 pub(crate) const SHARED_MEMORY_TARGET: &str = "stress/shared.md";
+/// Lower bound for a scripted document size, in bytes. Scripted content is
+/// a read-back token plus deterministic padding; below 4 KiB the token
+/// dominates and sizes lose meaning, and the issue's workloads start at
+/// 4 KiB.
+pub(crate) const MIN_SCRIPTED_DOC_SIZE_BYTES: usize = 4096;
 /// Upper bound for a scripted document size, in bytes.
 pub(crate) const MAX_SCRIPTED_DOC_SIZE_BYTES: usize = 8 * 1024 * 1024;
 /// Number of assistant turns to wait for a scripted tool to be disclosed
@@ -316,7 +321,7 @@ pub(crate) fn parse_marker(content: &str) -> Option<ScriptedOp> {
     let key = ScriptKey::parse(parts.next()?)?;
     let identity = parts.next()?;
     let size_bytes = parts.next()?.parse::<usize>().ok()?;
-    if size_bytes == 0 || size_bytes > MAX_SCRIPTED_DOC_SIZE_BYTES {
+    if !(MIN_SCRIPTED_DOC_SIZE_BYTES..=MAX_SCRIPTED_DOC_SIZE_BYTES).contains(&size_bytes) {
         return None;
     }
     let (user, op) = identity.split_once(IDENTITY_SEPARATOR)?;
@@ -677,6 +682,10 @@ mod tests {
         );
         assert_eq!(
             parse_marker("ironclaw-stress-tool memory_roundtrip u0__1 0"),
+            None
+        );
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool memory_roundtrip u0__1 4095"),
             None
         );
         assert_eq!(

--- a/tools/ironclaw_stress/src/scripted.rs
+++ b/tools/ironclaw_stress/src/scripted.rs
@@ -1,0 +1,1046 @@
+//! Scripted tool-call workloads for the API stress scenario.
+//!
+//! The API driver embeds a deterministic marker in each user message:
+//!
+//! ```text
+//! ironclaw-stress-tool <script> <user>__<op> <size_bytes>
+//! ```
+//!
+//! The mock LLM sidecar recognizes the marker and drives a scripted tool
+//! sequence for that operation (write/append/read steps through the real
+//! capability host), then finishes with a verdict text:
+//!
+//! ```text
+//! ironclaw-stress-tool result <user>__<op> <verdict>
+//! ```
+//!
+//! Every scripted write embeds a read-back token
+//! (`IRONCLAW_STRESS_READBACK_<user>__<op>`) in its content, and every
+//! scripted sequence ends with a read step, so the verdict is derived from
+//! what the tool actually returned through the production path:
+//!
+//! - `confirmed`: the read returned exactly this operation's token.
+//! - `contended`: another operation of the same user overwrote the document
+//!   between write and read (hot-document contention — expected under
+//!   concurrent same-user writers, counted not failed).
+//! - `leak`: the read returned another user's token (cross-user isolation
+//!   violation — a hard failure).
+//! - `missing`: the read returned no token at all (durable write lost — a
+//!   hard failure).
+//! - `undisclosed`: the required tool was never advertised to the model
+//!   (progressive-disclosure / agent-surface regression — a hard failure).
+//!
+//! The module is deliberately pure: no I/O, no globals. Everything the
+//! sidecar and the driver need is a function of the conversation JSON and
+//! the advertised tool names, which keeps the state machine unit-testable
+//! and deterministic.
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Prefix of every scripted driver marker in a user message.
+pub(crate) const MARKER_PREFIX: &str = "ironclaw-stress-tool";
+/// Prefix of the final verdict text emitted by the sidecar.
+pub(crate) const RESULT_PREFIX: &str = "ironclaw-stress-tool result";
+/// Prefix of every read-back token embedded in scripted write content.
+pub(crate) const READBACK_MARKER: &str = "IRONCLAW_STRESS_READBACK";
+/// Relative memory document path every memory script targets. All users
+/// share the same logical relative path, so each operation doubles as a
+/// same-relative-path isolation check.
+pub(crate) const SHARED_MEMORY_TARGET: &str = "stress/shared.md";
+/// Upper bound for a scripted document size, in bytes.
+pub(crate) const MAX_SCRIPTED_DOC_SIZE_BYTES: usize = 8 * 1024 * 1024;
+/// Number of assistant turns to wait for a scripted tool to be disclosed
+/// before declaring the operation `undisclosed`.
+pub(crate) const UNDISCLOSED_ATTEMPTS: usize = 2;
+/// Separator between the user part and the op part of a marker identity.
+/// `-` and `.` can appear in user labels, so `__` is the split token.
+const IDENTITY_SEPARATOR: &str = "__";
+/// Interim text the sidecar emits while a scripted tool is not yet
+/// advertised. The driver detects it in the timeline and classifies the op
+/// as `undisclosed` instead of a plain timeout.
+pub(crate) const PLACEHOLDER_TEXT: &str =
+    "ironclaw-stress-tool pending \u{2014} I'll perform the stress tool action next.";
+
+/// Scripted workload keys. The wire key is what the driver puts in the
+/// marker and the sidecar switches on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ScriptKey {
+    /// `builtin.write_file` then `builtin.read_file` of the same unique
+    /// workspace path.
+    WriteFileRoundtrip,
+    /// `ironclaw.memory.write` (replace) then `ironclaw.memory.read` of the
+    /// shared relative memory target.
+    MemoryRoundtrip,
+    /// `ironclaw.memory.write` (quarter) then append (three quarters) then
+    /// read of the shared target — growing-append slope workload.
+    MemoryGrow,
+    /// `ironclaw.memory.write` (half), read, append (half), read of the
+    /// shared target — mixed read/write workload.
+    MemoryMixed,
+}
+
+impl ScriptKey {
+    pub(crate) fn parse(key: &str) -> Option<Self> {
+        match key {
+            "write_file_roundtrip" => Some(Self::WriteFileRoundtrip),
+            "memory_roundtrip" => Some(Self::MemoryRoundtrip),
+            "memory_grow" => Some(Self::MemoryGrow),
+            "memory_mixed" => Some(Self::MemoryMixed),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::WriteFileRoundtrip => "write_file_roundtrip",
+            Self::MemoryRoundtrip => "memory_roundtrip",
+            Self::MemoryGrow => "memory_grow",
+            Self::MemoryMixed => "memory_mixed",
+        }
+    }
+
+    pub(crate) fn known_keys() -> &'static [&'static str] {
+        &[
+            "write_file_roundtrip",
+            "memory_roundtrip",
+            "memory_grow",
+            "memory_mixed",
+        ]
+    }
+
+    /// Number of tool-result messages the driver must observe in the
+    /// timeline before the operation's tool sequence is complete.
+    pub(crate) fn expected_tool_results(self) -> usize {
+        self.steps().len()
+    }
+
+    pub(crate) fn steps(self) -> &'static [ScriptStep] {
+        match self {
+            Self::WriteFileRoundtrip => &[
+                ScriptStep {
+                    capability_id: "builtin.write_file",
+                    kind: StepKind::WriteFile,
+                },
+                ScriptStep {
+                    capability_id: "builtin.read_file",
+                    kind: StepKind::ReadFile,
+                },
+            ],
+            Self::MemoryRoundtrip => &[
+                ScriptStep {
+                    capability_id: "ironclaw.memory.write",
+                    kind: StepKind::MemoryWrite {
+                        append: false,
+                        fraction: 4,
+                    },
+                },
+                ScriptStep {
+                    capability_id: "ironclaw.memory.read",
+                    kind: StepKind::MemoryRead,
+                },
+            ],
+            Self::MemoryGrow => &[
+                ScriptStep {
+                    capability_id: "ironclaw.memory.write",
+                    kind: StepKind::MemoryWrite {
+                        append: false,
+                        fraction: 1,
+                    },
+                },
+                ScriptStep {
+                    capability_id: "ironclaw.memory.write",
+                    kind: StepKind::MemoryWrite {
+                        append: true,
+                        fraction: 3,
+                    },
+                },
+                ScriptStep {
+                    capability_id: "ironclaw.memory.read",
+                    kind: StepKind::MemoryRead,
+                },
+            ],
+            Self::MemoryMixed => &[
+                ScriptStep {
+                    capability_id: "ironclaw.memory.write",
+                    kind: StepKind::MemoryWrite {
+                        append: false,
+                        fraction: 2,
+                    },
+                },
+                ScriptStep {
+                    capability_id: "ironclaw.memory.read",
+                    kind: StepKind::MemoryRead,
+                },
+                ScriptStep {
+                    capability_id: "ironclaw.memory.write",
+                    kind: StepKind::MemoryWrite {
+                        append: true,
+                        fraction: 2,
+                    },
+                },
+                ScriptStep {
+                    capability_id: "ironclaw.memory.read",
+                    kind: StepKind::MemoryRead,
+                },
+            ],
+        }
+    }
+}
+
+/// One tool call of a scripted sequence.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ScriptStep {
+    /// Dotted capability id the step targets (e.g. `builtin.write_file`).
+    pub(crate) capability_id: &'static str,
+    pub(crate) kind: StepKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StepKind {
+    WriteFile,
+    ReadFile,
+    MemoryWrite {
+        append: bool,
+        /// Content share of the operation's total size: numerator of a
+        /// fraction with denominator 4 (1 = quarter, 2 = half, 3 = three
+        /// quarters, 4 = full).
+        fraction: u8,
+    },
+    MemoryRead,
+}
+
+/// A parsed scripted operation marker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScriptedOp {
+    pub(crate) key: ScriptKey,
+    /// User identity part of the marker (`u0`, `u1`, ...).
+    pub(crate) user: String,
+    /// Operation identity part of the marker (`0`, `1`, `h2-3`, ...).
+    pub(crate) op: String,
+    /// Document size for this operation, in bytes.
+    pub(crate) size_bytes: usize,
+}
+
+impl ScriptedOp {
+    pub(crate) fn identity(&self) -> String {
+        format!("{}{IDENTITY_SEPARATOR}{}", self.user, self.op)
+    }
+
+    pub(crate) fn readback_token(&self) -> String {
+        format!("{READBACK_MARKER}_{}", self.identity())
+    }
+}
+
+/// Verdict the sidecar derives from what the read-back tool actually
+/// returned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Verdict {
+    Confirmed,
+    Contended,
+    Leak,
+    Missing,
+    Undisclosed,
+}
+
+impl Verdict {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Confirmed => "confirmed",
+            Self::Contended => "contended",
+            Self::Leak => "leak",
+            Self::Missing => "missing",
+            Self::Undisclosed => "undisclosed",
+        }
+    }
+
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "confirmed" => Some(Self::Confirmed),
+            "contended" => Some(Self::Contended),
+            "leak" => Some(Self::Leak),
+            "missing" => Some(Self::Missing),
+            "undisclosed" => Some(Self::Undisclosed),
+            _ => None,
+        }
+    }
+
+    /// Whether this verdict is a hard failure for the driver.
+    pub(crate) fn is_failure(self) -> bool {
+        matches!(self, Self::Leak | Self::Missing | Self::Undisclosed)
+    }
+}
+
+/// What the sidecar should answer for a request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ScriptedDecision {
+    /// Emit a tool call for the next script step.
+    ToolCall(ToolCallSpec),
+    /// Emit the final verdict text.
+    FinalText(String),
+    /// Emit an interim text response while waiting for tool disclosure.
+    Placeholder,
+    /// No scripted marker in this conversation; fall through to the default
+    /// text path.
+    None,
+}
+
+/// A single tool call to emit, with the exact wire name advertised in the
+/// request and the arguments to pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolCallSpec {
+    pub(crate) wire_name: String,
+    pub(crate) arguments: Value,
+}
+
+/// Build the driver marker for one operation.
+pub(crate) fn marker_message(key: ScriptKey, user: &str, op: &str, size_bytes: usize) -> String {
+    format!(
+        "{MARKER_PREFIX} {} {}__{} {size_bytes}",
+        key.as_str(),
+        user,
+        op
+    )
+}
+
+/// Parse a driver marker out of a message's text.
+pub(crate) fn parse_marker(content: &str) -> Option<ScriptedOp> {
+    let mut parts = content.split_whitespace();
+    if parts.next()? != MARKER_PREFIX {
+        return None;
+    }
+    let key = ScriptKey::parse(parts.next()?)?;
+    let identity = parts.next()?;
+    let size_bytes = parts.next()?.parse::<usize>().ok()?;
+    if size_bytes == 0 || size_bytes > MAX_SCRIPTED_DOC_SIZE_BYTES {
+        return None;
+    }
+    let (user, op) = identity.split_once(IDENTITY_SEPARATOR)?;
+    if user.is_empty() || op.is_empty() {
+        return None;
+    }
+    Some(ScriptedOp {
+        key,
+        user: user.to_string(),
+        op: op.to_string(),
+        size_bytes,
+    })
+}
+
+/// Pick the document size for an operation index from a size list, cycling.
+pub(crate) fn doc_size_for(sizes: &[usize], op_index: usize) -> usize {
+    if sizes.is_empty() {
+        return 4096;
+    }
+    sizes[op_index % sizes.len()]
+}
+
+/// Extract the text of a chat message, accepting both a plain string and the
+/// OpenAI parts-array shape.
+pub(crate) fn message_text(message: &Value) -> Option<String> {
+    let content = message.get("content")?;
+    match content {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(parts) => {
+            let mut text = String::new();
+            for part in parts {
+                if let Some(part_text) = part.get("text").and_then(Value::as_str) {
+                    text.push_str(part_text);
+                }
+            }
+            Some(text)
+        }
+        _ => None,
+    }
+}
+
+/// Messages of a conversation split into user messages, tool results, and
+/// assistant messages, in conversation order.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Conversation {
+    pub(crate) user_messages: Vec<(usize, String)>,
+    pub(crate) tool_results: Vec<(usize, String)>,
+    pub(crate) assistant_messages: Vec<(usize, String)>,
+}
+
+impl Conversation {
+    pub(crate) fn from_messages(messages: &[Value]) -> Self {
+        let mut conversation = Self::default();
+        for (index, message) in messages.iter().enumerate() {
+            let Some(role) = message.get("role").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(text) = message_text(message) else {
+                continue;
+            };
+            match role {
+                "user" => conversation.user_messages.push((index, text)),
+                "tool" => conversation.tool_results.push((index, text)),
+                "assistant" => conversation.assistant_messages.push((index, text)),
+                _ => {}
+            }
+        }
+        conversation
+    }
+}
+
+/// Decide what the mock LLM sidecar should answer for a chat completion
+/// request. Pure function of the conversation and the advertised tools.
+pub(crate) fn decide(
+    messages: &[Value],
+    available_tool_names: &HashSet<String>,
+) -> ScriptedDecision {
+    let conversation = Conversation::from_messages(messages);
+    let Some((marker_position, op)) = find_latest_op(&conversation) else {
+        return ScriptedDecision::None;
+    };
+
+    if conversation_has_result(&conversation, marker_position, &op) {
+        return ScriptedDecision::None;
+    }
+
+    let tool_results_after = conversation
+        .tool_results
+        .iter()
+        .filter(|(position, _)| *position > marker_position)
+        .map(|(_, text)| text.as_str())
+        .collect::<Vec<_>>();
+    let step_index = tool_results_after.len();
+    let steps = op.key.steps();
+    if step_index < steps.len() {
+        let step = &steps[step_index];
+        if let Some(wire_name) = resolve_wire_name(available_tool_names, step.capability_id) {
+            let arguments = build_arguments(&op, step);
+            return ScriptedDecision::ToolCall(ToolCallSpec {
+                wire_name,
+                arguments,
+            });
+        }
+        let assistant_turns_after = conversation
+            .assistant_messages
+            .iter()
+            .filter(|(position, _)| *position > marker_position)
+            .count();
+        if assistant_turns_after >= UNDISCLOSED_ATTEMPTS {
+            let verdict = result_text(&op, Verdict::Undisclosed);
+            return ScriptedDecision::FinalText(verdict);
+        }
+        return ScriptedDecision::Placeholder;
+    }
+
+    let verdict = compute_verdict(&op, &tool_results_after);
+    ScriptedDecision::FinalText(result_text(&op, verdict))
+}
+
+/// Sidecar-side counters for scripted workloads, reported in the run
+/// summary for operation attribution.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub(crate) struct ScriptedMockCounters {
+    /// Completion requests that carried a scripted marker, per script key.
+    #[serde(default)]
+    pub(crate) requests_seen: BTreeMap<String, u64>,
+    /// Tool calls emitted by the mock, per script key.
+    #[serde(default)]
+    pub(crate) tool_calls_emitted: BTreeMap<String, u64>,
+    /// Interim text responses while waiting for tool disclosure.
+    #[serde(default)]
+    pub(crate) placeholder_responses: u64,
+    /// Final verdict texts emitted, per verdict.
+    #[serde(default)]
+    pub(crate) final_verdicts: BTreeMap<String, u64>,
+}
+
+/// Find the latest scripted marker among the user messages of a
+/// conversation.
+pub(crate) fn latest_op(messages: &[Value]) -> Option<ScriptedOp> {
+    find_latest_op(&Conversation::from_messages(messages)).map(|(_, op)| op)
+}
+
+/// Find the latest scripted marker among the user messages.
+fn find_latest_op(conversation: &Conversation) -> Option<(usize, ScriptedOp)> {
+    conversation
+        .user_messages
+        .iter()
+        .filter_map(|(position, text)| parse_marker(text).map(|op| (*position, op)))
+        .max_by_key(|(position, _)| *position)
+}
+
+/// Whether the conversation already contains the final result text for this
+/// operation (prevents re-driving a completed sequence).
+fn conversation_has_result(
+    conversation: &Conversation,
+    marker_position: usize,
+    op: &ScriptedOp,
+) -> bool {
+    conversation
+        .assistant_messages
+        .iter()
+        .filter(|(position, _)| *position > marker_position)
+        .any(|(_, text)| text.contains(&format!("{RESULT_PREFIX} {}", op.identity())))
+}
+
+/// Derive the read-back verdict from the tool results of this operation.
+pub(crate) fn compute_verdict(op: &ScriptedOp, tool_result_texts: &[&str]) -> Verdict {
+    let own_token = op.readback_token();
+    let mut own_found = false;
+    let mut foreign_user_found = false;
+    let mut same_user_found = false;
+    for text in tool_result_texts {
+        for token in readback_tokens(text) {
+            if token == own_token {
+                own_found = true;
+            } else if let Some(rest) = token.strip_prefix(&format!("{READBACK_MARKER}_"))
+                && let Some((user, _)) = rest.split_once(IDENTITY_SEPARATOR)
+            {
+                if user == op.user {
+                    same_user_found = true;
+                } else {
+                    foreign_user_found = true;
+                }
+            }
+        }
+    }
+    if foreign_user_found {
+        Verdict::Leak
+    } else if own_found {
+        Verdict::Confirmed
+    } else if same_user_found {
+        Verdict::Contended
+    } else {
+        Verdict::Missing
+    }
+}
+
+/// Extract every read-back token from tool-result text.
+pub(crate) fn readback_tokens(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut remainder = text;
+    while let Some(start) = remainder.find(READBACK_MARKER) {
+        let after = &remainder[start + READBACK_MARKER.len()..];
+        let token_end = after
+            .find(|ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_' && ch != '.')
+            .unwrap_or(after.len());
+        tokens.push(format!("{READBACK_MARKER}{}", &after[..token_end]));
+        remainder = &after[token_end..];
+    }
+    tokens
+}
+
+fn result_text(op: &ScriptedOp, verdict: Verdict) -> String {
+    format!("{RESULT_PREFIX} {} {}", op.identity(), verdict.as_str())
+}
+
+/// Resolve the advertised wire name for a capability id, accepting the
+/// `__`-encoded form, the dotted capability id, and the bare tool name.
+pub(crate) fn resolve_wire_name(
+    available_tool_names: &HashSet<String>,
+    capability_id: &str,
+) -> Option<String> {
+    let encoded = capability_id.replace('.', "__");
+    let bare = capability_id.rsplit('.').next().unwrap_or(capability_id);
+    for candidate in [encoded.as_str(), capability_id, bare] {
+        if let Some(name) = available_tool_names.get(candidate) {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+/// Build the arguments for a script step from the operation marker.
+pub(crate) fn build_arguments(op: &ScriptedOp, step: &ScriptStep) -> Value {
+    match step.kind {
+        StepKind::WriteFile => {
+            let path = format!("stress/{}.txt", sanitize_path_segment(&op.identity()));
+            let content = scripted_content(op, op.size_bytes);
+            serde_json::json!({ "path": path, "content": content })
+        }
+        StepKind::ReadFile => {
+            let path = format!("stress/{}.txt", sanitize_path_segment(&op.identity()));
+            serde_json::json!({ "path": path })
+        }
+        StepKind::MemoryWrite { append, fraction } => {
+            let size = fraction_size(op.size_bytes, fraction);
+            serde_json::json!({
+                "target": SHARED_MEMORY_TARGET,
+                "content": scripted_content(op, size),
+                "append": append,
+            })
+        }
+        StepKind::MemoryRead => {
+            serde_json::json!({ "path": SHARED_MEMORY_TARGET })
+        }
+    }
+}
+
+/// Content share of the operation's total size: fraction out of 4.
+fn fraction_size(size_bytes: usize, fraction: u8) -> usize {
+    (size_bytes * fraction as usize) / 4
+}
+
+/// Build deterministic write content of exactly `size_bytes` carrying the
+/// operation's read-back token.
+pub(crate) fn scripted_content(op: &ScriptedOp, size_bytes: usize) -> String {
+    let token = op.readback_token();
+    if size_bytes <= token.len() + 1 {
+        return token;
+    }
+    let padding_len = size_bytes - token.len() - 1;
+    let padding = "x".repeat(padding_len);
+    format!("{token} {padding}")
+}
+
+/// Sanitize an identity so it is safe inside a workspace-relative path.
+pub(crate) fn sanitize_path_segment(identity: &str) -> String {
+    identity
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Parse the verdict out of a finalized assistant message for this operation.
+pub(crate) fn parse_result_verdict(content: &str, op: &ScriptedOp) -> Option<Verdict> {
+    let prefix = format!("{RESULT_PREFIX} {}", op.identity());
+    let rest = content.strip_prefix(&prefix)?.trim_start();
+    let verdict = rest.split_whitespace().next()?;
+    Verdict::parse(verdict)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn message(role: &str, content: &str) -> Value {
+        json!({ "role": role, "content": content })
+    }
+
+    fn tool_result(content: &str) -> Value {
+        message("tool", content)
+    }
+
+    fn assistant(content: &str) -> Value {
+        message("assistant", content)
+    }
+
+    fn user(content: &str) -> Value {
+        message("user", content)
+    }
+
+    fn tools(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
+    fn op(key: ScriptKey, user: &str, op_id: &str, size: usize) -> ScriptedOp {
+        ScriptedOp {
+            key,
+            user: user.to_string(),
+            op: op_id.to_string(),
+            size_bytes: size,
+        }
+    }
+
+    #[test]
+    fn marker_roundtrips_through_parse() {
+        let message = marker_message(ScriptKey::MemoryRoundtrip, "u3", "12", 32768);
+        assert_eq!(
+            message,
+            "ironclaw-stress-tool memory_roundtrip u3__12 32768"
+        );
+        let parsed = parse_marker(&message).expect("marker parses");
+        assert_eq!(parsed.key, ScriptKey::MemoryRoundtrip);
+        assert_eq!(parsed.user, "u3");
+        assert_eq!(parsed.op, "12");
+        assert_eq!(parsed.size_bytes, 32768);
+    }
+
+    #[test]
+    fn marker_rejects_malformed_input() {
+        assert_eq!(parse_marker("not a marker"), None);
+        assert_eq!(parse_marker("ironclaw-stress-tool"), None);
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool unknown_key u0__1 4096"),
+            None
+        );
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool memory_roundtrip u0__1"),
+            None
+        );
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool memory_roundtrip u0__1 0"),
+            None
+        );
+        assert_eq!(
+            parse_marker(&format!(
+                "ironclaw-stress-tool memory_roundtrip u0__1 {}",
+                MAX_SCRIPTED_DOC_SIZE_BYTES + 1
+            )),
+            None
+        );
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool memory_roundtrip u01 4096"),
+            None
+        );
+        assert_eq!(
+            parse_marker("ironclaw-stress-tool memory_roundtrip __1 4096"),
+            None
+        );
+    }
+
+    #[test]
+    fn decide_returns_none_without_marker() {
+        let messages = vec![user("plain chat message")];
+        assert_eq!(
+            decide(&messages, &tools(&["builtin__write_file"])),
+            ScriptedDecision::None
+        );
+    }
+
+    #[test]
+    fn fresh_memory_roundtrip_emits_write_step() {
+        let messages = vec![user(&marker_message(
+            ScriptKey::MemoryRoundtrip,
+            "u0",
+            "1",
+            4096,
+        ))];
+        match decide(
+            &messages,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.wire_name, "ironclaw__memory__write");
+                assert_eq!(spec.arguments["target"], SHARED_MEMORY_TARGET);
+                assert_eq!(spec.arguments["append"], false);
+                let content = spec.arguments["content"].as_str().expect("string");
+                assert_eq!(content.len(), 4096);
+                assert!(content.contains(READBACK_MARKER));
+            }
+            other => panic!("expected tool call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_roundtrip_read_step_after_one_tool_result() {
+        let marker = marker_message(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let messages = vec![
+            user(&marker),
+            tool_result("Tool ironclaw.memory.write returned: written"),
+        ];
+        match decide(
+            &messages,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.wire_name, "ironclaw__memory__read");
+                assert_eq!(spec.arguments["path"], SHARED_MEMORY_TARGET);
+            }
+            other => panic!("expected read tool call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_roundtrip_final_verdict_confirmed() {
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let token = parsed.readback_token();
+        let marker = marker_message(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let messages = vec![
+            user(&marker),
+            tool_result("Tool ironclaw.memory.write returned: written"),
+            tool_result(&format!("Tool ironclaw.memory.read returned: {token}")),
+        ];
+        match decide(
+            &messages,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::FinalText(text) => {
+                assert_eq!(text, "ironclaw-stress-tool result u0__1 confirmed");
+            }
+            other => panic!("expected final text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verdict_detects_cross_user_leak() {
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let own = parsed.readback_token();
+        let foreign = format!("{READBACK_MARKER}_u1__3");
+        let text = format!("Tool returned: {own} {foreign}");
+        assert_eq!(compute_verdict(&parsed, &[&text]), Verdict::Leak);
+    }
+
+    #[test]
+    fn verdict_detects_same_user_contention() {
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let own = parsed.readback_token();
+        let same_user = format!("{READBACK_MARKER}_u0__2");
+        let text = format!("Tool returned: {own} {same_user}");
+        assert_eq!(compute_verdict(&parsed, &[&text]), Verdict::Confirmed);
+        let only_same_user = format!("Tool returned: {same_user}");
+        assert_eq!(
+            compute_verdict(&parsed, &[&only_same_user]),
+            Verdict::Contended
+        );
+    }
+
+    #[test]
+    fn verdict_missing_when_no_tokens() {
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        assert_eq!(compute_verdict(&parsed, &[]), Verdict::Missing);
+        let empty = "Tool returned: empty".to_string();
+        assert_eq!(compute_verdict(&parsed, &[&empty]), Verdict::Missing);
+    }
+
+    #[test]
+    fn verdict_leak_takes_precedence_over_own_token() {
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let own = parsed.readback_token();
+        let foreign = format!("{READBACK_MARKER}_u1__3");
+        let text = format!("{own} {foreign}");
+        assert_eq!(compute_verdict(&parsed, &[&text]), Verdict::Leak);
+    }
+
+    #[test]
+    fn tool_not_disclosed_starts_with_placeholder_then_undisclosed() {
+        let marker = marker_message(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let first = vec![user(&marker)];
+        assert_eq!(
+            decide(&first, &tools(&["ironclaw__memory__read"])),
+            ScriptedDecision::Placeholder
+        );
+        let nudge = vec![
+            user(&marker),
+            assistant("I'll perform the stress tool action next."),
+        ];
+        assert_eq!(
+            decide(&nudge, &tools(&["ironclaw__memory__read"])),
+            ScriptedDecision::Placeholder
+        );
+        let second_nudge = vec![
+            user(&marker),
+            assistant("I'll perform the stress tool action next."),
+            assistant("I'll perform the stress tool action next."),
+        ];
+        match decide(&second_nudge, &tools(&["ironclaw__memory__read"])) {
+            ScriptedDecision::FinalText(text) => {
+                assert_eq!(text, "ironclaw-stress-tool result u0__1 undisclosed");
+            }
+            other => panic!("expected undisclosed final, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completed_operation_is_not_redriven() {
+        let marker = marker_message(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let token = parsed.readback_token();
+        let messages = vec![
+            user(&marker),
+            tool_result("write ok"),
+            tool_result(&format!("read: {token}")),
+            assistant("ironclaw-stress-tool result u0__1 confirmed"),
+        ];
+        assert_eq!(
+            decide(
+                &messages,
+                &tools(&["ironclaw__memory__write", "ironclaw__memory__read"])
+            ),
+            ScriptedDecision::None
+        );
+    }
+
+    #[test]
+    fn write_file_roundtrip_uses_unique_path_and_steps() {
+        let marker = marker_message(ScriptKey::WriteFileRoundtrip, "u2", "7", 8192);
+        let messages = vec![user(&marker)];
+        match decide(
+            &messages,
+            &tools(&["builtin__write_file", "builtin__read_file"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.wire_name, "builtin__write_file");
+                assert_eq!(spec.arguments["path"], "stress/u2__7.txt");
+                assert_eq!(spec.arguments["content"].as_str().unwrap().len(), 8192);
+            }
+            other => panic!("expected write_file tool call, got {other:?}"),
+        }
+        let after_write = vec![
+            user(&marker),
+            tool_result("Tool write_file returned: written"),
+        ];
+        match decide(
+            &after_write,
+            &tools(&["builtin__write_file", "builtin__read_file"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.wire_name, "builtin__read_file");
+                assert_eq!(spec.arguments["path"], "stress/u2__7.txt");
+            }
+            other => panic!("expected read_file tool call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wire_name_resolution_accepts_encoded_dotted_and_bare() {
+        let encoded = tools(&["builtin__write_file"]);
+        assert_eq!(
+            resolve_wire_name(&encoded, "builtin.write_file").as_deref(),
+            Some("builtin__write_file")
+        );
+        let dotted = tools(&["builtin.write_file"]);
+        assert_eq!(
+            resolve_wire_name(&dotted, "builtin.write_file").as_deref(),
+            Some("builtin.write_file")
+        );
+        let bare = tools(&["write_file"]);
+        assert_eq!(
+            resolve_wire_name(&bare, "builtin.write_file").as_deref(),
+            Some("write_file")
+        );
+        assert_eq!(resolve_wire_name(&tools(&[]), "builtin.write_file"), None);
+    }
+
+    #[test]
+    fn memory_grow_steps_write_quarter_then_append_three_quarters() {
+        let marker = marker_message(ScriptKey::MemoryGrow, "u0", "5", 4096);
+        let write = vec![user(&marker)];
+        match decide(
+            &write,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.arguments["append"], false);
+                assert_eq!(spec.arguments["content"].as_str().unwrap().len(), 1024);
+            }
+            other => panic!("expected initial write, got {other:?}"),
+        }
+        let after_write = vec![user(&marker), tool_result("write ok")];
+        match decide(
+            &after_write,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.arguments["append"], true);
+                assert_eq!(spec.arguments["content"].as_str().unwrap().len(), 3072);
+            }
+            other => panic!("expected append, got {other:?}"),
+        }
+        let after_append = vec![
+            user(&marker),
+            tool_result("write ok"),
+            tool_result("append ok"),
+        ];
+        match decide(
+            &after_append,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.arguments["path"], SHARED_MEMORY_TARGET);
+            }
+            other => panic!("expected read, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_mixed_has_four_steps_with_half_sizes() {
+        assert_eq!(ScriptKey::MemoryMixed.expected_tool_results(), 4);
+        let marker = marker_message(ScriptKey::MemoryMixed, "u1", "2", 32768);
+        let messages = vec![user(&marker)];
+        match decide(
+            &messages,
+            &tools(&["ironclaw__memory__write", "ironclaw__memory__read"]),
+        ) {
+            ScriptedDecision::ToolCall(spec) => {
+                assert_eq!(spec.arguments["append"], false);
+                assert_eq!(spec.arguments["content"].as_str().unwrap().len(), 16384);
+            }
+            other => panic!("expected first write, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn expected_tool_results_per_script() {
+        assert_eq!(ScriptKey::WriteFileRoundtrip.expected_tool_results(), 2);
+        assert_eq!(ScriptKey::MemoryRoundtrip.expected_tool_results(), 2);
+        assert_eq!(ScriptKey::MemoryGrow.expected_tool_results(), 3);
+        assert_eq!(ScriptKey::MemoryMixed.expected_tool_results(), 4);
+    }
+
+    #[test]
+    fn doc_sizes_cycle_in_order() {
+        let sizes = vec![4096, 32768, 131072, 1048576];
+        assert_eq!(doc_size_for(&sizes, 0), 4096);
+        assert_eq!(doc_size_for(&sizes, 3), 1048576);
+        assert_eq!(doc_size_for(&sizes, 4), 4096);
+        assert_eq!(doc_size_for(&[], 2), 4096);
+    }
+
+    #[test]
+    fn readback_tokens_extract_from_wrapped_tool_text() {
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        let own = parsed.readback_token();
+        let text = format!("Tool `memory.read` returned: prefix {own} suffix");
+        assert_eq!(readback_tokens(&text), vec![own]);
+    }
+
+    #[test]
+    fn parse_result_verdict_extracts_verdict() {
+        let parsed = op(ScriptKey::MemoryRoundtrip, "u0", "1", 4096);
+        assert_eq!(
+            parse_result_verdict("ironclaw-stress-tool result u0__1 confirmed", &parsed),
+            Some(Verdict::Confirmed)
+        );
+        assert_eq!(
+            parse_result_verdict("ironclaw-stress-tool result u0__1 leak", &parsed),
+            Some(Verdict::Leak)
+        );
+        assert_eq!(parse_result_verdict("unrelated text", &parsed), None);
+        assert_eq!(
+            parse_result_verdict("ironclaw-stress-tool result u0__1 unknown", &parsed),
+            None
+        );
+    }
+
+    #[test]
+    fn content_padding_is_exact_and_deterministic() {
+        let parsed = op(ScriptKey::MemoryGrow, "u4", "9", 1000);
+        let content = scripted_content(&parsed, 1000);
+        assert_eq!(content.len(), 1000);
+        assert!(content.starts_with(&parsed.readback_token()));
+        assert_eq!(scripted_content(&parsed, 1000), content);
+        let tiny = scripted_content(&parsed, 4);
+        assert_eq!(tiny, parsed.readback_token());
+    }
+
+    #[test]
+    fn marker_identity_survives_sanitization() {
+        assert_eq!(sanitize_path_segment("u0__1"), "u0__1");
+        assert_eq!(sanitize_path_segment("h2-3"), "h2-3");
+        assert_eq!(sanitize_path_segment("a b/c"), "a-b-c");
+    }
+
+    #[test]
+    fn message_text_accepts_parts_array() {
+        let parts = json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "ironclaw-stress-tool memory_roundtrip u0__1 4096"},
+                {"type": "text", "text": " more"}
+            ]
+        });
+        assert_eq!(
+            message_text(&parts).unwrap(),
+            "ironclaw-stress-tool memory_roundtrip u0__1 4096 more"
+        );
+        assert_eq!(message_text(&json!({"role": "user"})), None);
+    }
+}

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -148,6 +148,83 @@ fn chat_turn_rejects_multi_process_runs() {
     assert!(error.contains("--scenario chat-turn requires --processes 1"));
 }
 
+fn scripted_api_args() -> Args {
+    let mut args = test_args();
+    args.scenario = Scenario::ApiUserCapacity;
+    args.api_base_url = Some("http://127.0.0.1:4216".to_string());
+    args.api_scripted_tool = Some("memory_roundtrip".to_string());
+    args.mock_llm_bind = Some("127.0.0.1:19090".parse().expect("bind address parses"));
+    args
+}
+
+#[test]
+fn scripted_api_requires_api_scenario() {
+    let mut args = scripted_api_args();
+    args.scenario = Scenario::ChatTurn;
+
+    let error = validate_args(&args).expect_err("scripted mode needs the api scenario");
+
+    assert!(error.contains("--api-scripted-tool requires --scenario api-user-capacity"));
+}
+
+#[test]
+fn scripted_api_rejects_unknown_script_key() {
+    let mut args = scripted_api_args();
+    args.api_scripted_tool = Some("not_a_script".to_string());
+
+    let error = validate_args(&args).expect_err("unknown script key should be rejected");
+
+    assert!(error.contains("unknown --api-scripted-tool"));
+}
+
+#[test]
+fn scripted_api_requires_mock_llm_bind() {
+    let mut args = scripted_api_args();
+    args.mock_llm_bind = None;
+
+    let error = validate_args(&args).expect_err("scripted mode needs the mock sidecar");
+
+    assert!(error.contains("--api-scripted-tool requires --mock-llm-bind"));
+}
+
+#[test]
+fn scripted_api_requires_wait_for_assistant() {
+    let mut args = scripted_api_args();
+    args.api_wait_for_assistant = false;
+
+    let error = validate_args(&args).expect_err("scripted mode needs verdict polling");
+
+    assert!(error.contains("--api-scripted-tool requires --api-wait-for-assistant"));
+}
+
+#[test]
+fn scripted_api_rejects_out_of_range_doc_sizes() {
+    let mut args = scripted_api_args();
+    args.api_scripted_doc_sizes = vec![0];
+
+    let error = validate_args(&args).expect_err("zero-byte documents are meaningless");
+
+    assert!(error.contains("--api-scripted-doc-sizes values must be between 1 and"));
+}
+
+#[test]
+fn scripted_api_hot_writers_require_script_key() {
+    let mut args = test_args();
+    args.scenario = Scenario::ApiUserCapacity;
+    args.api_base_url = Some("http://127.0.0.1:4216".to_string());
+    args.api_hot_writers = 2;
+
+    let error = validate_args(&args).expect_err("hot writers need a script");
+
+    assert!(error.contains("--api-hot-writers requires --api-scripted-tool"));
+}
+
+#[test]
+fn scripted_api_accepts_valid_configuration() {
+    let args = scripted_api_args();
+    validate_args(&args).expect("valid scripted api configuration should pass validation");
+}
+
 #[test]
 fn prewarm_dispatches_secret_and_process_local_scenarios() {
     assert_eq!(
@@ -1370,6 +1447,9 @@ fn test_args() -> Args {
         api_poll_interval_ms: 250,
         api_request_timeout_ms: 10_000,
         api_setup_concurrency: 16,
+        api_scripted_tool: None,
+        api_scripted_doc_sizes: vec![4096, 32768, 131072, 1048576],
+        api_hot_writers: 0,
         api_threads_per_user: 1,
         thread_list_untitled: false,
         api_background_users: 0,

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -152,7 +152,7 @@ fn scripted_api_args() -> Args {
     let mut args = test_args();
     args.scenario = Scenario::ApiUserCapacity;
     args.api_base_url = Some("http://127.0.0.1:4216".to_string());
-    args.api_scripted_tool = Some("memory_roundtrip".to_string());
+    args.api_scripted_tool = Some(scripted::ScriptKey::MemoryRoundtrip);
     args.mock_llm_bind = Some("127.0.0.1:19090".parse().expect("bind address parses"));
     args
 }
@@ -165,16 +165,6 @@ fn scripted_api_requires_api_scenario() {
     let error = validate_args(&args).expect_err("scripted mode needs the api scenario");
 
     assert!(error.contains("--api-scripted-tool requires --scenario api-user-capacity"));
-}
-
-#[test]
-fn scripted_api_rejects_unknown_script_key() {
-    let mut args = scripted_api_args();
-    args.api_scripted_tool = Some("not_a_script".to_string());
-
-    let error = validate_args(&args).expect_err("unknown script key should be rejected");
-
-    assert!(error.contains("unknown --api-scripted-tool"));
 }
 
 #[test]
@@ -200,11 +190,89 @@ fn scripted_api_requires_wait_for_assistant() {
 #[test]
 fn scripted_api_rejects_out_of_range_doc_sizes() {
     let mut args = scripted_api_args();
+
+    // Below the floor: 1024 bytes cannot survive the /4 memory-grow split
+    // and stay above the read-back token, so the recorded size bucket would
+    // not describe the bytes actually written.
     args.api_scripted_doc_sizes = vec![1024];
-
     let error = validate_args(&args).expect_err("sub-4KiB documents are meaningless");
-
     assert!(error.contains("--api-scripted-doc-sizes values must be between 4096 and"));
+
+    // Above the ceiling: stops an operator from requesting a multi-gigabyte
+    // durable write against the hosted Postgres target.
+    args.api_scripted_doc_sizes = vec![scripted::MAX_SCRIPTED_DOC_SIZE_BYTES + 1];
+    let error = validate_args(&args).expect_err("oversized documents are rejected");
+    assert!(error.contains("--api-scripted-doc-sizes values must be between"));
+
+    args.api_scripted_doc_sizes = Vec::new();
+    let error = validate_args(&args).expect_err("an empty size list is rejected");
+    assert!(error.contains("--api-scripted-doc-sizes must not be empty"));
+}
+
+#[test]
+fn scripted_api_hot_writers_reject_file_roundtrip_script() {
+    let mut args = scripted_api_args();
+    args.api_scripted_tool = Some(scripted::ScriptKey::WriteFileRoundtrip);
+    args.api_hot_writers = 2;
+
+    let error = validate_args(&args)
+        .expect_err("hot writers need a shared document; write_file_roundtrip uses per-op paths");
+
+    assert!(error.contains("--api-hot-writers requires a memory script"));
+}
+
+#[test]
+fn scripted_cli_flag_combination_parses_and_gates_execution() {
+    // Drive the scripted flag combination through the CLI parser (clap
+    // typing and default resolution) and then through the validation gate
+    // that runs before any workload starts.
+    let args = Args::try_parse_from([
+        "ironclaw_stress",
+        "--backend",
+        "libsql",
+        "--scenario",
+        "api-user-capacity",
+        "--api-base-url",
+        "http://127.0.0.1:4216",
+        "--api-scripted-tool",
+        "memory_roundtrip",
+        "--mock-llm-bind",
+        "127.0.0.1:19090",
+    ])
+    .expect("scripted flag combination parses");
+    assert_eq!(
+        args.api_scripted_tool,
+        Some(scripted::ScriptKey::MemoryRoundtrip)
+    );
+    assert_eq!(
+        args.api_scripted_doc_sizes,
+        vec![4096, 32768, 131072, 1048576]
+    );
+    validate_args(&args).expect("valid scripted configuration passes the startup gate");
+
+    // An unknown script key is rejected by clap itself before validation.
+    let parse_error = Args::try_parse_from([
+        "ironclaw_stress",
+        "--backend",
+        "libsql",
+        "--scenario",
+        "api-user-capacity",
+        "--api-base-url",
+        "http://127.0.0.1:4216",
+        "--api-scripted-tool",
+        "not_a_script",
+        "--mock-llm-bind",
+        "127.0.0.1:19090",
+    ])
+    .expect_err("unknown script key is rejected at parse time");
+    assert!(parse_error.to_string().contains("possible values"));
+
+    // A valid key without the required sidecar is rejected by validation
+    // before any workload starts.
+    let mut missing_sidecar = args;
+    missing_sidecar.mock_llm_bind = None;
+    let error = validate_args(&missing_sidecar).expect_err("sidecar is required");
+    assert!(error.contains("--api-scripted-tool requires --mock-llm-bind"));
 }
 
 #[test]

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -200,11 +200,11 @@ fn scripted_api_requires_wait_for_assistant() {
 #[test]
 fn scripted_api_rejects_out_of_range_doc_sizes() {
     let mut args = scripted_api_args();
-    args.api_scripted_doc_sizes = vec![0];
+    args.api_scripted_doc_sizes = vec![1024];
 
-    let error = validate_args(&args).expect_err("zero-byte documents are meaningless");
+    let error = validate_args(&args).expect_err("sub-4KiB documents are meaningless");
 
-    assert!(error.contains("--api-scripted-doc-sizes values must be between 1 and"));
+    assert!(error.contains("--api-scripted-doc-sizes values must be between 4096 and"));
 }
 
 #[test]

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -273,6 +273,13 @@ fn scripted_cli_flag_combination_parses_and_gates_execution() {
     missing_sidecar.mock_llm_bind = None;
     let error = validate_args(&missing_sidecar).expect_err("sidecar is required");
     assert!(error.contains("--api-scripted-tool requires --mock-llm-bind"));
+
+    // Scripted verdicts are read from the timeline, so assistant polling is
+    // required for the flow to complete.
+    let mut no_polling = scripted_api_args();
+    no_polling.api_wait_for_assistant = false;
+    let error = validate_args(&no_polling).expect_err("assistant polling is required");
+    assert!(error.contains("--api-scripted-tool requires --api-wait-for-assistant"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Phase 1 of #7360: scripted tool-call workloads for the API stress scenario — the mock LLM sidecar now drives deterministic builtin/memory tool sequences, and the driver verifies durable write read-back through the production path.
- New `--api-scripted-tool` mode on `api-user-capacity` with read-back verdicts (`confirmed` / `contended` / `leak` / `missing` / `undisclosed`), per-document-size buckets (4 KiB–1 MiB), submit-to-tool-visible / submit-to-finalize stage timings, and `--api-hot-writers` same-user contention.
- Nightly leg added to the hosted-single-tenant Postgres stress job (server stays up; leg rebinds the mock sidecar on the same port).
- 40 new unit tests (scripted state machine, verdict computation incl. leak precedence, disclosure fallback, wire-shape rig deserialization, timeline helpers, summary buckets, flag validation).

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Part of #7360 — Phase 1 foundation slice: scripted-tool harness + persistent-memory roundtrip coverage. Reindex/churn workloads, the libSQL leg, and Phases 2–3 remain tracked in the issue.

## Validation

- [x] `cargo fmt -p ironclaw_stress -- --check`
- [x] `cargo clippy -p ironclaw_stress --all-targets --all-features -- -D warnings`
- [x] `cargo build -p ironclaw_stress --release`
- [x] Relevant tests pass: `cargo test -p ironclaw_stress` (119 passed)
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no crate-level integration behavior changed; E2E path covered by the new nightly stress job (postgres-api-capacity scripted leg), which requires a live server + Postgres and runs on schedule
- [x] Manual testing: full local E2E — real hosted-single-tenant server (dist build) + local Postgres 16 + pgvector, scripted leg driven through the real capability host: `memory_roundtrip` 9/9 clean (6 confirmed + 3 contended under one hot writer, 0 leaks), `memory_grow` 8/8 confirmed, per-size buckets and stage latencies present. E2E caught a hot-writer client_action_id collision (409 duplicate) that is fixed and covered by the rerun.
- [ ] `review-pr` / `pr-shepherd` — not run (not available in this session)

## Test Strategy

User behavior: Not applicable — developer tooling (ironclaw_stress) and CI; no product UX change.

Risk areas:
- [ ] Model behavior — mock LLM only, scripted/deterministic
- [ ] Browser
- [x] Side effect — durable writes (memory docs, workspace files) are the workload under test; verified via read-back verdicts
- [x] Persistence — memory + workspace write paths exercised through the production capability host; both read-back and cross-user isolation verified per op
- [ ] Security or permissions — tools exercised through normal origin gates; auto-approve enabled via the production settings API, same as a real user
- [ ] External provider
- [x] Cross-component behavior — HTTP → turn → capability host → scoped filesystem → event/projection path (API-driven by design)

Tests added or updated:
- Unit or contract: 31 tests — marker parsing/roundtrip, per-op step sequencing, tool-name resolution (encoded/dotted/bare), verdict computation (confirmed/contended/leak/missing, leak precedence), disclosure fallback (placeholder → undisclosed), no-redrive after completion, content padding determinism, timeline tool/verdict/placeholder helpers, per-size summary buckets, `--api-*` flag validation
- Reborn integration: Not applicable — the scripted leg is the integration surface; it runs in the nightly Postgres stress job
- Recorded fixture: Not applicable
- Browser E2E: Not applicable
- Backend or runtime: new nightly `postgres-api-capacity` scripted leg (memory_roundtrip, 4 sizes, 2 hot writers, failure-rate + p95 thresholds; loose first-run ceilings pending baseline artifact)
- Live canary: Not applicable

What the tests prove: the scripted state machine emits the right tool call per step from the conversation alone; read-back verdicts correctly distinguish confirmed/contended/leak/missing/undisclosed; operations are not redriven after completion; the driver attributes per-op outcomes to document size and stage; invalid flag combinations fail fast.

Commands run: `cargo fmt -p ironclaw_stress -- --check`, `cargo clippy -p ironclaw_stress --all-targets --all-features -- -D warnings`, `cargo test -p ironclaw_stress`, `cargo build -p ironclaw_stress --release`

## Compatibility / rollback notes

- New flags are opt-in; existing `api-user-capacity` runs unchanged (sidecar falls through to text when no marker is present).
- Summary JSON gains optional `scripted` sections (skipped when absent) — `--compare-json` consumers unaffected.
- CI: new steps only inside the existing nightly-only Postgres job.
- Follow-ups (in issue #7360): libSQL leg of the capability-write matrix, `memory_grow`/`memory_mixed`/`write_file_roundtrip` nightly legs, Phase 2 (workspace/spill/trigger/config/extension families), Phase 3 inventory ratchet, per-case threshold tightening after the first baseline.
