### PR TITLE
test(kernel): pin admission contracts the AgentExecution seam must preserve (PR A)

### DIFF
--- a/crates/kernel/ironclaw_processes/src/journal.rs
+++ b/crates/kernel/ironclaw_processes/src/journal.rs
@@ -1388,6 +1388,111 @@ mod tests {
         assert_eq!(checkpoint.as_str(), "checkpoint:ok");
     }
 
+    /// Pins the durable wire spelling of every process kind. Journal rows live
+    /// forever under never-delete, so these spellings are a persistence
+    /// contract: renaming a variant or changing the serde representation
+    /// silently orphans every stored row of that kind.
+    #[test]
+    fn process_kind_wire_spellings_are_pinned() {
+        for (kind, wire) in [
+            (ProcessKind::AgentTurn, serde_json::json!("agent_turn")),
+            (
+                ProcessKind::CapabilityInvocation,
+                serde_json::json!("capability_invocation"),
+            ),
+            (
+                ProcessKind::CapabilityInvocationState,
+                serde_json::json!("capability_invocation_state"),
+            ),
+            (ProcessKind::Internal, serde_json::json!("internal")),
+        ] {
+            let encoded = serde_json::to_value(&kind).expect("serialize process kind");
+            assert_eq!(encoded, wire, "wire spelling changed for {kind:?}");
+            let decoded: ProcessKind =
+                serde_json::from_value(encoded).expect("round-trip process kind");
+            assert_eq!(decoded, kind);
+        }
+    }
+
+    /// The process kind is deliberately FAIL-CLOSED on unknown wire values —
+    /// the opposite of the lenient checkpoint-kind field above. A build that
+    /// does not know a kind cannot claim, execute, or reproject rows of that
+    /// kind, so a snapshot carrying one must refuse to deserialize rather than
+    /// be misread as some kind this build does understand. This is the
+    /// rolling-compatibility guarantee a new run class relies on: rows written
+    /// by a newer build are rejected by older readers instead of executed.
+    #[test]
+    fn snapshot_with_unrecognized_process_kind_fails_closed() {
+        let snapshot = JournaledProcessSnapshot {
+            process_id: ProcessId::new(),
+            process_kind: ProcessKind::AgentTurn,
+            scope: ResourceScope {
+                tenant_id: TenantId::new("tenant-kind-compat").expect("tenant"),
+                user_id: UserId::new("user-kind-compat").expect("user"),
+                agent_id: None,
+                project_id: None,
+                mission_id: None,
+                thread_id: None,
+                invocation_id: ironclaw_host_api::ids::InvocationId::new(),
+            },
+            status: ProcessLifecycleStatus::Queued,
+            suspension: None,
+            checkpoint_ref: None,
+            checkpoint_kind: None,
+            input_ref: None,
+            failure: None,
+            journal_cursor: ProcessJournalCursor(1),
+            lease: None,
+            crash_reclaim_count: 0,
+            created_at: chrono::Utc::now(),
+            owner_user_id: None,
+            concurrency_class: None,
+            parent_process_id: None,
+            root_process_id: None,
+            metadata: Value::Null,
+        };
+        let mut encoded =
+            serde_json::to_value(&snapshot).expect("serialize journaled process snapshot");
+        let object = encoded.as_object_mut().expect("snapshot object");
+
+        object.insert(
+            "process_kind".to_string(),
+            Value::String("kind_from_a_future_build".to_string()),
+        );
+        let unknown_unit = serde_json::from_value::<JournaledProcessSnapshot>(encoded.clone());
+        assert!(
+            unknown_unit.is_err(),
+            "a snapshot carrying an unknown process kind must fail closed, not misclassify"
+        );
+
+        encoded.as_object_mut().expect("snapshot object").insert(
+            "process_kind".to_string(),
+            serde_json::json!({ "kind_from_a_future_build": "payload" }),
+        );
+        let unknown_tagged = serde_json::from_value::<JournaledProcessSnapshot>(encoded);
+        assert!(
+            unknown_tagged.is_err(),
+            "an unknown payload-carrying process kind must also fail closed"
+        );
+
+        // The claim filter shares the vocabulary: a claim request scoped to a
+        // kind this build knows round-trips unchanged.
+        let claim = ClaimProcessesRequest {
+            worker_id: ProcessWorkerId::from_trusted("worker-kind-compat"),
+            scope_filter: None,
+            process_id_filter: None,
+            process_kind_filter: Some(ProcessKind::AgentTurn),
+            max_processes: 1,
+        };
+        let claim_encoded = serde_json::to_value(&claim).expect("serialize claim request");
+        let claim_decoded: ClaimProcessesRequest =
+            serde_json::from_value(claim_encoded).expect("round-trip claim request");
+        assert_eq!(
+            claim_decoded.process_kind_filter,
+            Some(ProcessKind::AgentTurn)
+        );
+    }
+
     /// The wire boundary lease recovery depends on: a persisted snapshot whose
     /// checkpoint kind an older or newer build does not recognize must degrade
     /// to `None` ("unknown kind") instead of failing the whole row, and a row

