### PR TITLE
fix(threads): restore listability for unprojected thread index rows

### DIFF
--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -42,7 +42,7 @@ pub use transcript_migration::{LegacyAppendMigrationReport, TranscriptMigrationR
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, Weak},
 };
 
 use async_trait::async_trait;
@@ -164,11 +164,24 @@ where
     filesystem: Arc<ScopedFilesystem<F>>,
     known_thread_index_rows: Mutex<HashSet<String>>,
     ready_thread_index_scopes: Mutex<HashSet<String>>,
+    /// Scopes whose required-path repair (migrate-if-needed, else reconcile)
+    /// has already run once in this process. Deliberately separate from
+    /// `ready_thread_index_scopes`: that set only records that the index specs
+    /// were *declared*, which an optional write-path call does too, and the
+    /// durable migration marker it would otherwise be gated on survives across
+    /// process restarts. Without this separate gate, a write that declares the
+    /// scope before the first required listing call short-circuits on the
+    /// already-complete marker and repair never runs for the life of the
+    /// process.
+    reconciled_thread_index_scopes: Mutex<HashSet<String>>,
     /// Mounts whose `/threads`-root index specs are already declared, keyed by
     /// `tenant:user` — the pair the alias resolves through. Keeps thread create
     /// off the index-DDL path after a mount's first thread.
     ready_index_mounts: Mutex<HashSet<(TenantId, UserId)>>,
-    thread_index_declaration_lock: tokio::sync::Mutex<()>,
+    /// Ephemeral admission locks for required migration/reconcile work. The
+    /// declaration path deliberately remains lockless because index
+    /// declaration is idempotent; only per-scope repair needs serialization.
+    thread_index_reconcile_locks: Mutex<HashMap<String, Weak<tokio::sync::Mutex<()>>>>,
     one_shot_context_windows: Mutex<HashMap<String, ContextWindow>>,
 }
 
@@ -195,8 +208,9 @@ where
             filesystem,
             known_thread_index_rows: Mutex::new(HashSet::new()),
             ready_thread_index_scopes: Mutex::new(HashSet::new()),
+            reconciled_thread_index_scopes: Mutex::new(HashSet::new()),
             ready_index_mounts: Mutex::new(HashSet::new()),
-            thread_index_declaration_lock: tokio::sync::Mutex::new(()),
+            thread_index_reconcile_locks: Mutex::new(HashMap::new()),
             one_shot_context_windows: Mutex::new(HashMap::new()),
         }
     }

--- a/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use ironclaw_filesystem::{
     CasApply, CasExpectation, ContentType, Entry, FileType, Filter, IndexKey, IndexKind, IndexName,
     IndexSpec, IndexValue, OrderedPage, OrderedQueryCursor, Page, RecordKind, RootFilesystem,
-    SortDirection, cas_update,
+    SortDirection, VersionedEntry, cas_update,
 };
 use ironclaw_host_api::{ids::ThreadId, path::ScopedPath};
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,10 @@ const THREAD_SCOPE_INDEX_KEY: &str = "scope_key";
 const THREAD_ACTIVITY_SORT_KEY: &str = "activity_sort";
 const THREAD_ID_INDEX_KEY: &str = "thread_id";
 const THREAD_INDEX_KNOWN_ROW_MAX: usize = 100_000;
