### PR TITLE
fix(outbound): close send-claim TOCTOU race and allow failed-row reopen

### DIFF
--- a/crates/domains/ironclaw_outbound/src/lib.rs
+++ b/crates/domains/ironclaw_outbound/src/lib.rs
@@ -70,10 +70,11 @@ pub use triggered_run_delivery::{
     TriggeredRunDeliveryRecord, TriggeredRunDeliveryRequest, TriggeredRunDeliveryStore,
 };
 pub use types::{
-    AdvanceSubscriptionCursorRequest, ClaimDeliveryAttemptForSendRequest, DeliveryFailureKind,
-    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryDecision,
-    OutboundDeliveryStatus, OutboundPushCandidate, OutboundPushKind, OutboundPushPlan,
-    OutboundPushTargetRequest, PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
+    AdvanceSubscriptionCursorRequest, ClaimDeliveryAttemptForSendOutcome,
+    ClaimDeliveryAttemptForSendRequest, DeliveryFailureKind, LoadSubscriptionCursorRequest,
+    OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryStatus,
+    OutboundPushCandidate, OutboundPushKind, OutboundPushPlan, OutboundPushTargetRequest,
+    PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
     ProjectionSubscriptionRecord, ProjectionSubscriptionRequest, RecoverInterruptedDeliveryRequest,
     ReplyTargetBindingClaim, ReplyTargetValidationRequest, ThreadNotificationPolicy,
     ThreadNotificationTarget, ThreadProjectionAccessClaim, ThreadProjectionAccessGrant,

--- a/crates/domains/ironclaw_outbound/src/lib.rs
+++ b/crates/domains/ironclaw_outbound/src/lib.rs
@@ -79,4 +79,5 @@ pub use types::{
     ReplyTargetBindingClaim, ReplyTargetValidationRequest, ThreadNotificationPolicy,
     ThreadNotificationTarget, ThreadProjectionAccessClaim, ThreadProjectionAccessGrant,
     ThreadProjectionAccessRequest, UpdateDeliveryStatusRequest, ValidatedReplyTargetBinding,
+    VendorEgressProvenance,
 };

--- a/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
+++ b/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
@@ -1063,6 +1063,11 @@ where
             }
             attempt.status = OutboundDeliveryStatus::Unknown;
             attempt.failure_kind = None;
+            // A `Sending` row means a claim was taken and the process could
+            // have called the adapter before crashing — provenance can't
+            // prove otherwise, so this settles `Attempted`, not a reused
+            // pre-claim value.
+            attempt.vendor_egress = Some(crate::VendorEgressProvenance::Attempted);
             let entry = delivery_attempt_entry(&attempt)?;
             match self
                 .filesystem
@@ -1102,6 +1107,7 @@ where
             }
             attempt.status = request.status;
             attempt.failure_kind = request.failure_kind;
