### PR TITLE
fix(product): stop releasing the connect-nudge throttle on ref-less delivery

### DIFF
--- a/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
+++ b/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
@@ -241,15 +241,19 @@ pub enum CoordinatedDeliveryOutcome {
     Failed {
         attempt: OutboundDeliveryAttempt,
         failure_kind: DeliveryFailureKind,
+        /// Whether any part reached the vendor during THIS invocation. Kept
+        /// separate from refs because a successful accept may return no ref.
+        vendor_reached: bool,
         /// Vendor refs for parts THIS invocation confirmed sent before the
-        /// terminal failure. Non-empty only for the partial-multipart case
+        /// terminal failure. Populated only for the partial-multipart case
         /// (OUT-7): an adapter may split one `OutboundPart` into several
         /// vendor-level chunks (`ChannelAdapter::deliver` owns splitting —
         /// Slack and Telegram both chunk oversized text), so a single-part
         /// envelope can still fail after an earlier chunk reached the
-        /// vendor. Empty whenever nothing reached the vendor, including the
-        /// claim-miss path (`outcome_for_claimed_delivery`), which has no
-        /// egress evidence of its own to report.
+        /// vendor. May still be empty when an accepted chunk returned no ref;
+        /// `vendor_reached` is the authoritative reachability evidence. Also
+        /// empty on the claim-miss path (`outcome_for_claimed_delivery`),
+        /// which has no egress evidence of its own to report.
         vendor_message_refs: Vec<String>,
     },
 }
@@ -753,6 +757,7 @@ impl DeliveryCoordinator {
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_reached: any_sent,
                             vendor_message_refs: sent_refs,
                         });
                     }
@@ -767,6 +772,7 @@ impl DeliveryCoordinator {
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_reached: any_sent,
                             vendor_message_refs: sent_refs,
                         });
                     }
@@ -781,6 +787,7 @@ impl DeliveryCoordinator {
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_reached: false,
                             vendor_message_refs: Vec::new(),
                         });
                     }
@@ -799,6 +806,7 @@ impl DeliveryCoordinator {
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_reached: false,
                             vendor_message_refs: Vec::new(),
                         });
                     }
@@ -852,6 +860,7 @@ impl DeliveryCoordinator {
                 Ok(CoordinatedDeliveryOutcome::Failed {
                     attempt: existing,
                     failure_kind,
+                    vendor_reached: false,
                     // The persisted row does not retain vendor refs, and this
                     // invocation never drove the send that produced this row
                     // — there is no partial-egress evidence to report here.
@@ -862,6 +871,7 @@ impl DeliveryCoordinator {
                 Ok(CoordinatedDeliveryOutcome::Failed {
                     attempt: existing,
                     failure_kind: DeliveryFailureKind::Unknown,
+                    vendor_reached: false,
                     vendor_message_refs: Vec::new(),
                 })
             }

--- a/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
+++ b/crates/product/ironclaw_assistant/src/delivery_coordinator.rs
@@ -241,6 +241,16 @@ pub enum CoordinatedDeliveryOutcome {
     Failed {
         attempt: OutboundDeliveryAttempt,
         failure_kind: DeliveryFailureKind,
+        /// Vendor refs for parts THIS invocation confirmed sent before the
+        /// terminal failure. Non-empty only for the partial-multipart case
+        /// (OUT-7): an adapter may split one `OutboundPart` into several
+        /// vendor-level chunks (`ChannelAdapter::deliver` owns splitting —
+        /// Slack and Telegram both chunk oversized text), so a single-part
+        /// envelope can still fail after an earlier chunk reached the
+        /// vendor. Empty whenever nothing reached the vendor, including the
+        /// claim-miss path (`outcome_for_claimed_delivery`), which has no
+        /// egress evidence of its own to report.
+        vendor_message_refs: Vec<String>,
     },
 }
 
@@ -732,26 +742,38 @@ impl DeliveryCoordinator {
                         });
                     }
                     if unauthorized {
+                        // `sent_refs` may be non-empty here too: the report
+                        // covers every part of THIS delivery pass, and an
+                        // adapter that splits one part into several vendor
+                        // chunks (Slack/Telegram) can accept an earlier chunk
+                        // before a later one comes back `Unauthorized`.
                         let kind = DeliveryFailureKind::AuthorizationRevoked;
                         self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
                             .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_message_refs: sent_refs,
                         });
                     }
                     if permanent || (retryable && any_sent) {
                         // Partial multipart (OUT-7): retrying the whole
                         // envelope would duplicate already-accepted parts.
+                        // `sent_refs` carries whatever vendor evidence exists
+                        // for the parts that DID land before this failure.
                         let kind = DeliveryFailureKind::Rejected;
                         self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
                             .await;
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_message_refs: sent_refs,
                         });
                     }
-                    // Fully-retryable report (nothing sent).
+                    // Fully-retryable report (nothing sent): `any_sent` is
+                    // false here by construction (a `true` value would have
+                    // taken the branch above), so there is no egress
+                    // evidence to carry forward.
                     if attempts_used >= self.retry.max_attempts {
                         let kind = DeliveryFailureKind::TransportUnavailable;
                         self.mark_terminal(&attempt, OutboundDeliveryStatus::Failed, Some(kind))
@@ -759,6 +781,7 @@ impl DeliveryCoordinator {
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_message_refs: Vec::new(),
                         });
                     }
                     tokio::time::sleep(self.retry.backoff).await;
@@ -776,6 +799,7 @@ impl DeliveryCoordinator {
                         return Ok(CoordinatedDeliveryOutcome::Failed {
                             attempt,
                             failure_kind: kind,
+                            vendor_message_refs: Vec::new(),
                         });
                     }
                     tokio::time::sleep(self.retry.backoff).await;
