### PR TITLE
test(stress): inventory built-in writes and schedule workspace coverage

### DIFF
--- a/.github/workflows/ironclaw-stress.yml
+++ b/.github/workflows/ironclaw-stress.yml
@@ -368,6 +368,31 @@ jobs:
               > "${outdir}/summary.json" \
               2> "${outdir}/report.txt" || failed=1
           done
+
+          outdir="target/ironclaw-stress/ironclaw-stress-libsql-scripted-write_file_roundtrip"
+          mkdir -p "${outdir}"
+          target/release/ironclaw_stress \
+            --backend libsql \
+            --scenario api-user-capacity \
+            --api-base-url http://127.0.0.1:18080 \
+            --api-admin-bearer-token "$IRONCLAW_REBORN_WEBUI_TOKEN" \
+            --users 6 \
+            --concurrency 3 \
+            --operations 4 \
+            --api-scripted-tool write_file_roundtrip \
+            --api-scripted-doc-sizes 4096,32768,131072,1048576 \
+            --mock-llm-bind 127.0.0.1:19090 \
+            --mock-llm-latency-ms 250 \
+            --api-poll-interval-ms 10000 \
+            --api-terminal-timeout-ms 120000 \
+            --progress-interval-seconds 0 \
+            --human-read \
+            --bottleneck-report \
+            --output-jsonl "${outdir}/summary.jsonl" \
+            --max-failure-rate 0 \
+            --max-p95-ms 120000 \
+            > "${outdir}/summary.json" \
+            2> "${outdir}/report.txt" || failed=1
           exit "$failed"
 
       - name: Upload libsql scripted memory_roundtrip artifacts
@@ -403,6 +428,18 @@ jobs:
             target/ironclaw-stress/ironclaw-stress-libsql-scripted-memory_mixed/summary.jsonl
             target/ironclaw-stress/ironclaw-stress-libsql-scripted-memory_mixed/summary.json
             target/ironclaw-stress/ironclaw-stress-libsql-scripted-memory_mixed/report.txt
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload libsql scripted workspace write artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ironclaw-stress-libsql-scripted-write-file-roundtrip
+          path: |
+            target/ironclaw-stress/ironclaw-stress-libsql-scripted-write_file_roundtrip/summary.jsonl
+            target/ironclaw-stress/ironclaw-stress-libsql-scripted-write_file_roundtrip/summary.json
+            target/ironclaw-stress/ironclaw-stress-libsql-scripted-write_file_roundtrip/report.txt
           if-no-files-found: error
           retention-days: 14
 
@@ -614,6 +651,29 @@ jobs:
             > target/ironclaw-stress/postgres-api-scripted-summary.json \
             2> target/ironclaw-stress/postgres-api-scripted-report.txt
 
+          target/release/ironclaw_stress \
+            --backend libsql \
+            --scenario api-user-capacity \
+            --api-base-url http://127.0.0.1:18080 \
+            --api-admin-bearer-token "$IRONCLAW_REBORN_WEBUI_TOKEN" \
+            --users 6 \
+            --concurrency 3 \
+            --operations 4 \
+            --api-scripted-tool write_file_roundtrip \
+            --api-scripted-doc-sizes 4096,32768,131072,1048576 \
+            --mock-llm-bind 127.0.0.1:19090 \
+            --mock-llm-latency-ms 250 \
+            --api-poll-interval-ms 10000 \
+            --api-terminal-timeout-ms 120000 \
+            --progress-interval-seconds 0 \
+            --human-read \
+            --bottleneck-report \
+            --output-jsonl target/ironclaw-stress/postgres-api-scripted-workspace.jsonl \
+            --max-failure-rate 0 \
+            --max-p95-ms 120000 \
+            > target/ironclaw-stress/postgres-api-scripted-workspace-summary.json \
+            2> target/ironclaw-stress/postgres-api-scripted-workspace-report.txt
+
       - name: Upload Postgres API capacity artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -627,6 +687,9 @@ jobs:
             target/ironclaw-stress/postgres-api-scripted.jsonl
             target/ironclaw-stress/postgres-api-scripted-summary.json
             target/ironclaw-stress/postgres-api-scripted-report.txt
