### PR TITLE
feat(stress): measure libSQL table writes

### DIFF
--- a/tools/ironclaw_stress/README.md
+++ b/tools/ironclaw_stress/README.md
@@ -261,7 +261,7 @@ defaults.
 | --- | --- |
 | `chat-baseline` | Baseline user-turn storage latency and throughput. |
 | `hot-thread` | Same-thread serialization and busy-thread rejection behavior. |
-| `db-write-measurement` | One deterministic Postgres user turn with 10 tool calls, plus an idle write window. |
+| `db-write-measurement` | One deterministic user turn with 10 tool calls, plus an idle write window. |
 | `large-context` | Context read amplification with prefilled history. |
 | `tool-heavy` | Tool transcript writes and larger tool output payloads. |
 | `model-tail` | Tail-spike synthetic model latency. |
@@ -292,15 +292,16 @@ cargo run -p ironclaw_stress --release -- \
   --bottleneck-report
 ```
 
-### Postgres DB write measurement
+### DB write measurement
 
 `db-write-measurement` is a fixed workload: one user, one thread, one turn, and
 10 successful tool calls. Unlike general presets, its workload-shape flags
-cannot be overridden. The report contains before/after/delta
-`pg_stat_user_tables` insert/update/delete counters and normalized
-`pg_stat_statements` calls for RootFilesystem entry/event/index/sequence tables
-and trigger tables. Statement output contains query IDs, operation names, and
-table names, never SQL text.
+cannot be overridden.
+
+On Postgres, the report contains before/after/delta `pg_stat_user_tables`
+insert/update/delete counters and normalized `pg_stat_statements` calls for
+RootFilesystem entry/event/index/sequence tables and trigger tables. Statement
+output contains query IDs, operation names, and table names, never SQL text.
 
 ```bash
 export IRONCLAW_FILESYSTEM_POSTGRES_URL='postgresql://USER:PASSWORD@HOST:PORT/DB'
