### PR TITLE
fix(live-qa): verify triggered Slack delivery through the two-lane contract

### DIFF
--- a/docs/internal/live-canary.md
+++ b/docs/internal/live-canary.md
@@ -165,6 +165,25 @@ LANE=auth-live-seeded CASES=gmail,github scripts/live-canary/run.sh
 LANE=auth-browser-consent CASES=google,github scripts/live-canary/run.sh
 ```
 
+## Slack Delivery Verification (two-lane model)
+
+Since the explicit channel delivery tool landed (#7157), a triggered fire's
+result is never pushed by the completion driver: the fire itself calls
+`builtin.outbound_deliver`, and the background-run notifier's
+`triggered-run-delivery` record describes notice delivery only — `skipped`
+is the healthy record for a cleanly completed fire. The
+`reborn-webui-v2-live-qa` delivery cases therefore verify:
+
+- the durable `outbound/deliveries/` model-delivery record for the exact
+  fire run (`status == "delivered"`, target = the expected DM), and
+- the delivery marker in an independent Slack `conversations.history`
+  read-back (bot-authored, exactly once for one-shot routines).
+
+Only `failed`/`denied` notifier records fail a delivery case. Case prompts
+bind the marker to the **delivered Slack message** (the fire composes the
+message separately from its final answer, so a final-answer-only phrasing
+produces marker-less deliveries).
+
 ## Artifact Policy
 
 Artifacts are written under `artifacts/live-canary/`.

--- a/scripts/live-canary/emit_results_json.py
+++ b/scripts/live-canary/emit_results_json.py
@@ -109,7 +109,12 @@ REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"sk-ant-[A-Za-z0-9_-]{10,}"), "<REDACTED_ANTHROPIC_KEY>"),
     (re.compile(r"sk-(?!ant-)[A-Za-z0-9_-]{20,}"), "<REDACTED_OPENAI_KEY>"),
     (re.compile(r"AKIA[0-9A-Z]{16}"), "<REDACTED_AWS_ACCESS_KEY>"),
-    (re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]+"), "Bearer <REDACTED>"),
+    # 16+ token-alphabet chars only, mirroring scrub-artifacts.sh: prose from
+    # model-visible tool descriptions ("bearer for a static API token …")
+    # lands in results via tool_search output and must not be mangled, while
+    # every real bearer credential shape is far longer than any English word
+    # that can follow "bearer".
+    (re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{16,}"), "Bearer <REDACTED>"),
     # Generic `key=value` / `key: value` assignments. Mirrors the
     # corresponding rules in scrub-artifacts.sh so anything that script
     # would have stripped from a log file also gets stripped from a

--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -211,7 +211,12 @@ if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" || "${STRICT_ARTIFACT_SCRUB}" == "1" 
 fi
 
 patterns=(
-  'bearer[[:space:]]+[A-Za-z0-9._~+/=-]+'
+  # 16+ token-alphabet chars only: model-visible tool descriptions say things
+  # like "bearer for a static API token or PAT sent as a Bearer token", and
+  # tool_search output lands in traces — prose after "bearer" must not trip
+  # the guardrail, while real bearer credentials (JWTs, xoxb-, ya29., ghp_…)
+  # are all far longer than any English word that can follow "bearer".
+  'bearer[[:space:]]+[A-Za-z0-9._~+/=-]{16,}'
   'api[_-]?key[[:space:]]*[:=][[:space:]]*[^[:space:]]+'
   'access[_-]?token[[:space:]]*[:=][[:space:]]*[^[:space:]]+'
   'refresh[_-]?token[[:space:]]*[:=][[:space:]]*[^[:space:]]+'
@@ -239,7 +244,7 @@ trap 'rm -f "${tmp_matches}" "${tmp_files}"' EXIT
 
 redact_matches() {
   sed -E \
-    -e 's/(bearer[[:space:]]+)[^[:space:]\",}]+/\1<REDACTED>/Ig' \
+    -e 's/(bearer[[:space:]]+)[A-Za-z0-9._~+\/=-]{16,}/\1<REDACTED>/Ig' \
     -e 's/gh[pousr]_[A-Za-z0-9_]{20,}/<REDACTED_GITHUB_TOKEN>/g' \
     -e 's/github_pat_[A-Za-z0-9_]{20,}/<REDACTED_GITHUB_PAT>/g' \
     -e 's/ya29\.[A-Za-z0-9._-]{20,}/<REDACTED_GOOGLE_TOKEN>/g' \

--- a/scripts/live-canary/test_emit_results_json.py
+++ b/scripts/live-canary/test_emit_results_json.py
@@ -329,6 +329,18 @@ class TokenRedactionTests(unittest.TestCase):
             redacted = emit.redact(raw)
             self.assertIn(marker, redacted, f"redact() failed for {raw!r}")
 
+    def test_bearer_prose_survives_redaction(self):
+        # Mirrors the scrub-artifacts.sh {16,} floor: prose after "bearer"
+        # (model-visible tool descriptions recorded via tool_search output)
+        # is not a credential and must pass through untouched, while real
+        # bearer tokens stay redacted (covered above).
+        prose = (
+            "no_auth only for a documented public endpoint, bearer for a "
+            "static API token or PAT sent as a Bearer token, and oauth for "
+            "a browser authorization-code flow"
+        )
+        self.assertEqual(emit.redact(prose), prose)
+
     def test_anthropic_key_wins_over_openai_pattern(self):
         # Both `sk-ant-…` and `sk-…` are valid prefixes. The Anthropic
         # rule is listed first so the dedicated label survives — and

--- a/scripts/live-canary/test_emit_results_json.py
+++ b/scripts/live-canary/test_emit_results_json.py
@@ -341,6 +341,19 @@ class TokenRedactionTests(unittest.TestCase):
         )
         self.assertEqual(emit.redact(prose), prose)
 
+    def test_bearer_length_boundary(self):
+        # Pin the exact {16,} floor: 15 token-alphabet chars pass through,
+        # 16 get redacted. The prose test alone would not catch a {15,}
+        # regression.
+        self.assertEqual(
+            emit.redact("Bearer abcdefghijklmno"),
+            "Bearer abcdefghijklmno",
+        )
+        self.assertEqual(
+            emit.redact("Bearer abcdefghijklmnop"),
+            "Bearer <REDACTED>",
+        )
+
     def test_anthropic_key_wins_over_openai_pattern(self):
         # Both `sk-ant-…` and `sk-…` are valid prefixes. The Anthropic
         # rule is listed first so the dedicated label survives — and

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -302,6 +302,37 @@ class ScrubArtifactsTests(unittest.TestCase):
             self.assertEqual(trace.read_text(encoding="utf-8"), original + "\n")
             self.assertNotIn("Potential secret material", result.stdout)
 
+    def test_bearer_length_boundary(self) -> None:
+        # Pin the exact {16,} floor on the shell side too (the emitter's
+        # mirror rule pins it in test_emit_results_json.py): 15 token-alphabet
+        # chars after "bearer" pass through untouched, 16 trip the guardrail.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            below = root / "below.log"
+            below.write_text("bearer abcdefghijklmno\n", encoding="utf-8")
+
+            result = self.run_scrub(root, strict=True)
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertEqual(
+                below.read_text(encoding="utf-8"),
+                "bearer abcdefghijklmno\n",
+            )
+            self.assertNotIn("Potential secret material", result.stdout)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            at_floor = root / "at-floor.log"
+            at_floor.write_text("bearer abcdefghijklmnop\n", encoding="utf-8")
+
+            result = self.run_scrub(root, strict=True)
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertIn(
+                "bearer <REDACTED>",
+                at_floor.read_text(encoding="utf-8"),
+            )
+
     def test_strict_scrub_fails_if_redacted_artifact_still_matches_secret_shape(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -241,7 +241,7 @@ class ScrubArtifactsTests(unittest.TestCase):
             trace = root / "llm-traces" / "case_a.json"
             trace.parent.mkdir()
             trace.write_text(
-                '{"steps":[{"response":{"content":"Bearer relative-secret"}}]}\n',
+                '{"steps":[{"response":{"content":"Bearer relative-secret-token"}}]}\n',
                 encoding="utf-8",
             )
             runner_temp = root / "runner-temp"
@@ -266,6 +266,41 @@ class ScrubArtifactsTests(unittest.TestCase):
                 scrubbed["steps"][0]["response"]["content"],
                 "Bearer <REDACTED>",
             )
+
+    def test_strict_scrub_ignores_bearer_prose_in_tool_descriptions(self) -> None:
+        # Regression for the 2026-08-07 QA 6D-6E lane failure: progressive
+        # tool disclosure records ironclaw.tool_search output in traces, and
+        # the builtin.extension_register_hosted_mcp description legitimately
+        # says "bearer for a static API token or PAT sent as a Bearer token".
+        # Prose after "bearer" is not a credential; only token-shaped strings
+        # (16+ chars of token alphabet) may trip the guardrail.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            trace = root / "traces" / "qa_case.json"
+            trace.parent.mkdir()
+            original = json.dumps(
+                {
+                    "entries": [
+                        {
+                            "content": (
+                                "Choose auth_type from provider documentation: "
+                                "no_auth only for a documented public endpoint, "
+                                "bearer for a static API token or PAT sent as a "
+                                "Bearer token, and oauth for a browser "
+                                "authorization-code flow."
+                            )
+                        }
+                    ]
+                }
+            )
+            trace.write_text(original + "\n", encoding="utf-8")
+
+            result = self.run_scrub(root, strict=True)
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertTrue(trace.exists())
+            self.assertEqual(trace.read_text(encoding="utf-8"), original + "\n")
+            self.assertNotIn("Potential secret material", result.stdout)
 
     def test_strict_scrub_fails_if_redacted_artifact_still_matches_secret_shape(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -2781,6 +2781,99 @@ def _triggered_delivery_outcome(reborn_home: Path, run_id: str) -> dict[str, obj
     return {"path": row[0], "raw_contents": payload}
 
 
+def _classify_triggered_notice_outcome(outcome: dict[str, object] | None) -> str:
+    """Classify the background-run notifier's outcome record for one fire.
+
+    Since the two-lane delivery model (#7157), the ``triggered-run-delivery``
+    record describes NOTICE delivery only (gate/auth/failure prompts): a
+    cleanly completed fire records ``skipped`` (or ``no_default_configured``
+    when the creator has no notification channels), and ``delivered`` means a
+    notice went out (for example the fire parked on an approval gate) — never
+    the fire's result. Result-delivery evidence lives in the run's own
+    ``builtin.outbound_deliver`` call and its durable ``outbound/deliveries/``
+    record instead, so only ``failed``/``denied`` are canary-failing states
+    here. Unknown future vocabulary reads as ``pending`` and surfaces through
+    the timeout diagnostics rather than hard-failing the lane.
+    """
+    if not isinstance(outcome, dict):
+        return "pending"
+    kind = str(outcome.get("outcome") or "")
+    if kind in ("failed", "denied"):
+        return "notifier_failure"
+    if kind in ("delivered", "skipped", "no_default_configured"):
+        return "healthy_terminal"
+    return "pending"
+
+
+def _model_delivery_summary(
+    reborn_home: Path, run_id: str, expected_channel_id: str | None
+) -> dict[str, object]:
+    """Aggregate one fire run's durable ``outbound/deliveries/`` records.
+
+    Only aggregate counts leave this helper: the raw records carry the sealed
+    reply-target ref (workspace and conversation ids), which must never be
+    copied into canary results.
+    """
+    summary: dict[str, object] = {
+        "record_count": 0,
+        "delivered_count": 0,
+        "expected_channel_delivered_count": 0,
+        "other_status_count": 0,
+    }
+    db_path = reborn_home / "local-dev" / "reborn-local-dev.db"
+    if not db_path.exists():
+        summary["read_error"] = "reborn-local-dev.db missing"
+        return summary
+    try:
+        database_uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        with closing(sqlite3.connect(database_uri, uri=True)) as db:
+            rows = db.execute(
+                """
+                SELECT contents
+                FROM root_filesystem_entries
+                WHERE is_dir = 0
+                  AND content_type = 'application/json'
+                  AND path LIKE '%/outbound/deliveries/%'
+                """
+            ).fetchall()
+    except sqlite3.Error as exc:
+        summary["read_error"] = _exc_text(exc)
+        return summary
+    expected_target_piece = (
+        f"conversation:{len(expected_channel_id)}:{expected_channel_id};"
+        if expected_channel_id
+        else None
+    )
+    for (raw_contents,) in rows:
+        if isinstance(raw_contents, bytes):
+            raw_contents = raw_contents.decode("utf-8", errors="replace")
+        try:
+            record = json.loads(raw_contents)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        candidate = record.get("candidate")
+        if not isinstance(candidate, dict):
+            continue
+        if (
+            str(candidate.get("turn_run_id") or "") != run_id
+            or str(candidate.get("kind") or "") != "model_delivery"
+        ):
+            continue
+        summary["record_count"] = int(summary["record_count"]) + 1
+        if str(record.get("status") or "") == "delivered":
+            summary["delivered_count"] = int(summary["delivered_count"]) + 1
+            target = str(candidate.get("target") or "")
+            if expected_target_piece and expected_target_piece in target:
+                summary["expected_channel_delivered_count"] = (
+                    int(summary["expected_channel_delivered_count"]) + 1
+                )
+        else:
+            summary["other_status_count"] = int(summary["other_status_count"]) + 1
+    return summary
+
+
 def _delivered_gate_routes_for_run(reborn_home: Path, run_id: str) -> list[dict[str, object]]:
     db_path = reborn_home / "local-dev" / "reborn-local-dev.db"
     if not db_path.exists() or not run_id:
@@ -3512,12 +3605,20 @@ async def _slack_history_contains_marker(
 
 
 def _slack_delivery_observed(
-    outcome: dict[str, object] | None,
+    model_delivery: dict[str, object] | None,
     history: dict[str, object] | None,
 ) -> bool:
+    """Two-sided delivery evidence for the two-lane model.
+
+    The durable ``outbound/deliveries/`` model-delivery record proves the
+    fire's own ``builtin.outbound_deliver`` call reached the expected DM, and
+    the independent Slack history read-back proves the marker actually
+    arrived. The retired completion-driver ``outcome == "delivered"`` push
+    record no longer exists for results and must not be required.
+    """
     return (
-        isinstance(outcome, dict)
-        and outcome.get("outcome") == "delivered"
+        isinstance(model_delivery, dict)
+        and int(model_delivery.get("expected_channel_delivered_count") or 0) >= 1
         and isinstance(history, dict)
         and bool(history.get("found"))
     )
@@ -3637,27 +3738,132 @@ def _trigger_run_slack_send_evidence(
     return evidence
 
 
+def _trigger_run_outbound_deliver_evidence(
+    reborn_home: Path,
+    *,
+    run_id: str,
+    thread_id: str,
+    marker: str,
+) -> dict[str, object]:
+    """Read sanitized ``builtin.outbound_deliver`` evidence for one trigger run.
+
+    The deliver-lane sibling of ``_trigger_run_slack_send_evidence``: it
+    counts the fire's completed ``builtin.outbound_deliver`` calls and how
+    many composed a content payload carrying the delivery marker. Only
+    aggregate counts leave this helper — target ids and message content stay
+    in the local runtime database.
+    """
+    evidence: dict[str, object] = {
+        "completed_deliver_count": 0,
+        "marker_deliver_count": 0,
+        "parse_error_count": 0,
+    }
+    db_path = reborn_home / "local-dev" / "reborn-local-dev.db"
+    if not db_path.exists():
+        evidence["read_error"] = "reborn-local-dev.db missing"
+        return evidence
+    try:
+        database_uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        with closing(sqlite3.connect(database_uri, uri=True)) as db:
+            rows = db.execute(
+                """
+                SELECT contents
+                FROM root_filesystem_entries
+                WHERE is_dir = 0
+                  AND content_type = 'application/json'
+                  AND path LIKE ?
+                """,
+                (f"%/threads/{thread_id}/messages/%",),
+            ).fetchall()
+    except sqlite3.Error as exc:
+        evidence["read_error"] = _exc_text(exc)
+        return evidence
+
+    def json_object(value: object) -> dict[str, object] | None:
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, bytes):
+            value = value.decode("utf-8", errors="replace")
+        if not isinstance(value, str):
+            return None
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    for (raw_contents,) in rows:
+        message = json_object(raw_contents)
+        if (
+            message is None
+            or message.get("turn_run_id") != run_id
+            or message.get("kind") != "capability_display_preview"
+        ):
+            continue
+        preview = json_object(message.get("content"))
+        if preview is None:
+            evidence["parse_error_count"] = int(evidence["parse_error_count"]) + 1
+            continue
+        if preview.get("capability_id") != "builtin.outbound_deliver":
+            continue
+        input_summary = json_object(preview.get("input_summary"))
+        if input_summary is None:
+            evidence["parse_error_count"] = int(evidence["parse_error_count"]) + 1
+            continue
+        if str(preview.get("status") or "") == "completed":
+            evidence["completed_deliver_count"] = (
+                int(evidence["completed_deliver_count"]) + 1
+            )
+        if marker in str(input_summary.get("content") or ""):
+            evidence["marker_deliver_count"] = (
+                int(evidence["marker_deliver_count"]) + 1
+            )
+    return evidence
+
+
 def _slack_delivery_readback_is_inconclusive(
-    outcome: dict[str, object] | None,
+    model_delivery: dict[str, object] | None,
     history: dict[str, object] | None,
-    evidence: dict[str, object],
+    vendor_evidence: dict[str, object],
+    deliver_evidence: dict[str, object],
 ) -> bool:
-    """Distinguish a Slack history miss from wrong or duplicate model sends."""
-    return (
-        isinstance(outcome, dict)
-        and outcome.get("outcome") == "delivered"
-        and isinstance(history, dict)
+    """Distinguish a Slack history read-back miss from a real delivery failure.
+
+    Inconclusive means: the fire verifiably sent exactly one marker-carrying
+    message to the expected DM — through either lane — but the independent
+    ``conversations.history`` read-back never exposed it before timeout.
+    A send whose content lacks the marker is NOT inconclusive: that is the
+    deterministic stale-prompt failure mode and must stay red.
+    """
+    history_clean_miss = (
+        isinstance(history, dict)
         and history.get("checked") is True
         and not history.get("found")
         and not history.get("error")
-        and not evidence.get("read_error")
-        and evidence.get("completed_send_count") == 1
-        and evidence.get("marker_send_count") == 1
-        and evidence.get("expected_channel_marker_send_count") == 1
-        and evidence.get("expected_channel_marker_ok_count") == 1
-        and evidence.get("wrong_channel_marker_send_count") == 0
-        and evidence.get("parse_error_count") == 0
     )
+    if not history_clean_miss:
+        return False
+    if vendor_evidence.get("read_error") or deliver_evidence.get("read_error"):
+        return False
+    if (
+        vendor_evidence.get("wrong_channel_marker_send_count") != 0
+        or vendor_evidence.get("parse_error_count") != 0
+    ):
+        return False
+    vendor_exact_send = (
+        vendor_evidence.get("completed_send_count") == 1
+        and vendor_evidence.get("marker_send_count") == 1
+        and vendor_evidence.get("expected_channel_marker_send_count") == 1
+        and vendor_evidence.get("expected_channel_marker_ok_count") == 1
+    )
+    deliver_exact_send = (
+        isinstance(model_delivery, dict)
+        and model_delivery.get("expected_channel_delivered_count") == 1
+        and deliver_evidence.get("completed_deliver_count") == 1
+        and deliver_evidence.get("marker_deliver_count") == 1
+        and deliver_evidence.get("parse_error_count") == 0
+    )
+    return vendor_exact_send or deliver_exact_send
 
 
 async def _wait_for_slack_delivery_marker(
@@ -3676,8 +3882,8 @@ async def _wait_for_slack_delivery_marker(
     last_rows: list[dict[str, object]] = []
     last_outcome: dict[str, object] | None = None
     last_history: dict[str, object] | None = None
-    last_delivered_row: dict[str, object] | None = None
-    last_delivered_outcome: dict[str, object] | None = None
+    last_model_delivery: dict[str, object] | None = None
+    last_run_row: dict[str, object] | None = None
     approved_gate_refs: set[str] = set()
     approval_attempts: list[dict[str, object]] = []
     while time.monotonic() < deadline:
@@ -3689,12 +3895,15 @@ async def _wait_for_slack_delivery_marker(
                 run_id = str(row.get("run_id") or "")
                 if not run_id:
                     continue
+                last_run_row = row
                 outcome = _triggered_delivery_outcome(ctx.reborn_home, run_id)
                 if outcome:
                     last_outcome = outcome
-                    if outcome.get("outcome") == "delivered":
-                        last_delivered_row = row
-                        last_delivered_outcome = outcome
+                model_delivery = _model_delivery_summary(
+                    ctx.reborn_home, run_id, channel_id
+                )
+                if int(model_delivery.get("record_count") or 0) > 0:
+                    last_model_delivery = model_delivery
                 for route in _delivered_gate_routes_for_run(ctx.reborn_home, run_id):
                     gate_ref = str(route.get("gate_ref") or "")
                     if gate_ref in approved_gate_refs:
@@ -3739,45 +3948,93 @@ async def _wait_for_slack_delivery_marker(
                             "error": _exc_text(history_exc),
                         }
                     last_history = history
-                if _slack_delivery_observed(outcome, history):
+                if _slack_delivery_observed(model_delivery, history):
                     return {
                         "trigger_run": row,
                         "delivery_outcome": outcome,
+                        "model_delivery": model_delivery,
                         "slack_history": history,
                         "approval_attempts": approval_attempts[-5:],
                     }
-                if isinstance(outcome, dict) and outcome.get("outcome") not in (None, "delivered"):
+                notice_state = _classify_triggered_notice_outcome(outcome)
+                if notice_state == "notifier_failure":
                     raise AssertionError(
-                        "triggered Slack delivery completed without delivered outcome: "
+                        "background-run notifier recorded a terminal failure "
+                        "for the fire (notices could not be delivered): "
                         f"run={row!r} outcome={outcome!r} history={history!r}"
                     )
+                if isinstance(outcome, dict) and outcome.get("outcome") in (
+                    "skipped",
+                    "no_default_configured",
+                ):
+                    # The fire is settled (the notifier saw it complete), so
+                    # the delivered content is final. A completed
+                    # outbound_deliver whose composed content lacks the
+                    # marker can never satisfy the history read-back — fail
+                    # deterministically instead of timing out.
+                    thread_id = str(row.get("thread_id") or "")
+                    deliver_evidence = _trigger_run_outbound_deliver_evidence(
+                        ctx.reborn_home,
+                        run_id=run_id,
+                        thread_id=thread_id,
+                        marker=marker,
+                    )
+                    if (
+                        not deliver_evidence.get("read_error")
+                        and int(deliver_evidence.get("parse_error_count") or 0) == 0
+                        and int(deliver_evidence.get("completed_deliver_count") or 0)
+                        >= 1
+                        and int(deliver_evidence.get("marker_deliver_count") or 0)
+                        == 0
+                    ):
+                        raise AssertionError(
+                            "the fire delivered a Slack message whose content "
+                            "lacks the required marker — the delivered message "
+                            "itself, not only the routine's final answer, must "
+                            f"carry the marker: run={row!r} "
+                            f"deliver_evidence={deliver_evidence!r} "
+                            f"model_delivery={model_delivery!r} "
+                            f"history={history!r}"
+                        )
         await asyncio.sleep(2.0)
-    if last_delivered_row is not None:
-        run_id = str(last_delivered_row.get("run_id") or "")
-        thread_id = str(last_delivered_row.get("thread_id") or "")
+    if last_run_row is not None:
+        run_id = str(last_run_row.get("run_id") or "")
+        thread_id = str(last_run_row.get("thread_id") or "")
         if run_id and thread_id:
-            send_evidence = _trigger_run_slack_send_evidence(
+            vendor_evidence = _trigger_run_slack_send_evidence(
                 ctx.reborn_home,
                 run_id=run_id,
                 thread_id=thread_id,
                 expected_channel_id=channel_id,
                 marker=marker,
             )
+            deliver_evidence = _trigger_run_outbound_deliver_evidence(
+                ctx.reborn_home,
+                run_id=run_id,
+                thread_id=thread_id,
+                marker=marker,
+            )
             if _slack_delivery_readback_is_inconclusive(
-                last_delivered_outcome,
+                last_model_delivery,
                 last_history,
-                send_evidence,
+                vendor_evidence,
+                deliver_evidence,
             ):
                 raise SlackDeliveryReadbackInconclusive(
                     "the exact trigger run completed one verified Slack send to the "
                     "expected DM, but the independent Slack history readback did not "
                     "expose the marker before timeout",
-                    send_evidence,
+                    {
+                        **vendor_evidence,
+                        **deliver_evidence,
+                        "model_delivery": last_model_delivery,
+                    },
                 )
     raise AssertionError(
         "Slack delivery marker was not observed before timeout. "
         f"routine_name={routine_name!r} marker={marker!r} "
         f"last_rows={last_rows[:3]!r} last_outcome={last_outcome!r} "
+        f"last_model_delivery={last_model_delivery!r} "
         f"last_history={last_history!r} approvals={approval_attempts[-3:]!r}"
     )
 
@@ -5284,6 +5541,21 @@ async def case_qa_3c_endpoint_status_slack_routine(ctx: LiveQaContext) -> ProbeR
     )
 
 
+def _delivery_marker_prompt_requirement(delivery_marker: str) -> str:
+    """The delivery-marker sentence for routine-creation prompts.
+
+    Under the two-lane delivery model the fire composes the Slack message
+    separately from its final answer, so the marker requirement must bind to
+    the DELIVERED message — a final-answer-only phrasing produced live fires
+    whose Slack message carried no marker while the thread answer did.
+    """
+    return (
+        "The delivered Slack message itself must include the exact marker "
+        f"{delivery_marker}, and the routine's final answer must also "
+        "include that exact marker."
+    )
+
+
 async def _slack_delivery_routine_case(
     ctx: LiveQaContext,
     *,
@@ -5318,8 +5590,9 @@ async def _slack_delivery_routine_case(
         required_text=["routine"],
         prompt=(
             f"QA case {case_name}: create a routine named {routine_name}. {schedule_instruction} "
-            f"{routine_instruction} The routine's final answer must include the exact "
-            f"marker {delivery_marker}. Create the routine now; do not "
+            f"{routine_instruction} "
+            f"{_delivery_marker_prompt_requirement(delivery_marker)} "
+            "Create the routine now; do not "
             "run it immediately. During routine creation, do not perform the routine's "
             "live check, web/search/HTTP lookup, or Slack send. "
             f"In your final answer include the exact marker {creation_marker} and include "
@@ -5546,6 +5819,7 @@ async def _slack_delivery_routine_case(
                 "required_delivery_text": text_checks,
                 "trigger_run": delivery.get("trigger_run"),
                 "delivery_outcome": delivery.get("delivery_outcome"),
+                "model_delivery": delivery.get("model_delivery"),
                 "slack_history": history,
                 "exactly_once": exactly_once,
             },

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -3810,10 +3810,15 @@ def _trigger_run_outbound_deliver_evidence(
         if input_summary is None:
             evidence["parse_error_count"] = int(evidence["parse_error_count"]) + 1
             continue
-        if str(preview.get("status") or "") == "completed":
-            evidence["completed_deliver_count"] = (
-                int(evidence["completed_deliver_count"]) + 1
-            )
+        # Only completed calls are evidence: a failed or in-flight deliver
+        # whose content happens to carry the marker never reached Slack, so
+        # counting it would fake the exactly-one-verified-send inconclusive
+        # classification and suppress the deterministic markerless red.
+        if str(preview.get("status") or "") != "completed":
+            continue
+        evidence["completed_deliver_count"] = (
+            int(evidence["completed_deliver_count"]) + 1
+        )
         if marker in str(input_summary.get("content") or ""):
             evidence["marker_deliver_count"] = (
                 int(evidence["marker_deliver_count"]) + 1
@@ -3972,6 +3977,15 @@ async def _wait_for_slack_delivery_marker(
                     # outbound_deliver whose composed content lacks the
                     # marker can never satisfy the history read-back — fail
                     # deterministically instead of timing out.
+                    #
+                    # Deliberately NOT the whole healthy_terminal class:
+                    # `delivered` means a NOTICE went out, which includes a
+                    # fire parked on an approval gate whose run is not
+                    # settled — it resumes after the approve and may only
+                    # then make its marker-carrying deliver call. Running
+                    # this check there would hard-fail a fire that is still
+                    # going to deliver; a genuinely marker-less gated fire
+                    # still fails via the timeout path.
                     thread_id = str(row.get("thread_id") or "")
                     deliver_evidence = _trigger_run_outbound_deliver_evidence(
                         ctx.reborn_home,
@@ -4024,9 +4038,13 @@ async def _wait_for_slack_delivery_marker(
                     "the exact trigger run completed one verified Slack send to the "
                     "expected DM, but the independent Slack history readback did not "
                     "expose the marker before timeout",
+                    # Namespaced per lane: both evidence dicts carry a
+                    # parse_error_count, and a flat merge would let one lane
+                    # silently overwrite the other's in the persisted
+                    # delivery_readback_evidence.
                     {
-                        **vendor_evidence,
-                        **deliver_evidence,
+                        "vendor_evidence": vendor_evidence,
+                        "deliver_evidence": deliver_evidence,
                         "model_delivery": last_model_delivery,
                     },
                 )

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -10327,45 +10327,15 @@ class TwoLaneDeliveryContractTests(unittest.TestCase):
 
     @staticmethod
     def _create_store(reborn_home: Path) -> Path:
+        # The production schema helper, so this fixture cannot drift from the
+        # columns the readers filter on (is_dir, content_type).
         db_path = reborn_home / "local-dev" / "reborn-local-dev.db"
-        db_path.parent.mkdir(parents=True)
-        with closing(sqlite3.connect(db_path)) as db:
-            db.execute(
-                """
-                CREATE TABLE root_filesystem_entries (
-                    path TEXT PRIMARY KEY,
-                    contents BLOB NOT NULL,
-                    is_dir INTEGER NOT NULL DEFAULT 0,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    content_type TEXT NOT NULL,
-                    kind TEXT,
-                    indexed TEXT NOT NULL DEFAULT '{}',
-                    version INTEGER NOT NULL DEFAULT 0
-                )
-                """
-            )
-            db.commit()
+        run_live_qa._root_filesystem_create_table(db_path)
         return db_path
 
     @staticmethod
     def _insert_json(db_path: Path, path: str, payload: dict) -> None:
-        with closing(sqlite3.connect(db_path)) as db:
-            db.execute(
-                """
-                INSERT INTO root_filesystem_entries (
-                    path, contents, is_dir, created_at, updated_at,
-                    content_type, kind
-                ) VALUES (?, ?, 0, ?, ?, 'application/json', 'record')
-                """,
-                (
-                    path,
-                    json.dumps(payload),
-                    "2026-08-08T00:00:00.000Z",
-                    "2026-08-08T00:00:00.000Z",
-                ),
-            )
-            db.commit()
+        run_live_qa._put_root_filesystem_json(db_path, path, payload)
 
     def _model_delivery_record(
         self,
@@ -10533,6 +10503,19 @@ class TwoLaneDeliveryContractTests(unittest.TestCase):
                 "/tenants/t/users/u/threads/a/threads/thread-fire-1/messages/2.json",
                 self._outbound_deliver_preview_message(
                     invocation="invocation-2", content="no marker here"
+                ),
+            )
+            # A failed (non-completed) deliver carrying the marker must count
+            # toward NEITHER counter: a marker that never reached Slack would
+            # otherwise fake the exactly-one-verified-send inconclusive
+            # classification and suppress the deterministic markerless red.
+            self._insert_json(
+                db_path,
+                "/tenants/t/users/u/threads/a/threads/thread-fire-1/messages/3.json",
+                self._outbound_deliver_preview_message(
+                    invocation="invocation-3",
+                    content=f"aborted body {marker}",
+                    status="failed",
                 ),
             )
 

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -8799,21 +8799,25 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIn("IRONCLAW_REBORN_GOOGLE_CLIENT_SECRET", action)
 
     def test_slack_delivery_observed_is_status_agnostic_after_gate_resume(self):
+        # The notifier's notice record (delivered-after-gate vs skipped) is
+        # no longer an input at all: observation keys on the fire's durable
+        # model-delivery record plus the independent history read-back, so a
+        # gate-resumed fire and a clean fire observe identically.
         self.assertTrue(
             run_live_qa._slack_delivery_observed(
-                {"outcome": "delivered", "run_id": "run-123"},
+                {"expected_channel_delivered_count": 1},
                 {"found": True, "marker_found": True},
             )
         )
         self.assertFalse(
             run_live_qa._slack_delivery_observed(
-                {"outcome": "gate_required", "run_id": "run-123"},
+                {"expected_channel_delivered_count": 0},
                 {"found": True, "marker_found": True},
             )
         )
         self.assertFalse(
             run_live_qa._slack_delivery_observed(
-                {"outcome": "delivered", "run_id": "run-123"},
+                {"expected_channel_delivered_count": 1},
                 {"found": False, "marker_found": True},
             )
         )
@@ -8882,7 +8886,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
     def test_slack_delivery_readback_inconclusive_requires_one_verified_send(self):
         history_miss = {"checked": True, "found": False, "message_count": 7}
-        delivered = {"outcome": "delivered"}
+        no_model_delivery = {"expected_channel_delivered_count": 0}
         exact_send = {
             "completed_send_count": 1,
             "marker_send_count": 1,
@@ -8891,12 +8895,18 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             "wrong_channel_marker_send_count": 0,
             "parse_error_count": 0,
         }
+        no_deliver = {
+            "completed_deliver_count": 0,
+            "marker_deliver_count": 0,
+            "parse_error_count": 0,
+        }
 
         self.assertTrue(
             run_live_qa._slack_delivery_readback_is_inconclusive(
-                delivered,
+                no_model_delivery,
                 history_miss,
                 exact_send,
+                no_deliver,
             )
         )
         for changed in (
@@ -8908,16 +8918,18 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             with self.subTest(changed=changed):
                 self.assertFalse(
                     run_live_qa._slack_delivery_readback_is_inconclusive(
-                        delivered,
+                        no_model_delivery,
                         history_miss,
                         {**exact_send, **changed},
+                        no_deliver,
                     )
                 )
         self.assertFalse(
             run_live_qa._slack_delivery_readback_is_inconclusive(
-                delivered,
+                no_model_delivery,
                 {**history_miss, "error": "missing_scope"},
                 exact_send,
+                no_deliver,
             )
         )
 
@@ -10288,6 +10300,592 @@ class RunCaseWithRetriesTests(unittest.TestCase):
                 configured_attempts=3,
             ),
             1,
+        )
+
+
+class TwoLaneDeliveryContractTests(unittest.TestCase):
+    """Pins the delivery verification contract for the two-lane model (#7157).
+
+    A triggered fire's result is never pushed by the completion driver any
+    more: the fire itself calls ``builtin.outbound_deliver``, which records a
+    durable ``outbound/deliveries/`` model-delivery record, while the
+    background-run notifier's ``triggered-run-delivery`` record describes
+    NOTICE delivery only (``skipped`` is the healthy record for a cleanly
+    completed fire). These tests pin that the runner treats the new records
+    as the contract instead of the retired ``outcome == "delivered"`` push.
+    """
+
+    _EXPECTED_CHANNEL = "D0TESTDM1"
+
+    def _dummy_ctx(self) -> run_live_qa.LiveQaContext:
+        return run_live_qa.LiveQaContext(
+            base_url="http://127.0.0.1:9",
+            output_dir=Path("/tmp"),
+            reborn_home=Path("/tmp/reborn-home"),
+            env={},
+        )
+
+    @staticmethod
+    def _create_store(reborn_home: Path) -> Path:
+        db_path = reborn_home / "local-dev" / "reborn-local-dev.db"
+        db_path.parent.mkdir(parents=True)
+        with closing(sqlite3.connect(db_path)) as db:
+            db.execute(
+                """
+                CREATE TABLE root_filesystem_entries (
+                    path TEXT PRIMARY KEY,
+                    contents BLOB NOT NULL,
+                    is_dir INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    content_type TEXT NOT NULL,
+                    kind TEXT,
+                    indexed TEXT NOT NULL DEFAULT '{}',
+                    version INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            db.commit()
+        return db_path
+
+    @staticmethod
+    def _insert_json(db_path: Path, path: str, payload: dict) -> None:
+        with closing(sqlite3.connect(db_path)) as db:
+            db.execute(
+                """
+                INSERT INTO root_filesystem_entries (
+                    path, contents, is_dir, created_at, updated_at,
+                    content_type, kind
+                ) VALUES (?, ?, 0, ?, ?, 'application/json', 'record')
+                """,
+                (
+                    path,
+                    json.dumps(payload),
+                    "2026-08-08T00:00:00.000Z",
+                    "2026-08-08T00:00:00.000Z",
+                ),
+            )
+            db.commit()
+
+    def _model_delivery_record(
+        self,
+        *,
+        run_id: str = "run-fire-1",
+        status: str = "delivered",
+        conversation: str = "D0TESTDM1",
+    ) -> dict:
+        # Mirrors the production record shape written by
+        # builtin.outbound_deliver (observed live in the 2026-08-08 canary
+        # runs), with neutralized workspace identifiers.
+        target = (
+            "reply:adapter:8:slack_v2;installation:5:slack;"
+            "agent:16:reborn-cli-agent;project:0:;space:9:T0TESTTM1;"
+            f"conversation:{len(conversation)}:{conversation};topic:0:;"
+            "actor_kind:10:slack_user;actor:9:U0TESTUSR;"
+        )
+        return {
+            "delivery_id": "30e461cd-2067-5581-a379-8ee481462418",
+            "candidate": {
+                "tenant_id": "reborn-cli",
+                "agent_id": "reborn-cli-agent",
+                "project_id": None,
+                "thread_id": "thread-fire-1",
+                "turn_run_id": run_id,
+                "target": target,
+                "kind": "model_delivery",
+                "projection_ref": f"model-delivery:{run_id}:invocation-1",
+                "requires_reply_target_revalidation": True,
+            },
+            "status": status,
+            "attempted_at": "2026-08-08T00:28:20.527116273Z",
+            "failure_kind": None,
+        }
+
+    def _outbound_deliver_preview_message(
+        self,
+        *,
+        run_id: str = "run-fire-1",
+        thread_id: str = "thread-fire-1",
+        invocation: str = "invocation-1",
+        content: str = "delivered body",
+        status: str = "completed",
+    ) -> dict:
+        preview = {
+            "version": 1,
+            "invocation_id": invocation,
+            "capability_id": "builtin.outbound_deliver",
+            "status": status,
+            "input_summary": json.dumps(
+                {
+                    "content": content,
+                    "target_id": "slack:personal-dm:T0TESTTM1:qa-user",
+                },
+                indent=2,
+            ),
+            "output_preview": "Delivered to Slack DM",
+        }
+        return {
+            "message_id": f"message-{invocation}",
+            "thread_id": thread_id,
+            "kind": "capability_display_preview",
+            "turn_run_id": run_id,
+            "content": json.dumps(preview),
+        }
+
+    def test_classify_triggered_notice_outcome_maps_two_lane_vocabulary(self):
+        # The exact record shape observed live for a cleanly completed fire.
+        skipped = {
+            "run_id": "run-fire-1",
+            "outcome": "skipped",
+            "recorded_at": "2026-08-08T00:28:32.193651088Z",
+        }
+        healthy = ["skipped", "no_default_configured", "delivered"]
+        for kind in healthy:
+            self.assertEqual(
+                run_live_qa._classify_triggered_notice_outcome(
+                    {**skipped, "outcome": kind}
+                ),
+                "healthy_terminal",
+                kind,
+            )
+        for kind in ("failed", "denied"):
+            self.assertEqual(
+                run_live_qa._classify_triggered_notice_outcome(
+                    {**skipped, "outcome": kind}
+                ),
+                "notifier_failure",
+                kind,
+            )
+        self.assertEqual(
+            run_live_qa._classify_triggered_notice_outcome(None), "pending"
+        )
+        self.assertEqual(
+            run_live_qa._classify_triggered_notice_outcome({"outcome": ""}),
+            "pending",
+        )
+        # Unknown future vocabulary must not hard-fail the canary: it reads
+        # as pending and surfaces in the timeout diagnostics instead.
+        self.assertEqual(
+            run_live_qa._classify_triggered_notice_outcome(
+                {"outcome": "some_future_state"}
+            ),
+            "pending",
+        )
+
+    def test_model_delivery_summary_reads_durable_records(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reborn_home = Path(tmpdir) / "reborn-home"
+            db_path = self._create_store(reborn_home)
+            self._insert_json(
+                db_path,
+                "/tenants/reborn-cli/users/qa-user/outbound/deliveries/1.json",
+                self._model_delivery_record(),
+            )
+            # A delivery for another run must not count.
+            self._insert_json(
+                db_path,
+                "/tenants/reborn-cli/users/qa-user/outbound/deliveries/2.json",
+                self._model_delivery_record(run_id="run-other"),
+            )
+            # A delivered record for a different conversation counts as
+            # delivered but not as the expected channel.
+            self._insert_json(
+                db_path,
+                "/tenants/reborn-cli/users/qa-user/outbound/deliveries/3.json",
+                self._model_delivery_record(conversation="C0ELSEWHER"),
+            )
+
+            summary = run_live_qa._model_delivery_summary(
+                reborn_home, "run-fire-1", self._EXPECTED_CHANNEL
+            )
+
+        self.assertEqual(summary.get("record_count"), 2)
+        self.assertEqual(summary.get("delivered_count"), 2)
+        self.assertEqual(summary.get("expected_channel_delivered_count"), 1)
+        self.assertNotIn("read_error", summary)
+        # Sanitization: the sealed target ref (workspace/conversation ids)
+        # must never leave the helper.
+        self.assertNotIn(
+            self._EXPECTED_CHANNEL, json.dumps(summary), summary
+        )
+
+    def test_model_delivery_summary_survives_missing_db(self):
+        summary = run_live_qa._model_delivery_summary(
+            Path("/nonexistent-reborn-home"), "run-fire-1", self._EXPECTED_CHANNEL
+        )
+        self.assertEqual(summary.get("record_count"), 0)
+        self.assertIn("read_error", summary)
+
+    def test_outbound_deliver_evidence_counts_marker_content(self):
+        marker = "REBORN_QA_TEST_SLACK_DELIVERED_1"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reborn_home = Path(tmpdir) / "reborn-home"
+            db_path = self._create_store(reborn_home)
+            self._insert_json(
+                db_path,
+                "/tenants/t/users/u/threads/a/threads/thread-fire-1/messages/1.json",
+                self._outbound_deliver_preview_message(
+                    content=f"result body {marker}"
+                ),
+            )
+            self._insert_json(
+                db_path,
+                "/tenants/t/users/u/threads/a/threads/thread-fire-1/messages/2.json",
+                self._outbound_deliver_preview_message(
+                    invocation="invocation-2", content="no marker here"
+                ),
+            )
+
+            evidence = run_live_qa._trigger_run_outbound_deliver_evidence(
+                reborn_home,
+                run_id="run-fire-1",
+                thread_id="thread-fire-1",
+                marker=marker,
+            )
+
+        self.assertEqual(evidence.get("completed_deliver_count"), 2)
+        self.assertEqual(evidence.get("marker_deliver_count"), 1)
+        self.assertEqual(evidence.get("parse_error_count"), 0)
+        self.assertNotIn(marker, json.dumps(evidence.get("read_error", "")))
+
+    def test_slack_delivery_observed_requires_record_and_history(self):
+        delivered = {"expected_channel_delivered_count": 1}
+        found = {"checked": True, "found": True}
+        self.assertTrue(run_live_qa._slack_delivery_observed(delivered, found))
+        self.assertFalse(
+            run_live_qa._slack_delivery_observed(
+                {"expected_channel_delivered_count": 0}, found
+            )
+        )
+        self.assertFalse(
+            run_live_qa._slack_delivery_observed(
+                delivered, {"checked": True, "found": False}
+            )
+        )
+        self.assertFalse(run_live_qa._slack_delivery_observed(None, found))
+        self.assertFalse(run_live_qa._slack_delivery_observed(delivered, None))
+
+    def test_readback_inconclusive_accepts_deliver_lane_exact_send(self):
+        clean_miss = {"checked": True, "found": False}
+        no_vendor = {
+            "completed_send_count": 0,
+            "marker_send_count": 0,
+            "expected_channel_marker_send_count": 0,
+            "expected_channel_marker_ok_count": 0,
+            "wrong_channel_marker_send_count": 0,
+            "parse_error_count": 0,
+        }
+        deliver_exact = {
+            "completed_deliver_count": 1,
+            "marker_deliver_count": 1,
+            "parse_error_count": 0,
+        }
+        self.assertTrue(
+            run_live_qa._slack_delivery_readback_is_inconclusive(
+                {"expected_channel_delivered_count": 1},
+                clean_miss,
+                no_vendor,
+                deliver_exact,
+            )
+        )
+        # The vendor-lane exact-send leg still classifies as inconclusive
+        # even without a model-delivery record (slack.send_message lane).
+        vendor_exact = {
+            "completed_send_count": 1,
+            "marker_send_count": 1,
+            "expected_channel_marker_send_count": 1,
+            "expected_channel_marker_ok_count": 1,
+            "wrong_channel_marker_send_count": 0,
+            "parse_error_count": 0,
+        }
+        no_deliver = {
+            "completed_deliver_count": 0,
+            "marker_deliver_count": 0,
+            "parse_error_count": 0,
+        }
+        self.assertTrue(
+            run_live_qa._slack_delivery_readback_is_inconclusive(
+                {"expected_channel_delivered_count": 0},
+                clean_miss,
+                vendor_exact,
+                no_deliver,
+            )
+        )
+        # A found or errored history read is never inconclusive.
+        self.assertFalse(
+            run_live_qa._slack_delivery_readback_is_inconclusive(
+                {"expected_channel_delivered_count": 1},
+                {"checked": True, "found": True},
+                no_vendor,
+                deliver_exact,
+            )
+        )
+        self.assertFalse(
+            run_live_qa._slack_delivery_readback_is_inconclusive(
+                {"expected_channel_delivered_count": 1},
+                {"checked": True, "found": False, "error": "ratelimited"},
+                no_vendor,
+                deliver_exact,
+            )
+        )
+
+    def test_readback_inconclusive_rejects_markerless_deliver(self):
+        # A delivered message WITHOUT the marker is a deterministic failure
+        # (stale prompt phrasing), never an infrastructure flake.
+        clean_miss = {"checked": True, "found": False}
+        no_vendor = {
+            "completed_send_count": 0,
+            "marker_send_count": 0,
+            "expected_channel_marker_send_count": 0,
+            "expected_channel_marker_ok_count": 0,
+            "wrong_channel_marker_send_count": 0,
+            "parse_error_count": 0,
+        }
+        self.assertFalse(
+            run_live_qa._slack_delivery_readback_is_inconclusive(
+                {"expected_channel_delivered_count": 1},
+                clean_miss,
+                no_vendor,
+                {
+                    "completed_deliver_count": 1,
+                    "marker_deliver_count": 0,
+                    "parse_error_count": 0,
+                },
+            )
+        )
+
+    def _run_wait(
+        self,
+        *,
+        outcomes,
+        model_deliveries,
+        histories,
+        deliver_evidence=None,
+        vendor_evidence=None,
+        timeout: float = 30.0,
+    ):
+        """Drive _wait_for_slack_delivery_marker with scripted poll results.
+
+        Each argument is a list consumed one element per poll pass; the last
+        element repeats once exhausted.
+        """
+
+        def scripted(values):
+            state = {"i": 0}
+
+            def read(*_args, **_kwargs):
+                value = values[min(state["i"], len(values) - 1)]
+                state["i"] += 1
+                return value
+
+            return read
+
+        outcome_reader = scripted(outcomes)
+        delivery_reader = scripted(model_deliveries)
+        history_reader = scripted(histories)
+
+        async def fake_history(*_args, **_kwargs):
+            return history_reader()
+
+        async def fake_sleep(_seconds):
+            return None
+
+        row = {
+            "run_id": "run-fire-1",
+            "thread_id": "thread-fire-1",
+            "status": "ok",
+            "name": "reborn-qa-test-routine",
+        }
+        deliver_evidence = deliver_evidence or {
+            "completed_deliver_count": 0,
+            "marker_deliver_count": 0,
+            "parse_error_count": 0,
+        }
+        vendor_evidence = vendor_evidence or {
+            "completed_send_count": 0,
+            "marker_send_count": 0,
+            "expected_channel_marker_send_count": 0,
+            "expected_channel_marker_ok_count": 0,
+            "wrong_channel_marker_send_count": 0,
+            "parse_error_count": 0,
+        }
+        with (
+            patch.object(
+                run_live_qa, "_slack_delivery_channel_id", return_value=self._EXPECTED_CHANNEL
+            ),
+            patch.object(run_live_qa, "_trigger_run_rows", return_value=[row]),
+            patch.object(
+                run_live_qa,
+                "_triggered_delivery_outcome",
+                side_effect=lambda *_a, **_k: outcome_reader(),
+            ),
+            patch.object(
+                run_live_qa,
+                "_model_delivery_summary",
+                side_effect=lambda *_a, **_k: delivery_reader(),
+            ),
+            patch.object(
+                run_live_qa, "_delivered_gate_routes_for_run", return_value=[]
+            ),
+            patch.object(
+                run_live_qa,
+                "_trigger_run_outbound_deliver_evidence",
+                return_value=deliver_evidence,
+            ),
+            patch.object(
+                run_live_qa,
+                "_trigger_run_slack_send_evidence",
+                return_value=vendor_evidence,
+            ),
+            patch.object(
+                run_live_qa, "_slack_history_contains_marker", new=fake_history
+            ),
+            patch.object(run_live_qa.asyncio, "sleep", new=fake_sleep),
+        ):
+            return asyncio.run(
+                run_live_qa._wait_for_slack_delivery_marker(
+                    self._dummy_ctx(),
+                    routine_name="reborn-qa-test-routine",
+                    marker="REBORN_QA_TEST_SLACK_DELIVERED_1",
+                    oldest_epoch=0.0,
+                    timeout=timeout,
+                )
+            )
+
+    def test_wait_passes_on_skipped_notice_with_model_delivery_and_history(self):
+        skipped = {"run_id": "run-fire-1", "outcome": "skipped"}
+        delivered = {
+            "record_count": 1,
+            "delivered_count": 1,
+            "expected_channel_delivered_count": 1,
+        }
+        found = {"checked": True, "found": True, "marker_found": True}
+        result = self._run_wait(
+            outcomes=[skipped],
+            model_deliveries=[delivered],
+            histories=[found],
+        )
+        self.assertEqual(result["slack_history"], found)
+        self.assertEqual(result["model_delivery"], delivered)
+        self.assertEqual(result["delivery_outcome"], skipped)
+
+    def test_wait_keeps_polling_past_skipped_until_history_readback(self):
+        # The completion record lands seconds after the fire's own
+        # outbound_deliver call, while Slack history read-back can lag —
+        # a skipped record must keep the wait alive, not abort it.
+        skipped = {"run_id": "run-fire-1", "outcome": "skipped"}
+        delivered = {
+            "record_count": 1,
+            "delivered_count": 1,
+            "expected_channel_delivered_count": 1,
+        }
+        miss = {"checked": True, "found": False}
+        found = {"checked": True, "found": True, "marker_found": True}
+        deliver_with_marker = {
+            "completed_deliver_count": 1,
+            "marker_deliver_count": 1,
+            "parse_error_count": 0,
+        }
+        result = self._run_wait(
+            outcomes=[skipped],
+            model_deliveries=[delivered],
+            histories=[miss, miss, found],
+            deliver_evidence=deliver_with_marker,
+        )
+        self.assertEqual(result["slack_history"], found)
+
+    def test_wait_fails_fast_on_notifier_failure_outcome(self):
+        failed = {"run_id": "run-fire-1", "outcome": "failed"}
+        with self.assertRaises(AssertionError) as caught:
+            self._run_wait(
+                outcomes=[failed],
+                model_deliveries=[{"record_count": 0}],
+                histories=[{"checked": True, "found": False}],
+            )
+        self.assertIn("notifier", str(caught.exception))
+
+    def test_wait_fails_when_delivered_content_lacks_marker(self):
+        # The qa_8d live failure mode: outbound_deliver sent the message,
+        # but the composed content carried no marker (it only reached the
+        # final answer). Deterministic red, not a timeout or a flake.
+        skipped = {"run_id": "run-fire-1", "outcome": "skipped"}
+        delivered = {
+            "record_count": 1,
+            "delivered_count": 1,
+            "expected_channel_delivered_count": 1,
+        }
+        with self.assertRaises(AssertionError) as caught:
+            self._run_wait(
+                outcomes=[skipped],
+                model_deliveries=[delivered],
+                histories=[{"checked": True, "found": False}],
+                deliver_evidence={
+                    "completed_deliver_count": 1,
+                    "marker_deliver_count": 0,
+                    "parse_error_count": 0,
+                },
+            )
+        self.assertIn("marker", str(caught.exception))
+        self.assertIn("delivered", str(caught.exception))
+
+    def test_wait_times_out_inconclusive_on_clean_readback_miss(self):
+        skipped = {"run_id": "run-fire-1", "outcome": "skipped"}
+        delivered = {
+            "record_count": 1,
+            "delivered_count": 1,
+            "expected_channel_delivered_count": 1,
+        }
+        with self.assertRaises(
+            run_live_qa.SlackDeliveryReadbackInconclusive
+        ):
+            self._run_wait(
+                outcomes=[skipped],
+                model_deliveries=[delivered],
+                histories=[{"checked": True, "found": False}],
+                deliver_evidence={
+                    "completed_deliver_count": 1,
+                    "marker_deliver_count": 1,
+                    "parse_error_count": 0,
+                },
+                timeout=0.05,
+            )
+
+    def test_delivery_case_prompt_requires_marker_in_delivered_message(self):
+        sentence = run_live_qa._delivery_marker_prompt_requirement("MARKER_1")
+        self.assertIn("delivered Slack message", sentence)
+        self.assertIn("MARKER_1", sentence)
+        self.assertIn("final answer", sentence)
+
+        captured: dict[str, str] = {}
+
+        async def fake_creation_case(_ctx, **kwargs):
+            captured["prompt"] = kwargs.get("prompt") or ""
+            return run_live_qa.ProbeResult(
+                provider="test",
+                mode="live:test",
+                success=False,
+                latency_ms=1,
+                details={"error": "stop after prompt capture"},
+            )
+
+        with patch.object(
+            run_live_qa, "_routine_creation_case", new=fake_creation_case
+        ):
+            asyncio.run(
+                run_live_qa._slack_delivery_routine_case(
+                    self._dummy_ctx(),
+                    case_name="qa_test_delivery",
+                    routine_prefix="reborn-qa-test",
+                    marker_prefix="REBORN_QA_TEST",
+                    routine_instruction="send the result to Slack",
+                    required_delivery_text=[],
+                )
+            )
+
+        self.assertIn("delivered Slack message", captured["prompt"])
+        self.assertNotIn(
+            "final answer must include the exact marker REBORN_QA_TEST_SLACK",
+            captured["prompt"],
         )
 
 


### PR DESCRIPTION
## Summary

- The scheduled `reborn-webui-v2-live-qa` lane has failed every run since #7157 merged: the delivery cases (`qa_3d`, `qa_8d`, `qa_9b`, `qa_9d`) still require the retired completion-driver push record (`triggered-run-delivery` outcome == `delivered`), which post-#7157 is never written for results — a cleanly completed fire records `skipped` by design ("Completed delivers NOTHING", spec §8).
- **#7157 itself is working correctly live**: in the first post-merge canary run (2026-08-08 00:24 UTC), all four fire-runs pinned the target at creation and delivered via `builtin.outbound_deliver` with `provider_confirmed: true` and real Slack `ts` refs; three had the marker verifiably sitting in Slack history while the runner declared failure on the stale record.
- The delivery waiter now verifies the two-lane contract: success = the fire's durable `outbound/deliveries/` **model-delivery record** for the exact run (status `delivered`, target = the expected DM) **plus** the independent Slack `conversations.history` read-back finding the marker. Notifier records `skipped`/`no_default_configured`/`delivered` are healthy terminals; only `failed`/`denied` fail a case; unknown vocabulary surfaces in timeout diagnostics instead of hard-failing.
- The fourth failure mode is now deterministic: `qa_8d`'s fire delivered a message whose content lacked the marker because the case prompt bound the marker to "the routine's final answer" — which pre-#7157 *was* the delivered payload and no longer is. Case prompts now bind the marker to the delivered Slack message itself (shared `_delivery_marker_prompt_requirement` helper), and a completed `outbound_deliver` whose content lacks the marker fails immediately with a distinct error rather than timing out.
- Also fixes the QA 6D-6E strict-scrub false positive (green cases, red job at 18:20 UTC): under default progressive disclosure (#6958), `ironclaw.tool_search` output lands in traces, and the `builtin.extension_register_hosted_mcp` description prose "bearer for a static API token or PAT sent as a Bearer token" tripped the `bearer` pattern → strict scrub deleted the trace and exited 1. The pattern now requires 16+ token-alphabet characters (every real bearer credential shape is far longer than any English word that can follow "bearer").

## Change Type

- [x] Bug fix
- [x] CI/Infrastructure

## Linked Issue

None (canary regression diagnosed from run 31229982850 artifacts; full evidence below).

## Root-cause evidence (from the failing run's own artifacts)

- `qa_3d`: runner error `outcome={'outcome': 'skipped', …}` while its own history probe recorded `found: True, marker_found: True, bot_authored_marker_matches: 1` — delivery succeeded, assertion contract stale.
- `qa_9b`/`qa_9d`: same — `marker_found: True` in the error's own history payload; `qa_9d`'s persisted routine prompt contains the pinned `builtin__outbound_deliver` step with the resolved target id.
- `qa_8d`: runtime DB in the artifact shows `builtin.outbound_deliver` completed with `{"delivered":true,"provider_confirmed":true,"provider_message_refs":["1786148900.639239"], …}` to the pinned DM target; the composed content had no marker (prompt phrasing), final answer did.
- Merged notifier code (`ironclaw_assistant/src/run_delivery/triggered.rs`): completed run → plan `None` → records `Skipped`; `Delivered` is reserved for notices (e.g. parked-gate prompts). Nothing writes `delivered` for results.
- Pre-#7157 reds on this lane were a different family (LLM marker flubs, digest latency, `qa_2e` creation timeouts, QA 7/10 model-behavior probes) — those chronic flakes are unchanged by this PR and keep their existing classifications.

## Validation

- [x] `python3 scripts/reborn_webui_v2_live_qa/test_run_live_qa.py` — 217 tests OK (13 new)
- [x] `python3 scripts/live-canary/test_scrub_artifacts.py` — 18 tests OK (1 new)
- [x] New tests were written first and observed failing for the intended reasons (12 errors + 1 failure before the runner change; scrub prose test red before the pattern change)
- [ ] `cargo fmt` / `clippy` / `build`: Not applicable — no Rust changes.

## Test Strategy

User behavior: scheduled live-canary verification of routine→Slack delivery; no product behavior changes.

Risk areas:
- [x] Model behavior (canary-side judgment of it)
- [x] External provider (Slack history read-back semantics)

Tests added or updated:
- Unit or contract: `TwoLaneDeliveryContractTests` (13 tests) pin the outcome-vocabulary classifier, the durable model-delivery record reader (against the production record shape captured from the artifact, neutralized ids), the outbound_deliver evidence reader, the observed/inconclusive deciders, the waiter's pass/keep-polling/fail-fast/deterministic-content-fail/timeout paths, and that the case-builder prompt binds the marker to the delivered message. `test_strict_scrub_ignores_bearer_prose_in_tool_descriptions` reproduces the exact 18:20 trace false positive byte-shape.
- Reborn integration / Recorded fixture / Browser E2E / Backend or runtime: Not applicable — the change is the live-canary runner and scrub guardrail themselves.
- Live canary: the next scheduled `reborn-webui-v2-live-qa` run is the end-to-end proof; delivery cases stay `retry_policy = "never"`.

What the tests prove: the runner passes exactly when the fire durably delivered to the expected DM and the marker is independently read back; healthy notifier records can no longer fail a case; marker-less delivered content is a deterministic red, not a flake; prose after "bearer" no longer kills green shards.

Commands run: the two suites above.

## Security Impact

Scrub guardrail: the `bearer` pattern now requires 16+ token-alphabet chars after the keyword. Known real bearer-credential shapes (JWT `eyJ…`, `xox[baprs]-…`, `ya29.…`, `gh[pousr]_…`, `sk-…`, `AKIA…`) are all ≥16 and remain caught by this and their dedicated patterns; JSON-quoted `"access_token": "…"` shapes are unchanged. What is deliberately no longer flagged: ≤15-char words after "bearer" — i.e. English prose from model-visible tool descriptions, which strict mode was deleting from green shards. Canary results never persist message bodies/targets: the new record/evidence readers emit aggregate counts only (pinned by a sanitization assertion).

## Database Impact

None (read-only queries against the per-shard local runtime DB the runner already reads).

## Blast Radius

`scripts/reborn_webui_v2_live_qa/run_live_qa.py` delivery waiter + delivery-case prompts; `scripts/live-canary/scrub-artifacts.sh` bearer pattern; their test suites; `docs/internal/live-canary.md`. No production code. Worst case: a delivery case misclassifies again on the next scheduled run — visible immediately in the lane.

## Rollback Plan

`git revert` of this single commit restores the previous runner and scrub behavior (the lane then returns to deterministic post-#7157 red).

## Review Follow-Through

Two follow-ups are product-side and intentionally NOT in this PR (different layer/rollback): (1) `builtin.outbound_deliver` + `builtin.outbound_delivery_targets_list` are not in `CORE_TOOL_NAMES`, so on catalogs past the defer threshold the delivery pair drops out of the visible surface and `delivery.md` steering is silently not injected (`delivery_tools_visible=false`) — observed producing a live web-created routine whose prompt instructed `slack.send_message` to reach the requester; (2) `TRIGGER_CREATE_DESCRIPTION`'s "never call builtin__outbound_deliver in a web-app-created routine" clause is over-applied by weaker models when a destination IS named (verbatim in qa_8d's creation reasoning). Companion PR follows.

---

**Review track**: C (CI guardrail + canary contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