+            target/ironclaw-stress/postgres-api-scripted-workspace.jsonl
+            target/ironclaw-stress/postgres-api-scripted-workspace-summary.json
+            target/ironclaw-stress/postgres-api-scripted-workspace-report.txt
           if-no-files-found: ignore
 
       - name: Upload Postgres scripted memory roundtrip artifacts
@@ -638,5 +701,17 @@ jobs:
             target/ironclaw-stress/postgres-api-scripted.jsonl
             target/ironclaw-stress/postgres-api-scripted-summary.json
             target/ironclaw-stress/postgres-api-scripted-report.txt
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Postgres scripted workspace write artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ironclaw-stress-postgres-scripted-write-file-roundtrip
+          path: |
+            target/ironclaw-stress/postgres-api-scripted-workspace.jsonl
+            target/ironclaw-stress/postgres-api-scripted-workspace-summary.json
+            target/ironclaw-stress/postgres-api-scripted-workspace-report.txt
           if-no-files-found: error
           retention-days: 14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4916,6 +4916,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "toml 1.1.3+spec-1.1.0",
  "uuid",
 ]
 

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -36,6 +36,7 @@ from ws12_workflow_contracts import (
     validate_libsql_scripted_memory_job,
     validate_postgres_scripted_parity,
     validate_production_lint_targets,
+    validate_scripted_workspace_parity,
     validate_windows_webui_install_shell,
     validate_webui_frontend_sites,
     validate_workflow_texts,
@@ -976,6 +977,71 @@ class CrateNameResidueSabotageTests(unittest.TestCase):
         return _Patch()
 
 
+class ScriptedWorkspaceParitySabotageTests(unittest.TestCase):
+    """#7360 Phase 2: workspace writes stay scheduled on both DB backends."""
+
+    JOBS = ("libsql-scripted-memory", "postgres-api-capacity")
+
+    def setUp(self) -> None:
+        self.text = load_workflows(ROOT)[STRESS_WORKFLOW]
+
+    def mutate_job(self, job: str, old: str, new: str) -> str:
+        block, detail = extract_job_block(self.text, job)
+        self.assertIsNotNone(block, detail)
+        mutated = block.replace(old, new)
+        self.assertNotEqual(mutated, block, f"no-op sabotage in {job}: {old!r}")
+        start = self.text.find(block)
+        self.assertNotEqual(start, -1)
+        return self.text[:start] + mutated + self.text[start + len(block) :]
+
+    def test_checked_in_workspace_matrix_meets_the_contract(self) -> None:
+        self.assertEqual(validate_scripted_workspace_parity(self.text), [])
+
+    def test_each_backend_requires_the_workspace_runner(self) -> None:
+        for job in self.JOBS:
+            with self.subTest(job=job):
+                sabotaged = self.mutate_job(
+                    job,
+                    "--api-scripted-tool write_file_roundtrip",
+                    "--api-scripted-tool memory_roundtrip",
+                )
+                errors = validate_scripted_workspace_parity(sabotaged)
+                self.assertTrue(
+                    any(job in error and "exactly one" in error for error in errors),
+                    errors,
+                )
+
+    def test_workspace_runner_rejects_shared_hot_writers(self) -> None:
+        for job in self.JOBS:
+            with self.subTest(job=job):
+                hot_writer_flag = "            --api-hot-writers 2 \\\n"
+                sabotaged = self.mutate_job(
+                    job,
+                    "--api-scripted-tool write_file_roundtrip \\",
+                    "--api-scripted-tool write_file_roundtrip \\\n"
+                    + hot_writer_flag.rstrip("\n"),
+                )
+                errors = validate_scripted_workspace_parity(sabotaged)
+                self.assertTrue(
+                    any(job in error and "must not use" in error for error in errors),
+                    errors,
+                )
+
+    def test_each_backend_requires_workspace_artifacts(self) -> None:
+        artifacts = {
+            "libsql-scripted-memory": "ironclaw-stress-libsql-scripted-write-file-roundtrip",
+            "postgres-api-capacity": "ironclaw-stress-postgres-scripted-write-file-roundtrip",
+        }
+        for job, artifact in artifacts.items():
+            with self.subTest(job=job):
+                sabotaged = self.mutate_job(job, artifact, "removed-workspace-artifact")
+                errors = validate_scripted_workspace_parity(sabotaged)
+                self.assertTrue(
+                    any(job in error and "upload workspace" in error for error in errors),
+                    errors,
+                )
+
+
 class LibsqlScriptedMemoryJobSabotageTests(unittest.TestCase):
     """#7360: the libsql-scripted-memory job's lifecycle and artifact contract.
 
@@ -1564,12 +1630,15 @@ class LibsqlScriptedMemoryJobSabotageTests(unittest.TestCase):
         fixed = self.fixed_workflows()
         mutated = copy.deepcopy(fixed)
         mutated[STRESS_WORKFLOW] = mutated[STRESS_WORKFLOW].replace(
-            '              2> "${outdir}/report.txt" || failed=1\n'
-            "          done\n"
-            '          exit "$failed"\n',
-            '              2> "${outdir}/report.txt" || failed=1\n'
+            "          done\n\n"
+            '          outdir="target/ironclaw-stress/ironclaw-stress-libsql-',
             '          exit "$failed"\n'
-            "          done\n",
+            "          done\n\n"
+            '          outdir="target/ironclaw-stress/ironclaw-stress-libsql-',
+        ).replace(
+            '            2> "${outdir}/report.txt" || failed=1\n'
+            '          exit "$failed"\n',
+            '            2> "${outdir}/report.txt" || failed=1\n',
         )
         errors = self.errors_for(mutated)
         self.assertTrue(

--- a/scripts/ci/ws12_workflow_contracts.py
+++ b/scripts/ci/ws12_workflow_contracts.py
@@ -843,6 +843,23 @@ POSTGRES_SCRIPTED_MAX_FAILURE_RATE = re.compile(
     r"--max-failure-rate[ \t]+0(?![0-9.])"
 )
 
+# The workspace script is the first Phase-2 write family. It runs as a
+# separate command because memory hot writers intentionally share one
+# document, while write_file_roundtrip uses one isolated path per operation
+# and rejects --api-hot-writers.
+SCRIPTED_WORKSPACE_TOOL = "--api-scripted-tool write_file_roundtrip"
+SCRIPTED_WORKSPACE_FLAGS = (
+    re.compile(r"--users[ \t]+6(?![0-9.])"),
+    re.compile(r"--concurrency[ \t]+3(?![0-9.])"),
+    re.compile(r"--operations[ \t]+4(?![0-9.])"),
+    POSTGRES_SCRIPTED_DOC_SIZES,
+    POSTGRES_SCRIPTED_MAX_FAILURE_RATE,
+)
+SCRIPTED_WORKSPACE_ARTIFACTS = {
+    LIBSQL_SCRIPTED_MEMORY_JOB: "ironclaw-stress-libsql-scripted-write-file-roundtrip",
+    POSTGRES_API_CAPACITY_JOB: "ironclaw-stress-postgres-scripted-write-file-roundtrip",
+}
+
 
 def validate_postgres_scripted_parity(text: str) -> list[str]:
     """Return every way the Postgres scripted leg stops reaching every
@@ -910,6 +927,64 @@ def validate_postgres_scripted_parity(text: str) -> list[str]:
             "on its runner command — one leak or lost write must fail the "
             "32-operation parity leg"
         )
