### PR TITLE
chore(webui): scaffold @ironclaw/ui design-system package (Phase 3 reference)

### DIFF
--- a/crates/product/ironclaw_webui/frontend/packages/ui/README.md
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/README.md
@@ -1,0 +1,51 @@
+# `@ironclaw/ui` — design-system package (scaffold)
+
+Target home for the IronClaw WebUI design system as a first-class package,
+scaffolded now as a **reference for the Phase-3 reskin** (Epic
+[#7038](https://github.com/nearai/ironclaw/issues/7038)). This is the framework
+the current `../../src/design-system/` primitives migrate **into** over Phases
+3–4.
+
+> **Status: inert scaffold — not yet wired.** Every file here is a stub. The
+> package is deliberately **not** in `pnpm-workspace.yaml`, the Storybook stories
+> glob, or `tsconfig.json`, so it neither builds nor runs today. Phase 3 wires it
+> in (workspace member → tokens → components), one component at a time.
+
+## Structure
+
+```
+packages/ui/src/
+├── tokens/       colors · typography · spacing · radii · shadows · motion   (one .css per token layer)
+├── themes/       light.css · dark.css · themes.stories.tsx                  (theme token values + preview)
+├── icons/        icon.tsx · registry.ts · icons.stories.tsx · index.ts
+├── components/   button · input · select · card · modal · badge · switch    (one folder each)
+│   └── button/   button.tsx · button.variants.ts · button.stories.tsx · button.test.tsx · index.ts
+└── styles/       index.css                                                  (package style entry: @imports the token + theme layers)
+```
+
+**Per-component convention** (see `components/button/` as the worked template):
+
+| File | Role |
+|------|------|
+| `<name>.tsx` | The component — presentational; styled through tokens, never hardcoded hex/px |
+| `<name>.variants.ts` | Variant/size map (cva-style) kept out of the component body |
+| `<name>.stories.tsx` | Storybook catalog entry (smoke + variant + `play` where it proves something) |
+| `<name>.test.tsx` | Unit test |
+| `index.ts` | Public re-export |
+
+## Migration mapping (Phase 3)
+
+| Today (`src/design-system/`) | Target (`packages/ui/src/`) |
+|---|---|
+| `app.css` `@theme` + `--v2-*` (in `src/styles/`) | `tokens/*.css` + `themes/{light,dark}.css` |
+| `button.tsx`, `input.tsx`, `select-menu.tsx`, `card.tsx`, `modal.tsx`, `badge.tsx`, `switch.tsx` | `components/<name>/` |
+| `icons.tsx` | `icons/` |
+| `*.stories.tsx` (colocated) | colocated in each `components/<name>/` |
+| `src/test-support/storybook-decorators.tsx` | `.storybook/decorators.tsx` (shared) |
+
+## Rules
+
+Governed by [`DESIGN.md`](../../DESIGN.md) and
+[`.claude/rules/design-system.md`](../../../../../../.claude/rules/design-system.md):
+native M3X on React + Tailwind, token-driven (no hardcoded hex/px), a story per
+component, WCAG AA + light/dark parity, `prefers-reduced-motion`-gated motion.

--- a/crates/product/ironclaw_webui/frontend/packages/ui/package.json
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@ironclaw/ui",
+  "version": "0.0.0",
+  "private": true,
+  "description": "IronClaw WebUI design-system package (@ironclaw/ui) — Phase-3 scaffold. Not yet wired into the build (see README).",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./styles": "./src/styles/index.css",
+    "./tokens/*": "./src/tokens/*"
+  },
+  "peerDependencies": {
+    "react": "^19",
+    "react-dom": "^19"
+  }
+}

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.stories.tsx
@@ -1,0 +1,1 @@
+// badge.stories.tsx (Phase 3). Template: src/design-system/badge.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.test.tsx
@@ -1,0 +1,1 @@
+// badge.test.tsx (Phase 3). Template: src/design-system/badge.test.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.tsx
@@ -1,0 +1,2 @@
+// @ironclaw/ui <badge> (Phase 3). Migrate from src/design-system/badge.tsx; style via tokens, not hex/px.
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.variants.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/badge.variants.ts
@@ -1,0 +1,2 @@
+// badge variant map (cva-style) (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/badge/index.ts
@@ -1,0 +1,2 @@
+// Public badge export (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.stories.tsx
@@ -1,0 +1,1 @@
+// button.stories.tsx (Phase 3). Template: src/design-system/button.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.test.tsx
@@ -1,0 +1,1 @@
+// button.test.tsx (Phase 3). Template: src/design-system/button.test.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.tsx
@@ -1,0 +1,2 @@
+// @ironclaw/ui <button> (Phase 3). Migrate from src/design-system/button.tsx; style via tokens, not hex/px.
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.variants.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/button.variants.ts
@@ -1,0 +1,2 @@
+// button variant map (cva-style) (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/button/index.ts
@@ -1,0 +1,2 @@
+// Public button export (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.stories.tsx
@@ -1,0 +1,1 @@
+// card.stories.tsx (Phase 3). Template: src/design-system/card.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.test.tsx
@@ -1,0 +1,1 @@
+// card.test.tsx (Phase 3). Template: src/design-system/card.test.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.tsx
@@ -1,0 +1,2 @@
+// @ironclaw/ui <card> (Phase 3). Migrate from src/design-system/card.tsx; style via tokens, not hex/px.
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.variants.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/card.variants.ts
@@ -1,0 +1,2 @@
+// card variant map (cva-style) (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/card/index.ts
@@ -1,0 +1,2 @@
+// Public card export (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/index.ts
@@ -1,0 +1,2 @@
+// Public input export (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.stories.tsx
@@ -1,0 +1,1 @@
+// input.stories.tsx (Phase 3). Template: src/design-system/input.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.test.tsx
@@ -1,0 +1,1 @@
+// input.test.tsx (Phase 3). Template: src/design-system/input.test.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.tsx
@@ -1,0 +1,2 @@
+// @ironclaw/ui <input> (Phase 3). Migrate from src/design-system/input.tsx; style via tokens, not hex/px.
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.variants.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/input/input.variants.ts
@@ -1,0 +1,2 @@
+// input variant map (cva-style) (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/index.ts
@@ -1,0 +1,2 @@
+// Public modal export (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.stories.tsx
@@ -1,0 +1,1 @@
+// modal.stories.tsx (Phase 3). Template: src/design-system/modal.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.test.tsx
@@ -1,0 +1,1 @@
+// modal.test.tsx (Phase 3). Template: src/design-system/modal.test.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.tsx
@@ -1,0 +1,2 @@
+// @ironclaw/ui <modal> (Phase 3). Migrate from src/design-system/modal.tsx; style via tokens, not hex/px.
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.variants.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/modal/modal.variants.ts
@@ -1,0 +1,2 @@
+// modal variant map (cva-style) (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/index.ts
@@ -1,0 +1,2 @@
+// Public select export (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.stories.tsx
@@ -1,0 +1,1 @@
+// select.stories.tsx (Phase 3). Template: src/design-system/select.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.test.tsx
@@ -1,0 +1,1 @@
+// select.test.tsx (Phase 3). Template: src/design-system/select.test.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.tsx
@@ -1,0 +1,2 @@
+// @ironclaw/ui <select> (Phase 3). Migrate from src/design-system/select.tsx; style via tokens, not hex/px.
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.variants.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/select/select.variants.ts
@@ -1,0 +1,2 @@
+// select variant map (cva-style) (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/index.ts
@@ -1,0 +1,2 @@
+// Public switch export (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.stories.tsx
@@ -1,0 +1,1 @@
+// switch.stories.tsx (Phase 3). Template: src/design-system/switch.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.test.tsx
@@ -1,0 +1,1 @@
+// switch.test.tsx (Phase 3). Template: src/design-system/switch.test.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.tsx
@@ -1,0 +1,2 @@
+// @ironclaw/ui <switch> (Phase 3). Migrate from src/design-system/switch.tsx; style via tokens, not hex/px.
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.variants.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/components/switch/switch.variants.ts
@@ -1,0 +1,2 @@
+// switch variant map (cva-style) (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/icon.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/icon.tsx
@@ -1,0 +1,1 @@
+// @ironclaw/ui Icon (Phase 3). Template: src/design-system/icons.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/icons.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/icons.stories.tsx
@@ -1,0 +1,1 @@
+// icons.stories.tsx — Icons gallery (Phase 3). Template: src/design-system/icons.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/index.ts
@@ -1,0 +1,2 @@
+// Public icon exports (Phase 3).
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/registry.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/icons/registry.ts
@@ -1,0 +1,2 @@
+// Icon name -> glyph registry (Phase 3).
+export const iconRegistry = {} as const;

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/index.ts
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/index.ts
@@ -1,0 +1,9 @@
+// @ironclaw/ui — public API (Phase 3).
+//
+// Populated as components migrate out of ../../src/design-system/ into
+// ./components/<name>/. Until then this is an inert scaffold entry point.
+//
+// export * from "./components/button";
+// export * from "./components/input";
+// export * from "./icons";
+export {};

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/styles/index.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/styles/index.css
@@ -1,0 +1,1 @@
+/* @ironclaw/ui — package style entry (Phase 3): @import token + theme layers here. */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/themes/dark.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/themes/dark.css
@@ -1,0 +1,1 @@
+/* @ironclaw/ui — dark theme token values (Phase 3). Derive from app.css :root[data-theme="dark"]. */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/themes/light.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/themes/light.css
@@ -1,0 +1,1 @@
+/* @ironclaw/ui — light theme token values (Phase 3). Derive from app.css :root. */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/themes/themes.stories.tsx
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/themes/themes.stories.tsx
@@ -1,0 +1,2 @@
+// themes.stories.tsx — Storybook 'Tokens/Themes' preview (Phase 3).
+// Template: src/design-system/tokens-colors.stories.tsx

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/colors.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/colors.css
@@ -1,0 +1,2 @@
+/* @ironclaw/ui — colors tokens (Phase 3 target).
+   Migrate the matching values from ../../../../src/styles/app.css (@theme + --v2-*). */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/motion.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/motion.css
@@ -1,0 +1,2 @@
+/* @ironclaw/ui — motion tokens (Phase 3 target).
+   Migrate the matching values from ../../../../src/styles/app.css (@theme + --v2-*). */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/radii.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/radii.css
@@ -1,0 +1,2 @@
+/* @ironclaw/ui — radii tokens (Phase 3 target).
+   Migrate the matching values from ../../../../src/styles/app.css (@theme + --v2-*). */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/shadows.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/shadows.css
@@ -1,0 +1,2 @@
+/* @ironclaw/ui — shadows tokens (Phase 3 target).
+   Migrate the matching values from ../../../../src/styles/app.css (@theme + --v2-*). */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/spacing.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/spacing.css
@@ -1,0 +1,2 @@
+/* @ironclaw/ui — spacing tokens (Phase 3 target).
+   Migrate the matching values from ../../../../src/styles/app.css (@theme + --v2-*). */