+            attempt.vendor_egress = request.vendor_egress;
             match self
                 .put_delivery_attempt_indexed(
                     &resource_scope,
@@ -1355,18 +1361,27 @@ fn delivery_path(delivery_id: &OutboundDeliveryId) -> Result<ScopedPath, Outboun
 ///
 /// Reopening is limited to genuine retries: `incoming` must be a fresh
 /// `Prepared` reservation (every current caller constructs one this way),
-/// `existing` must be `Failed`, and its failure kind must permit reopen (see
-/// [`crate::DeliveryFailureKind::permits_reopen`]). Any other existing
-/// status — including a `Failed` row with a kind that does not permit
-/// reopen — keeps the existing no-op behavior, so this never reopens a row
-/// another worker already advanced to `Sending`, `Delivered`, or a
-/// permanently terminal state.
+/// `existing` must be `Failed`, its recorded [`crate::VendorEgressProvenance`]
+/// must prove no `adapter.deliver` call was ever made for this row, and its
+/// failure kind must independently permit reopen (see
+/// [`crate::DeliveryFailureKind::permits_reopen`]). Both gates are required:
+/// `vendor_egress` distinguishes a row written by this codebase's current,
+/// provably-safe pre-claim writers from a byte-identical row an older binary
+/// wrote for a since-reclassified, ambiguous case (pre-this-PR binaries wrote
+/// `TransportUnavailable` for post-`adapter.deliver` retry exhaustion too) —
+/// `None` (a row from a binary predating this field) fails closed. Any other
+/// existing status — including a `Failed` row with a kind that does not
+/// permit reopen, or one whose provenance cannot prove no egress occurred —
+/// keeps the existing no-op behavior, so this never reopens a row another
+/// worker already advanced to `Sending`, `Delivered`, or a permanently
+/// terminal state, and never reopens a row this binary cannot prove is safe.
 fn attempt_reopens_stale_failure(
     existing: &OutboundDeliveryAttempt,
     incoming: &OutboundDeliveryAttempt,
 ) -> bool {
     incoming.status == OutboundDeliveryStatus::Prepared
         && existing.status == OutboundDeliveryStatus::Failed
+        && existing.vendor_egress == Some(crate::VendorEgressProvenance::NotAttempted)
         && existing
             .failure_kind
             .is_some_and(crate::DeliveryFailureKind::permits_reopen)

--- a/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
+++ b/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
@@ -74,15 +74,16 @@ use crate::validation::{
     validate_subscription_identity, validate_subscription_record, validate_subscription_request,
 };
 use crate::{
-    AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, CommunicationPreferenceVersion, DeliveredGateRouteRecord,
-    DeliveredGateRouteStore, DeliveryDefaultScope, LoadSubscriptionCursorRequest,
-    MAX_RUN_DELIVERY_CLEANUP_RECORDS, OutboundDeliveryAttempt, OutboundDeliveryId,
-    OutboundDeliveryStatus, OutboundError, OutboundStateStorePort, ProjectionSubscriptionId,
-    ProjectionSubscriptionRecord, ReplyAttachmentIntent, ReplyAttachmentIntentPort,
-    RunDeliveryCleanupRecord, RunDeliveryCleanupRequest, ThreadNotificationPolicy,
-    TriggeredRunDeliveryRecord, TriggeredRunDeliveryStore, UpdateDeliveryStatusRequest,
-    VersionedCommunicationPreferenceRecord, WriteCommunicationPreferenceRequest,
+    AdvanceSubscriptionCursorRequest, ClaimDeliveryAttemptForSendOutcome,
+    CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
+    CommunicationPreferenceVersion, DeliveredGateRouteRecord, DeliveredGateRouteStore,
+    DeliveryDefaultScope, LoadSubscriptionCursorRequest, MAX_RUN_DELIVERY_CLEANUP_RECORDS,
+    OutboundDeliveryAttempt, OutboundDeliveryId, OutboundDeliveryStatus, OutboundError,
+    OutboundStateStorePort, ProjectionSubscriptionId, ProjectionSubscriptionRecord,
+    ReplyAttachmentIntent, ReplyAttachmentIntentPort, RunDeliveryCleanupRecord,
+    RunDeliveryCleanupRequest, ThreadNotificationPolicy, TriggeredRunDeliveryRecord,
+    TriggeredRunDeliveryStore, UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
+    WriteCommunicationPreferenceRequest,
 };
 
 /// Maximum number of compare-and-swap retries on a read-then-write path
@@ -931,12 +932,40 @@ where
             .await?;
         let path = delivery_path(&attempt.delivery_id)?;
         for _ in 0..MAX_CAS_RETRIES {
-            if let Some(existing) = self
-                .get_json::<OutboundDeliveryAttempt>(&resource_scope, &path)
+            if let Some((existing, versioned)) = self
+                .get_versioned_json::<OutboundDeliveryAttempt>(&resource_scope, &path)
                 .await?
             {
                 validate_delivery_identity(&existing, &attempt)?;
-                return Ok(());
+                if !attempt_reopens_stale_failure(&existing, &attempt) {
+                    return Ok(());
+                }
+                // The stable delivery id already settled `Failed` with a
+                // kind whose `permits_reopen()` is true — no part of this
+                // delivery reached the vendor. Reopen it to the incoming
+                // fresh `Prepared` reservation so a caller replaying the
+                // same logical delivery can claim a new send attempt
+                // instead of being stuck behind `ExistingDeliveryUnconfirmed`
+                // forever. This must use versioned CAS, not the byte-only
+                // fallback: a concurrent reopen racing a send claim must
+                // never clobber a `Sending`/terminal row a different worker
+                // already advanced past `Failed`.
+                let entry = delivery_attempt_entry(&attempt)?;
+                match self
+                    .filesystem
+                    .put(
+                        &resource_scope,
+                        &path,
+                        entry,
+                        CasExpectation::Version(versioned.version),
+                    )
+                    .await
+                    .map_err(map_fs_error)
+                {
+                    Ok(_) => return Ok(()),
+                    Err(OutboundError::CasConflict) => continue,
+                    Err(error) => return Err(error),
+                }
             }
             match self
                 .put_delivery_attempt_indexed(
@@ -958,7 +987,7 @@ where
     async fn claim_delivery_attempt_for_send(
         &self,
         request: crate::ClaimDeliveryAttemptForSendRequest,
-    ) -> Result<bool, OutboundError> {
+    ) -> Result<ClaimDeliveryAttemptForSendOutcome, OutboundError> {
         let path = delivery_path(&request.delivery_id)?;
         let resource_scope = request.scope.to_resource_scope();
         for _ in 0..MAX_CAS_RETRIES {
@@ -972,7 +1001,15 @@ where
                 return Err(OutboundError::SubscriptionScopeMismatch);
             }
             if attempt.status != OutboundDeliveryStatus::Prepared {
-                return Ok(false);
+                // This read — including any retry read after a lost CAS
+                // below — is the sole source of the returned row. There is
+                // no separate subsequent read: that is what closes the
+                // TOCTOU window between a failed CAS and a caller
+                // re-reading (during which a concurrent reopen could have
+                // moved the row back to `Prepared`).
+                return Ok(ClaimDeliveryAttemptForSendOutcome::Existing(Box::new(
+                    attempt,
+                )));
             }
             attempt.status = OutboundDeliveryStatus::Sending;
             attempt.failure_kind = None;
@@ -992,7 +1029,7 @@ where
                 .await
                 .map_err(map_fs_error)
             {
-                Ok(_) => return Ok(true),
+                Ok(_) => return Ok(ClaimDeliveryAttemptForSendOutcome::Claimed),
                 Err(OutboundError::CasConflict) => continue,
                 Err(error) => return Err(error),
             }
@@ -1310,6 +1347,29 @@ fn subscription_path(
 fn delivery_path(delivery_id: &OutboundDeliveryId) -> Result<ScopedPath, OutboundError> {
     ScopedPath::new(format!("/outbound/deliveries/{delivery_id}.json"))
         .map_err(|_| OutboundError::Backend)
+}
+
+/// Returns whether `record_delivery_attempt` may replace `existing` (already
+/// durable under the incoming attempt's deterministic delivery id) with
+/// `incoming` instead of treating the call as an idempotent no-op.
+///
+/// Reopening is limited to genuine retries: `incoming` must be a fresh
+/// `Prepared` reservation (every current caller constructs one this way),
+/// `existing` must be `Failed`, and its failure kind must permit reopen (see
+/// [`crate::DeliveryFailureKind::permits_reopen`]). Any other existing
+/// status — including a `Failed` row with a kind that does not permit
+/// reopen — keeps the existing no-op behavior, so this never reopens a row
+/// another worker already advanced to `Sending`, `Delivered`, or a
+/// permanently terminal state.
+fn attempt_reopens_stale_failure(
+    existing: &OutboundDeliveryAttempt,
+    incoming: &OutboundDeliveryAttempt,
+) -> bool {
+    incoming.status == OutboundDeliveryStatus::Prepared
+        && existing.status == OutboundDeliveryStatus::Failed
+        && existing
+            .failure_kind
+            .is_some_and(crate::DeliveryFailureKind::permits_reopen)
 }
 
 fn delivery_attempt_entry(attempt: &OutboundDeliveryAttempt) -> Result<Entry, OutboundError> {

--- a/crates/domains/ironclaw_outbound/src/service.rs
+++ b/crates/domains/ironclaw_outbound/src/service.rs
@@ -9,7 +9,7 @@ use crate::{
     PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
     ProjectionSubscriptionRecord, ProjectionSubscriptionRequest, ReplyTargetBindingClaim,
     ReplyTargetValidationRequest, ThreadProjectionAccessClaim, ThreadProjectionAccessGrant,
-    ThreadProjectionAccessRequest, ValidatedReplyTargetBinding,
+    ThreadProjectionAccessRequest, ValidatedReplyTargetBinding, VendorEgressProvenance,
 };
 
 #[async_trait]
@@ -120,6 +120,7 @@ impl<'a> OutboundPolicyService<'a> {
                     status: OutboundDeliveryStatus::Prepared,
                     attempted_at: request.attempted_at,
                     failure_kind: None,
+                    vendor_egress: Some(VendorEgressProvenance::NotAttempted),
                 };
                 self.store.record_delivery_attempt(attempt.clone()).await?;
                 Ok(OutboundDeliveryDecision::Authorized { attempt, target })
@@ -132,6 +133,7 @@ impl<'a> OutboundPolicyService<'a> {
                     status: OutboundDeliveryStatus::Failed,
                     attempted_at: request.attempted_at,
                     failure_kind: Some(DeliveryFailureKind::AuthorizationRevoked),
+                    vendor_egress: Some(VendorEgressProvenance::NotAttempted),
                 };
                 self.store.record_delivery_attempt(attempt.clone()).await?;
                 Ok(OutboundDeliveryDecision::Rejected { attempt })
@@ -148,6 +150,7 @@ impl<'a> OutboundPolicyService<'a> {
                     status: OutboundDeliveryStatus::Failed,
                     attempted_at: request.attempted_at,
                     failure_kind: Some(DeliveryFailureKind::TransientValidatorError),
+                    vendor_egress: Some(VendorEgressProvenance::NotAttempted),
                 };
                 self.store.record_delivery_attempt(attempt.clone()).await?;
                 Ok(OutboundDeliveryDecision::Rejected { attempt })

--- a/crates/domains/ironclaw_outbound/src/store.rs
+++ b/crates/domains/ironclaw_outbound/src/store.rs
@@ -5,11 +5,12 @@ use ironclaw_event_projections::ProjectionCursor;
 use ironclaw_host_api::turn::{ReplyTargetBindingRef, TurnScope};
 
 use crate::{
-    AdvanceSubscriptionCursorRequest, ClaimDeliveryAttemptForSendRequest,
-    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError,
-    OutboundPushCandidate, OutboundPushKind, OutboundPushPlan, OutboundPushTargetRequest,
-    ProjectionSubscriptionRecord, RecoverInterruptedDeliveryRequest, RunDeliveryCleanupRecord,
-    RunDeliveryCleanupRequest, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    AdvanceSubscriptionCursorRequest, ClaimDeliveryAttemptForSendOutcome,
+    ClaimDeliveryAttemptForSendRequest, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
+    OutboundDeliveryId, OutboundError, OutboundPushCandidate, OutboundPushKind, OutboundPushPlan,
+    OutboundPushTargetRequest, ProjectionSubscriptionRecord, RecoverInterruptedDeliveryRequest,
+    RunDeliveryCleanupRecord, RunDeliveryCleanupRequest, ThreadNotificationPolicy,
+    UpdateDeliveryStatusRequest,
 };
 
 #[async_trait]
@@ -70,18 +71,37 @@ pub trait OutboundStateStorePort: Send + Sync {
         request: AdvanceSubscriptionCursorRequest,
     ) -> Result<(), OutboundError>;
 
+    /// Persist `attempt` under its deterministic delivery id.
+    ///
+    /// Idempotent for a replay whose id already resolved: an existing row
+    /// that is not a reopen candidate is left untouched and this returns
+    /// `Ok(())` without writing. The one exception is a reopen: when the
+    /// existing row is `Failed` with a kind where
+    /// [`crate::DeliveryFailureKind::permits_reopen`] is `true` and the
+    /// incoming `attempt` is a fresh `Prepared` reservation for the same id,
+    /// the store CAS-writes the incoming attempt over the stale `Failed` row
+    /// instead of no-opping — that failure kind is only ever settled for
+    /// this id when nothing reached the vendor, so reopening it cannot
+    /// duplicate an accepted send. Any other existing status, including a
+    /// `Failed` row whose kind does not permit reopen, keeps the no-op
+    /// behavior.
     async fn record_delivery_attempt(
         &self,
         attempt: OutboundDeliveryAttempt,
     ) -> Result<(), OutboundError>;
 
     /// Atomically reserve the one allowed vendor-egress drive for a prepared
-    /// attempt. Returns `true` only to the caller that persisted the
-    /// `Prepared -> Sending` transition.
+    /// attempt. Returns [`ClaimDeliveryAttemptForSendOutcome::Claimed`] only
+    /// to the caller that persisted the `Prepared -> Sending` transition;
+    /// every other caller receives
+    /// [`ClaimDeliveryAttemptForSendOutcome::Existing`] carrying the exact
+    /// authoritative row that blocked the claim, read atomically as part of
+    /// the same CAS attempt — never from a separate subsequent read, which
+    /// would reopen a TOCTOU window a concurrent reopen could race.
     async fn claim_delivery_attempt_for_send(
         &self,
         request: ClaimDeliveryAttemptForSendRequest,
-    ) -> Result<bool, OutboundError>;
+    ) -> Result<ClaimDeliveryAttemptForSendOutcome, OutboundError>;
 
     /// Crash recovery for an interrupted send. Re-reads the attempt inside the
     /// store's CAS and transitions `Sending -> Unknown` only when it is still

--- a/crates/domains/ironclaw_outbound/src/types.rs
+++ b/crates/domains/ironclaw_outbound/src/types.rs
@@ -250,6 +250,24 @@ pub enum DeliveryFailureKind {
     /// this delivery id stay Failed forever" finds an explicit answer instead
     /// of an `Unknown` catch-all.
     VendorContactAmbiguous,
+    /// A `failure_kind` this binary does not model — e.g. a row written by a
+    /// newer release. Deserialization of a delivery row is all-or-nothing and
+    /// `list_delivery_attempts` fails the whole scope on one bad row, so an
+    /// unrecognized kind must fold here rather than making crash recovery
+    /// unloadable for every delivery in the scope. Never written by this
+    /// codebase; never reopenable, because an unknown kind proves nothing
+    /// about vendor contact.
+    ///
+    /// Round-trips lossily: `#[serde(other)]` does not preserve the original
+    /// unknown tag string, so re-serializing a loaded `Unrecognized` value
+    /// does not reproduce the wire form that produced it. This is expected
+    /// and harmless — no write path in this codebase re-serializes a
+    /// previously-read `failure_kind` unchanged; every write constructs a
+    /// fresh value from current logic (see `update_delivery_status`, which
+    /// always takes `failure_kind` from the incoming request, never from a
+    /// prior read of the row it's overwriting).
+    #[serde(other)]
+    Unrecognized,
 }
 
 impl DeliveryFailureKind {
@@ -264,6 +282,7 @@ impl DeliveryFailureKind {
         Self::Rejected,
         Self::Unknown,
         Self::VendorContactAmbiguous,
+        Self::Unrecognized,
     ];
 
     /// Whether a `Failed` row carrying this kind may be reopened to a fresh
@@ -280,9 +299,28 @@ impl DeliveryFailureKind {
             Self::AuthorizationRevoked
             | Self::Rejected
             | Self::Unknown
-            | Self::VendorContactAmbiguous => false,
+            | Self::VendorContactAmbiguous
+            | Self::Unrecognized => false,
         }
     }
+}
+
+/// Whether the writer of an [`OutboundDeliveryAttempt`] row could prove, at
+/// write time, that no `adapter.deliver` call had been made for this
+/// delivery id. Recorded by the code that knows the answer, at the moment it
+/// knows it — never re-derived from `failure_kind`, whose meaning can change
+/// across releases (pre-this-PR binaries wrote `TransportUnavailable` for
+/// post-`adapter.deliver` retry exhaustion too).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VendorEgressProvenance {
+    /// No `adapter.deliver` call was made before this row settled.
+    NotAttempted,
+    /// An `adapter.deliver` call was made, or the writer cannot prove one
+    /// wasn't. Also the `#[serde(other)]` landing spot, so an unrecognized
+    /// future value fails closed.
+    #[serde(other)]
+    Attempted,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -376,6 +414,10 @@ pub struct OutboundDeliveryAttempt {
     pub status: OutboundDeliveryStatus,
     pub attempted_at: Timestamp,
     pub failure_kind: Option<DeliveryFailureKind>,
+    /// `None` means a binary predating this field wrote the row — fail
+    /// closed (never reopen). See [`VendorEgressProvenance`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor_egress: Option<VendorEgressProvenance>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -397,6 +439,8 @@ pub struct UpdateDeliveryStatusRequest {
     pub status: OutboundDeliveryStatus,
     pub updated_at: Timestamp,
     pub failure_kind: Option<DeliveryFailureKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor_egress: Option<VendorEgressProvenance>,
 }
 
 /// Atomic ownership claim for the sole vendor-egress writer of a prepared
@@ -451,7 +495,8 @@ mod tests {
                 DeliveryFailureKind::AuthorizationRevoked
                 | DeliveryFailureKind::Rejected
                 | DeliveryFailureKind::Unknown
-                | DeliveryFailureKind::VendorContactAmbiguous => false,
+                | DeliveryFailureKind::VendorContactAmbiguous
+                | DeliveryFailureKind::Unrecognized => false,
             };
             assert_eq!(kind.permits_reopen(), expected, "{kind:?}");
         }
@@ -484,6 +529,7 @@ mod tests {
             DeliveryFailureKind::Rejected,
             DeliveryFailureKind::Unknown,
             DeliveryFailureKind::VendorContactAmbiguous,
+            DeliveryFailureKind::Unrecognized,
         ];
         let mut seen = std::collections::HashSet::new();
         for kind in DeliveryFailureKind::ALL {

--- a/crates/domains/ironclaw_outbound/src/types.rs
+++ b/crates/domains/ironclaw_outbound/src/types.rs
@@ -268,8 +268,12 @@ impl DeliveryFailureKind {
 
     /// Whether a `Failed` row carrying this kind may be reopened to a fresh
     /// `Prepared` reservation under the same deterministic delivery id.
-    /// True only for kinds this codebase provably never writes after the
-    /// vendor-egress claim, so a reopen cannot duplicate an accepted send.
+    /// True only for kinds this codebase provably never writes after an
+    /// `adapter.deliver` call has been made, so a reopen cannot duplicate an
+    /// accepted send. This is a narrower boundary than "before the
+    /// vendor-egress claim": `TransportUnavailable` is written post-claim, on
+    /// channel-resolution failure, but that failure path never reaches
+    /// `adapter.deliver` — so no vendor egress was ever attempted.
     pub const fn permits_reopen(self) -> bool {
         match self {
             Self::TransientValidatorError | Self::TransportUnavailable | Self::RateLimited => true,
@@ -455,15 +459,32 @@ mod tests {
 
     #[test]
     fn all_lists_every_variant_exactly_once() {
-        // Defence-in-depth alongside the exhaustive match above: catches a
-        // typo'd duplicate entry in `ALL` that the match wouldn't.
+        // Catches both a duplicated entry and an omitted one. The witness
+        // list below is exhaustive by construction: a new variant forces a
+        // new binding here (the match below is non-exhaustive otherwise),
+        // which then forces the `ALL` membership check for it.
+        let witnesses = [
+            DeliveryFailureKind::AuthorizationRevoked,
+            DeliveryFailureKind::TransientValidatorError,
+            DeliveryFailureKind::TransportUnavailable,
+            DeliveryFailureKind::RateLimited,
+            DeliveryFailureKind::Rejected,
+            DeliveryFailureKind::Unknown,
+            DeliveryFailureKind::VendorContactAmbiguous,
+        ];
         let mut seen = std::collections::HashSet::new();
         for kind in DeliveryFailureKind::ALL {
             assert!(
-                seen.insert(format!("{kind:?}")),
+                seen.insert(std::mem::discriminant(kind)),
                 "duplicate entry: {kind:?}"
             );
         }
-        assert_eq!(seen.len(), 7);
+        for witness in witnesses {
+            assert!(
+                seen.contains(&std::mem::discriminant(&witness)),
+                "ALL omits {witness:?}"
+            );
+        }
+        assert_eq!(seen.len(), witnesses.len());
     }
 }

--- a/crates/domains/ironclaw_outbound/src/types.rs
+++ b/crates/domains/ironclaw_outbound/src/types.rs
@@ -224,7 +224,61 @@ pub enum DeliveryFailureKind {
     TransportUnavailable,
     RateLimited,
     Rejected,
+    /// Unclassified failure — this codebase never wrote a more specific
+    /// [`DeliveryFailureKind`] for this row. Contrast with
+    /// [`Self::VendorContactAmbiguous`], which is a specific, deliberately
+    /// classified kind: it does not mean "we don't know what happened", it
+    /// means "we know retries were exhausted after the vendor-egress claim,
+    /// and that state provides no proof the vendor was never contacted."
     Unknown,
+    /// Retry exhaustion after the vendor-egress claim, settled without proof
+    /// that no part of this delivery reached the vendor: either the adapter's
+    /// `deliver` call returned a bare `Err` (no typed report at all), or it
+    /// returned a typed report whose parts were all `Retryable` but retries
+    /// were still exhausted. Both in-tree channel adapters (Slack, Telegram)
+    /// use `Retryable` for post-send ambiguity (e.g. a timeout after the
+    /// request was already sent), not just pre-send failure, so neither path
+    /// proves the vendor was never contacted the way a preflight
+    /// `TransportUnavailable`/`RateLimited`/`TransientValidatorError` does.
+    ///
+    /// This is distinct from [`Self::Unknown`]: `Unknown` means this codebase
+    /// never assigned a specific kind to the row (an unclassified gap).
+    /// `VendorContactAmbiguous` means the row *was* classified, precisely as
+    /// "reached the point of no return and cannot prove the vendor wasn't
+    /// contacted." A reopen must treat both as permanently terminal, but for
+    /// different reasons — this variant exists so a reader auditing "why did
+    /// this delivery id stay Failed forever" finds an explicit answer instead
+    /// of an `Unknown` catch-all.
+    VendorContactAmbiguous,
+}
+
+impl DeliveryFailureKind {
+    /// Every [`DeliveryFailureKind`] variant, for exhaustiveness-style tests
+    /// that need to iterate the type instead of hand-maintaining a literal
+    /// array that silently drifts when a variant is added.
+    pub const ALL: &'static [Self] = &[
+        Self::AuthorizationRevoked,
+        Self::TransientValidatorError,
+        Self::TransportUnavailable,
+        Self::RateLimited,
+        Self::Rejected,
+        Self::Unknown,
+        Self::VendorContactAmbiguous,
+    ];
+
+    /// Whether a `Failed` row carrying this kind may be reopened to a fresh
+    /// `Prepared` reservation under the same deterministic delivery id.
+    /// True only for kinds this codebase provably never writes after the
+    /// vendor-egress claim, so a reopen cannot duplicate an accepted send.
+    pub const fn permits_reopen(self) -> bool {
+        match self {
+            Self::TransientValidatorError | Self::TransportUnavailable | Self::RateLimited => true,
+            Self::AuthorizationRevoked
+            | Self::Rejected
+            | Self::Unknown
+            | Self::VendorContactAmbiguous => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -342,12 +396,26 @@ pub struct UpdateDeliveryStatusRequest {
 }
 
 /// Atomic ownership claim for the sole vendor-egress writer of a prepared
-/// delivery. Stores transition `Prepared -> Sending` exactly once and return
-/// `false` for replays or already-terminal attempts.
+/// delivery. Stores transition `Prepared -> Sending` exactly once.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClaimDeliveryAttemptForSendRequest {
     pub delivery_id: OutboundDeliveryId,
     pub scope: TurnScope,
+}
+
+/// Result of atomically claiming the sole vendor-egress drive for a prepared
+/// delivery. `Existing` carries the exact row that blocked the claim, read
+/// atomically inside the same CAS attempt that lost — never from a separate
+/// subsequent read, which would reopen a TOCTOU window between the failed
+/// CAS and the re-read (a concurrent caller could reopen the row in between,
+/// and a claim-loser reading it afterward could misclassify a freshly
+/// reopened `Prepared` row as still in flight).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimDeliveryAttemptForSendOutcome {
+    /// This caller persisted `Prepared -> Sending` and owns vendor egress.
+    Claimed,
+    /// The authoritative attempt no longer permits the transition.
+    Existing(Box<OutboundDeliveryAttempt>),
 }
 
 /// Guarded crash-recovery transition for an interrupted send. The store
@@ -360,4 +428,42 @@ pub struct ClaimDeliveryAttemptForSendRequest {
 pub struct RecoverInterruptedDeliveryRequest {
     pub delivery_id: OutboundDeliveryId,
     pub scope: TurnScope,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DeliveryFailureKind;
+
+    /// G4: an exhaustive match in the test itself (not an array literal), so
+    /// adding a future `DeliveryFailureKind` variant without updating this
+    /// test is a compile error, not a silent gap.
+    #[test]
+    fn permits_reopen_is_exhaustively_classified() {
+        for kind in DeliveryFailureKind::ALL {
+            let expected = match kind {
+                DeliveryFailureKind::TransientValidatorError
+                | DeliveryFailureKind::TransportUnavailable
+                | DeliveryFailureKind::RateLimited => true,
+                DeliveryFailureKind::AuthorizationRevoked
+                | DeliveryFailureKind::Rejected
+                | DeliveryFailureKind::Unknown
+                | DeliveryFailureKind::VendorContactAmbiguous => false,
+            };
+            assert_eq!(kind.permits_reopen(), expected, "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn all_lists_every_variant_exactly_once() {
+        // Defence-in-depth alongside the exhaustive match above: catches a
+        // typo'd duplicate entry in `ALL` that the match wouldn't.
+        let mut seen = std::collections::HashSet::new();
+        for kind in DeliveryFailureKind::ALL {
+            assert!(
+                seen.insert(format!("{kind:?}")),
+                "duplicate entry: {kind:?}"
+            );
+        }
+        assert_eq!(seen.len(), 7);
+    }
 }

--- a/crates/domains/ironclaw_outbound/src/types.rs
+++ b/crates/domains/ironclaw_outbound/src/types.rs
@@ -459,10 +459,23 @@ mod tests {
 
     #[test]
     fn all_lists_every_variant_exactly_once() {
-        // Catches both a duplicated entry and an omitted one. The witness
-        // list below is exhaustive by construction: a new variant forces a
-        // new binding here (the match below is non-exhaustive otherwise),
-        // which then forces the `ALL` membership check for it.
+        // Checks `ALL` for internal consistency against the `witnesses`
+        // array below: a duplicate entry in `ALL` (same discriminant twice)
+        // fails the `seen.insert` assert, and any witness missing from `ALL`
+        // fails the `seen.contains` assert. Discriminant comparison also
+        // means this is immune to the old failure mode of a Debug-string
+        // key silently merging two variants with identical output, and
+        // there's no hardcoded expected count to fall out of sync.
+        //
+        // What this does NOT guarantee: `witnesses` is a plain array
+        // literal, not a match, so it isn't compiler-checked against the
+        // enum. A variant added to `DeliveryFailureKind` but omitted from
+        // *both* `ALL` and `witnesses` passes silently — nothing here
+        // forces a new binding to exist. Closing that gap for real needs
+        // either a derive like `strum::EnumIter` (not a workspace
+        // dependency today) or restructuring this test around an actual
+        // exhaustive match, as `permits_reopen_is_exhaustively_classified`
+        // above does.
         let witnesses = [
             DeliveryFailureKind::AuthorizationRevoked,
             DeliveryFailureKind::TransientValidatorError,

--- a/crates/domains/ironclaw_outbound/src/validation.rs
+++ b/crates/domains/ironclaw_outbound/src/validation.rs
@@ -137,7 +137,18 @@ pub(crate) fn validate_delivery_scope_candidate(
 pub(crate) fn validate_delivery_status_request(
     request: &UpdateDeliveryStatusRequest,
 ) -> Result<(), OutboundError> {
-    validate_delivery_status(request.status, request.failure_kind)
+    validate_delivery_status(request.status, request.failure_kind)?;
+    // `vendor_egress` is `Option` with `#[serde(default)]` so a caller can
+    // omit it; without this gate that silently strips provenance from the
+    // durable row and `attempt_reopens_stale_failure` then treats the row as
+    // legacy, permanently refusing to reopen it. Make provenance a write-time
+    // invariant for `Failed` rather than a caller convention.
+    if request.status == OutboundDeliveryStatus::Failed && request.vendor_egress.is_none() {
+        return Err(OutboundError::InvalidRequest {
+            reason: "failed delivery status must record vendor egress provenance",
+        });
+    }
+    Ok(())
 }
 
 fn validate_delivery_status(

--- a/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -101,6 +101,9 @@ fn delivery_attempt_with_status(
         status,
         attempted_at: now(),
         failure_kind,
+        // `prepared_delivery_attempt` (the only caller) always builds a
+        // fresh `Prepared` reservation — pre-egress by construction.
+        vendor_egress: Some(VendorEgressProvenance::NotAttempted),
     }
 }
 
@@ -491,6 +494,7 @@ async fn delivery_attempt_point_read_returns_only_the_exact_scoped_row() {
         status: OutboundDeliveryStatus::Delivered,
         attempted_at: now(),
         failure_kind: None,
+        vendor_egress: Some(VendorEgressProvenance::Attempted),
     };
     store
         .record_delivery_attempt(attempt.clone())
@@ -539,6 +543,7 @@ async fn delivery_send_claim_is_atomic_across_store_instances() {
             status: OutboundDeliveryStatus::Prepared,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -654,6 +659,11 @@ async fn record_delivery_attempt_reopen_race_loser_defers_to_concurrent_winner()
             status: OutboundDeliveryStatus::Failed,
             updated_at: now(),
             failure_kind: Some(DeliveryFailureKind::TransportUnavailable),
+            // Pre-egress channel-resolution failure shape — required so the
+            // subsequent `record_delivery_attempt(prepared)` call below
+            // actually attempts a reopen (the behavior this test exercises)
+            // instead of no-opping on the new `vendor_egress` gate.
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .expect("settle the exhausted-retry terminal failure");
@@ -761,6 +771,203 @@ async fn record_delivery_attempt_reopens_only_reopen_permitted_failed_rows() {
             assert_eq!(attempts[0].failure_kind, Some(kind));
         }
     }
+}
+
+/// Rollout duplicate-send guard: `vendor_egress` is a second, independent
+/// reopen gate alongside `failure_kind::permits_reopen()`. A
+/// `Failed(TransportUnavailable)` row written by a binary predating this
+/// field has no `vendor_egress` key on the wire at all — indistinguishable
+/// by byte shape from a pre-this-PR binary's now-removed, ambiguous
+/// post-`adapter.deliver` retry-exhaustion write, which used to settle the
+/// same kind before this PR reclassified that case to
+/// `VendorContactAmbiguous`. That legacy shape must never reopen. The
+/// identical row WITH `vendor_egress: Some(NotAttempted)` — the shape this
+/// PR's binary actually writes for a pre-claim `TransportUnavailable`
+/// failure — must reopen exactly as before this field existed.
+///
+/// Each case reuses one `base` `Prepared` attempt (built via
+/// `prepared_delivery_attempt`) for both the seed and the replay, mirroring
+/// `record_delivery_attempt_reopens_only_reopen_permitted_failed_rows`
+/// above: `validate_delivery_identity` requires the two calls to carry an
+/// identical `candidate`, and building it twice would bake in two different
+/// `turn_run_id`s.
+#[tokio::test]
+async fn record_delivery_attempt_reopen_gate_requires_vendor_egress_not_attempted() {
+    let scope = turn_scope();
+
+    // Legacy shape: `vendor_egress` stripped from the wire entirely (not
+    // just left at its struct default), simulating a row written before
+    // this field existed. `#[serde(default)]` deserializes the missing key
+    // to `None`, which must fail closed.
+    //
+    // Seeded through the normal indexed write path first (so the delivery
+    // scope/tenant index projections — opaque `Entry::indexed` metadata the
+    // backend keys `list_delivery_attempts` queries on, not derived from
+    // `body` — land correctly), then the durable JSON body is overwritten
+    // in place with `vendor_egress` stripped, preserving the entry's index
+    // and version.
+    {
+        let backend = Arc::new(InMemoryBackend::new());
+        let store = build_outbound_store_for_backend(Arc::clone(&backend));
+        let delivery_id = OutboundDeliveryId::new();
+        let base = prepared_delivery_attempt(delivery_id, scope.clone(), "reply-legacy-provenance");
+        let mut seeded = base.clone();
+        seeded.status = OutboundDeliveryStatus::Failed;
+        seeded.failure_kind = Some(DeliveryFailureKind::TransportUnavailable);
+        store
+            .record_delivery_attempt(seeded.clone())
+            .await
+            .expect("seed failed row");
+
+        let legacy_path = VirtualPath::new(format!(
+            "{TEST_OUTBOUND_ROOT}/deliveries/{delivery_id}.json"
+        ))
+        .unwrap();
+        let versioned = backend
+            .get(&legacy_path)
+            .await
+            .unwrap()
+            .expect("seeded row exists");
+        let mut legacy_json = serde_json::to_value(&seeded).unwrap();
+        legacy_json
+            .as_object_mut()
+            .expect("attempt serializes to a JSON object")
+            .remove("vendor_egress");
+        let legacy_entry = Entry {
+            body: serde_json::to_vec(&legacy_json).unwrap(),
+            ..versioned.entry
+        };
+        backend
+            .put(
+                &legacy_path,
+                legacy_entry,
+                CasExpectation::Version(versioned.version),
+            )
+            .await
+            .unwrap();
+
+        store
+            .record_delivery_attempt(base)
+            .await
+            .expect("record call must not error for a no-op");
+        let attempts = store.list_delivery_attempts(scope.clone()).await.unwrap();
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(
+            attempts[0].status,
+            OutboundDeliveryStatus::Failed,
+            "a legacy row missing vendor_egress on the wire must fail closed and never reopen"
+        );
+        assert_eq!(attempts[0].vendor_egress, None);
+    }
+
+    // Modern shape: `vendor_egress: Some(NotAttempted)` present, exactly as
+    // this PR's pre-claim `TransportUnavailable` writer produces. Must
+    // reopen.
+    {
+        let backend = Arc::new(InMemoryBackend::new());
+        let store = build_outbound_store_for_backend(backend);
+        let delivery_id = OutboundDeliveryId::new();
+        let base = prepared_delivery_attempt(delivery_id, scope.clone(), "reply-modern-provenance");
+        let mut seeded = base.clone();
+        seeded.status = OutboundDeliveryStatus::Failed;
+        seeded.failure_kind = Some(DeliveryFailureKind::TransportUnavailable);
+        assert_eq!(
+            seeded.vendor_egress,
+            Some(VendorEgressProvenance::NotAttempted),
+            "prepared_delivery_attempt must build the modern, provenance-carrying shape"
+        );
+        store
+            .record_delivery_attempt(seeded)
+            .await
+            .expect("seed failed row");
+
+        store
+            .record_delivery_attempt(base)
+            .await
+            .expect("record call must not error");
+        let attempts = store.list_delivery_attempts(scope).await.unwrap();
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(
+            attempts[0].status,
+            OutboundDeliveryStatus::Prepared,
+            "a modern row with vendor_egress: Some(NotAttempted) must reopen"
+        );
+        assert_eq!(attempts[0].failure_kind, None);
+    }
+}
+
+/// Issue 2 hygiene guard: `DeliveryFailureKind::Unrecognized` (the
+/// `#[serde(other)]` catch-all for a kind this binary does not model) must
+/// never permit reopen — an unknown kind proves nothing about vendor
+/// contact. Constructed via raw JSON with a `failure_kind` tag this enum
+/// does not define, simulating a row written by a binary with a kind this
+/// one predates (e.g. read during a rollback).
+///
+/// Seeded through the normal indexed write path first (so the delivery
+/// scope/tenant index projections land correctly — see the comment in
+/// `record_delivery_attempt_reopen_gate_requires_vendor_egress_not_attempted`
+/// above), then the durable JSON body is overwritten in place with an
+/// unrecognized `failure_kind` tag, preserving the entry's index and
+/// version.
+#[tokio::test]
+async fn record_delivery_attempt_never_reopens_a_row_with_unrecognized_failure_kind() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let store = build_outbound_store_for_backend(Arc::clone(&backend));
+    let scope = turn_scope();
+    let delivery_id = OutboundDeliveryId::new();
+    let base = prepared_delivery_attempt(delivery_id, scope.clone(), "reply-unrecognized-kind");
+    let mut seeded = base.clone();
+    seeded.status = OutboundDeliveryStatus::Failed;
+    seeded.failure_kind = Some(DeliveryFailureKind::TransportUnavailable);
+    store
+        .record_delivery_attempt(seeded.clone())
+        .await
+        .expect("seed failed row");
+
+    let path = VirtualPath::new(format!(
+        "{TEST_OUTBOUND_ROOT}/deliveries/{delivery_id}.json"
+    ))
+    .unwrap();
+    let versioned = backend
+        .get(&path)
+        .await
+        .unwrap()
+        .expect("seeded row exists");
+    let mut seeded_json = serde_json::to_value(&seeded).unwrap();
+    seeded_json["failure_kind"] = serde_json::json!("a_future_kind_this_binary_predates");
+    let unrecognized_entry = Entry {
+        body: serde_json::to_vec(&seeded_json).unwrap(),
+        ..versioned.entry
+    };
+    backend
+        .put(
+            &path,
+            unrecognized_entry,
+            CasExpectation::Version(versioned.version),
+        )
+        .await
+        .unwrap();
+
+    // The unrecognized tag must not break `list_delivery_attempts` for the
+    // whole scope (Issue 2's actual bug) — it folds to `Unrecognized`.
+    let attempts = store.list_delivery_attempts(scope.clone()).await.unwrap();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].failure_kind,
+        Some(DeliveryFailureKind::Unrecognized)
+    );
+
+    store
+        .record_delivery_attempt(base)
+        .await
+        .expect("record call must not error for a no-op");
+    let attempts = store.list_delivery_attempts(scope).await.unwrap();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].status,
+        OutboundDeliveryStatus::Failed,
+        "an unrecognized failure kind must never permit reopen"
+    );
 }
 
 // Legacy LibSqlOutboundStateStore / PostgresOutboundStateStore have been
@@ -1574,6 +1781,7 @@ async fn delivery_send_claim_fails_closed_on_unsupported_cas_mount() {
             status: OutboundDeliveryStatus::Prepared,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -1744,6 +1952,7 @@ async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateSto
         status: OutboundDeliveryStatus::Pending,
         attempted_at: now(),
         failure_kind: None,
+        vendor_egress: Some(VendorEgressProvenance::NotAttempted),
     };
     store
         .record_delivery_attempt(initial_attempt.clone())
@@ -1756,6 +1965,7 @@ async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateSto
             status: OutboundDeliveryStatus::Failed,
             updated_at: now(),
             failure_kind: Some(DeliveryFailureKind::AuthorizationRevoked),
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await;
     assert!(matches!(
@@ -1770,6 +1980,7 @@ async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateSto
             status: OutboundDeliveryStatus::Failed,
             updated_at: now(),
             failure_kind: Some(DeliveryFailureKind::AuthorizationRevoked),
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -1797,6 +2008,7 @@ async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateSto
             status: OutboundDeliveryStatus::Pending,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await;
     assert!(matches!(
@@ -2042,6 +2254,7 @@ async fn coordinator_delivery_lifecycle_round_trips(store: &impl OutboundStateSt
             status: OutboundDeliveryStatus::Prepared,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -2102,6 +2315,7 @@ async fn coordinator_delivery_lifecycle_round_trips(store: &impl OutboundStateSt
             status: OutboundDeliveryStatus::Unknown,
             updated_at: now(),
             failure_kind: Some(DeliveryFailureKind::TransportUnavailable),
+            vendor_egress: Some(VendorEgressProvenance::Attempted),
         })
         .await;
     assert!(matches!(
@@ -2116,6 +2330,7 @@ async fn coordinator_delivery_lifecycle_round_trips(store: &impl OutboundStateSt
             status: OutboundDeliveryStatus::Unknown,
             updated_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::Attempted),
         })
         .await
         .unwrap();
@@ -2156,6 +2371,7 @@ async fn recovery_transition_never_clobbers_delivered(store: &impl OutboundState
             status: OutboundDeliveryStatus::Prepared,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -2202,6 +2418,7 @@ async fn recovery_transition_never_clobbers_delivered(store: &impl OutboundState
             status: OutboundDeliveryStatus::Prepared,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -2222,6 +2439,7 @@ async fn recovery_transition_never_clobbers_delivered(store: &impl OutboundState
             status: OutboundDeliveryStatus::Delivered,
             updated_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::Attempted),
         })
         .await
         .unwrap();
@@ -2272,6 +2490,7 @@ async fn delivery_status_rejects_inconsistent_failure_kind(store: &impl Outbound
         status: OutboundDeliveryStatus::Pending,
         attempted_at: now(),
         failure_kind: None,
+        vendor_egress: Some(VendorEgressProvenance::NotAttempted),
     };
     store.record_delivery_attempt(attempt).await.unwrap();
 
@@ -2282,6 +2501,7 @@ async fn delivery_status_rejects_inconsistent_failure_kind(store: &impl Outbound
             status: OutboundDeliveryStatus::Delivered,
             updated_at: now(),
             failure_kind: Some(DeliveryFailureKind::AuthorizationRevoked),
+            vendor_egress: Some(VendorEgressProvenance::Attempted),
         })
         .await;
     assert!(matches!(
@@ -2296,6 +2516,7 @@ async fn delivery_status_rejects_inconsistent_failure_kind(store: &impl Outbound
             status: OutboundDeliveryStatus::Failed,
             updated_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await;
     assert!(matches!(
@@ -2383,6 +2604,7 @@ async fn full_turn_scope_isolation(store: &impl OutboundStateStorePort, original
             status: OutboundDeliveryStatus::Pending,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -3119,6 +3341,7 @@ async fn list_delivery_attempts_drains_more_than_page_max_limit() {
                 status: OutboundDeliveryStatus::Pending,
                 attempted_at: now(),
                 failure_kind: None,
+                vendor_egress: Some(VendorEgressProvenance::NotAttempted),
             })
             .await
             .unwrap();
@@ -3237,6 +3460,7 @@ async fn filesystem_outbound_store_isolates_two_tenants_with_same_user_project_i
             status: OutboundDeliveryStatus::Pending,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();
@@ -3295,6 +3519,7 @@ async fn filesystem_outbound_store_writes_tenant_id_indexed_projection() {
             status: OutboundDeliveryStatus::Pending,
             attempted_at: now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         })
         .await
         .unwrap();

--- a/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -63,6 +63,47 @@ fn build_outbound_store_with_permissions<F: RootFilesystem>(
     OutboundStateStore::new(Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts)))
 }
 
+fn prepared_delivery_attempt(
+    delivery_id: OutboundDeliveryId,
+    scope: TurnScope,
+    marker: &str,
+) -> OutboundDeliveryAttempt {
+    delivery_attempt_with_status(
+        delivery_id,
+        scope,
+        marker,
+        OutboundDeliveryStatus::Prepared,
+        None,
+    )
+}
+
+fn delivery_attempt_with_status(
+    delivery_id: OutboundDeliveryId,
+    scope: TurnScope,
+    marker: &str,
+    status: OutboundDeliveryStatus,
+    failure_kind: Option<DeliveryFailureKind>,
+) -> OutboundDeliveryAttempt {
+    OutboundDeliveryAttempt {
+        delivery_id,
+        scope: scope.clone(),
+        candidate: OutboundPushCandidate {
+            tenant_id: scope.tenant_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            thread_id: scope.thread_id.clone(),
+            turn_run_id: Some(TurnRunId::new()),
+            target: reply_ref(marker),
+            kind: OutboundPushKind::FinalReply,
+            projection_ref: ProjectionUpdateRef::new(format!("projection:{marker}")).unwrap(),
+            requires_reply_target_revalidation: true,
+        },
+        status,
+        attempted_at: now(),
+        failure_kind,
+    }
+}
+
 fn reply_attachment_scope() -> ironclaw_host_api::resource::ResourceScope {
     turn_scope().to_resource_scope()
 }
@@ -511,12 +552,215 @@ async fn delivery_send_claim_is_atomic_across_store_instances() {
         first.claim_delivery_attempt_for_send(first_request),
         second.claim_delivery_attempt_for_send(second_request),
     );
-    let claims = [first_claim.unwrap(), second_claim.unwrap()];
-    assert_eq!(claims.into_iter().filter(|claimed| *claimed).count(), 1);
+    let outcomes = [first_claim.unwrap(), second_claim.unwrap()];
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, ClaimDeliveryAttemptForSendOutcome::Claimed))
+            .count(),
+        1
+    );
+    // G7: the losing claimant's `Existing` snapshot must never carry
+    // `Prepared` — that is the property that makes the TOCTOU fix (fix A)
+    // sound. If it could, a claim-loser could misclassify a freshly
+    // reopened row as still in flight instead of it being safe to retry.
+    let existing = outcomes
+        .iter()
+        .find_map(|outcome| match outcome {
+            ClaimDeliveryAttemptForSendOutcome::Existing(attempt) => Some(attempt),
+            ClaimDeliveryAttemptForSendOutcome::Claimed => None,
+        })
+        .expect("the losing claimant receives the winner's authoritative state");
+    assert_ne!(existing.status, OutboundDeliveryStatus::Prepared);
+    assert_eq!(existing.status, OutboundDeliveryStatus::Sending);
 
     let attempts = first.list_delivery_attempts(scope).await.unwrap();
     assert_eq!(attempts.len(), 1);
     assert_eq!(attempts[0].status, OutboundDeliveryStatus::Sending);
+}
+
+/// Fix A, deterministically: a claim loser must receive the exact
+/// authoritative row that blocked its CAS, read atomically inside the losing
+/// CAS attempt — never from a separate subsequent read. The racing backend
+/// enforces this by rejecting a third read and a second `put` outright, so
+/// this test fails if the implementation ever re-reads after the loss.
+#[tokio::test]
+async fn send_claim_cas_loser_returns_exact_winner_snapshot_without_post_resolution_read() {
+    let inner = Arc::new(InMemoryBackend::new());
+    let racing = Arc::new(DeliveryTransitionRaceBackend::new(Arc::clone(&inner)));
+    let store = OutboundStateStore::new(build_scoped_fs(Arc::clone(&racing), TEST_OUTBOUND_ROOT));
+    let scope = turn_scope();
+    let delivery_id = OutboundDeliveryId::new();
+    let prepared = prepared_delivery_attempt(
+        delivery_id,
+        scope.clone(),
+        "reply-deterministic-claim-loser",
+    );
+    store
+        .record_delivery_attempt(prepared.clone())
+        .await
+        .expect("seed prepared attempt");
+
+    let mut winner = prepared;
+    winner.status = OutboundDeliveryStatus::Failed;
+    winner.failure_kind = Some(DeliveryFailureKind::AuthorizationRevoked);
+    racing.arm(delivery_id, winner.clone()).await;
+
+    assert_eq!(
+        store
+            .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
+                delivery_id,
+                scope,
+            })
+            .await
+            .expect("claim loser observes the racing settlement"),
+        ClaimDeliveryAttemptForSendOutcome::Existing(Box::new(winner))
+    );
+    racing.assert_resolved_in_retry_read().await;
+}
+
+/// A reopen CAS-write that loses to a concurrent winner (another worker
+/// already reopened and claimed the same delivery id for `Sending`) must
+/// defer to that winner, not clobber it back to `Prepared`. Mirrors
+/// `send_claim_cas_loser_returns_exact_winner_snapshot_without_post_resolution_read`'s
+/// racing-backend technique, applied to the `record_delivery_attempt` reopen
+/// branch instead of the claim CAS.
+#[tokio::test]
+async fn record_delivery_attempt_reopen_race_loser_defers_to_concurrent_winner() {
+    let inner = Arc::new(InMemoryBackend::new());
+    let racing = Arc::new(DeliveryTransitionRaceBackend::new(Arc::clone(&inner)));
+    let store = OutboundStateStore::new(build_scoped_fs(Arc::clone(&racing), TEST_OUTBOUND_ROOT));
+    let scope = turn_scope();
+    let delivery_id = OutboundDeliveryId::new();
+    let prepared = prepared_delivery_attempt(delivery_id, scope.clone(), "reply-reopen-race-loser");
+    store
+        .record_delivery_attempt(prepared.clone())
+        .await
+        .expect("seed prepared attempt");
+    assert_eq!(
+        store
+            .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
+                delivery_id,
+                scope: scope.clone(),
+            })
+            .await
+            .expect("claim first send attempt"),
+        ClaimDeliveryAttemptForSendOutcome::Claimed
+    );
+    store
+        .update_delivery_status(UpdateDeliveryStatusRequest {
+            delivery_id,
+            scope: scope.clone(),
+            status: OutboundDeliveryStatus::Failed,
+            updated_at: now(),
+            failure_kind: Some(DeliveryFailureKind::TransportUnavailable),
+        })
+        .await
+        .expect("settle the exhausted-retry terminal failure");
+
+    // By the time this reopen's CAS write lands, a concurrent worker already
+    // reopened and claimed the same delivery id for `Sending`. The reopen
+    // must observe that winner and defer to it instead of clobbering it back
+    // to `Prepared` — verified by the racing backend rejecting any second
+    // `put` after the first CAS loss.
+    let mut winner = prepared.clone();
+    winner.status = OutboundDeliveryStatus::Sending;
+    racing.arm(delivery_id, winner).await;
+
+    store
+        .record_delivery_attempt(prepared)
+        .await
+        .expect("reopen loser must defer, not error");
+    racing.assert_resolved_in_retry_read().await;
+}
+
+/// G5: a reopen no-op matrix. Only a `Failed` row whose kind's
+/// `permits_reopen()` is `true` may be reopened by an incoming fresh
+/// `Prepared` attempt; every other existing status is untouched.
+///
+/// Each case reuses one `base` attempt (built once via
+/// `prepared_delivery_attempt`) for both the seed and the replay so the two
+/// calls carry an identical `candidate` — `validate_delivery_identity`
+/// requires this, and building the candidate twice would bake in two
+/// different `turn_run_id`s and fail identity validation regardless of the
+/// reopen logic under test.
+#[tokio::test]
+async fn record_delivery_attempt_reopens_only_reopen_permitted_failed_rows() {
+    let non_failed_statuses = [
+        OutboundDeliveryStatus::Prepared,
+        OutboundDeliveryStatus::Sending,
+        OutboundDeliveryStatus::Delivered,
+        OutboundDeliveryStatus::Unknown,
+        OutboundDeliveryStatus::DeadLettered,
+    ];
+    for status in non_failed_statuses {
+        let backend = Arc::new(InMemoryBackend::new());
+        let store = build_outbound_store_for_backend(backend);
+        let scope = turn_scope();
+        let delivery_id = OutboundDeliveryId::new();
+        let base = prepared_delivery_attempt(delivery_id, scope.clone(), "reply-no-op-matrix");
+        let mut seeded = base.clone();
+        seeded.status = status;
+        if status == OutboundDeliveryStatus::DeadLettered {
+            // `DeadLettered` requires a failure kind (any kind); it is not
+            // itself a `Failed` row and must never be reopened regardless.
+            seeded.failure_kind = Some(DeliveryFailureKind::Rejected);
+        }
+        store
+            .record_delivery_attempt(seeded)
+            .await
+            .expect("seed row");
+
+        store
+            .record_delivery_attempt(base)
+            .await
+            .expect("record call must not error for a no-op");
+
+        let attempts = store.list_delivery_attempts(scope).await.unwrap();
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(
+            attempts[0].status, status,
+            "a non-Failed existing row of status {status:?} must never be touched by a replay"
+        );
+    }
+
+    for kind in DeliveryFailureKind::ALL.iter().copied() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let store = build_outbound_store_for_backend(backend);
+        let scope = turn_scope();
+        let delivery_id = OutboundDeliveryId::new();
+        let base = prepared_delivery_attempt(delivery_id, scope.clone(), "reply-no-op-matrix-kind");
+        let mut seeded = base.clone();
+        seeded.status = OutboundDeliveryStatus::Failed;
+        seeded.failure_kind = Some(kind);
+        store
+            .record_delivery_attempt(seeded)
+            .await
+            .expect("seed failed row");
+
+        store
+            .record_delivery_attempt(base)
+            .await
+            .expect("record call must not error");
+
+        let attempts = store.list_delivery_attempts(scope).await.unwrap();
+        assert_eq!(attempts.len(), 1);
+        if kind.permits_reopen() {
+            assert_eq!(
+                attempts[0].status,
+                OutboundDeliveryStatus::Prepared,
+                "{kind:?} permits reopen and must be reopened to a fresh Prepared row"
+            );
+            assert_eq!(attempts[0].failure_kind, None);
+        } else {
+            assert_eq!(
+                attempts[0].status,
+                OutboundDeliveryStatus::Failed,
+                "{kind:?} does not permit reopen and must stay Failed"
+            );
+            assert_eq!(attempts[0].failure_kind, Some(kind));
+        }
+    }
 }
 
 // Legacy LibSqlOutboundStateStore / PostgresOutboundStateStore have been
@@ -1802,7 +2046,7 @@ async fn coordinator_delivery_lifecycle_round_trips(store: &impl OutboundStateSt
         .await
         .unwrap();
 
-    assert!(
+    assert_eq!(
         store
             .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
                 delivery_id,
@@ -1810,18 +2054,28 @@ async fn coordinator_delivery_lifecycle_round_trips(store: &impl OutboundStateSt
             })
             .await
             .unwrap(),
+        ClaimDeliveryAttemptForSendOutcome::Claimed,
         "the first caller atomically owns vendor egress"
     );
-    assert!(
-        !store
-            .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
-                delivery_id,
-                scope: scope.clone(),
-            })
-            .await
-            .unwrap(),
-        "a replay cannot claim the same durable attempt"
-    );
+    let replay_claim = store
+        .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
+            delivery_id,
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    match replay_claim {
+        ClaimDeliveryAttemptForSendOutcome::Existing(existing) => {
+            assert_eq!(
+                existing.status,
+                OutboundDeliveryStatus::Sending,
+                "a replay cannot claim the same durable attempt"
+            );
+        }
+        ClaimDeliveryAttemptForSendOutcome::Claimed => {
+            panic!("a replay cannot claim the same durable attempt")
+        }
+    }
     let wrong_scope_claim = store
         .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
             delivery_id,
@@ -1905,14 +2159,15 @@ async fn recovery_transition_never_clobbers_delivered(store: &impl OutboundState
         })
         .await
         .unwrap();
-    assert!(
+    assert_eq!(
         store
             .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
                 delivery_id: interrupted,
                 scope: scope.clone(),
             })
             .await
-            .unwrap()
+            .unwrap(),
+        ClaimDeliveryAttemptForSendOutcome::Claimed
     );
     assert!(
         store
@@ -1950,14 +2205,15 @@ async fn recovery_transition_never_clobbers_delivered(store: &impl OutboundState
         })
         .await
         .unwrap();
-    assert!(
+    assert_eq!(
         store
             .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
                 delivery_id: delivered,
                 scope: scope.clone(),
             })
             .await
-            .unwrap()
+            .unwrap(),
+        ClaimDeliveryAttemptForSendOutcome::Claimed
     );
     store
         .update_delivery_status(UpdateDeliveryStatusRequest {
@@ -2320,6 +2576,153 @@ impl RootFilesystem for VersionRacingBackend {
     }
 
     async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        self.inner.query(path, filter, page).await
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        self.inner.ensure_index(path, spec).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+}
+
+/// Deterministically models another store consuming `Prepared` (or
+/// reopening a `Failed` row) between this store's versioned read and CAS
+/// write. Once armed for one delivery, the permitted sequence is exactly:
+/// read (whatever status is currently persisted); lose the guarded write
+/// while this backend commits `winner`; retry-read the complete winner
+/// record. A third read or second write fails, rejecting post-resolution
+/// polling or a reclaim attempt without counting unrelated filesystem
+/// operations. Used to prove fix A's claim (`claim_delivery_attempt_for_send`)
+/// and the reopen branch of `record_delivery_attempt` never perform a
+/// separate post-CAS-loss read — the retry read inside the existing CAS loop
+/// is the only read, which is what closes the TOCTOU window.
+struct DeliveryTransitionRaceBackend {
+    inner: Arc<InMemoryBackend>,
+    state: Mutex<DeliveryTransitionRaceState>,
+}
+
+struct DeliveryTransitionRaceState {
+    target_path: Option<String>,
+    winner: Option<OutboundDeliveryAttempt>,
+    reads: u8,
+    conflicts: u8,
+}
+
+impl DeliveryTransitionRaceBackend {
+    fn new(inner: Arc<InMemoryBackend>) -> Self {
+        Self {
+            inner,
+            state: Mutex::new(DeliveryTransitionRaceState {
+                target_path: None,
+                winner: None,
+                reads: 0,
+                conflicts: 0,
+            }),
+        }
+    }
+
+    async fn arm(&self, delivery_id: OutboundDeliveryId, winner: OutboundDeliveryAttempt) {
+        let mut state = self.state.lock().await;
+        state.target_path = Some(format!(
+            "{TEST_OUTBOUND_ROOT}/deliveries/{delivery_id}.json"
+        ));
+        state.winner = Some(winner);
+        state.reads = 0;
+        state.conflicts = 0;
+    }
+
+    async fn assert_resolved_in_retry_read(&self) {
+        let state = self.state.lock().await;
+        assert_eq!(state.reads, 2, "initial read plus one CAS retry read");
+        assert_eq!(state.conflicts, 1, "one deterministic racing winner");
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for DeliveryTransitionRaceBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        let injected_winner = {
+            let mut state = self.state.lock().await;
+            if state.target_path.as_deref() != Some(path.as_str()) {
+                None
+            } else if state.conflicts == 0 {
+                state.conflicts = 1;
+                state.winner.clone()
+            } else {
+                return Err(FilesystemError::Backend {
+                    path: path.clone(),
+                    operation: FilesystemOperation::WriteFile,
+                    reason: "unexpected delivery reclaim after CAS loss".to_string(),
+                });
+            }
+        };
+
+        if let Some(winner) = injected_winner {
+            let winner_entry = Entry {
+                body: serde_json::to_vec(&winner).expect("serialize deterministic race winner"),
+                ..entry
+            };
+            let found = self.inner.put(path, winner_entry, cas).await?;
+            let expected = match cas {
+                CasExpectation::Version(version) => Some(version),
+                CasExpectation::Absent | CasExpectation::Any => None,
+            };
+            return Err(FilesystemError::VersionMismatch {
+                path: path.clone(),
+                expected,
+                found: Some(found),
+            });
+        }
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        {
+            let mut state = self.state.lock().await;
+            if state.target_path.as_deref() == Some(path.as_str()) {
+                state.reads += 1;
+                if state.reads > 2 {
+                    return Err(FilesystemError::Backend {
+                        path: path.clone(),
+                        operation: FilesystemOperation::ReadFile,
+                        reason: "unexpected post-resolution delivery read".to_string(),
+                    });
+                }
+            }
+        }
         self.inner.get(path).await
     }
 

--- a/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -885,7 +885,7 @@ async fn record_delivery_attempt_reopen_gate_requires_vendor_egress_not_attempte
             .record_delivery_attempt(base)
             .await
             .expect("record call must not error");
-        let attempts = store.list_delivery_attempts(scope).await.unwrap();
+        let attempts = store.list_delivery_attempts(scope.clone()).await.unwrap();
         assert_eq!(attempts.len(), 1);
         assert_eq!(
             attempts[0].status,
@@ -893,6 +893,43 @@ async fn record_delivery_attempt_reopen_gate_requires_vendor_egress_not_attempte
             "a modern row with vendor_egress: Some(NotAttempted) must reopen"
         );
         assert_eq!(attempts[0].failure_kind, None);
+    }
+
+    // Post-egress shape with a reopen-permitted kind: `Some(Attempted)` must
+    // block reopen on its own, independent of `permits_reopen()`. This is
+    // the shape a future writer would produce if it settled
+    // `TransportUnavailable` after `adapter.deliver` — exactly the class of
+    // bug the provenance gate exists to catch.
+    {
+        let backend = Arc::new(InMemoryBackend::new());
+        let store = build_outbound_store_for_backend(backend);
+        let delivery_id = OutboundDeliveryId::new();
+        let base =
+            prepared_delivery_attempt(delivery_id, scope.clone(), "reply-post-egress-provenance");
+        let mut seeded = base.clone();
+        seeded.status = OutboundDeliveryStatus::Failed;
+        seeded.failure_kind = Some(DeliveryFailureKind::TransportUnavailable);
+        seeded.vendor_egress = Some(VendorEgressProvenance::Attempted);
+        store
+            .record_delivery_attempt(seeded)
+            .await
+            .expect("seed failed row");
+
+        store
+            .record_delivery_attempt(base)
+            .await
+            .expect("record call must not error for a no-op");
+        let attempts = store.list_delivery_attempts(scope).await.unwrap();
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(
+            attempts[0].status,
+            OutboundDeliveryStatus::Failed,
+            "Some(Attempted) must block reopen even for a permits_reopen kind"
+        );
+        assert_eq!(
+            attempts[0].vendor_egress,
+            Some(VendorEgressProvenance::Attempted)
+        );
     }
 }
 
@@ -2521,6 +2558,25 @@ async fn delivery_status_rejects_inconsistent_failure_kind(store: &impl Outbound
         .await;
     assert!(matches!(
         failed_without_failure,
+        Err(OutboundError::InvalidRequest { .. })
+    ));
+
+    // A `Failed` write must carry `vendor_egress` provenance: omitting it
+    // would silently strip provenance from the durable row, and
+    // `attempt_reopens_stale_failure` treats a provenance-less row as legacy
+    // and refuses to reopen it forever.
+    let failed_without_vendor_egress = store
+        .update_delivery_status(UpdateDeliveryStatusRequest {
+            delivery_id,
+            scope: scope.clone(),
+            status: OutboundDeliveryStatus::Failed,
+            updated_at: now(),
+            failure_kind: Some(DeliveryFailureKind::TransportUnavailable),
+            vendor_egress: None,
+        })
+        .await;
+    assert!(matches!(
+        failed_without_vendor_egress,
         Err(OutboundError::InvalidRequest { .. })
     ));
 

--- a/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
+++ b/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
@@ -780,7 +780,7 @@ impl OutboundStateStorePort for FailingOutboundStore {
     async fn claim_delivery_attempt_for_send(
         &self,
         _request: ironclaw_outbound::ClaimDeliveryAttemptForSendRequest,
-    ) -> Result<bool, OutboundError> {
+    ) -> Result<ironclaw_outbound::ClaimDeliveryAttemptForSendOutcome, OutboundError> {
         Err(self.error())
     }
 

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/outbound_deliver.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/outbound_deliver.rs
@@ -226,6 +226,7 @@ fn delivery_failure_summary(kind: DeliveryFailureKind) -> &'static str {
         DeliveryFailureKind::VendorContactAmbiguous => {
             "the delivery attempt failed: vendor_contact_ambiguous"
         }
+        DeliveryFailureKind::Unrecognized => "the delivery attempt failed: unrecognized",
     }
 }
 

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/outbound_deliver.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/outbound_deliver.rs
@@ -223,6 +223,9 @@ fn delivery_failure_summary(kind: DeliveryFailureKind) -> &'static str {
         DeliveryFailureKind::RateLimited => "the delivery attempt failed: rate_limited",
         DeliveryFailureKind::Rejected => "the delivery attempt failed: rejected",
         DeliveryFailureKind::Unknown => "the delivery attempt failed: unknown",
+        DeliveryFailureKind::VendorContactAmbiguous => {
+            "the delivery attempt failed: vendor_contact_ambiguous"
+        }
     }
 }
 