+    return errors
+
+
+def validate_scripted_workspace_parity(text: str) -> list[str]:
+    """Pin workspace write/read-back coverage in both scheduled backends."""
+
+    errors: list[str] = []
+    for job in (LIBSQL_SCRIPTED_MEMORY_JOB, POSTGRES_API_CAPACITY_JOB):
+        block, detail = extract_job_block(text, job)
+        if block is None:
+            errors.append(f"{STRESS_WORKFLOW}: {detail}")
+            continue
+        label = f"{STRESS_WORKFLOW} ({job} job):"
+        executable = "\n".join(
+            line for line in block.splitlines() if not line.lstrip().startswith("#")
+        )
+        commands = [
+            command
+            for command in extract_continued_commands(
+                executable, "target/release/ironclaw_stress"
+            )
+            if SCRIPTED_WORKSPACE_TOOL in command
+        ]
+        if len(commands) != 1:
+            errors.append(
+                f"{label} must contain exactly one {SCRIPTED_WORKSPACE_TOOL} "
+                f"runner command, found {len(commands)}"
+            )
+            continue
+        runner = commands[0]
+        if any(pattern.search(runner) is None for pattern in SCRIPTED_WORKSPACE_FLAGS):
+            errors.append(
+                f"{label} workspace write coverage must run users=6, concurrency=3, "
+                "operations=4, all four document sizes, and max-failure-rate=0"
+            )
+        if "--api-hot-writers" in runner:
+            errors.append(
+                f"{label} workspace write coverage must not use --api-hot-writers; "
+                "write_file_roundtrip isolates each operation path"
+            )
+        artifact = SCRIPTED_WORKSPACE_ARTIFACTS[job]
+        if artifact not in executable:
+            errors.append(
+                f"{label} must upload workspace write evidence as {artifact!r}"
+            )
+        if job == LIBSQL_SCRIPTED_MEMORY_JOB:
+            if "|| failed=1" not in runner:
+                errors.append(
+                    f"{label} workspace runner must record failure with `|| failed=1` "
+                    "so memory and workspace evidence are both retained"
+                )
+            runner_at = executable.find(SCRIPTED_WORKSPACE_TOOL)
+            exit_at = executable.find('exit "$failed"', runner_at)
+            if exit_at < 0:
+                errors.append(
+                    f"{label} must exit with the accumulated failure status after "
+                    "the workspace runner"
+                )
     return errors
 
 
