### PR TITLE
perf: reduce trigger and outbound state writes

### DIFF
--- a/crates/domains/ironclaw_auth/src/product_auth/durable/tests.rs
+++ b/crates/domains/ironclaw_auth/src/product_auth/durable/tests.rs
@@ -979,6 +979,9 @@ async fn filesystem_oauth_callback_claim_is_one_shot_and_completion_persists() {
         })
         .await
         .unwrap();
+    // A callback can land on another worker after the start request returned.
+    // Both services share only durable filesystem and secret-store state.
+    let callback_worker = test_service(Arc::clone(&filesystem), Arc::clone(&secret_store));
     let claim = OAuthCallbackClaimRequest {
         flow_id: flow.id,
         opaque_state_hash: state_hash("state"),
@@ -986,7 +989,7 @@ async fn filesystem_oauth_callback_claim_is_one_shot_and_completion_persists() {
         pkce_verifier_hash: pkce_hash("pkce"),
     };
 
-    let claimed = service
+    let claimed = callback_worker
         .claim_oauth_callback(&scope, claim.clone())
         .await
         .unwrap();
@@ -1002,8 +1005,11 @@ async fn filesystem_oauth_callback_claim_is_one_shot_and_completion_persists() {
         .await
         .expect_err("in-flight callback claim must be one-shot");
     assert_eq!(second_claim, AuthProductError::FlowAlreadyTerminal);
+    // Completion may move again after a restart; the callback claim contains
+    // every field needed to finish without process-local flow state.
+    let completion_worker = test_service(Arc::clone(&filesystem), Arc::clone(&secret_store));
 
-    let completed = service
+    let completed = completion_worker
         .complete_oauth_callback(
             &scope,
             OAuthCallbackInput {

--- a/crates/domains/ironclaw_outbound/src/lib.rs
+++ b/crates/domains/ironclaw_outbound/src/lib.rs
@@ -69,8 +69,8 @@ pub use triggered_run_delivery::{
     TriggeredRunDeliveryRecord, TriggeredRunDeliveryRequest, TriggeredRunDeliveryStore,
 };
 pub use types::{
-    AdvanceSubscriptionCursorRequest, ClaimDeliveryAttemptForSendRequest, DeliveryFailureKind,
-    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryDecision,
+    ClaimDeliveryAttemptForSendRequest, DeliveryFailureKind, LoadSubscriptionCursorRequest,
+    OutboundDeliveryAttempt, OutboundDeliveryDecision,
     OutboundDeliveryStatus, OutboundPushCandidate, OutboundPushKind, OutboundPushPlan,
     OutboundPushTargetRequest, PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
     ProjectionSubscriptionRecord, ProjectionSubscriptionRequest, RecoverInterruptedDeliveryRequest,

--- a/crates/domains/ironclaw_outbound/src/lib.rs
+++ b/crates/domains/ironclaw_outbound/src/lib.rs
@@ -70,9 +70,9 @@ pub use triggered_run_delivery::{
 };
 pub use types::{
     ClaimDeliveryAttemptForSendRequest, DeliveryFailureKind, LoadSubscriptionCursorRequest,
-    OutboundDeliveryAttempt, OutboundDeliveryDecision,
-    OutboundDeliveryStatus, OutboundPushCandidate, OutboundPushKind, OutboundPushPlan,
-    OutboundPushTargetRequest, PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
+    OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryStatus,
+    OutboundPushCandidate, OutboundPushKind, OutboundPushPlan, OutboundPushTargetRequest,
+    PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
     ProjectionSubscriptionRecord, ProjectionSubscriptionRequest, RecoverInterruptedDeliveryRequest,
     ReplyTargetBindingClaim, ReplyTargetValidationRequest, ThreadNotificationPolicy,
     ThreadNotificationTarget, ThreadProjectionAccessClaim, ThreadProjectionAccessGrant,

--- a/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
+++ b/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
@@ -69,20 +69,20 @@ use sha2::{Digest, Sha256};
 
 use crate::reply_attachment_intents::validate_reply_attachment_intents;
 use crate::validation::{
-    validate_advance_request, validate_communication_preference, validate_delivery_attempt,
-    validate_delivery_identity, validate_delivery_status_request, validate_policy,
-    validate_subscription_identity, validate_subscription_record, validate_subscription_request,
+    validate_communication_preference, validate_delivery_attempt, validate_delivery_identity,
+    validate_delivery_status_request, validate_policy, validate_subscription_identity,
+    validate_subscription_record, validate_subscription_request,
 };
 use crate::{
-    AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, CommunicationPreferenceVersion, DeliveredGateRouteRecord,
-    DeliveredGateRouteStore, DeliveryDefaultScope, LoadSubscriptionCursorRequest,
-    MAX_RUN_DELIVERY_CLEANUP_RECORDS, OutboundDeliveryAttempt, OutboundDeliveryId,
-    OutboundDeliveryStatus, OutboundError, OutboundStateStorePort, ProjectionSubscriptionId,
-    ProjectionSubscriptionRecord, ReplyAttachmentIntent, ReplyAttachmentIntentPort,
-    RunDeliveryCleanupRecord, RunDeliveryCleanupRequest, ThreadNotificationPolicy,
-    TriggeredRunDeliveryRecord, TriggeredRunDeliveryStore, UpdateDeliveryStatusRequest,
-    VersionedCommunicationPreferenceRecord, WriteCommunicationPreferenceRequest,
+    CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
+    CommunicationPreferenceVersion, DeliveredGateRouteRecord, DeliveredGateRouteStore,
+    DeliveryDefaultScope, LoadSubscriptionCursorRequest, MAX_RUN_DELIVERY_CLEANUP_RECORDS,
+    OutboundDeliveryAttempt, OutboundDeliveryId, OutboundDeliveryStatus, OutboundError,
+    OutboundStateStorePort, ProjectionSubscriptionId, ProjectionSubscriptionRecord,
+    ReplyAttachmentIntent, ReplyAttachmentIntentPort, RunDeliveryCleanupRecord,
+    RunDeliveryCleanupRequest, ThreadNotificationPolicy, TriggeredRunDeliveryRecord,
+    TriggeredRunDeliveryStore, UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
+    WriteCommunicationPreferenceRequest,
 };
 
 /// Maximum number of compare-and-swap retries on a read-then-write path
@@ -880,45 +880,6 @@ where
         Ok(record.cursor)
     }
 
-    async fn advance_subscription_cursor(
-        &self,
-        request: AdvanceSubscriptionCursorRequest,
-    ) -> Result<(), OutboundError> {
-        let path = subscription_path(
-            &request.subscription_id,
-            &request.actor,
-            &request.cursor.scope,
-            &request.thread_id,
-        )?;
-        let resource_scope = ResourceScope::system();
-        self.ensure_tenant_id_index(&resource_scope, &subscriptions_root()?)
-            .await?;
-        for _ in 0..MAX_CAS_RETRIES {
-            let Some((mut record, versioned)) = self
-                .get_versioned_json::<ProjectionSubscriptionRecord>(&resource_scope, &path)
-                .await?
-            else {
-                return Err(OutboundError::SubscriptionScopeMismatch);
-            };
-            validate_advance_request(&record, &request)?;
-            record.cursor = Some(request.cursor.clone());
-            match self
-                .put_json(
-                    &resource_scope,
-                    &path,
-                    &record,
-                    &record.scope.stream.tenant_id,
-                    CasExpectation::Version(versioned.version),
-                )
-                .await
-            {
-                Ok(()) => return Ok(()),
-                Err(OutboundError::CasConflict) => continue,
-                Err(error) => return Err(error),
-            }
-        }
-        Err(OutboundError::Backend)
-    }
 
     async fn record_delivery_attempt(
         &self,

--- a/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
+++ b/crates/domains/ironclaw_outbound/src/outbound_state_store.rs
@@ -880,7 +880,6 @@ where
         Ok(record.cursor)
     }
 
-
     async fn record_delivery_attempt(
         &self,
         attempt: OutboundDeliveryAttempt,

--- a/crates/domains/ironclaw_outbound/src/store.rs
+++ b/crates/domains/ironclaw_outbound/src/store.rs
@@ -5,11 +5,11 @@ use ironclaw_event_projections::ProjectionCursor;
 use ironclaw_host_api::turn::{ReplyTargetBindingRef, TurnScope};
 
 use crate::{
-    AdvanceSubscriptionCursorRequest, ClaimDeliveryAttemptForSendRequest,
-    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError,
-    OutboundPushCandidate, OutboundPushKind, OutboundPushPlan, OutboundPushTargetRequest,
-    ProjectionSubscriptionRecord, RecoverInterruptedDeliveryRequest, RunDeliveryCleanupRecord,
-    RunDeliveryCleanupRequest, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    ClaimDeliveryAttemptForSendRequest, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
+    OutboundDeliveryId, OutboundError, OutboundPushCandidate, OutboundPushKind, OutboundPushPlan,
+    OutboundPushTargetRequest, ProjectionSubscriptionRecord, RecoverInterruptedDeliveryRequest,
+    RunDeliveryCleanupRecord, RunDeliveryCleanupRequest, ThreadNotificationPolicy,
+    UpdateDeliveryStatusRequest,
 };
 
 #[async_trait]
@@ -65,10 +65,6 @@ pub trait OutboundStateStorePort: Send + Sync {
         request: LoadSubscriptionCursorRequest,
     ) -> Result<Option<ProjectionCursor>, OutboundError>;
 
-    async fn advance_subscription_cursor(
-        &self,
-        request: AdvanceSubscriptionCursorRequest,
-    ) -> Result<(), OutboundError>;
 
     async fn record_delivery_attempt(
         &self,

--- a/crates/domains/ironclaw_outbound/src/store.rs
+++ b/crates/domains/ironclaw_outbound/src/store.rs
@@ -65,7 +65,6 @@ pub trait OutboundStateStorePort: Send + Sync {
         request: LoadSubscriptionCursorRequest,
     ) -> Result<Option<ProjectionCursor>, OutboundError>;
 
-
     async fn record_delivery_attempt(
         &self,
         attempt: OutboundDeliveryAttempt,

--- a/crates/domains/ironclaw_outbound/src/types.rs
+++ b/crates/domains/ironclaw_outbound/src/types.rs
@@ -169,13 +169,6 @@ pub struct LoadSubscriptionCursorRequest {
     pub thread_id: ThreadId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AdvanceSubscriptionCursorRequest {
-    pub subscription_id: ProjectionSubscriptionId,
-    pub actor: TurnActor,
-    pub thread_id: ThreadId,
-    pub cursor: ProjectionCursor,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/domains/ironclaw_outbound/src/types.rs
+++ b/crates/domains/ironclaw_outbound/src/types.rs
@@ -169,7 +169,6 @@ pub struct LoadSubscriptionCursorRequest {
     pub thread_id: ThreadId,
 }
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OutboundDeliveryStatus {

--- a/crates/domains/ironclaw_outbound/src/validation.rs
+++ b/crates/domains/ironclaw_outbound/src/validation.rs
@@ -4,10 +4,9 @@ use ironclaw_host_api::turn::ReplyTargetBindingRef;
 
 use crate::NOTIFICATION_TARGETS_CAP;
 use crate::{
-    AdvanceSubscriptionCursorRequest, CommunicationPreferenceRecord, DeliveryDefaultScope,
-    DeliveryFailureKind, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
-    OutboundDeliveryStatus, OutboundError, ProjectionSubscriptionRecord, ThreadNotificationPolicy,
-    UpdateDeliveryStatusRequest,
+    CommunicationPreferenceRecord, DeliveryDefaultScope, DeliveryFailureKind,
+    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryStatus, OutboundError,
+    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
 };
 
 const MAX_NOTIFICATION_TARGETS: usize = 32;
@@ -97,19 +96,6 @@ pub(crate) fn validate_subscription_cursor_progression(
     }
 }
 
-pub(crate) fn validate_advance_request(
-    record: &ProjectionSubscriptionRecord,
-    request: &AdvanceSubscriptionCursorRequest,
-) -> Result<(), OutboundError> {
-    if record.subscription_id != request.subscription_id
-        || record.actor != request.actor
-        || record.thread_id != request.thread_id
-        || record.scope != request.cursor.scope
-    {
-        return Err(OutboundError::SubscriptionScopeMismatch);
-    }
-    validate_subscription_cursor_progression(record.cursor.as_ref(), Some(&request.cursor))
-}
 
 pub(crate) fn validate_delivery_attempt(
     attempt: &OutboundDeliveryAttempt,

--- a/crates/domains/ironclaw_outbound/src/validation.rs
+++ b/crates/domains/ironclaw_outbound/src/validation.rs
@@ -96,7 +96,6 @@ pub(crate) fn validate_subscription_cursor_progression(
     }
 }
 
-
 pub(crate) fn validate_delivery_attempt(
     attempt: &OutboundDeliveryAttempt,
 ) -> Result<(), OutboundError> {

--- a/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -1599,7 +1599,6 @@ async fn subscription_cursor_rejects_mismatched_scope(store: &impl OutboundState
     // from absence.
     assert!(matches!(result, Ok(None)));
 
-
     let rebind = store
         .upsert_subscription(ProjectionSubscriptionRecord {
             subscription_id: subscription_id(),
@@ -1704,7 +1703,6 @@ async fn subscription_upsert_rejects_backward_cursor(store: &impl OutboundStateS
         })
         .await
         .unwrap();
-
 
     let stale_upsert = store
         .upsert_subscription(ProjectionSubscriptionRecord {
@@ -2538,7 +2536,6 @@ impl RootFilesystem for UnsupportedCriticalCasBackend {
         self.inner.delete(path).await
     }
 }
-
 
 /// Audit finding F4 + F3: write more than `Page::MAX_LIMIT` (1024) delivery
 /// attempts for the same scope and assert `list_delivery_attempts` returns

--- a/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/domains/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -387,7 +387,7 @@ async fn outbound_state_store_satisfies_outbound_contract_on_in_memory_backend()
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
     subscription_ids_are_scoped_not_global(&store).await;
-    subscription_cursor_rejects_backward_advancement(&store).await;
+    subscription_upsert_rejects_backward_cursor(&store).await;
     delivery_status_rejects_inconsistent_failure_kind(&store).await;
     coordinator_delivery_lifecycle_round_trips(&store).await;
     recovery_transition_never_clobbers_delivered(&store).await;
@@ -1470,16 +1470,7 @@ async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateSto
     );
 
     seed_subscription(store).await;
-    let cursor = ProjectionCursor::for_scope(projection_scope(), EventCursor::new(42));
-    store
-        .advance_subscription_cursor(AdvanceSubscriptionCursorRequest {
-            subscription_id: subscription_id(),
-            actor: actor(),
-            thread_id: thread_id(),
-            cursor: cursor.clone(),
-        })
-        .await
-        .unwrap();
+    let initial_cursor = ProjectionCursor::origin_for_scope(projection_scope());
     let loaded = store
         .load_subscription_cursor(LoadSubscriptionCursorRequest {
             subscription_id: subscription_id(),
@@ -1490,7 +1481,10 @@ async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateSto
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(loaded, cursor);
+    assert_eq!(
+        loaded, initial_cursor,
+        "subscription creation must retain the caller's initial after_cursor"
+    );
 
     let delivery_id = OutboundDeliveryId::new();
     let initial_attempt = OutboundDeliveryAttempt {
@@ -1605,20 +1599,6 @@ async fn subscription_cursor_rejects_mismatched_scope(store: &impl OutboundState
     // from absence.
     assert!(matches!(result, Ok(None)));
 
-    let mut wrong_scope = projection_scope();
-    wrong_scope.read_scope.thread_id = Some(ThreadId::new("thread-other").unwrap());
-    let result = store
-        .advance_subscription_cursor(AdvanceSubscriptionCursorRequest {
-            subscription_id: subscription_id(),
-            actor: actor(),
-            thread_id: thread_id(),
-            cursor: ProjectionCursor::for_scope(wrong_scope, EventCursor::new(7)),
-        })
-        .await;
-    assert!(matches!(
-        result,
-        Err(OutboundError::SubscriptionScopeMismatch)
-    ));
 
     let rebind = store
         .upsert_subscription(ProjectionSubscriptionRecord {
@@ -1707,7 +1687,7 @@ async fn subscription_ids_are_scoped_not_global(store: &impl OutboundStateStoreP
     assert!(matches!(unrelated_lookup, Ok(None)));
 }
 
-async fn subscription_cursor_rejects_backward_advancement(store: &impl OutboundStateStorePort) {
+async fn subscription_upsert_rejects_backward_cursor(store: &impl OutboundStateStorePort) {
     let subscription_id =
         ProjectionSubscriptionId::new(format!("webui-subscription-backward-{}", TurnRunId::new()))
             .unwrap();
@@ -1725,18 +1705,6 @@ async fn subscription_cursor_rejects_backward_advancement(store: &impl OutboundS
         .await
         .unwrap();
 
-    let regression = store
-        .advance_subscription_cursor(AdvanceSubscriptionCursorRequest {
-            subscription_id: subscription_id.clone(),
-            actor: actor(),
-            thread_id: thread_id(),
-            cursor: ProjectionCursor::for_scope(projection_scope(), EventCursor::new(7)),
-        })
-        .await;
-    assert!(matches!(
-        regression,
-        Err(OutboundError::InvalidRequest { .. })
-    ));
 
     let stale_upsert = store
         .upsert_subscription(ProjectionSubscriptionRecord {
@@ -2571,115 +2539,6 @@ impl RootFilesystem for UnsupportedCriticalCasBackend {
     }
 }
 
-/// Audit finding F4: prove the CAS retry loop on
-/// `advance_subscription_cursor` converges when a racing writer bumps the
-/// version exactly once between the store's read and put. Before F1 this
-/// would silently lose the forward progression because the put used
-/// `CasExpectation::Any`; before F5 the retry loop couldn't distinguish a
-/// transient race from a permanent backend error.
-#[tokio::test]
-async fn advance_subscription_cursor_retries_through_cas_conflict() {
-    let inner = Arc::new(InMemoryBackend::new());
-    let racing = Arc::new(VersionRacingBackend::new(Arc::clone(&inner)));
-    let store = OutboundStateStore::new(build_scoped_fs(
-        Arc::clone(&racing),
-        "/engine/tenants/test/users/test/outbound",
-    ));
-    seed_subscription(&store).await;
-
-    // Arm one injected conflict on the next put to any subscription path.
-    // The store's read returns version v1; we inject `VersionMismatch` on
-    // the first put, forcing the retry loop to re-read, re-validate
-    // progression, and put again with the new version — which succeeds.
-    // The injected prefix matches the resolved VirtualPath the
-    // ScopedFilesystem produces for the `/outbound/subscriptions/...` alias.
-    racing
-        .arm("/engine/tenants/test/users/test/outbound/subscriptions/", 1)
-        .await;
-
-    let cursor = ProjectionCursor::for_scope(projection_scope(), EventCursor::new(101));
-    store
-        .advance_subscription_cursor(AdvanceSubscriptionCursorRequest {
-            subscription_id: subscription_id(),
-            actor: actor(),
-            thread_id: thread_id(),
-            cursor: cursor.clone(),
-        })
-        .await
-        .expect("retry loop must converge after one transient CAS conflict");
-
-    assert_eq!(
-        racing.injected_count().await,
-        1,
-        "exactly one CAS conflict should have been injected and recovered from",
-    );
-
-    let loaded = store
-        .load_subscription_cursor(LoadSubscriptionCursorRequest {
-            subscription_id: subscription_id(),
-            actor: actor(),
-            scope: projection_scope(),
-            thread_id: thread_id(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(loaded, cursor);
-}
-
-/// Audit finding F4: with two racing advancers, the loser must NOT silently
-/// overwrite the winner's higher cursor. F1's retry loop re-reads and
-/// re-validates progression on every attempt, so the loser's request is
-/// rejected with `InvalidRequest` because its target cursor is now
-/// regressing against the winner's persisted state.
-#[tokio::test]
-async fn concurrent_backwards_race_rejected_after_winner_advances() {
-    let backend = Arc::new(InMemoryBackend::new());
-    let store = build_outbound_store_for_backend(Arc::clone(&backend));
-    seed_subscription(&store).await;
-
-    // Winner advances first to cursor=100.
-    let winner_cursor = ProjectionCursor::for_scope(projection_scope(), EventCursor::new(100));
-    store
-        .advance_subscription_cursor(AdvanceSubscriptionCursorRequest {
-            subscription_id: subscription_id(),
-            actor: actor(),
-            thread_id: thread_id(),
-            cursor: winner_cursor.clone(),
-        })
-        .await
-        .unwrap();
-
-    // Loser tries to advance to a strictly lower cursor=50. Even without a
-    // racing CAS conflict, the progression re-check inside the retry loop
-    // catches the regression on the first iteration.
-    let loser_cursor = ProjectionCursor::for_scope(projection_scope(), EventCursor::new(50));
-    let regression = store
-        .advance_subscription_cursor(AdvanceSubscriptionCursorRequest {
-            subscription_id: subscription_id(),
-            actor: actor(),
-            thread_id: thread_id(),
-            cursor: loser_cursor,
-        })
-        .await;
-    assert!(
-        matches!(regression, Err(OutboundError::InvalidRequest { .. })),
-        "regressing cursor must be rejected, got {regression:?}",
-    );
-
-    // And the winner's progress is preserved.
-    let loaded = store
-        .load_subscription_cursor(LoadSubscriptionCursorRequest {
-            subscription_id: subscription_id(),
-            actor: actor(),
-            scope: projection_scope(),
-            thread_id: thread_id(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(loaded, winner_cursor);
-}
 
 /// Audit finding F4 + F3: write more than `Page::MAX_LIMIT` (1024) delivery
 /// attempts for the same scope and assert `list_delivery_attempts` returns

--- a/crates/domains/ironclaw_triggers/src/in_memory.rs
+++ b/crates/domains/ironclaw_triggers/src/in_memory.rs
@@ -578,6 +578,8 @@ impl TriggerRepository for InMemoryTriggerRepository {
                 run.completed_at = Some(completed_at);
                 run
             });
+        // Recovery may synthesize a completion row when the Running row is
+        // missing, so this edge can still increase cardinality and must prune.
         prune_run_history_locked(&mut state, &request.tenant_id, request.trigger_id);
         Ok(Some(record))
     }
@@ -714,7 +716,6 @@ impl InMemoryTriggerRepository {
         );
         run.thread_id = preserved_thread_id;
         state.runs.insert(key, run);
-        prune_run_history_locked(&mut state, tenant_id, trigger_id);
         Ok(())
     }
 
@@ -752,6 +753,8 @@ impl InMemoryTriggerRepository {
                 run.completed_at = Some(completed_at);
                 run
             });
+        // Terminal recovery can insert a missing history row; retain strict
+        // retention on that conservative fallback.
         prune_run_history_locked(&mut state, tenant_id, trigger_id);
         Ok(())
     }

--- a/crates/domains/ironclaw_triggers/src/libsql.rs
+++ b/crates/domains/ironclaw_triggers/src/libsql.rs
@@ -834,6 +834,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
                 ),
             )
             .await?;
+            prune_run_history(&transaction, &request.tenant_id, request.trigger_id).await?;
             Ok(Some(record))
         }
         .await;
@@ -1788,7 +1789,6 @@ async fn upsert_run_history(
     )
     .await
     .map_err(|error| backend_error("upsert trigger run history", error))?;
-    prune_run_history(conn, &run.tenant_id, run.trigger_id).await?;
     Ok(())
 }
 fn trigger_ids_json_array(trigger_ids: &[TriggerId]) -> String {
@@ -1836,6 +1836,8 @@ async fn complete_run_history(
     )
     .await
     .map_err(|error| backend_error("complete trigger run history", error))?;
+    // Completion normally updates the claim row, but recovery may insert a
+    // missing row. Keep pruning on that conservative compatibility path.
     prune_run_history(conn, tenant_id, trigger_id).await?;
     Ok(())
 }

--- a/crates/domains/ironclaw_triggers/src/postgres.rs
+++ b/crates/domains/ironclaw_triggers/src/postgres.rs
@@ -606,6 +606,7 @@ impl TriggerRepository for PostgresTriggerRepository {
             ),
         )
         .await?;
+        prune_run_history(&tx, &record.tenant_id, record.trigger_id).await?;
         tx.commit()
             .await
             .map_err(|error| backend_error("commit trigger fire claim", error))?;
@@ -1244,7 +1245,6 @@ async fn upsert_run_history(
         )
         .await
         .map_err(|error| backend_error("upsert trigger run history", error))?;
-    prune_run_history(client, &run.tenant_id, run.trigger_id).await?;
     Ok(())
 }
 
@@ -1287,6 +1287,8 @@ async fn complete_run_history(
         )
         .await
         .map_err(|error| backend_error("complete trigger run history", error))?;
+    // Completion normally updates the claim row, but recovery may insert a
+    // missing row. Keep pruning on that conservative compatibility path.
     prune_run_history(client, tenant_id, trigger_id).await?;
     Ok(())
 }

--- a/crates/domains/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/domains/ironclaw_triggers/tests/repository_contract.rs
@@ -3759,8 +3759,7 @@ mod fire_claim_contract {
         repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), base_fire_slot))
             .await
             .expect("insert retention record");
-        let other_trigger_id =
-            TriggerId::parse("01J00000000000000000000036").expect("ulid");
+        let other_trigger_id = TriggerId::parse("01J00000000000000000000036").expect("ulid");
         repo.upsert_trigger(sample_record(
             other_trigger_id,
             tenant_id.clone(),
@@ -3888,8 +3887,7 @@ mod fire_claim_contract {
         let recovery_fire_slot = fire_slot;
         let recovery_run_id =
             TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f84").expect("valid run");
-        let mut recovery_record =
-            sample_record(trigger_id, tenant_id.clone(), recovery_fire_slot);
+        let mut recovery_record = sample_record(trigger_id, tenant_id.clone(), recovery_fire_slot);
         recovery_record.active_fire_slot = Some(recovery_fire_slot);
         recovery_record.active_run_ref = Some(recovery_run_id);
         repo.upsert_trigger(recovery_record)

--- a/crates/domains/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/domains/ironclaw_triggers/tests/repository_contract.rs
@@ -3759,6 +3759,51 @@ mod fire_claim_contract {
         repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), base_fire_slot))
             .await
             .expect("insert retention record");
+        let other_trigger_id =
+            TriggerId::parse("01J00000000000000000000036").expect("ulid");
+        repo.upsert_trigger(sample_record(
+            other_trigger_id,
+            tenant_id.clone(),
+            base_fire_slot,
+        ))
+        .await
+        .expect("insert unrelated trigger");
+        let other_trigger_claim = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id: other_trigger_id,
+                fire_slot: base_fire_slot,
+                now: base_fire_slot,
+            })
+            .await
+            .expect("claim unrelated trigger fire");
+        assert!(matches!(
+            other_trigger_claim,
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+
+        let other_tenant_id = tenant("tenant-run-history-retention-other");
+        repo.upsert_trigger(sample_record(
+            trigger_id,
+            other_tenant_id.clone(),
+            base_fire_slot,
+        ))
+        .await
+        .expect("insert unrelated tenant trigger");
+        let other_tenant_claim = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: other_tenant_id.clone(),
+                trigger_id,
+                fire_slot: base_fire_slot,
+                now: base_fire_slot,
+            })
+            .await
+            .expect("claim unrelated tenant fire");
+        assert!(matches!(
+            other_tenant_claim,
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+
         let mut fire_slot = base_fire_slot;
         let mut claimed_slots = Vec::with_capacity(501);
 
@@ -3775,6 +3820,31 @@ mod fire_claim_contract {
                 .await
                 .expect("claim retention fire");
             assert!(matches!(claimed, ClaimDueFireOutcome::Claimed(_)));
+            if offset == 500 {
+                let retained_at_claim = repo
+                    .list_trigger_run_history(tenant_id.clone(), trigger_id, 501)
+                    .await
+                    .expect("list retained run history at claim");
+                assert_eq!(
+                    retained_at_claim.len(),
+                    500,
+                    "the 501st claim must prune before acceptance"
+                );
+                assert_eq!(
+                    retained_at_claim
+                        .first()
+                        .expect("newest retained at claim")
+                        .fire_slot,
+                    claimed_slots.last().cloned().expect("newest claimed slot")
+                );
+                assert_eq!(
+                    retained_at_claim
+                        .last()
+                        .expect("oldest retained at claim")
+                        .fire_slot,
+                    claimed_slots.get(1).cloned().expect("oldest retained slot")
+                );
+            }
             repo.mark_fire_accepted(FireAcceptedRequest {
                 tenant_id: tenant_id.clone(),
                 trigger_id,
@@ -3802,7 +3872,7 @@ mod fire_claim_contract {
         }
 
         let retained = repo
-            .list_trigger_run_history(tenant_id, trigger_id, 501)
+            .list_trigger_run_history(tenant_id.clone(), trigger_id, 501)
             .await
             .expect("list retained run history");
         assert_eq!(retained.len(), 500);
@@ -3814,6 +3884,69 @@ mod fire_claim_contract {
             retained.last().expect("oldest retained").fire_slot,
             claimed_slots.get(1).cloned().expect("oldest retained slot")
         );
+
+        let recovery_fire_slot = fire_slot;
+        let recovery_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f84").expect("valid run");
+        let mut recovery_record =
+            sample_record(trigger_id, tenant_id.clone(), recovery_fire_slot);
+        recovery_record.active_fire_slot = Some(recovery_fire_slot);
+        recovery_record.active_run_ref = Some(recovery_run_id);
+        repo.upsert_trigger(recovery_record)
+            .await
+            .expect("insert active recovery record without running history");
+
+        repo.clear_active_fire(ClearActiveFireRequest {
+            tenant_id: tenant_id.clone(),
+            trigger_id,
+            fire_slot: recovery_fire_slot,
+            run_id: recovery_run_id,
+            status: TriggerRunHistoryStatus::Ok,
+        })
+        .await
+        .expect("complete recovery fire without running history")
+        .expect("active recovery fire should clear");
+
+        let retained_after_recovery = repo
+            .list_trigger_run_history(tenant_id.clone(), trigger_id, 501)
+            .await
+            .expect("list retained run history after recovery completion");
+        assert_eq!(
+            retained_after_recovery.len(),
+            500,
+            "completion-time recovery must retain exactly 500 rows"
+        );
+        assert_eq!(
+            retained_after_recovery
+                .first()
+                .expect("newest retained after recovery")
+                .fire_slot,
+            recovery_fire_slot
+        );
+        assert_eq!(
+            retained_after_recovery
+                .last()
+                .expect("oldest retained after recovery")
+                .fire_slot,
+            claimed_slots
+                .get(2)
+                .cloned()
+                .expect("oldest retained after recovery")
+        );
+
+        let other_trigger_history = repo
+            .list_trigger_run_history(tenant_id, other_trigger_id, 501)
+            .await
+            .expect("list unrelated trigger history");
+        assert_eq!(other_trigger_history.len(), 1);
+        assert_eq!(other_trigger_history[0].fire_slot, base_fire_slot);
+
+        let other_tenant_history = repo
+            .list_trigger_run_history(other_tenant_id, trigger_id, 501)
+            .await
+            .expect("list unrelated tenant history");
+        assert_eq!(other_tenant_history.len(), 1);
+        assert_eq!(other_tenant_history[0].fire_slot, base_fire_slot);
     }
 
     async fn seed_persisted_run_history(repo: &impl TriggerRepository) -> (TenantId, TriggerId) {

--- a/crates/domains/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/domains/ironclaw_triggers/tests/repository_contract.rs
@@ -3763,12 +3763,28 @@ mod fire_claim_contract {
         for offset in 0..=500 {
             let fire_slot = base_fire_slot + chrono::Duration::minutes(offset);
             let run_id = TurnRunId::new();
-            let mut active_record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
-            active_record.active_fire_slot = Some(fire_slot);
-            active_record.active_run_ref = Some(run_id);
-            repo.upsert_trigger(active_record)
+            let claimed = repo
+                .claim_due_fire(ClaimDueFireRequest {
+                    tenant_id: tenant_id.clone(),
+                    trigger_id,
+                    fire_slot,
+                    now: fire_slot,
+                })
                 .await
-                .expect("upsert active retention record");
+                .expect("claim retention fire");
+            assert!(matches!(claimed, ClaimDueFireOutcome::Claimed(_)));
+            repo.mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id,
+                thread_id: ThreadId::new(format!("thread-retention-{offset}"))
+                    .expect("valid thread id"),
+                submitted_at: fire_slot,
+            })
+            .await
+            .expect("accept retention fire")
+            .expect("accepted retention fire should persist");
             repo.clear_active_fire(ClearActiveFireRequest {
                 tenant_id: tenant_id.clone(),
                 trigger_id,

--- a/crates/domains/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/domains/ironclaw_triggers/tests/repository_contract.rs
@@ -3759,9 +3759,11 @@ mod fire_claim_contract {
         repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), base_fire_slot))
             .await
             .expect("insert retention record");
+        let mut fire_slot = base_fire_slot;
+        let mut claimed_slots = Vec::with_capacity(501);
 
         for offset in 0..=500 {
-            let fire_slot = base_fire_slot + chrono::Duration::minutes(offset);
+            claimed_slots.push(fire_slot);
             let run_id = TurnRunId::new();
             let claimed = repo
                 .claim_due_fire(ClaimDueFireRequest {
@@ -3785,16 +3787,18 @@ mod fire_claim_contract {
             .await
             .expect("accept retention fire")
             .expect("accepted retention fire should persist");
-            repo.clear_active_fire(ClearActiveFireRequest {
-                tenant_id: tenant_id.clone(),
-                trigger_id,
-                fire_slot,
-                run_id,
-                status: TriggerRunHistoryStatus::Ok,
-            })
-            .await
-            .expect("clear retention fire")
-            .expect("active fire should clear");
+            let cleared = repo
+                .clear_active_fire(ClearActiveFireRequest {
+                    tenant_id: tenant_id.clone(),
+                    trigger_id,
+                    fire_slot,
+                    run_id,
+                    status: TriggerRunHistoryStatus::Ok,
+                })
+                .await
+                .expect("clear retention fire")
+                .expect("active fire should clear");
+            fire_slot = cleared.next_run_at;
         }
 
         let retained = repo
@@ -3804,11 +3808,11 @@ mod fire_claim_contract {
         assert_eq!(retained.len(), 500);
         assert_eq!(
             retained.first().expect("newest retained").fire_slot,
-            base_fire_slot + chrono::Duration::minutes(500)
+            claimed_slots.last().cloned().expect("newest claimed slot")
         );
         assert_eq!(
             retained.last().expect("oldest retained").fire_slot,
-            base_fire_slot + chrono::Duration::minutes(1)
+            claimed_slots.get(1).cloned().expect("oldest retained slot")
         );
     }
 

--- a/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
+++ b/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
@@ -763,12 +763,6 @@ impl OutboundStateStorePort for FailingOutboundStore {
         Err(self.error())
     }
 
-    async fn advance_subscription_cursor(
-        &self,
-        _request: AdvanceSubscriptionCursorRequest,
-    ) -> Result<(), OutboundError> {
-        Err(self.error())
-    }
 
     async fn record_delivery_attempt(
         &self,

--- a/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/support/imports.rs
+++ b/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/support/imports.rs
@@ -24,11 +24,10 @@ use ironclaw_filesystem::{
 use ironclaw_host_api::{ids::{CapabilityId, ExtensionId, InvocationId, MissionId, ProjectId, TenantId, ThreadId, UserId}, path::{MountAlias, VirtualPath}, mount::{MountGrant, MountPermissions, MountView}, runtime::RuntimeKind};
 use ironclaw_outbound::test_support::in_memory_backed_outbound_state_store;
 use ironclaw_outbound::{
-    AdvanceSubscriptionCursorRequest, OutboundStateStore, LoadSubscriptionCursorRequest,
-    OutboundDeliveryAttempt, OutboundError, OutboundPushKind, OutboundPushPlan,
-    OutboundPushTargetRequest, OutboundStateStorePort, ProjectionSubscriptionRecord,
-    ProjectionUpdateRef, ThreadNotificationPolicy, ThreadNotificationTarget,
-    UpdateDeliveryStatusRequest,
+    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundError, OutboundPushKind,
+    OutboundPushPlan, OutboundPushTargetRequest, OutboundStateStore,
+    OutboundStateStorePort, ProjectionSubscriptionRecord, ProjectionUpdateRef,
+    ThreadNotificationPolicy, ThreadNotificationTarget, UpdateDeliveryStatusRequest,
 };
 use ironclaw_host_api::turn::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
 use tokio::{

--- a/crates/product/ironclaw_assistant/tests/outbound_delivery_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/outbound_delivery_contract.rs
@@ -1959,12 +1959,6 @@ impl OutboundStateStorePort for TerminalDeliveredWriteFailingStore {
     ) -> Result<Option<ironclaw_event_projections::ProjectionCursor>, OutboundError> {
         self.inner.load_subscription_cursor(request).await
     }
-    async fn advance_subscription_cursor(
-        &self,
-        request: ironclaw_outbound::AdvanceSubscriptionCursorRequest,
-    ) -> Result<(), OutboundError> {
-        self.inner.advance_subscription_cursor(request).await
-    }
     async fn record_delivery_attempt(
         &self,
         attempt: OutboundDeliveryAttempt,

--- a/docs/internal/reborn/contracts/storage-placement.md
+++ b/docs/internal/reborn/contracts/storage-placement.md
@@ -100,7 +100,7 @@ TransactionalStore backend transaction boundary for multi-record operations
 These primitives are not replacements for domain APIs. For example, callers
 should still use `ProcessTransitionPort::claim_next_processes`,
 `SessionThreadService::accept_inbound_message`,
-`OutboundStateStore::advance_subscription_cursor`, and the secret-store APIs
+`OutboundStateStore::load_subscription_cursor`, and the secret-store APIs
 instead of reaching into primitive stores directly.
 
 Rules:


### PR DESCRIPTION
## Summary

- Move trigger run-history retention pruning from every Running-row update to the initial fire claim, where a new `fire_slot` is normally inserted.
- Retain completion-time pruning on the recovery path because completion can synthesize a missing Running row; this preserves strict retention and historical recovery behavior.
- Remove the unused `advance_subscription_cursor` request, validation, trait method, implementation, and test doubles while preserving `ProjectionSubscriptionRecord.cursor`, `load_subscription_cursor`, and subscription creation's initial cursor.
- Extend the durable OAuth callback contract so start, claim, and completion happen on separate service instances sharing only durable stores.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7591
Related #7595
Related #7597
Related #7604 (auth-flow bullet 4)

### Coverage and explicit exclusions

This PR fully covers the trigger prune relocation from #7595 and the dead outbound mutator removal from #7597. It adds restart/cross-worker proof for #7604 auth-flow bullet 4, but deliberately retains the durable `CallbackReceived` claim and continuation fence because both are required for cross-worker single exchange and at-least-once continuation recovery.

#7600 is not included. The accepted-message idempotency row is coupled to reply-target and replay writes in the current conversation singleton. Splitting it without a multi-record recovery protocol would introduce a crash window. Threads/transcript, process lifecycle, runtime events, and the append-only `AuditBefore`/`AuditAfter` pair are untouched.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: local validation intentionally pending coordinator validation under the four-PR batch contract
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed
- [ ] Manual testing: not run; batch contract forbids worker-side validation
- [ ] If a coding agent was used and supports it, review tooling was run

## Test Strategy

User behavior: trigger history still shows Running, accepted thread ids, and terminal status within the 500-row limit. Subscription creation still exposes its initial cursor. OAuth callback state survives process/worker changes.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: trigger retention now uses the production claim -> accept -> clear lifecycle; outbound contract pins the initial subscription cursor and removes dead-mutator assertions; durable auth callback runs creation, claim, and completion on distinct service instances.
- Reborn integration: Not applicable; these behaviors are owned by crate-level persistence contracts.
- Recorded fixture: Not applicable; no model behavior.
- Browser E2E: Not applicable; no browser change.
- Backend or runtime: Existing trigger contract exercises in-memory, libSQL, and PostgreSQL repository implementations.
- Live canary: Not applicable.

What the tests prove: strict trigger retention and full Running/thread/terminal history remain observable; the retained cursor is the creation cursor; callback-critical fields remain durable across worker boundaries.

Commands run: None. Worker-side tests, builds, formatters, and linters were intentionally skipped per the batch contract.

Coordinator validation to run:
- `cargo test -p ironclaw_triggers --test repository_contract`
- `cargo test -p ironclaw_outbound --test outbound_state_store_contract`
- `cargo test -p ironclaw_auth filesystem_oauth_callback_claim_is_one_shot_and_completion_persists`
- `cargo test -p ironclaw_event_streams --test event_stream_manager_contract`
- `cargo test -p ironclaw_assistant --test outbound_delivery_contract`
- `cargo fmt --all -- --check`

## Security Impact

No authority or secret-custody behavior changes. OAuth callback durability transitions and PKCE secret-store handling remain unchanged. `AuditBefore` and `AuditAfter` remain separate append-only records.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new types.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: unchanged.
- [x] Hashes declare purpose: unchanged.
- [x] New/changed status, exit, policy, runtime, or error variants: none.
- [x] Security/durability `serde(default)` fields: none added or changed.
- [x] Queues/maps/buffers/counters: trigger retention remains capped at 500.
- [x] Driver/operator-visible errors: unchanged.
- [x] Sandbox/native/host names: unchanged.

## Database Impact

No migration or schema change. PostgreSQL, libSQL, and in-memory trigger repositories relocate the normal prune call to the same atomic claim lifecycle. Completion retains pruning because legacy/recovery paths may insert a missing run-history row.

## Blast Radius

Trigger run-history write cadence and the outbound store trait/test doubles. Production outbound setup keeps its initial cursor and read API. Auth production behavior is unchanged; only contract coverage expands.

## Compatibility

Historical trigger rows remain readable. Running status, accepted `thread_id`, terminal status, active-run coordination fields, and the 500-row limit are unchanged. Existing subscription records keep their cursor field and load behavior. OAuth flow records and PKCE secret storage are unchanged.

## Rollback Plan

Revert commits `ce28ecedd0`, `cf4738b2a1`, and `fd7bd48744` independently. No data migration or backfill is required.

## Review Follow-Through

Reviewer judgment is requested on the conservative completion-time prune. Removing it would save another statement but would violate the existing completion-only recovery contract that can create a history row.

---

**Review track**: C (database-backed persistence behavior and public trait removal)