### PR TITLE
fix(release): resolve candidates by package identity

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -204,6 +204,7 @@ jobs:
           python3 scripts/ci/test_ws12_workflow_contracts.py
           python3 scripts/ci/test-check-target-tree.py
           python3 scripts/ci/test-check-guidance.py
+          python3 scripts/ci/test_cut_ironclaw_release.py
           scripts/ci/test-hermetic-test-process.sh
           scripts/ci/test-reborn-docker-entrypoint.sh
           # #7144: this 204-test module had never been run by any lane, so five

--- a/scripts/ci/cut_ironclaw_release.py
+++ b/scripts/ci/cut_ironclaw_release.py
@@ -19,7 +19,7 @@ import tomllib
 # traceback with no actionable next step.
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
 try:
-    from crate_tree import CrateTreeError, crate_directory  # noqa: E402
+    from crate_tree import CrateTreeError, crate_directories  # noqa: E402
 except ImportError as error:  # pragma: no cover - deployment error, not logic
     raise SystemExit(
         "cut_ironclaw_release: cannot import scripts/ci/lib/crate_tree.py "
@@ -37,6 +37,7 @@ VERSION_PATTERN = re.compile(
 )
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 MAX_ANNOTATED_TAG_DEPTH = 8
+SHIPPING_PACKAGE_NAME = "ironclaw"
 
 
 class ReleaseTagError(RuntimeError):
@@ -166,22 +167,44 @@ def _checked_out_sha(candidate_root: Path) -> str:
 
 
 def _manifest_version(candidate_root: Path) -> str:
-    # Resolved by crate NAME through the shared inventory
-    # (scripts/ci/lib/crate_tree.py) against the CANDIDATE checkout, not a
-    # literal `crates/ironclaw_cli` path — the target-architecture
-    # family move (PROPOSAL §5) would otherwise make this raise FileNotFoundError
-    # (or, worse, silently resolve nothing) once the candidate commit has moved
-    # past the flat layout (docs/reborn/target-architecture/CHECKLIST.md WS10).
+    # Resolve the shipping Cargo PACKAGE through the candidate's crate
+    # inventory. Directory names are not a stable release contract: supported
+    # release branches use `ironclaw_reborn_cli`, while main uses
+    # `app/ironclaw_cli` after the target-architecture move.
     try:
-        crate_dir = crate_directory("ironclaw_cli", candidate_root)
+        crate_dirs = crate_directories(candidate_root)
     except CrateTreeError as error:
         raise ReleaseTagError(
-            "cannot resolve the ironclaw_cli crate in the candidate "
+            "cannot inventory crates in the candidate "
             f"checkout: {error}"
         ) from error
-    manifest = candidate_root / crate_dir / "Cargo.toml"
-    with manifest.open("rb") as manifest_file:
-        return str(tomllib.load(manifest_file)["package"]["version"])
+
+    matches: list[tuple[Path, dict[str, object]]] = []
+    for crate_dir in crate_dirs:
+        manifest = candidate_root / crate_dir / "Cargo.toml"
+        try:
+            with manifest.open("rb") as manifest_file:
+                document = tomllib.load(manifest_file)
+        except OSError as error:
+            raise ReleaseTagError(
+                f"cannot read candidate manifest {manifest}: {error}"
+            ) from error
+        package = document.get("package")
+        if isinstance(package, dict) and package.get("name") == SHIPPING_PACKAGE_NAME:
+            matches.append((manifest, package))
+
+    if len(matches) != 1:
+        paths = [str(manifest.relative_to(candidate_root)) for manifest, _ in matches]
+        raise ReleaseTagError(
+            f"expected exactly one candidate package named {SHIPPING_PACKAGE_NAME!r}, "
+            f"found {len(matches)}: {paths}"
+        )
+
+    manifest, package = matches[0]
+    version = package.get("version")
+    if not isinstance(version, str):
+        raise ReleaseTagError(f"candidate package manifest {manifest} has no version")
+    return version
 
 
 def main() -> int:

--- a/scripts/ci/cut_ironclaw_release.py
+++ b/scripts/ci/cut_ironclaw_release.py
@@ -6,26 +6,10 @@ import argparse
 import json
 import re
 import subprocess
-import sys
 from collections.abc import Callable
 from pathlib import Path
 
 import tomllib
-
-# This script is invoked from a "release-tools" checkout while it judges a
-# separate "candidate" checkout (see .github/workflows/cut-ironclaw-release.yml
-# and _manifest_version below), so — like scripts/ci/regression-test-check.py —
-# an import failure must say which file is missing rather than dump a
-# traceback with no actionable next step.
-sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
-try:
-    from crate_tree import CrateTreeError, crate_directories  # noqa: E402
-except ImportError as error:  # pragma: no cover - deployment error, not logic
-    raise SystemExit(
-        "cut_ironclaw_release: cannot import scripts/ci/lib/crate_tree.py "
-        f"({error}). The candidate's crate manifest is resolved through the "
-        "crate inventory and this script will not run without it."
-    ) from error
 
 NUMERIC_IDENTIFIER = r"(?:0|[1-9][0-9]*)"
 PRERELEASE_IDENTIFIER = r"(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
@@ -167,25 +151,55 @@ def _checked_out_sha(candidate_root: Path) -> str:
 
 
 def _manifest_version(candidate_root: Path) -> str:
-    # Resolve the shipping Cargo PACKAGE through the candidate's crate
-    # inventory. Directory names are not a stable release contract: supported
-    # release branches use `ironclaw_reborn_cli`, while main uses
-    # `app/ironclaw_cli` after the target-architecture move.
+    # Resolve the shipping Cargo PACKAGE through Cargo's authoritative
+    # workspace membership. Directory names are not a stable release contract:
+    # supported release branches use `ironclaw_reborn_cli`, while main uses
+    # `app/ironclaw_cli` after the target-architecture move. A filesystem scan
+    # is insufficient because it can include manifests cargo-dist will ignore.
+    candidate_root = candidate_root.resolve()
     try:
-        crate_dirs = crate_directories(candidate_root)
-    except CrateTreeError as error:
+        metadata_result = subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            cwd=candidate_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
         raise ReleaseTagError(
-            "cannot inventory crates in the candidate "
-            f"checkout: {error}"
+            f"cannot inventory Cargo workspace in the candidate checkout: {error}"
         ) from error
+    if metadata_result.returncode != 0:
+        raise ReleaseTagError(
+            "cannot inventory Cargo workspace in the candidate checkout: "
+            f"{metadata_result.stderr.strip()}"
+        )
+    try:
+        metadata = json.loads(metadata_result.stdout)
+        workspace_members = set(metadata["workspace_members"])
+        packages = metadata["packages"]
+    except (json.JSONDecodeError, KeyError, TypeError) as error:
+        raise ReleaseTagError(
+            f"cargo metadata returned an invalid workspace inventory: {error}"
+        ) from error
+    if not isinstance(packages, list):
+        raise ReleaseTagError("cargo metadata returned a non-list package inventory")
 
     matches: list[tuple[Path, dict[str, object]]] = []
-    for crate_dir in crate_dirs:
-        manifest = candidate_root / crate_dir / "Cargo.toml"
+    for metadata_package in packages:
+        if (
+            not isinstance(metadata_package, dict)
+            or metadata_package.get("id") not in workspace_members
+        ):
+            continue
+        manifest_path = metadata_package.get("manifest_path")
+        if not isinstance(manifest_path, str):
+            raise ReleaseTagError("candidate workspace package has no manifest path")
+        manifest = Path(manifest_path)
         try:
             with manifest.open("rb") as manifest_file:
                 document = tomllib.load(manifest_file)
-        except OSError as error:
+        except (OSError, tomllib.TOMLDecodeError) as error:
             raise ReleaseTagError(
                 f"cannot read candidate manifest {manifest}: {error}"
             ) from error
@@ -196,7 +210,8 @@ def _manifest_version(candidate_root: Path) -> str:
     if len(matches) != 1:
         paths = [str(manifest.relative_to(candidate_root)) for manifest, _ in matches]
         raise ReleaseTagError(
-            f"expected exactly one candidate package named {SHIPPING_PACKAGE_NAME!r}, "
+            "expected exactly one candidate workspace package named "
+            f"{SHIPPING_PACKAGE_NAME!r}, "
             f"found {len(matches)}: {paths}"
         )
 

--- a/scripts/ci/test_cut_ironclaw_release.py
+++ b/scripts/ci/test_cut_ironclaw_release.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import tempfile
 import unittest
@@ -17,11 +18,6 @@ release = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = release
 SPEC.loader.exec_module(release)
 
-# `release` imports crate_tree as a side effect of exec_module above (it
-# inserts scripts/ci/lib onto sys.path), so this import is safe here without
-# repeating the path insertion.
-import crate_tree  # noqa: E402
-
 VERSION = "1.1.0-rc.1"
 SHA = "a" * 40
 
@@ -33,21 +29,26 @@ def _write_candidate_manifest(
     *,
     package_name: str = "ironclaw",
 ) -> None:
-    """A candidate checkout fixture: the shipping crate at
-    `crate_relative_dir` plus enough filler crates to clear crate_tree's
-    discovery floor (a realistic-enough tree, not a one-crate stub)."""
+    """Add a package to a minimal candidate Cargo workspace fixture."""
     manifest = root / crate_relative_dir / "Cargo.toml"
     manifest.parent.mkdir(parents=True, exist_ok=True)
     manifest.write_text(
-        f'[package]\nname = "{package_name}"\nversion = "{version}"\n',
+        f'[package]\nname = "{package_name}"\nversion = "{version}"\n'
+        'edition = "2021"\n',
         encoding="utf-8",
     )
-    for index in range(crate_tree.MIN_CRATE_DIRECTORIES + 2):
-        filler = root / "crates" / f"ironclaw_filler_{index}"
-        filler.mkdir(parents=True, exist_ok=True)
-        (filler / "Cargo.toml").write_text(
-            f'[package]\nname = "ironclaw_filler_{index}"\n', encoding="utf-8"
-        )
+    (manifest.parent / "src").mkdir(exist_ok=True)
+    (manifest.parent / "src/lib.rs").write_text("", encoding="utf-8")
+
+    members = sorted(
+        manifest.parent.relative_to(root).as_posix()
+        for manifest in (root / "crates").rglob("Cargo.toml")
+    )
+    rendered_members = ",\n".join(f'  "{member}"' for member in members)
+    (root / "Cargo.toml").write_text(
+        f'[workspace]\nresolver = "2"\nmembers = [\n{rendered_members}\n]\n',
+        encoding="utf-8",
+    )
 
 
 class ReleaseTagTests(unittest.TestCase):
@@ -291,7 +292,7 @@ class ReleaseTagTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(
                 release.ReleaseTagError,
-                "exactly one candidate package named 'ironclaw', found 0",
+                "exactly one candidate workspace package named 'ironclaw', found 0",
             ):
                 release._manifest_version(candidate_root)
 
@@ -306,7 +307,65 @@ class ReleaseTagTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(
                 release.ReleaseTagError,
-                "exactly one candidate package named 'ironclaw', found 2",
+                "cannot inventory Cargo workspace.*two packages named `ironclaw`",
+            ):
+                release._manifest_version(candidate_root)
+
+    def test_candidate_manifest_resolution_rejects_non_workspace_package(
+        self,
+    ) -> None:
+        """A filesystem crate excluded from Cargo's workspace cannot identify
+        the package that cargo-dist will release."""
+        with tempfile.TemporaryDirectory() as directory:
+            candidate_root = Path(directory)
+            _write_candidate_manifest(
+                candidate_root,
+                "crates/workspace_member",
+                VERSION,
+                package_name="not-the-shipping-package",
+            )
+            unlisted = candidate_root / "crates/unlisted_ironclaw"
+            (unlisted / "src").mkdir(parents=True)
+            (unlisted / "Cargo.toml").write_text(
+                f'[package]\nname = "ironclaw"\nversion = "{VERSION}"\n'
+                'edition = "2021"\n',
+                encoding="utf-8",
+            )
+            (unlisted / "src/lib.rs").write_text("", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                release.ReleaseTagError,
+                "exactly one candidate workspace package named 'ironclaw', found 0",
+            ):
+                release._manifest_version(candidate_root)
+
+    def test_candidate_manifest_resolution_rejects_malformed_toml(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            candidate_root = Path(directory)
+            manifest = candidate_root / "crates/ironclaw_cli/Cargo.toml"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text('[package\nname = "ironclaw"\n', encoding="utf-8")
+            metadata = {
+                "workspace_members": ["ironclaw-id"],
+                "packages": [
+                    {
+                        "id": "ironclaw-id",
+                        "manifest_path": str(manifest),
+                    }
+                ],
+            }
+            completed = mock.Mock(
+                returncode=0,
+                stdout=json.dumps(metadata),
+                stderr="",
+            )
+
+            with (
+                mock.patch.object(release.subprocess, "run", return_value=completed),
+                self.assertRaisesRegex(
+                    release.ReleaseTagError,
+                    "cannot read candidate manifest.*Expected ']'",
+                ),
             ):
                 release._manifest_version(candidate_root)
 
@@ -317,16 +376,15 @@ class ReleaseTagTests(unittest.TestCase):
         silently read `manifest_version` as empty or wrong."""
         with tempfile.TemporaryDirectory() as directory:
             candidate_root = Path(directory)
-            for index in range(crate_tree.MIN_CRATE_DIRECTORIES + 2):
-                filler = candidate_root / "crates" / f"ironclaw_filler_{index}"
-                filler.mkdir(parents=True)
-                (filler / "Cargo.toml").write_text(
-                    f'[package]\nname = "ironclaw_filler_{index}"\n',
-                    encoding="utf-8",
-                )
+            _write_candidate_manifest(
+                candidate_root,
+                "crates/not_ironclaw",
+                VERSION,
+                package_name="not-the-shipping-package",
+            )
             with self.assertRaisesRegex(
                 release.ReleaseTagError,
-                "exactly one candidate package named 'ironclaw', found 0",
+                "exactly one candidate workspace package named 'ironclaw', found 0",
             ):
                 release._manifest_version(candidate_root)
 

--- a/scripts/ci/test_cut_ironclaw_release.py
+++ b/scripts/ci/test_cut_ironclaw_release.py
@@ -27,15 +27,19 @@ SHA = "a" * 40
 
 
 def _write_candidate_manifest(
-    root: Path, crate_relative_dir: str, version: str
+    root: Path,
+    crate_relative_dir: str,
+    version: str,
+    *,
+    package_name: str = "ironclaw",
 ) -> None:
-    """A candidate checkout fixture: the reborn-cli crate at
+    """A candidate checkout fixture: the shipping crate at
     `crate_relative_dir` plus enough filler crates to clear crate_tree's
     discovery floor (a realistic-enough tree, not a one-crate stub)."""
     manifest = root / crate_relative_dir / "Cargo.toml"
     manifest.parent.mkdir(parents=True, exist_ok=True)
     manifest.write_text(
-        f'[package]\nname = "ironclaw"\nversion = "{version}"\n',
+        f'[package]\nname = "{package_name}"\nversion = "{version}"\n',
         encoding="utf-8",
     )
     for index in range(crate_tree.MIN_CRATE_DIRECTORIES + 2):
@@ -232,6 +236,13 @@ class ReleaseTagTests(unittest.TestCase):
         )
         self.assertNotIn("candidate/scripts/ci/cut_ironclaw_release.py", workflow)
 
+        code_style = (ROOT / ".github/workflows/code_style.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "python3 scripts/ci/test_cut_ironclaw_release.py", code_style
+        )
+
     def test_candidate_metadata_comes_from_supplied_checkout(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             candidate_root = Path(directory)
@@ -250,10 +261,8 @@ class ReleaseTagTests(unittest.TestCase):
     def test_candidate_manifest_resolves_through_crate_inventory_when_nested(
         self,
     ) -> None:
-        """WS10: the candidate's ironclaw_cli manifest is found by
-        crate NAME even after the target-architecture family move
-        (crates/<family>/ironclaw_cli, PROPOSAL §5) — this is exactly
-        the shape a release cut against a moved candidate commit hits."""
+        """WS10: the shipping package is found after the target-architecture
+        family move (`crates/<family>/ironclaw_cli`, PROPOSAL §5)."""
         with tempfile.TemporaryDirectory() as directory:
             candidate_root = Path(directory)
             _write_candidate_manifest(
@@ -261,12 +270,51 @@ class ReleaseTagTests(unittest.TestCase):
             )
             self.assertEqual(release._manifest_version(candidate_root), VERSION)
 
+    def test_candidate_manifest_resolves_historical_reborn_cli_layout(self) -> None:
+        """Release tooling on main must validate supported release branches
+        without requiring them to adopt main's current crate directory layout."""
+        with tempfile.TemporaryDirectory() as directory:
+            candidate_root = Path(directory)
+            _write_candidate_manifest(
+                candidate_root, "crates/ironclaw_reborn_cli", VERSION
+            )
+            self.assertEqual(release._manifest_version(candidate_root), VERSION)
+
+    def test_candidate_manifest_resolution_uses_package_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            candidate_root = Path(directory)
+            _write_candidate_manifest(
+                candidate_root,
+                "crates/ironclaw_cli",
+                VERSION,
+                package_name="not-the-shipping-package",
+            )
+            with self.assertRaisesRegex(
+                release.ReleaseTagError,
+                "exactly one candidate package named 'ironclaw', found 0",
+            ):
+                release._manifest_version(candidate_root)
+
+    def test_candidate_manifest_resolution_rejects_ambiguous_package(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            candidate_root = Path(directory)
+            _write_candidate_manifest(
+                candidate_root, "crates/ironclaw_reborn_cli", VERSION
+            )
+            _write_candidate_manifest(
+                candidate_root, "crates/app/ironclaw_cli", VERSION
+            )
+            with self.assertRaisesRegex(
+                release.ReleaseTagError,
+                "exactly one candidate package named 'ironclaw', found 2",
+            ):
+                release._manifest_version(candidate_root)
+
     def test_candidate_manifest_resolution_fails_closed_when_crate_missing(
         self,
     ) -> None:
-        """A candidate checkout that cannot resolve ironclaw_cli must
-        refuse loudly, not silently read `manifest_version` as empty/wrong —
-        the WS10 failure mode this whole module guards against."""
+        """A candidate without the shipping package must refuse loudly, not
+        silently read `manifest_version` as empty or wrong."""
         with tempfile.TemporaryDirectory() as directory:
             candidate_root = Path(directory)
             for index in range(crate_tree.MIN_CRATE_DIRECTORIES + 2):
@@ -278,7 +326,7 @@ class ReleaseTagTests(unittest.TestCase):
                 )
             with self.assertRaisesRegex(
                 release.ReleaseTagError,
-                "cannot resolve the ironclaw_cli crate",
+                "exactly one candidate package named 'ironclaw', found 0",
             ):
                 release._manifest_version(candidate_root)
 


### PR DESCRIPTION
## Summary

- Resolve the approved candidate manifest by Cargo package identity (`name = "ironclaw"`) instead of the candidate crate directory basename.
- Support both historical release layouts such as `crates/ironclaw_reborn_cli` and current family layouts such as `crates/app/ironclaw_cli`.
- Fail closed when the shipping package is absent or ambiguous, and run the cutter test suite in Code Style CI.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None — blocks cutting `ironclaw-v1.1.1-rc.1` from approved commit `6fb60b1dd1da715a829e7272804e4117c2043b1c`.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`: Not applicable; no Rust changed.
- [ ] `cargo build`: Not applicable; Python release tooling only.
- [x] Relevant tests pass: cutter unit/regression suite and WS12 workflow contracts.
- [ ] `cargo test -p <owning-crate> --features integration`: Not applicable; no database or runtime behavior changed.
- [x] Manual testing: main-side resolver read the actual v1.1.1 release worktree and returned `1.1.1-rc.1`.
- [x] Focused diff reviewed before requesting review.

## Test Strategy

User behavior: A release owner can cut an approved historical release-branch commit without moving that branch to main’s current crate directory layout.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: historical flat Reborn CLI layout, current/nested layout, package-name-over-directory identity, missing package, and duplicate package rejection.
- Reborn integration: Not applicable; the changed seam is the isolated release cutter.
- Recorded fixture: Not applicable.
- Browser E2E: Not applicable.
- Backend or runtime: Not applicable.
- Live canary: Not applicable; the protected cut workflow remains independently approval-gated.

What the tests prove: The cutter reads version metadata from exactly one Cargo package named `ironclaw` in the supplied candidate checkout, regardless of its directory layout, and refuses absent or ambiguous identities before creating a tag.

Commands run:
- `uv run --python 3.12 python scripts/ci/test_cut_ironclaw_release.py`
- `python3 scripts/ci/test_ws12_workflow_contracts.py`
- `python3 -m py_compile scripts/ci/cut_ironclaw_release.py scripts/ci/test_cut_ironclaw_release.py`
- `cargo fmt --all -- --check`
- YAML parse of `.github/workflows/code_style.yml`
- Actual `_manifest_version` lookup against the v1.1.1 release worktree

## Security Impact

The immutable tag permission boundary is unchanged: release tooling still comes from the default branch, the candidate checkout remains separate, the full approved SHA and manifest version must match, and only the approval-gated GitHub App token can create the tag. Candidate-controlled directory names no longer determine which manifest is trusted; exact Cargo package identity does.

## Reborn Trust-Boundary Checklist

N/A: no Reborn runtime, request, prompt, persistence, or capability boundary changed. The release-tag boundary remains fail-closed and has direct contract coverage.

## Database Impact

None.

## Blast Radius

`Cut Ironclaw Release` candidate validation and the Code Style static self-test list. A faulty resolver could block tag creation; it cannot redirect the tag because the existing full-SHA checkout and tag-target validation remain unchanged.

## Rollback Plan

Revert this commit. Current-main candidates continue to work with the old directory-based resolver; historical-layout candidates would again be rejected before tag creation.

## Review Follow-Through

After merge, redispatch `Cut Ironclaw Release` for version `1.1.1-rc.1` and exact approved SHA `6fb60b1dd1da715a829e7272804e4117c2043b1c`, then verify the immutable tag target before artifact QA.

---

**Review track**: C (release CI/security boundary)