### PR TITLE
feat(tool-search): make deferred-tool retrieval a swappable provider

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
@@ -671,7 +671,17 @@ fn reborn_contracts_crates_carry_a_checked_size_ceiling() {
         // hand-synced now lives once on the contract type (its callers in
         // composition and loop_host DELETED their copies). Reason recorded
         // in the PR body; count read from this test's failure message.
-        ("ironclaw_loop_contracts", 13_107),
+        // 13_107 -> 13_246 (2026-08-09, swappable deferred-tool retrieval):
+        // +139 lines for the `ToolRetrievalProvider`/`ToolRetrievalIndex` port
+        // behind `tool_search`, plus its `ToolSearchOutcome`/
+        // `ToolSearchQueryClass` DTOs. Declarations and the contracts an
+        // implementation must hold (authorization, determinism,
+        // confidentiality) — zero ranking logic: the bounded BM25F ranker stays
+        // whole in `ironclaw_loop_host::tool_search`, which is also the only
+        // crate that names it. Most of the added lines are those contract doc
+        // comments, which is the growth this tier is *for*. Count read from
+        // this test's own failure message.
+        ("ironclaw_loop_contracts", 13_246),
         // Raised 15_685 -> 15_758 by #7220 (operator inspector API): the growth
         // is bounded, output-only read-view descriptors. Capture, retention,
         // authorization, and transport behavior remain in their owning

--- a/crates/contracts/ironclaw_loop_contracts/README.md
+++ b/crates/contracts/ironclaw_loop_contracts/README.md
@@ -32,6 +32,12 @@ Almost purely trait + DTO, re-exported flat from `src/lib.rs`:
 - `RedactedCheckpointPayload` + `MAX_CHECKPOINT_STATE_PAYLOAD_BYTES`;
   loop-side error and safe-summary vocabulary (`AgentLoopHostError*`,
   `LoopSafeSummary`).
+- `ToolRetrievalProvider` / `ToolRetrievalIndex` (+ `ToolSearchOutcome`,
+  `ToolSearchQueryClass`) — the deferred-tool ranking port behind
+  `tool_search`, so a deployment can bind a retriever other than the
+  host-bundled BM25F one without any crate below `app` naming it. The module
+  docs carry the authorization, determinism, and confidentiality contracts an
+  implementation must hold.
 
 ## Depends on / consumed by
 

--- a/crates/contracts/ironclaw_loop_contracts/src/lib.rs
+++ b/crates/contracts/ironclaw_loop_contracts/src/lib.rs
@@ -46,6 +46,7 @@ mod skill_context;
 mod snapshot;
 mod snippet_ref;
 mod system_inference;
+mod tool_retrieval;
 
 pub use checkpoint_payload::{MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, RedactedCheckpointPayload};
 pub use compaction::{
@@ -151,4 +152,7 @@ pub use system_inference::{
     SystemInferenceError, SystemInferenceIdentity, SystemInferencePort, SystemInferenceRequest,
     SystemInferenceResponse, SystemInferenceTaskId, SystemPromptId, SystemPromptSource,
     SystemTaskKind,
+};
+pub use tool_retrieval::{
+    ToolRetrievalIndex, ToolRetrievalProvider, ToolSearchOutcome, ToolSearchQueryClass,
 };

--- a/crates/contracts/ironclaw_loop_contracts/src/tool_retrieval.rs
+++ b/crates/contracts/ironclaw_loop_contracts/src/tool_retrieval.rs
@@ -1,0 +1,135 @@
+//! Deferred-tool retrieval port for the agent loop host.
+//!
+//! This module defines the [`ToolRetrievalProvider`] / [`ToolRetrievalIndex`]
+//! pair — the loop-host port that ranks the authorized deferred-tool corpus for
+//! a `tool_search` bridge call. The host-bundled provider is a bounded BM25F
+//! ranker; this port is what lets a deployment bind a different one (a dense
+//! retriever, a hosted ranking service) without the loop host naming it.
+//!
+//! # Why two traits
+//!
+//! Ranking is fitted, not stateless. The host rebuilds the corpus only when the
+//! authorized surface actually changes (turn boundary, surface version, or
+//! definition fingerprint), then serves many `tool_search` calls against that
+//! one fitted corpus. Splitting "fit an index" from "search it" keeps that
+//! amortization in the port instead of forcing every provider to re-derive
+//! per-call state or cache behind an interior mutex.
+//!
+//! # Authorization contract
+//!
+//! [`ToolRetrievalProvider::fit`] is only ever handed the **effective
+//! authorized** definitions. Providers must not widen that set, and must not
+//! let a denied definition influence corpus statistics, ordering, or result
+//! counts — the caller relies on denied schemas being unable to affect IDF or
+//! rank. A provider that fetches externally must not transmit schemas it was
+//! not given.
+//!
+//! # Determinism contract
+//!
+//! For one fitted index, the same `(query, limit)` must produce the same
+//! [`ToolSearchOutcome`] — including the tie-break order between equal scores.
+//! Two runs over an identical corpus must rank identically; the loop host
+//! records search rank into turn state and a nondeterministic ranker would make
+//! disclosure order irreproducible.
+//!
+//! # Confidentiality contract
+//!
+//! Implementations must not log raw queries or schema text. The loop host emits
+//! only the query *class*, result count, and latency for exactly this reason.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use super::host::ProviderToolDefinition;
+
+/// How a provider classified the query it was given.
+///
+/// This is reported in host telemetry in place of the raw query, so it must
+/// stay coarse enough to be non-identifying.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolSearchQueryClass {
+    /// The query matched a tool's exact identifier (capability id or provider
+    /// tool name), so ranking was an identifier lookup rather than retrieval.
+    ExactIdentifier,
+    /// The query was ranked lexically/semantically against the corpus.
+    Lexical,
+    /// Nothing matched, or the query carried no usable terms.
+    NoMatch,
+}
+
+impl ToolSearchQueryClass {
+    /// Stable telemetry label. Kept as an explicit match so a new variant has
+    /// to choose its label deliberately rather than inherit a derived name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExactIdentifier => "exact_identifier",
+            Self::Lexical => "lexical",
+            Self::NoMatch => "no_match",
+        }
+    }
+}
+
+/// The ranked result of one `tool_search` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolSearchOutcome {
+    /// Provider tool names, best match first, already truncated to the
+    /// requested limit.
+    pub names: Vec<String>,
+    /// How the query was classified, for telemetry.
+    pub query_class: ToolSearchQueryClass,
+}
+
+impl ToolSearchOutcome {
+    /// The empty outcome — no usable query terms, or nothing matched.
+    pub fn no_match() -> Self {
+        Self {
+            names: Vec::new(),
+            query_class: ToolSearchQueryClass::NoMatch,
+        }
+    }
+}
+
+/// An index fitted over one authorized deferred-tool corpus.
+///
+/// Held by the loop host for as long as the authorized surface is unchanged,
+/// and queried once per `tool_search` bridge call.
+pub trait ToolRetrievalIndex: Send + Sync + Debug {
+    /// Rank the fitted corpus against `query`, returning at most `limit` names.
+    ///
+    /// `limit` is already clamped by the caller. A `limit` of zero must return
+    /// [`ToolSearchOutcome::no_match`] rather than an unbounded result.
+    fn search(&self, query: &str, limit: usize) -> ToolSearchOutcome;
+}
+
+/// Fits a [`ToolRetrievalIndex`] over the authorized corpus.
+///
+/// One provider is bound per deployment and reused across turns; `fit` is
+/// called on every genuine surface change, so it must be cheap enough to run
+/// inside a turn and must not block on network I/O without a bound.
+pub trait ToolRetrievalProvider: Send + Sync + Debug {
+    /// Stable ranker identifier recorded in host telemetry (for example
+    /// `"bounded-bm25f-v1"`). Changing ranking behavior must change this, so a
+    /// trace can be attributed to the ranker that produced it.
+    fn ranker_version(&self) -> &str;
+
+    /// Fit an index over the **effective authorized** definitions.
+    ///
+    /// See the module-level authorization contract: the provider must treat
+    /// this slice as the complete and only corpus.
+    fn fit(&self, definitions: &[ProviderToolDefinition]) -> Arc<dyn ToolRetrievalIndex>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_class_labels_are_stable() {
+        assert_eq!(
+            ToolSearchQueryClass::ExactIdentifier.as_str(),
+            "exact_identifier"
+        );
+        assert_eq!(ToolSearchQueryClass::Lexical.as_str(), "lexical");
+        assert_eq!(ToolSearchQueryClass::NoMatch.as_str(), "no_match");
+    }
+}

