### PR TITLE
fix(live-canary): widen the seeded slack grant to the manifest union and narrate scrub verdicts

### DIFF
--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -208,13 +208,20 @@ try:
     if not trusted_files:
         raise ValueError("trusted source is empty")
     if [relative for relative, _ in trusted_files] != [relative for relative, _ in staged_files]:
-        raise ValueError("staged bundle file set differs from trusted source")
-    if not all(
-        files_equal(trusted_path, staged_path)
-        for (_, trusted_path), (_, staged_path) in zip(trusted_files, staged_files)
-    ):
-        raise ValueError("staged bundle content differs from trusted source")
-except (OSError, UnicodeError, ValueError):
+        raise ValueError(
+            "staged bundle file set differs from trusted source: "
+            f"trusted={[relative for relative, _ in trusted_files]} "
+            f"staged={[relative for relative, _ in staged_files]}"
+        )
+    for (relative, trusted_path), (_, staged_path) in zip(trusted_files, staged_files):
+        if not files_equal(trusted_path, staged_path):
+            raise ValueError(
+                f"staged bundle content differs from trusted source at {relative}"
+            )
+except (OSError, UnicodeError, ValueError) as error:
+    # The verdict reason feeds the step log via the caller's narration —
+    # file names and relative paths only, never file content.
+    print(f"scrub: {error}", file=sys.stderr)
     sys.exit(1)
 PY
 }