@@ -828,12 +852,17 @@ impl DeliveryCoordinator {
                 Ok(CoordinatedDeliveryOutcome::Failed {
                     attempt: existing,
                     failure_kind,
+                    // The persisted row does not retain vendor refs, and this
+                    // invocation never drove the send that produced this row
+                    // — there is no partial-egress evidence to report here.
+                    vendor_message_refs: Vec::new(),
                 })
             }
             OutboundDeliveryStatus::Unknown | OutboundDeliveryStatus::Pending => {
                 Ok(CoordinatedDeliveryOutcome::Failed {
                     attempt: existing,
                     failure_kind: DeliveryFailureKind::Unknown,
+                    vendor_message_refs: Vec::new(),
                 })
             }
             OutboundDeliveryStatus::Prepared | OutboundDeliveryStatus::Sending => {

--- a/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
+++ b/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
@@ -842,6 +842,7 @@ async fn deliver_for_model_maps_terminal_failure_kinds() {
             CoordinatedDeliveryOutcome::Failed {
                 attempt: sample_attempt(),
                 failure_kind: kind,
+                vendor_reached: false,
                 vendor_message_refs: Vec::new(),
             },
         );

--- a/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
+++ b/crates/product/ironclaw_assistant/src/model_channel_delivery/tests.rs
@@ -842,6 +842,7 @@ async fn deliver_for_model_maps_terminal_failure_kinds() {
             CoordinatedDeliveryOutcome::Failed {
                 attempt: sample_attempt(),
                 failure_kind: kind,
+                vendor_message_refs: Vec::new(),
             },
         );
         assert_eq!(failed, Err(ModelChannelDeliveryError::Failed { kind }));

--- a/crates/product/ironclaw_assistant/src/run_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery.rs
@@ -230,8 +230,12 @@ impl NoticeEgress {
 }
 
 /// Classify one NOTICE outcome into what the caller may claim. Keyed off the
-/// outcome VARIANT, never off ref emptiness: an empty `vendor_message_refs`
-/// is not evidence that nothing was sent.
+/// outcome VARIANT first: for `Delivered`/`DeliveredUnconfirmed`/
+/// `AlreadyDelivered`, an empty `vendor_message_refs` is NOT evidence that
+/// nothing was sent (those variants are only reached once the vendor
+/// accepted something). `Failed` is the one variant where ref emptiness
+/// itself is the signal: an empty list means no chunk ever reached the
+/// vendor, a non-empty one means a partial multipart send did.
 pub(crate) fn notice_egress_from_outcome(outcome: &CoordinatedDeliveryOutcome) -> NoticeEgress {
     match outcome {
         CoordinatedDeliveryOutcome::Delivered { .. } => NoticeEgress::Sent {
@@ -250,14 +254,32 @@ pub(crate) fn notice_egress_from_outcome(outcome: &CoordinatedDeliveryOutcome) -
             durably_recorded: true,
             message: None,
         },
-        // `Failed` covers partial-multipart (some parts sent), but a notice
-        // carries exactly one `OutboundPart::Text`, so the partial case is
-        // structurally unreachable here and `Failed` means nothing went out.
-        // This mapping is notice-path-specific; do not lift it to a general
-        // outcome classifier without revisiting that.
-        CoordinatedDeliveryOutcome::NoDelivery
-        | CoordinatedDeliveryOutcome::Rejected { .. }
-        | CoordinatedDeliveryOutcome::Failed { .. } => NoticeEgress::NotSent,
+        CoordinatedDeliveryOutcome::NoDelivery | CoordinatedDeliveryOutcome::Rejected { .. } => {
+            NoticeEgress::NotSent
+        }
+        // A notice's envelope carries exactly one `OutboundPart`, but
+        // `ChannelAdapter::deliver` owns vendor splitting (module docs,
+        // `channel_adapter.rs`): Slack and Telegram both chunk oversized
+        // text into several vendor-level posts, and manifest-provided
+        // notice copy (e.g. `connect_required`) has no length bound. So
+        // `Failed` can still follow an earlier chunk that reached the
+        // vendor — `vendor_message_refs` carries that evidence when it
+        // exists. Empty refs means genuinely nothing went out. This mapping
+        // is notice-path-specific; do not lift it to a general outcome
+        // classifier without revisiting that.
+        CoordinatedDeliveryOutcome::Failed {
+            vendor_message_refs,
+            ..
+        } => {
+            if vendor_message_refs.is_empty() {
+                NoticeEgress::NotSent
+            } else {
+                NoticeEgress::Sent {
+                    durably_recorded: false,
+                    message: None,
+                }
+            }
+        }
     }
 }
 
@@ -744,8 +766,34 @@ mod notice_egress_tests {
         let failed = CoordinatedDeliveryOutcome::Failed {
             attempt: test_attempt(OutboundDeliveryStatus::Failed),
             failure_kind: DeliveryFailureKind::TransportUnavailable,
+            vendor_message_refs: Vec::new(),
         };
-        assert_eq!(notice_egress_from_outcome(&failed), NoticeEgress::NotSent);
+        assert_eq!(
+            notice_egress_from_outcome(&failed),
+            NoticeEgress::NotSent,
+            "no vendor evidence at all must stay NotSent"
+        );
+
+        // Partial multipart (OUT-7): an adapter split one `OutboundPart`
+        // into several vendor chunks and an earlier chunk landed before a
+        // later one failed. This is reachable for a notice — Slack and
+        // Telegram both chunk oversized text, and manifest-provided notice
+        // copy (e.g. `connect_required`) has no length bound — so `Failed`
+        // must NOT collapse to `NotSent` when the coordinator reports
+        // evidence that something already reached the vendor.
+        let partial_failed = CoordinatedDeliveryOutcome::Failed {
+            attempt: test_attempt(OutboundDeliveryStatus::Failed),
+            failure_kind: DeliveryFailureKind::Rejected,
+            vendor_message_refs: vec!["ts-partial-1".to_string()],
+        };
+        assert_eq!(
+            notice_egress_from_outcome(&partial_failed),
+            NoticeEgress::Sent {
+                durably_recorded: false,
+                message: None,
+            },
+            "a partial multipart send must hold the reservation, not release it"
+        );
     }
 
     #[test]

--- a/crates/product/ironclaw_assistant/src/run_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery.rs
@@ -190,6 +190,77 @@ pub(crate) fn delivered_messages_from_outcome(
     }
 }
 