--- a/crates/loop/ironclaw_loop_host/README.md
+++ b/crates/loop/ironclaw_loop_host/README.md
@@ -31,6 +31,11 @@ and the loop tier's system-prompt content assets.
 - Progressive tool disclosure (`tool_disclosure*.rs`): catalog/selector, the
   deferring `LoopCapabilityPort` decorator, the `REBORN_TOOL_DISCLOSURE`
   switch.
+- Deferred-tool retrieval (`tool_search.rs`): `NativeBm25fToolRetrieval`, the
+  host-bundled bounded BM25F ranker and the default binding for the
+  `ToolRetrievalProvider` port in `ironclaw_loop_contracts`. It is the only
+  ranker this crate names; a deployment binds another through
+  `ToolDisclosureCapabilityDecorator::with_retrieval_provider`.
 - Prompt-context builders (`identity_context.rs`, `skill_context.rs`) and
   `skill_activation/` (the dissolved `ironclaw_first_party_extension_ports`
   crate, WS8).

--- a/crates/loop/ironclaw_loop_host/src/lib.rs
+++ b/crates/loop/ironclaw_loop_host/src/lib.rs
@@ -183,6 +183,7 @@ pub use tool_diagnostics::{HostManagedToolDiagnosticEmitter, PreparedToolDiagnos
 pub use tool_disclosure::bridge_capability_ids;
 pub use tool_disclosure_mode::{REBORN_TOOL_DISCLOSURE_ENV, ToolDisclosureMode};
 pub use tool_disclosure_port::ToolDisclosureCapabilityDecorator;
+pub use tool_search::NativeBm25fToolRetrieval;
 pub use user_profile_context::{EmptyUserProfileSource, HostUserProfileSource};
 pub const COMPACTION_SYSTEM_PROMPT: &str =
     include_str!("../prompts/compaction_summarizer_fresh.md");

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -15,7 +15,8 @@ use ironclaw_loop_contracts::{
     CapabilityInputRef, CapabilityProgress, CapabilitySurfaceVersion, LoopCapabilityPort,
     LoopRequest, LoopRequestBatch, LoopRunContext, ProviderToolCall, ProviderToolCallCapabilityIds,
     ProviderToolCallReplay, ProviderToolDefinition, RegisterProviderToolCallRequest,
-    VisibleCapabilityRequest, VisibleCapabilitySurface, resolution,
+    ToolRetrievalIndex, ToolRetrievalProvider, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    resolution,
 };
 use ironclaw_turns::{CapabilityActivityId, TurnId};
 use serde_json::{Value, json};
@@ -27,7 +28,7 @@ use crate::tool_disclosure::{
     is_bridge_capability_id, is_bridge_name, select_active_set,
 };
 use crate::tool_search::{
-    AuthorizedToolSearchIndex, MAX_SEARCH_QUERY_BYTES, definitions_fingerprint,
+    MAX_SEARCH_QUERY_BYTES, NativeBm25fToolRetrieval, definitions_fingerprint,
 };
 
 const DISCLOSURE_INPUT_PREFIX: &str = "input:tool-disclosure:";
@@ -53,6 +54,7 @@ pub struct ToolDisclosureCapabilityDecorator {
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     promoted_by_scope: Arc<Mutex<HashMap<PromotionScopeKey, PromotedSet>>>,
     caps: DisclosureCaps,
+    retrieval: Arc<dyn ToolRetrievalProvider>,
 }
 
 impl ToolDisclosureCapabilityDecorator {
@@ -61,7 +63,18 @@ impl ToolDisclosureCapabilityDecorator {
             result_writer,
             promoted_by_scope: Arc::new(Mutex::new(HashMap::new())),
             caps: DisclosureCaps::default(),
+            retrieval: Arc::new(NativeBm25fToolRetrieval),
         }
+    }
+
+    /// Bind a different deferred-tool ranker.
+    ///
+    /// The default is the host-bundled BM25F provider, so omitting this leaves
+    /// ranking behavior exactly as it was. Composition is the layer expected to
+    /// call this; nothing below it names a concrete provider.
+    pub fn with_retrieval_provider(mut self, retrieval: Arc<dyn ToolRetrievalProvider>) -> Self {
+        self.retrieval = retrieval;
+        self
     }
 
     /// Wrap one run's capability port with disclosure using the exact
@@ -79,6 +92,7 @@ impl ToolDisclosureCapabilityDecorator {
             promoted_by_scope: Arc::clone(&self.promoted_by_scope),
             caps: self.caps,
             policy,
+            retrieval: Arc::clone(&self.retrieval),
             turn_state: Mutex::new(None),
             bridge_inputs: Mutex::new(BTreeMap::new()),
             tool_call_target_inputs: Mutex::new(BTreeMap::new()),
@@ -97,6 +111,10 @@ struct ToolDisclosureCapabilityPort {
     /// tool_search/tool_describe metadata *and* the tool_search bridge's own
     /// advertised description (the always-on catalog index).
     policy: Arc<CapabilitySurfacePolicy>,
+    /// The bound deferred-tool ranker. Defaults to the host-bundled BM25F
+    /// provider; a deployment may bind another through
+    /// [`ToolDisclosureCapabilityDecorator::with_retrieval_provider`].
+    retrieval: Arc<dyn ToolRetrievalProvider>,
     turn_state: Mutex<Option<ToolDisclosureTurnState>>,
     bridge_inputs: Mutex<BTreeMap<String, BridgeInvocation>>,
     tool_call_target_inputs: Mutex<BTreeMap<String, CapabilityId>>,
@@ -113,7 +131,9 @@ struct ToolDisclosureTurnState {
     definitions_fingerprint: u64,
     surface_version: Option<CapabilitySurfaceVersion>,
     catalog: CapabilityCatalog,
-    search_index: AuthorizedToolSearchIndex,
+    /// Fitted by the bound [`ToolRetrievalProvider`]; the host holds only the
+    /// port type, never a concrete ranker.
+    search_index: Arc<dyn ToolRetrievalIndex>,
     active: ActiveSet,
     disclosed_names: BTreeSet<String>,
     search_ranks: BTreeMap<String, usize>,
@@ -609,7 +629,8 @@ impl ToolDisclosureCapabilityPort {
             .into_iter()
             .filter(|definition| authorized_capability_ids.contains(&definition.capability_id))
             .collect();
-        let fingerprint = definitions_fingerprint(&authorized_definitions);
+        let fingerprint =
+            definitions_fingerprint(self.retrieval.ranker_version(), &authorized_definitions);
         let mut guard = self.lock_turn_state()?;
         // Fit and cache retrieval only over the effective authorized corpus.
         // Denied schemas therefore cannot affect IDF, ordering, counts, cache
@@ -629,9 +650,10 @@ impl ToolDisclosureCapabilityPort {
         if rebuild {
             let index_started_at = std::time::Instant::now();
             let catalog = CapabilityCatalog::new(&authorized_definitions, &[]);
-            let search_index = AuthorizedToolSearchIndex::new(authorized_definitions.iter());
+            let search_index = self.retrieval.fit(&authorized_definitions);
             debug!(
                 target: "ironclaw::reborn::tool_search",
+                ranker_version = self.retrieval.ranker_version(),
                 authorized_document_count = authorized_definitions.len(),
                 index_build_micros = index_started_at.elapsed().as_micros(),
                 metadata_fingerprint = fingerprint,
@@ -1472,7 +1494,7 @@ mod tests {
     };
     use ironclaw_loop_contracts::{
         CapabilityDescriptorView, ConcurrencyHint, InMemoryRunProfileResolver, ResolvedRunProfile,
-        RunProfileResolutionRequest, RunProfileResolver,
+        RunProfileResolutionRequest, RunProfileResolver, ToolSearchOutcome,
     };
     use ironclaw_turns::{LoopResultRef, TurnRunId, TurnScope};
 
@@ -3488,6 +3510,113 @@ mod tests {
         );
     }
 
+    /// Drive one `tool_search` call through the port and return the emitted
+    /// result names in rank order.
+    async fn search_names(
+        port: &ToolDisclosureCapabilityPort,
+        outputs: &Mutex<Vec<Value>>,
+    ) -> Vec<String> {
+        port.visible_capabilities(VisibleCapabilityRequest)
+            .await
+            .expect("surface builds turn state");
+        let candidate = port
+            .register_provider_tool_call(RegisterProviderToolCallRequest::new(provider_call(
+                TOOL_SEARCH_NAME,
+                json!({"query": "read a file"}),
+            )))
+            .await
+            .expect("tool_search registers");
+        port.invoke_capability(LoopRequest {
+            activity_id: candidate.activity_id,
+            surface_version: candidate.surface_version,
+            capability_id: candidate.capability_id,
+            input_ref: candidate.input_ref,
+            approval_resume: None,
+            auth_resume: None,
+        })
+        .await
+        .expect("tool_search invokes");
+
+        let captured = outputs.lock().expect("capture is not poisoned");
+        let output = captured.last().expect("tool_search wrote a result");
+        output
+            .get("results")
+            .and_then(Value::as_array)
+            .expect("tool_search output carries results")
+            .iter()
+            .filter_map(|entry| entry.get("name").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn three_tool_spy() -> Arc<SpyPort> {
+        Arc::new(SpyPort {
+            definitions: vec![
+                provider_definition("fixture.read_file", "read_file", "Read a file"),
+                provider_definition("fixture.write_file", "write_file", "Write a file"),
+                provider_definition("fixture.send_email", "send_email", "Send an email"),
+            ],
+            surface_version: CapabilitySurfaceVersion::new("surface:retrieval-swap")
+                .expect("valid surface version"),
+            registered_calls: Mutex::new(Vec::new()),
+            invocations: Mutex::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn tool_search_ranks_with_the_bound_retrieval_provider_not_the_native_one() {
+        // Control: the host-bundled BM25F ranker puts the lexically-closest
+        // tool first for this query.
+        let native_outputs = Arc::new(Mutex::new(Vec::new()));
+        let native_port = disclosure_port_with(
+            three_tool_spy() as Arc<dyn LoopCapabilityPort>,
+            run_context(TurnId::new()).await,
+            Arc::new(CapturingWriter {
+                outputs: Arc::clone(&native_outputs),
+            }),
+            Arc::new(NativeBm25fToolRetrieval),
+        );
+        let native_names = search_names(&native_port, &native_outputs).await;
+        assert_eq!(
+            native_names.first().map(String::as_str),
+            Some("read_file"),
+            "native BM25F should rank the matching tool first"
+        );
+
+        // Swapped: the same corpus and query, ranked by the bound provider.
+        let fitted_corpus_sizes = Arc::new(Mutex::new(Vec::new()));
+        let swapped_outputs = Arc::new(Mutex::new(Vec::new()));
+        let swapped_port = disclosure_port_with(
+            three_tool_spy() as Arc<dyn LoopCapabilityPort>,
+            run_context(TurnId::new()).await,
+            Arc::new(CapturingWriter {
+                outputs: Arc::clone(&swapped_outputs),
+            }),
+            Arc::new(FixedRankingRetrieval {
+                order: vec!["send_email".to_string(), "write_file".to_string()],
+                fitted_corpus_sizes: Arc::clone(&fitted_corpus_sizes),
+            }),
+        );
+        let swapped_names = search_names(&swapped_port, &swapped_outputs).await;
+
+        assert_eq!(
+            swapped_names,
+            vec!["send_email".to_string(), "write_file".to_string()],
+            "the bound provider's ranking must be what tool_search returns"
+        );
+        assert_ne!(
+            native_names, swapped_names,
+            "the swap must actually change ranking, or this test proves nothing"
+        );
+        assert_eq!(
+            *fitted_corpus_sizes
+                .lock()
+                .expect("fit recorder is not poisoned"),
+            vec![3],
+            "the provider is fitted once over the whole authorized corpus"
+        );
+    }
+
     #[tokio::test]
     async fn tool_search_rejects_missing_non_string_or_blank_query() {
         let inner = Arc::new(SpyPort {
@@ -3548,6 +3677,94 @@ mod tests {
         }
     }
 
+    /// Records every `fit` it is handed and ranks by a caller-supplied order,
+    /// so a test can tell the bound provider's ranking apart from BM25F's.
+    #[derive(Debug)]
+    struct FixedRankingRetrieval {
+        order: Vec<String>,
+        fitted_corpus_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    #[derive(Debug)]
+    struct FixedRankingIndex {
+        order: Vec<String>,
+    }
+
+    impl ToolRetrievalIndex for FixedRankingIndex {
+        fn search(&self, _query: &str, limit: usize) -> ToolSearchOutcome {
+            ToolSearchOutcome {
+                names: self.order.iter().take(limit).cloned().collect(),
+                query_class: ironclaw_loop_contracts::ToolSearchQueryClass::Lexical,
+            }
+        }
+    }
+
+    impl ToolRetrievalProvider for FixedRankingRetrieval {
+        fn ranker_version(&self) -> &str {
+            "fixed-ranking-test-v1"
+        }
+
+        fn fit(&self, definitions: &[ProviderToolDefinition]) -> Arc<dyn ToolRetrievalIndex> {
+            self.fitted_corpus_sizes
+                .lock()
+                .expect("fit recorder is not poisoned")
+                .push(definitions.len());
+            Arc::new(FixedRankingIndex {
+                order: self.order.clone(),
+            })
+        }
+    }
+
+    /// Captures the bridge output so a test can read what `tool_search` emitted.
+    struct CapturingWriter {
+        outputs: Arc<Mutex<Vec<Value>>>,
+    }
+
+    #[async_trait]
+    impl LoopCapabilityResultWriter for CapturingWriter {
+        async fn write_capability_result(
+            &self,
+            write: CapabilityResultWrite<'_>,
+        ) -> Result<CapabilityWriteResult, AgentLoopHostError> {
+            self.outputs
+                .lock()
+                .expect("output capture is not poisoned")
+                .push(write.output.clone());
+            let result_digest = ironclaw_host_api::approval::sha256_digest_token(
+                write.input_ref.as_str().as_bytes(),
+            )
+            .replace(':', ".");
+            Ok(CapabilityWriteResult::without_output_digest(
+                LoopResultRef::new(format!("result:{result_digest}")).expect("valid result ref"),
+                write.output.to_string().len() as u64,
+            ))
+        }
+    }
+
+    fn disclosure_port_with(
+        inner: Arc<dyn LoopCapabilityPort>,
+        run_context: LoopRunContext,
+        result_writer: Arc<dyn LoopCapabilityResultWriter>,
+        retrieval: Arc<dyn ToolRetrievalProvider>,
+    ) -> ToolDisclosureCapabilityPort {
+        ToolDisclosureCapabilityPort {
+            inner,
+            run_context,
+            result_writer,
+            promoted_by_scope: Arc::new(Mutex::new(HashMap::new())),
+            caps: DisclosureCaps {
+                max_tokens: u32::MAX,
+                max_tools: 5,
+                ctx_limit: None,
+            },
+            policy: Arc::new(CapabilitySurfacePolicy::allow_all()),
+            retrieval,
+            turn_state: Mutex::new(None),
+            bridge_inputs: Mutex::new(BTreeMap::new()),
+            tool_call_target_inputs: Mutex::new(BTreeMap::new()),
+        }
+    }
+
     fn disclosure_port(
         inner: Arc<dyn LoopCapabilityPort>,
         run_context: LoopRunContext,
@@ -3566,6 +3783,7 @@ mod tests {
             // Unnarrowed — unit tests here exercise disclosure mechanics, not
             // profile narrowing (that's the integration tier).
             policy: Arc::new(CapabilitySurfacePolicy::allow_all()),
+            retrieval: Arc::new(NativeBm25fToolRetrieval),
             turn_state: Mutex::new(None),
             bridge_inputs: Mutex::new(BTreeMap::new()),
             tool_call_target_inputs: Mutex::new(BTreeMap::new()),

--- a/crates/loop/ironclaw_loop_host/src/tool_search.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_search.rs
@@ -6,8 +6,11 @@ use std::{
 };
 
 use ironclaw_host_api::{capability::CapabilityDescriptionTrust, ids::CapabilityId};
-use ironclaw_loop_contracts::ProviderToolDefinition;
+use ironclaw_loop_contracts::{
+    ProviderToolDefinition, ToolRetrievalIndex, ToolRetrievalProvider, ToolSearchOutcome,
+};
 use serde_json::Value;
+use std::sync::Arc;
 
 pub(crate) const MAX_SEARCH_QUERY_BYTES: usize = 1_024;
 const MAX_QUERY_TERMS: usize = 32;
@@ -43,27 +46,35 @@ struct IndexedDocument {
     length: f64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SearchQueryClass {
-    ExactIdentifier,
-    Lexical,
-    NoMatch,
-}
+/// The query classes and outcome shape now live in `ironclaw_loop_contracts`
+/// so a bound provider outside this crate can produce them. Aliased here so the
+/// module (and its tests) keep reading in the local vocabulary.
+pub(crate) use ironclaw_loop_contracts::ToolSearchOutcome as SearchOutcome;
+pub(crate) use ironclaw_loop_contracts::ToolSearchQueryClass as SearchQueryClass;
 
-impl SearchQueryClass {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ExactIdentifier => "exact_identifier",
-            Self::Lexical => "lexical",
-            Self::NoMatch => "no_match",
-        }
+/// The host-bundled ranker: bounded BM25F over name, provider, parameters and
+/// description, with an exact-identifier short circuit.
+///
+/// This is the default binding for [`ToolRetrievalProvider`] and the only
+/// ranker this crate names. A deployment that binds a different provider gets
+/// its ranking instead, with no change here.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeBm25fToolRetrieval;
+
+impl ToolRetrievalProvider for NativeBm25fToolRetrieval {
+    fn ranker_version(&self) -> &str {
+        RANKER_VERSION
+    }
+
+    fn fit(&self, definitions: &[ProviderToolDefinition]) -> Arc<dyn ToolRetrievalIndex> {
+        Arc::new(AuthorizedToolSearchIndex::new(definitions.iter()))
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SearchOutcome {
-    pub(crate) names: Vec<String>,
-    pub(crate) query_class: SearchQueryClass,
+impl ToolRetrievalIndex for AuthorizedToolSearchIndex {
+    fn search(&self, query: &str, limit: usize) -> ToolSearchOutcome {
+        AuthorizedToolSearchIndex::search(self, query, limit)
+    }
 }
 
 impl AuthorizedToolSearchIndex {
@@ -99,10 +110,7 @@ impl AuthorizedToolSearchIndex {
 
     pub(crate) fn search(&self, query: &str, limit: usize) -> SearchOutcome {
         if limit == 0 {
-            return SearchOutcome {
-                names: Vec::new(),
-                query_class: SearchQueryClass::NoMatch,
-            };
+            return SearchOutcome::no_match();
         }
         let normalized_query = query.trim().to_lowercase();
         let query_terms: Vec<String> = tokenize(&normalized_query)
@@ -110,10 +118,7 @@ impl AuthorizedToolSearchIndex {
             .take(MAX_QUERY_TERMS)
             .collect();
         if query_terms.is_empty() {
-            return SearchOutcome {
-                names: Vec::new(),
-                query_class: SearchQueryClass::NoMatch,
-            };
+            return SearchOutcome::no_match();
         }
 
         let exact = self
@@ -358,11 +363,18 @@ fn tokenize(value: &str) -> Vec<String> {
 
 /// Stable for a fixed ranker version and effective authorized metadata. Object
 /// keys are sorted recursively so semantically identical schemas share a key.
-pub(crate) fn definitions_fingerprint(definitions: &[ProviderToolDefinition]) -> u64 {
+///
+/// `ranker_version` comes from the *bound* provider rather than a constant, so
+/// rebinding retrieval invalidates a cached index instead of silently serving
+/// the previous ranker's fitted corpus.
+pub(crate) fn definitions_fingerprint(
+    ranker_version: &str,
+    definitions: &[ProviderToolDefinition],
+) -> u64 {
     let mut definitions: Vec<_> = definitions.iter().collect();
     definitions.sort_by(|left, right| left.capability_id.cmp(&right.capability_id));
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    RANKER_VERSION.hash(&mut hasher);
+    ranker_version.hash(&mut hasher);
     definitions.len().hash(&mut hasher);
     for definition in definitions {
         definition.capability_id.hash(&mut hasher);
@@ -742,13 +754,37 @@ mod tests {
         );
 
         assert_eq!(
-            definitions_fingerprint(std::slice::from_ref(&first)),
-            definitions_fingerprint(&[reordered])
+            definitions_fingerprint(RANKER_VERSION, std::slice::from_ref(&first)),
+            definitions_fingerprint(RANKER_VERSION, &[reordered])
         );
         assert_ne!(
-            definitions_fingerprint(&[first]),
-            definitions_fingerprint(&[changed])
+            definitions_fingerprint(RANKER_VERSION, &[first]),
+            definitions_fingerprint(RANKER_VERSION, &[changed])
         );
+    }
+
+    #[test]
+    fn fingerprint_separates_rankers_over_an_identical_corpus() {
+        // Rebinding retrieval must invalidate a cached fitted index. If the
+        // fingerprint ignored the ranker, a swapped provider would keep serving
+        // the previous ranker's index until the surface happened to change.
+        let corpus = [definition(
+            "fixture.lookup",
+            "fixture__lookup",
+            "Lookup.",
+            json!({"type":"object","properties":{"city":{"type":"string"}}}),
+            CapabilityDescriptionTrust::Untrusted,
+        )];
+
+        assert_ne!(
+            definitions_fingerprint(RANKER_VERSION, &corpus),
+            definitions_fingerprint("some-other-ranker-v1", &corpus)
+        );
+    }
+
+    #[test]
+    fn native_provider_reports_the_ranker_version_it_fingerprints_with() {
+        assert_eq!(NativeBm25fToolRetrieval.ranker_version(), RANKER_VERSION);
     }
 
     #[test]
@@ -769,8 +805,8 @@ mod tests {
         );
 
         assert_eq!(
-            definitions_fingerprint(&[first.clone(), second.clone()]),
-            definitions_fingerprint(&[second, first])
+            definitions_fingerprint(RANKER_VERSION, &[first.clone(), second.clone()]),
+            definitions_fingerprint(RANKER_VERSION, &[second, first])
         );
     }
 


### PR DESCRIPTION
## Reborn: make deferred-tool retrieval a swappable provider

Follows the seam [#6345](https://github.com/nearai/ironclaw/pull/6345) established for memory: the host depends on a **port**, the host-bundled implementation becomes one *binding* of it, and nothing below `app` names a concrete provider. This does the same for the ranker behind `tool_search`.

Today `AuthorizedToolSearchIndex` is a concrete `pub(crate)` type constructed inline in `tool_disclosure_port.rs`. It is a good ranker — bounded BM25F, field-weighted, IDF, length-normalized — but it is the *only* ranker reachable, and swapping it means editing the loop host. A deployment that wants a dense retriever, a hosted ranking service, or a domain-tuned index has no seam to bind one through.

### The port

`ironclaw_loop_contracts::tool_retrieval` — declarations only, no ranking logic:

- `ToolRetrievalProvider::fit(&[ProviderToolDefinition]) -> Arc<dyn ToolRetrievalIndex>`
- `ToolRetrievalIndex::search(&str, limit) -> ToolSearchOutcome`
- `ToolSearchOutcome` / `ToolSearchQueryClass` (moved from `tool_search.rs`, which now aliases them so the module and its tests keep their local vocabulary)

**Why two traits rather than one `rank(query, corpus)` call.** Ranking is fitted, not stateless. The host already rebuilds the corpus only on a genuine surface change (turn boundary, surface version, or definition fingerprint) and then serves many `tool_search` calls against that one fitted corpus. Splitting fit from search keeps that amortization in the port, instead of forcing every provider to re-derive per-call state or hide a cache behind interior mutability.

The module docs carry the three contracts an implementation must hold, each of which the current ranker already satisfies and a careless replacement would not:

- **Authorization** — `fit` is only ever handed the effective authorized definitions; a provider must not widen that set, and denied schemas must not reach corpus statistics, ordering, or counts.
- **Determinism** — one fitted index must rank a given `(query, limit)` identically every time, tie-breaks included. The host records search rank into turn state, so a nondeterministic ranker makes disclosure order irreproducible.
- **Confidentiality** — no logging of raw queries or schema text. This is why the host emits only query *class*, count, and latency.

### Wiring

- `NativeBm25fToolRetrieval` in `ironclaw_loop_host::tool_search` implements the port over the existing index. The ranker's code is untouched — it moved behind a trait, it did not change.
- `ToolDisclosureCapabilityDecorator::new` binds it by default, so **behavior is identical unless a deployment opts out**. `with_retrieval_provider(...)` is the opt-out.
- `ToolDisclosureTurnState::search_index` is now `Arc<dyn ToolRetrievalIndex>`; the host holds the port type only.

### One real behavior change: the fingerprint covers the ranker

`definitions_fingerprint` hashed the `RANKER_VERSION` *constant*. With a bindable provider that is a latent bug — rebinding retrieval would leave the cached fitted index in place until the surface happened to change, silently serving the previous ranker's results. It now takes the bound provider's `ranker_version()`. Covered by `fingerprint_separates_rankers_over_an_identical_corpus`.

The rebuild log line gained a `ranker_version` field so a trace can be attributed to the ranker that produced it.

### Tests

- `tool_search_ranks_with_the_bound_retrieval_provider_not_the_native_one` — the swap test. Same corpus and query through both bindings; asserts the native ranking, asserts the bound provider's ranking is what `tool_search` actually returns, asserts the two differ (so the test cannot pass vacuously), and asserts the provider was fitted exactly once over the whole authorized corpus.
- `fingerprint_separates_rankers_over_an_identical_corpus`, `native_provider_reports_the_ranker_version_it_fingerprints_with`.
- All 922 existing `ironclaw_loop_host` tests pass unchanged — including `committed_corpus_quality_gate_and_benchmark_report`, the retrieval-quality gate, which is the load-bearing evidence that the default binding did not shift ranking.

### Architecture ratchet raised

`reborn_contracts_crates_carry_a_checked_size_ceiling`: `ironclaw_loop_contracts` 13_107 → 13_246 (+139). `main` sits exactly at its ceiling, so this is an explicit raise, per the gate's own instruction to record the reason here.

The growth is the port traits, two DTOs, and the contract doc comments above — no ranking logic crossed the tier. The BM25F implementation stays whole in `ironclaw_loop_host::tool_search`, still the only crate in the workspace that names it. I first cut ~35 lines of speculative surface from this module (an `Empty*` no-op provider pair with no caller in this PR) rather than ratchet for API nothing uses; `ToolSearchOutcome::no_match()` survived because the native ranker now uses it for its two early returns.

**No provider-neutrality dependency gate yet, deliberately.** The memory analogue (`only_the_sanctioned_residue_names_a_memory_provider`) polices crate *edges*, and exists because the memory providers are separate packages. This PR adds no second provider crate, so that gate would have nothing to measure. It belongs with the first alternate provider, which is where the `[tool_retrieval]` binding config also belongs — a binding policy selecting between one option is dead config.

### Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ironclaw_loop_contracts -p ironclaw_loop_host --all-targets -- -D warnings` — zero warnings
- `cargo check --workspace --tests` — clean
- `cargo test -p ironclaw_loop_host` — 922 passed, 0 failed
- `cargo test -p ironclaw_architecture_tests` — green with the ratchet above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
