### PR TITLE
ci: tolerate sccache install outages

### DIFF
--- a/.github/actions/setup-sccache-dist/action.yml
+++ b/.github/actions/setup-sccache-dist/action.yml
@@ -52,13 +52,22 @@ runs:
       run: echo "::notice title=OVH sccache skipped::SCCACHE_DIST_AUTH_TOKEN or OVH Redis cache credentials are unavailable; using local compilation."
 
     - name: Install sccache
+      id: install_sccache
       if: ${{ inputs.auth-token != '' || (inputs.redis-password != '' && inputs.cache-ssh-private-key != '' && inputs.cache-ssh-host != '' && inputs.cache-ssh-known-hosts != '') }}
+      # Compilation caching is optional; a release-asset outage must not keep
+      # the caller's tests from running without a cache.
+      continue-on-error: true
       uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       with:
         version: v0.16.0
 
+    - name: Fall back to local compilation
+      if: ${{ steps.install_sccache.outcome == 'failure' }}
+      shell: bash
+      run: echo "::warning title=sccache installation failed::The optional sccache binary could not be installed; using local compilation."
+
     - name: Configure OVH sccache
-      if: ${{ inputs.auth-token != '' || (inputs.redis-password != '' && inputs.cache-ssh-private-key != '' && inputs.cache-ssh-host != '' && inputs.cache-ssh-known-hosts != '') }}
+      if: ${{ (inputs.auth-token != '' || (inputs.redis-password != '' && inputs.cache-ssh-private-key != '' && inputs.cache-ssh-host != '' && inputs.cache-ssh-known-hosts != '')) && steps.install_sccache.outcome == 'success' }}
       shell: bash
       env:
         SCCACHE_CACHE_SSH_HOST: ${{ inputs.cache-ssh-host }}

--- a/docs/internal/design/2026-08-12-sccache-install-fallback.md
+++ b/docs/internal/design/2026-08-12-sccache-install-fallback.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-The shared `setup-sccache-dist` composite action makes every opted-in CI lane depend on downloading an `sccache` release asset. The upstream installer retries transient download failures, but after those retries are exhausted the lane fails before its tests start. This removed PR #7477 from the merge queue twice even though `sccache` is only a compilation-cache optimization.
+The shared `setup-sccache-dist` composite action makes every opted-in CI lane depend on downloading an `sccache` release asset. The upstream installer retries transient download failures, but after those retries are exhausted the lane fails before its tests start. This failed two independent runs for PR #7477 and ultimately removed it from the merge queue even though `sccache` is only a compilation-cache optimization.
 
 ## Design
 

--- a/docs/internal/design/2026-08-12-sccache-install-fallback.md
+++ b/docs/internal/design/2026-08-12-sccache-install-fallback.md
@@ -1,0 +1,21 @@
+# Best-Effort sccache Installation
+
+## Problem
+
+The shared `setup-sccache-dist` composite action makes every opted-in CI lane depend on downloading an `sccache` release asset. The upstream installer retries transient download failures, but after those retries are exhausted the lane fails before its tests start. This removed PR #7477 from the merge queue twice even though `sccache` is only a compilation-cache optimization.
+
+## Design
+
+Keep the existing pinned installer and its built-in retries, but mark only that installer step as best-effort. Give the step the ID `install_sccache` so later composite-action steps can inspect its pre-`continue-on-error` outcome.
+
+When installation succeeds, preserve the current behavior: validate the cache and distributed-compiler settings, establish the SSH tunnel, write the configuration, set `RUSTC_WRAPPER=sccache`, and probe the scheduler. Configuration and connection failures remain fatal because they indicate an IronClaw-owned setup defect after the binary is available.
+
+When installation fails, emit a warning, skip all cache configuration, do not set `RUSTC_WRAPPER`, and let the caller continue with ordinary local Rust compilation. No additional retry layer is added because the upstream action already retries the release download.
+
+## Verification
+
+Extend the existing CI workflow-contract validator and sabotage tests to pin three properties: the installer is best-effort, configuration requires a successful installer outcome, and a failed installer produces a local-compilation warning. Run the focused workflow-contract tests, the checked-in workflow validator, `actionlint` when available, and the docs publication-boundary check.
+
+## Compatibility and rollback
+
+Successful cache setup is unchanged. The failure path is slower because it compiles locally, but it no longer turns an optional cache outage into a false test failure. Rollback is a one-commit revert of the composite-action and contract changes.