@@ -253,7 +260,10 @@ if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" || "${STRICT_ARTIFACT_SCRUB}" == "1" 
       "${ARTIFACT_DIR}"/*/reborn-home/*/local-dev/system/skills/*|\
       "${ARTIFACT_DIR}"/reborn-home/*/local-dev/system/skills/*)
         if is_verified_bundled_skill "${marker}" "${skill_dir}"; then
+          echo "scrub: pruned marker-verified bundled skill snapshot: ${skill_dir}"
           rm -rf -- "${skill_dir}"
+        else
+          echo "scrub: kept skill snapshot for scanning (marker failed verification): ${skill_dir}"
         fi
         ;;
     esac
@@ -283,7 +293,11 @@ if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" || "${STRICT_ARTIFACT_SCRUB}" == "1" 
           continue
         fi
         if is_source_identical_bundled_skill "${skill_dir}"; then
+          echo "scrub: pruned source-identical bundled skill snapshot: ${skill_dir}"
           rm -rf -- "${skill_dir}"
+        else
+          # The python verdict above printed the exact mismatch reason.
+          echo "scrub: kept skill snapshot for scanning (not source-identical): ${skill_dir}"
         fi
         ;;
     esac

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -404,11 +404,16 @@ class ScrubArtifactsTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stdout)
             self.assertFalse(bundled.exists())
+            self.assertIn(
+                "scrub: pruned source-identical bundled skill snapshot:",
+                result.stdout,
+            )
 
     def test_strict_scrub_still_scans_marker_less_divergent_skill(self) -> None:
         """A marker-less snapshot that DIVERGES from the source bundle is not
         provably repository content — secret-shaped material in it must still
-        fail the strict lane."""
+        fail the strict lane, and the verdict must name the mismatch so a red
+        lane is diagnosable from the step log alone."""
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir) / "artifacts"
             root.mkdir()
@@ -427,6 +432,14 @@ class ScrubArtifactsTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 1, result.stdout)
             self.assertFalse((bundled / "SKILL.md").exists())
+            self.assertIn(
+                "scrub: kept skill snapshot for scanning (not source-identical):",
+                result.stdout,
+            )
+            self.assertIn(
+                "staged bundle content differs from trusted source at SKILL.md",
+                result.stdout + (result.stderr or ""),
+            )
 
     def test_strict_scrub_still_scans_unmanaged_system_skill(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/reborn_webui_v2_live_qa/slack_helpers.py
+++ b/scripts/reborn_webui_v2_live_qa/slack_helpers.py
@@ -78,6 +78,15 @@ def _slack_extension_manifest_path() -> Path:
 # never silently skip. Today no default-wired case hard-requires it; the bot
 # token is actor B wherever a bot can act.
 SLACK_SECOND_USER_TOKEN_ENV = "AUTH_LIVE_SLACK_SECOND_USER_TOKEN"
+# The seeded account's STORED grant, kept in lockstep with the slack
+# manifest's [[tools.credentials]] scope union
+# (crates/extensions/packages/slack/manifest.toml). Runtime account selection
+# requires the stored grant to carry every tool's manifest scopes, so a
+# stale list here parks slack activation on the auth gate and the connect
+# cases never reach installation_state=active (exactly what turned QA lanes
+# red when the eight new standard ops widened the union). The LIVE canary
+# Slack app must also grant the write additions to its user token for the
+# reaction/DM ops to succeed vendor-side.
 SLACK_PERSONAL_OAUTH_SCOPES = [
     "search:read",
     "channels:history",
@@ -90,6 +99,9 @@ SLACK_PERSONAL_OAUTH_SCOPES = [
     "mpim:read",
     "users:read",
     "chat:write",
+    "reactions:read",
+    "reactions:write",
+    "im:write",
 ]
 SIGNED_SLACK_EVENT_CASES = {
     "qa_5d_slack_strategy_doc_answer",


### PR DESCRIPTION
## Summary

Follow-up to #7574, driven by run [31715187702](https://github.com/nearai/ironclaw/actions/runs/31715187702) — the first scheduled Live Canary after #7515 (slack's eight new standard ops) merged.

**1. QA lanes now crash at slack connect — fixed (confirmed root cause).** The lane log shows `Extension setup completion did not produce a fully ready projection (required installation_state=active)` ~80s in. `SLACK_PERSONAL_OAUTH_SCOPES` (scripts/reborn_webui_v2_live_qa/slack_helpers.py) seeds the **stored grant** of the canary's personal Slack account, and runtime account selection requires the stored grant to cover every tool's manifest scopes. #7515 widened the union with `reactions:read`/`reactions:write`/`im:write`, so the stale eleven-scope seed parks activation on the auth gate — the exact live twin of the merge-queue fixture widening inside #7515 (that sweep covered `tests/`; this seeder lives under `scripts/`). The list now carries the full union with a lockstep comment. Note for ops: the canary Slack app's **live user token** must also be granted the three write additions for reaction/DM ops to succeed vendor-side.

**2. Scrub verdict narration — diagnosis for the remaining red.** The run still flagged `skills/local-test/SKILL.md` placeholder lines despite #7574, and the redacted report is genuinely ambiguous: it cannot distinguish "pruning did not engage" from "the staged snapshot really diverged from the repo bundle" (live cases run a real agent inside that home, and flagged *values* are redacted, so they may not be placeholders at all). Local reproduction of #7574's pruning passes on macOS **and** Linux/GNU with the exact production path shape, so remote forensics are exhausted. The strict pruning now prints one verdict line per snapshot — `pruned marker-verified` / `pruned source-identical` / `kept … (marker failed verification)` / `kept … (not source-identical)` plus the precise mismatch (file-set listing or first differing file; **names only, never content**) — so the next scheduled run pins the cause from the step log alone.

## Test Strategy

- `scripts/live-canary/test_scrub_artifacts.py`: **21 pass** — the marker-less divergent case now asserts both the kept-verdict line and the named mismatch (`… differs from trusted source at SKILL.md`); the identical case asserts the pruned-verdict line.
- `scripts/reborn_webui_v2_live_qa/test_run_live_qa.py`: **218 pass** (4 pre-existing expected failures).
- Not applicable — Rust tiers: scripts-only change.
- Definitive proof for fix 1 and the diagnosis for item 2 land with the next scheduled Live Canary.

## Compatibility / rollback

Scripts-only. The seeder change only widens a test fixture's stored grant to match the shipped manifest; the scrubber change adds log lines and a more precise refusal reason without altering any prune/keep/exit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)