### PR TITLE
feat(canary): report model-emitted tool batches

### DIFF
--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -116,12 +116,13 @@ security-sensitive output declare `retry_policy: "never"` in
 deterministic failure.
 
 Model-driving cases also publish privacy-safe scalar `details.metrics` in
-`results.json`: model/tool call counts, input/output/cache-read/uncached-input
-tokens, and USD cost when provider pricing is available. Counts come from the
-complete per-case LLM trace before that raw trace is excluded from uploaded
-artifacts; prompt, response, tool argument, and tool output content are never
-copied into the metrics. Legacy or interrupted traces report unavailable cache
-or cost values as `null` rather than zero.
+`results.json`: model/tool call counts, model-emitted tool-call batch counts and
+width distributions, input/output/cache-read/uncached-input tokens, and USD
+cost when provider pricing is available. Counts come from the complete
+per-case LLM trace before that raw trace is excluded from uploaded artifacts;
+prompt, response, tool argument, and tool output content are never copied into
+the metrics. Legacy or interrupted traces report unavailable batch, cache, or
+cost values as `null` rather than zero.
 
 Use CI-style browser installation for auth browser lanes:
 

--- a/scripts/live-canary/notify_slack.py
+++ b/scripts/live-canary/notify_slack.py
@@ -85,6 +85,11 @@ class RebornQaCaseReport:
     inconclusive: bool = False
     model_call_count: int | None = None
     tool_call_count: int | None = None
+    tool_call_batch_count: int | None = None
+    multi_tool_call_batch_count: int | None = None
+    tool_calls_in_multi_batches: int | None = None
+    max_tool_call_batch_width: int | None = None
+    tool_call_batch_width_counts: dict[int, int] | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
     cache_read_tokens: int | None = None
@@ -472,6 +477,28 @@ def parse_reborn_qa_case_reports(lane_dir: Path, report: LaneReport) -> None:
                 return value
             return None
 
+        def metric_batch_width_counts() -> dict[int, int] | None:
+            raw_counts = metrics.get("tool_call_batch_width_counts")
+            if not isinstance(raw_counts, dict) or len(raw_counts) > 64:
+                return None
+            counts: dict[int, int] = {}
+            for raw_width, raw_count in raw_counts.items():
+                try:
+                    width = int(raw_width)
+                except (TypeError, ValueError):
+                    return None
+                if (
+                    width < 1
+                    or width > 10_000
+                    or not isinstance(raw_count, int)
+                    or isinstance(raw_count, bool)
+                    or raw_count < 0
+                    or width in counts
+                ):
+                    return None
+                counts[width] = raw_count
+            return counts
+
         cost_usd = metrics.get("cost_usd")
         if isinstance(cost_usd, str):
             try:
@@ -507,6 +534,11 @@ def parse_reborn_qa_case_reports(lane_dir: Path, report: LaneReport) -> None:
                 inconclusive=classification.inconclusive,
                 model_call_count=metric_int("model_call_count"),
                 tool_call_count=metric_int("tool_call_count"),
+                tool_call_batch_count=metric_int("tool_call_batch_count"),
+                multi_tool_call_batch_count=metric_int("multi_tool_call_batch_count"),
+                tool_calls_in_multi_batches=metric_int("tool_calls_in_multi_batches"),
+                max_tool_call_batch_width=metric_int("max_tool_call_batch_width"),
+                tool_call_batch_width_counts=metric_batch_width_counts(),
                 input_tokens=metric_int("input_tokens"),
                 output_tokens=metric_int("output_tokens"),
                 cache_read_tokens=metric_int("cache_read_tokens"),
@@ -790,7 +822,43 @@ def _format_reborn_metric_summary(cases: list[RebornQaCaseReport]) -> list[str]:
         coverage = f" ({len(costs)}/{count} cases)" if len(costs) != count else ""
         parts.append(f"${sum(costs, Decimal(0)).normalize()}{coverage}")
 
