### PR TITLE
fix(reborn): load the operator .env, and stop reporting session faults as a bad API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,15 @@
+# Where this file is read from, strongest source first. A variable that is
+# already set is never overwritten, so the first source to define a key wins:
+#
+#   1. the real process environment (shell export, systemd unit, launchd plist)
+#   2. ./.env, searched upward from the working directory — for dev checkouts
+#   3. $IRONCLAW_REBORN_HOME/.env (default ~/.ironclaw/reborn/.env) — the
+#      operator file, beside config.toml and providers.json
+#
+# Put an installed host's real values in (3): a service started from anywhere
+# but a checkout has no (2) to read, and a `config.toml` slot whose
+# `api_key_env` names a variable nobody set resolves to no credential at all.
+
 # Database Configuration
 DATABASE_URL=postgres://localhost/ironclaw
 DATABASE_POOL_SIZE=30  # multi-tenant default; reduce to 5-10 for single-user or low-resource deployments

--- a/crates/app/ironclaw_cli/AGENTS.md
+++ b/crates/app/ironclaw_cli/AGENTS.md
@@ -8,6 +8,7 @@ This crate owns the standalone `ironclaw` command surface. Keep it small, explic
 - Register each command in `src/commands/mod.rs` and dispatch through `Command::execute`.
 - Keep `src/cli.rs` as the clap root only: parse top-level CLI and hand off to command modules.
 - Put shared process/env boot state in `RebornCliContext` from `src/context.rs`.
+- `src/main.rs` runs exactly two steps: `bootstrap_env::load()` then `cli::run()`. `src/bootstrap_env.rs` seeds the process environment from `./.env` and then `$IRONCLAW_REBORN_HOME/.env`, never overwriting an already-set variable, so precedence is real env > working directory > Reborn home. Every command therefore sees bootstrap variables before dispatch; do not re-read `.env` from a command.
 
 ## Boundaries
 

--- a/crates/app/ironclaw_cli/src/bootstrap_env.rs
+++ b/crates/app/ironclaw_cli/src/bootstrap_env.rs
@@ -1,0 +1,56 @@
+//! Bootstrap `.env` loading, performed once before any command runs.
+//!
+//! Bootstrap variables (`DATABASE_URL`, `LLM_BACKEND`, and every `api_key_env`
+//! a `config.toml` slot names) have to be readable before the runtime exists to
+//! read them from anywhere else, so they come from the process environment and
+//! the `.env` files that seed it.
+
+use ironclaw_config::RebornHome;
+
+/// Load the bootstrap `.env` files into the process environment.
+///
+/// Precedence, strongest first. `dotenvy` never overwrites a variable that is
+/// already set, so the first loader to define a key wins:
+///
+/// 1. the real process environment (shell export, systemd unit, launchd plist)
+/// 2. `./.env`, searched upward from the working directory, for dev checkouts
+/// 3. `$IRONCLAW_REBORN_HOME/.env`, the operator file that sits beside
+///    `config.toml` and `providers.json`
+///
+/// (3) is resolved *after* (2) so a checkout may point the binary at a
+/// different home and have that redirection respected.
+///
+/// Only (2) used to be loaded. A host started from anywhere but a checkout
+/// carrying a `.env` therefore booted with none of its bootstrap variables,
+/// even though its own Reborn home held them: `[llm.default]` with
+/// `api_key_env = "NEARAI_API_KEY"` resolved to no key at all, and the nearai
+/// provider fell through to a session-token path that no `SessionRenewer` is
+/// wired to renew at `serve` boot. The run then failed advising the operator to
+/// check an API key that had never been read.
+pub(crate) fn load() {
+    // Silent on a missing file — production hosts use shell-exported env or a
+    // unit file, not `.env` — but any other error (parse failure, permission
+    // denied) is surfaced to stderr so a malformed file does not boot the host
+    // with stale env. Boot still proceeds, because operators may have already
+    // exported the same keys in their shell.
+    if let Err(error) = dotenvy::dotenv()
+        && !error.not_found()
+    {
+        eprintln!("warning: failed to load .env: {error}");
+    }
+
+    // silent-ok: a home that does not resolve simply has no operator `.env` to
+    // load. Every command that needs the home resolves it again through
+    // `RebornCliContext` and reports the failure there with full context, so
+    // swallowing it here cannot hide it.
+    let Ok(home) = RebornHome::resolve_from_env() else {
+        return;
+    };
+
+    let path = home.path().join(".env");
+    if let Err(error) = dotenvy::from_path(&path)
+        && !error.not_found()
+    {
+        eprintln!("warning: failed to load {}: {error}", path.display());
+    }
+}

--- a/crates/app/ironclaw_cli/src/main.rs
+++ b/crates/app/ironclaw_cli/src/main.rs
@@ -1,3 +1,4 @@
+mod bootstrap_env;
 mod cli;
 mod commands;
 mod context;