+/// What one best-effort notice actually achieved. `Option<DeliveredChannelMessage>`
+/// answered only "did the vendor hand back a retraction handle?", which is not
+/// the same question as "did anything reach the user" — an adapter may report
+/// `Sent` with no vendor ref (web push always does; Slack does when
+/// `chat.postMessage` returns `ok` without a `ts`). Throttles and
+/// duplicate-suppression reservations MUST key off [`Self::reached_vendor`],
+/// never off the handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NoticeEgress {
+    /// Nothing reached the vendor: no target, policy rejection, terminal
+    /// failure, or the coordinator itself errored before egress.
+    NotSent,
+    /// The provider accepted the notice. It exists in the channel; never resend it.
+    Sent {
+        /// `true` when the durable `Delivered` row committed; `false` for
+        /// [`CoordinatedDeliveryOutcome::DeliveredUnconfirmed`].
+        durably_recorded: bool,
+        /// The vendor's retraction handle, absent on a ref-less accept.
+        message: Option<DeliveredChannelMessage>,
+    },
+}
+
+impl NoticeEgress {
+    /// True under any confirmation strength. Releasing a duplicate-suppression
+    /// reservation when this is true readmits a message the user already received.
+    pub(crate) fn reached_vendor(&self) -> bool {
+        matches!(self, Self::Sent { .. })
+    }
+
+    /// The retraction handle, when the vendor returned a usable ref. `None`
+    /// on a ref-less accept: the notice was sent, it just cannot be retracted.
+    pub(crate) fn into_retraction_handle(self) -> Option<DeliveredChannelMessage> {
+        match self {
+            Self::NotSent => None,
+            Self::Sent { message, .. } => message,
+        }
+    }
+}
+
+/// Classify one NOTICE outcome into what the caller may claim. Keyed off the
+/// outcome VARIANT, never off ref emptiness: an empty `vendor_message_refs`
+/// is not evidence that nothing was sent.
+pub(crate) fn notice_egress_from_outcome(outcome: &CoordinatedDeliveryOutcome) -> NoticeEgress {
+    match outcome {
+        CoordinatedDeliveryOutcome::Delivered { .. } => NoticeEgress::Sent {
+            durably_recorded: true,
+            message: delivered_messages_from_outcome(outcome).into_iter().next(),
+        },
+        CoordinatedDeliveryOutcome::DeliveredUnconfirmed { .. } => NoticeEgress::Sent {
+            durably_recorded: false,
+            message: delivered_messages_from_outcome(outcome).into_iter().next(),
+        },
+        // Refs are not retained on the durable row, so there is no handle —
+        // but this exact notice demonstrably reached the user in an earlier
+        // invocation, which is the strongest possible reason NOT to release a
+        // duplicate-suppression reservation.
+        CoordinatedDeliveryOutcome::AlreadyDelivered { .. } => NoticeEgress::Sent {
+            durably_recorded: true,
+            message: None,
+        },
+        // `Failed` covers partial-multipart (some parts sent), but a notice
+        // carries exactly one `OutboundPart::Text`, so the partial case is
+        // structurally unreachable here and `Failed` means nothing went out.
+        // This mapping is notice-path-specific; do not lift it to a general
+        // outcome classifier without revisiting that.
+        CoordinatedDeliveryOutcome::NoDelivery
+        | CoordinatedDeliveryOutcome::Rejected { .. }
+        | CoordinatedDeliveryOutcome::Failed { .. } => NoticeEgress::NotSent,
+    }
+}
+
 /// Failures raised while watching a run and delivering its outputs.
 #[derive(Debug, thiserror::Error)]
 pub enum RunDeliveryError {
@@ -390,7 +461,14 @@ pub(crate) fn turn_scope_from_thread_scope(
 impl RunDeliveryServices {
     /// Best-effort source-routed system notice on `conversation`. Failures
     /// are logged, never propagated — a notice must not break the flow that
-    /// raised it.
+    /// raised it. Every `CoordinatedDeliveryError` reachable from
+    /// `deliver_notice` is raised strictly before vendor egress (policy/
+    /// validation failures, store errors on `record_delivery_attempt` or
+    /// `claim_delivery_attempt_for_send`, an `AlreadyInFlight` single-flight
+    /// miss, or `ChannelUnavailable` from channel resolution — all before
+    /// `drive_prepared` ever calls the adapter), so `NoticeEgress::NotSent`
+    /// on `Err` is sound: no error path can be reached after the notice
+    /// already left for the vendor.
     pub(crate) async fn post_notice(
         &self,
         intent: DeliveryIntent,
@@ -399,7 +477,7 @@ impl RunDeliveryServices {
         conversation: &ExternalConversationRef,
         text: &str,
         notice_ref: String,
-    ) -> Option<DeliveredChannelMessage> {
+    ) -> NoticeEgress {
         match self
             .coordinator
             .deliver_notice(NoticeDeliveryRequest {
@@ -414,14 +492,14 @@ impl RunDeliveryServices {
             })
             .await
         {
-            Ok(outcome) => delivered_messages_from_outcome(&outcome).into_iter().next(),
+            Ok(outcome) => notice_egress_from_outcome(&outcome),
             Err(error) => {
                 tracing::debug!(
                     target: "ironclaw::reborn::run_delivery",
                     %error,
                     "channel notice delivery failed (best-effort)"
                 );
-                None
+                NoticeEgress::NotSent
             }
         }
     }
@@ -534,5 +612,163 @@ impl RunDeliveryServices {
                 "channel reaction delivery failed (best-effort)"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod notice_egress_tests {
+    use super::*;
+    use ironclaw_host_api::ids::{AgentId, TenantId, ThreadId};
+    use ironclaw_outbound::{
+        DeliveryFailureKind, OutboundDeliveryAttempt, OutboundDeliveryId, OutboundDeliveryStatus,
+        OutboundPushCandidate, OutboundPushKind,
+    };
+    use ironclaw_turns::ReplyTargetBindingRef;
+
+    fn test_scope() -> TurnScope {
+        TurnScope::new_with_owner(
+            TenantId::new("tenant-test").expect("tenant"),
+            Some(AgentId::new("agent-test").expect("agent")),
+            None,
+            ThreadId::new("thread-test").expect("thread"),
+            None,
+        )
+    }
+
+    fn test_attempt(status: OutboundDeliveryStatus) -> OutboundDeliveryAttempt {
+        let scope = test_scope();
+        OutboundDeliveryAttempt {
+            delivery_id: OutboundDeliveryId::new(),
+            scope: scope.clone(),
+            candidate: OutboundPushCandidate {
+                tenant_id: scope.tenant_id.clone(),
+                agent_id: scope.agent_id.clone(),
+                project_id: scope.project_id.clone(),
+                thread_id: scope.thread_id.clone(),
+                turn_run_id: None,
+                target: ReplyTargetBindingRef::new("reply:test".to_string()).expect("ref"),
+                kind: OutboundPushKind::DeliveryStatus,
+                projection_ref: ironclaw_outbound::ProjectionUpdateRef::new(
+                    "projection:test".to_string(),
+                )
+                .expect("projection ref"),
+                requires_reply_target_revalidation: false,
+            },
+            status,
+            attempted_at: chrono::Utc::now(),
+            failure_kind: None,
+        }
+    }
+
+    fn test_conversation() -> ExternalConversationRef {
+        ExternalConversationRef::new(Some("space-1"), "conv-1", None, None).expect("conversation")
+    }
+
+    /// Directly exercises [`notice_egress_from_outcome`] against every
+    /// [`CoordinatedDeliveryOutcome`] variant, explicitly including a
+    /// `Delivered` with an empty `vendor_message_refs` (web push, or a Slack
+    /// accept with no `ts`) and `AlreadyDelivered` (no refs retained on the
+    /// durable row) — both must classify as `Sent`, never `NotSent`.
+    #[test]
+    fn notice_egress_from_outcome_covers_every_variant() {
+        let conversation = test_conversation();
+
+        let delivered = CoordinatedDeliveryOutcome::Delivered {
+            attempt: test_attempt(OutboundDeliveryStatus::Delivered),
+            conversation: conversation.clone(),
+            vendor_message_refs: vec!["ts-1".to_string()],
+        };
+        assert_eq!(
+            notice_egress_from_outcome(&delivered),
+            NoticeEgress::Sent {
+                durably_recorded: true,
+                message: Some(DeliveredChannelMessage {
+                    conversation: conversation.clone(),
+                    vendor_message_ref: "ts-1".to_string(),
+                }),
+            }
+        );
+
+        let delivered_no_ref = CoordinatedDeliveryOutcome::Delivered {
+            attempt: test_attempt(OutboundDeliveryStatus::Delivered),
+            conversation: conversation.clone(),
+            vendor_message_refs: vec![],
+        };
+        assert_eq!(
+            notice_egress_from_outcome(&delivered_no_ref),
+            NoticeEgress::Sent {
+                durably_recorded: true,
+                message: None,
+            },
+            "a ref-less accept (web push; Slack `ok` with no `ts`) must still be Sent"
+        );
+
+        let delivered_unconfirmed = CoordinatedDeliveryOutcome::DeliveredUnconfirmed {
+            attempt: test_attempt(OutboundDeliveryStatus::Sending),
+            conversation: conversation.clone(),
+            vendor_message_refs: vec!["ts-2".to_string()],
+        };
+        assert_eq!(
+            notice_egress_from_outcome(&delivered_unconfirmed),
+            NoticeEgress::Sent {
+                durably_recorded: false,
+                message: Some(DeliveredChannelMessage {
+                    conversation: conversation.clone(),
+                    vendor_message_ref: "ts-2".to_string(),
+                }),
+            }
+        );
+
+        let already_delivered = CoordinatedDeliveryOutcome::AlreadyDelivered {
+            attempt: test_attempt(OutboundDeliveryStatus::Delivered),
+        };
+        assert_eq!(
+            notice_egress_from_outcome(&already_delivered),
+            NoticeEgress::Sent {
+                durably_recorded: true,
+                message: None,
+            },
+            "a durably-confirmed prior delivery must be Sent even with no retained ref"
+        );
+
+        assert_eq!(
+            notice_egress_from_outcome(&CoordinatedDeliveryOutcome::NoDelivery),
+            NoticeEgress::NotSent
+        );
+
+        let rejected = CoordinatedDeliveryOutcome::Rejected {
+            attempt: test_attempt(OutboundDeliveryStatus::Failed),
+        };
+        assert_eq!(notice_egress_from_outcome(&rejected), NoticeEgress::NotSent);
+
+        let failed = CoordinatedDeliveryOutcome::Failed {
+            attempt: test_attempt(OutboundDeliveryStatus::Failed),
+            failure_kind: DeliveryFailureKind::TransportUnavailable,
+        };
+        assert_eq!(notice_egress_from_outcome(&failed), NoticeEgress::NotSent);
+    }
+
+    #[test]
+    fn reached_vendor_and_retraction_handle_agree_with_the_variant() {
+        assert!(!NoticeEgress::NotSent.reached_vendor());
+        assert_eq!(NoticeEgress::NotSent.into_retraction_handle(), None);
+
+        let sent_no_ref = NoticeEgress::Sent {
+            durably_recorded: true,
+            message: None,
+        };
+        assert!(sent_no_ref.reached_vendor());
+        assert_eq!(sent_no_ref.into_retraction_handle(), None);
+
+        let message = DeliveredChannelMessage {
+            conversation: test_conversation(),
+            vendor_message_ref: "ts-3".to_string(),
+        };
+        let sent_with_ref = NoticeEgress::Sent {
+            durably_recorded: true,
+            message: Some(message.clone()),
+        };
+        assert!(sent_with_ref.reached_vendor());
+        assert_eq!(sent_with_ref.into_retraction_handle(), Some(message));
     }
 }

--- a/crates/product/ironclaw_assistant/src/run_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery.rs
@@ -233,9 +233,8 @@ impl NoticeEgress {
 /// outcome VARIANT first: for `Delivered`/`DeliveredUnconfirmed`/
 /// `AlreadyDelivered`, an empty `vendor_message_refs` is NOT evidence that
 /// nothing was sent (those variants are only reached once the vendor
-/// accepted something). `Failed` is the one variant where ref emptiness
-/// itself is the signal: an empty list means no chunk ever reached the
-/// vendor, a non-empty one means a partial multipart send did.
+/// accepted something). `Failed` carries reachability separately because an
+/// accepted chunk may have no vendor reference.
 pub(crate) fn notice_egress_from_outcome(outcome: &CoordinatedDeliveryOutcome) -> NoticeEgress {
     match outcome {
         CoordinatedDeliveryOutcome::Delivered { .. } => NoticeEgress::Sent {
@@ -263,21 +262,17 @@ pub(crate) fn notice_egress_from_outcome(outcome: &CoordinatedDeliveryOutcome) -
         // text into several vendor-level posts, and manifest-provided
         // notice copy (e.g. `connect_required`) has no length bound. So
         // `Failed` can still follow an earlier chunk that reached the
-        // vendor — `vendor_message_refs` carries that evidence when it
-        // exists. Empty refs means genuinely nothing went out. This mapping
-        // is notice-path-specific; do not lift it to a general outcome
-        // classifier without revisiting that.
-        CoordinatedDeliveryOutcome::Failed {
-            vendor_message_refs,
-            ..
-        } => {
-            if vendor_message_refs.is_empty() {
-                NoticeEgress::NotSent
-            } else {
+        // vendor. `vendor_reached` carries that evidence even when an
+        // accepted chunk returned no ref. This mapping is notice-path-specific;
+        // do not lift it to a general outcome classifier without revisiting that.
+        CoordinatedDeliveryOutcome::Failed { vendor_reached, .. } => {
+            if *vendor_reached {
                 NoticeEgress::Sent {
                     durably_recorded: false,
                     message: None,
                 }
+            } else {
+                NoticeEgress::NotSent
             }
         }
     }
@@ -766,6 +761,7 @@ mod notice_egress_tests {
         let failed = CoordinatedDeliveryOutcome::Failed {
             attempt: test_attempt(OutboundDeliveryStatus::Failed),
             failure_kind: DeliveryFailureKind::TransportUnavailable,
+            vendor_reached: false,
             vendor_message_refs: Vec::new(),
         };
         assert_eq!(
@@ -784,6 +780,7 @@ mod notice_egress_tests {
         let partial_failed = CoordinatedDeliveryOutcome::Failed {
             attempt: test_attempt(OutboundDeliveryStatus::Failed),
             failure_kind: DeliveryFailureKind::Rejected,
+            vendor_reached: true,
             vendor_message_refs: vec!["ts-partial-1".to_string()],
         };
         assert_eq!(
@@ -793,6 +790,21 @@ mod notice_egress_tests {
                 message: None,
             },
             "a partial multipart send must hold the reservation, not release it"
+        );
+
+        let ref_less_partial_failed = CoordinatedDeliveryOutcome::Failed {
+            attempt: test_attempt(OutboundDeliveryStatus::Failed),
+            failure_kind: DeliveryFailureKind::Rejected,
+            vendor_reached: true,
+            vendor_message_refs: Vec::new(),
+        };
+        assert_eq!(
+            notice_egress_from_outcome(&ref_less_partial_failed),
+            NoticeEgress::Sent {
+                durably_recorded: false,
+                message: None,
+            },
+            "a ref-less partial send must use reachability evidence, not ref presence"
         );
     }
 

--- a/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery/observer.rs
@@ -733,7 +733,8 @@ impl RunDeliveryObserver {
                             prompts::working_message(notice_seed),
                             format!("working:{run_id}"),
                         )
-                        .await;
+                        .await
+                        .into_retraction_handle();
                     self.set_source_reaction(
                         scope,
                         run_id,
@@ -765,7 +766,8 @@ impl RunDeliveryObserver {
                             prompts::long_running_message(notice_seed, nudge_count),
                             format!("working:{run_id}:{nudge_count}"),
                         )
-                        .await;
+                        .await
+                        .into_retraction_handle();
                 }
             }
             tokio::time::sleep(super::jittered_poll_interval(poll_interval, &run_id)).await;
@@ -1237,7 +1239,7 @@ impl RunDeliveryObserver {
         let Some(reserved_at) = self.reserve_connect_nudge(conversation_key.clone()) else {
             return true;
         };
-        let delivered = self
+        let egress = self
             .services
             .post_notice(
                 DeliveryIntent::ConnectRequired,
@@ -1248,7 +1250,12 @@ impl RunDeliveryObserver {
                 format!("connect-nudge:{}", envelope.external_event_id().as_str()),
             )
             .await;
-        if delivered.is_none() {
+        // Release ONLY on proven non-delivery. A vendor accept with no
+        // message ref (web push, a Slack `ok` without `ts`) and an
+        // unconfirmed-but-sent delivery both put the nudge in front of the
+        // user; releasing either readmits a duplicate — the same rule
+        // `reserve_connect_nudge` fails closed on at saturation.
+        if !egress.reached_vendor() {
             self.release_connect_nudge(&conversation_key, reserved_at);
         }
         true

--- a/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
@@ -2722,6 +2722,60 @@ async fn observer_connect_nudge_holds_reservation_when_a_multipart_notice_partia
     );
 }
 
+/// A partial multipart send remains vendor egress even when the accepted
+/// chunk has no provider reference. Reachability and retractability are
+/// separate facts: the missing handle must not release the nudge reservation.
+#[tokio::test]
+async fn observer_connect_nudge_holds_reservation_when_a_ref_less_chunk_partially_sends() {
+    let harness = build_harness(
+        vec![scripted_state(TurnStatus::Running, None)],
+        true,
+        None,
+        Duration::from_millis(20),
+    );
+    harness
+        .adapter
+        .reports
+        .lock()
+        .expect("reports lock")
+        .push_back(DeliveryReport {
+            parts: vec![
+                PartDeliveryOutcome::Sent {
+                    vendor_message_ref: None,
+                },
+                PartDeliveryOutcome::Retryable {
+                    reason: "rate limited".to_string(),
+                },
+            ],
+        });
+    let rejected = ProductInboundAck::Rejected(ProductRejection::permanent(
+        ProductRejectionKind::BindingRequired,
+        "unbound",
+    ));
+
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-partial-no-ref-1"),
+            rejected.clone(),
+        )
+        .await;
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-partial-no-ref-2"),
+            rejected,
+        )
+        .await;
+
+    let texts = harness.adapter.texts();
+    assert_eq!(
+        texts,
+        vec![harness.connection_notices.connect_required.clone()],
+        "a ref-less partial send must hold the reservation, not release it for a duplicate: {texts:?}"
+    );
+}
+
 #[tokio::test]
 async fn observer_connect_nudge_saturation_does_not_evict_in_flight_reservations() {
     const RESERVATION_CAP: usize = 1024;

--- a/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
@@ -1017,6 +1017,40 @@ fn build_harness_with_settings(
             }) as Arc<dyn BlockedAuthPromptSource>
         }),
         None,
+        None,
+    )
+}
+
+/// Same as `build_harness`, but with an explicit `OutboundStateStorePort`
+/// override in place of the harness's own in-memory store — for a test that
+/// must observe a downstream store failure (e.g.
+/// `TerminalDeliveredWriteFailingStore`) while keeping every other seam
+/// (adapter, coordinator, observer, connection notices) wired identically to
+/// every other connect-nudge test, instead of hand-assembling a parallel
+/// `RunDeliveryServices`/`DeliveryCoordinator`/`RunDeliveryObserver`.
+fn build_harness_with_outbound_store(
+    states: Vec<ScriptedRunState>,
+    bind_fails: bool,
+    max_wait: Duration,
+    outbound_store: Arc<dyn OutboundStateStorePort>,
+) -> Harness {
+    build_harness_with_gate_ports(
+        states,
+        bind_fails,
+        RunDeliverySettings {
+            poll_interval: Duration::from_millis(1),
+            max_wait,
+            max_concurrent_deliveries: NonZeroUsize::new(4).expect("nz"),
+            max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
+            first_nudge_after: Duration::from_secs(3600),
+            renudge_interval: Duration::from_secs(3600),
+        },
+        &["status"],
+        None,
+        binding(),
+        None,
+        None,
+        Some(outbound_store),
     )
 }
 
@@ -1035,16 +1069,25 @@ fn build_harness_with_gate_ports(
     resolved_binding: ironclaw_product_contracts::binding::ResolvedBinding,
     blocked_auth_prompts: Option<Arc<dyn BlockedAuthPromptSource>>,
     auth_flow_cancel: Option<Arc<dyn ironclaw_auth::product_prompt::BlockedAuthFlowCanceller>>,
+    // Overrides the coordinator's/services' `outbound_store` (the
+    // `RunDeliveryServices::communication_preferences` reader stays on the
+    // in-memory `store` below either way — a decorator like
+    // `TerminalDeliveredWriteFailingStore` only implements
+    // `OutboundStateStorePort`, not `CommunicationPreferenceRepository`).
+    // `None` reproduces today's behavior exactly.
+    outbound_store_override: Option<Arc<dyn OutboundStateStorePort>>,
 ) -> Harness {
     let adapter = Arc::new(RecordingChannelAdapter::new());
     let store = Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let outbound_store = outbound_store_override
+        .unwrap_or_else(|| Arc::clone(&store) as Arc<dyn OutboundStateStorePort>);
     let route_store =
         Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
     let turns = Arc::new(ScriptedTurnCoordinator::with_states(states));
     let threads = Arc::new(InMemorySessionThreadService::default());
     let project_files = Arc::new(ScriptedProjectFilesystemReader::default());
     let coordinator = Arc::new(DeliveryCoordinator::new(
-        Arc::clone(&store) as Arc<dyn OutboundStateStorePort>,
+        Arc::clone(&outbound_store),
         Arc::new(StaticResolver {
             adapter: Arc::clone(&adapter),
         }),
@@ -1061,7 +1104,7 @@ fn build_harness_with_gate_ports(
         }),
         thread_service: Arc::clone(&threads) as Arc<dyn SessionThreadService>,
         turn_coordinator: Arc::clone(&turns) as Arc<dyn TurnCoordinator>,
-        outbound_store: Arc::clone(&store) as Arc<dyn OutboundStateStorePort>,
+        outbound_store: Arc::clone(&outbound_store),
         route_store: Arc::clone(&route_store) as Arc<dyn DeliveredGateRouteStore>,
         communication_preferences: Arc::clone(&store) as Arc<dyn CommunicationPreferenceRepository>,
         project_filesystem: Arc::clone(&project_files) as Arc<dyn ProjectFilesystemReader>,
@@ -2578,85 +2621,104 @@ async fn observer_connect_nudge_holds_reservation_when_delivery_is_unconfirmed()
     let store = Arc::new(TerminalDeliveredWriteFailingStore {
         inner: Arc::clone(&inner_store),
     });
-    let adapter = Arc::new(RecordingChannelAdapter::new());
-    let turns = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
-        TurnStatus::Running,
-        None,
-    )]));
-    let threads = Arc::new(InMemorySessionThreadService::default());
-    let project_files = Arc::new(ScriptedProjectFilesystemReader::default());
-    let coordinator = Arc::new(DeliveryCoordinator::new(
-        Arc::clone(&store) as Arc<dyn OutboundStateStorePort>,
-        Arc::new(StaticResolver {
-            adapter: Arc::clone(&adapter),
-        }),
-        Arc::new(NoStoredReplyContext),
-        DeliveryRetryPolicy {
-            max_attempts: 2,
-            backoff: Duration::ZERO,
-        },
-    ));
-    let services = RunDeliveryServices {
-        binding_service: Arc::new(StaticBindingService {
-            binding: binding(),
-            fail: true,
-        }),
-        thread_service: Arc::clone(&threads) as Arc<dyn SessionThreadService>,
-        turn_coordinator: Arc::clone(&turns) as Arc<dyn TurnCoordinator>,
-        outbound_store: Arc::clone(&store) as Arc<dyn OutboundStateStorePort>,
-        route_store: Arc::clone(&inner_store) as Arc<dyn DeliveredGateRouteStore>,
-        communication_preferences: Arc::clone(&inner_store)
-            as Arc<dyn CommunicationPreferenceRepository>,
-        project_filesystem: Arc::clone(&project_files) as Arc<dyn ProjectFilesystemReader>,
-        delivery_targets: Arc::new(StaticTargetCatalog {
-            targets: Vec::new(),
-        }) as Arc<dyn OutboundDeliveryTargetProvider>,
-        coordinator,
-        extension_id: EXTENSION_ID.to_string(),
-        fallback_notice_scope: fallback_scope(),
-        approval_context: None,
-        blocked_auth_prompts: None,
-        auth_flow_cancel: None,
-    };
-    let connection_notices = ChannelConnectionNoticePolicy::generic("Acme");
-    let observer = Arc::new(
-        RunDeliveryObserver::with_settings_and_connection_notices(
-            services,
-            RunDeliverySettings {
-                poll_interval: Duration::from_millis(1),
-                max_wait: Duration::from_millis(20),
-                max_concurrent_deliveries: NonZeroUsize::new(4).expect("nz"),
-                max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
-                first_nudge_after: Duration::from_secs(3600),
-                renudge_interval: Duration::from_secs(3600),
-            },
-            connection_notices.clone(),
-        )
-        .with_enabled_commands(["status"], None),
+    let harness = build_harness_with_outbound_store(
+        vec![scripted_state(TurnStatus::Running, None)],
+        true,
+        Duration::from_millis(20),
+        store as Arc<dyn OutboundStateStorePort>,
     );
 
     let rejected = ProductInboundAck::Rejected(ProductRejection::permanent(
         ProductRejectionKind::BindingRequired,
         "unbound",
     ));
-    observer
+    harness
+        .observer
         .observe_ack(
             user_message_envelope(ProductTriggerReason::DirectChat, "evt-unconfirmed-1"),
             rejected.clone(),
         )
         .await;
-    observer
+    harness
+        .observer
         .observe_ack(
             user_message_envelope(ProductTriggerReason::DirectChat, "evt-unconfirmed-2"),
             rejected,
         )
         .await;
 
-    let texts = adapter.texts();
+    let texts = harness.adapter.texts();
     assert_eq!(
         texts,
-        vec![connection_notices.connect_required.clone()],
+        vec![harness.connection_notices.connect_required.clone()],
         "an unconfirmed-but-sent delivery must hold the reservation, not release it: {texts:?}"
+    );
+}
+
+/// Review finding (PR #7475, ironloopai): `Failed` is not always evidence
+/// that nothing reached the vendor. `ChannelAdapter::deliver` owns vendor
+/// splitting (Slack and Telegram both chunk oversized text into several
+/// vendor-level posts), so a notice's single `OutboundPart::Text` can still
+/// land partially — an earlier chunk accepted, a later one failing —
+/// before the coordinator returns `Failed` for the whole attempt (OUT-7:
+/// retrying would duplicate the accepted chunk). The connect-nudge
+/// reservation must stay held in that case exactly as it does for a
+/// ref-less `Sent`, or a duplicate "please connect" nudge follows a notice
+/// the user partially already received.
+#[tokio::test]
+async fn observer_connect_nudge_holds_reservation_when_a_multipart_notice_partially_sends() {
+    let harness = build_harness(
+        vec![scripted_state(TurnStatus::Running, None)],
+        true,
+        None,
+        Duration::from_millis(20),
+    );
+    // One chunk reached the vendor before a later chunk failed retryably —
+    // the coordinator's OUT-7 rule makes this terminal `Failed`, not another
+    // retry attempt.
+    harness
+        .adapter
+        .reports
+        .lock()
+        .expect("reports lock")
+        .push_back(DeliveryReport {
+            parts: vec![
+                PartDeliveryOutcome::Sent {
+                    vendor_message_ref: Some("ts-chunk-1".to_string()),
+                },
+                PartDeliveryOutcome::Retryable {
+                    reason: "rate limited".to_string(),
+                },
+            ],
+        });
+    let rejected = ProductInboundAck::Rejected(ProductRejection::permanent(
+        ProductRejectionKind::BindingRequired,
+        "unbound",
+    ));
+
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-partial-1"),
+            rejected.clone(),
+        )
+        .await;
+    // A second unbound ping in the same conversation, still inside the
+    // throttle window: must NOT draw a second nudge — the first chunk
+    // already reached the user.
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-partial-2"),
+            rejected,
+        )
+        .await;
+
+    let texts = harness.adapter.texts();
+    assert_eq!(
+        texts,
+        vec![harness.connection_notices.connect_required.clone()],
+        "a partial multipart send must hold the reservation, not release it for a duplicate: {texts:?}"
     );
 }
 

--- a/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/run_delivery_contract.rs
@@ -410,6 +410,106 @@ impl DeliveryReplyContextSource for NoStoredReplyContext {
     }
 }
 
+/// Delegating store whose terminal `Delivered` status write fails — the
+/// durable shape behind a vendor accept that never gets durably confirmed
+/// ([`ironclaw_assistant::CoordinatedDeliveryOutcome::DeliveredUnconfirmed`]).
+/// Mirrors `outbound_delivery_contract.rs`'s `TerminalDeliveredWriteFailingStore`
+/// (each test binary compiles independently, so the fixture is duplicated
+/// rather than shared).
+struct TerminalDeliveredWriteFailingStore {
+    inner: Arc<OutboundStateStore<ironclaw_filesystem::InMemoryBackend>>,
+}
+
+#[async_trait]
+impl OutboundStateStorePort for TerminalDeliveredWriteFailingStore {
+    async fn put_run_delivery_cleanup(
+        &self,
+        record: ironclaw_outbound::RunDeliveryCleanupRecord,
+    ) -> Result<(), OutboundError> {
+        self.inner.put_run_delivery_cleanup(record).await
+    }
+    async fn load_run_delivery_cleanup(
+        &self,
+        request: ironclaw_outbound::RunDeliveryCleanupRequest,
+    ) -> Result<Vec<ironclaw_outbound::RunDeliveryCleanupRecord>, OutboundError> {
+        self.inner.load_run_delivery_cleanup(request).await
+    }
+    async fn complete_run_delivery_cleanup(
+        &self,
+        record: &ironclaw_outbound::RunDeliveryCleanupRecord,
+    ) -> Result<(), OutboundError> {
+        self.inner.complete_run_delivery_cleanup(record).await
+    }
+    async fn put_thread_notification_policy(
+        &self,
+        policy: ironclaw_outbound::ThreadNotificationPolicy,
+    ) -> Result<(), OutboundError> {
+        self.inner.put_thread_notification_policy(policy).await
+    }
+    async fn load_thread_notification_policy(
+        &self,
+        scope: ironclaw_turns::TurnScope,
+    ) -> Result<ironclaw_outbound::ThreadNotificationPolicy, OutboundError> {
+        self.inner.load_thread_notification_policy(scope).await
+    }
+    async fn upsert_subscription(
+        &self,
+        record: ironclaw_outbound::ProjectionSubscriptionRecord,
+    ) -> Result<(), OutboundError> {
+        self.inner.upsert_subscription(record).await
+    }
+    async fn load_subscription_cursor(
+        &self,
+        request: ironclaw_outbound::LoadSubscriptionCursorRequest,
+    ) -> Result<Option<ironclaw_event_projections::ProjectionCursor>, OutboundError> {
+        self.inner.load_subscription_cursor(request).await
+    }
+    async fn advance_subscription_cursor(
+        &self,
+        request: ironclaw_outbound::AdvanceSubscriptionCursorRequest,
+    ) -> Result<(), OutboundError> {
+        self.inner.advance_subscription_cursor(request).await
+    }
+    async fn record_delivery_attempt(
+        &self,
+        attempt: ironclaw_outbound::OutboundDeliveryAttempt,
+    ) -> Result<(), OutboundError> {
+        self.inner.record_delivery_attempt(attempt).await
+    }
+    async fn claim_delivery_attempt_for_send(
+        &self,
+        request: ironclaw_outbound::ClaimDeliveryAttemptForSendRequest,
+    ) -> Result<bool, OutboundError> {
+        self.inner.claim_delivery_attempt_for_send(request).await
+    }
+    async fn recover_interrupted_delivery_attempt(
+        &self,
+        request: ironclaw_outbound::RecoverInterruptedDeliveryRequest,
+    ) -> Result<bool, OutboundError> {
+        self.inner
+            .recover_interrupted_delivery_attempt(request)
+            .await
+    }
+    async fn update_delivery_status(
+        &self,
+        request: ironclaw_outbound::UpdateDeliveryStatusRequest,
+    ) -> Result<(), OutboundError> {
+        if matches!(
+            request.status,
+            ironclaw_outbound::OutboundDeliveryStatus::Delivered
+        ) {
+            return Err(OutboundError::Backend);
+        }
+        self.inner.update_delivery_status(request).await
+    }
+    async fn list_delivery_attempts(
+        &self,
+        scope: ironclaw_turns::TurnScope,
+    ) -> Result<Vec<ironclaw_outbound::OutboundDeliveryAttempt>, OutboundError> {
+        self.inner.list_delivery_attempts(scope).await
+    }
+}
+
 #[derive(Default)]
 struct ScriptedProjectFilesystemReader {
     files: Mutex<HashMap<String, Result<WorkspaceFile, ProjectFsError>>>,
@@ -1416,6 +1516,54 @@ async fn observer_posts_working_indicator_and_retracts_it_after_final_reply() {
     );
 }
 
+/// Pins `NoticeEgress::into_retraction_handle()` at the `working_message`
+/// call site: a vendor accept with no message ref (web push; a Slack `ok`
+/// with no `ts`) still delivers the working indicator, but leaves no handle
+/// to retract — the working-indicator retraction after the final reply must
+/// be skipped, not attempted against a nonexistent ref.
+#[tokio::test]
+async fn observer_working_indicator_skips_retraction_when_the_vendor_omits_a_message_ref() {
+    let harness = build_harness(
+        vec![
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::Running, None),
+            scripted_state(TurnStatus::Completed, None),
+        ],
+        false,
+        None,
+        Duration::from_secs(5),
+    );
+    harness
+        .adapter
+        .reports
+        .lock()
+        .expect("reports lock")
+        .push_back(DeliveryReport {
+            parts: vec![PartDeliveryOutcome::Sent {
+                vendor_message_ref: None,
+            }],
+        });
+    let run_id = TurnRunId::new();
+    seed_final_message(&harness.threads, run_id, "done thinking").await;
+
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-working-no-ref"),
+            accepted_ack(run_id),
+        )
+        .await;
+
+    let texts = harness.adapter.texts();
+    assert_eq!(texts.len(), 2, "working indicator then final reply");
+    assert_eq!(texts[1], "done thinking");
+    assert!(
+        harness.adapter.retracted_refs().is_empty(),
+        "a ref-less working indicator has no retraction handle and must not be retracted: {:?}",
+        harness.adapter.retracted_refs()
+    );
+}
+
 /// A run whose triggering message has a vendor ref is marked 👀 while working
 /// and swapped to ✅ when it completes, so a busy channel shows at a glance
 /// which ping is being handled.