-    return [f"*Usage:* {' · '.join(parts)}"] if parts else []
+    lines = [f"*Usage:* {' · '.join(parts)}"] if parts else []
+
+    width_counts: dict[int, int] = {}
+    covered_cases = 0
+    for case in cases:
+        if case.tool_call_batch_width_counts is None:
+            continue
+        covered_cases += 1
+        for width, batch_count in case.tool_call_batch_width_counts.items():
+            width_counts[width] = width_counts.get(width, 0) + batch_count
+    if width_counts:
+        total_batches = sum(width_counts.values())
+        multi_batches = sum(
+            batch_count for width, batch_count in width_counts.items() if width > 1
+        )
+        calls_in_multi_batches = sum(
+            width * batch_count
+            for width, batch_count in width_counts.items()
+            if width > 1
+        )
+        sorted_widths = sorted(width_counts.items())
+        widths = ", ".join(
+            f"{width}×{batch_count}" for width, batch_count in sorted_widths[:8]
+        )
+        if len(sorted_widths) > 8:
+            widths += f", +{len(sorted_widths) - 8} widths"
+        coverage = (
+            f" ({covered_cases}/{count} cases)" if covered_cases != count else ""
+        )
+        lines.append(
+            f"*Model-emitted tool batches:* {total_batches:,} total · "
+            f"{multi_batches:,} multi-call · "
+            f"{calls_in_multi_batches:,} calls in multi-call batches · "
+            f"max width {max(width_counts):,} · widths {widths}{coverage}"
+        )
+
+    return lines
 
 
 def _format_reborn_failure_lines(
@@ -1097,6 +1165,15 @@ def _markdown_reborn_case_metrics(case: RebornQaCaseReport) -> str:
         parts.append(f"{case.model_call_count:,} model calls")
     if case.tool_call_count is not None:
         parts.append(f"{case.tool_call_count:,} tool calls")
+    if case.multi_tool_call_batch_count is not None:
+        batch_label = (
+            "batch" if case.multi_tool_call_batch_count == 1 else "batches"
+        )
+        parts.append(
+            f"{case.multi_tool_call_batch_count:,} multi-call {batch_label}"
+        )
+    if case.max_tool_call_batch_width is not None:
+        parts.append(f"max batch width {case.max_tool_call_batch_width:,}")
     if case.input_tokens is not None:
         parts.append(f"{case.input_tokens:,} input tokens")
     if case.cache_read_tokens is not None:

--- a/scripts/live-canary/test_notify_slack.py
+++ b/scripts/live-canary/test_notify_slack.py
@@ -317,6 +317,11 @@ class RebornQaSlackReportTests(unittest.TestCase):
                                     "metrics": {
                                         "model_call_count": 2,
                                         "tool_call_count": 3,
+                                        "tool_call_batch_count": 2,
+                                        "multi_tool_call_batch_count": 1,
+                                        "tool_calls_in_multi_batches": 2,
+                                        "max_tool_call_batch_width": 2,
+                                        "tool_call_batch_width_counts": {"1": 1, "2": 1},
                                         "input_tokens": 1000,
                                         "output_tokens": 200,
                                         "cache_read_tokens": 400,
@@ -387,6 +392,14 @@ class RebornQaSlackReportTests(unittest.TestCase):
         self.assertEqual(report.reborn_qa_cases[0].message, "")
         self.assertEqual(report.reborn_qa_cases[0].model_call_count, 2)
         self.assertEqual(report.reborn_qa_cases[0].tool_call_count, 3)
+        self.assertEqual(report.reborn_qa_cases[0].tool_call_batch_count, 2)
+        self.assertEqual(report.reborn_qa_cases[0].multi_tool_call_batch_count, 1)
+        self.assertEqual(report.reborn_qa_cases[0].tool_calls_in_multi_batches, 2)
+        self.assertEqual(report.reborn_qa_cases[0].max_tool_call_batch_width, 2)
+        self.assertEqual(
+            report.reborn_qa_cases[0].tool_call_batch_width_counts,
+            {1: 1, 2: 1},
+        )
         self.assertEqual(report.reborn_qa_cases[0].input_tokens, 1000)
         self.assertEqual(report.reborn_qa_cases[0].output_tokens, 200)
         self.assertEqual(report.reborn_qa_cases[0].cache_read_tokens, 400)
@@ -857,6 +870,11 @@ class RebornQaSlackReportTests(unittest.TestCase):
                     latency_ms=1200,
                     model_call_count=2,
                     tool_call_count=3,
+                    tool_call_batch_count=2,
+                    multi_tool_call_batch_count=1,
+                    tool_calls_in_multi_batches=2,
+                    max_tool_call_batch_width=2,
+                    tool_call_batch_width_counts={1: 1, 2: 1},
                     input_tokens=1000,
                     output_tokens=200,
                     cache_read_tokens=400,
@@ -906,9 +924,16 @@ class RebornQaSlackReportTests(unittest.TestCase):
             "$0.0123 (1/2 cases)",
             body,
         )
+        self.assertIn(
+            "*Model-emitted tool batches:* 2 total · 1 multi-call · "
+            "2 calls in multi-call batches · max width 2 · widths 1×1, 2×1 "
+            "(1/2 cases)",
+            body,
+        )
         self.assertIn(":white_check_mark: `2A` Gmail connection flow", body)
         self.assertIn(
-            "2 model calls · 3 tool calls · 1,000 input tokens · "
+            "2 model calls · 3 tool calls · 1 multi-call batch · "
+            "max batch width 2 · 1,000 input tokens · "
             "400 cache-read · 600 uncached input · 200 output tokens · $0.0123",
             body,
         )
@@ -925,6 +950,11 @@ class RebornQaSlackReportTests(unittest.TestCase):
                 success=True,
                 model_call_count=2,
                 tool_call_count=3,
+                tool_call_batch_count=2,
+                multi_tool_call_batch_count=1,
+                tool_calls_in_multi_batches=2,
+                max_tool_call_batch_width=2,
+                tool_call_batch_width_counts={1: 1, 2: 1},
                 input_tokens=1000,
                 output_tokens=200,
                 cache_read_tokens=400,
@@ -938,6 +968,11 @@ class RebornQaSlackReportTests(unittest.TestCase):
                 success=True,
                 model_call_count=1,
                 tool_call_count=0,
+                tool_call_batch_count=0,
+                multi_tool_call_batch_count=0,
+                tool_calls_in_multi_batches=0,
+                max_tool_call_batch_width=0,
+                tool_call_batch_width_counts={},
                 input_tokens=500,
                 output_tokens=100,
                 cache_read_tokens=None,
@@ -948,14 +983,37 @@ class RebornQaSlackReportTests(unittest.TestCase):
 
         summary = notify._format_reborn_metric_summary(cases)
 
-        self.assertEqual(len(summary), 1)
+        self.assertEqual(len(summary), 2)
         self.assertIn("3 model calls", summary[0])
         self.assertIn("3 tool calls", summary[0])
         self.assertIn("1,500 input tokens", summary[0])
         self.assertIn("300 output tokens", summary[0])
         self.assertIn("400 cache-read (1/2 cases)", summary[0])
         self.assertIn("600 uncached input (1/2 cases)", summary[0])
+        self.assertEqual(
+            summary[1],
+            "*Model-emitted tool batches:* 2 total · 1 multi-call · "
+            "2 calls in multi-call batches · max width 2 · widths 1×1, 2×1",
+        )
         self.assertIn("$0.0123 (1/2 cases)", summary[0])
+
+    def test_reborn_metric_summary_bounds_batch_width_distribution(self):
+        case = notify.RebornQaCaseReport(
+            rows=("2A",),
+            case="a",
+            feature="a",
+            success=True,
+            tool_call_batch_width_counts={width: 1 for width in range(1, 11)},
+        )
+
+        summary = notify._format_reborn_metric_summary([case])
+
+        self.assertEqual(len(summary), 1)
+        self.assertIn(
+            "widths 1×1, 2×1, 3×1, 4×1, 5×1, 6×1, 7×1, 8×1, +2 widths",
+            summary[0],
+        )
+        self.assertNotIn("9×1", summary[0])
 
     def test_github_comment_body_includes_junit_fallback_for_failed_lane(self):
         report = notify.LaneReport(

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -807,6 +807,11 @@ def parse_case_llm_trace_metrics(trace_path: Path) -> dict[str, object]:
 
     model_call_count = 0
     tool_call_count = 0
+    tool_call_batch_count = 0
+    multi_tool_call_batch_count = 0
+    tool_calls_in_multi_batches = 0
+    max_tool_call_batch_width = 0
+    tool_call_batch_width_counts: dict[str, int] = {}
     step_input_tokens = 0
     step_output_tokens = 0
     for step in steps:
@@ -826,7 +831,18 @@ def parse_case_llm_trace_metrics(trace_path: Path) -> dict[str, object]:
         if isinstance(output_tokens, int) and not isinstance(output_tokens, bool):
             step_output_tokens += max(0, output_tokens)
         if response_type == "tool_calls" and isinstance(response.get("tool_calls"), list):
-            tool_call_count += len(response["tool_calls"])
+            batch_width = len(response["tool_calls"])
+            tool_call_count += batch_width
+            if batch_width > 0:
+                tool_call_batch_count += 1
+                max_tool_call_batch_width = max(max_tool_call_batch_width, batch_width)
+                width_key = str(batch_width)
+                tool_call_batch_width_counts[width_key] = (
+                    tool_call_batch_width_counts.get(width_key, 0) + 1
+                )
+                if batch_width > 1:
+                    multi_tool_call_batch_count += 1
+                    tool_calls_in_multi_batches += batch_width
 
     usage = payload.get("usage")
     has_provider_usage = isinstance(usage, dict)
@@ -860,6 +876,11 @@ def parse_case_llm_trace_metrics(trace_path: Path) -> dict[str, object]:
     return {
         "model_call_count": model_call_count,
         "tool_call_count": tool_call_count,
+        "tool_call_batch_count": tool_call_batch_count,
+        "multi_tool_call_batch_count": multi_tool_call_batch_count,
+        "tool_calls_in_multi_batches": tool_calls_in_multi_batches,
+        "max_tool_call_batch_width": max_tool_call_batch_width,
+        "tool_call_batch_width_counts": tool_call_batch_width_counts,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "cache_read_tokens": cache_read_tokens,
@@ -873,6 +894,11 @@ def _zero_case_metrics() -> dict[str, object]:
     return {
         "model_call_count": 0,
         "tool_call_count": 0,
+        "tool_call_batch_count": 0,
+        "multi_tool_call_batch_count": 0,
+        "tool_calls_in_multi_batches": 0,
+        "max_tool_call_batch_width": 0,
+        "tool_call_batch_width_counts": {},
         "input_tokens": 0,
         "output_tokens": 0,
         "cache_read_tokens": 0,
@@ -886,6 +912,11 @@ def _unavailable_case_metrics() -> dict[str, object]:
     return {
         "model_call_count": None,
         "tool_call_count": None,
+        "tool_call_batch_count": None,
+        "multi_tool_call_batch_count": None,
+        "tool_calls_in_multi_batches": None,
+        "max_tool_call_batch_width": None,
+        "tool_call_batch_width_counts": None,
         "input_tokens": None,
         "output_tokens": None,
         "cache_read_tokens": None,

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -9654,6 +9654,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                     {
                         "model_call_count": 1,
                         "tool_call_count": 0,
+                        "tool_call_batch_count": 0,
+                        "multi_tool_call_batch_count": 0,
+                        "tool_calls_in_multi_batches": 0,
+                        "max_tool_call_batch_width": 0,
+                        "tool_call_batch_width_counts": {},
                         "input_tokens": 10,
                         "output_tokens": 2,
                         "cache_read_tokens": 4,
@@ -9715,6 +9720,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             {
                 "model_call_count": 2,
                 "tool_call_count": 2,
+                "tool_call_batch_count": 1,
+                "multi_tool_call_batch_count": 1,
+                "tool_calls_in_multi_batches": 2,
+                "max_tool_call_batch_width": 2,
+                "tool_call_batch_width_counts": {"2": 1},
                 "input_tokens": 180,
                 "output_tokens": 35,
                 "cache_read_tokens": 70,
@@ -9751,6 +9761,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
         self.assertEqual(metrics["model_call_count"], 1)
         self.assertEqual(metrics["tool_call_count"], 0)
+        self.assertEqual(metrics["tool_call_batch_count"], 0)
+        self.assertEqual(metrics["multi_tool_call_batch_count"], 0)
+        self.assertEqual(metrics["tool_calls_in_multi_batches"], 0)
+        self.assertEqual(metrics["max_tool_call_batch_width"], 0)
+        self.assertEqual(metrics["tool_call_batch_width_counts"], {})
         self.assertEqual(metrics["input_tokens"], 12)
         self.assertEqual(metrics["output_tokens"], 3)
         self.assertIsNone(metrics["cache_read_tokens"])
@@ -9821,6 +9836,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             {
                 "model_call_count": None,
                 "tool_call_count": None,
+                "tool_call_batch_count": None,
+                "multi_tool_call_batch_count": None,
+                "tool_calls_in_multi_batches": None,
+                "max_tool_call_batch_width": None,
+                "tool_call_batch_width_counts": None,
                 "input_tokens": None,
                 "output_tokens": None,
                 "cache_read_tokens": None,


### PR DESCRIPTION
## Summary

- Record exact model-emitted tool-call batch counts and width distributions in each live-QA case.
- Aggregate multi-call batch frequency, calls in multi-call batches, maximum width, and the bounded width histogram in Slack and PR canary reports.
- Keep telemetry privacy-safe: no prompt, response, tool argument, or tool output content is copied.

## Stack

This PR is stacked on #7533 and should merge after it. Its base is `codex/model-owned-parallel-tool-calls`.

## Compatibility and rollback

- Additive `details.metrics` fields only; legacy/interrupted traces remain supported with `null` batch metrics.
- Report parsing ignores unavailable or malformed batch distributions instead of treating them as zero.
- Rollback is limited to these canary parser/report fields and does not change runtime tool execution.

### Test card

User behavior: Maintainers can see how often the model emitted tool batches and their widths in live-canary results.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: live-QA trace metric parsing, unavailable/zero metric shapes, report ingestion, aggregation, bounded rendering, and PR comment output.
- Reborn integration: Not applicable: this change reads existing per-case trace output and does not alter runtime behavior.
- Recorded fixture: Not applicable: no model tool-selection contract changes.
- Browser E2E: Not applicable: no WebUI behavior changes.
- Backend or runtime: Not applicable: no backend or runtime behavior changes.
- Live canary: Not run locally: requires hosted credentials; the stacked PR canary will exercise the new report fields.

What the tests prove:
- Multi-call response widths are counted exactly without copying private content.
- Missing legacy metrics remain unknown rather than zero.
- Canary summaries aggregate distributions and bound rendered cardinality.
- Existing artifact scrubbing accepts and protects the additive scalar fields.

Commands run:
```text
/Users/firatsertgoz/.local/bin/python3.11 scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
/Users/firatsertgoz/.local/bin/python3.11 scripts/live-canary/test_notify_slack.py
/Users/firatsertgoz/.local/bin/python3.11 scripts/live-canary/test_scrub_artifacts.py
/Users/firatsertgoz/.local/bin/python3.11 -m compileall -q scripts/reborn_webui_v2_live_qa/run_live_qa.py scripts/live-canary/notify_slack.py
python3 scripts/ci/docs_publication_boundary.py
git diff --check
```