--- a/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/typography.css
+++ b/crates/product/ironclaw_webui/frontend/packages/ui/src/tokens/typography.css
@@ -1,0 +1,2 @@
+/* @ironclaw/ui — typography tokens (Phase 3 target).
+   Migrate the matching values from ../../../../src/styles/app.css (@theme + --v2-*). */


### PR DESCRIPTION
## What this is

An **inert scaffold** for `@ironclaw/ui` — the target structure for the WebUI design system as a first-class package, added as a **reference for the Phase-3 reskin** (Epic #7038). It mirrors the requested framework at `crates/product/ironclaw_webui/frontend/packages/ui/src/`:

```
tokens/       colors · typography · spacing · radii · shadows · motion
themes/       light.css · dark.css · themes.stories.tsx
icons/        icon.tsx · registry.ts · icons.stories.tsx · index.ts
components/   button · input · select · card · modal · badge · switch   (5-file pattern each)
styles/       index.css
```

## The shape

Every file is a **stub**. The package is deliberately **not** wired into `pnpm-workspace.yaml`, the Storybook stories glob, or `tsconfig.json` — so it neither builds nor runs today. Verified: `pnpm typecheck` and the vitest `unit` project are both `src/`-scoped and ignore `packages/` (typecheck green with the scaffold present). Phase 3 wires it in component-by-component.

## Decisions recorded

- Structure follows the agreed `@ironclaw/ui` layout; `components/button/` is the worked 5-file template (`*.tsx`, `*.variants.ts`, `*.stories.tsx`, `*.test.tsx`, `index.ts`).
- Kept inert (not wired) so it can't affect the green Phase-1/2 gates; wiring is Phase-3 work.
- Governed by `DESIGN.md` + `.claude/rules/design-system.md` (native M3X, token-driven, story-per-component).

## How to review

See [`packages/ui/README.md`](https://github.com/nearai/ironclaw/blob/chore/ui-package-scaffold/crates/product/ironclaw_webui/frontend/packages/ui/README.md) — it documents the per-component file convention and the **migration mapping** from `src/design-system/` into `packages/ui/`.

## Status & relationships

- Part of Epic #7038 (Phase-3 prep). **Supersedes the closed #6836** (@ironclaw/ui workspace refactor).
- The active Storybook + governance work is #7039 (Phase 1) and #7043 (Phase 2), both now re-homed onto `crates/product/ironclaw_webui/frontend/` and mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