@@ -2356,6 +2504,160 @@ async fn observer_connect_nudge_releases_failed_delivery_reservation_for_retry()
         attempts.last().map(|attempt| attempt.status),
         Some(ironclaw_outbound::OutboundDeliveryStatus::Delivered)
     ));
+}
+
+/// Headline regression for #7473: `post_notice` used to collapse "nothing
+/// sent" and "sent, but no vendor ref came back" into the same `None`, so the
+/// connect-nudge throttle released its reservation on ANY ref-less result —
+/// including a genuinely-delivered notice. web push always omits a message
+/// ref, and Slack does whenever `chat.postMessage` succeeds without a `ts`;
+/// either one used to reopen the reservation and let a duplicate "please
+/// connect" nudge through. This must fail on the pre-fix release condition
+/// (`delivered.is_none()`) and pass once the release is keyed off
+/// `NoticeEgress::reached_vendor()` instead.
+#[tokio::test]
+async fn observer_connect_nudge_holds_reservation_when_the_vendor_accepts_without_a_message_ref() {
+    let harness = build_harness(
+        vec![scripted_state(TurnStatus::Running, None)],
+        true,
+        None,
+        Duration::from_millis(20),
+    );
+    // The vendor accepted the notice — `Sent` — but returned no ref.
+    harness
+        .adapter
+        .reports
+        .lock()
+        .expect("reports lock")
+        .push_back(DeliveryReport {
+            parts: vec![PartDeliveryOutcome::Sent {
+                vendor_message_ref: None,
+            }],
+        });
+    let rejected = ProductInboundAck::Rejected(ProductRejection::permanent(
+        ProductRejectionKind::BindingRequired,
+        "unbound",
+    ));
+
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-no-ref-1"),
+            rejected.clone(),
+        )
+        .await;
+    // A second unbound ping in the same conversation, still inside the
+    // throttle window: must NOT draw a second nudge — the first one already
+    // reached the user, ref or no ref.
+    harness
+        .observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-no-ref-2"),
+            rejected,
+        )
+        .await;
+
+    let texts = harness.adapter.texts();
+    assert_eq!(
+        texts,
+        vec![harness.connection_notices.connect_required.clone()],
+        "a ref-less vendor accept must hold the reservation, not release it for a duplicate: {texts:?}"
+    );
+}
+
+/// `DeliveredUnconfirmed` (vendor accepted, refs came back, but the durable
+/// `Delivered` write failed) is the other outcome the pre-fix code
+/// mishandled: `delivered_messages_from_outcome` DOES return a message for
+/// it, so that half was accidentally correct — but the mapping needed to be
+/// principled (keyed off the outcome variant), not lucky. Assert the
+/// reservation is held here too.
+#[tokio::test]
+async fn observer_connect_nudge_holds_reservation_when_delivery_is_unconfirmed() {
+    let inner_store =
+        Arc::new(ironclaw_outbound::test_support::in_memory_backed_outbound_state_store());
+    let store = Arc::new(TerminalDeliveredWriteFailingStore {
+        inner: Arc::clone(&inner_store),
+    });
+    let adapter = Arc::new(RecordingChannelAdapter::new());
+    let turns = Arc::new(ScriptedTurnCoordinator::with_states(vec![scripted_state(
+        TurnStatus::Running,
+        None,
+    )]));
+    let threads = Arc::new(InMemorySessionThreadService::default());
+    let project_files = Arc::new(ScriptedProjectFilesystemReader::default());
+    let coordinator = Arc::new(DeliveryCoordinator::new(
+        Arc::clone(&store) as Arc<dyn OutboundStateStorePort>,
+        Arc::new(StaticResolver {
+            adapter: Arc::clone(&adapter),
+        }),
+        Arc::new(NoStoredReplyContext),
+        DeliveryRetryPolicy {
+            max_attempts: 2,
+            backoff: Duration::ZERO,
+        },
+    ));
+    let services = RunDeliveryServices {
+        binding_service: Arc::new(StaticBindingService {
+            binding: binding(),
+            fail: true,
+        }),
+        thread_service: Arc::clone(&threads) as Arc<dyn SessionThreadService>,
+        turn_coordinator: Arc::clone(&turns) as Arc<dyn TurnCoordinator>,
+        outbound_store: Arc::clone(&store) as Arc<dyn OutboundStateStorePort>,
+        route_store: Arc::clone(&inner_store) as Arc<dyn DeliveredGateRouteStore>,
+        communication_preferences: Arc::clone(&inner_store)
+            as Arc<dyn CommunicationPreferenceRepository>,
+        project_filesystem: Arc::clone(&project_files) as Arc<dyn ProjectFilesystemReader>,
+        delivery_targets: Arc::new(StaticTargetCatalog {
+            targets: Vec::new(),
+        }) as Arc<dyn OutboundDeliveryTargetProvider>,
+        coordinator,
+        extension_id: EXTENSION_ID.to_string(),
+        fallback_notice_scope: fallback_scope(),
+        approval_context: None,
+        blocked_auth_prompts: None,
+        auth_flow_cancel: None,
+    };
+    let connection_notices = ChannelConnectionNoticePolicy::generic("Acme");
+    let observer = Arc::new(
+        RunDeliveryObserver::with_settings_and_connection_notices(
+            services,
+            RunDeliverySettings {
+                poll_interval: Duration::from_millis(1),
+                max_wait: Duration::from_millis(20),
+                max_concurrent_deliveries: NonZeroUsize::new(4).expect("nz"),
+                max_pending_deliveries: NonZeroUsize::new(8).expect("nz"),
+                first_nudge_after: Duration::from_secs(3600),
+                renudge_interval: Duration::from_secs(3600),
+            },
+            connection_notices.clone(),
+        )
+        .with_enabled_commands(["status"], None),
+    );
+
+    let rejected = ProductInboundAck::Rejected(ProductRejection::permanent(
+        ProductRejectionKind::BindingRequired,
+        "unbound",
+    ));
+    observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-unconfirmed-1"),
+            rejected.clone(),
+        )
+        .await;
+    observer
+        .observe_ack(
+            user_message_envelope(ProductTriggerReason::DirectChat, "evt-unconfirmed-2"),
+            rejected,
+        )
+        .await;
+
+    let texts = adapter.texts();
+    assert_eq!(
+        texts,
+        vec![connection_notices.connect_required.clone()],
+        "an unconfirmed-but-sent delivery must hold the reservation, not release it: {texts:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`post_notice` collapsed "nothing sent" and "sent, but no vendor ref came back" into the same `None`. The connect-nudge anti-duplicate throttle released its reservation on any `None`, so a genuinely-delivered notice with no ref (web push always; Slack whenever `chat.postMessage` succeeds without a `ts`) incorrectly reopened the throttle and let a duplicate "please connect" nudge through.

Fix: `post_notice` now returns `NoticeEgress` (`NotSent` / `Sent { durably_recorded, message }`), classified from `CoordinatedDeliveryOutcome` via an exhaustive match (no wildcard, so a new variant fails to compile here instead of defaulting fail-open). The connect-nudge release condition now keys off `!egress.reached_vendor()` instead of handle presence — it releases only on proven non-delivery, holds on any `Sent` regardless of ref or durability confirmation. The two working-indicator call sites use `into_retraction_handle()` to keep their existing behavior unchanged.

## Tests

- Headline regression: a ref-less `Sent` accept must hold the reservation, not release it for a duplicate. I reverted the release condition to the old buggy logic and confirmed the test fails (duplicate nudge observed); restored it and confirmed it passes.
- `DeliveredUnconfirmed` (vendor accepted, durable write failed) must also hold the reservation.
- Unit test on `notice_egress_from_outcome` against every `CoordinatedDeliveryOutcome` variant.
- Pin `into_retraction_handle()` behavior at the working-indicator call site for a ref-less accept.

`cargo test -p ironclaw_assistant` is green (1017 tests), clippy and fmt are clean. One test (`triggered_run_crossing_terminal_during_timeout_grace_delivers_cancellation_notice`) is flaky; I confirmed it's flaky identically on unmodified `upstream/main`, unrelated to this change.

Fixes #7473.