### PR TITLE
test(tool-search): baseline catalogs at 100-1,000 tools

### DIFF
--- a/crates/loop/ironclaw_loop_host/src/tool_search.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_search.rs
@@ -397,7 +397,7 @@ fn hash_json(value: &Value, hasher: &mut impl Hasher) {
 mod tests {
     use super::*;
     use ironclaw_host_api::ids::ProviderToolName;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
     use serde_json::json;
     use std::time::Instant;
 
@@ -798,7 +798,7 @@ mod tests {
         relevance: BTreeMap<String, u8>,
     }
 
-    #[derive(Debug, Default)]
+    #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
     struct QualityMetrics {
         recall_at_1: f64,
         recall_at_5: f64,
@@ -806,6 +806,38 @@ mod tests {
         mrr: f64,
         ndcg_at_10: f64,
         no_match_accuracy: f64,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct ScaleBaseline {
+        version: u32,
+        seed: u64,
+        intent_count: usize,
+        synthetic_namespace_count: usize,
+        cases: Vec<ScaleBaselineCase>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct ScaleBaselineCase {
+        tool_count: usize,
+        quality: QualityMetrics,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct ScaleBenchmarkReport {
+        version: u32,
+        seed: u64,
+        intent_count: usize,
+        cases: Vec<ScaleBenchmarkCaseReport>,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct ScaleBenchmarkCaseReport {
+        tool_count: usize,
+        synthetic_namespace_count: usize,
+        index_build_micros: u128,
+        query_total_micros: u128,
+        quality: QualityMetrics,
     }
 
     #[derive(Debug)]
@@ -855,23 +887,7 @@ mod tests {
                 );
             }
         }
-        let definitions: Vec<_> = corpus
-            .tools
-            .iter()
-            .map(|tool| {
-                definition(
-                    &tool.capability_id,
-                    &tool.name,
-                    &tool.description,
-                    tool.parameters.clone(),
-                    if tool.verified {
-                        CapabilityDescriptionTrust::VerifiedCatalog
-                    } else {
-                        CapabilityDescriptionTrust::Untrusted
-                    },
-                )
-            })
-            .collect();
+        let definitions: Vec<_> = corpus.tools.iter().map(corpus_definition).collect();
 
         let build_started = Instant::now();
         let index = AuthorizedToolSearchIndex::new(definitions.iter());
@@ -970,6 +986,251 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn committed_scale_baseline_covers_100_500_and_1000_tools() {
+        let corpus: Corpus =
+            serde_json::from_str(include_str!("../tests/fixtures/tool_search_relevance.json"))
+                .expect("committed tool-search corpus is valid");
+        let baseline: ScaleBaseline = serde_json::from_str(include_str!(
+            "../tests/fixtures/tool_search_scale_baseline.json"
+        ))
+        .expect("committed tool-search scale baseline is valid");
+
+        assert_eq!(baseline.version, 1, "unknown scale baseline version");
+        assert_eq!(
+            baseline.intent_count,
+            corpus.intents.len(),
+            "scale baseline must cover the complete judged intent corpus"
+        );
+        assert_eq!(
+            baseline
+                .cases
+                .iter()
+                .map(|case| case.tool_count)
+                .collect::<Vec<_>>(),
+            vec![100, 500, 1_000]
+        );
+        let mut reports = Vec::new();
+        for case in &baseline.cases {
+            let first = scaled_definitions(&corpus, case.tool_count, baseline.seed);
+            let second = scaled_definitions(&corpus, case.tool_count, baseline.seed);
+            assert_eq!(first, second, "scaled catalog must be deterministic");
+            assert_eq!(first.len(), case.tool_count);
+
+            let synthetic_namespace_counts = synthetic_namespace_counts(&corpus, &first);
+            assert_eq!(
+                synthetic_namespace_counts.len(),
+                baseline.synthetic_namespace_count,
+                "every configured synthetic namespace must be represented"
+            );
+            let smallest_namespace = synthetic_namespace_counts
+                .values()
+                .min()
+                .copied()
+                .expect("scale fixture has synthetic namespaces");
+            let largest_namespace = synthetic_namespace_counts
+                .values()
+                .max()
+                .copied()
+                .expect("scale fixture has synthetic namespaces");
+            assert!(
+                largest_namespace.saturating_sub(smallest_namespace) <= 1,
+                "synthetic tools must be distributed evenly across namespaces: {synthetic_namespace_counts:?}"
+            );
+
+            let build_started = Instant::now();
+            let index = AuthorizedToolSearchIndex::new(first.iter());
+            let index_build_micros = build_started.elapsed().as_micros();
+            let query_started = Instant::now();
+            let rankings: Vec<_> = corpus
+                .intents
+                .iter()
+                .map(|intent| index.search(&intent.query, 10).names)
+                .collect();
+            let query_total_micros = query_started.elapsed().as_micros();
+            let quality = quality_metrics(&corpus.intents, &rankings);
+            reports.push(ScaleBenchmarkCaseReport {
+                tool_count: case.tool_count,
+                synthetic_namespace_count: synthetic_namespace_counts.len(),
+                index_build_micros,
+                query_total_micros,
+                quality,
+            });
+        }
+
+        let report = ScaleBenchmarkReport {
+            version: baseline.version,
+            seed: baseline.seed,
+            intent_count: corpus.intents.len(),
+            cases: reports,
+        };
+        eprintln!(
+            "tool-search scale baseline:\n{}",
+            serde_json::to_string_pretty(&report).expect("serialize scale benchmark report")
+        );
+        for (actual, expected) in report.cases.iter().zip(&baseline.cases) {
+            assert_quality_matches_baseline(actual.tool_count, actual.quality, expected.quality);
+        }
+    }
+
+    fn scaled_definitions(
+        corpus: &Corpus,
+        tool_count: usize,
+        seed: u64,
+    ) -> Vec<ProviderToolDefinition> {
+        assert!(
+            tool_count >= corpus.tools.len(),
+            "scale target cannot discard judged corpus tools"
+        );
+        let mut definitions: Vec<_> = corpus.tools.iter().map(corpus_definition).collect();
+        let synthetic_count = tool_count - definitions.len();
+        let namespace_offset = seed as usize % SCALE_NAMESPACES.len();
+        let action_offset = seed as usize % SCALE_ACTIONS.len();
+        let noun_offset = seed as usize % SCALE_NOUNS.len();
+        for ordinal in 0..synthetic_count {
+            let namespace = SCALE_NAMESPACES[(ordinal + namespace_offset) % SCALE_NAMESPACES.len()];
+            let action = SCALE_ACTIONS[(ordinal + action_offset) % SCALE_ACTIONS.len()];
+            let noun = SCALE_NOUNS[(ordinal + noun_offset) % SCALE_NOUNS.len()];
+            let local_name = format!("{action}_{ordinal:04}");
+            definitions.push(definition(
+                &format!("{namespace}.{local_name}"),
+                &format!("{namespace}__{local_name}"),
+                &format!("{action} {noun} records in the {namespace} benchmark integration."),
+                json!({
+                    "type": "object",
+                    "properties": {
+                        format!("{noun}_id"): {"type": "string"},
+                        "cursor": {"type": "string"},
+                        "limit": {"type": "integer"}
+                    },
+                    "required": [format!("{noun}_id")]
+                }),
+                CapabilityDescriptionTrust::Untrusted,
+            ));
+        }
+        definitions
+    }
+
+    fn corpus_definition(tool: &CorpusTool) -> ProviderToolDefinition {
+        definition(
+            &tool.capability_id,
+            &tool.name,
+            &tool.description,
+            tool.parameters.clone(),
+            if tool.verified {
+                CapabilityDescriptionTrust::VerifiedCatalog
+            } else {
+                CapabilityDescriptionTrust::Untrusted
+            },
+        )
+    }
+
+    fn synthetic_namespace_counts(
+        corpus: &Corpus,
+        definitions: &[ProviderToolDefinition],
+    ) -> BTreeMap<String, usize> {
+        definitions.iter().skip(corpus.tools.len()).fold(
+            BTreeMap::new(),
+            |mut counts, definition| {
+                let namespace = definition
+                    .capability_id
+                    .as_str()
+                    .split_once('.')
+                    .map_or(definition.capability_id.as_str(), |(namespace, _)| {
+                        namespace
+                    });
+                counts
+                    .entry(namespace.to_string())
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+                counts
+            },
+        )
+    }
+
+    fn assert_quality_matches_baseline(
+        tool_count: usize,
+        actual: QualityMetrics,
+        expected: QualityMetrics,
+    ) {
+        for (name, actual, expected) in [
+            ("recall_at_1", actual.recall_at_1, expected.recall_at_1),
+            ("recall_at_5", actual.recall_at_5, expected.recall_at_5),
+            ("recall_at_10", actual.recall_at_10, expected.recall_at_10),
+            ("mrr", actual.mrr, expected.mrr),
+            ("ndcg_at_10", actual.ndcg_at_10, expected.ndcg_at_10),
+            (
+                "no_match_accuracy",
+                actual.no_match_accuracy,
+                expected.no_match_accuracy,
+            ),
+        ] {
+            assert!(
+                (actual - expected).abs() <= QUALITY_BASELINE_TOLERANCE,
+                "{tool_count}-tool {name} baseline drifted: expected {expected:.16}, actual {actual:.16}"
+            );
+        }
+    }
+
+    const QUALITY_BASELINE_TOLERANCE: f64 = 1e-12;
+
+    const SCALE_NAMESPACES: [&str; 20] = [
+        "asset_hub",
+        "audit_log",
+        "billing_ops",
+        "compliance_archive",
+        "content_registry",
+        "customer_directory",
+        "data_exchange",
+        "device_fleet",
+        "document_vault",
+        "incident_queue",
+        "inventory_ledger",
+        "media_pipeline",
+        "network_inventory",
+        "quality_control",
+        "research_catalog",
+        "service_directory",
+        "support_queue",
+        "telemetry_store",
+        "training_library",
+        "workflow_admin",
+    ];
+
+    const SCALE_ACTIONS: [&str; 16] = [
+        "archive_record",
+        "compare_snapshot",
+        "export_summary",
+        "get_status",
+        "inspect_artifact",
+        "list_categories",
+        "normalize_dataset",
+        "record_checkpoint",
+        "resolve_reference",
+        "review_manifest",
+        "summarize_usage",
+        "sync_metadata",
+        "validate_policy",
+        "verify_checksum",
+        "view_history",
+        "write_annotation",
+    ];
+
+    const SCALE_NOUNS: [&str; 12] = [
+        "artifact",
+        "batch",
+        "bundle",
+        "checkpoint",
+        "entry",
+        "manifest",
+        "record",
+        "reference",
+        "snapshot",
+        "summary",
+        "version",
+        "workspace",
+    ];
 
     fn legacy_rank(
         definitions: &[ProviderToolDefinition],

--- a/crates/loop/ironclaw_loop_host/tests/fixtures/tool_search_scale_baseline.json
+++ b/crates/loop/ironclaw_loop_host/tests/fixtures/tool_search_scale_baseline.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "seed": 7405,
+  "intent_count": 72,
+  "synthetic_namespace_count": 20,
+  "cases": [
+    {
+      "tool_count": 100,
+      "quality": {
+        "recall_at_1": 0.7864583333333334,
+        "recall_at_5": 0.9375,
+        "recall_at_10": 0.9661458333333334,
+        "mrr": 0.94921875,
+        "ndcg_at_10": 0.9426374896514516,
+        "no_match_accuracy": 1.0
+      }
+    },
+    {
+      "tool_count": 500,
+      "quality": {
+        "recall_at_1": 0.7864583333333334,
+        "recall_at_5": 0.9375,
+        "recall_at_10": 0.9557291666666667,
+        "mrr": 0.94921875,
+        "ndcg_at_10": 0.9403590604241029,
+        "no_match_accuracy": 1.0
+      }
+    },
+    {
+      "tool_count": 1000,
+      "quality": {
+        "recall_at_1": 0.7864583333333334,
+        "recall_at_5": 0.9375,
+        "recall_at_10": 0.9557291666666667,
+        "mrr": 0.94921875,
+        "ndcg_at_10": 0.9403590604241029,
+        "no_match_accuracy": 1.0
+      }
+    }
+  ]
+}

--- a/docs/internal/tool-discovery-evaluation.md
+++ b/docs/internal/tool-discovery-evaluation.md
@@ -1,0 +1,147 @@
+# Tool discovery evaluation contract
+
+This document defines the evidence required by issue #7405 before changing
+IronClaw's progressive tool-discovery interaction. Retrieval quality and
+end-to-end model behavior are separate measurements; neither substitutes for
+the other.
+
+## Retrieval baseline
+
+The crate-owned retrieval gate is
+`tool_search::tests::committed_corpus_quality_gate_and_benchmark_report` in
+`ironclaw_loop_host`. Its committed corpus contains 50 tools and 72 judged
+intents spanning exact names, aliases, canonical IDs, provider names,
+parameters, nested schemas, ambiguous queries, hard negatives, and no-match
+queries.
+
+`committed_scale_baseline_covers_100_500_and_1000_tools` retains all judged
+tools and intents, then adds deterministic distractors across 20 synthetic
+namespaces. The generator is seeded, distributes namespace membership evenly,
+and builds the catalog twice to prove byte-equivalent definitions. The
+committed baseline stores deterministic quality metrics only. Index-build and
+query timings are printed for diagnosis but are not committed as gates because
+they vary by host and build profile.
+
+| Tools | Recall@1 | Recall@5 | Recall@10 | MRR | NDCG@10 | No-match |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100 | 0.7865 | 0.9375 | 0.9661 | 0.9492 | 0.9426 | 1.0000 |
+| 500 | 0.7865 | 0.9375 | 0.9557 | 0.9492 | 0.9404 | 1.0000 |
+| 1,000 | 0.7865 | 0.9375 | 0.9557 | 0.9492 | 0.9404 | 1.0000 |
+
+The synthetic additions are intentionally unjudged distractors. They test
+ranking stability and expose index cost as the catalog grows; they do not
+claim to represent 950 additional human-judged user intents. New semantic
+domains require new judged tools and intents in the base corpus.
+
+Run the retrieval evidence with:
+
+```bash
+cargo test -p ironclaw_loop_host committed_corpus_quality_gate_and_benchmark_report -- --nocapture
+cargo test -p ironclaw_loop_host committed_scale_baseline_covers_100_500_and_1000_tools -- --nocapture
+```
+
+## End-to-end benchmark arms
+
+Run the same task set and catalog seed for every arm:
+
+1. Full advertised schemas.
+2. Current `tool_search` → `tool_describe` → invocation protocol.
+3. Bounded complete signatures returned from `tool_search`.
+4. Namespace summaries plus bounded complete signatures.
+5. Namespace summaries, bounded complete signatures, and reviewed profile
+   pins.
+
+The 100-, 500-, and 1,000-tool catalogs must preserve the same judged tasks.
+Each size may add deterministic distractors, but the report must record the
+generator version and seed.
+
+## End-to-end report schema
+
+Each observation records one arm, catalog size, model route, temperature,
+cold/warm class, and repetition. Aggregate reports must retain the underlying
+per-task observations so a broad score cannot hide a failed capability.
+
+```json
+{
+  "schema_version": 1,
+  "catalog": {
+    "generator_version": "tool-search-scale-v1",
+    "seed": 7405,
+    "tool_count": 500,
+    "namespace_count": 20
+  },
+  "arm": "bounded_complete_signatures",
+  "model": {
+    "provider": "provider-id",
+    "model": "model-id",
+    "temperature": 0.0
+  },
+  "run": {
+    "thermal_class": "warm",
+    "repetition": 1
+  },
+  "task": {
+    "id": "email-to-calendar",
+    "completed": true,
+    "correct_tool_recalled": true,
+    "unauthorized_tool_leaks": 0
+  },
+  "counts": {
+    "model_turns": 3,
+    "discovery_turns": 1,
+    "tool_calls": 3,
+    "tool_search_calls": 1,
+    "tool_describe_calls": 0
+  },
+  "tokens": {
+    "input": 12000,
+    "cached_input": 8000,
+    "output": 600
+  },
+  "latency_ms": {
+    "time_to_first_correct_tool_call": 900,
+    "end_to_end": 2400
+  },
+  "cache": {
+    "tool_definition_signature_changes": 0
+  },
+  "failure": null
+}
+```
+
+`failure`, when present, uses a stable category such as `retrieval_miss`,
+`invalid_arguments`, `authorization_denied`, `approval_blocked`,
+`provider_error`, or `task_incomplete`. Raw prompts, user content, credentials,
+and tool arguments are not benchmark dimensions and must not be logged.
+
+## Required scenarios
+
+- Exact tool name and canonical capability ID.
+- Alias and natural-language action queries.
+- Ambiguous queries with multiple relevant tools.
+- Argument-only vocabulary found in nested schemas.
+- Relevant denied tools mixed with allowed distractors.
+- Cross-namespace workflows, including finding an email and creating a
+  calendar event.
+- No-match tasks where the correct behavior is to report that no authorized
+  capability exists.
+
+Every model/provider configuration runs at least one cold repetition and three
+warm repetitions. Reports include median, worst case, spread, and failure
+categories; cache-provider measurements additionally report cached-input
+tokens and tool-definition signature changes.
+
+## Rollout gates
+
+- Zero unauthorized namespace, signature, provider-reference, ranking, or
+  callable-target leakage.
+- Existing retrieval recall, MRR, NDCG, and no-match gates remain satisfied.
+- Complete-signature tasks reduce discovery turns without increasing invalid
+  calls attributable to missing schemas.
+- Task completion does not materially regress at any catalog size.
+- Providers with stable deferred loading retain one byte-identical advertised
+  tool surface throughout discovery and invocation.
+
+Bounded orchestration is not an arm until the preceding interaction changes
+have shipped and this report shows that model round trips remain a dominant
+latency source. It requires a separate design and issue.


### PR DESCRIPTION
## Summary

- Establishes PR 1 / Step 0 of #7405 without changing production tool-discovery behavior.
- Extends the existing 50-tool, 72-intent judged corpus with deterministic namespace-balanced distractors at 100, 500, and 1,000 tools.
- Commits retrieval-quality baselines at every scale and prints diagnostic index/query timings without turning host-dependent timings into flaky gates.
- Documents the end-to-end comparison arms, per-task result schema, required scenarios, rollout gates, and the boundary for any later orchestration work.

### Findings

The current BM25F ranker remains stable as unjudged distractors scale the catalog from 100 to 1,000 tools. Recall@1 stays at 0.7865, MRR at 0.9492, and no-match accuracy at 1.0. Recall@10 moves from 0.9661 at 100 tools to 0.9557 at 500 and 1,000 tools; NDCG@10 moves from 0.9426 to 0.9404. This supports keeping BM25F as the retrieval authority while the following PRs improve the interaction around it.

This is deliberately not an end-to-end model claim. The added tools are realistic deterministic distractors around the same 72 human-judged intents. Later slices must still run full-schema, current search/describe/call, complete-signature, namespace-summary, and pinned-profile arms while measuring task completion, discovery turns, tokens, latency, cache signatures, and unauthorized-tool leakage.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7405

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run workspace-wide; affected crate passed `cargo clippy -p ironclaw_loop_host --all-targets --all-features -- -D warnings`
- [ ] `cargo build` — not run separately; the affected crate was compiled by tests and Clippy
- [x] Relevant tests pass: `cargo test -p ironclaw_loop_host` (914 tests, 0 failures)
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed — not applicable; no database or runtime behavior changed
- [ ] Manual testing: not applicable; test and documentation-only change
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run; final diff was manually audited and all affected-crate gates passed

Additional checks:

- `python3 scripts/ci/docs_publication_boundary.py`
- `git diff --check`

## Test Strategy

User behavior:

No production behavior changes. This freezes the evidence required to compare the user-visible discovery improvements in later PRs.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: extended the existing tool-search quality harness with deterministic 100/500/1,000-tool cases, complete-corpus retention, namespace-balance checks, reproducibility checks, and committed metric comparisons.
- Reborn integration: Not applicable: production behavior is unchanged.
- Recorded fixture: Not applicable: the committed JSON is a deterministic retrieval baseline, not an external-provider recording.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Not applicable: no backend or runtime behavior changed.
- Live canary: Not applicable: no production behavior changed.

What the tests prove:

- A fixed seed produces identical tool definitions.
- Every scale contains the complete 72-intent judged core and exactly 100, 500, or 1,000 tools.
- Synthetic tools are distributed evenly across all 20 configured namespaces.
- Current retrieval quality remains pinned at each scale, including no-match behavior.

Commands run:

```bash
cargo test -p ironclaw_loop_host committed_corpus_quality_gate_and_benchmark_report -- --nocapture
cargo test -p ironclaw_loop_host committed_scale_baseline_covers_100_500_and_1000_tools -- --nocapture
cargo test -p ironclaw_loop_host
cargo clippy -p ironclaw_loop_host --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
python3 scripts/ci/docs_publication_boundary.py
git diff --check
```

## Security Impact

None. The benchmark uses synthetic data and the existing authorization-fitted search index; production permissions, network calls, secrets, file access, tool execution, and sandbox policy are unchanged.

## Reborn Trust-Boundary Checklist

N/A: test and internal-documentation changes only; no trust-bearing types, prompt ingress, status/error contracts, runtime paths, or queues changed.

## Database Impact

None.

## Blast Radius

Limited to the `ironclaw_loop_host` test suite and an internal evaluation document. A legitimate future ranking change may require intentional review and regeneration of the committed quality baseline.

## Rollback Plan

Revert this commit to remove the scale fixture, contract test, and internal evaluation document. No runtime or data rollback is required.

## Review Follow-Through

This PR intentionally stops before complete-signature search, namespace presentation, profile pins, or provider-specific behavior. Those remain separately reviewable slices in #7405, with #7353 defining the Anthropic-native boundary.

---

**Review track**: A (docs/tests/chore)
