### PR TITLE
fix(channels): shared channels invoke the bot only on explicit mention

### DIFF
--- a/crates/product/ironclaw_assistant/src/workflow.rs
+++ b/crates/product/ironclaw_assistant/src/workflow.rs
@@ -12,7 +12,7 @@ use ironclaw_product_contracts::command::ProductCommandContext;
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_auth::{AuthFlowId, CredentialAccountId};
-use ironclaw_extension_contracts::channel_adapter::ChannelAdapter;
+use ironclaw_extension_contracts::channel_adapter::{ChannelAdapter, ProductTriggerReason};
 use ironclaw_extension_contracts::external::ExternalConversationRef;
 use ironclaw_extension_contracts::tool_adapter::RestrictedEgress;
 use ironclaw_host_api::product_adapter::{
@@ -291,6 +291,15 @@ fn build_channel_envelope(
     )?;
     let payload = match request.classification {
         Some(classification) => ProductInboundPayload::from(classification),
+        // A shared-channel run is invoked ONLY by an explicit @mention, which
+        // arrives as its own `BotMention` event. A plain thread reply
+        // (`ReplyToBot`) that is not a gate resolution or command (those are the
+        // `Some(_)` arm above) is bystander chatter — ack it durably and drop it
+        // as a NoOp, never spawning a run. Direct messages (`DirectChat`) and
+        // mentions (`BotMention`) still run.
+        None if request.message.trigger == ProductTriggerReason::ReplyToBot => {
+            ProductInboundPayload::NoOp
+        }
         None => ProductInboundPayload::UserMessage(
             UserMessagePayload::new(
                 request.message.text.clone(),
@@ -2033,13 +2042,15 @@ fn rejection_kind_for_approval_interaction(
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
+    use ironclaw_extension_contracts::channel_adapter::NormalizedInboundMessage;
     use ironclaw_extension_contracts::external::{
         ExternalActorRef, ExternalConversationRef, ExternalEventId,
     };
     use ironclaw_host_api::product_adapter::auth::{AuthRequirement, ProtocolAuthEvidence};
     use ironclaw_host_api::product_adapter::{AdapterInstallationId, ProductAdapterId};
     use ironclaw_product_contracts::inbound::{
-        ParsedProductInbound, ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload,
+        ChannelInboundClassification, InboundCommandPayload, ParsedProductInbound,
+        ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload, ProductSourceChannel,
         TrustedInboundContext,
     };
     use ironclaw_turns::{AcceptedMessageRef, AdmissionRejection, TurnRunId};
@@ -2130,6 +2141,93 @@ mod tests {
             ActionDispatchKind::UserMessageTurn {
                 run_id: rejected_run_id
             }
+        );
+    }
+
+    fn channel_request(
+        trigger: ProductTriggerReason,
+        classification: Option<ChannelInboundClassification>,
+    ) -> ChannelInboundSurfaceRequest {
+        let installation_id = AdapterInstallationId::new("install_alpha").expect("install");
+        let evidence = ProtocolAuthEvidence::test_verified(
+            AuthRequirement::SharedSecretHeader {
+                header_name: "X-Secret".into(),
+            },
+            installation_id.as_str(),
+        );
+        ChannelInboundSurfaceRequest {
+            adapter_id: ProductAdapterId::new("test_adapter").expect("adapter"),
+            source_channel: ProductSourceChannel::new("test_adapter").expect("source channel"),
+            installation_id,
+            evidence,
+            received_at: Utc::now(),
+            message: NormalizedInboundMessage {
+                actor: ExternalActorRef::new("test", "user1", None::<String>).expect("actor"),
+                conversation: ExternalConversationRef::new(None, "conv1", None, None)
+                    .expect("conversation"),
+                event_id: ExternalEventId::new("evt:1").expect("event"),
+                text: "hey team".to_string(),
+                trigger,
+                attachments: Vec::new(),
+                reply_context: None,
+            },
+            classification,
+            channel_context: None,
+        }
+    }
+
+    /// Regression (#7397 shared-channel UX): in a shared channel the bot is
+    /// invoked ONLY by an explicit mention. A plain thread reply that carries no
+    /// reserved classification is bystander chatter and must be dropped as a
+    /// NoOp — never spawning a run (which previously re-ran the same instruction
+    /// once per follow-up message). Mentions, DMs, and classified replies
+    /// (approve/deny, commands) are unaffected.
+    #[test]
+    fn shared_channel_plain_thread_reply_is_dropped_but_mentions_dms_and_gates_run() {
+        let reply = build_channel_envelope(channel_request(ProductTriggerReason::ReplyToBot, None))
+            .expect("envelope");
+        assert!(
+            matches!(reply.payload(), ProductInboundPayload::NoOp),
+            "a non-mention thread reply must be a NoOp (no run), got {:?}",
+            reply.payload()
+        );
+
+        let mention =
+            build_channel_envelope(channel_request(ProductTriggerReason::BotMention, None))
+                .expect("envelope");
+        assert!(
+            matches!(mention.payload(), ProductInboundPayload::UserMessage(_)),
+            "an explicit @mention must spawn a run, got {:?}",
+            mention.payload()
+        );
+
+        let dm = build_channel_envelope(channel_request(ProductTriggerReason::DirectChat, None))
+            .expect("envelope");
+        assert!(
+            matches!(dm.payload(), ProductInboundPayload::UserMessage(_)),
+            "a direct message must spawn a run without a mention, got {:?}",
+            dm.payload()
+        );
+
+        // A classified reply (here a command; approvals take the same `Some(_)`
+        // arm) is preserved — the mention-only drop applies only to unclassified
+        // ordinary messages, so approve/deny replies keep resolving gates.
+        let command = build_channel_envelope(channel_request(
+            ProductTriggerReason::ReplyToBot,
+            Some(ChannelInboundClassification::Command(
+                InboundCommandPayload::new(
+                    "status".to_string(),
+                    String::new(),
+                    ProductTriggerReason::ReplyToBot,
+                )
+                .expect("command"),
+            )),
+        ))
+        .expect("envelope");
+        assert!(
+            matches!(command.payload(), ProductInboundPayload::Command(_)),
+            "a classified thread reply must be preserved, got {:?}",
+            command.payload()
         );
     }
 


### PR DESCRIPTION
## Problem

In a shared channel, the bot was invoked by **every** thread message, not just @mentions. Tested live: mentioning the bot and then any follow-up chatter in the thread made it send the same DM **3×** and post several duplicate replies.

Root cause has two parts:

1. **The adapters deliver non-mention thread replies as triggers.** Slack classifies any threaded `message` event as `ReplyToBot` (`packages/slack/src/payload.rs`), and Telegram does the same for a reply to the bot's message — no @mention required. Both then spawn a run.
2. **Ephemeral-per-ping (#7397) makes each one its own run, hydrated with thread history.** Because the bot's DM went out-of-thread, each new run's context still shows the "send Firat a DM" instruction as if pending → it re-sends. N follow-up messages → N runs → N repeats. (The bot's self-aware "needs sanding" reply was itself a re-prompted run.)

## Fix

**Shared channels invoke the bot only on an explicit mention.** In `build_channel_envelope` (`ironclaw_assistant/src/workflow.rs`), a channel message whose trigger is `ReplyToBot` and which carries no reserved classification is acked to the vendor and dropped as a `NoOp` — **no run, no reply**.

- `@mentions` arrive as their own `BotMention` event → still run.
- DMs (`DirectChat`) → still run (a DM needs no mention).
- **Approve/deny** replies and **slash commands** are classified upstream (`Some(_)` arm), so they're preserved — gate resolution still works without a re-mention.
- Host-level and trigger-based → fixes **Slack and Telegram** together (both produce `ReplyToBot` for non-mention group replies).

## Test

`shared_channel_plain_thread_reply_is_dropped_but_mentions_dms_and_gates_run` (`workflow.rs`): a non-mention reply → `NoOp` (no run); `BotMention` → runs; `DirectChat` → runs; a classified reply (command/approval) → preserved.

## Follow-ups (not in this PR)

- The "Ironclaw is still working… please resend" message users saw was a Slack webhook **retry** hitting an in-flight run — with mention-only triggering there'll be far fewer, but we should also silence that notice for redeliveries instead of telling the user to resend.
- Even with mention-only, a *re-mention* spins up a fresh run hydrated from thread history that can't see the bot's own out-of-thread actions (the DM it already sent) — worth including the bot's recent replies/tool-results in hydration so it doesn't repeat an action.

## Test Strategy

- Unit/decision: the regression test above pins the classification→payload decision at the channel admission seam for all four trigger kinds.
- Not applicable (integration): the existing channel-delivery integration coverage exercises the mention/DM run paths; the drop path is a pure decision on `build_channel_envelope` with no new cross-crate wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
