### PR TITLE
fix(llm): prefer the authenticated NEAR AI session for default probes

### DIFF
--- a/crates/domains/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/domains/ironclaw_llm/src/nearai_chat.rs
@@ -134,6 +134,30 @@ fn parse_nearai_models(response_text: &str) -> Vec<ModelInfo> {
         .unwrap_or_default()
 }
 
+/// Return whether model discovery targets an official public NEAR AI catalog.
+///
+/// These catalogs intentionally allow unauthenticated model listing. All other
+/// endpoints are treated as private so custom deployments and `private.near.ai`
+/// retain their configured API-key or session authentication.
+fn is_public_nearai_model_catalog(base_url: &str) -> bool {
+    let Ok(url) = url::Url::parse(base_url.trim()) else {
+        return false;
+    };
+    let path = url.path().trim_end_matches('/');
+
+    url.scheme() == "https"
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.port_or_known_default() == Some(443)
+        && url.query().is_none()
+        && url.fragment().is_none()
+        && matches!(
+            url.host_str(),
+            Some("cloud-api.near.ai" | "cloud-stg-api.near.ai")
+        )
+        && matches!(path, "" | "/v1")
+}
+
 /// Default NEAR AI model used when no model is configured.
 pub const DEFAULT_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 
@@ -641,7 +665,10 @@ impl NearAiChatProvider {
     pub async fn list_models_full(&self) -> Result<Vec<ModelInfo>, LlmError> {
         match self.list_models_inner().await {
             Ok(models) => Ok(models),
-            Err(LlmError::SessionExpired { .. }) if !self.uses_api_key() => {
+            Err(LlmError::SessionExpired { .. })
+                if !is_public_nearai_model_catalog(&self.config.base_url)
+                    && !self.uses_api_key() =>
+            {
                 self.session.handle_auth_failure().await?;
                 self.list_models_inner().await
             }
@@ -651,18 +678,21 @@ impl NearAiChatProvider {
 
     async fn list_models_inner(&self) -> Result<Vec<ModelInfo>, LlmError> {
         let url = self.api_url("models");
+        let requires_auth = !is_public_nearai_model_catalog(&self.config.base_url);
 
         tracing::debug!("Fetching models from: {}", url);
 
-        let response = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| LlmError::RequestFailed {
-                provider: "nearai_chat".to_string(),
-                reason: format!("Failed to fetch models: {}", e),
-            })?;
+        let request = self.client.get(&url);
+        let request = if requires_auth {
+            let token = self.resolve_bearer_token().await?;
+            request.header("Authorization", format!("Bearer {}", token))
+        } else {
+            request
+        };
+        let response = request.send().await.map_err(|e| LlmError::RequestFailed {
+            provider: "nearai_chat".to_string(),
+            reason: format!("Failed to fetch models: {}", e),
+        })?;
 
         let status = response.status();
         let response_text = response.text().await.map_err(|e| LlmError::RequestFailed {
@@ -671,7 +701,7 @@ impl NearAiChatProvider {
         })?;
 
         if !status.is_success() {
-            if status.as_u16() == 401 && !self.uses_api_key() {
+            if status.as_u16() == 401 && requires_auth && !self.uses_api_key() {
                 return Err(LlmError::SessionExpired {
                     provider: "nearai_chat".to_string(),
                 });
@@ -1781,6 +1811,37 @@ mod tests {
         assert!(parse_nearai_models("").is_empty());
     }
 
+    #[test]
+    fn public_model_catalog_auth_is_scoped_to_official_cloud_endpoints() {
+        for base_url in [
+            "https://cloud-api.near.ai",
+            "https://cloud-api.near.ai/",
+            "https://cloud-api.near.ai/v1",
+            "https://cloud-stg-api.near.ai/v1/",
+        ] {
+            assert!(
+                is_public_nearai_model_catalog(base_url),
+                "expected public catalog: {base_url}"
+            );
+        }
+
+        for base_url in [
+            "https://private.near.ai",
+            "http://cloud-api.near.ai",
+            "https://cloud-api.near.ai.example.com",
+            "https://cloud-api.near.ai:8443",
+            "https://user@cloud-api.near.ai",
+            "https://cloud-api.near.ai/v2",
+            "https://cloud-api.near.ai/v1?tenant=private",
+            "not-a-url",
+        ] {
+            assert!(
+                !is_public_nearai_model_catalog(base_url),
+                "expected authenticated catalog: {base_url}"
+            );
+        }
+    }
+
     fn test_nearai_config(base_url: &str) -> NearAiConfig {
         NearAiConfig {
             model: "test-model".to_string(),
@@ -1805,7 +1866,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_models_does_not_require_authentication() {
+    async fn private_model_discovery_uses_session_authentication() {
         use tokio::net::TcpListener;
         use tokio::sync::oneshot;
 
@@ -1813,14 +1874,23 @@ mod tests {
         let base_url = format!("http://{}", listener.local_addr().unwrap());
         let (headers_tx, headers_rx) = oneshot::channel();
         tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.expect("accept models request");
-            let (headers, _) = read_http_request_body(&mut socket).await;
-            headers_tx.send(headers).expect("capture request headers");
-            write_http_json_response(
-                &mut socket,
-                serde_json::json!({ "data": [{ "id": "nearai/test-model" }] }),
-            )
-            .await;
+            let mut headers_tx = Some(headers_tx);
+            loop {
+                let (mut socket, _) = listener.accept().await.expect("accept provider request");
+                let (headers, _) = read_http_request_body(&mut socket).await;
+                if headers.starts_with("GET /v1/models ") {
+                    if let Some(headers_tx) = headers_tx.take() {
+                        headers_tx.send(headers).expect("capture request headers");
+                    }
+                    write_http_json_response(
+                        &mut socket,
+                        serde_json::json!({ "data": [{ "id": "nearai/test-model" }] }),
+                    )
+                    .await;
+                    break;
+                }
+                write_http_json_response(&mut socket, serde_json::json!({ "data": [] })).await;
+            }
         });
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -1830,21 +1900,24 @@ mod tests {
             auth_base_url: "http://127.0.0.1:1".to_string(),
             session_path: temp.path().join("missing-session.json"),
         }));
+        session
+            .set_token(secrecy::SecretString::from("session-token"))
+            .await;
         let provider = NearAiChatProvider::new(config, session).expect("provider");
 
         let models = provider
             .list_models_full()
             .await
-            .expect("public model catalog should not require authentication");
+            .expect("private model discovery should use the session token");
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].name, "nearai/test-model");
         let headers = headers_rx.await.expect("models request headers");
         assert!(
-            !headers
+            headers
                 .lines()
-                .any(|line| line.to_ascii_lowercase().starts_with("authorization:")),
-            "public model discovery must not send credentials: {headers}"
+                .any(|line| line.eq_ignore_ascii_case("authorization: Bearer session-token")),
+            "private model discovery must send the session token: {headers}"
         );
     }
 

--- a/crates/domains/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/domains/ironclaw_llm/src/nearai_chat.rs
@@ -651,14 +651,12 @@ impl NearAiChatProvider {
 
     async fn list_models_inner(&self) -> Result<Vec<ModelInfo>, LlmError> {
         let url = self.api_url("models");
-        let token = self.resolve_bearer_token().await?;
 
         tracing::debug!("Fetching models from: {}", url);
 
         let response = self
             .client
             .get(&url)
-            .header("Authorization", format!("Bearer {}", token))
             .send()
             .await
             .map_err(|e| LlmError::RequestFailed {
@@ -1804,6 +1802,50 @@ mod tests {
 
     fn test_session() -> Arc<SessionManager> {
         Arc::new(SessionManager::new(SessionConfig::default()))
+    }
+
+    #[tokio::test]
+    async fn list_models_does_not_require_authentication() {
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (headers_tx, headers_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept models request");
+            let (headers, _) = read_http_request_body(&mut socket).await;
+            headers_tx.send(headers).expect("capture request headers");
+            write_http_json_response(
+                &mut socket,
+                serde_json::json!({ "data": [{ "id": "nearai/test-model" }] }),
+            )
+            .await;
+        });
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut config = test_nearai_config(&base_url);
+        config.api_key = None;
+        let session = Arc::new(SessionManager::new(SessionConfig {
+            auth_base_url: "http://127.0.0.1:1".to_string(),
+            session_path: temp.path().join("missing-session.json"),
+        }));
+        let provider = NearAiChatProvider::new(config, session).expect("provider");
+
+        let models = provider
+            .list_models_full()
+            .await
+            .expect("public model catalog should not require authentication");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].name, "nearai/test-model");
+        let headers = headers_rx.await.expect("models request headers");
+        assert!(
+            !headers
+                .lines()
+                .any(|line| line.to_ascii_lowercase().starts_with("authorization:")),
+            "public model discovery must not send credentials: {headers}"
+        );
     }
 
     async fn read_http_request_body(socket: &mut tokio::net::TcpStream) -> (String, String) {

--- a/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
@@ -356,10 +356,11 @@ impl RebornLlmConfigService {
             .clone()
             .filter(|model| !model.trim().is_empty())
             .unwrap_or_default();
+        let is_nearai_protocol = protocol == ProviderProtocol::NearAi;
 
         let definition = custom_definition(&request.provider_id, protocol, base_url.clone(), model);
         let registry = ProviderRegistry::new(vec![definition]);
-        let stored_key_allowed = self.probe_matches_persisted_provider(request).await?;
+        let persisted_endpoint_matches = self.probe_matches_persisted_provider(request).await?;
         let selection = LlmSlotSelection {
             provider_id: Some(request.provider_id.clone()),
             model: request
@@ -379,9 +380,10 @@ impl RebornLlmConfigService {
         // Prefer the request's inline key. Stored operator credentials are only
         // safe when the probe targets the persisted provider endpoint; otherwise
         // a caller-controlled base_url could exfiltrate that key.
+        let mut runtime_nearai_session = None;
         if let Some(key) = request.api_key.as_ref() {
             apply_stored_api_key(&mut config, key.clone());
-        } else if stored_key_allowed {
+        } else if persisted_endpoint_matches {
             if let Some(stored) = self
                 .keys
                 .read(&request.provider_id)
@@ -389,6 +391,11 @@ impl RebornLlmConfigService {
                 .map_err(|_| LlmConfigServiceError::Unavailable)?
             {
                 apply_stored_api_key(&mut config, stored);
+            } else if is_nearai_protocol {
+                // NEAR AI account login writes into the runtime session manager,
+                // not the generic operator key store. Reuse that exact manager
+                // only when the probe targets the persisted/default endpoint.
+                runtime_nearai_session = self.nearai_session.clone();
             }
         } else if self
             .keys
@@ -404,12 +411,25 @@ impl RebornLlmConfigService {
                 reason: "inline api_key is required when probing an overridden provider endpoint"
                     .to_string(),
             });
+        } else if is_nearai_protocol {
+            // A fresh SessionManager can load a NEAR AI token from disk or the
+            // environment. Never construct one for a caller-overridden endpoint,
+            // because doing so could send ambient session authority off-host.
+            return Err(LlmConfigServiceError::InvalidRequest {
+                field: Some("api_key".to_string()),
+                reason: "inline api_key is required when probing an overridden NEAR AI endpoint"
+                    .to_string(),
+            });
         }
         // Otherwise there is neither an inline key nor a stored key to protect,
         // so probe keyless — local OpenAI-compatible endpoints (e.g. Ollama)
         // need no auth and must not be blocked behind a phantom key requirement.
 
-        let session = ironclaw_llm::create_session_manager(config.session.clone()).await;
+        let session = if let Some(session) = runtime_nearai_session {
+            session
+        } else {
+            ironclaw_llm::create_session_manager(config.session.clone()).await
+        };
         ironclaw_llm::build_static_provider_chain(&config, session)
             .await
             .map_err(|_| LlmConfigServiceError::Unavailable)
@@ -433,9 +453,29 @@ impl RebornLlmConfigService {
         let Some(protocol) = parse_adapter(&request.adapter) else {
             return Ok(false);
         };
-        Ok(protocol == definition.protocol
-            && normalized_endpoint(request.base_url.as_deref())
-                == normalized_endpoint(definition.default_base_url.as_deref()))
+        if protocol != definition.protocol {
+            return Ok(false);
+        }
+
+        let nearai_default = || {
+            default_nearai_base_url(ironclaw_common::env_helpers::env_or_override(
+                "NEARAI_BASE_URL",
+            ))
+        };
+        let persisted_base_url = definition
+            .default_base_url
+            .clone()
+            .or_else(|| (protocol == ProviderProtocol::NearAi).then(&nearai_default));
+        let requested_base_url = request
+            .base_url
+            .clone()
+            .filter(|base_url| !base_url.trim().is_empty())
+            .or_else(|| (protocol == ProviderProtocol::NearAi).then(nearai_default));
+
+        Ok(
+            normalized_probe_endpoint(protocol, requested_base_url.as_deref())
+                == normalized_probe_endpoint(protocol, persisted_base_url.as_deref()),
+        )
     }
 
     async fn admin_list_async(
@@ -1081,6 +1121,19 @@ fn normalized_endpoint(value: Option<&str>) -> Option<String> {
         .map(|value| value.trim_end_matches('/').to_string())
 }
 
+fn normalized_probe_endpoint(protocol: ProviderProtocol, value: Option<&str>) -> Option<String> {
+    let endpoint = normalized_endpoint(value)?;
+    if protocol == ProviderProtocol::NearAi {
+        return Some(
+            endpoint
+                .strip_suffix("/v1")
+                .unwrap_or(&endpoint)
+                .to_string(),
+        );
+    }
+    Some(endpoint)
+}
+
 /// Build a transient provider from a not-yet-persisted provider/key/model
 /// combination and list its models — used by
 /// [`crate::RebornProviderAdmin::probe_candidate`] (onboard's pre-write
@@ -1512,6 +1565,107 @@ mod tests {
             model: Some("acme-1".to_string()),
             api_key: api_key.map(SecretString::from),
         }
+    }
+
+    fn nearai_probe_request(base_url: &str) -> LlmProbeRequest {
+        LlmProbeRequest {
+            provider_id: "nearai".to_string(),
+            adapter: "nearai".to_string(),
+            base_url: Some(base_url.to_string()),
+            model: Some("nearai/test-model".to_string()),
+            api_key: None,
+        }
+    }
+
+    fn nearai_upsert_request(base_url: &str) -> UpsertLlmProviderRequest {
+        UpsertLlmProviderRequest {
+            id: "nearai".to_string(),
+            client_action_id: None,
+            name: Some("NEAR AI".to_string()),
+            adapter: "nearai".to_string(),
+            base_url: Some(base_url.to_string()),
+            default_model: Some("nearai/test-model".to_string()),
+            api_key: None,
+            set_active: false,
+            model: Some("nearai/test-model".to_string()),
+        }
+    }
+
+    async fn runtime_nearai_session(
+        session_path: std::path::PathBuf,
+    ) -> Arc<ironclaw_llm::SessionManager> {
+        let session = Arc::new(ironclaw_llm::SessionManager::new(
+            ironclaw_llm::SessionConfig {
+                auth_base_url: "https://private.near.ai".to_string(),
+                session_path,
+            },
+        ));
+        session
+            .set_token(SecretString::from("runtime-session-token"))
+            .await;
+        session
+    }
+
+    async fn spawn_nearai_models_server() -> (String, tokio::sync::oneshot::Receiver<String>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind model server");
+        let base_url = format!("http://{}/v1", listener.local_addr().expect("local addr"));
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let mut tx = Some(tx);
+            for _ in 0..4 {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut request = Vec::with_capacity(1024);
+                let mut chunk = [0_u8; 1024];
+                while request.len() < 8192 {
+                    let remaining = 8192 - request.len();
+                    let read_len = remaining.min(chunk.len());
+                    let Ok(n) = socket.read(&mut chunk[..read_len]).await else {
+                        break;
+                    };
+                    if n == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&chunk[..n]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8_lossy(&request).to_string();
+                let body = if request.starts_with("GET /v1/models ") {
+                    if let Some(tx) = tx.take() {
+                        let _ = tx.send(request);
+                    }
+                    serde_json::json!({
+                        "data": [
+                            { "id": "anthropic/claude-test" },
+                            { "model": "openai/gpt-test" }
+                        ]
+                    })
+                    .to_string()
+                } else {
+                    serde_json::json!({ "data": [] }).to_string()
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                if tx.is_none() {
+                    break;
+                }
+            }
+        });
+
+        (base_url, rx)
     }
 
     /// An unknown adapter (validated locally, not via the network) must
@@ -2006,6 +2160,146 @@ mod tests {
             store.call_count(OperatorSecretValueOp::Contains),
             0,
             "snapshot must not probe stored keys one provider at a time"
+        );
+    }
+
+    #[tokio::test]
+    async fn nearai_model_list_reuses_runtime_session_for_persisted_endpoint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        let boot = boot_for_home(&reborn_home);
+        let (base_url, observed_request) = spawn_nearai_models_server().await;
+        let session = runtime_nearai_session(temp.path().join("runtime-session.json")).await;
+        let service = RebornLlmConfigService::new(boot, key_store()).with_nearai_session(session);
+        service
+            .upsert_provider(caller(), nearai_upsert_request(&base_url))
+            .await
+            .expect("persist NEAR AI endpoint");
+
+        let result = service
+            .list_models(caller(), nearai_probe_request(&base_url))
+            .await
+            .expect("model probe should complete");
+
+        assert!(result.ok, "model probe should succeed: {result:?}");
+        assert_eq!(
+            result.models,
+            vec![
+                "anthropic/claude-test".to_string(),
+                "openai/gpt-test".to_string()
+            ]
+        );
+
+        let request = tokio::time::timeout(Duration::from_secs(2), observed_request)
+            .await
+            .expect("models endpoint should be requested")
+            .expect("request observer should complete");
+        assert!(
+            request.lines().any(
+                |line| line.eq_ignore_ascii_case("authorization: Bearer runtime-session-token")
+            ),
+            "persisted NEAR AI model probe must use the runtime session token; request was {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn nearai_model_list_does_not_send_runtime_session_to_overridden_endpoint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        let boot = boot_for_home(&reborn_home);
+        let (persisted_base_url, _) = spawn_nearai_models_server().await;
+        let session = runtime_nearai_session(temp.path().join("runtime-session.json")).await;
+        let service = RebornLlmConfigService::new(boot, key_store()).with_nearai_session(session);
+        service
+            .upsert_provider(caller(), nearai_upsert_request(&persisted_base_url))
+            .await
+            .expect("persist NEAR AI endpoint");
+        let (overridden_base_url, observed_request) = spawn_nearai_models_server().await;
+
+        let error = service
+            .list_models(caller(), nearai_probe_request(&overridden_base_url))
+            .await
+            .expect_err("overridden NEAR AI endpoint must require an inline key");
+
+        assert!(
+            matches!(
+                error,
+                LlmConfigServiceError::InvalidRequest {
+                    field: Some(ref field),
+                    ref reason,
+                } if field == "api_key" && reason.contains("overridden NEAR AI endpoint")
+            ),
+            "overridden endpoint should fail before provider construction: {error:?}"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), observed_request)
+                .await
+                .is_err(),
+            "overridden endpoint must not receive the runtime NEAR AI session token"
+        );
+    }
+
+    #[tokio::test]
+    async fn nearai_model_list_uses_inline_key_for_overridden_endpoint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        let boot = boot_for_home(&reborn_home);
+        let (persisted_base_url, _) = spawn_nearai_models_server().await;
+        let session = runtime_nearai_session(temp.path().join("runtime-session.json")).await;
+        let service = RebornLlmConfigService::new(boot, key_store()).with_nearai_session(session);
+        service
+            .upsert_provider(caller(), nearai_upsert_request(&persisted_base_url))
+            .await
+            .expect("persist NEAR AI endpoint");
+        let (overridden_base_url, observed_request) = spawn_nearai_models_server().await;
+        let mut request = nearai_probe_request(&overridden_base_url);
+        request.api_key = Some(SecretString::from("inline-override-key"));
+
+        let result = service
+            .list_models(caller(), request)
+            .await
+            .expect("inline-key probe should complete");
+
+        assert!(result.ok, "inline-key probe should succeed: {result:?}");
+        let request = tokio::time::timeout(Duration::from_secs(2), observed_request)
+            .await
+            .expect("overridden endpoint should be requested")
+            .expect("request observer should complete");
+        assert!(
+            request
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("authorization: Bearer inline-override-key")),
+            "overridden endpoint must receive only the inline key; request was {request}"
+        );
+        assert!(
+            !request.contains("runtime-session-token"),
+            "overridden endpoint must not receive the runtime session token"
+        );
+    }
+
+    #[tokio::test]
+    async fn nearai_default_endpoint_matches_the_builtin_provider() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        let boot = boot_for_home(&reborn_home);
+        let service = RebornLlmConfigService::new(boot, key_store());
+        let expected_base_url = default_nearai_base_url(
+            ironclaw_common::env_helpers::env_or_override("NEARAI_BASE_URL"),
+        );
+
+        let request_base_url = if expected_base_url.trim_end_matches('/').ends_with("/v1") {
+            expected_base_url
+        } else {
+            format!("{}/v1", expected_base_url.trim_end_matches('/'))
+        };
+        let matches = service
+            .probe_matches_persisted_provider(&nearai_probe_request(&request_base_url))
+            .await
+            .expect("provider match should resolve");
+
+        assert!(
+            matches,
+            "equivalent NEAR AI base URLs with or without `/v1` must be eligible for the runtime session"
         );
     }
 

--- a/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
@@ -383,6 +383,12 @@ impl RebornLlmConfigService {
         let mut runtime_nearai_session = None;
         if let Some(key) = request.api_key.as_ref() {
             apply_stored_api_key(&mut config, key.clone());
+        } else if persisted_endpoint_matches && is_nearai_protocol && self.nearai_session.is_some()
+        {
+            // The NEAR account login session is the authority for probes of
+            // the configured NEAR AI endpoint. Prefer it over any stale API
+            // key that may still exist in the generic operator key store.
+            runtime_nearai_session = self.nearai_session.clone();
         } else if persisted_endpoint_matches {
             if let Some(stored) = self
                 .keys
@@ -391,11 +397,6 @@ impl RebornLlmConfigService {
                 .map_err(|_| LlmConfigServiceError::Unavailable)?
             {
                 apply_stored_api_key(&mut config, stored);
-            } else if is_nearai_protocol {
-                // NEAR AI account login writes into the runtime session manager,
-                // not the generic operator key store. Reuse that exact manager
-                // only when the probe targets the persisted/default endpoint.
-                runtime_nearai_session = self.nearai_session.clone();
             }
         } else if self
             .keys
@@ -453,29 +454,18 @@ impl RebornLlmConfigService {
         let Some(protocol) = parse_adapter(&request.adapter) else {
             return Ok(false);
         };
-        if protocol != definition.protocol {
-            return Ok(false);
-        }
-
-        let nearai_default = || {
+        let nearai_default = (protocol == ProviderProtocol::NearAi).then(|| {
             default_nearai_base_url(ironclaw_common::env_helpers::env_or_override(
                 "NEARAI_BASE_URL",
             ))
-        };
+        });
         let persisted_base_url = definition
             .default_base_url
-            .clone()
-            .or_else(|| (protocol == ProviderProtocol::NearAi).then(&nearai_default));
-        let requested_base_url = request
-            .base_url
-            .clone()
-            .filter(|base_url| !base_url.trim().is_empty())
-            .or_else(|| (protocol == ProviderProtocol::NearAi).then(nearai_default));
-
-        Ok(
-            normalized_probe_endpoint(protocol, requested_base_url.as_deref())
-                == normalized_probe_endpoint(protocol, persisted_base_url.as_deref()),
-        )
+            .as_deref()
+            .or(nearai_default.as_deref());
+        Ok(protocol == definition.protocol
+            && normalized_endpoint(request.base_url.as_deref())
+                == normalized_endpoint(persisted_base_url))
     }
 
     async fn admin_list_async(
@@ -1121,19 +1111,6 @@ fn normalized_endpoint(value: Option<&str>) -> Option<String> {
         .map(|value| value.trim_end_matches('/').to_string())
 }
 
-fn normalized_probe_endpoint(protocol: ProviderProtocol, value: Option<&str>) -> Option<String> {
-    let endpoint = normalized_endpoint(value)?;
-    if protocol == ProviderProtocol::NearAi {
-        return Some(
-            endpoint
-                .strip_suffix("/v1")
-                .unwrap_or(&endpoint)
-                .to_string(),
-        );
-    }
-    Some(endpoint)
-}
-
 /// Build a transient provider from a not-yet-persisted provider/key/model
 /// combination and list its models — used by
 /// [`crate::RebornProviderAdmin::probe_candidate`] (onboard's pre-write
@@ -1607,62 +1584,53 @@ mod tests {
     }
 
     async fn spawn_nearai_models_server() -> (String, tokio::sync::oneshot::Receiver<String>) {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use axum::{
+            Json, Router,
+            extract::State,
+            http::{HeaderMap, StatusCode, header::AUTHORIZATION},
+            response::{IntoResponse, Response},
+            routing::get,
+        };
         use tokio::net::TcpListener;
+
+        type RequestObserver =
+            Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<String>>>>;
+
+        async fn list_models(
+            State(observer): State<RequestObserver>,
+            headers: HeaderMap,
+        ) -> Response {
+            let authorization = headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            if let Some(observer) = observer.lock().await.take() {
+                let _ = observer.send(authorization.clone());
+            }
+            if authorization != "Bearer runtime-session-token" {
+                return StatusCode::UNAUTHORIZED.into_response();
+            }
+            Json(serde_json::json!({
+                "data": [
+                    { "id": "anthropic/claude-test" },
+                    { "model": "openai/gpt-test" }
+                ]
+            }))
+            .into_response()
+        }
 
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind model server");
         let base_url = format!("http://{}/v1", listener.local_addr().expect("local addr"));
         let (tx, rx) = tokio::sync::oneshot::channel();
-
+        let observer = Arc::new(tokio::sync::Mutex::new(Some(tx)));
+        let app = Router::new()
+            .route("/v1/models", get(list_models))
+            .with_state(observer);
         tokio::spawn(async move {
-            let mut tx = Some(tx);
-            for _ in 0..4 {
-                let Ok((mut socket, _)) = listener.accept().await else {
-                    break;
-                };
-                let mut request = Vec::with_capacity(1024);
-                let mut chunk = [0_u8; 1024];
-                while request.len() < 8192 {
-                    let remaining = 8192 - request.len();
-                    let read_len = remaining.min(chunk.len());
-                    let Ok(n) = socket.read(&mut chunk[..read_len]).await else {
-                        break;
-                    };
-                    if n == 0 {
-                        break;
-                    }
-                    request.extend_from_slice(&chunk[..n]);
-                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
-                        break;
-                    }
-                }
-                let request = String::from_utf8_lossy(&request).to_string();
-                let body = if request.starts_with("GET /v1/models ") {
-                    if let Some(tx) = tx.take() {
-                        let _ = tx.send(request);
-                    }
-                    serde_json::json!({
-                        "data": [
-                            { "id": "anthropic/claude-test" },
-                            { "model": "openai/gpt-test" }
-                        ]
-                    })
-                    .to_string()
-                } else {
-                    serde_json::json!({ "data": [] }).to_string()
-                };
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                    body.len(),
-                    body
-                );
-                let _ = socket.write_all(response.as_bytes()).await;
-                if tx.is_none() {
-                    break;
-                }
-            }
+            let _ = axum::serve(listener, app).await;
         });
 
         (base_url, rx)
@@ -2164,15 +2132,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nearai_model_list_reuses_runtime_session_for_persisted_endpoint() {
+    async fn nearai_probe_apis_prefer_runtime_session_over_stored_key() {
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         let boot = boot_for_home(&reborn_home);
         let (base_url, observed_request) = spawn_nearai_models_server().await;
         let session = runtime_nearai_session(temp.path().join("runtime-session.json")).await;
         let service = RebornLlmConfigService::new(boot, key_store()).with_nearai_session(session);
+        let mut upsert = nearai_upsert_request(&base_url);
+        upsert.api_key = Some(SecretString::from("stale-stored-key"));
         service
-            .upsert_provider(caller(), nearai_upsert_request(&base_url))
+            .upsert_provider(caller(), upsert)
             .await
             .expect("persist NEAR AI endpoint");
 
@@ -2190,16 +2160,36 @@ mod tests {
             ]
         );
 
-        let request = tokio::time::timeout(Duration::from_secs(2), observed_request)
+        let authorization = tokio::time::timeout(Duration::from_secs(2), observed_request)
             .await
             .expect("models endpoint should be requested")
             .expect("request observer should complete");
         assert!(
-            request.lines().any(
-                |line| line.eq_ignore_ascii_case("authorization: Bearer runtime-session-token")
-            ),
-            "persisted NEAR AI model probe must use the runtime session token; request was {request}"
+            authorization.eq_ignore_ascii_case("Bearer runtime-session-token"),
+            "persisted NEAR AI model probe must use the runtime session token; authorization was {authorization}"
         );
+
+        let result = service
+            .test_connection(caller(), nearai_probe_request(&base_url))
+            .await
+            .expect("connection probe should complete");
+        assert!(result.ok, "connection probe should succeed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn nearai_builtin_cloud_endpoint_is_session_eligible() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = RebornLlmConfigService::new(
+            boot_for_home(&temp.path().join("reborn-home")),
+            key_store(),
+        );
+
+        let matches = service
+            .probe_matches_persisted_provider(&nearai_probe_request(NEARAI_CLOUD_DEFAULT_BASE_URL))
+            .await
+            .expect("provider match should resolve");
+
+        assert!(matches, "the built-in cloud endpoint must use the session");
     }
 
     #[tokio::test]
@@ -2236,70 +2226,6 @@ mod tests {
                 .await
                 .is_err(),
             "overridden endpoint must not receive the runtime NEAR AI session token"
-        );
-    }
-
-    #[tokio::test]
-    async fn nearai_model_list_uses_inline_key_for_overridden_endpoint() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let reborn_home = temp.path().join("reborn-home");
-        let boot = boot_for_home(&reborn_home);
-        let (persisted_base_url, _) = spawn_nearai_models_server().await;
-        let session = runtime_nearai_session(temp.path().join("runtime-session.json")).await;
-        let service = RebornLlmConfigService::new(boot, key_store()).with_nearai_session(session);
-        service
-            .upsert_provider(caller(), nearai_upsert_request(&persisted_base_url))
-            .await
-            .expect("persist NEAR AI endpoint");
-        let (overridden_base_url, observed_request) = spawn_nearai_models_server().await;
-        let mut request = nearai_probe_request(&overridden_base_url);
-        request.api_key = Some(SecretString::from("inline-override-key"));
-
-        let result = service
-            .list_models(caller(), request)
-            .await
-            .expect("inline-key probe should complete");
-
-        assert!(result.ok, "inline-key probe should succeed: {result:?}");
-        let request = tokio::time::timeout(Duration::from_secs(2), observed_request)
-            .await
-            .expect("overridden endpoint should be requested")
-            .expect("request observer should complete");
-        assert!(
-            request
-                .lines()
-                .any(|line| line.eq_ignore_ascii_case("authorization: Bearer inline-override-key")),
-            "overridden endpoint must receive only the inline key; request was {request}"
-        );
-        assert!(
-            !request.contains("runtime-session-token"),
-            "overridden endpoint must not receive the runtime session token"
-        );
-    }
-
-    #[tokio::test]
-    async fn nearai_default_endpoint_matches_the_builtin_provider() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let reborn_home = temp.path().join("reborn-home");
-        let boot = boot_for_home(&reborn_home);
-        let service = RebornLlmConfigService::new(boot, key_store());
-        let expected_base_url = default_nearai_base_url(
-            ironclaw_common::env_helpers::env_or_override("NEARAI_BASE_URL"),
-        );
-
-        let request_base_url = if expected_base_url.trim_end_matches('/').ends_with("/v1") {
-            expected_base_url
-        } else {
-            format!("{}/v1", expected_base_url.trim_end_matches('/'))
-        };
-        let matches = service
-            .probe_matches_persisted_provider(&nearai_probe_request(&request_base_url))
-            .await
-            .expect("provider match should resolve");
-
-        assert!(
-            matches,
-            "equivalent NEAR AI base URLs with or without `/v1` must be eligible for the runtime session"
         );
     }
 

--- a/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
@@ -356,11 +356,10 @@ impl RebornLlmConfigService {
             .clone()
             .filter(|model| !model.trim().is_empty())
             .unwrap_or_default();
-        let is_nearai_protocol = protocol == ProviderProtocol::NearAi;
 
         let definition = custom_definition(&request.provider_id, protocol, base_url.clone(), model);
         let registry = ProviderRegistry::new(vec![definition]);
-        let persisted_endpoint_matches = self.probe_matches_persisted_provider(request).await?;
+        let stored_key_allowed = self.probe_matches_persisted_provider(request).await?;
         let selection = LlmSlotSelection {
             provider_id: Some(request.provider_id.clone()),
             model: request
@@ -380,16 +379,9 @@ impl RebornLlmConfigService {
         // Prefer the request's inline key. Stored operator credentials are only
         // safe when the probe targets the persisted provider endpoint; otherwise
         // a caller-controlled base_url could exfiltrate that key.
-        let mut runtime_nearai_session = None;
         if let Some(key) = request.api_key.as_ref() {
             apply_stored_api_key(&mut config, key.clone());
-        } else if persisted_endpoint_matches && is_nearai_protocol && self.nearai_session.is_some()
-        {
-            // The NEAR account login session is the authority for probes of
-            // the configured NEAR AI endpoint. Prefer it over any stale API
-            // key that may still exist in the generic operator key store.
-            runtime_nearai_session = self.nearai_session.clone();
-        } else if persisted_endpoint_matches {
+        } else if stored_key_allowed {
             if let Some(stored) = self
                 .keys
                 .read(&request.provider_id)
@@ -412,25 +404,12 @@ impl RebornLlmConfigService {
                 reason: "inline api_key is required when probing an overridden provider endpoint"
                     .to_string(),
             });
-        } else if is_nearai_protocol {
-            // A fresh SessionManager can load a NEAR AI token from disk or the
-            // environment. Never construct one for a caller-overridden endpoint,
-            // because doing so could send ambient session authority off-host.
-            return Err(LlmConfigServiceError::InvalidRequest {
-                field: Some("api_key".to_string()),
-                reason: "inline api_key is required when probing an overridden NEAR AI endpoint"
-                    .to_string(),
-            });
         }
         // Otherwise there is neither an inline key nor a stored key to protect,
         // so probe keyless — local OpenAI-compatible endpoints (e.g. Ollama)
         // need no auth and must not be blocked behind a phantom key requirement.
 
-        let session = if let Some(session) = runtime_nearai_session {
-            session
-        } else {
-            ironclaw_llm::create_session_manager(config.session.clone()).await
-        };
+        let session = ironclaw_llm::create_session_manager(config.session.clone()).await;
         ironclaw_llm::build_static_provider_chain(&config, session)
             .await
             .map_err(|_| LlmConfigServiceError::Unavailable)
@@ -454,18 +433,9 @@ impl RebornLlmConfigService {
         let Some(protocol) = parse_adapter(&request.adapter) else {
             return Ok(false);
         };
-        let nearai_default = (protocol == ProviderProtocol::NearAi).then(|| {
-            default_nearai_base_url(ironclaw_common::env_helpers::env_or_override(
-                "NEARAI_BASE_URL",
-            ))
-        });
-        let persisted_base_url = definition
-            .default_base_url
-            .as_deref()
-            .or(nearai_default.as_deref());
         Ok(protocol == definition.protocol
             && normalized_endpoint(request.base_url.as_deref())
-                == normalized_endpoint(persisted_base_url))
+                == normalized_endpoint(definition.default_base_url.as_deref()))
     }
 
     async fn admin_list_async(
@@ -1544,98 +1514,6 @@ mod tests {
         }
     }
 
-    fn nearai_probe_request(base_url: &str) -> LlmProbeRequest {
-        LlmProbeRequest {
-            provider_id: "nearai".to_string(),
-            adapter: "nearai".to_string(),
-            base_url: Some(base_url.to_string()),
-            model: Some("nearai/test-model".to_string()),
-            api_key: None,
-        }
-    }
-
-    fn nearai_upsert_request(base_url: &str) -> UpsertLlmProviderRequest {
-        UpsertLlmProviderRequest {
-            id: "nearai".to_string(),
-            client_action_id: None,
-            name: Some("NEAR AI".to_string()),
-            adapter: "nearai".to_string(),
-            base_url: Some(base_url.to_string()),
-            default_model: Some("nearai/test-model".to_string()),
-            api_key: None,
-            set_active: false,
-            model: Some("nearai/test-model".to_string()),
-        }
-    }
-
-    async fn runtime_nearai_session(
-        session_path: std::path::PathBuf,
-    ) -> Arc<ironclaw_llm::SessionManager> {
-        let session = Arc::new(ironclaw_llm::SessionManager::new(
-            ironclaw_llm::SessionConfig {
-                auth_base_url: "https://private.near.ai".to_string(),
-                session_path,
-            },
-        ));
-        session
-            .set_token(SecretString::from("runtime-session-token"))
-            .await;
-        session
-    }
-
-    async fn spawn_nearai_models_server() -> (String, tokio::sync::oneshot::Receiver<String>) {
-        use axum::{
-            Json, Router,
-            extract::State,
-            http::{HeaderMap, StatusCode, header::AUTHORIZATION},
-            response::{IntoResponse, Response},
-            routing::get,
-        };
-        use tokio::net::TcpListener;
-
-        type RequestObserver =
-            Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<String>>>>;
-
-        async fn list_models(
-            State(observer): State<RequestObserver>,
-            headers: HeaderMap,
-        ) -> Response {
-            let authorization = headers
-                .get(AUTHORIZATION)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string();
-            if let Some(observer) = observer.lock().await.take() {
-                let _ = observer.send(authorization.clone());
-            }
-            if authorization != "Bearer runtime-session-token" {
-                return StatusCode::UNAUTHORIZED.into_response();
-            }
-            Json(serde_json::json!({
-                "data": [
-                    { "id": "anthropic/claude-test" },
-                    { "model": "openai/gpt-test" }
-                ]
-            }))
-            .into_response()
-        }
-
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind model server");
-        let base_url = format!("http://{}/v1", listener.local_addr().expect("local addr"));
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let observer = Arc::new(tokio::sync::Mutex::new(Some(tx)));
-        let app = Router::new()
-            .route("/v1/models", get(list_models))
-            .with_state(observer);
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-
-        (base_url, rx)
-    }
-
     /// An unknown adapter (validated locally, not via the network) must
     /// report `ok: false` like every other probe failure — never `Err` —
     /// since `provision_via_menu` treats all `ok: false` the same way.
@@ -2128,104 +2006,6 @@ mod tests {
             store.call_count(OperatorSecretValueOp::Contains),
             0,
             "snapshot must not probe stored keys one provider at a time"
-        );
-    }
-
-    #[tokio::test]
-    async fn nearai_probe_apis_prefer_runtime_session_over_stored_key() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let reborn_home = temp.path().join("reborn-home");
-        let boot = boot_for_home(&reborn_home);
-        let (base_url, observed_request) = spawn_nearai_models_server().await;
-        let session = runtime_nearai_session(temp.path().join("runtime-session.json")).await;
-        let service = RebornLlmConfigService::new(boot, key_store()).with_nearai_session(session);
-        let mut upsert = nearai_upsert_request(&base_url);
-        upsert.api_key = Some(SecretString::from("stale-stored-key"));
-        service
-            .upsert_provider(caller(), upsert)
-            .await
-            .expect("persist NEAR AI endpoint");
-
-        let result = service
-            .list_models(caller(), nearai_probe_request(&base_url))
-            .await
-            .expect("model probe should complete");
-
-        assert!(result.ok, "model probe should succeed: {result:?}");
-        assert_eq!(
-            result.models,
-            vec![
-                "anthropic/claude-test".to_string(),
-                "openai/gpt-test".to_string()
-            ]
-        );
-
-        let authorization = tokio::time::timeout(Duration::from_secs(2), observed_request)
-            .await
-            .expect("models endpoint should be requested")
-            .expect("request observer should complete");
-        assert!(
-            authorization.eq_ignore_ascii_case("Bearer runtime-session-token"),
-            "persisted NEAR AI model probe must use the runtime session token; authorization was {authorization}"
-        );
-
-        let result = service
-            .test_connection(caller(), nearai_probe_request(&base_url))
-            .await
-            .expect("connection probe should complete");
-        assert!(result.ok, "connection probe should succeed: {result:?}");
-    }
-
-    #[tokio::test]
-    async fn nearai_builtin_cloud_endpoint_is_session_eligible() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = RebornLlmConfigService::new(
-            boot_for_home(&temp.path().join("reborn-home")),
-            key_store(),
-        );
-
-        let matches = service
-            .probe_matches_persisted_provider(&nearai_probe_request(NEARAI_CLOUD_DEFAULT_BASE_URL))
-            .await
-            .expect("provider match should resolve");
-
-        assert!(matches, "the built-in cloud endpoint must use the session");
-    }
-
-    #[tokio::test]
-    async fn nearai_model_list_does_not_send_runtime_session_to_overridden_endpoint() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let reborn_home = temp.path().join("reborn-home");
-        let boot = boot_for_home(&reborn_home);
-        let (persisted_base_url, _) = spawn_nearai_models_server().await;
-        let session = runtime_nearai_session(temp.path().join("runtime-session.json")).await;
-        let service = RebornLlmConfigService::new(boot, key_store()).with_nearai_session(session);
-        service
-            .upsert_provider(caller(), nearai_upsert_request(&persisted_base_url))
-            .await
-            .expect("persist NEAR AI endpoint");
-        let (overridden_base_url, observed_request) = spawn_nearai_models_server().await;
-
-        let error = service
-            .list_models(caller(), nearai_probe_request(&overridden_base_url))
-            .await
-            .expect_err("overridden NEAR AI endpoint must require an inline key");
-
-        assert!(
-            matches!(
-                error,
-                LlmConfigServiceError::InvalidRequest {
-                    field: Some(ref field),
-                    ref reason,
-                } if field == "api_key" && reason.contains("overridden NEAR AI endpoint")
-            ),
-            "overridden endpoint should fail before provider construction: {error:?}"
-        );
-        assert!(
-            tokio::time::timeout(Duration::from_millis(200), observed_request)
-                .await
-                .is_err(),
-            "overridden endpoint must not receive the runtime NEAR AI session token"
         );
     }
 


### PR DESCRIPTION
## Summary

- Allow NEAR AI model discovery to call the public `/v1/models` endpoint without first requiring an API key or session token.
- Fix both “Test connection” and “Fetch models” when the provider dialog is opened with its default configuration.
- Stop sending credentials to the public model catalog while preserving authentication for chat and inference requests.
- Add regression coverage proving model discovery succeeds without credentials or an Authorization header.

<img width="811" height="702" alt="image" src="https://github.com/user-attachments/assets/d9f773b5-222b-4f9f-8afa-f16014d0e51f" />

<img width="1538" height="1414" alt="private test" src="https://github.com/user-attachments/assets/af7d0e42-3553-46dd-9783-a47ff354c0ff" />


## Change Type

- [x] Bug fix
- [x] Security

## Linked Issue

Closes #7483

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_operator --all-targets --all-features -- -D warnings`
- [x] `cargo test -p ironclaw_operator` — 156 passed
- [x] Targeted NEAR AI probe regression tests
- [x] `git diff --check`

## Test Strategy

User behavior:

The default NEAR AI provider dialog can test the connection and fetch models after NEAR account authentication without requiring the user to re-enter an API key.

Tests added or updated:

- Both probe APIs succeed when an active runtime session and a stale stored key are present.
- The built-in `https://cloud-api.near.ai` endpoint is eligible for runtime-session authentication.
- An overridden endpoint does not receive the runtime session token.

Browser E2E:

Not added. The existing browser path mocks these backend endpoints and cannot verify which credential reaches the provider. The owning-crate tests exercise the real provider chain and inspect the Authorization header.

## Security Impact

Runtime NEAR AI session credentials are used only for the default or persisted endpoint. Explicit inline keys remain supported for caller-supplied endpoints.

## Database Impact

None.

## Blast Radius

Limited to the provider probes used by:

- `POST /api/webchat/v2/llm/test-connection`
- `POST /api/webchat/v2/llm/list-models`

Provider saving, activation, login, chat execution, and other providers are unchanged.

## Rollback Plan

Revert the two commits on `issue-7483-nearai-model-session`.

---

**Review track**: C