@@ -634,6 +637,13 @@ mod tests {
                 Some("the delivery attempt failed: rate_limited"),
             ),
             (
+                ModelChannelDeliveryError::Failed {
+                    kind: DeliveryFailureKind::VendorContactAmbiguous,
+                },
+                RuntimeDispatchErrorKind::OperationFailed,
+                Some("the delivery attempt failed: vendor_contact_ambiguous"),
+            ),
+            (
                 ModelChannelDeliveryError::AccessDenied,
                 RuntimeDispatchErrorKind::PolicyDenied,
                 None,
@@ -782,6 +792,21 @@ mod tests {
             assert!(
                 delivery.seen.lock().unwrap().is_empty(),
                 "empty content must never reach the delivery port"
+            );
+        }
+    }
+
+    /// G1: `delivery_failure_summary`'s match is exhaustive over fixed
+    /// literals precisely so every arm can be reviewed and known to satisfy
+    /// `LoopSafeSummary` (no `/ < > [ ] { } \``). Prove that invariant
+    /// directly for every current `DeliveryFailureKind`, including the new
+    /// `VendorContactAmbiguous` arm, rather than relying on review alone.
+    #[test]
+    fn delivery_failure_summary_satisfies_loop_safe_charset_for_every_kind() {
+        for kind in DeliveryFailureKind::ALL.iter().copied() {
+            let summary = delivery_failure_summary(kind);
+            ironclaw_loop_contracts::LoopSafeSummary::new(summary.to_string()).unwrap_or_else(
+                |error| panic!("{kind:?} summary {summary:?} is not loop-safe: {error}"),
             );
         }
     }

