### PR TITLE
chore(fork): catch up to upstream ironclaw-v1.2.0-rc.3

### DIFF
--- a/.claude/skills/fork-release/SKILL.md
+++ b/.claude/skills/fork-release/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: fork-release
+description: Guide cutting a *marked* release tag on this fork (k-l-sorensen/ironclaw) — NOT upstream nearai/ironclaw. Use when the user wants to create a release tag, cut a release, build release binaries (incl. ARM64 Linux via cargo-dist), publish a GitHub Release, or verify/repair the fork's git-workflow settings (remotes, credential helper, branch tracking). Trigger on: "cut a release", "create a tag", "release the fork", "build ARM64 binaries", "tag a version", "fix my git remotes/credentials".
+---
+
+# Fork Release (tag-driven, cargo-dist)
+
+> **RATIONALE:** This is a *fork* of `nearai/ironclaw`. Releases here must be
+> (1) pushed only to the fork (`origin`), never `upstream`, and (2) visibly
+> marked as a fork build so they are never mistaken for an official upstream
+> release. Both are enforced below. Fork-specific divergences are tracked in
+> `CLAUDE-local.md`.
+
+## How releases work here
+
+The release pipeline is **[cargo-dist](https://opensource.axo.dev/cargo-dist/)
+v0.31.0**, generated into `.github/workflows/ironclaw-release.yml`. It triggers
+**only** on pushing a git tag matching:
+
+```
+ironclaw**[0-9]+.[0-9]+.[0-9]+*
+```
+
+On a matching tag, cargo-dist reads `[workspace.metadata.dist]` in the root
+`Cargo.toml` (workspace-wide dist settings — targets, installers, tag
+namespace), and `[package.metadata.dist]` / `[package.metadata.wix]` in
+`crates/app/ironclaw_cli/Cargo.toml` (the sole dist-able package — since the v1
+monolith was deleted upstream, the root package is now `ironclaw_integration_tests`,
+`dist = false`, and only hosts the integration test suite). It builds every
+target in `targets = [...]` (including `aarch64-unknown-linux-gnu` and
+`aarch64-unknown-linux-musl` natively on `ubuntu-24.04-arm` runners), packages
+`.tar.gz` archives + installers, and publishes a GitHub Release. **cargo-dist
+requires the tag's version to equal the `ironclaw` package version in
+`crates/app/ironclaw_cli/Cargo.toml`** — so the version bump and the tag must agree.
+**`crates/app/ironclaw_cli/wix/main.wxs` is a committed, generated file — cargo-dist
+0.31 checks it against what it *would* generate from `[package.metadata.wix]`
+plus the package's `homepage`/`repository`, and fails the `plan` job
+(`dist host --steps=create`) if they've drifted.** Confirmed the hard way:
+the first `1.1.0-rc.1-mistral-fork.1` build failed here because the
+committed file still had `ARPHELPLINK` pointing at
+`https://github.com/nearai/ironclaw` after the fork's homepage/repository
+repoint (below) — the metadata changed but the generated file wasn't
+regenerated to match. No `dist`/`cargo-dist` CLI is installed locally on this
+machine, so the practical fix is a direct text patch of the drifted line(s) —
+`grep -rn 'nearai/ironclaw' crates/app/ironclaw_cli/wix/` finds them — rather
+than running `dist init`. Re-check this file whenever `homepage`/`repository`/
+`authors`/version-adjacent metadata on the `ironclaw` package changes.
+
+Nothing here runs on normal pushes/PRs. On a **public** fork the runners
+(`ubuntu-*`, `ubuntu-*-arm`, `macos-*`, `windows-*`) are **free**.
+
+> **`cut-ironclaw-release.yml` is upstream's own tooling, not ours.** Upstream
+> added a `workflow_dispatch`-triggered "Cut Ironclaw Release" workflow gated
+> behind a protected `ironclaw-release` GitHub Environment and a GitHub App
+> token (`secrets.GH_RELEASES_MANAGER_APP_ID`) that only `nearai/ironclaw` has.
+> The fork has neither the environment nor the app credentials, and doesn't
+> need them — a direct annotated-tag push (below) still triggers
+> `ironclaw-release.yml` exactly as before. Do not try to invoke
+> `cut-ironclaw-release.yml` on the fork.
+
+## Fork marking convention
+
+Mark every fork release with a **prerelease suffix** on the version:
+
+```
+<base-version>-mistral-fork.<N>   e.g.  1.1.0-rc.1-mistral-fork.1, 1.1.0-rc.1-mistral-fork.2, 1.1.0-mistral-fork.1
+```
+
+This does three things at once:
+- Keeps the tag matching the cargo-dist trigger glob (the trailing `*` covers `-mistral-fork.N`).
+- Makes the version semver-prerelease, so cargo-dist **auto-flags the GitHub
+  Release as a pre-release** — distinct from upstream's clean `ironclaw-v0.29.1`.
+- States the fork lineage in the version string itself, branded after the
+  fork's flagship divergence (the custom Mistral `reasoning_effort=high`
+  provider — see `CLAUDE-local.md` "Active local changes").
+
+`<base-version>` is whatever upstream version you forked from / are building on.
+Increment `<N>` for each fork release of the same base; bump the base when you
+rebase onto a newer upstream version.
+
+> **History:** the first three fork releases (`0.29.1-fork.1`/`.2`/`.3`) used a
+> generic `-fork.<N>` suffix before the `-mistral-fork.<N>` convention was
+> adopted 2026-08-10. Don't reuse the generic form for new releases.
+>
+> **Choosing `<base-version>`:** it's the version currently in
+> `crates/app/ironclaw_cli/Cargo.toml` / the top non-`Unreleased` `CHANGELOG.md`
+> heading — i.e. whatever our `main` actually contains, not necessarily
+> upstream's latest tag. Upstream cuts weekly release branches
+> (`release/<version>`) off an `-rc.N` point and backports a handful of
+> hotfixes onto *that branch only*; those commits often never reach
+> `upstream/main` under any hash. Since this fork only ever tracks and catches
+> up against `upstream/main`, a final `x.y.0` tag existing upstream does not
+> mean our fork contains it — check with `git merge-base --is-ancestor
+> <upstream-tag> HEAD` before assuming a later base than the one in
+> `Cargo.toml`.
+>
+> **Going forward:** `CLAUDE-local.md` → "Catch-up cadence: sync to upstream
+> releases, not intermediate `main` commits" is now the standing policy —
+> catch-ups stop at `git merge-base ironclaw-v<latest-non-rc-version>
+> upstream/main`, not `upstream/main`'s tip, specifically so a release's
+> `<base-version>` cleanly names a real upstream release instead of an
+> arbitrary in-flight point. This release (`1.1.0-rc.1-mistral-fork.1`) predates
+> that policy and was deliberately left as-is rather than rebuilt against it —
+> the next catch-up is where it takes effect.
+
+---
+
+## Procedure
+
+Run these in order. **Stop and report if any preflight check fails** — do not
+improvise around a wrong remote or a hung credential prompt.
+
+### 1. Preflight: git workflow settings (fail closed)
+
+```bash
+# 1a. Remotes must be: origin = the fork, upstream = nearai. Refuse otherwise.
+git remote -v
+#   origin    -> github.com/k-l-sorensen/ironclaw   (push target)
+#   upstream  -> github.com/nearai/ironclaw         (NEVER a tag push target)
+
+# 1b. Hard guard: origin must be the fork, not upstream.
+git remote get-url origin | grep -q 'k-l-sorensen/ironclaw' \
+  && echo "OK: origin is the fork" \
+  || { echo "ABORT: origin is not the fork — fix remotes before releasing"; exit 1; }
+git remote get-url origin | grep -qi 'nearai' \
+  && { echo "ABORT: origin points at upstream nearai — refusing to release"; exit 1; } \
+  || echo "OK: origin is not upstream"
+
+# 1c. Credential helper must use gh, or HTTPS pushes hang on a silent prompt.
+git config --get-all credential.'https://github.com'.helper | grep -q 'gh auth' \
+  && echo "OK: gh credential helper active" \
+  || { echo "Fixing: routing git auth through gh"; gh auth setup-git; }
+
+# 1d. Be on the fork's main, current, and clean.
+git switch main
+git fetch origin
+git status -sb         # working tree must be clean before tagging
+
+# 1e. Committed WiX file must already point at the fork, not upstream —
+# this is a *build-time* cargo-dist drift check (see "How releases work
+# here"), so catch it here rather than from a failed tag-push build.
+grep -rn 'nearai/ironclaw' crates/app/ironclaw_cli/wix/ \
+  && { echo "ABORT: wix/main.wxs still references nearai/ironclaw — patch the drifted line(s) before tagging"; exit 1; } \
+  || echo "OK: wix/main.wxs has no stale nearai/ironclaw references"
+```
+
+> **Branch-tracking note:** local `main` historically tracks `upstream/main`,
+> but **releases are cut from the fork's `main`** (`origin/main`). After merging
+> a feature PR into the fork's main, sync with `git pull origin main`. If the
+> user wants `main` to follow the fork by default, offer:
+> `git branch --set-upstream-to=origin/main main` (this is a fork-workflow
+> change — confirm before doing it, and record it in `CLAUDE-local.md`).
+
+### 2. Choose the fork version
+
+Ask the user for the base version (default: current `ironclaw` package version)
+and the fork increment `N`. Compute `VERSION = <base>-mistral-fork.<N>` and
+`TAG = ironclaw-v<VERSION>`.
+
+```bash
+# Current ironclaw package version (the base, unless rebasing onto newer upstream):
+grep -m1 -A1 '^\[package\]' crates/app/ironclaw_cli/Cargo.toml | grep '^version' # e.g. version = "1.1.0-rc.1"
+
+# Make sure the tag doesn't already exist locally or on the fork:
+git tag -l "$TAG"
+git ls-remote --tags origin "$TAG"
+```
+
+### 3. Set the version + update the changelog + commit
+
+**3a. Bump the version.** cargo-dist demands the package version equal the tag
+version, so bump the `ironclaw` `[package]` version in
+`crates/app/ironclaw_cli/Cargo.toml` (not the root `Cargo.toml` — that package is
+`ironclaw_integration_tests`, `dist = false`, and carries no release version)
+to the fork version:
+
+```bash
+# Edit crates/app/ironclaw_cli/Cargo.toml [package] version -> the fork version, e.g.:
+#   version = "1.1.0-rc.1-fork.1"
+# (Use the Edit tool; update only the ironclaw [package] version line.)
+cargo update -w 2>/dev/null || cargo check -q   # refresh the ironclaw entry in Cargo.lock
+```
+
+**3b. Add a `CHANGELOG.md` entry — REQUIRED, do not skip.** cargo-dist's `host`
+step generates the GitHub Release body from the `CHANGELOG.md` section whose
+heading matches the tag version. **If no `## [<VERSION>]` heading exists, it
+falls back to the nearest base-version section (e.g. `## [1.1.0-rc.1]`) and
+publishes *upstream's* notes — with `nearai/ironclaw` PR links and none of the
+fork's changes.** (This is exactly what went wrong on the first
+`0.29.1-fork.1` build.)
+
+Insert a section for the fork version **between `## [Unreleased]` and the base
+version's section**, using the fork repo for the heading link:
+
+```markdown
+## [<VERSION>](https://github.com/k-l-sorensen/ironclaw/releases/tag/ironclaw-v<VERSION>) - <YYYY-MM-DD>
+
+First/Nth marked release of the **k-l-sorensen/ironclaw fork** — unofficial, not
+affiliated with upstream nearai/ironclaw. Built on upstream `main` past the
+`<base>` tag plus the fork-only changes below. See `CLAUDE-local.md` for the
+full divergence list.
+
+### Added / Changed / CI · Release
+- one bullet per fork-relevant change in this build (e.g. the Mistral
+  `reasoning_effort` provider, release repointing, new skills). Do NOT try to
+  enumerate the upstream commits the fork merged — link the lineage instead.
+```
+
+Derive the bullets from `git log --oneline --no-merges <base-tag>..HEAD` filtered
+to fork-authored commits (`chore(fork)`, `feat`/`fix` you added) and from the
+"Active local changes" list in `CLAUDE-local.md`.
+
+**3c. Commit both, push to the fork:**
+
+```bash
+git add crates/app/ironclaw_cli/Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "chore(fork): release ironclaw-v<VERSION> (fork build, not upstream)
+
+Marked fork release of k-l-sorensen/ironclaw. Prerelease suffix
+'-mistral-fork.<N>' keeps this distinct from upstream nearai/ironclaw and flags the GitHub
+Release as a pre-release. Includes the matching CHANGELOG.md section so
+cargo-dist emits fork notes, not upstream's base-version notes.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git push origin main      # fork only
+```
+
+> **Upstream-merge caveat:** the version line (in `crates/app/ironclaw_cli/Cargo.toml`)
+> will conflict when you later merge a newer upstream. Resolve by taking
+> upstream's base version and re-applying the `-mistral-fork.<N>` suffix. Note
+> this in `CLAUDE-local.md` under active local changes.
+
+### 4. Create the marked, annotated tag
+
+Always an **annotated** tag (`-a`) whose message states the fork lineage:
+
+```bash
+git tag -a "$TAG" -m "ironclaw v<VERSION> — FORK BUILD (k-l-sorensen/ironclaw)
+
+Unofficial fork release. Not produced by or affiliated with upstream
+nearai/ironclaw. Built locally via cargo-dist."
+git tag -v "$TAG" 2>/dev/null; git show --no-patch "$TAG"   # sanity-check the tag
+```
+
+### 5. Push the tag — to the FORK only
+
+> **RATIONALE:** A tag push is what triggers the build. It must go to `origin`.
+> Never `git push upstream` and never `git push --tags` (which can fan out to
+> multiple remotes). Push the one tag explicitly.
+
+```bash
+git push origin "refs/tags/$TAG"      # explicit single-tag push to the fork
+```
+
+If this hangs with no output, the credential helper regressed — re-run
+`gh auth setup-git` (step 1c) and retry. Do not `kill` and leave a half-push.
+
+### 6. Watch the release build and verify
+
+```bash
+# The release workflow should appear within ~30s of the tag push:
+gh run list --repo k-l-sorensen/ironclaw --workflow ironclaw-release.yml --limit 3
+gh run watch  --repo k-l-sorensen/ironclaw $(gh run list --repo k-l-sorensen/ironclaw \
+  --workflow ironclaw-release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# When done, confirm the Release exists, is marked prerelease, and has ARM64 Linux assets:
+gh release view "$TAG" --repo k-l-sorensen/ironclaw \
+  --json tagName,isPrerelease,assets --jq \
+  '{tag:.tagName, prerelease:.isPrerelease, assets:[.assets[].name]}'
+
+# Confirm the Release Notes are FORK notes, not upstream's base-version fallback.
+# This must print nothing — any hit means step 3b's changelog entry was missed:
+gh release view "$TAG" --repo k-l-sorensen/ironclaw --json body --jq '.body' \
+  | grep -n 'nearai/ironclaw/pull' && echo "BAD: upstream PR links in notes — fix CHANGELOG (step 3b) and re-tag"
+```
+
+Confirm to the user: `isPrerelease: true`; assets include
+`ironclaw-aarch64-unknown-linux-gnu.tar.gz` and `-musl.tar.gz`; and the release
+notes describe the **fork** changes (no `nearai/ironclaw/pull/...` links).
+
+> **If the notes are wrong on an already-published release** (changelog entry was
+> missed), you don't have to rebuild. Fix `CHANGELOG.md` on `main`, then patch the
+> live body in place, preserving the generated Install/Download sections:
+> save the current body, replace everything above `## Install ...` with the fork
+> notes, and `gh release edit "$TAG" --repo k-l-sorensen/ironclaw --notes-file <file>`.
+
+---
+
+## Git-workflow maintenance (run anytime, not just at release)
+
+Use this checklist when the user asks to "fix git settings" or a push misbehaves:
+
+```bash
+git remote -v                                   # origin=fork, upstream=nearai
+git remote get-url origin | grep k-l-sorensen   # origin must be the fork
+git config --get-all credential.'https://github.com'.helper  # should be 'gh auth git-credential'
+gh auth status                                  # gh logged in, scope includes 'repo'/'workflow'
+git branch -vv                                  # see what each branch tracks
+```
+
+Common repairs:
+- **Push hangs / asks for a password** → `gh auth setup-git` (routes HTTPS auth through gh).
+- **Wrong origin** → `git remote set-url origin https://github.com/k-l-sorensen/ironclaw.git`.
+- **Missing upstream** → `git remote add upstream https://github.com/nearai/ironclaw.git`.
+- **`main` should follow the fork** → `git branch --set-upstream-to=origin/main main`.
+- **Accidental tag created** → delete locally and on the fork:
+  `git tag -d "$TAG" && git push origin :refs/tags/"$TAG"`.
+
+## Hard rules
+
+- Never push tags, branches, or releases to `upstream` (nearai). The fork owns its releases.
+- Never use `git push --tags` here; push the single intended tag by full ref.
+- Every fork release version carries the `-mistral-fork.<N>` suffix and an annotated tag
+  whose message states it is an unofficial fork build.
+- Record any new fork-only divergence (version scheme, branch tracking change) in `CLAUDE-local.md`.

--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,16 @@ DATABASE_POOL_SIZE=30  # multi-tenant default; reduce to 5-10 for single-user or
 # MINIMAX_MODEL=MiniMax-M2.7
 # MINIMAX_BASE_URL=https://api.minimax.io/v1   # default (global); use https://api.minimaxi.com/v1 for China
 
+# === Mistral (reasoning_effort=high on Medium 3.5 / Small 4) ===
+# LLM_BACKEND=mistral
+# MISTRAL_API_KEY=...
+# MISTRAL_MODEL=mistral-medium-latest             # default (Medium 3.5); or mistral-small-latest (Small 4)
+# reasoning_effort toggle — high emits the full thinking trace (array response):
+#   high (default) = send reasoning_effort:"high" on supported models (small/medium)
+#   none/off       = omit the param (plain string response)
+# Only Mistral Small 4 / Medium 3.5 accept it; mistral-large/tiny/nemo always omit it.
+# MISTRAL_REASONING=high
+
 # === Anthropic Direct ===
 # LLM_BACKEND=anthropic
 # ANTHROPIC_MODEL=claude-sonnet-4-6

