### PR TITLE
fix(shell): tell the model the tool takes a command line, not one primitive per call

### DIFF
--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -323,20 +323,32 @@ mod tests {
         // so the model treated it as one-primitive-per-call and paid a round
         // trip per `ls`/`cat` (~2.2x the tool calls of harnesses whose shell
         // description carries calling guidance, for the same work).
+        // Each assertion pins one instruction, not just a keyword: a
+        // description that names `workdir` while dropping "instead of a
+        // leading cd" has lost the guidance and must still fail here.
         let description = manifest().expect("shell manifest builds").description;
-        assert!(
-            description.contains("full shell command line"),
-            "description must say one call takes a whole command line: {description}"
-        );
-        assert!(
-            description.contains("workdir"),
-            "description must point at the per-call workdir parameter instead of a leading cd: \
-             {description}"
-        );
+        for required in [
+            "full shell command line",
+            "single call",
+            "rather than one call per step",
+            "workdir",
+            "instead of a leading `cd`",
+            "does not carry over",
+        ] {
+            assert!(
+                description.contains(required),
+                "description lost the calling guidance ({required:?} missing): {description}"
+            );
+        }
     }
 
     #[test]
-    fn the_command_forms_the_description_recommends_actually_validate() {
+    fn the_recommended_command_forms_pass_validation_and_workdir_parsing() {
+        // Scope is deliberately validation + parsing, the two gates a batched
+        // call meets before dispatch. Execution is not covered: this handler's
+        // scoped-path branch fails closed pending a process backend that can
+        // take a virtual cwd, so there is no executor here to assert against.
+        //
         // The description tells the model to batch with `&&`, loops, and
         // heredocs, and to pass `workdir`. If validation is ever tightened to
         // reject composition, that advice becomes a lie the model cannot

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -318,6 +318,50 @@ mod tests {
     }
 
     #[test]
+    fn the_manifest_tells_the_model_how_to_call_the_tool_not_only_what_it_does() {
+        // Regression: the description used to state only what the tool does,
+        // so the model treated it as one-primitive-per-call and paid a round
+        // trip per `ls`/`cat` (~2.2x the tool calls of harnesses whose shell
+        // description carries calling guidance, for the same work).
+        let description = manifest().expect("shell manifest builds").description;
+        assert!(
+            description.contains("full shell command line"),
+            "description must say one call takes a whole command line: {description}"
+        );
+        assert!(
+            description.contains("workdir"),
+            "description must point at the per-call workdir parameter instead of a leading cd: \
+             {description}"
+        );
+    }
+
+    #[test]
+    fn the_command_forms_the_description_recommends_actually_validate() {
+        // The description tells the model to batch with `&&`, loops, and
+        // heredocs, and to pass `workdir`. If validation is ever tightened to
+        // reject composition, that advice becomes a lie the model cannot
+        // discover except by burning a rejected call — so pin the forms here.
+        for command in [
+            "ls -la && cat notes.md",
+            "for id in 1 2 3; do curl -s \"http://svc.test/items/$id\"; done",
+            "sh <<'EOF'\nls -la\ncat notes.md\nEOF",
+            "grep -r needle . | head -20",
+        ] {
+            assert!(
+                shell_core::validate_command(command, false).is_ok(),
+                "description recommends this form, so it must validate: {command}"
+            );
+        }
+
+        let request = shell_core::parse_shell_request(&serde_json::json!({
+            "command": "cat notes.md",
+            "workdir": "/workspace/sub",
+        }))
+        .expect("workdir is a per-call parameter");
+        assert_eq!(request.workdir.as_deref(), Some("/workspace/sub"));
+    }
+
+    #[test]
     fn shell_error_carries_the_invalid_parameter_reason() {
         // The model must see WHY its shell call was rejected (e.g. which
         // parameter was missing); a bare input-encode category leaves it

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -34,7 +34,15 @@ const SAVED_OUTPUT_SCOPED_DIR: &str = "command-outputs";
 pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
     first_party_capability_manifest(
         SHELL_CAPABILITY_ID,
-        "Execute shell commands with copied v1 validation and saved-file references for large local output",
+        // The two hints after the first sentence are the model-facing calling
+        // convention, not decoration: `command` takes a whole shell command
+        // line, and `workdir` is per-call. Without them the model treats this
+        // as one-primitive-per-call and pays a round trip per `ls`/`cat`.
+        "Execute shell commands with copied v1 validation and saved-file references for large local \
+         output. One call runs a full shell command line, so related steps belong in a single call \
+         (`a && b`, a `for` loop over ids, a heredoc script) rather than one call per step. Pass \
+         `workdir` instead of a leading `cd` — the working directory is per-call and does not carry \
+         over between calls.",
         vec![
             EffectKind::DispatchCapability,
             EffectKind::SpawnProcess,


### PR DESCRIPTION
## What

Adds calling guidance to `builtin.shell`'s model-facing description. Description string only — no handler, schema, or validation change.

```diff
-"Execute shell commands with copied v1 validation and saved-file references for large local output"
+"Execute shell commands with copied v1 validation and saved-file references for large local
+ output. One call runs a full shell command line, so related steps belong in a single call
+ (`a && b`, a `for` loop over ids, a heredoc script) rather than one call per step. Pass
+ `workdir` instead of a leading `cd` — the working directory is per-call and does not carry
+ over between calls."
```

## Why

While benchmarking reborn against openclaw and hermes on a 45-task corpus (same model, `deepseek-v4-flash` via OpenRouter, `--parallelism 1`), reborn issued **~2.2× the tool calls for indistinguishable scores**:

| | reborn | openclaw | hermes |
|---|---|---|---|
| tool calls (45 tasks) | **957** | 426 | 639 |
| mean score | 0.915 | 0.915 | 0.947 |

Per-task, on the worst offenders: 102 calls vs 21, 90 vs 8, 67 vs 18. 83–92% of every harness's calls are shell/terminal, so this is almost entirely shell granularity.

Same model in every case, so the difference comes from the tool surface. hermes's `terminal` description carries ~700 characters of calling guidance; `builtin.shell`'s carries none — it describes what the tool *is* and never says how to call it. The observed behaviour matches: reborn does one `ls`, one `cat`, one `grep` per call and pays a round trip each time.

## Both added claims verified against the handler

- **`command` is a full command line.** `a && b`, `for` loops, and heredocs all pass `validate_command` / `detect_command_injection` — those reject specific exfil and escalation shapes (`| sh`, `base64 -d |`, netcat piping, `eval `), not composition.
- **`workdir` is per-call** (`parse_shell_request`, `shell_core.rs`), so a leading `cd` is wasted.

I deliberately did **not** copy hermes's "filesystem and environment persist between calls" framing. reborn's shell does not work that way — `workdir` being a per-call parameter is the evidence — and an agent acting on a false persistence claim would break. Empirically reborn uses `export` in 0% of 2306 shell calls vs hermes's 8%, consistent with that.

## Testing

- `cargo test -p ironclaw_host_runtime` — 875 tests pass, no failures.
- `cargo check -p ironclaw_host_runtime` clean.
- No test or doc referenced the old string (single occurrence in the tree).

**Not measured end-to-end.** I could not A/B this from the benchmark harness: nearai-bench consumes ironclaw as a git dependency, whose crates resolve to several different revisions, so a single-revision path patch won't build. The behavioural claim above is observational (reborn vs two harnesses whose descriptions carry guidance), not a controlled before/after on this diff. If there's a cheap way to run reborn against a branch build I'm happy to produce the paired numbers on the four worst tasks — the effect size should be obvious.

## Risk

Low. Worst case the model reads the hint and batches commands that were always legal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