--- a/crates/kernel/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/kernel/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -2448,6 +2448,69 @@ async fn process_submission_idempotency_ignores_fresh_invocation_identity() {
     assert_eq!(replayed.journal_cursor, submitted.journal_cursor);
 }
 
+/// Pins the journal-level idempotency semantics the turn pipeline is built on:
+/// the replay key is `(scope owner, process kind, operation id)` and the
+/// PAYLOAD IS NOT COMPARED. A retry carrying the same operation id but a
+/// different metadata payload replays the ORIGINAL snapshot verbatim — it does
+/// not mint a second process and it does not surface a mismatch error at this
+/// layer. Callers that need same-key/different-payload to fail closed must
+/// enforce it in front of the journal (rule-12 adapter retries always carry an
+/// identical payload, so this layer never needs to tell them apart).
+#[tokio::test]
+async fn process_submission_idempotency_replays_original_despite_payload_drift() {
+    let store = ProcessJournalStore::new(in_memory_backed_processes_filesystem());
+    let scope = scope();
+    let owner_user_id = scope.user_id.clone();
+    let request = |process_id, metadata: serde_json::Value| SubmitProcessRequest {
+        process_id,
+        process_kind: ProcessKind::Internal,
+        scope: scope.clone(),
+        exclusive_within_scope: false,
+        operation_id: Some(ProcessOperationId::from_trusted("payload-drift-operation")),
+        owner_user_id: Some(owner_user_id.clone()),
+        concurrency_class: None,
+        parent_process_id: None,
+        root_process_id: None,
+        spawn_tree_descendant_cap: None,
+        dependency: None,
+        checkpoint_ref: None,
+        input: None,
+        created_at: Utc::now(),
+        metadata,
+    };
+
+    let submitted = store
+        .submit_process(request(
+            ProcessId::new(),
+            serde_json::json!({ "payload": "original" }),
+        ))
+        .await
+        .expect("initial submission");
+    let replayed = store
+        .submit_process(request(
+            ProcessId::new(),
+            serde_json::json!({ "payload": "drifted" }),
+        ))
+        .await
+        .expect("same-key retry with a different payload replays at this layer");
+
+    assert_eq!(replayed.process_id, submitted.process_id);
+    assert_eq!(replayed.journal_cursor, submitted.journal_cursor);
+    assert_eq!(
+        replayed.metadata, submitted.metadata,
+        "replay must return the ORIGINAL payload, never the drifted retry's"
+    );
+    let persisted = store
+        .process_snapshots(&scope)
+        .await
+        .expect("read persisted process snapshots");
+    assert_eq!(
+        persisted.len(),
+        1,
+        "a drifted same-key retry must not mint a second process"
+    );
+}
+
 #[tokio::test]
 async fn process_claim_enforces_owner_and_class_concurrency_limits_atomically() {
     let owner_store = ProcessJournalStore::new(in_memory_backed_processes_filesystem())

--- a/crates/kernel/ironclaw_turns/tests/coordinator_prepared_run_contract.rs
+++ b/crates/kernel/ironclaw_turns/tests/coordinator_prepared_run_contract.rs
@@ -1,0 +1,230 @@
+//! Pins for the coordinator's `prepare_turn` scope-binding reservation.
+//!
+//! `prepare_turn` mints a run id without side effects and records the scope it
+//! was prepared under; `submit_turn` consumes that reservation and rejects a
+//! cross-scope submission so a prepared id cannot inject lineage into a
+//! different scope. Subagent spawn legitimately prepares an id in the parent
+//! scope and submits under a child scope, which is exempted via
+//! `parent_run_id`. These semantics were previously untested; the AgentExecution
+//! seam (Phase 2) moves conversation submission behind a port that must keep
+//! them byte-identical, so this file is part of that migration evidence.
+
+use chrono::{TimeZone, Utc};
+use ironclaw_host_api::ids::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_turns::{
+    AcceptedMessageRef, DefaultTurnCoordinator, GetRunStateRequest, IdempotencyKey,
+    ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef, SubmitTurnRequest,
+    SubmitTurnResponse, TurnActor, TurnCapacityResource, TurnCoordinator, TurnError, TurnRunId,
+    TurnScope, test_support::in_memory_agent_turn_process_system,
+};
+use std::sync::Arc;
+
+fn scope_for_thread(thread: &str) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant-prepared-run").expect("tenant"),
+        Some(AgentId::new("agent-prepared-run").expect("agent")),
+        Some(ProjectId::new("project-prepared-run").expect("project")),
+        ThreadId::new(thread).expect("thread"),
+    )
+}
+
+fn submit_request(
+    scope: TurnScope,
+    requested_run_id: Option<TurnRunId>,
+    parent_run_id: Option<TurnRunId>,
+    idempotency_key: &str,
+) -> SubmitTurnRequest {
+    SubmitTurnRequest {
+        scope,
+        actor: TurnActor::new(UserId::new("user-prepared-run").expect("user")),
+        accepted_message_ref: AcceptedMessageRef::new("message-prepared-run").expect("accepted"),
+        source_binding_ref: SourceBindingRef::new("source-prepared-run").expect("source"),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-prepared-run").expect("reply"),
+        requested_run_profile: Some(RunProfileRequest::new("default").expect("profile")),
+        requested_model: None,
+        idempotency_key: IdempotencyKey::new(idempotency_key).expect("idempotency key"),
+        received_at: Utc.with_ymd_and_hms(2026, 8, 13, 12, 0, 0).unwrap(),
+        requested_run_id,
+        parent_run_id,
+        subagent_depth: 0,
+        spawn_tree_root_run_id: None,
+        product_context: None,
+    }
+}
+
+#[tokio::test]
+async fn prepared_run_id_is_consumed_on_first_submit_in_the_prepared_scope() {
+    let processes = in_memory_agent_turn_process_system();
+    let coordinator = DefaultTurnCoordinator::new(Arc::new(processes.runtime()));
+    let scope = scope_for_thread("thread-prepared-same-scope");
+
+    let prepared = coordinator
+        .prepare_turn(scope.clone())
+        .await
+        .expect("prepare turn");
+
+    let response = coordinator
+        .submit_turn(submit_request(
+            scope.clone(),
+            Some(prepared),
+            None,
+            "idem-prepared-same-scope",
+        ))
+        .await
+        .expect("submit under the prepared scope");
+    let SubmitTurnResponse::Accepted { run_id, .. } = response;
+    assert_eq!(run_id, prepared, "the prepared id must become the run id");
+
+    let state = coordinator
+        .get_run_state(GetRunStateRequest {
+            scope,
+            run_id: prepared,
+        })
+        .await
+        .expect("run state for the admitted prepared run");
+    assert_eq!(state.run_id, prepared);
+}
+
+#[tokio::test]
+async fn prepared_run_id_rejects_cross_scope_submission_without_a_parent() {
+    let processes = in_memory_agent_turn_process_system();
+    let coordinator = DefaultTurnCoordinator::new(Arc::new(processes.runtime()));
+    let prepared_scope = scope_for_thread("thread-prepared-origin");
+    let foreign_scope = scope_for_thread("thread-prepared-foreign");
+
+    let prepared = coordinator
+        .prepare_turn(prepared_scope.clone())
+        .await
+        .expect("prepare turn");
+
+    let error = coordinator
+        .submit_turn(submit_request(
+            foreign_scope.clone(),
+            Some(prepared),
+            None,
+            "idem-prepared-cross-scope",
+        ))
+        .await
+        .expect_err("cross-scope submission of a prepared id must be rejected");
+    assert_eq!(error, TurnError::Unauthorized);
+
+    // Nothing was admitted under either scope for the rejected id.
+    for scope in [prepared_scope, foreign_scope.clone()] {
+        let state = coordinator
+            .get_run_state(GetRunStateRequest {
+                scope,
+                run_id: prepared,
+            })
+            .await;
+        assert_eq!(
+            state.expect_err("the rejected prepared id must not have been admitted"),
+            TurnError::ScopeNotFound
+        );
+    }
+
+    // The reservation is consumed by the FIRST submit attempt, even a rejected
+    // one: a retry of the same wrong-scope submission is no longer caught by
+    // the coordinator reservation check and falls through to the store, which
+    // admits it as an ordinary run in the submitted scope. This pins the
+    // documented consume-on-first-attempt semantics.
+    let retried = coordinator
+        .submit_turn(submit_request(
+            foreign_scope,
+            Some(prepared),
+            None,
+            "idem-prepared-cross-scope-retry",
+        ))
+        .await
+        .expect("post-consumption retry falls back to store admission");
+    let SubmitTurnResponse::Accepted { run_id, .. } = retried;
+    assert_eq!(run_id, prepared);
+}
+
+#[tokio::test]
+async fn prepared_run_id_cross_scope_submission_with_a_parent_is_exempt() {
+    let processes = in_memory_agent_turn_process_system();
+    let coordinator = DefaultTurnCoordinator::new(Arc::new(processes.runtime()));
+    let parent_scope = scope_for_thread("thread-prepared-parent");
+    let child_scope = scope_for_thread("thread-prepared-child");
+
+    // Subagent spawn prepares the child id under the parent scope and submits
+    // it under the child scope; `parent_run_id` marks the submission as a
+    // child run, which skips the cross-scope rejection.
+    let prepared = coordinator
+        .prepare_turn(parent_scope.clone())
+        .await
+        .expect("prepare turn");
+    let parent_run_id = TurnRunId::new();
+
+    let response = coordinator
+        .submit_turn(submit_request(
+            child_scope,
+            Some(prepared),
+            Some(parent_run_id),
+            "idem-prepared-child-exempt",
+        ))
+        .await
+        .expect("child-run submission under a different scope is exempt");
+    let SubmitTurnResponse::Accepted { run_id, .. } = response;
+    assert_eq!(run_id, prepared);
+}
+
+#[tokio::test]
+async fn abort_prepared_turn_releases_the_reservation() {
+    let processes = in_memory_agent_turn_process_system();
+    let coordinator = DefaultTurnCoordinator::new(Arc::new(processes.runtime()));
+    let prepared_scope = scope_for_thread("thread-prepared-abort-origin");
+    let other_scope = scope_for_thread("thread-prepared-abort-other");
+
+    let prepared = coordinator
+        .prepare_turn(prepared_scope)
+        .await
+        .expect("prepare turn");
+    coordinator
+        .abort_prepared_turn(prepared)
+        .await
+        .expect("abort prepared turn");
+
+    // With the reservation released, the id is an ordinary requested run id:
+    // submitting it under a different scope is no longer a cross-scope
+    // violation of a live reservation.
+    let response = coordinator
+        .submit_turn(submit_request(
+            other_scope,
+            Some(prepared),
+            None,
+            "idem-prepared-after-abort",
+        ))
+        .await
+        .expect("submission after abort is not bound to the prepared scope");
+    let SubmitTurnResponse::Accepted { run_id, .. } = response;
+    assert_eq!(run_id, prepared);
+}
+
+#[tokio::test]
+async fn prepare_turn_reservations_are_capped() {
+    let processes = in_memory_agent_turn_process_system();
+    let coordinator = DefaultTurnCoordinator::new(Arc::new(processes.runtime()));
+    let scope = scope_for_thread("thread-prepared-cap");
+
+    // MAX_PREPARED_RUN_IDS reservations succeed; the next one fails closed
+    // with the submit-turn capacity resource instead of growing unbounded.
+    const PREPARED_RUN_ID_CAP: u64 = 4096;
+    for _ in 0..PREPARED_RUN_ID_CAP {
+        coordinator
+            .prepare_turn(scope.clone())
+            .await
+            .expect("prepare within the reservation cap");
+    }
+    let error = coordinator
+        .prepare_turn(scope)
+        .await
+        .expect_err("reservations beyond the cap must be rejected");
+    assert_eq!(
+        error,
+        TurnError::CapacityExceeded {
+            resource: TurnCapacityResource::SubmitTurn,
+            cap: PREPARED_RUN_ID_CAP,
+        }
+    );
+}

