### PR TITLE
fix(live-canary): prune marker-less bundled skills and follow the session channel message route

### DIFF
--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -151,6 +151,74 @@ except (OSError, UnicodeError, ValueError):
 PY
 }
 
+is_source_identical_bundled_skill() {
+  local skill_dir="$1"
+  local skill_name
+  skill_name="$(basename "${skill_dir}")"
+
+  python3 - "${BUNDLED_SKILLS_ROOT}/${skill_name}" "${skill_dir}" \
+    "${BUNDLED_SKILL_MARKER}" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+trusted_dir = Path(sys.argv[1])
+staged_dir = Path(sys.argv[2])
+marker_name = sys.argv[3]
+
+
+def regular_files(root: Path) -> list[tuple[str, Path]]:
+    if not root.is_dir() or root.is_symlink():
+        raise ValueError("bundle root is not a real directory")
+    files: list[tuple[str, Path]] = []
+    for current, directories, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for directory in directories:
+            if (current_path / directory).is_symlink():
+                raise ValueError("bundle contains a symlinked directory")
+        for filename in filenames:
+            path = current_path / filename
+            relative = path.relative_to(root).as_posix()
+            if relative == marker_name:
+                raise ValueError("unexpected runtime marker in bundle")
+            if not stat.S_ISREG(path.lstat().st_mode):
+                raise ValueError("bundle contains a non-regular file")
+            files.append((relative, path))
+    return sorted(files)
+
+
+def files_equal(left: Path, right: Path) -> bool:
+    if left.stat().st_size != right.stat().st_size:
+        return False
+    with left.open("rb") as left_file, right.open("rb") as right_file:
+        while True:
+            left_chunk = left_file.read(1024 * 1024)
+            right_chunk = right_file.read(1024 * 1024)
+            if left_chunk != right_chunk:
+                return False
+            if not left_chunk:
+                return True
+
+
+try:
+    trusted_files = regular_files(trusted_dir)
+    staged_files = regular_files(staged_dir)
+    if not trusted_files:
+        raise ValueError("trusted source is empty")
+    if [relative for relative, _ in trusted_files] != [relative for relative, _ in staged_files]:
+        raise ValueError("staged bundle file set differs from trusted source")
+    if not all(
+        files_equal(trusted_path, staged_path)
+        for (_, trusted_path), (_, staged_path) in zip(trusted_files, staged_files)
+    ):
+        raise ValueError("staged bundle content differs from trusted source")
+except (OSError, UnicodeError, ValueError):
+    sys.exit(1)
+PY
+}
+
 is_verified_first_party_extension_manifest() {
   local manifest="$1"
   local extension_dir
@@ -172,9 +240,12 @@ is_verified_first_party_extension_manifest() {
 }
 
 # Reborn live QA copies each case's full home into the artifact staging tree.
-# In strict mode, remove only managed system-skill installations whose marker,
-# stable content hash, file set, and bytes all match the source-controlled
-# bundle. Unverified and operator-owned skills remain in scope for scanning.
+# In strict mode, remove managed system-skill installations that are provably
+# the source-controlled bundle: either the runtime ownership marker verifies
+# (marker + stable content hash + file set + bytes), or — for the
+# marker-less trees the backend-generic skill mount exports — the file set
+# and bytes are identical to the source bundle. Unverified, divergent, and
+# operator-owned skills remain in scope for scanning.
 if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" || "${STRICT_ARTIFACT_SCRUB}" == "1" ]]; then
   while IFS= read -r -d '' marker; do
     skill_dir="$(dirname "${marker}")"
@@ -190,6 +261,36 @@ if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" || "${STRICT_ARTIFACT_SCRUB}" == "1" 
     find "${ARTIFACT_DIR}" -type f \
       -path '*/reborn-home/*/local-dev/system/skills/*/.ironclaw-reborn-bundled.json' \
       -print0
+  )
+
+  # Skill mounts moved onto one backend-generic tree (#7171), and the case
+  # homes exported into artifacts no longer carry the runtime ownership
+  # marker — the marker-keyed pruning above stopped engaging, and the
+  # long-committed placeholder text in `skills/local-test/SKILL.md`
+  # (`-e NEARAI_API_KEY=<your-key>` docker examples) started failing every
+  # strict lane. A marker-less skill snapshot whose file set and bytes are
+  # identical to the source-controlled bundle is repository content whether
+  # or not the runtime stamped it; prune those too. Anything divergent —
+  # operator-authored, truncated, or modified — stays in scope for scanning.
+  while IFS= read -r -d '' skill_dir; do
+    skill_dir="${skill_dir%/}"
+    case "${skill_dir}" in
+      "${ARTIFACT_DIR}"/*/reborn-home/*/local-dev/system/skills/*|\
+      "${ARTIFACT_DIR}"/reborn-home/*/local-dev/system/skills/*)
+        if [[ -f "${skill_dir}/${BUNDLED_SKILL_MARKER}" ]]; then
+          # The marker-keyed verification above owns marker-carrying dirs;
+          # a marker that failed verification must stay in scanning scope.
+          continue
+        fi
+        if is_source_identical_bundled_skill "${skill_dir}"; then
+          rm -rf -- "${skill_dir}"
+        fi
+        ;;
+    esac
+  done < <(
+    find "${ARTIFACT_DIR}" -type d \
+      -path '*/reborn-home/*/local-dev/system/skills/*' \
+      -prune -print0
   )
 
   # Installed first-party extension manifests are also source-controlled

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -125,6 +125,7 @@ class ScrubArtifactsTests(unittest.TestCase):
         source_body: str,
         staged_body: str | None = None,
         marker: dict[str, object] | str | None = None,
+        include_marker: bool = True,
     ) -> tuple[Path, Path]:
         trusted_root = artifact_dir.parent / "trusted-skills"
         trusted_skill = trusted_root / "local-test"
@@ -146,20 +147,21 @@ class ScrubArtifactsTests(unittest.TestCase):
             source_body if staged_body is None else staged_body,
             encoding="utf-8",
         )
-        marker_payload = marker or {
-            "owner": "ironclaw_reborn_composition_bundled_skill",
-            "format": 1,
-            "content_hash": self.bundle_hash("local-test", trusted_skill),
-        }
-        marker_text = (
-            marker_payload
-            if isinstance(marker_payload, str)
-            else json.dumps(marker_payload)
-        )
-        (staged_skill / ".ironclaw-reborn-bundled.json").write_text(
-            marker_text,
-            encoding="utf-8",
-        )
+        if include_marker:
+            marker_payload = marker or {
+                "owner": "ironclaw_reborn_composition_bundled_skill",
+                "format": 1,
+                "content_hash": self.bundle_hash("local-test", trusted_skill),
+            }
+            marker_text = (
+                marker_payload
+                if isinstance(marker_payload, str)
+                else json.dumps(marker_payload)
+            )
+            (staged_skill / ".ironclaw-reborn-bundled.json").write_text(
+                marker_text,
+                encoding="utf-8",
+            )
         return trusted_root, staged_skill
 
     @staticmethod
@@ -380,6 +382,51 @@ class ScrubArtifactsTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stdout)
             self.assertFalse(bundled.exists())
             self.assertTrue((unmanaged / "SKILL.md").exists())
+
+    def test_strict_scrub_prunes_marker_less_source_identical_skill(self) -> None:
+        """The backend-generic skill mount exports no runtime marker (#7171);
+        a snapshot byte-identical to the source bundle is still repository
+        content and must not fail the strict lane."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, bundled = self.write_bundled_skill_fixture(
+                root,
+                source_body="docker run -e NEARAI_API_KEY=<your-key> ironclaw-test\n",
+                include_marker=False,
+            )
+
+            result = self.run_scrub(
+                root,
+                strict=True,
+                bundled_skills_root=trusted_root,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertFalse(bundled.exists())
+
+    def test_strict_scrub_still_scans_marker_less_divergent_skill(self) -> None:
+        """A marker-less snapshot that DIVERGES from the source bundle is not
+        provably repository content — secret-shaped material in it must still
+        fail the strict lane."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "artifacts"
+            root.mkdir()
+            trusted_root, bundled = self.write_bundled_skill_fixture(
+                root,
+                source_body="docker run ironclaw-test\n",
+                staged_body="api_key: live-secret-value\n",
+                include_marker=False,
+            )
+
+            result = self.run_scrub(
+                root,
+                strict=True,
+                bundled_skills_root=trusted_root,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertFalse((bundled / "SKILL.md").exists())
 
     def test_strict_scrub_still_scans_unmanaged_system_skill(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -203,6 +203,16 @@ DEFAULT_USER_ID = "reborn-webui-v2-live-qa-user"
 ENDPOINT_STATUS_URL = "https://near.ai"
 PROVIDER = "reborn-webui-v2"
 MODE = "live"
+# The composer's message POST rides the session channel ingress route since
+# the channel normalization split (#7477):
+# `/api/webchat/v2/channels/<extension>/messages`. The older thread-scoped
+# route is still accepted so one harness spans binaries on either side of
+# that split — the same migration the stress client made in #7568. QA 10
+# went 0/10 (submission-identity capture timing out on a healthy, streaming
+# turn) when this predicate only knew the retired route.
+SUBMISSION_MESSAGE_ROUTE_RE = re.compile(
+    r"/api/webchat/v2/(?:threads|channels)/[^/]+/messages$"
+)
 # Live QA is model- and network-nondeterministic: the same commit can pass then
 # flake red hours later. Retry a transient (assertion/behavioral) case failure up
 # to this many total attempts before recording a red. Default 2 = one retry;
@@ -1859,8 +1869,7 @@ async def _live_chat_case(
             request = response.request  # type: ignore[attr-defined]
             if request.method != "POST":
                 return False
-            if not re.search(
-                r"/api/webchat/v2/threads/[^/]+/messages$",
+            if not SUBMISSION_MESSAGE_ROUTE_RE.search(
                 str(response.url),  # type: ignore[attr-defined]
             ):
                 return False

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -2587,6 +2587,23 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertLess(auth_index, chat_index)
         self.assertLess(chat_index, submit_index)
 
+    def test_submission_route_matches_channel_and_thread_message_posts(self):
+        """The composer posts to the session channel route since the channel
+        normalization split (#7477); the retired thread-scoped route stays
+        accepted so one harness spans binaries on either side (QA 10 went
+        0/10 when the predicate knew only the retired route)."""
+        pattern = run_live_qa.SUBMISSION_MESSAGE_ROUTE_RE
+        base = "http://127.0.0.1:5000/api/webchat/v2"
+        self.assertIsNotNone(pattern.search(f"{base}/channels/web-app/messages"))
+        self.assertIsNotNone(
+            pattern.search(f"{base}/threads/6f9e2f34-1c2d-5abc-9def-0123456789ab/messages")
+        )
+        self.assertIsNone(pattern.search(f"{base}/channels/web-app/messages/123"))
+        self.assertIsNone(pattern.search(f"{base}/channels/messages"))
+        self.assertIsNone(
+            pattern.search(f"{base}/threads/6f9e2f34/messages?replay=1")
+        )
+
     def test_submission_capture_retries_once_after_no_post_and_connect_dismissal(self):
         submitted = {
             "outcome": "submitted",


### PR DESCRIPTION
## Summary

Two independent regressions have kept every **scheduled Live Canary** red (last green: Aug 7, 15:20 UTC). This PR fixes both. Neither is a product regression — the product-side turns are healthy; both failures live in the canary tooling.

**1. Strict scrub fails all 12 shards on repo-committed placeholder text (since #7171 — Aug 9, 21:11 UTC).**
#7171 moved skill mounts onto one backend-generic tree, and the case homes exported into artifacts no longer carry the `.ironclaw-reborn-bundled.json` runtime marker — verified directly: **zero markers across all 31 materialized skills** in the QA-10 artifact of run [31641918366](https://github.com/nearai/ironclaw/actions/runs/31641918366). The marker-keyed bundled-skill pruning (#6453) therefore never engages, and the ancient placeholder docs in `skills/local-test/SKILL.md` (`-e NEARAI_API_KEY=<your-key>` docker examples, committed in #524) trip the `api_key=` pattern in every shard. The flagged line numbers match the repo file exactly — the content is byte-identical repository text.
**Fix:** in strict mode, additionally prune a *marker-less* skill snapshot whose file set and bytes are identical to the source-controlled bundle (`skills/<name>`). Identical-to-repo content is definitionally public. Anything divergent, truncated, or operator-authored stays in scanning scope — the fail-closed posture is unchanged, and a marker that exists but fails verification still stays in scope.

**2. QA 10 went 9/10 → 0/10 on a retired route (since #7477 — Aug 12, 21:18 UTC).**
#7477 moved WebChat message submission onto the session channel ingress route (`/api/webchat/v2/channels/<extension>/messages`). The live-QA submission-identity capture still waited on `/threads/<id>/messages`, so every QA 10 case (the shard that captures submission identity) timed out at `expect_response` after 15s — on turns that were *healthy and streaming the correct answers* (the failure screenshots show the right marker codes mid-stream). This is the same migration the stress client already made in #7568.
**Fix:** the predicate accepts both routes (module-level `SUBMISSION_MESSAGE_ROUTE_RE`), so one harness spans binaries on either side of the split.

| When (UTC) | Scheduled-canary state | Cause |
|---|---|---|
| Aug 7 15:20 | last green | — |
| Aug 7–8 | red at QA lanes | delivery-contract drift (fixed by #7389) |
| Aug 8 03:33 → | scrub failures, flickering | model-dependent trace text meeting the secret patterns |
| Aug 9 21:11 → | scrub fails all 12 shards, deterministic | **#7171 → this PR's fix 1** |
| Aug 12 21:18 → | QA 10 cases 0/10 on top | **#7477 → this PR's fix 2** |

Not addressed here (pre-existing, now-latent): the flickering trace-content variant from Aug 8 (secret-shaped prose in model output/trace previews) — the 16+-char bearer guard already bounds the worst of it; can follow up separately if it recurs.

## Test Strategy

- **Script self-tests (the owning tier for both files):** `scripts/live-canary/test_scrub_artifacts.py` — 21 pass, including two new cases: a marker-less snapshot identical to the source bundle is pruned and the strict lane passes; a marker-less snapshot that diverges (secret-shaped line) is still deleted and fails the lane. Sabotage-verified: the identical-snapshot test **fails against the unfixed script**. `scripts/reborn_webui_v2_live_qa/test_run_live_qa.py` — 218 pass (4 pre-existing expected failures), including a new route-pattern regression test (channel + thread routes accepted; suffixed/query/malformed URLs rejected).
- **Not applicable — Rust tiers:** scripts-only change; no crate code touched.
- **Definitive proof** is the next scheduled Live Canary run after merge.

## Compatibility / rollback

Scripts-only; no persisted state, no workflow changes. Revert restores the prior scrubber and predicate (and the red canaries). The scrubber change only *widens pruning* for provably-repo-identical content; every scanning path and the strict exit semantics are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
