### PR TITLE
fix(automations): reject unusable scheduled output

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
@@ -677,7 +677,11 @@ fn reborn_contracts_crates_carry_a_checked_size_ceiling() {
         // `RuntimeCredentialTarget::Basic` declaration, username validation,
         // and wire-contract vocabulary; RFC 7617 composition remains in
         // ironclaw_host_runtime.
-        ("ironclaw_host_api", 18_994),
+        // 18_994 -> 19_017 (#7525): add the typed
+        // `UnattendedQuestionEndingResponse` invalid-output reason and its
+        // sanitized user-facing summary. Classification and recovery remain in
+        // ironclaw_agent_loop; this crate owns only shared failure vocabulary.
+        ("ironclaw_host_api", 19_017),
         // 14_479 -> 13_949 (2026-08-07, #7157): downward re-capture after the
         // delivery-heuristic vocabulary (stored trigger delivery targets and
         // their run-profile plumbing) left this crate with the two-lane

--- a/crates/contracts/ironclaw_host_api/src/failure/summary.rs
+++ b/crates/contracts/ironclaw_host_api/src/failure/summary.rs
@@ -283,6 +283,9 @@ impl ModelInvalidOutputFailureSummary for ModelInvalidOutputDetailReason {
             Self::EmptyAssistantResponse => {
                 "The run failed because the model returned an empty assistant response. Retry the run or choose a different model."
             }
+            Self::UnattendedQuestionEndingResponse => {
+                "The scheduled run failed because the model ended by asking for input when no user was present. Make the automation prompt self-contained or choose a different model."
+            }
             Self::TextualToolCallSyntax => {
                 "The run failed because the model returned a tool call as text instead of structured tool-call data. Retry the run or choose a different model."
             }
@@ -371,6 +374,17 @@ mod tests {
                 Some(ModelInvalidOutputDetailReason::EmptyAssistantResponse),
             ),
             "The run failed because the model returned an empty assistant response. Retry the run or choose a different model."
+        );
+    }
+
+    #[test]
+    fn unattended_question_detail_has_scheduled_run_guidance() {
+        assert_eq!(
+            reborn_failure_summary_for_category_and_detail(
+                Some("invalid_model_output"),
+                Some(ModelInvalidOutputDetailReason::UnattendedQuestionEndingResponse),
+            ),
+            "The scheduled run failed because the model ended by asking for input when no user was present. Make the automation prompt self-contained or choose a different model."
         );
     }
 

