### PR TITLE
fix(ci): re-pin slack/telegram integration coverage floors to observed reality

### DIFF
--- a/tests/integration/coverage-floor.toml
+++ b/tests/integration/coverage-floor.toml
@@ -576,11 +576,18 @@ captured_date = "2026-08-14"
 rationale = "Channel adapter on the ingress trust membrane: payload parsing and normalization of untrusted vendor input."
 issue = "https://github.com/nearai/ironclaw/issues/7083"
 
+# The telegram percent dropped from ~90% to ~57% when #7464 merged: the
+# linked-device half (~2.7k lines: MTProto login, session pool, transport,
+# ops) is deliberately covered at the crate tier — its handshake needs a live
+# vendor conversation the integration harness cannot script — so it inflates
+# this crate's integration-tier denominator without integration-tier hits.
+# The bot/channel half this floor was created to protect remains covered; the
+# floor guards against regression from today's observed reality.
 [[crate]]
 name = "telegram"
-floor_percent = 87.46
-floor_covered_lines = 1200
-captured_total_lines = 1372
+floor_percent = 56.63
+floor_covered_lines = 2410
+captured_total_lines = 4256
 captured_date = "2026-08-14"
 rationale = "Channel adapter on the ingress trust membrane: payload parsing and normalization of untrusted vendor input."
 issue = "https://github.com/nearai/ironclaw/issues/7083"

--- a/tests/integration/coverage-floor.toml
+++ b/tests/integration/coverage-floor.toml
@@ -569,19 +569,19 @@ issue = "https://github.com/nearai/ironclaw/issues/7083"
 
 [[crate]]
 name = "slack"
-floor_percent = 93.95
-floor_covered_lines = 3697
-captured_total_lines = 3935
-captured_date = "2026-08-04"
+floor_percent = 93.57
+floor_covered_lines = 3666
+captured_total_lines = 3918
+captured_date = "2026-08-14"
 rationale = "Channel adapter on the ingress trust membrane: payload parsing and normalization of untrusted vendor input."
 issue = "https://github.com/nearai/ironclaw/issues/7083"
 
 [[crate]]
 name = "telegram"
-floor_percent = 90.31
-floor_covered_lines = 1435
-captured_total_lines = 1589
-captured_date = "2026-08-04"
+floor_percent = 87.46
+floor_covered_lines = 1200
+captured_total_lines = 1372
+captured_date = "2026-08-14"
 rationale = "Channel adapter on the ingress trust membrane: payload parsing and normalization of untrusted vendor input."
 issue = "https://github.com/nearai/ironclaw/issues/7083"
 


### PR DESCRIPTION
## What

Re-pins the integration-tier coverage ratchet floors for the two failing crates to the observed numbers from main's own gate output ([run 31796056891](https://github.com/nearai/ironclaw/actions/runs/31796056891)):

| crate | floor (was, 2026-08-04) | observed / re-pinned (2026-08-14) |
|---|---|---|
| `slack` | 93.95% · 3697 of 3935 | 93.57% · 3666 of 3918 |
| `telegram` | 90.31% · 1435 of 1589 | 56.63% · 2410 of 4256 (post-#7464; see below) |

Tolerances, rationale, and issue links are unchanged; only the four captured numbers move per entry.

## Why

**Every main push since 2026-08-13 12:12 has failed `Tests (Reborn)`** on the `Reborn integration-tier coverage report` job (first red: [run 31698975156](https://github.com/nearai/ironclaw/actions/runs/31698975156); last green main push: 2026-08-12 18:32). The 08-13 merges legitimately shrank both floored crates — code and tests deleted together (slack standard-ops rework era, telegram sticker/voice ingress pruning) — which is exactly the "legitimate shrinkage" case the gate's failure text says to resolve by re-pinning the `[[crate]]` entry to observed numbers.

Nobody noticed for ~24h because the coverage-report job is **planned only on main pushes**: the PR lanes and the merge queue both skip it, so the queue kept merging over a red main.

## Compatibility / rollback

Data-free CI-config change; revert the commit to restore the old floors. No runtime behavior.

## Follow-ups

- ~~The `telegram` entry must be re-measured when #7464 lands~~ — happened before merge; the entry is now pinned to main's own post-#7464 gate output (run 31819915736): 56.63% · 2410 of 4256. The percent drop is denominator growth from the linked-device half, which is deliberately crate-tier covered (the MTProto handshake cannot run in the integration harness); a comment above the entry records the tier split.
- Worth a separate look: whether the coverage-report job should also be planned in `merge_group` so floor breaches eject in the queue instead of landing on main.

Regression-test exemption: deterministic reproduction is impossible because this PR changes only the coverage gate's own data manifest (four floor numbers in tests/integration/coverage-floor.toml); the consuming gate runs solely on main pushes, so the next main push after merge is the only executable verification, and no unit of production behavior exists to reproduce or pin.

## Test Strategy

- Integration: Not applicable — no runtime code changes; the changed file is the gate's own manifest. The gate re-evaluates on the next main push, which is the production verification for this file.
- Crate/unit: Not applicable (CI data file). TOML validated locally with `tomllib`; entry schema matches the file's documented `[[crate]]` shape (all four captured fields updated together).
- E2E: Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LACC5dKyNy3GNXRNbvgz57