+const THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES: usize = 128;
+const THREAD_INDEX_SUFFIX: &str = ".json";
+
+mod projection_repair;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct ThreadIndexRecord {
@@ -85,36 +89,8 @@ where
         if already_declared && !required {
             return Ok(());
         }
-        if already_declared {
-            let marker = thread_index_migration_marker_path(scope)?;
-            if self
-                .filesystem
-                .get(&scope.to_resource_scope(), &marker)
-                .await?
-                .is_some()
-            {
-                return Ok(());
-            }
-        }
-        let _declaration_guard = self.thread_index_declaration_lock.lock().await;
-        let already_declared = self
-            .ready_thread_index_scopes
-            .lock()
-            .map(|ready| ready.contains(&scope_key))
-            .unwrap_or(false);
-        if already_declared && !required {
+        if already_declared && self.thread_index_reconciled(&scope_key) {
             return Ok(());
-        }
-        if already_declared {
-            let marker = thread_index_migration_marker_path(scope)?;
-            if self
-                .filesystem
-                .get(&scope.to_resource_scope(), &marker)
-                .await?
-                .is_some()
-            {
-                return Ok(());
-            }
         }
         // The listing projection is declared once per mount at the `/threads`
         // alias root, not per scope. Ancestor-prefix resolution lets the
@@ -130,41 +106,78 @@ where
         .await?;
         if let Ok(mut ready) = self.ready_thread_index_scopes.lock() {
             ready.insert(scope_key.clone());
-            evict_entry_over_limit(&mut ready, 128, &scope_key);
+            evict_entry_over_limit(&mut ready, THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES, &scope_key);
         }
-        if required {
-            let marker = thread_index_migration_marker_path(scope)?;
+        if !required {
+            return Ok(());
+        }
+
+        let scope_lock = self.thread_index_reconcile_lock(&scope_key);
+        let _scope_guard = scope_lock.lock().await;
+        if self.thread_index_reconciled(&scope_key) {
+            return Ok(());
+        }
+
+        let marker = thread_index_migration_marker_path(scope)?;
+        let repair_succeeded = if self
+            .filesystem
+            .get(&scope.to_resource_scope(), &marker)
+            .await?
+            .is_none()
+        {
+            if let Err(error) = self.migrate_thread_index_for_scope(scope).await {
+                if let Ok(mut ready) = self.ready_thread_index_scopes.lock() {
+                    ready.remove(&scope_key);
+                }
+                return Err(error);
+            }
+            self.filesystem
+                .put(
+                    &scope.to_resource_scope(),
+                    &marker,
+                    Entry::bytes(b"thread-index-v1".to_vec()),
+                    CasExpectation::Any,
+                )
+                .await?;
             if self
                 .filesystem
                 .get(&scope.to_resource_scope(), &marker)
                 .await?
                 .is_none()
             {
-                if let Err(error) = self.migrate_thread_index_for_scope(scope).await {
-                    if let Ok(mut ready) = self.ready_thread_index_scopes.lock() {
-                        ready.remove(&scope_key);
-                    }
-                    return Err(error);
-                }
-                self.filesystem
-                    .put(
-                        &scope.to_resource_scope(),
-                        &marker,
-                        Entry::bytes(b"thread-index-v1".to_vec()),
-                        CasExpectation::Any,
-                    )
-                    .await?;
-                if self
-                    .filesystem
-                    .get(&scope.to_resource_scope(), &marker)
-                    .await?
-                    .is_none()
-                {
-                    return Err(SessionThreadError::Backend(
-                        "thread index migration marker was not durable after write".to_string(),
-                    ));
+                return Err(SessionThreadError::Backend(
+                    "thread index migration marker was not durable after write".to_string(),
+                ));
+            }
+            true
+        } else {
+            match self.reconcile_thread_index_projection(scope).await {
+                Ok(()) => true,
+                Err(error) => {
+                    // Best-effort by design: this repairs rows the listing
+                    // cannot see anyway. Before this pass a scope with its
+                    // marker written did no further I/O here and could not
+                    // fail, so propagating a transient storage error would
+                    // turn a listing that used to succeed into a failure.
+                    // Degrade to the rows we can project, but do not cache a
+                    // failed repair as complete: a later list retries it.
+                    // `debug!`, not `warn!`: background diagnostics must not
+                    // reach the REPL/TUI display.
+                    tracing::debug!(
+                        error = %error,
+                        "thread index projection reconcile failed; listing continues with projected rows"
+                    );
+                    false
                 }
             }
+        };
+        if repair_succeeded && let Ok(mut reconciled) = self.reconciled_thread_index_scopes.lock() {
+            reconciled.insert(scope_key.clone());
+            evict_entry_over_limit(
+                &mut reconciled,
+                THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES,
+                &scope_key,
+            );
         }
         Ok(())
     }
@@ -459,16 +472,11 @@ where
         limit: usize,
     ) -> Result<(Vec<ThreadIndexRecord>, bool), SessionThreadError> {
         self.ensure_thread_index_query(scope, true).await?;
-        let root = thread_index_root(scope)?;
-        let mut page = OrderedPage::new(
-            thread_index_name()?,
-            thread_index_key(THREAD_ACTIVITY_SORT_KEY)?,
-            thread_index_key(THREAD_ID_INDEX_KEY)?,
-            SortDirection::Ascending,
+        let mut page = Self::thread_index_ordered_page(
             u32::try_from(limit.saturating_add(1))
                 .unwrap_or(Page::MAX_LIMIT)
                 .min(Page::MAX_LIMIT),
-        );
+        )?;
         if let Some(cursor) = cursor {
             let cursor = self.decode_thread_index_cursor(scope, cursor).await?;
             page = page.after(OrderedQueryCursor {
@@ -476,18 +484,7 @@ where
                 tie_breaker: IndexValue::Text(cursor.thread_id),
             });
         }
-        let rows = self
-            .filesystem
-            .query_ordered(
-                &scope.to_resource_scope(),
-                &root,
-                &Filter::Eq {
-                    key: thread_index_key(THREAD_SCOPE_INDEX_KEY)?,
-                    value: IndexValue::Text(thread_index_cache_key(scope)),
-                },
-                &page,
-            )
-            .await?;
+        let rows = self.query_thread_index_rows(scope, &page).await?;
         let has_more = rows.len() > limit;
         let records = rows
             .into_iter()
@@ -498,6 +495,38 @@ where
         // explicit migration/repair path; rereading every source row here
         // turns each user-facing page into an N+1 storage operation.
         Ok((records, has_more))
+    }
+
+    /// The canonical ordered page shape for the thread-listing projection.
+    pub(super) fn thread_index_ordered_page(limit: u32) -> Result<OrderedPage, SessionThreadError> {
+        Ok(OrderedPage::new(
+            thread_index_name()?,
+            thread_index_key(THREAD_ACTIVITY_SORT_KEY)?,
+            thread_index_key(THREAD_ID_INDEX_KEY)?,
+            SortDirection::Ascending,
+            limit,
+        ))
+    }
+
+    /// Query thread-listing projection rows for one scope.
+    pub(super) async fn query_thread_index_rows(
+        &self,
+        scope: &ThreadScope,
+        page: &OrderedPage,
+    ) -> Result<Vec<VersionedEntry>, SessionThreadError> {
+        let root = thread_index_root(scope)?;
+        self.filesystem
+            .query_ordered(
+                &scope.to_resource_scope(),
+                &root,
+                &Filter::Eq {
+                    key: thread_index_key(THREAD_SCOPE_INDEX_KEY)?,
+                    value: IndexValue::Text(thread_index_cache_key(scope)),
+                },
+                page,
+            )
+            .await
+            .map_err(Into::into)
     }
 
     async fn decode_thread_index_cursor(

--- a/crates/domains/ironclaw_threads/src/filesystem_service/thread_index/projection_repair.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/thread_index/projection_repair.rs
@@ -1,0 +1,227 @@
+//! Recovery for thread-index rows that exist durably but project no listing row.
+//!
+//! The sidebar reads the ordered projection, never the index directory, and the
+//! projection only carries a row when the stored entry holds the listing keys.
+//! A row written without them is therefore invisible to `list_threads` even
+//! though its thread record, index record and messages are all intact — and
+//! because a scope's completion marker suppresses the migration that would
+//! rewrite it, nothing repairs it for the life of the volume.
+//!
+//! Kept beside the index query rather than inside it: this is migration-shaped
+//! repair work, the same concern `startup_migration` and `transcript_migration`
+//! own for their projections.
+
+use ironclaw_filesystem::{CasApply, FileType, Page, RootFilesystem, cas_update};
+use ironclaw_host_api::ids::ThreadId;
+
+use crate::{FilesystemSessionThreadService, SessionThreadError, ThreadScope};
+
+use super::{
+    THREAD_INDEX_SUFFIX, ThreadIndexRecord, no_op_thread_index_record, thread_activity_index_spec,
+    thread_index_record_path, thread_index_root,
+};
+use crate::filesystem_service::{deserialize, invalid_path, is_not_found, map_cas_error};
+
+impl<F> FilesystemSessionThreadService<F>
+where
+    F: RootFilesystem,
+{
+    /// Whether this process has already run required-path repair for
+    /// `scope_key` at least once. Kept separate from the durable migration
+    /// marker (see the field doc on `reconciled_thread_index_scopes`): the
+    /// marker can already be complete on disk from a previous process, and
+    /// gating on it directly would let the reconcile step be skipped forever
+    /// once an optional call has declared the scope in this process.
+    pub(super) fn thread_index_reconciled(&self, scope_key: &str) -> bool {
+        self.reconciled_thread_index_scopes
+            .lock()
+            .map(|reconciled| reconciled.contains(scope_key))
+            .unwrap_or(false)
+    }
+
+    /// Returns the short-lived lock for one scope's required repair path.
+    /// Weak entries let the registry shed idle scopes without a separate cache
+    /// eviction policy; active callers keep the `Arc` alive through their
+    /// awaitable repair work.
+    pub(super) fn thread_index_reconcile_lock(
+        &self,
+        scope_key: &str,
+    ) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self
+            .thread_index_reconcile_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(scope_key).and_then(std::sync::Weak::upgrade) {
+            return lock;
+        }
+        let lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(scope_key.to_string(), std::sync::Arc::downgrade(&lock));
+        lock
+    }
+
+    /// Repair rows the listing projection cannot see, when there are any.
+    ///
+    /// Discovery cannot run through the projection, because a damaged row is
+    /// exactly what the projection is missing. It compares the durable index
+    /// directory against the projected rows instead and only pays for repair
+    /// when they disagree.
+    ///
+    /// Bounded on purpose: the comparison costs one directory listing and one
+    /// capped query. This runs inside a live listing request, so an unbounded
+    /// scan would put a latency spike proportional to scope size on whichever
+    /// request arrives first after a restart. The listing asks for one entry
+    /// past [`Page::MAX_LIMIT`], which is enough to recognise an oversized
+    /// scope without materializing all of it on backends that stop early.
+    ///
+    /// A scope holding more rows than that cap is skipped, and today nothing
+    /// else repairs it: `migrate_thread_index_for_scope` runs only while the
+    /// scope's completion marker is absent, and both the listing path and the
+    /// deployment-wide startup migration reach this function once the marker
+    /// exists. Such a scope therefore keeps its damaged rows until an explicit
+    /// repair path is built for it — see the follow-up tracked from #7470.
+    pub(super) async fn reconcile_thread_index_projection(
+        &self,
+        scope: &ThreadScope,
+    ) -> Result<(), SessionThreadError> {
+        let root = thread_index_root(scope)?;
+        let durable = match self
+            .filesystem
+            .list_dir_bounded(
+                &scope.to_resource_scope(),
+                &root,
+                Page::MAX_LIMIT as usize + 1,
+            )
+            .await
+        {
+            Ok(entries) => entries,
+            // A scope that has never written an index row has nothing to
+            // reconcile; the initial migration owns that case.
+            Err(error) if is_not_found(&error) => return Ok(()),
+            Err(error) => return Err(error.into()),
+        };
+        let index_rows: Vec<&str> = durable
+            .iter()
+            .filter(|entry| entry.file_type == FileType::File)
+            .filter_map(|entry| entry.name.strip_suffix(THREAD_INDEX_SUFFIX))
+            .collect();
+        if index_rows.is_empty() {
+            return Ok(());
+        }
+        if index_rows.len() > Page::MAX_LIMIT as usize {
+            // Surfaced rather than skipped silently: an oversized scope with
+            // damaged rows has no repair path at all, so leaving no trace would
+            // make it invisible in telemetry as well as in the sidebar.
+            tracing::debug!(
+                index_rows = index_rows.len(),
+                "thread index scope exceeds the reconcile cap; projection repair skipped"
+            );
+            return Ok(());
+        }
+        if self.count_projected_thread_index_rows(scope).await? >= index_rows.len() {
+            return Ok(());
+        }
+        for raw_id in index_rows {
+            let thread_id = ThreadId::new(raw_id.to_string()).map_err(invalid_path)?;
+            self.restore_thread_index_projection(scope, &thread_id)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Count the rows the listing projection can actually see for `scope`.
+    ///
+    /// Capped at [`Page::MAX_LIMIT`]; callers only reach this after confirming
+    /// the scope holds no more index rows than that, so a single query answers
+    /// the comparison exactly.
+    async fn count_projected_thread_index_rows(
+        &self,
+        scope: &ThreadScope,
+    ) -> Result<usize, SessionThreadError> {
+        let page = Self::thread_index_ordered_page(Page::MAX_LIMIT)?;
+        let rows = self.query_thread_index_rows(scope, &page).await?;
+        Ok(rows.len())
+    }
+
+    /// Rewrite one index row so the ordered projection picks it up again.
+    ///
+    /// Uses the shared bounded CAS helper so a concurrent index-row writer is
+    /// never clobbered. `CasApply::force_write` intentionally bypasses only
+    /// the decoded-body equality fast-path: entry sidecars are not represented
+    /// in `ThreadIndexRecord`, so a row whose body already matches but whose
+    /// indexed projection keys are gone still needs a physical rewrite.
+    async fn restore_thread_index_projection(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        let path = thread_index_record_path(scope, thread_id)?;
+        let Some(versioned) = self
+            .filesystem
+            .get(&scope.to_resource_scope(), &path)
+            .await?
+        else {
+            return Ok(());
+        };
+        let record = deserialize::<ThreadIndexRecord>(&versioned.entry.body)?;
+        // A row whose body disagrees with its own path is not ours to rewrite;
+        // stale and cross-scope rows belong to the explicit migration.
+        if record.record.scope != *scope || record.record.thread_id != *thread_id {
+            return Ok(());
+        }
+        // Selective repair matters: one missing projection row should not
+        // rewrite every otherwise-valid row in the bounded scope. The CAS loop
+        // below takes a fresh read before writing, so this precheck only admits
+        // rows whose sidecars are currently proven stale; it is not itself a
+        // read-modify-write operation.
+        let rebuilt = Self::thread_index_entry(&record)?;
+        let projection_current = thread_activity_index_spec()?
+            .keys
+            .iter()
+            .all(|key| versioned.entry.indexed.get(key) == rebuilt.indexed.get(key));
+        if projection_current {
+            return Ok(());
+        }
+        let resource_scope = scope.to_resource_scope();
+        let scope_for_retry = scope.clone();
+        let thread_id_for_retry = thread_id.clone();
+        let repaired = cas_update(
+            self.filesystem.as_ref(),
+            &resource_scope,
+            &path,
+            |bytes: &[u8]| deserialize::<ThreadIndexRecord>(bytes),
+            |record: &ThreadIndexRecord| Self::thread_index_entry(record),
+            |current: Option<ThreadIndexRecord>| {
+                let scope = scope_for_retry.clone();
+                let thread_id = thread_id_for_retry.clone();
+                async move {
+                    let Some(record) = current else {
+                        return Ok(CasApply::no_op(
+                            no_op_thread_index_record(scope, thread_id),
+                            false,
+                        ));
+                    };
+                    // A row whose body disagrees with its own path is not ours
+                    // to rewrite; stale and cross-scope rows belong to the
+                    // explicit migration.
+                    if record.record.scope != scope || record.record.thread_id != thread_id {
+                        return Ok(CasApply::no_op(record, false));
+                    }
+                    // The CAS helper intentionally passes only the decoded
+                    // record to `apply`; entry-sidecar metadata is rebuilt by
+                    // `encode`. The precheck admitted only a row whose
+                    // sidecar is stale, so force-write it without treating
+                    // body equality as proof that its ordered keys are
+                    // current.
+                    Ok(CasApply::force_write(record, true))
+                }
+            },
+        )
+        .await
+        .map_err(map_cas_error)?;
+        if repaired {
+            self.mark_thread_index_known(scope, thread_id);
+        }
+        Ok(())
+    }
+}

--- a/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -47,7 +47,10 @@ use ironclaw_threads::{
     ToolResultReferenceEnvelope, ToolResultSafeSummary, UpdateAssistantDraftRequest,
     UpdateToolResultReferenceRequest,
 };
-use tokio::sync::{Barrier, Mutex, OwnedMutexGuard};
+use tokio::{
+    sync::{Barrier, Mutex, OwnedMutexGuard},
+    time::{Duration, timeout},
+};
 
 fn provider_call_reference(call_id: &str) -> ProviderToolCallReferenceEnvelope {
     ProviderToolCallReferenceEnvelope {
@@ -3228,6 +3231,708 @@ async fn filesystem_list_threads_merges_partial_thread_index_with_source_rows() 
     assert!(ids.contains(&"legacy-missing"));
 }
 
+/// Break caught: an index row can exist with its projection keys missing —
+/// observed in staging, where a thread kept its record, its index row and all
+/// of its messages but never appeared in the sidebar. The ordered projection
+/// only emits a row when `indexed` carries the listing keys, so such a row is
+/// invisible to `list_threads`, and the scope's completion marker makes the
+/// repair pass skip the scope on every later start. Without self-healing the
+/// thread stays unreachable for the rest of the volume's life.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_index_row_without_projection_keys() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-unprojected", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-unprojected");
+
+    for id in ["projected-thread", "unprojected-thread"] {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    // Listing once writes the scope's thread-index completion marker, which is
+    // what later suppresses the repair pass.
+    let seeded = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        seeded.threads.len(),
+        2,
+        "both threads must list before the index row is damaged"
+    );
+
+    // Reproduce the staging row shape: no ordered-projection metadata on the
+    // entry while the durable record body remains intact.
+    let index_path = thread_index_record_path_for_test(&scope, "unprojected-thread");
+    let damaged: serde_json::Value = serde_json::from_slice(
+        &scoped
+            .get(&scope.to_resource_scope(), &index_path)
+            .await
+            .unwrap()
+            .expect("ensure_thread writes a derived index row")
+            .entry
+            .body,
+    )
+    .unwrap();
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(serde_json::to_vec_pretty(&damaged).unwrap()),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup rewrites the index row without projection keys");
+
+    // A fresh service stands in for a process restart: no in-memory scope
+    // cache, so the scope is re-declared from durable state alone.
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"projected-thread"),
+        "the undamaged thread must still list; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"unprojected-thread"),
+        "a thread whose index row lost its projection keys must still be \
+         listable after a restart; got {ids:?}"
+    );
+}
+
+/// Break caught: repairing through the merge helper is not enough. `cas_update`
+/// compares only the decoded body, so an index row whose body already matches a
+/// rebuilt record — but whose projection keys are gone — takes the equality
+/// no-op path and is never physically rewritten. The repair then reports
+/// success while the thread stays invisible, and every later start repeats the
+/// scan for nothing. Recovery must not depend on the body differing.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_current_version_index_row_without_projection_keys() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-unprojected-current", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-unprojected-current");
+
+    for id in ["projected-thread", "unprojected-thread"] {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+
+    // Strip only the projection metadata: the body is left byte-for-byte as
+    // written, so a rebuilt record compares equal to it.
+    let index_path = thread_index_record_path_for_test(&scope, "unprojected-thread");
+    let body = scoped
+        .get(&scope.to_resource_scope(), &index_path)
+        .await
+        .unwrap()
+        .expect("ensure_thread writes a derived index row")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup strips the projection metadata only");
+
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"unprojected-thread"),
+        "recovery must not depend on the record body differing from a rebuild; \
+         got {ids:?}"
+    );
+}
+
+/// Break caught: the repair's completeness check only looked for `scope_key`.
+/// The ordered projection also sorts and paginates on `activity_sort` and
+/// `thread_id`, so a row that kept `scope_key` but lost either of those two
+/// keys took the early-return "already projected" path and was never
+/// rewritten — invisible to `list_threads` forever, same as a row missing all
+/// three keys.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_index_row_missing_only_activity_sort_key() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-partial-keys", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-partial-keys");
+
+    for id in ["projected-thread", "partial-keys-thread"] {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+
+    // Rewrite the row keeping `scope_key` (the only key the old check looked
+    // at) but dropping `activity_sort` and `thread_id` — the two keys
+    // `query_ordered` actually sorts and paginates on.
+    let index_path = thread_index_record_path_for_test(&scope, "partial-keys-thread");
+    let versioned = scoped
+        .get(&scope.to_resource_scope(), &index_path)
+        .await
+        .unwrap()
+        .expect("ensure_thread writes a derived index row");
+    let mut damaged = versioned.entry.clone();
+    damaged.indexed.retain(|key, _| key.as_str() == "scope_key");
+    assert_eq!(
+        damaged.indexed.len(),
+        1,
+        "test setup must strip every key except scope_key"
+    );
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            damaged,
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup rewrites the index row missing activity_sort/thread_id");
+
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"projected-thread"),
+        "the undamaged thread must still list; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"partial-keys-thread"),
+        "a row retaining scope_key but missing activity_sort/thread_id must \
+         still be repaired and listable; got {ids:?}"
+    );
+}
+
+/// Break caught: `ensure_thread` (an optional, `required: false` caller of
+/// `ensure_thread_index_query`) declared the scope and cached it as "ready"
+/// without ever running repair. A later `required: true` listing call then
+/// saw the scope already declared *and* the durable migration marker already
+/// complete (written by an earlier process) and returned early before
+/// reaching the reconcile step — so in the common production ordering, where
+/// a write happens before the first list in a process, self-healing never ran
+/// at all.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_index_row_when_write_precedes_first_list() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-write-before-list", "alice");
+    let scope = scope("index-write-before-list");
+
+    // Seed durable state, including the scope's migration-complete marker,
+    // using a first process that lists before ever writing again.
+    {
+        let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+        for id in ["projected-thread", "unprojected-thread"] {
+            seeding_service
+                .ensure_thread(EnsureThreadRequest {
+                    scope: scope.clone(),
+                    thread_id: Some(ThreadId::new(id).unwrap()),
+                    created_by_actor_id: "actor-a".into(),
+                    title: Some(id.into()),
+                    metadata_json: None,
+                })
+                .await
+                .unwrap();
+        }
+        seeding_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: None,
+                cursor: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    // Damage one row's projection keys, same shape as the other recovery
+    // tests, so a fresh process has real repair work to do.
+    let index_path = thread_index_record_path_for_test(&scope, "unprojected-thread");
+    let damaged: serde_json::Value = serde_json::from_slice(
+        &scoped
+            .get(&scope.to_resource_scope(), &index_path)
+            .await
+            .unwrap()
+            .expect("ensure_thread writes a derived index row")
+            .entry
+            .body,
+    )
+    .unwrap();
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(serde_json::to_vec_pretty(&damaged).unwrap()),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup rewrites the index row without projection keys");
+
+    // Fresh process, durable migration marker already complete from seeding.
+    // Critically, perform a WRITE (`ensure_thread`) before the first list —
+    // the ordering that reproduces the bug — so the optional declaration path
+    // caches the scope as "ready" before any required call ever runs. Uses a
+    // brand-new thread id, distinct from the damaged row: `ensure_thread`
+    // would otherwise refresh the damaged row's own index entry as a side
+    // effect (because the fresh process's in-memory "known row" cache is
+    // empty too), which would repair it incidentally and defeat the test.
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    restarted
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("write-before-list-thread").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("write-before-list-thread".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"projected-thread"),
+        "the undamaged thread must still list; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"unprojected-thread"),
+        "a damaged row must still be repaired and listable even when a write \
+         happens before the first list in the process; got {ids:?}"
+    );
+}
+
+/// Required-path repair is serialized only with another repair for the same
+/// scope. A slow first reconcile for one sidebar must not hold unrelated
+/// scopes behind it: index declaration itself is idempotent and intentionally
+/// lockless, while repair mutates only the scoped projection rows.
+#[tokio::test]
+async fn filesystem_list_threads_reconciles_unrelated_scopes_independently() {
+    let blocked_scope = scope("index-scope-lock-blocked");
+    let unrelated_scope = scope("index-scope-lock-unrelated");
+    let backend = Arc::new(BlockingScopeReconcileBackend::new(format!(
+        "/agents/{}/",
+        blocked_scope.agent_id.as_str()
+    )));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-index-scope-lock", "alice");
+    let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+
+    for (scope, thread_id) in [
+        (&blocked_scope, "blocked-scope-thread"),
+        (&unrelated_scope, "unrelated-scope-thread"),
+    ] {
+        seeding_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(thread_id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(thread_id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        seeding_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: None,
+                cursor: None,
+            })
+            .await
+            .expect("seed listing writes the completed migration marker");
+    }
+
+    backend.arm();
+    let restarted = Arc::new(FilesystemSessionThreadService::new(scoped));
+    let blocked_service = Arc::clone(&restarted);
+    let blocked_scope_for_task = blocked_scope.clone();
+    let blocked_listing = tokio::spawn(async move {
+        blocked_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: blocked_scope_for_task,
+                limit: None,
+                cursor: None,
+            })
+            .await
+    });
+    backend.reconcile_entered.wait().await;
+
+    let unrelated = timeout(
+        Duration::from_millis(250),
+        restarted.list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: unrelated_scope,
+            limit: None,
+            cursor: None,
+        }),
+    )
+    .await
+    .expect("unrelated scope must not wait behind another scope's reconcile")
+    .expect("unrelated scope listing succeeds");
+    assert_eq!(unrelated.threads.len(), 1);
+
+    backend.release_reconcile.wait().await;
+    blocked_listing
+        .await
+        .expect("blocked listing task joins")
+        .expect("blocked listing succeeds after release");
+}
+
+/// Reconciliation is a best-effort repair for rows that the listing projection
+/// cannot see. A transient failure while discovering those rows must not turn
+/// an otherwise-readable sidebar page into a hard listing failure.
+#[tokio::test]
+async fn filesystem_list_threads_degrades_to_projected_rows_when_reconcile_fails() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(
+        Arc::clone(&backend),
+        "tenant-index-reconcile-failure",
+        "alice",
+    );
+    let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-reconcile-failure");
+
+    for id in ["projected-before-failure-a", "projected-before-failure-b"] {
+        seeding_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    seeding_service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("seed listing writes the completed migration marker");
+
+    let damaged_path = thread_index_record_path_for_test(&scope, "projected-before-failure-b");
+    let damaged_body = scoped
+        .get(&scope.to_resource_scope(), &damaged_path)
+        .await
+        .unwrap()
+        .expect("seeded index row exists")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &damaged_path,
+            Entry::bytes(damaged_body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup removes the damaged row's projection keys");
+
+    // A fresh process reaches the marker-complete reconcile branch. Fail its
+    // bounded directory discovery so the caller must preserve the projected
+    // rows instead of returning the reconcile error.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::ListDir)
+            .path("/thread_index")
+            .nth(1)
+            .backend("projection reconcile directory listing fails once"),
+    );
+    let restarted = FilesystemSessionThreadService::new(scoped);
+    let degraded = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("a reconcile failure must degrade to projected listing rows");
+    let degraded_ids: Vec<&str> = degraded
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert_eq!(degraded_ids.len(), 1);
+    assert!(degraded_ids.contains(&"projected-before-failure-a"));
+    assert!(!degraded_ids.contains(&"projected-before-failure-b"));
+
+    // A best-effort failure is not a completed reconcile. Once the transient
+    // fault is spent, the next list must retry and restore the missing row.
+    let repaired = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("the next list retries the failed reconcile");
+    let repaired_ids: Vec<&str> = repaired
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert_eq!(repaired_ids.len(), 2);
+    assert!(repaired_ids.contains(&"projected-before-failure-a"));
+    assert!(repaired_ids.contains(&"projected-before-failure-b"));
+}
+
+/// A current-version record can still be invisible when its entry sidecar
+/// loses the ordered keys. Repair must use the shared CAS retry loop rather
+/// than a one-shot conditional put, because a benign concurrent rewrite can
+/// race this best-effort projection repair.
+#[tokio::test]
+async fn filesystem_list_threads_retries_reconcile_projection_repair_after_cas_race() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(
+        Arc::clone(&backend),
+        "tenant-index-reconcile-cas-race",
+        "alice",
+    );
+    let scope = scope("index-reconcile-cas-race");
+    let thread_id = ThreadId::new("current-version-damaged-row").unwrap();
+    let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    seeding_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("current version damaged row".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    seeding_service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("seed listing writes the completed migration marker");
+
+    let index_path = thread_index_record_path_for_test(&scope, thread_id.as_str());
+    let current_body = scoped
+        .get(&scope.to_resource_scope(), &index_path)
+        .await
+        .unwrap()
+        .expect("seeded index row exists")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(current_body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup removes current row projection keys");
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path(format!("/thread_index/{}.json", thread_id.as_str()))
+            .nth(1)
+            .version_mismatch(),
+    );
+
+    let restarted = FilesystemSessionThreadService::new(scoped);
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("listing retries the projection repair after a CAS race");
+    assert_eq!(listed.threads.len(), 1);
+    assert_eq!(listed.threads[0].thread_id, thread_id);
+}
+
+/// The live reconcile pass intentionally bounds itself at one backend page.
+/// Above that cap it must skip repair without failing the listing, leaving a
+/// damaged row absent until the separate pagewise/background repair exists.
+#[tokio::test]
+async fn filesystem_list_threads_skips_reconcile_for_oversized_scope() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-oversized", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-oversized");
+    let damaged_id = ThreadId::new("thread-oversized-hidden").unwrap();
+
+    for index in 0..Page::MAX_LIMIT {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(format!("thread-oversized-{index:04}")).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(format!("thread {index}")),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(damaged_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("damaged oversized row".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    // Make the fresh service take its marker-complete reconcile branch instead
+    // of the full migration. Then remove the damaged row's projection keys.
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &thread_index_migration_marker_path_for_test(&scope),
+            Entry::bytes(b"thread-index-v1".to_vec()),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("seed completed thread-index migration marker");
+    let damaged_path = thread_index_record_path_for_test(&scope, damaged_id.as_str());
+    let damaged_body = scoped
+        .get(&scope.to_resource_scope(), &damaged_path)
+        .await
+        .unwrap()
+        .expect("damaged row exists")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &damaged_path,
+            Entry::bytes(damaged_body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("strip damaged row projection keys");
+
+    let restarted = FilesystemSessionThreadService::new(scoped);
+    let mut listed_ids = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = restarted
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: Some(200),
+                cursor,
+            })
+            .await
+            .expect("oversized reconcile skip must not fail listing");
+        listed_ids.extend(page.threads.into_iter().map(|record| record.thread_id));
+        let Some(next_cursor) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+
+    assert_eq!(listed_ids.len(), Page::MAX_LIMIT as usize);
+    assert!(
+        !listed_ids.contains(&damaged_id),
+        "the damaged row must remain unlisted when the oversized scope skips repair"
+    );
+}
+
 #[tokio::test]
 async fn filesystem_list_threads_does_not_treat_partial_source_cache_as_complete() {
     use ironclaw_threads::ListThreadsForScopeRequest;
@@ -4251,6 +4956,17 @@ struct QueryCountingBackend {
     get_count: AtomicUsize,
 }
 
+/// Holds the first reconcile directory scan for one scope so the caller test
+/// can prove another scope's required listing still makes progress.
+struct BlockingScopeReconcileBackend {
+    inner: InMemoryBackend,
+    blocked_scope_path: String,
+    armed: AtomicBool,
+    blocked_once: AtomicBool,
+    reconcile_entered: Arc<Barrier>,
+    release_reconcile: Arc<Barrier>,
+}
+
 struct MigrationRaceBackend {
     inner: InMemoryBackend,
     armed: AtomicBool,
@@ -4292,6 +5008,30 @@ impl QueryCountingBackend {
 
     fn get_count(&self) -> usize {
         self.get_count.load(Ordering::SeqCst)
+    }
+}
+
+impl BlockingScopeReconcileBackend {
+    fn new(blocked_scope_path: String) -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            blocked_scope_path,
+            armed: AtomicBool::new(false),
+            blocked_once: AtomicBool::new(false),
+            reconcile_entered: Arc::new(Barrier::new(2)),
+            release_reconcile: Arc::new(Barrier::new(2)),
+        }
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+
+    fn blocks_reconcile_for(&self, path: &VirtualPath) -> bool {
+        self.armed.load(Ordering::SeqCst)
+            && path.as_str().contains(&self.blocked_scope_path)
+            && path.as_str().ends_with("/thread_index")
+            && !self.blocked_once.swap(true, Ordering::SeqCst)
     }
 }
 
@@ -4437,6 +5177,76 @@ impl RootFilesystem for QueryCountingBackend {
         page: &OrderedPage,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         self.query_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.query_ordered(path, filter, page).await
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        self.inner.ensure_index(path, spec).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        self.inner.begin(path).await
+    }
+
+    async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
+        self.inner.reserve_sequence(path).await
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for BlockingScopeReconcileBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        if self.blocks_reconcile_for(path) {
+            self.reconcile_entered.wait().await;
+            self.release_reconcile.wait().await;
+        }
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        self.inner.query(path, filter, page).await
+    }
+
+    async fn query_ordered(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: &OrderedPage,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         self.inner.query_ordered(path, filter, page).await
     }
 

--- a/crates/substrates/ironclaw_filesystem/src/cas.rs
+++ b/crates/substrates/ironclaw_filesystem/src/cas.rs
@@ -27,7 +27,9 @@
 //! 2. Run the caller's `apply` closure, which computes the next snapshot plus a
 //!    caller-defined outcome (`T`) or returns the caller's error (`E`).
 //! 3. If the snapshot is unchanged (or the caller explicitly returns a no-op),
-//!    return the outcome without writing.
+//!    return the outcome without writing. A caller that must rewrite entry
+//!    sidecars despite an unchanged decoded snapshot can explicitly request a
+//!    force write.
 //! 4. Otherwise either `put` the encoded snapshot back with the read version as
 //!    the CAS precondition (`CasExpectation::Absent` for a first write), or
 //!    conditionally delete it when the caller returns [`CasApply::delete`].
@@ -106,7 +108,7 @@ pub const FILESYSTEM_CAS_BACKOFF_MAX: Duration = Duration::from_millis(50);
 /// `snapshot` is the next snapshot to persist; `outcome` is whatever the caller
 /// wants returned from the whole `cas_update` call on success.
 ///
-/// The caller selects one of three typed mutation outcomes:
+/// The caller selects one of four typed mutation outcomes:
 ///
 /// 1. **Write** — return `CasApply::new`. When the returned snapshot equals the
 ///    existing value that `apply` received, `cas_update` skips the write as a
@@ -117,6 +119,11 @@ pub const FILESYSTEM_CAS_BACKOFF_MAX: Duration = Duration::from_millis(50);
 /// 3. **Delete** — return `CasApply::delete`. The helper conditionally deletes
 ///    the version just read, then re-runs `apply` against a fresh read to prove
 ///    the caller's postcondition across delete + recreate ABA cycles.
+/// 4. **Force write** — return `CasApply::force_write`. This bypasses only the
+///    decoded-snapshot equality fast-path, so the entry is encoded and written
+///    with the same bounded, capability-gated CAS retry behavior as a normal
+///    write. Use it when entry sidecars such as indexed projection metadata
+///    need repair even though the decoded body is already current.
 pub struct CasApply<S, T> {
     /// The new snapshot to write back. Ignored for persistence when writing is
     /// not selected (i.e., constructed via [`CasApply::no_op`] or
@@ -130,6 +137,7 @@ pub struct CasApply<S, T> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CasApplyOperation {
     Write,
+    ForceWrite,
     NoOp,
     Delete,
 }
@@ -137,15 +145,31 @@ enum CasApplyOperation {
 impl<S, T> CasApply<S, T> {
     /// Produce a [`CasApply`] that **writes** `snapshot` back to the store.
     ///
-    /// All existing callers use this constructor; its signature is unchanged.
-    /// If `snapshot` equals the value `apply` was handed (i.e. nothing
-    /// changed), `cas_update` still skips the write via the `PartialEq` fast
-    /// path — no API change needed for callers that rely on that behavior.
+    /// This is the normal write constructor. If `snapshot` equals the value
+    /// `apply` was handed (i.e. nothing changed), `cas_update` still skips the
+    /// write via the `PartialEq` fast path. Use [`CasApply::force_write`] when
+    /// an entry-sidecar repair must persist despite decoded equality.
     pub fn new(snapshot: S, outcome: T) -> Self {
         Self {
             snapshot,
             outcome,
             operation: CasApplyOperation::Write,
+        }
+    }
+
+    /// Produce a [`CasApply`] that writes `snapshot` even when it equals the
+    /// value `apply` received.
+    ///
+    /// This bypasses only `cas_update`'s decoded-snapshot equality fast-path.
+    /// The write still uses the version read by this attempt and therefore
+    /// retains the helper's bounded retries, timeout, and capability gate.
+    /// Use it for entry-sidecar repairs (for example, missing indexed
+    /// projection metadata) that are not represented in `S`.
+    pub fn force_write(snapshot: S, outcome: T) -> Self {
+        Self {
+            snapshot,
+            outcome,
+            operation: CasApplyOperation::ForceWrite,
         }
     }
 
@@ -266,6 +290,10 @@ impl<E: std::fmt::Display + std::fmt::Debug> std::error::Error for CasUpdateErro
 ///     `unchanged_snapshot` equals what `apply` was handed; `cas_update`
 ///     detects the equality via `PartialEq` and skips the write as a
 ///     convenience fast path.
+///   - Return `CasApply::force_write(snapshot, outcome)` to persist an entry
+///     despite decoded equality, such as when its indexed sidecar needs a
+///     physical rewrite. It still uses the same conditional put and retry
+///     behavior as `CasApply::new`.
 ///   - Return `CasApply::delete(snapshot, outcome)` to conditionally delete the
 ///     current version. The helper re-runs `apply` after deletion to establish
 ///     the caller-defined postcondition across delete + recreate ABA cycles.
@@ -397,7 +425,7 @@ where
         mutation_attempts += 1;
 
         match operation {
-            CasApplyOperation::Write => {
+            CasApplyOperation::Write | CasApplyOperation::ForceWrite => {
                 // Verification found that a different mutation is now needed;
                 // its outcome supersedes any earlier delete outcome.
                 drop(successful_delete_outcome.take());

--- a/crates/substrates/ironclaw_filesystem/src/cas/tests.rs
+++ b/crates/substrates/ironclaw_filesystem/src/cas/tests.rs
@@ -285,6 +285,71 @@ struct AlwaysMismatchBackend {
     put_attempts: AtomicUsize,
 }
 
+/// CAS-capable backend that simulates one competing rewrite before accepting
+/// the caller's retry. The competing rewrite preserves the decoded snapshot,
+/// so this proves a force rewrite bypasses only `cas_update`'s equality
+/// fast-path and still re-reads after a real `VersionMismatch`.
+struct OneMismatchThenSuccessBackend {
+    inner: InMemoryBackend,
+    mismatch_once: AtomicBool,
+    put_attempts: AtomicUsize,
+}
+
+impl OneMismatchThenSuccessBackend {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            mismatch_once: AtomicBool::new(false),
+            put_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn arm_mismatch(&self) {
+        self.mismatch_once.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for OneMismatchThenSuccessBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities::in_memory_full()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.put_attempts.fetch_add(1, Ordering::SeqCst);
+        if self.mismatch_once.swap(false, Ordering::SeqCst) {
+            let found = self.inner.put(path, entry, CasExpectation::Any).await?;
+            let expected = match cas {
+                CasExpectation::Version(version) => Some(version),
+                CasExpectation::Absent | CasExpectation::Any => None,
+            };
+            return Err(FilesystemError::VersionMismatch {
+                path: path.clone(),
+                expected,
+                found: Some(found),
+            });
+        }
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+}
+
 impl AlwaysMismatchBackend {
     fn new() -> Self {
         Self {
@@ -457,6 +522,68 @@ async fn no_op_apply_skips_write() {
     assert_eq!(
         version_before, version_after,
         "no-op apply must not issue a write"
+    );
+}
+
+#[tokio::test]
+async fn force_write_rewrites_equal_snapshot_and_retries_one_version_mismatch() {
+    let backend = Arc::new(OneMismatchThenSuccessBackend::new());
+    let fs = Arc::new(scoped(Arc::clone(&backend)));
+    let scope = ResourceScope::system();
+
+    cas_update(
+        fs.as_ref(),
+        &scope,
+        &counter_path(),
+        decode_counter,
+        encode_counter,
+        |_: Option<Counter>| async move { Ok::<_, TestError>(CasApply::new(Counter { value: 5 }, ())) },
+    )
+    .await
+    .expect("seed counter");
+    let version_before = fs
+        .get(&scope, &counter_path())
+        .await
+        .expect("read seeded counter")
+        .expect("seeded counter exists")
+        .version;
+
+    backend.arm_mismatch();
+    let outcome = cas_update(
+        fs.as_ref(),
+        &scope,
+        &counter_path(),
+        decode_counter,
+        encode_counter,
+        |current: Option<Counter>| async move {
+            Ok::<_, TestError>(CasApply::force_write(
+                current.expect("seeded counter"),
+                "rewritten",
+            ))
+        },
+    )
+    .await
+    .expect("force rewrite retries and succeeds");
+
+    assert_eq!(outcome, "rewritten");
+    assert_eq!(
+        backend.put_attempts.load(Ordering::SeqCst),
+        3,
+        "one seed write, one mismatched rewrite, and one successful retry"
+    );
+    let stored = fs
+        .get(&scope, &counter_path())
+        .await
+        .expect("read force-rewritten counter")
+        .expect("force-rewritten counter exists");
+    assert_eq!(
+        decode_counter(&stored.entry.body).unwrap(),
+        Counter { value: 5 }
+    );
+    assert_eq!(
+        stored.version,
+        version_before.next().next(),
+        "the competing equal rewrite and force rewrite both persist"
     );
 }
 


### PR DESCRIPTION
## Summary

- Port #7470's thread-index projection self-heal to the `release/2026-08-11` family layout.
- Reconcile marker-complete scopes once per process, repairing durable thread-index rows whose ordered-projection sidecar is missing or incomplete.
- Use the shared bounded CAS loop with an explicit forced write so sidecar-only damage is repaired even when the decoded record body is unchanged.
- Keep reconciliation bounded and non-fatal: healthy scopes pay one bounded directory listing plus one capped projection query, and scopes above `Page::MAX_LIMIT` are skipped.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7178

Port of #7470 to `release/2026-08-11`.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_filesystem`; `cargo test -p ironclaw_threads`
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (the root `integration` feature is empty — the flag is per-crate)
- [ ] Manual testing: Not run; the regression is covered through the filesystem service contract.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional lint evidence: `cargo clippy -p ironclaw_filesystem -p ironclaw_threads --all-targets --all-features -- -D warnings` passed.

`bash scripts/pre-commit-safety.sh` remains blocked by the target branch's existing composition-budget baseline: composition source is 1,654 LOC above the effective absolute ceiling and `Arc<dyn>` dispatch is one site above the effective ceiling. This PR changes no composition files.

## Test Strategy

User behavior: A thread whose durable index row loses some or all ordered-projection keys becomes visible in the sidebar again after the next process restart/listing request.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: filesystem CAS force-write regressions and filesystem thread-service recovery, retry, isolation, concurrency, partial-key, and oversized-scope contract tests.
- Reborn integration: Not applicable: the owning filesystem service contract exercises the production caller and in-memory backend; existing PostgreSQL and libSQL filesystem/CAS contract suites also passed.
- Recorded fixture: Not applicable: no provider or serialized transport fixture changed.
- Browser E2E: Not applicable: no frontend behavior changed; the backend listing result is asserted directly.
- Backend or runtime: `cargo test -p ironclaw_filesystem` includes in-memory, libSQL, and PostgreSQL filesystem/CAS contracts; `cargo test -p ironclaw_threads` includes libSQL/PostgreSQL release-pair migration contracts.
- Live canary: Not run for this port; #7470 documents the staging evidence for the original failure.

What the tests prove: sidecar-only damage is physically rewritten despite equal decoded bodies; incomplete projection keys are repaired; optional writes cannot suppress the first required repair; CAS races retry; failures degrade non-fatally and retry; unrelated scopes progress independently; oversized scopes remain bounded.

Commands run:

```text
cargo fmt --check
cargo test -p ironclaw_filesystem
cargo test -p ironclaw_threads
cargo clippy -p ironclaw_filesystem -p ironclaw_threads --all-targets --all-features -- -D warnings
git diff --check
bash scripts/pre-commit-safety.sh  # blocked by unrelated target-branch composition baseline
```

## Security Impact

None. This does not change permissions, network calls, secrets, sandbox policy, or capability execution. It rewrites only an already-authorized thread-index record within the caller's existing scoped filesystem mount.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new public trust-bearing types.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. N/A: no prompt path changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. N/A: no hashing changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: N/A; no variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. N/A: this target-specific port does not add a persisted field.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Scope caches are capped at 128; repair is capped at `Page::MAX_LIMIT`; lock entries are weak and pruned.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). No new operator-visible error class; reconcile failure degrades to existing projected rows and remains retryable.
- [x] Sandbox/native/host names accurately describe trust boundary. N/A: no runtime lane changed.

## Database Impact

No schema migration. Existing index entries may be rewritten through their current backend using version-checked CAS. The target branch's existing `thread-index-v1.complete` marker path and body are preserved; this port intentionally does not import `release/1.1.1`'s separate `projection_schema_version` mechanism.

## Blast Radius

Touches the shared filesystem CAS helper and filesystem-backed thread listing. A regression could cause unnecessary index-row rewrites, delay the first listing after restart, or leave a damaged row hidden. Work is selective, version-checked, bounded, and once per scope per process after success. Scopes larger than `Page::MAX_LIMIT` retain current behavior and are not repaired.

## Rollback Plan

Revert commit `97d912525`. There is no schema change or new durable marker. Any successfully repaired index sidecars remain valid under the previous binary.

## Review Follow-Through

Please focus on the target-specific adaptation around the existing `thread-index-v1` marker and the removal of the source branch's projection-version dependency. The known follow-up remains a background/pagewise repair path for scopes above `Page::MAX_LIMIT`.

---

**Review track**: C (persistence/runtime behavior)