--- a/crates/contracts/ironclaw_host_api/src/turn.rs
+++ b/crates/contracts/ironclaw_host_api/src/turn.rs
@@ -535,6 +535,7 @@ const MODEL_INVALID_OUTPUT_DETAIL_MAX_BYTES: usize = 512;
 #[serde(rename_all = "snake_case")]
 pub enum ModelInvalidOutputDetailReason {
     EmptyAssistantResponse,
+    UnattendedQuestionEndingResponse,
     TextualToolCallSyntax,
     OutsideCapabilitySurface,
     ToolUseFinishWithoutToolCalls,
@@ -551,6 +552,9 @@ impl ModelInvalidOutputDetailReason {
     pub fn safe_summary(self) -> &'static str {
         match self {
             Self::EmptyAssistantResponse => "model returned an empty assistant response",
+            Self::UnattendedQuestionEndingResponse => {
+                "scheduled run ended by requesting user input"
+            }
             Self::TextualToolCallSyntax => {
                 "model returned textual tool-call syntax instead of structured tool calls"
             }
@@ -572,6 +576,7 @@ impl ModelInvalidOutputDetailReason {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::EmptyAssistantResponse => "empty_assistant_response",
+            Self::UnattendedQuestionEndingResponse => "unattended_question_ending_response",
             Self::TextualToolCallSyntax => "textual_tool_call_syntax",
             Self::OutsideCapabilitySurface => "outside_capability_surface",
             Self::ToolUseFinishWithoutToolCalls => "tool_use_finish_without_tool_calls",
@@ -600,6 +605,9 @@ impl ModelInvalidOutputDetailReason {
         }
         match safe_summary {
             "model returned an empty assistant response" => Some(Self::EmptyAssistantResponse),
+            "scheduled run ended by requesting user input" => {
+                Some(Self::UnattendedQuestionEndingResponse)
+            }
             "model returned textual tool-call syntax instead of structured tool calls" => {
                 Some(Self::TextualToolCallSyntax)
             }
@@ -1267,6 +1275,7 @@ mod tests {
 
         for reason in [
             Reason::EmptyAssistantResponse,
+            Reason::UnattendedQuestionEndingResponse,
             Reason::TextualToolCallSyntax,
             Reason::OutsideCapabilitySurface,
             Reason::ToolUseFinishWithoutToolCalls,

--- a/crates/loop/ironclaw_agent_loop/Cargo.toml
+++ b/crates/loop/ironclaw_agent_loop/Cargo.toml
@@ -14,7 +14,9 @@ publish = false
 layer = "loops"
 
 [features]
-test-support = []
+# Dev-only seam: downstream harnesses use `tokio::sync::Notify` to drive
+# cancellation deterministically.
+test-support = ["tokio/sync"]
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/loop/ironclaw_agent_loop/src/executor.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor.rs
@@ -47,9 +47,11 @@ use gates::{AwaitDependentRunGateInput, AwaitDependentRunGateStage, GateInput, G
 #[cfg(test)]
 use input::consume_drainable_inputs;
 use input::{DrainInput, InputStage, InputStep, UserFacingInputDrainMode};
+#[cfg(test)]
+use loop_exit::reply_trailed_off;
 use loop_exit::{
     COMPLETION_NUDGE_LIMIT, ExitInput, ExitStage, completion_nudge_control_message,
-    reply_trailed_off,
+    reply_completion_signals, scheduled_trigger_run,
 };
 use mapping::{
     batch_policy_kind, blocked_kind, capability_batch_counts, capability_error_failure_category,

--- a/crates/loop/ironclaw_agent_loop/src/executor/assistant_reply.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/assistant_reply.rs
@@ -34,7 +34,10 @@ impl ExecutorStage<AssistantReplyInput> for AssistantReplyStage {
         // Record whether this reply trailed off without a real closing answer so
         // the stop handling can decide a graceful stop warrants a tools-capable
         // completion nudge. Captured before `reply` is moved into the transcript.
-        state.last_reply_trailed_off = super::reply_trailed_off(&input.reply.content);
+        let completion_signals = super::reply_completion_signals(&input.reply.content);
+        state.last_reply_trailed_off = completion_signals.trailed_off;
+        state.last_reply_empty = completion_signals.empty;
+        state.last_reply_ended_with_question = completion_signals.ended_with_question;
         let reply_ref = ctx
             .host
             .finalize_assistant_message(FinalizeAssistantMessage { reply: input.reply })

--- a/crates/loop/ironclaw_agent_loop/src/executor/canonical.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/canonical.rs
@@ -11,7 +11,7 @@ use super::{
     DefaultExecutorPipeline, DrainInput, ExecutorStage, ExitInput, InputStep, ModelInput,
     ModelStep, PromptInput, PromptStep, ReplyAdmissionInput, ReplyAdmissionStep, StageContext,
     StopInput, StopKind, StopObservationInput, StopObservationStep, StopStep, TurnCompletedStep,
-    UserFacingInputDrainMode, latency,
+    UserFacingInputDrainMode, latency, scheduled_trigger_run,
 };
 
 impl DefaultExecutorPipeline {
@@ -305,6 +305,8 @@ impl DefaultExecutorPipeline {
                                 stop_state.completion_nudges_used += 1;
                                 stop_state.completion_nudge_pending = true;
                                 stop_state.last_reply_trailed_off = false;
+                                stop_state.last_reply_empty = false;
+                                stop_state.last_reply_ended_with_question = false;
                                 debug!(
                                     iteration = stop_state.iteration,
                                     ?kind,
@@ -530,7 +532,10 @@ fn completion_nudge_should_fire(
     }
     match kind {
         StopKind::NoProgressDetected => false,
-        StopKind::GracefulStop => state.last_reply_trailed_off,
+        StopKind::GracefulStop => {
+            state.last_reply_trailed_off
+                || (scheduled_trigger_run(host) && state.last_reply_ended_with_question)
+        }
         StopKind::Aborted(_) => false,
     }
 }

--- a/crates/loop/ironclaw_agent_loop/src/executor/loop_exit.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/loop_exit.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
+use ironclaw_host_api::turn::{ModelInvalidOutputDetailReason, SanitizedFailure, TurnOriginKind};
 use ironclaw_loop_contracts::{
-    LoopExit, LoopFailureKind, LoopInlineMessage, LoopInlineMessageBody, LoopInlineMessageRole,
+    AgentLoopDriverHost, LoopExit, LoopFailureKind, LoopInlineMessage, LoopInlineMessageBody,
+    LoopInlineMessageRole,
 };
 
 use crate::{
@@ -30,10 +32,20 @@ pub(super) const COMPLETION_NUDGE_LIMIT: u32 = 2;
 /// step — "Let me write the file:" — but emitted no tool call, so the turn ended
 /// mid-intent). Mirrors nearai-bench's `trailed_off_without_answer` so the
 /// in-loop nudge fires on the same signal the out-of-loop bench nudge used.
-pub(super) fn reply_trailed_off(content: &str) -> bool {
+pub(super) struct ReplyCompletionSignals {
+    pub(super) trailed_off: bool,
+    pub(super) empty: bool,
+    pub(super) ended_with_question: bool,
+}
+
+pub(super) fn reply_completion_signals(content: &str) -> ReplyCompletionSignals {
     let trimmed = content.trim();
     if trimmed.is_empty() {
-        return true;
+        return ReplyCompletionSignals {
+            trailed_off: true,
+            empty: true,
+            ended_with_question: false,
+        };
     }
     let last_line = trimmed.lines().next_back().unwrap_or(trimmed).trim_start();
     // A block quote at the end is displayed content, not narration of a next
@@ -41,7 +53,38 @@ pub(super) fn reply_trailed_off(content: &str) -> bool {
     // prefix and then quote it (for example `> Daily summary:`); treating that
     // literal colon as a trail-off caused two completion nudges and three
     // user-visible confirmations from one run.
-    !last_line.starts_with('>') && trimmed.ends_with(':')
+    ReplyCompletionSignals {
+        trailed_off: !last_line.starts_with('>') && trimmed.ends_with(':'),
+        empty: false,
+        ended_with_question: last_line.ends_with('?'),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn reply_trailed_off(content: &str) -> bool {
+    reply_completion_signals(content).trailed_off
+}
+
+pub(super) fn scheduled_trigger_run(host: &(dyn AgentLoopDriverHost + Send + Sync)) -> bool {
+    host.run_context()
+        .product_context
+        .as_ref()
+        .is_some_and(|context| context.origin == TurnOriginKind::ScheduledTrigger)
+}
+
+fn invalid_scheduled_final_output(
+    host: &(dyn AgentLoopDriverHost + Send + Sync),
+    state: &LoopExecutionState,
+) -> Option<ModelInvalidOutputDetailReason> {
+    if !scheduled_trigger_run(host) {
+        return None;
+    }
+    if state.last_reply_empty {
+        return Some(ModelInvalidOutputDetailReason::EmptyAssistantResponse);
+    }
+    state
+        .last_reply_ended_with_question
+        .then_some(ModelInvalidOutputDetailReason::UnattendedQuestionEndingResponse)
 }
 
 /// Inline control message carrying the completion-nudge instruction. Delivered
@@ -89,6 +132,33 @@ impl ExitStage {
         state: LoopExecutionState,
         kind: StopKind,
     ) -> Result<LoopExit, AgentLoopExecutorError> {
+        if matches!(kind, StopKind::GracefulStop)
+            && let Some(detail_reason) = invalid_scheduled_final_output(ctx.host, &state)
+        {
+            let mut state = match CheckpointStage.cancel_if_requested(ctx, state).await? {
+                CancelCheck::Continue(state) => *state,
+                CancelCheck::Exit(exit) => return Ok(exit),
+            };
+            let failure_kind = LoopFailureKind::InvalidModelOutput;
+            let explanation_message_ref =
+                attach_failure_explanation(ctx, &mut state, failure_kind).await?;
+            let checked = CheckpointStage
+                .write(ctx, state, CheckpointKind::Final)
+                .await?;
+            return failed_exit(
+                ctx.host,
+                checked.state,
+                failure_kind,
+                Some(checked.checkpoint_id),
+                FailedExitDetails {
+                    safe_summary: Some(
+                        SanitizedFailure::from_trusted_static(failure_kind.as_str())
+                            .with_detail(detail_reason.safe_summary()),
+                    ),
+                    explanation_message_ref,
+                },
+            );
+        }
         match kind {
             StopKind::GracefulStop => {
                 let checked = CheckpointStage

--- a/crates/loop/ironclaw_agent_loop/src/executor/reply_admission.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/reply_admission.rs
@@ -22,7 +22,7 @@ use crate::{
     strategies::ReplyAdmissionOutcome,
 };
 
-use super::{AgentLoopExecutorError, ExecutorStage, StageContext};
+use super::{AgentLoopExecutorError, ExecutorStage, StageContext, scheduled_trigger_run};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct ReplyAdmissionStage;
@@ -62,12 +62,20 @@ impl ExecutorStage<ReplyAdmissionInput> for ReplyAdmissionStage {
         input: ReplyAdmissionInput,
     ) -> Result<ReplyAdmissionStep, AgentLoopExecutorError> {
         let mut state = input.state;
-        match ctx
-            .planner
-            .reply_admission()
-            .admit_reply(&state, &input.reply)
-            .await
+        // Scheduled runs must retain an empty candidate as transcript evidence
+        // so completion handling can classify it as a typed invalid-output
+        // failure. Interactive runs keep the default admission behavior and
+        // reject empty replies before they become user-visible.
+        let admission = if scheduled_trigger_run(ctx.host) && input.reply.content.trim().is_empty()
         {
+            ReplyAdmissionOutcome::AcceptFinal
+        } else {
+            ctx.planner
+                .reply_admission()
+                .admit_reply(&state, &input.reply)
+                .await
+        };
+        match admission {
             ReplyAdmissionOutcome::AcceptFinal => {
                 // A real final reply supersedes any earlier rejected candidate.
                 // Clear the pending control state so the next turn starts clean.

--- a/crates/loop/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/tests.rs
@@ -2,8 +2,7 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use ironclaw_host_api::turn::{
-    CapabilityActivityId, GateResumeDisposition, LoopGateRef, LoopMessageRef, LoopResultRef,
-    TurnRunId,
+    CapabilityActivityId, GateResumeDisposition, LoopGateRef, LoopResultRef, TurnRunId,
 };
 use ironclaw_host_api::{
     decision::DenyReason,
@@ -2744,7 +2743,6 @@ async fn scheduled_question_after_nudge_budget_fails_and_retains_replies() {
         reply_response_with_text(questions[0]),
         reply_response_with_text(questions[1]),
         reply_response_with_text(questions[2]),
-        reply_response_with_text("The scheduled run could not produce a self-contained result."),
     ])
     .with_driver_nudges_enabled()
     .with_scheduled_trigger_origin();
@@ -2772,45 +2770,34 @@ async fn scheduled_question_after_nudge_budget_fails_and_retains_replies() {
 }
 
 #[tokio::test]
-async fn scheduled_admitted_empty_reply_fails_when_nudge_is_unavailable() {
-    let host = MockHost::new(vec![reply_response_with_text(
-        "The scheduled run returned no usable output.",
-    )])
-    .with_scheduled_trigger_origin();
-    let family = crate::families::default();
-    let ctx = StageContext {
-        planner: family.planner(),
-        host: &host,
-    };
-    let mut state = LoopExecutionState::initial_for_run(host.run_context());
-    state.last_reply_trailed_off = true;
-    state.last_reply_empty = true;
-    state
-        .assistant_refs
-        .push(LoopMessageRef::new("msg:empty-reply").expect("valid"));
+async fn scheduled_empty_reply_fails_through_canonical_executor() {
+    let host =
+        MockHost::new(vec![reply_response_with_text("   \n")]).with_scheduled_trigger_origin();
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
 
-    let exit = ExitStage
-        .process(
-            ctx,
-            ExitInput {
-                state,
-                kind: StopKind::GracefulStop,
-            },
-        )
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
         .await
-        .expect("exit stage");
+        .expect("execute");
 
     let LoopExit::Failed(failed) = exit else {
-        panic!("expected admitted empty scheduled output to fail, got {exit:?}");
+        panic!("expected empty scheduled output to fail, got {exit:?}");
     };
     assert_eq!(failed.reason_kind, LoopFailureKind::InvalidModelOutput);
-    assert!(
-        failed
-            .explanation_message_refs
-            .iter()
-            .any(|message_ref| message_ref.as_str() == "msg:empty-reply"),
-        "the rejected empty reply reference must remain in failure evidence"
+    let summary = failed
+        .safe_summary
+        .expect("empty scheduled output must carry typed failure detail");
+    assert_eq!(summary.category(), "invalid_model_output");
+    assert_eq!(
+        summary.detail(),
+        Some("model returned an empty assistant response")
     );
+    assert_eq!(
+        host.finalized_assistant_messages(),
+        vec!["   \n".to_string()]
+    );
+    assert_eq!(final_staged_state(&host).completion_nudges_used, 0);
 }
 
 #[tokio::test]

--- a/crates/loop/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/tests.rs
@@ -2,7 +2,8 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use ironclaw_host_api::turn::{
-    CapabilityActivityId, GateResumeDisposition, LoopGateRef, LoopResultRef, TurnRunId,
+    CapabilityActivityId, GateResumeDisposition, LoopGateRef, LoopMessageRef, LoopResultRef,
+    TurnRunId,
 };
 use ironclaw_host_api::{
     decision::DenyReason,
@@ -2702,6 +2703,154 @@ async fn completion_nudge_skips_confirmation_with_quoted_literal_ending_in_colon
         "a quoted literal is completed content, not an unfinished narration"
     );
     assert_eq!(host.prompt_requests().len(), 1);
+    assert_eq!(final_staged_state(&host).completion_nudges_used, 0);
+}
+
+#[tokio::test]
+async fn scheduled_question_gets_bounded_nudge_then_completes_with_answer() {
+    let host = MockHost::new(vec![
+        reply_response_with_text("Which repository should I inspect?"),
+        reply_response_with_text("Inspected nearai/ironclaw. No blocking failures found."),
+    ])
+    .with_driver_nudges_enabled()
+    .with_scheduled_trigger_origin();
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
+    assert_eq!(host.prompt_requests().len(), 2);
+    assert_eq!(final_staged_state(&host).completion_nudges_used, 1);
+    assert!(
+        host.prompt_requests()[1]
+            .inline_messages
+            .iter()
+            .any(|message| message.safe_body.as_str().contains("Finish the task now"))
+    );
+}
+
+#[tokio::test]
+async fn scheduled_question_after_nudge_budget_fails_and_retains_replies() {
+    let questions = [
+        "Which repository should I inspect?",
+        "Should I inspect the main branch?",
+        "Would you like me to continue?",
+    ];
+    let host = MockHost::new(vec![
+        reply_response_with_text(questions[0]),
+        reply_response_with_text(questions[1]),
+        reply_response_with_text(questions[2]),
+        reply_response_with_text("The scheduled run could not produce a self-contained result."),
+    ])
+    .with_driver_nudges_enabled()
+    .with_scheduled_trigger_origin();
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    let LoopExit::Failed(failed) = exit else {
+        panic!("expected invalid scheduled output to fail, got {exit:?}");
+    };
+    assert_eq!(failed.reason_kind, LoopFailureKind::InvalidModelOutput);
+    assert_eq!(final_staged_state(&host).completion_nudges_used, 2);
+    let finalized = host.finalized_assistant_messages();
+    for question in questions {
+        assert!(finalized.iter().any(|message| message == question));
+    }
+    assert!(
+        !failed.explanation_message_refs.is_empty(),
+        "the failed exit must retain assistant transcript evidence"
+    );
+}
+
+#[tokio::test]
+async fn scheduled_admitted_empty_reply_fails_when_nudge_is_unavailable() {
+    let host = MockHost::new(vec![reply_response_with_text(
+        "The scheduled run returned no usable output.",
+    )])
+    .with_scheduled_trigger_origin();
+    let family = crate::families::default();
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.last_reply_trailed_off = true;
+    state.last_reply_empty = true;
+    state
+        .assistant_refs
+        .push(LoopMessageRef::new("msg:empty-reply").expect("valid"));
+
+    let exit = ExitStage
+        .process(
+            ctx,
+            ExitInput {
+                state,
+                kind: StopKind::GracefulStop,
+            },
+        )
+        .await
+        .expect("exit stage");
+
+    let LoopExit::Failed(failed) = exit else {
+        panic!("expected admitted empty scheduled output to fail, got {exit:?}");
+    };
+    assert_eq!(failed.reason_kind, LoopFailureKind::InvalidModelOutput);
+    assert!(
+        failed
+            .explanation_message_refs
+            .iter()
+            .any(|message_ref| message_ref.as_str() == "msg:empty-reply"),
+        "the rejected empty reply reference must remain in failure evidence"
+    );
+}
+
+#[tokio::test]
+async fn interactive_question_remains_a_normal_completion() {
+    let host = MockHost::new(vec![reply_response_with_text(
+        "Which repository should I inspect?",
+    )])
+    .with_driver_nudges_enabled();
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
+    assert_eq!(host.prompt_requests().len(), 1);
+    assert_eq!(final_staged_state(&host).completion_nudges_used, 0);
+}
+
+#[tokio::test]
+async fn scheduled_answer_with_internal_question_completes_without_nudge() {
+    let answer = "Did the deployment pass? Yes. All required checks passed.";
+    let host = MockHost::new(vec![reply_response_with_text(answer)])
+        .with_driver_nudges_enabled()
+        .with_scheduled_trigger_origin();
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
+    assert_eq!(
+        host.finalized_assistant_messages(),
+        vec![answer.to_string()]
+    );
     assert_eq!(final_staged_state(&host).completion_nudges_used, 0);
 }
 

--- a/crates/loop/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -4,10 +4,11 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use ironclaw_host_api::turn::{
-    LoopMessageRef, RunProfileId, RunProfileVersion, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
+    LoopMessageRef, ProductTurnContext, RunProfileId, RunProfileVersion, TurnCheckpointId, TurnId,
+    TurnOriginKind, TurnOwner, TurnRunId, TurnScope,
 };
 use ironclaw_host_api::{
-    ids::{CapabilityId, ProviderToolName, TenantId, ThreadId},
+    ids::{CapabilityId, ProviderToolName, TenantId, ThreadId, UserId},
     runtime::RuntimeKind,
 };
 use ironclaw_loop_contracts::{
@@ -152,6 +153,18 @@ impl MockHost {
             .resolved_run_profile
             .steering_policy
             .allow_driver_specific_nudges = true;
+        self
+    }
+
+    pub(super) fn with_scheduled_trigger_origin(mut self) -> Self {
+        self.context.product_context = Some(ProductTurnContext::new(
+            TurnOriginKind::ScheduledTrigger,
+            None,
+            None,
+            TurnOwner::Personal {
+                user: UserId::new("user-executor").expect("valid"),
+            },
+        ));
         self
     }
 

--- a/crates/loop/ironclaw_agent_loop/src/state.rs
+++ b/crates/loop/ironclaw_agent_loop/src/state.rs
@@ -124,6 +124,19 @@ pub struct LoopExecutionState {
     #[serde(default)]
     pub last_reply_trailed_off: bool,
 
+    /// Whether the most recent admitted assistant reply was empty after
+    /// trimming. Kept separately from `last_reply_trailed_off` so unattended
+    /// runs can fail empty output after their bounded nudge budget without
+    /// changing the existing trailing-colon terminal behavior.
+    #[serde(default)]
+    pub last_reply_empty: bool,
+
+    /// Whether the most recent admitted assistant reply's trimmed final line
+    /// ended in a question mark. Scheduled runs cannot obtain an answer from a
+    /// user, so this drives their origin-scoped completion recovery only.
+    #[serde(default)]
+    pub last_reply_ended_with_question: bool,
+
     // strategy slots — one per strategy that mutates state.
     pub context_state: ContextStrategyState,
     pub capability_state: CapabilityStrategyState,
@@ -341,6 +354,8 @@ impl LoopExecutionState {
             pending_model_retry_directive: None,
             terminal_warning_state: TerminalWarningState::default(),
             last_reply_trailed_off: false,
+            last_reply_empty: false,
+            last_reply_ended_with_question: false,
             context_state: ContextStrategyState::default(),
             capability_state: CapabilityStrategyState::default(),
             model_state: ModelStrategyState::default(),

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -296,6 +296,14 @@ A trigger fire is synthetic inbound, not a parallel agent loop.
   preserves host approval, authentication, authorization, and policy gates.
   The trusted turn origin is the switch; an interactive run must not receive
   this protocol merely because it shares a run profile or process.
+- A graceful scheduled-trigger exit is valid only when its final assistant
+  reply is non-empty and its trimmed final line does not end in `?`. Empty
+  replies and question-ending replies use the existing bounded, tools-capable
+  completion-nudge path. If no further nudge is available, the loop exits with
+  `invalid_model_output` instead of `Completed`. Every rejected assistant reply
+  remains in the transcript and failed-exit evidence. This validation is keyed
+  on `TurnOriginKind::ScheduledTrigger`; interactive question-ending replies
+  retain their conversational completion behavior.
 
 Host-trusted trigger ingress request fields are:
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -50,7 +50,7 @@ Tier-selection rule: `.claude/rules/testing.md`.
 | Auth / credentials / OAuth | 3 | 7 | ✓ | ✓ (heaviest) |
 | Extension lifecycle | 14 | 6 | ✓ | ✓ |
 | Channels (Slack/Telegram/webhook) | 2 | 3 | ✓ | ✓ |
-| Triggers / automations / routines | 10 | 2 | ✓ | ✓ |
+| Triggers / automations / routines | 11 | 2 | ✓ | ✓ |
 | Memory & workspace | 5 | 2 | — | ✓ |
 | Skills | 1 | 1 | — | ✓ |
 | Multi-user / scope isolation | 5 | 2 | 9 | ✓ |
@@ -62,7 +62,7 @@ Tier-selection rule: `.claude/rules/testing.md`.
 | Providers (Google/Slack/GitHub contracts) | — | — | ✓ | ✓ |
 | Coverage/meta gates | — | 2 | ✓ | ✓ |
 
-Totals: **51** group scenarios · **55** flat integration bins (49 in
+Totals: **52** group scenarios · **55** flat integration bins (49 in
 `tests/integration/`, 6 in `tests/integration/auth/`) · **39** top-level Rust bins ·
 **102** Python scenario files (**869** test functions) registered in the active
 Reborn coverage map below. Section 6 separately inventories retained and legacy
@@ -145,7 +145,7 @@ the canonical "a user does X in one conversation and sees the effect in another"
 |---|---|
 | List, install, and remove a skill, with each step visible from a different conversation | `scenario_install_list_remove.rs` |
 
-### 3.7 Triggers & automations — `group_triggers/` (10)
+### 3.7 Triggers & automations — `group_triggers/` (11)
 
 | The user can… | Evidence |
 |---|---|
@@ -155,6 +155,7 @@ the canonical "a user does X in one conversation and sees the effect in another"
 | Have a scheduled run chain through *two* approval prompts and still be recognised as a scheduled run | `scenario_triggered_chained_gate.rs` |
 | See "waiting on you" on an automation whose run is parked, and see it clear when the run ends | `scenario_triggered_gate_hold_visible.rs` |
 | Trust that a scheduled run can't create/remove/pause its own automations | `scenario_trigger_self_create_denied.rs` |
+| Have a scheduled run that repeatedly asks the absent user a question fail truthfully after two bounded nudges while retaining every rejected reply | `scenario_scheduled_final_output.rs` |
 | Create an automation whose create input carries no delivery-routing field at all | `scenario_trigger_create_has_no_delivery_target_field.rs` |
 | See and rename their automations in the WebUI, backed by the real trigger store | `scenario_webui_automations_list.rs`, `scenario_webui_automations_rename.rs` |
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -70,7 +70,7 @@ Python scenarios, so its exhaustive totals are intentionally broader.
 
 ---
 
-## 3. Group scenarios — `tests/integration/group_*/` (51)
+## 3. Group scenarios — `tests/integration/group_*/` (52)
 
 Multi-thread journeys over ONE shared runtime and ONE shared set of stores. These are
 the canonical "a user does X in one conversation and sees the effect in another" tests.

--- a/tests/integration/group_triggers/main.rs
+++ b/tests/integration/group_triggers/main.rs
@@ -23,6 +23,7 @@ mod reborn_support;
 #[path = "../../support/mod.rs"]
 mod support;
 
+mod scenario_scheduled_final_output;
 mod scenario_trigger_create_has_no_delivery_target_field;
 mod scenario_trigger_persists_after_reopen;
 mod scenario_trigger_self_create_denied;
@@ -102,6 +103,56 @@ async fn triggers_group_e2e() {
     );
 
     report.assert_all_passed();
+}
+
+/// #7525: an unattended run that repeatedly asks the absent user a question
+/// consumes exactly the two existing nudges, then fails with retained
+/// transcript evidence instead of reporting false success.
+///
+/// This has its own test because `triggers_group_e2e` is already a large
+/// sequential async future; keeping the independent scenario separate avoids
+/// inflating that test's stack footprint.
+#[test]
+fn scheduled_final_output_group() {
+    run_async_test_with_stack(
+        "scheduled_final_output_group",
+        scheduled_final_output_group_inner,
+    );
+}
+
+async fn scheduled_final_output_group_inner() {
+    let g = RebornIntegrationGroup::triggers()
+        .await
+        .expect("group builds");
+    let mut report = ScenarioReport::new();
+
+    report.record(
+        "scheduled_final_output_validation",
+        scenario_scheduled_final_output::run(&g).await,
+    );
+
+    report.assert_all_passed();
+}
+
+fn run_async_test_with_stack<F, Fut>(name: &'static str, test: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio test runtime")
+                .block_on(test());
+        })
+        .expect("spawn stack-sized test thread");
+    if let Err(panic) = handle.join() {
+        std::panic::resume_unwind(panic);
+    }
 }
 
 /// Triggered-origin runs raise, park on, and resume from REAL approval gates,

--- a/tests/integration/group_triggers/scenario_scheduled_final_output.rs
+++ b/tests/integration/group_triggers/scenario_scheduled_final_output.rs
@@ -1,0 +1,74 @@
+//! A trusted scheduled-trigger run cannot report success after repeatedly
+//! ending with a question for an absent user. The real runner issues its two
+//! bounded completion nudges, then persists `invalid_model_output` while
+//! retaining every rejected reply in the trigger thread.
+
+use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
+use super::reborn_support::reply::RebornScriptedReply;
+use ironclaw_turns::{TurnOriginKind, TurnStatus};
+
+pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
+    let h = g
+        .thread("conv-triggered-invalid-final-output")
+        .build()
+        .await?;
+    let questions = [
+        "Which repository should I inspect?",
+        "Should I inspect the main branch?",
+        "Would you like me to continue?",
+    ];
+
+    let submission = h
+        .submit_triggered_turn_scripted(
+            "inspect the repository and report the result without asking questions",
+            [
+                RebornScriptedReply::text(questions[0]),
+                RebornScriptedReply::text(questions[1]),
+                RebornScriptedReply::text(questions[2]),
+                RebornScriptedReply::text(
+                    "The scheduled run could not produce a self-contained result.",
+                ),
+            ],
+        )
+        .await?;
+
+    let state = h
+        .wait_for_status_in_scope(
+            &submission.turn_scope,
+            submission.run_id,
+            TurnStatus::Failed,
+        )
+        .await?;
+    if state.product_context.as_ref().map(|context| context.origin)
+        != Some(TurnOriginKind::ScheduledTrigger)
+    {
+        return Err("failed run lost its trusted ScheduledTrigger origin".into());
+    }
+    let failure = state
+        .failure
+        .as_ref()
+        .ok_or("failed scheduled run missing failure evidence")?;
+    if failure.category() != "invalid_model_output" {
+        return Err(format!(
+            "expected invalid_model_output, got {:?}",
+            failure.category()
+        )
+        .into());
+    }
+
+    let history = h
+        .thread_harness
+        .history(submission.turn_scope.thread_id.clone())
+        .await?;
+    for question in questions {
+        if !history.iter().any(|message| {
+            message
+                .content
+                .as_deref()
+                .is_some_and(|content| content.contains(question))
+        }) {
+            return Err(format!("rejected reply was not retained: {question:?}").into());
+        }
+    }
+    Ok(())
+}

--- a/tests/integration/group_triggers/scenario_scheduled_final_output.rs
+++ b/tests/integration/group_triggers/scenario_scheduled_final_output.rs
@@ -5,7 +5,7 @@
 
 use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
 use super::reborn_support::reply::RebornScriptedReply;
-use ironclaw_turns::{TurnOriginKind, TurnStatus};
+use ironclaw_host_api::turn::{TurnOriginKind, TurnStatus};
 
 pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
     let h = g
@@ -25,9 +25,6 @@ pub async fn run(g: &RebornIntegrationGroup) -> HarnessResult<()> {
                 RebornScriptedReply::text(questions[0]),
                 RebornScriptedReply::text(questions[1]),
                 RebornScriptedReply::text(questions[2]),
-                RebornScriptedReply::text(
-                    "The scheduled run could not produce a self-contained result.",
-                ),
             ],
         )
         .await?;


### PR DESCRIPTION
## Summary

- validate unattended scheduled-run final output before reporting completion
- reuse the existing two completion nudges when a scheduled response ends with a question
- fail exhausted empty or question-ending output as `invalid_model_output` while retaining rejected replies as transcript evidence
- preserve existing interactive-run completion behavior

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #7525
Related #6879

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `ironclaw_host_api`, `ironclaw_agent_loop`, scheduled final-output integration scenario, and `ironclaw_architecture_tests`
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (Not applicable: no database-backed crate behavior changed)
- [ ] Manual testing: Not applicable; the behavior is covered through the production-wired scripted-model harness
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Targeted clippy passed with zero warnings:

```text
cargo clippy -p ironclaw_host_api -p ironclaw_agent_loop -p ironclaw_turn_runner --all-targets --all-features -- -D warnings
```

## Test Strategy

User behavior: Given a trusted scheduled automation with no user present, when the model repeatedly ends by asking for input, Ironclaw uses its bounded recovery attempts and then records a failed run with retained evidence instead of false success. Interactive questions continue to complete normally.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: final-output classification, scheduled-only nudge behavior, bounded exhaustion, empty-output failure, interactive control, typed failure reason parsing, and user-facing failure summary
- Reborn integration: trusted scheduled submission through the real runner/agent-loop path asserts `Failed`, `invalid_model_output`, scheduled origin, and retention of all rejected question replies
- Recorded fixture: Not applicable; deterministic response classification does not test model tool selection
- Browser E2E: Not applicable; no WebUI presentation or interaction changed
- Backend or runtime: Not applicable; the hermetic Reborn integration uses the production runner path and no backend-specific behavior changed
- Live canary: Not applicable; correctness is deterministic and does not depend on a provider

What the tests prove: Question-ending output is recoverable only for scheduled runs; exactly two existing nudges are available; exhaustion cannot transition to `Completed`; rejected output remains durable evidence; interactive and self-contained responses remain compatible.

Commands run:

```text
cargo test -p ironclaw_host_api
cargo test -p ironclaw_agent_loop
cargo test -p ironclaw_integration_tests --test reborn_group_triggers scheduled_final_output_group -- --nocapture
cargo test -p ironclaw_architecture_tests --quiet
cargo clippy -p ironclaw_host_api -p ironclaw_agent_loop -p ironclaw_turn_runner --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
python3 scripts/ci/docs_publication_boundary.py
git diff --check
```

`cargo test -p ironclaw_turn_runner` was also run: 247 tests passed and the unrelated existing `trace_capture::tests::capture_skips_when_policy_missing_or_disabled` test failed identically on an isolated rerun (`no queue dir for non-enrolled scope`). This change does not touch trace capture.

## Security Impact

None. Trusted scheduled origin is read from the existing typed product context; authentication, permissions, capabilities, secrets, and external I/O are unchanged.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: the new typed invalid-output detail is constructed by the agent loop after checking the host-minted `ScheduledTrigger` origin
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. N/A: no new untrusted prompt content or prompt construction was added; the existing static completion nudge is reused
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. N/A: no hashes changed
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: `rg -n "ModelInvalidOutputDetailReason|last_reply_empty|last_reply_ended_with_question" crates tests`; owning and architecture test suites pass
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Both checkpoint booleans default to `false`, preserving legacy interactive/completion behavior
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. The existing completion-nudge counter and limit of two are reused
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). The existing stable `invalid_model_output` category is reused with a typed detail
- [x] Sandbox/native/host names accurately describe trust boundary. N/A: no runtime lane or host naming changed

## Database Impact

None. No migrations, schemas, PostgreSQL behavior, or libSQL behavior changed. New checkpoint fields are serde-defaulted for backward compatibility.

## Blast Radius

Scheduled-trigger completion classification in the canonical agent loop, persisted loop checkpoints, public failure summaries, and trigger integration coverage. Interactive turns are explicitly excluded and covered by a regression control.

## Rollback Plan

Revert this commit to restore the prior scheduled-run completion behavior. No migration or data rollback is required; older readers ignore the new defaulted checkpoint fields and retained transcript evidence remains valid.

## Review Follow-Through

Reviewer judgment is requested on the deliberately narrow `final line ends with ?` classifier. More semantic output validation remains outside this bug fix.

---

**Review track**: C (runtime exit semantics and durable checkpoint fields)