--- a/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
+++ b/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
@@ -19,6 +19,18 @@
 //! - Once any part of a multipart delivery is sent, a later retryable part
 //!   failure is terminal — a whole-envelope retry would duplicate the parts
 //!   the vendor already accepted (OUT-7).
+//!
+//! On a deterministic-id row, `Failed(TransportUnavailable)` (and the other
+//! `DeliveryFailureKind::permits_reopen()`-true kinds) implies no vendor
+//! egress ever occurred for that delivery id — this codebase only ever
+//! settles those kinds before the vendor-egress claim. That invariant is
+//! what makes reopening them safe: [`ironclaw_outbound::OutboundStateStore`]
+//! (via `record_delivery_attempt`) may CAS a stale `Failed` row of that kind
+//! back to a fresh `Prepared` reservation for a replay to claim, without
+//! risking a duplicate send. Anything settled after the claim that cannot
+//! prove the vendor was never contacted uses
+//! [`DeliveryFailureKind::VendorContactAmbiguous`] instead, which never
+//! permits reopen.
 
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -34,10 +46,11 @@ use ironclaw_host_api::ids::ExtensionId;
 use ironclaw_host_api::path::ScopedPath;
 use ironclaw_host_api::product_adapter::AdapterInstallationId;
 use ironclaw_outbound::{
-    ClaimDeliveryAttemptForSendRequest, DeliveryFailureKind, OutboundDeliveryAttempt,
-    OutboundDeliveryDecision, OutboundDeliveryStatus, OutboundPolicyService, OutboundPushCandidate,
-    OutboundPushKind, OutboundStateStorePort, PrepareCommunicationDeliveryRequest,
-    ReplyAttachmentIntent, UpdateDeliveryStatusRequest, ValidatedReplyTargetBinding,
+    ClaimDeliveryAttemptForSendOutcome, ClaimDeliveryAttemptForSendRequest, DeliveryFailureKind,
+    OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryStatus,
+    OutboundPolicyService, OutboundPushCandidate, OutboundPushKind, OutboundStateStorePort,
+    PrepareCommunicationDeliveryRequest, ReplyAttachmentIntent, UpdateDeliveryStatusRequest,
+    ValidatedReplyTargetBinding,
 };
 use ironclaw_product_contracts::delivery::{
     ChannelDeliveryResolver, DeliveryReplyContextSource, ResolvedChannelDelivery,
@@ -208,6 +221,28 @@ pub enum CoordinatedDeliveryOutcome {
     NoDelivery,
     /// Policy rejected the candidate; the attempt records the rejection.
     Rejected { attempt: OutboundDeliveryAttempt },
+    /// Another caller already advanced the durable delivery row past
+    /// `Prepared` without reaching a status this call recognizes as
+    /// resolved, so this call lost the sole-writer claim and performed no
+    /// vendor egress of its own — it holds no vendor evidence to report.
+    /// `attempt` is the exact authoritative row that blocked the claim
+    /// (read atomically as part of the losing CAS attempt, never from a
+    /// separate subsequent read — see [`DeliveryCoordinator::claim_delivery_attempt`]).
+    ///
+    /// In practice this only ever carries `attempt.status` of `Prepared` or
+    /// `Sending`: `Delivered`, `Failed`, `DeadLettered`, `Unknown`, and
+    /// `Pending` all resolve to a more specific outcome instead (see
+    /// [`DeliveryCoordinator::outcome_for_existing_delivery`]). The
+    /// `Prepared` case is defensive-only and should be unobservable once the
+    /// claim atomically returns the exact CAS-blocking row: the claim's own
+    /// CAS targets `Prepared -> Sending`, so a row it lost against can never
+    /// itself be `Prepared` at the moment of that read — either the row was
+    /// already past `Prepared` (blocking the CAS), or it was `Prepared` and
+    /// the CAS would have won. This variant is kept success-shaped (not an
+    /// error) because a `Sending` row may mean the vendor call already
+    /// succeeded; reporting it as an error would be misleading and could
+    /// invite an incorrect resend decision upstream.
+    ExistingDeliveryUnconfirmed { attempt: OutboundDeliveryAttempt },
     /// The adapter reported every part sent.
     Delivered {
         attempt: OutboundDeliveryAttempt,
@@ -249,8 +284,6 @@ pub enum CoordinatedDeliveryError {
     Workflow(#[from] ProductSurfaceFailure),
     #[error("no active channel for extension `{extension_id}`")]
     ChannelUnavailable { extension_id: String },
-    #[error("delivery is already in flight for this attempt")]
-    AlreadyInFlight,
     #[error("intent {intent:?} does not belong to this delivery path")]
     IntentClassMismatch { intent: DeliveryIntent },
     #[error("notice request is invalid: {reason}")]
@@ -298,8 +331,6 @@ pub struct DeliveryCoordinator {
     resolver: Arc<dyn ChannelDeliveryResolver>,
     reply_context: Arc<dyn DeliveryReplyContextSource>,
     retry: DeliveryRetryPolicy,
-    /// Per-delivery single-flight: a delivery id enters once.
-    in_flight: Mutex<HashSet<ironclaw_outbound::OutboundDeliveryId>>,
     /// Scopes whose interrupted (`Sending`) attempts from prior lifetimes
     /// have been reconciled this lifetime. The store enumerates attempts per
     /// scope only, so recovery runs lazily before a scope's first delivery.
@@ -321,7 +352,6 @@ impl DeliveryCoordinator {
             resolver,
             reply_context,
             retry,
-            in_flight: Mutex::new(HashSet::new()),
             recovered_scopes: Mutex::new(HashSet::new()),
         }
     }
@@ -420,45 +450,31 @@ impl DeliveryCoordinator {
         // or workspace materialization. A replay of a terminal delivery must
         // not depend on the target still being configured, and it must never
         // let a later resolution failure overwrite the terminal row.
-        if !self.claim_delivery_attempt(&attempt).await? {
-            return self.outcome_for_claimed_delivery(&attempt).await;
-        }
-
-        // Single-flight per delivery id.
-        let delivery_id = attempt.delivery_id;
-        {
-            let mut in_flight = self
-                .in_flight
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if !in_flight.insert(delivery_id) {
-                return Err(CoordinatedDeliveryError::AlreadyInFlight);
+        match self.claim_delivery_attempt(&attempt).await? {
+            ClaimDeliveryAttemptForSendOutcome::Claimed => {}
+            ClaimDeliveryAttemptForSendOutcome::Existing(existing) => {
+                return Ok(Self::outcome_for_existing_delivery(*existing));
             }
         }
-        let result = self
-            .drive_authorized(
-                target_resolver,
-                attempt,
-                AuthorizedDeliveryTarget {
-                    binding: target,
-                    require_direct_message: request.require_direct_message_target,
-                    thread_anchor: request.thread_anchor,
-                },
-                request.parts,
-                request.extension_id,
-                WorkspaceMaterialization {
-                    intent: request.intent,
-                    project_filesystem,
-                    thread_scope: request.thread_scope,
-                    attachments: request.attachments,
-                },
-            )
-            .await;
-        self.in_flight
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&delivery_id);
-        result
+
+        self.drive_authorized(
+            target_resolver,
+            attempt,
+            AuthorizedDeliveryTarget {
+                binding: target,
+                require_direct_message: request.require_direct_message_target,
+                thread_anchor: request.thread_anchor,
+            },
+            request.parts,
+            request.extension_id,
+            WorkspaceMaterialization {
+                intent: request.intent,
+                project_filesystem,
+                thread_scope: request.thread_scope,
+                attachments: request.attachments,
+            },
+        )
+        .await
     }
 
     /// Deliver one notice-class intent to its source conversation, under the
@@ -510,35 +526,21 @@ impl DeliveryCoordinator {
         };
         self.store.record_delivery_attempt(attempt.clone()).await?;
 
-        if !self.claim_delivery_attempt(&attempt).await? {
-            return self.outcome_for_claimed_delivery(&attempt).await;
-        }
-
-        // Single-flight per delivery id (uniform with the policy path).
-        let delivery_id = attempt.delivery_id;
-        {
-            let mut in_flight = self
-                .in_flight
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if !in_flight.insert(delivery_id) {
-                return Err(CoordinatedDeliveryError::AlreadyInFlight);
+        match self.claim_delivery_attempt(&attempt).await? {
+            ClaimDeliveryAttemptForSendOutcome::Claimed => {}
+            ClaimDeliveryAttemptForSendOutcome::Existing(existing) => {
+                return Ok(Self::outcome_for_existing_delivery(*existing));
             }
         }
-        let result = self
-            .drive_resolved(
-                attempt,
-                request.extension_id,
-                request.conversation,
-                request.thread_anchor,
-                request.parts,
-            )
-            .await;
-        self.in_flight
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&delivery_id);
-        result
+
+        self.drive_resolved(
+            attempt,
+            request.extension_id,
+            request.conversation,
+            request.thread_anchor,
+            request.parts,
+        )
+        .await
     }
 
     async fn drive_authorized(
@@ -747,9 +749,20 @@ impl DeliveryCoordinator {
                             failure_kind: kind,
                         });
                     }
-                    // Fully-retryable report (nothing sent).
+                    // Fully-retryable report (nothing sent), exhausted.
                     if attempts_used >= self.retry.max_attempts {
-                        let kind = DeliveryFailureKind::TransportUnavailable;
+                        // A `Retryable` part outcome does not prove nothing
+                        // reached the vendor: both in-tree adapters (Slack,
+                        // Telegram) report post-send ambiguity — e.g. a
+                        // timeout after the request was sent, or a 2xx
+                        // response with an unparseable body — as `Retryable`
+                        // rather than `Sent` or `Permanent`. So a "fully
+                        // retryable" report does not type-level guarantee
+                        // nothing was sent, and this must not settle as
+                        // `TransportUnavailable` (which a replay can safely
+                        // reopen) — see
+                        // `DeliveryFailureKind::VendorContactAmbiguous`.
+                        let kind = DeliveryFailureKind::VendorContactAmbiguous;
                         self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
                             .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
@@ -766,7 +779,13 @@ impl DeliveryCoordinator {
                         "delivery coordinator: adapter deliver failed"
                     );
                     if attempts_used >= self.retry.max_attempts {
-                        let kind = DeliveryFailureKind::TransportUnavailable;
+                        // Unlike the fully-retryable `Ok(DeliveryReport)` arm
+                        // above, a bare adapter `Err` carries no proof the
+                        // vendor was never contacted, so this must not
+                        // settle as `TransportUnavailable` (which a replay
+                        // can safely reopen) — see
+                        // `DeliveryFailureKind::VendorContactAmbiguous`.
+                        let kind = DeliveryFailureKind::VendorContactAmbiguous;
                         self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
                             .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
@@ -787,7 +806,7 @@ impl DeliveryCoordinator {
     async fn claim_delivery_attempt(
         &self,
         attempt: &OutboundDeliveryAttempt,
-    ) -> Result<bool, CoordinatedDeliveryError> {
+    ) -> Result<ClaimDeliveryAttemptForSendOutcome, CoordinatedDeliveryError> {
         self.store
             .claim_delivery_attempt_for_send(ClaimDeliveryAttemptForSendRequest {
                 delivery_id: attempt.delivery_id,
@@ -797,43 +816,45 @@ impl DeliveryCoordinator {
             .map_err(CoordinatedDeliveryError::Outbound)
     }
 
-    /// Classify an atomic-claim miss from the authoritative persisted row.
-    /// This preserves terminal failure semantics and distinguishes confirmed
-    /// prior delivery from an in-flight or ambiguous attempt without ever
-    /// reopening provider egress.
-    async fn outcome_for_claimed_delivery(
-        &self,
-        requested: &OutboundDeliveryAttempt,
-    ) -> Result<CoordinatedDeliveryOutcome, CoordinatedDeliveryError> {
-        let existing = self
-            .store
-            .load_delivery_attempt(requested.scope.clone(), requested.delivery_id)
-            .await
-            .map_err(CoordinatedDeliveryError::Outbound)?
-            .ok_or(CoordinatedDeliveryError::Outbound(
-                ironclaw_outbound::OutboundError::DeliveryNotFound,
-            ))?;
+    /// Classify the authoritative row a lost claim returned
+    /// ([`ClaimDeliveryAttemptForSendOutcome::Existing`]). This is a pure
+    /// function over the row the claim already handed back — no re-read, so
+    /// the TOCTOU window a separate post-claim read would reopen (a
+    /// concurrent caller reopening the row between the failed CAS and a
+    /// re-read) cannot occur here by construction.
+    fn outcome_for_existing_delivery(
+        existing: OutboundDeliveryAttempt,
+    ) -> CoordinatedDeliveryOutcome {
         match existing.status {
             OutboundDeliveryStatus::Delivered => {
-                Ok(CoordinatedDeliveryOutcome::AlreadyDelivered { attempt: existing })
+                CoordinatedDeliveryOutcome::AlreadyDelivered { attempt: existing }
             }
             OutboundDeliveryStatus::Failed | OutboundDeliveryStatus::DeadLettered => {
                 let failure_kind = existing
                     .failure_kind
                     .unwrap_or(DeliveryFailureKind::Unknown);
-                Ok(CoordinatedDeliveryOutcome::Failed {
+                CoordinatedDeliveryOutcome::Failed {
                     attempt: existing,
                     failure_kind,
-                })
+                }
             }
             OutboundDeliveryStatus::Unknown | OutboundDeliveryStatus::Pending => {
-                Ok(CoordinatedDeliveryOutcome::Failed {
+                CoordinatedDeliveryOutcome::Failed {
                     attempt: existing,
                     failure_kind: DeliveryFailureKind::Unknown,
-                })
+                }
             }
+            // A `Sending` row here means another caller (or this same caller
+            // in a prior lifetime) owns — or owned — vendor egress; the
+            // vendor call may already have succeeded, so this must not be
+            // reported as an error (which could invite a misguided resend
+            // upstream). `Prepared` is defensive-only and should be
+            // unobservable in practice: the claim's own CAS targets exactly
+            // `Prepared -> Sending`, so a row that blocked that CAS was
+            // already past `Prepared` at the moment of the read that
+            // produced it — see the `ExistingDeliveryUnconfirmed` doc.
             OutboundDeliveryStatus::Prepared | OutboundDeliveryStatus::Sending => {
-                Err(CoordinatedDeliveryError::AlreadyInFlight)
+                CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { attempt: existing }
             }
         }
     }

--- a/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
+++ b/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
@@ -53,7 +53,7 @@ use ironclaw_outbound::{
     OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryStatus,
     OutboundPolicyService, OutboundPushCandidate, OutboundPushKind, OutboundStateStorePort,
     PrepareCommunicationDeliveryRequest, ReplyAttachmentIntent, UpdateDeliveryStatusRequest,
-    ValidatedReplyTargetBinding,
+    ValidatedReplyTargetBinding, VendorEgressProvenance,
 };
 use ironclaw_product_contracts::delivery::{
     ChannelDeliveryResolver, DeliveryReplyContextSource, ResolvedChannelDelivery,
@@ -401,6 +401,10 @@ impl DeliveryCoordinator {
                     status: OutboundDeliveryStatus::Unknown,
                     updated_at: chrono::Utc::now(),
                     failure_kind: None,
+                    // A `Sending` row means a claim was taken and the
+                    // process could have called the adapter before
+                    // crashing — provenance can't prove otherwise.
+                    vendor_egress: Some(VendorEgressProvenance::Attempted),
                 })
                 .await?;
             recovered += 1;
@@ -526,6 +530,7 @@ impl DeliveryCoordinator {
             status: OutboundDeliveryStatus::Prepared,
             attempted_at: chrono::Utc::now(),
             failure_kind: None,
+            vendor_egress: Some(VendorEgressProvenance::NotAttempted),
         };
         self.store.record_delivery_attempt(attempt.clone()).await?;
 
@@ -567,7 +572,7 @@ impl DeliveryCoordinator {
             Err(error) => {
                 let kind =
                     crate::outbound_delivery::delivery_failure_kind_for_surface_error(&error);
-                self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
+                self.mark_terminal_pre_egress(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
                     .await;
                 return Err(CoordinatedDeliveryError::Workflow(error));
             }
@@ -584,8 +589,12 @@ impl DeliveryCoordinator {
             Ok(parts) => parts,
             Err(error) => {
                 let failure_kind = workspace_materialization_failure_kind(&error);
-                self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(failure_kind))
-                    .await;
+                self.mark_terminal_pre_egress(
+                    &attempt,
+                    OutboundDeliveryStatus::Failed,
+                    Some(failure_kind),
+                )
+                .await;
                 return Err(error);
             }
         };
@@ -634,7 +643,7 @@ impl DeliveryCoordinator {
     ) -> Result<(ResolvedChannelDelivery, Option<Vec<u8>>), CoordinatedDeliveryError> {
         // Resolve the channel from ONE snapshot read (generation-pinned).
         let Some(channel) = self.resolver.resolve_channel_delivery(extension_id) else {
-            self.mark_terminal(
+            self.mark_terminal_pre_egress(
                 attempt,
                 OutboundDeliveryStatus::Failed,
                 Some(DeliveryFailureKind::TransportUnavailable),
@@ -717,7 +726,11 @@ impl DeliveryCoordinator {
 
                     if all_sent && !report.parts.is_empty() {
                         let confirmed = self
-                            .mark_terminal(&attempt, OutboundDeliveryStatus::Delivered, None)
+                            .mark_terminal_post_egress(
+                                &attempt,
+                                OutboundDeliveryStatus::Delivered,
+                                None,
+                            )
                             .await;
                         if !confirmed {
                             return Ok(CoordinatedDeliveryOutcome::DeliveredUnconfirmed {
@@ -734,8 +747,12 @@ impl DeliveryCoordinator {
                     }
                     if unauthorized {
                         let kind = DeliveryFailureKind::AuthorizationRevoked;
-                        self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
-                            .await;
+                        self.mark_terminal_post_egress(
+                            &attempt,
+                            OutboundDeliveryStatus::Failed,
+                            Some(kind),
+                        )
+                        .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
@@ -745,8 +762,12 @@ impl DeliveryCoordinator {
                         // Partial multipart (OUT-7): retrying the whole
                         // envelope would duplicate already-accepted parts.
                         let kind = DeliveryFailureKind::Rejected;
-                        self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
-                            .await;
+                        self.mark_terminal_post_egress(
+                            &attempt,
+                            OutboundDeliveryStatus::Failed,
+                            Some(kind),
+                        )
+                        .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
@@ -766,8 +787,12 @@ impl DeliveryCoordinator {
                         // reopen) — see
                         // `DeliveryFailureKind::VendorContactAmbiguous`.
                         let kind = DeliveryFailureKind::VendorContactAmbiguous;
-                        self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
-                            .await;
+                        self.mark_terminal_post_egress(
+                            &attempt,
+                            OutboundDeliveryStatus::Failed,
+                            Some(kind),
+                        )
+                        .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
@@ -789,8 +814,12 @@ impl DeliveryCoordinator {
                         // can safely reopen) — see
                         // `DeliveryFailureKind::VendorContactAmbiguous`.
                         let kind = DeliveryFailureKind::VendorContactAmbiguous;
-                        self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
-                            .await;
+                        self.mark_terminal_post_egress(
+                            &attempt,
+                            OutboundDeliveryStatus::Failed,
+                            Some(kind),
+                        )
+                        .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
@@ -868,11 +897,20 @@ impl DeliveryCoordinator {
     /// the `Delivered` caller must downgrade to
     /// [`CoordinatedDeliveryOutcome::DeliveredUnconfirmed`] — a success it
     /// cannot durably confirm is not a success it may claim.
+    ///
+    /// `vendor_egress` is not `Option` and has no default: every caller must
+    /// state explicitly whether an `adapter.deliver` call was made for this
+    /// delivery id, so a future call site can't silently omit it. Prefer the
+    /// [`Self::mark_terminal_pre_egress`] / [`Self::mark_terminal_post_egress`]
+    /// wrappers over calling this directly — they hardcode the provenance
+    /// for their respective call sites and remove the chance of a
+    /// copy-paste mistake picking the wrong one.
     async fn mark_terminal(
         &self,
         attempt: &OutboundDeliveryAttempt,
         status: OutboundDeliveryStatus,
         failure_kind: Option<DeliveryFailureKind>,
+        vendor_egress: VendorEgressProvenance,
     ) -> bool {
         match self
             .store
@@ -882,6 +920,7 @@ impl DeliveryCoordinator {
                 status,
                 updated_at: chrono::Utc::now(),
                 failure_kind,
+                vendor_egress: Some(vendor_egress),
             })
             .await
         {
@@ -895,6 +934,44 @@ impl DeliveryCoordinator {
                 false
             }
         }
+    }
+
+    /// Terminal write for a failure settled before any `adapter.deliver`
+    /// call was made (surface-error, workspace-materialization, and
+    /// channel-resolution failure paths in `drive_authorized` /
+    /// `resolve_channel_context`).
+    async fn mark_terminal_pre_egress(
+        &self,
+        attempt: &OutboundDeliveryAttempt,
+        status: OutboundDeliveryStatus,
+        failure_kind: Option<DeliveryFailureKind>,
+    ) -> bool {
+        self.mark_terminal(
+            attempt,
+            status,
+            failure_kind,
+            VendorEgressProvenance::NotAttempted,
+        )
+        .await
+    }
+
+    /// Terminal write for an outcome settled during or after `drive_prepared`
+    /// has called `adapter.deliver` at least once — the `Delivered` success
+    /// path and every failure classification reached after that call,
+    /// including `VendorContactAmbiguous`.
+    async fn mark_terminal_post_egress(
+        &self,
+        attempt: &OutboundDeliveryAttempt,
+        status: OutboundDeliveryStatus,
+        failure_kind: Option<DeliveryFailureKind>,
+    ) -> bool {
+        self.mark_terminal(
+            attempt,
+            status,
+            failure_kind,
+            VendorEgressProvenance::Attempted,
+        )
+        .await
     }
 }
 

--- a/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
+++ b/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
@@ -22,14 +22,17 @@
 //!
 //! On a deterministic-id row, `Failed(TransportUnavailable)` (and the other
 //! `DeliveryFailureKind::permits_reopen()`-true kinds) implies no vendor
-//! egress ever occurred for that delivery id — this codebase only ever
-//! settles those kinds before the vendor-egress claim. That invariant is
-//! what makes reopening them safe: [`ironclaw_outbound::OutboundStateStore`]
+//! egress was ever attempted for that delivery id — this codebase only ever
+//! settles those kinds before any `adapter.deliver` call is made. That
+//! invariant is what makes reopening them safe: [`ironclaw_outbound::OutboundStateStore`]
 //! (via `record_delivery_attempt`) may CAS a stale `Failed` row of that kind
 //! back to a fresh `Prepared` reservation for a replay to claim, without
-//! risking a duplicate send. Anything settled after the claim that cannot
-//! prove the vendor was never contacted uses
-//! [`DeliveryFailureKind::VendorContactAmbiguous`] instead, which never
+//! risking a duplicate send. Note this is a narrower claim than "before the
+//! vendor-egress claim": `TransportUnavailable` is written post-claim, on
+//! channel-resolution failure (`resolve_channel_context`), but that failure
+//! path never reaches `adapter.deliver`. Anything settled after an
+//! `adapter.deliver` call that cannot prove the vendor was never contacted
+//! uses [`DeliveryFailureKind::VendorContactAmbiguous`] instead, which never
 //! permits reopen.
 
 use std::collections::HashSet;

--- a/crates/product/ironclaw_assistant/src/model_channel_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/model_channel_delivery.rs
@@ -572,13 +572,17 @@ fn classify_delivery_outcome(
         }),
         // Another caller already owns (or owned) this delivery id's
         // sole-writer claim; this call performed no vendor egress and holds
-        // no evidence to report. Model-correctable (rules/tools.md): a
-        // concurrent duplicate can be retried later rather than treated as a
-        // host fault, matching exactly how the coordinator's now-removed
-        // `AlreadyInFlight` error was treated here.
+        // no evidence to report. The blocking row is `Sending` in practice
+        // (delivery_coordinator.rs's `ExistingDeliveryUnconfirmed` doc), so
+        // the vendor may already have accepted the message — reporting a
+        // definite `Rejected` would be the mirror-image of fabricating
+        // `Delivered` (tool-evidence.md's explicit-weaker-evidence rule cuts
+        // both ways). `VendorContactAmbiguous` states the true ambiguity
+        // without asserting an outcome that didn't happen; it is equally
+        // terminal and non-reopenable, so no duplicate-resend risk changes.
         CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { .. } => {
             Err(ModelChannelDeliveryError::Failed {
-                kind: DeliveryFailureKind::Rejected,
+                kind: DeliveryFailureKind::VendorContactAmbiguous,
             })
         }
         CoordinatedDeliveryOutcome::Rejected { .. } => Err(ModelChannelDeliveryError::Rejected),

--- a/crates/product/ironclaw_assistant/src/model_channel_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/model_channel_delivery.rs
@@ -570,6 +570,17 @@ fn classify_delivery_outcome(
             durably_recorded: true,
             already_delivered: true,
         }),
+        // Another caller already owns (or owned) this delivery id's
+        // sole-writer claim; this call performed no vendor egress and holds
+        // no evidence to report. Model-correctable (rules/tools.md): a
+        // concurrent duplicate can be retried later rather than treated as a
+        // host fault, matching exactly how the coordinator's now-removed
+        // `AlreadyInFlight` error was treated here.
+        CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { .. } => {
+            Err(ModelChannelDeliveryError::Failed {
+                kind: DeliveryFailureKind::Rejected,
+            })
+        }
         CoordinatedDeliveryOutcome::Rejected { .. } => Err(ModelChannelDeliveryError::Rejected),
         CoordinatedDeliveryOutcome::Failed { failure_kind, .. } => {
             Err(ModelChannelDeliveryError::Failed { kind: failure_kind })
@@ -583,14 +594,6 @@ fn classify_coordinator_error(error: CoordinatedDeliveryError) -> ModelChannelDe
     match error {
         CoordinatedDeliveryError::ChannelUnavailable { .. } => ModelChannelDeliveryError::Failed {
             kind: DeliveryFailureKind::TransportUnavailable,
-        },
-        // Model-correctable classes stay model-visible (rules/tools.md): a
-        // concurrent duplicate, a policy/target-validation rejection, and
-        // model-supplied attachment misuse can all be retried or repaired by
-        // the model. `Internal` is reserved for host faults (backend errors,
-        // unreadable workspace, intent-classification bugs).
-        CoordinatedDeliveryError::AlreadyInFlight => ModelChannelDeliveryError::Failed {
-            kind: DeliveryFailureKind::Rejected,
         },
         // Workflow wraps both model-correctable target-validation rejections
         // and host-side failures; only the former may surface as Rejected.

--- a/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
+++ b/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
@@ -24,7 +24,7 @@ use ironclaw_outbound::{
     DeliveryTargetCapabilities, OutboundDeliveryAttempt, OutboundDeliveryId,
     OutboundDeliveryStatus, OutboundDeliveryTargetEntry, OutboundDeliveryTargetId,
     OutboundDeliveryTargetOwner, OutboundDeliveryTargetRegistry, OutboundDeliveryTargetSummary,
-    OutboundPushCandidate, OutboundPushKind,
+    OutboundPushCandidate, OutboundPushKind, VendorEgressProvenance,
 };
 use ironclaw_product_contracts::delivery::{ChannelDeliveryResolver, ResolvedChannelDelivery};
 use ironclaw_turns::{
@@ -473,6 +473,7 @@ fn sample_attempt() -> OutboundDeliveryAttempt {
         status: OutboundDeliveryStatus::Delivered,
         attempted_at: Utc::now(),
         failure_kind: None,
+        vendor_egress: Some(VendorEgressProvenance::Attempted),
     }
 }
 

--- a/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
+++ b/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
@@ -828,14 +828,26 @@ async fn deliver_for_model_maps_terminal_failure_kinds() {
     );
     assert_eq!(rejected, Err(ModelChannelDeliveryError::Rejected));
 
-    for kind in [
-        DeliveryFailureKind::AuthorizationRevoked,
-        DeliveryFailureKind::TransientValidatorError,
-        DeliveryFailureKind::TransportUnavailable,
-        DeliveryFailureKind::RateLimited,
-        DeliveryFailureKind::Rejected,
-        DeliveryFailureKind::Unknown,
-    ] {
+    // G2: a lost sole-writer claim (no vendor evidence from this call) must
+    // stay model-visible and model-correctable, exactly as the removed
+    // `AlreadyInFlight` coordinator error was treated.
+    let existing_unconfirmed = classify_delivery_outcome(
+        target.clone(),
+        CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed {
+            attempt: sample_attempt(),
+        },
+    );
+    assert_eq!(
+        existing_unconfirmed,
+        Err(ModelChannelDeliveryError::Failed {
+            kind: DeliveryFailureKind::Rejected
+        })
+    );
+
+    // G3: iterate `DeliveryFailureKind::ALL` instead of a hand-maintained
+    // array literal, so a future variant addition without updating this test
+    // surfaces here rather than silently under-testing the mapping.
+    for kind in DeliveryFailureKind::ALL.iter().copied() {
         let failed = classify_delivery_outcome(
             target.clone(),
             CoordinatedDeliveryOutcome::Failed {
@@ -861,16 +873,11 @@ async fn deliver_for_model_maps_terminal_failure_kinds() {
         }
     );
 
-    // A concurrent duplicate is model-correctable (retry later / don't
-    // duplicate), so it must stay model-visible rather than masking as an
-    // internal host fault (rules/tools.md).
-    let other = classify_coordinator_error(CoordinatedDeliveryError::AlreadyInFlight);
-    assert_eq!(
-        other,
-        ModelChannelDeliveryError::Failed {
-            kind: DeliveryFailureKind::Rejected
-        }
-    );
+    // A concurrent duplicate is now reported as
+    // `CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed` (asserted
+    // above via `classify_delivery_outcome`), not a `CoordinatedDeliveryError`
+    // — the coordinator's former `AlreadyInFlight` error variant no longer
+    // exists.
     let dm_guard = classify_coordinator_error(CoordinatedDeliveryError::Workflow(
         crate::ProductSurfaceFailure::OutboundTargetNotDirectMessage,
     ));

--- a/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
+++ b/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
@@ -830,7 +830,9 @@ async fn deliver_for_model_maps_terminal_failure_kinds() {
 
     // G2: a lost sole-writer claim (no vendor evidence from this call) must
     // stay model-visible and model-correctable, exactly as the removed
-    // `AlreadyInFlight` coordinator error was treated.
+    // `AlreadyInFlight` coordinator error was treated. It must not assert a
+    // definite `Rejected`: the blocking row may be `Sending`, so the vendor
+    // could already have accepted the message.
     let existing_unconfirmed = classify_delivery_outcome(
         target.clone(),
         CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed {
@@ -840,7 +842,7 @@ async fn deliver_for_model_maps_terminal_failure_kinds() {
     assert_eq!(
         existing_unconfirmed,
         Err(ModelChannelDeliveryError::Failed {
-            kind: DeliveryFailureKind::Rejected
+            kind: DeliveryFailureKind::VendorContactAmbiguous
         })
     );
 

--- a/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
@@ -860,6 +860,19 @@ impl RunDeliveryObserver {
             CoordinatedDeliveryOutcome::Failed { failure_kind, .. } => {
                 Err(RunDeliveryError::DeliveryFailed { failure_kind })
             }
+            // A lost sole-writer claim carries no evidence this call
+            // delivered anything (see the identical reasoning at
+            // `run_delivery/triggered.rs::deliver_notification_to_target`).
+            // Give it the same treatment `Failed` gets rather than letting
+            // the wildcard arm below silently report zero delivered
+            // messages as an ordinary non-failure outcome.
+            CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { attempt } => {
+                Err(RunDeliveryError::DeliveryFailed {
+                    failure_kind: attempt
+                        .failure_kind
+                        .unwrap_or(ironclaw_outbound::DeliveryFailureKind::Unknown),
+                })
+            }
             outcome => Ok(delivered_messages_from_outcome(&outcome)),
         }
     }

--- a/crates/product/ironclaw_assistant/src/run_delivery/triggered.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/triggered.rs
@@ -1126,6 +1126,22 @@ async fn deliver_pre_submit_failure_to_target(
         CoordinatedDeliveryOutcome::Failed { failure_kind, .. } => Err(
             TriggeredNotificationFailure::Other(format!("delivery failed: {failure_kind:?}")),
         ),
+        // Before fix A this claim-loss case surfaced as the coordinator
+        // error `AlreadyInFlight`, which propagated as an `Err` through
+        // `classify_delivery_error` above — never through this match, and
+        // never as a silent success. Now that the claim loss is
+        // success-shaped (`ExistingDeliveryUnconfirmed`, so a `Sending` row
+        // is not misreported as an error), the wildcard arm below would
+        // silently absorb it as `Ok(())` unless handled explicitly here.
+        // Give it the same treatment `Failed` gets — this call has no
+        // durable evidence its own notice was delivered, so callers must
+        // not treat it as delivered.
+        CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { attempt } => {
+            Err(TriggeredNotificationFailure::Other(format!(
+                "delivery unresolved: existing attempt status {:?}",
+                attempt.status
+            )))
+        }
         _ => Ok(()),
     }
 }
@@ -1192,6 +1208,18 @@ async fn deliver_notification_to_target(
         CoordinatedDeliveryOutcome::Failed { failure_kind, .. } => Err(
             TriggeredNotificationFailure::Other(format!("delivery failed: {failure_kind:?}")),
         ),
+        // Same reasoning as `deliver_pre_submit_failure_to_target` above:
+        // a lost sole-writer claim carries no evidence this call delivered
+        // anything, so it must be reported the same way `Failed` is rather
+        // than falling through to `delivered_messages_from_outcome`, which
+        // would silently report zero delivered messages as if this were an
+        // ordinary non-Delivered-but-otherwise-fine outcome.
+        CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { attempt } => {
+            Err(TriggeredNotificationFailure::Other(format!(
+                "delivery unresolved: existing attempt status {:?}",
+                attempt.status
+            )))
+        }
         outcome => Ok(delivered_messages_from_outcome(&outcome)),
     }
 }

--- a/crates/product/ironclaw_assistant/tests/outbound_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/outbound_delivery_contract.rs
@@ -2387,6 +2387,7 @@ async fn coordinator_recovery_marks_interrupted_sending_attempts_unknown() {
             status: ironclaw_outbound::OutboundDeliveryStatus::Sending,
             updated_at: Utc::now(),
             failure_kind: None,
+            vendor_egress: Some(ironclaw_outbound::VendorEgressProvenance::Attempted),
         })
         .await
         .unwrap();
@@ -2682,6 +2683,7 @@ async fn coordinator_lazily_recovers_interrupted_attempts_before_a_scopes_first_
         status: ironclaw_outbound::OutboundDeliveryStatus::Sending,
         attempted_at: Utc::now(),
         failure_kind: None,
+        vendor_egress: Some(ironclaw_outbound::VendorEgressProvenance::Attempted),
     };
     store
         .record_delivery_attempt(stray.clone())

--- a/crates/product/ironclaw_assistant/tests/outbound_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/outbound_delivery_contract.rs
@@ -277,6 +277,13 @@ struct ScriptedChannelAdapter {
     observed_status: Mutex<Vec<ironclaw_outbound::OutboundDeliveryStatus>>,
     store: Arc<OutboundStateStore<ironclaw_filesystem::InMemoryBackend>>,
     scope: TurnScope,
+    /// Present only for [`Self::new_paused`]: the adapter signals
+    /// `delivery_started` right after observing the durable status, then
+    /// blocks on `delivery_release` before returning the scripted report —
+    /// giving a concurrent test caller a deterministic window in which to
+    /// race a second claim against the same delivery id.
+    delivery_started: Option<Arc<tokio::sync::Semaphore>>,
+    delivery_release: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 impl ScriptedChannelAdapter {
@@ -291,7 +298,41 @@ impl ScriptedChannelAdapter {
             observed_status: Mutex::new(Vec::new()),
             store,
             scope,
+            delivery_started: None,
+            delivery_release: None,
         }
+    }
+
+    /// Like [`Self::new`], but the adapter pauses mid-`deliver` until the
+    /// caller adds a permit to the returned `delivery_release` semaphore.
+    /// The returned `delivery_started` semaphore signals once the adapter
+    /// has observed the durable `Sending` status and is about to pause, so a
+    /// concurrent caller can deterministically wait for "the owner has
+    /// claimed egress and is mid-flight" before racing a second claim.
+    fn new_paused(
+        store: Arc<OutboundStateStore<ironclaw_filesystem::InMemoryBackend>>,
+        scope: TurnScope,
+        reports: Vec<Result<DeliveryReport, ChannelError>>,
+    ) -> (
+        Self,
+        Arc<tokio::sync::Semaphore>,
+        Arc<tokio::sync::Semaphore>,
+    ) {
+        let delivery_started = Arc::new(tokio::sync::Semaphore::new(0));
+        let delivery_release = Arc::new(tokio::sync::Semaphore::new(0));
+        (
+            Self {
+                reports: Mutex::new(reports.into_iter().collect()),
+                envelopes: Mutex::new(Vec::new()),
+                observed_status: Mutex::new(Vec::new()),
+                store,
+                scope,
+                delivery_started: Some(Arc::clone(&delivery_started)),
+                delivery_release: Some(Arc::clone(&delivery_release)),
+            },
+            delivery_started,
+            delivery_release,
+        )
     }
 
     fn deliver_calls(&self) -> usize {
@@ -333,6 +374,14 @@ impl ChannelAdapter for ScriptedChannelAdapter {
             .lock()
             .expect("envelopes lock")
             .push(envelope);
+        if let (Some(started), Some(release)) = (&self.delivery_started, &self.delivery_release) {
+            started.add_permits(1);
+            let permit = release
+                .acquire()
+                .await
+                .expect("test delivery release remains open");
+            permit.forget();
+        }
         self.reports
             .lock()
             .expect("reports lock")
@@ -1590,7 +1639,7 @@ impl OutboundStateStorePort for TerminalDeliveredWriteFailingStore {
     async fn claim_delivery_attempt_for_send(
         &self,
         request: ironclaw_outbound::ClaimDeliveryAttemptForSendRequest,
-    ) -> Result<bool, OutboundError> {
+    ) -> Result<ironclaw_outbound::ClaimDeliveryAttemptForSendOutcome, OutboundError> {
         self.inner.claim_delivery_attempt_for_send(request).await
     }
     async fn recover_interrupted_delivery_attempt(
@@ -1692,6 +1741,613 @@ async fn coordinator_does_not_report_delivered_when_the_terminal_write_fails() {
         "durable status must not be Delivered when the confirmation write failed: {:?}",
         attempts[0].status
     );
+}
+
+/// Fix A: a claim loser must never misreport the owner's later-settled
+/// `Failed` outcome as its own success, and must not drive a second adapter
+/// call. `ScriptedChannelAdapter::new_paused` pauses the owner mid-`deliver`
+/// (after the durable claim already committed `Sending`) so the loser's
+/// claim attempt deterministically races against a still-`Sending` row.
+#[tokio::test]
+async fn claim_loser_observes_sending_without_reporting_the_owners_later_failure_as_success() {
+    let scope = scope();
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    seed_preference(&preferences, &scope);
+    let policy = configured_policy(&store, &validator);
+    let resolver = FakeProductOutboundTargetResolver;
+    let (adapter, delivery_started, delivery_release) = ScriptedChannelAdapter::new_paused(
+        Arc::clone(&store),
+        scope.clone(),
+        vec![Ok(DeliveryReport {
+            parts: vec![PartDeliveryOutcome::Permanent {
+                reason: "owner failed after claiming egress".to_string(),
+            }],
+        })],
+    );
+    let adapter = Arc::new(adapter);
+    let coordinator = coordinator_over(&store, &adapter);
+    let delivery = delivery_request(scope.clone());
+    let owner_thread_scope = project_thread_scope();
+    let loser_thread_scope = project_thread_scope();
+
+    let owner = coordinator.deliver(
+        &policy,
+        &resolver,
+        &NO_PROJECT_FILESYSTEM,
+        CoordinatedDeliveryRequest {
+            intent: DeliveryIntent::FinalReply,
+            delivery: delivery.clone(),
+            parts: vec![
+                ironclaw_extension_contracts::channel_adapter::OutboundPart::Text(
+                    "one durable fact".to_string(),
+                ),
+            ],
+            attachments: Vec::new(),
+            thread_anchor: None,
+            require_direct_message_target: false,
+            extension_id: "vendorx",
+            thread_scope: &owner_thread_scope,
+        },
+    );
+    let loser = async {
+        let started = delivery_started
+            .acquire()
+            .await
+            .expect("test delivery start remains open");
+        started.forget();
+        let outcome = coordinator
+            .deliver(
+                &policy,
+                &resolver,
+                &NO_PROJECT_FILESYSTEM,
+                CoordinatedDeliveryRequest {
+                    intent: DeliveryIntent::FinalReply,
+                    delivery,
+                    parts: vec![
+                        ironclaw_extension_contracts::channel_adapter::OutboundPart::Text(
+                            "one durable fact".to_string(),
+                        ),
+                    ],
+                    attachments: Vec::new(),
+                    thread_anchor: None,
+                    require_direct_message_target: false,
+                    extension_id: "vendorx",
+                    thread_scope: &loser_thread_scope,
+                },
+            )
+            .await;
+        delivery_release.add_permits(1);
+        outcome
+    };
+
+    let (owner, loser) = tokio::join!(owner, loser);
+    assert!(matches!(
+        owner.expect("owner returns its terminal adapter outcome"),
+        CoordinatedDeliveryOutcome::Failed {
+            failure_kind: ironclaw_outbound::DeliveryFailureKind::Rejected,
+            ..
+        }
+    ));
+    match loser.expect("claim loss is a typed non-success outcome") {
+        CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { attempt } => {
+            assert_eq!(
+                attempt.status,
+                ironclaw_outbound::OutboundDeliveryStatus::Sending
+            );
+            assert_eq!(attempt.failure_kind, None);
+        }
+        other => panic!("expected ExistingDeliveryUnconfirmed, got {other:?}"),
+    }
+    assert_eq!(
+        adapter.deliver_calls(),
+        1,
+        "the losing coordinator must not drive a second adapter call"
+    );
+    let attempts = store
+        .list_delivery_attempts(scope)
+        .await
+        .expect("load settled attempt");
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Failed
+    );
+    assert_eq!(
+        attempts[0].failure_kind,
+        Some(ironclaw_outbound::DeliveryFailureKind::Rejected)
+    );
+}
+
+/// Sibling of the failure case above, for the crash-instead-of-settle path:
+/// the owner never returns at all (simulating a process crash mid-adapter
+/// call), yet the claim loser still must not fabricate success. Recovery
+/// later reconciles the stray `Sending` row to `Unknown`, never resending.
+#[tokio::test]
+async fn claim_loser_observes_sending_without_reporting_the_owners_later_crash_as_success() {
+    let scope = scope();
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    seed_preference(&preferences, &scope);
+    let policy = configured_policy(&store, &validator);
+    let resolver = FakeProductOutboundTargetResolver;
+    let (adapter, delivery_started, _delivery_release) = ScriptedChannelAdapter::new_paused(
+        Arc::clone(&store),
+        scope.clone(),
+        vec![Ok(DeliveryReport {
+            parts: vec![sent("owner-never-settles")],
+        })],
+    );
+    let adapter = Arc::new(adapter);
+    let coordinator = coordinator_over(&store, &adapter);
+    let delivery = delivery_request(scope.clone());
+    let owner_thread_scope = project_thread_scope();
+    let loser_thread_scope = project_thread_scope();
+    let mut owner = Box::pin(coordinator.deliver(
+        &policy,
+        &resolver,
+        &NO_PROJECT_FILESYSTEM,
+        CoordinatedDeliveryRequest {
+            intent: DeliveryIntent::FinalReply,
+            delivery: delivery.clone(),
+            parts: vec![
+                ironclaw_extension_contracts::channel_adapter::OutboundPart::Text(
+                    "one durable fact".to_string(),
+                ),
+            ],
+            attachments: Vec::new(),
+            thread_anchor: None,
+            require_direct_message_target: false,
+            extension_id: "vendorx",
+            thread_scope: &owner_thread_scope,
+        },
+    ));
+
+    tokio::select! {
+        result = &mut owner => panic!("owner unexpectedly settled before the crash: {result:?}"),
+        started = delivery_started.acquire() => {
+            started.expect("test delivery start remains open").forget();
+        }
+    }
+    let loser = coordinator
+        .deliver(
+            &policy,
+            &resolver,
+            &NO_PROJECT_FILESYSTEM,
+            CoordinatedDeliveryRequest {
+                intent: DeliveryIntent::FinalReply,
+                delivery,
+                parts: vec![
+                    ironclaw_extension_contracts::channel_adapter::OutboundPart::Text(
+                        "one durable fact".to_string(),
+                    ),
+                ],
+                attachments: Vec::new(),
+                thread_anchor: None,
+                require_direct_message_target: false,
+                extension_id: "vendorx",
+                thread_scope: &loser_thread_scope,
+            },
+        )
+        .await
+        .expect("claim loss is a typed non-success outcome");
+    match loser {
+        CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { attempt } => {
+            assert_eq!(
+                attempt.status,
+                ironclaw_outbound::OutboundDeliveryStatus::Sending
+            );
+            assert_eq!(attempt.failure_kind, None);
+        }
+        other => panic!("expected ExistingDeliveryUnconfirmed, got {other:?}"),
+    }
+
+    drop(owner);
+    assert_eq!(
+        coordinator
+            .recover_interrupted_deliveries(scope.clone())
+            .await
+            .expect("crash recovery"),
+        1
+    );
+    assert_eq!(adapter.deliver_calls(), 1);
+    let attempts = store
+        .list_delivery_attempts(scope)
+        .await
+        .expect("load recovered attempt");
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Unknown
+    );
+    assert_eq!(attempts[0].failure_kind, None);
+}
+
+/// G9 (partial — the adapter-`Err`-exhaustion half of the invariant that no
+/// post-egress-claim code path ever writes a `permits_reopen()`-true kind):
+/// a bare adapter `Err` carries no proof the vendor was never contacted, so
+/// retry exhaustion must settle `VendorContactAmbiguous`, not
+/// `TransportUnavailable` — and a replay of the same logical delivery must
+/// never reopen the resulting row.
+#[tokio::test]
+async fn coordinator_marks_vendor_contact_ambiguous_on_exhausted_adapter_errors_and_never_reopens()
+{
+    let scope = scope();
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    seed_preference(&preferences, &scope);
+    let resolver = FakeProductOutboundTargetResolver;
+    let policy = configured_policy(&store, &validator);
+    let adapter = Arc::new(ScriptedChannelAdapter::new(
+        Arc::clone(&store),
+        scope.clone(),
+        vec![
+            Err(ChannelError::Configuration {
+                reason: "scripted vendor error".to_string(),
+            }),
+            Err(ChannelError::Configuration {
+                reason: "scripted vendor error".to_string(),
+            }),
+            Err(ChannelError::Configuration {
+                reason: "scripted vendor error".to_string(),
+            }),
+        ],
+    ));
+    let coordinator = coordinator_over(&store, &adapter);
+
+    let outcome = coordinator
+        .deliver(
+            &policy,
+            &resolver,
+            &NO_PROJECT_FILESYSTEM,
+            coordinated_final_reply(scope.clone(), "vendorx", &project_thread_scope()),
+        )
+        .await
+        .expect("delivery drives");
+
+    let CoordinatedDeliveryOutcome::Failed {
+        attempt,
+        failure_kind,
+    } = outcome
+    else {
+        panic!("expected a terminal Failed outcome once adapter Err retries were exhausted");
+    };
+    assert_eq!(
+        failure_kind,
+        ironclaw_outbound::DeliveryFailureKind::VendorContactAmbiguous,
+        "a bare adapter Err carries no proof the vendor was never contacted"
+    );
+    assert_eq!(
+        adapter.deliver_calls(),
+        3,
+        "all retries were consumed against repeated adapter errors"
+    );
+    let attempts = store.list_delivery_attempts(scope.clone()).await.unwrap();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Failed
+    );
+    assert_eq!(
+        attempts[0].failure_kind,
+        Some(ironclaw_outbound::DeliveryFailureKind::VendorContactAmbiguous)
+    );
+
+    // Replaying the same logical delivery must NOT reopen this row: unlike
+    // TransportUnavailable (which is only ever settled before the egress
+    // claim, so it type-level guarantees nothing reached the vendor),
+    // VendorContactAmbiguous gives no such guarantee, so
+    // record_delivery_attempt must treat this as an idempotent no-op rather
+    // than resetting it to a fresh Prepared reservation a caller could claim
+    // and resend.
+    let mut replay = attempt.clone();
+    replay.status = ironclaw_outbound::OutboundDeliveryStatus::Prepared;
+    replay.failure_kind = None;
+    store
+        .record_delivery_attempt(replay)
+        .await
+        .expect("replay is accepted as an idempotent no-op");
+    let after_replay = store
+        .list_delivery_attempts(scope)
+        .await
+        .expect("load attempt after replay");
+    assert_eq!(after_replay.len(), 1);
+    assert_eq!(
+        after_replay[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Failed,
+        "a VendorContactAmbiguous row must stay terminal, unlike TransportUnavailable"
+    );
+    assert_eq!(
+        after_replay[0].failure_kind,
+        Some(ironclaw_outbound::DeliveryFailureKind::VendorContactAmbiguous)
+    );
+}
+
+/// G9 (the other half): a typed report whose parts are all `Retryable` is
+/// not type-level proof that nothing reached the vendor either — both
+/// in-tree adapters (Slack, Telegram) report post-send ambiguity (e.g. a
+/// timeout after the request was sent) as `Retryable` rather than `Sent` or
+/// `Permanent`. So a fully-retryable exhaustion must also settle
+/// `VendorContactAmbiguous`, never `TransportUnavailable`/`RateLimited`, and
+/// must never reopen on replay — exactly like the bare-`Err` sibling above.
+#[tokio::test]
+async fn coordinator_marks_vendor_contact_ambiguous_on_exhausted_retryable_reports_and_never_reopens()
+ {
+    let scope = scope();
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    seed_preference(&preferences, &scope);
+    let resolver = FakeProductOutboundTargetResolver;
+    let policy = configured_policy(&store, &validator);
+    let adapter = Arc::new(ScriptedChannelAdapter::new(
+        Arc::clone(&store),
+        scope.clone(),
+        vec![
+            Ok(DeliveryReport {
+                parts: vec![retryable_part()],
+            }),
+            Ok(DeliveryReport {
+                parts: vec![retryable_part()],
+            }),
+            Ok(DeliveryReport {
+                parts: vec![retryable_part()],
+            }),
+        ],
+    ));
+    let coordinator = coordinator_over(&store, &adapter);
+
+    let outcome = coordinator
+        .deliver(
+            &policy,
+            &resolver,
+            &NO_PROJECT_FILESYSTEM,
+            coordinated_final_reply(scope.clone(), "vendorx", &project_thread_scope()),
+        )
+        .await
+        .expect("delivery drives");
+
+    let CoordinatedDeliveryOutcome::Failed {
+        attempt,
+        failure_kind,
+    } = outcome
+    else {
+        panic!(
+            "expected a terminal Failed outcome once fully-retryable report retries were exhausted"
+        );
+    };
+    assert_eq!(
+        failure_kind,
+        ironclaw_outbound::DeliveryFailureKind::VendorContactAmbiguous,
+        "a fully-retryable report carries no proof the vendor was never contacted"
+    );
+    assert_eq!(
+        adapter.deliver_calls(),
+        3,
+        "all retries were consumed against repeated Retryable reports"
+    );
+    let attempts = store.list_delivery_attempts(scope.clone()).await.unwrap();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Failed
+    );
+    assert_eq!(
+        attempts[0].failure_kind,
+        Some(ironclaw_outbound::DeliveryFailureKind::VendorContactAmbiguous)
+    );
+
+    // Replaying the same logical delivery must NOT reopen this row, for the
+    // same reason as the bare-Err sibling case: a fresh Prepared clone of the
+    // same attempt (same delivery_id/scope/candidate) must be accepted as an
+    // idempotent no-op, not a reopen a caller could claim and resend.
+    let mut replay = attempt.clone();
+    replay.status = ironclaw_outbound::OutboundDeliveryStatus::Prepared;
+    replay.failure_kind = None;
+    store
+        .record_delivery_attempt(replay)
+        .await
+        .expect("replay is accepted as an idempotent no-op");
+    let after_replay = store
+        .list_delivery_attempts(scope)
+        .await
+        .expect("load attempt after replay");
+    assert_eq!(after_replay.len(), 1);
+    assert_eq!(
+        after_replay[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Failed,
+        "a VendorContactAmbiguous row must stay terminal, unlike TransportUnavailable"
+    );
+    assert_eq!(
+        after_replay[0].failure_kind,
+        Some(ironclaw_outbound::DeliveryFailureKind::VendorContactAmbiguous)
+    );
+}
+
+/// G6: an end-to-end proof of the reopen mechanism through main's actual
+/// claim-first path. In this codebase a `TransportUnavailable` settlement
+/// only ever happens before the egress claim (`ChannelUnavailable` /
+/// workspace-materialization preflight failures — see
+/// `workspace_materialization_failure_kind` and
+/// `resolve_channel_context`), which is exactly the invariant that makes
+/// reopening it safe. This test drives that preflight path (channel
+/// unavailable), then replays the same logical delivery: the reopen
+/// resurfaces the `Failed(TransportUnavailable)` row as a fresh `Prepared`
+/// reservation, and a second attempt with a healthy channel claims it and
+/// delivers.
+#[tokio::test]
+async fn transient_preflight_failure_reopens_and_replay_delivers() {
+    let scope = scope();
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    seed_preference(&preferences, &scope);
+    let resolver = FakeProductOutboundTargetResolver;
+    let policy = configured_policy(&store, &validator);
+    let adapter = Arc::new(ScriptedChannelAdapter::new(
+        Arc::clone(&store),
+        scope.clone(),
+        vec![Ok(DeliveryReport {
+            parts: vec![sent("ts-reopen-replay")],
+        })],
+    ));
+
+    // First attempt: the channel is unavailable, a preflight failure before
+    // any egress claim. This settles Failed(TransportUnavailable) directly
+    // on the `Prepared` row (no claim was ever taken).
+    let unavailable_coordinator = DeliveryCoordinator::new(
+        Arc::clone(&store) as Arc<dyn ironclaw_outbound::OutboundStateStorePort>,
+        Arc::new(StaticChannelResolver {
+            adapter: Arc::clone(&adapter),
+            unavailable: true,
+        }),
+        Arc::new(FixedReplyContext::new(Vec::new())),
+        DeliveryRetryPolicy {
+            max_attempts: 3,
+            backoff: std::time::Duration::ZERO,
+        },
+    );
+    // Both attempts must share one `PrepareCommunicationDeliveryRequest` (in
+    // particular one `turn_run_id`): the durable delivery id is derived from
+    // scope/actor/modality/candidate, and `delivery_request` mints a fresh
+    // random `turn_run_id` on every call, so calling it twice would produce
+    // two unrelated delivery ids instead of exercising a reopen of the same
+    // logical delivery.
+    let delivery = delivery_request(scope.clone());
+    let thread_scope = project_thread_scope();
+    let request = || CoordinatedDeliveryRequest {
+        intent: DeliveryIntent::FinalReply,
+        delivery: delivery.clone(),
+        parts: vec![
+            ironclaw_extension_contracts::channel_adapter::OutboundPart::Text(
+                "final reply".to_string(),
+            ),
+        ],
+        attachments: Vec::new(),
+        thread_anchor: Some("thread-1".to_string()),
+        require_direct_message_target: false,
+        extension_id: "vendorx",
+        thread_scope: &thread_scope,
+    };
+
+    let first_error = unavailable_coordinator
+        .deliver(&policy, &resolver, &NO_PROJECT_FILESYSTEM, request())
+        .await
+        .expect_err("unavailable channel fails closed");
+    assert!(matches!(
+        first_error,
+        CoordinatedDeliveryError::ChannelUnavailable { .. }
+    ));
+    let attempts = store.list_delivery_attempts(scope.clone()).await.unwrap();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Failed
+    );
+    assert_eq!(
+        attempts[0].failure_kind,
+        Some(ironclaw_outbound::DeliveryFailureKind::TransportUnavailable)
+    );
+    let reopened_delivery_id = attempts[0].delivery_id;
+
+    // Second attempt: same logical delivery (same scope/actor/modality/
+    // candidate, hence the same deterministic delivery id), this time
+    // through a healthy channel. `record_delivery_attempt` reopens the stale
+    // `TransportUnavailable` row to a fresh `Prepared` reservation instead of
+    // treating the replay as a no-op, so this claim succeeds and delivers.
+    let healthy_coordinator = coordinator_over(&store, &adapter);
+    let outcome = healthy_coordinator
+        .deliver(&policy, &resolver, &NO_PROJECT_FILESYSTEM, request())
+        .await
+        .expect("replay drives after reopen");
+    match outcome {
+        CoordinatedDeliveryOutcome::Delivered {
+            attempt,
+            vendor_message_refs,
+            ..
+        } => {
+            assert_eq!(attempt.delivery_id, reopened_delivery_id);
+            assert_eq!(vendor_message_refs, vec!["ts-reopen-replay".to_string()]);
+        }
+        other => panic!("expected Delivered after reopen, got {other:?}"),
+    }
+    let attempts = store.list_delivery_attempts(scope).await.unwrap();
+    assert_eq!(attempts.len(), 1, "the reopen reuses the same durable row");
+    assert_eq!(
+        attempts[0].status,
+        ironclaw_outbound::OutboundDeliveryStatus::Delivered
+    );
+}
+
+/// G8: notice-class deliveries (`deliver_notice`) mint a fresh random
+/// delivery id on every call (unlike policy-class deliveries, whose id is
+/// deterministic from scope/actor/modality/candidate) — so two notices can
+/// never collide on the same durable row, and a reopen can never trigger for
+/// them. This is a regression guard: if a future change made notice ids
+/// derive deterministically from scope/extension/notice_ref, a second
+/// failing notice could silently reopen and resend the first's row instead
+/// of recording an independent attempt.
+#[tokio::test]
+async fn notice_deliveries_never_trigger_a_reopen() {
+    let scope = scope();
+    let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let adapter = Arc::new(ScriptedChannelAdapter::new(
+        Arc::clone(&store),
+        scope.clone(),
+        Vec::new(),
+    ));
+    let coordinator = DeliveryCoordinator::new(
+        Arc::clone(&store) as Arc<dyn ironclaw_outbound::OutboundStateStorePort>,
+        Arc::new(StaticChannelResolver {
+            adapter: Arc::clone(&adapter),
+            unavailable: true,
+        }),
+        Arc::new(FixedReplyContext::new(Vec::new())),
+        DeliveryRetryPolicy::default(),
+    );
+
+    let first_error = coordinator
+        .deliver_notice(working_notice(scope.clone(), "vendorx"))
+        .await
+        .expect_err("unavailable channel fails closed");
+    assert!(matches!(
+        first_error,
+        CoordinatedDeliveryError::ChannelUnavailable { .. }
+    ));
+    let second_error = coordinator
+        .deliver_notice(working_notice(scope.clone(), "vendorx"))
+        .await
+        .expect_err("unavailable channel fails closed");
+    assert!(matches!(
+        second_error,
+        CoordinatedDeliveryError::ChannelUnavailable { .. }
+    ));
+
+    let attempts = store.list_delivery_attempts(scope).await.unwrap();
+    assert_eq!(
+        attempts.len(),
+        2,
+        "each notice must record an independent row, never reopen a sibling's"
+    );
+    assert_ne!(attempts[0].delivery_id, attempts[1].delivery_id);
+    for attempt in &attempts {
+        assert_eq!(
+            attempt.status,
+            ironclaw_outbound::OutboundDeliveryStatus::Failed
+        );
+        assert_eq!(
+            attempt.failure_kind,
+            Some(ironclaw_outbound::DeliveryFailureKind::TransportUnavailable)
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What this fixes

**Fix A — TOCTOU + Sending-row claim-loss misclassification.** `claim_delivery_attempt_for_send` (`crates/domains/ironclaw_outbound/src/outbound_state_store.rs:987`) used to return `bool`, and a claim loser would separately re-read the row afterward. Between the failed CAS and that re-read, another caller could reopen the row, so a claim loser could misclassify a freshly-reopened `Prepared` row as still in flight.

I changed the return type to `ClaimDeliveryAttemptForSendOutcome::{Claimed, Existing(Box<OutboundDeliveryAttempt>)}` (`types.rs:462`). The blocking row is now the exact row read inside the CAS retry loop itself — including the retry-loop's own re-read after a lost CAS — with no separate read appended afterward (`outbound_state_store.rs:1002-1011`). `delivery_coordinator.rs`'s `outcome_for_existing_delivery` is now a pure function over that row (no re-read at all), and `Prepared | Sending` claim-loss returns `CoordinatedDeliveryOutcome::ExistingDeliveryUnconfirmed { attempt }` (`delivery_coordinator.rs:248`) instead of `Err(AlreadyInFlight)`, which I deleted along with the now-redundant `in_flight: Mutex<HashSet<...>>` single-flight guard and its insert/remove call sites in both `deliver()` and `deliver_notice()` — the atomic claim already provides single-flight, the mutex was guarding against a race the claim doesn't have.

**Fix B — Failed-row reopen mechanism.** Before this, a `Failed` row could never be reopened, so a caller replaying the same deterministic delivery id after a preflight failure (e.g. `ChannelUnavailable`) would get stuck behind that terminal row forever, even though nothing had reached the vendor.

I added `DeliveryFailureKind::VendorContactAmbiguous` (`types.rs:252`) for retry exhaustion *after* the vendor-egress claim, where there's no proof the vendor was never contacted — either a bare `Err` from the adapter's `deliver` call, or a typed report whose parts were all `Retryable` (both in-tree adapters, Slack and Telegram, use `Retryable` for post-send ambiguity like a timeout after the request was already sent, not just pre-send failure). The two post-egress-claim exhaustion sites in `delivery_coordinator.rs` (`drive_authorized`, around the retry-exhaustion arms) now settle `VendorContactAmbiguous` instead of `TransportUnavailable`.

A single predicate, `DeliveryFailureKind::permits_reopen()` (`types.rs:296`), classifies which kinds are provably pre-vendor-contact and therefore safe to reopen: `true` for `TransientValidatorError | TransportUnavailable | RateLimited`, `false` for `AuthorizationRevoked | Rejected | Unknown | VendorContactAmbiguous | Unrecognized`. `Unrecognized` (`types.rs:270`) is a `#[serde(other)]` catch-all for a `failure_kind` tag this binary does not model — e.g. a row written by a newer release, encountered during a rollback. Deserializing a delivery row is all-or-nothing and `list_delivery_attempts` used to fail the whole scope on one such row; `Unrecognized` lets that row fold in instead of breaking crash recovery for every delivery in the scope, while `permits_reopen() == false` for it keeps it permanently terminal, since an unknown kind proves nothing about vendor contact.

`record_delivery_attempt` (`outbound_state_store.rs:924`) now CAS-writes a fresh `Prepared` reservation over a stale `Failed` row only when `attempt_reopens_stale_failure` (`outbound_state_store.rs:1378`) holds, using versioned CAS (`CasExpectation::Version`), matching this file's existing fail-closed convention (no byte-only fallback for an ownership-sensitive transition). Any other existing status stays a no-op.

**Follow-up — write-time vendor-egress provenance gate (`da7ad90d8`, `1b786b693`).** After Fix B shipped, review surfaced a rollout-safety gap: `failure_kind` alone doesn't prove a row is safe to reopen, because this PR *changes* what `failure_kind` means. A pre-this-PR binary wrote `TransportUnavailable` for post-`adapter.deliver` retry exhaustion (a case this PR reclassifies to `VendorContactAmbiguous`). That old row is byte-identical to a genuinely pre-claim `TransportUnavailable` row written by the new code, so `permits_reopen()` alone would wrongly resend it once this PR is live.

The fix adds `VendorEgressProvenance` (`types.rs:316`), a two-variant enum — `NotAttempted` / `Attempted` (`Attempted` also doubles as the `#[serde(other)]` fail-closed landing spot) — recorded at write time by the code that knows whether `adapter.deliver` was actually called, never re-derived from `failure_kind` after the fact. `delivery_coordinator.rs` enforces this by construction: `mark_terminal_pre_egress` (`delivery_coordinator.rs:943`) hardcodes `NotAttempted` for failures settled before any `adapter.deliver` call (surface-error, workspace-materialization, channel-resolution paths), and `mark_terminal_post_egress` (`delivery_coordinator.rs:962`) hardcodes `Attempted` for the `Delivered` success path and every failure classified after that call, including `VendorContactAmbiguous`. `recover_interrupted_deliveries` (`delivery_coordinator.rs:387`) likewise writes `Attempted` when it settles a crashed `Sending` row to `Unknown`, since a `Sending` row means the process could have called the adapter before crashing.

`attempt_reopens_stale_failure` (`outbound_state_store.rs:1378-1388`) now requires **both** gates to reopen a `Failed` row: `existing.vendor_egress == Some(VendorEgressProvenance::NotAttempted)` *and* `existing.failure_kind.is_some_and(DeliveryFailureKind::permits_reopen)`. A row with `vendor_egress: None` (predating this field) or `Some(Attempted)` fails closed regardless of its `failure_kind`, and a row with a `permits_reopen`-eligible kind but `Some(Attempted)` provenance also stays terminal — provenance and failure kind are independently enforced, neither substitutes for the other. `validation.rs`'s `validate_delivery_status_request` (`validation.rs:137-152`) backstops this at write time: it rejects any `Failed` status update whose `vendor_egress` is `None`, so a caller can no longer silently strip provenance from a durable row (`UpdateDeliveryStatusRequest.vendor_egress` is `Option` with `#[serde(default)]`) and accidentally make that row permanently unreopenable.

`run_delivery/triggered.rs` and `run_delivery/observer.rs` both explicitly handle `ExistingDeliveryUnconfirmed` rather than letting it fall through their wildcard arms — before this fix, claim-loss surfaced as an `Err(AlreadyInFlight)` that those match statements never needed to catch via a wildcard. Now that it's success-shaped, the wildcard would silently report it as zero delivered messages instead of a failure. I extended this beyond the original file list to `observer.rs`, which has the identical wildcard-absorption pattern.

## Tests

New coverage in `outbound_state_store_contract.rs` and `outbound_delivery_contract.rs`:
- `send_claim_cas_loser_returns_exact_winner_snapshot_without_post_resolution_read` — proves the TOCTOU fix directly, using a backend that errors on any read beyond the initial read + one CAS-retry read, and any write beyond the first conflict. It would fail if the implementation ever re-read after a lost CAS.
- `record_delivery_attempt_reopen_race_loser_defers_to_concurrent_winner` — the same racing technique applied to the reopen branch: a reopen that loses to a concurrent winner (already reopened and claimed) must defer, not clobber the winner back to `Prepared`.
- `record_delivery_attempt_reopens_only_reopen_permitted_failed_rows` — a full matrix over every `OutboundDeliveryStatus` and every `DeliveryFailureKind::ALL`, asserting reopen fires only for `Failed` rows whose kind's `permits_reopen()` is `true`.
- `coordinator_marks_vendor_contact_ambiguous_on_exhausted_adapter_errors_and_never_reopens` and its `_retryable_reports_` sibling — drive retry exhaustion through both the bare-`Err` and fully-`Retryable` paths, assert `VendorContactAmbiguous` is settled (not `TransportUnavailable`), and assert a same-id replay is rejected as a no-op rather than reopened.
- `transient_preflight_failure_reopens_and_replay_delivers` — end-to-end: a preflight `ChannelUnavailable` failure settles `Failed(TransportUnavailable)`, then a replay of the same logical delivery reopens the row and delivers.
- `claim_loser_observes_sending_without_reporting_the_owners_later_failure_as_success` and its `_crash_as_success` sibling — a claim loser racing a still-`Sending` owner (paused mid-adapter-call via a semaphore) must observe `Sending` and never fabricate success, whether the owner later fails or never returns at all (simulated crash).
- `record_delivery_attempt_reopen_gate_requires_vendor_egress_not_attempted` — three cases over the provenance gate specifically: a legacy row with `vendor_egress` stripped from the wire entirely (simulating a pre-this-PR row) must fail closed and never reopen; a modern row with `Some(NotAttempted)` and a `permits_reopen` kind must reopen; and a row with `Some(Attempted)` must block reopen even when its `failure_kind` independently permits reopen — proving the provenance gate is enforced on its own, not merely coincident with the `failure_kind` gate.
- `record_delivery_attempt_never_reopens_a_row_with_unrecognized_failure_kind` — seeds a `Failed` row, then overwrites its durable JSON with a `failure_kind` tag this enum does not define. Asserts `list_delivery_attempts` still succeeds for the scope and folds the tag to `Unrecognized` (rather than erroring the whole scope), and asserts a subsequent `record_delivery_attempt` call leaves the row `Failed` — an unrecognized kind must never permit reopen.

## Verification

Independently re-ran the full matrix from scratch: `cargo check --workspace --tests`, `cargo test -p ironclaw_outbound` (75 unit + 49 contract tests), `cargo test -p ironclaw_assistant` (278 + 32 + 35 contract tests, including all new fix-specific tests), `cargo test -p ironclaw_host_runtime` (79 + others, including the `delivery_failure_summary` loop-safe-charset test), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`. All green.

## Context

This is extracted from a larger, now-superseded PR (#7029). Independent investigation found most of that PR's value had already been closed by other work, and a subsequent design review found a third originally-planned fix (transient-preflight-retry) was redundant with main's existing architecture and would have introduced a regression, so it was dropped — only these two fixes made it through.