### PR TITLE
fix(ci): resolve SANDBOX_DOCKER_EXACT_PATHS crate prefixes dynamically

### DIFF
--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -156,25 +156,10 @@ QA_HARNESS_PREFIXES = (
     "scripts/telegram_smoke/",
 )
 CHANGED_COVERAGE_MANIFEST = "tests/integration/changed-coverage-exemptions.toml"
-SANDBOX_DOCKER_EXACT_PATHS = {
+# Path classes with no owning crate: no relocation can ever change them, so
+# they stay plain literals.
+SANDBOX_DOCKER_EXACT_PATH_LITERALS = (
     "Dockerfile.sandbox-worker",
-    "crates/app/ironclaw_cli/src/runtime/mod.rs",
-    "crates/app/ironclaw_composition/src/sandbox.rs",
-    "crates/app/ironclaw_composition/src/builtin_capability_policy.rs",
-    "crates/app/ironclaw_composition/src/deployment.rs",
-    "crates/app/ironclaw_composition/src/factory/production_backend_assembly.rs",
-    "crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs",
-    "crates/app/ironclaw_composition/src/input.rs",
-    "crates/app/ironclaw_config/src/profile.rs",
-    "crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs",
-    "crates/kernel/ironclaw_host_runtime/src/invocation_services.rs",
-    "crates/kernel/ironclaw_host_runtime/src/process_port.rs",
-    "crates/kernel/ironclaw_host_runtime/src/services.rs",
-    "crates/kernel/ironclaw_host_runtime/src/services/builder.rs",
-    "crates/kernel/ironclaw_runtime_policy/src/planner.rs",
-    "crates/kernel/ironclaw_runtime_policy/src/resolver.rs",
-    "crates/lanes/ironclaw_sandbox/tests/support/docker_gate.rs",
-    "crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live.rs",
     "tests/integration/reborn_sandbox_shell_turn.rs",
     "tests/e2e_trace_runtime_policy_serde.rs",
     "tests/fixtures/llm_traces/runtime_policy/hosted_dev_no_shell.json",
@@ -184,7 +169,59 @@ SANDBOX_DOCKER_EXACT_PATHS = {
     "tests/integration/support/harness/mod.rs",
     "tests/integration/support/harness/options.rs",
     "tests/integration/support/harness/profiles/sandbox_shell.rs",
+)
+# Crate-relative suffixes for entries that live inside a workspace crate's own
+# directory. `_sandbox_docker_exact_paths()` resolves each crate's root by
+# name through the shared inventory (scripts/ci/lib/crate_tree.py), the same
+# mechanism `_sandbox_docker_prefixes()` above already uses for
+# `ironclaw_sandbox` — a hardcoded `crates/<family>/<crate>` prefix stops
+# matching the moment any of these crates is relocated, and the planner would
+# then silently stop routing that crate's listed files to the Docker lane.
+SANDBOX_DOCKER_EXACT_PATH_CRATE_SUFFIXES: dict[str, tuple[str, ...]] = {
+    "ironclaw_cli": ("src/runtime/mod.rs",),
+    "ironclaw_composition": (
+        "src/sandbox.rs",
+        "src/builtin_capability_policy.rs",
+        "src/deployment.rs",
+        "src/factory/production_backend_assembly.rs",
+        "src/factory/runtime_lane_assembly.rs",
+        "src/input.rs",
+    ),
+    "ironclaw_config": ("src/profile.rs",),
+    "ironclaw_host_runtime": (
+        "src/first_party_tools/mod.rs",
+        "src/invocation_services.rs",
+        "src/process_port.rs",
+        "src/services.rs",
+        "src/services/builder.rs",
+    ),
+    "ironclaw_runtime_policy": (
+        "src/planner.rs",
+        "src/resolver.rs",
+    ),
+    "ironclaw_sandbox": (
+        "tests/support/docker_gate.rs",
+        "tests/user_sandbox_docker_live.rs",
+    ),
 }
+
+
+def _sandbox_docker_exact_paths() -> set[str]:
+    """Exact-match sandbox Docker paths, crate-owned entries resolved by name."""
+    paths = set(SANDBOX_DOCKER_EXACT_PATH_LITERALS)
+    for crate, suffixes in SANDBOX_DOCKER_EXACT_PATH_CRATE_SUFFIXES.items():
+        try:
+            directory = crate_directory(crate, ROOT)
+        except CrateTreeError as error:
+            raise RuntimeError(
+                f"reborn_pr_test_plan: cannot resolve the {crate} crate, so "
+                "the exact source paths used to route the Docker lane are "
+                f"unknown: {error}"
+            ) from error
+        paths.update(f"{directory}/{suffix}" for suffix in suffixes)
+    return paths
+
+
 # Asset trees that live outside every crate root but are compiled *into* a
 # workspace crate through a relative `include_bytes!` / `include_str!` that
 # escapes its own crate (the §11.2.7 reach-ins inventoried by
@@ -724,7 +761,7 @@ def build_plan(
     root_inventory = _root_test_partitions()
     integration_inventory = _integration_test_lanes()
     sandbox_docker_prefixes = _sandbox_docker_prefixes()
-    sandbox_docker_exact_paths = set(SANDBOX_DOCKER_EXACT_PATHS)
+    sandbox_docker_exact_paths = _sandbox_docker_exact_paths()
     if sandbox_docker_prefixes:
         sandbox_crate_directory = sandbox_docker_prefixes[0].removesuffix(
             "/src/sandbox_process"

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -381,6 +381,9 @@ class RebornPrTestPlanTests(unittest.TestCase):
             with (
                 mock.patch.object(planner, "_sandbox_docker_prefixes", return_value=()),
                 mock.patch.object(
+                    planner, "_sandbox_docker_exact_paths", return_value=set()
+                ),
+                mock.patch.object(
                     planner,
                     "crate_directory",
                     return_value="crates/substrates/ironclaw_webui",
@@ -406,6 +409,9 @@ class RebornPrTestPlanTests(unittest.TestCase):
         try:
             with (
                 mock.patch.object(planner, "_sandbox_docker_prefixes", return_value=()),
+                mock.patch.object(
+                    planner, "_sandbox_docker_exact_paths", return_value=set()
+                ),
                 mock.patch.object(
                     planner,
                     "crate_directory",
@@ -589,6 +595,51 @@ class RebornPrTestPlanTests(unittest.TestCase):
                     )
                     self.assertTrue(plan["run_sandbox_docker"])
         resolver.assert_any_call("ironclaw_sandbox", planner.ROOT)
+
+    def test_sandbox_docker_exact_paths_resolve_through_crate_inventory_when_nested(
+        self,
+    ) -> None:
+        """A family-moved crate among the six sandbox-Docker exact-path owners
+        still contributes its entries at the new location, and the old
+        location's entries stop appearing — the same relocation-safety
+        `_sandbox_docker_prefixes` already provides for `ironclaw_sandbox`.
+        """
+        from crate_tree import crate_directory as real_crate_directory
+
+        moved_directory = "crates/kernel-next/ironclaw_runtime_policy"
+
+        def fake_crate_directory(name: str, root: Path = planner.ROOT) -> str:
+            if name == "ironclaw_runtime_policy":
+                return moved_directory
+            return real_crate_directory(name, root)
+
+        with mock.patch.object(
+            planner, "crate_directory", side_effect=fake_crate_directory
+        ):
+            exact_paths = planner._sandbox_docker_exact_paths()
+
+        self.assertIn(f"{moved_directory}/src/planner.rs", exact_paths)
+        self.assertIn(f"{moved_directory}/src/resolver.rs", exact_paths)
+        self.assertNotIn(
+            "crates/kernel/ironclaw_runtime_policy/src/planner.rs", exact_paths
+        )
+        self.assertNotIn(
+            "crates/kernel/ironclaw_runtime_policy/src/resolver.rs", exact_paths
+        )
+        # An unrelated owner's entries are untouched by the relocation.
+        self.assertIn("crates/app/ironclaw_cli/src/runtime/mod.rs", exact_paths)
+
+    def test_sandbox_docker_exact_paths_resolution_failure_fails_closed(self) -> None:
+        """An unresolvable crate must raise, never silently drop that crate's
+        entries from the exact-path set — the same fail-closed contract as
+        `_sandbox_docker_prefixes` and `_webui_frontend_prefix`."""
+        with mock.patch.object(
+            planner, "crate_directory", side_effect=planner.CrateTreeError("boom")
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "cannot resolve the ironclaw_cli crate"
+            ):
+                planner._sandbox_docker_exact_paths()
 
     def test_sandbox_docker_paths_preserve_regular_test_inventory_selection(
         self,

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -629,6 +629,51 @@ class RebornPrTestPlanTests(unittest.TestCase):
         # An unrelated owner's entries are untouched by the relocation.
         self.assertIn("crates/app/ironclaw_cli/src/runtime/mod.rs", exact_paths)
 
+    def test_sandbox_docker_exact_paths_route_relocated_crate_through_build_plan(
+        self,
+    ) -> None:
+        """The sibling test above pins that a relocated crate's entries
+        appear in `_sandbox_docker_exact_paths()`'s returned set. That alone
+        would stay green even if `build_plan()` stopped consuming the
+        resolved set or stopped setting `run_sandbox_docker` for a matched
+        path — the exact silent loss of Docker coverage this change exists
+        to prevent. Drive `build_plan()` itself, the same way
+        `test_sandbox_docker_prefix_follows_crate_inventory_when_nested`
+        already does for `_sandbox_docker_prefixes`, and assert the emitted
+        Docker-lane flag."""
+        from crate_tree import crate_directory as real_crate_directory
+
+        moved_directory = "crates/kernel-next/ironclaw_runtime_policy"
+        moved_metadata = metadata()
+        next(
+            package
+            for package in moved_metadata["packages"]
+            if package["id"] == "alpha"
+        )["manifest_path"] = str(ROOT / moved_directory / "Cargo.toml")
+
+        def fake_crate_directory(name: str, root: Path = planner.ROOT) -> str:
+            if name == "ironclaw_runtime_policy":
+                return moved_directory
+            return real_crate_directory(name, root)
+
+        with mock.patch.object(
+            planner, "crate_directory", side_effect=fake_crate_directory
+        ):
+            plan = planner.build_plan(
+                event="pull_request",
+                changed_paths=[f"{moved_directory}/src/planner.rs"],
+                metadata=moved_metadata,
+                canonical_packages=self.canonical,
+            )
+
+        # `mode` must be "selected", not "full" — a package-resolution miss
+        # falls back to the exhaustive plan (see `build_plan`'s "a crate path
+        # maps to no workspace package" arm), which also sets
+        # `run_sandbox_docker`, but for the wrong reason and without
+        # exercising the exact-path routing this test targets.
+        self.assertEqual(plan["mode"], "selected")
+        self.assertTrue(plan["run_sandbox_docker"])
+
     def test_sandbox_docker_exact_paths_resolution_failure_fails_closed(self) -> None:
         """An unresolvable crate must raise, never silently drop that crate's
         entries from the exact-path set — the same fail-closed contract as


### PR DESCRIPTION
`SANDBOX_DOCKER_EXACT_PATHS` in `scripts/ci/reborn_pr_test_plan.py` hardcoded the crate-root prefix (`crates/app/...`, `crates/kernel/...`, `crates/lanes/...`) for every entry owned by `ironclaw_cli`, `ironclaw_composition`, `ironclaw_config`, `ironclaw_host_runtime`, `ironclaw_runtime_policy`, and `ironclaw_sandbox`. If any of those crates is relocated, the literal stops matching and the planner silently stops routing that crate's listed files to the Docker sandbox lane — no error, just quietly dark coverage. This is the same bug class `ironclaw_wasm` has hit at least twice already (`538b1f021` moved it into `crates/lanes/`, `8ed9d4afc` moved every crate into its family directory), each time requiring a follow-up fix (`48e27e0f9`, `00d9679b3`) to re-resolve the path dynamically.

I replaced the constant with `_sandbox_docker_exact_paths()`, matching the pattern already established in this file by `_sandbox_docker_prefixes()` and `_webui_frontend_prefix()`:

- `SANDBOX_DOCKER_EXACT_PATH_LITERALS` — the 10 entries with no owning crate (`Dockerfile.sandbox-worker`, root-level `tests/...` paths), unchanged as plain literals.
- `SANDBOX_DOCKER_EXACT_PATH_CRATE_SUFFIXES` — a `dict[str, tuple[str, ...]]` mapping the 6 crate names to their 17 crate-relative suffixes, joined at call time with `crate_directory(crate, ROOT)`.
- Fails closed with `RuntimeError` if a crate can't be resolved, same message style as `_sandbox_docker_prefixes()`.

I verified all 27 original entries are represented 1:1 in the new split (10 literals + 17 crate suffixes), and independently confirmed `crate_directory()` resolves all 6 crate names to the exact prefixes the old literals assumed.

Tests: added `test_sandbox_docker_exact_paths_resolve_through_crate_inventory_when_nested` (proves a relocated crate's entries follow it, old-location entries disappear) and `test_sandbox_docker_exact_paths_resolution_failure_fails_closed` (proves the `RuntimeError` fail-closed path). Updated two pre-existing tests to mock `_sandbox_docker_exact_paths` since it's now called unconditionally in `build_plan()` alongside their own `crate_directory` mocks — verified this guard is load-bearing by removing it and confirming both tests fail for the expected reason. Added `test_sandbox_docker_exact_paths_route_relocated_crate_through_build_plan` in response to CodeRabbit feedback that the first test above only pins `_sandbox_docker_exact_paths()`'s return value, which would stay green even if `build_plan()` stopped consuming the resolved set or setting `run_sandbox_docker` for a matched path — this test drives `build_plan()` itself with a relocated crate and asserts the emitted Docker-lane flag, closing that coverage gap.

`test_reborn_pr_test_plan.py`: 75/75 passing. `test_ws12_workflow_contracts.py`: 52/52 passing.