### PR TITLE
fix(disclosure): parallelize read-only bridge lookups

### DIFF
--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -1048,8 +1048,19 @@ fn bridge_descriptor(definition: &ProviderToolDefinition) -> CapabilityDescripto
         safe_name: definition.name.to_string(),
         safe_description: definition.description.clone(),
         description_trust: Default::default(),
-        concurrency_hint: ConcurrencyHint::Exclusive,
+        concurrency_hint: bridge_concurrency_hint(definition.name.as_str()),
         parameters_schema: definition.parameters.clone(),
+    }
+}
+
+/// Search and describe only inspect the per-turn disclosure catalog. An
+/// unresolved `tool_call` can target any capability, so its bridge fallback
+/// remains conservative; resolved calls carry the target capability id and
+/// therefore use that target's own descriptor hint.
+fn bridge_concurrency_hint(name: &str) -> ConcurrencyHint {
+    match name {
+        TOOL_SEARCH_NAME | TOOL_DESCRIBE_NAME => ConcurrencyHint::SafeForParallel,
+        _ => ConcurrencyHint::Exclusive,
     }
 }
 

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{CapabilityResultWrite, DurablePersistence, LoopCapabilityResultWriter};
 use async_trait::async_trait;
+use futures::future::join_all;
 use ironclaw_host_api::{
     capability_surface::CapabilitySurfacePolicy,
     ids::{AgentId, CapabilityId, InvocationId, ProjectId, ProviderToolName, TenantId, ThreadId},
@@ -671,6 +672,25 @@ impl LoopCapabilityPort for ToolDisclosureCapabilityPort {
         &self,
         request: LoopRequestBatch,
     ) -> Result<ResolutionBatch, AgentLoopHostError> {
+        // The executor clears this flag only for a planner-approved parallel
+        // batch. Preserve invocation order in the returned vector while
+        // allowing the read-only bridge futures to overlap.
+        if !request.stop_on_first_suspension {
+            let resolutions = join_all(
+                request
+                    .invocations
+                    .into_iter()
+                    .map(|invocation| self.invoke_capability(invocation)),
+            )
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+            return Ok(ResolutionBatch {
+                resolutions,
+                stopped_on_suspension: false,
+            });
+        }
+
         let mut resolutions = Vec::with_capacity(request.invocations.len());
         let mut stopped_on_suspension = false;
         for invocation in request.invocations {
@@ -2009,9 +2029,95 @@ mod tests {
         }
     }
 
+    struct BarrierWriter {
+        barrier: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait]
+    impl LoopCapabilityResultWriter for BarrierWriter {
+        async fn write_capability_result(
+            &self,
+            write: CapabilityResultWrite<'_>,
+        ) -> Result<CapabilityWriteResult, AgentLoopHostError> {
+            self.barrier.wait().await;
+            TestWriter.write_capability_result(write).await
+        }
+    }
+
     #[derive(Default)]
     struct CapturingWriter {
         outputs: Mutex<Vec<Value>>,
+    }
+
+    #[tokio::test]
+    async fn parallel_discovery_batch_overlaps_bridge_invocations() {
+        let definitions = (0..6)
+            .map(|index| {
+                provider_definition(
+                    &format!("fixture.lookup_{index}"),
+                    &format!("fixture__lookup_{index}"),
+                    "Lookup records",
+                )
+            })
+            .collect();
+        let inner = Arc::new(SpyPort {
+            definitions,
+            surface_version: CapabilitySurfaceVersion::new("surface:parallel-discovery")
+                .expect("valid surface version"),
+            registered_calls: Mutex::new(Vec::new()),
+            invocations: Mutex::new(Vec::new()),
+        });
+        let port = disclosure_port_with_writer(
+            inner as Arc<dyn LoopCapabilityPort>,
+            run_context(TurnId::new()).await,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(BarrierWriter {
+                barrier: Arc::new(tokio::sync::Barrier::new(2)),
+            }),
+        );
+        port.visible_capabilities(VisibleCapabilityRequest)
+            .await
+            .expect("visible surface initializes the disclosure catalog");
+
+        let search = port
+            .register_provider_tool_call(RegisterProviderToolCallRequest::new(provider_call(
+                TOOL_SEARCH_NAME,
+                json!({"query": "lookup", "limit": 2}),
+            )))
+            .await
+            .expect("search registers");
+        let describe = port
+            .register_provider_tool_call(RegisterProviderToolCallRequest::new(provider_call(
+                TOOL_DESCRIBE_NAME,
+                json!({"name": "fixture__lookup_5"}),
+            )))
+            .await
+            .expect("describe registers");
+        let requests = [search, describe]
+            .into_iter()
+            .map(|candidate| LoopRequest {
+                activity_id: candidate.activity_id,
+                surface_version: candidate.surface_version,
+                capability_id: candidate.capability_id,
+                input_ref: candidate.input_ref,
+                approval_resume: None,
+                auth_resume: None,
+            })
+            .collect();
+
+        let batch = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            port.invoke_capability_batch(LoopRequestBatch {
+                invocations: requests,
+                stop_on_first_suspension: false,
+            }),
+        )
+        .await
+        .expect("parallel discovery calls must reach the writer concurrently")
+        .expect("parallel discovery batch succeeds");
+
+        assert_eq!(batch.resolutions.len(), 2);
+        assert!(!batch.stopped_on_suspension);
     }
 
     #[async_trait]

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -2101,6 +2101,29 @@ mod tests {
             .visible_capabilities(VisibleCapabilityRequest)
             .await
             .expect("visible surface");
+        let hint_of = |name: &str| {
+            surface
+                .descriptors
+                .iter()
+                .find(|descriptor| descriptor.safe_name == name)
+                .unwrap_or_else(|| panic!("{name} descriptor on the deferred surface"))
+                .concurrency_hint
+        };
+        assert_eq!(
+            hint_of(TOOL_SEARCH_NAME),
+            ConcurrencyHint::SafeForParallel,
+            "tool_search is a side-effect-free catalog lookup"
+        );
+        assert_eq!(
+            hint_of(TOOL_DESCRIBE_NAME),
+            ConcurrencyHint::SafeForParallel,
+            "tool_describe is a side-effect-free schema lookup"
+        );
+        assert_eq!(
+            hint_of(TOOL_CALL_NAME),
+            ConcurrencyHint::Exclusive,
+            "an unresolved tool_call can target an arbitrary capability"
+        );
         assert!(
             !surface
                 .descriptors

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -20,7 +20,7 @@
 use ironclaw_config::BudgetDefaults;
 use ironclaw_event_log::{SecurityBoundary, SecurityDecision};
 use ironclaw_host_api::ids::ProcessId;
-use ironclaw_loop_contracts::{LoopHostMilestoneKind, LoopRecoveryClass};
+use ironclaw_loop_contracts::{BatchPolicyKind, LoopHostMilestoneKind, LoopRecoveryClass};
 use ironclaw_processes::ProcessKind;
 use ironclaw_resources::{ResourceAccount, ResourceGovernor, ResourceTally};
 use ironclaw_threads::SessionThreadService as _;
@@ -1076,6 +1076,36 @@ impl RebornIntegrationHarness {
         }
         Err(format!(
             "expected model recovery class {expected:?} and no {forbidden:?}; saw {classes:?}"
+        )
+        .into())
+    }
+
+    /// Assert the loop's caller-visible policy for a capability batch of the
+    /// specified size. The policy controls whether execution may proceed in
+    /// parallel and whether a suspension stops the remaining batch.
+    pub async fn assert_capability_batch_policy(
+        &self,
+        call_count: u32,
+        expected: BatchPolicyKind,
+    ) -> HarnessResult<()> {
+        let policies = self
+            .loop_milestones()
+            .into_iter()
+            .filter_map(|milestone| match milestone.kind {
+                LoopHostMilestoneKind::CapabilityBatchStarted {
+                    call_count: actual_count,
+                    policy,
+                    ..
+                } if actual_count == call_count => Some(policy),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if policies.contains(&expected) {
+            return Ok(());
+        }
+        Err(format!(
+            "no CapabilityBatchStarted milestone for a {call_count}-call batch classified \
+             {expected:?}; saw {policies:?}"
         )
         .into())
     }

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -41,6 +41,7 @@ mod reborn_support;
 mod support;
 
 use ironclaw_host_api::capability_surface::CapabilitySurfacePolicy;
+use ironclaw_loop_contracts::BatchPolicyKind;
 use ironclaw_loop_host::ToolDisclosureMode;
 use ironclaw_turns::TurnStatus;
 use reborn_support::builder::RebornIntegrationHarness;
@@ -241,6 +242,58 @@ async fn bridged_disclosure_never_advertises_globally_disabled_spawn_subagent() 
         .assert_reply_contains("done without spawning")
         .await
         .expect("the run continues after the recoverable unknown-tool results");
+}
+
+/// Search and describe are read-only catalog lookups, so one model response
+/// may safely probe them together. A recoverable bad describe must not prevent
+/// its valid siblings from completing.
+#[tokio::test]
+async fn discovery_batch_classifies_parallel_and_preserves_valid_siblings() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_tool_disclosure_bridged()
+        .with_github_issue_tools()
+        .script([
+            RebornScriptedReply::tool_calls([
+                (
+                    TOOL_SEARCH_NAME,
+                    serde_json::json!({"query": "get repository", "limit": 5}),
+                ),
+                (
+                    TOOL_DESCRIBE_NAME,
+                    serde_json::json!({"name": FLAT_GITHUB_TOOL_NAME}),
+                ),
+                (
+                    TOOL_DESCRIBE_NAME,
+                    serde_json::json!({"name": "missing__catalog_tool"}),
+                ),
+            ]),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("bridged-disclosure harness builds");
+
+    harness
+        .submit_turn("probe the github catalog")
+        .await
+        .expect("discovery batch completes despite one recoverable lookup failure");
+
+    harness
+        .assert_capability_batch_policy(3, BatchPolicyKind::Parallel)
+        .await
+        .expect("side-effect-free discovery bridges classify parallel");
+    harness
+        .assert_model_message_content_contains("tool_search returned catalog matches")
+        .await
+        .expect("valid search sibling reaches the next model request");
+    harness
+        .assert_model_message_content_contains("tool_describe returned schema")
+        .await
+        .expect("valid describe sibling reaches the next model request");
+    harness
+        .assert_reply_contains("done")
+        .await
+        .expect("turn continues after the recoverable bad describe");
 }
 
 /// Negative control: the SAME wide catalog under explicit

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -291,6 +291,10 @@ async fn discovery_batch_classifies_parallel_and_preserves_valid_siblings() {
         .await
         .expect("valid describe sibling reaches the next model request");
     harness
+        .assert_model_message_content_contains("tool_describe target is unknown")
+        .await
+        .expect("recoverable invalid describe reaches the next model request");
+    harness
         .assert_reply_contains("done")
         .await
         .expect("turn continues after the recoverable bad describe");


### PR DESCRIPTION
## Summary

- Advertise `tool_search` and `tool_describe` as safe for parallel execution because they only inspect the per-turn disclosure catalog.
- Keep unresolved `tool_call` conservative while preserving the existing target-derived hint for calls resolved before dispatch.
- Execute planner-approved parallel batches concurrently inside the disclosure decorator while preserving result order.
- Add an overlap-enforcing unit regression and production-wired coverage proving the invalid describe diagnostic and valid sibling results all reach the next model request.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7488

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: affected-crate suites and the full disclosure integration target
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: this crate has no integration feature for this path)
- [ ] Manual testing: not applicable; the production-wired integration harness covers the caller path
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Scoped zero-warning clippy passed for `ironclaw_loop_host`, `ironclaw_agent_loop`, and `ironclaw_integration_tests`, including the disclosure integration target.

## Test Strategy

User behavior: A model can issue `tool_search` and multiple `tool_describe` calls in one response without the discovery batch being forced sequential; a recoverable invalid describe does not discard valid siblings.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Pins search/describe as parallel-safe, unresolved call as exclusive, and uses a two-party result-writer barrier to prove parallel bridge invocations actually overlap.
- Reborn integration: Added `discovery_batch_classifies_parallel_and_preserves_valid_siblings` through the production runner and milestone sink.
- Recorded fixture: Not applicable: no provider wire format changed.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: Full `ironclaw_loop_host` and `ironclaw_agent_loop` suites passed.
- Live canary: Not applicable: the behavior is deterministic and covered at the production-wired integration seam.

What the tests prove: The model-visible descriptors feed the executor’s batch planner as `Parallel`, the disclosure decorator dispatches those calls concurrently while preserving ordered results, unresolved fallback remains `Exclusive`, and the recoverable invalid-describe diagnostic reaches the model alongside valid sibling results.

Commands run:
- `cargo fmt --all --check`
- `cargo test -p ironclaw_loop_host -p ironclaw_agent_loop`
- `cargo test -p ironclaw_integration_tests --test reborn_integration_tool_disclosure`
- `cargo clippy -p ironclaw_loop_host --tests --all-features -- -D warnings`
- `cargo clippy -p ironclaw_integration_tests --test reborn_integration_tool_disclosure --all-features -- -D warnings`

## Security Impact

None. Capability authorization, approval, dispatch, and callable-surface checks are unchanged. Only the scheduling hint for two read-only host metadata bridges changes.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no public types added; bridge descriptors remain host-constructed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: no prompt construction changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: no hash behavior changed.
- [x] New/changed status, exit, policy, runtime, or error variants: none.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: no serialized fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: no bounds or counters changed.
- [x] Driver/operator-visible errors have stable class semantics: no error semantics changed.
- [x] Sandbox/native/host names accurately describe trust boundary: runtime and capability identities are unchanged.

## Database Impact

None.

## Blast Radius

Progressive tool disclosure and the agent-loop batch planner. The only newly parallel-eligible capabilities are `tool_search` and `tool_describe`; arbitrary target dispatch through unresolved `tool_call` stays exclusive.

## Rollback Plan

Revert this PR. This restores conservative sequential discovery without a data migration or compatibility step.

## Review Follow-Through

Reviewer judgment is requested on the concurrency classification boundary: resolved `tool_call` continues to use its target capability descriptor, while only unresolved bridge fallback remains exclusive.

---

**Review track**: C (runtime scheduling behavior)

