### PR TITLE
fix(channels): sticker/voice attachments no longer brick Telegram — kind validator, truthful sticker MIMEs, ingress ack-discard for deterministic failures

### DIFF
--- a/crates/contracts/ironclaw_extension_contracts/src/channel_adapter.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/channel_adapter.rs
@@ -584,6 +584,15 @@ pub struct DirectTargetProvisionRequest {
 
 /// Typed channel-adapter failures.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+/// Channel capability failures, split by what vendor redelivery can do about
+/// them. Ingress answers **5xx** only for the transient variants
+/// (`Configuration`, `VendorWiring`, `AttachmentTransfer { retryable: true }`)
+/// — redelivering the same update later may genuinely succeed. Every other
+/// variant is deterministic for a given payload: redelivery replays the same
+/// bytes into the same failure, and vendors with strictly ordered webhook
+/// redelivery re-send any non-2xx update and hold every later update in
+/// the conversation behind it. Ingress therefore acknowledges (2xx),
+/// discards, and warn-logs deterministic failures instead of rejecting them.
 pub enum ChannelError {
     #[error("inbound request could not be parsed: {reason}")]
     Parse { reason: String },
@@ -596,6 +605,10 @@ pub enum ChannelError {
     Render { reason: String },
     #[error("vendor wiring failed: {reason}")]
     VendorWiring { reason: String },
+    /// `retryable` decides the ingress disposition: `true` means a transient
+    /// transfer fault (5xx, vendor may redeliver with success), `false` means
+    /// the transfer can never succeed for this payload (adapters degrade or
+    /// ingress acknowledges-and-discards).
     #[error("attachment transfer failed: {reason}")]
     AttachmentTransfer { reason: String, retryable: bool },
     #[error("channel operation is not supported by this adapter")]

--- a/crates/contracts/ironclaw_extension_contracts/src/external.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/external.rs
@@ -458,20 +458,32 @@ fn validate_attachment_filename(value: &str) -> Result<(), ProductAdapterError> 
     Ok(())
 }
 
+/// Kind-vs-MIME agreement runs in one direction only: the three media-mirror
+/// kinds (`Image`, `Audio`, `Video`) claim exactly what the MIME base states,
+/// so a mismatch there is an adapter mislabel and is rejected. The semantic
+/// kinds (`Sticker`, `Voice`, `Document`, `Other`) carry vendor presentation
+/// meaning a MIME base cannot express — a Telegram sticker is `image/webp`,
+/// `video/webm`, or `application/x-tgsticker`; a voice note is `audio/ogg`; a
+/// document is any MIME "sent as file" — and accept any MIME. The previous
+/// reverse rule (media MIME forces the media kind) made those pairs
+/// unconstructible, which failed whole-update parsing at ingress and let one
+/// sticker poison a vendor's webhook redelivery queue.
 fn validate_attachment_kind(
     mime_type: &str,
     kind: ProductAttachmentKind,
 ) -> Result<(), ProductAdapterError> {
     let base = mime_type.split('/').next().unwrap_or_default();
-    let expected = match base {
-        "image" => Some(ProductAttachmentKind::Image),
-        "audio" => Some(ProductAttachmentKind::Audio),
-        "video" => Some(ProductAttachmentKind::Video),
-        _ => None,
+    let required_base = match kind {
+        ProductAttachmentKind::Image => Some("image"),
+        ProductAttachmentKind::Audio => Some("audio"),
+        ProductAttachmentKind::Video => Some("video"),
+        ProductAttachmentKind::Sticker
+        | ProductAttachmentKind::Voice
+        | ProductAttachmentKind::Document
+        | ProductAttachmentKind::Other => None,
     };
-    if let Some(expected) = expected
-        && kind != expected
-        && kind != ProductAttachmentKind::Other
+    if let Some(required_base) = required_base
+        && base != required_base
     {
         return Err(ProductAdapterError::InvalidIdentifier {
             kind: "attachment_kind",
@@ -557,6 +569,57 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn attachment_semantic_kinds_construct_for_real_vendor_shapes() {
+        // Regression: Telegram stickers (`image/webp` + `Sticker`) and voice
+        // notes (`audio/ogg` + `Voice`) were unconstructible, so the whole
+        // update failed parse, ingress answered non-2xx, and Telegram's
+        // in-order redelivery bricked the chat behind the poison update.
+        let cases = [
+            ("image/webp", ProductAttachmentKind::Sticker),
+            ("video/webm", ProductAttachmentKind::Sticker),
+            ("application/x-tgsticker", ProductAttachmentKind::Sticker),
+            ("audio/ogg", ProductAttachmentKind::Voice),
+            ("image/jpeg", ProductAttachmentKind::Document),
+            ("video/mp4", ProductAttachmentKind::Document),
+            ("audio/mpeg", ProductAttachmentKind::Document),
+            ("image/png", ProductAttachmentKind::Other),
+        ];
+        for (mime, kind) in cases {
+            assert!(
+                ProductAttachmentDescriptor::new("file_42", mime, None, Some(64), kind).is_ok(),
+                "expected `{mime}` + {kind:?} to be constructible"
+            );
+        }
+    }
+
+    #[test]
+    fn attachment_media_kinds_still_require_matching_mime_base() {
+        let rejected = [
+            ("application/pdf", ProductAttachmentKind::Image),
+            ("image/png", ProductAttachmentKind::Audio),
+            ("audio/ogg", ProductAttachmentKind::Video),
+            ("text/plain", ProductAttachmentKind::Video),
+        ];
+        for (mime, kind) in rejected {
+            assert!(
+                ProductAttachmentDescriptor::new("file_42", mime, None, Some(64), kind).is_err(),
+                "expected `{mime}` + {kind:?} to be rejected as a mislabel"
+            );
+        }
+        let accepted = [
+            ("image/png", ProductAttachmentKind::Image),
+            ("audio/mpeg", ProductAttachmentKind::Audio),
+            ("video/mp4", ProductAttachmentKind::Video),
+        ];
+        for (mime, kind) in accepted {
+            assert!(
+                ProductAttachmentDescriptor::new("file_42", mime, None, Some(64), kind).is_ok(),
+                "expected `{mime}` + {kind:?} to be constructible"
+            );
+        }
     }
 
     #[test]

--- a/crates/contracts/ironclaw_extension_contracts/src/external.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/external.rs
@@ -462,8 +462,8 @@ fn validate_attachment_filename(value: &str) -> Result<(), ProductAdapterError> 
 /// kinds (`Image`, `Audio`, `Video`) claim exactly what the MIME base states,
 /// so a mismatch there is an adapter mislabel and is rejected. The semantic
 /// kinds (`Sticker`, `Voice`, `Document`, `Other`) carry vendor presentation
-/// meaning a MIME base cannot express — a Telegram sticker is `image/webp`,
-/// `video/webm`, or `application/x-tgsticker`; a voice note is `audio/ogg`; a
+/// meaning a MIME base cannot express — a sticker is `image/webp`,
+/// `video/webm`, or a vendor animated format; a voice note is `audio/ogg`; a
 /// document is any MIME "sent as file" — and accept any MIME. The previous
 /// reverse rule (media MIME forces the media kind) made those pairs
 /// unconstructible, which failed whole-update parsing at ingress and let one
@@ -573,9 +573,9 @@ mod tests {
 
     #[test]
     fn attachment_semantic_kinds_construct_for_real_vendor_shapes() {
-        // Regression: Telegram stickers (`image/webp` + `Sticker`) and voice
-        // notes (`audio/ogg` + `Voice`) were unconstructible, so the whole
-        // update failed parse, ingress answered non-2xx, and Telegram's
+        // Regression: stickers (`image/webp` + `Sticker`) and voice notes
+        // (`audio/ogg` + `Voice`) were unconstructible, so the whole update
+        // failed parse, ingress answered non-2xx, and the sending vendor's
         // in-order redelivery bricked the chat behind the poison update.
         let cases = [
             ("image/webp", ProductAttachmentKind::Sticker),

--- a/crates/extensions/ironclaw_extension_host/src/ingress/router.rs
+++ b/crates/extensions/ironclaw_extension_host/src/ingress/router.rs
@@ -97,7 +97,8 @@ pub enum InboundAdmissionAck {
 }
 
 /// A failed admission. `retryable` selects 503 (vendor should redeliver)
-/// versus 400 (permanent rejection).
+/// versus an acknowledged discard (the same message re-fails on every
+/// redelivery, so the router 2xx-acks it away and warn-logs the drop).
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("inbound admission failed: {reason}")]
 pub struct InboundSinkError {
@@ -192,6 +193,11 @@ pub struct IngressResponse {
     pub body: Vec<u8>,
 }
 
+/// Body marker for [`IngressResponse::acknowledged_discarded`]. The batch
+/// processor keys its terminal-state decision on it, and operators reading
+/// HTTP captures can tell a discard from an ordinary ack.
+const ACKNOWLEDGED_DISCARDED_BODY: &[u8] = br#"{"status":"acknowledged_discarded"}"#;
+
 impl IngressResponse {
     fn error(status: u16, category: &str) -> Self {
         Self {
@@ -206,6 +212,20 @@ impl IngressResponse {
             status: 200,
             content_type: Some("text/plain".to_string()),
             body: b"ok".to_vec(),
+        }
+    }
+
+    /// 2xx acknowledgment for a verified update the host consciously drops.
+    /// Deterministic failures replay identically on redelivery, and vendors
+    /// with ordered webhook queues redeliver any non-2xx update and hold
+    /// every later update in the conversation behind it — one unusable
+    /// update bricked a whole chat. Every discard is logged at warn by its
+    /// call site; nothing is admitted.
+    fn acknowledged_discarded() -> Self {
+        Self {
+            status: 200,
+            content_type: Some("application/json".to_string()),
+            body: ACKNOWLEDGED_DISCARDED_BODY.to_vec(),
         }
     }
 }
@@ -459,29 +479,27 @@ impl ExtensionIngressRouter {
                 .await
             {
                 Ok(Ok(outcome)) => outcome,
-                Ok(Err(ChannelError::Configuration { .. })) => {
+                // Transient failures earn a 5xx so the vendor's redelivery
+                // can succeed later. Every other adapter failure is
+                // deterministic — redelivery replays the same bytes into the
+                // same failure, and vendors with ordered webhook queues hold
+                // every later update in the conversation behind a non-2xx'd
+                // one — so the host acks and discards instead.
+                Ok(Err(error)) if channel_error_is_transient(&error) => {
                     tracing::debug!(
                         extension_id = %binding.extension_id(),
-                        "channel adapter host configuration is unavailable"
-                    );
-                    return IngressResponse::error(503, "temporarily_unavailable");
-                }
-                Ok(Err(ChannelError::AttachmentTransfer {
-                    retryable: true, ..
-                })) => {
-                    tracing::debug!(
-                        extension_id = %binding.extension_id(),
-                        "channel adapter attachment transfer is temporarily unavailable"
+                        error = %error,
+                        "channel adapter failed transiently; vendor redelivery may succeed"
                     );
                     return IngressResponse::error(503, "temporarily_unavailable");
                 }
                 Ok(Err(error)) => {
-                    tracing::debug!(
+                    tracing::warn!(
                         extension_id = %binding.extension_id(),
                         error = %error,
-                        "channel adapter rejected verified inbound request"
+                        "acknowledging and discarding verified inbound update after a deterministic adapter failure"
                     );
-                    return IngressResponse::error(400, "malformed_payload");
+                    return IngressResponse::acknowledged_discarded();
                 }
                 Err(_) => {
                     tracing::warn!(
@@ -587,6 +605,21 @@ impl RestrictedEgress for UnavailableRestrictedEgress {
     }
 }
 
+/// Transient failures may succeed on vendor redelivery; everything else is
+/// deterministic and is acknowledged-and-discarded by ingress (see
+/// [`IngressResponse::acknowledged_discarded`]).
+fn channel_error_is_transient(error: &ChannelError) -> bool {
+    matches!(
+        error,
+        ChannelError::Configuration { .. }
+            | ChannelError::VendorWiring { .. }
+            | ChannelError::AttachmentTransfer {
+                retryable: true,
+                ..
+            }
+    )
+}
+
 async fn admit_messages(
     deps: &ExtensionIngressRouterDeps,
     extension_id: &str,
@@ -598,12 +631,12 @@ async fn admit_messages(
     }
     for message in messages {
         if let Err(error) = message.validate() {
-            tracing::debug!(
+            tracing::warn!(
                 extension_id,
                 error = %error,
-                "channel adapter emitted an out-of-bounds normalized message"
+                "acknowledging and discarding an out-of-bounds normalized message"
             );
-            return IngressResponse::error(400, "malformed_payload");
+            return IngressResponse::acknowledged_discarded();
         }
         // reply_context is stored host-side, keyed to the conversation
         // source binding, before the admission commit — the delivery
@@ -644,12 +677,16 @@ async fn admit_messages(
                 return IngressResponse::error(503, "temporarily_unavailable");
             }
             Err(error) => {
-                tracing::debug!(
+                // A permanent admission rejection is deterministic: the same
+                // message re-fails on every redelivery, so a non-2xx would
+                // wedge ordered vendors behind it. Acking drops a verified
+                // user message — the loudest non-fatal log level it gets.
+                tracing::warn!(
                     extension_id,
                     error = %error,
-                    "inbound admission rejected permanently"
+                    "acknowledging and discarding a message the admission sink permanently rejected"
                 );
-                return IngressResponse::error(400, "rejected");
+                return IngressResponse::acknowledged_discarded();
             }
         }
     }
@@ -674,12 +711,12 @@ impl InboundBatchProcessor {
         fragment: InboundBatchFragment,
     ) -> IngressResponse {
         if let Err(error) = fragment.validate() {
-            tracing::debug!(
+            tracing::warn!(
                 extension_id,
                 error = %error,
-                "channel adapter emitted invalid inbound batch metadata"
+                "acknowledging and discarding an inbound batch fragment with invalid metadata"
             );
-            return IngressResponse::error(400, "malformed_payload");
+            return IngressResponse::acknowledged_discarded();
         }
         let request = InboundBatchStageRequest {
             key: InboundBatchKey {
@@ -700,7 +737,13 @@ impl InboundBatchProcessor {
             }
             Ok(InboundBatchStageOutcome::AlreadyCompleted) => IngressResponse::ok(),
             Ok(InboundBatchStageOutcome::Rejected) => {
-                IngressResponse::error(400, "malformed_payload")
+                // The batch is durably tombstoned; redelivering the fragment
+                // can only re-fail, so ack it away.
+                tracing::warn!(
+                    extension_id,
+                    "acknowledging and discarding a fragment the staged batch rejected"
+                );
+                IngressResponse::acknowledged_discarded()
             }
             Err(error) if error.retryable => {
                 tracing::debug!(
@@ -711,12 +754,12 @@ impl InboundBatchProcessor {
                 IngressResponse::error(503, "temporarily_unavailable")
             }
             Err(error) => {
-                tracing::debug!(
+                tracing::warn!(
                     extension_id,
                     error = %error,
-                    "inbound batch staging rejected the payload"
+                    "acknowledging and discarding a fragment inbound batch staging permanently rejected"
                 );
-                IngressResponse::error(400, "malformed_payload")
+                IngressResponse::acknowledged_discarded()
             }
         }
     }
@@ -783,7 +826,11 @@ impl InboundBatchProcessor {
                 }
             };
             if response.status == 200 {
-                self.finish_claim(&claim, true).await;
+                // An acknowledged discard is terminal but not a completion:
+                // the merged message was consciously dropped, so the batch
+                // record keeps the truthful `rejected` tombstone.
+                let completed = response.body != ACKNOWLEDGED_DISCARDED_BODY;
+                self.finish_claim(&claim, completed).await;
                 return;
             }
             if response.status != 503 {

--- a/crates/extensions/ironclaw_extension_host/tests/ingress_router_contract.rs
+++ b/crates/extensions/ironclaw_extension_host/tests/ingress_router_contract.rs
@@ -130,6 +130,8 @@ enum AdapterMode {
     Panic,
     ParseError,
     ConfigurationError,
+    PermanentTransferError,
+    RetryableTransferError,
 }
 
 struct ScriptedChannelAdapter {
@@ -160,6 +162,14 @@ impl ChannelIngress for ScriptedChannelAdapter {
             }),
             AdapterMode::ConfigurationError => Err(ChannelError::Configuration {
                 reason: "scripted host configuration failure".to_string(),
+            }),
+            AdapterMode::PermanentTransferError => Err(ChannelError::AttachmentTransfer {
+                reason: "scripted permanent transfer failure".to_string(),
+                retryable: false,
+            }),
+            AdapterMode::RetryableTransferError => Err(ChannelError::AttachmentTransfer {
+                reason: "scripted retryable transfer failure".to_string(),
+                retryable: true,
             }),
             AdapterMode::Ignore => Ok(InboundOutcome::Ignore),
             AdapterMode::Respond => Ok(InboundOutcome::Respond(ImmediateResponse {
@@ -719,8 +729,13 @@ async fn provider_batch_rejects_aggregate_attachment_bytes_before_staging() {
         .handle(signed_request(second_body.as_bytes()))
         .await;
     assert_eq!(
-        second.status, 400,
-        "the fragment that exceeds the batch-wide budget is a permanent rejection"
+        second.status, 200,
+        "the fragment that exceeds the batch-wide budget is acknowledged and discarded \
+         (a non-2xx would have the vendor redeliver an update that can only re-fail)"
+    );
+    assert_eq!(
+        second.body, br#"{"status":"acknowledged_discarded"}"#,
+        "the discard is distinguishable from an ordinary ack"
     );
 
     tokio::time::sleep(Duration::from_millis(300)).await;
@@ -926,13 +941,16 @@ async fn inconsistent_provider_batch_fails_closed_without_partial_admission() {
     let (first_response, second_response) =
         tokio::join!(harness.router.handle(first), harness.router.handle(second));
 
-    let mut statuses = [first_response.status, second_response.status];
-    statuses.sort_unstable();
+    assert_eq!(first_response.status, 200);
+    assert_eq!(second_response.status, 200);
+    let discarded = [&first_response, &second_response]
+        .iter()
+        .filter(|response| response.body == br#"{"status":"acknowledged_discarded"}"#)
+        .count();
     assert_eq!(
-        statuses,
-        [200, 400],
-        "the first durable fragment is acknowledged, while the conflicting \
-         fragment rejects and tombstones the whole batch"
+        discarded, 1,
+        "the first durable fragment is acknowledged, while the conflicting fragment \
+         is acknowledged-and-discarded and tombstones the whole batch"
     );
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(
@@ -1287,37 +1305,49 @@ async fn adapter_panic_is_isolated_and_the_router_survives() {
     );
 }
 
+/// Deterministic adapter failures are acknowledged (2xx) and discarded with
+/// nothing admitted; transient failures stay 503 so vendor redelivery can
+/// help. A non-2xx on a deterministic failure hands the vendor an update it
+/// will redeliver forever — Telegram delivers per chat in order, so one
+/// unparseable update wedged the whole chat behind it (the retired WASM
+/// channel acked malformed payloads for exactly this reason).
 #[tokio::test]
-async fn adapter_errors_distinguish_payload_from_host_configuration() {
+async fn adapter_errors_distinguish_deterministic_discard_from_transient_retry() {
     let body = br#"{"text":"hi","event":"ev-error","conversation":"C-1"}"#;
 
-    let malformed = harness_with_activation(HarnessOptions {
-        adapter_mode: AdapterMode::ParseError,
-        ..HarnessOptions::default()
-    })
-    .await;
-    let malformed_response = malformed.router.handle(signed_request(body)).await;
-    assert_eq!(malformed_response.status, 400);
-    assert_eq!(malformed_response.body, br#"{"error":"malformed_payload"}"#);
+    for deterministic_mode in [AdapterMode::ParseError, AdapterMode::PermanentTransferError] {
+        let harness = harness_with_activation(HarnessOptions {
+            adapter_mode: deterministic_mode,
+            ..HarnessOptions::default()
+        })
+        .await;
+        let response = harness.router.handle(signed_request(body)).await;
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, br#"{"status":"acknowledged_discarded"}"#);
+        assert!(harness.admitted.lock().expect("admitted").is_empty());
+    }
 
-    let misconfigured = harness_with_activation(HarnessOptions {
-        adapter_mode: AdapterMode::ConfigurationError,
-        ..HarnessOptions::default()
-    })
-    .await;
-    let misconfigured_response = misconfigured.router.handle(signed_request(body)).await;
-    assert_eq!(misconfigured_response.status, 503);
-    assert_eq!(
-        misconfigured_response.body,
-        br#"{"error":"temporarily_unavailable"}"#
-    );
-    assert!(malformed.admitted.lock().expect("admitted").is_empty());
-    assert!(misconfigured.admitted.lock().expect("admitted").is_empty());
+    for transient_mode in [
+        AdapterMode::ConfigurationError,
+        AdapterMode::RetryableTransferError,
+    ] {
+        let harness = harness_with_activation(HarnessOptions {
+            adapter_mode: transient_mode,
+            ..HarnessOptions::default()
+        })
+        .await;
+        let response = harness.router.handle(signed_request(body)).await;
+        assert_eq!(response.status, 503);
+        assert_eq!(response.body, br#"{"error":"temporarily_unavailable"}"#);
+        assert!(harness.admitted.lock().expect("admitted").is_empty());
+    }
 }
 
-/// ING-8 (unit leg): 2xx only after the durable admission commit — a failing
-/// sink yields retryable 503 / permanent 400 with nothing acked; a duplicate
-/// commit still acks 200.
+/// ING-8 (unit leg): 2xx only after the durable admission commit or a
+/// conscious, logged discard — a retryably-failing sink yields 503 with
+/// nothing acked; a permanently-failing sink is acknowledged-and-discarded
+/// (redelivery replays the identical rejection and would wedge ordered
+/// vendors) with nothing admitted; a duplicate commit still acks 200.
 #[tokio::test]
 async fn two_hundred_only_after_durable_admission_commit() {
     let body = br#"{"text":"hi","event":"ev-5","conversation":"C-1"}"#;
@@ -1352,10 +1382,13 @@ async fn two_hundred_only_after_durable_admission_commit() {
         ..HarnessOptions::default()
     })
     .await;
+    let permanent_response = permanent.router.handle(signed_request(body)).await;
+    assert_eq!(permanent_response.status, 200);
     assert_eq!(
-        permanent.router.handle(signed_request(body)).await.status,
-        400
+        permanent_response.body,
+        br#"{"status":"acknowledged_discarded"}"#
     );
+    assert!(permanent.admitted.lock().expect("admitted").is_empty());
 
     // A secrets-port outage is a retryable 503, never an unauthenticated 401.
     let outage = harness_with_activation(HarnessOptions {

--- a/crates/extensions/packages/telegram/src/channel.rs
+++ b/crates/extensions/packages/telegram/src/channel.rs
@@ -126,6 +126,13 @@ impl ChannelIngress for TelegramChannelAdapter {
                     pending_attachments,
                 } = *parsed;
                 let message = complete_message(message, pending_attachments, egress).await?;
+                if message.text.trim().is_empty() && message.attachments.is_empty() {
+                    // Nothing usable survived (e.g. a sticker-only update whose
+                    // transfer failed permanently, or an update type we carry
+                    // no content for): acknowledge instead of starting an
+                    // empty turn.
+                    return Ok(InboundOutcome::Ignore);
+                }
                 Ok(InboundOutcome::Messages(vec![message]))
             }
             TelegramInboundEvent::BatchFragment(parsed) => {
@@ -135,6 +142,9 @@ impl ChannelIngress for TelegramChannelAdapter {
                 } = *parsed;
                 fragment.message =
                     complete_message(fragment.message, pending_attachments, egress).await?;
+                // A degraded-to-empty fragment still ships: the batch key and
+                // order slot must survive so sibling fragments settle into one
+                // coherent message.
                 Ok(InboundOutcome::BatchFragment(Box::new(fragment)))
             }
         }
@@ -147,8 +157,37 @@ async fn complete_message(
     egress: &dyn RestrictedEgress,
 ) -> Result<NormalizedInboundMessage, ChannelError> {
     for pending in pending_attachments {
-        let fetched = crate::attachment_transfer::fetch_attachment(&pending, egress).await?;
-        message.attachments.push(pending.complete(fetched)?);
+        // A retryable transfer failure keeps failing the whole request so
+        // ingress answers 503 and vendor redelivery can succeed later with the
+        // full content. Every deterministic failure degrades to "message
+        // without this attachment" instead: failing the update would make
+        // Telegram redeliver a payload that can never improve, wedging the
+        // chat's in-order queue behind it.
+        let external_file_id = pending.descriptor.external_file_id.clone();
+        match crate::attachment_transfer::fetch_attachment(&pending, egress).await {
+            Ok(fetched) => match pending.complete(fetched) {
+                Ok(attachment) => message.attachments.push(attachment),
+                Err(error) => {
+                    tracing::warn!(
+                        %external_file_id,
+                        %error,
+                        "dropping telegram attachment whose fetched bytes failed completion"
+                    );
+                }
+            },
+            Err(
+                error @ ChannelError::AttachmentTransfer {
+                    retryable: true, ..
+                },
+            ) => return Err(error),
+            Err(error) => {
+                tracing::warn!(
+                    %external_file_id,
+                    %error,
+                    "dropping telegram attachment after a non-retryable transfer failure"
+                );
+            }
+        }
     }
     Ok(message)
 }

--- a/crates/extensions/packages/telegram/src/channel.rs
+++ b/crates/extensions/packages/telegram/src/channel.rs
@@ -168,7 +168,7 @@ async fn complete_message(
             Ok(fetched) => match pending.complete(fetched) {
                 Ok(attachment) => message.attachments.push(attachment),
                 Err(error) => {
-                    tracing::warn!(
+                    tracing::debug!(
                         %external_file_id,
                         %error,
                         "dropping telegram attachment whose fetched bytes failed completion"
@@ -181,7 +181,7 @@ async fn complete_message(
                 },
             ) => return Err(error),
             Err(error) => {
-                tracing::warn!(
+                tracing::debug!(
                     %external_file_id,
                     %error,
                     "dropping telegram attachment after a non-retryable transfer failure"

--- a/crates/extensions/packages/telegram/src/payload.rs
+++ b/crates/extensions/packages/telegram/src/payload.rs
@@ -619,9 +619,19 @@ fn collect_attachments(
         )?);
     }
     if let Some(sticker) = message.sticker.as_ref() {
+        // Truthful MIME per the Bot API sticker format flags: static stickers
+        // are WEBP, animated stickers are gzipped Lottie (.tgs), video
+        // stickers are WEBM.
+        let mime_type = if sticker.is_video {
+            "video/webm"
+        } else if sticker.is_animated {
+            "application/x-tgsticker"
+        } else {
+            "image/webp"
+        };
         out.push(make_attachment(
             &sticker.file_id,
-            "image/webp",
+            mime_type,
             None,
             sticker.file_size,
             ProductAttachmentKind::Sticker,
@@ -782,6 +792,10 @@ struct TelegramSticker {
     file_id: String,
     #[serde(default)]
     file_size: Option<u64>,
+    #[serde(default)]
+    is_animated: bool,
+    #[serde(default)]
+    is_video: bool,
 }
 
 // keep clippy happy about read-only fields on edited_message / channel_post.

--- a/crates/extensions/packages/telegram/src/tests/channel_fetch.rs
+++ b/crates/extensions/packages/telegram/src/tests/channel_fetch.rs
@@ -137,6 +137,137 @@ async fn fetch_attachment_looks_up_then_downloads_through_restricted_egress() {
 }
 
 #[tokio::test]
+async fn receive_degrades_permanently_failed_attachments_and_keeps_the_message() {
+    // Regression: a permanently failing transfer used to fail the whole
+    // update, so ingress answered non-2xx and Telegram's in-order redelivery
+    // wedged the chat behind a payload that could never improve.
+    let egress = ScriptedEgress::new(vec![ScriptedEgress::response(403, Vec::new())]);
+    let config = [(
+        TELEGRAM_BOT_USERNAME_CONFIG.to_string(),
+        "ironclaw_test_bot".to_string(),
+    )];
+    let outcome = TelegramChannelAdapter::default()
+        .receive(
+            VerifiedInbound {
+                extension_id: "telegram",
+                installation_id: "install_alpha",
+                config: &config,
+                body: br#"{
+                    "update_id": 510,
+                    "message": {
+                        "message_id": 51,
+                        "date": 1710000000,
+                        "from": {"id": 1001, "is_bot": false, "first_name": "Alice"},
+                        "chat": {"id": 555, "type": "private"},
+                        "caption": "look at this",
+                        "document": {
+                            "file_id": "vendor-file-id",
+                            "file_name": "original.txt",
+                            "mime_type": "text/plain",
+                            "file_size": 5
+                        }
+                    }
+                }"#,
+                headers: &[],
+                can_reply_in_threads: false,
+            },
+            &egress,
+        )
+        .await
+        .expect("permanent transfer failure degrades instead of failing the update");
+    let InboundOutcome::Messages(messages) = outcome else {
+        panic!("expected degraded message");
+    };
+    assert_eq!(messages[0].text, "look at this");
+    assert!(messages[0].attachments.is_empty());
+}
+
+#[tokio::test]
+async fn receive_ignores_updates_degraded_to_nothing() {
+    // A sticker-only update whose transfer fails permanently leaves neither
+    // text nor attachments: acknowledge and ignore rather than start an empty
+    // turn (and never hand the vendor a redeliverable failure status).
+    let egress = ScriptedEgress::new(vec![ScriptedEgress::response(403, Vec::new())]);
+    let config = [(
+        TELEGRAM_BOT_USERNAME_CONFIG.to_string(),
+        "ironclaw_test_bot".to_string(),
+    )];
+    let outcome = TelegramChannelAdapter::default()
+        .receive(
+            VerifiedInbound {
+                extension_id: "telegram",
+                installation_id: "install_alpha",
+                config: &config,
+                body: br#"{
+                    "update_id": 511,
+                    "message": {
+                        "message_id": 52,
+                        "date": 1710000000,
+                        "from": {"id": 1001, "is_bot": false, "first_name": "Alice"},
+                        "chat": {"id": 555, "type": "private"},
+                        "sticker": {"file_id": "st-1", "file_size": 4096}
+                    }
+                }"#,
+                headers: &[],
+                can_reply_in_threads: false,
+            },
+            &egress,
+        )
+        .await
+        .expect("fully degraded update is acknowledged");
+    assert!(matches!(outcome, InboundOutcome::Ignore), "expected Ignore");
+}
+
+#[tokio::test]
+async fn receive_propagates_retryable_attachment_failures() {
+    // Transient transfer failures must keep failing the request so ingress
+    // answers 503 and vendor redelivery can succeed later with full content.
+    let egress = ScriptedEgress::new(vec![ScriptedEgress::response(500, Vec::new())]);
+    let config = [(
+        TELEGRAM_BOT_USERNAME_CONFIG.to_string(),
+        "ironclaw_test_bot".to_string(),
+    )];
+    let result = TelegramChannelAdapter::default()
+        .receive(
+            VerifiedInbound {
+                extension_id: "telegram",
+                installation_id: "install_alpha",
+                config: &config,
+                body: br#"{
+                    "update_id": 512,
+                    "message": {
+                        "message_id": 53,
+                        "date": 1710000000,
+                        "from": {"id": 1001, "is_bot": false, "first_name": "Alice"},
+                        "chat": {"id": 555, "type": "private"},
+                        "caption": "look at this",
+                        "document": {
+                            "file_id": "vendor-file-id",
+                            "file_name": "original.txt",
+                            "mime_type": "text/plain",
+                            "file_size": 5
+                        }
+                    }
+                }"#,
+                headers: &[],
+                can_reply_in_threads: false,
+            },
+            &egress,
+        )
+        .await;
+    let Err(error) = result else {
+        panic!("retryable transfer failure must propagate");
+    };
+    assert!(matches!(
+        error,
+        ChannelError::AttachmentTransfer {
+            retryable: true,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
 async fn fetch_attachment_downloads_when_optional_size_metadata_is_absent() {
     let egress = ScriptedEgress::new(vec![
         ScriptedEgress::response(

--- a/crates/extensions/packages/telegram/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/telegram/src/tests/payload_normalized.rs
@@ -128,6 +128,70 @@ fn complete_protocol_metadata_is_normalized_without_file_bytes() {
 }
 
 #[test]
+fn sticker_updates_normalize_with_truthful_mime_types() {
+    // Regression: stickers hardcoded `image/webp` + kind `Sticker`, a pair the
+    // descriptor validator rejected — the whole update failed parse and
+    // Telegram's redelivery queue wedged behind it. Static stickers are WEBP,
+    // animated stickers are gzipped Lottie (.tgs), video stickers are WEBM.
+    let cases = [
+        (
+            r#"{"file_id": "st-static", "file_size": 4096}"#,
+            "image/webp",
+        ),
+        (
+            r#"{"file_id": "st-animated", "file_size": 4096, "is_animated": true}"#,
+            "application/x-tgsticker",
+        ),
+        (
+            r#"{"file_id": "st-video", "file_size": 4096, "is_video": true}"#,
+            "video/webm",
+        ),
+    ];
+    for (sticker_json, expected_mime) in cases {
+        let payload = format!(
+            r#"{{
+                "update_id": 601,
+                "message": {{
+                    "message_id": 91,
+                    "date": 1700000000,
+                    "from": {{"id": 777, "is_bot": false, "first_name": "Alice"}},
+                    "chat": {{"id": 777, "type": "private"}},
+                    "sticker": {sticker_json}
+                }}
+            }}"#
+        );
+        let message = message(payload.as_bytes());
+        assert!(message.text.is_empty());
+        assert_eq!(message.pending_attachments.len(), 1, "{sticker_json}");
+        let descriptor = &message.pending_attachments[0].descriptor;
+        assert_eq!(descriptor.mime_type, expected_mime, "{sticker_json}");
+        assert_eq!(descriptor.kind, ProductAttachmentKind::Sticker);
+    }
+}
+
+#[test]
+fn voice_updates_normalize_as_voice_attachments() {
+    // Regression twin of the sticker case: `audio/ogg` + kind `Voice` was
+    // unconstructible for the same reason.
+    let payload = br#"{
+        "update_id": 602,
+        "message": {
+            "message_id": 92,
+            "date": 1700000000,
+            "from": {"id": 777, "is_bot": false, "first_name": "Alice"},
+            "chat": {"id": 777, "type": "private"},
+            "voice": {"file_id": "voice-1", "mime_type": "audio/ogg", "file_size": 2048}
+        }
+    }"#;
+    let message = message(payload);
+    assert!(message.text.is_empty());
+    assert_eq!(message.pending_attachments.len(), 1);
+    let descriptor = &message.pending_attachments[0].descriptor;
+    assert_eq!(descriptor.mime_type, "audio/ogg");
+    assert_eq!(descriptor.kind, ProductAttachmentKind::Voice);
+}
+
+#[test]
 fn media_group_fragments_share_one_event_but_keep_distinct_fragment_ids() {
     let payload = |update_id: i64, message_id: i64, file_id: &str| {
         serde_json::to_vec(&serde_json::json!({


### PR DESCRIPTION
## Summary

- **Root cause fix (`ironclaw_extension_contracts`)**: `validate_attachment_kind` made `Sticker`/`Voice` attachment descriptors unconstructible (`image/webp + Sticker`, `audio/ogg + Voice` → "must match normalized MIME base type"), so any Telegram sticker or voice note failed whole-update parsing at ingress. Kind-vs-MIME agreement now runs one direction only: media-mirror kinds (`Image`/`Audio`/`Video`) must match the MIME base (mislabel guard kept, now enforced in the direction that catches real mislabels); semantic kinds (`Sticker`/`Voice`/`Document`/`Other`) accept any MIME.
- **Poison-update fix (`ironclaw_extension_host` ingress)**: the generic ingress returned **400** for adapter-deterministic failures. Vendors with strictly ordered webhook redelivery (Telegram) re-send any non-2xx update and hold every later update in the conversation behind it — one sticker bricked the chat until the update expired (~24h). Deterministic failures (parse, render, permanent transfer, out-of-bounds normalized messages, permanent sink rejections, batch tombstones/budget rejections) are now **acknowledged (200, `{"status":"acknowledged_discarded"}`) and warn-logged, admitting nothing**; transient failures (configuration, vendor wiring, retryable transfer/sink/staging, panics, deadlines) keep **503** so redelivery can help. The batch processor keys its terminal state on the discard marker so a consciously dropped merged message keeps the truthful `rejected` tombstone. The retired WASM channel acked malformed payloads for exactly this reason (comment preserved in `tests/e2e/scenarios/test_telegram_e2e.py`); the Reborn ingress had regressed it.
- **Telegram ingestion (`ironclaw_telegram_extension`)**: stickers carry truthful MIMEs via the Bot API format flags (`image/webp` static, `video/webm` video, `application/x-tgsticker` animated). A permanently failing attachment fetch degrades to "message minus that attachment" instead of failing the update (retryable fetch failures still 503 so redelivery can deliver full content); an update degraded to neither text nor attachments is acknowledged as `Ignore` rather than starting an empty turn; media-group fragments still ship so sibling parts settle.

**Live incident evidence** (QA `ironclaw-qa-testing-libsql`, 2026-08-13 02:21–02:47Z): `channel adapter rejected verified inbound request extension_id=telegram error=... invalid attachment_kind identifier: must match normalized MIME base type` repeating on Telegram's redelivery cadence for 26+ minutes; the chat stayed dead behind the sticker. The validator (f8b4415297) and the Telegram sticker mapping (b7084eb29d) landed the same day (2026-05-07) and were never exercised together — the Telegram package had zero sticker/voice tests.

## Change Type

- [x] Bug fix

## Linked Issue

None (root-caused live from the QA deployment).

## Validation

- [x] `cargo fmt` on touched crates (`--all -- --check` equivalent for the diff)
- [x] `cargo clippy -p ironclaw_extension_contracts -p ironclaw_telegram_extension -p ironclaw_extension_host --all-targets --all-features -- -D warnings` (workspace-wide lane also run before marking ready)
- [x] `cargo build`
- [x] `cargo test -p ironclaw_extension_contracts` — 120 tests
- [x] `cargo test -p ironclaw_telegram_extension` — 63 tests (includes conformance)
- [x] `cargo test -p ironclaw_extension_host --all-features --no-fail-fast` — 457 tests
- [x] `cargo test -p ironclaw_slack_extension` — 80 tests (sibling adapter unaffected)
- [x] `cargo test -p ironclaw_architecture_tests` — green, including the extension-specificity gate
- [x] `cargo test -p ironclaw_integration_tests --test reborn_integration_extension_ingress --test reborn_integration_extension_delivery` — all legs green (Postgres legs via colima Docker)
- [x] Manual testing: root-caused against the live QA deployment logs; the failing update class reproduces the exact log signature this PR removes

## Test Strategy

User behavior: sending a sticker or voice note to a Telegram-connected agent produces a normal turn (attachment ingested), and no update — malformed, oversized, or otherwise unusable — can stop the bot from answering subsequent messages.

Risk areas:
- [x] Side effect
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `external.rs` descriptor regression tests (semantic kinds constructible: sticker webp/webm/tgs, voice ogg, document any-mime; media-kind mislabels rejected both directions where meaningful); telegram `payload_normalized` sticker (3 formats) + voice cases; telegram `channel_fetch` degrade cases (permanent → degraded message / Ignore when nothing survives; retryable → propagates); `ingress_router_contract` deterministic-vs-transient mapping (parse + permanent transfer → 200 discard; configuration + retryable transfer → 503), permanent sink rejection → 200 discard with nothing admitted, batch budget/inconsistency → 200 discard with truthful tombstone
- Reborn integration: existing `reborn_integration_extension_ingress` + `reborn_integration_extension_delivery` (telegram update → turn → coordinated reply) green on both storage legs; no new scenario needed — the router contract suite drives the real router + admission sink at the route-response seam, which is the nearest meaningful caller seam for the status-mapping change
- Recorded fixture: Not applicable: no model-request shape change
- Browser E2E: Not applicable: no UI change
- Backend or runtime: Not applicable: no persistence-schema change (batch terminal states unchanged, only which response maps to them)
- Live canary: existing `tests/e2e/scenarios/test_telegram_e2e.py` malformed-payload (expects 200) and failed-download (expects degrade + reply) tests encode this contract already — they documented the retired WASM channel's behavior this PR restores

What the tests prove: sticker/voice descriptors construct with truthful MIMEs; mislabeled media kinds are still rejected; a permanently unusable attachment degrades instead of failing the update; deterministic failures ack-and-discard with a distinguishable body and nothing admitted; transient failures still 503; batch tombstones stay truthful under the discard ack.

Commands run: listed under Validation, all green locally.

## Compatibility / rollback

- Validator change is strictly loosening for persisted rows (no row could contain the previously-unconstructible pairs); the tightened direction (kind claims a media class, MIME disagrees) had zero in-tree producers (Slack derives kind from MIME; the fixture and assistant tests use consistent pairs).
- Ingress status change alters webhook semantics for **deterministic** failures only: vendors stop redelivering those updates. Redelivery cannot fix a deterministic failure, and on ordered-queue vendors it blocks the conversation. Transient semantics unchanged. Roll back by reverting the extension-host commit alone (`5e8ceaedb`); the contracts and telegram commits stand independently.
- Discarded updates are warn-logged (`acknowledging and discarding …`) — the observability hook for anything that starts being dropped.
- Follow-up candidates (deliberately out of scope): Slack adapter adopting the same per-attachment degrade; pre-truncating over-long Telegram document filenames (no longer bricking, still whole-update discarded); `video_note` (round video) ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)