### PR TITLE
fix(memory): resolve target aliases in the domain contract layer (#7505)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,6 +4536,7 @@ name = "ironclaw_memory"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "chrono-tz",
  "hex",
  "ironclaw_host_api",

--- a/crates/domains/ironclaw_memory/Cargo.toml
+++ b/crates/domains/ironclaw_memory/Cargo.toml
@@ -20,6 +20,9 @@ async-trait = "0.1"
 # IANA timezone names; the constructor must stay an inherent method on the
 # contract type so the existing consumer call site is unchanged.
 chrono-tz = "0.10"
+# Clock for `daily_log` target resolution (the domain-owned alias table in
+# `target.rs`); timezone names themselves are validated via `chrono-tz`.
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 hex = "0.4"
 ironclaw_host_api = { path = "../../contracts/ironclaw_host_api", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/domains/ironclaw_memory/README.md
+++ b/crates/domains/ironclaw_memory/README.md
@@ -25,12 +25,20 @@ point.
   tools built on it.
 - Path/scope grammar: `MemoryDocumentScope`, `MemoryDocumentPath` (validating
   constructors; fail-closed), `MemoryContext`.
+- Optional conventional document-tool vocabulary (`target`): providers that
+  declare `ironclaw.memory.write` + `.read` with the shared prompt/schema use
+  the reserved aliases (`memory` → `MEMORY.md`, `daily_log` → today's dated
+  log, `heartbeat`, `bootstrap`) and the domain-owned resolution/identity
+  helpers (`resolve_document_target`, `same_document_target`). Providers may
+  instead expose different tools or none; only conventional document-tool
+  providers opt into this vocabulary and its conformance suite.
 - Prompt-write-safety vocabulary (`safety`): operation, source, severity,
   reason codes, policy trait, event sink — the *shape* of what a provider must
   enforce; the enforcement engine lives in the providers.
 - Metadata + hashing helpers (`metadata`, `hash`); significant-event/audit
   contracts (`events`).
-- `test_support` — the shared conformance suite every provider wires against.
+- `test_support` — shared lifecycle conformance every applicable provider
+  wires, plus the separate opt-in conventional document-tool conformance.
 
 ## Depends on / consumed by
 

--- a/crates/domains/ironclaw_memory/src/lib.rs
+++ b/crates/domains/ironclaw_memory/src/lib.rs
@@ -15,6 +15,7 @@ mod metadata;
 mod path;
 mod safety;
 mod service;
+mod target;
 /// Provider-level contract suite every `MemoryService` impl wires; see the
 /// module docs. Test-only (zero bytes in production builds; the
 /// `src/test_support.rs` name is the repo-wide feature-gated convention).
@@ -54,4 +55,9 @@ pub use service::{
     MemoryWriteStatus, PROFILE_SET_CAPABILITY_ID, memory_context_disabled,
     profile_set_response_output, read_response_output, search_response_output,
     tree_response_output, write_response_output,
+};
+pub use target::{
+    BOOTSTRAP_DOCUMENT_PATH, BOOTSTRAP_DOCUMENT_TARGET, DAILY_LOG_DOCUMENT_TARGET,
+    HEARTBEAT_DOCUMENT_PATH, HEARTBEAT_DOCUMENT_TARGET, MEMORY_DOCUMENT_PATH,
+    MEMORY_DOCUMENT_TARGET, document_target_aliases, resolve_document_target, same_document_target,
 };

--- a/crates/domains/ironclaw_memory/src/safety.rs
+++ b/crates/domains/ironclaw_memory/src/safety.rs
@@ -15,6 +15,7 @@ use ironclaw_host_api::{error::HostApiError, path::VirtualPath};
 
 use crate::events::{MemoryAuditContext, MemoryEventSinkError};
 use crate::path::{MemoryDocumentPath, MemoryDocumentScope, validated_memory_relative_path};
+use crate::target::{BOOTSTRAP_DOCUMENT_PATH, HEARTBEAT_DOCUMENT_PATH, MEMORY_DOCUMENT_PATH};
 
 /// Version identifier for the protected prompt-path policy registry.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -150,10 +151,10 @@ pub const DEFAULT_PROMPT_PROTECTED_PATHS: &[&str] = &[
     "USER.md",
     "IDENTITY.md",
     "SYSTEM.md",
-    "MEMORY.md",
+    MEMORY_DOCUMENT_PATH,
     "TOOLS.md",
-    "HEARTBEAT.md",
-    "BOOTSTRAP.md",
+    HEARTBEAT_DOCUMENT_PATH,
+    BOOTSTRAP_DOCUMENT_PATH,
     "context/assistant-directives.md",
     "context/profile.json",
 ];

--- a/crates/domains/ironclaw_memory/src/service.rs
+++ b/crates/domains/ironclaw_memory/src/service.rs
@@ -910,9 +910,14 @@ fn optional_u64(input: &Value, key: &'static str) -> Option<u64> {
 /// `*_DOCUMENT_TARGET` vocabulary in `crate::target`) and ordinary relative
 /// document paths (`notes/x.md`) pass unchanged; resolution to the canonical
 /// document is the domain-owned [`resolve_document_target`] table.
-fn reject_out_of_scope_target(target: &str) -> Result<(), MemoryServiceError> {
+///
+/// `pub(crate)`: also the input gate of [`resolve_document_target`], so the
+/// exported resolver is fail-closed regardless of which caller routes through
+/// it — never only at `from_tool_input`.
+pub(crate) fn reject_out_of_scope_target(target: &str) -> Result<(), MemoryServiceError> {
     if target.trim().is_empty()
         || target.starts_with('/')
+        || target.starts_with("~/")
         || target.contains("..")
         || target.contains('\\')
     {

--- a/crates/domains/ironclaw_memory/src/service.rs
+++ b/crates/domains/ironclaw_memory/src/service.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
 use crate::metadata::DocumentMetadata;
+use crate::target::DAILY_LOG_DOCUMENT_TARGET;
 
 const MAX_LOCALE_LEN: usize = 35;
 
@@ -81,7 +82,7 @@ impl MemoryServiceWriteRequest {
         // semantics.
         let target = match input.get("target") {
             Some(Value::String(target)) => target.to_string(),
-            Some(Value::Null) | None => "daily_log".to_string(),
+            Some(Value::Null) | None => DAILY_LOG_DOCUMENT_TARGET.to_string(),
             Some(_) => return Err(MemoryServiceError::input()),
         };
         // Provider-neutral containment: reject a target that would escape the
@@ -107,7 +108,7 @@ impl MemoryServiceWriteRequest {
             .get("new_string")
             .and_then(Value::as_str)
             .map(str::to_string);
-        let append = if target == "daily_log" {
+        let append = if target == DAILY_LOG_DOCUMENT_TARGET {
             true
         } else {
             input.get("append").and_then(Value::as_bool).unwrap_or(true)
@@ -905,9 +906,10 @@ fn optional_u64(input: &Value, key: &'static str) -> Option<u64> {
 /// Reject a write `target` that would escape the scoped memory mount or fail to
 /// name a document. Mirrors the fail-closed `not` pattern the model-facing
 /// `document-write` input schema advertises: blank, absolute path (leading `/`),
-/// any `..` traversal, or a backslash separator. Reserved names (`daily_log`,
-/// `memory`, `heartbeat`, `bootstrap`) and ordinary relative document paths
-/// (`notes/x.md`) pass unchanged.
+/// any `..` traversal, or a backslash separator. Reserved aliases (the
+/// `*_DOCUMENT_TARGET` vocabulary in `crate::target`) and ordinary relative
+/// document paths (`notes/x.md`) pass unchanged; resolution to the canonical
+/// document is the domain-owned [`resolve_document_target`] table.
 fn reject_out_of_scope_target(target: &str) -> Result<(), MemoryServiceError> {
     if target.trim().is_empty()
         || target.starts_with('/')

--- a/crates/domains/ironclaw_memory/src/target.rs
+++ b/crates/domains/ironclaw_memory/src/target.rs
@@ -16,7 +16,7 @@
 //! | `daily_log`           | `daily/<YYYY-MM-DD>.md` (today, timezone-aware) |
 //! | `heartbeat`           | `HEARTBEAT.md` (the standing checklist) |
 //! | `bootstrap`           | `BOOTSTRAP.md` (a write clears it)     |
-//! | any other relative path | itself (unchanged)                   |
+//! | any other relative path | itself (unchanged; out-of-scope paths error) |
 //!
 //! Providers declaring the conventional document-tool pair with this shared
 //! vocabulary route write/read path resolution through
@@ -29,6 +29,7 @@ use chrono::Utc;
 use chrono_tz::Tz;
 
 use crate::MemoryServiceError;
+use crate::service::reject_out_of_scope_target;
 
 /// `target: "memory"` — the standing durable memory document ([`MEMORY_DOCUMENT_PATH`]).
 pub const MEMORY_DOCUMENT_TARGET: &str = "memory";
@@ -47,61 +48,78 @@ pub const HEARTBEAT_DOCUMENT_PATH: &str = "HEARTBEAT.md";
 /// Canonical relative document path of the standing bootstrap checklist document.
 pub const BOOTSTRAP_DOCUMENT_PATH: &str = "BOOTSTRAP.md";
 
+/// The fixed alias → canonical-path pairs of the shared document-tool
+/// vocabulary. THE single source of the mapping: [`resolve_document_target`]
+/// looks it up for writes and [`document_target_aliases`] filters it for
+/// read-side legacy compatibility, so the two views are structurally
+/// incapable of diverging (adding an alias is one table row). `daily_log` is
+/// date-derived and stays special-cased in [`resolve_document_target`].
+const DOCUMENT_TARGETS: &[(&str, &str)] = &[
+    (MEMORY_DOCUMENT_TARGET, MEMORY_DOCUMENT_PATH),
+    (HEARTBEAT_DOCUMENT_TARGET, HEARTBEAT_DOCUMENT_PATH),
+    (BOOTSTRAP_DOCUMENT_TARGET, BOOTSTRAP_DOCUMENT_PATH),
+];
+
 /// Resolve a write `target` to its canonical relative document path.
 ///
-/// Fixed aliases map to their canonical documents; `daily_log` maps to
-/// today's date in the given IANA `timezone` (UTC when absent — an invalid
-/// timezone is an input error, mirroring the pre-contract native behavior);
-/// any other relative path passes through unchanged. For providers declaring
-/// the conventional document tools, the resolved path is what the provider
+/// Fail-closed on the exported boundary itself: a target that would escape
+/// the scoped memory mount or fail to name a document (blank, absolute
+/// leading `/`, `..` traversal, backslash separator) is an input error —
+/// invalid values are never silently coerced to a document identity. Fixed
+/// aliases map to their canonical documents; `daily_log` maps to today's
+/// date in the given IANA `timezone` (UTC when absent — an invalid timezone
+/// is an input error, mirroring the pre-contract native behavior); any other
+/// relative path passes through unchanged. For providers declaring the
+/// conventional document tools, the resolved path is what the provider
 /// stores/addresses — the alias itself is not the document identity (#7505).
 pub fn resolve_document_target(
     target: &str,
     timezone: Option<&str>,
 ) -> Result<String, MemoryServiceError> {
-    match target {
-        MEMORY_DOCUMENT_TARGET => Ok(MEMORY_DOCUMENT_PATH.to_string()),
-        HEARTBEAT_DOCUMENT_TARGET => Ok(HEARTBEAT_DOCUMENT_PATH.to_string()),
-        BOOTSTRAP_DOCUMENT_TARGET => Ok(BOOTSTRAP_DOCUMENT_PATH.to_string()),
-        DAILY_LOG_DOCUMENT_TARGET => {
-            let timezone = match timezone {
-                Some(value) => value
-                    .parse::<Tz>()
-                    .map_err(|_| MemoryServiceError::input())?,
-                None => Tz::UTC,
-            };
-            let now = Utc::now().with_timezone(&timezone);
-            Ok(format!("daily/{}.md", now.format("%Y-%m-%d")))
-        }
-        path => Ok(path.to_string()),
+    reject_out_of_scope_target(target)?;
+    if let Some((_, path)) = DOCUMENT_TARGETS.iter().find(|(alias, _)| *alias == target) {
+        return Ok((*path).to_string());
     }
+    if target == DAILY_LOG_DOCUMENT_TARGET {
+        let timezone = match timezone {
+            Some(value) => value
+                .parse::<Tz>()
+                .map_err(|_| MemoryServiceError::input())?,
+            None => Tz::UTC,
+        };
+        let now = Utc::now().with_timezone(&timezone);
+        return Ok(format!("daily/{}.md", now.format("%Y-%m-%d")));
+    }
+    Ok(target.to_string())
 }
 
-/// The legacy aliases whose canonical document path is `path`.
+/// The legacy aliases whose canonical document path is `path`, derived from
+/// the shared [`DOCUMENT_TARGETS`] table.
 ///
 /// Read-side compatibility (#7505): rows stored under a pre-resolution alias
 /// (mem0 historically tagged `"memory"` verbatim) must stay reachable by
 /// their canonical path (e.g. `MEMORY.md` — the path the host's always-on
 /// prompt lane reads). `daily_log` has no fixed canonical path (its target
 /// encodes the write date), so it has no entry here.
-pub fn document_target_aliases(path: &str) -> &'static [&'static str] {
-    match path {
-        MEMORY_DOCUMENT_PATH => &[MEMORY_DOCUMENT_TARGET],
-        HEARTBEAT_DOCUMENT_PATH => &[HEARTBEAT_DOCUMENT_TARGET],
-        BOOTSTRAP_DOCUMENT_PATH => &[BOOTSTRAP_DOCUMENT_TARGET],
-        _ => &[],
-    }
+pub fn document_target_aliases(path: &str) -> impl Iterator<Item = &'static str> + '_ {
+    DOCUMENT_TARGETS
+        .iter()
+        .filter(move |(_, canonical)| *canonical == path)
+        .map(|(alias, _)| *alias)
 }
 
 /// Whether a stored document identity and a requested path name the same
-/// document: exact equality, or the stored identity is a legacy alias of the
-/// requested canonical path (see [`document_target_aliases`]).
+/// document: exact equality, or either side is a legacy alias of the other's
+/// canonical path (see [`document_target_aliases`]). Symmetric — the
+/// argument order never matters.
 ///
 /// Used by tag-based document stores (mem0 filters memories by their
-/// `target` metadata tag) so reads find both canonically-tagged rows and
-/// pre-fix alias-tagged rows.
+/// `target` metadata tag) so reads find canonically-tagged rows, pre-fix
+/// alias-tagged rows, and alias-path reads of canonical-tagged rows alike.
 pub fn same_document_target(stored: &str, requested: &str) -> bool {
-    stored == requested || document_target_aliases(requested).contains(&stored)
+    stored == requested
+        || document_target_aliases(requested).any(|alias| alias == stored)
+        || document_target_aliases(stored).any(|alias| alias == requested)
 }
 
 #[cfg(test)]
@@ -164,27 +182,88 @@ mod tests {
     #[test]
     fn alias_table_round_trips_canonical_paths() {
         assert_eq!(
-            document_target_aliases(MEMORY_DOCUMENT_PATH),
-            &[MEMORY_DOCUMENT_TARGET]
+            document_target_aliases(MEMORY_DOCUMENT_PATH).collect::<Vec<_>>(),
+            vec![MEMORY_DOCUMENT_TARGET]
         );
         assert_eq!(
-            document_target_aliases(HEARTBEAT_DOCUMENT_PATH),
-            &[HEARTBEAT_DOCUMENT_TARGET]
+            document_target_aliases(HEARTBEAT_DOCUMENT_PATH).collect::<Vec<_>>(),
+            vec![HEARTBEAT_DOCUMENT_TARGET]
         );
         assert_eq!(
-            document_target_aliases(BOOTSTRAP_DOCUMENT_PATH),
-            &[BOOTSTRAP_DOCUMENT_TARGET]
+            document_target_aliases(BOOTSTRAP_DOCUMENT_PATH).collect::<Vec<_>>(),
+            vec![BOOTSTRAP_DOCUMENT_TARGET]
         );
-        assert!(document_target_aliases("notes/a.md").is_empty());
-        assert!(document_target_aliases(MEMORY_DOCUMENT_TARGET).is_empty());
+        assert!(document_target_aliases("notes/a.md").next().is_none());
+        assert!(
+            document_target_aliases(MEMORY_DOCUMENT_TARGET)
+                .next()
+                .is_none()
+        );
     }
 
     #[test]
-    fn same_document_target_tolerates_legacy_aliases() {
+    fn resolver_and_alias_views_agree_on_the_shared_table() {
+        // The write-side resolver and the read-side alias view derive from
+        // the same table; pin the agreement so a future fourth alias cannot
+        // ship with only one side updated.
+        for (alias, canonical) in DOCUMENT_TARGETS {
+            assert_eq!(resolve_document_target(alias, None).unwrap(), *canonical);
+            assert!(
+                document_target_aliases(canonical).any(|entry| entry == *alias),
+                "{alias} must be listed as a legacy alias of {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn same_document_target_is_symmetric_across_legacy_aliases() {
         assert!(same_document_target("MEMORY.md", "MEMORY.md"));
+        // Canonical-path reads of legacy-alias rows (the compat direction).
         assert!(same_document_target("memory", "MEMORY.md"));
+        // Alias-path reads of canonical-tagged rows (the pre-fix round-trip
+        // direction the shared prompt taught: write "memory", read "memory").
+        assert!(same_document_target("MEMORY.md", "memory"));
+        assert!(same_document_target("HEARTBEAT.md", "heartbeat"));
         assert!(!same_document_target("HEARTBEAT.md", "MEMORY.md"));
+        assert!(!same_document_target("memory", "HEARTBEAT.md"));
+        // daily_log encodes the write date; no fixed alias relation exists.
         assert!(!same_document_target("daily_log", "daily/2026-08-11.md"));
-        assert!(!same_document_target("MEMORY.md", "memory"));
+        assert!(!same_document_target("daily/2026-08-11.md", "daily_log"));
+    }
+
+    #[test]
+    fn resolve_document_target_ignores_invalid_timezone_for_non_daily_targets() {
+        // timezone is consulted only by the `daily_log` arm; a stray invalid
+        // timezone with a fixed alias or ordinary path must not fail the
+        // write (the shared prompt may send both fields together).
+        assert_eq!(
+            resolve_document_target(MEMORY_DOCUMENT_TARGET, Some("not/a-zone")).unwrap(),
+            MEMORY_DOCUMENT_PATH
+        );
+        assert_eq!(
+            resolve_document_target("notes/a.md", Some("not/a-zone")).unwrap(),
+            "notes/a.md"
+        );
+    }
+
+    #[test]
+    fn resolve_document_target_rejects_out_of_scope_targets() {
+        // The exported resolver is fail-closed on its own boundary: a target
+        // that would escape the memory mount or fail to name a document is an
+        // input error, never a silently-coerced document identity.
+        for target in [
+            "",
+            "   ",
+            "/abs.md",
+            "notes/../SECRET.md",
+            r"notes\back.md",
+            "~/mem.md",
+        ] {
+            assert_eq!(
+                resolve_document_target(target, None).unwrap_err().kind(),
+                MemoryServiceErrorKind::Input,
+                "target {target:?} must be rejected"
+            );
+        }
     }
 }

--- a/crates/domains/ironclaw_memory/src/target.rs
+++ b/crates/domains/ironclaw_memory/src/target.rs
@@ -1,0 +1,190 @@
+//! Document target aliases — the reserved model-facing `target` values of the
+//! shared memory write tool and their canonical relative document paths.
+//!
+//! This is the OPTIONAL conventional `ironclaw.memory.write` / `.read` tool
+//! vocabulary, owned here beside their shared capability ids, request DTOs,
+//! and wire helpers — never copied between providers. A provider may expose
+//! different tools or none at all; a provider declaring this conventional
+//! document-tool pair with the shared prompt/schema uses this table so the
+//! same alias means the same canonical document across backend swaps (#7505).
+//! The shared write prompt (`memory-native/prompts/memory-native/write.md`,
+//! reused verbatim by mem0) teaches the model the aliases:
+//!
+//! | `target` alias        | canonical document                     |
+//! |-----------------------|----------------------------------------|
+//! | `memory`              | `MEMORY.md` (the standing durable fact doc) |
+//! | `daily_log`           | `daily/<YYYY-MM-DD>.md` (today, timezone-aware) |
+//! | `heartbeat`           | `HEARTBEAT.md` (the standing checklist) |
+//! | `bootstrap`           | `BOOTSTRAP.md` (a write clears it)     |
+//! | any other relative path | itself (unchanged)                   |
+//!
+//! Providers declaring the conventional document-tool pair with this shared
+//! vocabulary route write/read path resolution through
+//! [`resolve_document_target`] / [`same_document_target`] rather than
+//! reimplementing the table. They opt into the separate
+//! `crate::memory_document_tool_contract!` suite; lifecycle-only providers do
+//! not.
+
+use chrono::Utc;
+use chrono_tz::Tz;
+
+use crate::MemoryServiceError;
+
+/// `target: "memory"` — the standing durable memory document ([`MEMORY_DOCUMENT_PATH`]).
+pub const MEMORY_DOCUMENT_TARGET: &str = "memory";
+/// `target: "daily_log"` — today's dated log (timezone-aware, `daily/<YYYY-MM-DD>.md`).
+pub const DAILY_LOG_DOCUMENT_TARGET: &str = "daily_log";
+/// `target: "heartbeat"` — the standing heartbeat checklist document ([`HEARTBEAT_DOCUMENT_PATH`]).
+pub const HEARTBEAT_DOCUMENT_TARGET: &str = "heartbeat";
+/// `target: "bootstrap"` — the standing bootstrap checklist document ([`BOOTSTRAP_DOCUMENT_PATH`]);
+/// a write clears it.
+pub const BOOTSTRAP_DOCUMENT_TARGET: &str = "bootstrap";
+
+/// Canonical relative document path of the standing durable memory document.
+pub const MEMORY_DOCUMENT_PATH: &str = "MEMORY.md";
+/// Canonical relative document path of the standing heartbeat checklist document.
+pub const HEARTBEAT_DOCUMENT_PATH: &str = "HEARTBEAT.md";
+/// Canonical relative document path of the standing bootstrap checklist document.
+pub const BOOTSTRAP_DOCUMENT_PATH: &str = "BOOTSTRAP.md";
+
+/// Resolve a write `target` to its canonical relative document path.
+///
+/// Fixed aliases map to their canonical documents; `daily_log` maps to
+/// today's date in the given IANA `timezone` (UTC when absent — an invalid
+/// timezone is an input error, mirroring the pre-contract native behavior);
+/// any other relative path passes through unchanged. For providers declaring
+/// the conventional document tools, the resolved path is what the provider
+/// stores/addresses — the alias itself is not the document identity (#7505).
+pub fn resolve_document_target(
+    target: &str,
+    timezone: Option<&str>,
+) -> Result<String, MemoryServiceError> {
+    match target {
+        MEMORY_DOCUMENT_TARGET => Ok(MEMORY_DOCUMENT_PATH.to_string()),
+        HEARTBEAT_DOCUMENT_TARGET => Ok(HEARTBEAT_DOCUMENT_PATH.to_string()),
+        BOOTSTRAP_DOCUMENT_TARGET => Ok(BOOTSTRAP_DOCUMENT_PATH.to_string()),
+        DAILY_LOG_DOCUMENT_TARGET => {
+            let timezone = match timezone {
+                Some(value) => value
+                    .parse::<Tz>()
+                    .map_err(|_| MemoryServiceError::input())?,
+                None => Tz::UTC,
+            };
+            let now = Utc::now().with_timezone(&timezone);
+            Ok(format!("daily/{}.md", now.format("%Y-%m-%d")))
+        }
+        path => Ok(path.to_string()),
+    }
+}
+
+/// The legacy aliases whose canonical document path is `path`.
+///
+/// Read-side compatibility (#7505): rows stored under a pre-resolution alias
+/// (mem0 historically tagged `"memory"` verbatim) must stay reachable by
+/// their canonical path (e.g. `MEMORY.md` — the path the host's always-on
+/// prompt lane reads). `daily_log` has no fixed canonical path (its target
+/// encodes the write date), so it has no entry here.
+pub fn document_target_aliases(path: &str) -> &'static [&'static str] {
+    match path {
+        MEMORY_DOCUMENT_PATH => &[MEMORY_DOCUMENT_TARGET],
+        HEARTBEAT_DOCUMENT_PATH => &[HEARTBEAT_DOCUMENT_TARGET],
+        BOOTSTRAP_DOCUMENT_PATH => &[BOOTSTRAP_DOCUMENT_TARGET],
+        _ => &[],
+    }
+}
+
+/// Whether a stored document identity and a requested path name the same
+/// document: exact equality, or the stored identity is a legacy alias of the
+/// requested canonical path (see [`document_target_aliases`]).
+///
+/// Used by tag-based document stores (mem0 filters memories by their
+/// `target` metadata tag) so reads find both canonically-tagged rows and
+/// pre-fix alias-tagged rows.
+pub fn same_document_target(stored: &str, requested: &str) -> bool {
+    stored == requested || document_target_aliases(requested).contains(&stored)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MemoryServiceErrorKind;
+
+    #[test]
+    fn fixed_aliases_resolve_to_their_canonical_documents() {
+        assert_eq!(
+            resolve_document_target(MEMORY_DOCUMENT_TARGET, None).unwrap(),
+            MEMORY_DOCUMENT_PATH
+        );
+        assert_eq!(
+            resolve_document_target(HEARTBEAT_DOCUMENT_TARGET, None).unwrap(),
+            HEARTBEAT_DOCUMENT_PATH
+        );
+        assert_eq!(
+            resolve_document_target(BOOTSTRAP_DOCUMENT_TARGET, None).unwrap(),
+            BOOTSTRAP_DOCUMENT_PATH
+        );
+    }
+
+    #[test]
+    fn daily_log_resolves_to_today_dated_path() {
+        let resolved = resolve_document_target(DAILY_LOG_DOCUMENT_TARGET, None).unwrap();
+        assert!(
+            resolved.starts_with("daily/") && resolved.ends_with(".md"),
+            "daily_log must resolve to today's dated document, got {resolved}"
+        );
+        let date = &resolved["daily/".len()..resolved.len() - ".md".len()];
+        assert_eq!(
+            date.len(),
+            10,
+            "date component must be YYYY-MM-DD, got {date}"
+        );
+        date.parse::<chrono::NaiveDate>()
+            .expect("date component must parse");
+    }
+
+    #[test]
+    fn daily_log_accepts_a_valid_timezone_and_rejects_an_invalid_one() {
+        assert!(resolve_document_target(DAILY_LOG_DOCUMENT_TARGET, Some("Europe/Berlin")).is_ok());
+        assert_eq!(
+            resolve_document_target(DAILY_LOG_DOCUMENT_TARGET, Some("not/a-zone"))
+                .unwrap_err()
+                .kind(),
+            MemoryServiceErrorKind::Input
+        );
+    }
+
+    #[test]
+    fn ordinary_paths_pass_through_unchanged() {
+        assert_eq!(
+            resolve_document_target("notes/alpha.md", None).unwrap(),
+            "notes/alpha.md"
+        );
+    }
+
+    #[test]
+    fn alias_table_round_trips_canonical_paths() {
+        assert_eq!(
+            document_target_aliases(MEMORY_DOCUMENT_PATH),
+            &[MEMORY_DOCUMENT_TARGET]
+        );
+        assert_eq!(
+            document_target_aliases(HEARTBEAT_DOCUMENT_PATH),
+            &[HEARTBEAT_DOCUMENT_TARGET]
+        );
+        assert_eq!(
+            document_target_aliases(BOOTSTRAP_DOCUMENT_PATH),
+            &[BOOTSTRAP_DOCUMENT_TARGET]
+        );
+        assert!(document_target_aliases("notes/a.md").is_empty());
+        assert!(document_target_aliases(MEMORY_DOCUMENT_TARGET).is_empty());
+    }
+
+    #[test]
+    fn same_document_target_tolerates_legacy_aliases() {
+        assert!(same_document_target("MEMORY.md", "MEMORY.md"));
+        assert!(same_document_target("memory", "MEMORY.md"));
+        assert!(!same_document_target("HEARTBEAT.md", "MEMORY.md"));
+        assert!(!same_document_target("daily_log", "daily/2026-08-11.md"));
+        assert!(!same_document_target("MEMORY.md", "memory"));
+    }
+}

--- a/crates/domains/ironclaw_memory/src/test_support.rs
+++ b/crates/domains/ironclaw_memory/src/test_support.rs
@@ -1,13 +1,13 @@
-//! Provider-level contract suite for [`MemoryService`](crate::MemoryService)
-//! implementations.
+//! Provider-level contract suites for [`MemoryService`](crate::MemoryService)
+//! implementations and the optional conventional memory document tools.
 //!
 //! Same scaffolding pattern as `ironclaw_memory_native::contract_tests`
 //! (factory closures, one `#[tokio::test]` per contract per impl via a wiring
-//! macro): the invariants every bound memory provider must honor are defined
-//! ONCE here, and each provider crate wires the suite over a real (or
-//! stateful-fake) backing so the contract is proven per impl, not per mock.
+//! macro): an invariant is defined ONCE here, and each applicable provider
+//! wires the suite over a real (or stateful-fake) backing so the contract is
+//! proven per impl, not per mock.
 //!
-//! Contracts:
+//! The lifecycle contracts every applicable provider wires:
 //! - **Scope isolation** across tenant/user/agent/project: content written in
 //!   one scope is invisible to retrieval in any scope differing on any axis.
 //! - **Lane disjointness** (F4 regression) for providers declaring BOTH
@@ -18,19 +18,32 @@
 //!   providers declaring the hook: a recorded exchange reports
 //!   `recorded: true` and is retrievable from the short-term lane.
 //!
+//! The optional conventional document-tool contract:
+//! - **Target-alias resolution** (#7505): a provider declaring the conventional
+//!   `ironclaw.memory.write` + `.read` tools with the shared prompt/schema must
+//!   return a fact written with `target: "memory"` at canonical `MEMORY.md`,
+//!   never store/read it only under the alias.
+//!
 //! F6 note (owner decision, 2026-07-27): there is deliberately NO profile-CAS
 //! contract — profile-write atomicity is per-provider (native CASes; mem0
 //! read-merge-writes), accepted variance behind the shared tool id.
 //!
-//! Tool surfaces are provider-owned (registry-routed handlers), so the suite
-//! cannot seed content through a shared trait method: each wiring supplies a
-//! SEED async closure that writes through the provider's own write operation.
+//! Tool surfaces are provider-owned (registry-routed handlers). The
+//! `memory_service_contract_*` macros therefore take a SEED closure only for
+//! arranging lifecycle-test content; they do NOT require a provider to expose
+//! document tools. A provider that opts into the conventional
+//! `ironclaw.memory.write` + `.read` surface separately wires
+//! [`memory_document_tool_contract!`] with WRITE and READ closures through its
+//! own inherent tool operations.
 //!
-//! Wire with [`memory_service_contract_full!`] (both lanes + recording — the
-//! native shape) or [`memory_service_contract_retrieval_only!`] (a
-//! long-term-only provider — the mem0 shape); both take
-//! `(label, factory, seed)` where `seed` is
-//! `async |service, invocation, write_request| { … }`.
+//! Lifecycle wiring:
+//! - [`memory_service_contract_full!`] `(label, factory, seed)` for both lanes
+//!   plus recording (the native shape).
+//! - [`memory_service_contract_retrieval_only!`] `(label, factory, seed)` for a
+//!   long-term-only provider (the mem0 shape).
+//!
+//! Optional document-tool wiring:
+//! - [`memory_document_tool_contract!`] `(label, factory, write, read)`.
 
 use ironclaw_host_api::{
     ids::{AgentId, CorrelationId, InvocationId, ProjectId, TenantId, ThreadId, UserId},
@@ -38,9 +51,10 @@ use ironclaw_host_api::{
 };
 
 use crate::{
-    MemoryContextProfileId, MemoryInteractionMessage, MemoryInteractionRole, MemoryInvocation,
-    MemoryService, MemoryServiceContextRequest, MemoryServiceContextSnippet,
-    MemoryServiceRecordRequest, MemoryServiceWriteRequest,
+    MEMORY_DOCUMENT_PATH, MEMORY_DOCUMENT_TARGET, MemoryContextProfileId, MemoryInteractionMessage,
+    MemoryInteractionRole, MemoryInvocation, MemoryService, MemoryServiceContextRequest,
+    MemoryServiceContextSnippet, MemoryServiceError, MemoryServiceReadRequest,
+    MemoryServiceReadResponse, MemoryServiceRecordRequest, MemoryServiceWriteRequest,
 };
 
 /// Base scope every contract writes under: the full four-axis tuple, so each
@@ -374,9 +388,59 @@ where
     );
 }
 
-/// Wire the FULL provider contract suite (both retrieval lanes + interaction
-/// recording — the shape native declares). `$factory` must return a fresh
-/// service over a fresh backing per call.
+/// Optional conventional document-tool contract (#7505): a provider that
+/// declares `ironclaw.memory.write` + `.read` with the shared prompt/schema
+/// resolves their target aliases identically. A fact written with
+/// `target: "memory"` (the alias the shared write prompt teaches) must be
+/// returned by a read of canonical `MEMORY.md` — the path the host's
+/// always-on prompt lane reads. A provider that stores the alias unresolved
+/// (or skips compatibility matching on its read path) fails this contract.
+pub async fn target_aliases_resolve_to_canonical_documents<S, F, Write, Read>(
+    factory: F,
+    write: Write,
+    read: Read,
+) where
+    S: MemoryService,
+    F: Fn() -> S,
+    Write: AsyncFn(&S, MemoryInvocation, MemoryServiceWriteRequest),
+    Read: AsyncFn(
+        &S,
+        MemoryInvocation,
+        MemoryServiceReadRequest,
+    ) -> Result<MemoryServiceReadResponse, MemoryServiceError>,
+{
+    let service = factory();
+    let inv = invocation(base_scope());
+    write(
+        &service,
+        inv.clone(),
+        write_request(MEMORY_DOCUMENT_TARGET, "alias contract marker ibis"),
+    )
+    .await;
+
+    let canonical = read(
+        &service,
+        inv,
+        MemoryServiceReadRequest {
+            path: MEMORY_DOCUMENT_PATH.to_string(),
+        },
+    )
+    .await
+    .expect("reading the canonical document must succeed (not fail or report absent)");
+    assert!(
+        canonical.content.contains("alias contract marker ibis"),
+        "a fact written with `target: \"memory\"` must be readable at `MEMORY.md` — \
+         a provider that stores the alias unresolved fails the optional conventional \
+         document-tool contract (#7505); read back: {:?}",
+        canonical.content
+    );
+}
+
+/// Wire the FULL provider lifecycle contract suite (both retrieval lanes +
+/// interaction recording — the native shape). `$factory` must return a fresh
+/// service over a fresh backing per call. `$seed` arranges test content
+/// through a provider-specific seam; it does not imply a model-facing write
+/// tool.
 #[macro_export]
 macro_rules! memory_service_contract_full {
     ($label:ident, $factory:expr, $seed:expr) => {
@@ -404,10 +468,10 @@ macro_rules! memory_service_contract_full {
     };
 }
 
-/// Wire the contract suite for a provider declaring ONLY the long-term
-/// retrieval lane (the mem0 shape): scope isolation applies; the lane and
-/// recording contracts do not (those hooks are undeclared, so the host never
-/// calls them).
+/// Wire the provider lifecycle contract suite for a provider declaring ONLY
+/// the long-term retrieval lane (the mem0 shape): scope isolation applies;
+/// lane and recording contracts do not (those hooks are undeclared, so the
+/// host never calls them). `$seed` need not be a model-facing tool.
 #[macro_export]
 macro_rules! memory_service_contract_retrieval_only {
     ($label:ident, $factory:expr, $seed:expr) => {
@@ -418,6 +482,27 @@ macro_rules! memory_service_contract_retrieval_only {
             async fn scope_isolation_across_tenant_user_agent_project() {
                 $crate::test_support::scope_isolation_across_tenant_user_agent_project(
                     $factory, $seed,
+                )
+                .await;
+            }
+        }
+    };
+}
+
+/// Wire the OPTIONAL conventional document-tool contract for a provider
+/// whose manifest declares `ironclaw.memory.write` + `.read` with the shared
+/// prompt/schema vocabulary. Providers exposing different tools do not wire
+/// this suite.
+#[macro_export]
+macro_rules! memory_document_tool_contract {
+    ($label:ident, $factory:expr, $write:expr, $read:expr) => {
+        mod $label {
+            use super::*;
+
+            #[tokio::test]
+            async fn target_aliases_resolve_to_canonical_documents() {
+                $crate::test_support::target_aliases_resolve_to_canonical_documents(
+                    $factory, $write, $read,
                 )
                 .await;
             }

--- a/crates/extensions/packages/mem0/src/service.rs
+++ b/crates/extensions/packages/mem0/src/service.rs
@@ -336,9 +336,10 @@ impl Mem0MemoryService {
         // document reads back scrambled. `sort_by` is stable, so fragments that
         // share (or lack) a `created_at` keep their relative list order.
         //
-        // Tag matching is alias-aware (#7505): new writes are tagged with the
-        // canonical path (`MEMORY.md`), and pre-fix rows tagged with the legacy
-        // alias (`memory`) must stay reachable by that same canonical path.
+        // Tag matching is alias-aware and symmetric (#7505): new writes are
+        // tagged with the canonical path (`MEMORY.md`), pre-fix rows tagged
+        // with the legacy alias (`memory`) stay reachable by that canonical
+        // path, and alias-path reads still find canonical-tagged rows.
         let mut fragments: Vec<&Value> = response_items(&response.body)
             .map_err(MemoryServiceError::operation_from)?
             .into_iter()
@@ -910,13 +911,15 @@ mod tests {
     async fn read_matches_legacy_alias_tags_alongside_canonical_paths() {
         // #7505: pre-fix rows tagged with the legacy alias (`memory`) must stay
         // reachable by the canonical path (`MEMORY.md` — what the host's
-        // always-on lane reads), alongside post-fix canonical tags.
+        // always-on lane reads), alongside post-fix canonical tags. The match
+        // is symmetric: an alias-path read finds the canonical-tagged rows
+        // too, preserving the pre-fix write-then-read-by-alias round-trip.
         let (service, _transport) = service_with(MockMem0Transport::always_ok(json!([
             { "memory": "legacy alias row", "metadata": { "target": "memory" } },
             { "memory": "canonical row", "metadata": { "target": "MEMORY.md" } },
             { "memory": "other doc", "metadata": { "target": "HEARTBEAT.md" } }
         ])));
-        let read = service
+        let canonical = service
             .read(
                 invocation(),
                 MemoryServiceReadRequest {
@@ -926,8 +929,23 @@ mod tests {
             .await
             .expect("read should succeed");
         assert_eq!(
-            read.content, "legacy alias row\ncanonical row",
+            canonical.content, "legacy alias row\ncanonical row",
             "both the legacy-alias and canonical tags must reconstruct the document"
+        );
+
+        let by_alias = service
+            .read(
+                invocation(),
+                MemoryServiceReadRequest {
+                    path: "memory".to_string(),
+                },
+            )
+            .await
+            .expect("alias-path read should succeed");
+        assert_eq!(
+            by_alias.content, "legacy alias row\ncanonical row",
+            "an alias-path read must also find canonical-tagged rows (same_document_target is \
+             symmetric)"
         );
     }
 

--- a/crates/extensions/packages/mem0/src/service.rs
+++ b/crates/extensions/packages/mem0/src/service.rs
@@ -26,6 +26,18 @@
 //! | `profile_set`      | read-merge-write a `kind=profile` memory       | good     |
 //! | `profile_read`     | latest `kind=profile` memory bytes             | loose    |
 //!
+//! ## Conventional document-tool target aliases (#7505)
+//!
+//! This provider declares `ironclaw.memory.write` + `.read` with the same
+//! prompt/schema as native, so its `target` tag follows that optional shared
+//! vocabulary. The tag stored in mem0 metadata is the CANONICAL document path,
+//! resolved through `ironclaw_memory::resolve_document_target`: a write with
+//! `target: "memory"` is tagged `MEMORY.md`, exactly as native addresses it,
+//! so one logical document keeps one identity across backend swaps and the
+//! host's always-on lane (`read_document("MEMORY.md")`) finds it. Reads use
+//! `ironclaw_memory::same_document_target`, so rows tagged with a pre-fix
+//! legacy alias remain reachable by their canonical path.
+//!
 //! ## `infer=false` (verbatim) document-tool mapping
 //!
 //! mem0's `add` defaults to running an LLM to *extract facts* from the message
@@ -48,7 +60,7 @@ use ironclaw_memory::{
     MemoryServiceReadResponse, MemoryServiceSearchRequest, MemoryServiceSearchResponse,
     MemoryServiceSearchResult, MemoryServiceTreeRequest, MemoryServiceTreeResponse,
     MemoryServiceWriteRequest, MemoryServiceWriteResponse, MemoryWriteStatus,
-    memory_context_disabled,
+    memory_context_disabled, resolve_document_target, same_document_target,
 };
 use serde_json::{Map, Value, json};
 
@@ -276,7 +288,13 @@ impl Mem0MemoryService {
             return Err(MemoryServiceError::input());
         }
         let namespace = self.scoped_namespace(&invocation.scope);
-        let metadata = json!({ TARGET_KEY: request.target, SOURCE_KEY: SOURCE_VALUE });
+        // Target aliases are contract vocabulary (#7505): resolve through the
+        // domain-owned table so the stored tag is the CANONICAL document path
+        // (`target: "memory"` → `MEMORY.md`), matching what the host's
+        // always-on lane reads. Never store the alias unresolved.
+        let resolved_target =
+            resolve_document_target(&request.target, request.timezone.as_deref())?;
+        let metadata = json!({ TARGET_KEY: resolved_target, SOURCE_KEY: SOURCE_VALUE });
         let body = self.add_body(&namespace, &request.content, metadata);
         let response = self
             .transport
@@ -286,7 +304,10 @@ impl Mem0MemoryService {
         ensure_success(&response, "write").map_err(MemoryServiceError::operation_from)?;
         Ok(MemoryServiceWriteResponse {
             status: MemoryWriteStatus::Written,
-            path: request.target,
+            // Report the canonical path (native reports its resolved path
+            // too), so the model learns the document's real address, not the
+            // alias it wrote with.
+            path: resolved_target,
             // mem0 is inherently additive: every write adds a memory.
             append: true,
             content_length: request.content.len(),
@@ -314,10 +335,17 @@ impl Mem0MemoryService {
         // fragments by `created_at` before joining; otherwise an append-style
         // document reads back scrambled. `sort_by` is stable, so fragments that
         // share (or lack) a `created_at` keep their relative list order.
+        //
+        // Tag matching is alias-aware (#7505): new writes are tagged with the
+        // canonical path (`MEMORY.md`), and pre-fix rows tagged with the legacy
+        // alias (`memory`) must stay reachable by that same canonical path.
         let mut fragments: Vec<&Value> = response_items(&response.body)
             .map_err(MemoryServiceError::operation_from)?
             .into_iter()
-            .filter(|item| item_metadata_str(item, TARGET_KEY) == Some(request.path.as_str()))
+            .filter(|item| {
+                item_metadata_str(item, TARGET_KEY)
+                    .is_some_and(|stored| same_document_target(stored, &request.path))
+            })
             .collect();
         fragments.sort_by(|left, right| item_created_at(left).cmp(item_created_at(right)));
         let parts: Vec<String> = fragments
@@ -655,6 +683,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_resolves_target_aliases_to_canonical_paths_before_storing() {
+        // #7505: the stored `target` tag must be the canonical document path
+        // (`MEMORY.md`), never the alias the model wrote with — the host's
+        // always-on lane reads the canonical path.
+        let (service, transport) =
+            service_with(MockMem0Transport::always_ok(json!({ "id": "m-1" })));
+        let response = service
+            .write(
+                invocation(),
+                MemoryServiceWriteRequest {
+                    target: "memory".to_string(),
+                    content: "durable fact via alias".to_string(),
+                    append: true,
+                    old_string: None,
+                    new_string: None,
+                    replace_all: false,
+                    metadata: None,
+                    timezone: None,
+                },
+            )
+            .await
+            .expect("write should succeed");
+        assert_eq!(
+            response.path, "MEMORY.md",
+            "the write response must report the canonical path, not the alias"
+        );
+
+        let recorded = transport.recorded();
+        assert_eq!(recorded.len(), 1);
+        let body = recorded[0].body.as_ref().expect("add body");
+        assert_eq!(
+            body["metadata"]["target"],
+            json!("MEMORY.md"),
+            "a `target: \"memory\"` write must be tagged with the canonical document path"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_resolves_daily_log_through_the_shared_timezone_rule() {
+        let (service, transport) =
+            service_with(MockMem0Transport::always_ok(json!({ "id": "m-1" })));
+        service
+            .write(
+                invocation(),
+                MemoryServiceWriteRequest {
+                    target: "daily_log".to_string(),
+                    content: "today's log entry".to_string(),
+                    append: true,
+                    old_string: None,
+                    new_string: None,
+                    replace_all: false,
+                    metadata: None,
+                    timezone: Some("Europe/Berlin".to_string()),
+                },
+            )
+            .await
+            .expect("write should succeed");
+        let recorded = transport.recorded();
+        assert_eq!(recorded.len(), 1);
+        let stored = recorded[0].body.as_ref().expect("add body")["metadata"]["target"]
+            .as_str()
+            .expect("target tag");
+        assert!(
+            stored.starts_with("daily/") && stored.ends_with(".md"),
+            "daily_log must resolve to today's dated canonical path, got {stored}"
+        );
+
+        let invalid = service
+            .write(
+                invocation(),
+                MemoryServiceWriteRequest {
+                    target: "daily_log".to_string(),
+                    content: "rejected".to_string(),
+                    append: true,
+                    old_string: None,
+                    new_string: None,
+                    replace_all: false,
+                    metadata: None,
+                    timezone: Some("not/a-zone".to_string()),
+                },
+            )
+            .await
+            .expect_err("an invalid timezone must fail the write");
+        assert_eq!(invalid.kind(), MemoryServiceErrorKind::Input);
+    }
+
+    #[tokio::test]
     async fn write_patch_is_unsupported() {
         let (service, _transport) = service_with(MockMem0Transport::always_ok(json!({})));
         let error = service
@@ -789,6 +904,31 @@ mod tests {
             .await
             .expect_err("absent target is not found");
         assert_eq!(missing.kind(), MemoryServiceErrorKind::Input);
+    }
+
+    #[tokio::test]
+    async fn read_matches_legacy_alias_tags_alongside_canonical_paths() {
+        // #7505: pre-fix rows tagged with the legacy alias (`memory`) must stay
+        // reachable by the canonical path (`MEMORY.md` — what the host's
+        // always-on lane reads), alongside post-fix canonical tags.
+        let (service, _transport) = service_with(MockMem0Transport::always_ok(json!([
+            { "memory": "legacy alias row", "metadata": { "target": "memory" } },
+            { "memory": "canonical row", "metadata": { "target": "MEMORY.md" } },
+            { "memory": "other doc", "metadata": { "target": "HEARTBEAT.md" } }
+        ])));
+        let read = service
+            .read(
+                invocation(),
+                MemoryServiceReadRequest {
+                    path: "MEMORY.md".to_string(),
+                },
+            )
+            .await
+            .expect("read should succeed");
+        assert_eq!(
+            read.content, "legacy alias row\ncanonical row",
+            "both the legacy-alias and canonical tags must reconstruct the document"
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/packages/mem0/tests/memory_service_contract.rs
+++ b/crates/extensions/packages/mem0/tests/memory_service_contract.rs
@@ -121,3 +121,23 @@ ironclaw_memory::memory_service_contract_retrieval_only!(
             .expect("seed write through mem0's own write operation");
     }
 );
+
+// The mem0 manifest separately declares the OPTIONAL conventional
+// `ironclaw.memory.write` + `.read` tool pair with the same prompt/schema as
+// native, so it also opts into the document-target vocabulary contract.
+ironclaw_memory::memory_document_tool_contract!(
+    mem0_document_tools,
+    || Mem0MemoryService::new(
+        Arc::new(FakeMem0Server::default()),
+        Mem0Config { app_id: None },
+    ),
+    async |service: &Mem0MemoryService, invocation, request| {
+        service
+            .write(invocation, request)
+            .await
+            .expect("write through mem0's conventional document tool");
+    },
+    async |service: &Mem0MemoryService, invocation, request| {
+        service.read(invocation, request).await
+    }
+);

--- a/crates/extensions/packages/memory-native/src/service.rs
+++ b/crates/extensions/packages/memory-native/src/service.rs
@@ -13,13 +13,12 @@ use crate::{
     MemoryWriteOutcome, RepositoryMemoryBackend,
 };
 use async_trait::async_trait;
-use chrono::Utc;
-use chrono_tz::Tz;
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::ids::ThreadId;
 use ironclaw_memory::{
-    DocumentMetadata, MemoryContext, MemoryDocumentPath, MemoryDocumentScope,
-    PromptSafetyAllowanceId, PromptWriteSafetyEventSink, content_bytes_sha256,
+    BOOTSTRAP_DOCUMENT_PATH, BOOTSTRAP_DOCUMENT_TARGET, DocumentMetadata, MemoryContext,
+    MemoryDocumentPath, MemoryDocumentScope, PromptSafetyAllowanceId, PromptWriteSafetyEventSink,
+    content_bytes_sha256, resolve_document_target,
 };
 use ironclaw_memory::{
     MemoryInteractionMessage, MemoryInvocation, MemoryProfileSetStatus, MemoryService,
@@ -39,9 +38,6 @@ use serde_json::{Map, Value, json};
 // republish them under `ironclaw_memory_native::` — and this module exports
 // only `NativeMemoryService`, the native adapter implemented below.
 
-const MEMORY_PATH: &str = "MEMORY.md";
-const HEARTBEAT_PATH: &str = "HEARTBEAT.md";
-const BOOTSTRAP_PATH: &str = "BOOTSTRAP.md";
 const PROFILE_DOCUMENT_PATH: &str = "context/profile.json";
 const MAX_MEMORY_PATCH_RETRIES: usize = 8;
 
@@ -131,7 +127,9 @@ impl NativeMemoryService {
     ) -> Result<MemoryServiceWriteResponse, MemoryServiceError> {
         reject_local_or_traversal_path(&request.target)?;
         let (scope, context) = self.scoped_context(&invocation)?;
-        let resolved_path = resolve_target_path(&request.target, request.timezone.as_deref())?;
+        // Native declares the conventional document-tool vocabulary; resolve
+        // its aliases through the shared domain table (#7505), never locally.
+        let resolved_path = resolve_document_target(&request.target, request.timezone.as_deref())?;
         // The `threads/` namespace is reserved for per-thread short-term scratch
         // written ONLY by the trusted after-turn recorder via `record_interaction`
         // (which routes through `write_reserved_document`, bypassing this guard). A
@@ -145,8 +143,10 @@ impl NativeMemoryService {
         let path = document_path(&scope, &resolved_path)?;
         let options = write_options(request.metadata.as_ref());
 
-        if request.target == "bootstrap" {
-            if path.relative_path() != BOOTSTRAP_PATH || resolved_path != BOOTSTRAP_PATH {
+        if request.target == BOOTSTRAP_DOCUMENT_TARGET {
+            if path.relative_path() != BOOTSTRAP_DOCUMENT_PATH
+                || resolved_path != BOOTSTRAP_DOCUMENT_PATH
+            {
                 return Err(MemoryServiceError::operation());
             }
             let context = context.clone().with_prompt_write_safety_allowance(
@@ -491,7 +491,7 @@ impl NativeMemoryService {
             return Err(MemoryServiceError::input());
         }
         let (scope, context) = self.scoped_context(invocation)?;
-        let resolved_path = resolve_target_path(target, None)?;
+        let resolved_path = resolve_document_target(target, None)?;
         // Defense in depth: this bypass writes ONLY the reserved `threads/`
         // namespace. Reject anything else so a future caller cannot smuggle an
         // arbitrary path past the public `write` guard through this helper.
@@ -590,25 +590,6 @@ fn build_native_backend(
         backend = backend.with_prompt_write_safety_event_sink(prompt_write_safety_event_sink);
     }
     Arc::new(backend)
-}
-
-fn resolve_target_path(target: &str, timezone: Option<&str>) -> Result<String, MemoryServiceError> {
-    match target {
-        "memory" => Ok(MEMORY_PATH.to_string()),
-        "heartbeat" => Ok(HEARTBEAT_PATH.to_string()),
-        "bootstrap" => Ok(BOOTSTRAP_PATH.to_string()),
-        "daily_log" => {
-            let timezone = match timezone {
-                Some(value) => value
-                    .parse::<Tz>()
-                    .map_err(|_| MemoryServiceError::input())?,
-                None => Tz::UTC,
-            };
-            let now = Utc::now().with_timezone(&timezone);
-            Ok(format!("daily/{}.md", now.format("%Y-%m-%d")))
-        }
-        path => Ok(path.to_string()),
-    }
 }
 
 fn document_path(

--- a/crates/extensions/packages/memory-native/tests/memory_service_contract.rs
+++ b/crates/extensions/packages/memory-native/tests/memory_service_contract.rs
@@ -1268,3 +1268,20 @@ ironclaw_memory::memory_service_contract_full!(
             .expect("seed write through native's own write operation");
     }
 );
+
+// The native manifest separately declares the OPTIONAL conventional
+// `ironclaw.memory.write` + `.read` tool pair with the shared prompt/schema,
+// so it also opts into the document-target vocabulary contract (#7505).
+ironclaw_memory::memory_document_tool_contract!(
+    native_document_tools,
+    || NativeMemoryService::from_filesystem(Arc::new(InMemoryBackend::new()), None),
+    async |service: &NativeMemoryService, invocation, request| {
+        service
+            .write(invocation, request)
+            .await
+            .expect("write through native's conventional document tool");
+    },
+    async |service: &NativeMemoryService, invocation, request| {
+        service.read(invocation, request).await
+    }
+);

--- a/crates/extensions/packages/memory-native/tests/memory_service_contract.rs
+++ b/crates/extensions/packages/memory-native/tests/memory_service_contract.rs
@@ -102,6 +102,67 @@ async fn native_provider_reads_writes_lists_and_searches_through_memory_service(
 }
 
 #[tokio::test]
+async fn native_write_resolves_daily_log_through_the_shared_timezone_rule() {
+    // Caller-level pin of the domain resolver's timezone contract through
+    // native's own write seam (#7505 review): an invalid timezone fails the
+    // write, a valid one lands at today's dated document and round-trips.
+    let service = NativeMemoryService::from_filesystem(Arc::new(InMemoryBackend::new()), None);
+
+    let invalid = service
+        .write(
+            invocation(),
+            MemoryServiceWriteRequest {
+                target: "daily_log".to_string(),
+                content: "timezone should reject".to_string(),
+                append: true,
+                old_string: None,
+                new_string: None,
+                replace_all: false,
+                metadata: None,
+                timezone: Some("not/a-zone".to_string()),
+            },
+        )
+        .await
+        .expect_err("an invalid timezone must fail native write");
+    assert_eq!(invalid.kind(), MemoryServiceErrorKind::Input);
+
+    let written = service
+        .write(
+            invocation(),
+            MemoryServiceWriteRequest {
+                target: "daily_log".to_string(),
+                content: "berlin log entry".to_string(),
+                append: true,
+                old_string: None,
+                new_string: None,
+                replace_all: false,
+                metadata: None,
+                timezone: Some("Europe/Berlin".to_string()),
+            },
+        )
+        .await
+        .expect("a valid timezone write must succeed");
+    assert!(
+        written.path.starts_with("daily/") && written.path.ends_with(".md"),
+        "daily_log must resolve to today's dated canonical path, got {:?}",
+        written.path
+    );
+
+    let read = service
+        .read(
+            invocation(),
+            MemoryServiceReadRequest { path: written.path },
+        )
+        .await
+        .expect("the daily log must round-trip at the resolved path");
+    assert!(
+        read.content.contains("berlin log entry"),
+        "the daily log write must be readable back, got {:?}",
+        read.content
+    );
+}
+
+#[tokio::test]
 async fn native_search_preserves_oversized_provider_result() {
     const QUERY: &str = "needle";
     const RESULT_BOUND: usize = 8 * 1024;


### PR DESCRIPTION
## Summary

- **The bug:** the two bundled providers declare the same conventional `ironclaw.memory.write` / `.read` tools and reuse the same prompt/schema, but only native resolved the prompt's target aliases. mem0 stored `target: "memory"` verbatim, so a canonical `MEMORY.md` read could never find it.
- **Ownership:** add the optional conventional document-tool target vocabulary to `ironclaw_memory`, beside the capability IDs, request DTOs, and wire helpers that already define those shared tools. This is **not** a requirement on every `MemoryService` provider: providers may expose different tools or none, exactly as `service.rs` documents.
- **Providers:** native deletes its private alias table and uses the shared resolver. mem0 resolves aliases before storing `metadata.target`, reports the canonical path, and matches legacy alias tags on reads so pre-existing `"memory"` rows remain reachable at `MEMORY.md`.
- **Conformance:** lifecycle conformance remains independent and keeps its original `(factory, seed)` shape. A new, separate opt-in `memory_document_tool_contract!` is wired only by providers whose manifests declare the conventional write/read pair with the shared prompt/schema. Both bundled providers opt in; a future lifecycle-only or custom-tool provider does not.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #7505

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_memory -p ironclaw_memory_native -p ironclaw_memory_mem0 --all-targets --all-features -- -D warnings`
- [x] Relevant tests pass: see Test Strategy
- [x] `cargo test -p ironclaw_architecture_tests` — 290 passed
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable: no database schema/runtime wiring changed; provider behavior is covered through the provider conformance seam and mem0 stateful fake
- [ ] Manual testing — not applicable beyond the automated provider seams
- [ ] `review-pr` / `pr-shepherd --fix` — not run

## Test Strategy

**User behavior:** a fact saved through mem0's conventional write tool with `target: "memory"` is readable at `MEMORY.md`; pre-existing mem0 rows tagged with legacy `"memory"` remain readable.

Risk areas:
- [x] Model behavior — mem0 now reports the canonical path in its write response; prompt wording is unchanged
- [ ] Browser
- [x] Side effect — new mem0 rows store the canonical target tag
- [x] Persistence — legacy alias tags remain readable; no migration/deletion
- [ ] Security or permissions
- [x] External provider — mem0 adapter mapping
- [x] Cross-component behavior — optional domain tool vocabulary → native/mem0 adapters → opt-in conformance

Tests added or updated:
- **Unit or contract:**
  - `ironclaw_memory` target vocabulary: fixed aliases, timezone-aware `daily_log`, invalid timezone, pass-through paths, legacy alias identity.
  - New opt-in `memory_document_tool_contract!`: write `target: "memory"`, read `MEMORY.md`, require the fact. The existing lifecycle macros no longer know about or require document tools.
  - Native and mem0 explicitly opt in because both manifests declare `ironclaw.memory.write` + `.read` with the shared prompt/schema.
  - mem0 unit tests pin canonical stored/write-response path, shared `daily_log` timezone behavior, and legacy `"memory"` + canonical `MEMORY.md` read compatibility.
- **Reborn integration:** Not applicable; no host/composition wiring changed.
- **Recorded fixture:** Not applicable; wire shape is unchanged, only the target tag value is canonicalized.
- **Browser E2E:** Not applicable; no UI change.
- **Backend or runtime:** mem0 provider contract uses the stateful fake server; composition `memory_mem0_swap` remains green.
- **Live canary:** Not applicable; no credentials/live endpoint required.

**What the tests prove:** the exact divergence is fixed for providers opting into the shared document-tool vocabulary, without asserting that every memory provider ships those tools or aliases.

Commands run:

```text
cargo fmt --all -- --check
cargo test -p ironclaw_memory -p ironclaw_memory_native -p ironclaw_memory_mem0
# 213 passed across 13 suites; 3 ignored
cargo clippy -p ironclaw_memory -p ironclaw_memory_native -p ironclaw_memory_mem0 --all-targets --all-features -- -D warnings
cargo test -p ironclaw_host_runtime --test first_party_builtin_tools memory_write
cargo test -p ironclaw_host_runtime --test memory_prompt_context
cargo test -p ironclaw_composition --features memory-mem0 --test memory_mem0_swap
cargo test -p ironclaw_architecture_tests
# 290 passed across 40 suites
```

Not run: Postgres-gated suites, browser E2E, live mem0 probe, full workspace test.
