### PR TITLE
chore(release): promote 1.2.0-rc.3 to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0-rc.3] - 2026-08-12
+## [1.2.0] - 2026-08-13
 
-### Fixed
+Stable promotion of `1.2.0-rc.3`, including the fixes validated in RC2 and
+RC3 and the complete RC1 feature set below.
+
+### Fixed in 1.2.0-rc.3
 
 - The runtime container image now installs `curl`, so in-container HTTP
   healthchecks can execute. Orchestrators probe the worker with
@@ -17,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   probe could never run, the container was never marked healthy, and the deploy
   timed out into `error` while the listener served 200s throughout.
 
-### Changed
+### Changed in 1.2.0-rc.3
 
 - Reborn PR test planning and the root-partition runner now share one test
   inventory covering every `tests/*.rs` target, and container image inputs
@@ -25,17 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   partition assignment, so a scheduled root test could be reported green
   without having run.
 
-## [1.2.0-rc.2] - 2026-08-12
-
-### Fixed
+### Fixed in 1.2.0-rc.2
 
 - Windows first-start filesystem publication now uses native atomic rename
   semantics instead of hard links and tolerates unsupported directory syncs.
 - Release smoke runs preserve the Windows account identity required to secure
   the standalone secrets key, isolate workspace state, and keep `icacls`
   status output from contaminating machine-readable CLI JSON.
-
-## [1.2.0-rc.1] - 2026-08-11
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,7 +3455,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironclaw"
-version = "1.2.0-rc.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/app/ironclaw_cli/Cargo.toml
+++ b/crates/app/ironclaw_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw"
-version = "1.2.0-rc.3"
+version = "1.2.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
## Summary

- Promote the fully validated `ironclaw-v1.2.0-rc.3` candidate to stable `1.2.0`.
- Update the shipping package manifest and lockfile together.
- Consolidate the RC1–RC3 changelog entries under the stable release heading.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not run; no Rust code changed.
- [ ] `cargo build` — not run separately; the targeted Rust test compiled the `ironclaw` 1.2.0 binary test target.
- [x] Relevant tests pass: release cutter tests, release smoke harness tests, and release CI workflow contract.
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; no runtime or database behavior changed.
- [ ] Manual testing — not applicable to the metadata-only promotion commit; RC3 itself completed the full release workflow.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — not run; metadata-only release promotion.

## Test Strategy

User behavior: The stable artifact reports version `1.2.0` and publishes the complete RC3 release notes.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable; no executable behavior changed.
- Reborn integration: Not applicable; the code is byte-for-byte RC3 apart from release metadata.
- Recorded fixture: Not applicable; no model behavior changed.
- Browser E2E: Not applicable; no browser behavior changed.
- Backend or runtime: Not applicable; no runtime behavior changed.
- Live canary: Not added. Existing `ironclaw-v1.2.0-rc.3` release workflow passed all seven native artifact smokes, upgrade canaries from 1.0.0 and 1.1.1-rc.1, and Docker publication.

What the tests prove: The cutter accepts the stable SemVer, Cargo resolves exactly one shipping `ironclaw` package at version 1.2.0, and the release workflow still targets and smokes the shipping binary.

Commands run:
- `cargo metadata --locked --no-deps --format-version 1`
- `python3 -m unittest scripts/ci/test_cut_ironclaw_release.py tests/test_smoke_release_binary.py` (34 passed)
- `cargo test -p ironclaw --test smoke release_ci_compiles_reborn_for_all_supported_targets -- --exact --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

## Security Impact

None. This changes release metadata and changelog structure only.

## Reborn Trust-Boundary Checklist

N/A: no Reborn runtime, policy, persistence, security, or trust-boundary code changed.

## Database Impact

None.

## Blast Radius

Release identity and generated release notes only. An incorrect version would make the cutter reject the commit or publish under the wrong tag; locked metadata and cutter tests guard this.

## Rollback Plan

Before tagging, revert this commit. After tagging, do not move the immutable tag; cut a patch release from a corrective commit.

## Review Follow-Through

Verify the PR contains only the three intended metadata files and remains based on `ironclaw-v1.2.0-rc.3`.

---

**Review track**: A (docs/tests/chore)
