### PR TITLE
fix(stress): follow session channel message route

### DIFF
--- a/tools/ironclaw_stress/src/api_capacity.rs
+++ b/tools/ironclaw_stress/src/api_capacity.rs
@@ -223,12 +223,18 @@ struct ApiAdminCreatedUserRecord {
     user_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct ApiSessionResponse {
+    session_channel_extension_id: Option<String>,
+}
+
 #[derive(Clone)]
 struct ApiHarness {
     client: Client,
     base_url: String,
     page_size: u32,
     request_timeout: Duration,
+    session_channel_extension_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -489,6 +495,12 @@ pub(crate) async fn run(
     let identity_count = args.users.saturating_add(args.api_background_users).max(1);
     let identities = load_identities(args, identity_count).await?;
     let identities = provision_missing_identities(args, run_id, &harness, identities).await?;
+    let session_bearer_token = identities
+        .first()
+        .and_then(|identity| identity.bearer_token.as_deref());
+    let harness = harness
+        .resolve_session_channel(session_bearer_token)
+        .await?;
     let foreground_identities = select_identities(&identities, 0, args.users);
     let background_identities =
         select_identities(&identities, args.users, args.api_background_users);
@@ -1164,13 +1176,7 @@ async fn run_full_flow(
         ),
     });
     let send = harness
-        .request_json(
-            user,
-            flow_kind.send_sample_name(),
-            Method::POST,
-            &format!("/api/webchat/v2/threads/{}/messages", user.thread_id),
-            Some(body),
-        )
+        .send_message(user, flow_kind.send_sample_name(), body)
         .await;
     let send_value = send.value.clone();
     api_samples.push(send.sample);
@@ -1292,13 +1298,7 @@ async fn run_scripted_full_flow(
         "content": stress_payload(marker, args.user_message_bytes),
     });
     let send = harness
-        .request_json(
-            user,
-            flow_kind.send_sample_name(),
-            Method::POST,
-            &format!("/api/webchat/v2/threads/{}/messages", user.thread_id),
-            Some(body),
-        )
+        .send_message(user, flow_kind.send_sample_name(), body)
         .await;
     let send_value = send.value.clone();
     api_samples.push(send.sample);
@@ -1607,7 +1607,70 @@ impl ApiHarness {
             base_url,
             page_size: args.api_page_size,
             request_timeout,
+            session_channel_extension_id: None,
         })
