### PR TITLE
fix(ci): restore main coverage gates

### DIFF
--- a/crates/extensions/packages/telegram/src/tests/channel_deliver.rs
+++ b/crates/extensions/packages/telegram/src/tests/channel_deliver.rs
@@ -118,37 +118,44 @@ async fn deliver_retract_part_deletes_the_referenced_message() {
 }
 
 #[tokio::test]
-async fn deliver_react_add_sets_the_mapped_reaction_emoji() {
-    let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(r#"{"ok":true,"result":true}"#)]);
-    let report = TelegramChannelAdapter::default()
-        .deliver(
-            envelope(
-                vec![OutboundPart::React {
-                    vendor_message_ref: "42".to_string(),
-                    reaction: RunReaction::Working,
-                    action: ReactionAction::Add,
-                }],
-                None,
-            ),
-            &egress,
-        )
-        .await
-        .expect("deliver drives");
+async fn deliver_react_add_maps_every_run_reaction_to_a_telegram_emoji() {
+    for (reaction, expected_emoji) in [
+        (RunReaction::Working, "👀"),
+        (RunReaction::Done, "👌"),
+        (RunReaction::NeedsInput, "🤔"),
+        (RunReaction::Failed, "👎"),
+    ] {
+        let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(r#"{"ok":true,"result":true}"#)]);
+        let report = TelegramChannelAdapter::default()
+            .deliver(
+                envelope(
+                    vec![OutboundPart::React {
+                        vendor_message_ref: "42".to_string(),
+                        reaction,
+                        action: ReactionAction::Add,
+                    }],
+                    None,
+                ),
+                &egress,
+            )
+            .await
+            .expect("deliver drives");
 
-    assert!(matches!(&report.parts[0], PartDeliveryOutcome::Sent { .. }));
-    let requests = egress.requests.lock().unwrap();
-    assert_eq!(
-        requests[0].url,
-        "https://api.telegram.org/bot{telegram_bot_token}/setMessageReaction"
-    );
-    let body: serde_json::Value =
-        serde_json::from_slice(requests[0].body.as_deref().unwrap_or_default()).unwrap();
-    assert_eq!(body["chat_id"], "8675309");
-    assert_eq!(body["message_id"], 42);
-    assert_eq!(
-        body["reaction"],
-        serde_json::json!([{ "type": "emoji", "emoji": "👀" }])
-    );
+        assert!(matches!(&report.parts[0], PartDeliveryOutcome::Sent { .. }));
+        let requests = egress.requests.lock().unwrap();
+        assert_eq!(
+            requests[0].url,
+            "https://api.telegram.org/bot{telegram_bot_token}/setMessageReaction"
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(requests[0].body.as_deref().unwrap_or_default()).unwrap();
+        assert_eq!(body["chat_id"], "8675309");
+        assert_eq!(body["message_id"], 42);
+        assert_eq!(
+            body["reaction"],
+            serde_json::json!([{ "type": "emoji", "emoji": expected_emoji }])
+        );
+    }
 }
 
 #[tokio::test]
@@ -199,6 +206,67 @@ async fn deliver_react_with_non_numeric_ref_is_permanent_without_egress() {
         PartDeliveryOutcome::Permanent { .. }
     ));
     assert!(egress.requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn deliver_react_retries_vendor_status_and_malformed_success_response() {
+    for (response, expected_reason) in [
+        (
+            Ok(RestrictedEgressResponse {
+                status: 429,
+                body: Vec::new(),
+            }),
+            "status 429",
+        ),
+        (ScriptedEgress::ok("not-json"), "was not valid JSON"),
+    ] {
+        let egress = ScriptedEgress::new(vec![response]);
+        let report = TelegramChannelAdapter::default()
+            .deliver(
+                envelope(
+                    vec![OutboundPart::React {
+                        vendor_message_ref: "42".to_string(),
+                        reaction: RunReaction::Working,
+                        action: ReactionAction::Add,
+                    }],
+                    None,
+                ),
+                &egress,
+            )
+            .await
+            .expect("deliver drives");
+
+        assert!(matches!(
+            &report.parts[0],
+            PartDeliveryOutcome::Retryable { reason } if reason.contains(expected_reason)
+        ));
+    }
+}
+
+#[tokio::test]
+async fn deliver_react_preserves_vendor_auth_rejection_evidence() {
+    let egress = ScriptedEgress::new(vec![ScriptedEgress::ok(
+        r#"{"ok":false,"error_code":403,"description":"bot was blocked"}"#,
+    )]);
+    let report = TelegramChannelAdapter::default()
+        .deliver(
+            envelope(
+                vec![OutboundPart::React {
+                    vendor_message_ref: "42".to_string(),
+                    reaction: RunReaction::Failed,
+                    action: ReactionAction::Add,
+                }],
+                None,
+            ),
+            &egress,
+        )
+        .await
+        .expect("deliver drives");
+
+    assert!(matches!(
+        &report.parts[0],
+        PartDeliveryOutcome::Unauthorized { reason } if reason.contains("bot was blocked")
+    ));
 }
 
 #[tokio::test]

--- a/tests/e2e/scenarios/test_admin_api.py
+++ b/tests/e2e/scenarios/test_admin_api.py
@@ -519,6 +519,7 @@ async def test_admin_configuration_renders_uninstalled_manifest_groups_and_keeps
         "Slack deployment configuration",
         "Telegram deployment configuration",
         "Google OAuth client credentials",
+        "Web push deployment configuration",
     ]
     for group_name in group_names:
         await expect(

--- a/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py
@@ -2496,7 +2496,10 @@ async def test_reborn_v2_current_extension_setup_and_delivery_matrix(
             page.get_by_text("Slack direct message", exact=True)
         ).to_have_count(0)
         await expect(
-            page.get_by_text("Notifications stay in the web app", exact=True)
+            page.get_by_text(
+                "No notification channel is selected — approval prompts, auth prompts, and failure notices won't be delivered anywhere.",
+                exact=True,
+            )
         ).to_be_visible()
 
         _assert_install_requests(


### PR DESCRIPTION
## Summary

- cover every Telegram run-reaction mapping and the vendor rate-limit, malformed-response, and auth-rejection paths that dropped the Telegram coverage ratchet below its floor
- update the served admin configuration E2E expectation for the Web Push deployment group added by #7398
- update the notification-channel empty-state assertion to the current user-visible copy

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Unblocks failing `main` runs 31468070491 and 31468070517.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: test-only changes covered by owning-crate compile/tests and targeted served-browser E2E.
- [ ] `cargo build` — Not applicable: both the owning-crate tests and served-browser harness compile the affected test targets and shipping binary.
- [x] Relevant tests pass:
  - `cargo test -p ironclaw_telegram_extension` (116 passed)
  - `cargo test -p ironclaw_telegram_extension deliver_react_` (5 passed)
  - `uv run --project tests/e2e pytest tests/e2e/scenarios/test_admin_api.py::test_admin_configuration_renders_uninstalled_manifest_groups_and_keeps_secrets_write_only tests/e2e/scenarios/test_reborn_webui_v2_legacy_extensions.py::test_reborn_v2_current_extension_setup_and_delivery_matrix -q` (2 passed)
  - `cargo llvm-cov -p ironclaw_telegram_extension --summary-only` (116 passed; new tests execute more than the six previously missing lines required by the ratchet)
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed or runtime-integration behavior changed.
- [ ] Manual testing — Not applicable: deterministic tests reproduce both failing CI gates.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; narrow test-only diff reviewed locally.

## Test Strategy

User behavior: Main's deterministic coverage gates accept the shipped Web Push configuration surface, current notification empty state, and Telegram reaction behavior so release branching can proceed from a green commit.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Telegram `ChannelAdapter::deliver` caller-path tests cover all reaction mappings and provider failure classifications.
- Reborn integration: Not applicable: no cross-crate production behavior changed.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Updated the two assertions failing in the shipping-binary E2E coverage lane.
- Backend or runtime: Not applicable: no backend/runtime behavior changed.
- Live canary: Not applicable: all provider responses are hermetic.

What the tests prove: Telegram reaction delivery cannot falsely report success for malformed or rejected vendor responses, each neutral reaction maps to the intended Telegram emoji, and the served SPA reflects the current Web Push/admin and notification-empty-state contracts.

Commands run: listed under Validation.

## Security Impact

None. Test-only changes; no permissions, network policy, secrets, filesystem, tool execution, or sandbox behavior changed.

## Reborn Trust-Boundary Checklist

N/A: test-only changes do not alter Reborn trust-bearing types, ingress, persistence, runtime, or error contracts.

## Database Impact

None.

## Blast Radius

Limited to Telegram adapter tests and two served-browser E2E expectations. Production code is unchanged.

## Rollback Plan

Revert commit `c00270eecc` if the updated expectations do not match the intended product contract.

## Review Follow-Through

The full Code Coverage workflow is push-to-main only. After merge, verify both `Tests (Reborn)` and `Code Coverage` on the merge SHA before cutting the release branch.

---

**Review track**: A (tests/chore)