@@ -11,18 +12,6 @@ mod serve_invocation;
 mod webui_token;
 
 fn main() -> anyhow::Result<()> {
-    // Mirror the v1 binary's behavior so dev workflows can keep LLM
-    // keys / base URLs in `.env`. Silent on missing file — production
-    // hosts use shell-exported env or systemd unit env, not `.env` —
-    // but any other error (parse failure, permission denied) is
-    // surfaced to stderr so a malformed file does not boot the host
-    // with stale env. The boot itself still proceeds because
-    // operators may have already exported the same keys in their
-    // shell.
-    if let Err(error) = dotenvy::dotenv()
-        && !error.not_found()
-    {
-        eprintln!("warning: failed to load .env: {error}");
-    }
+    bootstrap_env::load();
     cli::run()
 }

--- a/crates/app/ironclaw_cli/tests/smoke.rs
+++ b/crates/app/ironclaw_cli/tests/smoke.rs
@@ -3886,6 +3886,113 @@ fn doctor_rejects_empty_profile_override() {
     assert!(stderr.contains(INVALID_PROFILE_MESSAGE), "stderr: {stderr}");
 }
 
+/// The operator `.env` that sits in the Reborn home — beside the `config.toml`
+/// whose `api_key_env` names the very variables it holds — must reach the
+/// process environment.
+///
+/// Regression: only the working-directory `.env` was ever loaded, so a host
+/// started from anywhere but a checkout containing one booted with none of its
+/// bootstrap variables. A `[llm.default]` slot with
+/// `api_key_env = "NEARAI_API_KEY"` then resolved to *no key*, and the nearai
+/// provider silently fell through to a session-token path that no
+/// `SessionRenewer` is wired to renew — surfacing as "check the selected
+/// provider's API key and base URL" for a key that was never read.
+///
+/// The profile variable is the observable because it fails closed, loudly, and
+/// without starting a listener.
+#[test]
+fn dot_env_in_the_reborn_home_reaches_the_process_environment() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("create reborn home");
+    std::fs::write(
+        reborn_home.join(".env"),
+        "IRONCLAW_REBORN_PROFILE=definitely-not-a-profile\n",
+    )
+    .expect("write reborn-home .env");
+
+    let output = reborn_command()
+        .arg("doctor")
+        .current_dir(temp.path())
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env_remove("IRONCLAW_REBORN_PROFILE")
+        .output()
+        .expect("ironclaw-reborn doctor should run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "the Reborn-home .env must be loaded, so the invalid profile it sets \
+         should fail the command; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(INVALID_PROFILE_MESSAGE),
+        "failure should name the profile the Reborn-home .env set: {stderr}"
+    );
+}
+
+/// An exported variable outranks the file. `dotenvy` must be loaded in
+/// non-overriding mode, or a systemd/launchd unit's explicit environment would
+/// be silently replaced by a stale file on disk.
+#[test]
+fn exported_environment_outranks_the_reborn_home_dot_env() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("create reborn home");
+    std::fs::write(
+        reborn_home.join(".env"),
+        "IRONCLAW_REBORN_PROFILE=definitely-not-a-profile\n",
+    )
+    .expect("write reborn-home .env");
+
+    let output = reborn_command()
+        .arg("doctor")
+        .current_dir(temp.path())
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_REBORN_PROFILE", "local-dev")
+        .output()
+        .expect("ironclaw-reborn doctor should run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains(INVALID_PROFILE_MESSAGE),
+        "the exported profile must win over the Reborn-home .env: {stderr}"
+    );
+}
+
+/// A working-directory `.env` outranks the Reborn-home one, so a checkout can
+/// override an installed host's operator file without editing it.
+#[test]
+fn working_directory_dot_env_outranks_the_reborn_home_dot_env() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("create reborn home");
+    std::fs::write(
+        reborn_home.join(".env"),
+        "IRONCLAW_REBORN_PROFILE=definitely-not-a-profile\n",
+    )
+    .expect("write reborn-home .env");
+    std::fs::write(
+        temp.path().join(".env"),
+        "IRONCLAW_REBORN_PROFILE=local-dev\n",
+    )
+    .expect("write working-directory .env");
+
+    let output = reborn_command()
+        .arg("doctor")
+        .current_dir(temp.path())
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env_remove("IRONCLAW_REBORN_PROFILE")
+        .output()
+        .expect("ironclaw-reborn doctor should run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains(INVALID_PROFILE_MESSAGE),
+        "the working-directory .env must win over the Reborn-home one: {stderr}"
+    );
+}
+
 #[test]
 fn run_rejects_invalid_profile() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/domains/ironclaw_llm/CONTRACT.md
