### PR TITLE
feat(channels): rich working indicator — reactions, failure states, progress nudges

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
@@ -635,7 +635,14 @@ fn reborn_contracts_crates_carry_a_checked_size_ceiling() {
         // flag. Contract vocabulary only — the fetch impl lives in the slack
         // package, the flag is consumed by the channel workflow. Count read from
         // this test's failure on the rebased base.
-        ("ironclaw_extension_contracts", 7_851),
+        // 7_851 -> 7_885 (2026-08-10, rich working indicator #7446): the
+        // `OutboundPart::React` variant plus the neutral `RunReaction` /
+        // `ReactionAction` enums for run-lifecycle reactions on the triggering
+        // message. Contract vocabulary only — vendor reaction rendering (Slack
+        // reactions.add/remove, Telegram setMessageReaction) lives in the channel
+        // packages and the reaction lifecycle in the delivery observer. Count
+        // read from this test's failure message.
+        ("ironclaw_extension_contracts", 7_885),
         // Raised 17_501 -> 18_570 by #6831 (standardized messaging framework):
         // the growth is the `messaging` vocabulary — the StandardMessagingOp
         // enum, the 12-code error taxonomy, compiled-in canonical schema/prompt

--- a/crates/app/ironclaw_composition/tests/first_party_manifest_v3_parity.rs
+++ b/crates/app/ironclaw_composition/tests/first_party_manifest_v3_parity.rs
@@ -485,6 +485,8 @@ fn slack_v3_declares_only_bounded_file_transfer_egress() {
             "/api/chat.delete",
             "/api/conversations.open",
             "/api/files.completeUploadExternal",
+            "/api/reactions.add",
+            "/api/reactions.remove",
         ]
     );
     assert_eq!(api_post.request_body_limit_bytes, Some(256 * 1024));
@@ -561,6 +563,7 @@ fn telegram_v3_declares_only_the_bot_api_and_bounded_file_transfer_paths() {
             "/bot{telegram_bot_token}/deleteWebhook",
             "/bot{telegram_bot_token}/sendMessage",
             "/bot{telegram_bot_token}/deleteMessage",
+            "/bot{telegram_bot_token}/setMessageReaction",
             "/bot{telegram_bot_token}/getFile",
             "/bot{telegram_bot_token}/sendDocument",
         ]

--- a/crates/contracts/ironclaw_extension_contracts/src/channel_adapter.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/channel_adapter.rs
@@ -365,8 +365,8 @@ pub enum OutboundPart {
     /// `vendor_message_ref` is the target message's vendor id (a source
     /// message's `reply_target_message_id`, or a bot message ref). Each adapter
     /// maps the neutral [`RunReaction`] to a vendor-safe emoji — a raw emoji
-    /// would be unsafe because e.g. Telegram's `setMessageReaction` only accepts
-    /// a fixed allowlist. Best-effort: a failed reaction never fails the run.
+    /// would be unsafe because some vendors' reaction APIs only accept a fixed
+    /// emoji allowlist. Best-effort: a failed reaction never fails the run.
     React {
         vendor_message_ref: String,
         reaction: RunReaction,

--- a/crates/contracts/ironclaw_extension_contracts/src/channel_adapter.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/channel_adapter.rs
@@ -359,6 +359,41 @@ pub enum OutboundPart {
     Retract {
         vendor_message_ref: String,
     },
+    /// Add or remove a run-lifecycle reaction on an existing vendor message —
+    /// typically the inbound message that triggered the run, so a channel with
+    /// several runs in flight shows which message each one is working on.
+    /// `vendor_message_ref` is the target message's vendor id (a source
+    /// message's `reply_target_message_id`, or a bot message ref). Each adapter
+    /// maps the neutral [`RunReaction`] to a vendor-safe emoji — a raw emoji
+    /// would be unsafe because e.g. Telegram's `setMessageReaction` only accepts
+    /// a fixed allowlist. Best-effort: a failed reaction never fails the run.
+    React {
+        vendor_message_ref: String,
+        reaction: RunReaction,
+        action: ReactionAction,
+    },
+}
+
+/// A neutral run-lifecycle reaction. The adapter owns the vendor emoji so the
+/// mapping stays inside each vendor's allowed-reaction set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunReaction {
+    /// The run is actively working on the message (👀).
+    Working,
+    /// The run finished successfully (✅ / vendor equivalent).
+    Done,
+    /// The run is parked waiting on the user — an approval or auth prompt
+    /// (⚠️ / vendor equivalent).
+    NeedsInput,
+    /// The run failed or timed out (❌ / vendor equivalent).
+    Failed,
+}
+
+/// Whether a [`OutboundPart::React`] adds or clears a reaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReactionAction {
+    Add,
+    Remove,
 }
 
 /// Structured per-attempt delivery report. The adapter cannot mark anything

--- a/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -2785,7 +2785,12 @@ async fn slack_dm_posts_working_indicator_and_deletes_it_after_final_reply() {
     let messages = harness.slack_messages();
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0]["channel"], CHANNEL);
-    assert_eq!(messages[0]["text"], "Ironclaw is thinking...");
+    assert!(
+        messages[0]["text"]
+            .as_str()
+            .is_some_and(|text| !text.is_empty()),
+        "a running turn posts a working indicator before the reply"
+    );
 
     harness
         .coordinator
@@ -3015,7 +3020,12 @@ async fn slack_dm_delivers_final_reply_after_auth_completes_outside_slack() {
     let messages = harness.slack_messages();
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[1]["channel"], CHANNEL);
-    assert_eq!(messages[1]["text"], "Ironclaw is thinking...");
+    assert!(
+        messages[1]["text"]
+            .as_str()
+            .is_some_and(|text| !text.is_empty()),
+        "the resumed turn posts a working indicator before the reply"
+    );
 
     harness
         .coordinator
@@ -3262,8 +3272,8 @@ impl RecordingTurnCoordinator {
     ///
     /// This prevents the delivery loop from waking in the gap between
     /// `resume_blocked_run_to_running` and `complete_active_run`, observing
-    /// `Running` with no blocked marker, and posting the "Ironclaw is thinking..."
-    /// working indicator — which would produce a spurious 4th message and make the
+    /// `Running` with no blocked marker, and posting the working indicator —
+    /// which would produce a spurious 4th message and make the
     /// `messages.len() == 3` assertion flaky.
     async fn complete_blocked_run(&self, text: &str) -> Result<(), ProductSurfaceFailure> {
         // Append the final assistant message first (does not touch `state`).

--- a/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -635,6 +635,8 @@ async fn build_harness_with_options(options: HarnessOptions) -> Harness {
                     max_wait: options.max_wait,
                     max_concurrent_deliveries: NonZeroUsize::new(4).expect("nonzero"), // safety: static test literal is non-zero.
                     max_pending_deliveries: NonZeroUsize::new(16).expect("nonzero"), // safety: static test literal is non-zero.
+                    first_nudge_after: Duration::from_secs(3600),
+                    renudge_interval: Duration::from_secs(3600),
                 },
                 triggered_delivery_store: Arc::clone(&triggered_delivery_store),
             }),
