### PR TITLE
test(disclosure): measure the Core delivery pair in the wide-catalog benchmark

### DIFF
--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -1976,13 +1976,19 @@ mod tests {
     /// - 83.7%: after the bridge grew (`tool_search`'s description became the
     ///   always-on catalog index, plus `tool_describe`/`tool_call`) and the
     ///   always-advertised Core tier was introduced.
-    /// - 82.9% (21,130 -> 3,618, 20 advertised): current, with 17 Core-tier
+    /// - 82.9% (21,130 -> 3,618, 20 advertised): with 17 Core-tier
     ///   loop primitives in this fixture always advertised alongside the three
     ///   bridge tools.
     ///
+    /// - 82.0% (21,355 -> 3,843, 22 advertised): current — core-set width
+    ///   plus fixture change: the outbound delivery pair
+    ///   (`outbound_deliver`, `outbound_delivery_targets_list`) became
+    ///   Core-tier so routine-delivery steering stays deterministic, and the
+    ///   fixture now models both (19 Core fixtures).
+    ///
     /// Moving this constant is allowed, but the PR that moves it must say which
     /// of core-set width, bridge-schema growth, or fixture change caused it.
-    const REPRESENTATIVE_REDUCTION_BASELINE_PCT: f64 = 82.9;
+    const REPRESENTATIVE_REDUCTION_BASELINE_PCT: f64 = 82.0;
 
     /// Band around the recorded baseline that counts as noise rather than
     /// material drift.
@@ -2052,7 +2058,7 @@ mod tests {
             "\n| full_count | full_tokens | disclosed_count | disclosed_tokens | reduction_abs | reduction_pct |\n| ---: | ---: | ---: | ---: | ---: | ---: |\n| {full_count} | {full_tokens} | {disclosed_count} | {disclosed_tokens} | {reduction_abs} | {reduction_pct:.1}% |\n{breakdown}"
         );
 
-        assert_eq!(full_count, 91);
+        assert_eq!(full_count, 93);
         assert!(disclosed.deferred);
         assert_eq!(
             discoverable.0, 0,
@@ -2110,6 +2116,20 @@ mod tests {
             })
             .collect();
 
+        // The outbound delivery pair rides Core (always advertised) so the
+        // benchmark measures its standing disclosure cost: a bounded deliver
+        // call and a no-argument target lister.
+        definitions.push(fixture_tool(
+            "outbound_deliver",
+            "Deliver content to one connected channel destination from the assistant identity.",
+            medium_schema(17),
+        ));
+        definitions.push(fixture_tool(
+            "outbound_delivery_targets_list",
+            "List the caller's connected outbound delivery destinations.",
+            small_no_arg_schema(),
+        ));
+
         for index in 0..15 {
             definitions.push(fixture_tool(
                 format!("small_status_{index:02}"),
@@ -2138,7 +2158,7 @@ mod tests {
             ));
         }
 
-        assert_eq!(definitions.len(), 91);
+        assert_eq!(definitions.len(), 93);
         definitions
     }
 


### PR DESCRIPTION
## Summary

- Follow-up to #7390 (merged before this review finding could land in-branch): the representative wide-catalog disclosure benchmark now models the two tools #7390 moved to Core-tier — `outbound_deliver` (bounded two-field call) and `outbound_delivery_targets_list` (no-argument lister) — so their standing advertised cost is measured instead of invisible.
- Re-pins the recorded baseline 82.9% → 82.0% per the constant's own instructions, with the drift-history entry naming the cause (core-set width + fixture change). The 50% hard floor is untouched and comfortably clear.

## Change Type

- [x] Bug fix (test-measurement gap)

## Linked Issue

Follow-up to #7390 review feedback (CodeRabbit comment on `tool_disclosure.rs`).

## Validation

- [x] `cargo test -p ironclaw_loop_host --lib` — 635 passed (fixture count assertions updated 91 → 93; benchmark measures 82.0%, within its re-centered band)
- [x] `cargo fmt -p ironclaw_loop_host -- --check` / `cargo clippy -p ironclaw_loop_host --all-targets --all-features -- -D warnings`

## Test Strategy

Test-only change to the benchmark fixture and its recorded baseline. User behavior: none. Risk areas: none (measurement fidelity). What the tests prove: the reduction floor now sees the Core delivery pair's real cost, so future Core-set or bridge growth is measured from the true current value.

## Security Impact

None.

## Database Impact

None.

## Blast Radius

One test fixture + one pinned constant in `ironclaw_loop_host`.

## Rollback Plan

Revert the single commit.

---

**Review track**: A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