+++ b/crates/domains/ironclaw_llm/CONTRACT.md
@@ -181,7 +181,7 @@ Closed (normal)
       → Open (if any probe fails)
 ```
 
-**Transient vs non-transient errors:** `RequestFailed`, `RateLimited`, `BadGateway`, `StreamInterrupted`, `SessionExpired`, and `SessionRenewalFailed` count toward the threshold. `Http` and `Io` count only when their concrete status/error kind carries transient connection evidence. `InvalidResponse`, `EmptyResponse`, `AuthFailed`, `ContextLengthExceeded`, `ModelNotAvailable`, `QuotaExceeded`, and `Json` never trip the breaker.
+**Transient vs non-transient errors:** `RequestFailed`, `RateLimited`, `BadGateway`, `StreamInterrupted`, `SessionExpired`, and `SessionRenewalFailed` count toward the threshold. `Http` and `Io` count only when their concrete status/error kind carries transient connection evidence. `InvalidResponse`, `EmptyResponse`, `AuthFailed`, `SessionRenewalUnavailable`, `ContextLengthExceeded`, `ModelNotAvailable`, `QuotaExceeded`, and `Json` never trip the breaker. `SessionRenewalUnavailable` is deliberately on the non-transient side even though its sibling `SessionRenewalFailed` is not: it means *this host* has no renewal path, so counting it would trip the breaker against a backend that is answering perfectly well.
 
 Configure via `LlmConfig` fields: `circuit_breaker_threshold` (env: `LLM_CIRCUIT_BREAKER_THRESHOLD`, falls back to `CIRCUIT_BREAKER_THRESHOLD`; None = disabled), `circuit_breaker_recovery_secs` (env: `LLM_CIRCUIT_BREAKER_RECOVERY_SECS`; default: 30).
 
@@ -197,7 +197,9 @@ The circuit breaker wraps the retry/routing/failover chain (`apply_decorator_cha
 
 ## Retry
 
-`RetryProvider` in `retry.rs` wraps any `LlmProvider` with exponential backoff. Retries on: `RequestFailed`, `RateLimited`, `BadGateway`, `StreamInterrupted`, `SessionRenewalFailed`, plus `Http` / `Io` only with concrete transient evidence. Does **not** retry completed `InvalidResponse` / `EmptyResponse`, `AuthFailed`, `SessionExpired`, `ContextLengthExceeded`, `ModelNotAvailable`, `QuotaExceeded`, or `Json`.
+`RetryProvider` in `retry.rs` wraps any `LlmProvider` with exponential backoff. Retries on: `RequestFailed`, `RateLimited`, `BadGateway`, `StreamInterrupted`, `SessionRenewalFailed`, plus `Http` / `Io` only with concrete transient evidence. Does **not** retry completed `InvalidResponse` / `EmptyResponse`, `AuthFailed`, `SessionExpired`, `SessionRenewalUnavailable`, `ContextLengthExceeded`, `ModelNotAvailable`, `QuotaExceeded`, or `Json`.
+
+`SessionRenewalFailed` and `SessionRenewalUnavailable` split on exactly this question. The first is a renewal *attempt* that failed for a reason that may not recur (a validation request that timed out), so retrying can work. The second means no renewal path exists in this build at all — the answer is settled before the first attempt, and retrying only spends the budget and delays the failure.
 
 **Backoff schedule:** base 1s doubled per attempt with ±25% jitter, minimum floor 100ms. Attempt 0: ~1s, attempt 1: ~2s, attempt 2: ~4s. For `RateLimited`, uses the `retry_after` duration from the error (provider-supplied) instead of backoff.
 