--- a/tests/integration/steering.rs
+++ b/tests/integration/steering.rs
@@ -119,6 +119,91 @@ async fn queued_steering_message_reaches_the_model_mid_run() {
     );
 }
 
+/// Cancel-time queue reconciliation (conversation-binding rule 12): a run
+/// cancelled before draining its steering queue has its still-queued messages
+/// flipped `Queued` → `RejectedBusy` by the cancel-time reconciler and NEVER
+/// auto-resubmitted — the user resends; the thread is free for the next turn.
+///
+/// This is the root-tier pin of the behavior `CancelReconcilingTurnCoordinator`
+/// (wired in this harness exactly as in production composition) provides; the
+/// composition-tier twin is
+/// `deferred_busy_message_not_auto_submitted_after_run_cancellation`.
+#[tokio::test]
+async fn cancelled_run_flips_queued_steering_to_rejected_busy_without_resubmit() {
+    let gate = ParkingModelGate::new();
+    let harness = RebornIntegrationHarness::test_default()
+        .park_model(gate.clone())
+        .script([
+            RebornScriptedReply::text("should never be finalized"),
+            RebornScriptedReply::text("next turn done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    let run_id = harness
+        .submit_turn_async("start a long task")
+        .await
+        .expect("turn A submitted");
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_until_parked())
+        .await
+        .expect("model call parks before the timeout");
+
+    // Queue B behind the parked run.
+    let ack = harness
+        .submit_turn_ack("steer the doomed task")
+        .await
+        .expect("busy submit does not error");
+    let ProductInboundAck::DeferredBusy { active_run_id, .. } = ack else {
+        panic!("expected DeferredBusy while the thread has an active run, got {ack:?}");
+    };
+    assert_eq!(active_run_id, run_id);
+    let queued = harness
+        .user_message_record("steer the doomed task")
+        .await
+        .expect("queued message persisted");
+    assert_eq!(queued.status, MessageStatus::Queued);
+
+    // Cancel A while parked, then release so the loop observes the cancel.
+    harness.cancel_run(run_id).await.expect("cancel accepted");
+    gate.release();
+    harness
+        .wait_for_status(run_id, TurnStatus::Cancelled)
+        .await
+        .expect("parked run reaches Cancelled after cancel");
+
+    // The queued row settles RejectedBusy — reconciled, never resubmitted.
+    let reconciled = harness
+        .user_message_record("steer the doomed task")
+        .await
+        .expect("reconciled message still in transcript");
+    assert_eq!(
+        reconciled.status,
+        MessageStatus::RejectedBusy,
+        "cancel-time reconciliation must flip the stranded row Queued → RejectedBusy"
+    );
+
+    // Never auto-resubmitted: the steering text must not have reached any
+    // model request, and no run was minted for it.
+    assert!(
+        harness
+            .assert_model_saw_user_message("steer the doomed task")
+            .await
+            .is_err(),
+        "a reconciled steering message must never reach a model request"
+    );
+
+    // The thread is free: the next submission is accepted and completes.
+    harness
+        .submit_turn("do the next thing")
+        .await
+        .expect("next turn on the freed thread completes");
+    harness
+        .assert_reply_contains("next turn done")
+        .await
+        .expect("next turn's reply persisted");
+}
+
 /// The durable steering guarantee across a restart (review: High): a message
 /// queued behind a run parked on a durable approval gate survives a full
 /// planned-runtime restart over the same LibSQL store — the resumed run drains


### PR DESCRIPTION
## Summary

- **Tests only** — PR A of the AgentExecution seam train (design: `docs/internal/design/2026-08-12-agent-execution-seam.md` + companion architecture doc, PR #7562). Pins TODAY's admission behavior at the exact seams Phase 2 will move behind the `AgentExecution` port, so the cutover has a referee.
- New `coordinator_prepared_run_contract.rs`: `prepare_turn` scope-binding reservation semantics — previously completely untested (consume-on-first-attempt, cross-scope `Unauthorized`, the subagent `parent_run_id` exemption, `abort_prepared_turn`, the 4096 cap failing closed).
- `ironclaw_processes` journal tests: durable wire spellings of every `ProcessKind` variant, and the fail-closed contract that a snapshot carrying an unknown kind **refuses to deserialize** (the rolling-compat guarantee the new detached run class in PR B relies on: rows written by a newer build are rejected by older readers, never misclassified/executed).
- `process_journal_store_contract.rs`: same-operation-id retries with a **different payload** replay the ORIGINAL snapshot verbatim — the payload is not part of the journal replay key. (See "spec vs live" below.)
- `tests/integration/steering.rs`: root-tier pin of cancel-time queue reconciliation (conversation-binding rule 12) — a cancelled run's still-queued steering message flips `Queued → RejectedBusy`, never reaches a model request, is never auto-resubmitted, and the thread is free for the next turn.

### The migration-evidence inventory (what already pins the rest)

Phase 2's referee is this PR's additions **plus** the existing suite, enumerated here so the cutover PR can point at one list:

- **Busy admission (`DeferredBusy`/`RejectedBusy`)**: `tests/integration/steering.rs` (queued message reaches the model mid-run; survives runtime restart), `tests/integration/generated_gate_sequences.rs::generated_same_thread_double_submit_interleavings_admit_one_run`, `crates/product/ironclaw_assistant/tests/inbound_turn_contract.rs` (`busy_thread_*` family incl. profile `allow_steering=false → RejectedBusy`, mark-before-drainable ordering, ack-edge tolerance), `reborn_services_contract.rs` (WebUI lane + notice copy), threads store status machine (`session_thread_contract.rs` + filesystem twin: `RejectedBusy` durably terminal, resequencing, legacy `DeferredBusy` round-trip).
- **Duplicate-delivery replay of each outcome**: `tests/integration/idempotent_replay.rs`, `inbound_turn_contract.rs` (`rejected_busy_replay_is_re_rejected_not_resubmitted`, `queued_replay_re_enqueues_crash_orphaned_message`, `queued_replay_settles_rejected_when_active_run_is_terminal`), `product_surface_contract.rs` (settled `RejectedBusy` → transport retry `Duplicate`), `reborn_services_contract.rs` replay family, `conversations` `inbound_contract.rs::busy_thread_retry_uses_fresh_submit_key_for_same_accepted_message`.
- **Submit idempotency (`ProcessOperationId`)**: `process_journal_store_contract.rs::process_submission_idempotency_ignores_fresh_invocation_identity` (+ the new payload-drift pin), observer no-redelivery, bounded idempotency maps.
- **One-active-run-per-thread**: `process_journal_store_contract.rs::exclusive_process_submission_uses_authoritative_live_projection`, state-machine matrix tests, `tests/integration/cancel.rs` lock-release arms, `reborn_turn_state_lock_free_submit_parity.rs`.
- **Trigger trusted path**: `tests/integration/triggered_submit.rs` (origin pin, unsafe-prompt reject, completion), `tests/integration/group_triggers/` scenarios, `conversations::inbound` unit suite (replay-first, sealed mint), composition `trigger_poller_trusted_submit` suite (ThreadBusy on a fire = retryable-backend).
- **Subagent child-run submission**: `process_projection/tests.rs::child_submission_persists_computed_lineage_and_is_idempotent` (+ depth overflow), `tests/integration/subagent_await_edge.rs`, the ~60-test `subagent_spawn_port` unit suite. (The live spawn e2e binaries are currently `#[ignore]`d upstream via the `TEMP(disable-spawn-subagents)` capability deny filter — pre-existing, unrelated to this train.)

### Spec vs live behavior, flagged per the train's ground rules

The seam doc (§4.2) specifies *"same key + different payload fails closed"* for `AgentExecution::submit`. **Live behavior today**: the journal layer replays the original snapshot without comparing payloads (now pinned here), and route-mismatch fail-closed exists only at the conversations tier (rule 11) plus the WebUI `client_action_id` lane (`ClientActionReplayMismatch`). PR B therefore implements the payload-fingerprint fail-closed check **in the seam, in front of the journal** — rule-12 adapter retries always carry an identical payload, so conversation semantics are unchanged. This PR pins the journal-layer semantics so that layering stays honest.

## Change Type

- [x] Documentation <!-- tests-only; no production code changed -->

(Tests only — no production behavior change. Closest template fit: Track A tests/chore.)

## Linked Issue

Related: design PR #7562 (the two design documents this train implements).

## Validation

- [x] `cargo fmt --all -- --check` (touched files formatted)
- [x] `cargo clippy -p ironclaw_processes -p ironclaw_turns --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p ironclaw_integration_tests --tests -- -D warnings` (root package is not covered by per-crate clippy)
- [x] `cargo build` (via test builds)
- [x] Relevant tests pass: `cargo test -p ironclaw_processes` (full), `cargo test -p ironclaw_turns` (full), `cargo test -p ironclaw_integration_tests --test reborn_integration_steering` — all green in one pass.
- [ ] Manual testing: Not applicable — tests-only PR.

## Test Strategy

User behavior: unchanged — this PR only pins existing behavior (busy admission, cancel reconciliation, reservation binding, journal idempotency, process-kind wire contract) ahead of the Phase 1/2 seam implementation.

Risk areas:
- [x] Persistence
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `ironclaw_processes` journal wire pins (2 new), `process_journal_store_contract.rs` payload-drift pin (1 new), `ironclaw_turns/tests/coordinator_prepared_run_contract.rs` (5 new).
- Reborn integration: `tests/integration/steering.rs::cancelled_run_flips_queued_steering_to_rejected_busy_without_resubmit` (1 new).
- Recorded fixture: Not applicable — no model-behavior change; scripted in-memory traces suffice.
- Browser E2E: Not applicable — no UI change.
- Backend or runtime: Not applicable — no runtime change; libSQL-backed steering-restart test already covers the durable path.
- Live canary: Not applicable — tests only.

What the tests prove: today's admission semantics at each seam the AgentExecution port will front are pinned and green **before** any implementation lands; PR B must keep every one green unchanged before and after.

Commands run: `cargo test -p ironclaw_processes` · `cargo test -p ironclaw_turns` · `cargo test -p ironclaw_integration_tests --test reborn_integration_steering` · clippy as above.

## Security Impact

None (tests only). The process-kind fail-closed pin *documents* a security-relevant property: unknown durable kinds are rejected, never misclassified into an executable kind.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added or changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive — unchanged; no prompt paths touched.
- [x] Hashes declare purpose — none added.
- [x] New/changed status, exit, policy, runtime, or error variants: none. Command/output: `git diff --stat docs/agent-execution-design..HEAD` → 4 files, tests only.
- [x] Security/durability `serde(default)` fields: none added; the new tests PIN existing fail-closed deserialization (`ProcessKind`) and replay (`ProcessOperationId`) semantics.
- [x] Queues/maps/buffers/counters: none added; the prepared-run-id cap (4096) is now test-enforced.
- [x] Driver/operator-visible errors: none added.
- [x] Sandbox/native/host names: unchanged.

## Database Impact

None. No migrations, no schema changes; tests use the in-memory/libSQL harness backends that exist today.

## Blast Radius

Test-only additions in `ironclaw_processes`, `ironclaw_turns`, and the root integration package. Nothing shipped changes. The one thing that could "break" is a future PR violating a pinned contract — which is the point.

## Rollback Plan

Revert the single commit; no production code or data is affected.

## Review Follow-Through

- This PR **retargets to `main` automatically when its base (`docs/agent-execution-design`, PR #7562) merges.**
- PR B (`agent-execution/impl` → this branch) implements Phase 1 (seam + detached run class) and Phase 2 (conversations behind the seam); these pins must pass unchanged before and after it.

---

**Review track**: A (tests only)
