### PR TITLE
[experimental] feat(runtime): add ACP harness executor

### DIFF
--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -662,6 +662,27 @@ jobs:
       - name: Build Python sandbox worker
         run: docker build -f Dockerfile.sandbox-worker -t ironclaw-worker:latest .
 
+      - name: Build fake ACP adapter
+        run: docker build -f tests/fixtures/acp-fake/Dockerfile -t ironclaw-acp-fake:latest tests/fixtures/acp-fake
+
+      - name: Build pinned Claude Code ACP adapter
+        run: docker build -f Dockerfile.claude-code-acp -t ironclaw-claude-code-acp:dev .
+
+      - name: Verify pinned Claude Code ACP handshake
+        run: |
+          timeout 20 docker run --rm -i \
+            -e ANTHROPIC_API_KEY=protocol-canary \
+            ironclaw-claude-code-acp:dev \
+            < tests/fixtures/acp-claude-code/initialize-request.json \
+            > "${RUNNER_TEMP}/claude-code-acp-initialize.json"
+          expected_version="$(sed -n 's/^ARG CLAUDE_AGENT_ACP_VERSION=//p' Dockerfile.claude-code-acp)"
+          test -n "${expected_version}"
+          jq -e --arg expected_version "${expected_version}" '
+            .result.protocolVersion == 1 and
+            .result.agentCapabilities.loadSession == true and
+            .result.agentInfo.version == $expected_version
+          ' "${RUNNER_TEMP}/claude-code-acp-initialize.json"
+
       - name: Verify production local-sandbox profile wiring
         run: cargo test -p ironclaw local_sandbox_profile_selects_docker_process_binding_when_required -- --nocapture
 
@@ -670,6 +691,9 @@ jobs:
 
       - name: Run full-turn sandbox shell integration
         run: cargo test -p ironclaw_integration_tests --test reborn_integration_sandbox_shell_turn -- --nocapture
+
+      - name: Run full-turn ACP harness integration
+        run: cargo test -p ironclaw_integration_tests --test reborn_integration_acp_harness -- --nocapture
 
   reborn-integration-coverage:
     name: Reborn integration tests (${{ matrix.lane }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-io",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "rustc-hash 2.1.3",
+ "rustix 1.1.4",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
+dependencies = [
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "tracing",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +377,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +401,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +456,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -370,6 +497,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1105,6 +1238,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bollard"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1738,15 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -2232,6 +2387,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.119",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2609,6 +2765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +2895,19 @@ checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
 ]
 
 [[package]]
@@ -5131,10 +5306,12 @@ dependencies = [
 name = "ironclaw_turn_runner"
 version = "0.1.0"
 dependencies = [
+ "agent-client-protocol",
  "async-trait",
  "blake3",
  "chrono",
  "futures-util",
+ "hex",
  "http 1.5.0",
  "ironclaw_agent_loop",
  "ironclaw_approvals",
@@ -5169,6 +5346,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -6493,7 +6671,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.14.0",
 ]
 
@@ -6620,6 +6798,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6672,6 +6861,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7998,6 +8201,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -8141,6 +8345,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -9348,6 +9558,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,10 @@ name = "reborn_integration_sandbox_shell_turn"
 path = "tests/integration/reborn_sandbox_shell_turn.rs"
 
 [[test]]
+name = "reborn_integration_acp_harness"
+path = "tests/integration/reborn_acp_harness.rs"
+
+[[test]]
 name = "reborn_integration_subagent_await_edge"
 path = "tests/integration/subagent_await_edge.rs"
 

--- a/Dockerfile.claude-code-acp
+++ b/Dockerfile.claude-code-acp
@@ -1,0 +1,16 @@
+FROM node:22.18.0-bookworm-slim@sha256:752ea8a2f758c34002a0461bd9f1cee4f9a3c36d48494586f60ffce1fc708e0e
+
+# Keep the maintained Claude ACP adapter pinned. Updating it requires re-running
+# the ACP compatibility canary and the Docker integration suite.
+ARG CLAUDE_AGENT_ACP_VERSION=0.67.0
+ARG CLAUDE_CODE_VERSION=2.1.232
+
+RUN npm install --global \
+      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+      "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" \
+    && npm cache clean --force
+
+WORKDIR /workspace
+ENV HOME=/workspace/.home
+
+ENTRYPOINT ["claude-agent-acp"]

--- a/crates/app/ironclaw_cli/src/commands/config/init.rs
+++ b/crates/app/ironclaw_cli/src/commands/config/init.rs
@@ -205,9 +205,17 @@ default_owner  = "reborn-cli"
 # additional = ["planned"]
 
 # [harness]
-# # Active harness lands with epic #3036. Leave this section commented in
-# # this slice; `run` rejects it rather than silently ignoring operator intent.
-# id = "red-team"
+# # Experimental and default-off. Only standalone development profiles may
+# # route listed run profiles to this harness. Hosted policy pins Docker.
+# id = "claude-code-acp"
+# run_profiles = ["reborn-planned-default"]
+# placement = "host" # "host" or "docker"
+# command = "claude-agent-acp" # host placement only
+# image = "ironclaw-claude-code-acp:dev"
+# timeout_secs = 600
+# max_update_bytes = 1048576
+# anthropic_api_key_env = "ANTHROPIC_API_KEY"
+# vcs_token_env = "GH_TOKEN"
 
 [runner]
 heartbeat_interval_secs = 5

--- a/crates/app/ironclaw_cli/src/runtime/mod.rs
+++ b/crates/app/ironclaw_cli/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 // arch-exempt: large_file, Google OAuth resolution hardening remains at the existing runtime config seam, plan #4088
+use std::collections::HashSet;
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -9,12 +10,14 @@ use ironclaw_composition::TriggerFireAccessPolicy;
 use ironclaw_composition::host_api::{AgentId, TenantId, UserId};
 use ironclaw_composition::hosted_single_tenant_runtime_policy;
 use ironclaw_composition::{
-    KeepaliveSweepSettings, OAuthClientConfig, PollSettings, RebornCompositionProfile,
-    RebornHostBindings, RebornRuntimeIdentity, RebornRuntimeInput, RebornRuntimeProfileOptions,
-    TurnRunnerSettings, build_reborn_runtime, local_runtime_build_input_with_options,
+    HarnessPlacementSettings, HarnessRuntimeSettings, KeepaliveSweepSettings, OAuthClientConfig,
+    PollSettings, RebornCompositionProfile, RebornHostBindings, RebornRuntimeIdentity,
+    RebornRuntimeInput, RebornRuntimeProfileOptions, TurnRunnerSettings, build_reborn_runtime,
+    local_runtime_build_input_with_options,
 };
 use ironclaw_config::{
-    REBORN_PROFILE_ENV, RebornBootConfig, RebornProfile, seed_default_config_file_if_missing,
+    HarnessPlacement, REBORN_PROFILE_ENV, RebornBootConfig, RebornProfile,
+    seed_default_config_file_if_missing,
 };
 use ironclaw_extension_host::FirstPartyPackageBundle;
 use ironclaw_operator::OperatorLogLayer;
@@ -616,10 +619,104 @@ pub(crate) fn build_runtime_input_with_options(
     if let Some(manifest_url) = ironhub_manifest_url_from_env()? {
         runtime_input = runtime_input.with_ironhub_manifest_url(manifest_url);
     }
+    if let Some(harness) = harness_runtime_settings(config, runtime_services.config_file.as_ref())?
+    {
+        runtime_input = runtime_input.with_harness_settings(harness);
+    }
 
     Ok(BuiltRuntimeInput {
         inner: runtime_input,
     })
+}
+
+fn harness_runtime_settings(
+    config: &RebornBootConfig,
+    config_file: Option<&ironclaw_config::RebornConfigFile>,
+) -> anyhow::Result<Option<HarnessRuntimeSettings>> {
+    let Some(section) = config_file.and_then(|file| file.harness.as_ref()) else {
+        return Ok(None);
+    };
+    let Some(id) = section.id.as_deref() else {
+        return Ok(None);
+    };
+    if id != "claude-code-acp" {
+        anyhow::bail!("unsupported [harness].id `{id}`; expected `claude-code-acp`");
+    }
+
+    let run_profile_ids = section
+        .run_profiles
+        .as_ref()
+        .ok_or_else(|| {
+            anyhow::anyhow!("[harness].run_profiles is required when the harness is enabled")
+        })?
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let placement = match section.placement.unwrap_or(HarnessPlacement::Docker) {
+        HarnessPlacement::Host => {
+            if !matches!(
+                config.profile(),
+                RebornProfile::Standalone | RebornProfile::StandaloneUnrestricted
+            ) {
+                anyhow::bail!(
+                    "deployment profile `{}` pins harness placement to `docker`",
+                    config.profile()
+                );
+            }
+            HarnessPlacementSettings::Host {
+                command: section
+                    .command
+                    .clone()
+                    .unwrap_or_else(|| "claude-agent-acp".to_string()),
+            }
+        }
+        HarnessPlacement::Docker => HarnessPlacementSettings::Docker {
+            image: section.image.clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "[harness].image is required when Docker harness placement is enabled"
+                )
+            })?,
+        },
+    };
+    if !matches!(
+        config.profile(),
+        RebornProfile::Standalone | RebornProfile::StandaloneUnrestricted
+    ) {
+        anyhow::bail!("ACP harness routing is only available in standalone development profiles");
+    }
+    let anthropic_env = section.anthropic_api_key_env.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("[harness].anthropic_api_key_env is required when the harness is enabled")
+    })?;
+    let mut environment = vec![format!(
+        "ANTHROPIC_API_KEY={}",
+        required_harness_host_env(anthropic_env)?
+    )];
+    if let Some(host_env) = section.vcs_token_env.as_deref() {
+        environment.push(format!("GH_TOKEN={}", required_harness_host_env(host_env)?));
+    }
+
+    HarnessRuntimeSettings::new(
+        run_profile_ids,
+        config.home().path().join("harness-workspaces"),
+        placement,
+        environment,
+        Duration::from_secs(section.timeout_secs.unwrap_or(600)),
+        section.max_update_bytes.unwrap_or(1_048_576),
+    )
+    .map(Some)
+    .map_err(anyhow::Error::msg)
+}
+
+fn required_harness_host_env(name: &str) -> anyhow::Result<String> {
+    match std::env::var(name) {
+        Ok(value) if !value.is_empty() => Ok(value),
+        Ok(_) | Err(std::env::VarError::NotPresent) => {
+            anyhow::bail!("host environment variable `{name}` required by [harness] is unset")
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("host environment variable `{name}` required by [harness] is not UTF-8")
+        }
+    }
 }
 
 pub(crate) fn ironhub_manifest_url_from_env()
