### PR TITLE
chore: enable IronLoop tester

### DIFF
--- a/.ironloop/config.yaml
+++ b/.ironloop/config.yaml
@@ -16,3 +16,6 @@ resolver:
   auto_resolve:
     enabled: true
     max_runs: 10
+
+tester:
+  network_access: true


### PR DESCRIPTION
Enables the QA role with network access so IronLoop can run preview QA on IronClaw pull requests.