### PR TITLE
fix(extensions): refresh bundled MCP state after auth

### DIFF
--- a/crates/extensions/ironclaw_extension_host/src/available_extensions.rs
+++ b/crates/extensions/ironclaw_extension_host/src/available_extensions.rs
@@ -500,10 +500,8 @@ impl AvailableExtensionCatalog {
         record: &ExtensionManifestRecord,
     ) -> Result<Option<AvailableExtensionPackage>, ProductOperationFailure> {
         let extension_id = &record.resolved().id;
-        let package_ref = LifecyclePackageRef::new(
-            LifecyclePackageKind::Extension,
-            extension_id.as_str(),
-        )?;
+        let package_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id.as_str())?;
         let Some(existing) = self.resolve_optional(&package_ref)? else {
             return Ok(None);
         };

--- a/crates/extensions/ironclaw_extension_host/src/available_extensions.rs
+++ b/crates/extensions/ironclaw_extension_host/src/available_extensions.rs
@@ -74,7 +74,7 @@ impl HostManagedCredentialExtension {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AvailableExtensionAsset {
     pub path: String,
     pub content: AvailableExtensionAssetContent,
@@ -84,12 +84,12 @@ pub struct AvailableExtensionAsset {
 /// remove -> reinstall re-materializes from the entry alone (a `Filesystem`
 /// path-pointer variant existed before that invariant and dangled after
 /// `remove` deleted the extension dir).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AvailableExtensionAssetContent {
     Bytes(Vec<u8>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AvailableExtensionPackage {
     pub package_ref: LifecyclePackageRef,
     pub manifest_toml: String,
@@ -477,6 +477,71 @@ impl AvailableExtensionCatalog {
                 self.packages.push(package);
             }
         }
+    }
+
+    /// Refresh runtime-derived package data after hosted discovery while
+    /// retaining the catalog metadata injected by the original loader.
+    pub(crate) fn refresh_resolved_manifest(
+        &mut self,
+        record: &ExtensionManifestRecord,
+    ) -> Result<bool, ProductOperationFailure> {
+        let Some(refreshed) = self.refreshed_resolved_manifest(record)? else {
+            return Ok(false);
+        };
+        self.extend(Self::from_packages(vec![refreshed]));
+        Ok(true)
+    }
+
+    /// Build a replacement catalog entry without mutating the catalog, so a
+    /// caller can complete other fallible synchronization before committing
+    /// the refresh.
+    pub(crate) fn refreshed_resolved_manifest(
+        &self,
+        record: &ExtensionManifestRecord,
+    ) -> Result<Option<AvailableExtensionPackage>, ProductOperationFailure> {
+        let extension_id = &record.resolved().id;
+        let Some(existing) = self
+            .packages
+            .iter()
+            .find(|package| package.package.id == *extension_id)
+        else {
+            return Ok(None);
+        };
+        if existing.source != record.manifest().source {
+            return Err(ProductOperationFailure::InvalidBindingRequest {
+                reason: format!(
+                    "extension {} changed manifest source during runtime discovery",
+                    extension_id.as_str()
+                ),
+            });
+        }
+        let manifest: ironclaw_extension_registry::ExtensionManifest =
+            record.manifest().clone().try_into().map_err(|error| {
+                ProductOperationFailure::InvalidBindingRequest {
+                    reason: format!(
+                        "extension {} discovered an invalid manifest: {error}",
+                        extension_id.as_str()
+                    ),
+                }
+            })?;
+        let package = crate::generic_host::rebuild_package_from_resolved(
+            manifest,
+            record.resolved(),
+            extension_id.as_str(),
+        )
+        .map_err(|reason| ProductOperationFailure::InvalidBindingRequest { reason })?;
+        let surface_kinds = surface_kinds_from_manifest_record(record, extension_id.as_str())?;
+        let channel_directions =
+            channel_directions_from_manifest_record(record, extension_id.as_str())?;
+        let channel_presentation = channel_presentation_from_manifest_record(record);
+        let mut refreshed = existing.as_ref().clone();
+        refreshed.manifest_toml = record.raw_toml().to_string();
+        refreshed.resolved_manifest = Arc::new(record.resolved().clone());
+        refreshed.package = package;
+        refreshed.surface_kinds = surface_kinds;
+        refreshed.channel_directions = channel_directions;
+        refreshed.channel_presentation = channel_presentation;
+        Ok(Some(refreshed))
     }
 
     pub(crate) fn remove(

--- a/crates/extensions/ironclaw_extension_host/src/available_extensions.rs
+++ b/crates/extensions/ironclaw_extension_host/src/available_extensions.rs
@@ -500,11 +500,11 @@ impl AvailableExtensionCatalog {
         record: &ExtensionManifestRecord,
     ) -> Result<Option<AvailableExtensionPackage>, ProductOperationFailure> {
         let extension_id = &record.resolved().id;
-        let Some(existing) = self
-            .packages
-            .iter()
-            .find(|package| package.package.id == *extension_id)
-        else {
+        let package_ref = LifecyclePackageRef::new(
+            LifecyclePackageKind::Extension,
+            extension_id.as_str(),
+        )?;
+        let Some(existing) = self.resolve_optional(&package_ref)? else {
             return Ok(None);
         };
         if existing.source != record.manifest().source {
@@ -524,12 +524,15 @@ impl AvailableExtensionCatalog {
                     ),
                 }
             })?;
-        let package = crate::generic_host::rebuild_package_from_resolved(
+        let mut package = crate::generic_host::rebuild_package_from_resolved(
             manifest,
             record.resolved(),
             extension_id.as_str(),
         )
         .map_err(|reason| ProductOperationFailure::InvalidBindingRequest { reason })?;
+        // Discovery changes only runtime-derived descriptors. Retain the
+        // loader-computed digest that pins trust to the bundled manifest bytes.
+        package.manifest_digest = existing.package.manifest_digest.clone();
         let surface_kinds = surface_kinds_from_manifest_record(record, extension_id.as_str())?;
         let channel_directions =
             channel_directions_from_manifest_record(record, extension_id.as_str())?;
@@ -2388,6 +2391,30 @@ handle = "web_token"
         // gmail migrated to the inventory; its digest (still sha256-token) is
         // asserted through the trust policy in
         // `factory::tests::builtin_first_party_trust_policy_grants_migrated_gmail_via_inventory`.
+    }
+
+    #[test]
+    fn refreshing_bundled_runtime_descriptors_preserves_manifest_digest() {
+        let mut catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
+        let package_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion").unwrap();
+        let original = catalog.resolve(&package_ref).unwrap();
+        let original_digest = original
+            .package
+            .manifest_digest()
+            .expect("bundled manifest digest");
+        let record = ExtensionManifestRecord::from_resolved(
+            original.manifest_toml.clone(),
+            original.source,
+            original.resolved_manifest.as_ref().clone(),
+            None,
+        )
+        .expect("bundled manifest record");
+
+        assert!(catalog.refresh_resolved_manifest(&record).unwrap());
+
+        let refreshed = catalog.resolve(&package_ref).unwrap();
+        assert_eq!(refreshed.package.manifest_digest(), Some(original_digest));
     }
 
     #[test]

--- a/crates/extensions/ironclaw_extension_host/src/hosted_mcp_preparation.rs
+++ b/crates/extensions/ironclaw_extension_host/src/hosted_mcp_preparation.rs
@@ -641,10 +641,11 @@ impl HostedMcpPreparationService {
                 .await
                 .map_err(crate::product_lifecycle::map_extension_installation_error)?;
         }
-        let refreshed = {
-            let catalog = self.catalog.read().await;
-            catalog.refreshed_resolved_manifest(&finalized)?
-        };
+        // Serialize the read/replace decision against catalog imports and
+        // removals. The guard spans lifecycle synchronization, but the catalog
+        // itself is not mutated until that fallible step succeeds.
+        let mut catalog = self.catalog.write().await;
+        let refreshed = catalog.refreshed_resolved_manifest(&finalized)?;
         let replacement = match refreshed {
             Some(refreshed) => Some(refreshed),
             None if finalized.manifest().source == ManifestSource::UserRegistered => {
@@ -661,10 +662,7 @@ impl HostedMcpPreparationService {
         };
         self.sync_lifecycle_package(extension_id).await?;
         if let Some(replacement) = replacement {
-            self.catalog
-                .write()
-                .await
-                .extend(AvailableExtensionCatalog::from_packages(vec![replacement]));
+            catalog.extend(AvailableExtensionCatalog::from_packages(vec![replacement]));
         }
         Ok(None)
     }

--- a/crates/extensions/ironclaw_extension_host/src/hosted_mcp_preparation.rs
+++ b/crates/extensions/ironclaw_extension_host/src/hosted_mcp_preparation.rs
@@ -650,7 +650,14 @@ impl HostedMcpPreparationService {
             None if finalized.manifest().source == ManifestSource::UserRegistered => {
                 Some(crate::hosted_mcp_manifest::available_package(&finalized)?)
             }
-            None => None,
+            None => {
+                tracing::debug!(
+                    extension_id = extension_id.as_str(),
+                    source = ?finalized.manifest().source,
+                    "hosted MCP discovery finalized without a catalog entry to refresh"
+                );
+                None
+            }
         };
         self.sync_lifecycle_package(extension_id).await?;
         if let Some(replacement) = replacement {

--- a/crates/extensions/ironclaw_extension_host/src/hosted_mcp_preparation.rs
+++ b/crates/extensions/ironclaw_extension_host/src/hosted_mcp_preparation.rs
@@ -641,15 +641,24 @@ impl HostedMcpPreparationService {
                 .await
                 .map_err(crate::product_lifecycle::map_extension_installation_error)?;
         }
-        if finalized.manifest().source == ManifestSource::UserRegistered {
+        let refreshed = {
+            let catalog = self.catalog.read().await;
+            catalog.refreshed_resolved_manifest(&finalized)?
+        };
+        let replacement = match refreshed {
+            Some(refreshed) => Some(refreshed),
+            None if finalized.manifest().source == ManifestSource::UserRegistered => {
+                Some(crate::hosted_mcp_manifest::available_package(&finalized)?)
+            }
+            None => None,
+        };
+        self.sync_lifecycle_package(extension_id).await?;
+        if let Some(replacement) = replacement {
             self.catalog
                 .write()
                 .await
-                .extend(AvailableExtensionCatalog::from_packages(vec![
-                    crate::hosted_mcp_manifest::available_package(&finalized)?,
-                ]));
+                .extend(AvailableExtensionCatalog::from_packages(vec![replacement]));
         }
-        self.sync_lifecycle_package(extension_id).await?;
         Ok(None)
     }
 

--- a/crates/extensions/ironclaw_extension_host/src/lifecycle_restore.rs
+++ b/crates/extensions/ironclaw_extension_host/src/lifecycle_restore.rs
@@ -68,10 +68,12 @@ pub async fn restore_extension_lifecycle_state(
                 hash_error,
             )
             .await?;
-        } else if available.source == ManifestSource::HostBundled
-            && stored_manifest
+        } else if let Some(stored) = stored_manifest.as_ref()
+            && available.source == ManifestSource::HostBundled
+            && stored
+                .resolved()
+                .mcp
                 .as_ref()
-                .and_then(|manifest| manifest.resolved().mcp.as_ref())
                 .is_some_and(|mcp| !mcp.dynamic_input_schemas.is_empty())
         {
             // Same-bundle restart: hosted discovery enriched the durable
@@ -81,14 +83,12 @@ pub async fn restore_extension_lifecycle_state(
             // On binary upgrades the mismatch path above retains the new
             // catalog contract and performs the existing migration instead of
             // reviving stale endpoint/auth/effect policy.
-            catalog.refresh_resolved_manifest(stored_manifest.as_ref().ok_or_else(|| {
-                ProductOperationFailure::InvalidBindingRequest {
-                    reason: format!(
-                        "extension {} has discovery metadata without an installed manifest",
-                        installation.extension_id().as_str()
-                    ),
-                }
-            })?)?;
+            if !catalog.refresh_resolved_manifest(stored)? {
+                tracing::warn!(
+                    extension_id = installation.extension_id().as_str(),
+                    "stored discovery metadata did not match the bundled catalog package"
+                );
+            }
             available = catalog.resolve(&package_ref)?;
         }
         if available.source != ManifestSource::UserRegistered {

--- a/crates/extensions/ironclaw_extension_host/src/lifecycle_restore.rs
+++ b/crates/extensions/ironclaw_extension_host/src/lifecycle_restore.rs
@@ -47,7 +47,7 @@ pub async fn restore_extension_lifecycle_state(
             LifecyclePackageKind::Extension,
             installation.extension_id().as_str(),
         )?;
-        let available = match catalog.resolve(&package_ref) {
+        let mut available = match catalog.resolve(&package_ref) {
             Ok(available) => available,
             Err(error) => {
                 tracing::warn!(
@@ -59,7 +59,8 @@ pub async fn restore_extension_lifecycle_state(
                 continue;
             }
         };
-        if let Err(hash_error) = validate_restored_manifest_hash(&installation, &available) {
+        let hash_matches_catalog = validate_restored_manifest_hash(&installation, &available);
+        if let Err(hash_error) = hash_matches_catalog {
             migrate_host_bundled_manifest_hash(
                 installation_store,
                 &available,
@@ -67,6 +68,28 @@ pub async fn restore_extension_lifecycle_state(
                 hash_error,
             )
             .await?;
+        } else if available.source == ManifestSource::HostBundled
+            && stored_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.resolved().mcp.as_ref())
+                .is_some_and(|mcp| !mcp.dynamic_input_schemas.is_empty())
+        {
+            // Same-bundle restart: hosted discovery enriched the durable
+            // resolved contract while leaving the loader-owned definition
+            // hash unchanged. Rehydrate those capabilities only after proving
+            // the stored row still belongs to this exact bundled definition.
+            // On binary upgrades the mismatch path above retains the new
+            // catalog contract and performs the existing migration instead of
+            // reviving stale endpoint/auth/effect policy.
+            catalog.refresh_resolved_manifest(stored_manifest.as_ref().ok_or_else(|| {
+                ProductOperationFailure::InvalidBindingRequest {
+                    reason: format!(
+                        "extension {} has discovery metadata without an installed manifest",
+                        installation.extension_id().as_str()
+                    ),
+                }
+            })?)?;
+            available = catalog.resolve(&package_ref)?;
         }
         if available.source != ManifestSource::UserRegistered {
             materialize_available_extension(filesystem.as_ref(), &available).await?;

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -190,7 +190,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Shell commands dispatch through the real path without spawning an OS process | `process_port.rs` |
 | A sandbox-profile shell turn executes as an unprivileged user in a real Docker worker and keeps its workspace across calls | `reborn_sandbox_shell_turn.rs` |
 | MCP tools work over a real loopback HTTP MCP server | `mcp.rs` |
-| User-registered hosted MCP servers register, authenticate, restore, and invoke | `hosted_mcp_registration.rs` |
+| User-registered and bundled hosted MCP servers register, authenticate, project active, restore, and invoke | `hosted_mcp_registration.rs` |
 | Web search/fetch runs the real Exa MCP handshake | `web_access.rs` |
 | Outbound HTTP crosses the real security pipeline (network policy + leak scan) | `real_egress_pipeline.rs` |
 | Tools marked host-internal are never advertised to the model, and calls to them are rejected | `extension_visibility.rs`, `surface_disclosure.rs` |

--- a/tests/integration/hosted_mcp_registration.rs
+++ b/tests/integration/hosted_mcp_registration.rs
@@ -621,6 +621,10 @@ async fn bundled_oauth_mcp_projects_active_after_callback_discovers_tools() {
         .await
         .expect("discovered manifest readback before upgrade simulation")
         .expect("discovered Notion manifest persists");
+    let current_hash = stale_manifest
+        .manifest_hash()
+        .cloned()
+        .expect("current bundled manifest hash");
     let stale_raw = format!(
         "{}\n# previous bundled definition\n",
         stale_manifest.raw_toml()
@@ -676,6 +680,20 @@ async fn bundled_oauth_mcp_projects_active_after_callback_discovers_tools() {
             .as_ref()
             .is_some_and(|mcp| mcp.dynamic_input_schemas.is_empty()),
         "a bundle hash mismatch must retain the current loader contract instead of stale discovery: {migrated:#?}"
+    );
+    assert_eq!(migrated.manifest_hash(), Some(&current_hash));
+    let migrated_installation = upgraded
+        .extension_management
+        .installation_store_for_test()
+        .list_installations()
+        .await
+        .expect("migrated installation readback")
+        .into_iter()
+        .find(|installation| installation.extension_id().as_str() == "notion")
+        .expect("migrated Notion installation persists");
+    assert_eq!(
+        migrated_installation.manifest_ref().manifest_hash(),
+        Some(&current_hash)
     );
 }
 

--- a/tests/integration/hosted_mcp_registration.rs
+++ b/tests/integration/hosted_mcp_registration.rs
@@ -1,8 +1,7 @@
 //! Hosted-MCP registration protocol journeys.
 //!
-//! This is deliberately a new suite: existing integration files cover bundled
-//! MCP discovery, while these scenarios need mutable authentication and OAuth
-//! metadata fixtures for user-registered endpoints.
+//! Hosted-MCP authentication and discovery journeys for user-registered and
+//! bundled endpoints, using mutable OAuth metadata fixtures.
 
 #[allow(dead_code)]
 #[path = "../support/hosted_mcp_registration_server.rs"]
@@ -40,7 +39,10 @@ use ironclaw_extension_manager::lifecycle_test_support::{
     lifecycle_product_context, rebuild_lifecycle_test_services_with_auth_provider,
     webui_gate_resource_scope_for_owner,
 };
-use ironclaw_extension_registry::{ExtensionInstallationStorePort, ExtensionManifestRecord};
+use ironclaw_extension_registry::{
+    ExtensionInstallation, ExtensionInstallationStorePort, ExtensionManifestRecord,
+    ExtensionManifestRef, ManifestHash,
+};
 use ironclaw_host_api::{
     action::{NetworkPolicy, NetworkScheme, NetworkTargetPattern},
     capability::{CapabilityGrant, CapabilitySet, EffectKind, GrantConstraints},
@@ -69,6 +71,14 @@ fn runtime_context(
     scope: ironclaw_host_api::resource::ResourceScope,
     capability: &str,
 ) -> ironclaw_host_api::scope::ExecutionContext {
+    runtime_context_for_host(scope, capability, "mcp.example.test")
+}
+
+fn runtime_context_for_host(
+    scope: ironclaw_host_api::resource::ResourceScope,
+    capability: &str,
+    allowed_host: &str,
+) -> ironclaw_host_api::scope::ExecutionContext {
     let grantee = ExtensionId::new("hosted-mcp-registration-test").expect("test extension id");
     let mut context = ironclaw_host_api::scope::ExecutionContext::local_default(
         scope.user_id.clone(),
@@ -91,7 +101,7 @@ fn runtime_context(
                     network: NetworkPolicy {
                         allowed_targets: vec![NetworkTargetPattern {
                             scheme: Some(NetworkScheme::Https),
-                            host_pattern: "mcp.example.test".to_string(),
+                            host_pattern: allowed_host.to_string(),
                             port: None,
                         }],
                         deny_private_ip_ranges: true,
@@ -395,6 +405,15 @@ async fn complete_fixture_oauth_callback(
     scope: &ironclaw_host_api::resource::ResourceScope,
     provider: ironclaw_auth::AuthProviderId,
 ) -> Result<ironclaw_auth::RebornOAuthCallbackResponse, ironclaw_auth::RebornOAuthCallbackError> {
+    complete_extension_oauth_callback(services, scope, provider, "mcp-fixture").await
+}
+
+async fn complete_extension_oauth_callback(
+    services: &ironclaw_extension_manager::lifecycle_test_support::ExtensionLifecycleTestServices,
+    scope: &ironclaw_host_api::resource::ResourceScope,
+    provider: ironclaw_auth::AuthProviderId,
+    extension_id: &str,
+) -> Result<ironclaw_auth::RebornOAuthCallbackResponse, ironclaw_auth::RebornOAuthCallbackError> {
     let auth_scope = AuthProductScope::credential_owner(scope, AuthSurface::Api);
     let state_hash =
         OpaqueStateHash::new(fixture_digest("hosted-oauth-state")).expect("state digest");
@@ -407,7 +426,7 @@ async fn complete_fixture_oauth_callback(
             flow_id: None,
             scope: auth_scope.clone(),
             provider: provider.clone(),
-            requester_extension: Some(ExtensionId::new("mcp-fixture").expect("extension id")),
+            requester_extension: Some(ExtensionId::new(extension_id).expect("extension id")),
             authorization_url: OAuthAuthorizationUrl::new("https://auth.example.test/authorize")
                 .expect("fixture authorization URL"),
             opaque_state_hash: state_hash.clone(),
@@ -415,7 +434,7 @@ async fn complete_fixture_oauth_callback(
             pkce_verifier: SecretString::from("hosted-oauth-pkce".to_string()),
             update_binding: None,
             continuation: AuthContinuationRef::LifecycleActivation {
-                package_ref: ironclaw_auth::LifecyclePackageRef::new("mcp-fixture")
+                package_ref: ironclaw_auth::LifecyclePackageRef::new(extension_id)
                     .expect("auth package ref"),
             },
             expires_at: Utc::now() + ChronoDuration::minutes(5),
@@ -451,6 +470,213 @@ async fn complete_fixture_oauth_callback(
             },
         })
         .await
+}
+
+#[tokio::test]
+async fn bundled_oauth_mcp_projects_active_after_callback_discovers_tools() {
+    let server = HostedMcpRegistrationServer::start(
+        HostedMcpAuthPolicy::ExactBearer {
+            token: "oauth-token".to_string(),
+        },
+        vec![HostedMcpTool::read_only("search", json!("ok"))],
+    )
+    .await;
+    let fixture_secret_store = Arc::new(OnceLock::new());
+    let services = build_lifecycle_test_services_with_auth_provider(
+        "bundled-hosted-mcp-oauth-user",
+        Some(Arc::new(
+            HostedMcpRegistrationNetworkEgress::for_server_with_mcp_host(&server, "mcp.notion.com"),
+        )),
+        false,
+        Arc::new(FixtureOAuthProvider {
+            secret_store: Arc::clone(&fixture_secret_store),
+            access_token: "oauth-token".to_string(),
+        }),
+    )
+    .await;
+    assert!(fixture_secret_store.set(services.secret_store()).is_ok());
+    let scope = webui_gate_resource_scope_for_owner("bundled-hosted-mcp-oauth-user");
+    let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion")
+        .expect("bundled package ref");
+
+    let install = services
+        .lifecycle_service
+        .execute(
+            lifecycle_product_context(scope.clone()),
+            LifecycleProductAction::ExtensionInstall {
+                package_ref: package_ref.clone(),
+            },
+        )
+        .await
+        .expect("bundled OAuth MCP install reaches setup");
+    let provider = credential_provider_from_response(&install);
+    complete_extension_oauth_callback(&services, &scope, provider, "notion")
+        .await
+        .expect("OAuth callback activates the bundled MCP");
+
+    let capability = services
+        .extension_management
+        .active_model_visible_capabilities()
+        .await
+        .expect("active capability projection")
+        .into_iter()
+        .find(|capability| {
+            capability.id.as_str().starts_with("notion.")
+                && capability.id.as_str().ends_with(".search")
+        })
+        .expect("OAuth callback publishes the bundled Notion search tool");
+    let listed = services
+        .lifecycle_service
+        .execute(
+            lifecycle_product_context(scope.clone()),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("installation list after bundled OAuth callback");
+    let Some(LifecycleProductPayload::ExtensionList { extensions, .. }) = listed.payload else {
+        panic!("list returns installed extension summaries")
+    };
+    assert!(
+        extensions.iter().any(|extension| {
+            extension.summary.package_ref == package_ref
+                && extension.phase == ironclaw_extension_contracts::state::InstallationState::Active
+                && extension
+                    .summary
+                    .visible_capability_ids
+                    .iter()
+                    .any(|id| id == capability.id.as_str())
+        }),
+        "an active bundled MCP must project as active with discovered tools: {extensions:#?}"
+    );
+    let outcome = invoke_with_standalone_approval(
+        &services,
+        capability.id.as_str(),
+        runtime_context_for_host(scope.clone(), capability.id.as_str(), "mcp.notion.com"),
+        json!({}),
+    )
+    .await;
+    assert!(matches!(
+        outcome,
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Completed(_)
+    ));
+
+    let restored_secret_store = Arc::new(OnceLock::new());
+    let restored = rebuild_lifecycle_test_services_with_auth_provider(
+        &services,
+        "bundled-hosted-mcp-oauth-user",
+        Some(Arc::new(
+            HostedMcpRegistrationNetworkEgress::for_server_with_mcp_host(&server, "mcp.notion.com"),
+        )),
+        false,
+        Arc::new(FixtureOAuthProvider {
+            secret_store: Arc::clone(&restored_secret_store),
+            access_token: "oauth-token".to_string(),
+        }),
+    )
+    .await;
+    assert!(restored_secret_store.set(restored.secret_store()).is_ok());
+    let restored_list = restored
+        .lifecycle_service
+        .execute(
+            lifecycle_product_context(scope),
+            LifecycleProductAction::ExtensionList,
+        )
+        .await
+        .expect("installation list after restart");
+    let Some(LifecycleProductPayload::ExtensionList { extensions, .. }) = restored_list.payload
+    else {
+        panic!("restored list returns installed extension summaries")
+    };
+    assert!(
+        extensions.iter().any(|extension| {
+            extension.summary.package_ref == package_ref
+                && extension.phase == ironclaw_extension_contracts::state::InstallationState::Active
+                && extension
+                    .summary
+                    .visible_capability_ids
+                    .iter()
+                    .any(|id| id == capability.id.as_str())
+        }),
+        "a restarted bundled MCP must retain its active discovered projection: {extensions:#?}"
+    );
+    assert!(server.requests().iter().any(|request| {
+        request.rpc_method.as_deref() == Some("tools/call") && request.authorization_matches
+    }));
+
+    // Simulate a bundled-definition upgrade: the installation hash no longer
+    // matches the binary catalog, while the old persisted manifest still
+    // carries discovered schemas. Restore must migrate to the current bundle,
+    // not let the stale discovered record overwrite it and make old-to-old
+    // hash validation pass.
+    let store = restored.extension_management.installation_store_for_test();
+    let installed = store
+        .list_installations()
+        .await
+        .expect("installation readback before upgrade simulation")
+        .into_iter()
+        .find(|installation| installation.extension_id().as_str() == "notion")
+        .expect("Notion installation persists");
+    let stale_manifest = store
+        .get_manifest(installed.extension_id())
+        .await
+        .expect("discovered manifest readback before upgrade simulation")
+        .expect("discovered Notion manifest persists");
+    let stale_raw = format!(
+        "{}\n# previous bundled definition\n",
+        stale_manifest.raw_toml()
+    );
+    assert_ne!(stale_raw, stale_manifest.raw_toml());
+    let stale_hash = ManifestHash::new(ironclaw_host_api::approval::sha256_digest_token(
+        stale_raw.as_bytes(),
+    ))
+    .expect("stale manifest hash");
+    let stale_manifest = ExtensionManifestRecord::from_resolved(
+        stale_raw,
+        stale_manifest.manifest().source,
+        stale_manifest.resolved().clone(),
+        Some(stale_hash.clone()),
+    )
+    .expect("stale bundled manifest record");
+    store
+        .upsert_manifest_and_installation(
+            stale_manifest,
+            ExtensionInstallation::new(
+                installed.installation_id().clone(),
+                installed.extension_id().clone(),
+                ExtensionManifestRef::new(installed.extension_id().clone(), Some(stale_hash)),
+                installed.credential_bindings().to_vec(),
+                installed.updated_at(),
+                installed.owner().clone(),
+            )
+            .expect("upgrade simulation installation"),
+        )
+        .await
+        .expect("upgrade simulation persists the stale hash");
+    let upgraded = rebuild_lifecycle_test_services_with_auth_provider(
+        &restored,
+        "bundled-hosted-mcp-oauth-user",
+        Some(Arc::new(
+            HostedMcpRegistrationNetworkEgress::for_server_with_mcp_host(&server, "mcp.notion.com"),
+        )),
+        false,
+        Arc::new(ironclaw_auth::UnavailableAuthProviderClient),
+    )
+    .await;
+    let migrated = upgraded
+        .extension_management
+        .installation_store_for_test()
+        .get_manifest(&ExtensionId::new("notion").expect("Notion extension id"))
+        .await
+        .expect("migrated manifest readback")
+        .expect("migrated Notion manifest persists");
+    assert!(
+        migrated
+            .resolved()
+            .mcp
+            .as_ref()
+            .is_some_and(|mcp| mcp.dynamic_input_schemas.is_empty()),
+        "a bundle hash mismatch must retain the current loader contract instead of stale discovery: {migrated:#?}"
+    );
 }
 
 fn mrc_trace_tools() -> Vec<HostedMcpTool> {

--- a/tests/support/hosted_mcp_registration_server.rs
+++ b/tests/support/hosted_mcp_registration_server.rs
@@ -113,6 +113,7 @@ impl HostedMcpRegistrationProbeGate {
 /// explicitly allowlisted origins to the loopback fixture.
 pub struct HostedMcpRegistrationNetworkEgress {
     loopback_base: String,
+    mcp_host: String,
     client: reqwest::Client,
     /// When set, any request whose path contains this substring fails at the
     /// transport layer instead of reaching the fixture server, scripting the
@@ -123,8 +124,18 @@ pub struct HostedMcpRegistrationNetworkEgress {
 
 impl HostedMcpRegistrationNetworkEgress {
     pub fn for_server(server: &HostedMcpRegistrationServer) -> Self {
+        Self::for_server_with_mcp_host(server, "mcp.example.test")
+    }
+
+    /// Map a specific production-shaped MCP host to the loopback fixture while
+    /// retaining the fixture authorization-server origin.
+    pub fn for_server_with_mcp_host(
+        server: &HostedMcpRegistrationServer,
+        mcp_host: impl Into<String>,
+    ) -> Self {
         Self {
             loopback_base: server.base_url.clone(),
+            mcp_host: mcp_host.into(),
             client: reqwest::Client::builder()
                 .redirect(reqwest::redirect::Policy::none())
                 .build()
@@ -165,9 +176,16 @@ impl NetworkHttpEgress for HostedMcpRegistrationNetworkEgress {
             || source.port().is_some()
             || !source.username().is_empty()
             || source.password().is_some()
-            || !matches!(host, "mcp.example.test" | "auth.example.test")
+            || (host != self.mcp_host && host != "auth.example.test")
         {
-            return Err(NetworkHttpError::PolicyDenied { reason: "hosted MCP fixture accepts only mcp.example.test and auth.example.test HTTPS origins".to_string(), request_bytes, response_bytes: 0 });
+            return Err(NetworkHttpError::PolicyDenied {
+                reason: format!(
+                    "hosted MCP fixture accepts only {} and auth.example.test HTTPS origins",
+                    self.mcp_host
+                ),
+                request_bytes,
+                response_bytes: 0,
+            });
         }
         if let Some(path_substr) = &self.fail_transport_for_path
             && source.path().contains(path_substr.as_str())


### PR DESCRIPTION
## Summary

- Refresh bundled hosted-MCP catalog projections after OAuth discovery so active tools no longer appear as `setup_needed` in Extensions.
- Rehydrate same-version discovered tools on restart while preserving newer bundled endpoint/auth/effect policy across upgrades.
- Add a hermetic bundled Notion regression covering OAuth completion, active listing, authenticated invocation, restart, and bundle-hash migration.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: hosted-MCP integration suite, extension-host test-support suite, architecture boundary suites
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no database/backend behavior changed)
- [ ] Manual testing: not run; the provider path is covered hermetically with the production lifecycle and OAuth continuation
- [x] If a coding agent was used and supports it, multi-lane code review was run before requesting review

## Test Strategy

User behavior: Completing OAuth for bundled Notion publishes its discovered tool and projects the extension as active instead of continuing to show Finish Setup.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: existing extension-host and lifecycle restore contracts remain green.
- Reborn integration: added bundled Notion OAuth, authenticated invocation, restart, and bundle-upgrade projection coverage in `hosted_mcp_registration.rs`.
- Recorded fixture: Not applicable: no model trace behavior changed.
- Browser E2E: Not applicable: frontend consumes the existing authoritative `installation_state` field; no browser code changed.
- Backend or runtime: Not applicable: no database or runtime backend implementation changed.
- Live canary: Not applicable: hermetic loopback MCP/OAuth fixture covers the provider boundary; live credentialed tests remain ignored canaries.

What the tests prove: The exact production callback/lifecycle continuation publishes a bundled Notion tool, invokes it with the configured bearer credential, lists it active with the discovered capability, restores the same projection after restart, and does not let stale discovery overwrite a newer bundled security contract.

Commands run:

- `cargo test -p ironclaw_integration_tests --test reborn_integration_hosted_mcp_registration`
- `cargo test -p ironclaw_extension_host --features test-support`
- `cargo clippy -p ironclaw_extension_host --features test-support --all-targets -- -D warnings`
- `cargo test -p ironclaw_architecture_tests`
- `cargo test -p ironclaw_architecture_tests --test reborn_extension_specificity --test reborn_registration_pipeline_boundary --test reborn_extension_host_port_inversion`
- `python3 scripts/ci/docs_publication_boundary.py`
- `git diff --check`

## Security Impact

No permissions, credential handling, or network policy is weakened. Restart hydration is hash-gated: persisted discovery is reused only for the exact current host-bundled definition; bundle mismatches retain and migrate the newer loader-owned endpoint/auth/effect policy.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new public types; catalog refresh remains extension-host-owned.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. N/A: prompt construction is unchanged.
- [x] Hashes declare purpose; existing SHA-256 manifest binding gates restart hydration.
- [x] New/changed status, exit, policy, runtime, or error variants: none.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. N/A: no schema fields changed; bundle mismatch migration is covered.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. N/A: none added.
- [x] Driver/operator-visible errors have stable class semantics. Existing `ProductOperationFailure` mappings are preserved.
- [x] Sandbox/native/host names accurately describe trust boundary.

## Database Impact

None. No migration or schema change; the existing installation store contract is reused.

## Blast Radius

Bundled and user-registered hosted-MCP discovery, extension listing projections, and boot restore. Static WASM/channel extensions are unchanged. A failed lifecycle synchronization cannot publish the refreshed catalog projection.

## Rollback Plan

Revert this commit. Existing persisted manifests remain compatible; rollback returns to the prior stale bundled listing behavior without a data migration.

## Review Follow-Through

Multi-lane review covered lifecycle correctness, security/provenance, failure atomicity, test fidelity, product projection, architecture boundaries, and simplicity. No known follow-up remains.

---

**Review track**: C (runtime lifecycle and persisted security-contract hydration)