@@ -1487,9 +1584,6 @@ fn reject_unsupported_runtime_sections(
     if file.drivers.is_some() {
         sections.push("[drivers]");
     }
-    if file.harness.is_some() {
-        sections.push("[harness]");
-    }
     if sections.is_empty() {
         Ok(())
     } else {
@@ -1710,9 +1804,10 @@ mod tests {
     use super::{
         GoogleOAuthConfigState, GoogleOAuthEnvInputs, GoogleOAuthResolution, RuntimeInputCaller,
         RuntimeInputOptions, apply_credential_refresh_override, block_on_cli, build_runtime_input,
-        build_runtime_input_with_options, initialize_local_runtime_storage_root,
-        no_assistant_text_message, protect_reborn_log_filter, resolve_google_oauth_config,
-        resolve_google_oauth_config_state, resolve_google_oauth_config_state_merged,
+        build_runtime_input_with_options, harness_runtime_settings,
+        initialize_local_runtime_storage_root, no_assistant_text_message,
+        protect_reborn_log_filter, resolve_google_oauth_config, resolve_google_oauth_config_state,
+        resolve_google_oauth_config_state_merged,
         resolve_google_oauth_config_state_with_store_loader, runner_settings,
         with_binary_host_extension_bindings_from_bundles,
     };
@@ -1746,6 +1841,121 @@ mod tests {
             &std::path::PathBuf::from("/test/config.toml"),
         )
         .expect("must parse")
+    }
+
+    #[test]
+    fn harness_host_placement_is_accepted_for_standalone_profile() {
+        let _runtime_env = lock_runtime_env();
+        let _key = EnvGuard::set("IRONCLAW_TEST_HARNESS_KEY", "developer-key");
+        let config_toml = r#"
+[harness]
+id = "claude-code-acp"
+run_profiles = ["reborn-planned-default"]
+placement = "host"
+command = "claude-agent-acp"
+anthropic_api_key_env = "IRONCLAW_TEST_HARNESS_KEY"
+"#;
+        let (_temp, config) = boot_config_with_config_toml("local-dev", config_toml);
+        let config_file =
+            ironclaw_config::RebornConfigFile::load(&config.home().config_file_path())
+                .expect("config loads")
+                .expect("config exists");
+
+        harness_runtime_settings(&config, Some(&config_file))
+            .expect("standalone host placement is allowed")
+            .expect("harness enabled");
+    }
+
+    #[test]
+    fn harness_host_placement_requires_explicit_developer_credentials() {
+        let _runtime_env = lock_runtime_env();
+        let _missing = EnvGuard::clear("IRONCLAW_TEST_MISSING_HARNESS_KEY");
+        let config_toml = r#"
+[harness]
+id = "claude-code-acp"
+run_profiles = ["reborn-planned-default"]
+placement = "host"
+command = "claude-agent-acp"
+anthropic_api_key_env = "IRONCLAW_TEST_MISSING_HARNESS_KEY"
+"#;
+        let (_temp, config) = boot_config_with_config_toml("local-dev", config_toml);
+        let config_file =
+            ironclaw_config::RebornConfigFile::load(&config.home().config_file_path())
+                .expect("config loads")
+                .expect("config exists");
+
+        let error = match harness_runtime_settings(&config, Some(&config_file)) {
+            Ok(_) => panic!("host placement must require configured developer credentials"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("IRONCLAW_TEST_MISSING_HARNESS_KEY"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn hosted_profile_rejects_host_harness_placement() {
+        let _runtime_env = lock_runtime_env();
+        let _key = EnvGuard::set("IRONCLAW_TEST_HARNESS_KEY", "developer-key");
+        let config_toml = r#"
+[harness]
+id = "claude-code-acp"
+run_profiles = ["reborn-planned-default"]
+placement = "host"
+command = "claude-agent-acp"
+anthropic_api_key_env = "IRONCLAW_TEST_HARNESS_KEY"
+"#;
+        let (_temp, config) =
+            boot_config_with_config_toml("hosted-single-tenant-volume", config_toml);
+        let config_file =
+            ironclaw_config::RebornConfigFile::load(&config.home().config_file_path())
+                .expect("config loads")
+                .expect("config exists");
+
+        let error = match harness_runtime_settings(&config, Some(&config_file)) {
+            Ok(_) => panic!("hosted profile must pin Docker placement"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("pins harness placement to `docker`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn hosted_profile_rejects_docker_harness_routing_until_hosted_rollout() {
+        let _runtime_env = lock_runtime_env();
+        let _key = EnvGuard::set("IRONCLAW_TEST_HARNESS_KEY", "developer-key");
+        let config_toml = r#"
+[harness]
+id = "claude-code-acp"
+run_profiles = ["reborn-planned-default"]
+placement = "docker"
+image = "ironclaw-claude-code-acp:dev"
+anthropic_api_key_env = "IRONCLAW_TEST_HARNESS_KEY"
+"#;
+        let (_temp, config) =
+            boot_config_with_config_toml("hosted-single-tenant-volume", config_toml);
+        let config_file =
+            ironclaw_config::RebornConfigFile::load(&config.home().config_file_path())
+                .expect("config loads")
+                .expect("config exists");
+
+        let error = match harness_runtime_settings(&config, Some(&config_file)) {
+            Ok(_) => panic!("hosted harness routing must remain disabled"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("only available in standalone development profiles"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/app/ironclaw_composition/src/lib.rs
+++ b/crates/app/ironclaw_composition/src/lib.rs
@@ -205,8 +205,9 @@ pub use runtime::{
 // check contract (`TriggerFireAccessCheck`/`Checker`/`Decision`/`Error`) is NOT
 // forwarded — `ironclaw_triggers` is its one import path (§11.2.4).
 pub use runtime_input::{
-    KeepaliveSweepSettings, PollSettings, RebornRuntimeIdentity, RebornRuntimeInput,
-    TriggerFireAccessGrant, TriggerFireAccessPolicy, TriggerPollerSettings, TurnRunnerSettings,
+    HarnessPlacementSettings, HarnessRuntimeSettings, KeepaliveSweepSettings, PollSettings,
+    RebornRuntimeIdentity, RebornRuntimeInput, TriggerFireAccessGrant, TriggerFireAccessPolicy,
+    TriggerPollerSettings, TurnRunnerSettings,
 };
 
 /// Re-exported IronHub command vocabulary for the `ironclaw` binary's

--- a/crates/app/ironclaw_composition/src/runtime.rs
+++ b/crates/app/ironclaw_composition/src/runtime.rs
@@ -3047,6 +3047,7 @@ pub(crate) async fn build_runtime_with_resource_governor(
         ironhub_agent_shared_key,
         ironhub_manifest_url,
         runner,
+        harness,
         tool_disclosure,
         trigger_poller,
         credential_refresh,
@@ -3853,6 +3854,14 @@ pub(crate) async fn build_runtime_with_resource_governor(
         )),
         subagent_spawn_limits: ironclaw_loop_host::SubagentSpawnLimits::default(),
         loop_exit_evidence,
+        harness: harness.map(|settings| {
+            ironclaw_turn_runner::harness_turn_run_executor::HarnessTurnRunConfig {
+                run_profile_ids: settings.run_profile_ids,
+                timeout: settings.timeout,
+                max_update_bytes: settings.max_update_bytes,
+                placement: settings.placement,
+            }
+        }),
         config: DefaultPlannedRuntimeConfig {
             heartbeat_interval: runner.heartbeat_interval,
             poll_interval: runner.poll_interval,

--- a/crates/app/ironclaw_composition/src/runtime_input.rs
+++ b/crates/app/ironclaw_composition/src/runtime_input.rs
@@ -20,6 +20,8 @@
 //! The CLI builds this struct from env vars / config; it does not call into
 //! `ironclaw_turn_runner` or `ironclaw_llm` directly.
 
+use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -32,6 +34,9 @@ use ironclaw_loop_host::HostSkillContextSource;
 use ironclaw_loop_host::ToolDisclosureMode;
 use ironclaw_triggers::TriggerFireAccessChecker;
 use ironclaw_triggers::TriggerPollerWorkerConfig;
+use ironclaw_turn_runner::agent_placement::{
+    AgentPlacement, DockerAgentPlacement, HostAgentPlacement,
+};
 use ironclaw_turn_runner::runtime::{
     DEFAULT_MAX_CONCURRENT_RUNS_PER_USER, DEFAULT_MAX_CONCURRENT_TRIGGER_RUNS,
     DEFAULT_TURN_RUNNER_WORKER_COUNT,
@@ -39,6 +44,61 @@ use ironclaw_turn_runner::runtime::{
 
 use crate::input::RebornHostBindings;
 use crate::observability::hooks::HooksActivationConfig;
+
+/// Deployment-selected location for an ACP agent process.
+pub enum HarnessPlacementSettings {
+    Host { command: String },
+    Docker { image: String },
+}
+
+/// Explicit, default-off configuration for routing selected run profiles to
+/// an ACP agent. Placement policy is resolved by the caller before composition.
+pub struct HarnessRuntimeSettings {
+    pub(crate) run_profile_ids: HashSet<String>,
+    pub(crate) timeout: Duration,
+    pub(crate) max_update_bytes: usize,
+    pub(crate) placement: Arc<dyn AgentPlacement>,
+}
+
+impl HarnessRuntimeSettings {
+    pub fn new(
+        run_profile_ids: HashSet<String>,
+        workspace_root: PathBuf,
+        placement: HarnessPlacementSettings,
+        environment: Vec<String>,
+        timeout: Duration,
+        max_update_bytes: usize,
+    ) -> Result<Self, String> {
+        if run_profile_ids.is_empty() {
+            return Err("ACP harness requires at least one routed run profile".to_string());
+        }
+        if timeout.is_zero() {
+            return Err("ACP harness timeout must be greater than zero".to_string());
+        }
+        let placement: Arc<dyn AgentPlacement> = match placement {
+            HarnessPlacementSettings::Host { command } => Arc::new(
+                HostAgentPlacement::new(
+                    workspace_root,
+                    command.into(),
+                    Vec::new(),
+                    environment,
+                    max_update_bytes,
+                )
+                .map_err(|error| error.to_string())?,
+            ),
+            HarnessPlacementSettings::Docker { image } => Arc::new(
+                DockerAgentPlacement::new(workspace_root, image, environment, max_update_bytes)
+                    .map_err(|error| error.to_string())?,
+            ),
+        };
+        Ok(Self {
+            run_profile_ids,
+            timeout,
+            max_update_bytes,
+            placement,
+        })
+    }
+}
 
 /// Caller-owned identity for an assembled Reborn runtime.
 ///
@@ -329,6 +389,7 @@ pub struct RebornRuntimeInput {
     /// Validated signed-catalog URL resolved by the CLI/config boundary.
     pub ironhub_manifest_url: ironclaw_extension_manager::ironhub::IronhubManifestUrl,
     pub runner: TurnRunnerSettings,
+    pub harness: Option<HarnessRuntimeSettings>,
     pub tool_disclosure: Option<ToolDisclosureMode>,
     pub trigger_poller: TriggerPollerSettings,
     pub credential_refresh: KeepaliveSweepSettings,
@@ -409,6 +470,7 @@ impl RebornRuntimeInput {
             ironhub_agent_shared_key: None,
             ironhub_manifest_url,
             runner: TurnRunnerSettings::default(),
+            harness: None,
             tool_disclosure: None,
             trigger_poller: TriggerPollerSettings::default(),
             credential_refresh: KeepaliveSweepSettings::default(),
@@ -431,6 +493,11 @@ impl RebornRuntimeInput {
             #[cfg(any(test, feature = "test-support"))]
             model_availability_retry_attempts_override: None,
         }
+    }
+
+    pub fn with_harness_settings(mut self, harness: HarnessRuntimeSettings) -> Self {
+        self.harness = Some(harness);
+        self
     }
 
     /// The declarative deployment config (Phase A) — the authoritative "what

--- a/crates/app/ironclaw_composition/tests/product_live_adapters.rs
+++ b/crates/app/ironclaw_composition/tests/product_live_adapters.rs
@@ -1429,6 +1429,7 @@ async fn adapter_bundle_satisfies_product_live_runtime_readiness_gate() {
                 as Arc<dyn ironclaw_turn_runner::loop_exit_applier::AwaitDependentRunEvidenceStore>,
             thread_scope,
         )),
+        harness: None,
         config: DefaultPlannedRuntimeConfig::default(),
         model_route_resolver: Some(adapters.model_route_resolver),
         cancellation_factory: Some(adapters.cancellation_factory),

--- a/crates/app/ironclaw_config/src/config_file.rs
+++ b/crates/app/ironclaw_config/src/config_file.rs
@@ -223,12 +223,41 @@ pub struct DriversSection {
     pub additional: Option<Vec<String>>,
 }
 
+/// Process placement for the experimental ACP harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessPlacement {
+    /// Spawn the pinned adapter directly on the operator's machine.
+    Host,
+    /// Spawn the pinned adapter inside the configured Docker image.
+    Docker,
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HarnessSection {
-    /// Active harness id. Composition logs the value at boot; takes
-    /// effect when the harness substrate from epic #3036 lands.
+    /// Active harness id. `claude-code-acp` is the only supported v0 value.
     pub id: Option<String>,
+    /// Run-profile ids routed to the harness. Profiles not listed here keep the
+    /// canonical Reborn executor, even while the harness is enabled.
+    pub run_profiles: Option<Vec<String>>,
+    /// Process placement. Hosted deployments fail closed unless this is
+    /// `docker`; standalone deployments may explicitly choose either value.
+    pub placement: Option<HarnessPlacement>,
+    /// Adapter executable for host placement. Defaults are resolved by the
+    /// bootstrap layer rather than by this syntax-only schema.
+    pub command: Option<String>,
+    /// Locally-built ACP adapter image. No registry/default image is implied.
+    pub image: Option<String>,
+    /// Hard wall-clock limit for one harness turn.
+    pub timeout_secs: Option<u64>,
+    /// Maximum aggregate bytes retained from ACP session updates.
+    pub max_update_bytes: Option<usize>,
+    /// Explicit host environment variable containing the developer Anthropic
+    /// credential. The value itself is never accepted in TOML.
+    pub anthropic_api_key_env: Option<String>,
+    /// Optional host environment variable containing a developer VCS token.
+    pub vcs_token_env: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -1006,6 +1035,50 @@ impl RebornConfigFile {
         {
             check(Cow::Borrowed("harness.id"), id)?;
         }
+        if let Some(harness) = &self.harness {
+            if let Some(run_profiles) = &harness.run_profiles {
+                if run_profiles.is_empty() {
+                    return Err(RebornConfigFileError::InvalidField {
+                        path: path_str(),
+                        field: "harness.run_profiles".to_string(),
+                        reason: "must contain at least one run profile id".to_string(),
+                    });
+                }
+                for profile in run_profiles {
+                    check(Cow::Borrowed("harness.run_profiles"), profile)?;
+                }
+            }
+            if let Some(image) = &harness.image {
+                check(Cow::Borrowed("harness.image"), image)?;
+            }
+            if let Some(command) = &harness.command {
+                check(Cow::Borrowed("harness.command"), command)?;
+            }
+            if harness.timeout_secs == Some(0) {
+                return Err(RebornConfigFileError::InvalidField {
+                    path: path_str(),
+                    field: "harness.timeout_secs".to_string(),
+                    reason: "must be greater than zero".to_string(),
+                });
+            }
+            if harness.max_update_bytes == Some(0) {
+                return Err(RebornConfigFileError::InvalidField {
+                    path: path_str(),
+                    field: "harness.max_update_bytes".to_string(),
+                    reason: "must be greater than zero".to_string(),
+                });
+            }
+            if let Some(env_name) = &harness.anthropic_api_key_env {
+                validate_env_var_reference(
+                    "harness.anthropic_api_key_env",
+                    env_name,
+                    attributed_path,
+                )?;
+            }
+            if let Some(env_name) = &harness.vcs_token_env {
+                validate_env_var_reference("harness.vcs_token_env", env_name, attributed_path)?;
+            }
+        }
         if let Some(llm) = &self.llm {
             for (slot, selection) in llm {
                 check(Cow::Borrowed("llm.<slot>"), slot)?;
@@ -1494,6 +1567,59 @@ max_concurrent_conversation_runs = 4
     fn absent_runner_leaves_new_fields_none() {
         let cfg = RebornConfigFile::parse_text("", &attributed()).expect("empty TOML is valid");
         assert!(cfg.runner.is_none());
+    }
+
+    #[test]
+    fn acp_harness_section_round_trips() {
+        let toml = r#"
+[harness]
+id = "claude-code-acp"
+run_profiles = ["reborn-planned-default"]
+placement = "host"
+command = "claude-agent-acp"
+image = "ironclaw-claude-code-acp:dev"
+timeout_secs = 600
+max_update_bytes = 1048576
+anthropic_api_key_env = "ANTHROPIC_API_KEY"
+vcs_token_env = "GH_TOKEN"
+"#;
+        let cfg = RebornConfigFile::parse_text(toml, &attributed()).expect("must parse");
+        let harness = cfg.harness.expect("harness section present");
+        assert_eq!(harness.id.as_deref(), Some("claude-code-acp"));
+        assert_eq!(
+            harness.run_profiles,
+            Some(vec!["reborn-planned-default".to_string()])
+        );
+        assert_eq!(harness.placement, Some(HarnessPlacement::Host));
+        assert_eq!(harness.command.as_deref(), Some("claude-agent-acp"));
+        assert_eq!(
+            harness.image.as_deref(),
+            Some("ironclaw-claude-code-acp:dev")
+        );
+        assert_eq!(harness.timeout_secs, Some(600));
+        assert_eq!(harness.max_update_bytes, Some(1_048_576));
+        assert_eq!(
+            harness.anthropic_api_key_env.as_deref(),
+            Some("ANTHROPIC_API_KEY")
+        );
+        assert_eq!(harness.vcs_token_env.as_deref(), Some("GH_TOKEN"));
+    }
+
+    #[test]
+    fn acp_harness_rejects_empty_routing_and_zero_limits() {
+        for (field, value) in [
+            ("run_profiles", "[]"),
+            ("timeout_secs", "0"),
+            ("max_update_bytes", "0"),
+        ] {
+            let toml = format!("[harness]\nid = \"claude-code-acp\"\n{field} = {value}\n");
+            let error = RebornConfigFile::parse_text(&toml, &attributed())
+                .expect_err("invalid harness bound must fail closed");
+            assert!(
+                error.to_string().contains(field),
+                "error must identify {field}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/ironclaw_config/src/lib.rs
+++ b/crates/app/ironclaw_config/src/lib.rs
@@ -46,8 +46,8 @@ pub use capability_remediation::{
 pub use config_file::{
     BootSection, BudgetSection, DefaultLlmSlotUpdate, DefaultLlmSlotUpdateSession, DriversSection,
     GoogleFieldUpdate, GoogleOauthConfigUpdate, GoogleOauthConfigUpdateSession, GoogleSection,
-    HarnessSection, IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection, MemoryAdminOverride,
-    MemorySection, PolicySection, REBORN_CONFIG_API_VERSION, RebornConfigFile,
+    HarnessPlacement, HarnessSection, IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection,
+    MemoryAdminOverride, MemorySection, PolicySection, REBORN_CONFIG_API_VERSION, RebornConfigFile,
     RebornConfigFileError, RebornConfigFileUpdateError, RunnerSection, StorageBackend,
     StorageSection, TriggerPollerConfigSection, begin_default_llm_slot_update,
     begin_google_oauth_config_update, update_default_llm_slot, update_google_oauth_config,

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process.rs
@@ -31,6 +31,7 @@ mod ca;
 mod connect;
 mod container_identity;
 mod credential_firewall;
+mod harness_container;
 mod key_codec;
 mod mounts;
 mod network_allowlist;
@@ -51,6 +52,10 @@ use mounts::RebornSandboxMountSources;
 pub use broker::{RebornSandboxNetworkBroker, RebornSandboxSecretBroker};
 pub use connect::{SandboxDockerReadiness, connect_docker_with_retry, sandbox_docker_readiness};
 pub use container_identity::{RebornSandboxContainerIdentity, RebornSandboxWorkspaceMode};
+pub use harness_container::{
+    HarnessContainerConfig, HarnessContainerSession, HarnessContainerTemplate, HarnessLineSink,
+    HarnessLineStream,
+};
 pub use network_allowlist::{
     DEFAULT_SANDBOX_ALLOWED_DOMAINS, DEFAULT_SANDBOX_MAX_EGRESS_BYTES,
     SANDBOX_EXTRA_ALLOWED_DOMAINS_ENV, SANDBOX_MAX_EGRESS_BYTES_ENV, sandbox_allowed_domains,

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/harness_container.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/harness_container.rs
@@ -1,0 +1,417 @@
+//! Interactive Docker stdio for the experimental ACP harness executor.
+//!
+//! This is deliberately narrower than the command transport: one pinned image,
+//! one typed workspace bind, an explicit environment allowlist, and no Docker
+//! flag escape hatch. The caller must terminate the returned session.
+
+use std::{path::PathBuf, pin::Pin};
+
+use bollard::{
+    Docker,
+    container::{
+        AttachContainerOptions, Config, CreateContainerOptions, LogOutput, RemoveContainerOptions,
+        StartContainerOptions,
+    },
+    models::HostConfig,
+};
+use futures_util::{Sink, Stream, StreamExt};
+use ironclaw_host_api::ids::ThreadId;
+use ironclaw_host_api::process::RuntimeProcessError;
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+
+use super::connect_docker_with_retry;
+
+const CONTAINER_WORKSPACE: &str = "/workspace";
+const MAX_MEMORY_BYTES: i64 = 4 * 1024 * 1024 * 1024;
+const MAX_PIDS: i64 = 512;
+const CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+pub type HarnessLineSink = Pin<Box<dyn Sink<String, Error = std::io::Error> + Send + 'static>>;
+pub type HarnessLineStream = Pin<Box<dyn Stream<Item = std::io::Result<String>> + Send + 'static>>;
+
+/// Opaque, reusable launch template. Credential values remain inside the lane;
+/// the loop tier can only request a container for a typed thread id.
+pub struct HarnessContainerTemplate {
+    workspace_root: PathBuf,
+    image: String,
+    environment: Vec<String>,
+    max_protocol_line_bytes: usize,
+}
+
+impl HarnessContainerTemplate {
+    pub fn new(
+        workspace_root: PathBuf,
+        image: String,
+        environment: Vec<String>,
+        max_protocol_line_bytes: usize,
+    ) -> Result<Self, RuntimeProcessError> {
+        HarnessContainerConfig::validate(&image, &environment, max_protocol_line_bytes)?;
+        Ok(Self {
+            workspace_root,
+            image,
+            environment,
+            max_protocol_line_bytes,
+        })
+    }
+
+    pub fn workspace_for_thread(&self, thread_id: &ThreadId) -> PathBuf {
+        let digest = Sha256::digest(thread_id.as_str().as_bytes());
+        self.workspace_root.join(hex::encode(digest))
+    }
+
+    pub async fn start_for_thread(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<HarnessContainerSession, RuntimeProcessError> {
+        HarnessContainerConfig::new(
+            self.workspace_for_thread(thread_id),
+            self.image.clone(),
+            self.environment.clone(),
+            self.max_protocol_line_bytes,
+        )?
+        .start()
+        .await
+    }
+}
+
+/// Trusted launch data assembled by the composition root.
+///
+/// `environment` contains already-resolved developer credentials and therefore
+/// intentionally has no `Debug`, `Serialize`, or accessor API.
+pub struct HarnessContainerConfig {
+    workspace: PathBuf,
+    image: String,
+    environment: Vec<String>,
+    max_protocol_line_bytes: usize,
+}
+
+impl HarnessContainerConfig {
+    pub fn new(
+        workspace: PathBuf,
+        image: String,
+        environment: Vec<String>,
+        max_protocol_line_bytes: usize,
+    ) -> Result<Self, RuntimeProcessError> {
+        Self::validate(&image, &environment, max_protocol_line_bytes)?;
+        Ok(Self {
+            workspace,
+            image,
+            environment,
+            max_protocol_line_bytes,
+        })
+    }
+
+    fn validate(
+        image: &str,
+        environment: &[String],
+        max_protocol_line_bytes: usize,
+    ) -> Result<(), RuntimeProcessError> {
+        if image.trim().is_empty() {
+            return Err(invalid("harness image must not be empty"));
+        }
+        if max_protocol_line_bytes == 0 {
+            return Err(invalid(
+                "harness protocol line limit must be greater than zero",
+            ));
+        }
+        if environment.iter().any(|entry| {
+            entry.as_bytes().contains(&0)
+                || !entry.contains('=')
+                || entry.starts_with('=')
+                || entry.starts_with("PATH=")
+                || entry.starts_with("HOME=")
+        }) {
+            return Err(invalid("harness environment contains an invalid entry"));
+        }
+        Ok(())
+    }
+
+    pub async fn start(self) -> Result<HarnessContainerSession, RuntimeProcessError> {
+        tokio::fs::create_dir_all(&self.workspace)
+            .await
+            .map_err(|error| invalid(format!("harness workspace could not be created: {error}")))?;
+        let workspace = tokio::fs::canonicalize(&self.workspace)
+            .await
+            .map_err(|error| {
+                invalid(format!("harness workspace could not be resolved: {error}"))
+            })?;
+        let workspace = workspace
+            .to_str()
+            .ok_or_else(|| invalid("harness workspace path is not valid UTF-8"))?;
+        if workspace.contains(':') || workspace.contains('\n') || workspace.contains('\r') {
+            return Err(invalid(
+                "harness workspace path is not safe for a Docker bind",
+            ));
+        }
+
+        let docker = connect_docker_with_retry().await?;
+        let container_name = format!("ironclaw-harness-{}", uuid::Uuid::new_v4());
+        let launch = Config {
+            image: Some(self.image),
+            working_dir: Some(CONTAINER_WORKSPACE.to_string()),
+            env: Some(self.environment),
+            open_stdin: Some(true),
+            stdin_once: Some(false),
+            attach_stdin: Some(true),
+            attach_stdout: Some(true),
+            attach_stderr: Some(true),
+            tty: Some(false),
+            host_config: Some(HostConfig {
+                binds: Some(vec![format!("{workspace}:{CONTAINER_WORKSPACE}:rw")]),
+                auto_remove: Some(false),
+                network_mode: Some("bridge".to_string()),
+                cap_drop: Some(vec!["ALL".to_string()]),
+                security_opt: Some(vec!["no-new-privileges:true".to_string()]),
+                readonly_rootfs: Some(true),
+                pids_limit: Some(MAX_PIDS),
+                memory: Some(MAX_MEMORY_BYTES),
+                tmpfs: Some(
+                    [(
+                        "/tmp".to_string(),
+                        "rw,nosuid,nodev,noexec,size=256m".to_string(),
+                    )]
+                    .into_iter()
+                    .collect(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let created = docker
+            .create_container(
+                Some(CreateContainerOptions {
+                    name: container_name,
+                    platform: None,
+                }),
+                launch,
+            )
+            .await
+            .map_err(|error| invalid(format!("harness container create failed: {error}")))?;
+        let container_id = created.id;
+
+        let attached = match docker
+            .attach_container(
+                &container_id,
+                Some(AttachContainerOptions::<String> {
+                    stdin: Some(true),
+                    stdout: Some(true),
+                    stderr: Some(true),
+                    stream: Some(true),
+                    logs: Some(false),
+                    ..Default::default()
+                }),
+            )
+            .await
+        {
+            Ok(attached) => attached,
+            Err(error) => {
+                remove_best_effort(&docker, &container_id).await;
+                return Err(invalid(format!("harness container attach failed: {error}")));
+            }
+        };
+        if let Err(error) = docker
+            .start_container(&container_id, None::<StartContainerOptions<String>>)
+            .await
+        {
+            remove_best_effort(&docker, &container_id).await;
+            return Err(invalid(format!("harness container start failed: {error}")));
+        }
+
+        let outgoing = Box::pin(futures_util::sink::unfold(
+            attached.input,
+            async move |mut input, mut line: String| {
+                line.push('\n');
+                input.write_all(line.as_bytes()).await?;
+                input.flush().await?;
+                Ok::<_, std::io::Error>(input)
+            },
+        ));
+        let incoming = Box::pin(futures_util::stream::unfold(
+            (attached.output, Vec::<u8>::new()),
+            move |(mut output, mut buffered)| async move {
+                loop {
+                    if let Some(newline) = buffered.iter().position(|byte| *byte == b'\n') {
+                        if newline > self.max_protocol_line_bytes {
+                            return Some((
+                                Err(std::io::Error::new(
+                                    std::io::ErrorKind::InvalidData,
+                                    "ACP protocol line exceeded configured limit",
+                                )),
+                                (output, Vec::new()),
+                            ));
+                        }
+                        let mut line = buffered.drain(..=newline).collect::<Vec<_>>();
+                        if line.last() == Some(&b'\n') {
+                            line.pop();
+                        }
+                        if line.last() == Some(&b'\r') {
+                            line.pop();
+                        }
+                        let decoded = String::from_utf8(line).map_err(|_| {
+                            std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "ACP adapter emitted non-UTF-8 stdout",
+                            )
+                        });
+                        return Some((decoded, (output, buffered)));
+                    }
+                    if buffered.len() > self.max_protocol_line_bytes {
+                        return Some((
+                            Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "ACP protocol line exceeded configured limit",
+                            )),
+                            (output, Vec::new()),
+                        ));
+                    }
+                    match output.next().await {
+                        Some(Ok(LogOutput::StdOut { message }))
+                        | Some(Ok(LogOutput::Console { message })) => {
+                            buffered.extend_from_slice(&message);
+                        }
+                        Some(Ok(LogOutput::StdErr { .. })) => {
+                            tracing::debug!("ACP harness adapter emitted stderr output");
+                        }
+                        Some(Ok(LogOutput::StdIn { .. })) => {}
+                        Some(Err(error)) => {
+                            return Some((
+                                Err(std::io::Error::other(format!(
+                                    "ACP container stream failed: {error}"
+                                ))),
+                                (output, Vec::new()),
+                            ));
+                        }
+                        None if buffered.is_empty() => return None,
+                        None => {
+                            let decoded =
+                                String::from_utf8(std::mem::take(&mut buffered)).map_err(|_| {
+                                    std::io::Error::new(
+                                        std::io::ErrorKind::InvalidData,
+                                        "ACP adapter emitted non-UTF-8 stdout",
+                                    )
+                                });
+                            return Some((decoded, (output, buffered)));
+                        }
+                    }
+                }
+            },
+        ));
+
+        Ok(HarnessContainerSession {
+            docker,
+            container_id: Some(container_id),
+            outgoing: Some(outgoing),
+            incoming: Some(incoming),
+        })
+    }
+}
+
+#[must_use = "harness containers must be explicitly terminated"]
+pub struct HarnessContainerSession {
+    docker: Docker,
+    container_id: Option<String>,
+    outgoing: Option<HarnessLineSink>,
+    incoming: Option<HarnessLineStream>,
+}
+
+impl HarnessContainerSession {
+    pub fn take_transport(
+        &mut self,
+    ) -> Result<(HarnessLineSink, HarnessLineStream), RuntimeProcessError> {
+        let outgoing = self
+            .outgoing
+            .take()
+            .ok_or_else(|| invalid("harness container transport was already taken"))?;
+        let incoming = self
+            .incoming
+            .take()
+            .ok_or_else(|| invalid("harness container transport was already taken"))?;
+        Ok((outgoing, incoming))
+    }
+
+    pub async fn terminate(mut self) -> Result<(), RuntimeProcessError> {
+        let container_id = self
+            .container_id
+            .take()
+            .ok_or_else(|| invalid("ACP harness container was already removed"))?;
+        match tokio::time::timeout(CLEANUP_TIMEOUT, remove(&self.docker, &container_id)).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => {
+                self.container_id = Some(container_id);
+                Err(invalid("ACP harness container removal failed"))
+            }
+            Err(_) => {
+                self.container_id = Some(container_id);
+                Err(invalid("timed out removing ACP harness container"))
+            }
+        }
+    }
+}
+
+impl Drop for HarnessContainerSession {
+    fn drop(&mut self) {
+        let Some(container_id) = self.container_id.take() else {
+            return;
+        };
+        let docker = self.docker.clone();
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            tracing::debug!("could not schedule dropped ACP harness container cleanup");
+            return;
+        };
+        let _cleanup = runtime.spawn(async move {
+            match tokio::time::timeout(CLEANUP_TIMEOUT, remove(&docker, &container_id)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    tracing::debug!("failed to remove dropped ACP harness container");
+                }
+                Err(_) => {
+                    tracing::debug!("timed out removing dropped ACP harness container");
+                }
+            }
+        });
+    }
+}
+
+async fn remove_best_effort(docker: &Docker, container_id: &str) {
+    if let Err(error) = remove(docker, container_id).await {
+        tracing::debug!(
+            ?error,
+            "best-effort removal of ACP harness container failed"
+        );
+    }
+}
+
+async fn remove(docker: &Docker, container_id: &str) -> Result<(), bollard::errors::Error> {
+    docker
+        .remove_container(
+            container_id,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await
+}
+
+fn invalid(reason: impl Into<String>) -> RuntimeProcessError {
+    RuntimeProcessError::ExecutionFailed(reason.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_config_rejects_ambient_process_environment_entries() {
+        let error = HarnessContainerConfig::new(
+            PathBuf::from("workspace"),
+            "image:dev".to_string(),
+            vec!["HOME=/host/home".to_string()],
+            1024,
+        )
+        .err()
+        .expect("ambient HOME must be rejected");
+        assert!(error.to_string().contains("invalid entry"));
+    }
+}

--- a/crates/loop/ironclaw_turn_runner/Cargo.toml
+++ b/crates/loop/ironclaw_turn_runner/Cargo.toml
@@ -26,6 +26,7 @@ layer = "loops"
 test-support = ["ironclaw_turns/test-support"]
 
 [dependencies]
+agent-client-protocol = "=2.0.0"
 async-trait = "0.1"
 # Scope-roster shard-prefix hashing only (§4.5) — same version already used
 # by `ironclaw_filesystem` for the identical stable-hex-from-key pattern
@@ -34,6 +35,7 @@ async-trait = "0.1"
 blake3 = "1"
 chrono = "0.4"
 futures-util = { version = "0.3", default-features = false }
+hex = "0.4"
 ironclaw_agent_loop = { path = "../ironclaw_agent_loop", version = "0.1.0" }
 ironclaw_event_log = { path = "../../events/ironclaw_event_log", version = "0.1.0" }
 ironclaw_hooks = { path = "../ironclaw_hooks", version = "0.1.0" }
@@ -46,6 +48,7 @@ ironclaw_outbound = { path = "../../domains/ironclaw_outbound", version = "0.1.0
 ironclaw_processes = { path = "../../kernel/ironclaw_processes", version = "0.1.0" }
 ironclaw_approvals = { path = "../../kernel/ironclaw_approvals", version = "0.1.0" }
 ironclaw_safety = { path = "../../substrates/ironclaw_safety", version = "0.2.2" }
+ironclaw_sandbox = { path = "../../lanes/ironclaw_sandbox", version = "0.1.0" }
 ironclaw_filesystem = { path = "../../substrates/ironclaw_filesystem", version = "0.1.0" }
 ironclaw_threads = { path = "../../domains/ironclaw_threads", version = "0.1.0" }
 ironclaw_loop_contracts = { path = "../../contracts/ironclaw_loop_contracts", version = "0.1.0" }
@@ -58,9 +61,10 @@ libsql = { version = "0.9", default-features = false, features = ["core", "repli
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.11"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "rt"] }
 # Message ids for the captured-transcript adaptation in `trace_capture`.
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"

--- a/crates/loop/ironclaw_turn_runner/README.md
+++ b/crates/loop/ironclaw_turn_runner/README.md
@@ -22,6 +22,11 @@ before anything durable commits. It never decides durability itself.
   with the process supervisor; `turn_scheduler.rs` is an agent-turn
   *projection* over the generic supervisor (#6696), not a scheduler of its
   own.
+- `HarnessRoutingTurnRunExecutor` (`harness_turn_run_executor.rs`) — a
+  default-off ACP adapter that diverts only explicitly configured run profiles
+  to an externally placed agent and otherwise delegates to
+  `RebornTurnRunExecutor`. `agent_placement.rs` keeps host-process and Docker
+  policy outside the ACP conversation executor.
 - `DriverRegistry` + the two production drivers: `PlannedDriver` (adapts
   `ironclaw_agent_loop`) and `text_loop_driver.rs` (smallest supported
   behavior). Fallback between them is an explicit profile/readiness decision,
@@ -42,12 +47,12 @@ before anything durable commits. It never decides durability itself.
 
 ## Depends on / consumed by
 
-- **Normal workspace deps (17):** `ironclaw_agent_loop`, `ironclaw_loop_host`,
+- **Normal workspace deps (18):** `ironclaw_agent_loop`, `ironclaw_loop_host`,
   `ironclaw_hooks` (the declared decorator chain), kernel (`ironclaw_turns`,
   `ironclaw_processes`, `ironclaw_host_runtime`, `ironclaw_approvals`),
   contracts (`ironclaw_host_api`, `ironclaw_loop_contracts`), plus
   `ironclaw_event_log`, `ironclaw_filesystem`, `ironclaw_memory`,
-  `ironclaw_observability`, `ironclaw_outbound`, `ironclaw_safety`,
+  `ironclaw_observability`, `ironclaw_outbound`, `ironclaw_safety`, `ironclaw_sandbox`,
   `ironclaw_threads`, `ironclaw_trace_commons`. **Not `ironclaw_llm`** — the
   provider cone left with the model gateway (WS3); re-adding it means provider
   behavior came back.

--- a/crates/loop/ironclaw_turn_runner/README.md
+++ b/crates/loop/ironclaw_turn_runner/README.md
@@ -22,11 +22,13 @@ before anything durable commits. It never decides durability itself.
   with the process supervisor; `turn_scheduler.rs` is an agent-turn
   *projection* over the generic supervisor (#6696), not a scheduler of its
   own.
-- `HarnessRoutingTurnRunExecutor` (`harness_turn_run_executor.rs`) — a
-  default-off ACP adapter that diverts only explicitly configured run profiles
-  to an externally placed agent and otherwise delegates to
-  `RebornTurnRunExecutor`. `agent_placement.rs` keeps host-process and Docker
-  policy outside the ACP conversation executor.
+- `ProfileRoutingTurnRunExecutor` (`profile_routing_turn_run_executor.rs`) —
+  neutral per-profile selection between replaceable `TurnRunExecutor`
+  implementations, with `RebornTurnRunExecutor` as the default.
+- `HarnessTurnRunExecutor` (`harness_turn_run_executor.rs`) — an ACP-only
+  external-agent executor that is unaware of routing and other loop
+  implementations. `agent_placement.rs` keeps host-process and Docker policy
+  outside the ACP conversation executor.
 - `DriverRegistry` + the two production drivers: `PlannedDriver` (adapts
   `ironclaw_agent_loop`) and `text_loop_driver.rs` (smallest supported
   behavior). Fallback between them is an explicit profile/readiness decision,

--- a/crates/loop/ironclaw_turn_runner/README.md
+++ b/crates/loop/ironclaw_turn_runner/README.md
@@ -28,7 +28,9 @@ before anything durable commits. It never decides durability itself.
 - `HarnessTurnRunExecutor` (`harness_turn_run_executor.rs`) — an ACP-only
   external-agent executor that is unaware of routing and other loop
   implementations. `agent_placement.rs` keeps host-process and Docker policy
-  outside the ACP conversation executor.
+  outside the ACP conversation executor. ACP text chunks publish cumulative,
+  sanitized `ModelTextDelta` milestones through the same live projection used
+  by the canonical loop; only the final reply is persisted.
 - `DriverRegistry` + the two production drivers: `PlannedDriver` (adapts
   `ironclaw_agent_loop`) and `text_loop_driver.rs` (smallest supported
   behavior). Fallback between them is an explicit profile/readiness decision,

--- a/crates/loop/ironclaw_turn_runner/src/agent_placement.rs
+++ b/crates/loop/ironclaw_turn_runner/src/agent_placement.rs
@@ -1,0 +1,418 @@
+//! Process placement for external ACP agents.
+//!
+//! The harness executor depends only on [`AgentPlacement`]. Host and Docker
+//! launch policy stays behind this boundary, while both implementations expose
+//! the same line-oriented ACP transport and cleanup contract.
+
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    pin::Pin,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use futures_util::{Sink, SinkExt, Stream, StreamExt};
+use ironclaw_host_api::ids::ThreadId;
+use ironclaw_sandbox::sandbox_process::{HarnessContainerSession, HarnessContainerTemplate};
+use sha2::{Digest, Sha256};
+use tokio::{
+    io::{AsyncReadExt, AsyncWrite},
+    process::{Child, Command},
+    task::JoinHandle,
+};
+use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
+
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub type AgentLineSink = Pin<Box<dyn Sink<String, Error = std::io::Error> + Send + 'static>>;
+pub type AgentLineStream = Pin<Box<dyn Stream<Item = std::io::Result<String>> + Send + 'static>>;
+
+/// Placement-owned process handle. The executor can use and terminate it, but
+/// cannot observe whether it is backed by a host process or a container.
+#[must_use = "agent processes must be explicitly terminated"]
+pub struct AgentProcess {
+    workspace: PathBuf,
+    working_directory: PathBuf,
+    outgoing: Option<AgentLineSink>,
+    incoming: Option<AgentLineStream>,
+    control: Option<Box<dyn AgentProcessControl>>,
+}
+
+impl AgentProcess {
+    fn new(
+        workspace: PathBuf,
+        working_directory: PathBuf,
+        outgoing: AgentLineSink,
+        incoming: AgentLineStream,
+        control: Box<dyn AgentProcessControl>,
+    ) -> Self {
+        Self {
+            workspace,
+            working_directory,
+            outgoing: Some(outgoing),
+            incoming: Some(incoming),
+            control: Some(control),
+        }
+    }
+
+    /// Persistent host path shared by successive processes for this thread.
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    /// Absolute workspace path as seen by the placed process.
+    pub fn working_directory(&self) -> &Path {
+        &self.working_directory
+    }
+
+    pub fn take_transport(
+        &mut self,
+    ) -> Result<(AgentLineSink, AgentLineStream), AgentPlacementError> {
+        let outgoing = self
+            .outgoing
+            .take()
+            .ok_or(AgentPlacementError::TransportAlreadyTaken)?;
+        let incoming = self
+            .incoming
+            .take()
+            .ok_or(AgentPlacementError::TransportAlreadyTaken)?;
+        Ok((outgoing, incoming))
+    }
+
+    pub async fn terminate(mut self) -> Result<(), AgentPlacementError> {
+        self.outgoing.take();
+        self.incoming.take();
+        let control = self
+            .control
+            .take()
+            .ok_or(AgentPlacementError::AlreadyTerminated)?;
+        control.terminate().await
+    }
+}
+
+#[async_trait]
+trait AgentProcessControl: Send {
+    async fn terminate(self: Box<Self>) -> Result<(), AgentPlacementError>;
+}
+
+#[async_trait]
+pub trait AgentPlacement: Send + Sync {
+    fn workspace_for_thread(&self, thread_id: &ThreadId) -> PathBuf;
+
+    async fn spawn(&self, thread_id: &ThreadId) -> Result<AgentProcess, AgentPlacementError>;
+}
+
+/// Runs the configured adapter directly on the host in a thread-scoped working
+/// directory. Only explicitly supplied environment entries are inherited.
+pub struct HostAgentPlacement {
+    workspace_root: PathBuf,
+    program: OsString,
+    arguments: Vec<OsString>,
+    environment: Vec<(OsString, OsString)>,
+    max_protocol_line_bytes: usize,
+}
+
+impl HostAgentPlacement {
+    pub fn new(
+        workspace_root: PathBuf,
+        program: OsString,
+        arguments: Vec<OsString>,
+        environment: Vec<String>,
+        max_protocol_line_bytes: usize,
+    ) -> Result<Self, AgentPlacementError> {
+        if program.is_empty() {
+            return Err(AgentPlacementError::InvalidConfig(
+                "harness command must not be empty",
+            ));
+        }
+        let environment = validate_environment(environment, max_protocol_line_bytes)?;
+        Ok(Self {
+            workspace_root,
+            program,
+            arguments,
+            environment,
+            max_protocol_line_bytes,
+        })
+    }
+}
+
+#[async_trait]
+impl AgentPlacement for HostAgentPlacement {
+    fn workspace_for_thread(&self, thread_id: &ThreadId) -> PathBuf {
+        thread_workspace(&self.workspace_root, thread_id)
+    }
+
+    async fn spawn(&self, thread_id: &ThreadId) -> Result<AgentProcess, AgentPlacementError> {
+        let workspace = prepare_workspace(self.workspace_for_thread(thread_id)).await?;
+        let home = workspace.join(".home");
+        tokio::fs::create_dir_all(&home)
+            .await
+            .map_err(AgentPlacementError::Workspace)?;
+
+        let mut command = Command::new(&self.program);
+        command
+            .args(&self.arguments)
+            .current_dir(&workspace)
+            .env_clear()
+            .env("HOME", home)
+            .env("PATH", trusted_host_path())
+            .envs(self.environment.iter().cloned())
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = command.spawn().map_err(AgentPlacementError::Spawn)?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(AgentPlacementError::MissingPipe("stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(AgentPlacementError::MissingPipe("stdout"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or(AgentPlacementError::MissingPipe("stderr"))?;
+
+        let outgoing = boxed_line_sink(stdin);
+        let incoming = Box::pin(
+            FramedRead::new(
+                stdout,
+                LinesCodec::new_with_max_length(self.max_protocol_line_bytes),
+            )
+            .map(|line| line.map_err(codec_error)),
+        );
+        let stderr_task = tokio::spawn(async move {
+            let mut stderr = stderr;
+            let mut buffer = [0_u8; 4096];
+            loop {
+                match stderr.read(&mut buffer).await {
+                    Ok(0) => break,
+                    Ok(_) => tracing::debug!("ACP harness adapter emitted stderr output"),
+                    Err(_) => {
+                        tracing::debug!("ACP harness adapter stderr stream failed");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(AgentProcess::new(
+            workspace.clone(),
+            workspace,
+            outgoing,
+            incoming,
+            Box::new(HostProcessControl { child, stderr_task }),
+        ))
+    }
+}
+
+/// Runs the configured adapter through the existing hardened Docker sandbox
+/// lane while presenting the same process contract as host placement.
+pub struct DockerAgentPlacement {
+    template: HarnessContainerTemplate,
+}
+
+impl DockerAgentPlacement {
+    pub fn new(
+        workspace_root: PathBuf,
+        image: String,
+        environment: Vec<String>,
+        max_protocol_line_bytes: usize,
+    ) -> Result<Self, AgentPlacementError> {
+        let template = HarnessContainerTemplate::new(
+            workspace_root,
+            image,
+            environment,
+            max_protocol_line_bytes,
+        )
+        .map_err(|error| AgentPlacementError::Docker(error.to_string()))?;
+        Ok(Self { template })
+    }
+}
+
+#[async_trait]
+impl AgentPlacement for DockerAgentPlacement {
+    fn workspace_for_thread(&self, thread_id: &ThreadId) -> PathBuf {
+        self.template.workspace_for_thread(thread_id)
+    }
+
+    async fn spawn(&self, thread_id: &ThreadId) -> Result<AgentProcess, AgentPlacementError> {
+        let workspace = self.template.workspace_for_thread(thread_id);
+        let mut session = self
+            .template
+            .start_for_thread(thread_id)
+            .await
+            .map_err(|error| AgentPlacementError::Docker(error.to_string()))?;
+        let (outgoing, incoming) = session
+            .take_transport()
+            .map_err(|error| AgentPlacementError::Docker(error.to_string()))?;
+        Ok(AgentProcess::new(
+            workspace,
+            PathBuf::from("/workspace"),
+            outgoing,
+            incoming,
+            Box::new(DockerProcessControl { session }),
+        ))
+    }
+}
+
+struct HostProcessControl {
+    child: Child,
+    stderr_task: JoinHandle<()>,
+}
+
+#[async_trait]
+impl AgentProcessControl for HostProcessControl {
+    async fn terminate(mut self: Box<Self>) -> Result<(), AgentPlacementError> {
+        let running = self
+            .child
+            .try_wait()
+            .map_err(AgentPlacementError::Cleanup)?
+            .is_none();
+        if running {
+            self.child
+                .start_kill()
+                .map_err(AgentPlacementError::Cleanup)?;
+        }
+        let wait = tokio::time::timeout(CLEANUP_TIMEOUT, self.child.wait()).await;
+        self.stderr_task.abort();
+        match wait {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(error)) => Err(AgentPlacementError::Cleanup(error)),
+            Err(_) => Err(AgentPlacementError::CleanupTimeout),
+        }
+    }
+}
+
+impl Drop for HostProcessControl {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        self.stderr_task.abort();
+    }
+}
+
+struct DockerProcessControl {
+    session: HarnessContainerSession,
+}
+
+#[async_trait]
+impl AgentProcessControl for DockerProcessControl {
+    async fn terminate(self: Box<Self>) -> Result<(), AgentPlacementError> {
+        let DockerProcessControl { session } = *self;
+        session
+            .terminate()
+            .await
+            .map_err(|error| AgentPlacementError::Docker(error.to_string()))
+    }
+}
+
+fn boxed_line_sink(writer: impl AsyncWrite + Send + Unpin + 'static) -> AgentLineSink {
+    Box::pin(SinkExt::<String>::sink_map_err(
+        FramedWrite::new(writer, LinesCodec::new()),
+        codec_error,
+    ))
+}
+
+fn codec_error(error: LinesCodecError) -> std::io::Error {
+    match error {
+        LinesCodecError::Io(error) => error,
+        LinesCodecError::MaxLineLengthExceeded => std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ACP protocol line exceeded configured limit",
+        ),
+    }
+}
+
+fn validate_environment(
+    environment: Vec<String>,
+    max_protocol_line_bytes: usize,
+) -> Result<Vec<(OsString, OsString)>, AgentPlacementError> {
+    if max_protocol_line_bytes == 0 {
+        return Err(AgentPlacementError::InvalidConfig(
+            "harness protocol line limit must be greater than zero",
+        ));
+    }
+    environment
+        .into_iter()
+        .map(|entry| {
+            if entry.as_bytes().contains(&0) {
+                return Err(AgentPlacementError::InvalidConfig(
+                    "harness environment contains an invalid entry",
+                ));
+            }
+            let (name, value) = entry
+                .split_once('=')
+                .ok_or(AgentPlacementError::InvalidConfig(
+                    "harness environment contains an invalid entry",
+                ))?;
+            if name.is_empty() || matches!(name, "PATH" | "HOME") {
+                return Err(AgentPlacementError::InvalidConfig(
+                    "harness environment contains an invalid entry",
+                ));
+            }
+            Ok((OsString::from(name), OsString::from(value)))
+        })
+        .collect()
+}
+
+async fn prepare_workspace(workspace: PathBuf) -> Result<PathBuf, AgentPlacementError> {
+    tokio::fs::create_dir_all(&workspace)
+        .await
+        .map_err(AgentPlacementError::Workspace)?;
+    tokio::fs::canonicalize(workspace)
+        .await
+        .map_err(AgentPlacementError::Workspace)
+}
+
+fn thread_workspace(root: &Path, thread_id: &ThreadId) -> PathBuf {
+    let digest = Sha256::digest(thread_id.as_str().as_bytes());
+    root.join(hex::encode(digest))
+}
+
+fn trusted_host_path() -> OsString {
+    std::env::var_os("PATH").unwrap_or_else(|| OsString::from("/usr/local/bin:/usr/bin:/bin"))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AgentPlacementError {
+    #[error("invalid agent placement: {0}")]
+    InvalidConfig(&'static str),
+    #[error("agent workspace preparation failed: {0}")]
+    Workspace(std::io::Error),
+    #[error("agent process spawn failed: {0}")]
+    Spawn(std::io::Error),
+    #[error("agent process did not expose {0}")]
+    MissingPipe(&'static str),
+    #[error("agent process transport was already taken")]
+    TransportAlreadyTaken,
+    #[error("agent process was already terminated")]
+    AlreadyTerminated,
+    #[error("agent process cleanup failed: {0}")]
+    Cleanup(std::io::Error),
+    #[error("agent process cleanup timed out")]
+    CleanupTimeout,
+    #[error("Docker agent placement failed: {0}")]
+    Docker(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_placement_rejects_ambient_environment_overrides() {
+        let error = HostAgentPlacement::new(
+            PathBuf::from("workspace"),
+            OsString::from("agent"),
+            Vec::new(),
+            vec!["HOME=/host/home".to_string()],
+            1024,
+        )
+        .err()
+        .expect("ambient HOME must be rejected");
+        assert!(error.to_string().contains("invalid entry"));
+    }
+}

--- a/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
@@ -1,0 +1,391 @@
+//! Explicitly configured ACP harness execution for selected run profiles.
+
+use std::{
+    collections::HashSet,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::schema::v1::{
+    ContentBlock, ContentChunk, InitializeRequest, LoadSessionRequest, NewSessionRequest,
+    PermissionOptionKind, PromptRequest, RequestPermissionOutcome, RequestPermissionRequest,
+    RequestPermissionResponse, SelectedPermissionOutcome, SessionId, SessionNotification,
+    SessionUpdate, TextContent,
+};
+use agent_client_protocol::{Agent, ConnectionTo, Lines};
+use async_trait::async_trait;
+use ironclaw_host_api::failure::categories::{
+    HOST_STAGE_UNAVAILABLE_INPUT_CATEGORY, TRANSCRIPT_WRITE_FAILED_CATEGORY,
+};
+use ironclaw_loop_contracts::{
+    AssistantReply, FinalizeAssistantMessage, LoopCompleted, LoopCompletionKind, LoopExit,
+};
+use ironclaw_processes::ProcessTransitionPort;
+use ironclaw_threads::{MessageKind, SessionThreadService, ThreadMessageId, ThreadScope};
+use ironclaw_turns::{SanitizedFailure, TurnError, runner::ClaimedTurnRun};
+use tracing::debug;
+
+use crate::{
+    agent_placement::{AgentLineSink, AgentLineStream, AgentPlacement},
+    turn_run_executor::RebornTurnRunExecutor,
+    turn_runner::HostFactory,
+    turn_scheduler::{TurnRunExecutor, TurnRunExecutorError},
+};
+
+const SESSION_ID_FILE: &str = ".ironclaw-acp-session";
+
+/// Explicit routing and resource limits for the ACP executor.
+#[derive(Clone)]
+pub struct HarnessTurnRunConfig {
+    pub run_profile_ids: HashSet<String>,
+    pub timeout: Duration,
+    pub max_update_bytes: usize,
+    pub placement: Arc<dyn AgentPlacement>,
+}
+
+/// Routes selected profiles to the ACP harness and delegates every other run
+/// to the existing executor unchanged.
+pub struct HarnessRoutingTurnRunExecutor {
+    fallback: Arc<RebornTurnRunExecutor>,
+    host_factory: Arc<dyn HostFactory>,
+    thread_service: Arc<dyn SessionThreadService>,
+    thread_scope: ThreadScope,
+    config: HarnessTurnRunConfig,
+}
+
+impl HarnessRoutingTurnRunExecutor {
+    pub fn new(
+        fallback: Arc<RebornTurnRunExecutor>,
+        host_factory: Arc<dyn HostFactory>,
+        thread_service: Arc<dyn SessionThreadService>,
+        thread_scope: ThreadScope,
+        config: HarnessTurnRunConfig,
+    ) -> Result<Self, String> {
+        if config.run_profile_ids.is_empty() {
+            return Err("ACP harness requires at least one routed run profile".to_string());
+        }
+        if config.timeout.is_zero() {
+            return Err("ACP harness timeout must be greater than zero".to_string());
+        }
+        if config.max_update_bytes == 0 {
+            return Err("ACP harness update bound must be greater than zero".to_string());
+        }
+        Ok(Self {
+            fallback,
+            host_factory,
+            thread_service,
+            thread_scope,
+            config,
+        })
+    }
+
+    fn routes(&self, claimed: &ClaimedTurnRun) -> bool {
+        self.config
+            .run_profile_ids
+            .contains(claimed.resolved_run_profile.profile_id.as_str())
+    }
+
+    async fn execute_harness(&self, claimed: ClaimedTurnRun) -> Result<(), TurnRunExecutorError> {
+        let prompt = self.load_prompt(&claimed).await?;
+        let mut process = self
+            .config
+            .placement
+            .spawn(&claimed.state.scope.thread_id)
+            .await
+            .map_err(|_| failure("driver_unavailable"))?;
+        let workspace = process.workspace().to_path_buf();
+        let working_directory = process.working_directory().to_path_buf();
+        let transport = process
+            .take_transport()
+            .map_err(|_| failure("driver_unavailable"));
+
+        let result = match transport {
+            Ok((outgoing, incoming)) => {
+                let protocol = self.run_acp(
+                    prompt,
+                    workspace,
+                    working_directory,
+                    Lines::new(outgoing, incoming),
+                );
+                match tokio::time::timeout(self.config.timeout, protocol).await {
+                    Ok(result) => result,
+                    Err(_) => Err(failure("interrupted_unexpectedly")),
+                }
+            }
+            Err(error) => Err(error),
+        };
+        process
+            .terminate()
+            .await
+            .map_err(|_| failure("driver_failed"))?;
+        let reply = result?;
+
+        let host = self
+            .host_factory
+            .create_host(&claimed)
+            .await
+            .map_err(|_| failure("host_creation_failed"))?;
+        let reply_ref = host
+            .finalize_assistant_message(FinalizeAssistantMessage {
+                reply: AssistantReply { content: reply },
+            })
+            .await
+            .map_err(|_| failure(TRANSCRIPT_WRITE_FAILED_CATEGORY))?;
+        let exit_id = ironclaw_turns::LoopExitId::new(format!(
+            "exit:{}-harness-completed",
+            claimed.state.run_id
+        ))
+        .map_err(|_| failure("driver_protocol_violation"))?;
+        let exit = LoopExit::Completed(LoopCompleted {
+            completion_kind: LoopCompletionKind::FinalReply,
+            reply_message_refs: vec![reply_ref],
+            result_refs: Vec::new(),
+            final_checkpoint_id: None,
+            model_usage: None,
+            exit_id,
+        });
+        self.fallback
+            .apply_exit(&claimed, exit)
+            .await
+            .map_err(|()| failure("exit_application_failed"))
+    }
+
+    async fn load_prompt(&self, claimed: &ClaimedTurnRun) -> Result<String, TurnRunExecutorError> {
+        let raw_message_id = claimed
+            .state
+            .accepted_message_ref
+            .as_str()
+            .strip_prefix("msg:")
+            .ok_or_else(|| failure("driver_invalid_request"))?;
+        let message_id = ThreadMessageId::parse(raw_message_id)
+            .map_err(|_| failure("driver_invalid_request"))?;
+        let scope = ironclaw_loop_host::ThreadScopeResolver::resolve_for_turn(
+            &self.thread_scope,
+            &claimed.state.scope,
+            claimed.state.actor.as_ref(),
+        );
+        let message = self
+            .thread_service
+            .read_thread_message(&scope, &claimed.state.scope.thread_id, message_id)
+            .await
+            .map_err(|_| failure(HOST_STAGE_UNAVAILABLE_INPUT_CATEGORY))?
+            .ok_or_else(|| failure(HOST_STAGE_UNAVAILABLE_INPUT_CATEGORY))?;
+        if message.kind != MessageKind::User {
+            return Err(failure("driver_invalid_request"));
+        }
+        message
+            .content
+            .ok_or_else(|| failure("driver_invalid_request"))
+    }
+
+    async fn run_acp(
+        &self,
+        prompt: String,
+        workspace: std::path::PathBuf,
+        working_directory: std::path::PathBuf,
+        transport: Lines<AgentLineSink, AgentLineStream>,
+    ) -> Result<String, TurnRunExecutorError> {
+        let output = Arc::new(Mutex::new(BoundedOutput::new(self.config.max_update_bytes)));
+        let output_for_updates = Arc::clone(&output);
+        let session_file = workspace.join(SESSION_ID_FILE);
+
+        agent_client_protocol::Client
+            .builder()
+            .name("ironclaw-harness-v0")
+            .on_receive_notification(
+                async move |notification: SessionNotification, _cx| {
+                    if let SessionUpdate::AgentMessageChunk(ContentChunk {
+                        content: ContentBlock::Text(text),
+                        ..
+                    }) = notification.update
+                        && let Ok(mut output) = output_for_updates.lock()
+                    {
+                        output.push(&text.text);
+                    }
+                    Ok(())
+                },
+                agent_client_protocol::on_receive_notification!(),
+            )
+            .on_receive_request(
+                async move |request: RequestPermissionRequest, responder, _connection| {
+                    debug!(
+                        session_id = %request.session_id,
+                        "auto-approving ACP harness permission request"
+                    );
+                    let response = match request.options.iter().find(|option| {
+                        matches!(
+                            option.kind,
+                            PermissionOptionKind::AllowOnce | PermissionOptionKind::AllowAlways
+                        )
+                    }) {
+                        Some(option) => {
+                            RequestPermissionResponse::new(RequestPermissionOutcome::Selected(
+                                SelectedPermissionOutcome::new(option.option_id.clone()),
+                            ))
+                        }
+                        None => RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled),
+                    };
+                    responder.respond(response)
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .connect_with(transport, |connection: ConnectionTo<Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                let session_id = match load_session_id(&session_file).await {
+                    Ok(Some(session_id)) => {
+                        connection
+                            .send_request(LoadSessionRequest::new(
+                                session_id.clone(),
+                                &working_directory,
+                            ))
+                            .block_task()
+                            .await?;
+                        session_id
+                    }
+                    Ok(None) => {
+                        let response = connection
+                            .send_request(NewSessionRequest::new(&working_directory))
+                            .block_task()
+                            .await?;
+                        persist_session_id(&session_file, &response.session_id).await?;
+                        response.session_id
+                    }
+                    Err(error) => return Err(error),
+                };
+                connection
+                    .send_request(PromptRequest::new(
+                        session_id,
+                        vec![ContentBlock::Text(TextContent::new(prompt))],
+                    ))
+                    .block_task()
+                    .await?;
+                Ok(())
+            })
+            .await
+            .map_err(|_| failure("driver_protocol_violation"))?;
+
+        let output = output
+            .lock()
+            .map_err(|_| failure("driver_protocol_violation"))?
+            .render();
+        if output.trim().is_empty() {
+            return Err(failure("invalid_model_output"));
+        }
+        Ok(output)
+    }
+}
+
+#[async_trait]
+impl TurnRunExecutor for HarnessRoutingTurnRunExecutor {
+    async fn execute_claimed_run(
+        &self,
+        claimed: ClaimedTurnRun,
+        process_transitions: Arc<dyn ProcessTransitionPort<Error = TurnError>>,
+    ) -> Result<(), TurnRunExecutorError> {
+        if self.routes(&claimed) {
+            self.execute_harness(claimed).await
+        } else {
+            self.fallback
+                .execute_claimed_run(claimed, process_transitions)
+                .await
+        }
+    }
+}
+
+struct BoundedOutput {
+    text: String,
+    limit: usize,
+    truncated: bool,
+}
+
+impl BoundedOutput {
+    fn new(limit: usize) -> Self {
+        Self {
+            text: String::new(),
+            limit,
+            truncated: false,
+        }
+    }
+
+    fn push(&mut self, value: &str) {
+        if self.text.len() >= self.limit {
+            self.truncated = true;
+            return;
+        }
+        let remaining = self.limit - self.text.len();
+        if value.len() <= remaining {
+            self.text.push_str(value);
+        } else {
+            let mut end = remaining;
+            while end > 0 && !value.is_char_boundary(end) {
+                end -= 1;
+            }
+            self.text.push_str(&value[..end]);
+            self.truncated = true;
+        }
+    }
+
+    fn render(&self) -> String {
+        if self.truncated {
+            format!("{}\n[ACP output truncated]", self.text)
+        } else {
+            self.text.clone()
+        }
+    }
+}
+
+async fn load_session_id(path: &Path) -> agent_client_protocol::Result<Option<SessionId>> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(raw) => {
+            let value = raw.trim();
+            if value.is_empty() || value.len() > 1024 {
+                return Err(agent_client_protocol::Error::internal_error()
+                    .data("persisted ACP session id is invalid"));
+            }
+            Ok(Some(SessionId::new(value.to_string())))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(agent_client_protocol::Error::internal_error().data(format!(
+            "persisted ACP session id could not be read: {error}"
+        ))),
+    }
+}
+
+async fn persist_session_id(
+    path: &Path,
+    session_id: &SessionId,
+) -> agent_client_protocol::Result<()> {
+    let temporary = path.with_extension("tmp");
+    tokio::fs::write(&temporary, session_id.to_string())
+        .await
+        .map_err(|error| {
+            agent_client_protocol::Error::internal_error()
+                .data(format!("ACP session id could not be staged: {error}"))
+        })?;
+    tokio::fs::rename(&temporary, path).await.map_err(|error| {
+        agent_client_protocol::Error::internal_error()
+            .data(format!("ACP session id could not be persisted: {error}"))
+    })
+}
+
+fn failure(category: &'static str) -> TurnRunExecutorError {
+    let failure = SanitizedFailure::from_trusted_static(category);
+    TurnRunExecutorError::from_failure(failure)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BoundedOutput;
+
+    #[test]
+    fn bounded_output_truncates_at_utf8_boundary_with_marker() {
+        let mut output = BoundedOutput::new(5);
+        output.push("abc😀");
+        assert_eq!(output.render(), "abc\n[ACP output truncated]");
+    }
+}

--- a/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
@@ -29,7 +29,6 @@ use tracing::debug;
 
 use crate::{
     agent_placement::{AgentLineSink, AgentLineStream, AgentPlacement},
-    turn_run_executor::RebornTurnRunExecutor,
     turn_runner::HostFactory,
     turn_scheduler::{TurnRunExecutor, TurnRunExecutorError},
 };
@@ -45,27 +44,41 @@ pub struct HarnessTurnRunConfig {
     pub placement: Arc<dyn AgentPlacement>,
 }
 
-/// Routes selected profiles to the ACP harness and delegates every other run
-/// to the existing executor unchanged.
-pub struct HarnessRoutingTurnRunExecutor {
-    fallback: Arc<RebornTurnRunExecutor>,
+pub struct HarnessExecutorConfig {
+    timeout: Duration,
+    max_update_bytes: usize,
+    placement: Arc<dyn AgentPlacement>,
+}
+
+impl HarnessTurnRunConfig {
+    pub fn into_routing_parts(self) -> (HashSet<String>, HarnessExecutorConfig) {
+        (
+            self.run_profile_ids,
+            HarnessExecutorConfig {
+                timeout: self.timeout,
+                max_update_bytes: self.max_update_bytes,
+                placement: self.placement,
+            },
+        )
+    }
+}
+
+/// ACP-only turn executor. Profile selection belongs to the neutral executor
+/// router, so this implementation contains no knowledge of other loops.
+pub struct HarnessTurnRunExecutor {
     host_factory: Arc<dyn HostFactory>,
     thread_service: Arc<dyn SessionThreadService>,
     thread_scope: ThreadScope,
-    config: HarnessTurnRunConfig,
+    config: HarnessExecutorConfig,
 }
 
-impl HarnessRoutingTurnRunExecutor {
+impl HarnessTurnRunExecutor {
     pub fn new(
-        fallback: Arc<RebornTurnRunExecutor>,
         host_factory: Arc<dyn HostFactory>,
         thread_service: Arc<dyn SessionThreadService>,
         thread_scope: ThreadScope,
-        config: HarnessTurnRunConfig,
+        config: HarnessExecutorConfig,
     ) -> Result<Self, String> {
-        if config.run_profile_ids.is_empty() {
-            return Err("ACP harness requires at least one routed run profile".to_string());
-        }
         if config.timeout.is_zero() {
             return Err("ACP harness timeout must be greater than zero".to_string());
         }
@@ -73,18 +86,11 @@ impl HarnessRoutingTurnRunExecutor {
             return Err("ACP harness update bound must be greater than zero".to_string());
         }
         Ok(Self {
-            fallback,
             host_factory,
             thread_service,
             thread_scope,
             config,
         })
-    }
-
-    fn routes(&self, claimed: &ClaimedTurnRun) -> bool {
-        self.config
-            .run_profile_ids
-            .contains(claimed.resolved_run_profile.profile_id.as_str())
     }
 
     async fn execute_harness(&self, claimed: ClaimedTurnRun) -> Result<(), TurnRunExecutorError> {
@@ -281,19 +287,13 @@ impl HarnessRoutingTurnRunExecutor {
 }
 
 #[async_trait]
-impl TurnRunExecutor for HarnessRoutingTurnRunExecutor {
+impl TurnRunExecutor for HarnessTurnRunExecutor {
     async fn execute_claimed_run(
         &self,
         claimed: ClaimedTurnRun,
-        process_transitions: Arc<dyn ProcessTransitionPort<Error = TurnError>>,
+        _process_transitions: Arc<dyn ProcessTransitionPort<Error = TurnError>>,
     ) -> Result<(), TurnRunExecutorError> {
-        if self.routes(&claimed) {
-            self.execute_harness(claimed).await
-        } else {
-            self.fallback
-                .execute_claimed_run(claimed, process_transitions)
-                .await
-        }
+        self.execute_harness(claimed).await
     }
 }
 

--- a/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
@@ -21,10 +21,14 @@ use ironclaw_host_api::failure::categories::{
 };
 use ironclaw_loop_contracts::{
     AssistantReply, FinalizeAssistantMessage, LoopCompleted, LoopCompletionKind, LoopExit,
+    LoopHostMilestoneEmitter, LoopHostMilestoneSink, LoopRunInfoPort as _,
+    sanitize_model_visible_text,
 };
 use ironclaw_processes::ProcessTransitionPort;
 use ironclaw_threads::{MessageKind, SessionThreadService, ThreadMessageId, ThreadScope};
-use ironclaw_turns::{SanitizedFailure, TurnError, runner::ClaimedTurnRun};
+use ironclaw_turns::{
+    SanitizedFailure, TurnError, loop_exit::LoopExitApplier, runner::ClaimedTurnRun,
+};
 use tracing::debug;
 
 use crate::{
@@ -69,6 +73,8 @@ pub struct HarnessTurnRunExecutor {
     host_factory: Arc<dyn HostFactory>,
     thread_service: Arc<dyn SessionThreadService>,
     thread_scope: ThreadScope,
+    loop_exit_applier: Arc<LoopExitApplier>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     config: HarnessExecutorConfig,
 }
 
@@ -77,6 +83,8 @@ impl HarnessTurnRunExecutor {
         host_factory: Arc<dyn HostFactory>,
         thread_service: Arc<dyn SessionThreadService>,
         thread_scope: ThreadScope,
+        loop_exit_applier: Arc<LoopExitApplier>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
         config: HarnessExecutorConfig,
     ) -> Result<Self, String> {
         if config.timeout.is_zero() {
@@ -89,12 +97,26 @@ impl HarnessTurnRunExecutor {
             host_factory,
             thread_service,
             thread_scope,
+            loop_exit_applier,
+            milestone_sink,
             config,
         })
     }
 
     async fn execute_harness(&self, claimed: ClaimedTurnRun) -> Result<(), TurnRunExecutorError> {
         let prompt = self.load_prompt(&claimed).await?;
+        let host = self
+            .host_factory
+            .create_host(&claimed)
+            .await
+            .map_err(|_| failure("host_creation_failed"))?;
+        let milestones = LoopHostMilestoneEmitter::new(
+            host.run_context().clone(),
+            Arc::clone(&self.milestone_sink),
+        );
+        if let Err(error) = milestones.model_started(None).await {
+            debug!(?error, "ACP model-started milestone could not be published");
+        }
         let mut process = self
             .config
             .placement
@@ -114,6 +136,7 @@ impl HarnessTurnRunExecutor {
                     workspace,
                     working_directory,
                     Lines::new(outgoing, incoming),
+                    milestones,
                 );
                 match tokio::time::timeout(self.config.timeout, protocol).await {
                     Ok(result) => result,
@@ -128,11 +151,6 @@ impl HarnessTurnRunExecutor {
             .map_err(|_| failure("driver_failed"))?;
         let reply = result?;
 
-        let host = self
-            .host_factory
-            .create_host(&claimed)
-            .await
-            .map_err(|_| failure("host_creation_failed"))?;
         let reply_ref = host
             .finalize_assistant_message(FinalizeAssistantMessage {
                 reply: AssistantReply { content: reply },
@@ -152,10 +170,11 @@ impl HarnessTurnRunExecutor {
             model_usage: None,
             exit_id,
         });
-        self.fallback
-            .apply_exit(&claimed, exit)
+        self.loop_exit_applier
+            .apply(&claimed, exit)
             .await
-            .map_err(|()| failure("exit_application_failed"))
+            .map(|_| ())
+            .map_err(|_| failure("exit_application_failed"))
     }
 
     async fn load_prompt(&self, claimed: &ClaimedTurnRun) -> Result<String, TurnRunExecutorError> {
@@ -192,9 +211,11 @@ impl HarnessTurnRunExecutor {
         workspace: std::path::PathBuf,
         working_directory: std::path::PathBuf,
         transport: Lines<AgentLineSink, AgentLineStream>,
+        milestones: LoopHostMilestoneEmitter<dyn LoopHostMilestoneSink>,
     ) -> Result<String, TurnRunExecutorError> {
         let output = Arc::new(Mutex::new(BoundedOutput::new(self.config.max_update_bytes)));
         let output_for_updates = Arc::clone(&output);
+        let milestones_for_updates = milestones.clone();
         let session_file = workspace.join(SESSION_ID_FILE);
 
         agent_client_protocol::Client
@@ -206,9 +227,20 @@ impl HarnessTurnRunExecutor {
                         content: ContentBlock::Text(text),
                         ..
                     }) = notification.update
-                        && let Ok(mut output) = output_for_updates.lock()
                     {
-                        output.push(&text.text);
+                        let cumulative_text = match output_for_updates.lock() {
+                            Ok(mut output) if output.push(&text.text) => {
+                                Some(sanitize_model_visible_text(output.render()))
+                            }
+                            Ok(_) | Err(_) => None,
+                        };
+                        if let Some(cumulative_text) = cumulative_text
+                            && let Err(error) = milestones_for_updates
+                                .model_text_delta(cumulative_text)
+                                .await
+                        {
+                            debug!(?error, "ACP model-text milestone could not be published");
+                        }
                     }
                     Ok(())
                 },
@@ -312,11 +344,14 @@ impl BoundedOutput {
         }
     }
 
-    fn push(&mut self, value: &str) {
+    fn push(&mut self, value: &str) -> bool {
         if self.text.len() >= self.limit {
+            let changed = !self.truncated;
             self.truncated = true;
-            return;
+            return changed;
         }
+        let previous_len = self.text.len();
+        let was_truncated = self.truncated;
         let remaining = self.limit - self.text.len();
         if value.len() <= remaining {
             self.text.push_str(value);
@@ -328,6 +363,7 @@ impl BoundedOutput {
             self.text.push_str(&value[..end]);
             self.truncated = true;
         }
+        self.text.len() != previous_len || self.truncated != was_truncated
     }
 
     fn render(&self) -> String {
@@ -385,7 +421,16 @@ mod tests {
     #[test]
     fn bounded_output_truncates_at_utf8_boundary_with_marker() {
         let mut output = BoundedOutput::new(5);
-        output.push("abc😀");
+        assert!(output.push("abc😀"));
+        assert_eq!(output.render(), "abc\n[ACP output truncated]");
+    }
+
+    #[test]
+    fn bounded_output_reports_only_visible_changes() {
+        let mut output = BoundedOutput::new(3);
+        assert!(output.push("abc"));
+        assert!(output.push("d"));
+        assert!(!output.push("e"));
         assert_eq!(output.render(), "abc\n[ACP output truncated]");
     }
 }

--- a/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs
@@ -21,8 +21,7 @@ use ironclaw_host_api::failure::categories::{
 };
 use ironclaw_loop_contracts::{
     AssistantReply, FinalizeAssistantMessage, LoopCompleted, LoopCompletionKind, LoopExit,
-    LoopHostMilestoneEmitter, LoopHostMilestoneSink, LoopRunInfoPort as _,
-    sanitize_model_visible_text,
+    LoopHostMilestoneEmitter, LoopHostMilestoneSink, sanitize_model_visible_text,
 };
 use ironclaw_processes::ProcessTransitionPort;
 use ironclaw_threads::{MessageKind, SessionThreadService, ThreadMessageId, ThreadScope};
@@ -229,10 +228,10 @@ impl HarnessTurnRunExecutor {
                     }) = notification.update
                     {
                         let cumulative_text = match output_for_updates.lock() {
-                            Ok(mut output) if output.push(&text.text) => {
-                                Some(sanitize_model_visible_text(output.render()))
-                            }
-                            Ok(_) | Err(_) => None,
+                            Ok(mut output) => output
+                                .push(&text.text)
+                                .then(|| sanitize_model_visible_text(output.render())),
+                            Err(_) => None,
                         };
                         if let Some(cumulative_text) = cumulative_text
                             && let Err(error) = milestones_for_updates

--- a/crates/loop/ironclaw_turn_runner/src/lib.rs
+++ b/crates/loop/ironclaw_turn_runner/src/lib.rs
@@ -43,6 +43,7 @@ mod model_failure_mapping;
 pub mod planned_driver;
 pub mod planned_driver_factory;
 pub mod production_readiness;
+pub mod profile_routing_turn_run_executor;
 pub mod runtime;
 pub mod steering_reconcile;
 pub mod subagent;

--- a/crates/loop/ironclaw_turn_runner/src/lib.rs
+++ b/crates/loop/ironclaw_turn_runner/src/lib.rs
@@ -17,6 +17,7 @@
 //! the boundary tests are designed to prevent.
 
 pub mod after_turn_memory;
+pub mod agent_placement;
 pub mod app_loop_family;
 pub mod driver_registry;
 /// Failure **classification** only — the category identifiers and the
@@ -27,6 +28,7 @@ pub mod failure_lane;
 /// The writer half of the checkpoint-rejection envelope; its reader and the
 /// summary tables live in `ironclaw_host_api::failure::summary`.
 mod failure_summary;
+pub mod harness_turn_run_executor;
 pub mod hook_gate_refs;
 pub mod retry_disposition;
 

--- a/crates/loop/ironclaw_turn_runner/src/profile_routing_turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/profile_routing_turn_run_executor.rs
@@ -39,7 +39,7 @@ impl ProfileRoutingTurnRunExecutor {
                 .is_some()
             {
                 return Err(format!(
-                    "turn executor route for profile `{profile_id}` is duplicated"
+                    "turn executor route for profile `{raw_profile_id}` is duplicated"
                 ));
             }
             route_count = route_count.saturating_add(1);

--- a/crates/loop/ironclaw_turn_runner/src/profile_routing_turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/profile_routing_turn_run_executor.rs
@@ -1,0 +1,123 @@
+//! Profile-based selection between replaceable turn-run executor implementations.
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use ironclaw_processes::ProcessTransitionPort;
+use ironclaw_turns::{RunProfileId, TurnError, runner::ClaimedTurnRun};
+
+use crate::turn_scheduler::{TurnRunExecutor, TurnRunExecutorError};
+
+/// Routes explicitly registered run profiles to alternate executors and sends
+/// every other profile to the canonical default executor.
+pub struct ProfileRoutingTurnRunExecutor {
+    default_executor: Arc<dyn TurnRunExecutor>,
+    executors_by_profile: HashMap<RunProfileId, Arc<dyn TurnRunExecutor>>,
+}
+
+impl ProfileRoutingTurnRunExecutor {
+    pub fn new(default_executor: Arc<dyn TurnRunExecutor>) -> Self {
+        Self {
+            default_executor,
+            executors_by_profile: HashMap::new(),
+        }
+    }
+
+    pub fn with_routes(
+        mut self,
+        profile_ids: impl IntoIterator<Item = String>,
+        executor: Arc<dyn TurnRunExecutor>,
+    ) -> Result<Self, String> {
+        let mut route_count = 0_usize;
+        for raw_profile_id in profile_ids {
+            let profile_id = RunProfileId::new(&raw_profile_id).map_err(|error| {
+                format!("turn executor route profile id `{raw_profile_id}` is invalid: {error}")
+            })?;
+            if self
+                .executors_by_profile
+                .insert(profile_id.clone(), Arc::clone(&executor))
+                .is_some()
+            {
+                return Err(format!(
+                    "turn executor route for profile `{profile_id}` is duplicated"
+                ));
+            }
+            route_count = route_count.saturating_add(1);
+        }
+        if route_count == 0 {
+            return Err("turn executor route requires at least one run profile".to_string());
+        }
+        Ok(self)
+    }
+
+    fn executor_for_profile(&self, profile_id: &RunProfileId) -> Arc<dyn TurnRunExecutor> {
+        self.executors_by_profile
+            .get(profile_id)
+            .cloned()
+            .unwrap_or_else(|| Arc::clone(&self.default_executor))
+    }
+}
+
+#[async_trait]
+impl TurnRunExecutor for ProfileRoutingTurnRunExecutor {
+    async fn execute_claimed_run(
+        &self,
+        claimed: ClaimedTurnRun,
+        process_transitions: Arc<dyn ProcessTransitionPort<Error = TurnError>>,
+    ) -> Result<(), TurnRunExecutorError> {
+        self.executor_for_profile(&claimed.resolved_run_profile.profile_id)
+            .execute_claimed_run(claimed, process_transitions)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct UnusedExecutor;
+
+    #[async_trait]
+    impl TurnRunExecutor for UnusedExecutor {
+        async fn execute_claimed_run(
+            &self,
+            _claimed: ClaimedTurnRun,
+            _process_transitions: Arc<dyn ProcessTransitionPort<Error = TurnError>>,
+        ) -> Result<(), TurnRunExecutorError> {
+            unreachable!("selection tests do not execute a turn")
+        }
+    }
+
+    #[test]
+    fn selected_profile_uses_registered_executor_and_other_profiles_use_default() {
+        let default: Arc<dyn TurnRunExecutor> = Arc::new(UnusedExecutor);
+        let alternate: Arc<dyn TurnRunExecutor> = Arc::new(UnusedExecutor);
+        let router = ProfileRoutingTurnRunExecutor::new(Arc::clone(&default))
+            .with_routes(
+                ["assistant".to_string(), "coding".to_string()],
+                Arc::clone(&alternate),
+            )
+            .expect("valid routes");
+
+        assert!(Arc::ptr_eq(
+            &router.executor_for_profile(&RunProfileId::new("assistant").expect("profile id")),
+            &alternate
+        ));
+        assert!(Arc::ptr_eq(
+            &router.executor_for_profile(&RunProfileId::new("automation").expect("profile id")),
+            &default
+        ));
+    }
+
+    #[test]
+    fn duplicate_profile_routes_fail_closed() {
+        let default: Arc<dyn TurnRunExecutor> = Arc::new(UnusedExecutor);
+        let alternate: Arc<dyn TurnRunExecutor> = Arc::new(UnusedExecutor);
+        let error = ProfileRoutingTurnRunExecutor::new(default)
+            .with_routes(["coding".to_string(), "coding".to_string()], alternate)
+            .err()
+            .expect("duplicate route must fail");
+
+        assert!(error.contains("duplicated"));
+    }
+}

--- a/crates/loop/ironclaw_turn_runner/src/runtime.rs
+++ b/crates/loop/ironclaw_turn_runner/src/runtime.rs
@@ -36,7 +36,7 @@ use ironclaw_turns::{
 use crate::{
     app_loop_family::build_loop_family_registry_with_overrides,
     driver_registry::{DriverRegistry, DriverRegistryError},
-    harness_turn_run_executor::{HarnessRoutingTurnRunExecutor, HarnessTurnRunConfig},
+    harness_turn_run_executor::{HarnessTurnRunConfig, HarnessTurnRunExecutor},
     loop_driver_host::{
         HookDispatcherBuilderFactory, RebornLoopDriverHostFactory, TextOnlyLoopHostConfig,
         apply_capability_surface_policy, capability_resolve_error_to_agent_host_error,
@@ -47,6 +47,7 @@ use crate::{
         register_default_planned_driver, register_default_text_only_driver,
         register_subagent_planned_driver,
     },
+    profile_routing_turn_run_executor::ProfileRoutingTurnRunExecutor,
     subagent::{
         capability_surface::SubagentCapabilitySurfaceResolver, flavors,
         prompt_material::GateBackedSubagentPromptMaterialSource,
@@ -946,18 +947,23 @@ where
     if let Some(recorder) = after_turn_memory_recorder {
         executor = executor.with_after_turn_memory_recorder(recorder);
     }
-    let executor = Arc::new(executor);
+    let executor: Arc<dyn crate::turn_scheduler::TurnRunExecutor> = Arc::new(executor);
     let executor: Arc<dyn crate::turn_scheduler::TurnRunExecutor> =
         if let Some(harness) = parts.harness {
-            Arc::new(
-                HarnessRoutingTurnRunExecutor::new(
-                    Arc::clone(&executor),
+            let (run_profile_ids, harness_config) = harness.into_routing_parts();
+            let harness_executor: Arc<dyn crate::turn_scheduler::TurnRunExecutor> = Arc::new(
+                HarnessTurnRunExecutor::new(
                     host_factory.clone() as Arc<dyn crate::turn_runner::HostFactory>,
                     Arc::clone(&parts.thread_service),
                     parts.thread_scope.clone(),
-                    harness,
+                    harness_config,
                 )
                 .map_err(DefaultPlannedRuntimeBuildError::Harness)?,
+            );
+            Arc::new(
+                ProfileRoutingTurnRunExecutor::new(Arc::clone(&executor))
+                    .with_routes(run_profile_ids, harness_executor)
+                    .map_err(DefaultPlannedRuntimeBuildError::Harness)?,
             )
         } else {
             executor

--- a/crates/loop/ironclaw_turn_runner/src/runtime.rs
+++ b/crates/loop/ironclaw_turn_runner/src/runtime.rs
@@ -865,6 +865,7 @@ where
             parts.thread_scope.clone(),
         ))
     });
+    let harness_milestone_sink = Arc::clone(&parts.milestone_sink);
     let mut host_factory = RebornLoopDriverHostFactory::new(
         Arc::clone(&parts.thread_service),
         parts.thread_scope.clone(),
@@ -956,6 +957,8 @@ where
                     host_factory.clone() as Arc<dyn crate::turn_runner::HostFactory>,
                     Arc::clone(&parts.thread_service),
                     parts.thread_scope.clone(),
+                    Arc::clone(&loop_exit_applier),
+                    harness_milestone_sink,
                     harness_config,
                 )
                 .map_err(DefaultPlannedRuntimeBuildError::Harness)?,

--- a/crates/loop/ironclaw_turn_runner/src/runtime.rs
+++ b/crates/loop/ironclaw_turn_runner/src/runtime.rs
@@ -36,6 +36,7 @@ use ironclaw_turns::{
 use crate::{
     app_loop_family::build_loop_family_registry_with_overrides,
     driver_registry::{DriverRegistry, DriverRegistryError},
+    harness_turn_run_executor::{HarnessRoutingTurnRunExecutor, HarnessTurnRunConfig},
     loop_driver_host::{
         HookDispatcherBuilderFactory, RebornLoopDriverHostFactory, TextOnlyLoopHostConfig,
         apply_capability_surface_policy, capability_resolve_error_to_agent_host_error,
@@ -370,6 +371,8 @@ where
     pub subagent_spawn_input_codec: Arc<dyn SpawnSubagentInputCodec>,
     pub subagent_spawn_limits: SubagentSpawnLimits,
     pub loop_exit_evidence: Arc<dyn LoopExitEvidencePort>,
+    /// Optional ACP routing for explicitly selected run profiles.
+    pub harness: Option<HarnessTurnRunConfig>,
     pub config: DefaultPlannedRuntimeConfig,
     pub model_route_resolver: Option<Arc<dyn ModelRouteResolver>>,
     pub cancellation_factory: Option<Arc<dyn RunCancellationFactory>>,
@@ -478,6 +481,7 @@ pub enum DefaultPlannedRuntimeBuildError {
     RunProfile(String),
     SubagentCompletion(String),
     SteeringReconcileObserver(String),
+    Harness(String),
 }
 
 impl fmt::Display for DefaultPlannedRuntimeBuildError {
@@ -495,6 +499,7 @@ impl fmt::Display for DefaultPlannedRuntimeBuildError {
                     "steering reconcile observer wiring failed: {error}"
                 )
             }
+            Self::Harness(error) => write!(formatter, "ACP harness wiring failed: {error}"),
         }
     }
 }
@@ -861,7 +866,7 @@ where
     });
     let mut host_factory = RebornLoopDriverHostFactory::new(
         Arc::clone(&parts.thread_service),
-        parts.thread_scope,
+        parts.thread_scope.clone(),
         Arc::clone(&parts.model_gateway),
         agent_turn_runtime_port,
         Arc::clone(&parts.loop_checkpoint_store),
@@ -942,6 +947,21 @@ where
         executor = executor.with_after_turn_memory_recorder(recorder);
     }
     let executor = Arc::new(executor);
+    let executor: Arc<dyn crate::turn_scheduler::TurnRunExecutor> =
+        if let Some(harness) = parts.harness {
+            Arc::new(
+                HarnessRoutingTurnRunExecutor::new(
+                    Arc::clone(&executor),
+                    host_factory.clone() as Arc<dyn crate::turn_runner::HostFactory>,
+                    Arc::clone(&parts.thread_service),
+                    parts.thread_scope.clone(),
+                    harness,
+                )
+                .map_err(DefaultPlannedRuntimeBuildError::Harness)?,
+            )
+        } else {
+            executor
+        };
     let scheduler_config = TurnRunSchedulerConfig::default()
         .with_max_concurrent_runs(scheduler_permit_count(parts.config.worker_count))
         .with_runner_heartbeat_interval(parts.config.heartbeat_interval)

--- a/crates/loop/ironclaw_turn_runner/src/turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/turn_run_executor.rs
@@ -349,7 +349,11 @@ impl RebornTurnRunExecutor {
     ///   `record_runner_failure` fail — a double-failure that leaves the run in
     ///   an unknown state. The caller (`execute_claimed_run`) converts this to a
     ///   `TurnRunExecutorError` so the scheduler can record a terminal failure.
-    async fn apply_exit(&self, claimed: &ClaimedTurnRun, mut exit: LoopExit) -> Result<(), ()> {
+    pub(crate) async fn apply_exit(
+        &self,
+        claimed: &ClaimedTurnRun,
+        mut exit: LoopExit,
+    ) -> Result<(), ()> {
         let started_at = live_latency_started_at();
         let run_id = claimed.state.run_id;
         let runner_id = claimed.runner_id;

--- a/crates/product/ironclaw_assistant/tests/inbound_turn_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/inbound_turn_contract.rs
@@ -931,6 +931,7 @@ async fn user_message_no_profile_uses_product_live_runtime_and_persists_reply() 
             )
             .with_cancellation_factory(cancellation_factory.clone()),
         ),
+        harness: None,
         config: DefaultPlannedRuntimeConfig::default(),
         model_route_resolver: Some(model_route_resolver),
         cancellation_factory: Some(cancellation_factory.clone()),
@@ -1104,6 +1105,7 @@ async fn user_message_no_profile_can_cancel_product_live_run_from_product_path()
             subagent_await_edge_evidence,
             thread_scope.clone(),
         )),
+        harness: None,
         config: DefaultPlannedRuntimeConfig::default(),
         model_route_resolver: Some(model_route_resolver),
         cancellation_factory: Some(cancellation_factory.clone()),
@@ -1292,6 +1294,7 @@ async fn product_live_runtime_rejects_unretained_cancellation_factory() {
             subagent_await_edge_evidence,
             thread_scope,
         )),
+        harness: None,
         config: DefaultPlannedRuntimeConfig::default(),
         model_route_resolver: Some(model_route_resolver),
         cancellation_factory: Some(Arc::new(UnretainedRunCancellationFactory)),

--- a/crates/product/ironclaw_assistant/tests/support/planned_agent_loop.rs
+++ b/crates/product/ironclaw_assistant/tests/support/planned_agent_loop.rs
@@ -424,6 +424,7 @@ impl ProductLiveAgentLoopHarness {
                 )
                 .with_cancellation_factory(cancellation_factory.clone()),
             ),
+            harness: None,
             config: DefaultPlannedRuntimeConfig::default(),
             model_route_resolver: Some(model_route_resolver),
             cancellation_factory: Some(cancellation_factory.clone()),

--- a/docs/internal/plans/composition-pubuse.snapshot
+++ b/docs/internal/plans/composition-pubuse.snapshot
@@ -78,8 +78,9 @@ pub use runtime::{
     product_auth_challenge_provider,
 };
 pub use runtime_input::{
-    KeepaliveSweepSettings, PollSettings, RebornRuntimeIdentity, RebornRuntimeInput,
-    TriggerFireAccessGrant, TriggerFireAccessPolicy, TriggerPollerSettings, TurnRunnerSettings,
+    HarnessPlacementSettings, HarnessRuntimeSettings, KeepaliveSweepSettings, PollSettings,
+    RebornRuntimeIdentity, RebornRuntimeInput, TriggerFireAccessGrant, TriggerFireAccessPolicy,
+    TriggerPollerSettings, TurnRunnerSettings,
 };
 pub use ironclaw_identity::{
     ExternalSubjectId, ProviderKind, RebornIdentityError, RebornIdentityResolver,

--- a/docs/internal/reborn/2026-08-harness-v0-findings.md
+++ b/docs/internal/reborn/2026-08-harness-v0-findings.md
@@ -16,6 +16,10 @@ the maintained package replaces that implementation.
 
 ## Implementation observations
 
+- Run-profile selection is owned by a neutral executor router whose default is
+  the canonical Rust executor. The ACP executor implements `TurnRunExecutor`
+  directly and has no fallback or knowledge of other loop implementations, so
+  another executor can be registered without changing the harness.
 - ACP gives Ironclaw a small, typed integration surface: initialize, session
   new/load, prompt, updates, and permission requests. Keeping the protocol at
   this boundary avoided translating Claude Code internals into Ironclaw tools.

--- a/docs/internal/reborn/2026-08-harness-v0-findings.md
+++ b/docs/internal/reborn/2026-08-harness-v0-findings.md
@@ -55,10 +55,11 @@ Docker lane to pin placement parity.
 
 A developer-supplied `ANTHROPIC_API_KEY` was loaded from the macOS keychain and
 passed only through the explicitly configured developer environment variable.
-The evaluation used commit `9a03c1c174`, Claude Code 2.1.232,
-`claude-agent-acp` 0.67.0, and six isolated shared clones. Both lanes received
-the same prompts and seeded regressions. No tests were run, no remote pull
-requests were created, and every coding change stayed inside its task clone.
+The evaluation used commit `9a03c1c174`, Claude Code 2.1.232, and
+`claude-agent-acp` 0.67.0, with an isolated shared clone for each task and lane.
+Both lanes received the same prompts and seeded regressions. No tests were run,
+no remote pull requests were created, and every coding change stayed inside its
+task clone.
 
 The task set was:
 

--- a/docs/internal/reborn/2026-08-harness-v0-findings.md
+++ b/docs/internal/reborn/2026-08-harness-v0-findings.md
@@ -23,6 +23,11 @@ the maintained package replaces that implementation.
 - ACP gives Ironclaw a small, typed integration surface: initialize, session
   new/load, prompt, updates, and permission requests. Keeping the protocol at
   this boundary avoided translating Claude Code internals into Ironclaw tools.
+- ACP agent-message chunks are accumulated, bounded, and sanitized before they
+  enter the existing cumulative `ModelTextDelta` milestone path. The WebUI can
+  therefore show the reply while it is generated without a harness-specific
+  transport or one durable transcript write per chunk; the completed reply is
+  still finalized once through the canonical transcript boundary.
 - A stable workspace derived from the typed thread id is enough to retain both
   repository changes and the ACP session id across turns without putting ACP
   state into tenant storage.
@@ -41,9 +46,10 @@ the maintained package replaces that implementation.
 ## Evaluation status
 
 The deterministic fake-adapter host tests cover protocol compatibility,
-multi-turn session reuse, permission handling, process death, timeout cleanup,
-lease release, and reply persistence without paid API use. The same fake runs
-through Docker in the repository's gated Docker lane to pin placement parity.
+cumulative live text updates, multi-turn session reuse, permission handling,
+process death, timeout cleanup, lease release, and reply persistence without
+paid API use. The same fake runs through Docker in the repository's gated
+Docker lane to pin placement parity.
 A live Claude Code smoke run still requires an operator-provided developer key
 through the explicitly named host environment variable. No live latency or cost
 numbers are recorded here because no credential was supplied during

--- a/docs/internal/reborn/2026-08-harness-v0-findings.md
+++ b/docs/internal/reborn/2026-08-harness-v0-findings.md
@@ -50,12 +50,85 @@ cumulative live text updates, multi-turn session reuse, permission handling,
 process death, timeout cleanup, lease release, and reply persistence without
 paid API use. The same fake runs through Docker in the repository's gated
 Docker lane to pin placement parity.
-A live Claude Code smoke run still requires an operator-provided developer key
-through the explicitly named host environment variable. No live latency or cost
-numbers are recorded here because no credential was supplied during
-implementation.
 
-Recommendation: keep the harness experimental and default-off. Consider a
-broader product integration only after repeated live trials show stable ACP
-behavior and a clear quality or engineering-throughput advantage over the
-canonical executor.
+### Live paired evaluation (2026-08-14)
+
+A developer-supplied `ANTHROPIC_API_KEY` was loaded from the macOS keychain and
+passed only through the explicitly configured developer environment variable.
+The evaluation used commit `9a03c1c174`, Claude Code 2.1.232,
+`claude-agent-acp` 0.67.0, and six isolated shared clones. Both lanes received
+the same prompts and seeded regressions. No tests were run, no remote pull
+requests were created, and every coding change stayed inside its task clone.
+
+The task set was:
+
+1. Trace WebUI submission through profile-level executor routing.
+2. Explain `credential_name` versus `extension_name` and its setup-UI effect.
+3. Repair a seeded 1.5-second live-text coalescing regression, add focused
+   coverage, make a local commit, and draft the pull request handoff.
+4. Diagnose and repair UTF-8 truncation across two turns.
+5. Diagnose and repair an incorrect profile-routing lookup across two turns.
+6. Retain an architecture map across four turns, create a continuity note, and
+   review that note against the original facts.
+
+Scoring is deliberately small and auditable: 2 means the requested outcome was
+correct and complete, 1 means materially useful but missing or wrong on a key
+requirement, and 0 means no usable outcome. A timeout was 900 seconds per
+assistant reply.
+
+| Task | ACP harness | Rust loop | Observed outcome |
+| --- | ---: | ---: | --- |
+| Turn-path Q&A | 145 s, 2/2 | 399 s, 1/2 | Harness identified `ProfileRoutingTurnRunExecutor`; Rust cited retired top-level crate paths and missed the new executor-routing seam. |
+| Extension identity Q&A | 167 s, 2/2 | 86 s, 2/2 | Both answered correctly; Rust was faster. |
+| Small streaming fix + PR | 315 s, 2/2 | 902 s, 0/2 | Harness restored 16 ms behavior, added a timer-only regression test, committed it, and returned a PR handoff. Rust timed out without a reply or edit beyond the seed. |
+| UTF-8 debugging, two turns | 108 s, 2/2 | 137 s, 0/2 | Harness restored boundary-safe truncation and added a focused edge case. Rust described and claimed a separate `acp_chunker` crate and 12 tests that did not exist; the seeded panic remained. |
+| Profile routing, two turns | 281 s, 2/2 | 908 s, 0/2 | Harness restored claimed-profile dispatch and added caller-path coverage. Rust timed out on the diagnostic turn with the seed untouched. |
+| Four-turn continuity | 512 s, 2/2 | stopped at 687 s, 0/2 | Harness retained the session, created the note, and corrected it on the fourth turn. The Rust run produced no first reply and was stopped once the earlier failures made further waiting uninformative. Four transient Anthropic HTTP errors make this last Rust observation network-contaminated. |
+| **Total** | **6/6 tasks, 12/12; 1,528 s** | **1/6 strict task successes, 3/12; >3,118 s observed** | Harness median task time was 224 s. Two Rust tasks exhausted the 900-second reply timeout before the intentionally stopped continuity run. |
+
+The harness-side Claude transcripts reported 220 uncached input tokens, 99,322
+output tokens, 1,262,214 cache-creation input tokens, and 14,209,681 cache-read
+input tokens across 125 provider messages. The Ironclaw ACP executor currently
+records `model_usage: None`, and the live run-artifact API did not expose native
+Rust-loop usage, so a symmetric token or USD comparison is not available. This
+is an accounting gap, not evidence that either lane used no tokens.
+
+This was an operational comparison, not a controlled model-quality A/B. The
+Rust lane was configured for `claude-sonnet-4-6`; the ACP transcripts show that
+Claude Code selected `claude-opus-5`. Each task was run once, the seeded changes
+were uncommitted working-tree mutations, and the Rust continuity task was
+stopped at the operator's direction after the preceding timeouts. These
+limitations prevent attributing the quality delta solely to loop design.
+
+### Stability and placement observations
+
+- The maintained ACP adapter completed all 11 harness turns. Session resume
+  worked across the four-turn continuity task, and no adapter or driver failure
+  occurred.
+- Host placement was used for the live paired tasks because it exposes the
+  developer's installed `git`, Rust toolchain, and repository. The pinned
+  Docker image built successfully but does not contain `git` or `cargo`; using
+  it would have made the coding cases an image-tooling test rather than a loop
+  comparison.
+- Cumulative `ModelTextDelta` streaming and the 16 ms projection window were
+  exercised indirectly by the streaming-fix task. The benchmark measured
+  end-to-end reply latency, not time-to-first-token or per-chunk cadence.
+- The native Rust loop's two clean timeouts had no provider error in their
+  server logs. The stopped continuity run did show transient provider HTTP
+  retries, so it must not be grouped with those clean timeouts.
+
+### Recommendation
+
+Keep harness routing experimental, explicit, and default-off. The v0 question
+has a positive answer for host-based developer work: the off-the-shelf ACP
+harness completed this task mix, including edits and session continuity, while
+the current Rust loop did not.
+
+Unlock **#7622 only**, scoped first to the breadth/image trigger demonstrated
+here: a pinned coding-capable image, durable workspace/session behavior, and
+usage accounting that permits a symmetric rerun. Do not unlock #7621: this eval
+used only a developer credential and demonstrated no customer-credential need.
+Do not unlock #7623: it exercised neither extension-tool access nor a controlled
+same-model production-promotion benchmark. Before either later rung, repeat the
+set with the same pinned model in both lanes, record time-to-first-text and
+chunk cadence, and collect provider usage through the common run artifact.

--- a/docs/internal/reborn/2026-08-harness-v0-findings.md
+++ b/docs/internal/reborn/2026-08-harness-v0-findings.md
@@ -1,0 +1,51 @@
+# ACP harness v0 findings
+
+Issue #7624 adds a deliberately narrow evaluation lane for running Claude Code
+through the official ACP client protocol. The lane is default-off and selected
+by explicit `[harness]` configuration plus a list of run-profile ids. Only
+standalone development profiles may route turns; hosted profiles reject
+routing and also fail closed if configured with host placement.
+
+Host and Docker placement use the same pins from
+`Dockerfile.claude-code-acp`; `scripts/install-claude-code-acp.sh` installs
+those pins on a developer machine. The container uses the maintained
+`@agentclientprotocol/claude-agent-acp`
+adapter. The deprecated `@zed-industries/claude-code-acp` 0.16.2 advertised
+session loading but failed to resume a session after its adapter process exited;
+the maintained package replaces that implementation.
+
+## Implementation observations
+
+- ACP gives Ironclaw a small, typed integration surface: initialize, session
+  new/load, prompt, updates, and permission requests. Keeping the protocol at
+  this boundary avoided translating Claude Code internals into Ironclaw tools.
+- A stable workspace derived from the typed thread id is enough to retain both
+  repository changes and the ACP session id across turns without putting ACP
+  state into tenant storage.
+- The v0 permission policy intentionally chooses the adapter's first offered
+  allow option. This is suitable only for explicitly enabled developer harness
+  runs.
+- Container termination, bounded update collection, and terminal scheduler
+  failures are mandatory. Without all three, a hung adapter can consume a
+  worker indefinitely or cause a failed turn to be re-driven.
+- The ACP executor receives only an opaque process transport and kill handle.
+  Host placement starts a process with an empty ambient environment and an
+  explicit developer credential list; Docker placement delegates lifecycle and
+  mounts to the existing sandbox lane. Customer secret stores are not reachable
+  from either configuration path.
+
+## Evaluation status
+
+The deterministic fake-adapter host tests cover protocol compatibility,
+multi-turn session reuse, permission handling, process death, timeout cleanup,
+lease release, and reply persistence without paid API use. The same fake runs
+through Docker in the repository's gated Docker lane to pin placement parity.
+A live Claude Code smoke run still requires an operator-provided developer key
+through the explicitly named host environment variable. No live latency or cost
+numbers are recorded here because no credential was supplied during
+implementation.
+
+Recommendation: keep the harness experimental and default-off. Consider a
+broader product integration only after repeated live trials show stable ACP
+behavior and a clear quality or engineering-throughput advantage over the
+canonical executor.

--- a/docs/internal/reborn/2026-08-harness-v0-findings.md
+++ b/docs/internal/reborn/2026-08-harness-v0-findings.md
@@ -51,15 +51,23 @@ process death, timeout cleanup, lease release, and reply persistence without
 paid API use. The same fake runs through Docker in the repository's gated
 Docker lane to pin placement parity.
 
-### Live paired evaluation (2026-08-14)
+### Live paired evaluation (corrected 2026-08-14 run)
 
 A developer-supplied `ANTHROPIC_API_KEY` was loaded from the macOS keychain and
 passed only through the explicitly configured developer environment variable.
-The evaluation used commit `9a03c1c174`, Claude Code 2.1.232, and
-`claude-agent-acp` 0.67.0, with an isolated shared clone for each task and lane.
-Both lanes received the same prompts and seeded regressions. No tests were run,
-no remote pull requests were created, and every coding change stayed inside its
-task clone.
+The corrected evaluation used commit `679ca696a3`, Claude Code 2.1.232,
+`claude-agent-acp` 0.67.0, and `claude-sonnet-4-6` in both lanes. The Claude Code
+model was pinned with `ANTHROPIC_MODEL`; every non-synthetic model-bearing ACP
+transcript record reported `claude-sonnet-4-6`.
+
+Each lane received the same task text, a task-local clone, and the same committed
+seed regression. Every turn also named its allowed workspace root and required
+`pwd` plus `git rev-parse --show-toplevel` before work. Preflight in both lanes
+observed commit `679ca696a3`, origin `https://github.com/nearai/ironclaw.git`,
+the first `Cargo.toml` line `[workspace]`, and a probe file written into the
+evaluated clone. The ACP transcript auditor found zero tool inputs that escaped
+the task checkout. No tests were run, no remote pull requests were created, and
+all coding changes remained in ignored task clones.
 
 The task set was:
 
@@ -75,61 +83,71 @@ The task set was:
 Scoring is deliberately small and auditable: 2 means the requested outcome was
 correct and complete, 1 means materially useful but missing or wrong on a key
 requirement, and 0 means no usable outcome. A timeout was 900 seconds per
-assistant reply.
+assistant reply. Because the operator requested CI-only validation, scoring
+uses response review and static diff inspection; generated tests were not
+compiled locally.
 
-| Task | ACP harness | Rust loop | Observed outcome |
+| Task | ACP harness | Rust loop | Semantic observation |
 | --- | ---: | ---: | --- |
-| Turn-path Q&A | 145 s, 2/2 | 399 s, 1/2 | Harness identified `ProfileRoutingTurnRunExecutor`; Rust cited retired top-level crate paths and missed the new executor-routing seam. |
-| Extension identity Q&A | 167 s, 2/2 | 86 s, 2/2 | Both answered correctly; Rust was faster. |
-| Small streaming fix + PR | 315 s, 2/2 | 902 s, 0/2 | Harness restored 16 ms behavior, added a timer-only regression test, committed it, and returned a PR handoff. Rust timed out without a reply or edit beyond the seed. |
-| UTF-8 debugging, two turns | 108 s, 2/2 | 137 s, 0/2 | Harness restored boundary-safe truncation and added a focused edge case. Rust described and claimed a separate `acp_chunker` crate and 12 tests that did not exist; the seeded panic remained. |
-| Profile routing, two turns | 281 s, 2/2 | 908 s, 0/2 | Harness restored claimed-profile dispatch and added caller-path coverage. Rust timed out on the diagnostic turn with the seed untouched. |
-| Four-turn continuity | 512 s, 2/2 | stopped at 687 s, 0/2 | Harness retained the session, created the note, and corrected it on the fourth turn. The Rust run produced no first reply and was stopped once the earlier failures made further waiting uninformative. Four transient Anthropic HTTP errors make this last Rust observation network-contaminated. |
-| **Total** | **6/6 tasks, 12/12; 1,528 s** | **1/6 strict task successes, 3/12; >3,118 s observed** | Harness median task time was 224 s. Two Rust tasks exhausted the 900-second reply timeout before the intentionally stopped continuity run. |
+| Turn-path Q&A | 242 s, 2/2 | 904 s, 0/2 | Harness traced the current handler, coordinator, scheduler, and `ProfileRoutingTurnRunExecutor` path. Rust exhausted the reply deadline without a final message. Its log contained four transient Anthropic HTTP retries, so this timeout is network-contaminated. |
+| Extension identity Q&A | 90 s, 2/2 | 475 s, 1/2 | Harness cited the `CredentialName`/`ExtensionName` newtypes and the shared setup-routing rule. Rust explained the storage-vs-UI distinction but incorrectly treated `extension_name` as the manifest display string and did not identify the canonical identity contract. |
+| Small streaming fix + PR | 263 s, 2/2 | 229 s, 2/2 | Both restored the 16 ms window, added caller-facing timer coverage, created a local commit, and returned a usable PR handoff. Rust was faster. |
+| UTF-8 debugging, two turns | 135 s, 2/2 | 189 s, 2/2 | Both diagnosed the byte-boundary panic and restored boundary-safe truncation in the evaluated checkout. Harness reused the existing exact regression; Rust expanded it with two edge cases. |
+| Profile routing, two turns | 704 s, 1/2 | 1,090 s, 1/2 | Both restored dispatch through `claimed.resolved_run_profile.profile_id`. Harness completed both replies, but its `NoopTransitionPort` implementation omitted the required `#[async_trait]`, so the generated coverage is statically invalid. Rust edited during the diagnose-only turn and then timed out before its second reply. This Rust timeout had no provider error. |
+| Four-turn continuity | 775 s, 2/2 | 1,343 s, 1/2 | Harness completed all four turns, wrote the note, and reviewed it against source. Rust retained the map through two turns but timed out on turn three before writing the note; its log contained nine transient Anthropic HTTP retries. |
+| **Total** | **5/6 strict; 11/12 points; 11/11 turns; 2,208 s** | **2/6 strict; 7/12 points; 7/11 turns; 4,230 s** | Harness median task time was 252 s; Rust median was 689 s. The corrected result still favors the harness, but it is not the original 12/12-vs-3/12 headline. |
 
-The harness-side Claude transcripts reported 220 uncached input tokens, 99,322
-output tokens, 1,262,214 cache-creation input tokens, and 14,209,681 cache-read
-input tokens across 125 provider messages. The Ironclaw ACP executor currently
+The harness-side Claude transcripts reported 167 uncached input tokens, 102,381
+output tokens, 954,588 cache-creation input tokens, and 12,419,380 cache-read
+input tokens across 144 provider messages. The Ironclaw ACP executor currently
 records `model_usage: None`, and the live run-artifact API did not expose native
-Rust-loop usage, so a symmetric token or USD comparison is not available. This
-is an accounting gap, not evidence that either lane used no tokens.
+Rust-loop usage, so a symmetric token or USD comparison remains unavailable.
+This is an accounting gap, not evidence that either lane used no tokens.
 
-This was an operational comparison, not a controlled model-quality A/B. The
-Rust lane was configured for `claude-sonnet-4-6`; the ACP transcripts show that
-Claude Code selected `claude-opus-5`. Each task was run once, the seeded changes
-were uncommitted working-tree mutations, and the Rust continuity task was
-stopped at the operator's direction after the preceding timeouts. These
-limitations prevent attributing the quality delta solely to loop design.
+This is a same-model, same-task operational comparison, but not a repeated
+statistical benchmark. Each task ran once. Claude Code's built-in `Agent` tool
+was disabled after an ACP run showed a completed Claude subagent whose result
+never returned to the parent session; both measured lanes therefore ran as
+single-agent loops. The 13 Rust provider retries contaminate its turn-path and
+continuity timings, while its clean profile-routing timeout still provides a
+non-network example of loop inefficiency.
 
-### Stability and placement observations
+### Evaluation-isolation findings
 
-- The maintained ACP adapter completed all 11 harness turns. Session resume
-  worked across the four-turn continuity task, and no adapter or driver failure
-  occurred.
-- Host placement was used for the live paired tasks because it exposes the
-  developer's installed `git`, Rust toolchain, and repository. The pinned
-  Docker image built successfully but does not contain `git` or `cargo`; using
-  it would have made the coding cases an image-tooling test rather than a loop
-  comparison.
-- Cumulative `ModelTextDelta` streaming and the 16 ms projection window were
-  exercised indirectly by the streaming-fix task. The benchmark measured
-  end-to-end reply latency, not time-to-first-token or per-chunk cadence.
-- The native Rust loop's two clean timeouts had no provider error in their
-  server logs. The stopped continuity run did show transient provider HTTP
-  retries, so it must not be grouped with those clean timeouts.
+The first paired run is superseded for loop-quality conclusions. It had two
+material confounders: Claude Code selected `claude-opus-5` while Rust used
+Sonnet 4.6, and the Rust file tools wrote to the durable virtual `/workspace`
+instead of the checked-out repository. The latter explains the apparent
+`acp_chunker` fix that never existed in the clone.
+
+A second attempted run exposed a different leak: although Claude Code's ACP
+session `cwd` was the task clone, read-only QA commands selected the source
+worktree by absolute path. Rewriting the clone's origin to GitHub alone did not
+prevent it. The corrected run therefore supplies the task workspace explicitly
+on every turn and rejects ACP results whose tool inputs reference the source
+worktree outside the task clone. The measured run produced zero such leaks.
+
+Host placement was retained because the coding tasks require the developer's
+installed `git` and Rust toolchain. The benchmark measured end-to-end reply
+latency, not time-to-first-text or per-chunk cadence. Cumulative
+`ModelTextDelta` streaming and the 16 ms projection window were exercised by
+the streaming-fix task but were not separately timed.
 
 ### Recommendation
 
-Keep harness routing experimental, explicit, and default-off. The v0 question
-has a positive answer for host-based developer work: the off-the-shelf ACP
-harness completed this task mix, including edits and session continuity, while
-the current Rust loop did not.
+Keep harness routing experimental, explicit, and default-off. The corrected
+same-model run still supports the core hypothesis: the ACP harness completed
+more of this repository-work task mix, preserved long-session continuity, and
+used substantially less wall time than the current Rust loop. It also found a
+real harness-side weakness in generated regression coverage, so promotion
+should remain evidence-gated rather than automatic.
 
 Unlock **#7622 only**, scoped first to the breadth/image trigger demonstrated
-here: a pinned coding-capable image, durable workspace/session behavior, and
-usage accounting that permits a symmetric rerun. Do not unlock #7621: this eval
-used only a developer credential and demonstrated no customer-credential need.
-Do not unlock #7623: it exercised neither extension-tool access nor a controlled
-same-model production-promotion benchmark. Before either later rung, repeat the
-set with the same pinned model in both lanes, record time-to-first-text and
-chunk cadence, and collect provider usage through the common run artifact.
+here: a pinned coding-capable image, durable workspace/session behavior,
+workspace-escape detection, and usage accounting that permits symmetric cost
+measurement. Do not unlock #7621: this eval used only a developer credential
+and demonstrated no customer-credential need. Do not unlock #7623: it exercised
+neither extension-tool access nor repeated production-promotion evidence.
+Before either later rung, repeat the corrected set, record time-to-first-text
+and chunk cadence, compile generated task diffs in CI, and collect provider
+usage through the common run artifact.

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -164,6 +164,7 @@ QA_HARNESS_PREFIXES = (
 )
 CHANGED_COVERAGE_MANIFEST = "tests/integration/changed-coverage-exemptions.toml"
 SANDBOX_DOCKER_EXACT_PATHS = {
+    "Dockerfile.claude-code-acp",
     "Dockerfile.sandbox-worker",
     "crates/app/ironclaw_cli/src/runtime/mod.rs",
     "crates/app/ironclaw_composition/src/sandbox.rs",
@@ -173,6 +174,7 @@ SANDBOX_DOCKER_EXACT_PATHS = {
     "crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs",
     "crates/app/ironclaw_composition/src/input.rs",
     "crates/app/ironclaw_config/src/profile.rs",
+    "crates/app/ironclaw_config/src/config_file.rs",
     "crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs",
     "crates/kernel/ironclaw_host_runtime/src/invocation_services.rs",
     "crates/kernel/ironclaw_host_runtime/src/process_port.rs",
@@ -182,6 +184,13 @@ SANDBOX_DOCKER_EXACT_PATHS = {
     "crates/kernel/ironclaw_runtime_policy/src/resolver.rs",
     "crates/lanes/ironclaw_sandbox/tests/support/docker_gate.rs",
     "crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live.rs",
+    "crates/loop/ironclaw_turn_runner/src/agent_placement.rs",
+    "crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs",
+    "scripts/install-claude-code-acp.sh",
+    "tests/fixtures/acp-fake/Dockerfile",
+    "tests/fixtures/acp-fake/agent.mjs",
+    "tests/fixtures/acp-claude-code/initialize-request.json",
+    "tests/integration/reborn_acp_harness.rs",
     "tests/integration/reborn_sandbox_shell_turn.rs",
     "tests/e2e_trace_runtime_policy_serde.rs",
     "tests/fixtures/llm_traces/runtime_policy/hosted_dev_no_shell.json",
@@ -266,6 +275,8 @@ def _is_shipped_asset_markdown(path: str) -> bool:
         return True
     return "prompts" in Path(path).parts[:-1]
 INTEGRATION_SUPPORT_OWNERS = {
+    "tests/fixtures/acp-fake/Dockerfile": "tests/integration/reborn_acp_harness.rs",
+    "tests/fixtures/acp-fake/agent.mjs": "tests/integration/reborn_acp_harness.rs",
     "tests/fixtures/extensions/acme-messenger/manifest.toml": (
         "tests/integration/extension_runtime.rs"
     ),
@@ -882,6 +893,7 @@ def build_plan(
                 not path.startswith("crates/")
                 and path not in root_inventory
                 and path not in integration_inventory
+                and path not in INTEGRATION_SUPPORT_OWNERS
             ):
                 continue
         if path.startswith(_webui_frontend_prefix()):

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -548,6 +548,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
 
     def test_user_sandbox_worker_change_selects_real_docker_lane(self) -> None:
         for path in (
+            "Dockerfile.claude-code-acp",
             "Dockerfile.sandbox-worker",
             "crates/lanes/ironclaw_sandbox/Cargo.toml",
             "crates/lanes/ironclaw_sandbox/src/lib.rs",
@@ -561,6 +562,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
             "crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs",
             "crates/app/ironclaw_composition/src/input.rs",
             "crates/app/ironclaw_config/src/profile.rs",
+            "crates/app/ironclaw_config/src/config_file.rs",
             "crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs",
             "crates/kernel/ironclaw_host_runtime/src/invocation_services.rs",
             "crates/kernel/ironclaw_host_runtime/src/process_port.rs",
@@ -569,6 +571,13 @@ class RebornPrTestPlanTests(unittest.TestCase):
             "crates/kernel/ironclaw_runtime_policy/src/planner.rs",
             "crates/kernel/ironclaw_runtime_policy/src/resolver.rs",
             "crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live.rs",
+            "crates/loop/ironclaw_turn_runner/src/agent_placement.rs",
+            "crates/loop/ironclaw_turn_runner/src/harness_turn_run_executor.rs",
+            "scripts/install-claude-code-acp.sh",
+            "tests/fixtures/acp-fake/Dockerfile",
+            "tests/fixtures/acp-fake/agent.mjs",
+            "tests/fixtures/acp-claude-code/initialize-request.json",
+            "tests/integration/reborn_acp_harness.rs",
             "tests/integration/reborn_sandbox_shell_turn.rs",
             "tests/e2e_trace_runtime_policy_serde.rs",
             "tests/fixtures/llm_traces/runtime_policy/hosted_dev_no_shell.json",
@@ -634,6 +643,18 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertTrue(docker_only_plan["run_sandbox_docker"])
         self.assertEqual(docker_only_plan["root_partitions"], [])
         self.assertEqual(docker_only_plan["integration_lanes"], [])
+
+    def test_acp_fake_fixture_selects_host_integration_and_docker_parity(self) -> None:
+        integration_path = "tests/integration/reborn_acp_harness.rs"
+        integration_inventory = planner._integration_test_lanes()
+
+        plan = self.plan("pull_request", ["tests/fixtures/acp-fake/agent.mjs"])
+
+        self.assertEqual(
+            plan["integration_lanes"],
+            [integration_inventory[integration_path]],
+        )
+        self.assertTrue(plan["run_sandbox_docker"])
 
     def test_empty_diff_fails_fast(self) -> None:
         with self.assertRaisesRegex(ValueError, "empty pull-request diff"):
@@ -1904,6 +1925,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertIn("needs.changes.outputs.run_sandbox_docker", workflow)
         self.assertIn("--test user_sandbox_docker_live", workflow)
         self.assertIn("--test reborn_integration_sandbox_shell_turn", workflow)
+        self.assertIn("--test reborn_integration_acp_harness", workflow)
         self.assertIn(
             '"${feature_args[@]}" --ignore-rust-version --all-targets',
             workflow,

--- a/scripts/install-claude-code-acp.sh
+++ b/scripts/install-claude-code-acp.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "${script_dir}/.." && pwd)"
+pin_file="${repository_root}/Dockerfile.claude-code-acp"
+
+read_pin() {
+  local name="$1"
+  sed -n "s/^ARG ${name}=//p" "${pin_file}"
+}
+
+claude_code_version="$(read_pin CLAUDE_CODE_VERSION)"
+adapter_version="$(read_pin CLAUDE_AGENT_ACP_VERSION)"
+if [[ -z "${claude_code_version}" || -z "${adapter_version}" ]]; then
+  echo "could not read Claude Code ACP pins from ${pin_file}" >&2
+  exit 1
+fi
+
+npm install --global \
+  "@anthropic-ai/claude-code@${claude_code_version}" \
+  "@agentclientprotocol/claude-agent-acp@${adapter_version}"
+
+claude --version
+command -v claude-agent-acp > /dev/null
+echo "installed claude-agent-acp ${adapter_version}"

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -189,7 +189,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Saved, transcript-shaped JSON can be queried through scoped storage with plain or `$`-rooted paths; bounded collection operations can select the last item and aggregate numeric rows; invalid JSON produces model-visible correction guidance | `tool_call.rs` |
 | Shell commands dispatch through the real path without spawning an OS process | `process_port.rs` |
 | A sandbox-profile shell turn executes as an unprivileged user in a real Docker worker and keeps its workspace across calls | `reborn_sandbox_shell_turn.rs` |
-| A neutral profile router keeps unselected turns on the canonical executor while an explicitly routed ACP turn uses the ACP-only executor under host and Docker placements, auto-approves adapter permissions, persists the reply, reuses its per-thread session, and tears down terminal failures | `reborn_acp_harness.rs` |
+| A neutral profile router keeps unselected turns on the canonical executor while an explicitly routed ACP turn uses the ACP-only executor under host and Docker placements, streams cumulative text chunks, auto-approves adapter permissions, persists the final reply, reuses its per-thread session, and tears down terminal failures | `reborn_acp_harness.rs` |
 | MCP tools work over a real loopback HTTP MCP server | `mcp.rs` |
 | User-registered and bundled hosted MCP servers register, authenticate, project active, restore, and invoke | `hosted_mcp_registration.rs` |
 | Web search/fetch runs the real Exa MCP handshake | `web_access.rs` |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -189,6 +189,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Saved, transcript-shaped JSON can be queried through scoped storage with plain or `$`-rooted paths; bounded collection operations can select the last item and aggregate numeric rows; invalid JSON produces model-visible correction guidance | `tool_call.rs` |
 | Shell commands dispatch through the real path without spawning an OS process | `process_port.rs` |
 | A sandbox-profile shell turn executes as an unprivileged user in a real Docker worker and keeps its workspace across calls | `reborn_sandbox_shell_turn.rs` |
+| An explicitly routed ACP harness turn uses one executor under host and Docker placements, auto-approves adapter permissions, persists the reply, reuses its per-thread session, and tears down terminal failures | `reborn_acp_harness.rs` |
 | MCP tools work over a real loopback HTTP MCP server | `mcp.rs` |
 | User-registered and bundled hosted MCP servers register, authenticate, project active, restore, and invoke | `hosted_mcp_registration.rs` |
 | Web search/fetch runs the real Exa MCP handshake | `web_access.rs` |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -189,7 +189,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Saved, transcript-shaped JSON can be queried through scoped storage with plain or `$`-rooted paths; bounded collection operations can select the last item and aggregate numeric rows; invalid JSON produces model-visible correction guidance | `tool_call.rs` |
 | Shell commands dispatch through the real path without spawning an OS process | `process_port.rs` |
 | A sandbox-profile shell turn executes as an unprivileged user in a real Docker worker and keeps its workspace across calls | `reborn_sandbox_shell_turn.rs` |
-| An explicitly routed ACP harness turn uses one executor under host and Docker placements, auto-approves adapter permissions, persists the reply, reuses its per-thread session, and tears down terminal failures | `reborn_acp_harness.rs` |
+| A neutral profile router keeps unselected turns on the canonical executor while an explicitly routed ACP turn uses the ACP-only executor under host and Docker placements, auto-approves adapter permissions, persists the reply, reuses its per-thread session, and tears down terminal failures | `reborn_acp_harness.rs` |
 | MCP tools work over a real loopback HTTP MCP server | `mcp.rs` |
 | User-registered and bundled hosted MCP servers register, authenticate, project active, restore, and invoke | `hosted_mcp_registration.rs` |
 | Web search/fetch runs the real Exa MCP handshake | `web_access.rs` |

--- a/tests/fixtures/acp-claude-code/initialize-request.json
+++ b/tests/fixtures/acp-claude-code/initialize-request.json
@@ -1,0 +1,1 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{},"clientInfo":{"name":"ironclaw-canary","version":"1"}}}

--- a/tests/fixtures/acp-fake/Dockerfile
+++ b/tests/fixtures/acp-fake/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:22.18.0-alpine@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b
+COPY agent.mjs /agent.mjs
+WORKDIR /workspace
+ENTRYPOINT ["node", "/agent.mjs"]

--- a/tests/fixtures/acp-fake/agent.mjs
+++ b/tests/fixtures/acp-fake/agent.mjs
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+const workspaceFile = (name) => path.join(process.cwd(), name);
+const log = (event) => fs.appendFileSync(workspaceFile("fake-events.log"), `${event}\n`);
+const send = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
+let pendingPrompt = null;
+
+log(`env:${Object.keys(process.env).sort().join(",")}`);
+
+readline.createInterface({ input: process.stdin }).on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+      authMethods: [],
+      agentInfo: { name: "ironclaw-acp-fake", version: "1" }
+    }});
+  } else if (message.method === "session/new") {
+    log("new:fake-session");
+    log(`new-cwd:${message.params.cwd}`);
+    send({ jsonrpc: "2.0", id: message.id, result: { sessionId: "fake-session" }});
+  } else if (message.method === "session/load") {
+    log(`load:${message.params.sessionId}`);
+    log(`load-cwd:${message.params.cwd}`);
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "session/prompt") {
+    if (JSON.stringify(message.params.prompt).includes("crash")) {
+      log("crash");
+      process.exit(17);
+    }
+    if (JSON.stringify(message.params.prompt).includes("hang")) {
+      log("hang");
+      return;
+    }
+    pendingPrompt = { id: message.id, sessionId: message.params.sessionId };
+    send({ jsonrpc: "2.0", id: 900, method: "session/request_permission", params: {
+      sessionId: pendingPrompt.sessionId,
+      toolCall: { toolCallId: "fake-tool" },
+      options: [
+        { optionId: "reject-once", name: "Reject once", kind: "reject_once" },
+        { optionId: "allow-once", name: "Allow once", kind: "allow_once" }
+      ]
+    }});
+  } else if (message.id === 900 && pendingPrompt) {
+    log(`permission:${JSON.stringify(message.result)}`);
+    const countPath = workspaceFile("prompt-count");
+    const count = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, "utf8")) + 1 : 1;
+    fs.writeFileSync(countPath, String(count));
+    send({ jsonrpc: "2.0", method: "session/update", params: {
+      sessionId: pendingPrompt.sessionId,
+      update: { sessionUpdate: "agent_message_chunk", content: {
+        type: "text", text: `fake ACP reply ${count}`
+      }}
+    }});
+    send({ jsonrpc: "2.0", id: pendingPrompt.id, result: { stopReason: "end_turn" }});
+    pendingPrompt = null;
+  }
+});

--- a/tests/fixtures/acp-fake/agent.mjs
+++ b/tests/fixtures/acp-fake/agent.mjs
@@ -52,7 +52,13 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     send({ jsonrpc: "2.0", method: "session/update", params: {
       sessionId: pendingPrompt.sessionId,
       update: { sessionUpdate: "agent_message_chunk", content: {
-        type: "text", text: `fake ACP reply ${count}`
+        type: "text", text: "fake ACP "
+      }}
+    }});
+    send({ jsonrpc: "2.0", method: "session/update", params: {
+      sessionId: pendingPrompt.sessionId,
+      update: { sessionUpdate: "agent_message_chunk", content: {
+        type: "text", text: `reply ${count}`
       }}
     }});
     send({ jsonrpc: "2.0", id: pendingPrompt.id, result: { stopReason: "end_turn" }});

--- a/tests/integration/reborn_acp_harness.rs
+++ b/tests/integration/reborn_acp_harness.rs
@@ -65,10 +65,14 @@ async fn host_placement_reuses_session_and_auto_approves_permissions() {
         .await
         .expect("harness builds");
 
-    harness
+    let first_run = harness
         .submit_turn("first")
         .await
         .expect("first turn completes");
+    harness
+        .assert_streamed_model_text(first_run, &["fake ACP ", "fake ACP reply 1"])
+        .await
+        .expect("ACP chunks stream as cumulative model text");
     harness
         .assert_reply_contains("fake ACP reply 1")
         .await

--- a/tests/integration/reborn_acp_harness.rs
+++ b/tests/integration/reborn_acp_harness.rs
@@ -1,0 +1,272 @@
+//! Full-turn ACP harness proof using a deterministic Docker adapter.
+
+#[allow(dead_code)]
+#[path = "support/docker_gate.rs"]
+mod docker_gate;
+#[allow(dead_code)]
+#[path = "support/mod.rs"]
+mod reborn_support;
+#[allow(dead_code)]
+#[path = "../support/mod.rs"]
+mod support;
+
+use std::{collections::HashSet, fs, path::Path, sync::Arc, time::Duration};
+
+use ironclaw_turn_runner::{
+    agent_placement::{DockerAgentPlacement, HostAgentPlacement},
+    harness_turn_run_executor::HarnessTurnRunConfig,
+};
+use ironclaw_turns::TurnStatus;
+use reborn_support::builder::RebornIntegrationHarness;
+use reborn_support::reply::RebornScriptedReply;
+
+const IMAGE: &str = "ironclaw-acp-fake:latest";
+const PROFILE: &str = "reborn-planned-default";
+
+#[tokio::test]
+async fn unselected_profile_keeps_the_canonical_executor() {
+    let workspace_root = tempfile::tempdir().expect("workspace root");
+    let config = HarnessTurnRunConfig {
+        run_profile_ids: HashSet::from(["not-selected".to_string()]),
+        timeout: Duration::from_secs(1),
+        max_update_bytes: 1024,
+        placement: Arc::new(
+            HostAgentPlacement::new(
+                workspace_root.path().to_path_buf(),
+                "command-that-must-not-start".into(),
+                Vec::new(),
+                Vec::new(),
+                1024,
+            )
+            .expect("valid unused host placement"),
+        ),
+    };
+    let harness = RebornIntegrationHarness::test_default()
+        .with_acp_harness_for_test(config)
+        .script([RebornScriptedReply::text("canonical reply")])
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness.submit_turn("hello").await.expect("turn completes");
+    harness
+        .assert_reply_contains("canonical reply")
+        .await
+        .expect("canonical executor reply persisted");
+}
+
+#[tokio::test]
+async fn host_placement_reuses_session_and_auto_approves_permissions() {
+    let workspace_root = tempfile::tempdir().expect("workspace root");
+    let config = host_config(workspace_root.path(), Duration::from_secs(10));
+    let harness = RebornIntegrationHarness::test_default()
+        .with_acp_harness_for_test(config)
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness
+        .submit_turn("first")
+        .await
+        .expect("first turn completes");
+    harness
+        .assert_reply_contains("fake ACP reply 1")
+        .await
+        .expect("first ACP reply persisted");
+    harness
+        .submit_turn("second")
+        .await
+        .expect("second turn completes");
+    harness
+        .assert_reply_contains("fake ACP reply 2")
+        .await
+        .expect("second ACP reply persisted");
+
+    let events = find_file(workspace_root.path(), "fake-events.log")
+        .and_then(|path| fs::read_to_string(path).ok())
+        .expect("fake adapter event log");
+    assert!(events.contains("new:fake-session"), "{events}");
+    assert!(events.contains("load:fake-session"), "{events}");
+    assert!(!events.contains("new-cwd:/workspace"), "{events}");
+    assert!(events.contains("env:HOME,PATH"), "{events}");
+    assert!(events.matches("permission:").count() >= 2, "{events}");
+    assert!(events.contains("allow-once"), "{events}");
+}
+
+#[tokio::test]
+async fn acp_timeout_is_terminal_and_releases_the_thread_for_another_turn() {
+    let workspace_root = tempfile::tempdir().expect("workspace root");
+    let config = host_config(workspace_root.path(), Duration::from_millis(200));
+    let harness = RebornIntegrationHarness::test_default()
+        .with_acp_harness_for_test(config)
+        .build()
+        .await
+        .expect("harness builds");
+
+    let failed_run = harness
+        .submit_turn_async("hang")
+        .await
+        .expect("turn submits");
+    let state = harness
+        .wait_for_status(failed_run, TurnStatus::Failed)
+        .await
+        .expect("timeout is terminal");
+    assert_eq!(
+        state.failure.as_ref().map(|failure| failure.category()),
+        Some("interrupted_unexpectedly")
+    );
+
+    harness
+        .submit_turn("recover")
+        .await
+        .expect("a later turn can run after timeout cleanup");
+    harness
+        .assert_reply_contains("fake ACP reply 1")
+        .await
+        .expect("later reply persisted");
+}
+
+#[tokio::test]
+async fn host_process_death_is_terminal_and_does_not_requeue() {
+    let workspace_root = tempfile::tempdir().expect("workspace root");
+    let config = host_config(workspace_root.path(), Duration::from_secs(10));
+    let harness = RebornIntegrationHarness::test_default()
+        .with_acp_harness_for_test(config)
+        .build()
+        .await
+        .expect("harness builds");
+
+    let failed_run = harness
+        .submit_turn_async("crash")
+        .await
+        .expect("turn submits");
+    let state = harness
+        .wait_for_status(failed_run, TurnStatus::Failed)
+        .await
+        .expect("process death is terminal");
+    assert_eq!(
+        state.failure.as_ref().map(|failure| failure.category()),
+        Some("driver_protocol_violation")
+    );
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let events = find_file(workspace_root.path(), "fake-events.log")
+        .and_then(|path| fs::read_to_string(path).ok())
+        .expect("fake adapter event log");
+    assert_eq!(events.matches("crash").count(), 1, "{events}");
+
+    harness
+        .submit_turn("recover")
+        .await
+        .expect("a later turn can run after process death");
+    harness
+        .assert_reply_contains("fake ACP reply 1")
+        .await
+        .expect("later reply persisted");
+}
+
+#[tokio::test]
+async fn docker_placement_matches_host_reply_and_session_behavior() {
+    if !docker_gate::docker_available().await {
+        eprintln!("SKIP: ACP harness Docker parity requires a Docker daemon");
+        return;
+    }
+    if !docker_gate::docker_image_available(IMAGE).await {
+        eprintln!("SKIP: ACP fake image {IMAGE:?} is not built");
+        return;
+    }
+
+    let workspace_root = tempfile::tempdir().expect("workspace root");
+    let config = HarnessTurnRunConfig {
+        run_profile_ids: HashSet::from([PROFILE.to_string()]),
+        timeout: Duration::from_secs(10),
+        max_update_bytes: 16 * 1024,
+        placement: Arc::new(
+            DockerAgentPlacement::new(
+                workspace_root.path().to_path_buf(),
+                IMAGE.to_string(),
+                Vec::new(),
+                16 * 1024,
+            )
+            .expect("valid Docker placement"),
+        ),
+    };
+    let harness = RebornIntegrationHarness::test_default()
+        .with_acp_harness_for_test(config)
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness.submit_turn("first").await.expect("first turn");
+    harness.submit_turn("second").await.expect("second turn");
+    harness
+        .assert_reply_contains("fake ACP reply 2")
+        .await
+        .expect("Docker reply persisted");
+
+    let failed_run = harness
+        .submit_turn_async("crash")
+        .await
+        .expect("Docker crash turn submits");
+    let state = harness
+        .wait_for_status(failed_run, TurnStatus::Failed)
+        .await
+        .expect("Docker process death is terminal");
+    assert_eq!(
+        state.failure.as_ref().map(|failure| failure.category()),
+        Some("driver_protocol_violation")
+    );
+
+    harness
+        .submit_turn("recover")
+        .await
+        .expect("Docker placement releases the thread after process death");
+    harness
+        .assert_reply_contains("fake ACP reply 3")
+        .await
+        .expect("Docker recovery reply persisted");
+
+    let events = find_file(workspace_root.path(), "fake-events.log")
+        .and_then(|path| fs::read_to_string(path).ok())
+        .expect("fake adapter event log");
+    assert!(events.contains("new:fake-session"), "{events}");
+    assert!(events.contains("load:fake-session"), "{events}");
+    assert!(events.contains("new-cwd:/workspace"), "{events}");
+    assert_eq!(events.matches("crash").count(), 1, "{events}");
+    assert!(events.matches("permission:").count() >= 3, "{events}");
+}
+
+fn host_config(workspace_root: &Path, timeout: Duration) -> HarnessTurnRunConfig {
+    let fake_agent =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/acp-fake/agent.mjs");
+    HarnessTurnRunConfig {
+        run_profile_ids: HashSet::from([PROFILE.to_string()]),
+        timeout,
+        max_update_bytes: 16 * 1024,
+        placement: Arc::new(
+            HostAgentPlacement::new(
+                workspace_root.to_path_buf(),
+                "node".into(),
+                vec![fake_agent.into_os_string()],
+                Vec::new(),
+                16 * 1024,
+            )
+            .expect("valid host placement"),
+        ),
+    }
+}
+
+fn find_file(root: &Path, name: &str) -> Option<std::path::PathBuf> {
+    for entry in fs::read_dir(root).ok()? {
+        let path = entry.ok()?.path();
+        if path.file_name().and_then(|value| value.to_str()) == Some(name) {
+            return Some(path);
+        }
+        if path.is_dir()
+            && let Some(found) = find_file(&path, name)
+        {
+            return Some(found);
+        }
+    }
+    None
+}

--- a/tests/integration/reborn_acp_harness.rs
+++ b/tests/integration/reborn_acp_harness.rs
@@ -24,7 +24,7 @@ const IMAGE: &str = "ironclaw-acp-fake:latest";
 const PROFILE: &str = "reborn-planned-default";
 
 #[tokio::test]
-async fn unselected_profile_keeps_the_canonical_executor() {
+async fn profile_router_keeps_unselected_profiles_on_the_canonical_executor() {
     let workspace_root = tempfile::tempdir().expect("workspace root");
     let config = HarnessTurnRunConfig {
         run_profile_ids: HashSet::from(["not-selected".to_string()]),

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -117,6 +117,34 @@ impl ToolErrorClass {
 }
 
 impl RebornIntegrationHarness {
+    /// Assert the cumulative model-text updates published for one run.
+    pub async fn assert_streamed_model_text(
+        &self,
+        run_id: TurnRunId,
+        expected: &[&str],
+    ) -> HarnessResult<()> {
+        let actual = self
+            .loop_milestones()
+            .into_iter()
+            .filter(|milestone| milestone.run_id == run_id)
+            .filter_map(|milestone| match milestone.kind {
+                LoopHostMilestoneKind::ModelTextDelta { safe_text } => Some(safe_text),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let expected = expected
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect::<Vec<_>>();
+        if actual == expected {
+            return Ok(());
+        }
+        Err(format!(
+            "expected cumulative model text updates {expected:?} for run {run_id}; saw {actual:?}"
+        )
+        .into())
+    }
+
     /// Assert the complete fail-closed outcome shared by assistant and tool
     /// transcript-write failures.
     pub async fn assert_transcript_failure_terminal(

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -205,9 +205,18 @@ pub struct RebornIntegrationHarnessBuilder {
     fail_append_tool_result_reference: bool,
     /// Additive raw-provider call recording for terminal side-effect assertions.
     record_model_calls: bool,
+    acp_harness: Option<ironclaw_turn_runner::harness_turn_run_executor::HarnessTurnRunConfig>,
 }
 
 impl RebornIntegrationHarnessBuilder {
+    pub fn with_acp_harness_for_test(
+        mut self,
+        harness: ironclaw_turn_runner::harness_turn_run_executor::HarnessTurnRunConfig,
+    ) -> Self {
+        self.acp_harness = Some(harness);
+        self
+    }
+
     /// Set the scripted model replies (consumed in order at the raw-provider seam).
     pub fn script(mut self, replies: impl IntoIterator<Item = RebornScriptedReply>) -> Self {
         self.replies = replies.into_iter().collect();
@@ -774,6 +783,9 @@ impl RebornIntegrationHarnessBuilder {
         if self.fail_append_tool_result_reference {
             group_builder = group_builder.fail_append_tool_result_reference_for_test();
         }
+        if let Some(harness) = self.acp_harness {
+            group_builder = group_builder.with_acp_harness_for_test(harness);
+        }
         let group: RebornIntegrationGroup = group_builder
             .build_with_capability(group_capability)
             .await?;
@@ -900,6 +912,7 @@ impl RebornIntegrationHarness {
             fail_append_finalized_assistant_message: false,
             fail_append_tool_result_reference: false,
             record_model_calls: false,
+            acp_harness: None,
         }
     }
 

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -495,6 +495,7 @@ impl RebornIntegrationGroup {
             real_gate_dispatch_services: false,
             channel_connection: None,
             bound_memory: None,
+            harness: None,
         }
     }
 
@@ -889,6 +890,7 @@ pub struct RebornIntegrationGroupBuilder {
         Arc<dyn ironclaw_memory::MemoryService>,
         ironclaw_extension_contracts::memory::MemoryDescriptor,
     )>,
+    harness: Option<ironclaw_turn_runner::harness_turn_run_executor::HarnessTurnRunConfig>,
 }
 
 impl RebornIntegrationGroupBuilder {
@@ -1232,6 +1234,7 @@ impl RebornIntegrationGroupBuilder {
             )),
             subagent_spawn_limits: SubagentSpawnLimits::default(),
             loop_exit_evidence,
+            harness: self.harness,
             config: DefaultPlannedRuntimeConfig {
                 poll_interval: Duration::from_millis(10),
                 lease_recovery_interval: self

--- a/tests/integration/support/group_options.rs
+++ b/tests/integration/support/group_options.rs
@@ -29,6 +29,14 @@ use super::super::builder::StorageMode;
 use super::RebornIntegrationGroupBuilder;
 
 impl RebornIntegrationGroupBuilder {
+    pub fn with_acp_harness_for_test(
+        mut self,
+        harness: ironclaw_turn_runner::harness_turn_run_executor::HarnessTurnRunConfig,
+    ) -> Self {
+        self.harness = Some(harness);
+        self
+    }
+
     /// Select the durable storage backend (default: `StorageMode::InMemory`).
     /// Use `StorageMode::LibSql` to exercise on-disk durability across
     /// `assert_reply_persists_after_reopen`.

--- a/tests/integration/support/planned_runtime_parts_shape.rs
+++ b/tests/integration/support/planned_runtime_parts_shape.rs
@@ -74,6 +74,7 @@ where
         subagent_spawn_input_codec: _,
         subagent_spawn_limits: _,
         loop_exit_evidence: _,
+        harness: _,
         config: _,
         model_route_resolver,
         cancellation_factory,

--- a/tests/support/reborn_parity_qa/binary_e2e.rs
+++ b/tests/support/reborn_parity_qa/binary_e2e.rs
@@ -893,6 +893,7 @@ impl RebornBinaryE2EHarness {
             )),
             subagent_spawn_limits: ironclaw_loop_host::SubagentSpawnLimits::default(),
             loop_exit_evidence: evidence,
+            harness: None,
             config: runtime_config,
             model_route_resolver: None,
             cancellation_factory: None,


### PR DESCRIPTION
## Summary

- Adds a neutral per-run-profile router over `Arc<dyn TurnRunExecutor>`, with the canonical Rust executor as its default and replaceable executor registrations.
- Adds an ACP-only harness executor for explicitly configured profiles; it has no routing logic or knowledge of other loop implementations.
- Separates ACP conversation logic from process placement through `AgentPlacement`; host and Docker placements expose the same bounded stdio and teardown contract.
- Adds profile-agnostic routing configuration, cumulative sanitized ACP text streaming through the existing live projection, per-thread session continuity, timeout/failure handling, pinned Claude Agent ACP image/setup, CI handshake coverage, and hermetic host/Docker parity tests.
- Experimental v0: sparse timeline, auto-approved ACP permissions, open egress, developer-supplied environment credentials, and no checkpoint/redrive support.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [x] Security
- [x] Dependencies

## Linked Issue

Closes #7624

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — targeted clippy was started but intentionally stopped; CI will run the complete lint gate.
- [ ] `cargo build` — covered through compiled test targets rather than a separate build command.
- [ ] Relevant tests — the ACP suite passed before this streaming follow-up; the updated cumulative-chunk coverage is left to CI per request.
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; this path uses the root Reborn integration harness and Docker placement test rather than a database feature gate.
- [x] Manual testing: real maintained `@agentclientprotocol/claude-agent-acp` 0.67.0 two-turn session, including cross-container `session/load`, plus WebUI launch.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — deferred while this remains an experimental draft.

## Test Strategy

User behavior: Given an explicitly routed profile, a turn runs through an ACP agent under host or Docker placement, streams cumulative text updates through the normal live projection, produces the normal finalized thread reply, and resumes the ACP session on the next turn. Unrouted profiles remain on the canonical loop.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: typed profile-route selection and duplicate rejection, configuration validation/round-trip, host environment fence, bounded UTF-8 output.
- Reborn integration: fake ACP agent exercises routing, cumulative live text chunks, final reply, session load, permissions, timeout, process death, lease release, host placement, and Docker parity.
- Recorded fixture: pinned initialize request and adapter handshake CI smoke.
- Browser E2E: Not applicable; no frontend contract changed and replies use the existing finalized-message projection.
- Backend or runtime: Docker placement runs the same fake agent assertions as host placement.
- Live canary: Manual real-adapter two-turn host/container smoke; intentionally not a required CI test because it needs paid provider credentials.

What the tests prove: Explicit routing is opt-in; both placements share executor behavior; sessions survive process/container replacement; failures terminate without requeue; live chunks use the existing ephemeral projection and final replies use the existing durable thread path; configuration and credential/environment fences fail closed.

Commands run:
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_turn_runner` (254 passed; one unrelated pre-existing trace-capture queue-directory assertion failed and also failed alone)
- `cargo test -p ironclaw_turn_runner harness_turn_run_executor`
- `cargo test -p ironclaw_turn_runner agent_placement`
- `cargo test -p ironclaw_config`
- `cargo test -p ironclaw_integration_tests --test reborn_integration_acp_harness`
- `cargo test -p ironclaw_architecture_tests`
- `python3.11 scripts/ci/test_reborn_pr_test_plan.py`
- `python3.11 scripts/ci/test_docs_publication_boundary.py`
- `python3.11 scripts/ci/docs_publication_boundary.py`
- `git diff --check`

## Security Impact

This adds process execution, filesystem access, open network egress, and environment credential injection behind explicit configuration. Ambient environment inheritance is cleared, `HOME`/`PATH` overrides are rejected, protocol/update sizes are bounded, workspaces are keyed from typed thread IDs, Docker containers are force-removed on terminal paths, and no tenant/customer secret store is reachable from the harness configuration. ACP permission requests are auto-approved by explicit experimental policy and logged at debug level.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: configuration constructs the routing and placement policy; the executor cannot mint trusted inbound requests.
- [x] Untrusted content enters prompts only through the existing accepted thread message path and ACP typed content blocks.
- [x] Hashes declare purpose; SHA-256 is used only to derive non-display per-thread workspace names.
- [x] New/changed status, exit, policy, runtime, or error variants: no new shared variants; existing sanitized failure categories and exit applier are reused. Audited with `rg -n "TurnRunExecutor|execute_claimed_run|LoopExit" crates/loop/ironclaw_turn_runner`.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: optional harness config leaves behavior unchanged; supplied config is strictly validated.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: protocol lines and accumulated updates are bounded; run timeout and cleanup timeout are explicit.
- [x] Driver/operator-visible errors have stable class semantics: failures map to existing sanitized terminal categories.
- [x] Sandbox/native/host names accurately describe trust boundary: ACP executor sees `AgentPlacement`; Docker/Bollard details remain in `ironclaw_sandbox`.

## Database Impact

None. ACP session identity is stored in the per-thread workspace; no schema or migration changes.

## Blast Radius

Opt-in runner composition, configuration parsing, Docker sandbox process transport, thread finalization, dependency graph, and CI selection. With `[harness]` absent, all profiles retain the existing executor. The sandbox wrapper is intentionally a narrow `HarnessContainerTemplate`, not a generalized process-lane API.

## Rollback Plan

Remove or disable the `[harness]` section to immediately restore canonical execution without data migration. Reverting this commit removes the executor, placement adapters, image, and tests; existing thread history remains valid. Per-thread ACP workspace files can be left inert or removed separately.

## Review Follow-Through

This is intentionally an experimental draft for evaluating loop quality. Reviewer judgment is requested on the placement seam, credential fence, minimal event contract, streamed-update behavior, and whether findings justify a subsequent production-hardening rung. ACP text chunks now feed the existing live text projection as bounded, sanitized cumulative updates; only the finalized reply is persisted.

---

**Review track**: C (runtime/security/CI)



## Live Paired Evaluation

On 2026-08-14, six isolated tasks (11 turns per lane) were run through the ACP harness and canonical Rust loop with a developer Anthropic key. Both lanes used `claude-sonnet-4-6`, the same committed seed regressions, and verified task-local workspaces. No local tests or external eval PRs were run or created.

- ACP harness: 5/6 strict task successes, 11/12 semantic points, 11/11 turns, 2,208 seconds total.
- Rust loop: 2/6 strict task successes, 7/12 semantic points, 7/11 turns, 4,230 seconds total.
- Both lanes repaired the streaming and UTF-8 regressions. The harness completed long-session continuity; Rust retained two turns but timed out before writing the note.
- Harness profile-routing received partial credit: its production fix was correct, but static review found a missing `#[async_trait]` on the generated test double. Rust also received partial credit after fixing the code during the diagnose-only turn and timing out before its second reply.
- Workspace preflights passed in both lanes. The ACP trace audit found zero source-worktree escapes in the measured run. Earlier mismatched-workspace and Opus-vs-Sonnet runs are superseded.
- Rust logged 13 transient Anthropic HTTP retries across its turn-path and continuity tasks; its profile-routing timeout was clean. Native Rust-loop token usage was not exposed symmetrically.
- Recommendation: keep the feature experimental/default-off and unlock #7622 only for the demonstrated image/toolchain breadth, workspace-escape detection, and accounting gaps. Do not unlock #7621 or #7623 from this evidence.

Full task definitions, per-task numbers, usage, semantic findings, and isolation caveats are in `docs/internal/reborn/2026-08-harness-v0-findings.md`.
