### PR TITLE
fix(ci): cover bounded memory search branches

### DIFF
--- a/crates/domains/ironclaw_memory/src/service.rs
+++ b/crates/domains/ironclaw_memory/src/service.rs
@@ -1322,6 +1322,64 @@ mod tests {
     }
 
     #[test]
+    fn multibyte_excerpt_desired_end_rounds_down_to_a_char_boundary() {
+        let body = format!("{}{}{}", "a".repeat(8_500), QUERY, "€".repeat(300));
+
+        let bounded = bound_search_result_content(body, QUERY);
+
+        assert!(bounded.len() <= MAX_SEARCH_RESULT_CONTENT_BYTES);
+        assert!(bounded.contains(QUERY));
+        assert!(std::str::from_utf8(bounded.as_bytes()).is_ok());
+        assert!(bounded.ends_with('€'));
+    }
+
+    #[test]
+    fn match_already_covered_by_the_previous_tail_excerpt_is_not_duplicated() {
+        let first = 8_900;
+        let second = 8_950;
+        let mut body = "a".repeat(9_000);
+        body.replace_range(first..first + QUERY.len(), QUERY);
+        body.replace_range(second..second + QUERY.len(), QUERY);
+        let expected = body[first - SEARCH_EXCERPT_PRE_BYTES..].to_string();
+
+        let bounded = bound_search_result_content(body, QUERY);
+
+        assert_eq!(bounded, expected);
+        assert_eq!(bounded.matches(QUERY).count(), 2);
+        assert!(!bounded.contains(SEARCH_EXCERPT_DELIMITER));
+    }
+
+    #[test]
+    fn contiguous_long_match_that_cannot_fit_stops_at_the_complete_prefix() {
+        let query = "q".repeat(4_100);
+        let body = query.repeat(2);
+
+        let bounded = bound_search_result_content(body, &query);
+
+        assert_eq!(bounded.len(), query.len() + SEARCH_EXCERPT_POST_BYTES);
+        assert!(bounded.starts_with(&query));
+        assert!(bounded.len() <= MAX_SEARCH_RESULT_CONTENT_BYTES);
+    }
+
+    #[test]
+    fn cap_clipped_multibyte_excerpt_rounds_start_and_end_to_char_boundaries() {
+        let query = "q".repeat(3_903);
+        let mut body = query.clone();
+        body.push_str(&"a".repeat(1_000));
+        body.push_str(&"€".repeat(400));
+        body.push_str(&query);
+        body.push_str(&"€".repeat(400));
+
+        let bounded = bound_search_result_content(body, &query);
+
+        assert!(bounded.len() <= MAX_SEARCH_RESULT_CONTENT_BYTES);
+        assert_eq!(bounded.matches(&query).count(), 2);
+        assert!(bounded.contains(SEARCH_EXCERPT_DELIMITER));
+        assert!(std::str::from_utf8(bounded.as_bytes()).is_ok());
+        assert!(bounded.ends_with('q'));
+    }
+
+    #[test]
     fn empty_query_keeps_bounded_head() {
         // The empty query matches everywhere; excerpting would degenerate to
         // the whole snippet, so the preview stays a plain head — the query


### PR DESCRIPTION
## Summary

- cover the UTF-8 desired-end rounding branch in bounded memory search excerpts
- cover suppression of an exact match already contained in the previous tail excerpt
- cover cap exhaustion for long contiguous matches and UTF-8 rounding when a later excerpt is clipped by the remaining budget
- restore the changed-line coverage gate broken after #7436 merged to `main`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7436. Unblocks failing main run 31474920506.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: test-only change compiled by the owning-crate suite.
- [ ] `cargo build` — Not applicable: the owning-crate test suite compiles the affected target.
- [x] Relevant tests pass: `cargo test -p ironclaw_memory` (31 passed)
- [x] Coverage verified: `cargo llvm-cov -p ironclaw_memory --lcov --output-path <temp>` reports execution counts for every line CI named as uncovered: 770–771, 776–777, 801–802, 804, and 809–810.
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed or runtime behavior changed.
- [ ] Manual testing — Not applicable: deterministic unit coverage reproduces the failing gate.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — Not run; single-file test-only diff reviewed locally.

## Test Strategy

User behavior: `main` retains the bounded, UTF-8-safe memory search previews introduced by #7436 while satisfying the required changed-line coverage gate so a release can be cut from a green commit.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Four focused tests at the provider-neutral memory output boundary.
- Reborn integration: Not applicable: production behavior is unchanged and the local contract owns these branches.
- Recorded fixture: Not applicable: no model selection or request shape changed.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Not applicable: no backend/runtime behavior changed.
- Live canary: Not applicable: no live dependency changed.

What the tests prove: Exact-match excerpts remain complete and deterministic at the byte cap, duplicate covered windows are not emitted, and every UTF-8 cut rounds to a character boundary without splitting the query.

Commands run: listed under Validation.

## Security Impact

None. Test-only changes.

## Reborn Trust-Boundary Checklist

N/A: no production, trust-bearing, ingress, persistence, runtime, or error contract changed.

## Database Impact

None.

## Blast Radius

Limited to unit tests in `ironclaw_memory::service`; production code is unchanged.

## Rollback Plan

Revert this test-only commit if the assertions conflict with an intentional change to the bounded excerpt contract.

## Review Follow-Through

Coverage enforcement is push-to-main only. After merge, verify `Tests (Reborn)` on the merge SHA before cutting the release branch.

---

**Review track**: A (tests/chore)