@@ -1580,6 +1582,8 @@ async fn triggered_approval_prompt_route_resolves_dm_approve_on_foreign_scope() 
             max_wait: Duration::from_secs(2),
             max_concurrent_deliveries: NonZeroUsize::new(4).expect("nonzero"), // safety: static test literal is non-zero.
             max_pending_deliveries: NonZeroUsize::new(16).expect("nonzero"), // safety: static test literal is non-zero.
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
         },
         Arc::new(in_memory_backed_outbound_state_store()),
         Arc::new(vec![Arc::new(SlackPreferenceTargetCodec)
@@ -1859,6 +1863,8 @@ async fn triggered_auth_prompt_route_delivers_dm_setup_link_on_foreign_scope() {
             max_wait: Duration::from_secs(2),
             max_concurrent_deliveries: NonZeroUsize::new(4).expect("nonzero"), // safety: static test literal is non-zero.
             max_pending_deliveries: NonZeroUsize::new(16).expect("nonzero"), // safety: static test literal is non-zero.
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
         },
         Arc::new(in_memory_backed_outbound_state_store()),
         Arc::new(vec![Arc::new(SlackPreferenceTargetCodec)
@@ -1985,6 +1991,8 @@ async fn triggered_auth_prompt_to_non_dm_channel_redacts_the_link_and_parks_the_
             max_wait: Duration::from_secs(2),
             max_concurrent_deliveries: NonZeroUsize::new(4).expect("nonzero"), // safety: static test literal is non-zero.
             max_pending_deliveries: NonZeroUsize::new(16).expect("nonzero"), // safety: static test literal is non-zero.
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
         },
         Arc::new(in_memory_backed_outbound_state_store()),
         Arc::new(vec![Arc::new(SlackPreferenceTargetCodec)
@@ -3023,8 +3031,9 @@ async fn slack_dm_delivers_final_reply_after_auth_completes_outside_slack() {
     assert!(
         messages[1]["text"]
             .as_str()
-            .is_some_and(|text| !text.is_empty()),
-        "the resumed turn posts a working indicator before the reply"
+            .is_some_and(|text| !text.is_empty())
+            && messages[1]["text"] != messages[0]["text"],
+        "the resumed turn posts a working indicator distinct from the auth prompt"
     );
 
     harness

--- a/crates/extensions/packages/slack/manifest.toml
+++ b/crates/extensions/packages/slack/manifest.toml
@@ -232,6 +232,11 @@ paths = [
   "/api/chat.delete",
   "/api/conversations.open",
   "/api/files.completeUploadExternal",
+  # 👀→✅ run-lifecycle reaction on the triggering message (needs the
+  # reactions:write scope operator-side; a missing scope fails the reaction
+  # best-effort and never fails the run).
+  "/api/reactions.add",
+  "/api/reactions.remove",
 ]
 request_body_limit_bytes = 262144
 response_body_limit_bytes = 262144

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -14,8 +14,8 @@ use async_trait::async_trait;
 use ironclaw_extension_contracts::auth_prompt::render_channel_auth_prompt;
 use ironclaw_extension_contracts::channel_adapter::{
     ChannelAdapter, ChannelError, DeliveryReport, ImmediateResponse, InboundOutcome,
-    NormalizedInboundMessage, OutboundEnvelope, OutboundPart, PartDeliveryOutcome, TargetCandidate,
-    TargetQuery, VerifiedInbound,
+    NormalizedInboundMessage, OutboundEnvelope, OutboundPart, PartDeliveryOutcome, ReactionAction,
+    RunReaction, TargetCandidate, TargetQuery, VerifiedInbound,
 };
 use ironclaw_extension_contracts::external::ExternalConversationRef;
 use ironclaw_extension_contracts::tool_adapter::{
@@ -199,6 +199,26 @@ impl ChannelAdapter for SlackChannelAdapter {
                     let outcome =
                         delete_slack_message(egress, &credential, &channel, vendor_message_ref)
                             .await;
+                    let sent = matches!(outcome, PartDeliveryOutcome::Sent { .. });
+                    parts.push(outcome);
+                    if !sent {
+                        break 'parts;
+                    }
+                }
+                OutboundPart::React {
+                    vendor_message_ref,
+                    reaction,
+                    action,
+                } => {
+                    let outcome = react_slack_message(
+                        egress,
+                        &credential,
+                        &channel,
+                        vendor_message_ref,
+                        slack_reaction_name(*reaction),
+                        *action,
+                    )
+                    .await;
                     let sent = matches!(outcome, PartDeliveryOutcome::Sent { .. });
                     parts.push(outcome);
                     if !sent {
@@ -429,6 +449,89 @@ async fn delete_slack_message(
     part_outcome_for_kind(
         slack_error_kind(&error),
         format!("slack rejected chat.delete ({error})"),
+    )
+}
+
+/// Slack reaction name (shortcode, no colons) for a neutral run reaction.
+fn slack_reaction_name(reaction: RunReaction) -> &'static str {
+    match reaction {
+        RunReaction::Working => "eyes",
+        RunReaction::Done => "white_check_mark",
+        RunReaction::NeedsInput => "warning",
+        RunReaction::Failed => "x",
+    }
+}
+
+/// Add or remove a reaction on `ts` via `reactions.add` / `reactions.remove`.
+/// Best-effort: `already_reacted` / `no_reaction` are treated as success so the
+/// idempotent 👀→✅ swap never surfaces a spurious failure on a retry.
+async fn react_slack_message(
+    egress: &dyn RestrictedEgress,
+    credential: &SecretHandle,
+    channel: &str,
+    ts: &str,
+    name: &str,
+    action: ReactionAction,
+) -> PartDeliveryOutcome {
+    let path = match action {
+        ReactionAction::Add => "reactions.add",
+        ReactionAction::Remove => "reactions.remove",
+    };
+    let body = match serde_json::to_vec(
+        &serde_json::json!({ "channel": channel, "timestamp": ts, "name": name }),
+    ) {
+        Ok(body) => body,
+        Err(error) => {
+            return PartDeliveryOutcome::Permanent {
+                reason: format!("{path} body did not serialize: {error}"),
+            };
+        }
+    };
+    let response = egress
+        .send(RestrictedEgressRequest {
+            method: NetworkMethod::Post,
+            url: format!("https://{SLACK_API_HOST}/api/{path}"),
+            headers: vec![(
+                "content-type".to_string(),
+                "application/json; charset=utf-8".to_string(),
+            )],
+            body: Some(body),
+            credential: Some(credential.clone()),
+            body_credentials: Vec::new(),
+        })
+        .await;
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => return part_outcome_for_egress_error(&error),
+    };
+    if !(200..300).contains(&response.status) {
+        return part_outcome_for_kind(
+            SlackDeliveryFailureKind::from_http_status(response.status),
+            format!("slack web api returned status {}", response.status),
+        );
+    }
+    let parsed: SlackChatPostMessageResponse = match serde_json::from_slice(&response.body) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return PartDeliveryOutcome::Retryable {
+                reason: format!("{path} response was not valid JSON: {error}"),
+            };
+        }
+    };
+    if parsed.ok {
+        return PartDeliveryOutcome::Sent {
+            vendor_message_ref: None,
+        };
+    }
+    let error = parsed.error.unwrap_or_else(|| "unknown_error".to_string());
+    if matches!(error.as_str(), "already_reacted" | "no_reaction") {
+        return PartDeliveryOutcome::Sent {
+            vendor_message_ref: None,
+        };
+    }
+    part_outcome_for_kind(
+        slack_error_kind(&error),
+        format!("slack rejected {path} ({error})"),
     )
 }
 
@@ -1952,6 +2055,89 @@ mod tests {
         let body = body_json(&requests[0]);
         assert_eq!(body["channel"], "D123");
         assert_eq!(body["ts"], "1710000001.000001");
+    }
+
+    #[tokio::test]
+    async fn deliver_react_add_calls_reactions_add_with_the_mapped_emoji() {
+        let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(r#"{"ok":true}"#)]);
+        let report = SlackChannelAdapter
+            .deliver(
+                envelope(
+                    vec![OutboundPart::React {
+                        vendor_message_ref: "1710000001.000001".to_string(),
+                        reaction: RunReaction::Working,
+                        action: ReactionAction::Add,
+                    }],
+                    None,
+                ),
+                &egress,
+            )
+            .await
+            .expect("deliver drives");
+
+        assert!(matches!(
+            &report.parts[0],
+            PartDeliveryOutcome::Sent {
+                vendor_message_ref: None
+            }
+        ));
+        let requests = egress.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url, "https://slack.com/api/reactions.add");
+        let body = body_json(&requests[0]);
+        assert_eq!(body["channel"], "D123");
+        assert_eq!(body["timestamp"], "1710000001.000001");
+        assert_eq!(body["name"], "eyes");
+    }
+
+    #[tokio::test]
+    async fn deliver_react_remove_calls_reactions_remove_and_maps_failure_to_x() {
+        let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(r#"{"ok":true}"#)]);
+        let report = SlackChannelAdapter
+            .deliver(
+                envelope(
+                    vec![OutboundPart::React {
+                        vendor_message_ref: "1710000001.000001".to_string(),
+                        reaction: RunReaction::Failed,
+                        action: ReactionAction::Remove,
+                    }],
+                    None,
+                ),
+                &egress,
+            )
+            .await
+            .expect("deliver drives");
+
+        assert!(matches!(&report.parts[0], PartDeliveryOutcome::Sent { .. }));
+        let requests = egress.requests();
+        assert_eq!(requests[0].url, "https://slack.com/api/reactions.remove");
+        assert_eq!(body_json(&requests[0])["name"], "x");
+    }
+
+    #[tokio::test]
+    async fn deliver_react_treats_already_reacted_as_sent() {
+        let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(
+            r#"{"ok":false,"error":"already_reacted"}"#,
+        )]);
+        let report = SlackChannelAdapter
+            .deliver(
+                envelope(
+                    vec![OutboundPart::React {
+                        vendor_message_ref: "1710000001.000001".to_string(),
+                        reaction: RunReaction::Working,
+                        action: ReactionAction::Add,
+                    }],
+                    None,
+                ),
+                &egress,
+            )
+            .await
+            .expect("deliver drives");
+
+        assert!(
+            matches!(&report.parts[0], PartDeliveryOutcome::Sent { .. }),
+            "an already-present reaction is a benign no-op for the idempotent swap"
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/packages/telegram/manifest.toml
+++ b/crates/extensions/packages/telegram/manifest.toml
@@ -79,6 +79,7 @@ paths = [
   "/bot{telegram_bot_token}/deleteWebhook",
   "/bot{telegram_bot_token}/sendMessage",
   "/bot{telegram_bot_token}/deleteMessage",
+  "/bot{telegram_bot_token}/setMessageReaction",
   "/bot{telegram_bot_token}/getFile",
   "/bot{telegram_bot_token}/sendDocument",
 ]

--- a/crates/extensions/packages/telegram/src/channel.rs
+++ b/crates/extensions/packages/telegram/src/channel.rs
@@ -12,7 +12,8 @@ use async_trait::async_trait;
 use ironclaw_extension_contracts::auth_prompt::render_channel_auth_prompt;
 use ironclaw_extension_contracts::channel_adapter::{
     ChannelAdapter, ChannelAttachmentRef, ChannelContext, ChannelError, DeliveryReport,
-    InboundOutcome, OutboundEnvelope, OutboundPart, PartDeliveryOutcome, VerifiedInbound,
+    InboundOutcome, OutboundEnvelope, OutboundPart, PartDeliveryOutcome, ReactionAction,
+    RunReaction, VerifiedInbound,
 };
 use ironclaw_extension_contracts::tool_adapter::{RestrictedEgress, RestrictedEgressRequest};
 use ironclaw_host_api::product_adapter::AdapterInstallationId;
@@ -313,6 +314,45 @@ impl ChannelAdapter for TelegramChannelAdapter {
                         break 'parts;
                     }
                 }
+                OutboundPart::React {
+                    vendor_message_ref,
+                    reaction,
+                    action,
+                } => {
+                    let outcome = match vendor_message_ref.parse::<i64>() {
+                        Ok(message_id) => {
+                            // `setMessageReaction` REPLACES the bot's reactions
+                            // on the message, so an add sets the single emoji and
+                            // a remove sets the empty set.
+                            let reaction_field = match action {
+                                ReactionAction::Add => serde_json::json!([{
+                                    "type": "emoji",
+                                    "emoji": telegram_reaction_emoji(*reaction),
+                                }]),
+                                ReactionAction::Remove => serde_json::json!([]),
+                            };
+                            set_telegram_reaction(
+                                egress,
+                                serde_json::json!({
+                                    "chat_id": chat_id,
+                                    "message_id": message_id,
+                                    "reaction": reaction_field,
+                                }),
+                            )
+                            .await
+                        }
+                        Err(_) => PartDeliveryOutcome::Permanent {
+                            reason: format!(
+                                "reaction target `{vendor_message_ref}` is not a telegram message id"
+                            ),
+                        },
+                    };
+                    let sent = matches!(outcome, PartDeliveryOutcome::Sent { .. });
+                    parts.push(outcome);
+                    if !sent {
+                        break 'parts;
+                    }
+                }
             }
         }
         Ok(DeliveryReport { parts })
@@ -340,6 +380,59 @@ async fn send_telegram_message(
         Err(error) => return telegram_outcome_for_egress_error(&error),
     };
     telegram_message_response_outcome("sendMessage", response.status, &response.body)
+}
+
+/// Telegram allowed-reaction emoji for a neutral run reaction. `setMessageReaction`
+/// accepts only a fixed allowlist, so the Slack ✅/⚠️/❌ map to the nearest
+/// allowed Telegram reactions (👌 / 🤔 / 👎).
+fn telegram_reaction_emoji(reaction: RunReaction) -> &'static str {
+    match reaction {
+        RunReaction::Working => "👀",
+        RunReaction::Done => "👌",
+        RunReaction::NeedsInput => "🤔",
+        RunReaction::Failed => "👎",
+    }
+}
+
+/// Set (or clear) the bot's reaction on a message. Best-effort: a failed
+/// reaction never fails the run.
+async fn set_telegram_reaction(
+    egress: &dyn RestrictedEgress,
+    body: serde_json::Value,
+) -> PartDeliveryOutcome {
+    let response = match egress
+        .send(bot_api_request("setMessageReaction", body))
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => return telegram_outcome_for_egress_error(&error),
+    };
+    if !(200..300).contains(&response.status) {
+        return telegram_outcome_for_status(
+            response.status,
+            format!("telegram bot api returned status {}", response.status),
+        );
+    }
+    let parsed: TelegramDeleteMessageResponse = match serde_json::from_slice(&response.body) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return PartDeliveryOutcome::Retryable {
+                reason: format!("setMessageReaction response was not valid JSON: {error}"),
+            };
+        }
+    };
+    if parsed.ok {
+        return PartDeliveryOutcome::Sent {
+            vendor_message_ref: None,
+        };
+    }
+    let description = parsed
+        .description
+        .unwrap_or_else(|| "unknown_error".to_string());
+    telegram_outcome_for_status(
+        parsed.error_code.unwrap_or(400),
+        format!("telegram rejected setMessageReaction ({description})"),
+    )
 }
 
 pub(super) fn telegram_message_response_outcome(

--- a/crates/extensions/packages/telegram/src/tests/channel_deliver.rs
+++ b/crates/extensions/packages/telegram/src/tests/channel_deliver.rs
@@ -2,7 +2,8 @@ use std::collections::VecDeque;
 use std::sync::Mutex;
 
 use ironclaw_extension_contracts::channel_adapter::{
-    OutboundEnvelope, OutboundPart, OutboundTarget, PartDeliveryOutcome,
+    OutboundEnvelope, OutboundPart, OutboundTarget, PartDeliveryOutcome, ReactionAction,
+    RunReaction,
 };
 use ironclaw_extension_contracts::external::ExternalConversationRef;
 use ironclaw_extension_contracts::tool_adapter::{RestrictedEgressError, RestrictedEgressResponse};
@@ -114,6 +115,90 @@ async fn deliver_retract_part_deletes_the_referenced_message() {
         serde_json::from_slice(requests[0].body.as_deref().unwrap_or_default()).unwrap();
     assert_eq!(body["chat_id"], "8675309");
     assert_eq!(body["message_id"], 42);
+}
+
+#[tokio::test]
+async fn deliver_react_add_sets_the_mapped_reaction_emoji() {
+    let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(r#"{"ok":true,"result":true}"#)]);
+    let report = TelegramChannelAdapter::default()
+        .deliver(
+            envelope(
+                vec![OutboundPart::React {
+                    vendor_message_ref: "42".to_string(),
+                    reaction: RunReaction::Working,
+                    action: ReactionAction::Add,
+                }],
+                None,
+            ),
+            &egress,
+        )
+        .await
+        .expect("deliver drives");
+
+    assert!(matches!(&report.parts[0], PartDeliveryOutcome::Sent { .. }));
+    let requests = egress.requests.lock().unwrap();
+    assert_eq!(
+        requests[0].url,
+        "https://api.telegram.org/bot{telegram_bot_token}/setMessageReaction"
+    );
+    let body: serde_json::Value =
+        serde_json::from_slice(requests[0].body.as_deref().unwrap_or_default()).unwrap();
+    assert_eq!(body["chat_id"], "8675309");
+    assert_eq!(body["message_id"], 42);
+    assert_eq!(
+        body["reaction"],
+        serde_json::json!([{ "type": "emoji", "emoji": "👀" }])
+    );
+}
+
+#[tokio::test]
+async fn deliver_react_remove_clears_the_reaction() {
+    let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(r#"{"ok":true,"result":true}"#)]);
+    let report = TelegramChannelAdapter::default()
+        .deliver(
+            envelope(
+                vec![OutboundPart::React {
+                    vendor_message_ref: "42".to_string(),
+                    reaction: RunReaction::Working,
+                    action: ReactionAction::Remove,
+                }],
+                None,
+            ),
+            &egress,
+        )
+        .await
+        .expect("deliver drives");
+
+    assert!(matches!(&report.parts[0], PartDeliveryOutcome::Sent { .. }));
+    let requests = egress.requests.lock().unwrap();
+    let body: serde_json::Value =
+        serde_json::from_slice(requests[0].body.as_deref().unwrap_or_default()).unwrap();
+    assert_eq!(body["reaction"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn deliver_react_with_non_numeric_ref_is_permanent_without_egress() {
+    let egress = ScriptedEgress::new(Vec::new());
+    let report = TelegramChannelAdapter::default()
+        .deliver(
+            envelope(
+                vec![OutboundPart::React {
+                    vendor_message_ref: "not-a-message-id".to_string(),
+                    reaction: RunReaction::Done,
+                    action: ReactionAction::Add,
+                }],
+                None,
+            ),
+            &egress,
+        )
+        .await
+        .expect("deliver drives");
+
+    assert!(matches!(
+        &report.parts[0],
+        PartDeliveryOutcome::Permanent { .. }
+    ));
+    assert!(egress.requests.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/extensions/packages/web-push/src/channel.rs
+++ b/crates/extensions/packages/web-push/src/channel.rs
@@ -110,6 +110,9 @@ impl ChannelAdapter for WebPushChannelAdapter {
                 OutboundPart::Retract { .. } => {
                     part_supported.push(Err("retraction is not supported by browser push"));
                 }
+                OutboundPart::React { .. } => {
+                    part_supported.push(Err("reactions are not supported by browser push"));
+                }
             }
         }
 

--- a/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
+++ b/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
@@ -76,6 +76,9 @@ pub enum DeliveryIntent {
     Working,
     /// Remove an earlier delivery (e.g. delete the working indicator).
     Cleanup,
+    /// Add or clear a run-lifecycle reaction on the triggering message
+    /// (👀 while working, ✅/⚠️ at the end). Best-effort, source-routed.
+    Reaction,
     /// A background (routine) run needs the user's attention on a
     /// notification channel: it failed, or it is parked on an auth gate whose
     /// authorization URL cannot be shown on this channel. Fanned out over the
@@ -119,6 +122,7 @@ impl DeliveryIntent {
             Self::CommandFeedback => "command-feedback",
             Self::Working => "working",
             Self::Cleanup => "cleanup",
+            Self::Reaction => "reaction",
             Self::BackgroundRunNotice => "background-run-notice",
             Self::ModelDelivery => "model-delivery",
         }
@@ -1034,9 +1038,10 @@ fn validate_final_workspace_files(parts: &[OutboundPart]) -> Result<(), Coordina
     let mut total_bytes = 0usize;
     for file in parts.iter().filter_map(|part| match part {
         OutboundPart::File(file) => Some(file),
-        OutboundPart::Text(_) | OutboundPart::AuthPrompt { .. } | OutboundPart::Retract { .. } => {
-            None
-        }
+        OutboundPart::Text(_)
+        | OutboundPart::AuthPrompt { .. }
+        | OutboundPart::Retract { .. }
+        | OutboundPart::React { .. } => None,
     }) {
         count = count
             .checked_add(1)

--- a/crates/product/ironclaw_assistant/src/run_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery.rs
@@ -27,7 +27,7 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use ironclaw_extension_contracts::channel_adapter::OutboundPart;
+use ironclaw_extension_contracts::channel_adapter::{OutboundPart, ReactionAction, RunReaction};
 use ironclaw_extension_contracts::external::{ExternalConversationRef, ExternalEventId};
 use ironclaw_host_api::product_adapter::ProductAdapterError;
 use ironclaw_host_api::turn::{TurnRunId, TurnScope, TurnStatus};
@@ -87,6 +87,12 @@ pub struct RunDeliverySettings {
     /// are recorded as `Skipped` rather than spawning an unbounded waiting
     /// task.
     pub max_pending_deliveries: NonZeroUsize,
+    /// How long a run may run before the working indicator is refreshed to a
+    /// "still working" nudge, so the user knows it hasn't stalled.
+    pub first_nudge_after: Duration,
+    /// Gap before the SECOND nudge; each subsequent gap doubles (e.g. 30s, then
+    /// +1m, +2m, +4m …) so a very long run backs off instead of spamming.
+    pub renudge_interval: Duration,
 }
 
 impl Default for RunDeliverySettings {
@@ -96,6 +102,8 @@ impl Default for RunDeliverySettings {
             max_wait: DEFAULT_RUN_DELIVERY_MAX_WAIT,
             max_concurrent_deliveries: NonZeroUsize::new(64).expect("non-zero literal"), // safety: static default literal is non-zero.
             max_pending_deliveries: NonZeroUsize::new(256).expect("non-zero literal"), // safety: static default literal is non-zero.
+            first_nudge_after: Duration::from_secs(30),
+            renudge_interval: Duration::from_secs(60),
         }
     }
 }
@@ -469,6 +477,61 @@ impl RunDeliveryServices {
                 target: "ironclaw::reborn::run_delivery",
                 %error,
                 "failed to retract channel prompt/status message"
+            );
+        }
+    }
+
+    /// Best-effort run-lifecycle reaction on the message that triggered the
+    /// run (its `reply_target_message_id`) — 👀 while working, ⚠️ when it needs
+    /// the user, ✅ done, ❌ failed. A conversation with no reply target (nothing
+    /// to react to) is a no-op, and any delivery failure is swallowed: a
+    /// reaction must never fail the run. `seq` is a per-run monotonic id so each
+    /// transition is a distinct, idempotent delivery — a retried loop replays the
+    /// same seq and dedupes, while a genuine re-transition gets a fresh one.
+    pub(crate) async fn react_to_source(
+        &self,
+        scope: TurnScope,
+        run_id: TurnRunId,
+        conversation: &ExternalConversationRef,
+        reaction: RunReaction,
+        action: ReactionAction,
+        seq: u64,
+    ) {
+        let Some(source_ref) = conversation.reply_target_message_id() else {
+            return;
+        };
+        let action_key = match action {
+            ReactionAction::Add => "add",
+            ReactionAction::Remove => "remove",
+        };
+        let reaction_key = match reaction {
+            RunReaction::Working => "working",
+            RunReaction::Done => "done",
+            RunReaction::NeedsInput => "needs-input",
+            RunReaction::Failed => "failed",
+        };
+        if let Err(error) = self
+            .coordinator
+            .deliver_notice(NoticeDeliveryRequest {
+                intent: DeliveryIntent::Reaction,
+                scope,
+                turn_run_id: Some(run_id),
+                conversation: conversation.clone(),
+                thread_anchor: None,
+                parts: vec![OutboundPart::React {
+                    vendor_message_ref: source_ref.to_string(),
+                    reaction,
+                    action,
+                }],
+                extension_id: &self.extension_id,
+                notice_ref: format!("{run_id}:{seq}:{action_key}-{reaction_key}"),
+            })
+            .await
+        {
+            tracing::debug!(
+                target: "ironclaw::reborn::run_delivery",
+                %error,
+                "channel reaction delivery failed (best-effort)"
             );
         }
     }

--- a/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
@@ -555,7 +555,7 @@ impl RunDeliveryObserver {
                     // genuine failure (not a completed-but-empty run) also post a
                     // brief failure notice and mark ❌ — source-routed through the
                     // same reliable path as the working indicator, so it reaches
-                    // Slack and Telegram even without a reply-target binding.
+                    // the originating channel even without a reply-target binding.
                     if actionable_state.status.is_terminal() {
                         self.delivery_runs
                             .lock()

--- a/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
@@ -598,6 +598,10 @@ impl RunDeliveryObserver {
                 return Err(RunDeliveryError::RunWaitTimedOut { run_id });
             }
             if working_message.is_none() && blocked_actionable_marker(&state).is_none() {
+                // Vary the notice per run so a channel with several runs in
+                // flight does not show a wall of identical lines; seeded by the
+                // run id so one run keeps one voice.
+                let notice_seed = run_id.to_string().bytes().map(u64::from).sum::<u64>();
                 *working_message = self
                     .services
                     .post_notice(
@@ -605,7 +609,7 @@ impl RunDeliveryObserver {
                         scope.clone(),
                         Some(run_id),
                         envelope.external_conversation_ref(),
-                        prompts::WORKING_MESSAGE,
+                        prompts::working_message(notice_seed),
                         format!("working:{run_id}"),
                     )
                     .await;

--- a/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
@@ -18,7 +18,9 @@ use crate::commands::{
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_extension_contracts::auth_prompt::AuthPromptChallengeKind;
-use ironclaw_extension_contracts::channel_adapter::{OutboundPart, ProductTriggerReason};
+use ironclaw_extension_contracts::channel_adapter::{
+    OutboundPart, ProductTriggerReason, ReactionAction, RunReaction,
+};
 use ironclaw_extension_contracts::external::{
     ExternalActorRef, ExternalConversationRef, ExternalEventId,
 };
@@ -76,6 +78,15 @@ struct RunNotificationDeliveryContext<'a> {
     scope: &'a TurnScope,
     thread_scope: &'a ThreadScope,
     actor: &'a TurnActor,
+}
+
+/// Mutable per-run reaction state threaded through the live delivery loop: the
+/// reaction currently shown on the triggering message, and a monotonic id so
+/// each transition is a distinct, idempotent delivery.
+#[derive(Default)]
+struct SourceReactionState {
+    current: Option<RunReaction>,
+    seq: u64,
 }
 
 /// Bound on the delivered-run memory. Evicted oldest-first; an evicted entry
@@ -457,39 +468,76 @@ impl RunDeliveryObserver {
         let mut delivered_blocked_marker: Option<BlockedActionableMarker> = None;
         let mut working_message: Option<DeliveredChannelMessage> = None;
         let mut messages_to_delete_after_final: Vec<DeliveredChannelMessage> = Vec::new();
+        // The current run-lifecycle reaction on the triggering message and a
+        // monotonic id for each transition. Stays `None` until a working phase
+        // places 👀 — an instant reply gets no reaction (and so no terminal swap).
+        let mut reaction_state = SourceReactionState::default();
         loop {
-            let actionable_state = {
-                self.wait_for_actionable(
+            let actionable_state = match self
+                .wait_for_actionable(
                     &envelope,
                     &scope,
                     run_id,
                     delivered_blocked_marker.as_ref(),
                     &mut working_message,
+                    &mut reaction_state,
                 )
                 .await
-                .map_err(|err| {
+            {
+                Ok(state) => state,
+                Err(err) => {
+                    // Timed out (or a wait error): don't leave a stuck "thinking"
+                    // indicator. Retract it and mark the triggering message ❌;
+                    // the caller posts the "taking longer / check the web app"
+                    // notice.
+                    if let Some(message) = working_message.take() {
+                        self.services
+                            .retract_message(scope.clone(), Some(run_id), message)
+                            .await;
+                    }
+                    self.set_source_reaction(
+                        &scope,
+                        run_id,
+                        envelope.external_conversation_ref(),
+                        &mut reaction_state,
+                        RunReaction::Failed,
+                    )
+                    .await;
                     // If a blocked-state notification was already delivered,
                     // a timeout does not leave the user in silence — convert
                     // to the quieter variant so feedback does not double-post.
-                    if matches!(err, RunDeliveryError::RunWaitTimedOut { .. })
-                        && delivered_blocked_marker.is_some()
-                    {
-                        RunDeliveryError::RunWaitTimedOutAfterNotification { run_id }
-                    } else {
-                        err
-                    }
-                })?
+                    return Err(
+                        if matches!(err, RunDeliveryError::RunWaitTimedOut { .. })
+                            && delivered_blocked_marker.is_some()
+                        {
+                            RunDeliveryError::RunWaitTimedOutAfterNotification { run_id }
+                        } else {
+                            err
+                        },
+                    );
+                }
             };
             if matches!(
                 actionable_state.status,
                 TurnStatus::BlockedApproval | TurnStatus::BlockedAuth
-            ) && let Some(message) = working_message.take()
-            {
-                self.services
-                    .retract_message(scope.clone(), Some(run_id), message)
-                    .await;
+            ) {
+                if let Some(message) = working_message.take() {
+                    self.services
+                        .retract_message(scope.clone(), Some(run_id), message)
+                        .await;
+                }
+                // Parked waiting on the user: swap 👀 → ⚠️ on the triggering
+                // message so it reads as "needs you" at a glance.
+                self.set_source_reaction(
+                    &scope,
+                    run_id,
+                    envelope.external_conversation_ref(),
+                    &mut reaction_state,
+                    RunReaction::NeedsInput,
+                )
+                .await;
             }
-            let Some(notification) = self
+            let notification = match self
                 .notification_for_actionable_state(
                     &envelope,
                     &binding,
@@ -499,8 +547,57 @@ impl RunDeliveryObserver {
                     &actionable_state,
                 )
                 .await?
-            else {
-                return Ok(());
+            {
+                Some(notification) => notification,
+                None => {
+                    // A terminal state produced no deliverable notification.
+                    // Never leave a stuck working indicator: retract it. For a
+                    // genuine failure (not a completed-but-empty run) also post a
+                    // brief failure notice and mark ❌ — source-routed through the
+                    // same reliable path as the working indicator, so it reaches
+                    // Slack and Telegram even without a reply-target binding.
+                    if actionable_state.status.is_terminal() {
+                        self.delivery_runs
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .record_delivered(run_id);
+                        if let Some(message) = working_message.take() {
+                            self.services
+                                .retract_message(scope.clone(), Some(run_id), message)
+                                .await;
+                        }
+                        if actionable_state.status == TurnStatus::Completed {
+                            self.set_source_reaction(
+                                &scope,
+                                run_id,
+                                envelope.external_conversation_ref(),
+                                &mut reaction_state,
+                                RunReaction::Done,
+                            )
+                            .await;
+                        } else {
+                            self.services
+                                .post_notice(
+                                    DeliveryIntent::FailureNotice,
+                                    scope.clone(),
+                                    Some(run_id),
+                                    envelope.external_conversation_ref(),
+                                    prompts::RUN_FAILED_MESSAGE,
+                                    format!("run-failed:{run_id}"),
+                                )
+                                .await;
+                            self.set_source_reaction(
+                                &scope,
+                                run_id,
+                                envelope.external_conversation_ref(),
+                                &mut reaction_state,
+                                RunReaction::Failed,
+                            )
+                            .await;
+                        }
+                    }
+                    return Ok(());
+                }
             };
             let next_blocked_marker = blocked_actionable_marker(&actionable_state);
             let event_kind = notification.event_kind;
@@ -549,6 +646,21 @@ impl RunDeliveryObserver {
                         .retract_message(scope.clone(), Some(run_id), message)
                         .await;
                 }
+                // Swap to the terminal reaction — ✅ done or ❌ failed. A no-op
+                // if the run never showed a working phase (nothing was reacted).
+                let terminal_reaction = if actionable_state.status == TurnStatus::Completed {
+                    RunReaction::Done
+                } else {
+                    RunReaction::Failed
+                };
+                self.set_source_reaction(
+                    &scope,
+                    run_id,
+                    envelope.external_conversation_ref(),
+                    &mut reaction_state,
+                    terminal_reaction,
+                )
+                .await;
                 for message in messages_to_delete_after_final {
                     self.services
                         .retract_message(scope.clone(), Some(run_id), message)
@@ -574,9 +686,16 @@ impl RunDeliveryObserver {
         run_id: TurnRunId,
         delivered_blocked_marker: Option<&BlockedActionableMarker>,
         working_message: &mut Option<DeliveredChannelMessage>,
+        reaction_state: &mut SourceReactionState,
     ) -> Result<TurnRunState, RunDeliveryError> {
         let start = Instant::now();
         let mut poll_interval = self.settings.poll_interval;
+        let notice_seed = run_id.to_string().bytes().map(u64::from).sum::<u64>();
+        // "Still working" nudges within this running stretch: the first at
+        // `first_nudge_after`, then each gap doubling so a long run backs off.
+        let mut nudge_count: u64 = 0;
+        let mut next_nudge_at = self.settings.first_nudge_after;
+        let mut nudge_gap = self.settings.renudge_interval;
         loop {
             let state = self
                 .services
@@ -597,28 +716,107 @@ impl RunDeliveryObserver {
             if start.elapsed() >= self.settings.max_wait {
                 return Err(RunDeliveryError::RunWaitTimedOut { run_id });
             }
-            if working_message.is_none() && blocked_actionable_marker(&state).is_none() {
-                // Vary the notice per run so a channel with several runs in
-                // flight does not show a wall of identical lines; seeded by the
-                // run id so one run keeps one voice.
-                let notice_seed = run_id.to_string().bytes().map(u64::from).sum::<u64>();
-                *working_message = self
-                    .services
-                    .post_notice(
-                        DeliveryIntent::Working,
-                        scope.clone(),
-                        Some(run_id),
+            if blocked_actionable_marker(&state).is_none() {
+                if working_message.is_none() {
+                    // First working notice for this running stretch. Vary the
+                    // line per run (seeded by the run id) so a channel with
+                    // several runs in flight keeps one voice each, and mark the
+                    // triggering message with 👀 so the user sees which ping is
+                    // being worked on.
+                    *working_message = self
+                        .services
+                        .post_notice(
+                            DeliveryIntent::Working,
+                            scope.clone(),
+                            Some(run_id),
+                            envelope.external_conversation_ref(),
+                            prompts::working_message(notice_seed),
+                            format!("working:{run_id}"),
+                        )
+                        .await;
+                    self.set_source_reaction(
+                        scope,
+                        run_id,
                         envelope.external_conversation_ref(),
-                        prompts::working_message(notice_seed),
-                        format!("working:{run_id}"),
+                        reaction_state,
+                        RunReaction::Working,
                     )
                     .await;
+                } else if start.elapsed() >= next_nudge_at {
+                    // The run is taking a while: refresh the indicator (retract +
+                    // repost) with an escalated "still working" line so the user
+                    // knows it hasn't stalled, keeping the latest status at the
+                    // bottom of the conversation. Each gap doubles.
+                    if let Some(previous) = working_message.take() {
+                        self.services
+                            .retract_message(scope.clone(), Some(run_id), previous)
+                            .await;
+                    }
+                    nudge_count += 1;
+                    next_nudge_at += nudge_gap;
+                    nudge_gap = nudge_gap.saturating_mul(2);
+                    *working_message = self
+                        .services
+                        .post_notice(
+                            DeliveryIntent::Working,
+                            scope.clone(),
+                            Some(run_id),
+                            envelope.external_conversation_ref(),
+                            prompts::long_running_message(notice_seed, nudge_count),
+                            format!("working:{run_id}:{nudge_count}"),
+                        )
+                        .await;
+                }
             }
             tokio::time::sleep(super::jittered_poll_interval(poll_interval, &run_id)).await;
             poll_interval = poll_interval
                 .saturating_mul(2)
                 .min(std::time::Duration::from_secs(5));
         }
+    }
+
+    /// Transition the run-lifecycle reaction on the triggering message to
+    /// `next` (👀 working → ⚠️ needs-input → 👀 working → ✅ done / ❌ failed),
+    /// removing the previous reaction first so only one shows at a time.
+    /// `current`/`seq` persist the state and a monotonic delivery id across the
+    /// run; a no-op when the reaction is unchanged or there is nothing to react
+    /// to. Best-effort throughout — a reaction never affects the run.
+    async fn set_source_reaction(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        conversation: &ExternalConversationRef,
+        state: &mut SourceReactionState,
+        next: RunReaction,
+    ) {
+        if state.current == Some(next) || conversation.reply_target_message_id().is_none() {
+            return;
+        }
+        if let Some(previous) = state.current.take() {
+            self.services
+                .react_to_source(
+                    scope.clone(),
+                    run_id,
+                    conversation,
+                    previous,
+                    ReactionAction::Remove,
+                    state.seq,
+                )
+                .await;
+            state.seq += 1;
+        }
+        self.services
+            .react_to_source(
+                scope.clone(),
+                run_id,
+                conversation,
+                next,
+                ReactionAction::Add,
+                state.seq,
+            )
+            .await;
+        state.seq += 1;
+        state.current = Some(next);
     }
 
     async fn notification_for_actionable_state(

--- a/crates/product/ironclaw_assistant/src/run_delivery/prompts.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/prompts.rs
@@ -12,7 +12,26 @@ use ironclaw_product_contracts::outbound::{ApprovalPromptContextView, GatePrompt
 
 use crate::is_approval_gate_ref;
 
-pub(crate) const WORKING_MESSAGE: &str = "Ironclaw is thinking...";
+/// A small rotation of warm "on it" notices posted while a run works, so a
+/// shared channel with several runs in flight does not fill with identical
+/// lines. Picked deterministically from a per-run seed (see [`working_message`])
+/// so a single run keeps one voice while concurrent runs vary.
+pub(crate) const WORKING_MESSAGES: &[&str] = &[
+    "On it!",
+    "Let me look into that…",
+    "Working on it…",
+    "Give me a sec…",
+    "Digging in…",
+    "Let me take care of that…",
+    "Looking into it…",
+    "Got it — on this now…",
+];
+
+/// Pick a working notice deterministically from `seed` (the run id), so the
+/// same run always shows the same line and two concurrent runs usually differ.
+pub(crate) fn working_message(seed: u64) -> &'static str {
+    WORKING_MESSAGES[(seed % WORKING_MESSAGES.len() as u64) as usize]
+}
 pub(crate) const AUTH_CANCELED_MESSAGE: &str = "Authentication canceled.";
 /// Posted when a run has no channel-serviceable auth challenge. This stays
 /// deliberately generic because missing/unknown challenge metadata cannot
@@ -281,6 +300,24 @@ mod tests {
     use super::*;
     use ironclaw_extension_contracts::auth_prompt::PairingPromptView;
     use ironclaw_host_api::turn::TurnRunId;
+
+    #[test]
+    fn working_message_is_always_a_member_and_varies_by_seed() {
+        // Every seed maps to one of the rotation lines.
+        for seed in 0u64..32 {
+            assert!(WORKING_MESSAGES.contains(&working_message(seed)));
+        }
+        // Deterministic for a given seed (one run keeps one voice).
+        assert_eq!(working_message(3), working_message(3));
+        // The rotation actually varies across runs (not one hardcoded line).
+        let distinct: std::collections::HashSet<&str> = (0u64..WORKING_MESSAGES.len() as u64)
+            .map(working_message)
+            .collect();
+        assert!(
+            distinct.len() > 1,
+            "the working notice should vary across runs, got {distinct:?}"
+        );
+    }
 
     /// The delivery id is derived from this ref, so two notices that share a
     /// string share a durable delivery identity — the second comes back

--- a/crates/product/ironclaw_assistant/src/run_delivery/prompts.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/prompts.rs
@@ -32,6 +32,22 @@ pub(crate) const WORKING_MESSAGES: &[&str] = &[
 pub(crate) fn working_message(seed: u64) -> &'static str {
     WORKING_MESSAGES[(seed % WORKING_MESSAGES.len() as u64) as usize]
 }
+
+/// Escalated "still working" notices that replace the initial indicator when a
+/// run runs long, so the user knows it hasn't stalled. Picked by `(seed, nudge)`
+/// so successive nudges on one run vary their wording (see [`long_running_message`]).
+pub(crate) const LONG_RUNNING_MESSAGES: &[&str] = &[
+    "Still on it — this one's taking a little longer than usual…",
+    "Hang tight, I haven't forgotten you — still working through this…",
+    "This is taking a bit longer than expected, but I'm still on it…",
+    "Bear with me — still crunching through this one…",
+];
+
+/// Pick an escalated "still working" notice for the `nudge`-th update of a run,
+/// varying the wording each time while staying deterministic for replays.
+pub(crate) fn long_running_message(seed: u64, nudge: u64) -> &'static str {
+    LONG_RUNNING_MESSAGES[(seed.wrapping_add(nudge) % LONG_RUNNING_MESSAGES.len() as u64) as usize]
+}
 pub(crate) const AUTH_CANCELED_MESSAGE: &str = "Authentication canceled.";
 /// Posted when a run has no channel-serviceable auth challenge. This stays
 /// deliberately generic because missing/unknown challenge metadata cannot
@@ -60,6 +76,12 @@ pub(crate) const DELIVERY_TIMEOUT_MESSAGE: &str =
     "This is taking longer than expected — check the WebUI for the result.";
 pub(crate) const DELIVERY_ERROR_MESSAGE: &str =
     "Something went wrong delivering the result here. Check the WebUI.";
+/// Posted when an interactive channel run reaches a terminal *failed* state
+/// (as opposed to a self-authored error reply): the working indicator is
+/// replaced with this so the user gets closure instead of a stuck "thinking"
+/// line. Channel-neutral and diagnostic-free — details stay in the web app.
+pub(crate) const RUN_FAILED_MESSAGE: &str =
+    "That run didn't finish — open the Ironclaw web app for details.";
 /// Posted when the blocking run is `BlockedApproval` and no gate_ref is
 /// available.
 pub(crate) const BUSY_APPROVAL_MESSAGE: &str = "Ironclaw is waiting on a pending approval before taking new messages — reply `approve` or `deny` (or `approve gate:<ref>`) to resume.";

--- a/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
@@ -24,7 +24,7 @@ use ironclaw_extension_contracts::auth_prompt::AuthPromptView;
 use ironclaw_extension_contracts::channel_adapter::ChannelAdapter;
 use ironclaw_extension_contracts::channel_adapter::{
     ChannelError, DeliveryReport, InboundOutcome, OutboundEnvelope, OutboundPart,
-    PartDeliveryOutcome, ProductTriggerReason, VerifiedInbound,
+    PartDeliveryOutcome, ProductTriggerReason, ReactionAction, RunReaction, VerifiedInbound,
 };
 use ironclaw_extension_contracts::external::{
     ExternalActorRef, ExternalConversationRef, ExternalEventId,
@@ -259,6 +259,24 @@ impl RecordingChannelAdapter {
                     OutboundPart::Retract { vendor_message_ref } => {
                         Some(vendor_message_ref.clone())
                     }
+                    _ => None,
+                })
+            })
+            .collect()
+    }
+
+    /// The ordered run-lifecycle reactions the adapter was asked to apply, as
+    /// `(target_ref, reaction, action)`.
+    fn reactions(&self) -> Vec<(String, RunReaction, ReactionAction)> {
+        self.envelopes()
+            .iter()
+            .flat_map(|envelope| {
+                envelope.parts.iter().filter_map(|part| match part {
+                    OutboundPart::React {
+                        vendor_message_ref,
+                        reaction,
+                        action,
+                    } => Some((vendor_message_ref.clone(), *reaction, *action)),
                     _ => None,
                 })
             })
@@ -829,6 +847,8 @@ fn build_harness_with_commands(
             max_wait,
             max_concurrent_deliveries: NonZeroUsize::new(4).expect("nz"),
             max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
         },
         commands,
         prefix,
@@ -1356,9 +1376,260 @@ async fn observer_posts_working_indicator_and_retracts_it_after_final_reply() {
     );
 }
 
+/// A run whose triggering message has a vendor ref is marked 👀 while working
+/// and swapped to ✅ when it completes, so a busy channel shows at a glance
+/// which ping is being handled.
+#[tokio::test]
+async fn observer_reacts_eyes_while_working_then_check_when_done() {
+    let harness = build_harness(
+        vec![
+            // guard, then Running (posts indicator + 👀), then Completed (✅).
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::Completed, None),
+        ],
+        false,
+        None,
+        Duration::from_secs(5),
+    );
+    let run_id = TurnRunId::new();
+    seed_final_message(&harness.threads, run_id, "done thinking").await;
+
+    harness
+        .observer
+        .observe_ack(
+            envelope_for_conversation_replying_to(
+                ProductInboundPayload::UserMessage(
+                    UserMessagePayload::new("hi", Vec::new(), ProductTriggerReason::BotMention)
+                        .expect("payload"),
+                ),
+                "evt-react",
+                "conv-1",
+                None,
+                Some("ts-source"),
+            ),
+            accepted_ack(run_id),
+        )
+        .await;
+
+    assert_eq!(
+        harness.adapter.reactions(),
+        vec![
+            (
+                "ts-source".to_string(),
+                RunReaction::Working,
+                ReactionAction::Add
+            ),
+            (
+                "ts-source".to_string(),
+                RunReaction::Working,
+                ReactionAction::Remove
+            ),
+            (
+                "ts-source".to_string(),
+                RunReaction::Done,
+                ReactionAction::Add
+            ),
+        ],
+        "the triggering message is 👀 while working and ✅ when done"
+    );
+}
+
+/// A run that reaches a terminal *failed* state no longer goes silent: the
+/// working indicator is retracted and replaced with a failure notice, and the
+/// triggering message is marked ❌.
+#[tokio::test]
+async fn observer_replaces_working_indicator_with_failure_notice_and_x_reaction() {
+    let harness = build_harness(
+        vec![
+            // guard, then Running (indicator + 👀), then a hard failure.
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::Failed, None),
+        ],
+        false,
+        None,
+        Duration::from_secs(5),
+    );
+    let run_id = TurnRunId::new();
+    // A failed run has no finalized assistant message.
+
+    harness
+        .observer
+        .observe_ack(
+            envelope_for_conversation_replying_to(
+                ProductInboundPayload::UserMessage(
+                    UserMessagePayload::new("hi", Vec::new(), ProductTriggerReason::BotMention)
+                        .expect("payload"),
+                ),
+                "evt-fail",
+                "conv-1",
+                None,
+                Some("ts-source"),
+            ),
+            accepted_ack(run_id),
+        )
+        .await;
+
+    // Working indicator, then a distinct, non-empty failure notice — not silence.
+    let texts = harness.adapter.texts();
+    assert_eq!(texts.len(), 2, "working indicator then failure notice");
+    assert!(
+        !texts[1].is_empty() && texts[1] != texts[0],
+        "the failure notice is distinct from the working indicator, got {:?}",
+        texts[1]
+    );
+    assert_eq!(
+        harness.adapter.retracted_refs().len(),
+        1,
+        "the stuck working indicator is retracted"
+    );
+    // 👀 → ❌ on the triggering message.
+    assert_eq!(
+        harness.adapter.reactions(),
+        vec![
+            (
+                "ts-source".to_string(),
+                RunReaction::Working,
+                ReactionAction::Add
+            ),
+            (
+                "ts-source".to_string(),
+                RunReaction::Working,
+                ReactionAction::Remove
+            ),
+            (
+                "ts-source".to_string(),
+                RunReaction::Failed,
+                ReactionAction::Add
+            ),
+        ],
+        "a failed run swaps 👀 for ❌"
+    );
+}
+
+/// The full lifecycle: 👀 working → ⚠️ when parked on an approval → 👀 again on
+/// resume → ✅ when it finishes.
+#[tokio::test]
+async fn observer_marks_needs_input_while_blocked_then_swaps_back_and_completes() {
+    let harness = build_harness(
+        vec![
+            scripted_state(TurnStatus::Running, None), // guard
+            scripted_state(TurnStatus::Running, None), // working + 👀
+            scripted_state(TurnStatus::BlockedApproval, Some("gate-1")), // ⚠️ + prompt
+            scripted_state(TurnStatus::Running, None), // resume → 👀
+            scripted_state(TurnStatus::Completed, None), // ✅
+        ],
+        false,
+        None,
+        Duration::from_secs(5),
+    );
+    let run_id = TurnRunId::new();
+    seed_final_message(&harness.threads, run_id, "approved and done").await;
+
+    harness
+        .observer
+        .observe_ack(
+            envelope_for_conversation_replying_to(
+                ProductInboundPayload::UserMessage(
+                    UserMessagePayload::new("hi", Vec::new(), ProductTriggerReason::BotMention)
+                        .expect("payload"),
+                ),
+                "evt-needs-input",
+                "conv-1",
+                None,
+                Some("ts-source"),
+            ),
+            accepted_ack(run_id),
+        )
+        .await;
+
+    let w = RunReaction::Working;
+    let ni = RunReaction::NeedsInput;
+    let add = ReactionAction::Add;
+    let rm = ReactionAction::Remove;
+    assert_eq!(
+        harness.adapter.reactions(),
+        vec![
+            ("ts-source".to_string(), w, add), // 👀 working
+            ("ts-source".to_string(), w, rm),  // → ⚠️
+            ("ts-source".to_string(), ni, add),
+            ("ts-source".to_string(), ni, rm), // resume → 👀
+            ("ts-source".to_string(), w, add),
+            ("ts-source".to_string(), w, rm), // → ✅
+            ("ts-source".to_string(), RunReaction::Done, add),
+        ],
+        "reaction tracks working → needs-input → working → done"
+    );
+}
+
+/// A long-running run refreshes its working indicator in place with escalating
+/// "still working" nudges (retract + repost) rather than a single stale line.
+#[tokio::test(start_paused = true)]
+async fn observer_refreshes_working_indicator_with_escalating_nudges_on_a_long_run() {
+    let settings = RunDeliverySettings {
+        poll_interval: Duration::from_millis(1),
+        first_nudge_after: Duration::from_millis(1),
+        renudge_interval: Duration::from_millis(1),
+        max_wait: Duration::from_secs(60),
+        ..RunDeliverySettings::default()
+    };
+    // guard + several Running polls (nudge on each) + Completed.
+    let mut states = vec![scripted_state(TurnStatus::Running, None)];
+    states.extend(std::iter::repeat_with(|| scripted_state(TurnStatus::Running, None)).take(5));
+    states.push(scripted_state(TurnStatus::Completed, None));
+    let harness = build_harness_with_settings(states, false, None, settings, &["status"], None);
+    let run_id = TurnRunId::new();
+    seed_final_message(&harness.threads, run_id, "slow done").await;
+
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-nudge"),
+            accepted_ack(run_id),
+        )
+        .await;
+
+    let texts = harness.adapter.texts();
+    assert!(
+        texts.len() >= 3,
+        "initial working notice + at least one nudge + final reply, got {texts:?}"
+    );
+    assert_eq!(
+        texts.last().map(String::as_str),
+        Some("slow done"),
+        "the final reply is delivered last"
+    );
+    let (notices, reply) = texts.split_at(texts.len() - 1);
+    assert!(
+        notices.iter().all(|t| !t.is_empty()),
+        "every working/nudge notice is non-empty, got {notices:?}"
+    );
+    assert_eq!(reply, ["slow done".to_string()]);
+    // Each nudge refreshes in place (retracts the prior indicator); the final
+    // reply retracts the last one.
+    assert!(
+        harness.adapter.retracted_refs().len() >= 2,
+        "nudges refresh the indicator in place, got {:?}",
+        harness.adapter.retracted_refs()
+    );
+    // The escalated nudges are worded differently from the initial "on it" line.
+    let distinct: std::collections::HashSet<&str> = notices.iter().map(String::as_str).collect();
+    assert!(
+        distinct.len() >= 2,
+        "the nudge copy escalates from the initial line, got {distinct:?}"
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn observer_keeps_watching_a_healthy_run_past_the_previous_two_minute_cutoff() {
-    let settings = RunDeliverySettings::default();
+    // Disable the "still working" nudges so this longevity test asserts exactly
+    // the working indicator + final reply, not the nudge cadence.
+    let settings = RunDeliverySettings {
+        first_nudge_after: Duration::from_secs(3600),
+        renudge_interval: Duration::from_secs(3600),
+        ..RunDeliverySettings::default()
+    };
     assert!(
         settings.max_wait > Duration::from_secs(2 * 60),
         "the live channel watcher must outlive a healthy run that exceeds the old two-minute cutoff"
@@ -1429,7 +1700,7 @@ async fn observer_retracts_working_indicator_and_auth_prompt_after_auth_completi
     assert_eq!(texts.len(), 3, "auth prompt + working + final reply");
     assert!(texts[0].contains("Authentication required"));
     assert!(
-        !texts[1].is_empty() && texts[1] != texts[2],
+        !texts[1].is_empty() && texts[1] != texts[0] && texts[1] != texts[2],
         "a distinct working indicator sits between the auth prompt and the reply, got {:?}",
         texts[1]
     );
@@ -2358,6 +2629,8 @@ fn build_triggered_harness_with_catalog(
             max_wait: Duration::from_millis(60),
             max_concurrent_deliveries: NonZeroUsize::new(4).expect("nz"),
             max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
         },
         Arc::clone(&delivery_store) as Arc<dyn TriggeredRunDeliveryStore>,
         Arc::clone(&codecs)

--- a/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
@@ -1331,13 +1331,13 @@ async fn observer_posts_working_indicator_and_retracts_it_after_final_reply() {
         .await;
 
     let texts = harness.adapter.texts();
-    assert_eq!(
-        texts,
-        vec![
-            "Ironclaw is thinking...".to_string(),
-            "done thinking".to_string()
-        ]
+    assert_eq!(texts.len(), 2, "working indicator then final reply");
+    assert!(
+        !texts[0].is_empty() && texts[0] != "done thinking",
+        "a distinct working indicator precedes the final reply, got {:?}",
+        texts[0]
     );
+    assert_eq!(texts[1], "done thinking");
     // The working indicator's vendor ref came back through the coordinator
     // outcome and was retracted after the final reply (Cleanup intent).
     let retracted = harness.adapter.retracted_refs();
@@ -1388,13 +1388,14 @@ async fn observer_keeps_watching_a_healthy_run_past_the_previous_two_minute_cuto
         tokio::time::Instant::now().duration_since(started) > Duration::from_secs(2 * 60),
         "the scripted run must cross the previous delivery deadline"
     );
-    assert_eq!(
-        harness.adapter.texts(),
-        vec![
-            "Ironclaw is thinking...".to_string(),
-            "slow run finished".to_string()
-        ]
+    let texts = harness.adapter.texts();
+    assert_eq!(texts.len(), 2, "working indicator then final reply");
+    assert!(
+        !texts[0].is_empty() && texts[0] != "slow run finished",
+        "a distinct working indicator precedes the final reply, got {:?}",
+        texts[0]
     );
+    assert_eq!(texts[1], "slow run finished");
     assert_eq!(harness.adapter.retracted_refs().len(), 1);
 }
 
@@ -1427,7 +1428,11 @@ async fn observer_retracts_working_indicator_and_auth_prompt_after_auth_completi
     let texts = harness.adapter.texts();
     assert_eq!(texts.len(), 3, "auth prompt + working + final reply");
     assert!(texts[0].contains("Authentication required"));
-    assert_eq!(texts[1], "Ironclaw is thinking...");
+    assert!(
+        !texts[1].is_empty() && texts[1] != texts[2],
+        "a distinct working indicator sits between the auth prompt and the reply, got {:?}",
+        texts[1]
+    );
     assert_eq!(texts[2], "authenticated and finished");
     assert_eq!(
         harness.adapter.retracted_refs(),

--- a/tests/integration/delivery_user_journeys.rs
+++ b/tests/integration/delivery_user_journeys.rs
@@ -1347,6 +1347,8 @@ fn background_run_notifier(
             max_wait: Duration::from_secs(10),
             max_concurrent_deliveries: std::num::NonZeroUsize::new(4).expect("non-zero"),
             max_pending_deliveries: std::num::NonZeroUsize::new(8).expect("non-zero"),
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
         },
         services
             .triggered_run_delivery_store_for_test()
@@ -2019,6 +2021,8 @@ fn web_push_background_run_notifier(
             max_wait: Duration::from_secs(10),
             max_concurrent_deliveries: std::num::NonZeroUsize::new(4).expect("non-zero"),
             max_pending_deliveries: std::num::NonZeroUsize::new(8).expect("non-zero"),
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
         },
         services
             .triggered_run_delivery_store_for_test()

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -1751,15 +1751,17 @@ async fn telegram_update_becomes_a_turn_and_a_coordinated_reply_impl(storage: St
     // The model is deliberately paused so the generic observer must surface
     // a working indicator through the real Telegram adapter before the final
     // reply exists.
-    // The model is paused, so the only `/sendMessage` posted before release is
-    // the working indicator (its copy varies per run, so match on the call, not
-    // the words — content is pinned in the assistant's prompt unit test).
+    // The model is paused, so the first `/sendMessage` AFTER the baseline is the
+    // working indicator (its copy varies per run, so match on the call, not the
+    // words — content is pinned in the assistant's prompt unit test). Selecting
+    // past the baseline avoids matching earlier pairing-feedback traffic.
     for _ in 0..200 {
-        if inbound
+        let send_message_count = inbound
             .captured_network_requests_for_test()
             .iter()
-            .any(|request| request.url.ends_with("/sendMessage"))
-        {
+            .filter(|request| request.url.ends_with("/sendMessage"))
+            .count();
+        if send_message_count > send_message_count_before_rejected_update {
             break;
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
@@ -1767,7 +1769,8 @@ async fn telegram_update_becomes_a_turn_and_a_coordinated_reply_impl(storage: St
     let requests = inbound.captured_network_requests_for_test();
     let working = requests
         .iter()
-        .find(|request| request.url.ends_with("/sendMessage"))
+        .filter(|request| request.url.ends_with("/sendMessage"))
+        .nth(send_message_count_before_rejected_update)
         .expect("a running Telegram turn must post the generic working indicator");
     let working_body: serde_json::Value =
         serde_json::from_slice(&working.body).expect("working sendMessage body is JSON");

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -1751,14 +1751,14 @@ async fn telegram_update_becomes_a_turn_and_a_coordinated_reply_impl(storage: St
     // The model is deliberately paused so the generic observer must surface
     // a working indicator through the real Telegram adapter before the final
     // reply exists.
+    // The model is paused, so the only `/sendMessage` posted before release is
+    // the working indicator (its copy varies per run, so match on the call, not
+    // the words — content is pinned in the assistant's prompt unit test).
     for _ in 0..200 {
         if inbound
             .captured_network_requests_for_test()
             .iter()
-            .any(|request| {
-                request.url.ends_with("/sendMessage")
-                    && String::from_utf8_lossy(&request.body).contains("Ironclaw is thinking...")
-            })
+            .any(|request| request.url.ends_with("/sendMessage"))
         {
             break;
         }
@@ -1767,10 +1767,7 @@ async fn telegram_update_becomes_a_turn_and_a_coordinated_reply_impl(storage: St
     let requests = inbound.captured_network_requests_for_test();
     let working = requests
         .iter()
-        .find(|request| {
-            request.url.ends_with("/sendMessage")
-                && String::from_utf8_lossy(&request.body).contains("Ironclaw is thinking...")
-        })
+        .find(|request| request.url.ends_with("/sendMessage"))
         .expect("a running Telegram turn must post the generic working indicator");
     let working_body: serde_json::Value =
         serde_json::from_slice(&working.body).expect("working sendMessage body is JSON");

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -3144,9 +3144,19 @@ async fn unbound_telegram_actor_pairs_via_web_minted_code_then_turns_attribute_t
     let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         let bodies = race_bodies();
-        if anchored_count(&bodies, RACE_REPLY, 618) == 1
-            && anchored_count(&bodies, "is thinking", 618) == 1
-        {
+        // The working indicator is the race-chat message anchored to 618 that is
+        // not the final reply (its copy varies per run, so it can't be matched by
+        // literal — content is pinned in the assistant's prompt unit test).
+        let working_indicator_anchored_to_618 = bodies
+            .iter()
+            .filter(|body| {
+                body["reply_to_message_id"].as_i64() == Some(618)
+                    && !body["text"]
+                        .as_str()
+                        .is_some_and(|text| text.contains(RACE_REPLY))
+            })
+            .count();
+        if anchored_count(&bodies, RACE_REPLY, 618) == 1 && working_indicator_anchored_to_618 == 1 {
             assert_eq!(
                 anchored_count(&bodies, "still working on a previous message", 619),
                 1,


### PR DESCRIPTION
## Rich working indicator for channel runs

Makes the channel "working" experience legible on Slack and Telegram. Four parts:

### 1. Varied working copy
The single `"Ironclaw is thinking..."` line is replaced with a small rotation of warm notices (`"On it!"`, `"Digging in…"`, …), picked deterministically per run (seeded by the run id) so a channel with several runs in flight keeps one voice each instead of a wall of identical lines.

### 2. Run-lifecycle reactions on the triggering message
The message you pinged is marked with a reaction that tracks the run, so a busy channel shows at a glance which message each run is handling:

- 👀 **working** → ✅ **done** on completion
- 👀 → ⚠️ **needs input** when the run parks on an approval/auth prompt, then back to 👀 on resume
- 👀 → ❌ **failed** on failure/timeout

Slack uses the exact emoji (`eyes` / `white_check_mark` / `warning` / `x`); Telegram's `setMessageReaction` only accepts a fixed allowlist, so it maps to the nearest allowed reactions (👀 / 👌 / 🤔 / 👎). The source message's vendor ref already rides `ExternalConversationRef.reply_target_message_id`, so no new ingress plumbing was needed.

### 3. Failure states now reach the channel
Previously a run that reached a terminal **failed/cancelled** state went silent and left a stuck "thinking…" line (`notification_for_actionable_state` returned `None` → the loop returned before the retract). Now the working indicator is retracted and replaced with a brief, diagnostic-free failure notice (source-routed through the same reliable path as the indicator), and the message is marked ❌. Timeouts retract the indicator too.

### 4. Progress updates on long runs
A run that runs long refreshes its indicator in place (retract + repost) with an escalating "still working…" line so it never looks stalled — first at 30s, then each gap doubling (≈ +1m, +2m, +4m …) so a very long run backs off instead of spamming.

## Layers touched

- **Contract** (`ironclaw_extension_contracts`): new `OutboundPart::React { vendor_message_ref, reaction, action }` + neutral `RunReaction`/`ReactionAction` enums.
- **Adapters**: Slack `reactions.add`/`reactions.remove`; Telegram `setMessageReaction`; egress allowlists updated in both manifests. `web-push` reports reactions unsupported.
- **Coordinator**: `DeliveryIntent::Reaction` (notice-class).
- **Observer** (`ironclaw_assistant`): a small reaction state machine (`set_source_reaction`) driving 👀/⚠️/✅/❌ across the run lifecycle, the doubling nudge cadence, and the terminal-failure/timeout retract + notice.

## Reviewer comments (prior revision)

- **CodeRabbit — preserve distinctness in auth-flow assertions**: fixed — the working indicator is now asserted distinct from both the auth prompt and the reply (`run_delivery_contract.rs`, `e2e_tests.rs`).
- **IronLoop — three tests still assert the old literal**: already fixed in the "assert structure, not copy" commit — stale.
- **CodeRabbit — test the working notice through the caller**: the new observer-level tests drive `observe_ack` and capture the delivered notices for real run ids (reaction/failure/needs-input/nudge lifecycles); the property test on the helper is retained.

## Test Strategy

- **Unit/contract** (`run_delivery_contract.rs`): reaction lifecycle (👀→✅), failure (👀→❌ + retract + notice), full needs-input lifecycle (👀→⚠️→👀→✅), and escalating in-place nudges — all driven through `RunDeliveryObserver::observe_ack` and asserted at the adapter seam.
- **Adapter** (`slack`, `telegram`): `React` renders to `reactions.add`/`reactions.remove` / `setMessageReaction` with the mapped emoji; `already_reacted`/non-numeric refs handled; the Slack idempotent no-op is covered.
- **Not applicable (e2e)**: the reaction/nudge behavior is exercised deterministically at the contract tier through the real observer; no new cross-crate wiring the e2e harness would add coverage for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