--- a/docs/internal/design/2026-08-12-sccache-install-fallback.md
+++ b/docs/internal/design/2026-08-12-sccache-install-fallback.md
@@ -14,8 +14,8 @@ When installation fails, emit a warning, skip all cache configuration, do not se
 
 ## Verification
 
-Extend the existing CI workflow-contract validator and sabotage tests to pin three properties: the installer is best-effort, configuration requires a successful installer outcome, and a failed installer produces a local-compilation warning. Run the focused workflow-contract tests, the checked-in workflow validator, `actionlint` when available, and the docs publication-boundary check.
+Extend the existing CI workflow-contract validator and sabotage tests to pin three properties: the installer is best-effort, configuration requires a successful installer outcome, and a failed installer produces a local-compilation warning. Because every Reborn test job consumes the shared action, map its directory to the exhaustive Reborn PR test plan and retain fail-closed handling for other unmapped local actions. Run the affected-area planner tests, focused workflow-contract tests, the checked-in workflow validator, `actionlint` when available, and the docs publication-boundary check.
 
 ## Compatibility and rollback
 
-Successful cache setup is unchanged. The failure path is slower because it compiles locally, but it no longer turns an optional cache outage into a false test failure. Rollback is a one-commit revert of the composite-action and contract changes.
+Successful cache setup is unchanged. The failure path is slower because it compiles locally, but it no longer turns an optional cache outage into a false test failure. Pull requests that change this shared action run the exhaustive Reborn plan, increasing CI cost only for this rare CI-infrastructure change class. Rollback is a revert of the composite-action, workflow-contract, and affected-area planner changes.

--- a/docs/internal/plans/2026-08-12-sccache-install-fallback.md
+++ b/docs/internal/plans/2026-08-12-sccache-install-fallback.md
@@ -106,3 +106,38 @@ Expected: only the composite action, its contract tests, and these internal desi
 Commit message: `ci: tolerate sccache install outages`
 
 PR title: `ci: tolerate sccache install outages`
+
+### Task 4: Classify the shared action in the Reborn PR planner
+
+**Files:**
+- Modify: `scripts/ci/reborn_pr_test_plan.py`
+- Modify: `scripts/ci/test_reborn_pr_test_plan.py`
+
+**Interfaces:**
+- Consumes: changed path `.github/actions/setup-sccache-dist/**`.
+- Produces: an exhaustive Reborn test plan for the shared action while other unmapped local actions remain fail-closed.
+
+- [ ] **Step 1: Add a regression test that reproduces the PR failure**
+
+Assert that the sccache action selects `mode=full` and that an unrelated local action still raises `unmapped test or CI path`.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run: `python3 -m unittest scripts.ci.test_reborn_pr_test_plan.RebornPrTestPlanTests.test_shared_sccache_action_widens_to_exhaustive_plan`
+
+Expected: FAIL with `unmapped test or CI path: .github/actions/setup-sccache-dist/action.yml`.
+
+- [ ] **Step 3: Add the minimal path classification**
+
+Recognize only `.github/actions/setup-sccache-dist/**`, finish validating the rest of the changed paths, and then return the exhaustive plan.
+
+- [ ] **Step 4: Run the planner and workflow-contract suites**
+
+Run:
+
+```bash
+python3 scripts/ci/test_reborn_pr_test_plan.py
+python3 scripts/ci/test_ws12_workflow_contracts.py
+```
+
+Expected: both suites pass.