@@ -1701,6 +1776,7 @@ def validate_workflow_texts(
     if stress is not None:
         errors.extend(validate_libsql_scripted_memory_job(stress))
         errors.extend(validate_postgres_scripted_parity(stress))
+        errors.extend(validate_scripted_workspace_parity(stress))
     errors.extend(validate_crate_scope_filters(workflows, root))
     errors.extend(validate_crate_name_residue(workflows, root))
     errors.extend(validate_webui_frontend_sites(workflows, root))

--- a/tools/ironclaw_stress/Cargo.toml
+++ b/tools/ironclaw_stress/Cargo.toml
@@ -39,3 +39,4 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 rig = { package = "rig-core", version = "0.33" }
+toml = "1.1"

--- a/tools/ironclaw_stress/README.md
+++ b/tools/ironclaw_stress/README.md
@@ -223,11 +223,12 @@ cargo run -p ironclaw_stress -- \
   --mock-llm-bind 127.0.0.1:3911
 ```
 
-### Nightly scripted memory matrix (CI lane)
+### Nightly scripted durable-write matrix (CI lane)
 
 `.github/workflows/ironclaw-stress.yml` runs a nightly (03:30 UTC, plus
 `workflow_dispatch`) matrix of the three memory scripts — `memory_roundtrip`,
-`memory_grow`, `memory_mixed` — against a real `ironclaw serve` binary. The
+`memory_grow`, `memory_mixed` — and the workspace `write_file_roundtrip`
+script against a real `ironclaw serve` binary. The
 server profile selects the persistence backend: `hosted-single-tenant` is
 Postgres-backed, `hosted-single-tenant-volume` is embedded libSQL storage
 with no `[storage]` section. The stress runner's `--backend` flag does not
@@ -240,7 +241,9 @@ document sizes 4096, 32768, 131072, and 1048576 bytes, with users=6,
 concurrency=3, operations=4, hot writers=2, mock latency 250ms, a 10000ms
 timeline polling interval, a 120000ms terminal/p95 ceiling, and the
 zero-tolerance gate `--max-failure-rate 0`: any failed, leaked, missing, or
-undisclosed scripted verdict fails the job.
+undisclosed scripted verdict fails the job. The workspace script uses the
+same user, concurrency, operation, size, latency, and failure settings, but no
+hot writers: each operation intentionally owns a distinct workspace path.
 
 Per-script outputs are stored under
 `target/ironclaw-stress/ironclaw-stress-libsql-scripted-<script>/` (JSONL,
@@ -250,7 +253,15 @@ separately, as `ironclaw-stress-libsql-scripted-server-log` (always, even
 when a script fails), so a failed run has a single log artifact to fetch. The
 Postgres job's scripted memory leg is additionally mirrored under
 `ironclaw-stress-postgres-scripted-memory-roundtrip`, alongside its existing
-aggregate `ironclaw-stress-postgres-api-capacity` artifact.
+aggregate `ironclaw-stress-postgres-api-capacity` artifact. Workspace evidence
+is uploaded as `ironclaw-stress-<backend>-scripted-write-file-roundtrip`.
+
+The fail-closed built-in write inventory lives at
+`fixtures/builtin_write_stress_coverage.toml`. Its unit test derives the
+write-effect surface from the shipping `builtin_capability_policy.toml`; a new
+`write_filesystem`, `delete_filesystem`, `external_write`, or
+`modify_approval` grant must be classified as nightly, implemented, or backlog
+in the same change.
 
 ## Presets
 

--- a/tools/ironclaw_stress/fixtures/builtin_write_stress_coverage.toml
+++ b/tools/ironclaw_stress/fixtures/builtin_write_stress_coverage.toml
@@ -1,0 +1,222 @@
+schema_version = 1
+
+# This inventory is deliberately derived from the shipping builtin capability
+# policy, not from the stress driver's current scripts. The companion test
+# fails closed when a grant adds write_filesystem, delete_filesystem,
+# external_write, or modify_approval without classifying its stress posture.
+#
+# Status meanings:
+# - nightly: production-path stress coverage runs on schedule.
+# - implemented: the production-path script exists but is not scheduled yet.
+# - backlog: no qualifying stress scenario exists yet; scenario names the
+#   intended workload family and reason states what must be exercised.
+
+[[entries]]
+capability = "ironclaw.memory.write"
+status = "nightly"
+scenario = "memory_roundtrip,memory_grow,memory_mixed"
+reason = "Postgres and libSQL scripted matrices verify durable read-back and isolation."
+
+[[entries]]
+capability = "builtin.write_file"
+status = "nightly"
+scenario = "write_file_roundtrip"
+reason = "Postgres and libSQL scripted matrices verify isolated workspace write/read-back."
+
+[[entries]]
+capability = "builtin.echo"
+status = "backlog"
+scenario = "large_result_spill"
+reason = "Exercise output large enough to cross the inline-result threshold."
+
+[[entries]]
+capability = "builtin.time"
+status = "backlog"
+scenario = "large_result_spill"
+reason = "Classify and verify any filesystem-backed result spill caused by the broad grant."
+
+[[entries]]
+capability = "builtin.json"
+status = "backlog"
+scenario = "large_result_spill"
+reason = "Exercise bounded large JSON output and result continuation storage."
+
+[[entries]]
+capability = "builtin.http.save"
+status = "backlog"
+scenario = "http_save_roundtrip"
+reason = "Use a hermetic HTTP double and verify the saved workspace file."
+
+[[entries]]
+capability = "ironclaw.memory.profile_set"
+status = "backlog"
+scenario = "profile_set_roundtrip"
+reason = "Write and read back each closed profile field through the production tool path."
+
+[[entries]]
+capability = "builtin.shell"
+status = "backlog"
+scenario = "bounded_shell_write"
+reason = "Pin an allowlisted command that writes through a scoped workspace mount."
+
+[[entries]]
+capability = "builtin.read_file"
+status = "backlog"
+scenario = "large_result_spill"
+reason = "Read beyond the inline-result threshold and verify bounded continuation storage."
+
+[[entries]]
+capability = "builtin.list_dir"
+status = "backlog"
+scenario = "large_result_spill"
+reason = "List enough fixture entries to exercise result spill without external I/O."
+
+[[entries]]
+capability = "builtin.glob"
+status = "backlog"
+scenario = "large_result_spill"
+reason = "Match enough fixture paths to exercise result spill and continuation reads."
+
+[[entries]]
+capability = "builtin.grep"
+status = "backlog"
+scenario = "large_result_spill"
+reason = "Produce bounded large search output and verify continuation storage."
+
+[[entries]]
+capability = "builtin.apply_patch"
+status = "backlog"
+scenario = "apply_patch_roundtrip"
+reason = "Create, patch, and read back an isolated workspace file."
+
+[[entries]]
+capability = "builtin.extension_register_hosted_mcp"
+status = "backlog"
+scenario = "extension_lifecycle"
+reason = "Use a hermetic hosted-MCP descriptor and verify durable registration."
+
+[[entries]]
+capability = "builtin.extension_install"
+status = "backlog"
+scenario = "extension_lifecycle"
+reason = "Install from a local fixture package and verify activation state."
+
+[[entries]]
+capability = "builtin.extension_remove"
+status = "backlog"
+scenario = "extension_lifecycle"
+reason = "Remove a fixture extension and verify durable lifecycle state."
+
+[[entries]]
+capability = "builtin.ironhub_install"
+status = "backlog"
+scenario = "extension_lifecycle"
+reason = "Use a hermetic IronHub fixture rather than measuring internet latency."
+
+[[entries]]
+capability = "builtin.operator_config_set_auto_approve"
+status = "backlog"
+scenario = "operator_configuration"
+reason = "Drive the authenticated API-only control-plane path and verify revisioned state."
+
+[[entries]]
+capability = "builtin.operator_config_set_tool_permission"
+status = "backlog"
+scenario = "operator_configuration"
+reason = "Drive the authenticated API-only control-plane path and verify scoped state."
+
+[[entries]]
+capability = "builtin.skill_list"
+status = "backlog"
+scenario = "skill_lifecycle"
+reason = "Exercise bootstrap/index writes, if any, against a local fixture catalog."
+
+[[entries]]
+capability = "builtin.skill_install"
+status = "backlog"
+scenario = "skill_lifecycle"
+reason = "Install a local fixture skill and verify durable files and catalog state."
+
+[[entries]]
+capability = "builtin.skill_update"
+status = "backlog"
+scenario = "skill_lifecycle"
+reason = "Update an installed fixture skill and verify read-back."
+
+[[entries]]
+capability = "builtin.skill_auto_activate_set"
+status = "backlog"
+scenario = "skill_lifecycle"
+reason = "Toggle per-skill activation and verify scoped durable configuration."
+
+[[entries]]
+capability = "builtin.skill_remove"
+status = "backlog"
+scenario = "skill_lifecycle"
+reason = "Remove an installed fixture skill and verify files and indexes are gone."
+
+[[entries]]
+capability = "builtin.skill_auto_activate_learned_set"
+status = "backlog"
+scenario = "skill_lifecycle"
+reason = "Exercise the API-only learned-skill selector configuration path."
+
+[[entries]]
+capability = "builtin.trigger_create"
+status = "backlog"
+scenario = "trigger_lifecycle"
+reason = "Create a trigger and verify its durable record through the real tool path."
+
+[[entries]]
+capability = "builtin.trigger_pause"
+status = "backlog"
+scenario = "trigger_lifecycle"
+reason = "Pause a fixture trigger and verify durable state."
+
+[[entries]]
+capability = "builtin.trigger_resume"
+status = "backlog"
+scenario = "trigger_lifecycle"
+reason = "Resume a fixture trigger and verify durable state."
+
+[[entries]]
+capability = "builtin.trigger_remove"
+status = "backlog"
+scenario = "trigger_lifecycle"
+reason = "Remove a fixture trigger without deleting retained run history."
+
+[[entries]]
+capability = "builtin.outbound_deliver"
+status = "backlog"
+scenario = "hermetic_outbound_write"
+reason = "Deliver through a hermetic channel double and separate provider latency from DB latency."
+
+[[entries]]
+capability = "builtin.attach_workspace_file_to_reply"
+status = "backlog"
+scenario = "attachment_delivery"
+reason = "Attach a bounded fixture file and verify the mediated outbound reference."
+
+[[entries]]
+capability = "builtin.trace_commons.onboard"
+status = "backlog"
+scenario = "hermetic_external_write"
+reason = "Use a hermetic Trace Commons double and exercise consent plus local state writes."
+
+[[entries]]
+capability = "builtin.trace_commons.profile_token"
+status = "backlog"
+scenario = "hermetic_external_write"
+reason = "Use a hermetic provider and verify local token-state persistence without secrets in artifacts."
+
+[[entries]]
+capability = "builtin.trace_commons.profile_set"
+status = "backlog"
+scenario = "hermetic_external_write"
+reason = "Use a hermetic provider and verify approval plus external mutation evidence."
+
+[[entries]]
+capability = "builtin.notification_channels_set"
+status = "backlog"
+scenario = "notification_configuration"
+reason = "Write and read back user-scoped notification channel configuration."

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -23,6 +23,9 @@ mod tests;
 mod trace;
 mod user_turn;
 
+#[cfg(test)]
+mod write_coverage_tests;
+
 use std::{
     any::Any,
     collections::BTreeMap,

--- a/tools/ironclaw_stress/src/write_coverage_tests.rs
+++ b/tools/ironclaw_stress/src/write_coverage_tests.rs
@@ -1,0 +1,104 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+
+const BUILTIN_POLICY: &str =
+    include_str!("../../../crates/app/ironclaw_composition/src/builtin_capability_policy.toml");
+const WRITE_COVERAGE: &str = include_str!("../fixtures/builtin_write_stress_coverage.toml");
+const WRITE_EFFECTS: [&str; 4] = [
+    "write_filesystem",
+    "delete_filesystem",
+    "external_write",
+    "modify_approval",
+];
+
+#[derive(Deserialize)]
+struct BuiltinPolicy {
+    grants: Vec<Grant>,
+}
+
+#[derive(Deserialize)]
+struct Grant {
+    capability: String,
+    effects: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct CoverageInventory {
+    schema_version: u32,
+    entries: Vec<CoverageEntry>,
+}
+
+#[derive(Deserialize)]
+struct CoverageEntry {
+    capability: String,
+    status: CoverageStatus,
+    scenario: String,
+    reason: String,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CoverageStatus {
+    Nightly,
+    Implemented,
+    Backlog,
+}
+
+#[test]
+fn every_builtin_write_effect_has_an_explicit_stress_classification() {
+    let policy: BuiltinPolicy = toml::from_str(BUILTIN_POLICY).expect("builtin policy parses");
+    let inventory: CoverageInventory =
+        toml::from_str(WRITE_COVERAGE).expect("write stress inventory parses");
+    assert_eq!(inventory.schema_version, 1, "unsupported inventory schema");
+
+    let expected = policy
+        .grants
+        .into_iter()
+        .filter(|grant| {
+            grant
+                .effects
+                .iter()
+                .any(|effect| WRITE_EFFECTS.contains(&effect.as_str()))
+        })
+        .map(|grant| grant.capability)
+        .collect::<BTreeSet<_>>();
+
+    let mut classified = BTreeMap::new();
+    for entry in inventory.entries {
+        assert!(
+            !entry.scenario.trim().is_empty(),
+            "{} has no workload family",
+            entry.capability
+        );
+        assert!(
+            !entry.reason.trim().is_empty(),
+            "{} has no classification reason",
+            entry.capability
+        );
+        if matches!(
+            entry.status,
+            CoverageStatus::Nightly | CoverageStatus::Implemented
+        ) {
+            assert!(
+                !entry.scenario.contains(char::is_whitespace),
+                "{} executable scenario names must not contain whitespace",
+                entry.capability
+            );
+        }
+        assert!(
+            classified
+                .insert(entry.capability.clone(), entry.status)
+                .is_none(),
+            "duplicate write stress classification for {}",
+            entry.capability
+        );
+    }
+
+    let actual = classified.into_keys().collect::<BTreeSet<_>>();
+    assert_eq!(
+        actual, expected,
+        "the built-in write surface changed; classify every added or removed capability in \
+         fixtures/builtin_write_stress_coverage.toml"
+    );
+}


### PR DESCRIPTION
## Summary

- Add a fail-closed inventory for all 35 built-in grants declaring filesystem write/delete, external-write, or approval-modification effects.
- Promote the existing production-path `write_file_roundtrip` script into scheduled Postgres and libSQL coverage across 4 KiB, 32 KiB, 128 KiB, and 1 MiB files.
- Pin both workspace runners, exact workload flags, zero-failure gates, and artifacts with workflow sabotage tests.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [x] Dependencies

## Linked Issue

Related #7360

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — owning-crate all-target/all-feature clippy passed; workspace-wide clippy was attempted but the machine ran out of disk while writing Wasmtime compiler metadata, before reporting a warning.
- [ ] `cargo build` — not run separately; the full owning-crate test and clippy builds passed.
- [x] Relevant tests pass: `cargo test -p ironclaw_stress` (171 passed); `python3 scripts/ci/test_ws12_workflow_contracts.py` (92 passed); workflow YAML parse; `scripts/pre-commit-safety.sh`.
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no production or database implementation changed.
- [ ] Manual testing — The existing production-path workspace script was implemented and tested in #7382; this PR schedules it and does not change its behavior. The scheduled binaries were not rebuilt locally because the machine had insufficient disk after verification.
- [ ] `review-pr` / `pr-shepherd --fix` — not run yet; PR opened as draft.

## Test Strategy

User behavior: Nightly evidence now fails when an isolated workspace write cannot be read back through the real HTTP -> turn -> capability-host path on either supported local database backend.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: derive the write-effect capability set from the shipping policy and require an exact inventory classification with no missing or duplicate entries.
- Reborn integration: Not applicable; existing scripted API flow is unchanged.
- Recorded fixture: Not applicable; deterministic mock model.
- Browser E2E: Not applicable; CI developer tooling only.
- Backend or runtime: scheduled workspace write/read-back leg added to both Postgres and libSQL jobs.
- Live canary: Not applicable; no live provider involved.

What the tests prove: new write-effect grants cannot land unclassified; workspace coverage cannot disappear from either backend, gain invalid shared hot writers, loosen its zero-failure gate, or stop uploading evidence without failing workflow contracts.

Commands run: `cargo test -p ironclaw_stress`; `cargo clippy -p ironclaw_stress --all-targets --all-features -- -D warnings`; `python3 scripts/ci/test_ws12_workflow_contracts.py`; YAML parse; `scripts/pre-commit-safety.sh`; attempted workspace clippy (disk-full failure documented above).

## Security Impact

No production permission or tool behavior changes. The nightly runner continues to enable auto-approval through the production settings API for isolated stress users. Inventory output contains capability IDs and workload classifications only.

## Reborn Trust-Boundary Checklist

N/A: test harness inventory and scheduled CI wiring only; no production trust-bearing types or runtime policy changed.

## Database Impact

No schema or migration changes. The same production-path workspace write/read-back scenario is now scheduled against both PostgreSQL and libSQL.

## Blast Radius

Scheduled stress duration increases by one 24-operation workspace workload per backend. A workflow error could false-red nightly or fail to upload evidence; exact scoped contract and sabotage tests cover those conditions.

## Rollback Plan

Revert this PR. The inventory and workspace workflow legs are additive and make no persisted schema or product behavior changes.

## Review Follow-Through

The remaining #7360 backlog is explicit in `builtin_write_stress_coverage.toml`: large-result spill, patch/HTTP/shell writes, trigger/configuration, skill/extension lifecycle, and hermetic external writes.

---

**Review track**: C (scheduled CI and production-path persistence stress coverage)