--- a/.github/workflows/upstream-release-watch.yml
+++ b/.github/workflows/upstream-release-watch.yml
@@ -1,0 +1,119 @@
+name: Upstream Release Watch
+
+# Fork-only workflow (not upstream). Nightly check for a published upstream
+# (nearai/ironclaw) release this fork hasn't caught up to yet.
+#
+# Per CLAUDE-local.md "Catch-up cadence: sync to upstream releases, not
+# intermediate main commits", a catch-up targets the merge-base of the latest
+# non-rc ironclaw-v<X.Y.Z> tag with upstream/main — not upstream/main's tip,
+# which is a moving target with no natural stopping point. This workflow only
+# detects and reports that gap; it deliberately does not attempt the catch-up
+# itself. Large-scale catch-ups routinely need conflict judgment (see
+# CLAUDE-local.md "Maintenance workflow") a bot can't safely make, so the
+# output here is a tracking issue, not a PR.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # daily 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: upstream-release-watch
+  cancel-in-progress: false
+
+jobs:
+  check-upstream-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compare against the latest published upstream release
+        id: check
+        run: |
+          set -euo pipefail
+          git remote add upstream https://github.com/nearai/ironclaw.git 2>/dev/null \
+            || git remote set-url upstream https://github.com/nearai/ironclaw.git
+          git fetch upstream --tags --quiet
+
+          # Final releases only: ironclaw-vX.Y.Z — no -rc./-fork./-mistral- suffix.
+          latest_tag="$(git for-each-ref --format='%(refname:short)' 'refs/tags/ironclaw-v*' \
+            | grep -E '^ironclaw-v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)"
+
+          if [ -z "$latest_tag" ]; then
+            echo "No upstream final-release tags found; nothing to check."
+            echo "should_open=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Release tags are cut onto a dedicated release/<version> branch and
+          # never merge back into upstream/main (verified 2026-08-10 for
+          # 1.1.0/1.1.0-rc.1) — merge-base finds the point on main's own line
+          # where that branch diverged, which is the fork's actual catch-up
+          # target.
+          catchup_point="$(git merge-base "$latest_tag" upstream/main)"
+
+          if git merge-base --is-ancestor "$catchup_point" HEAD; then
+            echo "Already caught up to $latest_tag (merge-base $catchup_point is an ancestor of HEAD)."
+            echo "should_open=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Fork main is behind $latest_tag (merge-base $catchup_point not yet in HEAD)."
+          echo "should_open=true" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "catchup_point=$catchup_point" >> "$GITHUB_OUTPUT"
+
+      - name: Open (or leave alone) the catch-up tracking issue
+        if: steps.check.outputs.should_open == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LATEST_TAG: ${{ steps.check.outputs.latest_tag }}
+          CATCHUP_POINT: ${{ steps.check.outputs.catchup_point }}
+        run: |
+          set -euo pipefail
+          title="Catch up to upstream ${LATEST_TAG}"
+
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label fork-catchup --search "in:title \"${LATEST_TAG}\"" \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already tracks ${LATEST_TAG}; nothing to do."
+            exit 0
+          fi
+
+          # One printf per line rather than a multi-line string or heredoc:
+          # a heredoc's terminator must sit at column 0 with zero leading
+          # whitespace, which is incompatible with YAML's block-literal
+          # style requiring every line here to carry this step's base
+          # indentation — confirmed the hard way (a first draft's unindented
+          # heredoc body broke YAML parsing; indenting it to satisfy YAML
+          # then broke the heredoc terminator match instead).
+          body_file="$(mktemp)"
+          {
+            printf '%s\n' "Upstream (\`nearai/ironclaw\`) has published **${LATEST_TAG}**, which this fork's \`main\` hasn't caught up to."
+            printf '\n'
+            printf '%s\n' "Per \`CLAUDE-local.md\` → \"Catch-up cadence: sync to upstream releases, not intermediate \`main\` commits\", the catch-up target is the merge-base of the release tag with \`upstream/main\`, not \`upstream/main\`'s tip:"
+            printf '\n'
+            printf '%s\n' '```'
+            printf '%s\n' "git fetch upstream --tags"
+            printf '%s\n' "git merge-base ${LATEST_TAG} upstream/main"
+            printf '%s\n' "# -> ${CATCHUP_POINT}"
+            printf '%s\n' '```'
+            printf '\n'
+            printf '%s\n' "Follow the routine or large-scale catch-up playbook in \`CLAUDE-local.md\` → \"Maintenance workflow\" depending on the size/shape of the gap between \`main\` and \`${CATCHUP_POINT}\`."
+            printf '\n'
+            printf '%s\n' "Opened automatically by \`.github/workflows/upstream-release-watch.yml\`. Close once \`main\` contains \`${CATCHUP_POINT}\` (this workflow won't reopen it, but will open a fresh issue for the *next* release if a new one ships before this one is closed)."
+          } > "$body_file"
+
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "$title" \
+            --label fork-catchup \
+            --body-file "$body_file"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- Fork-only entries (k-l-sorensen/ironclaw). Not upstream. -->
+
+## [0.29.1-fork.4] — fork build (not upstream)
+
+### Changed
+
+- Caught the fork up to upstream `nearai/ironclaw` (~203 commits). Local carry
+  reduced to: fork-release tooling, the worker job-status fix, and the
+  `RUSTSEC-2026-0187` advisory ignore.
+
+### Removed
+
+- Retired the custom Mistral `reasoning_effort` provider and its reasoning-replay
+  threading (CTR-1 / SIG-1 / `ReasoningBlock`). Upstream shipped a more general
+  native reasoning system (`reasoning` + `reasoning_details`) that supersedes it.
+  Re-architecture tracked in [fork issue #8](https://github.com/k-l-sorensen/ironclaw/issues/8);
+  pre-catch-up state preserved at tag `backup/main-pre-catchup`. Solution-independent
+  reference material (API research, design rationale, acceptance criteria, raw API
+  probe) retained in-tree under `docs/providers/`, `docs/plans/`, and `scripts/`.
+
 ## [Unreleased]
 
 ### Added
@@ -60,6 +80,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   presence-based — there is nothing to configure, and adding the bot to a
   channel is what admits it (see "Changed" above). Saved values for any of
   these retired handles are inert, and new saves fail closed as unknown fields.
+
+## [1.1.0-rc.1-mistral-fork.1](https://github.com/k-l-sorensen/ironclaw/releases/tag/ironclaw-v1.1.0-rc.1-mistral-fork.1) - 2026-08-10
+
+First marked release of the **k-l-sorensen/ironclaw fork** — unofficial, not
+affiliated with upstream nearai/ironclaw. Built on upstream `1.1.0-rc.1` plus
+the fork-only changes below. See `CLAUDE-local.md` for the full divergence
+list.
+
+### Added
+
+- Re-landed the custom Mistral `reasoning_effort=high` provider on top of
+  upstream's native reasoning system
+  ([fork issue #8](https://github.com/k-l-sorensen/ironclaw/issues/8)).
+
+### Fixed
+
+- Hosted Mistral models are now priced instead of billed as $0
+  ([fork issue #9](https://github.com/k-l-sorensen/ironclaw/issues/9), PR #13).
+
+### Security
+
+- Dropped the stale `RUSTSEC-2026-0187` (lopdf DoS) advisory ignore now that
+  lopdf is patched at 0.42.0
+  ([fork issue #2](https://github.com/k-l-sorensen/ironclaw/issues/2), PR #12).
+
+### CI · Release
+
+- Repointed `ironclaw_cli` release metadata (homepage/repository) to the fork
+  so cargo-dist publishes against `k-l-sorensen/ironclaw`.
+- Adopted the `<base>-mistral-fork.<N>` version/tag convention for fork
+  releases going forward (this release is `.1`).
 
 ## [1.1.0-rc.1] - 2026-08-03
 

--- a/CLAUDE-local.md
+++ b/CLAUDE-local.md
@@ -1,0 +1,452 @@
+# Local Fork Notes (not upstream)
+
+> This file documents **local-only** modifications to this clone. It is not
+> part of upstream `nearai/ironclaw` and exists only in this fork. Anything
+> described here is a deliberate local carry, not project canon.
+
+## Situation
+
+This is a personal fork of [`nearai/ironclaw`](https://github.com/nearai/ironclaw).
+We have **no affiliation** with the project and do **not** intend to upstream
+changes via PR. We run a modified build locally and pull upstream updates
+periodically.
+
+Git remotes:
+
+- `upstream` → `https://github.com/nearai/ironclaw.git` (the original project; read-only to us)
+- `origin` → our personal GitHub fork (where our branch lives)
+
+## Maintenance workflow
+
+For a routine catch-up (a handful of upstream commits, no structural changes),
+carry local changes as commits on a branch, rebased onto upstream so git
+reapplies them automatically:
+
+```bash
+git fetch upstream
+git rebase upstream/main                       # replays our carry commits on top
+git push --force-with-lease origin <branch>
+```
+
+A rebase conflict is the signal to look — it usually means upstream touched the
+same code (possibly fixing it themselves, at which point the local commit can be
+dropped). The 2026-07-05 catch-up did exactly that for the entire Mistral
+reasoning carry (see "Retired" below).
+
+**Once a prior catch-up has landed via merge (branch + PR) rather than a true
+rebase — which every catch-up since 2026-08-05 has — plain `git rebase
+upstream/main` (or `git rebase --onto <target> <old-merge-point>`) no longer
+works cleanly, even for a routine, small-commit-gap catch-up.** The fork-only
+files that predate the last merge point (`CLAUDE-local.md`, `mistral.rs`, the
+fork-release skill, …) exist in the branch's tree but were never *created* by
+a commit inside the slice being replayed — from git's point of view the new
+(pure-upstream) base "deleted" them, producing spurious `modify/delete`
+conflicts on files that were never actually in conflict. Hit on the
+2026-08-13 catch-up trying `git rebase --onto 499394df4 3113af34d …` (only
+26 upstream commits, zero renames — the textbook "routine" case). **Fix:**
+skip commit replay entirely and port the fork's *cumulative state* instead —
+diff the fork tip directly against the upstream commit the *previous*
+catch-up was based on (not the previous catch-up's merge commit), so every
+fork-only file shows as a clean file creation with nothing to conflict
+against:
+```bash
+git diff <old-upstream-catchup-base> <fork-tip> > carry.patch   # e.g. 4e05a033d d6185cb78
+git checkout -b catchup/<label> <new-upstream-catchup-base>     # e.g. 499394df4…
+git apply --3way carry.patch                                    # 3-way merges shared files against upstream's new content too
+```
+This is the same "port current state, not history" principle as the
+large-scale playbook above, just without needing a worktree or hand-authoring
+each item — the single cumulative diff already *is* the current state.
+
+**For a large-scale catch-up** (upstream deleted/renamed whole subsystems, or
+the commit gap is in the hundreds), rebase spends nearly all its effort
+resolving conflicts on carry commits that are dead anyway. The 2026-08-05
+catch-up (upstream 0.29.1-era → 1.1.0-rc.1, ~608 commits, full v1 `src/`
+monolith deletion + repo-wide Reborn crate de-prefixing) instead: branched a
+new `catchup/<label>` branch straight off `upstream/main` in a separate git
+worktree (`git worktree add`, so `main` and the in-progress feature branch are
+never touched mid-catch-up), then hand-authored each surviving carry item as a
+fresh, independently-validated commit against the clean tree rather than
+replaying old commit hashes. Safety tags (`safety/<branch>-pre-catchup`) were
+cut on both `main` and the feature branch first. See fork issue tracking for
+the specific catch-up if one exists.
+
+The **2026-08-10 catch-up** (upstream 19b1fb715 → 4e05a033d, 68 commits) hit
+the same large-scale trigger on a much smaller commit count: upstream's WS7
+"family directory moves" (#7206, #7212) reorganized the entire `crates/` tree
+into family subdirectories (`crates/app/`, `crates/contracts/`,
+`crates/domains/`, `crates/events/`, `crates/extensions/`, `crates/kernel/`,
+`crates/lanes/`, `crates/loop/`, `crates/product/`, `crates/substrates/`) —
+4,589 renames across 2,729+ files. Same worktree-branch playbook applied; the
+carry itself needed no logic changes, only path updates (`ironclaw_llm` →
+`crates/domains/ironclaw_llm`, `ironclaw_cli` → `crates/app/ironclaw_cli`).
+This confirms the trigger is "structural renames," independent of raw commit
+count — a two-digit commit gap can still warrant the worktree approach.
+
+**Landing a large-scale catch-up branch will show conflicts on the PR —
+this is expected, not a sign the port was done wrong.** The catch-up branch
+is built fresh off `upstream/main`, so it shares no history with `main`'s own
+carry commits past the old merge-base; `main` still has the pre-reorg carry
+sitting on the old paths. GitHub's merge preview (and a plain `git merge`)
+will show every file the carry touches as conflicting — `main`'s old-path
+version vs. the branch's already-relocated version — even though there is no
+real disagreement, just two paths for the same superseded content. Resolve by
+merging `main` into the catch-up branch locally (`git merge origin/main`) and
+taking "ours" (the catch-up branch) for every such conflict, since it is the
+supersede-set; genuine identical-content conflicts (git's rename tracking
+failing to match a file across two independently-authored paths to the same
+destination) resolve either way. Re-run the doc/lint/test gates after
+resolving — the merge can surface files the original port forgot entirely
+(the 2026-08-10 catch-up caught this way that the Mistral reference docs never
+got re-carried, see the Mistral entry below) — then push the merge commit to
+the same PR branch rather than force-pushing over `main`.
+
+### Catch-up cadence: sync to upstream releases, not intermediate `main` commits
+
+- **Rule (2026-08-10):** when catching up, stop at the commit on `upstream/main`
+  that corresponds to upstream's most recently *published* release — not
+  whatever `upstream/main`'s tip happens to be that day. `main` is a moving
+  target with no natural stopping point; a named release is.
+- **Why:** discovered while cutting the `1.1.0-rc.1-mistral-fork.1` release.
+  Upstream's release tags (`ironclaw-v<X.Y.Z>`, `ironclaw-v<X.Y.Z>-rc.N`) are
+  cut onto a dedicated `release/<version>` branch and **never merge back into
+  `main`** — confirmed with `git branch -r --contains ironclaw-v1.1.0` (lists
+  only `upstream/release/1.1.0-rc.1` and `upstream/release/1.1.1`, not
+  `upstream/main`) and `git merge-base --is-ancestor ironclaw-v1.1.0-rc.1
+  upstream/main` (fails). By the time of our 2026-08-10 catch-up (to
+  `4e05a033d`), `upstream/main` had already moved **83 commits** past the point
+  where the `1.1.0-rc.1`/`1.1.0` release branch was cut — none of that gap is
+  "the next release," it's ordinary in-flight development with no release
+  boundary yet. A fork release cut from that point can't honestly claim to be
+  "upstream v1.1.0 + fork edits" — it's "v1.1.0's branch point plus 83
+  unrelated commits plus fork edits," a materially different (and undocumented)
+  set of upstream content.
+- **How to apply — finding the stop point:** a release tag's *commit* isn't on
+  `main`, but `git merge-base` still finds where the branches diverged, which
+  is the right stop point for a `main`-tracking catch-up:
+  ```bash
+  git fetch upstream --tags
+  git merge-base ironclaw-v<latest-non-rc-version> upstream/main
+  ```
+  Catch up `main` to that commit (not `upstream/main`'s tip), using the routine
+  or large-scale playbook above as the commit-gap size dictates. This is a
+  **fork release doesn't have to wait for a fork catch-up** to happen the same
+  day, either — cut the release from the merge-base point directly, then catch
+  `main` up to it separately if/when there's other reason to.
+- **Note the gap, don't chase it:** the 3 commits that exist *only* on the
+  release branch (hotfix backports never merged to `main`, e.g. the 1.0→1.1
+  migration-state-preservation fix) are real content our `main`-tracking fork
+  will never receive through a normal catch-up. If one of those specifically
+  matters, it needs an explicit cherry-pick from the release branch, called out
+  in the fork issue/PR — don't assume `main` catch-up covers it.
+
+### Commit convention
+
+The repo (and we, for our carry commits) use **Conventional Commits** —
+`type(scope): subject` (e.g. `chore(fork): …`, `fix(worker): …`) — with a
+`Co-Authored-By: Claude …` trailer when a commit was authored with Claude.
+Keep planning/docs and implementation in **separate** commits.
+
+**Don't cite carry-commit SHAs in committed docs.** Rebasing onto upstream (and
+any history rewrite) re-hashes our carry commits, so a pinned SHA goes stale on
+the next `git rebase upstream/main`. Reference carry commits by their
+Conventional-Commit subject instead.
+
+## Active local changes
+
+### Mistral `reasoning_effort=high` on upstream's native `reasoning_details`
+
+- **What:** a dedicated `crates/domains/ironclaw_llm/src/mistral.rs` provider
+  (`ProviderProtocol::Mistral`) that owns Mistral's wire JSON so it can parse
+  the `reasoning_effort=high` array-shaped response (`[{thinking},{text}]`)
+  that rig-core 0.33 cannot. The thinking chunk (+ opaque signature) is mapped
+  onto **upstream's shared `reasoning_details` channel**
+  (`ReasoningDetail::Text { text, signature }`) — the same seam
+  DeepSeek/Gemini/OpenRouter use — and replayed on the next turn. Supporting
+  pieces: `MistralReasoningEffort` + `resolve_mistral_reasoning_from_env`
+  (`config.rs`), `supports_mistral_reasoning` gate (`reasoning_models.rs`),
+  `ProviderProtocol::Mistral` + factory dispatch (`registry.rs`/`lib.rs`),
+  `MISTRAL_REASONING` env wiring in `apply_registry_provider_env`
+  (`resolution.rs` — `ironclaw_llm` now owns its full env→config resolution
+  itself; there's no more binary-crate env-reading split, since `ironclaw_cli`
+  is architecturally forbidden from depending on `ironclaw_llm` directly),
+  `crates/domains/ironclaw_llm/assets/providers.json` switch
+  (`open_ai_completions` → `mistral`, default model → `mistral-medium-latest`),
+  offline parser matrix (`mistral/tests.rs`), and a live contract test
+  (`tests/reborn_live_mistral_reasoning_contract.rs` — the old
+  `tests/e2e_live_mistral_reasoning.rs` depended on a v1 agent-loop harness
+  deleted with the monolith; this one calls `MistralProvider` directly,
+  modeled on `tests/reborn_live_github_pat_contract.rs`).
+- **Why:** implements fork issue #8 per
+  `docs/internal/plans/2026-07-05-mistral-reasoning-native-arch.md`. Re-landed on the
+  2026-08-05 catch-up (upstream 0.29.1-era → 1.1.0-rc.1) from the original
+  `152c010bc4`; still no upstream native Mistral reasoning support at the new
+  base either, so this remains needed. No `ReasoningBlock`/CTR-1/SIG-1 carry,
+  no DB migration. Scope: Mistral Medium 3.5 (`mistral-medium-2604`) and Small
+  4 (`mistral-small-2603`).
+- **Re-landing deviations (2026-08-05):** cost lookup moved crates
+  (`crate::costs` → `ironclaw_common::llm_costs`, since `ironclaw_llm` no
+  longer owns cost tables); added an explicit `provider_id()` override (the
+  `LlmProvider` trait grew this method upstream, matching the
+  `github_copilot.rs` pattern); two `retry::is_retryable` test assertions
+  pinned to this tree's current policy (`InvalidResponse`/`EmptyResponse` are
+  now non-retryable, a policy change upstream made independently of this
+  carry).
+- **2026-08-10 catch-up:** pure path move, no logic change. `ironclaw_llm`
+  relocated to `crates/domains/ironclaw_llm` under upstream's WS7
+  family-directory reorg. The crate's own `CLAUDE.md`/`AGENTS.md` are now
+  symlink pointers (upstream's guidance-unification work landed in this same
+  range); the file-map and sub-owner-map entries for `mistral.rs` /
+  `mistral/tests.rs` now live in `crates/domains/ironclaw_llm/CONTRACT.md`
+  instead (enforced by `tests/module_charter.rs`).
+- **Known gap (tracked):** `ironclaw_common::llm_costs::is_local_model`
+  matches `mistral*`, so hosted Mistral currently bills as $0 — fork
+  follow-up issue; see the `TODO` in `mistral.rs::cost_per_token`.
+
+### Fork-release skill + tag-driven release convention
+
+- **What:** `.claude/skills/fork-release/SKILL.md` — a Claude Code skill that
+  guides cutting a *marked* release tag on this fork via cargo-dist, and that
+  doubles as the git-workflow maintenance checklist (remotes, `gh auth setup-git`
+  credential helper, branch tracking).
+- **Fork-marking convention (local-only):** fork releases use a prerelease
+  version suffix `-mistral-fork.<N>` (e.g. `1.1.0-rc.1-mistral-fork.1`).
+  **Changed 2026-08-10** from the earlier generic `-fork.<N>` (used for
+  `0.29.1-fork.1`/`.2`/`.3`) to brand the suffix after the fork's flagship
+  divergence (the custom Mistral `reasoning_effort=high` provider, above) —
+  chosen deliberately over the literal `-mistral-fork`/`-mistral-fork-v2` the
+  user first proposed, to keep the dot-incrementing `.<N>` pattern that's easy
+  to bump and unambiguous to parse. cargo-dist requires the `ironclaw`
+  `[package]` version to equal the tag version, so a fork release bumps that
+  version line — **this diverges from upstream and will conflict on `git
+  rebase upstream/main`** (or need re-applying on a reset-and-reapply
+  catch-up). Resolution: take upstream's base version, re-apply the
+  `-mistral-fork.<N>` suffix, reset `N` to 1 on a new base.
+- **Release targeting repointed to the fork (local-only):** upstream hardcodes
+  `nearai/ironclaw` in release generation. We repoint `repository`/`homepage`
+  → `k-l-sorensen/ironclaw` on the sole dist-able package,
+  **`crates/app/ironclaw_cli/Cargo.toml`** (cargo-dist bakes this into the
+  generated installers, including the WiX MSI's ARPHELPLINK). **Correction
+  (2026-08-10):** `crates/app/ironclaw_cli/wix/main.wxs` *is* a committed,
+  generated file — cargo-dist 0.31's `plan` job (`dist host --steps=create`)
+  diffs it against what it would regenerate from package metadata and fails
+  the whole release build if they've drifted. The first
+  `1.1.0-rc.1-mistral-fork.1` build failed exactly this way: the metadata
+  repoint above landed, but the committed `main.wxs` still had `ARPHELPLINK`
+  pointing at `nearai/ironclaw`. Fixed with a direct one-line text patch (no
+  `dist`/`cargo-dist` CLI installed locally to run `dist init`); the
+  fork-release skill's preflight now greps for stale `nearai/ironclaw`
+  references in that directory before tagging. The release workflow itself is
+  `.github/workflows/ironclaw-release.yml` (renamed from `release.yml`
+  upstream at some point past our old base). `authors` and the license are
+  deliberately left as NEAR AI. Upstream's new `cut-ironclaw-release.yml` is
+  their own App-token-gated release tooling — not usable by, or relevant to,
+  the fork; a direct annotated-tag push still triggers `ironclaw-release.yml`
+  as before.
+- **MSI installer dropped (local-only, 2026-08-10):** root `Cargo.toml`
+  `[workspace.metadata.dist] installers` is `["shell", "powershell"]`, not
+  upstream's `["shell", "powershell", "msi"]`. WiX's MSI-version mapper only
+  handles a version with one dotted prerelease group (`name.N`, e.g.
+  `1.2.3-prerelease.4` → `1.2.3.4`). A fork release built on an upstream
+  `-rc.N` base plus our `-mistral-fork.N` suffix produces *two*
+  (`1.1.0-rc.1-mistral-fork.1` → prerelease `rc.1-mistral-fork.1`, three
+  dot-separated identifiers), which WiX rejects — and since `dist build` runs
+  archive + shell + powershell + msi as one command per target, the MSI
+  failure aborted the *entire* Windows job (no `.zip`, no install scripts
+  either), which in turn blocked `host`/`announce` and lost the release for
+  all 8 platforms, not just Windows. Hit on the first
+  `1.1.0-rc.1-mistral-fork.1` build attempt; fixed by dropping `msi` rather
+  than reworking the version scheme. **Revisit once releases are cut from a
+  clean (non-`-rc.N`) base** per the catch-up-cadence policy above — a version
+  like `1.1.0-mistral-fork.1` has only one dotted prerelease group and should
+  satisfy WiX, so `msi` may be safe to re-add then; verify with a real build
+  before assuming it, not by inspection alone.
+- **Windows target dropped (local-only, 2026-08-10):** root `Cargo.toml`
+  `[workspace.metadata.dist] targets` no longer includes
+  `x86_64-pc-windows-msvc` (the `github-custom-runners` → `windows-2022`
+  mapping is left in place so re-adding is one line). After the `msi` fix
+  above unblocked the Windows *build*, cargo-dist's own release smoke test
+  (`ironclaw.exe extension search --json`) failed at runtime:
+  `filesystem backend error during write_file at
+  /projects/system/skills/.ironclaw-reborn-bundled.lock: permission denied` —
+  a Unix-style absolute path that doesn't resolve sensibly on Windows. This is
+  **not fork-caused** (no runtime/filesystem code changed this session) and
+  most likely reproduces on a vanilla upstream Windows build too. Tracked in
+  [fork issue #14](https://github.com/k-l-sorensen/ironclaw/issues/14); all 7
+  non-Windows targets built and passed cleanly. Re-add the target once fixed.
+- **2026-08-10 catch-up:** `ironclaw_cli` moved to `crates/app/ironclaw_cli`
+  under upstream's WS7 family-directory reorg; every path reference in the
+  skill and in this section was updated accordingly. No behavior change.
+- **Hard rule:** tags/branches/releases go to `origin` (the fork) only; never
+  `git push upstream`, never `git push --tags`.
+
+### GitHub Actions disable list
+
+- **What:** on a personal single-user fork with zero Actions secrets, upstream's
+  scheduled/publish workflows either spam failure emails or can never succeed.
+  Disabled via `gh workflow disable <file> -R k-l-sorensen/ironclaw`
+  (GitHub-level toggle, **not** a file edit — keeps the workflow YAML
+  unmodified and rebase/reset-and-reapply-safe). Reverse with
+  `gh workflow enable`.
+- **Disable (cron/push-to-main, will auto-fire and fail without secrets):**
+  `docker.yml`* (Docker Hub push, no `DOCKER_REGISTRY_*`), `live-canary.yml`
+  (3h schedule), `nightly-deep-ci.yml` (daily schedule), `coverage.yml`
+  (Codecov, no token), `nightly-watchdog.yml` (daily schedule — **new as of
+  the 2026-08-05 catch-up**, same rationale as `nightly-deep-ci.yml`), and
+  `main-ci-slack-alerts.yml` (**new as of the 2026-08-05 catch-up** —
+  `workflow_run`-triggered off our own CI failing, and the job itself
+  hard-fails, not skips, when `MAIN_CI_SLACK_WEBHOOK_URLS`/`SLACK_WEBHOOK_URL`
+  are unset — the exact "fires precisely when something already failed, then
+  fails again" pattern that motivated disabling the others).
+  \* `docker.yml` no longer has a standalone trigger on this tree — it's
+  `workflow_call`-only, invoked by `ironclaw-release.yml` during a release;
+  nothing to disable directly, the inertness (no Docker secrets) carries
+  through unchanged.
+- **Self-gated, no action needed:** `release-plz.yml`
+  (`if: github.repository_owner == 'nearai'`), `codebase-graph-refresh.yml`
+  (`if: github.repository == 'nearai/ironclaw'`, **new as of the 2026-08-05
+  catch-up**).
+- **Dormant by trigger, no action needed:** `sccache-dist-smoke.yml`,
+  `rebuild-release-image.yml`, `cut-ironclaw-release.yml` (upstream's own
+  App-token-gated release tooling, see above), `live-canary-command.yml` /
+  `nearai-bench.yml` (`issue_comment`), `nearai-bench-tests.yml`
+  (path-scoped to the bench workflow files themselves).
+- **Keep enabled:** PR-triggered CI (`code_style`, `platform-and-compat`,
+  `reborn-*`, `history-check.yml` — **new as of the 2026-08-05 catch-up**, a
+  PR-triggered repo-hygiene check with no external secrets — `pr-label-*`)
+  and `ironclaw-release.yml` (the intentional tag-driven fork release).
+- **2026-08-10 catch-up:** workflow file set is unchanged in this range (all
+  12 touched `.github/workflows/*` files in the 68-commit diff are
+  modifications, zero adds/removes/renames) — this disable list's content
+  stays accurate as-is.
+- **Action item:** the disable list above reflects the workflow set as of the
+  2026-08-05 catch-up; the actual `gh workflow disable` calls need re-running
+  once this branch's workflow files are live on `origin` (GitHub only lets you
+  disable a workflow once it has run/registered on that repo).
+
+## Retired local changes
+
+### Custom Mistral `reasoning_effort` provider + reasoning replay (CTR-1 / SIG-1 / ReasoningBlock)
+
+**Retired in the 2026-07-05 upstream catch-up.** The fork previously carried a
+custom `crates/ironclaw_llm/src/mistral.rs` provider plus a large reasoning-replay
+threading (CTR-1 cross-turn reasoning, SIG-1 ThinkChunk signature, and a
+`ReasoningBlock` bundling refactor) spanning ~35 files.
+
+During the catch-up we found that **upstream independently built a more general
+reasoning-replay system** — `reasoning` + `reasoning_details`
+(`ReasoningDetail::{ Text { text, signature }, Encrypted, Redacted, Summary }`),
+`with_reasoning` / `with_reasoning_details` builders, rig-adapter support — which
+supersedes ours and already carries a per-block signature. Rather than keep
+re-conflicting these files on every rebase, we **dropped the entire Mistral
+reasoning carry** and adopted upstream's system.
+
+Re-architecting Mistral support onto upstream's native reasoning path is tracked
+in **[fork issue #8](https://github.com/k-l-sorensen/ironclaw/issues/8)**. The
+full pre-catch-up state (all Mistral code + tests) is preserved at the
+`backup/main-pre-catchup` tag.
+
+**Status (2026-07-05): was IMPLEMENTED** on the approved design
+(`docs/plans/2026-07-05-mistral-reasoning-native-arch.md`, which supersedes the
+2026-06-24 design) — one thin `MistralProvider` at the wire boundary
+translating Mistral's chunk array onto `ReasoningDetail::Text{text,signature}`,
+a `ProviderProtocol::Mistral` variant, a `supports_mistral_reasoning()` gate,
+and `providers.json` config; no `ReasoningBlock`/CTR-1/SIG-1 rebuild, no new DB
+migrations. Scope: `reasoning_effort=high` for Mistral Medium 3.5
+(`mistral-medium-2604`) and Mistral Small 4 (`mistral-small-2603`).
+
+**Status (2026-08-05): re-landed** on the 608-commit upstream catch-up (which
+branched fresh off `upstream/main` rather than rebasing — see "Maintenance
+workflow" above — so the provider was re-created against the new tree, not
+carried; the old integration points, `src/config/llm.rs` and
+`src/cli/models.rs`, no longer exist, and `providers.json` moved to
+`crates/ironclaw_llm/assets/providers.json`). See the **"Mistral
+`reasoning_effort=high` on upstream's native `reasoning_details`"** entry
+under *Active local changes* above for the current shape and the specific
+re-landing deviations.
+
+**Status (2026-08-10): re-applied**, path-only, onto upstream's WS7
+family-directory reorg (`crates/ironclaw_llm` → `crates/domains/ironclaw_llm`).
+No logic changes; see the "2026-08-10 catch-up" note under *Active local
+changes* above. This same catch-up also relocated the reference docs below:
+upstream's `docs/ publication boundary` work (commit `50311eab4` in this
+range, enforced by `scripts/ci/docs_publication_boundary.py`) retired
+`docs/plans/` entirely in favor of `docs/internal/plans/`, and flagged our
+`docs/providers/mistral-reasoning.md` as an unfenced page (neither public-nav'd
+nor under `internal/`) — moved to `docs/internal/research/mistral-reasoning.md`.
+
+**Reference material retained in-tree to seed the re-architecture** (so it need
+not be reinvented):
+
+- `docs/internal/research/mistral-reasoning.md` — provider-agnostic API
+  research + the rig-core parse blocker (still valid).
+- `docs/internal/plans/2026-07-05-mistral-reasoning-native-arch.md` — the
+  **current approved** C4 L3 architecture (native `reasoning_details` path,
+  model catalog, components, rule-compliance, acceptance criteria).
+- `docs/internal/plans/2026-06-24-mistral-reasoning-provider-architecture.md`
+  — the superseded design (bannered), **plus the acceptance criteria** the
+  re-arch must re-satisfy (clean round-trip, multi-turn replay).
+- `docs/internal/plans/2026-06-24-mistral-reasoning-impl.md` — superseded
+  work breakdown, kept for the edge cases it enumerates.
+- `scripts/test-mistral-reasoning.sh` — raw Mistral API probe (no code coupling).
+
+The retired tests — `tests/e2e_live_mistral_reasoning.rs` (behavioral acceptance)
+and `crates/ironclaw_llm/src/mistral/tests.rs` (offline parser matrix, C1–C12) —
+live at the backup tag; their intent is captured in the acceptance criteria above.
+
+### Worker job-status fix
+
+**Dropped in the 2026-08-05 upstream catch-up.** A small cluster of
+`fix(worker)` / `refactor(worker)` / `docs(worker)` commits that emitted status
+on container result events, persisted detached sandbox job status, collapsed
+duplicated terminal-finalization into one helper, typed all `job.rs` status
+arms, and restored the "unknown job result status" warning via provenance.
+
+All of it targeted files that no longer exist: `src/agent/job_monitor.rs`,
+`src/orchestrator/api.rs`, `src/tools/builtin/job.rs`,
+`src/worker/{container,job}.rs` were deleted with the v1 `src/` monolith, and
+`crates/ironclaw_common/src/event.rs` (the shared event-type file the fix also
+touched) was deleted too — with no successor naming found anywhere in
+`crates/` (`JobStatus`/`job_status`/`ContainerResult` all came up empty).
+Dropped outright rather than re-homed; if the same class of bug resurfaces in
+Reborn's job/sandbox lane, it needs a fresh fix against that code, not a port
+of this one.
+
+### Advisory ignore: `RUSTSEC-2026-0187` (lopdf DoS)
+
+**Resolved in the 2026-08-10 catch-up cleanup.** `deny.toml` carried an
+`ignore` entry for `RUSTSEC-2026-0187` (lopdf stack-overflow DoS via deeply
+nested PDF objects, reachable through `pdf-extract` document text extraction
+in `crates/domains/ironclaw_extractors`), added on 2026-06-26 to unblock
+`cargo deny` while `lopdf` was still on the vulnerable `0.34.0`. Fork-tracked
+in [issue #2](https://github.com/k-l-sorensen/ironclaw/issues/2).
+
+By the 2026-08-05 and 2026-08-10 catch-ups, ordinary upstream dependency
+movement had already carried `lopdf` to `0.42.0` — the advisory's patched
+version (affected range `<= 0.41.0`, fixed `>= 0.42.0`; the fix adds a
+max-nesting-depth check so the parser now returns an `Err` instead of
+aborting). Both catch-ups reapplied the `ignore` entry anyway, unchanged,
+without checking the pinned version against the advisory's fixed threshold —
+the reapply commit messages note "lopdf is still pinned at 0.42.0" as if that
+meant still-vulnerable, when 0.42.0 was already the fix. The entry sat dead
+for two catch-ups before this cleanup removed it and confirmed `cargo deny
+check advisories` passes clean without it.
+
+**Fork-carry pitfall:** an `ignore` entry surviving a rebase/re-carry
+unchanged is not evidence it's still needed — a later catch-up can bump the
+offending dependency past an advisory's fix as a side effect of unrelated
+upstream work. Before reapplying an advisory ignore during a catch-up, check
+the ignored advisory's patched-version threshold against the dependency's
+*current* `Cargo.lock` pin, not just whether the version number looks
+unchanged from the last carry.
+
+The residual reachability point from the original issue still holds
+structurally — attachment bytes reach `extract_pdf`
+(`crates/domains/ironclaw_extractors/src/lib.rs`) with only an
+attachment-level `max_bytes` cap upstream of it, no PDF-specific
+timeout/sandbox in `ironclaw_extractors` itself — but the actual crash vector
+(unbounded recursion aborting the process) is now handled inside `lopdf`
+itself, which is what the advisory's fix does. No further app-level guard
+was judged necessary to close #2.
+
+<!-- Add new local changes above the "Retired" section, newest first. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # IronClaw — Claude Code adapter
 
+> **Local fork:** This clone carries local-only modifications not present in
+> upstream `nearai/ironclaw`. See [`CLAUDE-local.md`](CLAUDE-local.md) for the
+> fork situation, maintenance workflow, and the list of active local changes.
+
 @AGENTS.md
 
 Everything above (from `AGENTS.md`) is the canonical, tool-neutral contract.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,7 +3455,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.1-mistral-fork.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -508,11 +508,23 @@ ci = "github"
 tag-namespace = "ironclaw"
 # Install build-only prerequisites before cargo-dist compiles each target.
 github-build-setup = "../dist-build-setup.yml"
-# The installers to generate for each app
-installers = ["shell", "powershell", "msi"]
+# The installers to generate for each app.
+# Fork-only (local carry): dropped "msi" — WiX's MSI-version mapper only
+# handles a version with a single dotted prerelease group ("name.N"), and any
+# fork release built on an upstream -rc.N base plus our -mistral-fork.N suffix
+# produces two ("rc.1-mistral-fork.1"), which aborts the entire Windows build
+# job (not just the MSI step) and blocks the release for every platform. See
+# CLAUDE-local.md "Fork-release skill + tag-driven release convention".
+installers = ["shell", "powershell"]
 # Publish jobs to run in CI
 publish-jobs = []
-# Target platforms to build apps for (Rust target-triple syntax)
+# Target platforms to build apps for (Rust target-triple syntax).
+# Fork-only (local carry): x86_64-pc-windows-msvc dropped 2026-08-10 — the
+# packaged binary's own release smoke test fails on Windows with a permission
+# error writing a Unix-style absolute path (/projects/system/skills/...),
+# unrelated to any fork change (version string, wix, installers). Tracked in
+# fork issue #14; re-add once fixed. github-custom-runners below keeps the
+# windows-2022 mapping so re-adding is a one-line change.
 targets = [
     "aarch64-apple-darwin",
     "aarch64-unknown-linux-gnu",
@@ -520,7 +532,6 @@ targets = [
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
-    "x86_64-pc-windows-msvc",
 ]
 # The archive format to use for windows builds (defaults .zip)
 windows-archive = ".tar.gz"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+> **Fork notice.** This is a personal fork of [nearai/ironclaw](https://github.com/nearai/ironclaw).
+> It tracks upstream closely and carries a small set of local-only changes
+> (fork-release tooling, an advisory ignore) documented in
+> [`CLAUDE-local.md`](CLAUDE-local.md). All credit for the original work goes
+> to the upstream authors; the original license (MIT OR Apache-2.0) is retained
+> unchanged. A custom Mistral `reasoning_effort` provider lives here, layered on
+> upstream's native `reasoning_details` channel — see
+> [fork issue #8](https://github.com/k-l-sorensen/ironclaw/issues/8).
+> Fork-specific issues → [this fork's issues](https://github.com/k-l-sorensen/ironclaw/issues).
+> Core issues → [upstream](https://github.com/nearai/ironclaw/issues).
+
+---
+
 <p align="center">
   <img src="ironclaw.png?v=2" alt="IronClaw" width="200"/>
 </p>

--- a/crates/app/ironclaw_architecture_tests/tests/reborn_contracts_vendor_census.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_contracts_vendor_census.rs
@@ -29,7 +29,7 @@
 //!
 //! Running it turns up a **second** LLM-vendor surface in the contracts family
 //! that D-E did not know about: `ironclaw_common::llm_costs`, a per-model price
-//! table naming **9 distinct vendors across 91 occurrences** (`claude`, `gpt`,
+//! table naming **9 distinct vendors across 94 occurrences** (`claude`, `gpt`,
 //! `sonnet`, `opus`, `haiku`, `codex`, `mistral`, `deepseek`, `llama`). It is
 //! invisible to the specificity scanner for the same reason `operator_llm` is,
 //! which is precisely why nobody had seen it. This gate does not delete it —
@@ -159,13 +159,17 @@ const CENSUS: &[CensusScope] = &[
     },
     CensusScope {
         path: "crates/ironclaw_common/src/llm_costs.rs",
-        occurrences: 91,
+        occurrences: 94,
         distinct_vendors: 9,
         basis: "UNSANCTIONED RESIDUE, found by this census (#7150): a per-model price \
                 table in the contracts family that D-E's 'nowhere else' does not cover \
                 and the specificity scanner cannot see. Frozen and shrink-only pending \
                 an owner decision — the model-cost table is a candidate to move beside \
-                the llm providers, which §8.2 already sanctions for vendor names",
+                the llm providers, which §8.2 already sanctions for vendor names. \
+                Re-ratcheted 91→94 (fork k-l-sorensen/ironclaw#9): added real hosted \
+                Mistral Medium 3.5 / Small 4 pricing rows for the already-sanctioned \
+                `mistral` vendor — no new distinct vendor, just more occurrences of one \
+                already counted; the prior heuristic was pricing hosted Mistral at $0.",
     },
     CensusScope {
         path: "crates/ironclaw_prompt_envelope/src/lib.rs",

--- a/crates/app/ironclaw_cli/Cargo.toml
+++ b/crates/app/ironclaw_cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ironclaw"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.1-mistral-fork.1"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"
 authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/nearai/ironclaw"
-repository = "https://github.com/nearai/ironclaw"
+homepage = "https://github.com/k-l-sorensen/ironclaw"
+repository = "https://github.com/k-l-sorensen/ironclaw"
 publish = false
 
 [package.metadata.ironclaw]

--- a/crates/app/ironclaw_cli/tests/smoke.rs
+++ b/crates/app/ironclaw_cli/tests/smoke.rs
@@ -582,7 +582,10 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
     assert!(
         workspace_manifest.contains("packages = [\"ironclaw\"]")
             && workspace_manifest.contains("github-build-setup = \"../dist-build-setup.yml\"")
-            && workspace_manifest.contains("installers = [\"shell\", \"powershell\", \"msi\"]")
+            // Fork-only (local carry): "msi" dropped 2026-08-10 — WiX's version
+            // mapper rejects the fork's double prerelease suffix. See
+            // CLAUDE-local.md "Fork-release skill + tag-driven release convention".
+            && workspace_manifest.contains("installers = [\"shell\", \"powershell\"]")
             && workspace_manifest.contains("tag-namespace = \"ironclaw\"")
             && workspace_manifest.contains("pr-run-mode = \"skip\""),
         "cargo-dist must select only the canonical Reborn package and generate the supported installers without claiming the unavailable npm package name"
@@ -594,7 +597,9 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         "x86_64-apple-darwin",
         "x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl",
-        "x86_64-pc-windows-msvc",
+        // Fork-only (local carry): x86_64-pc-windows-msvc dropped 2026-08-10 —
+        // the packaged binary's own release smoke test fails on Windows
+        // (fork issue #14). See CLAUDE-local.md.
     ] {
         assert!(
             workspace_manifest.contains(&format!("    \"{target}\",")),

--- a/crates/app/ironclaw_cli/wix/main.wxs
+++ b/crates/app/ironclaw_cli/wix/main.wxs
@@ -173,7 +173,7 @@
         <!--<Icon Id='ProductICO' SourceFile='wix\Product.ico'/>-->
         <!--<Property Id='ARPPRODUCTICON' Value='ProductICO' />-->
 
-        <Property Id='ARPHELPLINK' Value='https://github.com/nearai/ironclaw'/>
+        <Property Id='ARPHELPLINK' Value='https://github.com/k-l-sorensen/ironclaw'/>
         
         <UI>
             <UIRef Id='WixUI_FeatureTree'/>

--- a/crates/contracts/ironclaw_common/src/llm_costs.rs
+++ b/crates/contracts/ironclaw_common/src/llm_costs.rs
@@ -75,6 +75,12 @@ pub fn model_cost(model_id: &str) -> Option<(Decimal, Decimal)> {
         | "claude-3-5-haiku-latest" => Some((dec!(0.0000008), dec!(0.000004))),
         "claude-3-haiku-20240307" => Some((dec!(0.00000025), dec!(0.00000125))),
 
+        // Mistral -- hosted API (direct, not Ollama-tagged). Placed before the
+        // `is_local_model` fallback so exact pricing always wins regardless of
+        // that heuristic (fork #9: hosted Mistral was billing as free).
+        "mistral-medium-latest" | "mistral-medium-2604" => Some((dec!(0.0000015), dec!(0.0000075))),
+        "mistral-small-latest" | "mistral-small-2603" => Some((dec!(0.00000015), dec!(0.0000006))),
+
         // Ollama / local models -- free
         _ if is_local_model(id) => Some((Decimal::ZERO, Decimal::ZERO)),
 
@@ -219,10 +225,15 @@ impl RunCost {
 }
 
 /// Heuristic to detect local/self-hosted models (Ollama, llama.cpp, etc.).
+///
+/// Deliberately does NOT match a bare `mistral*` prefix: Mistral's hosted API
+/// (Medium 3.5, Small 4, ...) uses unprefixed, untagged ids like
+/// `mistral-medium-latest`, and would otherwise price as free (fork #9).
+/// Ollama-style local Mistral pulls are still caught by the generic
+/// `:latest` / `:instruct` tag checks below, same as any other local family.
 fn is_local_model(model_id: &str) -> bool {
     let lower = model_id.to_lowercase();
     lower.starts_with("llama")
-        || lower.starts_with("mistral")
         || lower.starts_with("mixtral")
         || lower.starts_with("phi")
         || lower.starts_with("gemma")
@@ -266,6 +277,30 @@ mod tests {
         let (input, output) = model_cost("mistral:latest").unwrap();
         assert_eq!(input, Decimal::ZERO);
         assert_eq!(output, Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_hosted_mistral_models_bill_nonzero() {
+        // Regression for fork #9: hosted Mistral API models were billing at
+        // $0 because `is_local_model` matched any `mistral*` prefix.
+        let (input, output) = model_cost("mistral-medium-latest").unwrap();
+        assert_eq!(input, dec!(0.0000015));
+        assert_eq!(output, dec!(0.0000075));
+        assert!(output > input);
+
+        let (input, output) = model_cost("mistral-small-latest").unwrap();
+        assert_eq!(input, dec!(0.00000015));
+        assert_eq!(output, dec!(0.0000006));
+        assert!(output > input);
+    }
+
+    #[test]
+    fn test_untagged_unknown_mistral_model_is_not_free() {
+        // An untagged, unrecognized hosted Mistral id (no `:latest` /
+        // `:instruct` Ollama tag) must not resolve to the local/free branch
+        // — it should fall through to `None` so callers apply `default_cost`
+        // (fork #9: the old `starts_with("mistral")` heuristic zeroed this).
+        assert!(model_cost("mistral-large-latest").is_none());
     }
 
     #[test]

--- a/crates/domains/ironclaw_llm/CONTRACT.md
+++ b/crates/domains/ironclaw_llm/CONTRACT.md
@@ -11,6 +11,7 @@ Multi-provider LLM integration with circuit breaker, retry, failover, and respon
 | `error.rs` | `LlmError` enum used by all providers |
 | `provider.rs` | `LlmProvider` trait, `ChatMessage`, `ToolCall`, `CompletionRequest`, `sanitize_tool_messages` |
 | `nearai_chat.rs` | NEAR AI Chat Completions provider (dual auth: session token or API key) |
+| `mistral.rs` / `mistral/tests.rs` | Dedicated Mistral provider (own reqwest client): parses `reasoning_effort=high`'s array-shaped `message.content` that rig-core cannot deserialize, maps the thinking chunk onto the shared `reasoning_details` channel, replays it on the next turn |
 | `nearai_tool_message_flattening.rs` | NEAR AI compatibility rewrite for tool-call history |
 | `codex_auth.rs` | Reads Codex CLI `auth.json`, extracts tokens, refreshes ChatGPT OAuth access tokens |
 | `codex_chatgpt.rs` | Custom Responses API provider for Codex ChatGPT backend (`/backend-api/codex`) |
@@ -63,7 +64,7 @@ owner, and a deleted one fails until its entry goes.
 | Sub-owner | Owns | Never contains | Files |
 |---|---|---|---|
 | `core-contract` | The `LlmProvider` trait, the request/response vocabulary, the error taxonomy, the config types, shared HTTP hardening, and the factory that assembles everything | A vendor protocol, or reliability behavior | `lib.rs`, `provider.rs`, `error.rs`, `config.rs`, `url_check.rs` |
-| `providers` | One concrete `LlmProvider` per vendor and the protocol shims used by that vendor alone | Cross-provider normalization (that is `normalization`), or credential lifecycle (that is `auth-sessions`) | `nearai_chat.rs`, `rig_adapter.rs`, `gemini_oauth.rs`, `codex_chatgpt.rs`, `bedrock.rs`, `openai_codex_provider.rs`, `anthropic_oauth.rs`, `github_copilot.rs`, `nearai_tool_message_flattening.rs`, `responses_reasoning.rs`, `anthropic_thinking.rs` |
+| `providers` | One concrete `LlmProvider` per vendor and the protocol shims used by that vendor alone | Cross-provider normalization (that is `normalization`), or credential lifecycle (that is `auth-sessions`) | `nearai_chat.rs`, `rig_adapter.rs`, `gemini_oauth.rs`, `codex_chatgpt.rs`, `bedrock.rs`, `openai_codex_provider.rs`, `anthropic_oauth.rs`, `github_copilot.rs`, `nearai_tool_message_flattening.rs`, `responses_reasoning.rs`, `anthropic_thinking.rs`, `mistral.rs`, `mistral/tests.rs` |
 | `auth-sessions` | Acquiring, persisting, refreshing and revoking provider credentials, plus the host seam that stores them | Request/response shaping | `auth.rs`, `session.rs`, `openai_codex_session.rs`, `github_copilot_auth.rs`, `codex_auth.rs`, `token_refreshing.rs`, `host.rs` |
 | `registry` | The **provider** catalog: definitions, protocols, base-URL and api-key resolution | Model facts (that is `model-catalog`) | `registry.rs`, `resolution.rs` |
 | `decorators` | Anything that wraps `dyn LlmProvider` and is not credential work: retry, breaker, failover, cache, hot-reload, cost routing | Vendor protocol | `retry.rs`, `circuit_breaker.rs`, `failover.rs`, `response_cache.rs`, `runtime.rs`, `smart_routing.rs` |

--- a/crates/domains/ironclaw_llm/assets/providers.json
+++ b/crates/domains/ironclaw_llm/assets/providers.json
@@ -421,13 +421,13 @@
       "mistral_ai",
       "mistralai"
     ],
-    "protocol": "open_ai_completions",
+    "protocol": "mistral",
     "default_base_url": "https://api.mistral.ai/v1",
     "api_key_env": "MISTRAL_API_KEY",
     "api_key_required": true,
     "model_env": "MISTRAL_MODEL",
-    "default_model": "mistral-large-latest",
-    "description": "Mistral AI API",
+    "default_model": "mistral-medium-latest",
+    "description": "Mistral AI API (reasoning_effort=high on Medium 3.5 / Small 4)",
     "setup": {
       "kind": "api_key",
       "secret_name": "llm_mistral_api_key",

--- a/crates/domains/ironclaw_llm/src/config.rs
+++ b/crates/domains/ironclaw_llm/src/config.rs
@@ -65,6 +65,67 @@ impl std::fmt::Display for CacheRetention {
     }
 }
 
+/// Mistral `reasoning_effort` control.
+///
+/// Mistral's reasoning is an on/off toggle, *not* the OpenAI low/medium/high
+/// scale. The only on-state Mistral exposes is `"high"`, which emits the full
+/// thinking trace as an array-shaped response; "off" is expressed by *omitting*
+/// the param rather than by an explicit value.
+///
+/// Two wire behaviors are expressed as `Option<MistralReasoningEffort>` on
+/// [`RegistryProviderConfig`]:
+/// - `Option::None` — **omit** the param entirely (off, or an unsupported model).
+/// - `Some(High)` — send `reasoning_effort: "high"`.
+///
+/// Kept as an enum (rather than a `bool`) so a richer graded scale can be added
+/// here if Mistral ever exposes one; [`MistralReasoningEffort::wire_value`]
+/// renders the on-state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MistralReasoningEffort {
+    /// Full thinking trace (`reasoning_effort: "high"`). The only state; the default.
+    #[default]
+    High,
+}
+
+impl MistralReasoningEffort {
+    /// The exact string Mistral's API expects on the wire.
+    pub fn wire_value(self) -> &'static str {
+        match self {
+            Self::High => "high",
+        }
+    }
+}
+
+/// Resolve the Mistral `reasoning_effort` toggle from a raw env value.
+///
+/// Shared by the resolution paths so invalid input is handled identically.
+/// Policy is **fail-open**:
+///   - `None` (unset)            → `Some(High)` (the default-on contract)
+///   - `"high"`/`"on"`/`"1"`/…   → `Some(High)`
+///   - `"off"`/`"none"`/`"0"`/…  → `None` (omit the wire param)
+///   - anything else             → warn + `Some(High)`
+///
+/// "off" maps to `Option::None` so the wire body omits the param entirely. The
+/// provider further gates `Some(_)` on model capability before sending.
+///
+/// The crate stays env-agnostic: callers read the env var at their own
+/// boundary and pass the raw `Option<String>` in.
+pub fn resolve_mistral_reasoning_from_env(raw: Option<String>) -> Option<MistralReasoningEffort> {
+    let Some(raw) = raw else {
+        return Some(MistralReasoningEffort::High);
+    };
+    match raw.trim().to_lowercase().as_str() {
+        "high" | "on" | "true" | "1" => Some(MistralReasoningEffort::High),
+        "off" | "none" | "false" | "0" => None,
+        _ => {
+            tracing::warn!(
+                "Invalid MISTRAL_REASONING ({raw}); expected one of: high, none, on, off, true, false, 1, 0; defaulting to high"
+            );
+            Some(MistralReasoningEffort::High)
+        }
+    }
+}
+
 /// Resolved configuration for a registry-based provider.
 ///
 /// This single struct replaces what used to be five separate config types
@@ -98,6 +159,13 @@ pub struct RegistryProviderConfig {
     pub auth_path: Option<PathBuf>,
     /// Prompt cache retention (Anthropic-specific).
     pub cache_retention: CacheRetention,
+    /// Mistral `reasoning_effort` control (Mistral-specific).
+    ///
+    /// `None` omits the param (default for non-Mistral providers, or when
+    /// the selected model is not reasoning-capable). `Some(_)` is set at the
+    /// env boundary for the Mistral provider; the provider further gates it on
+    /// model capability before sending. See [`MistralReasoningEffort`].
+    pub mistral_reasoning: Option<MistralReasoningEffort>,
     /// Parameter names that this provider does not support (e.g., `["temperature"]`).
     /// Supported keys: `"temperature"`, `"max_tokens"`, `"stop_sequences"`.
     /// Listed parameters are stripped from requests before sending to avoid 400 errors.
@@ -126,6 +194,7 @@ impl RegistryProviderConfig {
             refresh_token: None,
             auth_path: None,
             cache_retention: CacheRetention::None,
+            mistral_reasoning: None,
             unsupported_params: Vec::new(),
         }
     }

--- a/crates/domains/ironclaw_llm/src/lib.rs
+++ b/crates/domains/ironclaw_llm/src/lib.rs
@@ -25,6 +25,7 @@ pub(crate) mod gemini_oauth;
 mod github_copilot;
 pub(crate) mod github_copilot_auth;
 pub mod host;
+pub mod mistral;
 pub mod nearai_chat;
 pub mod openai_codex_provider;
 pub(crate) mod openai_codex_session;
@@ -64,8 +65,9 @@ pub mod vision_models;
 
 pub use circuit_breaker::{CircuitBreakerConfig, CircuitBreakerProvider};
 pub use config::{
-    BedrockConfig, CacheRetention, GeminiOauthConfig, LlmBackendKind, LlmConfig, NearAiConfig,
-    OAUTH_PLACEHOLDER, OpenAiCodexConfig, RegistryProviderConfig,
+    BedrockConfig, CacheRetention, GeminiOauthConfig, LlmBackendKind, LlmConfig,
+    MistralReasoningEffort, NearAiConfig, OAUTH_PLACEHOLDER, OpenAiCodexConfig,
+    RegistryProviderConfig, resolve_mistral_reasoning_from_env,
 };
 pub use error::{LlmConfigError, LlmError, UNCONFIGURED_PROVIDER_ID};
 pub use failover::{CooldownConfig, FailoverProvider};
@@ -246,6 +248,7 @@ fn create_registry_provider_inner(
         ProviderProtocol::OpenRouter => {
             create_openrouter_from_registry(config, request_timeout_secs)
         }
+        ProviderProtocol::Mistral => create_mistral_from_registry(config, request_timeout_secs),
         ProviderProtocol::GithubCopilot => {
             let provider =
                 github_copilot::GithubCopilotProvider::new(config, request_timeout_secs)?;
@@ -614,6 +617,39 @@ fn create_ollama_from_registry(
         adapter = adapter.with_additional_params(serde_json::json!({ "think": true }));
     }
     Ok(Arc::new(adapter))
+}
+
+/// Build a Mistral provider via IronClaw's dedicated `MistralProvider`.
+///
+/// Mistral is not delegated to rig-core: it owns the request/response JSON so
+/// it can parse Mistral's array-shaped `reasoning_effort=high` response
+/// (`[{type:"thinking"},{type:"text"}]`), which rig-core's `String`-typed
+/// content model (the generic OpenAI-compat client and rig 0.33's dedicated
+/// Mistral client, which drops reasoning) cannot. The `reasoning_effort`
+/// toggle rides on `RegistryProviderConfig::mistral_reasoning`, populated at the
+/// env boundary; the provider further gates it on model capability.
+fn create_mistral_from_registry(
+    config: &RegistryProviderConfig,
+    request_timeout_secs: u64,
+) -> Result<Arc<dyn LlmProvider>, LlmError> {
+    let api_key = config.api_key.clone().ok_or_else(|| LlmError::AuthFailed {
+        provider: config.provider_id.clone(),
+    })?;
+
+    tracing::debug!(
+        provider = %config.provider_id,
+        model = %config.model,
+        reasoning = ?config.mistral_reasoning,
+        "Using Mistral provider (owns reasoning_effort array response + ThinkChunk replay)"
+    );
+
+    let provider = mistral::MistralProvider::new(
+        config.model.clone(),
+        api_key,
+        config.mistral_reasoning,
+        request_timeout_secs,
+    )?;
+    Ok(Arc::new(provider))
 }
 
 /// Build a DeepSeek provider via rig-core's dedicated DeepSeek client.

--- a/crates/domains/ironclaw_llm/src/mistral.rs
+++ b/crates/domains/ironclaw_llm/src/mistral.rs
@@ -1,0 +1,822 @@
+//! Mistral AI provider with first-class `reasoning_effort` support.
+//!
+//! IronClaw owns the Mistral request/response JSON here (rather than delegating
+//! to rig-core) because Mistral's `reasoning_effort=high` response models
+//! `message.content` as an **array of typed chunks**
+//! (`[{type:"thinking",…},{type:"text",…}]`) instead of a string. rig-core's
+//! OpenAI-compat client — and rig 0.33's dedicated Mistral client, which still
+//! models assistant content as `String` — cannot deserialize that shape, so the
+//! agent loop failed every turn with
+//! `JsonError: did not match any variant of untagged enum ApiResponse`.
+//!
+//! The novel logic lives in two places:
+//! - **Response parse** (`extract_content`): splits the array into the thinking
+//!   trace and the final answer. The thinking chunk (and its opaque signature)
+//!   is mapped onto the **shared upstream `reasoning_details` channel**
+//!   (`ReasoningDetail::Text { text, signature }`) — the same seam DeepSeek /
+//!   Gemini / OpenRouter use; no Mistral-specific reasoning type is introduced.
+//! - **Multi-turn replay** (`chat_message_to_wire`): when an assistant
+//!   `ChatMessage` carries `reasoning_details` (or the legacy `reasoning`
+//!   string), the request content is rebuilt as `[{thinking:[{text}]},{text}]`
+//!   so Mistral receives the prior ThinkChunk + signature — required to avoid
+//!   degraded multi-turn performance.
+//!
+//! Everything else (OpenAI-shape chat-completions, tool schema normalization,
+//! error mapping) reuses the shared crate seams.
+
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+use secrecy::{ExposeSecret, SecretString};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use ironclaw_common::llm_costs as costs;
+
+use crate::config::MistralReasoningEffort;
+use crate::error::LlmError;
+use crate::provider::{
+    ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ReasoningDetail,
+    ReasoningDetails, Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse,
+    ToolDefinition, sanitize_tool_messages,
+};
+use crate::reasoning_models::supports_mistral_reasoning;
+use crate::tool_schema::{ToolSchemaPolicy, shape_tool_schema};
+use crate::vision_models::is_vision_model;
+
+/// Provider identity used in error variants and logs.
+const PROVIDER: &str = "mistral";
+
+/// Mistral's API base URL. Hardcoded and not overridable: a user/operator
+/// base-URL knob would be an SSRF / credential-redirection surface, and the
+/// reasoning wire contract is Mistral-specific. Tests inject a loopback URL via
+/// the `#[cfg(test)]` constructor only.
+const MISTRAL_BASE_URL: &str = "https://api.mistral.ai/v1";
+
+/// Mistral provider: owns its HTTP client and request/response JSON model.
+pub struct MistralProvider {
+    client: reqwest::Client,
+    model: String,
+    api_key: SecretString,
+    /// Configured `reasoning_effort` toggle. `None` omits the param entirely;
+    /// `Some(_)` is further gated on model capability before sending.
+    reasoning: Option<MistralReasoningEffort>,
+    base_url: String,
+    active_model: std::sync::RwLock<String>,
+}
+
+impl MistralProvider {
+    /// Create a Mistral provider with the production base URL.
+    pub fn new(
+        model: impl Into<String>,
+        api_key: SecretString,
+        reasoning: Option<MistralReasoningEffort>,
+        request_timeout_secs: u64,
+    ) -> Result<Self, LlmError> {
+        Self::new_with_base_url(
+            model,
+            api_key,
+            reasoning,
+            request_timeout_secs,
+            MISTRAL_BASE_URL,
+        )
+    }
+
+    fn new_with_base_url(
+        model: impl Into<String>,
+        api_key: SecretString,
+        reasoning: Option<MistralReasoningEffort>,
+        request_timeout_secs: u64,
+        base_url: impl Into<String>,
+    ) -> Result<Self, LlmError> {
+        // Shared client-timeout hygiene: connect timeout, TCP keepalive, and
+        // idle-pool bound come from the crate-wide hardened builder.
+        let client = crate::config::hardened_client_builder(request_timeout_secs)
+            .build()
+            .map_err(|e| LlmError::RequestFailed {
+                provider: PROVIDER.to_string(),
+                reason: format!("Failed to build HTTP client: {e}"),
+            })?;
+        let model = model.into();
+        let active_model = std::sync::RwLock::new(model.clone());
+        Ok(Self {
+            client,
+            model,
+            api_key,
+            reasoning,
+            base_url: base_url.into(),
+            active_model,
+        })
+    }
+
+    /// Resolve the `reasoning_effort` wire value for a given model.
+    ///
+    /// Two states (D-ENUM): `None` omits the param; a `Some(_)` toggle is gated
+    /// on model capability first (model-gate beats the toggle, so e.g.
+    /// `mistral-large` never receives the param even with reasoning on). When
+    /// supported, the on-state renders as `"high"`; otherwise the param is omitted.
+    fn reasoning_effort_for(&self, model: &str) -> Option<&'static str> {
+        match self.reasoning {
+            Some(effort) if supports_mistral_reasoning(model) => Some(effort.wire_value()),
+            _ => None,
+        }
+    }
+
+    /// Build the typed wire request for a (possibly tool-bearing) completion.
+    fn build_request(&self, params: MistralRequestParams) -> MistralChatRequest {
+        let MistralRequestParams {
+            model,
+            mut messages,
+            tools,
+            temperature,
+            max_tokens,
+            stop,
+            tool_choice,
+        } = params;
+        sanitize_tool_messages(&mut messages);
+        let vision = is_vision_model(&model);
+        let wire_messages: Vec<MistralMessage> = messages
+            .into_iter()
+            .map(|m| chat_message_to_wire(m, vision))
+            .collect();
+
+        let wire_tools: Vec<MistralTool> = tools.into_iter().map(convert_tool_definition).collect();
+        let has_tools = !wire_tools.is_empty();
+        let reasoning_effort = self.reasoning_effort_for(&model);
+
+        MistralChatRequest {
+            model,
+            messages: wire_messages,
+            temperature,
+            max_tokens,
+            stop,
+            tools: has_tools.then_some(wire_tools),
+            tool_choice: has_tools.then_some(tool_choice).flatten(),
+            reasoning_effort,
+        }
+    }
+
+    /// POST the chat-completions request and map failures to `LlmError` at the
+    /// channel boundary. API-key auth only — no session renewal.
+    async fn post_chat(&self, body: &MistralChatRequest) -> Result<MistralChatResponse, LlmError> {
+        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+
+        if tracing::enabled!(tracing::Level::DEBUG)
+            && let Ok(json) = serde_json::to_string(body)
+        {
+            // The Authorization header is never part of the serialized body.
+            tracing::debug!(provider = PROVIDER, "Mistral request body: {json}");
+        }
+
+        let response = self
+            .client
+            .post(&url)
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.api_key.expose_secret()),
+            )
+            .header("Content-Type", "application/json")
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| LlmError::RequestFailed {
+                provider: PROVIDER.to_string(),
+                reason: e.to_string(),
+            })?;
+
+        let status = response.status();
+        // Only `Some(_)` when the header was actually present, so 5xx retries
+        // fall through to exponential backoff instead of a fixed default.
+        let retry_after_header: Option<Duration> = response
+            .headers()
+            .get("retry-after")
+            .map(crate::retry::parse_retry_after_value);
+        let text = response.text().await.map_err(|e| LlmError::RequestFailed {
+            provider: PROVIDER.to_string(),
+            reason: format!("Failed to read response body: {e}"),
+        })?;
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            tracing::trace!(provider = PROVIDER, "Mistral response body: {text}");
+        }
+
+        if !status.is_success() {
+            let code = status.as_u16();
+            if code == 401 {
+                return Err(LlmError::AuthFailed {
+                    provider: PROVIDER.to_string(),
+                });
+            }
+            if code == 429 {
+                return Err(LlmError::RateLimited {
+                    provider: PROVIDER.to_string(),
+                    retry_after: retry_after_header.or(Some(Duration::from_secs(60))),
+                });
+            }
+            // 413 → ContextLengthExceeded (also detects body wording); the shared
+            // helper keeps the mapping identical across direct-HTTP providers.
+            if let Some(err) = crate::error::context_length_error(code, &text) {
+                return Err(err);
+            }
+            if matches!(code, 500..=599) {
+                tracing::debug!(
+                    provider = PROVIDER,
+                    status = code,
+                    body_preview = ironclaw_common::truncate_for_preview(&text, 512).as_str(),
+                    "Mistral upstream 5xx response"
+                );
+                return Err(LlmError::BadGateway {
+                    provider: PROVIDER.to_string(),
+                    status: code,
+                    retry_after: retry_after_header,
+                });
+            }
+            let truncated = ironclaw_common::truncate_for_preview(&text, 512);
+            return Err(LlmError::RequestFailed {
+                provider: PROVIDER.to_string(),
+                reason: format!("HTTP {status}: {truncated}"),
+            });
+        }
+
+        // A 2xx body that won't deserialize is a transient/upstream-shape issue,
+        // not a caller bug — map to InvalidResponse (retryable), never bare Json.
+        parse_json(&text)
+    }
+
+    fn first_choice(response: MistralChatResponse) -> Result<MistralChoice, LlmError> {
+        response
+            .choices
+            .into_iter()
+            .next()
+            .ok_or_else(|| LlmError::EmptyResponse {
+                provider: PROVIDER.to_string(),
+            })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MistralProvider {
+    fn provider_id(&self) -> String {
+        PROVIDER.to_string()
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
+    fn cost_per_token(&self) -> (Decimal, Decimal) {
+        costs::model_cost(&self.active_model_name()).unwrap_or_else(costs::default_cost)
+    }
+
+    async fn complete(&self, mut req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
+        let request = self.build_request(MistralRequestParams {
+            model,
+            messages: req.messages,
+            tools: Vec::new(),
+            temperature: req.temperature,
+            max_tokens: req.max_tokens,
+            stop: req.stop_sequences,
+            tool_choice: None,
+        });
+        let response = self.post_chat(&request).await?;
+        let (input_tokens, output_tokens) = usage_tokens(&response.usage);
+        let MistralChoice {
+            message,
+            finish_reason,
+        } = Self::first_choice(response)?;
+
+        let (content, reasoning_details) = extract_content(message.content)?;
+        // For a plain completion the text chunk IS the answer; a reasoning-on
+        // array with no text chunk means the answer was lost — fail loud
+        // (EmptyResponse, retryable) rather than defaulting to "".
+        let content = content.ok_or_else(|| LlmError::EmptyResponse {
+            provider: PROVIDER.to_string(),
+        })?;
+        // CompletionResponse has no typed `reasoning_details` slot; carry the
+        // display text (the signature is only needed on the tool/agent path).
+        let reasoning = reasoning_details.as_ref().and_then(|d| d.display_text());
+        emit_reasoning_trace(reasoning.as_deref());
+
+        Ok(CompletionResponse {
+            content,
+            finish_reason: finish_reason_from(finish_reason.as_deref(), false),
+            input_tokens,
+            output_tokens,
+            reasoning,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+        })
+    }
+
+    async fn complete_with_tools(
+        &self,
+        mut req: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
+        let request = self.build_request(MistralRequestParams {
+            model,
+            messages: req.messages,
+            tools: req.tools,
+            temperature: req.temperature,
+            max_tokens: req.max_tokens,
+            stop: req.stop_sequences,
+            tool_choice: req.tool_choice,
+        });
+        let response = self.post_chat(&request).await?;
+        let (input_tokens, output_tokens) = usage_tokens(&response.usage);
+        let MistralChoice {
+            message,
+            finish_reason,
+        } = Self::first_choice(response)?;
+
+        let tool_calls = parse_tool_calls(message.tool_calls);
+        let (content, reasoning_details) = extract_content(message.content)?;
+
+        // Either a textual answer or at least one tool call is required; both
+        // empty means the turn produced nothing usable (fail loud).
+        if content.is_none() && tool_calls.is_empty() {
+            return Err(LlmError::EmptyResponse {
+                provider: PROVIDER.to_string(),
+            });
+        }
+        // Both the display text (legacy mirror) and the typed details are
+        // carried; callers attach `reasoning_details` to the stored assistant
+        // message so the ThinkChunk + signature replay on the next turn.
+        let reasoning = reasoning_details.as_ref().and_then(|d| d.display_text());
+        emit_reasoning_trace(reasoning.as_deref());
+
+        let has_tool_calls = !tool_calls.is_empty();
+        Ok(ToolCompletionResponse {
+            content,
+            tool_calls,
+            finish_reason: finish_reason_from(finish_reason.as_deref(), has_tool_calls),
+            input_tokens,
+            output_tokens,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning,
+            reasoning_details,
+        })
+    }
+
+    fn active_model_name(&self) -> String {
+        match self.active_model.read() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    fn set_model(&self, model: &str) -> Result<(), LlmError> {
+        match self.active_model.write() {
+            Ok(mut guard) => *guard = model.to_string(),
+            Err(poisoned) => *poisoned.into_inner() = model.to_string(),
+        }
+        Ok(())
+    }
+
+    async fn list_models(&self) -> Result<Vec<String>, LlmError> {
+        let url = format!("{}/models", self.base_url.trim_end_matches('/'));
+        let response = self
+            .client
+            .get(&url)
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.api_key.expose_secret()),
+            )
+            .send()
+            .await
+            .map_err(|e| LlmError::RequestFailed {
+                provider: PROVIDER.to_string(),
+                reason: e.to_string(),
+            })?;
+        if !response.status().is_success() {
+            return Err(LlmError::RequestFailed {
+                provider: PROVIDER.to_string(),
+                reason: format!("models endpoint returned HTTP {}", response.status()),
+            });
+        }
+        let text = response.text().await.map_err(|e| LlmError::RequestFailed {
+            provider: PROVIDER.to_string(),
+            reason: format!("Failed to read models response: {e}"),
+        })?;
+        let parsed: MistralModelsResponse = parse_json(&text)?;
+        Ok(parsed.data.into_iter().map(|m| m.id).collect())
+    }
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+fn parse_json<R: DeserializeOwned>(text: &str) -> Result<R, LlmError> {
+    serde_json::from_str(text).map_err(|e| {
+        let truncated = ironclaw_common::truncate_for_preview(text, 512);
+        LlmError::InvalidResponse {
+            provider: PROVIDER.to_string(),
+            reason: format!("JSON parse error: {e}. Raw: {truncated}"),
+        }
+    })
+}
+
+/// Split Mistral's `message.content` into `(answer, reasoning_details)`.
+///
+/// - String content → `(Some(text), None)` (reasoning off).
+/// - Array content → text chunk(s) concatenated as the answer; thinking
+///   chunk(s) flattened into a single `ReasoningDetail::Text { text, signature }`
+///   on the shared `reasoning_details` channel, with the first non-null
+///   ThinkChunk `signature` carried as the opaque replay token.
+///
+/// Returns `Ok((None, _))` only when there genuinely is no text chunk; callers
+/// decide whether that is an error. A malformed array surfaces through serde as
+/// an `InvalidResponse` before reaching here.
+fn extract_content(
+    content: Option<MistralMessageContent>,
+) -> Result<(Option<String>, Option<ReasoningDetails>), LlmError> {
+    match content {
+        None => Ok((None, None)),
+        Some(MistralMessageContent::Text(s)) => Ok((non_empty(s), None)),
+        Some(MistralMessageContent::Chunks(chunks)) => {
+            let mut answer = String::new();
+            let mut thinking = String::new();
+            let mut signature: Option<String> = None;
+            for chunk in chunks {
+                match chunk {
+                    MistralContentChunk::Text { text } => answer.push_str(&text),
+                    MistralContentChunk::Thinking {
+                        thinking: parts,
+                        signature: chunk_signature,
+                    } => {
+                        for MistralTextChunk::Text { text } in parts {
+                            thinking.push_str(&text);
+                        }
+                        // First non-null signature wins (single-block replay token).
+                        if signature.is_none() {
+                            signature = chunk_signature.filter(|s| !s.is_empty());
+                        }
+                    }
+                    // Assistant responses don't carry image parts; ignore any.
+                    MistralContentChunk::ImageUrl { .. } => {}
+                }
+            }
+            Ok((non_empty(answer), reasoning_details(thinking, signature)))
+        }
+    }
+}
+
+/// Build the shared-channel `ReasoningDetails` from a Mistral thinking trace and
+/// its opaque signature. Returns `None` only when both are empty; a
+/// signature-only block is preserved (`ReasoningDetails::is_empty` treats it as
+/// non-empty, matching the Gemini `thought_signature` precedent).
+fn reasoning_details(thinking: String, signature: Option<String>) -> Option<ReasoningDetails> {
+    let text = thinking.trim().to_string();
+    let signature = signature.filter(|s| !s.trim().is_empty());
+    if text.is_empty() && signature.is_none() {
+        return None;
+    }
+    Some(ReasoningDetails {
+        id: None,
+        content: vec![ReasoningDetail::Text { text, signature }],
+    })
+}
+
+fn non_empty(s: String) -> Option<String> {
+    if s.trim().is_empty() { None } else { Some(s) }
+}
+
+fn parse_tool_calls(calls: Option<Vec<MistralToolCall>>) -> Vec<ToolCall> {
+    calls
+        .unwrap_or_default()
+        .into_iter()
+        .map(|tc| {
+            // Mistral tool-call arguments arrive as a JSON-encoded string.
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(&tc.function.arguments);
+            let (arguments, arguments_parse_error) = match parsed {
+                Ok(value) => (value, None),
+                Err(e) => (
+                    serde_json::Value::Object(Default::default()),
+                    Some(format!("failed to parse tool-call arguments JSON: {e}")),
+                ),
+            };
+            ToolCall {
+                id: tc.id,
+                name: tc.function.name,
+                arguments,
+                reasoning: None,
+                signature: None,
+                arguments_parse_error,
+            }
+        })
+        .collect()
+}
+
+fn finish_reason_from(raw: Option<&str>, has_tool_calls: bool) -> FinishReason {
+    match raw {
+        Some("stop") => FinishReason::Stop,
+        Some("length") => FinishReason::Length,
+        Some("tool_calls") => FinishReason::ToolUse,
+        Some("content_filter") => FinishReason::ContentFilter,
+        _ if has_tool_calls => FinishReason::ToolUse,
+        _ => FinishReason::Unknown,
+    }
+}
+
+fn emit_reasoning_trace(reasoning: Option<&str>) {
+    if let Some(trace) = reasoning.filter(|s| !s.is_empty()) {
+        tracing::trace!(target: "ironclaw_llm::reasoning", "{trace}");
+    }
+}
+
+/// Pull a prior assistant message's reasoning trace + opaque signature off the
+/// shared `reasoning_details` channel, falling back to the legacy `reasoning`
+/// string. Mirrors `rig_adapter::assistant_reasoning_content`'s precedence:
+/// typed details win, plain string is the fallback.
+fn replay_reasoning(msg: &ChatMessage) -> (Option<String>, Option<String>) {
+    if let Some(details) = msg.reasoning_details.as_ref().filter(|d| !d.is_empty()) {
+        let text = details.display_text();
+        let signature = details.content.iter().find_map(|d| match d {
+            ReasoningDetail::Text {
+                signature: Some(sig),
+                ..
+            } if !sig.trim().is_empty() => Some(sig.clone()),
+            _ => None,
+        });
+        return (text.filter(|t| !t.trim().is_empty()), signature);
+    }
+    let text = msg
+        .reasoning
+        .as_ref()
+        .filter(|r| !r.trim().is_empty())
+        .cloned();
+    (text, None)
+}
+
+/// Convert an IronClaw `ChatMessage` into the Mistral wire message.
+///
+/// The reasoning-replay branch is the multi-turn requirement: when an assistant
+/// message carries a reasoning trace, the content is rebuilt as
+/// `[{thinking:[{text}], signature}, {text}]` so Mistral receives the prior
+/// ThinkChunk (and its opaque signature).
+fn chat_message_to_wire(msg: ChatMessage, vision: bool) -> MistralMessage {
+    let role = match msg.role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    };
+
+    let (trace, reasoning_signature) = replay_reasoning(&msg);
+
+    let tool_calls = msg.tool_calls.map(|calls| {
+        calls
+            .into_iter()
+            .map(|tc| MistralToolCall {
+                id: tc.id,
+                call_type: "function".to_string(),
+                function: MistralToolCallFunction {
+                    name: tc.name,
+                    arguments: tc.arguments.to_string(),
+                },
+            })
+            .collect()
+    });
+
+    let content = if let Some(trace) = trace {
+        // Multi-turn replay: reconstruct the full assistant message including
+        // the ThinkChunk (with its opaque signature), followed by the answer
+        // text chunk.
+        let mut chunks = vec![MistralContentChunk::Thinking {
+            thinking: vec![MistralTextChunk::Text { text: trace }],
+            signature: reasoning_signature,
+        }];
+        if !msg.content.is_empty() {
+            chunks.push(MistralContentChunk::Text { text: msg.content });
+        }
+        Some(MistralMessageContent::Chunks(chunks))
+    } else if role == "assistant" && tool_calls.is_some() && msg.content.is_empty() {
+        None
+    } else if vision && !msg.content_parts.is_empty() {
+        // Multimodal: forward text + image parts only when the model is
+        // vision-capable; otherwise images are dropped below (text only).
+        let mut chunks = vec![MistralContentChunk::Text { text: msg.content }];
+        for part in msg.content_parts {
+            if let crate::ContentPart::ImageUrl { mut image_url } = part {
+                image_url.detail = Some(image_url.normalized_openai_detail());
+                chunks.push(MistralContentChunk::ImageUrl { image_url });
+            }
+        }
+        Some(MistralMessageContent::Chunks(chunks))
+    } else {
+        if !vision && !msg.content_parts.is_empty() {
+            tracing::warn!(
+                provider = PROVIDER,
+                "Dropping image attachment(s): model is not vision-capable"
+            );
+        }
+        Some(MistralMessageContent::Text(msg.content))
+    };
+
+    MistralMessage {
+        role: role.to_string(),
+        content,
+        tool_call_id: msg.tool_call_id,
+        name: msg.name,
+        tool_calls,
+    }
+}
+
+fn convert_tool_definition(tool: ToolDefinition) -> MistralTool {
+    let mut description = tool.description.clone();
+    // Mistral speaks the OpenAI chat-completions tool format (non-strict); use
+    // the shared flatten-only policy so top-level combinators are flattened.
+    let parameters = shape_tool_schema(
+        ToolSchemaPolicy::FlattenOnly,
+        &tool.parameters,
+        &mut description,
+    );
+    MistralTool {
+        tool_type: "function".to_string(),
+        function: MistralFunction {
+            name: tool.name,
+            description: Some(description),
+            parameters: Some(parameters),
+        },
+    }
+}
+
+/// Inputs to [`MistralProvider::build_request`], bundled into a struct to keep
+/// the builder under clippy's argument ceiling (prefer a params struct over
+/// `#[allow(too_many_arguments)]` — `architecture.md`).
+struct MistralRequestParams {
+    model: String,
+    messages: Vec<ChatMessage>,
+    tools: Vec<ToolDefinition>,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    stop: Option<Vec<String>>,
+    tool_choice: Option<String>,
+}
+
+// ── wire model ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+struct MistralChatRequest {
+    model: String,
+    /// `"high"` / omitted (model-gated off / unsupported).
+    ///
+    /// Declared second (right after `model`) so it appears near the start of the
+    /// serialized body — the debug request-body log line is capped, and the
+    /// messages array easily exceeds that, so a trailing `reasoning_effort`
+    /// would be truncated away and invisible in logs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<&'static str>,
+    messages: Vec<MistralMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<MistralTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MistralMessage {
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<MistralMessageContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<MistralToolCall>>,
+}
+
+/// `message.content`: a plain string (reasoning off) or an array of typed
+/// chunks (reasoning on). The untagged enum is the actual fix for the original
+/// `ApiResponse` deserialization failure.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum MistralMessageContent {
+    Text(String),
+    Chunks(Vec<MistralContentChunk>),
+}
+
+/// One content chunk. Tagged on `type`; an unknown `type` fails loud (no
+/// `#[serde(other)]` fallback) rather than being silently skipped.
+/// `reference` / `file` / `audio` chunks are intentionally unsupported.
+///
+/// Unknown *fields within* a chunk stay lenient (no `deny_unknown_fields`) so
+/// old/new Mistral payloads and any future ThinkChunk fields keep deserializing
+/// — the loud failure is on an unknown chunk `type`, not on extra fields.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum MistralContentChunk {
+    Thinking {
+        thinking: Vec<MistralTextChunk>,
+        /// Opaque provider thought-signature metadata, not an IronClaw auth
+        /// signature. Echoed back on the next turn so Mistral can verify a
+        /// replayed reasoning block.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+    Text {
+        text: String,
+    },
+    ImageUrl {
+        image_url: crate::ImageUrl,
+    },
+}
+
+/// Inner element of a thinking chunk's `thinking` list (`{type:"text",text}`).
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum MistralTextChunk {
+    Text { text: String },
+}
+
+#[derive(Debug, Serialize)]
+struct MistralTool {
+    #[serde(rename = "type")]
+    tool_type: String,
+    function: MistralFunction,
+}
+
+#[derive(Debug, Serialize)]
+struct MistralFunction {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parameters: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MistralToolCall {
+    id: String,
+    #[serde(rename = "type")]
+    call_type: String,
+    function: MistralToolCallFunction,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MistralToolCallFunction {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MistralChatResponse {
+    choices: Vec<MistralChoice>,
+    #[serde(default)]
+    usage: Option<MistralUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MistralChoice {
+    message: MistralMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct MistralUsage {
+    #[serde(default)]
+    prompt_tokens: Option<u64>,
+    #[serde(default)]
+    completion_tokens: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MistralModelsResponse {
+    #[serde(default)]
+    data: Vec<MistralModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MistralModelEntry {
+    id: String,
+}
+
+/// Extract `(input_tokens, output_tokens)` from the usage block, saturating to
+/// `u32` and treating a missing block as zero.
+fn usage_tokens(usage: &Option<MistralUsage>) -> (u32, u32) {
+    let Some(u) = usage else {
+        return (0, 0);
+    };
+    let saturate = |v: u64| v.min(u32::MAX as u64) as u32;
+    (
+        u.prompt_tokens.map(saturate).unwrap_or(0),
+        u.completion_tokens.map(saturate).unwrap_or(0),
+    )
+}
+
+#[cfg(test)]
+#[path = "mistral/tests.rs"]
+mod tests;

--- a/crates/domains/ironclaw_llm/src/mistral/tests.rs
+++ b/crates/domains/ironclaw_llm/src/mistral/tests.rs
@@ -1,0 +1,589 @@
+//! Offline parser + request-builder matrix for the Mistral provider
+//! (co-located sibling to keep `mistral.rs` under the file-size budget).
+//!
+//! Coverage: C1/C9 drive the public trait methods against a loopback mock
+//! server; C2–C5 and C8 exercise the request builder / wire conversion; C6/C7
+//! the response parser; the signature cases the `reasoning_details` round-trip;
+//! C10/C10b the error-mapping boundary. No API key or network is required.
+//!
+//! Reasoning is carried on the shared upstream `reasoning_details` channel
+//! (`ReasoningDetail::Text { text, signature }`), so the assertions read text
+//! via `ReasoningDetails::display_text()` and the signature off the `Text`
+//! block — there is no Mistral-specific reasoning type.
+
+use super::*;
+use crate::provider::ContentPart;
+use crate::{ImageUrl, ToolDefinition};
+use secrecy::SecretString;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const MEDIUM: &str = "mistral-medium-latest";
+const SMALL: &str = "mistral-small-latest";
+const LARGE: &str = "mistral-large-latest";
+/// Pixtral is Mistral's vision line (matches `is_vision_model`).
+const PIXTRAL: &str = "pixtral-large-latest";
+
+fn provider(
+    model: &str,
+    reasoning: Option<MistralReasoningEffort>,
+    base_url: &str,
+) -> MistralProvider {
+    MistralProvider::new_with_base_url(
+        model,
+        SecretString::from("test-key"),
+        reasoning,
+        30,
+        base_url,
+    )
+    .expect("provider builds")
+}
+
+/// Concatenated thinking text off the shared `reasoning_details` channel.
+fn reasoning_text(details: &Option<ReasoningDetails>) -> Option<String> {
+    details.as_ref().and_then(|d| d.display_text())
+}
+
+/// First non-empty opaque signature off the `reasoning_details` `Text` block(s).
+fn reasoning_signature(details: &Option<ReasoningDetails>) -> Option<String> {
+    details.as_ref().and_then(|d| {
+        d.content.iter().find_map(|c| match c {
+            ReasoningDetail::Text {
+                signature: Some(sig),
+                ..
+            } if !sig.trim().is_empty() => Some(sig.clone()),
+            _ => None,
+        })
+    })
+}
+
+/// Build the (model, reasoning) request and return its serialized JSON body.
+fn request_json(
+    model: &str,
+    reasoning: Option<MistralReasoningEffort>,
+    msgs: Vec<ChatMessage>,
+    tools: Vec<ToolDefinition>,
+) -> String {
+    let p = provider(model, reasoning, MISTRAL_BASE_URL);
+    let req = p.build_request(MistralRequestParams {
+        model: model.to_string(),
+        messages: msgs,
+        tools,
+        temperature: None,
+        max_tokens: None,
+        stop: None,
+        tool_choice: None,
+    });
+    serde_json::to_string(&req).expect("request serializes")
+}
+
+/// Spawn a one-shot mock that captures the request body and replies with
+/// `status_line` (+ optional extra headers) and `response_body`. Returns the
+/// base URL and a handle yielding the captured request body.
+async fn serve_once(
+    status_line: &'static str,
+    extra_headers: &'static str,
+    response_body: String,
+) -> (String, tokio::task::JoinHandle<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept");
+        // Read headers, then the declared content-length body.
+        let mut buffer = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let n = socket.read(&mut chunk).await.expect("read headers");
+            assert!(n > 0, "connection closed before headers");
+            buffer.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buffer.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let headers = String::from_utf8_lossy(&buffer[..header_end]).to_string();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        while buffer.len() < header_end + content_length {
+            let n = socket.read(&mut chunk).await.expect("read body");
+            assert!(n > 0, "connection closed before body");
+            buffer.extend_from_slice(&chunk[..n]);
+        }
+        let body =
+            String::from_utf8_lossy(&buffer[header_end..header_end + content_length]).to_string();
+
+        let response = format!(
+            "HTTP/1.1 {status_line}\r\ncontent-type: application/json\r\n{extra_headers}content-length: {}\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        let _ = socket.write_all(response.as_bytes()).await;
+        body
+    });
+    (base_url, handle)
+}
+
+/// Canned reasoning-on (array content) success body.
+fn array_response() -> String {
+    serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": [{"type": "text", "text": "let me think"}]},
+                    {"type": "text", "text": "the answer"}
+                ]
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7}
+    })
+    .to_string()
+}
+
+// ── C1: complete() drives reasoning_effort onto the wire ────────────────────
+
+#[tokio::test]
+async fn c1_complete_sends_reasoning_effort_high() {
+    let (base_url, handle) = serve_once("200 OK", "", array_response()).await;
+    let p = provider(MEDIUM, Some(MistralReasoningEffort::High), &base_url);
+
+    let resp = p
+        .complete(CompletionRequest::new(vec![ChatMessage::user("hi")]))
+        .await
+        .expect("completion succeeds");
+    assert_eq!(resp.content, "the answer");
+    assert_eq!(resp.reasoning.as_deref(), Some("let me think"));
+    assert_eq!(resp.input_tokens, 11);
+    assert_eq!(resp.output_tokens, 7);
+
+    let body = handle.await.unwrap();
+    assert!(
+        body.contains(r#""reasoning_effort":"high""#),
+        "request body must carry reasoning_effort high: {body}"
+    );
+}
+
+// ── C2/C3/C4: request-builder gating (test THROUGH the request-build caller) ─
+
+#[tokio::test]
+async fn c2_reasoning_off_omits_param() {
+    // "reasoning OFF" is represented as Option::None at the config boundary.
+    let body = request_json(MEDIUM, None, vec![ChatMessage::user("hi")], vec![]);
+    assert!(
+        !body.contains("reasoning_effort"),
+        "off must omit reasoning_effort: {body}"
+    );
+}
+
+#[tokio::test]
+async fn c3_large_model_gate_beats_toggle() {
+    let body = request_json(
+        LARGE,
+        Some(MistralReasoningEffort::High),
+        vec![ChatMessage::user("hi")],
+        vec![],
+    );
+    assert!(
+        !body.contains("reasoning_effort"),
+        "mistral-large is not reasoning-capable; param must be omitted: {body}"
+    );
+}
+
+#[tokio::test]
+async fn c4_small_model_sends_param() {
+    let body = request_json(
+        SMALL,
+        Some(MistralReasoningEffort::High),
+        vec![ChatMessage::user("hi")],
+        vec![],
+    );
+    assert!(
+        body.contains(r#""reasoning_effort":"high""#),
+        "mistral-small must carry reasoning_effort: {body}"
+    );
+}
+
+// ── C5: image attachment survives ChatMessage→wire on a vision model ────────
+
+#[tokio::test]
+async fn c5_image_part_included_for_vision_model() {
+    let msg = ChatMessage::user_with_parts(
+        "describe this",
+        vec![ContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: "data:image/png;base64,AQIDBA==".to_string(),
+                detail: None,
+            },
+        }],
+    );
+    // Pixtral is vision-capable; reasoning is off (Pixtral is not a reasoning
+    // model), so only the image-part path is under test here.
+    let body = request_json(PIXTRAL, None, vec![msg], vec![]);
+    assert!(
+        body.contains("image_url") && body.contains("data:image/png;base64,AQIDBA=="),
+        "vision model wire request must include the image part: {body}"
+    );
+}
+
+#[tokio::test]
+async fn image_part_dropped_for_non_vision_model() {
+    let msg = ChatMessage::user_with_parts(
+        "describe this",
+        vec![ContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: "data:image/png;base64,AQIDBA==".to_string(),
+                detail: None,
+            },
+        }],
+    );
+    // mistral-large is not in the vision allowlist → image dropped.
+    let body = request_json(LARGE, None, vec![msg], vec![]);
+    assert!(
+        !body.contains("image_url"),
+        "non-vision model must drop image parts: {body}"
+    );
+}
+
+// ── C6/C7: response parser ──────────────────────────────────────────────────
+
+#[test]
+fn c6_array_response_splits_reasoning_and_content() {
+    let content: MistralMessageContent = serde_json::from_value(serde_json::json!([
+        {"type": "thinking", "thinking": [{"type": "text", "text": "step one "}, {"type": "text", "text": "step two"}]},
+        {"type": "text", "text": "final answer"}
+    ]))
+    .unwrap();
+    let (text, reasoning) = extract_content(Some(content)).unwrap();
+    assert_eq!(text.as_deref(), Some("final answer"));
+    assert_eq!(
+        reasoning_text(&reasoning).as_deref(),
+        Some("step one step two")
+    );
+}
+
+#[test]
+fn c7_string_response_has_no_reasoning() {
+    let content: MistralMessageContent =
+        serde_json::from_value(serde_json::json!("plain answer")).unwrap();
+    let (text, reasoning) = extract_content(Some(content)).unwrap();
+    assert_eq!(text.as_deref(), Some("plain answer"));
+    assert!(reasoning.is_none());
+}
+
+// ── C8: multi-turn replay reconstructs the ThinkChunk ───────────────────────
+
+#[test]
+fn c8_multi_turn_replays_think_chunk() {
+    // Turn-1 reasoning fed back via with_reasoning, as the agent loop does.
+    // `with_reasoning` back-fills `reasoning_details`, which the wire replay reads.
+    let assistant =
+        ChatMessage::assistant("the answer").with_reasoning(Some("prior reasoning trace".into()));
+    let wire = chat_message_to_wire(assistant, false);
+    let json = serde_json::to_value(&wire).unwrap();
+    let content = &json["content"];
+    assert!(
+        content.is_array(),
+        "replayed content must be an array: {json}"
+    );
+    let chunks = content.as_array().unwrap();
+    assert_eq!(chunks[0]["type"], "thinking");
+    assert_eq!(chunks[0]["thinking"][0]["text"], "prior reasoning trace");
+    assert_eq!(chunks[1]["type"], "text");
+    assert_eq!(chunks[1]["text"], "the answer");
+}
+
+/// A turn-2 request body (the full prior history the agent loop replays) must
+/// carry a `thinking` chunk for the prior assistant message — "no HTTP 400" is
+/// not evidence of replay.
+#[test]
+fn turn_two_request_replays_prior_think_chunk() {
+    let history = vec![
+        ChatMessage::user("What is 17 * 23?"),
+        ChatMessage::assistant("391").with_reasoning(Some("17 * 23 = 391".into())),
+        ChatMessage::user("Now multiply that by 3."),
+    ];
+
+    let wire: Vec<_> = history
+        .into_iter()
+        .map(|m| serde_json::to_value(chat_message_to_wire(m, false)).unwrap())
+        .collect();
+
+    // The prior assistant message (index 1) must replay its ThinkChunk.
+    let prior_assistant = &wire[1]["content"];
+    assert!(
+        prior_assistant.is_array(),
+        "prior assistant content must be a chunk array on turn 2: {:?}",
+        wire[1]
+    );
+    let chunks = prior_assistant.as_array().unwrap();
+    assert!(
+        chunks
+            .iter()
+            .any(|c| c["type"] == "thinking" && c["thinking"][0]["text"] == "17 * 23 = 391"),
+        "turn-2 request is missing the prior ThinkChunk: {chunks:?}"
+    );
+}
+
+// ── signature: ThinkChunk signature capture + replay + lenient serde ────────
+
+/// An array response whose thinking chunk carries a `signature` captures it onto
+/// the `reasoning_details` `Text` block (not dropped on deserialize).
+#[test]
+fn sig_array_response_captures_signature() {
+    let content: MistralMessageContent = serde_json::from_value(serde_json::json!([
+        {"type": "thinking", "thinking": [{"type": "text", "text": "reasoning"}], "signature": "opaque-sig-xyz"},
+        {"type": "text", "text": "answer"}
+    ]))
+    .unwrap();
+    let (text, reasoning) = extract_content(Some(content)).unwrap();
+    assert_eq!(text.as_deref(), Some("answer"));
+    assert_eq!(reasoning_text(&reasoning).as_deref(), Some("reasoning"));
+    assert_eq!(
+        reasoning_signature(&reasoning).as_deref(),
+        Some("opaque-sig-xyz")
+    );
+}
+
+/// `chat_message_to_wire` re-emits the captured signature on the rebuilt
+/// thinking chunk — a request-body assertion, not "no 400". The prior turn's
+/// `reasoning_details` (with a signature) round-trips back onto the wire.
+#[test]
+fn sig_wire_request_reemits_signature() {
+    let details = ReasoningDetails {
+        id: None,
+        content: vec![ReasoningDetail::Text {
+            text: "prior reasoning trace".to_string(),
+            signature: Some("opaque-sig-xyz".to_string()),
+        }],
+    };
+    let assistant = ChatMessage::assistant("the answer").with_reasoning_details(Some(details));
+    let wire = chat_message_to_wire(assistant, false);
+    let json = serde_json::to_value(&wire).unwrap();
+    let chunks = json["content"]
+        .as_array()
+        .expect("replayed content must be an array");
+    assert_eq!(chunks[0]["type"], "thinking");
+    assert_eq!(
+        chunks[0]["signature"], "opaque-sig-xyz",
+        "rebuilt thinking chunk must carry the captured signature: {json}"
+    );
+}
+
+/// A thinking chunk carrying an extra unknown field still deserializes (lenient
+/// serde — no `deny_unknown_fields` on the chunk).
+#[test]
+fn sig_lenient_serde_tolerates_unknown_fields() {
+    let content: MistralMessageContent = serde_json::from_value(serde_json::json!([
+        {"type": "thinking", "thinking": [{"type": "text", "text": "r"}], "signature": "s", "future_field": 42},
+        {"type": "text", "text": "answer"}
+    ]))
+    .expect("unknown fields within a chunk must not fail deserialization");
+    let (text, reasoning) = extract_content(Some(content)).unwrap();
+    assert_eq!(text.as_deref(), Some("answer"));
+    assert_eq!(reasoning_signature(&reasoning).as_deref(), Some("s"));
+}
+
+// ── C9: complete_with_tools carries both reasoning_effort and tool schema ────
+
+#[tokio::test]
+async fn c9_tools_and_reasoning_effort_both_present() {
+    let tool_response = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "abc123def",
+                    "type": "function",
+                    "function": {"name": "echo", "arguments": "{\"x\":1}"}
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    })
+    .to_string();
+    let (base_url, handle) = serve_once("200 OK", "", tool_response).await;
+    let p = provider(MEDIUM, Some(MistralReasoningEffort::High), &base_url);
+
+    let tools = vec![ToolDefinition {
+        name: "echo".to_string(),
+        description: "Echo input".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"x": {"type": "integer"}}
+        }),
+    }];
+    let resp = p
+        .complete_with_tools(ToolCompletionRequest::new(
+            vec![ChatMessage::user("call echo")],
+            tools,
+        ))
+        .await
+        .expect("tool completion succeeds");
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(resp.tool_calls[0].name, "echo");
+    assert_eq!(resp.tool_calls[0].arguments["x"], 1);
+
+    let body = handle.await.unwrap();
+    assert!(
+        body.contains(r#""reasoning_effort":"high""#),
+        "tool request must carry reasoning_effort: {body}"
+    );
+    assert!(
+        body.contains(r#""name":"echo""#) && body.contains("parameters"),
+        "tool request must carry the tool schema: {body}"
+    );
+}
+
+// ── C10: error mapping at the boundary, with class assertions ───────────────
+
+async fn complete_against(
+    status_line: &'static str,
+    extra_headers: &'static str,
+    body: serde_json::Value,
+) -> LlmError {
+    let (base_url, _handle) = serve_once(status_line, extra_headers, body.to_string()).await;
+    let p = provider(MEDIUM, None, &base_url);
+    p.complete(CompletionRequest::new(vec![ChatMessage::user("hi")]))
+        .await
+        .expect_err("expected error")
+}
+
+#[tokio::test]
+async fn c10_401_maps_to_auth_failed_non_transient() {
+    let err = complete_against(
+        "401 Unauthorized",
+        "",
+        serde_json::json!({"message": "bad key"}),
+    )
+    .await;
+    assert!(matches!(err, LlmError::AuthFailed { .. }), "got {err:?}");
+    assert!(
+        !crate::retry::is_retryable(&err),
+        "auth must not be retryable"
+    );
+}
+
+#[tokio::test]
+async fn c10_429_maps_to_rate_limited_transient() {
+    let err = complete_against(
+        "429 Too Many Requests",
+        "retry-after: 30\r\n",
+        serde_json::json!({"message": "slow down"}),
+    )
+    .await;
+    match err {
+        LlmError::RateLimited { retry_after, .. } => {
+            assert_eq!(retry_after, Some(std::time::Duration::from_secs(30)));
+        }
+        other => panic!("expected RateLimited, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn c10_413_context_overflow_maps_to_context_length() {
+    let err = complete_against(
+        "400 Bad Request",
+        "",
+        serde_json::json!({"message": "This model's maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens."}),
+    )
+    .await;
+    match err {
+        LlmError::ContextLengthExceeded { used, limit } => {
+            assert_eq!(used, 150000);
+            assert_eq!(limit, 128000);
+        }
+        other => panic!("expected ContextLengthExceeded, got {other:?}"),
+    }
+    assert!(
+        !crate::retry::is_retryable(&err),
+        "context overflow must not retry"
+    );
+}
+
+#[tokio::test]
+async fn c10_5xx_maps_to_bad_gateway_transient() {
+    let err = complete_against(
+        "500 Internal Server Error",
+        "",
+        serde_json::json!({"traceback": "Traceback (most recent call last) ..."}),
+    )
+    .await;
+    match &err {
+        LlmError::BadGateway { status, .. } => assert_eq!(*status, 500),
+        other => panic!("expected BadGateway, got {other:?}"),
+    }
+    // Class: must be retryable (the circuit breaker treats BadGateway as
+    // transient — covered by circuit_breaker's own is_transient tests).
+    assert!(crate::retry::is_retryable(&err), "5xx must be retryable");
+}
+
+#[tokio::test]
+async fn c10_malformed_2xx_maps_to_invalid_response() {
+    // 2xx with a body that isn't a valid envelope → InvalidResponse, not Json.
+    let err = complete_against("200 OK", "", serde_json::json!({"unexpected": true})).await;
+    assert!(
+        matches!(err, LlmError::InvalidResponse { .. }),
+        "got {err:?}"
+    );
+    // `retry::is_retryable` classifies `InvalidResponse` as non-retryable (a
+    // parse-shape issue that won't resolve on a bare retry of the same
+    // request) — this differs from the original fork design (which predated
+    // this crate's current retry-classification policy); pinned here so a
+    // future policy change is a deliberate edit, not a silent drift.
+    assert!(
+        !crate::retry::is_retryable(&err),
+        "invalid response is not retryable under the current policy"
+    );
+}
+
+#[tokio::test]
+async fn c10_2xx_array_without_text_chunk_is_empty_response() {
+    // Reasoning-on array with only a thinking chunk → answer lost → fail loud.
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": [{"type": "text", "text": "thinking only"}]}]
+            },
+            "finish_reason": "stop"
+        }]
+    });
+    let err = complete_against("200 OK", "", body).await;
+    assert!(matches!(err, LlmError::EmptyResponse { .. }), "got {err:?}");
+    // See the note on `c10_malformed_2xx_maps_to_invalid_response`:
+    // `EmptyResponse` is classified non-retryable under the current policy.
+    assert!(
+        !crate::retry::is_retryable(&err),
+        "empty response is not retryable under the current policy"
+    );
+}
+
+// ── C10b: unknown chunk type fails loud ─────────────────────────────────────
+
+#[tokio::test]
+async fn c10b_unknown_chunk_type_fails_loud() {
+    // An `audio` chunk is a known-to-Mistral but unsupported type; it must
+    // surface as a parse failure (InvalidResponse), never be silently skipped.
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "audio", "audio": "..."}, {"type": "text", "text": "answer"}]
+            },
+            "finish_reason": "stop"
+        }]
+    });
+    let err = complete_against("200 OK", "", body).await;
+    assert!(
+        matches!(err, LlmError::InvalidResponse { .. }),
+        "unknown chunk type must fail loud, got {err:?}"
+    );
+}

--- a/crates/domains/ironclaw_llm/src/reasoning_models.rs
+++ b/crates/domains/ironclaw_llm/src/reasoning_models.rs
@@ -127,6 +127,21 @@ pub fn supports_anthropic_enabled_thinking(model: &str) -> bool {
         .any(|p| lower.contains(p))
 }
 
+/// Mistral models that accept the `reasoning_effort` parameter.
+///
+/// Reasoning rides on the general small/medium models (Mistral Small 4,
+/// Mistral Medium 3.5) — the standalone Magistral models are deprecated and
+/// `magistral-small-latest` now aliases Mistral Small 4. `mistral-large`,
+/// `mistral-tiny`, and `mistral-nemo` do **not** support it, so the provider
+/// omits `reasoning_effort` for them even when the toggle is on.
+const MISTRAL_REASONING_PATTERNS: &[&str] = &["mistral-small", "mistral-medium", "magistral"];
+
+/// Returns `true` when *model* accepts Mistral's `reasoning_effort` parameter.
+pub fn supports_mistral_reasoning(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    MISTRAL_REASONING_PATTERNS.iter().any(|p| lower.contains(p))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,5 +245,31 @@ mod tests {
         assert!(!has_native_thinking("glm-4-air"));
         assert!(!has_native_thinking("glm-4v"));
         assert!(!has_native_thinking("step-3-mini"));
+    }
+
+    // ── supports_mistral_reasoning tests ──
+
+    #[test]
+    fn mistral_small_and_medium_support_reasoning() {
+        // Aliases and dated ids for Mistral Small 4 / Medium 3.5.
+        assert!(supports_mistral_reasoning("mistral-small-latest"));
+        assert!(supports_mistral_reasoning("mistral-small-2603"));
+        assert!(supports_mistral_reasoning("mistral-medium-latest"));
+        assert!(supports_mistral_reasoning("mistral-medium-2604"));
+        // magistral-small-latest now aliases Mistral Small 4.
+        assert!(supports_mistral_reasoning("magistral-small-latest"));
+        // Case-insensitive.
+        assert!(supports_mistral_reasoning("Mistral-Medium-2604"));
+    }
+
+    #[test]
+    fn mistral_large_tiny_nemo_do_not_support_reasoning() {
+        assert!(!supports_mistral_reasoning("mistral-large-latest"));
+        assert!(!supports_mistral_reasoning("mistral-tiny"));
+        assert!(!supports_mistral_reasoning("mistral-nemo"));
+        assert!(!supports_mistral_reasoning("mistral-7b"));
+        // Non-Mistral models never match.
+        assert!(!supports_mistral_reasoning("gpt-4o"));
+        assert!(!supports_mistral_reasoning(""));
     }
 }

--- a/crates/domains/ironclaw_llm/src/registry.rs
+++ b/crates/domains/ironclaw_llm/src/registry.rs
@@ -84,6 +84,16 @@ pub enum ProviderProtocol {
     /// tool calling on every reasoning model OpenRouter exposes (Claude with
     /// thinking, OpenAI o-series, DeepSeek-R1, Gemini 2.5+, Qwen QwQ, …).
     OpenRouter,
+    /// Mistral AI API. Routes through IronClaw's dedicated `MistralProvider`
+    /// (`crate::mistral`), which owns the request/response JSON so it can parse
+    /// Mistral's `reasoning_effort=high` response — an **array of typed chunks**
+    /// (`[{type:"thinking"},{type:"text"}]`) that rig-core's `String`-typed
+    /// content model (both the generic OpenAI-compat client and rig 0.33's
+    /// dedicated Mistral client, which drops reasoning) cannot deserialize. It
+    /// splits the thinking chunk onto the shared `reasoning_details` channel and
+    /// replays the prior `ThinkChunk` on the next turn, which Mistral requires
+    /// to stay coherent multi-turn.
+    Mistral,
     /// AWS Bedrock native Converse API (via `aws-sdk-bedrockruntime`).
     /// Reads its config from [`crate::config::LlmConfig::bedrock`].
     /// Feature-gated behind `--features bedrock`.
@@ -844,6 +854,16 @@ mod tests {
              strips reasoning_details and tool-call signatures, breaking \
              every thinking-mode model OpenRouter exposes (Claude with \
              thinking, OpenAI o-series, DeepSeek-R1, Gemini 2.5+, Qwen QwQ)",
+        );
+
+        let mistral = by_id("mistral").expect("mistral entry must exist");
+        assert_eq!(
+            mistral.protocol,
+            ProviderProtocol::Mistral,
+            "mistral must use the dedicated Mistral protocol — OpenAiCompletions \
+             cannot deserialize the reasoning_effort=high array-shaped content \
+             response and fails every turn with `did not match any variant of \
+             untagged enum ApiResponse`",
         );
     }
 

--- a/crates/domains/ironclaw_llm/src/resolution.rs
+++ b/crates/domains/ironclaw_llm/src/resolution.rs
@@ -235,7 +235,8 @@ pub fn build_llm_config_from_resolved_provider(
             | ProviderProtocol::GithubCopilot
             | ProviderProtocol::DeepSeek
             | ProviderProtocol::Gemini
-            | ProviderProtocol::OpenRouter => {
+            | ProviderProtocol::OpenRouter
+            | ProviderProtocol::Mistral => {
                 return Err(LlmError::RequestFailed {
                     provider: dedicated.provider_id,
                     reason: "registry provider protocol resolved as dedicated config".to_string(),
@@ -427,6 +428,22 @@ fn apply_registry_provider_env(config: &mut RegistryProviderConfig) -> Result<()
             }
         }
     }
+
+    if config.protocol == ProviderProtocol::Mistral {
+        // Resolve Mistral `reasoning_effort` from env (default: on/high).
+        //
+        // Two wire states are carried as `Option<MistralReasoningEffort>`:
+        //   - `MISTRAL_REASONING=high|on|true|1` (or unset) → `Some(High)` → "high"
+        //   - `MISTRAL_REASONING=off|none|false|0`          → `None`       → omit
+        //
+        // Gate on the resolved `protocol`, not the id string: a Mistral-protocol
+        // provider registered under a non-`"mistral"` id (custom overlay entry)
+        // must still default reasoning on. The provider further gates `Some(_)`
+        // on model capability (`supports_mistral_reasoning`) before sending.
+        config.mistral_reasoning =
+            crate::config::resolve_mistral_reasoning_from_env(nonempty_env("MISTRAL_REASONING"));
+    }
+
     Ok(())
 }
 
@@ -532,6 +549,7 @@ fn is_registry_protocol(protocol: ProviderProtocol) -> bool {
             | ProviderProtocol::DeepSeek
             | ProviderProtocol::Gemini
             | ProviderProtocol::OpenRouter
+            | ProviderProtocol::Mistral
     )
 }
 
@@ -955,5 +973,101 @@ mod tests {
         };
         assert_eq!(dedicated.model, "Qwen/Qwen3.5-122B-A10B");
         assert_eq!(dedicated.base_url, "https://private.near.ai");
+    }
+
+    // ── Mistral reasoning env→config boundary (test through the caller) ──────
+
+    const MISTRAL_ENV_VARS: &[&str] = &[
+        "LLM_BACKEND",
+        "MISTRAL_API_KEY",
+        "MISTRAL_MODEL",
+        "MISTRAL_REASONING",
+    ];
+
+    /// Drive the env→config boundary for Mistral reasoning through the public
+    /// `resolve_provider_config_from_env` caller: assert the `MISTRAL_REASONING`
+    /// env value maps to the right `Option<MistralReasoningEffort>` on the
+    /// resolved `RegistryProviderConfig`. A predicate-only test on
+    /// `resolve_mistral_reasoning_from_env` would not prove
+    /// `apply_registry_provider_env` gates on the Mistral protocol and threads
+    /// the value onto the config.
+    fn resolve_mistral_reasoning(
+        value: Option<&str>,
+    ) -> Option<crate::config::MistralReasoningEffort> {
+        let _env_lock = ironclaw_common::env_helpers::lock_env();
+        let env = EnvGuard::clear(MISTRAL_ENV_VARS);
+        env.set("LLM_BACKEND", "mistral");
+        env.set("MISTRAL_API_KEY", "test-key");
+        if let Some(value) = value {
+            env.set("MISTRAL_REASONING", value);
+        }
+
+        let resolved = resolve_provider_config_from_env(None)
+            .expect("env resolution should succeed")
+            .expect("mistral backend should resolve from env");
+        let ResolvedProviderConfig::Registry(config) = resolved else {
+            panic!("mistral must resolve as a registry provider config");
+        };
+        assert_eq!(config.protocol, ProviderProtocol::Mistral);
+        assert_eq!(config.provider_id, "mistral");
+        config.mistral_reasoning
+    }
+
+    #[test]
+    fn mistral_reasoning_defaults_to_high_when_unset() {
+        assert_eq!(
+            resolve_mistral_reasoning(None),
+            Some(crate::config::MistralReasoningEffort::High)
+        );
+    }
+
+    #[test]
+    fn mistral_reasoning_high_and_on_resolve_to_some_high() {
+        assert_eq!(
+            resolve_mistral_reasoning(Some("high")),
+            Some(crate::config::MistralReasoningEffort::High)
+        );
+        assert_eq!(
+            resolve_mistral_reasoning(Some("on")),
+            Some(crate::config::MistralReasoningEffort::High)
+        );
+    }
+
+    #[test]
+    fn mistral_reasoning_off_and_none_omit_the_param() {
+        // "off"/"none" omit the wire param entirely → Option::None.
+        assert_eq!(resolve_mistral_reasoning(Some("off")), None);
+        assert_eq!(resolve_mistral_reasoning(Some("none")), None);
+    }
+
+    #[test]
+    fn mistral_reasoning_invalid_warns_and_defaults_to_high() {
+        assert_eq!(
+            resolve_mistral_reasoning(Some("medium")),
+            Some(crate::config::MistralReasoningEffort::High)
+        );
+    }
+
+    /// A non-Mistral registry provider must never carry a Mistral reasoning
+    /// toggle — `apply_registry_provider_env` must gate strictly on
+    /// `ProviderProtocol::Mistral`.
+    #[test]
+    fn non_mistral_registry_provider_leaves_reasoning_none() {
+        let _env_lock = ironclaw_common::env_helpers::lock_env();
+        let env = EnvGuard::clear(CHAIN_ENV_VARS);
+        env.set("LLM_BACKEND", "openai");
+        env.set("OPENAI_API_KEY", "test-key");
+
+        let resolved = resolve_provider_config_from_env(None)
+            .expect("env resolution should succeed")
+            .expect("openai backend should resolve from env");
+        let ResolvedProviderConfig::Registry(config) = resolved else {
+            panic!("openai must resolve as a registry provider config");
+        };
+        assert_eq!(config.mistral_reasoning, None);
+
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+        }
     }
 }

--- a/docs/internal/plans/2026-06-24-mistral-reasoning-impl.md
+++ b/docs/internal/plans/2026-06-24-mistral-reasoning-impl.md
@@ -1,0 +1,456 @@
+# Mistral Reasoning — Implementation Plan
+
+> **⚠️ SUPERSEDED — retained as reference (2026-07-05 catch-up).** This is the
+> work-unit breakdown for the fork's *original* custom Mistral reasoning, retired
+> in the upstream catch-up (upstream shipped a native `reasoning_details` system).
+> Kept for the edge cases and scope it enumerates; the specific work units no
+> longer apply. Re-architecture: [#8](https://github.com/k-l-sorensen/ironclaw/issues/8).
+> Acceptance criteria live in the architecture doc's banner. Original code at
+> tag `backup/main-pre-catchup`.
+
+**Status:** v1 Implemented — offline gate green and live acceptance PASSED · Reborn
+follow-up (WU8–WU10) **scoped, unstarted** · **Date:** 2026-06-24 · **Scope:** v1
+(shipped) + Reborn
+
+> Companion to the design doc
+> [`2026-06-24-mistral-reasoning-provider-architecture.md`](2026-06-24-mistral-reasoning-provider-architecture.md)
+> (the `-architecture` doc). **That doc is the source of truth for *what* and
+> *why*; this doc is *how* and *in what order*.** Decision numbers (D1–D10),
+> component rows, and test IDs (C1–C12, U1/U2, G1) referenced below are defined
+> there — do not restate them, cite them.
+>
+> The work-unit breakdown is complete and the per-file detail is filled in.
+> Boxes checked `[x]` are done and verified by the offline test matrix + gate;
+> boxes left `[ ]` are genuinely outstanding (the final live acceptance run).
+> Keep this live until the feature is declared implemented.
+
+## Current state (read first)
+
+- The architecture is **approved and review-converged** (no open
+  architecture-level items; see the design doc's "Rule-compliance review
+  findings"). Implemented to the decisions as written.
+- **The build is committed** as the `feat(llm): …` commit, kept **separate** from
+  the planning `docs(llm): …` commit per `CLAUDE-local.md`. It was authored in one
+  pass against the post-review architecture doc (D1–D10 + F1–F12 already folded
+  in), so there was no pre-review drift to undo — WU0 below is a confirmation
+  audit, and every item holds.
+- **Offline verified:** the full matrix (C1–C12, U1/U2, G1) passes; `cargo fmt`,
+  `cargo clippy --all --benches --tests --examples --all-features` (zero
+  warnings), and `cargo test` are green.
+- **Not yet declared done:** the live acceptance script ran against the real API
+  and the receive path worked (no `ApiResponse` parse error) on small/medium/large,
+  but its reasoning-trace detection needed an ANSI fix, so a clean final
+  acceptance run is still outstanding (see WU7). Fork-level status lives in
+  `CLAUDE-local.md`.
+
+## Goal
+
+Ship the custom `ProviderProtocol::Mistral` provider so `reasoning_effort=high`
+works end-to-end through the v1 agent loop, with the Live-tier acceptance test
+`tests/e2e_live_mistral_reasoning.rs` passing against the real API. (Why/what: see
+the design doc Context + Decisions.)
+
+## Implementation plan (work units, in order)
+
+Each WU is independently reviewable. Acceptance = the listed test IDs pass +
+quality gate. All code lands as one `feat(llm): …` commit, kept split from the
+planning commit.
+
+### WU0 — Reconcile existing working-tree code with the approved decisions ✅
+Audited; all items confirmed (built against the converged decisions, no drift).
+- [x] `mistral.rs` reasoning effort is the typed enum, not a `bool` (**D3**) —
+      `MistralReasoningEffort` carried as `Option<…>`; no bool/`format!`.
+- [x] wire model uses tagged/untagged serde enums, no `chunk["type"]==…` (**D8**) —
+      `MistralMessageContent` (`#[serde(untagged)]`), `MistralContentChunk`
+      (`#[serde(tag="type", rename_all="snake_case")]`), `MistralTextChunk`.
+- [x] error mapping matches **D6** table; no bare `Json`, no `map_err(|_|)` —
+      `post_chat` maps 401/429/413/5xx/other/parse-fail/empty per the table.
+- [x] thinking extraction fails loud, no `unwrap_or_default()` (**D7**) —
+      `extract_content` returns `Result`; missing text chunk → `EmptyResponse`.
+- [x] endpoint pinned, key as `SecretString`, no header logging (**F10/F11**) —
+      `MISTRAL_BASE_URL` const (no override knob); `api_key: SecretString`,
+      `expose_secret()` only at the `Authorization` header; the request-body
+      `debug!` does not include the header.
+- **Acceptance:** existing code compiles and matches D3/D6/D7/D8/F10/F11. ✅
+
+### WU1 — Types foundation (no behavior yet) ✅
+- [x] `ProviderProtocol::Mistral` variant (`registry.rs`) — no serde alias of
+      `open_ai_completions` (**D9**); non-`has_dedicated_config`.
+- [x] `MistralReasoningEffort { High, None }` + `Option<…>` semantics (**D3**) —
+      `config.rs`: `FromStr` (`high|on|true|1`→High, `off|none|false|0`→None) +
+      `wire_value()`; re-exported from `lib.rs`.
+- [x] wire JSON model: `MistralMessageContent` (untagged) + `MistralContentChunk`
+      (tagged), unknown `type` fails loud (**D8**) — `mistral.rs`.
+- **Acceptance:** **G1** (registry guard, extended in `registry.rs`), **C6/C7/C10b**
+  (parser fixtures in `mistral/tests.rs`). ✅
+
+### WU2 — Capability registries ✅
+- [x] `supports_mistral_reasoning()` in `reasoning_models.rs` (**D4**) — patterns
+      `mistral-small` / `mistral-medium`, case-insensitive.
+- [x] `mistral-small`/`mistral-medium` added to `VISION_PATTERNS` (`vision_models.rs`).
+- **Acceptance:** **U1** (`reasoning_models.rs` tests), **U2** (`vision_models.rs` test). ✅
+
+### WU3 — The provider + factory dispatch ✅
+- [x] `crates/ironclaw_llm/src/mistral.rs` `impl LlmProvider` (`complete` +
+      `complete_with_tools`), reusing `tool_schema.rs` (`FlattenOnly`) +
+      `sanitize_tool_messages`; **736 lines** (`<800`, **D10**), tests in sibling
+      `mistral/tests.rs` via `#[path]`.
+- [x] request build: `reasoning_effort_for()` gates via the WU2 helper (three
+      states per D3); `chat_message_to_wire()` replays prior thinking as
+      `[{thinking},{text}]`. Builder takes a `MistralRequestParams` struct (D10 —
+      avoids an `#[allow(too_many_arguments)]`). `reasoning_effort` is declared as
+      the 2nd request field so it survives the 500 B/event debug-log cap
+      (behaviour-neutral; JSON key order is irrelevant to Mistral).
+- [x] response parse: `extract_content()` splits array → `reasoning` + `content`;
+      string path → `content` only; `usage_tokens()`; error mapping (**D6**).
+- [x] factory arm `Mistral => create_mistral_from_registry(...)` + `mod mistral;`
+      (`lib.rs`); also added the `Mistral` arm to the dedicated-config match in
+      `resolution.rs` (non-exhaustive-match fix).
+- **Acceptance:** **C1–C5, C8, C9, C10** (`mistral/tests.rs`). ✅
+
+### WU4 — Config wiring + registry switch + overlay migration ✅
+- [x] typed `Option<MistralReasoningEffort>` on `RegistryProviderConfig`
+      (`config.rs`) (**D3**); `::generic` defaults it to `None`; the three other
+      struct-literal sites (`src/config/llm.rs` custom path, `src/cli/models.rs`,
+      `tests/support/gateway_workflow_harness.rs`) set `None`.
+- [x] `MISTRAL_REASONING` env parse at the boundary (`src/config/llm.rs`
+      `resolve_registry_provider`) (**D5**, startup-only): unset/`high`→`Some(High)`;
+      `off`→`Option::None` (omit, per C2); invalid→warn+default `Some(High)`. Same
+      logic mirrored in `resolution.rs::apply_registry_provider_env` (factory path).
+- [x] `providers.json`: `open_ai_completions → mistral`; `default_model →
+      mistral-medium-latest`.
+- [x] overlay migration in the registry loader (**D9**) — `migrate_mistral_overlay`
+      in `registry.rs::try_load_from_path` rewrites a Mistral overlay pinned to
+      `open_ai_completions`.
+- **Acceptance:** **C12** (`registry.rs` test); env→field mapping covered by
+  caller-level tests in `src/config/llm.rs` (`resolve()` through the public
+  resolver, incl. the off→omit and default-on cases). ✅
+
+### WU5 — Safety (reasoning leak-scan) ✅
+- [x] route `reasoning` through `LeakDetector` at the shared response stage,
+      pre-persistence, covering existing DeepSeek/Gemini/OpenRouter too (**D7**).
+  - **Implementation note (location):** the design suggested `src/bridge/router.rs`,
+    but v1 has no single stage there — reasoning is round-tripped at ~4 sites.
+    The real single chokepoint is the crate's `Reasoning` engine: scanned in
+    `reasoning.rs::respond_with_tools` right after the provider call
+    (`response.reasoning = redact_reasoning(...)`), which feeds every
+    `RespondResult::ToolCalls` the agent loop persists and replays. So all
+    reasoning-emitting providers are covered, not just Mistral.
+  - Added `LeakDetector::redact_all()` to `crates/ironclaw_safety` (masks every
+    match, never blocks/fails — unlike `scan_and_clean` which errors on
+    Block-action, or `scan` whose `redacted_content` covers only Redact-action).
+  - Backed by a `LazyLock<LeakDetector>`; `StubLlm` gained
+    `with_response_reasoning` / `with_tool_call` for the caller-level test.
+- **Acceptance:** **C11** (caller-level test in `reasoning.rs` through
+  `respond_with_tools`; `redact_all` units in `leak_detector.rs`). ✅
+
+### WU6 — Docs + env (mind doc-hygiene **F12**) ✅
+- [x] `.env.example`: documented `MISTRAL_REASONING` (placeholder values only).
+- [x] `docs/capabilities/llm-providers.md`: Mistral row + a Mistral section
+      (`MISTRAL_REASONING`, default `mistral-medium-latest`, reasoning on-by-default).
+- **Acceptance:** `grep -rE '/(home|Users)/|op://' .env.example docs/capabilities/llm-providers.md`
+  clean. ✅
+
+### WU7 — Acceptance + gate ✅
+- [x] `cargo fmt` · `cargo clippy --all --benches --tests --examples --all-features`
+      (zero warnings) · `cargo test` — all green.
+- [x] **Test alignment:** the bespoke bash harness
+      (`scripts/test-mistral-reasoning-ironclaw.sh`) was replaced by a Live-tier Rust
+      test, `tests/e2e_live_mistral_reasoning.rs`, following the repo's standard
+      `#[ignore]` + `LiveTestHarness` convention (the offline matrix C1–C12 remains
+      the primary deterministic net; this is the smoke layer). `MISTRAL_API_KEY` was
+      added to the harness `SECRET_TO_ENV` hydration map. The two cases below are
+      the two `#[ignore]` tests in that file.
+- [x] live, round-trip: `mistral_reasoning_round_trips` PASSED against the real API
+      (clean 620-char reply, no `ApiResponse`/parse failure signature).
+- [x] multi-turn live: `mistral_reasoning_multi_turn_replays` PASSED — turn 2 succeeded,
+      confirming no HTTP 400 when the parsed thinking chunk is replayed. Both ran on the
+      v1 path (`engine_v2=false`), the feature's intended scope.
+      Run both:
+      `IRONCLAW_LIVE_TEST=1 LLM_BACKEND=mistral MISTRAL_API_KEY=... cargo test --features libsql --test e2e_live_mistral_reasoning -- --ignored --nocapture`.
+- [x] commit as `feat(llm): …` (separate from the planning commit) — landed.
+
+## Reborn follow-up (WU8–WU10) — scoped, unstarted
+
+Scope: the `ironclaw-reborn` binary only. Architecture/decisions (R1–R3) and the
+"already present in Reborn" inventory live in the `-architecture` doc's **"Reborn
+architecture (follow-up)"** section — cite, don't restate. Engine v2 is
+permanently out of scope (Reborn replaces it). All three WUs land as one
+`feat(llm)`/`feat(reborn)` commit, separate from docs.
+
+Why this is small: in Reborn the custom Mistral provider is already reachable
+(`build_static_provider_chain` → registry dispatch), the reasoning round-trip
+already exists (`model_gateway.rs`), and reasoning is already persisted
+(`ironclaw_turns` / `ironclaw_threads`). Only *enable*, *redact*, and *expose in
+UI* are missing.
+
+> **Correction (WU-CTR4, 2026-06-25):** the "reasoning round-trip already
+> exists / is already persisted" claim above holds only **within a single
+> turn's tool loop** (tool-call reasoning rides
+> `ProviderToolCallReferenceEnvelope.response_reasoning`). It is **false across
+> user turns** for a *plain assistant message*: `model_gateway.rs::convert_messages`
+> rebuilds it as `ChatMessage::assistant(content)` with no `.with_reasoning(...)`,
+> and there is **no `reasoning` field** on `ThreadMessageRecord` /
+> `ContextMessage` / `HostManagedModelMessage` to read back. Closing this is the
+> Reborn analogue of v1's CTR-1 fix and belongs in this follow-up (add the field
+> to the thread/loop-support records, persist the leak-scanned trace, and
+> re-attach it in `convert_messages`). It overlaps WU9's redaction work.
+
+### WU8 — Enable reasoning via the provider catalog (R1) ☐
+- [ ] Add `#[serde(default)] reasoning_effort: Option<MistralReasoningEffort>` to
+      `ProviderDefinition` (`crates/ironclaw_llm/src/registry.rs`); `#[serde(default)]`
+      keeps all other entries valid. Reuse the existing enum (no bool/string).
+- [ ] Built-in `providers.json` (repo root): add `"reasoning_effort": "high"` to
+      the `mistral` entry.
+- [ ] `resolution.rs::resolve_provider_definition`: at the
+      `RegistryProviderConfig::generic(...)` builder, set
+      `config.mistral_reasoning = provider.reasoning_effort`. This is the single
+      point feeding both the Reborn catalog path
+      (`llm_catalog::resolve_against_registry` → `build_llm_config_from_resolved_provider`)
+      and v1 selection/onboarding.
+- [ ] Verify precedence: the v1 primary-chain `apply_registry_provider_env` path
+      stays authoritative (catalog = default, env = override); an explicit
+      `MISTRAL_REASONING=off` must still win and not be re-defaulted to `High`.
+- **Acceptance:** caller-level test driving `resolve_against_registry` /
+      `resolve_provider_config_from_selection` for built-in `mistral` →
+      `mistral_reasoning == Some(High)`; a `mistral-large` case still omits the
+      param (model-gate); `ProviderDefinition` round-trip test that the embedded
+      `providers.json` parses the field and other entries (no field) still
+      deserialize.
+
+### WU9 — Leak-scan reasoning on the Reborn path (R2) ☐
+- [ ] In `crates/ironclaw_reborn/src/model_gateway.rs`, route `response.reasoning`
+      through `LeakDetector::redact_all` (added to `ironclaw_safety` in WU5)
+      **before** it lands on `HostManagedModelResponse`, so the redacted form is
+      what is persisted + replayed. Fail-soft (redact, never block). Covers all
+      reasoning-emitting providers on that gateway, not just Mistral.
+- **Acceptance:** test in `crates/ironclaw_reborn/tests/llm_gateway.rs` — a planted
+      secret in a provider `reasoning` value is redacted on the returned
+      `HostManagedModelResponse`. (Note: the store's `validate_optional_provider_text`
+      is shape validation, not secret scanning — WU9 is still required.)
+
+### WU10 — Surface the toggle in the Reborn WebUI v2 LLM settings (R3) ☐
+Extends the **existing** LLM-provider-config feature with one per-provider field
+(no new endpoint). The overlay is itself a `ProviderDefinition`, so the UI edits
+the same `reasoning_effort` field WU8 adds.
+- [ ] Port DTOs (`crates/ironclaw_product_workflow/src/reborn_services/llm_config.rs`):
+      add `reasoning_effort` to `UpsertLlmProviderRequest` (`#[serde(default)]`) and
+      `LlmProviderView` (`#[serde(skip_serializing_if = "Option::is_none")]`). No
+      trait/facade change.
+- [ ] Composition (`crates/ironclaw_reborn_composition/src/llm_config_service.rs`):
+      thread the field through `upsert_provider` → `build_overlay_definition`
+      (builtin-clone + custom paths) and read it back in `build_snapshot`. Add it
+      to `RebornProviderMetadata` and populate in `provider_admin.rs::provider_info`.
+- [ ] HTTP: no route change (16 KiB upsert cap). Confirm
+      `crates/ironclaw_webui_v2/tests/webui_v2_descriptors_contract.rs` still
+      passes unchanged.
+- [ ] Frontend (`crates/ironclaw_webui_v2_static/static/js/pages/settings/`):
+      `useProviderDialogForm.js` init `reasoning`, a Mistral-adapter-gated select
+      in `provider-dialog.js`, and add `reasoning_effort` to the save payload in
+      `useLlmProviders.js`. `node --check` the three JS files.
+- **Acceptance:** caller-level round-trip in the `llm_config_service.rs` test
+      module — `upsert_provider` with `reasoning_effort: Some(High)` persists it in
+      the overlay and `snapshot()` reads it back on `LlmProviderView` (test through
+      the service, not just the DTO).
+- **Per-crate gate (don't wait for the whole graph):**
+      `cargo build -p ironclaw_product_workflow --all-features`;
+      `cargo build -p ironclaw_webui_v2 --features webui-v2-beta`;
+      `cargo build -p ironclaw_reborn_composition --features "root-llm-provider webui-v2-beta libsql"`;
+      `cargo build -p ironclaw_reborn_cli`.
+
+### Reborn live acceptance (optional smoke) ☐
+- [ ] `ironclaw-reborn serve` with `mistral`: multi-turn exchange returns a clean
+      reply, no `ApiResponse` parse error, no turn-2 HTTP 400. Adapt the approach
+      from `tests/e2e_live_mistral_reasoning.rs` to the Reborn binary.
+
+## CTR-1 — Cross-turn reasoning replay (found post-ship)
+
+**Status:** v1 fix **implemented** (WU-CTR1–3 landed, offline gate green); WU-CTR4
+verification **done — confirmed a Reborn gap**, deferred to the Reborn follow-up.
+**Found:** 2026-06-25 by post-ship validation of the shipped v1 path. **v1 fix:**
+2026-06-25. Architecture and where-to-handle live in the `-architecture` doc's
+**"CTR-1 — Cross-turn reasoning replay defect"** section — cite, don't restate.
+
+Scope: the v1 agent loop's turn persistence + context rebuild, plus a Reborn check.
+Engine v2 remains permanently out of scope.
+
+### The one-line problem
+
+Mistral requires replaying the full assistant message **including its `ThinkChunk`**
+on every subsequent turn — and explicitly **not** rebuilding it from the answer text
+alone (docs: <https://docs.mistral.ai/en/studio-api/conversations/reasoning>; the SDK
+example's `messages.append(assistant_message)` with its "Do NOT rebuild the message
+with only the answer text" comment is quoted in the architecture doc). v1 does this
+**within a single tool loop** (`dispatcher.rs:863` et al.) but **drops it on every new
+user turn and after DB hydration**, because the reasoning trace is never stored on
+`Turn` and never re-attached in `Thread::messages()`. The shipped feature therefore
+does **not** meet the multi-turn requirement it was built for.
+
+### WU-CTR1 — Persist the reasoning trace on the turn ☑
+- [x] Added `reasoning: Option<String>` to `Turn` (`src/agent/session.rs`) and persist
+      it on the assistant **and** tool_calls rows. `ConversationMessage`
+      (`crates/ironclaw_reborn_traces/src/conversation_message.rs`) gained `reasoning`;
+      `reasoning TEXT` column added on **both** backends — PG `V31`
+      (`migrations/V32__conversation_messages_reasoning.sql` + `checksums.lock`), libSQL
+      base SCHEMA + incremental `v26` + idempotent marker. Threaded a new sibling trait
+      method `add_conversation_message_with_reasoning` through `ConversationStore`
+      (`src/db/mod.rs`), `Store` (`src/history/store.rs`), `postgres.rs`,
+      `libsql/conversations.rs` (write + read), and the test mock — chosen over a
+      signature change to avoid churning ~58 call sites. Stores the leak-scanned copy
+      (redaction at `reasoning.rs`'s `redact_reasoning`). See **CTR-D1/D6**.
+- [x] Populated from `RespondResult` on **both** paths. Per **CTR-D5**, extended
+      `RespondResult::Text` → `Text { text, reasoning }`; the no-tools branch now
+      leak-scans its reasoning too. ChatDelegate captures it onto the turn in
+      `execute_tool_calls` (tool path) and `handle_text_response` (text path; trait
+      signature gained a `reasoning` param, other delegates ignore it).
+- **Acceptance:** **CTR-C1** libSQL dual-backend round-trip
+      (`db::libsql::conversations::tests::test_conversation_message_reasoning_round_trips`,
+      runs under `cargo test`). The PG half shares the same trait + `Store` SQL; a
+      PG-only `--features integration` test needs a live database not available in this
+      environment.
+
+### WU-CTR2 — Re-attach on context rebuild ☑
+- [x] `Thread::messages()` (`src/agent/session.rs`): `.with_reasoning(turn.reasoning…)`
+      on both the `assistant_with_tool_calls` and the final `assistant` message.
+- [x] `rebuild_chat_messages_from_db()` (`src/agent/thread_ops.rs`): same on both the
+      assistant and tool_calls rebuild sites.
+- [x] No-regression for non-Mistral providers confirmed via the existing `rig_adapter`
+      round-trip (the field is load-bearing per **CTR-D4**); providers that ignore it
+      (OpenAI/Anthropic) are unaffected.
+- **Acceptance:** **CTR-C2/C3/C4** caller-level tests —
+      `session::tests::test_messages_reattaches_reasoning_{text,tool}_turn` and
+      `thread_ops::tests::test_rebuild_chat_messages_reattaches_reasoning`.
+
+### WU-CTR3 — Real multi-turn assertion ☑
+- [x] Added offline **CTR-C5** test
+      `mistral::tests::ctr_c5_turn_two_request_replays_prior_think_chunk`: builds a
+      turn-2 history (prior assistant message carrying reasoning) and asserts the
+      serialized request body contains a `thinking` chunk for that prior message — not
+      just "no 400". Complements the existing C8 wire test and the CTR-C2/C3 rebuild
+      tests.
+
+### WU-CTR4 — Reborn cross-turn check ☑ (verified — **gap confirmed, deferred**)
+- [x] Verified `crates/ironclaw_reborn/src/model_gateway.rs`. **Finding:** Reborn has
+      the **same** cross-turn drop for plain assistant messages. Tool-call reasoning
+      *is* replayed (`provider_tool_roundtrip_messages` → `.with_reasoning(...)` off
+      `ProviderToolCallReferenceEnvelope.response_reasoning`), but a plain assistant
+      message is rebuilt at `model_gateway.rs` `convert_messages` as
+      `ChatMessage::assistant(content)` with **no** `.with_reasoning(...)`, and no
+      `reasoning` field exists on `ThreadMessageRecord` / `ContextMessage` /
+      `HostManagedModelMessage` to read back. Closing it is a multi-crate Reborn change
+      (`ironclaw_threads` contract, `ironclaw_loop_support`, `ironclaw_reborn`) that
+      **overlaps WU8–WU10**, so per this WU's own "fold into WU8–WU10 if it overlaps"
+      guidance it is **deferred to the Reborn follow-up**, not landed in this v1 pass.
+      Engine v2 stays out of scope.
+
+**Gate (v1 pass):** `cargo fmt` clean · `cargo clippy --all --benches --tests --examples
+--all-features` **zero warnings** · changed-module tests green (`agent::` 517,
+`ironclaw_llm` 901, libSQL conversations 11, history/worker/hooks). Full `cargo test`
+also surfaces pre-existing `channels::wasm::wrapper` failures that are an environment
+issue (the wasm target std is unavailable here), unrelated to CTR-1. Lands as one
+`fix(agent)`/`fix(llm)` commit, separate from docs.
+
+## Open code-level questions (from the review, carry forward)
+- [x] **RESOLVED — no remap needed.** `BadGateway` and `EmptyResponse` are both
+      classified transient: `retry.rs::is_retryable` (lines 45–57) and
+      `circuit_breaker.rs::is_transient` (lines 231–238) explicitly list both. The
+      design-doc D6 note (worried the enumerated sets omitted them) was based on a
+      stale `CLAUDE.md` summary; the code names them. So 5xx→`BadGateway` and the
+      no-text-chunk→`EmptyResponse` mappings stand; C10 asserts the class.
+
+## Progress log
+> Append dated markers as WUs land. Move the Status line: Scaffold → in progress
+> → Implemented (<commit>).
+
+- 2026-06-24 — scaffold created; implementation already partially in working tree (pre-review). WU0 reconciliation pending.
+- 2026-06-24 — WU0–WU6 complete and verified. Offline matrix C1–C12 + U1/U2/G1 all pass; `cargo fmt` / `clippy --all-features` / `cargo test` green. Code uncommitted in working tree.
+- 2026-06-24 — Open code-level question resolved: `BadGateway` + `EmptyResponse` confirmed transient (`retry.rs:45-57`, `circuit_breaker.rs:231-238`); no 5xx remap.
+- 2026-06-24 — WU5 leak-scan landed in the crate `Reasoning` engine (shared v1 chokepoint) via new `LeakDetector::redact_all`; covers DeepSeek/Gemini/OpenRouter too.
+- 2026-06-24 — Live acceptance run against the real API: receive path works on small/medium/large, no `ApiResponse` parse error; thinking trace and answer surfaced separately. Acceptance script rebuilt to log the full interaction across 5 cases; a trace-detection ANSI bug (false FAIL) was found and fixed. WU7 remaining: clean final acceptance run + multi-turn check + `feat(llm)` commit.
+- 2026-06-24 — Implementation committed as the `feat(llm): …` commit, separate from the planning `docs(llm): …` commit. WU7 remaining: clean final live-acceptance run + multi-turn check.
+- 2026-06-24 — Test alignment: the bespoke bash acceptance harness was replaced by the Live-tier Rust test `tests/e2e_live_mistral_reasoning.rs` (`#[ignore]` + `LiveTestHarness`, skips cleanly without `IRONCLAW_LIVE_TEST`); `MISTRAL_API_KEY` added to the harness `SECRET_TO_ENV` map. **WU7 closed:** both live tests PASSED against the real API (round-trip: clean reply, no parse error; multi-turn: turn 2 OK), on the v1 path (`engine_v2=false`). Offline matrix remains the primary deterministic net.
+- 2026-06-25 — **CTR-1 found:** post-ship validation showed the ThinkChunk is replayed
+  only within a single turn's tool loop (`dispatcher.rs:863`) and dropped on every new
+  user turn + after DB hydration — `Turn` never stores the trace and `Thread::messages()`
+  / `rebuild_chat_messages_from_db()` rebuild assistant messages without `.with_reasoning(...)`.
+  The live multi-turn test is green on the degraded (no-ThinkChunk) path, so it gave false
+  confidence. Logged as CTR-1 (architecture section + WU-CTR1–4) for a fresh architecture
+  pass then implementation pass. Docs-only this change; no code.
+- 2026-06-24 — Reborn follow-up scoped (WU8–WU10, unstarted). Investigation found Reborn already has the provider reachable, the reasoning round-trip (`model_gateway.rs`), and reasoning persistence (`ironclaw_turns`/`ironclaw_threads`); the only gaps are enabling the catalog field (WU8), the leak-scan on the Reborn path (WU9), and the WebUI toggle (WU10). Engine v2 ruled permanently out of scope (Reborn replaces it). Decisions R1–R3 recorded in the `-architecture` doc's "Reborn architecture (follow-up)" section. Docs-only this pass; no code.
+- 2026-06-25 — **CTR-1 v1 fix implemented (WU-CTR1–3).** `Turn`/`ConversationMessage`
+  gained a leak-scanned `reasoning` field, persisted via a new
+  `add_conversation_message_with_reasoning` trait method on both backends (PG `V31`,
+  libSQL `v26`), captured from `RespondResult` (incl. extending `Text` per CTR-D5), and
+  re-attached at both context-rebuild gateways (`Thread::messages()` +
+  `rebuild_chat_messages_from_db()`). Offline tests CTR-C1 (libSQL round-trip),
+  CTR-C2/C3/C4 (rebuild caller-level), CTR-C5 (turn-2 wire replays the ThinkChunk) pass.
+  `cargo fmt`/`clippy --all-features` clean; changed-module suites green. Per the user,
+  the shared `ConversationMessage` field forced compile-only `reasoning: None` in a few
+  Reborn construction sites (Option A) — no Reborn behavior changed. Code only.
+- 2026-06-25 — **WU-CTR4 verified — Reborn has the same cross-turn drop, deferred.**
+  `model_gateway.rs::convert_messages` rebuilds a prior plain assistant message as
+  `ChatMessage::assistant(content)` with no `.with_reasoning(...)`, and no `reasoning`
+  field exists on `ThreadMessageRecord`/`ContextMessage`/`HostManagedModelMessage` to
+  read back (tool-call reasoning *is* replayed via `ProviderToolCallReferenceEnvelope`).
+  Closing it is a multi-crate Reborn change overlapping WU8–WU10, so it is folded into
+  the Reborn follow-up rather than landed in this v1 pass.
+
+## SIG-1 — ThinkChunk `signature` replay (found 2026-06-27)
+
+**Status:** v1 **implemented** (offline gate green). **Date:** 2026-06-27. Architecture
+and decisions (SIG-D1–D5, SIG-C1…C6) live in the `-architecture` doc's **"SIG-1 —
+ThinkChunk `signature` replay"** section — cite, don't restate. Scope: the custom Mistral
+provider + the CTR-1 persistence path it rides; v1 agent loop only. Reborn parity is a
+check; the plain-assistant cross-turn drop stays folded into WU8–WU10 (per WU-CTR4).
+
+### The one-line problem
+
+Mistral returns an opaque `signature` on every ThinkChunk and expects it echoed back to
+verify a replayed reasoning block. The custom provider dropped it on both sides (silent
+discard on deserialize; rebuilt the chunk with no signature on replay), so CTR-1 replayed
+a signature-less, text-flattened approximation — not the *full* ThinkChunk. Signature-less
+replay works today (no HTTP 400), so this is fidelity / forward-insurance, not a live
+defect. Per the approved plan, the full lossless plumbing was built now (SIG-D5).
+
+### WU-SIG1 — Mistral wire capture + replay ☑
+- [x] `signature: Option<String>` on `MistralContentChunk::Thinking` (lenient serde,
+      SIG-D3); `extract_content` → 3-tuple, first-non-null signature (SIG-D4);
+      `chat_message_to_wire` re-emits it; both response structs carry it.
+- **Acceptance:** SIG-C1 (capture), SIG-C2 (wire re-emit), SIG-C6 (lenient serde) — pass.
+
+### WU-SIG2 — v1 channel + compile-driven `None` ☑
+- [x] `reasoning_signature` on `ChatMessage`/`CompletionResponse`/`ToolCompletionResponse`
+      + `with_reasoning_signature`; `None` at all non-Mistral construction sites (inert).
+
+### WU-SIG3 — `RespondResult` + leak-scan EXEMPT (SIG-D2) ☑
+- [x] `reasoning_signature` on `Text` + `ToolCalls`; carried through `respond_with_tools`
+      **around** `redact_reasoning` (never leak-scanned).
+- **Acceptance:** SIG-C5 (signature with redactor-trigger bytes survives verbatim) — pass.
+
+### WU-SIG4 — Turn capture + context rebuild ☑
+- [x] `reasoning_signature` + `tool_call_reasoning_signature` on `Turn`/`TurnPersistSnapshot`;
+      captured in `dispatcher.rs`; re-attached at both `Thread::messages()` sites; threaded
+      through the `LoopDelegate` methods (all delegates).
+- **Acceptance:** SIG-C2 caller-level (`Thread::messages()` reattaches) — pass.
+
+### WU-SIG5 — Persistence (dual-backend) + trace record ☑
+- [x] Widened `add_conversation_message_with_reasoning(..., reasoning_signature)` (trait +
+      Store + postgres + libsql, write + read); `ConversationMessage.reasoning_signature`;
+      threaded through `thread_ops.rs` persist + `rebuild_chat_messages_from_db`. Proxy DTOs
+      (`worker/api.rs`, `orchestrator/api.rs`) carry it too (parity with CTR-1).
+- **Acceptance:** SIG-C3 (libSQL round-trip), SIG-C4 (hydration reattach) — pass.
+
+### WU-SIG6 — Migrations (dual-backend) ☑
+- [x] PG `V33__conversation_messages_reasoning_signature.sql` + `checksums.lock`; libSQL
+      base schema + incremental `v27` + `IDEMPOTENT_ADD_COLUMN_MIGRATIONS` marker.
+
+### WU-SIG7 — Reborn parity check ☑ (check, not rebuild)
+- [x] Per-tool-call `signature` already round-trips (`ProviderToolCall`); the Mistral
+      message-level signature now flows through `model_gateway.rs` (carried on the recovered
+      `ToolCompletionResponse`). The plain-assistant cross-turn drop is the **same WU-CTR4
+      gap**, deferred to the Reborn follow-up (WU8–WU10).
+
+### WU-SIG8 — Gate + acceptance
+- Offline: SIG-C1/C2/C3/C5/C6 + caller-level reattach/hydration pass; `cargo fmt` clean.
+  Live A/B (SIG-G0) folded into the live multi-turn acceptance as an observation (the full
+  plumbing was built regardless, per the approved decision).

--- a/docs/internal/plans/2026-06-24-mistral-reasoning-provider-architecture.md
+++ b/docs/internal/plans/2026-06-24-mistral-reasoning-provider-architecture.md
@@ -1,0 +1,826 @@
+# Mistral Reasoning — Provider Architecture (C4 Level 3)
+
+> **⚠️ SUPERSEDED APPROACH — retained as reference (2026-07-05 catch-up).**
+> This document describes the fork's *original* custom Mistral reasoning design
+> (a custom provider bypassing rig, a parallel `reasoning`/`reasoning_signature`
+> plumb, later bundled into `ReasoningBlock`). It was **retired** when the
+> upstream catch-up found that upstream had independently built a *more general*
+> native reasoning system — `reasoning` + typed `reasoning_details`
+> (`ReasoningDetail::{ Text { text, signature }, Encrypted, Redacted, Summary }`)
+> with `with_reasoning` / `with_reasoning_details` builders and rig-adapter
+> support. **Do not rebuild `ReasoningBlock` or a parallel plumb** — the
+> re-architecture ([#8](https://github.com/k-l-sorensen/ironclaw/issues/8))
+> should map Mistral's ThinkChunk (text + signature) onto upstream's
+> `ReasoningDetail::Text { text, signature }`. Decisions D1–D10 below are kept
+> for their *analysis*, not as a spec. Original code at tag `backup/main-pre-catchup`.
+>
+> ## Acceptance criteria (preserved from the retired live test)
+>
+> The re-architected Mistral support must satisfy — these are implementation-
+> independent and are the acceptance spec for #8 (from the retired
+> `tests/e2e_live_mistral_reasoning.rs`, preserved at the backup tag):
+>
+> 1. **Clean round-trip.** A real Mistral `reasoning_effort=high` response
+>    round-trips through the agent loop and yields a **non-empty reply with no
+>    failure signature** — specifically no `JsonError: did not match any variant
+>    of untagged enum ApiResponse` parse failure (the original blocker).
+> 2. **Multi-turn replay.** A second user turn does **not** HTTP 400 when the
+>    prior turn's parsed thinking chunk is replayed back to the provider.
+> 3. **Non-goal (documented).** Do *not* assert on `StatusUpdate::Thinking`
+>    events — on the v1 agent path they are reused for generic status, so their
+>    presence is not a reasoning signal. Prove reasoning *parsing* deterministically
+>    with offline cases; prove *replay* with the live multi-turn case.
+> 4. **Live invocation (for reference):**
+>    `IRONCLAW_LIVE_TEST=1 LLM_BACKEND=mistral MISTRAL_REASONING=high MISTRAL_API_KEY=… cargo test …`
+>    (the offline parser matrix — retired `crates/ironclaw_llm/src/mistral/tests.rs`,
+>    cases C1–C12 — enumerates the Mistral response shapes that must parse).
+
+**Status:** Approved architecture · **Date:** 2026-06-24 · **Scope:** v1 (shipped)
++ Reborn follow-up (scoped, unstarted — see "Reborn architecture (follow-up)" below)
+
+> This is an **architecture-level** design (C4 model, component level). It does
+> not specify line-level code; the code-level plan lives in the companion impl
+> doc and the build is committed (the `feat(llm): …` commit).
+>
+> Companion docs: `2026-06-24-mistral-reasoning-impl.md` (the code-level plan +
+> live status), `docs/providers/mistral-reasoning.md` (the API/blocker research this builds
+> on), `CLAUDE-local.md` (fork status). This document supersedes the "design
+> implications" sketch in `docs/providers/mistral-reasoning.md` §4.
+
+## Context
+
+This fork wants to use Mistral (largest EU provider) "to the fullest", which
+means running `mistral-small` / `mistral-medium` with **`reasoning_effort=high`**
+through IronClaw's full agent loop.
+
+Today Mistral is wired in `providers.json` as `protocol: open_ai_completions` and
+flows through `rig-core`'s OpenAI Chat Completions client via `RigAdapter`. That
+path **cannot consume Mistral's reasoning response**: with `reasoning_effort=high`,
+`message.content` becomes an array of typed chunks
+(`[{type:"thinking",…},{type:"text",…}]`) instead of a string, and the agent
+loop fails every turn (`JsonError: did not match any variant of untagged enum
+ApiResponse`). Full request/response details are in `docs/providers/mistral-reasoning.md`.
+
+### Gating decision — RESOLVED: build, don't upgrade
+
+The first required step was build-vs-upgrade (`docs/providers/mistral-reasoning.md` §3a):
+does a newer `rig-core` parse Mistral reasoning natively? **Verified against the
+latest `rig-core` (0.39.0, Jun 2026): no.**
+
+- The old `panic!("Reasoning content is not currently supported on Mistral via
+  Rig")` is gone — but only on the **request** side, where rig now *silently
+  skips* reasoning chunks (`providers/mistral/completion.rs` ~L163, L562).
+- On the **response** side, the dedicated Mistral client still models
+  `Message::Assistant.content` as a plain **`String`** (`completion.rs:71`), with
+  no array/untagged handling. Mistral's `high` array response still fails to
+  deserialize. The generic OpenAI-compat client has the same string-content
+  assumption.
+
+→ A `rig-core` bump does **not** rescue this. IronClaw must **own the Mistral
+request/response** via a custom provider. (A bump may still be desirable for
+other reasons, but it is orthogonal and out of scope here.)
+
+### Decisions locked
+
+- **Route strategy:** the custom provider owns **all** Mistral traffic (reasoning
+  on and off) under a new `ProviderProtocol::Mistral`. Single code path; honours
+  the existing registry rule that reasoning-aware providers must not use
+  `open_ai_completions`.
+- **Reasoning default:** **on (`high`) by default** for supported small/medium
+  models; a toggle (high/off) can disable it. Modeled as a typed 2-variant enum
+  `MistralReasoningEffort { High, None }`, **not** a `bool` and **not** the OpenAI
+  low/medium/high 3-level scale (see Decision 3).
+
+## Target architecture (C4 L3 — components)
+
+The change adds **one new provider component** inside the `ironclaw_llm` crate
+and threads a **typed reasoning-effort value** from the binary's env layer through
+to it. Everything else (decorator chain, agent loop, reasoning round-trip channel)
+is reused unchanged.
+
+```
+[ src/config/llm.rs ]  (binary — env-agnostic crate boundary)
+   reads MISTRAL_REASONING (+ existing MISTRAL_API_KEY / MISTRAL_MODEL)
+        │  populates RegistryProviderConfig (+ new reasoning flag)
+        ▼
+[ ironclaw_llm::lib.rs  factory dispatch ]
+   match config.protocol { … ProviderProtocol::Mistral => create_mistral_from_registry(config) }
+        │
+        ▼
+┌───────────────────────────────────────────────────────────┐
+│  NEW: MistralProvider  (crates/ironclaw_llm/src/mistral.rs)│  ← sibling of nearai_chat.rs
+│  impl LlmProvider                                          │
+│   • own reqwest client + own JSON request/response model   │
+│   • REQUEST:  sets reasoning_effort=high|none, gated to     │
+│     supported models (small/medium); maps ChatMessage→wire │
+│     incl. replaying prior thinking from ChatMessage.reasoning│
+│   • RESPONSE: parses array content → splits thinking-chunk  │
+│     into CompletionResponse.reasoning + text-chunk into     │
+│     .content; also handles string content (reasoning=off)  │
+│   • complete() AND complete_with_tools()                    │
+│   • maps Mistral error bodies → LlmError at the boundary    │
+└───────────────────────────────────────────────────────────┘
+        │ returns Arc<dyn LlmProvider>
+        ▼
+[ build_provider_chain() ]  → Retry → SmartRouting → Failover → CircuitBreaker → Cached → Swappable → Recording   (UNCHANGED)
+        ▼
+[ agent loop / Reasoning engine ]  (UNCHANGED)
+   round-trips ChatMessage.reasoning via existing .with_reasoning(...) channel
+```
+
+### Components touched
+
+| Component | File | Change |
+|---|---|---|
+| **MistralProvider (new)** | `crates/ironclaw_llm/src/mistral.rs` | New `LlmProvider` impl; own HTTP client + JSON model. Template: `nearai_chat.rs`. |
+| Protocol enum | `crates/ironclaw_llm/src/registry.rs` | Add `ProviderProtocol::Mistral` variant. |
+| Factory dispatch | `crates/ironclaw_llm/src/lib.rs` | Add `Mistral => create_mistral_from_registry(...)` arm; new constructor fn; `mod mistral;`. |
+| **Reasoning-model registry** | `crates/ironclaw_llm/src/reasoning_models.rs` | Add `supports_mistral_reasoning(model)` helper (patterns `mistral-small`, `mistral-medium`), mirroring `supports_openai_reasoning` / `supports_anthropic_*_thinking`. The provider gates `reasoning_effort` through this — **model-gating is NOT hardcoded in the provider.** |
+| **Vision-model registry** | `crates/ironclaw_llm/src/vision_models.rs` | Add `mistral-medium` / `mistral-small` to `VISION_PATTERNS` (small/medium are multimodal; `pixtral` is already present). Without this, switching the default to `mistral-medium-latest` would silently drop image attachments (same bug class the tier-first Claude patterns guard against). |
+| Provider registry | `providers.json` (repo root) | Switch Mistral entry `protocol: open_ai_completions → mistral`; change `default_model: mistral-large-latest → mistral-medium-latest` (large is **not** reasoning-capable; with reasoning on-by-default the default model must be reasoning-capable). |
+| **Overlay migration** | `registry.rs` loader (`~/.ironclaw/providers.json`, `$IRONCLAW_REBORN_HOME/providers.json`) | A user/operator overlay that copied the Mistral block still pins `open_ai_completions` and would **silently keep the broken rig path**. On load, rewrite an overlay Mistral entry whose protocol is `open_ai_completions` → `mistral` (or warn loudly). See Decision 9. |
+| Reasoning config field | `crates/ironclaw_llm/src/config.rs` (`RegistryProviderConfig`) | Add a **typed** `Option<MistralReasoningEffort>` field (`None` = omit param). Not a `bool`. Crate stays env-agnostic. |
+| Wire JSON model | `crates/ironclaw_llm/src/mistral.rs` | Typed serde model: `MistralMessageContent` (`#[serde(untagged)]` over `Text(String)` / `Chunks(Vec<…>)`) and `MistralContentChunk` (`#[serde(tag="type")]`, `Thinking`/`Text`). The untagged content enum is the actual fix for the original `ApiResponse` error. See Decision 8. |
+| Env read | `src/config/llm.rs` (binary) | Parse `MISTRAL_REASONING` (`high`/`on`/`true`/`1` → `High`; `off`/`none`/`false`/`0` → `None`; default `High`) into the typed field at the boundary. |
+| Reasoning leak-scan | shared response stage (`src/bridge/router.rs` / agent boundary) + `ironclaw_safety::LeakDetector` | Route the `reasoning` field through the same `LeakDetector` path as `content` before it is stored or replayed. Prefer the shared stage so existing DeepSeek/Gemini/OpenRouter reasoning is covered too. See Decision 7. |
+| Registry guard test | `crates/ironclaw_llm/src/registry.rs` | Extend `reasoning_aware_providers_use_dedicated_protocol_not_openai_compat` to assert the built-in Mistral entry resolves to `ProviderProtocol::Mistral` (equality), not merely "not OpenAiCompletions". |
+| Provider docs | `docs/capabilities/llm-providers.md` | Update the Mistral row (note reasoning support) and section: `MISTRAL_REASONING`, default `mistral-medium-latest`, supported reasoning models, on-by-default behavior. |
+| Env docs | `.env.example` | Document `MISTRAL_REASONING`. |
+
+### Reused — do NOT rebuild
+
+- **Reasoning round-trip channel:** `ChatMessage.reasoning` + `.with_reasoning(...)`
+  and `CompletionResponse/ToolCompletionResponse.reasoning` already exist (added
+  for DeepSeek/Gemini/OpenRouter, issues #3201/#3225). The new provider populates
+  the same fields; the agent loop already replays them. This satisfies Mistral's
+  multi-turn requirement (replay the ThinkChunk) with **no agent-loop change**.
+- **Decorator chain** (`build_provider_chain` in `lib.rs`): the new provider
+  returns `Arc<dyn LlmProvider>` and inherits retry/routing/failover/cache/record
+  for free.
+- **Tool-schema normalization** patterns from `nearai_chat.rs` / `rig_adapter.rs`
+  (OpenAI strict vs flatten-only) — reuse the appropriate one for tool calls.
+- **Model-capability registries** (`reasoning_models.rs`, `vision_models.rs`) —
+  extend with Mistral patterns rather than introducing ad-hoc model checks in the
+  provider. The provider calls these helpers; it does not own model lists.
+- **`LlmProvider` trait** is the single integration seam; no trait changes.
+
+## Key architectural decisions
+
+1. **Custom provider, not rig** — rig 0.39 still can't parse array content
+   (gating decision above). Owning the JSON model is the only correct route and
+   matches IronClaw's own rule against reasoning-aware providers on
+   `open_ai_completions`.
+2. **One protocol for all Mistral traffic** — `ProviderProtocol::Mistral` handles
+   both reasoning-on (array response) and reasoning-off (string response). No
+   conditional dual-path.
+3. **Reasoning effort is a typed marker enum, default on** —
+   `MistralReasoningEffort { High }`, rendered to the wire via `wire_value()`
+   (`"high"`). Kept as an enum (rather than a `bool`, which would force a
+   bool→magic-string `format!`, banned by `types.md`) so a richer graded scale can
+   be added here if Mistral ever exposes one — it is **never** the OpenAI 3-level
+   scale today. The env string is converted to this type at the binary boundary
+   only. Mistral exposes reasoning as an on/off toggle: the only on-state is
+   `"high"`, and "off" is expressed by *omitting* the param. The wire therefore has
+   **two** states, expressed as `Option<MistralReasoningEffort>`: `Option::None` =
+   **omit** the param (off, model-gated off, or unsupported model); `Some(High)` =
+   send `"high"` (C2 asserts the off case omits the param, not an explicit value).
+4. **Model-gating via the existing registry, not the provider** —
+   `reasoning_effort` is sent only for supported models (`mistral-small*`,
+   `mistral-medium*`) via a new `supports_mistral_reasoning()` helper in
+   `reasoning_models.rs`. For others (e.g. `mistral-large`) the param is
+   auto-omitted, so the toggle is safe regardless of selected model. Default model
+   becomes `mistral-medium-latest` so on-by-default reasoning engages out of the
+   box.
+5. **Env stays in the binary, toggle is startup-only** — `MISTRAL_REASONING` is
+   read and typed in `src/config/llm.rs`; the crate remains env-agnostic. The
+   toggle is **startup-env-only, not a hot-reloadable setting** — this sidesteps
+   the persist-then-reload atomicity hazard (`error-handling.md`). If it ever
+   becomes settings-backed, it must adopt pre-validate or snapshot+rollback.
+6. **Error mapping at the channel boundary, cause carried** — Mistral failures map
+   to specific `LlmError` variants inside `mistral.rs` (mirrors `nearai_chat.rs`),
+   so retry/circuit-breaker classification is correct and no internal detail leaks
+   to the user. **Never** `.map_err(|_| …)` (drops the cause; banned and
+   non-exemptible) and **never** let `serde_json` parse failures surface as bare
+   `LlmError::Json` (non-retryable + doesn't trip the breaker — wrong class for a
+   transient body). Mapping table:
+
+   | Mistral response | `LlmError` variant | Class |
+   |---|---|---|
+   | 401 auth | `AuthFailed { provider: "mistral" }` | non-transient (API-key only; no session renewal) |
+   | 429 rate limit | `RateLimited { retry_after }` (parse `Retry-After`) | transient |
+   | 413 / context overflow | `ContextLengthExceeded` via shared `error::context_length_error` | non-transient |
+   | 5xx | `BadGateway { provider, status, retry_after }` — body to `debug!` only, never on the error | transient |
+   | other non-2xx | `RequestFailed { reason: "HTTP {status}: {truncated}" }` | transient |
+   | 2xx, envelope won't deserialize | `InvalidResponse { reason }` (not `Json`) | transient |
+   | 2xx, well-formed, no `text` chunk / empty choices | `EmptyResponse` | transient |
+   | transport / reqwest error | `RequestFailed { reason: e.to_string() }` | transient |
+
+   **Class verification (code-pass):** the crate's enumerated retryable/breaker
+   sets (see `ironclaw_llm/CLAUDE.md`) list `RequestFailed`, `RateLimited`,
+   `InvalidResponse`, `Http`, `Io` — they do **not** explicitly name `BadGateway`
+   or `EmptyResponse`. Confirm `retry.rs::is_retryable()` + the circuit breaker
+   actually treat those two as transient; if not, remap the 5xx row to
+   `RequestFailed`. Test C10 must assert the **class** (retryable + trips breaker),
+   not just the variant.
+
+7. **Reasoning trace rides the same safety scan as content** — the `thinking`
+   trace is a new model-output surface that is both **stored** (LLM data is never
+   deleted) and **replayed into the LLM** next turn. It must pass through
+   `ironclaw_safety::LeakDetector` before storage/replay, exactly as `content`
+   does. Hook it at the **shared response stage** (so the existing
+   DeepSeek/Gemini/OpenRouter `reasoning` fields get covered too), not only inside
+   `mistral.rs`. The scan must occur **pre-persistence** so the stored reasoning is
+   already redacted and replay inherits it — do **not** reuse only the existing
+   response-before-user `LeakDetector` site, which fires on the outbound-to-user
+   path and would leave the reasoning-replay-to-LLM path unscanned (the rule's
+   "wrong stage" bug). The thinking-chunk extraction must **fail loud** (`EmptyResponse`/
+   `InvalidResponse`) on a malformed reasoning-on array — never `unwrap_or_default()`
+   to `""`, which would drop the answer *and* the ThinkChunk and cause the turn-2
+   HTTP 400 this design exists to prevent.
+8. **Typed wire model, no stringly-typed parsing** — request/response JSON uses
+   serde-tagged/untagged enums (`MistralMessageContent` untagged String-or-array;
+   `MistralContentChunk` tagged on `type`), never `chunk["type"] == "thinking"`
+   string matching. Unknown chunk `type` fails loud rather than being silently
+   skipped.
+9. **Overlay migration is in-scope** — changing the built-in `providers.json` does
+   not touch user/operator overlays, which would silently keep the broken
+   `open_ai_completions` route. The registry loader must rewrite (or loudly warn
+   on) an overlay Mistral entry pinned to `open_ai_completions`. `open_ai_completions`
+   is **not** serde-aliased onto `Mistral` (it remains a live value for other
+   providers) — this is a value migration, not an enum-rename.
+10. **Build guardrails (architecture-discipline)** — `mistral.rs` targets `< 800`
+    lines (the template `nearai_chat.rs` is ~2,988); co-locate tests in a sibling
+    rather than inline. Reuse the shared chat-completions wire-shaping seams
+    (`tool_schema.rs` normalization, `provider.rs::sanitize_tool_messages`) instead
+    of hand-rolling a 4th copy; keep only the genuinely novel logic (array/string
+    content parsing + ThinkChunk replay) Mistral-specific. Any unavoidable
+    `#[allow(clippy::too_many_arguments)]` carries an `// arch-exempt:` annotation
+    with a plan link — never bare; prefer a params struct.
+
+## Out of scope
+
+- `rig-core` version bump (orthogonal; doesn't solve this).
+- `prompt_mode` knob (risks layering Mistral's own system prompt over IronClaw's).
+- **Engine v2** (`crates/ironclaw_engine/`) — permanently out of scope. Reborn is
+  intended to replace both v1 and engine v2, so engine v2's reasoning plumbing
+  (which drops `reasoning` at the `LlmBridgeAdapter` and has no field on
+  `LlmOutput`/`LlmResponse`/`ThreadMessage`) is deliberately not pursued.
+- **Reborn** was originally out of scope for the v1 design but is now a scoped
+  follow-up — see "Reborn architecture (follow-up)" below.
+- Streaming reasoning surfacing in the TUI (round-trip + final answer is the goal;
+  live thinking display is a possible follow-up, not required).
+
+## Verification (for the future implementation pass)
+
+The regression net is **offline and deterministic**; the live scripts are
+complementary smoke tests, not the primary coverage. Both
+`supports_mistral_reasoning()` and `is_vision_model()` gate side effects, so per
+`testing.md` ("Test Through the Caller") helper unit tests alone are insufficient —
+call-site tests are mandatory.
+
+**Offline regression net (`cargo test`, no API key — use the crate `testing` feature / recorded fixtures):**
+
+| # | Driver | Input | Assert |
+|---|---|---|---|
+| C1 | **`complete()`** entry point | `mistral-medium-latest`, reasoning ON | body **contains** `reasoning_effort: "high"` (drives the public trait method, not a shared sub-helper) |
+| C2 | request builder | `mistral-medium-latest`, reasoning OFF | body **omits** `reasoning_effort` |
+| C3 | request builder | `mistral-large-latest`, reasoning ON | body **omits** it (model-gate beats toggle) |
+| C4 | request builder | `mistral-small-latest`, reasoning ON | body **contains** it |
+| C5 | ChatMessage→wire | `mistral-medium-latest` + image attachment | wire request **includes the image part** (proves `is_vision_model` consulted, attachment not dropped) |
+| C6 | response parser | recorded **array** fixture `[{thinking},{text}]` | `.reasoning` = thinking, `.content` = text, no error |
+| C7 | response parser | recorded **string** fixture | `.content` set, `.reasoning` none |
+| C8 | multi-turn builder | turn-1 `.reasoning` set, fed back via `.with_reasoning(...)` | turn-2 request replays the ThinkChunk |
+| C9 | `complete_with_tools` | tool-bearing request, reasoning ON | both `reasoning_effort` and tool schema present (test both trait methods) |
+| C10 | error mapping | recorded error bodies (401/429/413/5xx/malformed) | each maps to the variant in Decision 6's table; assert the **class** (retryable + trips-breaker), not just the variant |
+| C10b | response parser | 2xx well-formed envelope with an **unknown chunk `type`** | fails loud (`InvalidResponse`/`EmptyResponse`), **not** silently skipped (Decision 8) |
+| C11 | leak-scan (Decision 7) | planted secret in a `thinking` chunk | redacted in the persisted record **and** in the replayed prompt |
+| C12 | overlay migration | overlay Mistral entry pinned to `open_ai_completions` | loader rewrites to `mistral` (or warns) — not silently kept |
+| U1 | helper units | `supports_mistral_reasoning`: small/medium `true`, large `false`, case-insensitive, `auto` `false` | — |
+| U2 | helper units | `is_vision_model`: mistral small/medium `true`, `pixtral` still `true` | — |
+| G1 | registry guard | built-in registry | `find("mistral").protocol == ProviderProtocol::Mistral` |
+
+**Live smoke tests (`-- --ignored`, need `MISTRAL_API_KEY`):**
+
+These follow the repo's standard Live tier (`#[ignore]` Rust tests on
+`LiveTestHarness`), not a bespoke script — see `tests/support/LIVE_TESTING.md`.
+
+1. **Acceptance:** `tests/e2e_live_mistral_reasoning.rs::mistral_reasoning_round_trips`
+   — drives the real agent loop with Mistral + reasoning on; asserts a non-empty
+   reply with no `ApiResponse`/parse-failure signature (the original bug). The
+   harness resolves config from env, so select Mistral via
+   `LLM_BACKEND=mistral`; it builds with `with_no_trace_recording()` so the default
+   `cargo test` matrix skips it cleanly. (Replaces the former
+   `scripts/test-mistral-reasoning-ironclaw.sh` bash harness.)
+2. **Raw-API control:** `scripts/test-mistral-reasoning.sh` already PASSes.
+3. **Multi-turn live:** `tests/e2e_live_mistral_reasoning.rs::mistral_reasoning_multi_turn_replays`
+   — ≥2-turn exchange, reasoning on; asserts turn 2 succeeds (no HTTP 400 when the
+   parsed thinking chunk is replayed).
+
+**Gate:** `cargo fmt`, `cargo clippy --all --benches --tests --examples --all-features`
+(zero warnings), `cargo test`.
+
+## Rule-compliance review findings
+
+This architecture was reviewed against six `.claude/rules` (2026-06-24). Verdicts:
+doc-hygiene ✅ clean; architecture ✅ compliant-with-guardrails; error-handling,
+types, testing, safety ⚠️ concerns — all now folded into the decisions above. The
+table records each finding and whether it is **settled at architecture level**
+(decided here, code just implements it) or **deferred to code** (a constraint the
+implementation must honor, not resolvable in a design doc).
+
+| # | Rule | Finding | Resolution | State |
+|---|---|---|---|---|
+| F1 | safety | Reasoning trace stored + replayed to LLM but not leak-scanned | Decision 7 — scan via `LeakDetector` at shared response stage | Settled (design); impl deferred |
+| F2 | types | `providers.json` overlay still pins `open_ai_completions` → silent broken path | Decision 9 + overlay-migration component + test C12 | Settled |
+| F3 | types / arch | Toggle modeled as `bool` | Decision 3 — `MistralReasoningEffort { High, None }` as `Option` | Settled |
+| F4 | types | String/array content + chunk union parsed by ad-hoc `type` matching | Decision 8 — untagged + tagged serde enums; fail loud on unknown | Settled |
+| F5 | error-handling | Decision 6 under-specified; `Json` vs `InvalidResponse` class trap | Decision 6 — full mapping table; never bare `Json`, never `map_err(|_|)` | Settled |
+| F6 | error-handling | Thinking extraction could `unwrap_or_default()` → drops answer + turn-2 400 | Decision 7 — fail loud, never default to `""` | Settled |
+| F7 | error-handling | Persist-then-reload hazard for the toggle | Decision 5 — startup-env-only, not hot-reloadable | Settled |
+| F8 | testing | Helper-only tests insufficient; over-reliance on live script | Offline matrix C1–C12 + U1/U2/G1; live tests demoted to smoke | Settled (matrix); impl deferred |
+| F9 | architecture | `mistral.rs` may exceed file-size budget; risk of 4th wire-shaping copy | Decision 10 — `<800` target, reuse shared seams | Settled (constraint); impl deferred |
+| F10 | safety | Mistral endpoint must be pinned/validated; no user base-URL override | Impl constraint — hardcode `https://api.mistral.ai`, no override knob | Deferred to code |
+| F11 | safety | `MISTRAL_API_KEY` as `SecretString`; never log `Authorization` header | Impl constraint — `SecretString`, `expose_secret()` only at header build | Deferred to code |
+| F12 | doc-hygiene | Future `.env.example` / `llm-providers.md` edits must avoid `op://` ref + abs paths | Impl constraint — placeholder values only; grep before merge | Deferred to code |
+
+**What this leaves for the code-level pass:** F10–F12 are constraints that can only
+be verified against real code, plus the mechanical implementation of every
+"settled" item. No open architecture-level questions remain.
+
+## Reborn architecture (follow-up)
+
+**Status:** Scoped, **unstarted**. **Date:** 2026-06-24. **Scope:** Reborn stack
+only (`ironclaw-reborn` binary); engine v2 deliberately excluded (see Out of
+scope). The code-level work units live in the impl doc (WU8–WU10).
+
+The everything-above design targeted v1. Reborn (`crates/ironclaw_reborn/` and
+the `ironclaw_reborn_*` family, separate `ironclaw-reborn` binary) is a distinct
+execution stack with its own loop and model gateway. Because Reborn is intended
+to replace both v1 and engine v2, Mistral reasoning must work there too. An
+investigation found Reborn is **much closer to working than engine v2** — most of
+the machinery is already present; only two small gaps and one UI surface remain.
+
+### Reused — already present in Reborn (do NOT rebuild)
+
+| Concern | Where it already works in Reborn |
+|---|---|
+| Custom Mistral provider reachable | `ironclaw_llm::build_static_provider_chain` → `build_provider_chain_components_with_options` → registry dispatch (`lib.rs` `ProviderProtocol::Mistral => create_mistral_from_registry(...)`). The v1 provider, shared `providers.json`, and overlay migration all apply unchanged. |
+| Reasoning round-trip (capture + replay) | `crates/ironclaw_reborn/src/model_gateway.rs` captures `response.reasoning` (`assistant_reply_with_reasoning`, `capability_calls_with_reasoning`, `response_reasoning` on tool-call refs) and replays it via `ChatMessage::…with_reasoning(...)` in `convert_messages` / `provider_tool_roundtrip_messages`. Satisfies Mistral's multi-turn ThinkChunk-replay requirement (else turn-2 HTTP 400). |
+| Reasoning persistence | The store already carries it: `response_reasoning` + `reasoning` on `crates/ironclaw_turns/src/run_profile/host.rs` and `crates/ironclaw_threads/src/tool_result_reference.rs` (validated, 4096-char cap). No persistence work needed. |
+| Typed effort enum, model-gating, `LeakDetector::redact_all` | All landed in the v1 work (`MistralReasoningEffort`, `supports_mistral_reasoning`, `redact_all`). |
+
+### Gaps (the only Reborn-specific work)
+
+1. **Reasoning is never enabled on the Reborn config path.** Reborn resolves LLM
+   config via `llm_catalog::resolve_against_registry` →
+   `ironclaw_llm::build_llm_config_from_resolved_provider` (`resolution.rs`),
+   which assigns the resolved `RegistryProviderConfig` straight through and does
+   **not** call `apply_registry_provider_env`. The v1 default-on logic lives only
+   in `apply_registry_provider_env` (the env path). So
+   `RegistryProviderConfig.mistral_reasoning` stays at its `::generic` default of
+   `Option::None` → `reasoning_effort` is omitted → no reasoning, ever. **This is
+   why Mistral reasoning silently does nothing in Reborn today.**
+2. **Reborn bypasses the v1 reasoning leak-scan.** The v1 redaction lives in the
+   crate `Reasoning` engine (`reasoning.rs::respond_with_tools`), which Reborn
+   does not use; `model_gateway.rs` captures `response.reasoning` raw.
+
+### Decisions (Reborn follow-up)
+
+- **R1 — Toggle is a Reborn-native catalog field, not an env var.** Per the user,
+  add `reasoning_effort: Option<MistralReasoningEffort>` to `ProviderDefinition`
+  (`registry.rs`), default `"high"` on the built-in `mistral` entry in
+  `providers.json`, and apply it in `resolution.rs::resolve_provider_definition`
+  at the `RegistryProviderConfig::generic(...)` builder. This single injection
+  point feeds both the Reborn catalog path and the v1 selection/onboarding path;
+  the provider's `supports_mistral_reasoning` model-gate still auto-omits the
+  param for non-small/medium models. The v1 primary-chain env path
+  (`apply_registry_provider_env`) is unchanged and must remain authoritative
+  there (catalog = default, env = override) — verify no double-apply flips an
+  explicit `MISTRAL_REASONING=off`.
+- **R2 — Leak-scan at the Reborn chokepoint.** Route `response.reasoning` through
+  `LeakDetector::redact_all` in `model_gateway.rs` before it lands on
+  `HostManagedModelResponse` (so the redacted form is persisted + replayed).
+  Fail-soft. Also covers other reasoning-emitting providers on that gateway.
+- **R3 — Surface the toggle in the Reborn WebUI v2 LLM settings.** Per the user,
+  expose it as one more per-provider field on the **existing** LLM-provider-config
+  feature (no new endpoint). The crucial enabler: the WebUI per-provider overlay
+  is itself a `ProviderDefinition` persisted to
+  `$IRONCLAW_REBORN_HOME/providers.json` (via `ProviderRepo::upsert_async` /
+  `build_overlay_definition`), so the UI edits the *same* `reasoning_effort` field
+  R1 adds — one field, one storage shape, one resolution path. Add it to the port
+  DTOs (`UpsertLlmProviderRequest` / `LlmProviderView` in
+  `ironclaw_product_workflow`), thread it through
+  `llm_config_service.rs` (`upsert_provider` / `build_overlay_definition` /
+  `build_snapshot`) and `RebornProviderMetadata` (`provider_admin.rs`), and add a
+  Mistral-adapter-gated select in the `settings` frontend
+  (`useProviderDialogForm.js`, `provider-dialog.js`, `useLlmProviders.js`).
+  Backend stays generic; the value is ignored for non-Mistral providers.
+
+### Out of scope (Reborn follow-up)
+
+- **Engine v2** — see the top-level Out of scope; not pursued.
+- Streaming reasoning in the Reborn WebUI (round-trip + final answer is the goal).
+
+## CTR-1 — Cross-turn reasoning replay defect (found post-ship, 2026-06-25)
+
+**Status:** Open defect · **architecture pass needed** (run this before the impl
+pass). **Scope:** v1 agent loop's turn persistence + context rebuild; verify the
+Reborn path too. The implementation work units live in the companion impl doc's
+**"CTR-1 — Cross-turn reasoning replay"** section.
+
+### The defect
+
+Mistral's reasoning docs
+([docs.mistral.ai/en/studio-api/conversations/reasoning](https://docs.mistral.ai/en/studio-api/conversations/reasoning))
+are emphatic: on every subsequent turn you must **append the full assistant message —
+including its `ThinkChunk` — back into history**, and must **not** rebuild the message
+from the answer text alone, or multi-turn quality degrades. Mistral's own Python SDK
+example states it inline:
+
+```python
+for user_text in ["What is 17 * 23?", "Now multiply that by 3."]:
+    messages.append(UserMessage(content=user_text))
+    response = client.chat.complete(
+        model="mistral-medium-3-5", messages=messages, reasoning_effort="high",
+    )
+    assistant_message = response.choices[0].message
+    # ... extract TextChunk for display only ...
+
+    # IMPORTANT: append the full assistant message to history.
+    # This preserves ThinkChunk so the model can see its own
+    # reasoning trace in subsequent turns.
+    # Do NOT rebuild the message with only the answer text.
+    messages.append(assistant_message)
+```
+
+The v1 implementation honours this **only within a single agentic turn's tool loop**
+and **drops it on every new user turn** (and after DB hydration). This doc's
+"Reused — do NOT rebuild" claim (the `ChatMessage.reasoning` round-trip "satisfies
+Mistral's multi-turn requirement … with no agent-loop change") holds **within one
+turn's tool loop** but is **false across user turns** — the agent loop *does* need a
+change after all.
+
+### Where it works vs. breaks
+
+| Path | Site | Replays ThinkChunk? |
+|---|---|---|
+| Provider serialization | `crates/ironclaw_llm/src/mistral.rs:515` (`chat_message_to_wire`) | ✅ yes (test C8) |
+| Within-turn tool loop | `src/agent/dispatcher.rs:863`; `src/worker/job.rs:1770`; `src/worker/container.rs:549` (push `.with_reasoning(...)` onto `reason_ctx.messages`) | ✅ yes |
+| **New user-turn context build** | `src/agent/session.rs:587` (`ChatMessage::assistant(response)`) and `:562` (`assistant_with_tool_calls(None, …)`) — no `.with_reasoning(...)` | ❌ **dropped** |
+| **DB hydration** | `src/agent/thread_ops.rs:3047` / `:3098` (`rebuild_chat_messages_from_db`) — no `.with_reasoning(...)` | ❌ **dropped** |
+
+`Thread::messages()` (`src/agent/session.rs:518-591`) is the builder that seeds every
+new turn's context (confirmed at `thread_ops.rs:750`), so the `:562`/`:587` omissions
+are the live break.
+
+Root cause beneath the rebuild sites: the `Turn` struct (`src/agent/session.rs:716`)
+has **no field for the raw reasoning trace**. It stores `response` and `narrative`
+(the cleaned, channel-facing narrative — *not* the ThinkChunk). The trace is never
+persisted, so `Thread::messages()` has nothing to re-attach even if it tried, and it
+cannot survive a restart — which also conflicts with CLAUDE.md's "LLM data is never
+deleted."
+
+### Target architecture (C4 L3 — components)
+
+CTR-1 adds **no new component**. It threads a reasoning value that is already
+captured and redacted through two stages that currently drop it — **turn
+persistence** and **context rebuild** — by giving `Turn` and the persisted message
+record a first-class field and re-attaching it at the single context-build
+gateway. The provider serialization, the redaction chokepoint, and the
+`ChatMessage.reasoning` channel are all reused unchanged.
+
+```
+[ provider response ]  CompletionResponse.reasoning            (UNCHANGED capture)
+        │  redacted once at reasoning.rs:841 (LeakDetector — REUSED)
+        ▼
+[ RespondResult ]  ToolCalls{reasoning}  +  (NEW) reasoning on the Text path (CTR-D5)
+        │
+        ▼
+[ Turn ]  src/agent/session.rs:716  — NEW reasoning: Option<String>   (first-class
+        │                              turn data, not transient reason_ctx)
+        │  persist (flat, redacted) on the assistant / tool_calls row
+        ▼
+┌───────────────────────────────────────────────────────────────────┐
+│  Dual-backend persistence  (NEW column, both backends — CTR-D1/D6) │
+│   conversation_messages.reasoning TEXT   (PG V31 · libSQL incr v26)│
+│   ConversationMessage.reasoning: Option<String>                    │
+│   Store::add_conversation_message(… , reasoning)  write + read     │
+└───────────────────────────────────────────────────────────────────┘
+        │  hydrate
+        ▼
+[ SINGLE context-build gateway ]                       (NEW .with_reasoning — CTR-D2)
+  • Thread::messages()             session.rs:562 / :587
+  • rebuild_chat_messages_from_db  thread_ops.rs:3047 / :3098
+        │  ChatMessage.reasoning (flat Option<String>)             (REUSED channel)
+        ▼
+[ provider serialize ]  mistral.rs:515 re-wraps flat → nested ThinkChunk (UNCHANGED)
+  DeepSeek/Gemini/OpenRouter read it via rig_adapter.rs:406–462   (REQUIRED, not inert)
+```
+
+### Components touched
+
+| Component | File | Change |
+|---|---|---|
+| `Turn` struct | `src/agent/session.rs:716` | Add `reasoning: Option<String>` — first-class turn data (today it has only `response` + `narrative`; `narrative` is the cleaned channel-facing text, **not** the ThinkChunk). |
+| `RespondResult` | `crates/ironclaw_llm/src/reasoning.rs:444` | The `Text` variant carries **no** reasoning today; give it a reasoning channel so pure-text turns persist their trace (CTR-D5). |
+| `ConversationMessage` | `crates/ironclaw_reborn_traces/src/conversation_message.rs` | Add `reasoning: Option<String>` (today: `id/role/content/created_at`). Mirrors Reborn's typed field (CTR-D1). |
+| Persist write | `src/agent/thread_ops.rs` (`persist_assistant_response ~1246`, `persist_tool_calls ~1490`) | Write the redacted flat trace onto the `assistant` / `tool_calls` row. A turn is persisted as **three** rows, so this rides the existing write path. |
+| Store / DB trait | `src/history/store.rs` + `src/db/postgres.rs` + `src/db/libsql/conversations.rs` | `add_conversation_message(conv, role, content)` has no reasoning param today — thread it through (param or sibling method) on **both** backends, write + read. |
+| Schema (PostgreSQL) | `migrations/V32__conversation_messages_reasoning.sql` | `ALTER TABLE conversation_messages ADD COLUMN reasoning TEXT;` (verify next free version vs `origin/staging`). |
+| Schema (libSQL) | `src/db/libsql_migrations.rs` | Incremental `v26` `ADD COLUMN reasoning TEXT` + `IDEMPOTENT_ADD_COLUMN_MIGRATIONS` marker `(26,"conversation_messages","reasoning")` (the `source_channel`/V15 precedent). |
+| Context-build gateway | `src/agent/session.rs:562/:587` **and** `src/agent/thread_ops.rs:3047/:3098` | `.with_reasoning(...)` the rebuilt assistant message at **both** sites; treat as one gateway — no third copy (`architecture.md` smell #4). |
+| Reborn parity | `crates/ironclaw_reborn/src/model_gateway.rs`, `ironclaw_turns`, `ironclaw_threads` | Verify cross-turn (not just within-loop) carry + persistence; keep the field shape identical (CTR-D7). |
+
+### Reused — do NOT rebuild
+
+- **Redaction chokepoint** — `reasoning.rs:841` `redact_reasoning(...)` already runs
+  `LeakDetector::redact_all` on every within-turn response. The persisted copy
+  **must be the already-redacted one** (Decision 7's pre-persistence rule); do not
+  add a second scan.
+- **Flat `Option<String>` channel** — `ChatMessage.reasoning` + `.with_reasoning(...)`
+  and `mistral.rs`'s flat↔nested conversion are unchanged. CTR-1 persists/replays
+  the same flat shape DeepSeek/Gemini/OpenRouter already round-trip.
+- **Dual-backend column-add pattern** — follow the `source_channel` precedent
+  (`V15` + libSQL idempotent marker); `TEXT → TEXT`, no type negotiation.
+
+### Key architectural decisions
+
+- **CTR-D1 — First-class typed field, dual-backend (chosen to match Reborn).**
+  Persist a typed `reasoning: Option<String>` on the message record + a
+  `reasoning TEXT` column on both backends. This shape was selected **to match
+  Reborn as closely as possible**: Reborn already carries reasoning as dedicated
+  typed `response_reasoning` / `reasoning` fields on its records
+  (`crates/ironclaw_threads/src/tool_result_reference.rs`,
+  `crates/ironclaw_turns/src/run_profile/host.rs`, validated 4096-char cap) — a
+  typed field, **not** a key embedded in a free-form content blob. Since Reborn is
+  intended to replace v1, keeping the same field shape means WU-CTR4 becomes a
+  parity check, not a reconciliation. **Rejected:** JSON-embed in `content` (the
+  `narrative` precedent) — it diverges from Reborn, leaves reasoning
+  non-queryable, and would force the plain `assistant` row into a JSON envelope it
+  is not today. ADD only, never drop ("LLM data is never deleted").
+- **CTR-D2 — Single re-attachment gateway.** `Thread::messages()` and its
+  hydration twin `rebuild_chat_messages_from_db()` are the two converging "rebuild
+  assistant history" sites; both `.with_reasoning(...)` the reconstructed assistant
+  message. Treat them as one gateway — no third copy (`architecture.md` smell #4).
+- **CTR-D3 — Persist the redacted, normalized flat string.** Mistral reasoning is
+  **nested** on the wire — `content = [ThinkChunk{type:"thinking",
+  thinking:[TextChunk,…]}, TextChunk{type:"text"}]`, unlike DeepSeek's flat
+  top-level `reasoning_content`. The cross-provider channel
+  (`ChatMessage.reasoning` and the new persisted field) is a **flat
+  `Option<String>`**; `mistral.rs` is the **sole owner** of both directions
+  (`extract_content` joins `thinking[]` → String; `chat_message_to_wire:515`
+  re-wraps String → nested array). CTR-1 persists the **flat normalized string**,
+  never the raw nested JSON. The flatten concatenates the `thinking[]` segmentation
+  (lossless for the text, normalizes chunk boundaries) — an explicit, accepted
+  boundary.
+- **CTR-D4 — Cross-provider replay is load-bearing, and CTR-1's fix is generic.**
+  (Corrects the earlier "inert on their request side" claim.) `rig_adapter.rs:406–462`
+  **reads** `msg.reasoning` and forwards it to rig-core as `AssistantContent::Reasoning`;
+  DeepSeek/Gemini/OpenRouter **require** the echo (HTTP 400 if dropped — #3201/#3225).
+  Re-attaching reasoning on rebuilt history is therefore **required, not inert**, and
+  CTR-1 closes the *same* latent cross-turn drop for those providers via the shared
+  `ChatMessage.reasoning` channel — it is **not Mistral-specific**. Providers that
+  ignore the field (OpenAI/Anthropic via rig-core) are unaffected; verify no regression.
+- **CTR-D5 — Capture text-turn reasoning.** `RespondResult::Text(String)` has no
+  reasoning field — only `ToolCalls { …, reasoning }` does. A pure-text turn (the
+  most common shape, no tools) therefore has nowhere to read the trace from.
+  Specify the channel: **recommend extending `Text` to carry
+  `reasoning: Option<String>`**, mirroring `ToolCalls`, so the redaction at
+  `reasoning.rs:841` and the persist path apply uniformly.
+- **CTR-D6 — Migration discipline (dual-backend rule).** Number the PostgreSQL
+  migration after the highest version on `origin/staging`; add the libSQL
+  incremental + idempotent marker; check all three feature combos (`cargo check`,
+  `--no-default-features --features libsql`, `--all-features`). See `src/db/CLAUDE.md`.
+- **CTR-D7 — Reborn parity is a check, not a rebuild.** Keep the v1 persisted field
+  shape identical to Reborn's typed field so the Reborn cross-turn verification
+  (WU-CTR4) confirms carry/persistence rather than reconciling two shapes.
+
+### Verification matrix (CTR-C1…CTR-C8)
+
+Offline-first, mirroring the main section's matrix. The live test is a smoke
+layer, not the primary net.
+
+| # | Driver | Assert |
+|---|---|---|
+| CTR-C1 | dual-backend persistence round-trip (`--features integration`) | write a turn with reasoning → reload → field intact on **PostgreSQL and libSQL**. |
+| CTR-C2 | caller-level `Thread::messages()` | rebuilt assistant `ChatMessage` carries `reasoning`. |
+| CTR-C3 | caller-level `rebuild_chat_messages_from_db()` | same, after DB hydration. |
+| CTR-C4 | pure-text turn (no tools) | text-turn reasoning is persisted and replayed (exercises CTR-D5). |
+| CTR-C5 | turn-2 request body (mock server / trace capture) | request contains a `thinking` chunk for the prior assistant message — "no 400" is **not** evidence of replay. |
+| CTR-C6 | non-Mistral providers (DeepSeek/Gemini) | reattached `reasoning` is forwarded (load-bearing, CTR-D4); agnostic providers unaffected. |
+| CTR-C7 | redaction (CTR-D3) | planted secret in a `thinking` chunk is redacted in the **persisted** row **and** the **replayed** prompt. |
+| CTR-C8 | Reborn cross-turn (CTR-D7) | `model_gateway.rs` carries + persists reasoning across user turns. |
+
+### Verification gap to close
+
+The live `mistral_reasoning_multi_turn_replays` test
+(`tests/e2e_live_mistral_reasoning.rs:176`) passes **without proving replay**: it only
+asserts turn-2 is non-empty and free of failure markers, and its `REASONING_PROMPT`
+uses no tools, so the within-turn replay branch never fires. Dropping the ThinkChunk
+yields a valid plain-string assistant message Mistral accepts (no 400), so the test is
+green on the degraded path. CTR-1 must add a **request-body assertion** (mock server or
+trace capture) that the turn-2 request actually contains a `thinking` chunk for the
+prior assistant message — "no 400" is not evidence of replay. This is **CTR-C5** in the
+verification matrix above.
+
+## SIG-1 — ThinkChunk `signature` replay (found 2026-06-27)
+
+**Status:** Architecture assessed · **impl deferred to a separate plan** (do not
+implement from this section alone). **Date:** 2026-06-27. **Scope:** the custom
+Mistral provider's reasoning capture/replay + the same CTR-1 persistence path it
+rides. Reborn parity is a check, not a rebuild (the precedent already exists there).
+
+### The finding
+
+Mistral's API returns a `signature` string on every `ThinkChunk` (reasoning block).
+Mistral's own Python SDK documents it verbatim — *"Signature to replay some
+reasoning blocks across turns"* — and types it `OptionalNullable[str]` (optional +
+nullable). It is the analogue of Anthropic's thinking `signature` and Gemini's
+`thought_signature`: an **opaque server-side continuity token** the provider
+expects echoed back so it can verify/trust a replayed reasoning block.
+
+The custom provider **drops it on both sides**:
+
+| Side | Site | Behavior |
+|---|---|---|
+| Capture | `crates/ironclaw_llm/src/mistral.rs` `MistralContentChunk::Thinking { thinking: Vec<MistralTextChunk> }` | No `signature` field and no `deny_unknown_fields` → the incoming `signature` is **silently discarded** on deserialize. `extract_content` flattens only the thinking text into `reasoning: Option<String>` and never sees it. |
+| Replay | `mistral.rs` `chat_message_to_wire` | Reconstructs a thinking chunk from the flat reasoning string with **no signature** — the "rebuild the message from the answer text" anti-pattern Mistral warns against, at the chunk level. |
+
+This **completes CTR-1's stated goal.** CTR-1 set out to replay the *full*
+ThinkChunk across turns; the signature is the missing piece of "full." The current
+code replays a signature-less, text-flattened approximation.
+
+**Empirical caveat (shapes the recommendation).** The live multi-turn test passes
+today — Mistral currently accepts signature-less replay (no HTTP 400). So this is a
+**fidelity / forward-insurance** gap, not a live defect. The docstring's word
+*"some"* implies selective future enforcement, and the CTR-1 "verification gap to
+close" above means we have **no positive evidence** that signature-less replay
+preserves reasoning quality (the multi-turn test uses no tools and only checks
+"non-empty + no 400").
+
+### Target architecture (C4 L3 — components)
+
+Carry the signature as a **typed sibling `reasoning_signature: Option<String>`**
+(NOT folded into the `reasoning` string), threaded through the same channel CTR-1
+established. SIG-1 adds **no new component** — it mirrors the `reasoning` field one
+layer at a time.
+
+```
+[ Mistral wire ]  content[i] = ThinkChunk{ thinking:[…], signature:"…" }   (NEW: capture signature)
+        │  mistral.rs extract_content → (content, reasoning, reasoning_signature)
+        ▼
+[ CompletionResponse / ToolCompletionResponse ]  + reasoning_signature      (NEW sibling of .reasoning)
+        │  redacted: reasoning only — signature is leak-scan-EXEMPT (SIG-D2)
+        ▼
+[ ChatMessage ]  + reasoning_signature   .with_reasoning_signature(…)       (NEW sibling channel)
+        ▼
+[ Turn ]  + reasoning_signature + tool_call_reasoning_signature             (first-class turn data, CTR-1 mirror)
+        │  persist (flat, uncapped — mirrors the uncapped v1 reasoning text; see SIG-D2)
+        ▼
+┌───────────────────────────────────────────────────────────────────┐
+│  Dual-backend persistence  (NEW column, both backends)            │
+│   conversation_messages.reasoning_signature TEXT (PG V3x · libSQL) │
+│   ConversationMessage.reasoning_signature: Option<String>          │
+└───────────────────────────────────────────────────────────────────┘
+        │  hydrate
+        ▼
+[ SINGLE context-build gateway ]  .with_reasoning_signature(…) at the CTR-1 sites
+        ▼
+[ provider serialize ]  mistral.rs chat_message_to_wire re-emits signature on the rebuilt ThinkChunk
+  Non-Mistral providers: field stays None, inert (rig path replays via the reasoning string)
+```
+
+#### Components touched
+
+| Layer | File (repo-relative) | Change (described, not coded) |
+|---|---|---|
+| Wire deserialize | `crates/ironclaw_llm/src/mistral.rs` (`MistralContentChunk::Thinking`) | Add `#[serde(default, skip_serializing_if = "Option::is_none")] signature: Option<String>`; stay lenient (no `deny_unknown_fields`). Signature is on the **ThinkChunk**, not the inner `MistralTextChunk`. |
+| Wire parse | `mistral.rs` (`extract_content`) | Return the signature as a third value (answer, reasoning, reasoning_signature); first-non-null on multi-chunk (SIG-D4). |
+| Wire serialize / replay | `mistral.rs` (`chat_message_to_wire`) | Emit the captured signature on the rebuilt `Thinking` chunk. |
+| v1 channel | `crates/ironclaw_llm/src/provider.rs` | Add `reasoning_signature` to `ChatMessage`, `CompletionResponse`, `ToolCompletionResponse`; add a `with_reasoning_signature` setter. |
+| Provider construction sites | `crates/ironclaw_llm/src/rig_adapter.rs`, `nearai_chat.rs`, `bedrock.rs`, testing stubs, … | Compile-driven `reasoning_signature: None`. **Mistral-only; inert elsewhere** — the rig path replays via the reasoning string, and Gemini already smuggles its token inside that string. |
+| Turn + persist snapshot | `src/agent/session.rs` (`Turn`, `TurnPersistSnapshot`), `src/agent/dispatcher.rs`, `src/agent/thread_ops.rs` | Add `reasoning_signature` + `tool_call_reasoning_signature`, **named** (not positional) snapshot slots; set from the same source/guard as `reasoning`; re-attach on hydration at the CTR-1 gateway sites. |
+| ConversationMessage | `crates/ironclaw_reborn_traces/src/conversation_message.rs` | Add `reasoning_signature: Option<String>`. |
+| Store / DB trait + both backends | `src/db/mod.rs`, `src/history/store.rs`, `src/db/postgres.rs`, `src/db/libsql/conversations.rs` | Thread the column through write + read on **both** PostgreSQL and libSQL. |
+| Schema (dual-backend) | `migrations/V3x__conversation_messages_reasoning_signature.sql` + `src/db/libsql_migrations.rs` (base schema + incremental + `IDEMPOTENT_ADD_COLUMN_MIGRATIONS` marker) | `ADD COLUMN reasoning_signature TEXT;` — follow the CTR-1 `V32` / libSQL `v26` precedent; verify the next free PG version vs `origin/staging`. |
+| Reborn parity | `crates/ironclaw_reborn/src/model_gateway.rs`, `ironclaw_turns`, `ironclaw_threads` | **Check, not rebuild** — the typed `signature: Option<String>` field already exists on the Reborn tool-call records; verify the Mistral message-level signature lands there too. |
+
+### Reused — do NOT rebuild
+
+- **The CTR-1 plumbing** — field-threading path, named `TurnPersistSnapshot`,
+  dual-slot dispatcher handling (`reasoning` vs `tool_call_reasoning`), and the
+  dual-backend column-add pattern. `reasoning_signature` is a **mechanical mirror**
+  of `reasoning`, not net-new architecture.
+- **The Reborn `signature` precedent** — `ProviderToolCall` /
+  `ProviderToolCallReplay` / `ProviderToolCallReference`
+  (`crates/ironclaw_turns/src/run_profile/host.rs`) and
+  `ProviderToolCallReferenceEnvelope`
+  (`crates/ironclaw_threads/src/tool_result_reference.rs`) already carry
+  `signature: Option<String>` ("Opaque provider thought-signature metadata, not an
+  IronClaw auth signature", length-validated in that layer). Adopt its exact field
+  shape (typed `Option<String>`, leak-scan-exempt) — but **not** its length
+  validation on the v1 `ReasoningBlock`/`ChatMessage` path, which deliberately
+  stays uncapped to mirror the uncapped v1 reasoning text (see SIG-D2).
+
+### Key architectural decisions
+
+- **SIG-D1 — Name it `reasoning_signature`, not `signature`.** Avoids collision
+  with the existing per-tool-call `ToolCall.signature` (set to `None` in
+  `mistral.rs`; Reborn `host.rs`). Reads as "signature of the reasoning block,"
+  parallel to how `reasoning` is the reasoning text.
+- **SIG-D2 — leak-scan-EXEMPT, but dropped when the trace it signs is redacted.**
+  The signature is an opaque token, not model prose. Routing it through
+  `redact_reasoning` / `LeakDetector::redact_all` could match-and-replace bytes
+  inside it → silent corruption → turn-2 400 or an ignored block. So the
+  signature is **never concatenated into the `reasoning` string** and is **not**
+  itself leak-scanned. **Update (finding #2):** the signature is a continuity
+  token the provider issued for *those exact reasoning bytes*. When the trace's
+  own leak-scan actually alters the trace, the signature no longer matches the
+  replayed block, so it is **dropped** — a signature-less replay is safe, whereas
+  a signature that disagrees with its block can be rejected as tampered. A clean
+  (unaltered) trace keeps its signature verbatim.
+
+  **Structure (refactor):** the trace and signature are bundled into one
+  `ReasoningBlock { text, signature }` value object rather than threaded as two
+  parallel `Option<String>` siblings. The asymmetry above lives in exactly one
+  place — `ReasoningBlock::redacted` — and the persistence/wire edges flatten the
+  block back to two columns/fields.
+
+  **Length cap — resolved doc-only (uncapped on v1 by design, 2026-06-28).** An
+  earlier draft of this section directed that the replayed signature be
+  "length-capped (4096)," reusing the Reborn precedent. The shipped v1 code does
+  not cap it: on the `ReasoningBlock`/`ChatMessage` path the signature is only
+  filtered for emptiness (`provider.rs` `with_reasoning`, `mistral.rs`
+  `extract_content`/`chat_message_to_wire`) and stored unbounded in `TEXT`. This
+  is **intentional and consistent**, not a regression: the sibling `reasoning`
+  *text* field is likewise uncapped on this v1 path. The 4096-byte validation
+  exists **only** in the Reborn typed-envelope layer
+  (`crates/ironclaw_threads/src/tool_result_reference.rs:145`,
+  `validate_optional_provider_text`, which *rejects* rather than truncates) — it
+  was never on the v1 path for either the reasoning text or the signature. The
+  cited "4096" is itself stale: the canonical
+  `ironclaw_safety::PROVIDER_METADATA_TEXT_MAX_BYTES` was raised to **16384** ("4
+  KiB truncated legitimate reasoning… forced retries"), and only the older
+  `tool_result_reference.rs` still hardcodes 4096 — so "reuse the 4096 precedent"
+  was not a clean target. The residual exposure (an opaque token replayed
+  verbatim and stored unbounded) is a small storage / echo-amplification surface,
+  **accepted** here for parity with the uncapped v1 reasoning text. If a cap is
+  ever wanted, the contained fix is to **drop** (not truncate, not reject) an
+  over-length signature inside `ReasoningBlock` using the `ironclaw_safety` 16384
+  constant — a signature-less replay is safe per this decision's own
+  drop-on-redaction logic.
+- **SIG-D3 — Stay lenient serde; do NOT add `deny_unknown_fields`.** Add as
+  `#[serde(default)] Option<String>` so old/new Mistral payloads and any future
+  ThinkChunk fields keep deserializing. The existing loud-failure is on an unknown
+  chunk `type`, not on unknown fields *within* a chunk — keep it that way.
+- **SIG-D4 — One signature per message (accepted flatten boundary).** The channel
+  is flat `Option<String>` by CTR-1 design (CTR-D3); a single slot carries one
+  signature. Non-streaming Mistral chat returns one thinking block per message
+  (multi-chunk is the streaming-delta shape this provider does not use — "no
+  streaming support"), so take the **first non-null** signature deterministically
+  and document the single-block assumption in `extract_content`. A truly lossless
+  `Vec<{ text, signature }>` shape would require re-architecting the flat channel
+  end-to-end — **out of scope**.
+- **SIG-D5 — Increment analysis: full is the only non-asymmetric design.**
+  - *Capture-only* (parse + persist, no replay) is ≈95% of the cost for a
+    stored-but-never-read column → **dead data; rejected.**
+  - *Within-turn replay only* (carry on `ChatMessage`/`CompletionResponse`, stop
+    before `Turn`/DB) → a **live-vs-hydrated divergence** (an in-memory thread
+    replays the signature; the same thread reloaded from DB does not) → the
+    `architecture.md` "one divergent path is where the bug lives" smell →
+    **rejected.**
+  - **Full lossless** (capture + cross-turn replay + dual-backend persistence) is
+    the recommended target — the only increment with no asymmetry.
+
+### Pre-impl verification gate (SIG-G0)
+
+Because signature-less replay works today and the benefit is **unproven**, the
+architecture recommends a **verify-first spike before committing the full
+plumbing**: a controlled live A/B (multi-turn reasoning task, turn-2 request WITH
+the replayed signature vs WITHOUT) measuring whether Mistral's behavior/quality
+actually changes. If it measurably matters → build the full design. If not → the
+design stays documented as forward-insurance, and the cheap lenient-serde capture
+(SIG-D3) can be taken opportunistically. **This gate is the entry point for the
+separate impl plan.**
+
+### Verification matrix (SIG-C1…) — for the future impl pass
+
+Offline-first, mirroring the CTR-1 matrix; live = smoke.
+
+| # | Driver | Assert |
+|---|---|---|
+| SIG-C1 | response parser | array fixture with a `signature` on the thinking chunk → `reasoning_signature` captured (not dropped). |
+| SIG-C2 | request body (mock / trace capture) | `chat_message_to_wire` emits the captured signature on the rebuilt thinking chunk — a request-body assertion, **not** "no 400". |
+| SIG-C3 | dual-backend round-trip (`--features integration`) | persist a turn with a signature → reload → `reasoning_signature` intact on **PostgreSQL and libSQL**. |
+| SIG-C4 | hydration | `rebuild_chat_messages_from_db` re-attaches the signature after DB load. |
+| SIG-C5 | leak-scan exemption (SIG-D2) | a signature containing redactor-trigger bytes rides a **clean** trace through `respond_with_tools` **unmodified** (not itself scanned). |
+| SIG-C5b | redaction-drop (SIG-D2, finding #2) | when the trace IS redacted, the now-stale signature is **dropped**. |
+| SIG-C6 | lenient serde (SIG-D3) | a thinking chunk carrying an extra unknown field still deserializes. |
+
+### Out of scope (SIG-1)
+
+- `Vec<{ text, signature }>` lossless channel re-architecture (SIG-D4).
+- rig-adapter forwarding for non-Mistral providers — the signature is Mistral-only
+  and inert elsewhere; the only cost there is mechanical `None` initializers.
+- **Engine v2** — already permanently out of scope in this doc.
+- The actual code/impl plan and any code/migration/test — a **separate** document.

--- a/docs/internal/plans/2026-07-05-mistral-reasoning-native-arch.md
+++ b/docs/internal/plans/2026-07-05-mistral-reasoning-native-arch.md
@@ -1,0 +1,340 @@
+# Mistral Reasoning — Native `reasoning_details` Architecture (C4 Level 3)
+
+> **Status:** Approved architecture (C4 L3, component level). Date 2026-07-05.
+> Scope: enable `reasoning_effort=high` for **Mistral Medium 3.5** and **Mistral Small 4**
+> on **IronClaw v1** (the path in use today) and Reborn. Tracks fork issue
+> [k-l-sorensen/ironclaw#8](https://github.com/k-l-sorensen/ironclaw/issues/8).
+>
+> **Supersedes** `docs/plans/2026-06-24-mistral-reasoning-provider-architecture.md` (the
+> retired custom-provider design). That doc is retained for its preserved analysis (decisions
+> D1–D10) and acceptance criteria; the parts it built on top of — `ReasoningBlock`, the CTR-1
+> cross-turn plumb, the SIG-1 signature threading (~35 files) — are **withdrawn**: upstream now
+> owns them. Companion research: `docs/providers/mistral-reasoning.md` (provider-agnostic API
+> findings, still valid).
+>
+> This document is **purely C4 Level 3** — components and the seams between them. It is not a
+> code-implementation plan; the code-level work-unit breakdown is a separate follow-up.
+
+---
+
+## 1. Context — why re-architect
+
+The goal (locked by the user): use Mistral **to the fullest → `reasoning_effort=high`**, since
+Mistral is the largest EU provider and should be a first-class, properly-supported path.
+
+**What changed since the retired design.** Upstream shipped a general, provider-agnostic
+reasoning pipeline that the fork's custom carry now duplicates. Present in-tree today:
+
+- `ReasoningDetail` enum — `crates/ironclaw_llm/src/provider.rs:78` —
+  `{ Text { text, signature }, Encrypted(String), Redacted { data }, Summary(String) }`,
+  serde-tagged (`#[serde(tag = "type", content = "content", rename_all = "snake_case")]`).
+- `ReasoningDetails { id, content: Vec<ReasoningDetail> }` — `provider.rs:95`; `from_text`,
+  `is_empty` (treats a signature-only `Text` as non-empty — preserves Gemini `thought_signature`),
+  `display_text`.
+- `ChatMessage.reasoning: Option<String>` (`:182`) + `ChatMessage.reasoning_details:
+  Option<ReasoningDetails>` (`:186`); builders `with_reasoning` (`:278`), `with_reasoning_details`
+  (`:292`, keeps the legacy string in sync while preserving opaque/signature blocks).
+- `ToolCompletionResponse.reasoning_details` — `provider.rs:606`.
+- Full bidirectional round-trip in `crates/ironclaw_llm/src/rig_adapter.rs`:
+  `iron_reasoning_to_rig` (`:615`), `rig_reasoning_to_iron` (`:640`), collected in
+  `extract_response` (`:689`), emitted in `convert_messages` (`:414`, `:456`).
+- Persistence, cross-turn replay, and per-block signatures ride this typed channel — so the
+  retired `ReasoningBlock`/CTR-1/SIG-1 carry is **no longer needed** (a per-block signature is
+  already `ReasoningDetail::Text.signature`).
+
+**The gap that remains (why any Mistral-specific component is still needed).** rig-core is now
+pinned at **0.33** (`crates/ironclaw_llm/Cargo.toml`), but neither rig path carries Mistral
+reasoning:
+
+1. **Generic `open_ai_completions`** (Mistral's current wiring) models `message.content` as a
+   `String`; Mistral's `reasoning_effort=high` response is an **array of typed chunks**, so it
+   fails to deserialize — `JsonError: did not match any variant of untagged enum ApiResponse`
+   (every turn fails, retried, then errors).
+2. **rig-core's dedicated Mistral client** (`providers/mistral/completion.rs`) also models
+   assistant `content` as a plain `String`, **silently drops** `AssistantContent::Reasoning` on
+   send, and **never parses** reasoning on receive. Switching Mistral to a rig-mistral protocol
+   does not rescue it. This spans the pinned **0.33 through current (0.39)** — see §5 for the
+   verified current-rig state (the earlier hard `panic!`/deserialize failure became a *silent
+   skip*: crash-avoidance, not support).
+
+**Conclusion.** IronClaw must own the Mistral request/response at the wire boundary — but only to
+*translate* Mistral's chunk array onto upstream's existing `reasoning_details` seam. One thin new
+component; everything downstream is inherited. (The medium-term option of moving that translation
+into rig-core itself is assessed in §5 — it does not change View A's shape, only its eventual
+retirement path.)
+
+---
+
+## 2. Mistral model catalog (which models support `reasoning_effort=high`)
+
+Verified 2026-07-05 against `docs.mistral.ai/studio-api/conversations/reasoning`, promptfoo, and
+OpenRouter.
+
+| Model | API id | Aliases | `reasoning_effort=high`? |
+|---|---|---|---|
+| **Mistral Medium 3.5** | `mistral-medium-2604` | `mistral-medium-latest`, `mistral-medium-3.5` | **Yes** — recommended for agentic/code |
+| **Mistral Small 4** | `mistral-small-2603` | `mistral-small-latest`, `magistral-small-latest` | **Yes** — hybrid model |
+| Mistral Large | `mistral-large-latest` | — | No |
+| tiny / nemo / 7b / embeddings | — | — | No |
+
+Key facts to honour in the design:
+
+- **`reasoning_effort` is boolean-ish: `"high"` | `"none"`** — *not* the OpenAI low/medium/high
+  scale. Model it as a two-variant enum, never a 3-level enum.
+- At `"high"`, `message.content` is a **chunk array**: a `ThinkChunk` (`type:"thinking"`, whose
+  `thinking` is itself a list of `TextChunk`) followed by a `TextChunk` (`type:"text"`, the final
+  answer). At `"none"`/omitted, `content` is a plain string.
+- The **thinking is a separate chunk from the message** — parsing must split them, and multi-turn
+  replay must send the whole `content` array (thinking chunk *and* message chunk) back.
+- Standalone **Magistral** reasoning models are **deprecated**; reasoning now rides the general
+  small/medium models. `magistral-small-latest` now aliases Mistral Small 4.
+- Recommended sampling at `high`: `temperature=0.7`, `top_p=0.95`.
+
+---
+
+## 3. C4 L3 — View A: v1 / shared `ironclaw_llm` crate (the path in use today)
+
+`ironclaw_llm` is shared by both the v1 monolith and Reborn, so this view delivers the provider
+for both. It adds **exactly one new component** and threads a typed reasoning-effort value from
+the binary's env layer to it; everything else is reused.
+
+### Component diagram
+
+```
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │ BINARY (env boundary)                                                      │
+  │   src/config/llm.rs  ──reads MISTRAL_REASONING (high|none, default high)── │
+  └───────────────┬──────────────────────────────────────────────────────────┘
+                  │ typed MistralReasoningEffort (High|None) via RegistryProviderConfig
+                  ▼
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │ crates/ironclaw_llm                                                        │
+  │                                                                            │
+  │   lib.rs factory dispatch                                                  │
+  │     match ProviderProtocol::Mistral → create_mistral_from_registry(...)    │
+  │                          │                                                 │
+  │                          ▼                                                 │
+  │   ┌─────────────────────────────────────────────┐   gate:                 │
+  │   │ NEW  MistralProvider  (src/mistral.rs)       │◄── reasoning_models.rs  │
+  │   │  impl LlmProvider (own reqwest + JSON model) │    supports_mistral_    │
+  │   │  • REQUEST: set reasoning_effort (gated)     │    reasoning(model)     │
+  │   │  • RESPONSE: parse array content →           │                         │
+  │   │      ThinkChunk → ReasoningDetail::Text{      │                         │
+  │   │                     text, signature}         │                         │
+  │   │      TextChunk  → content                    │                         │
+  │   │    (also handles plain-string content)       │                         │
+  │   │  • complete() AND complete_with_tools()      │                         │
+  │   │  • Mistral error body → LlmError (w/ cause)  │                         │
+  │   └───────────────────────┬─────────────────────┘                         │
+  │                           │ CompletionResponse / ToolCompletionResponse    │
+  │                           │   .with_reasoning_details(...)   ── REUSED ──   │
+  │                           ▼                                                 │
+  │   build_provider_chain()  (Retry → SmartRouting → Failover →               │
+  │                            CircuitBreaker → Cached → Swappable →           │
+  │                            Recording)                      ── UNCHANGED ──  │
+  └───────────────────────────┬──────────────────────────────────────────────┘
+                              │ ChatMessage.reasoning_details (round-tripped)
+                              ▼
+   Agent loop / Reasoning engine  +  SafetyLayer leak-scan before user  ── REUSED/UNCHANGED ──
+```
+
+Multi-turn replay uses the **existing** `rig_adapter.rs` round-trip: on the next turn the prior
+assistant `reasoning_details` is re-emitted as `AssistantContent::Reasoning`. The `MistralProvider`
+translates that back into Mistral's `content` array shape on the wire.
+
+### Components touched
+
+| # | Component | Location | Change |
+|---|---|---|---|
+| A1 | **`MistralProvider`** (new) | `crates/ironclaw_llm/src/mistral.rs` (new) | `impl LlmProvider`; own reqwest client + JSON model; request sets `reasoning_effort` gated to supported models and replays prior thinking from `reasoning_details`; response parses array `content` → splits `ThinkChunk`→`ReasoningDetail::Text{text,signature}` + `TextChunk`→`content`, also handles string content; `complete()` + `complete_with_tools()`; maps error bodies → `LlmError`. |
+| A2 | **Protocol enum** | `registry.rs` (`ProviderProtocol`, `:62`) | Add `Mistral` variant (`#[serde(rename_all="snake_case")]` → wire `mistral`); include in `has_dedicated_config()` (`:122`). |
+| A3 | **Factory dispatch** | `crates/ironclaw_llm/src/lib.rs` | Add `create_mistral_from_registry(...)`, mirroring `create_deepseek_from_registry` (`:628`) / `create_openrouter_from_registry` (`:682`) / `create_gemini_from_registry` (`:775`); wrap so it still flows through `build_provider_chain` (`:1187`). |
+| A4 | **Reasoning-model gate** | `crates/ironclaw_llm/src/reasoning_models.rs` | Add `supports_mistral_reasoning(model)` (pattern-match `mistral-small`/`mistral-medium`; exclude large/tiny/nemo), alongside `supports_openai_reasoning` (`:78`) etc. |
+| A5 | **Reasoning-effort type** | `crates/ironclaw_llm/src/mistral.rs` (or a small sibling module) | `enum MistralReasoningEffort { High, None }`, wire-stable (`#[serde(rename_all="snake_case")]`). Owned by `ironclaw_llm`; not `ironclaw_common`. |
+| A6 | **Provider schema** | `registry.rs` (`ProviderDefinition`, `:327`) | Add optional reasoning-effort field carrying `MistralReasoningEffort` (`#[serde(deny_unknown_fields)]` forbids stray keys, so the field must be declared). |
+| A7 | **Provider registry** | `providers.json` (Mistral entry, `:418-438`) | `protocol` `open_ai_completions` → `mistral`; `default_model` `mistral-large-latest` → `mistral-medium-latest` (Medium 3.5); default reasoning `high`. |
+| A8 | **Env boundary** | `src/config/llm.rs` | Read `MISTRAL_REASONING` (`high`\|`none`, default `high`) → typed `MistralReasoningEffort`. Env parsing stays in the binary; the crate stays env-agnostic. |
+| A9 | **Registry guard test** | `registry.rs` (`reasoning_aware_providers_use_dedicated_protocol_not_openai_compat`, `:818`) | Extend to assert Mistral uses `ProviderProtocol::Mistral`, not `open_ai_completions`. |
+| A10 | **Reasoning leak-scan** | `SafetyLayer` / `ironclaw_safety::LeakDetector` response seam | Confirm Mistral thinking text flows through the existing response leak scan before user delivery (documented at `src/agent/CLAUDE.md:126`, `src/NETWORK_SECURITY.md`, `crates/ironclaw_llm/src/recording.rs`). Signature is opaque → exempt. **Implementation must confirm the exact reasoning-surfacing call site** (the retired doc's `src/bridge/router.rs` path no longer exists). |
+| A11 | **Provider / capability docs** | `docs/capabilities/llm-providers.md` | Add the Mistral reasoning row. |
+
+### Reused — do **NOT** rebuild
+
+- `ReasoningDetail` / `ReasoningDetails` + `with_reasoning_details` — `provider.rs:78/95/292/606`.
+- The `rig_adapter.rs` round-trip — `iron_reasoning_to_rig` `:615`, `rig_reasoning_to_iron` `:640`,
+  `extract_response` `:689`, `convert_messages` `:414/:456`.
+- The decorator chain — `build_provider_chain` (`lib.rs:1187`).
+- Model-capability registries — `reasoning_models.rs`, `vision_models.rs`.
+- The `LlmProvider` trait — the single seam; **no trait changes**.
+- Upstream persistence + cross-turn replay + per-block signature handling.
+
+**Explicitly withdrawn from the retired design:** `ReasoningBlock`, the CTR-1 cross-turn `reasoning`
+plumb, the SIG-1 `reasoning_signature` threading, and any parallel `reasoning` field. The signature
+rides in `ReasoningDetail::Text.signature`; cross-turn replay rides `reasoning_details`.
+
+---
+
+## 4. C4 L3 — View B: Reborn follow-up
+
+Because `ironclaw_llm` is shared, View A already delivers the provider to Reborn. This view is a
+**verification-first** pass — it is expected to add **no new component**, only to confirm (or
+close a gap in) the flow of `reasoning_details` through Reborn's persistence and context rebuild.
+
+### Component check
+
+```
+  MistralProvider ──reasoning_details──► ChatMessage ──► Reborn turn persistence ──► store
+                                                    │                                   │
+                                                    └──────── context rebuild ◄─────────┘
+                                                            (must carry reasoning_details)
+```
+
+| Component | Location | Verify |
+|---|---|---|
+| Reborn conversation record | `crates/ironclaw_reborn_traces/src/conversation_message.rs` (`ConversationMessage`) | Carries `reasoning_details` through persist + hydrate; nothing strips it. |
+| Turn persistence / context rebuild | Reborn thread/turn store + hydration path | Reasoning survives the write→read round-trip and re-enters context on the next turn. |
+
+### Persistence rule constraint (`database.md`)
+
+- The retired design added dedicated `reasoning` columns + dual-backend migrations (PG `V32` /
+  libSQL `v26`). **This re-architecture does not.** Upstream already persists `reasoning_details`.
+- `database.md` directs new persistence onto the unified `RootFilesystem`/`ScopedFilesystem`
+  plane — **not** new `src/db/` sub-traits or per-domain columns.
+- LLM reasoning is LLM output → **never stripped or deleted** ("Never Delete LLM Output Data").
+- **Finding to record:** if `reasoning_details` already survives the Reborn round-trip, state that
+  Reborn inherits reasoning for free and this view adds nothing. If a component drops it, close the
+  gap by routing through the existing `reasoning_details` path — not by adding schema.
+
+---
+
+## 5. rig-core — verified current state (2026-07-05) & the upstream-fix option
+
+Verified directly against a local rig checkout at **v0.39.0 +62 commits** (well ahead of the
+pinned **0.33**), because "is this rig's job?" changes the eventual retirement path of View A's
+`MistralProvider`. Findings:
+
+**a. Latest rig no longer crashes — but still does not *support* Mistral reasoning.** The
+0.30-era behaviour the research doc records (hard `panic!` in the dedicated client; the generic
+`open_ai_completions` path failing with `JsonError: did not match any variant of untagged enum
+ApiResponse`) is gone. In current rig (`crates/rig-core/src/providers/mistral/completion.rs`):
+
+- **Receive:** `mistral_content_value_to_text` flattens the chunk array but keeps **only
+  `type:"text"` parts**; `TryFrom<CompletionResponse>` never emits `AssistantContent::Reasoning`.
+  → the thinking trace is **silently discarded on the way in**.
+- **Send/replay:** `AssistantContent::Reasoning(_) => { /* silently skip */ }`, locked by a test
+  (`test_assistant_reasoning_is_skipped_in_message_conversion`). → the `ThinkChunk` is **not
+  round-tripped**, the exact multi-turn degradation §2 warns about.
+- **Request:** `MistralCompletionRequest` has **no `reasoning_effort` field** — it can only be
+  smuggled via `additional_params`, with no small/medium gating.
+
+So a bare rig bump would swap "every turn errors" for "reasoning quietly thrown away" — it clears
+the blocker but does **not** deliver `reasoning_effort=high` "to the fullest." This confirms
+**D-BUILD**: View A ships regardless.
+
+**b. But rig's *core* model is already Mistral-reasoning-capable — only the provider file is
+unwired.** This is the material update to the retired doc's "no native support" note:
+
+- `completion::message::ReasoningContent::Text { text, signature: Option<String> }` +
+  `Reasoning { id, content }` (`crates/rig-core/src/completion/message.rs`) already model reasoning
+  text **with an opaque provider signature** — a field-for-field peer of IronClaw's
+  `ReasoningDetail::Text { text, signature }`. Nothing in rig's core needs to change.
+- **DeepSeek already round-trips reasoning through that abstraction** in the same rig
+  (`providers/deepseek.rs`: receive → `AssistantContent::reasoning`, send → `reasoning_content`).
+  Mistral is simply **not wired to the same pattern** — a per-provider gap, not an
+  architecture gap.
+
+**c. Implication — the clean upstream fix is a well-scoped rig PR, not a fork carry.** Mirror
+DeepSeek in `providers/mistral/completion.rs`: parse `thinking` chunks →
+`ReasoningContent::Text { text, signature }` on receive, reconstruct them on send, and add a
+first-class `reasoning_effort` request field. Because rig's types already exist, this is a
+provider-file change, not a core-model change — genuinely upstreamable.
+
+**d. Recommended posture — phased, upstream-in-parallel (does not alter View A):**
+
+1. **Now:** ship `MistralProvider` (§3). It is the only path that delivers reasoning today, and it
+   already has the acceptance spec (§7).
+2. **In parallel:** open the rig PR from (c). This is the architecturally correct home and reduces
+   the ~1,400-line fork carry the fork-catch-up notes flag as a maintenance cost.
+3. **After it lands + IronClaw bumps rig:** collapse `MistralProvider` to a thin config shim —
+   `reasoning_effort` gating to small/medium + mapping rig's `AssistantContent::Reasoning` onto
+   `ReasoningDetails`. That mapping seam **already exists** (`rig_adapter.rs::rig_reasoning_to_iron`,
+   `:640`), so the collapse is small and low-risk. This is exactly the "reduce to a dependency bump
+   + protocol switch" outcome D-BUILD's gate anticipates.
+
+**e. One caveat if upstreaming.** IronClaw surfaces reasoning through its own `ReasoningDetails`
+channel, not rig's `AssistantContent::Reasoning` end-to-end; the collapse relies on the existing
+`rig_adapter.rs` mapping carrying signatures faithfully (it already handles Gemini
+`thought_signature`, so the seam is proven). Verify `ReasoningContent::Text.signature` survives that
+map before deleting any custom parsing.
+
+---
+
+## 6. Decisions
+
+- **D-BUILD (build now, upstream in parallel).** Own the Mistral wire via `MistralProvider` — a
+  bare rig-core bump does not rescue this (current rig, incl. 0.33 and 0.39, models content as a
+  `String` and silently drops/no-ops reasoning on both receive and send; §5a). **This decision is
+  unchanged.** What §5 refines is the *gate*: the clean long-term home is a rig PR wiring
+  `providers/mistral/completion.rs` to the reasoning types that already exist in rig's core
+  (`ReasoningContent::Text { text, signature }`) — the way DeepSeek already does (§5b/c). **Pre-work
+  gate:** re-confirm current-latest rig-core still lacks the Mistral reasoning round-trip; if that
+  PR lands (ours or upstream's) and IronClaw bumps rig, collapse `MistralProvider` to a config shim
+  per §5d — a dependency bump + protocol switch, not a rewrite.
+- **D-DEFAULT (reasoning default-on, default model Medium 3.5).** Per the user: `providers.json`
+  default reasoning `high`, `default_model` → `mistral-medium-latest`. Large stays available
+  (non-reasoning); `supports_mistral_reasoning` gates whether `reasoning_effort` is sent.
+- **D-ENUM (two-variant effort).** `MistralReasoningEffort { High, None }` — boolean-ish, never a
+  3-level enum. See `types.md`.
+- **D-REUSE (map onto upstream).** Translate `ThinkChunk` → `ReasoningDetail::Text{text,signature}`;
+  do not mirror or re-declare the upstream reasoning types (`type-placement.md`).
+
+## 7. Acceptance criteria (preserved from the retired live test)
+
+Implementation-independent; the acceptance spec for #8 (from the retired
+`tests/e2e_live_mistral_reasoning.rs`, preserved at tag `backup/main-pre-catchup`):
+
+1. **Clean round-trip.** A real Mistral `reasoning_effort=high` response round-trips through the
+   agent loop and yields a non-empty reply with **no** `JsonError: did not match any variant of
+   untagged enum ApiResponse` (the original blocker).
+2. **Multi-turn replay.** A second user turn does **not** HTTP 400 when the prior turn's parsed
+   thinking chunk is replayed back to the provider.
+3. **Non-goal.** Do not assert on `StatusUpdate::Thinking` events — on the v1 path they are reused
+   for generic status. Prove *parsing* deterministically offline; prove *replay* live.
+4. **Live invocation (reference):** `IRONCLAW_LIVE_TEST=1 LLM_BACKEND=mistral MISTRAL_REASONING=high
+   MISTRAL_API_KEY=… cargo test …`. The offline parser matrix (cases C1–C12) enumerates the
+   response shapes that must parse; recover it from the backup tag.
+
+## 8. Rule-compliance constraints (`.claude/rules/`)
+
+| Rule | Constraint baked into the design |
+|---|---|
+| `types.md` | `reasoning_effort` is an enum, not bool/string; Mistral wire chunks (`ThinkChunk`/`TextChunk`) get named types, not ad-hoc `Value` matching. |
+| `type-placement.md` | One definition each, owned by `ironclaw_llm`; **reuse** upstream `ReasoningDetail`/`ReasoningDetails` (a field-for-field mirror + `From` is a violation); no `pub use` shims; nothing added to `ironclaw_common`. |
+| `error-handling.md` | Map Mistral error bodies → `LlmError` **carrying the cause** (no `map_err(\|_\| …)` that drops it); detect **413 → `ContextOverflow`**, **5xx → `BadGateway`**; no `.unwrap()`/`.expect()` and no silent-failure on the array-parse path — a malformed reasoning response fails loud, never collapses to empty content. |
+| `safety-and-sandbox.md` | Mistral thinking text (LLM output toward the user) passes the response leak detector before delivery (A10); the opaque `signature` is exempt. |
+| `architecture.md` | One component through the existing `build_provider_chain` (no second dispatch pipeline); aggregate into a config struct rather than `#[allow(too_many_arguments)]` if the signature nears 7 args; no `Option<Arc<…>>`+`with_*` optional-dep smell; `mistral.rs` aims < 800 lines (split tests into a submodule if needed). |
+| `testing.md` | Tiers: offline parser matrix at **Unit** (`cargo test`); live multi-turn replay at **Live** (`cargo test --features integration -- --ignored`, `IRONCLAW_LIVE_TEST=1`). **Test through the caller:** `supports_mistral_reasoning()` gates whether `reasoning_effort` is sent, so assert at the request-build call site that a Small 4 / Medium 3.5 request **carries** `reasoning_effort=high` and a `mistral-large` request **omits** it — a predicate-only unit test is insufficient. |
+| `doc-hygiene.md` | No developer-local absolute paths in this or any committed doc. |
+
+## 9. Out of scope
+
+- rig-core bump (revisit only if the Mistral reasoning round-trip lands upstream — see §5d and the
+  D-BUILD gate; the phased upstream PR is a *parallel* track, not a blocker for View A).
+- `prompt_mode` (risks layering Mistral's own system prompt over IronClaw's).
+- New DB columns / migrations for reasoning (superseded by upstream `reasoning_details`).
+- TUI streaming of the thinking trace.
+- The code-level work-unit breakdown (a separate follow-up plan).
+
+## References
+
+- `docs/plans/2026-06-24-mistral-reasoning-provider-architecture.md` — superseded; preserved
+  analysis (D1–D10) + acceptance criteria.
+- `docs/plans/2026-06-24-mistral-reasoning-impl.md` — retired work-unit breakdown; useful for the
+  edge cases it enumerates.
+- `docs/providers/mistral-reasoning.md` — provider-agnostic API research (still valid).
+- Mistral reasoning docs: `docs.mistral.ai/studio-api/conversations/reasoning`.
+- `scripts/test-mistral-reasoning.sh` — raw-API probe confirming `reasoning_effort=high` behaviour.
+- rig-core (upstream, §5 findings): `rig-core/src/providers/mistral/completion.rs` (unwired
+  Mistral path), `rig-core/src/providers/deepseek.rs` (working reasoning round-trip to mirror),
+  `rig-core/src/completion/message.rs` (`ReasoningContent::Text { text, signature }` — the target
+  types already exist). Verified at rig `v0.39.0 +62`.

--- a/docs/internal/research/mistral-reasoning.md
+++ b/docs/internal/research/mistral-reasoning.md
@@ -1,0 +1,193 @@
+# Mistral Reasoning — Knowledge & Constraints (fork research)
+
+> **♻️ Retained reference (2026-07-05 catch-up).** The fork's custom Mistral
+> reasoning implementation was retired when upstream shipped a native reasoning
+> system — but the **API findings below are provider-agnostic and still stand**.
+> This is the primary starting point for the re-architecture tracked in
+> [k-l-sorensen/ironclaw#8](https://github.com/k-l-sorensen/ironclaw/issues/8).
+> Original implementation preserved at tag `backup/main-pre-catchup`.
+
+> Reference notes gathered while investigating how to make IronClaw use Mistral
+> reasoning "to the fullest" (`reasoning_effort=high`). Captured so the
+> architecture/implementation plan can be made without re-deriving any of it.
+> This is **research/documentation only** — the exploratory code was reverted;
+> see `CLAUDE-local.md`. Two live test scripts are retained under `scripts/`.
+>
+> Sources: https://docs.mistral.ai/studio-api/conversations/reasoning ,
+> Mistral `/v1/chat/completions` API reference, and live testing against
+> `mistral-medium-latest` on 2026-06-23.
+
+## 1. How Mistral reasoning works
+
+### Request parameter
+
+- **`reasoning_effort`** is the control. Documented values are **`"high"`** and
+  **`"none"`** — it is effectively a **boolean**, *not* the OpenAI-style
+  `low`/`medium`/`high` scale. (An earlier assumption that it was low/medium/high
+  was wrong — do not model it as a 3-level enum.)
+  - `"high"` — full thinking trace is produced and surfaced.
+  - `"none"` — no thinking trace.
+  - omitted — model default (for these models, behaves like plain output).
+- There is also a `prompt_mode` knob in some SDK surfaces (controls whether
+  Mistral injects its own default reasoning system prompt), but the reasoning
+  page treats `reasoning_effort` as the primary control. **Not needed** for our
+  purpose and risks layering Mistral's system prompt over IronClaw's.
+- Available on the chat-completions endpoint, and on the agents/conversations
+  endpoints via a `completion_args` field.
+
+### Supported models
+
+- `mistral-small-latest`
+- `mistral-medium-latest` / `mistral-medium-3-5` (`high` recommended for
+  agentic/code use cases)
+- **Not** `mistral-large`, `mistral-7b`, `mistral-tiny`, `mistral-nemo`, or
+  embedding models. The dedicated **Magistral** reasoning models are deprecated;
+  reasoning now rides on the general small/medium models.
+
+### Response format — THE crux
+
+The shape of `message.content` is dictated by `reasoning_effort`:
+
+| `reasoning_effort` | `message.content` |
+|---|---|
+| `"high"` | **array of chunks** (see below) |
+| `"none"` / omitted | **plain string** |
+
+When `"high"`, `message.content` is a list of typed chunks. **The thinking is a
+separate chunk from the message** — they are distinct entries in the `content`
+array, not a single string with the reasoning inlined:
+
+```jsonc
+"content": [
+  { "type": "thinking",
+    "thinking": [
+      { "type": "text", "text": "... first reasoning step ..." },
+      { "type": "text", "text": "... later reasoning step ..." }
+    ] },
+  { "type": "text", "text": "... final answer ..." }
+]
+```
+
+- `ThinkChunk` — `type: "thinking"`; its `thinking` field is itself a **list of
+  `TextChunk`** (one or more text fragments making up that turn's reasoning
+  trace). Treat it as a list, not a single string — a turn's thinking can span
+  several `TextChunk` entries.
+- `TextChunk` — `type: "text"`; when it appears at the top level of `content` it
+  is the final answer (the message). The same `TextChunk` type is reused *inside*
+  a `ThinkChunk`'s `thinking` list for the reasoning fragments.
+- (Other chunk types exist in the same union: `reference`, `file`, `audio`.)
+
+There is **no option to get the reasoning as inline `<think>…</think>` tags
+inside a string** (the DeepSeek style). With `reasoning_effort=high` the array
+is mandatory. So you cannot sidestep array parsing by asking for string output —
+that would mean `reasoning_effort=none`, i.e. no reasoning.
+
+### Multi-turn requirement
+
+The docs are explicit: to avoid degraded performance, **replay the full
+assistant message back into history on subsequent turns — both the `ThinkChunk`
+*and* the final `TextChunk` (the message), in the same array shape they were
+received.** Do not strip the `ThinkChunk` before replaying; the model relies on
+the reasoning trace to stay coherent across turns. It is not enough to replay
+only the final message text, nor only the thinking — the whole `content` array
+(thinking chunk + message chunk) must be sent back.
+
+So a correct integration must both (a) parse the array out (separating the
+thinking from the message) and (b) reconstruct and send that full array —
+thinking chunk *and* message chunk — back in on the next turn.
+
+## 2. Why it does not work in IronClaw today (`rig-core 0.30`)
+
+Mistral is wired in `providers.json` as `id: "mistral"`,
+`protocol: "open_ai_completions"`, so it flows through
+`crates/ironclaw_llm/src/lib.rs::create_openai_compat_from_registry` →
+`RigAdapter` over rig-core's OpenAI Chat Completions client.
+
+**Neither rig-core 0.30 path can consume the array-shaped reasoning response:**
+
+1. **Generic OpenAI-compat client** (current path): its response model expects
+   `message.content` to be a **string**. The array response fails to
+   deserialize:
+   `JsonError: data did not match any variant of untagged enum ApiResponse`.
+   (Observed live: every agent turn fails, retried 3× then errors.)
+
+2. **rig-core's dedicated `mistral` client**
+   (`rig-core-0.30.0/src/providers/mistral/`): also models assistant `content`
+   as `String`, and it **`panic!`s** on reasoning content when building requests
+   from history:
+   `panic!("Reasoning content is not currently supported on Mistral via Rig")`
+   (`completion.rs` ~lines 159 and 628). So switching Mistral to a dedicated
+   protocol (the fix that solved DeepSeek `reasoning_content` and Gemini
+   `thought_signature`) does **not** rescue Mistral here.
+
+Conclusion: with `rig-core` pinned at 0.30, there is **no off-the-shelf path**
+that parses Mistral's reasoning response. The codebase's own rule
+(`registry.rs` test `reasoning_aware_providers_use_dedicated_protocol_not_openai_compat`)
+says reasoning-aware providers must avoid `OpenAiCompletions` — but for Mistral
+the dedicated rig client is also a dead end at 0.30.
+
+## 3. Evidence (reproducible)
+
+- `scripts/test-mistral-reasoning.sh` — raw Mistral API, with vs. without
+  `reasoning_effort`. **PASS**: `reasoning_effort=high` returns
+  `content` as an array containing a `thinking` part; without it, `content` is a
+  string. Confirms Mistral honors the field.
+- Driving the real agent against the Mistral backend with reasoning on
+  originally **FAILED** with `JsonError: did not match any variant of untagged
+  enum ApiResponse`, confirming IronClaw's receive path could not parse the
+  array-shaped response (the bug this work fixes). That end-to-end check now
+  lives as the Live-tier test `tests/e2e_live_mistral_reasoning.rs` (run with
+  `IRONCLAW_LIVE_TEST=1 LLM_BACKEND=mistral`), which must PASS post-fix; it
+  superseded the earlier `scripts/test-mistral-reasoning-ironclaw.sh` bash harness.
+- Both scripts read `MISTRAL_API_KEY` from the environment; set/export it before
+  running (sourced from your own secret manager). No vault reference is committed.
+
+## 3a. FIRST STEP before any build — resolve build-vs-upgrade
+
+**Before committing to a custom provider, check whether a newer `rig-core`
+version natively supports Mistral reasoning** (array `content` parsing +
+round-tripping the `ThinkChunk`). This is a gating decision — it changes the
+entire shape of the work:
+
+- If a newer `rig-core` handles it → the fix may be a **dependency bump** (small,
+  but verify it doesn't regress the other providers pinned to 0.30's behavior).
+- If not → build the **custom Mistral provider** (Section 4).
+
+How to check: review `rig-core` releases > 0.30 on crates.io / its repo
+changelog and `providers/mistral/completion.rs` in the newer version; look for
+array-`content` deserialization and removal of the
+`"Reasoning ... not ... supported on Mistral via Rig"` `panic!`s. Validate any
+candidate version with the live acceptance test
+`tests/e2e_live_mistral_reasoning.rs` before adopting.
+
+## 4. Implications for the design (inputs to the plan)
+
+To use `reasoning_effort=high` properly, IronClaw must own the Mistral
+request/response, not delegate to rig-core 0.30. Likely shape (to be decided in
+the architectural plan):
+
+- A **custom Mistral provider** (sibling to `nearai_chat.rs`, the Codex
+  providers, etc.) implementing `LlmProvider` with its own HTTP client and
+  JSON model that:
+  - sends `reasoning_effort` on the request (gated to small/medium models);
+  - parses array `content` → IronClaw's `reasoning` field (from the
+    `thinking` chunk) + `content` (from the `text` chunk), for both
+    `complete` and `complete_with_tools`;
+  - on the next turn, reconstructs the assistant message **including** the
+    thinking content (multi-turn requirement) — IronClaw already round-trips a
+    `reasoning` field on `ChatMessage` (see `rig_adapter.rs` reasoning handling
+    and `provider.rs`), so there is an existing channel to reuse;
+  - maps Mistral error bodies to `LlmError` at the channel boundary.
+- A new `ProviderProtocol::Mistral` variant + `providers.json` switch from
+  `open_ai_completions` to `mistral`, and factory dispatch in `lib.rs`.
+- Config: a **boolean-ish** reasoning toggle (high/off), not a 3-level enum.
+  Env read stays in the binary's `src/config/llm.rs` (crate stays env-agnostic).
+- **Gating decision first:** resolve build-vs-upgrade (Section 3a) before
+  building the custom provider — a newer `rig-core` may handle this natively.
+
+## 5. Decisions already locked by the user
+
+- Goal is to use Mistral **to the fullest → `reasoning_effort=high`** (Mistral is
+  the largest EU provider; treat it as a first-class, properly-supported path).
+- Do it **properly** (not a minimal carry). Architecture + code plan to be made
+  in a fresh conversation.

--- a/scripts/test-mistral-reasoning.sh
+++ b/scripts/test-mistral-reasoning.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Live smoke test for Mistral reasoning_effort — LOCAL FORK helper.
+# (See CLAUDE-local.md → "Mistral reasoning fix".)
+#
+# Reads MISTRAL_API_KEY from the environment and sends the SAME reasoning prompt to
+# the Mistral API twice — once WITH reasoning_effort (the field this fork
+# injects) and once WITHOUT — then compares them. Reasoning shows up as a large
+# jump in completion tokens and, usually, a <think> trace in the content.
+#
+# This validates the API contract our injection relies on. The IronClaw-side
+# wiring (gating + flattening the field into the request) is covered by unit
+# tests: `cargo test -p ironclaw_llm mistral`.
+#
+# Usage (MISTRAL_API_KEY must be set in the environment):
+#   MISTRAL_API_KEY=... ./scripts/test-mistral-reasoning.sh
+#   MISTRAL_API_KEY=... MISTRAL_MODEL=mistral-small-latest MISTRAL_REASONING_EFFORT=low ./scripts/test-mistral-reasoning.sh
+#
+set -euo pipefail
+
+MODEL="${MISTRAL_MODEL:-mistral-medium-latest}"
+EFFORT="${MISTRAL_REASONING_EFFORT:-high}"
+ENDPOINT="https://api.mistral.ai/v1/chat/completions"
+PROMPT='John is one of 4 children. The first sister is 4 years old. Next year, the second sister will be twice as old as the first sister. The third sister is two years older than the second sister. The third sister is half the age of her older brother. How old is John?'
+
+for bin in jq curl; do
+  command -v "$bin" >/dev/null || { echo "error: '$bin' not found in PATH" >&2; exit 1; }
+done
+
+API_KEY="${MISTRAL_API_KEY:-}"
+[ -n "$API_KEY" ] || { echo "error: MISTRAL_API_KEY is not set in the environment" >&2; exit 1; }
+
+# Send one chat-completion request. $1 = full JSON body. Echoes the raw response.
+call() {
+  curl -sS "$ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $API_KEY" \
+    -d "$1"
+}
+
+# Reliable signal: Mistral returns `message.content` as a plain STRING normally,
+# but as a structured ARRAY with a "thinking" part when reasoning_effort engages.
+# $1 = label, $2 = response json. Human-readable lines → stderr; the machine value
+# (1 if a thinking part is present, else 0) → stdout for the caller to capture.
+report() {
+  local label="$1" resp="$2" ctype has_think text tokens
+  if ! ctype="$(echo "$resp" | jq -e -r '.choices[0].message.content | type' 2>/dev/null)"; then
+    echo "  [$label] unexpected response:" >&2
+    echo "$resp" | jq . >&2 2>/dev/null || echo "$resp" >&2
+    exit 1
+  fi
+  tokens="$(echo "$resp" | jq -r '.usage.completion_tokens // "?"')"
+  if [ "$ctype" = "array" ]; then
+    has_think="$(echo "$resp" | jq -r 'if (.choices[0].message.content | map(.type) | index("thinking")) != null then 1 else 0 end')"
+    text="$(echo "$resp" | jq -r '[.choices[0].message.content[] | select(.type=="text") | .text] | join(" ")')"
+  else
+    has_think=0
+    text="$(echo "$resp" | jq -r '.choices[0].message.content')"
+  fi
+  {
+    echo "  content shape     : $ctype"
+    echo "  thinking part     : $([ "$has_think" = 1 ] && echo yes || echo no)"
+    echo "  completion_tokens : $tokens"
+    echo "  answer (tail)     : $(echo "$text" | tail -c 160 | tr '\n' ' ')"
+  } >&2
+  echo "$has_think"   # stdout: 1 if a thinking part is present, else 0
+}
+
+base_body="$(jq -n --arg m "$MODEL" --arg p "$PROMPT" \
+  '{model:$m, messages:[{role:"user", content:$p}]}')"
+reasoning_body="$(echo "$base_body" | jq --arg e "$EFFORT" '. + {reasoning_effort:$e}')"
+
+echo
+echo "== WITHOUT reasoning_effort ($MODEL) =="
+think_off="$(report off "$(call "$base_body")" | tail -n1)"
+
+echo
+echo "== WITH reasoning_effort=$EFFORT ($MODEL) =="
+think_on="$(report on "$(call "$reasoning_body")" | tail -n1)"
+
+echo
+echo "== Verdict =="
+if [ "$think_on" = 1 ] && [ "$think_off" = 0 ]; then
+  echo "  PASS — reasoning_effort=$EFFORT engaged a 'thinking' content part that is"
+  echo "         absent without the field. Mistral honors the field this fork injects."
+elif [ "$think_on" = 1 ]; then
+  echo "  PASS (weak) — reasoning request produced a 'thinking' part, but the baseline"
+  echo "         also did (think_off=$think_off). Field is honored; contrast is muddy."
+else
+  echo "  FAIL — no 'thinking' part on the reasoning request (think_on=$think_on)."
+  echo "  The model may not support reasoning_effort (use mistral-small*/mistral-medium*)."
+  exit 1
+fi

--- a/tests/reborn_live_mistral_reasoning_contract.rs
+++ b/tests/reborn_live_mistral_reasoning_contract.rs
@@ -1,0 +1,139 @@
+//! Live smoke test for the Mistral `reasoning_effort=high` wire contract.
+//!
+//! The **primary** regression net for Mistral reasoning is the offline,
+//! deterministic matrix in `crates/ironclaw_llm/src/mistral/tests.rs`: it
+//! already proves — with loopback mock servers, no API key — that
+//! `reasoning_effort` is sent for small/medium and omitted for large/off, that
+//! the array (`[{thinking},{text}]`) and string responses both parse, the
+//! error mapping, and that a prior turn's thinking (+ signature) is replayed
+//! as a chunk on the next turn.
+//!
+//! This live test is a thin smoke layer over the one thing the offline matrix
+//! cannot reach: that a *real* Mistral response round-trips through
+//! `MistralProvider` without the original
+//! `JsonError: did not match any variant of untagged enum ApiResponse` parse
+//! failure, and that a second turn replaying the parsed thinking chunk does
+//! not 400.
+//!
+//! ## Why this shape, not a full agent-loop harness
+//!
+//! The fork's original version of this test drove the real v1 agent loop
+//! end-to-end (`ironclaw::channels::OutgoingResponse` + a bespoke
+//! `support::live_harness`). That whole harness tier was deleted with the v1
+//! monolith (see `docs/internal/live-canary.md`'s `deterministic-replay` row:
+//! "its `tests/e2e_live*.rs` fixtures ... were deleted with the v1 monolith").
+//! Resurrecting it here would fight that retirement. Instead this test talks
+//! to `MistralProvider` directly — the same shape as
+//! `reborn_live_github_pat_contract.rs` (a standalone reqwest-shaped live
+//! contract check, no shared harness) — which still proves the real thing the
+//! offline matrix cannot: an actual Mistral HTTP round-trip through the exact
+//! provider code the agent loop calls.
+//!
+//! ## Running
+//!
+//! ```bash
+//! MISTRAL_API_KEY=... cargo test --test reborn_live_mistral_reasoning_contract -- --ignored --nocapture
+//!
+//! # Point at the small model instead of the default mistral-medium-latest:
+//! MISTRAL_API_KEY=... MISTRAL_MODEL=mistral-small-latest \
+//!   cargo test --test reborn_live_mistral_reasoning_contract -- --ignored --nocapture
+//! ```
+
+use ironclaw_llm::{
+    ChatMessage, CompletionRequest, LlmProvider, MistralReasoningEffort, mistral::MistralProvider,
+};
+use secrecy::SecretString;
+
+/// The all-labels-wrong box puzzle: a genuine deduction task (not
+/// arithmetic/counting), reachable only by reasoning.
+const REASONING_PROMPT: &str = "Three boxes are labeled APPLES, ORANGES, and MIXED. You are told \
+     that every single label is wrong. You may take exactly one fruit out of exactly one box and \
+     look at it. From which one box should you take a fruit so that you can then correctly \
+     relabel all three boxes? Think before you answer, then end with \"ANSWER: <box label>\".";
+
+fn provider() -> MistralProvider {
+    let api_key = std::env::var("MISTRAL_API_KEY")
+        .expect("set MISTRAL_API_KEY to run this live Mistral contract test");
+    let model =
+        std::env::var("MISTRAL_MODEL").unwrap_or_else(|_| "mistral-medium-latest".to_string());
+    MistralProvider::new(
+        model,
+        SecretString::from(api_key),
+        Some(MistralReasoningEffort::High),
+        90,
+    )
+    .expect("MistralProvider::new should build a client")
+}
+
+/// Single reasoning turn: proves the real `[{thinking},{text}]` response
+/// deserializes and the provider produces a coherent answer (the exact path
+/// the original `ApiResponse` parse bug broke).
+#[tokio::test]
+#[ignore = "requires MISTRAL_API_KEY (live Mistral API call)"]
+async fn mistral_reasoning_round_trips() {
+    let provider = provider();
+    let response = provider
+        .complete(CompletionRequest::new(vec![ChatMessage::user(
+            REASONING_PROMPT,
+        )]))
+        .await
+        .expect("live Mistral completion should succeed");
+
+    assert!(
+        !response.content.trim().is_empty(),
+        "expected a non-empty reply from Mistral"
+    );
+    assert!(
+        response.content.to_ascii_uppercase().contains("ANSWER"),
+        "expected the model to follow the ANSWER: <box label> format, got: {}",
+        response.content
+    );
+    eprintln!(
+        "[MistralLiveContract] reasoning present: {}",
+        response.reasoning.is_some()
+    );
+}
+
+/// Multi-turn: the prior assistant turn (including its parsed thinking +
+/// signature) is replayed back to Mistral as a `[{thinking},{text}]` chunk on
+/// turn 2. Confirms the live ThinkChunk replay does not 400. Offline C8/turn_two
+/// tests prove the builder replays the chunk; this proves the real API accepts
+/// it.
+#[tokio::test]
+#[ignore = "requires MISTRAL_API_KEY (live Mistral API call)"]
+async fn mistral_reasoning_multi_turn_replay_does_not_400() {
+    let provider = provider();
+
+    let turn1 = provider
+        .complete(CompletionRequest::new(vec![ChatMessage::user(
+            REASONING_PROMPT,
+        )]))
+        .await
+        .expect("turn 1: live Mistral completion should succeed");
+    assert!(!turn1.content.trim().is_empty(), "turn 1: expected a reply");
+
+    // Rebuild the assistant message the agent loop would have stored,
+    // carrying the reasoning trace the provider parsed off turn 1 — this is
+    // exactly the input `chat_message_to_wire` reconstructs into a `thinking`
+    // chunk for turn 2's request.
+    let assistant_turn1 =
+        ChatMessage::assistant(turn1.content.clone()).with_reasoning(turn1.reasoning.clone());
+
+    let turn2 = provider
+        .complete(CompletionRequest::new(vec![
+            ChatMessage::user(REASONING_PROMPT),
+            assistant_turn1,
+            ChatMessage::user("Now briefly restate why that box was the right one to open."),
+        ]))
+        .await
+        .expect(
+            "turn 2: live Mistral completion should succeed — an HTTP 400 here means the \
+             ThinkChunk replay was rejected",
+        );
+    assert!(
+        !turn2.content.trim().is_empty(),
+        "turn 2: expected a reply after replaying the ThinkChunk"
+    );
+
+    eprintln!("[MistralLiveContract] multi-turn reasoning replay succeeded across 2 turns");
+}


### PR DESCRIPTION
## Summary

- Catches the fork up from upstream `4e05a033d` (the 2026-08-10 catch-up base) to `499394df4a0a31e26024d8b0bfc2a13a44b4c030` — the merge-base of upstream tag `ironclaw-v1.2.0-rc.3` (cut 2026-08-12) and `upstream/main`. Nothing past that point (including the 39 commits that exist only on the `1.2.0-rc.3` release branch, and anything upstream has landed on `main` since) is integrated, per the fork's catch-up-cadence policy in `CLAUDE-local.md`.
- 26 upstream commits in range, zero structural renames — classified as a routine catch-up. Notable upstream addition: a new `web-push` extension (two workspace crates).
- Re-lands the fork's carry unchanged in content, only rebased onto the new base: the Mistral `reasoning_effort=high` provider (fork issue #8), the hosted-Mistral cost-pricing fix (fork issue #9), and the release/cargo-dist repoint + customizations (msi/Windows-target drop).
- Fixes a real pre-existing gap surfaced by this catch-up's `cargo test --workspace` run: the fork's earlier msi/Windows-target-drop commits (already on `main`, not introduced by this PR) had broken `release_ci_compiles_reborn_for_all_supported_targets`, which nobody had caught since the full suite wasn't re-run after those commits landed.
- Documents a new maintenance-workflow gotcha in `CLAUDE-local.md`: once a prior catch-up lands via merge (true since 2026-08-05), a plain `git rebase`/`--onto` no longer works cleanly for fork-only files even on a routine, no-rename catch-up — worked around by diffing the fork tip against the *previous* catch-up's upstream base and applying that cumulative diff onto the new base.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — zero warnings
- [x] `cargo test --workspace --no-fail-fast` (with `IRONCLAW_DISABLE_OS_KEYCHAIN=1` and `ANTHROPIC_API_KEY`/`MISTRAL_API_KEY` unset) — first pass showed ~24 stack-overflow flakes plus known Docker-dependent failures; re-run with `RUST_MIN_STACK=64MiB` and `--test-threads=2` cleared every stack overflow, leaving only 5 targets failing, all confirmed `SocketNotFoundError("/var/run/docker.sock")` (no Docker/colima on this machine) — the same environmental class seen on every prior catch-up.
- [x] Confirmed the new upstream range doesn't touch `mistral.rs`, `deny.toml`, or add any new `.github/workflows/*` files that would need adding to the fork's Actions disable list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)