--- a/docs/internal/plans/2026-08-12-sccache-install-fallback.md
+++ b/docs/internal/plans/2026-08-12-sccache-install-fallback.md
@@ -1,0 +1,108 @@
+# Best-Effort sccache Installation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent transient `sccache` release-download failures from failing CI lanes before their tests run.
+
+**Architecture:** The shared composite action continues to use the pinned upstream installer and its retries. Only installer failure is tolerated; later configuration runs exclusively after a successful install and retains its current strict validation.
+
+**Tech Stack:** GitHub composite actions, Python `unittest` CI contract tests, repository CI validation scripts.
+
+## Global Constraints
+
+- `sccache` remains an optional performance optimization.
+- Invalid cache credentials or configuration remain fatal after installation succeeds.
+- Successful cache setup behavior and all callers remain unchanged.
+- No new dependency or Cargo feature is introduced.
+
+---
+
+### Task 1: Pin the fail-open installer contract
+
+**Files:**
+- Modify: `scripts/ci/ws12_workflow_contracts.py`
+- Modify: `scripts/ci/test_ws12_workflow_contracts.py`
+
+**Interfaces:**
+- Consumes: `.github/actions/setup-sccache-dist/action.yml` as checked-in text.
+- Produces: `validate_sccache_setup_action(text: str) -> list[str]`, wired into the top-level workflow contract validation.
+
+- [ ] **Step 1: Write sabotage tests for installer tolerance, configuration gating, and fallback warning**
+
+Add tests that mutate each required behavior independently and assert that `validate_sccache_setup_action` reports the broken contract.
+
+- [ ] **Step 2: Run the focused tests to verify RED**
+
+Run: `python3 scripts/ci/test_ws12_workflow_contracts.py`
+
+Expected: FAIL because `validate_sccache_setup_action` and the required action behavior do not yet exist.
+
+- [ ] **Step 3: Add the minimal validator interface**
+
+Load `.github/actions/setup-sccache-dist/action.yml` alongside workflow files, validate the three behavior markers, and return actionable errors through `validate_workflow_texts`.
+
+- [ ] **Step 4: Re-run the focused tests**
+
+Run: `python3 scripts/ci/test_ws12_workflow_contracts.py`
+
+Expected: The checked-in-action test remains red until Task 2; sabotage tests exercise the new validator.
+
+### Task 2: Make installation best-effort
+
+**Files:**
+- Modify: `.github/actions/setup-sccache-dist/action.yml`
+
+**Interfaces:**
+- Consumes: the existing cache-credential availability condition.
+- Produces: step outcome `steps.install_sccache.outcome` for configuration and fallback routing.
+
+- [ ] **Step 1: Mark the installer step with `id: install_sccache` and `continue-on-error: true`**
+
+- [ ] **Step 2: Require `steps.install_sccache.outcome == 'success'` before configuration**
+
+- [ ] **Step 3: Add a warning step for `steps.install_sccache.outcome == 'failure'` that states local compilation will be used**
+
+- [ ] **Step 4: Run the focused tests to verify GREEN**
+
+Run: `python3 scripts/ci/test_ws12_workflow_contracts.py`
+
+Expected: PASS.
+
+### Task 3: Verify and publish
+
+**Files:**
+- Verify the complete branch diff.
+
+**Interfaces:**
+- Consumes: Tasks 1 and 2.
+- Produces: a draft GitHub pull request against `main`.
+
+- [ ] **Step 1: Run focused repository verification**
+
+Run:
+
+```bash
+python3 scripts/ci/test_ws12_workflow_contracts.py
+python3 scripts/ci/ws12_workflow_contracts.py
+python3 scripts/ci/docs_publication_boundary.py
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Run GitHub Actions syntax validation when available**
+
+Run: `actionlint`
+
+Expected: exit 0; if unavailable, report that limitation explicitly.
+
+- [ ] **Step 3: Inspect the diff and working tree**
+
+Run: `git diff --check && git status --short && git diff --stat && git diff`
+
+Expected: only the composite action, its contract tests, and these internal design/plan files are changed.
+
+- [ ] **Step 4: Commit, push, and open a draft PR**
+
+Commit message: `ci: tolerate sccache install outages`
+
+PR title: `ci: tolerate sccache install outages`

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -486,6 +486,7 @@ DOCKER_RUNTIME_CONFIG_OWNERS = {
 # hook, while Code Style both triggers on the tree and lints its contents
 # (`scripts/ci/test-ci-comm-locale-pin.sh` follows the symlinks and scans them).
 PR_STATIC_CONTROL_PREFIXES = (".github/workflows/", "scripts/ci/", ".githooks/")
+SHARED_REBORN_ACTION_PREFIXES = (".github/actions/setup-sccache-dist/",)
 BUCKET_WEIGHTS = {
     "reborn-core": 12,
     "auth-security": 9,
@@ -769,6 +770,7 @@ def build_plan(
     run_sandbox_docker = False
     qa_evidence_changed = False
     nextest_config_changed = False
+    shared_reborn_action_changed = False
     reasons: list[str] = []
     root_inventory = _root_test_partitions()
     integration_inventory = _integration_test_lanes()
@@ -807,6 +809,14 @@ def build_plan(
             # dead `live_tests::zizmor_scan*` overrides failed the whole
             # `Tests (Reborn)` roll-up on the provider-matrix retirement PR.
             nextest_config_changed = True
+            continue
+        if path.startswith(SHARED_REBORN_ACTION_PREFIXES):
+            # Every `Tests (Reborn)` job installs the compiler cache through
+            # this local action. No narrow lane can exercise a change to it
+            # safely, so use the exhaustive plan just as we do for shared
+            # nextest configuration. Keep other `.github/actions/**` paths
+            # fail-closed until their consumers are mapped deliberately.
+            shared_reborn_action_changed = True
             continue
         if path in PR_STATIC_CONTROL_PATHS or path.startswith(
             PR_STATIC_CONTROL_PREFIXES
@@ -1062,6 +1072,11 @@ def build_plan(
     if nextest_config_changed:
         return _full_plan(
             "nextest runner config changed; this PR runs the exhaustive plan",
+            canonical_packages,
+        )
+    if shared_reborn_action_changed:
+        return _full_plan(
+            "shared sccache action changed; this PR runs the exhaustive plan",
             canonical_packages,
         )
 

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -947,6 +947,25 @@ class RebornPrTestPlanTests(unittest.TestCase):
                 [".config/nextest.toml", "scripts/some-undecided-helper.sh"],
             )
 
+    def test_shared_sccache_action_widens_to_exhaustive_plan(self) -> None:
+        """The shared sccache action is executed by every Reborn test lane."""
+        plan = self.plan(
+            "pull_request", [".github/actions/setup-sccache-dist/action.yml"]
+        )
+        self.assertEqual(plan["mode"], "full")
+        self.assertEqual(plan["root_partitions"], [0, 1, 2, 3])
+        self.assertEqual(plan["integration_lanes"], [0, 1, 2, 3, "groups"])
+        self.assertIn("shared sccache action changed", plan["reasons"][0])
+
+        with self.assertRaisesRegex(ValueError, "unmapped test or CI path"):
+            self.plan(
+                "pull_request",
+                [
+                    ".github/actions/setup-sccache-dist/action.yml",
+                    ".github/actions/some-undecided-action/action.yml",
+                ],
+            )
+
     def test_agent_guidance_is_classified_and_selects_no_rust_lane(self) -> None:
         """`.claude/**` is prose, like `docs/**`.
 

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -42,6 +42,88 @@ from ws12_workflow_contracts import (
 )
 
 ROOT = Path(__file__).resolve().parents[2]
+SCCACHE_SETUP_ACTION = (
+    ROOT / ".github" / "actions" / "setup-sccache-dist" / "action.yml"
+)
+
+
+class SccacheSetupActionContractTests(unittest.TestCase):
+    """The optional compiler cache must never gate the tests it accelerates."""
+
+    COMPLIANT_ACTION = """\
+runs:
+  using: composite
+  steps:
+    - name: Install sccache
+      id: install_sccache
+      continue-on-error: true
+      uses: mozilla-actions/sccache-action@example
+
+    - name: Configure OVH sccache
+      if: ${{ inputs.enabled == 'true' && steps.install_sccache.outcome == 'success' }}
+      shell: bash
+      run: configure-cache
+
+    - name: Fall back to local compilation
+      if: ${{ steps.install_sccache.outcome == 'failure' }}
+      shell: bash
+      run: echo "::warning title=sccache unavailable::Installation failed; using local compilation."
+"""
+
+    def validate(self, text: str) -> list[str]:
+        validator = getattr(
+            ws12_workflow_contracts, "validate_sccache_setup_action", None
+        )
+        self.assertIsNotNone(
+            validator,
+            "ws12_workflow_contracts must validate the shared sccache action",
+        )
+        return validator(text)
+
+    def test_checked_in_action_keeps_installation_best_effort(self) -> None:
+        action = SCCACHE_SETUP_ACTION.read_text(encoding="utf-8")
+        self.assertEqual(self.validate(action), [])
+
+    def test_compliant_fixture_passes(self) -> None:
+        self.assertEqual(self.validate(self.COMPLIANT_ACTION), [])
+
+    def test_install_failure_must_be_tolerated(self) -> None:
+        sabotaged = self.COMPLIANT_ACTION.replace(
+            "      continue-on-error: true\n", ""
+        )
+        errors = self.validate(sabotaged)
+        self.assertTrue(any("continue-on-error" in error for error in errors), errors)
+
+    def test_configuration_must_require_a_successful_install(self) -> None:
+        sabotaged = self.COMPLIANT_ACTION.replace(
+            " && steps.install_sccache.outcome == 'success'", ""
+        )
+        errors = self.validate(sabotaged)
+        self.assertTrue(
+            any("successful installation" in error for error in errors), errors
+        )
+
+    def test_install_failure_must_explain_the_local_fallback(self) -> None:
+        sabotaged = self.COMPLIANT_ACTION.replace(
+            "      if: ${{ steps.install_sccache.outcome == 'failure' }}\n",
+            "      if: ${{ steps.install_sccache.outcome == 'success' }}\n",
+        )
+        errors = self.validate(sabotaged)
+        self.assertTrue(any("local compilation" in error for error in errors), errors)
+
+    def test_action_failures_reach_the_top_level_contract(self) -> None:
+        original = ws12_workflow_contracts.validate_sccache_setup_action
+        sentinel = "sccache action contract sentinel"
+        ws12_workflow_contracts.validate_sccache_setup_action = lambda _text: [sentinel]
+        self.addCleanup(
+            setattr,
+            ws12_workflow_contracts,
+            "validate_sccache_setup_action",
+            original,
+        )
+
+        errors = validate_workflow_texts(load_workflows(ROOT), ROOT)
+        self.assertIn(sentinel, errors)
 
 
 class WorkflowContractSabotageTests(unittest.TestCase):

--- a/scripts/ci/ws12_workflow_contracts.py
+++ b/scripts/ci/ws12_workflow_contracts.py
@@ -953,6 +953,10 @@ def validate_postgres_scripted_parity(text: str) -> list[str]:
 PRODUCTION_LINT_STEP = "Check production-target lints"
 WINDOWS_CLIPPY_JOB = "clippy-windows"
 WEBUI_INSTALL_STEP = "Install WebUI frontend dependencies"
+SCCACHE_SETUP_ACTION = ".github/actions/setup-sccache-dist/action.yml"
+SCCACHE_INSTALL_STEP = "Install sccache"
+SCCACHE_CONFIGURE_STEP = "Configure OVH sccache"
+SCCACHE_FALLBACK_STEP = "Fall back to local compilation"
 
 # One `- name:` step heading. The scan is bounded to its own step because the
 # neighbouring `Check all-target lints` legitimately passes `--tests
@@ -1008,6 +1012,55 @@ def step_body(text: str, step_name: str) -> str | None:
         following = STEP_HEADING.search(text, heading.end())
         return text[heading.end() : following.start() if following else len(text)]
     return None
+
+
+def validate_sccache_setup_action(text: str) -> list[str]:
+    """Keep an optional compiler-cache download from gating CI correctness."""
+    errors: list[str] = []
+
+    install = step_body(text, SCCACHE_INSTALL_STEP)
+    if install is None:
+        return [
+            f"{SCCACHE_SETUP_ACTION}: could not find the {SCCACHE_INSTALL_STEP!r} step"
+        ]
+    if "id: install_sccache" not in install:
+        errors.append(
+            f"{SCCACHE_SETUP_ACTION}: {SCCACHE_INSTALL_STEP!r} must expose "
+            "`id: install_sccache` so later steps can route on its outcome"
+        )
+    if "continue-on-error: true" not in install:
+        errors.append(
+            f"{SCCACHE_SETUP_ACTION}: {SCCACHE_INSTALL_STEP!r} must set "
+            "`continue-on-error: true` because cache installation is optional"
+        )
+
+    configure = step_body(text, SCCACHE_CONFIGURE_STEP)
+    if configure is None:
+        errors.append(
+            f"{SCCACHE_SETUP_ACTION}: could not find the {SCCACHE_CONFIGURE_STEP!r} step"
+        )
+    elif "steps.install_sccache.outcome == 'success'" not in configure:
+        errors.append(
+            f"{SCCACHE_SETUP_ACTION}: {SCCACHE_CONFIGURE_STEP!r} must require a "
+            "successful installation before configuring or enabling `RUSTC_WRAPPER`"
+        )
+
+    fallback = step_body(text, SCCACHE_FALLBACK_STEP)
+    if fallback is None:
+        errors.append(
+            f"{SCCACHE_SETUP_ACTION}: could not find the {SCCACHE_FALLBACK_STEP!r} step"
+        )
+    elif (
+        "steps.install_sccache.outcome == 'failure'" not in fallback
+        or "::warning" not in fallback
+        or "local compilation" not in fallback
+    ):
+        errors.append(
+            f"{SCCACHE_SETUP_ACTION}: {SCCACHE_FALLBACK_STEP!r} must warn that a "
+            "failed installation is falling back to local compilation"
+        )
+
+    return errors
 
 
 def job_body(text: str, job_name: str) -> str | None:
@@ -1704,6 +1757,12 @@ def validate_workflow_texts(
     errors.extend(validate_crate_scope_filters(workflows, root))
     errors.extend(validate_crate_name_residue(workflows, root))
     errors.extend(validate_webui_frontend_sites(workflows, root))
+    try:
+        sccache_action = (root / SCCACHE_SETUP_ACTION).read_text(encoding="utf-8")
+    except OSError as error:
+        errors.append(f"{SCCACHE_SETUP_ACTION}: could not read action: {error}")
+    else:
+        errors.extend(validate_sccache_setup_action(sccache_action))
     return errors
 
 


### PR DESCRIPTION
## Summary

- Treat the pinned upstream `sccache` installer as best-effort so exhausted release-download retries do not fail CI before tests start.
- Configure and enable `RUSTC_WRAPPER` only after a successful install; invalid IronClaw-owned cache configuration remains fatal.
- Add workflow-contract coverage for installer tolerance, success gating, fallback messaging, and top-level wiring.
- Classify `.github/actions/setup-sccache-dist/**` as an exhaustive Reborn test-plan change while keeping other unmapped local actions fail-closed.
- Document compatibility, CI-cost, and rollback implications.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Observed twice while running PR #7477, including its merge-group run.

## Validation

- [ ] `cargo fmt --all -- --check` — not applicable; no Rust changed
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not applicable; no Rust changed
- [ ] `cargo build` — not applicable; no build graph changed
- [x] Relevant tests pass: 76 affected-area planner tests and 94 workflow-contract tests
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; no crate/runtime behavior changed
- [x] Manual testing: the complete PR path set produces an exhaustive Reborn plan; the composite action parses as YAML; changed Python modules compile

## Test Strategy

User behavior: CI lanes continue with uncached local Rust compilation when the optional `sccache` binary cannot be downloaded.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: extended `test_ws12_workflow_contracts.py` with focused action contracts and top-level wiring coverage.
- CI planner: added a regression proving the shared sccache action selects the exhaustive plan and unrelated local actions remain fail-closed.
- Reborn integration: Not applicable; the incident occurs during CI setup before Reborn tests start.
- Recorded fixture: Not applicable; no product behavior changed.
- Browser E2E: Not applicable; no browser behavior changed.
- Backend or runtime: Not applicable; no production runtime changed.
- Live canary: Not applicable; successful sccache configuration behavior is unchanged.

What the tests prove: installation is best-effort, configuration requires a successful install, failed installs warn about local compilation, the validator is wired into the repository CI contract, and the Reborn affected-area detector accepts this shared action without under-scheduling tests.

Commands run:

```bash
python3 scripts/ci/test_reborn_pr_test_plan.py
python3 scripts/ci/test_ws12_workflow_contracts.py
python3 scripts/ci/ws12_workflow_contracts.py
python3 scripts/ci/docs_publication_boundary.py
python3 -m py_compile scripts/ci/reborn_pr_test_plan.py scripts/ci/test_reborn_pr_test_plan.py scripts/ci/ws12_workflow_contracts.py scripts/ci/test_ws12_workflow_contracts.py
ruby -e 'require "yaml"; YAML.load(File.read(".github/actions/setup-sccache-dist/action.yml"))'
git diff --check origin/main...HEAD
```

`actionlint` and `ruff` were not installed locally; GitHub CI remains the authoritative composite-action execution check.

## Security Impact

No new permissions, network destinations, secrets, or credential handling. Cache configuration and SSH tunnel failures remain fatal after installation succeeds. When installation fails, the action skips configuration and does not set `RUSTC_WRAPPER`.

## Reborn Trust-Boundary Checklist

N/A: CI-only optional compiler-cache setup; no Reborn runtime, policy, evidence, ingress, or persistence boundary changes.

## Database Impact

None.

## Blast Radius

All workflows that call `.github/actions/setup-sccache-dist`. The successful path is unchanged. The new failure path is slower because it compiles locally, but it reaches the caller's tests. PRs that edit this shared action now run the exhaustive Reborn plan, increasing CI cost only for this rare infrastructure-change class.

## Rollback Plan

Revert the three commits in this PR. This restores the previous fail-closed installer behavior and removes the planner mapping without data or schema migration.

## Review Follow-Through

Reviewer focus: confirm GitHub Actions applies `continue-on-error` to the nested action's main and post steps, the outcome guard preserves strict configuration failures, and the exhaustive planner mapping is appropriate for a shared action used by every Reborn lane.

---

**Review track**: C (CI)