### PR TITLE
fix(ci): clear inherited main check failures

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -467,6 +467,7 @@ jobs:
         run: corepack enable pnpm
       - name: Install WebUI frontend dependencies
         if: contains(matrix.flags, '--all-features')
+        shell: bash
         run: |
           set -euo pipefail
           webui_dir="$(bash scripts/ci/crate-dir.sh ironclaw_webui)"

--- a/crates/domains/ironclaw_trace_commons/src/contribution/tests/privacy.rs
+++ b/crates/domains/ironclaw_trace_commons/src/contribution/tests/privacy.rs
@@ -1,7 +1,9 @@
 //! Policy preflight, deterministic redaction, the privacy-filter adapter and its canary, and per-tool payload redaction.
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use ironclaw_llm::recording::{TraceFile, TraceResponse};

--- a/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -3964,6 +3964,34 @@ async fn set_notification_channels_accepts_empty_list() {
 }
 
 #[tokio::test]
+async fn set_notification_channels_rejects_missing_target_ids_before_dispatch() {
+    let services = Arc::new(StubServices::default());
+    let router = router_with(services.clone());
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/webchat/v2/outbound/notification-channels")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{}"#))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(
+        services
+            .set_notification_channels_calls
+            .lock()
+            .expect("lock")
+            .is_empty(),
+        "a missing target_ids field must fail closed before service dispatch"
+    );
+}
+
+#[tokio::test]
 async fn list_outbound_delivery_targets_uses_product_view() {
     let services = Arc::new(StubServices::default());
     let router = router_with(services.clone());

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -24,12 +24,14 @@ from ws12_workflow_contracts import (
     WEBUI_NESTED_LOCKFILE_PATTERN,
     crate_directory,
     github_glob_to_regex,
+    job_body,
     load_workflows,
     step_body,
     validate_crate_name_residue,
     validate_crate_scope_filters,
     validate_e2e_scope_filters,
     validate_production_lint_targets,
+    validate_windows_webui_install_shell,
     validate_webui_frontend_sites,
     validate_workflow_texts,
 )
@@ -163,6 +165,22 @@ class WorkflowContractSabotageTests(unittest.TestCase):
         self.assertEqual(
             validate_production_lint_targets(self.workflows[CODE_STYLE_WORKFLOW]), []
         )
+
+    def test_windows_webui_install_step_requires_bash(self) -> None:
+        workflow = self.workflows[CODE_STYLE_WORKFLOW]
+        windows_job = job_body(workflow, "clippy-windows")
+        self.assertIsNotNone(windows_job)
+        self.assertEqual(validate_windows_webui_install_shell(workflow), [])
+
+        sabotaged_job = (windows_job or "").replace("        shell: bash\n", "")
+        self.assertNotEqual(sabotaged_job, windows_job)
+        sabotaged = dict(self.workflows)
+        sabotaged[CODE_STYLE_WORKFLOW] = workflow.replace(
+            windows_job or "", sabotaged_job, 1
+        )
+
+        errors = validate_workflow_texts(sabotaged)
+        self.assertTrue(any("must run" in error for error in errors), errors)
 
     def test_target_filters_on_the_production_lint_fail_loudly(self) -> None:
         """Every explicit target selector, in bare and value-bearing form.

--- a/scripts/ci/ws12_workflow_contracts.py
+++ b/scripts/ci/ws12_workflow_contracts.py
@@ -291,11 +291,14 @@ def validate_code_style_docs_guard_order(text: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 PRODUCTION_LINT_STEP = "Check production-target lints"
+WINDOWS_CLIPPY_JOB = "clippy-windows"
+WEBUI_INSTALL_STEP = "Install WebUI frontend dependencies"
 
 # One `- name:` step heading. The scan is bounded to its own step because the
 # neighbouring `Check all-target lints` legitimately passes `--tests
 # --examples`; unbounded, this contract would blame this step for them.
 STEP_HEADING = re.compile(r"^[ \t]*- name: (?P<name>.+)$", re.MULTILINE)
+JOB_HEADING = re.compile(r"^  (?P<name>[a-zA-Z0-9_-]+):[ \t]*$", re.MULTILINE)
 
 # `${{ matrix.flags }}` is the lane's other flag channel: `clippy_matrix` is
 # defined in this same workflow and expands into the command, so a target
@@ -345,6 +348,38 @@ def step_body(text: str, step_name: str) -> str | None:
         following = STEP_HEADING.search(text, heading.end())
         return text[heading.end() : following.start() if following else len(text)]
     return None
+
+
+def job_body(text: str, job_name: str) -> str | None:
+    """Return one workflow job's body, bounded by the next job heading."""
+    for heading in JOB_HEADING.finditer(text):
+        if heading.group("name") != job_name:
+            continue
+        following = JOB_HEADING.search(text, heading.end())
+        return text[heading.end() : following.start() if following else len(text)]
+    return None
+
+
+def validate_windows_webui_install_shell(text: str) -> list[str]:
+    """Keep POSIX WebUI setup commands out of PowerShell on Windows."""
+    windows_job = job_body(text, WINDOWS_CLIPPY_JOB)
+    if windows_job is None:
+        return [
+            f"{CODE_STYLE_WORKFLOW}: could not find the {WINDOWS_CLIPPY_JOB!r} job"
+        ]
+    install_step = step_body(windows_job, WEBUI_INSTALL_STEP)
+    if install_step is None:
+        return [
+            f"{CODE_STYLE_WORKFLOW}: {WINDOWS_CLIPPY_JOB!r} has no "
+            f"{WEBUI_INSTALL_STEP!r} step"
+        ]
+    if re.search(r"^[ \t]*shell:[ \t]*bash[ \t]*$", install_step, re.MULTILINE):
+        return []
+    return [
+        f"{CODE_STYLE_WORKFLOW}: {WINDOWS_CLIPPY_JOB!r} must run "
+        f"{WEBUI_INSTALL_STEP!r} with `shell: bash` because its commands use "
+        "POSIX shell syntax"
+    ]
 
 
 def validate_production_lint_targets(text: str) -> list[str]:
@@ -1001,6 +1036,7 @@ def validate_workflow_texts(
     if code_style is not None:
         errors.extend(validate_production_lint_targets(code_style))
         errors.extend(validate_code_style_docs_guard_order(code_style))
+        errors.extend(validate_windows_webui_install_shell(code_style))
     errors.extend(validate_crate_scope_filters(workflows, root))
     errors.extend(validate_crate_name_residue(workflows, root))
     errors.extend(validate_webui_frontend_sites(workflows, root))

--- a/tests/e2e/scenarios/test_reborn_webui_v2_automation_trace_outbound_api.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_automation_trace_outbound_api.py
@@ -175,16 +175,15 @@ async def test_reborn_v2_outbound_targets_and_channels_served(
         # route frames unknown ids as validation (`notification_channel_not_found`).
         assert unknown_channel.status_code == 400, unknown_channel.text
 
-        # `target_ids` defaults to empty when omitted entirely (a bare `{}`
-        # is a valid "clear the set" request); a wrong-typed value is what
-        # must be rejected at deserialization.
+        # Omitting `target_ids` must fail closed rather than silently clearing
+        # every configured notification channel. An explicit empty list above
+        # is the only valid clear-all request.
         omitted_field = await client.post(
             f"{reborn_v2_server}/api/webchat/v2/outbound/notification-channels",
             json={},
             timeout=15,
         )
-        omitted_field.raise_for_status()
-        assert omitted_field.json() == {"channels": []}
+        assert omitted_field.status_code == 422, omitted_field.text
 
         malformed_channels_body = await client.post(
             f"{reborn_v2_server}/api/webchat/v2/outbound/notification-channels",

--- a/tests/integration/coverage-floor.toml
+++ b/tests/integration/coverage-floor.toml
@@ -253,11 +253,15 @@ issue = "https://github.com/nearai/ironclaw/issues/6524"
 
 [[crate]]
 name = "ironclaw_outbound"
-floor_percent = 93.49
-floor_covered_lines = 4105
-captured_total_lines = 4391
-captured_date = "2026-07-30"
-rationale = "Outbound scope authorization and delivery metadata must not cross actors."
+# RECAPTURED 2026-08-10 after #7157 deleted the stored delivery-heuristic and
+# result-handoff paths. Covered/total moved 4105/4391 -> 3519/3761 while the
+# ratio rose 93.49% -> 93.57%, so the absolute floor stopped describing the
+# crate without a coverage regression.
+floor_percent = 93.57
+floor_covered_lines = 3519
+captured_total_lines = 3761
+captured_date = "2026-08-10"
+rationale = "Outbound scope authorization and delivery metadata must not cross actors. Recaptured after #7157 deleted obsolete stored delivery-heuristic and result-handoff paths while measured coverage rose."
 issue = "https://github.com/nearai/ironclaw/issues/6524"
 
 [[crate]]
@@ -360,12 +364,17 @@ name = "ironclaw_extension_host"
 #    it reds on noise; `tolerance_lines` is raised to 60, sized to the
 #    observed spread with the same headroom ratio the 0.5pp percent tolerance
 #    carries. The percent floor (tolerance 0.5pp) stays the tight guard.
-floor_percent = 88.12
-floor_covered_lines = 21515
+#
+# RECAPTURED 2026-08-10 after #7377 removed shared-route subject binding from
+# this crate under the run-as-invoker model. Covered/total moved
+# 21515/24415 -> 21347/24278; the 0.19pp ratio movement remains inside the
+# measured 0.5pp tolerance, while the absolute numerator alone became stale.
+floor_percent = 87.93
+floor_covered_lines = 21347
 tolerance_lines = 60
-captured_total_lines = 24415
-captured_date = "2026-08-07"
-rationale = "Channel ingress deduplication and outbound delivery routing are production-composed. Recaptured after the WS2.4 extension_manager split, the WS2 closeout embed move, the #7143 deletion adjustment, and again 2026-08-07 as the source side of the post-8/04 moves — with tolerance_lines sized to the measured same-commit cross-lane wobble; see the blocks above."
+captured_total_lines = 24278
+captured_date = "2026-08-10"
+rationale = "Channel ingress deduplication and outbound delivery routing are production-composed. Recaptured after the WS2.4 extension_manager split, subsequent source-side moves, and #7377's shared-route subject-binding removal; tolerance_lines remains sized to measured same-commit cross-lane wobble."
 issue = "https://github.com/nearai/ironclaw/issues/6524"
 
 [[crate]]


### PR DESCRIPTION
## Summary

- Consolidate the shippable Windows fixes from #7417 while preserving italic-jinxin's commit authorship; omit that PR's probe-only branch trigger.
- Make the Windows all-features setup explicitly use Bash and keep the POSIX-only `Path` import Unix-gated, with a static workflow regression test.
- Update the outbound notification-channel E2E contract to require explicit `target_ids`, and add a caller-path handler test proving an omitted field fails before service dispatch.
- Recapture the `ironclaw_outbound` and `ironclaw_extension_host` coverage floors after the structural deletions in #7157 and #7377.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7417, #7157, #7377, #6524

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run workspace-wide; targeted all-feature/all-target clippy passed for `ironclaw_webui`, and test clippy passed for `ironclaw_trace_commons`.
- [x] `cargo build` — the shipping `ironclaw` binary was built by the focused E2E fixture.
- [x] Relevant tests pass: WebUI handler contract (3 tests), shipping-binary outbound API E2E (1 test), WS12 workflow contracts (53 tests), and the full `ironclaw_architecture_tests` suite.
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; no database-backed or runtime-integration behavior changed.
- [x] Manual testing: inspected the failing main run and verified each changed CI contract against the observed failure.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run; this PR is intentionally limited to CI/test corrections.

## Test Strategy

User behavior: Main CI should complete on Windows; an omitted notification-channel target list remains fail-closed; coverage ratchets should represent the current source tree without masking coverage loss.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added a WebUI handler contract proving `{}` returns 422 and never dispatches to the service; added static workflow coverage for Bash selection.
- Reborn integration: Not applicable: production behavior is unchanged.
- Recorded fixture: Not applicable: no model/provider behavior changed.
- Browser E2E: Updated the shipping-binary HTTP E2E scenario; no browser rendering changed.
- Backend or runtime: Not applicable: no backend/runtime implementation changed.
- Live canary: Not applicable: no external provider or deployment path changed.

What the tests prove: Windows CI executes Bash-only setup consistently; Unix-only test imports do not compile on Windows; missing `target_ids` cannot silently clear notification channels; the revised floor numerators and denominators match the latest measured coverage artifacts.

Commands run:
- `cargo fmt --all -- --check`
- `cargo clippy -p ironclaw_trace_commons --tests -- -D warnings`
- `cargo clippy -p ironclaw_webui --all-features --all-targets -- -D warnings`
- `python3 scripts/ci/test_ws12_workflow_contracts.py`
- `cargo test -p ironclaw_webui --test webui_v2_handlers_contract set_notification_channels`
- `cargo test -p ironclaw_architecture_tests`
- `pytest scenarios/test_reborn_webui_v2_automation_trace_outbound_api.py::test_reborn_v2_outbound_targets_and_channels_served -q`
- Coverage TOML parsed and exact recaptured values asserted with Python 3.11.
- `bash scripts/ci/test-reborn-coverage.sh`: all coverage merge/summary/ratchet cases passed; the local macOS Bash 3.2 runner could not execute 12 sticky-comment-only cases because it lacks `mapfile` (Linux CI owns those cases).

## Security Impact

No production security behavior changed. The new caller-path test pins the existing fail-closed deserialization boundary: an omitted `target_ids` field returns 422 before any service side effect.

## Reborn Trust-Boundary Checklist

N/A: no public trust-bearing types, prompts, hashes, status variants, serialization defaults, queues, errors, or sandbox boundaries changed. The only boundary-sensitive change is regression coverage for the existing required request field.

## Database Impact

None.

## Blast Radius

Windows Code Style jobs, the outbound notification-channel API E2E assertion, and coverage-ratchet metadata for `ironclaw_outbound` and `ironclaw_extension_host`. No production implementation changes.

## Rollback Plan

Revert this PR. That restores the previous test/floor metadata and Windows workflow setup, but also restores the current main CI failures.

## Review Follow-Through

This PR supersedes the shippable fixes in #7417; that PR's probe-only workflow trigger is deliberately excluded. If #7395, #7397, or #7398 lands first and changes the affected crates, rerun coverage and recapture the exact floor inputs before merge.

---

**Review track**: C (CI)