@@ -312,15 +313,35 @@ cargo run -p ironclaw_stress --release -- \
   --human-read
 ```
 
+For libSQL, use an isolated database path:
+
+```bash
+cargo run -p ironclaw_stress --release -- \
+  --backend libsql \
+  --libsql-path /tmp/ironclaw-write-measurement.db \
+  --preset db-write-measurement \
+  --db-write-idle-seconds 300 \
+  --human-read
+```
+
+The harness installs row-level audit triggers on the measured tables for the
+measurement window, then removes them. These counters include writes caused by
+the filesystem's own index and full-text-search triggers. The report excludes
+audit-counter rows from the table totals. Audit-counter writes still contribute
+to DB/WAL byte growth, so
+use the byte metrics only as supplementary evidence. libSQL does not expose a
+database-wide equivalent of `pg_stat_statements`; the libSQL report therefore
+does not claim per-statement counts.
+
 The default uses non-destructive snapshots scoped to the current database.
 `pg_stat_statements` must be installed and loaded; the command fails with setup
 instructions when it is unavailable.
 
-`--db-write-reset-stats` is optional and destructive to shared statistics. It
-resets normalized statement counters for the current database and counters for
-the measured tables. Use it only on an isolated measurement database where
-discarding other observers' statistics is intentional. Omit it on arbitrary
-remote or shared databases.
+`--db-write-reset-stats` resets the selected backend's counters. On Postgres,
+it is destructive to shared statistics: it resets normalized statement
+counters for the current database and counters for the measured tables. Use it
+only on an isolated measurement database. On libSQL, it clears only the
+harness-owned audit counter table.
 
 ## Suites
 

--- a/tools/ironclaw_stress/src/db_probe.rs
+++ b/tools/ironclaw_stress/src/db_probe.rs
@@ -50,6 +50,10 @@ pub(crate) struct DbProbeSnapshot {
     pub(crate) libsql_wal_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) libsql_shm_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) libsql_table_writes: Vec<LibSqlTableWrites>,
+    #[serde(default)]
+    pub(crate) libsql_table_writes_total: LibSqlWriteCounts,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) postgres_database_size_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -70,6 +74,29 @@ pub(crate) struct DbProbeSnapshot {
     pub(crate) postgres_statement_calls_total: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct LibSqlWriteCounts {
+    pub(crate) inserts: u64,
+    pub(crate) updates: u64,
+    pub(crate) deletes: u64,
+}
+
+impl LibSqlWriteCounts {
+    pub(crate) fn total(&self) -> u64 {
+        self.inserts
+            .saturating_add(self.updates)
+            .saturating_add(self.deletes)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct LibSqlTableWrites {
+    pub(crate) table: String,
+    pub(crate) inserts: u64,
+    pub(crate) updates: u64,
+    pub(crate) deletes: u64,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -117,6 +144,10 @@ pub(crate) struct DbProbeDelta {
     pub(crate) libsql_wal_bytes: Option<i128>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) libsql_shm_bytes: Option<i128>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) libsql_table_writes: Vec<LibSqlTableWriteDelta>,
+    #[serde(default)]
+    pub(crate) libsql_table_writes_total: LibSqlWriteDelta,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) postgres_database_size_bytes: Option<i128>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -129,6 +160,27 @@ pub(crate) struct DbProbeDelta {
     pub(crate) postgres_statement_calls_by_table: Vec<PostgresTableStatementCallDelta>,
     #[serde(default)]
     pub(crate) postgres_statement_calls_total: i128,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct LibSqlWriteDelta {
+    pub(crate) inserts: i128,
+    pub(crate) updates: i128,
+    pub(crate) deletes: i128,
+}
+
+impl LibSqlWriteDelta {
+    pub(crate) fn total(&self) -> i128 {
+        self.inserts + self.updates + self.deletes
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct LibSqlTableWriteDelta {
+    pub(crate) table: String,
+    pub(crate) inserts: i128,
+    pub(crate) updates: i128,
+    pub(crate) deletes: i128,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -174,29 +226,68 @@ pub(crate) async fn capture(args: &Args) -> DbProbeSnapshot {
 }
 
 pub(crate) async fn begin_measurement(args: &Args) -> Result<DbProbeSnapshot, String> {
-    let url = crate::resolve_postgres_url(args)?;
-    let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
-        .await
-        .map_err(|error| sanitize_postgres_error(&url, error))?;
-    let connection_handle = tokio::spawn(async move {
-        if let Err(error) = connection.await {
-            eprintln!("[ironclaw-stress] postgres probe connection error: {error}");
+    match args.backend {
+        Backend::Libsql => {
+            let path = args
+                .libsql_path
+                .clone()
+                .unwrap_or_else(crate::default_libsql_path);
+            install_libsql_write_counters(&path, args.db_write_reset_stats)
+                .await
+                .map_err(|error| format!("libsql measurement setup failed: {error}"))?;
+            capture_measurement(args).await
         }
-    });
-    ensure_pg_stat_statements(&client, &url).await?;
-    if args.db_write_reset_stats {
-        reset_measurement_stats(&client, &url).await?;
+        Backend::Postgres => {
+            let url = crate::resolve_postgres_url(args)?;
+            let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+                .await
+                .map_err(|error| sanitize_postgres_error(&url, error))?;
+            let connection_handle = tokio::spawn(async move {
+                if let Err(error) = connection.await {
+                    eprintln!("[ironclaw-stress] postgres probe connection error: {error}");
+                }
+            });
+            ensure_pg_stat_statements(&client, &url).await?;
+            if args.db_write_reset_stats {
+                reset_measurement_stats(&client, &url).await?;
+            }
+            drop(client);
+            let _ = connection_handle.await;
+            capture_measurement(args).await
+        }
     }
-    drop(client);
-    let _ = connection_handle.await;
-    capture_measurement(args).await
 }
 
 pub(crate) async fn capture_measurement(args: &Args) -> Result<DbProbeSnapshot, String> {
-    let url = crate::resolve_postgres_url(args)?;
-    try_capture_postgres(&url, true)
+    match args.backend {
+        Backend::Libsql => {
+            let path = args
+                .libsql_path
+                .clone()
+                .unwrap_or_else(crate::default_libsql_path);
+            try_capture_libsql(path)
+                .await
+                .map_err(|error| format!("libsql probe failed: {error}"))
+        }
+        Backend::Postgres => {
+            let url = crate::resolve_postgres_url(args)?;
+            try_capture_postgres(&url, true)
+                .await
+                .map_err(|error| sanitize_postgres_error(&url, error))
+        }
+    }
+}
+pub(crate) async fn finish_measurement(args: &Args) -> Result<(), String> {
+    if !matches!(args.backend, Backend::Libsql) {
+        return Ok(());
+    }
+    let path = args
+        .libsql_path
+        .clone()
+        .unwrap_or_else(crate::default_libsql_path);
+    remove_libsql_write_counters(&path)
         .await
-        .map_err(|error| sanitize_postgres_error(&url, error))
+        .map_err(|error| format!("libsql measurement cleanup failed: {error}"))
 }
 
 pub(crate) fn summarize(before: DbProbeSnapshot, after: DbProbeSnapshot) -> DbProbeSummary {
@@ -250,13 +341,142 @@ async fn capture_libsql(args: &Args) -> DbProbeSnapshot {
     }
 }
 
-async fn try_capture_libsql(path: PathBuf) -> Result<DbProbeSnapshot, std::io::Error> {
+pub(crate) async fn try_capture_libsql(
+    path: PathBuf,
+) -> Result<DbProbeSnapshot, Box<dyn std::error::Error + Send + Sync>> {
+    let file_bytes = file_size(&path).await?;
+    let wal_bytes = file_size(&sidecar_path(&path, "-wal")).await?;
+    let shm_bytes = file_size(&sidecar_path(&path, "-shm")).await?;
+    let db = libsql::Builder::new_local(&path).build().await?;
+    let connection = db.connect()?;
+    let mut counter_table = connection
+        .query(
+            "SELECT 1 FROM sqlite_schema \
+             WHERE type = 'table' AND name = 'ironclaw_stress_write_counters'",
+            (),
+        )
+        .await?;
+    if counter_table.next().await?.is_none() {
+        return Ok(DbProbeSnapshot {
+            libsql_file_bytes: Some(file_bytes),
+            libsql_wal_bytes: Some(wal_bytes),
+            libsql_shm_bytes: Some(shm_bytes),
+            ..DbProbeSnapshot::default()
+        });
+    }
+    let mut rows = connection
+        .query(
+            "SELECT table_name, operation, row_count \
+             FROM ironclaw_stress_write_counters \
+             ORDER BY table_name, operation",
+            (),
+        )
+        .await?;
+    let mut table_writes = MEASUREMENT_TABLES
+        .iter()
+        .map(|table| {
+            (
+                (*table).to_string(),
+                LibSqlTableWrites {
+                    table: (*table).to_string(),
+                    ..LibSqlTableWrites::default()
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    while let Some(row) = rows.next().await? {
+        let table: String = row.get(0)?;
+        let operation: String = row.get(1)?;
+        let count: i64 = row.get(2)?;
+        let count = i64_to_u64(count).unwrap_or(0);
+        let Some(table_writes) = table_writes.get_mut(&table) else {
+            continue;
+        };
+        match operation.as_str() {
+            "insert" => table_writes.inserts = count,
+            "update" => table_writes.updates = count,
+            "delete" => table_writes.deletes = count,
+            _ => {}
+        }
+    }
     Ok(DbProbeSnapshot {
-        libsql_file_bytes: Some(file_size(&path).await?),
-        libsql_wal_bytes: Some(file_size(&sidecar_path(&path, "-wal")).await?),
-        libsql_shm_bytes: Some(file_size(&sidecar_path(&path, "-shm")).await?),
+        libsql_file_bytes: Some(file_bytes),
+        libsql_wal_bytes: Some(wal_bytes),
+        libsql_shm_bytes: Some(shm_bytes),
+        libsql_table_writes: table_writes.into_values().collect(),
         ..DbProbeSnapshot::default()
     })
+}
+
+pub(crate) async fn install_libsql_write_counters(
+    path: &std::path::Path,
+    reset: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let db = libsql::Builder::new_local(path).build().await?;
+    let connection = db.connect()?;
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS ironclaw_stress_write_counters (\
+                table_name TEXT NOT NULL,\
+                operation TEXT NOT NULL CHECK (operation IN ('insert', 'update', 'delete')),\
+                row_count INTEGER NOT NULL DEFAULT 0,\
+                PRIMARY KEY (table_name, operation)\
+             );",
+        )
+        .await?;
+    if reset {
+        connection
+            .execute("DELETE FROM ironclaw_stress_write_counters", ())
+            .await?;
+    }
+    for table in MEASUREMENT_TABLES {
+        let mut rows = connection
+            .query(
+                "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?1",
+                [*table],
+            )
+            .await?;
+        if rows.next().await?.is_none() {
+            continue;
+        }
+        for (suffix, timing, operation) in [
+            ("ai", "AFTER INSERT", "insert"),
+            ("au", "AFTER UPDATE", "update"),
+            ("ad", "AFTER DELETE", "delete"),
+        ] {
+            let sql = format!(
+                "CREATE TRIGGER IF NOT EXISTS ironclaw_stress_{table}_{suffix} \
+                 {timing} ON {table} BEGIN \
+                   INSERT INTO ironclaw_stress_write_counters(table_name, operation, row_count) \
+                   VALUES ('{table}', '{operation}', 1) \
+                   ON CONFLICT(table_name, operation) DO UPDATE \
+                   SET row_count = row_count + 1; \
+                 END;"
+            );
+            connection.execute_batch(&sql).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn remove_libsql_write_counters(
+    path: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let db = libsql::Builder::new_local(path).build().await?;
+    let connection = db.connect()?;
+    for table in MEASUREMENT_TABLES {
+        for suffix in ["ai", "au", "ad"] {
+            connection
+                .execute_batch(&format!(
+                    "DROP TRIGGER IF EXISTS ironclaw_stress_{table}_{suffix};"
+                ))
+                .await?;
+        }
+    }
+    connection
+        .execute_batch("DROP TABLE IF EXISTS ironclaw_stress_write_counters;")
+        .await?;
+    Ok(())
 }
 
 fn sidecar_path(path: &std::path::Path, suffix: &str) -> PathBuf {
@@ -518,6 +738,18 @@ fn statement_operation(query: &str) -> String {
 
 fn normalize_snapshot(mut snapshot: DbProbeSnapshot) -> DbProbeSnapshot {
     snapshot
+        .libsql_table_writes
+        .sort_by(|left, right| left.table.cmp(&right.table));
+    snapshot.libsql_table_writes_total = snapshot.libsql_table_writes.iter().fold(
+        LibSqlWriteCounts::default(),
+        |mut total, table| {
+            total.inserts = total.inserts.saturating_add(table.inserts);
+            total.updates = total.updates.saturating_add(table.updates);
+            total.deletes = total.deletes.saturating_add(table.deletes);
+            total
+        },
+    );
+    snapshot
         .postgres_table_writes
         .sort_by(|left, right| left.table.cmp(&right.table));
     snapshot.postgres_table_writes_total = snapshot.postgres_table_writes.iter().fold(
@@ -552,6 +784,16 @@ fn normalize_snapshot(mut snapshot: DbProbeSnapshot) -> DbProbeSnapshot {
 }
 
 fn snapshot_delta(before: &DbProbeSnapshot, after: &DbProbeSnapshot) -> DbProbeDelta {
+    let libsql_table_writes = libsql_table_write_delta(before, after);
+    let libsql_table_writes_total =
+        libsql_table_writes
+            .iter()
+            .fold(LibSqlWriteDelta::default(), |mut total, table| {
+                total.inserts += table.inserts;
+                total.updates += table.updates;
+                total.deletes += table.deletes;
+                total
+            });
     let postgres_table_writes = table_write_delta(before, after);
     let postgres_table_writes_total =
         postgres_table_writes
@@ -582,6 +824,8 @@ fn snapshot_delta(before: &DbProbeSnapshot, after: &DbProbeSnapshot) -> DbProbeD
         libsql_file_bytes: delta(before.libsql_file_bytes, after.libsql_file_bytes),
         libsql_wal_bytes: delta(before.libsql_wal_bytes, after.libsql_wal_bytes),
         libsql_shm_bytes: delta(before.libsql_shm_bytes, after.libsql_shm_bytes),
+        libsql_table_writes,
+        libsql_table_writes_total,
         postgres_database_size_bytes: delta(
             before.postgres_database_size_bytes,
             after.postgres_database_size_bytes,
@@ -592,6 +836,48 @@ fn snapshot_delta(before: &DbProbeSnapshot, after: &DbProbeSnapshot) -> DbProbeD
         postgres_statement_calls_by_table,
         postgres_statement_calls_total,
     }
+}
+
+fn libsql_table_write_delta(
+    before: &DbProbeSnapshot,
+    after: &DbProbeSnapshot,
+) -> Vec<LibSqlTableWriteDelta> {
+    let before = before
+        .libsql_table_writes
+        .iter()
+        .map(|table| (table.table.as_str(), table))
+        .collect::<BTreeMap<_, _>>();
+    let after = after
+        .libsql_table_writes
+        .iter()
+        .map(|table| (table.table.as_str(), table))
+        .collect::<BTreeMap<_, _>>();
+    before
+        .keys()
+        .chain(after.keys())
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|table| {
+            let before = before.get(table).copied();
+            let after = after.get(table).copied();
+            LibSqlTableWriteDelta {
+                table: table.to_string(),
+                inserts: counter_delta(
+                    before.map_or(0, |value| value.inserts),
+                    after.map_or(0, |value| value.inserts),
+                ),
+                updates: counter_delta(
+                    before.map_or(0, |value| value.updates),
+                    after.map_or(0, |value| value.updates),
+                ),
+                deletes: counter_delta(
+                    before.map_or(0, |value| value.deletes),
+                    after.map_or(0, |value| value.deletes),
+                ),
+            }
+        })
+        .collect()
 }
 
 fn table_write_delta(

--- a/tools/ironclaw_stress/src/human.rs
+++ b/tools/ironclaw_stress/src/human.rs
@@ -524,12 +524,110 @@ fn push_db_probe_table(output: &mut String, db_probe: &DbProbeSummary) {
         );
         push_metric(output, "stats_scope", measurement.stats_scope.clone());
         push_metric(output, "stats_reset", measurement.reset_stats.to_string());
-        push_postgres_table_write_table(output, db_probe);
-        push_postgres_statement_table(output, db_probe);
-        if let Some(idle_delta) = &db_probe.idle_delta {
-            push_postgres_idle_tables(output, idle_delta);
-            push_postgres_idle_statements(output, idle_delta);
+        if !db_probe.delta.libsql_table_writes.is_empty() {
+            push_libsql_table_write_table(output, db_probe);
         }
+        if !db_probe.delta.postgres_table_writes.is_empty() {
+            push_postgres_table_write_table(output, db_probe);
+        }
+        if !db_probe.delta.postgres_statement_calls.is_empty() {
+            push_postgres_statement_table(output, db_probe);
+        }
+        if let Some(idle_delta) = &db_probe.idle_delta {
+            if !idle_delta.postgres_table_writes.is_empty() {
+                push_postgres_idle_tables(output, idle_delta);
+            }
+            if !idle_delta.libsql_table_writes.is_empty() {
+                push_libsql_idle_tables(output, idle_delta);
+            }
+            if !idle_delta.postgres_statement_calls.is_empty() {
+                push_postgres_idle_statements(output, idle_delta);
+            }
+        }
+    }
+}
+
+fn push_libsql_table_write_table(output: &mut String, db_probe: &DbProbeSummary) {
+    let _ = writeln!(output, "\nlibSQL instrumented table writes");
+    let _ = writeln!(
+        output,
+        "{:<40} {:>10} {:>10} {:>10}",
+        "counter", "before", "after", "delta"
+    );
+    let _ = writeln!(output, "{:-<40} {:->10} {:->10} {:->10}", "", "", "", "");
+    for delta in &db_probe.delta.libsql_table_writes {
+        let before = db_probe
+            .before
+            .libsql_table_writes
+            .iter()
+            .find(|table| table.table == delta.table);
+        let after = db_probe
+            .after
+            .libsql_table_writes
+            .iter()
+            .find(|table| table.table == delta.table);
+        for (name, before, after, change) in [
+            (
+                "insert",
+                before.map(|table| table.inserts),
+                after.map(|table| table.inserts),
+                delta.inserts,
+            ),
+            (
+                "update",
+                before.map(|table| table.updates),
+                after.map(|table| table.updates),
+                delta.updates,
+            ),
+            (
+                "delete",
+                before.map(|table| table.deletes),
+                after.map(|table| table.deletes),
+                delta.deletes,
+            ),
+        ] {
+            let _ = writeln!(
+                output,
+                "{:<40} {:>10} {:>10} {:>+10}",
+                truncate(&format!("{}.{}", delta.table, name), 40),
+                format_optional(before),
+                format_optional(after),
+                change,
+            );
+        }
+    }
+    let total = &db_probe.delta.libsql_table_writes_total;
+    let _ = writeln!(
+        output,
+        "{:<40} {:>10} {:>10} {:>+10}",
+        "TOTAL.rows",
+        db_probe.before.libsql_table_writes_total.total(),
+        db_probe.after.libsql_table_writes_total.total(),
+        total.total(),
+    );
+    let _ = writeln!(
+        output,
+        "Note: counter-trigger writes are excluded above but included in DB/WAL byte growth."
+    );
+}
+
+fn push_libsql_idle_tables(output: &mut String, idle: &crate::db_probe::DbProbeDelta) {
+    let _ = writeln!(output, "\nlibSQL idle instrumented table writes");
+    let _ = writeln!(
+        output,
+        "{:<40} {:>10} {:>10} {:>10} {:>10}",
+        "table", "inserts", "updates", "deletes", "total"
+    );
+    for table in &idle.libsql_table_writes {
+        let _ = writeln!(
+            output,
+            "{:<40} {:>+10} {:>+10} {:>+10} {:>+10}",
+            truncate(&table.table, 40),
+            table.inserts,
+            table.updates,
+            table.deletes,
+            table.inserts + table.updates + table.deletes,
+        );
     }
 }
 

--- a/tools/ironclaw_stress/src/main.rs
+++ b/tools/ironclaw_stress/src/main.rs
@@ -171,8 +171,8 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = 300)]
     pub(crate) db_write_idle_seconds: u64,
 
-    /// Reset current-database pg_stat_statements and measured table counters before measurement.
-    /// This is destructive to shared statistics and requires --preset db-write-measurement.
+    /// Reset backend write counters before measurement.
+    /// PostgreSQL statistics are shared; use an isolated database.
     #[arg(long)]
     pub(crate) db_write_reset_stats: bool,
 
@@ -1122,9 +1122,6 @@ fn validate_args(args: &Args) -> Result<(), String> {
         );
     }
     if matches!(args.preset, Some(StressPreset::DbWriteMeasurement)) {
-        if !matches!(args.backend, Backend::Postgres) {
-            return Err("--preset db-write-measurement requires --backend postgres".to_string());
-        }
         if !matches!(args.scenario, Scenario::ToolSession)
             || args.processes != 1
             || args.concurrency != 1
@@ -2020,22 +2017,36 @@ async fn run_user_turn_in_process(
     };
     let started = Instant::now();
     let target = workload.target().to_string();
-    let samples = run_user_turn_tasks(Arc::clone(&workload), args, identities).await?;
+    let samples = match run_user_turn_tasks(Arc::clone(&workload), args, identities).await {
+        Ok(samples) => samples,
+        Err(error) => {
+            if measurement_enabled {
+                db_probe::finish_measurement(args).await?;
+            }
+            return Err(error);
+        }
+    };
     let elapsed = started.elapsed();
     let process = metrics.finish();
     let db_probe = if measurement_enabled {
-        let after = db_probe::capture_measurement(args).await?;
-        let idle_after = if args.db_write_idle_seconds == 0 {
-            None
-        } else {
-            eprintln!(
-                "{} observing idle database writes for {} seconds",
-                log_prefix(args),
-                args.db_write_idle_seconds
-            );
-            tokio::time::sleep(Duration::from_secs(args.db_write_idle_seconds)).await;
-            Some(db_probe::capture_measurement(args).await?)
-        };
+        let capture_result = async {
+            let after = db_probe::capture_measurement(args).await?;
+            let idle_after = if args.db_write_idle_seconds == 0 {
+                None
+            } else {
+                eprintln!(
+                    "{} observing idle database writes for {} seconds",
+                    log_prefix(args),
+                    args.db_write_idle_seconds
+                );
+                tokio::time::sleep(Duration::from_secs(args.db_write_idle_seconds)).await;
+                Some(db_probe::capture_measurement(args).await?)
+            };
+            Ok::<_, String>((after, idle_after))
+        }
+        .await;
+        db_probe::finish_measurement(args).await?;
+        let (after, idle_after) = capture_result?;
         db_probe::summarize_measurement(
             db_probe_before,
             after,

--- a/tools/ironclaw_stress/src/tests.rs
+++ b/tools/ironclaw_stress/src/tests.rs
@@ -384,6 +384,23 @@ fn db_write_measurement_preset_is_one_deterministic_tool_heavy_turn() {
 }
 
 #[test]
+fn db_write_measurement_preset_supports_libsql() {
+    let args = parse_test_args([
+        "ironclaw_stress",
+        "--backend",
+        "libsql",
+        "--preset",
+        "db-write-measurement",
+        "--db-write-idle-seconds",
+        "0",
+    ]);
+
+    validate_args(&args).expect("libSQL measurement preset is valid");
+    assert_eq!(args.scenario, Scenario::ToolSession);
+    assert_eq!(args.tool_calls_per_turn, 10);
+}
+
+#[test]
 fn preset_respects_explicit_overrides() {
     let args = parse_test_args([
         "ironclaw_stress",
@@ -1283,6 +1300,183 @@ fn postgres_write_delta_aggregates_tables_queries_and_totals() {
         json["delta"]["postgres_statement_calls_by_table"][0]["calls"],
         7
     );
+}
+
+#[test]
+fn libsql_write_delta_aggregates_instrumented_table_rows() {
+    let before = db_probe::DbProbeSnapshot {
+        libsql_table_writes: vec![db_probe::LibSqlTableWrites {
+            table: "root_filesystem_entries".to_string(),
+            inserts: 2,
+            updates: 1,
+            deletes: 0,
+        }],
+        ..db_probe::DbProbeSnapshot::default()
+    };
+    let after = db_probe::DbProbeSnapshot {
+        libsql_table_writes: vec![db_probe::LibSqlTableWrites {
+            table: "root_filesystem_entries".to_string(),
+            inserts: 5,
+            updates: 5,
+            deletes: 1,
+        }],
+        ..db_probe::DbProbeSnapshot::default()
+    };
+
+    let summary = db_probe::summarize_measurement(
+        before,
+        after,
+        None,
+        db_probe::DbWriteMeasurement {
+            workload: "single-tool-heavy-user-turn".to_string(),
+            tool_calls_per_turn: 10,
+            idle_observation_seconds: 0,
+            reset_stats: false,
+            stats_scope: "snapshot-delta-current-database".to_string(),
+        },
+    );
+
+    assert_eq!(summary.delta.libsql_table_writes[0].inserts, 3);
+    assert_eq!(summary.delta.libsql_table_writes[0].updates, 4);
+    assert_eq!(summary.delta.libsql_table_writes[0].deletes, 1);
+    assert_eq!(summary.delta.libsql_table_writes_total.total(), 8);
+}
+
+#[tokio::test]
+async fn libsql_probe_counts_insert_update_and_delete_rows_by_table() {
+    let path = std::env::temp_dir().join(format!(
+        "ironclaw-stress-write-probe-{}.db",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let db = libsql::Builder::new_local(&path)
+        .build()
+        .await
+        .expect("build local libSQL");
+    let connection = db.connect().expect("connect local libSQL");
+    connection
+        .execute_batch(
+            "CREATE TABLE root_filesystem_entries (path TEXT PRIMARY KEY, contents BLOB);\
+             CREATE TABLE root_filesystem_events (id INTEGER PRIMARY KEY, payload BLOB);",
+        )
+        .await
+        .expect("create measured tables");
+    drop(connection);
+    drop(db);
+
+    db_probe::install_libsql_write_counters(&path, true)
+        .await
+        .expect("install write counters");
+    let db = libsql::Builder::new_local(&path)
+        .build()
+        .await
+        .expect("reopen local libSQL");
+    let connection = db.connect().expect("reconnect local libSQL");
+    connection
+        .execute(
+            "INSERT INTO root_filesystem_entries(path, contents) VALUES (?1, ?2)",
+            libsql::params!["/one", vec![1_u8]],
+        )
+        .await
+        .expect("insert measured row");
+    connection
+        .execute(
+            "UPDATE root_filesystem_entries SET contents = ?1 WHERE path = ?2",
+            libsql::params![vec![2_u8], "/one"],
+        )
+        .await
+        .expect("update measured row");
+    connection
+        .execute(
+            "DELETE FROM root_filesystem_entries WHERE path = ?1",
+            ["/one"],
+        )
+        .await
+        .expect("delete measured row");
+    drop(connection);
+    drop(db);
+
+    let snapshot = db_probe::try_capture_libsql(path.clone())
+        .await
+        .expect("capture libSQL counters");
+    let entries = snapshot
+        .libsql_table_writes
+        .iter()
+        .find(|table| table.table == "root_filesystem_entries")
+        .expect("entries counter");
+    assert_eq!(
+        (entries.inserts, entries.updates, entries.deletes),
+        (1, 1, 1)
+    );
+    let mut args = test_args();
+    args.backend = Backend::Libsql;
+    args.libsql_path = Some(path.clone());
+    db_probe::finish_measurement(&args)
+        .await
+        .expect("remove write counters");
+    let db = libsql::Builder::new_local(&path)
+        .build()
+        .await
+        .expect("reopen cleaned libSQL");
+    let connection = db.connect().expect("connect cleaned libSQL");
+    let mut rows = connection
+        .query(
+            "SELECT COUNT(*) FROM sqlite_schema \
+             WHERE name LIKE 'ironclaw_stress_%'",
+            (),
+        )
+        .await
+        .expect("query instrumentation schema");
+    let row = rows
+        .next()
+        .await
+        .expect("read instrumentation count")
+        .expect("instrumentation count row");
+    let remaining: i64 = row.get(0).expect("instrumentation count");
+    assert_eq!(remaining, 0);
+    drop(rows);
+    drop(connection);
+    drop(db);
+    crate::cleanup_generated_libsql_path(&path).await;
+}
+
+#[test]
+fn human_summary_renders_libsql_write_measurement() {
+    let mut summary = run_summary_with_bottlenecks();
+    summary.db_probe = Some(db_probe::summarize_measurement(
+        db_probe::DbProbeSnapshot {
+            libsql_table_writes: vec![db_probe::LibSqlTableWrites {
+                table: "root_filesystem_entries".to_string(),
+                inserts: 1,
+                updates: 0,
+                deletes: 0,
+            }],
+            ..db_probe::DbProbeSnapshot::default()
+        },
+        db_probe::DbProbeSnapshot {
+            libsql_table_writes: vec![db_probe::LibSqlTableWrites {
+                table: "root_filesystem_entries".to_string(),
+                inserts: 4,
+                updates: 2,
+                deletes: 0,
+            }],
+            ..db_probe::DbProbeSnapshot::default()
+        },
+        None,
+        db_probe::DbWriteMeasurement {
+            workload: "single-tool-heavy-user-turn".to_string(),
+            tool_calls_per_turn: 10,
+            idle_observation_seconds: 0,
+            reset_stats: false,
+            stats_scope: "snapshot-delta-current-database".to_string(),
+        },
+    ));
+
+    let rendered = human::render_run_summary(&summary);
+
+    assert!(rendered.contains("libSQL instrumented table writes"));
+    assert!(rendered.contains("root_filesystem_entries.insert"));
+    assert!(rendered.contains("counter-trigger writes are excluded"));
+    assert!(!rendered.contains("Postgres table writes"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow the fixed DB-write workload to run against libSQL
- install measurement-window audit triggers for exact insert/update/delete row attribution across the seven tracked tables
- emit JSON and human before/after/delta reports, including idle-window deltas
- remove all harness triggers and counters after success or workload failure

Stacked on #7630. Merge #7630 first, then retarget this PR to main.

## Measurement contract
libSQL has no database-wide equivalent of pg_stat_statements. This PR reports exact row mutation events, including mutations caused by filesystem index/FTS triggers, but does not claim SQL statement counts. Audit-counter rows are excluded from row totals. Their writes still affect DB/WAL byte growth, which remains supplementary evidence.

## Verification
- cargo test -p ironclaw_stress: 180 passed
- cargo clippy -p ironclaw_stress --all-targets -- -D warnings: passed
- cargo fmt --all -- --check: passed
- cargo run -p ironclaw_stress -- --backend libsql --preset db-write-measurement --db-write-idle-seconds 0 --human-read: one deterministic turn succeeded; report attributed 303 measured row mutations and emitted no Postgres-only sections

## Compatibility and rollback
Only the stress tool changes. Production storage APIs and runtime paths are unchanged. The harness removes its instrumentation schema after capture. Rollback is a single revert; an interrupted explicit-path run can be cleaned by dropping objects named ironclaw_stress_*.

Closes the libSQL measurement gap in #7591.