### PR TITLE
fix(live-canary): align the bundled-skill marker owner with the runtime mint

### DIFF
--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -11,7 +11,14 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BUNDLED_SKILLS_ROOT="${LIVE_CANARY_BUNDLED_SKILLS_ROOT:-${REPO_ROOT}/skills}"
 NEARAI_MANIFEST_TEMPLATE="${REPO_ROOT}/scripts/live-canary/fixtures/nearai-runtime-manifest.toml"
 BUNDLED_SKILL_MARKER=".ironclaw-reborn-bundled.json"
-BUNDLED_SKILL_OWNER="ironclaw_reborn_composition_bundled_skill"
+# Must equal BUNDLED_MARKER_OWNER in
+# crates/extensions/ironclaw_extension_host/src/bundled_skills.rs — the
+# runtime mint this scrubber verifies. The WS6/WS7 crate renames changed
+# the Rust side to "ironclaw_composition_bundled_skill" while this copy
+# kept the retired "reborn" spelling, so EVERY marker failed the owner
+# check and the bundled-skill pruning silently never engaged (the
+# test-side lockstep pin now guards the pair).
+BUNDLED_SKILL_OWNER="ironclaw_composition_bundled_skill"
 
 # The default first-party extensions root hops from the ironclaw_extension_support
 # crate (found by NAME through the shared inventory, scripts/ci/lib/crate_tree.py)

--- a/scripts/live-canary/test_scrub_artifacts.py
+++ b/scripts/live-canary/test_scrub_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -149,7 +150,7 @@ class ScrubArtifactsTests(unittest.TestCase):
         )
         if include_marker:
             marker_payload = marker or {
-                "owner": "ironclaw_reborn_composition_bundled_skill",
+                "owner": "ironclaw_composition_bundled_skill",
                 "format": 1,
                 "content_hash": self.bundle_hash("local-test", trusted_skill),
             }
@@ -194,6 +195,47 @@ class ScrubArtifactsTests(unittest.TestCase):
             encoding="utf-8",
         )
         return trusted_root, staged_manifest
+
+    def test_bundled_skill_marker_vocabulary_matches_the_runtime_mint(self) -> None:
+        """The scrubber verifies markers the RUNTIME mints, and the two sides
+        live in different languages: a rename on the Rust side drifts
+        silently. That happened — the WS6/WS7 renames changed
+        BUNDLED_MARKER_OWNER while this script kept the retired "reborn"
+        spelling, every marker failed the owner check, and the bundled-skill
+        pruning never engaged across weeks of canary runs. Pin the owner and
+        the marker filename to the Rust constants so the next rename fails
+        here instead."""
+        rust_source = (
+            ROOT
+            / "crates"
+            / "extensions"
+            / "ironclaw_extension_host"
+            / "src"
+            / "bundled_skills.rs"
+        ).read_text(encoding="utf-8")
+        rust_owner = re.search(
+            r'const BUNDLED_MARKER_OWNER: &str = "([^"]+)";', rust_source
+        )
+        rust_marker_file = re.search(
+            r'const BUNDLED_MARKER_FILE: &str = "([^"]+)";', rust_source
+        )
+        self.assertIsNotNone(
+            rust_owner, "BUNDLED_MARKER_OWNER not found in bundled_skills.rs"
+        )
+        self.assertIsNotNone(
+            rust_marker_file, "BUNDLED_MARKER_FILE not found in bundled_skills.rs"
+        )
+
+        script_source = SCRIPT.read_text(encoding="utf-8")
+        script_owner = re.search(r'\nBUNDLED_SKILL_OWNER="([^"]+)"', script_source)
+        script_marker_file = re.search(
+            r'\nBUNDLED_SKILL_MARKER="([^"]+)"', script_source
+        )
+        self.assertIsNotNone(script_owner)
+        self.assertIsNotNone(script_marker_file)
+
+        self.assertEqual(rust_owner.group(1), script_owner.group(1))
+        self.assertEqual(rust_marker_file.group(1), script_marker_file.group(1))
 
     def test_strict_scrub_redacts_diagnostics_and_preserves_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -470,7 +512,7 @@ class ScrubArtifactsTests(unittest.TestCase):
             trusted_root, bundled = self.write_bundled_skill_fixture(
                 root,
                 source_body="api_key: live-secret-value\n",
-                marker='{"owner":"ironclaw_reborn_composition_bundled_skill"',
+                marker='{"owner":"ironclaw_composition_bundled_skill"',
             )
 
             result = self.run_scrub(


### PR DESCRIPTION
## Summary

The verdict narration added in #7579 paid off on its first run ([31734252239](https://github.com/nearai/ironclaw/actions/runs/31734252239), dispatched manually on post-#7579 main): every skill snapshot in every shard logs **`kept skill snapshot for scanning (marker failed verification)`** — which pinpoints the true root cause of the strict-scrub reds.

The runtime mints skill markers with `BUNDLED_MARKER_OWNER = "ironclaw_composition_bundled_skill"` (`bundled_skills.rs:29`), but the scrubber's copy of that string still read `ironclaw_reborn_composition_bundled_skill` — the retired spelling from before the WS6/WS7 crate renames (the Rust side changed in the Aug 9 skills stack, `102e5e05b8`, matching the deterministic-red boundary exactly). Every marker therefore failed the owner check, the bundled-skill pruning never engaged, and `skills/local-test`'s placeholder `API_KEY=<your-key>` doc lines failed every strict lane. Two red herrings resolved along the way: markers appeared absent in downloaded artifacts only because `actions/upload-artifact` **drops hidden files by default** (they were present at scrub time), and #7574's marker-less fallback never fired because the marker-carrying dirs are deliberately routed to the marker path.

**Fix:** one line — the scrubber's owner string now equals the mint — plus a **cross-language lockstep test** that extracts `BUNDLED_MARKER_OWNER` and `BUNDLED_MARKER_FILE` from `bundled_skills.rs` and asserts the script's constants match, so the next rename breaks the self-test loudly instead of silently disarming the scrubber for weeks.

With this, the dispatched run's remaining failures decompose as: 10/12 shards failed **only** at scrub (this fix) — their QA lanes are green after #7579's seeder fix — and QA 9/10 lane failures remain to be looked at separately (likely the live Slack app token needing the three new write scopes granted vendor-side, per #7579's ops note).

## Test Strategy

- `scripts/live-canary/test_scrub_artifacts.py`: **22 pass**, including the new lockstep pin. Sabotage-verified: the lockstep test fails against the pre-fix script (retired owner string).
- Not applicable — Rust tiers: scripts-only change; the Rust constants are read, not modified.
- Definitive proof: the next scheduled Live Canary should show `pruned marker-verified bundled skill snapshot` lines and a green scrub on the 10 lane-green shards.

## Compatibility / rollback

Scripts-only, no behavior change beyond the owner comparison now matching production mints. Revert restores the drift (and the red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)