+    }
+
+    async fn resolve_session_channel(mut self, bearer_token: Option<&str>) -> Result<Self, String> {
+        let session = self
+            .request_json_with_bearer(
+                bearer_token,
+                "resolve_session_channel",
+                Method::GET,
+                "/api/webchat/v2/session",
+                None,
+            )
+            .await
+            .value
+            .map_err(|failure| {
+                format!(
+                    "resolve session channel: {}: {}",
+                    failure.bucket, failure.detail
+                )
+            })?;
+        let session: ApiSessionResponse = serde_json::from_value(session)
+            .map_err(|error| format!("parse WebUI session response: {error}"))?;
+        let extension_id = session
+            .session_channel_extension_id
+            .filter(|extension_id| !extension_id.trim().is_empty())
+            .ok_or_else(|| {
+                "WebUI session response did not advertise a session channel extension id"
+                    .to_string()
+            })?;
+        self.session_channel_extension_id = Some(extension_id);
+        Ok(self)
+    }
+
+    async fn send_message(
+        &self,
+        user: &ApiUser,
+        name: &'static str,
+        mut body: Value,
+    ) -> ApiCallResult {
+        let Some(extension_id) = self.session_channel_extension_id.as_deref() else {
+            let failure = FailureCause::new(
+                "api_session_channel_unavailable",
+                name,
+                "WebUI session channel was not resolved before sending a message",
+            );
+            return ApiCallResult {
+                sample: ApiRequestSample {
+                    name,
+                    latency: Duration::ZERO,
+                    failure: Some(failure.clone()),
+                },
+                value: Err(failure),
+            };
+        };
+        body["thread_id"] = Value::String(user.thread_id.clone());
+        self.request_json(
+            user,
+            name,
+            Method::POST,
+            &format!("/api/webchat/v2/channels/{extension_id}/messages"),
+            Some(body),
+        )
+        .await
     }
 
     async fn create_thread(
@@ -3073,6 +3136,82 @@ mod tests {
         ];
         args.extend_from_slice(extra);
         Args::parse_from(args)
+    }
+
+    async fn read_test_http_request(stream: &mut TcpStream) -> Vec<u8> {
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            let read = stream.read(&mut buffer).await.expect("read request");
+            assert_ne!(read, 0, "connection closed before complete request");
+            request.extend_from_slice(&buffer[..read]);
+            let Some(header_end) = find_header_end(&request).map(|index| index + 4) else {
+                continue;
+            };
+            let headers = std::str::from_utf8(&request[..header_end]).expect("request headers");
+            let content_length = parse_content_length(headers).unwrap_or(0);
+            if request.len() >= header_end + content_length {
+                return request;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn regression_message_send_uses_advertised_session_channel_route() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("listener address");
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for response in [
+                json!({"session_channel_extension_id": "web-app"}),
+                json!({"status": "submitted"}),
+            ] {
+                let (mut stream, _) = listener.accept().await.expect("accept");
+                requests.push(read_test_http_request(&mut stream).await);
+                write_json_response(&mut stream, 200, &response)
+                    .await
+                    .expect("write response");
+            }
+            requests
+        });
+
+        let mut args = parsed_api_args(&[]);
+        args.api_base_url = Some(format!("http://{address}"));
+        let harness = ApiHarness::new(&args)
+            .expect("build harness")
+            .resolve_session_channel(Some("session-token"))
+            .await
+            .expect("resolve session channel");
+        let user = ApiUser {
+            index: 0,
+            label: "stress-user".to_string(),
+            bearer_token: Some("session-token".to_string()),
+            thread_id: "thread-1".to_string(),
+            extra_thread_ids: Vec::new(),
+        };
+        harness
+            .send_message(
+                &user,
+                "send_message",
+                json!({"client_action_id": "action-1", "content": "hello"}),
+            )
+            .await
+            .value
+            .expect("message send succeeds");
+
+        let requests = server.await.expect("server task");
+        let session_request = std::str::from_utf8(&requests[0]).expect("session request");
+        assert!(session_request.starts_with("GET /api/webchat/v2/session HTTP/1.1\r\n"));
+
+        let message_request = &requests[1];
+        let header_end = find_header_end(message_request).expect("message headers") + 4;
+        let headers = std::str::from_utf8(&message_request[..header_end]).expect("message headers");
+        assert!(headers.starts_with("POST /api/webchat/v2/channels/web-app/messages HTTP/1.1\r\n"));
+        let body: Value =
+            serde_json::from_slice(&message_request[header_end..]).expect("message body");
+        assert_eq!(body["thread_id"], "thread-1");
+        assert_eq!(body["client_action_id"], "action-1");
+        assert_eq!(body["content"], "hello");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Resolve the authenticated-session channel from `GET /api/webchat/v2/session` before starting API-capacity workloads.
- Send normal and scripted messages through `POST /api/webchat/v2/channels/{extension_id}/messages`, with `thread_id` in the request body.
- Add a caller-level HTTP regression test covering session-channel discovery and the resulting message URL/body.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Fixes the failure observed in scheduled run https://github.com/nearai/ironclaw/actions/runs/31666389045.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run workspace-wide; targeted package clippy passed.
- [ ] `cargo build` — covered by the targeted test build instead of a separate build.
- [x] Relevant tests pass: `cargo test -p ironclaw_stress` (171 passed)
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; no database implementation or runtime behavior changed.
- [ ] Manual testing — not applicable; the scheduled workload needs the hosted server matrix, and the HTTP contract is covered hermetically.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run; final diff and focused checks were reviewed locally.

Additional check: `cargo clippy -p ironclaw_stress --all-targets -- -D warnings`.

## Test Strategy

User behavior: Scheduled API-capacity and scripted-memory stress workloads can submit messages through the WebUI's advertised authenticated-session channel instead of receiving 404s from the retired thread-message route.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Added `regression_message_send_uses_advertised_session_channel_route`, an HTTP caller-level test in the stress harness.
- Reborn integration: Not applicable: production Reborn behavior and routing are unchanged; this fixes a client of the existing route contract.
- Recorded fixture: Not applicable: no model selection or request-shape behavior changed.
- Browser E2E: Not applicable: no browser-visible behavior changed.
- Backend or runtime: Not applicable: the harness's PostgreSQL/libSQL workload selection is unchanged.
- Live canary: Not applicable: no provider behavior changed.

What the tests prove: The harness first reads `session_channel_extension_id` from `/session`, then sends to `/channels/{extension_id}/messages` and includes the owned `thread_id`, action id, and content in the JSON body.

Commands run:

- `cargo test -p ironclaw_stress regression_message_send_uses_advertised_session_channel_route`
- `cargo test -p ironclaw_stress`
- `cargo clippy -p ironclaw_stress --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Security Impact

None. Authentication remains the existing bearer token, and the channel id is obtained from the authenticated server session response.

## Reborn Trust-Boundary Checklist

N/A: this changes only the stress client to consume the existing authenticated-session route contract; no trust-bearing types, queues, status variants, or runtime boundaries change.

## Database Impact

None. No migrations, schemas, stores, or backend implementations changed.

## Blast Radius

Limited to the `api-user-capacity` stress scenario, including its regular, background, and scripted message sends. Failure to advertise a session channel now stops the workload with a clear setup error instead of generating misleading 404 measurements.

## Rollback Plan

Revert this commit. That would restore the retired thread-message URL and reintroduce the scheduled stress failures while the current WebUI route contract remains in place.

## Review Follow-Through

No known follow-up. The next scheduled `IronClaw Stress` run should provide full hosted PostgreSQL and libSQL confirmation after merge.

---

**Review track**: A (test/CI harness bug fix)