@@ -258,6 +260,8 @@ with `rg -n "impl (SessionDb|SessionSecrets|SessionRenewer|SessionKeyPersistor) 
 before assuming any of these ports is wired.
 
 `NoopSessionRenewer` and `NoopKeyPersistor` are provided for headless / hosted contexts (return errors / no-ops) and are the only implementations in the tree today. A binary that needs real behavior plugs concrete impls into `SessionManager` at startup; no Reborn binary currently does.
+
+Because no binary attaches a renewer, `SessionManager::ensure_authenticated` on a host with no token always ends at `NoopSessionRenewer`. It reports `SessionRenewalUnavailable` — the permanent variant — so the decorator chain fails the call on the first attempt instead of retrying a dead end. Session-token auth is therefore not a working auth mode for `serve` today; `nearai` needs an API key, which is why `effective_api_key_required` (`ironclaw_operator::llm_admin::provider_admin`) overrides its catalog value to `true`.
 
 ## Response Cache
 

--- a/crates/domains/ironclaw_llm/src/circuit_breaker.rs
+++ b/crates/domains/ironclaw_llm/src/circuit_breaker.rs
@@ -289,6 +289,10 @@ fn is_transient(err: &LlmError) -> bool {
         | LlmError::ModelNotAvailable { .. }
         | LlmError::QuotaExceeded { .. }
         | LlmError::AuthFailed { .. }
+        // The backend is not degraded; this host simply has no way to renew a
+        // session. Tripping the breaker would blame the provider for a local
+        // configuration gap.
+        | LlmError::SessionRenewalUnavailable { .. }
         | LlmError::Json(_) => false,
     }
 }
@@ -737,6 +741,14 @@ mod tests {
         // NOT transient
         assert!(!is_transient(&LlmError::AuthFailed {
             provider: "p".into(),
+        }));
+        // A missing renewal path is a local configuration gap, not provider
+        // degradation. Counting it would trip the breaker against a backend
+        // that is answering perfectly well, and take every other caller of that
+        // provider down with it.
+        assert!(!is_transient(&LlmError::SessionRenewalUnavailable {
+            provider: "p".into(),
+            reason: "no renewer wired".into(),
         }));
         assert!(!is_transient(&LlmError::ContextLengthExceeded {
             used: 100_000,

--- a/crates/domains/ironclaw_llm/src/error.rs
+++ b/crates/domains/ironclaw_llm/src/error.rs
@@ -88,8 +88,22 @@ pub enum LlmError {
     #[error("Session expired for provider {provider}")]
     SessionExpired { provider: String },
 
+    /// A renewal *attempt* failed for a reason that may not recur — a
+    /// validation request that timed out, a transient 5xx from the auth
+    /// endpoint. Retrying can succeed, so [`crate::retry::is_retryable`] says
+    /// yes.
     #[error("Session renewal failed for provider {provider}: {reason}")]
     SessionRenewalFailed { provider: String, reason: String },
+
+    /// There is no renewal path at all in this build or deployment, so no
+    /// number of attempts can produce a session. Distinct from
+    /// [`Self::SessionRenewalFailed`] precisely so the retry layer can tell
+    /// "this might work next time" from "this can never work": the headless
+    /// `NoopSessionRenewer` used to report the second as the first, and every
+    /// failed run burned its full retry budget on a call whose outcome was
+    /// already decided.
+    #[error("Session renewal is unavailable for provider {provider}: {reason}")]
+    SessionRenewalUnavailable { provider: String, reason: String },
 
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),

--- a/crates/domains/ironclaw_llm/src/host.rs
+++ b/crates/domains/ironclaw_llm/src/host.rs
@@ -92,7 +92,7 @@ pub struct NoopSessionRenewer;
 #[async_trait]
 impl SessionRenewer for NoopSessionRenewer {
     async fn renew(&self, _manager: &super::session::SessionManager) -> Result<(), LlmError> {
-        Err(LlmError::SessionRenewalFailed {
+        Err(LlmError::SessionRenewalUnavailable {
             provider: "nearai".to_string(),
             reason: "interactive session renewal is unavailable in this build; \
                  set NEARAI_SESSION_TOKEN or NEARAI_API_KEY env var instead"

--- a/crates/domains/ironclaw_llm/src/retry.rs
+++ b/crates/domains/ironclaw_llm/src/retry.rs
@@ -37,9 +37,11 @@ pub(crate) const MAX_RETRY_AFTER_SECS: u64 = 3600;
 /// their concrete error carries transient connection/status evidence.
 ///
 /// Non-retryable: `InvalidRequest`, `AuthFailed`, `SessionExpired`,
-/// `ContextLengthExceeded`, `ModelNotAvailable`, `QuotaExceeded`, `Json`,
-/// `InvalidResponse`, `EmptyResponse`.
+/// `SessionRenewalUnavailable`, `ContextLengthExceeded`, `ModelNotAvailable`,
+/// `QuotaExceeded`, `Json`, `InvalidResponse`, `EmptyResponse`.
 /// - `SessionExpired` — handled by session renewal layer, not by retry
+/// - `SessionRenewalUnavailable` — no renewal path exists in this build, so
+///   the next attempt reaches the same dead end as this one
 /// - `ModelNotAvailable` — the model won't appear between attempts
 /// - `QuotaExceeded` — billing or credits require user action
 /// - `Json` — a serde parse bug, not a transient failure
@@ -63,6 +65,7 @@ pub fn is_retryable(err: &LlmError) -> bool {
         | LlmError::QuotaExceeded { .. }
         | LlmError::AuthFailed { .. }
         | LlmError::SessionExpired { .. }
+        | LlmError::SessionRenewalUnavailable { .. }
         | LlmError::Json(_) => false,
     }
 }
@@ -742,6 +745,13 @@ mod tests {
             provider: "p".into(),
             reason: "timeout".into(),
         }));
+        // A renewal attempt that could not happen at all is NOT retryable:
+        // the headless `NoopSessionRenewer` reports the same dead end on every
+        // attempt, so retrying only spends the budget and delays the failure.
+        assert!(!is_retryable(&LlmError::SessionRenewalUnavailable {
+            provider: "nearai".into(),
+            reason: "interactive session renewal is unavailable in this build".into(),
+        }));
         assert!(is_retryable(&LlmError::Io(std::io::Error::new(
             std::io::ErrorKind::ConnectionReset,
             "reset"
@@ -868,6 +878,34 @@ mod tests {
         assert!(matches!(err, LlmError::ContextLengthExceeded { .. }));
         // Should only be called once — no retries for non-transient errors
         assert_eq!(stub.calls(), 1);
+    }
+
+    /// Driven through `RetryProvider`, not `is_retryable` alone: the classifier
+    /// gates the retry loop, so the regression only shows up as an attempt
+    /// count.
+    ///
+    /// Regression: the headless `NoopSessionRenewer` reported "renewal is
+    /// impossible here" as `SessionRenewalFailed`, which is retryable. Every
+    /// run on a host with no renewer wired therefore spent its whole retry
+    /// budget (three attempts and ~7s of backoff) re-asking a question whose
+    /// answer could not change, before failing anyway.
+    #[tokio::test]
+    async fn unavailable_session_renewal_is_not_retried() {
+        use crate::testing::fault_injection::{FaultAction, FaultInjector, FaultType};
+
+        let injector = Arc::new(FaultInjector::sequence_loop([FaultAction::Fail(
+            FaultType::SessionRenewalUnavailable,
+        )]));
+        let stub = Arc::new(StubLlm::new("unused").with_fault_injector(injector));
+        let retry = RetryProvider::new(stub.clone(), fast_config(3));
+
+        let err = retry.complete(make_request()).await.unwrap_err();
+        assert!(matches!(err, LlmError::SessionRenewalUnavailable { .. }));
+        assert_eq!(
+            stub.calls(),
+            1,
+            "a renewal path that does not exist cannot appear on a later attempt"
+        );
     }
 
     #[tokio::test]

--- a/crates/domains/ironclaw_llm/src/session.rs
+++ b/crates/domains/ironclaw_llm/src/session.rs
@@ -709,6 +709,44 @@ mod tests {
         assert_eq!(data.auth_provider, Some("near".to_string()));
     }
 
+    /// The default renewer is the headless no-op, and its refusal must be the
+    /// *permanent* variant.
+    ///
+    /// Regression: it reported `SessionRenewalFailed`, which `is_retryable`
+    /// treats as retryable because a renewal attempt can fail transiently. But
+    /// "no renewer is wired in this build" is settled before the first attempt,
+    /// so every failing run on a headless host burned its full retry budget
+    /// (three attempts, ~7s of backoff) re-asking a question whose answer could
+    /// not change, and failed anyway.
+    ///
+    /// Driven through `ensure_authenticated`, the production entry point, so
+    /// the assertion covers the wiring and not just the no-op in isolation.
+    #[tokio::test]
+    async fn ensure_authenticated_without_a_renewer_fails_permanently() {
+        let dir = tempdir().unwrap();
+        let config = SessionConfig {
+            auth_base_url: "https://example.com".to_string(),
+            session_path: dir.path().join("nonexistent.json"),
+        };
+
+        let manager = SessionManager::new_async(config).await;
+        assert!(!manager.has_token().await, "no token should be loaded");
+
+        let error = manager
+            .ensure_authenticated()
+            .await
+            .expect_err("no token and no renewer cannot authenticate");
+
+        assert!(
+            matches!(error, LlmError::SessionRenewalUnavailable { .. }),
+            "the default renewer must report a permanent failure, got: {error:?}"
+        );
+        assert!(
+            !crate::retry::is_retryable(&error),
+            "a renewal path that does not exist cannot appear on a later attempt"
+        );
+    }
+
     #[tokio::test]
     async fn test_get_token_without_auth_fails() {
         let dir = tempdir().unwrap();

--- a/crates/domains/ironclaw_llm/src/testing/fault_injection.rs
+++ b/crates/domains/ironclaw_llm/src/testing/fault_injection.rs
@@ -39,6 +39,10 @@ pub enum FaultType {
     ContextLengthExceeded,
     /// Session expired (transient for circuit breaker, not retryable).
     SessionExpired,
+    /// No session-renewal path exists in this build (not retryable, and not a
+    /// backend fault — the provider is healthy, this host just cannot
+    /// authenticate to it).
+    SessionRenewalUnavailable,
 }
 
 impl FaultType {
@@ -70,6 +74,10 @@ impl FaultType {
             },
             FaultType::SessionExpired => LlmError::SessionExpired {
                 provider: provider.to_string(),
+            },
+            FaultType::SessionRenewalUnavailable => LlmError::SessionRenewalUnavailable {
+                provider: provider.to_string(),
+                reason: "injected fault: session renewal is unavailable".to_string(),
             },
         }
     }

--- a/crates/loop/ironclaw_loop_host/src/model_gateway.rs
+++ b/crates/loop/ironclaw_loop_host/src/model_gateway.rs
@@ -2741,7 +2741,8 @@ fn map_provider_error(error: LlmError) -> HostManagedModelError {
         ),
         LlmError::AuthFailed { .. }
         | LlmError::SessionExpired { .. }
-        | LlmError::SessionRenewalFailed { .. } => HostManagedModelError::safe(
+        | LlmError::SessionRenewalFailed { .. }
+        | LlmError::SessionRenewalUnavailable { .. } => HostManagedModelError::safe(
             HostManagedModelErrorKind::CredentialUnavailable,
             "model credentials are unavailable",
         ),

--- a/crates/loop/ironclaw_loop_host/src/model_gateway.rs
+++ b/crates/loop/ironclaw_loop_host/src/model_gateway.rs
@@ -2739,13 +2739,24 @@ fn map_provider_error(error: LlmError) -> HostManagedModelError {
             HostManagedModelErrorKind::PolicyDenied,
             "requested model is not available through this profile",
         ),
-        LlmError::AuthFailed { .. }
-        | LlmError::SessionExpired { .. }
-        | LlmError::SessionRenewalFailed { .. }
-        | LlmError::SessionRenewalUnavailable { .. } => HostManagedModelError::safe(
+        // A key the provider looked at and rejected. This is the one fault the
+        // pinned "check your API key and base URL" sentence actually describes,
+        // so it stays the unqualified member of the kind.
+        LlmError::AuthFailed { .. } => HostManagedModelError::safe(
             HostManagedModelErrorKind::CredentialUnavailable,
             "model credentials are unavailable",
         ),
+        // A session fault is not a bad key: there was no session to present, so
+        // the credential was never read. These three were the "fourth producer"
+        // `credential_unavailable_faults_carry_distinct_reason_kinds` warned
+        // about — carrying no reason kind, they inherited the bad-key advice.
+        LlmError::SessionExpired { .. }
+        | LlmError::SessionRenewalFailed { .. }
+        | LlmError::SessionRenewalUnavailable { .. } => HostManagedModelError::safe(
+            HostManagedModelErrorKind::CredentialUnavailable,
+            "model provider session is unavailable",
+        )
+        .with_reason_kind(MODEL_PROVIDER_SESSION_UNAVAILABLE_REASON_KIND),
         LlmError::RateLimited { retry_after, .. } => {
             let error = HostManagedModelError::safe(
                 HostManagedModelErrorKind::RateLimited,
@@ -3128,6 +3139,47 @@ mod tests {
             Some(MODEL_PROVIDER_SESSION_UNAVAILABLE_REASON_KIND),
             "session-storage faults must name their own cause, not a bad API key"
         );
+    }
+
+    /// An expired session, and a session that could not be renewed, are the
+    /// producers the sibling test warned about: they carried no reason kind, so
+    /// they inherited the bad-key sentence.
+    ///
+    /// The credential was never presented in any of these cases — there was no
+    /// session to present. Telling the operator to "check the selected
+    /// provider's API key and base URL" sends them to inspect a value that was
+    /// never read. This is the exact failure a `serve` host hits, because
+    /// nothing calls `attach_renewer`, so `NoopSessionRenewer` answers every
+    /// renewal with `SessionRenewalUnavailable`.
+    #[test]
+    fn session_faults_are_not_reported_as_invalid_credentials() {
+        for error in [
+            LlmError::SessionExpired {
+                provider: "fixture-provider".to_string(),
+            },
+            LlmError::SessionRenewalFailed {
+                provider: "fixture-provider".to_string(),
+                reason: "validation request timed out".to_string(),
+            },
+            LlmError::SessionRenewalUnavailable {
+                provider: "fixture-provider".to_string(),
+                reason: "interactive session renewal is unavailable in this build".to_string(),
+            },
+        ] {
+            let label = error.to_string();
+            let mapped = map_provider_error(error);
+
+            assert_eq!(
+                mapped.kind,
+                HostManagedModelErrorKind::CredentialUnavailable,
+                "a session fault still fails fast rather than retrying: {label}"
+            );
+            assert_eq!(
+                mapped.reason_kind,
+                Some(MODEL_PROVIDER_SESSION_UNAVAILABLE_REASON_KIND),
+                "a session fault must name signing in again, not a bad API key: {label}"
+            );
+        }
     }
 
     /// The three faults that share `CredentialUnavailable` must stay

--- a/tools/ironclaw_stress/src/user_turn.rs
+++ b/tools/ironclaw_stress/src/user_turn.rs
@@ -2116,7 +2116,8 @@ fn provider_latency_failure(error: LlmError) -> OperationFailure {
         LlmError::RateLimited { .. } => "model_provider_rate_limited",
         LlmError::AuthFailed { .. }
         | LlmError::SessionExpired { .. }
-        | LlmError::SessionRenewalFailed { .. } => "model_provider_auth",
+        | LlmError::SessionRenewalFailed { .. }
+        | LlmError::SessionRenewalUnavailable { .. } => "model_provider_auth",
         LlmError::ContextLengthExceeded { .. } => "model_provider_context_length",
         LlmError::InvalidRequest { .. } => "model_provider_invalid_request",
         LlmError::ModelNotAvailable { .. } => "model_provider_model_unavailable",


### PR DESCRIPTION
## Summary

Stacked on #7359 (`fix/credential-owner-scoping`), which owns the reason-kind vocabulary the third commit uses.

A real `serve` run failed with *"model credentials or provider configuration are invalid. Check the selected provider's API key and base URL"*. The key was valid the whole time — a live check against `cloud-api.near.ai` returned HTTP 200, and the configured model was in the response. Three separate defects sat between that healthy key and that message:

- **The key was never read.** `dotenvy::dotenv()` searches upward from the working directory only, so a host started anywhere but a checkout carrying a `.env` boots with none of its bootstrap variables — even though its own Reborn home holds them, beside the `config.toml` that names them. `api_key_env = "NEARAI_API_KEY"` resolved to no credential, so `uses_api_key()` was false and the nearai provider took the session-token branch instead of the Bearer-key one.
- **The dead end was retried.** Nothing calls `attach_renewer`, so every `serve` boot gets `NoopSessionRenewer`. It reported "renewal is unavailable in this build" as `SessionRenewalFailed`, which `is_retryable` treats as retryable — correctly for that variant, since a renewal *attempt* can fail transiently. "No renewal path exists here" is settled before the first attempt, so each failing run burned three attempts and ~7s of backoff before failing anyway.
- **The advice named the wrong thing.** Session faults carried no reason kind, so they inherited the bad-key sentence and sent the operator to inspect a value that had no part in the failure.

`credential_unavailable_faults_carry_distinct_reason_kinds` (added in #7359) predicted the third exactly: *"adding a fourth producer that forgets its reason kind silently rejoins the bad-key bucket."* These were that producer.

## Change Type

- [x] Bug fix

## Linked Issue

None — found while diagnosing a live `serve` failure.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (exit 0)
- [x] `cargo build`
- [x] Relevant tests pass: `ironclaw_llm` 922, `ironclaw_loop_host` 633, `ironclaw_turn_runner` 242, `ironclaw_assistant` 405, `ironclaw` smoke 149, `ironclaw_architecture_tests` all green
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed or runtime-integration behavior changed
- [x] Manual testing: reproduced the original failure from the live host's logs; confirmed the stored key returns HTTP 200 from `cloud-api.near.ai` and that the configured model is in its model list, establishing that the credential was healthy and only invisible to the process (`ps eww` on the running `serve` showed 39 env vars, none of them `NEARAI_*`)

One flake, unrelated to this change: `onboard_login_link_then_bearer_authorizes_a_protected_request` failed once in a full smoke run and passed on re-run and in isolation. It spawns a real `serve` and binds a port chosen by `unused_local_port()`, a TOCTOU race that is live on a machine already running `ironclaw serve`. This change is inert there — those temp homes contain no `.env`, and a missing file is ignored.

## Test Strategy

User behavior: an operator whose credentials live in the Reborn home gets a working host instead of a run that fails naming a key it never read; when a session genuinely cannot be established, the run fails on the first attempt and the message says to sign in again rather than to check an API key.

Risk areas:
- [x] External provider
- [x] Cross-component behavior
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions

Tests added or updated:
- Unit or contract: `model_gateway.rs::session_faults_are_not_reported_as_invalid_credentials` (all three session variants); `session.rs::ensure_authenticated_without_a_renewer_fails_permanently`; `retry.rs::unavailable_session_renewal_is_not_retried`; classifier assertions in `retry.rs` and `circuit_breaker.rs`
- Reborn integration: Not applicable: the `.env` seam is process bootstrap, reachable only by spawning the real binary (covered at the CLI tier below); the error-classification changes are pure mappings whose callers are covered at crate tier
- Recorded fixture: Not applicable: no model request/response shape changed
- Browser E2E: Not applicable: no user-visible WebUI flow changed
- Backend or runtime: `smoke.rs` — three tests driving the real `ironclaw` binary for `.env` precedence
- Live canary: Not applicable

What the tests prove: the Reborn-home `.env` reaches the process environment, and precedence holds in both directions (an exported variable outranks the file; a working-directory file outranks the home one) — so `dotenvy` cannot be switched to override mode without a failure. A renewal that cannot happen is attempted exactly once, asserted as an attempt count through `RetryProvider` rather than on the classifier alone, because that is the only place the regression is observable. Every session fault names its own cause instead of the bad-key sentence.

Each of the three was watched failing for the right reason before its fix.

Commands run:

```
cargo fmt --all --check
cargo clippy --all --benches --tests --examples --all-features -- -D warnings
cargo test -p ironclaw_llm --lib
cargo test -p ironclaw_loop_host --lib
cargo test -p ironclaw_turn_runner --lib
cargo test -p ironclaw_assistant --lib
cargo test -p ironclaw --test smoke
cargo test -p ironclaw_architecture_tests
bash scripts/pre-commit-safety.sh
```

## Security Impact

No change to permissions, secret storage, redaction, or network reach. One deliberate non-change: `~/.ironclaw/.env` (the v1 state root) is **not** a fallback. `home.rs` actively refuses that directory as a Reborn home, and reborn writes nothing there any more, so reading it back would resurrect a fenced-off path. Operators carrying a v1 file move it to `$IRONCLAW_REBORN_HOME/.env`; `.env.example` documents the load order. Secret *values* are never logged — the new warning lines name a path and an error, never a variable's contents.

## Reborn Trust-Boundary Checklist

- Public policy/evidence/trust-bearing types: none added. `SessionRenewalUnavailable` is a plain error variant with no authority.
- Untrusted content enters prompts only through an envelope/escaping primitive: N/A — no prompt path touched.
- Hashes declare purpose: N/A — no hashing.
- New/changed status, exit, policy, runtime, or error variants: **yes** — `LlmError::SessionRenewalUnavailable`. `LlmError` is matched exhaustively with no `_` arms, so the compiler enumerated the call sites; `cargo check --workspace --all-features --all-targets` surfaced the one outside the crates I had already edited (`tools/ironclaw_stress/src/user_turn.rs`, now handled). Command: `cargo check --workspace --all-features --all-targets`.
- Security/durability `serde(default)` fields: N/A — no serialized shape changed. `LlmError` is not persisted or sent over the wire.
- Queues/maps/buffers/counters: N/A.
- Driver/operator-visible errors have stable class semantics: **this is the point of the change.** The new variant is permanent where its sibling is transient, and it is non-retryable for `RetryProvider` and non-tripping for the circuit breaker, because a local configuration gap must not blame a healthy backend and take every other caller of that provider down with it. `ironclaw_llm/CONTRACT.md` enumerates both classification lists explicitly and is updated in the same commit.
- Sandbox/native/host names accurately describe trust boundary: N/A.

## Database Impact

None.

## Blast Radius

- `ironclaw_cli` bootstrap: every command now sees the Reborn-home `.env`. Because `dotenvy` never overwrites a set variable, a host that already exported its variables is bit-for-bit unaffected; the only behavior change is for variables that were previously invisible.
- `ironclaw_llm`: one new `LlmError` variant, produced today only by `NoopSessionRenewer`. Callers that grouped it with its sibling still group it (`ironclaw_stress` buckets both as `model_provider_auth`).
- `ironclaw_loop_host`: session faults keep `CredentialUnavailable`, so retry/fail-fast behavior at the loop tier is unchanged; only the reason kind and the safe summary differ, which changes the sentence the operator reads.

The plausible surprise is an operator who had a stale `$IRONCLAW_REBORN_HOME/.env` that was silently ignored and is now honored — but it still loses to anything exported, and honoring the file beside `config.toml` is the intended contract.

## Rollback Plan

Three independent commits, each revertable alone:

- `cff1acd` CLI `.env` loading — revert restores cwd-only loading.
- `847cf53` `SessionRenewalUnavailable` — revert restores the single variant and its retryable classification.
- `ff38a1a` session reason kind — revert restores the shared bad-key sentence.

No migration, no persisted state, no wire format, so revert is immediate and needs no data fix-up.

## Review Follow-Through

Two judgement calls worth a reviewer's eye:

1. **No v1 `.env` fallback** (see Security Impact). If we would rather read `~/.ironclaw/.env` with a deprecation warning for existing installs, that is a small addition — but it points reborn at the state root `home.rs` refuses, so I left it out deliberately rather than by omission.
2. **`SessionExpired` keeps tripping the circuit breaker** (`is_transient` returns true for it, unchanged). That predates this PR and is arguably the same category error as the retry bug fixed here, but changing it is a behavior change with its own blast radius and did not belong in the same diff.

Still not fixed, and out of scope: `serve` has no way to *recover* from a genuine session expiry, because there is no interactive terminal and no renewer is wired. The message now tells the operator to sign in again; making the run actually offer that through the existing auth-card surface is a feature, not a bug fix.

---

**Review track**: C (runtime + operator-visible error semantics)
